### PR TITLE
[cherry-pick][move] Fix formatting in disassembler + fix CI runner for Move (#20556)

### DIFF
--- a/external-crates/move/crates/move-disassembler/src/disassembler.rs
+++ b/external-crates/move/crates/move-disassembler/src/disassembler.rs
@@ -409,25 +409,25 @@ impl<'a> Disassembler<'a> {
 
         Self::disassemble_abilites(buffer, enum_handle.abilities)?;
 
-        any_writeln!(buffer, " {{")?;
-
         delimited_list(
             &enum_definition.variants,
             " {",
             ",",
-            "}",
+            "\n}\n",
             buffer,
             |buffer, variant| {
                 let variant_name = self
                     .source_mapper
                     .bytecode
                     .identifier_at(variant.variant_name);
-                any_write!(buffer, "\n\t{variant_name} {{")?;
+
+                any_write!(buffer, "\n\t{variant_name} {{ ")?;
+
                 delimited_list(
                     &variant.fields,
                     "",
                     ", ",
-                    "\n",
+                    "",
                     buffer,
                     |buffer, field_definition| {
                         let type_sig = &field_definition.signature;
@@ -444,11 +444,11 @@ impl<'a> Disassembler<'a> {
                         )
                     },
                 )?;
-                any_writeln!(buffer, "}}")
+
+                any_write!(buffer, " }}")
             },
         )?;
 
-        any_writeln!(buffer, "}}")?;
         Ok(())
     }
 
@@ -583,7 +583,7 @@ impl<'a> Disassembler<'a> {
             .skip(parameter_len)
             .enumerate()
         {
-            any_write!(buffer, "\t{name}: ")?;
+            any_write!(buffer, "L{local_idx}:\t{name}: ")?;
             self.disassemble_type_for_local(
                 buffer,
                 function_source_map,

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/declarations/function.exp
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/declarations/function.exp
@@ -4,11 +4,10 @@ task 0, lines 1-31:
 //# print-bytecode
 // Move bytecode v6
 module 3d10.Example {
+
 struct Coin {
 	value: u64
 }
-
-
 
 public value(Arg0: &Coin): u64 {
 B0:
@@ -18,8 +17,8 @@ B0:
 	3: MoveLoc[1](loc0: &u64)
 	4: ReadRef
 	5: Ret
-
 }
+
 public deposit(Arg0: &mut Coin, Arg1: Coin) {
 L0:	loc2: &Coin
 L1:	loc3: u64
@@ -48,27 +47,26 @@ B0:
 	19: Unpack[0](Coin)
 	20: StLoc[7](loc5: u64)
 	21: Ret
+}
 
 }
-}
+
 
 task 1, lines 33-46:
 //# print-bytecode
 // Move bytecode v6
 module 4d10.M {
 
-
-
-
 entry public f() {
 B0:
 	0: Ret
-
 }
+
 entry public g() {
 B0:
 	0: Call f()
 	1: Ret
+}
 
 }
-}
+

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/declarations/let.exp
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/declarations/let.exp
@@ -5,16 +5,14 @@ task 0, lines 1-9:
 // Move bytecode v6
 module 6.m {
 
-
-
-
 entry foo() {
 L0:	loc0: u64
 B0:
 	0: Ret
+}
 
 }
-}
+
 
 task 1, lines 11-20:
 //# print-bytecode

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/binary_add.exp
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/binary_add.exp
@@ -5,9 +5,6 @@ task 0, lines 1-13:
 // Move bytecode v6
 module e.Expressions {
 
-
-
-
 binary_add() {
 L0:	loc0: u64
 L1:	loc1: u64
@@ -22,6 +19,7 @@ B0:
 	6: Add
 	7: StLoc[2](loc2: u64)
 	8: Ret
+}
 
 }
-}
+

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/borrow.exp
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/borrow.exp
@@ -5,9 +5,6 @@ task 0, lines 1-13:
 // Move bytecode v6
 module 6.m {
 
-
-
-
 entry foo() {
 L0:	loc0: u64
 L1:	loc1: &u64
@@ -19,17 +16,15 @@ B0:
 	4: MoveLoc[1](loc1: &u64)
 	5: Pop
 	6: Ret
+}
 
 }
-}
+
 
 task 1, lines 15-28:
 //# print-bytecode
 // Move bytecode v6
 module 7.m {
-
-
-
 
 entry foo() {
 L0:	loc0: u64
@@ -43,19 +38,19 @@ B0:
 	4: ImmBorrowLoc[1](loc1: &u64)
 	5: StLoc[2](loc2: &u64)
 	6: Ret
+}
 
 }
-}
+
 
 task 2, lines 30-63:
 //# print-bytecode
 // Move bytecode v6
 module 1d4.M {
+
 struct T {
 	u: u64
 }
-
-
 
 f(Arg0: &T) {
 B0:
@@ -65,8 +60,8 @@ B0:
 	3: MoveLoc[1](loc0: &u64)
 	4: Pop
 	5: Ret
-
 }
+
 g(Arg0: &mut T) {
 B0:
 	0: MoveLoc[0](Arg0: &mut T)
@@ -75,8 +70,8 @@ B0:
 	3: MoveLoc[1](loc0: &u64)
 	4: Pop
 	5: Ret
-
 }
+
 public h(Arg0: &mut T) {
 B0:
 	0: MoveLoc[0](Arg0: &mut T)
@@ -85,41 +80,42 @@ B0:
 	3: MoveLoc[1](loc0: &mut u64)
 	4: Pop
 	5: Ret
+}
 
 }
-}
+
 
 task 3, lines 65-84:
 //# print-bytecode
 // Move bytecode v6
 module 2d4.M {
+
 struct T<Ty0> {
 	u: Ty0
 }
 
-
-
 f(Arg0: &T<u64>) {
 B0:
 	0: MoveLoc[0](Arg0: &T<u64>)
-	1: ImmBorrowFieldGeneric[0](T.u: Ty0)
+	1: ImmBorrowFieldGeneric[0](T.u: u64)
 	2: StLoc[1](loc0: &u64)
 	3: MoveLoc[1](loc0: &u64)
 	4: Pop
 	5: Ret
-
 }
+
 g(Arg0: &mut T<u128>) {
 B0:
 	0: MoveLoc[0](Arg0: &mut T<u128>)
-	1: ImmBorrowFieldGeneric[1](T.u: Ty0)
+	1: ImmBorrowFieldGeneric[1](T.u: u128)
 	2: StLoc[1](loc0: &u128)
 	3: MoveLoc[1](loc0: &u128)
 	4: Pop
 	5: Ret
+}
 
 }
-}
+
 
 task 5, lines 97-112:
 //# print-bytecode

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/borrow_mut.exp
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/borrow_mut.exp
@@ -5,9 +5,6 @@ task 0, lines 1-12:
 // Move bytecode v6
 module 6.m {
 
-
-
-
 entry foo() {
 L0:	loc0: u64
 L1:	loc1: &mut u64
@@ -20,19 +17,19 @@ B0:
 	5: MoveLoc[1](loc1: &mut u64)
 	6: WriteRef
 	7: Ret
+}
 
 }
-}
+
 
 task 1, lines 14-25:
 //# print-bytecode
 // Move bytecode v6
 module 3d.Foobar {
+
 struct FooCoin {
 	value: u64
 }
-
-
 
 public borrow_mut_field(Arg0: &mut FooCoin) {
 B0:
@@ -42,19 +39,19 @@ B0:
 	3: MoveLoc[1](loc0: &mut u64)
 	4: Pop
 	5: Ret
+}
 
 }
-}
+
 
 task 2, lines 27-38:
 //# print-bytecode
 // Move bytecode v6
 module 4d.Foobar {
+
 struct FooCoin<Ty0> {
 	value: u64
 }
-
-
 
 public borrow_mut_field(Arg0: &mut FooCoin<address>) {
 B0:
@@ -64,6 +61,7 @@ B0:
 	3: MoveLoc[1](loc0: &mut u64)
 	4: Pop
 	5: Ret
+}
 
 }
-}
+

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/builtins/vector.exp
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/builtins/vector.exp
@@ -5,9 +5,6 @@ task 0, lines 1-33:
 // Move bytecode v6
 module 6.m {
 
-
-
-
 entry foo() {
 L0:	loc0: vector<u64>
 L1:	loc1: &vector<u64>
@@ -60,6 +57,7 @@ B0:
 	41: MoveLoc[0](loc0: vector<u64>)
 	42: VecUnpack(1, 0)
 	43: Ret
+}
 
 }
-}
+

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/combined.exp
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/combined.exp
@@ -5,9 +5,6 @@ task 0, lines 1-13:
 // Move bytecode v6
 module 6.m {
 
-
-
-
 entry foo() {
 L0:	loc0: u64
 L1:	loc1: u64
@@ -26,6 +23,7 @@ B0:
 	10: Sub
 	11: StLoc[2](loc2: u64)
 	12: Ret
+}
 
 }
-}
+

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/pack.exp
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/pack.exp
@@ -4,20 +4,20 @@ task 0, lines 1-9:
 //# print-bytecode
 // Move bytecode v6
 module 2d20.M {
+
 struct T {
 	u: u64
 }
-
-
 
 f(): T {
 B0:
 	0: LdU64(0)
 	1: Pack[0](T)
 	2: Ret
+}
 
 }
-}
+
 
 task 1, lines 11-20:
 //# print-bytecode

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/unpack.exp
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/expressions/unpack.exp
@@ -4,19 +4,18 @@ task 0, lines 1-18:
 //# print-bytecode
 // Move bytecode v6
 module 1d12.M {
+
 struct T {
 	b: bool
 }
-
-
 
 new(): T {
 B0:
 	0: LdTrue
 	1: Pack[0](T)
 	2: Ret
-
 }
+
 f() {
 L0:	loc0: T
 L1:	loc1: bool
@@ -27,9 +26,10 @@ B0:
 	3: Unpack[0](T)
 	4: StLoc[1](loc1: bool)
 	5: Ret
+}
 
 }
-}
+
 
 task 2, lines 31-44:
 //# print-bytecode

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/statements/assert.exp
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/statements/assert.exp
@@ -5,9 +5,6 @@ task 0, lines 1-10:
 // Move bytecode v6
 module 6.m {
 
-
-
-
 entry foo() {
 L0:	loc0: u64
 B0:
@@ -23,6 +20,7 @@ B1:
 	8: Abort
 B2:
 	9: Ret
+}
 
 }
-}
+

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/statements/enums.exp
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/statements/enums.exp
@@ -5,7 +5,6 @@ task 0, lines 1-71:
 // Move bytecode v7
 module 3d8.M {
 
-
 enum T has drop {
 	X {  },
 	Y { f: u64 }
@@ -15,8 +14,8 @@ f(): T {
 B0:
 	0: PackVariant(VariantHandleIndex(0))
 	1: Ret
-
 }
+
 f1(): T {
 L0:	loc0: T
 L1:	loc1: u64
@@ -29,8 +28,8 @@ B0:
 	5: StLoc[1](loc1: u64)
 	6: PackVariant(VariantHandleIndex(0))
 	7: Ret
-
 }
+
 f2(): T {
 L0:	loc0: T
 L1:	loc1: u64
@@ -55,6 +54,7 @@ Jump tables:
 		Variant1 => jump 7
 	}
 }
+
 f3(): T {
 L0:	loc0: T
 L1:	loc1: u64
@@ -80,6 +80,7 @@ Jump tables:
 		Variant1 => jump 7
 	}
 }
+
 f4(): T {
 L0:	loc0: T
 L1:	loc1: u64
@@ -105,4 +106,6 @@ Jump tables:
 		Variant1 => jump 7
 	}
 }
+
 }
+

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/statements/jump.exp
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/statements/jump.exp
@@ -5,32 +5,28 @@ task 0, lines 1-8:
 // Move bytecode v6
 module 6.m {
 
-
-
-
 entry foo() {
 B0:
 	0: Branch(0)
+}
 
 }
-}
+
 
 task 1, lines 10-19:
 //# print-bytecode
 // Move bytecode v6
 module 7.m {
 
-
-
-
 entry foo() {
 B0:
 	0: Branch(1)
 B1:
 	1: Branch(0)
+}
 
 }
-}
+
 
 task 2, lines 21-32:
 //# print-bytecode

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/statements/jump_if.exp
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/statements/jump_if.exp
@@ -5,9 +5,6 @@ task 0, lines 1-24:
 // Move bytecode v6
 module 6.m {
 
-
-
-
 entry foo() {
 L0:	loc0: u64
 B0:
@@ -27,17 +24,15 @@ B3:
 	10: Branch(11)
 B4:
 	11: Ret
+}
 
 }
-}
+
 
 task 1, lines 26-45:
 //# print-bytecode
 // Move bytecode v6
 module 7.m {
-
-
-
 
 entry foo() {
 L0:	loc0: u64
@@ -55,17 +50,15 @@ B2:
 	8: StLoc[0](loc0: u64)
 B3:
 	9: Ret
+}
 
 }
-}
+
 
 task 2, lines 47-65:
 //# print-bytecode
 // Move bytecode v6
 module 8.m {
-
-
-
 
 entry foo() {
 L0:	loc0: u64
@@ -92,17 +85,15 @@ B4:
 	15: StLoc[0](loc0: u64)
 B5:
 	16: Ret
+}
 
 }
-}
+
 
 task 3, lines 67-82:
 //# print-bytecode
 // Move bytecode v6
 module 9.m {
-
-
-
 
 entry foo() {
 L0:	loc0: u64
@@ -121,6 +112,7 @@ B2:
 	9: Ret
 B3:
 	10: Ret
+}
 
 }
-}
+

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/statements/jump_if_false.exp
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/bytecode-generation/statements/jump_if_false.exp
@@ -5,9 +5,6 @@ task 0, lines 1-20:
 // Move bytecode v6
 module 6.m {
 
-
-
-
 entry foo() {
 L0:	loc0: u64
 B0:
@@ -26,17 +23,15 @@ B2:
 	10: Branch(2)
 B3:
 	11: Ret
+}
 
 }
-}
+
 
 task 1, lines 22-36:
 //# print-bytecode
 // Move bytecode v6
 module 7.m {
-
-
-
 
 entry foo() {
 L0:	loc0: u64
@@ -52,17 +47,15 @@ B3:
 	5: Branch(2)
 B4:
 	6: Ret
+}
 
 }
-}
+
 
 task 2, lines 38-48:
 //# print-bytecode
 // Move bytecode v6
 module 8.m {
-
-
-
 
 entry foo() {
 B0:
@@ -72,17 +65,15 @@ B1:
 	2: Branch(3)
 B2:
 	3: Ret
+}
 
 }
-}
+
 
 task 3, lines 50-63:
 //# print-bytecode
 // Move bytecode v6
 module 9.m {
-
-
-
 
 entry foo() {
 B0:
@@ -95,6 +86,7 @@ B3:
 	3: Branch(0)
 B4:
 	4: Ret
+}
 
 }
-}
+

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/comments.exp
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/comments.exp
@@ -5,60 +5,52 @@ task 0, lines 1-8:
 // Move bytecode v6
 module 6.m {
 
-
-
-
 entry foo() {
 B0:
 	0: Ret
+}
 
 }
-}
+
 
 task 1, lines 10-18:
 //# print-bytecode
 // Move bytecode v6
 module 7.m {
 
-
-
-
 entry foo() {
 B0:
 	0: Ret
+}
 
 }
-}
+
 
 task 2, lines 20-26:
 //# print-bytecode
 // Move bytecode v6
 module 8.m {
 
-
-
-
 entry foo() {
 B0:
 	0: Ret
+}
 
 }
-}
+
 
 task 3, lines 28-35:
 //# print-bytecode
 // Move bytecode v6
 module 9.m {
 
-
-
-
 entry foo() {
 B0:
 	0: Ret
+}
 
 }
-}
+
 
 task 4, lines 37-46:
 //# print-bytecode
@@ -69,12 +61,10 @@ task 5, lines 48-58:
 // Move bytecode v6
 module b.m {
 
-
-
-
 entry foo() {
 B0:
 	0: Ret
+}
 
 }
-}
+

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/crlf.exp
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/crlf.exp
@@ -5,60 +5,52 @@ task 0, lines 1-8:
 // Move bytecode v6
 module 6.m {
 
-
-
-
 entry foo() {
 B0:
 	0: Ret
+}
 
 }
-}
+
 
 task 1, lines 10-18:
 //# print-bytecode
 // Move bytecode v6
 module 7.m {
 
-
-
-
 entry foo() {
 B0:
 	0: Ret
+}
 
 }
-}
+
 
 task 2, lines 20-26:
 //# print-bytecode
 // Move bytecode v6
 module 8.m {
 
-
-
-
 entry foo() {
 B0:
 	0: Ret
+}
 
 }
-}
+
 
 task 3, lines 28-35:
 //# print-bytecode
 // Move bytecode v6
 module 9.m {
 
-
-
-
 entry foo() {
 B0:
 	0: Ret
+}
 
 }
-}
+
 
 task 4, lines 37-46:
 //# print-bytecode
@@ -69,12 +61,10 @@ task 5, lines 48-58:
 // Move bytecode v6
 module b.m {
 
-
-
-
 entry foo() {
 B0:
 	0: Ret
+}
 
 }
-}
+

--- a/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/named_addresses.exp
+++ b/external-crates/move/crates/move-ir-compiler-transactional-tests/tests/parsing/named_addresses.exp
@@ -6,25 +6,20 @@ task 2, lines 16-36:
 module 1.M {
 use 0000000000000000000000000000000000000000000000000000000000000001::T;
 
-
-
-
-
-
 f(): address {
 B0:
 	0: Call T::f()
 	1: LdConst[0](address: 0x00..)
 	2: Ret
-
 }
+
 h(): address {
 B0:
 	0: LdConst[0](address: 0x00..)
 	1: Call T::g(address): address
 	2: Ret
-
 }
+
 l(): address {
 L0:	loc0: address
 B0:
@@ -33,10 +28,10 @@ B0:
 	2: MoveLoc[0](loc0: address)
 	3: Call T::g(address): address
 	4: Ret
-
 }
 
 Constants [
 	0 => address: 0x0000000000000000000000000000000000000000000000000000000000000001
 ]
 }
+

--- a/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/print_bytecode.exp
+++ b/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/print_bytecode.exp
@@ -5,27 +5,23 @@ task 0, lines 1-7:
 // Move bytecode v6
 module 42.M {
 
-
-
-
 entry foo<Ty0, Ty1>() {
 B0:
 	0: Ret
+}
 
 }
-}
+
 
 task 1, lines 9-13:
 //# print-bytecode
 // Move bytecode v6
 module 43.M {
 
-
-
-
 entry foo<X, Y>() {
 B0:
 	0: Ret
+}
 
 }
-}
+

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/basic_poly_enum_type_mismatch.exp
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/basic_poly_enum_type_mismatch.exp
@@ -5,7 +5,6 @@ task 0, lines 1-24:
 // Move bytecode v7
 module 6.MonomorphicEnums {
 
-
 enum EnumWithTwoVariants<Ty0> {
 	One {  },
 	Two { x: u64 }
@@ -35,7 +34,9 @@ Jump tables:
 		Variant1 => jump 9
 	}
 }
+
 }
+
 
 task 1, lines 26-49:
 //# publish

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/enum_variant_jump_same_label.exp
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/enum_variant_jump_same_label.exp
@@ -5,7 +5,6 @@ task 0, lines 1-43:
 // Move bytecode v7
 module 6.Enums {
 
-
 enum EnumWithThreeVariants<Ty0> {
 	One {  },
 	Two { x: Ty0 },
@@ -20,8 +19,8 @@ B0:
 	3: MoveLoc[1](loc0: EnumWithThreeVariants<Ty0>)
 	4: Call f<Ty0>(EnumWithThreeVariants<Ty0>): Ty0
 	5: Ret
-
 }
+
 public call_fail_1<Ty0>(): Ty0 {
 L0:	loc0: EnumWithThreeVariants<Ty0>
 B0:
@@ -30,8 +29,8 @@ B0:
 	2: MoveLoc[0](loc0: EnumWithThreeVariants<Ty0>)
 	3: Call f<Ty0>(EnumWithThreeVariants<Ty0>): Ty0
 	4: Ret
-
 }
+
 public call_fail_3<Ty0>(): Ty0 {
 L0:	loc0: EnumWithThreeVariants<Ty0>
 B0:
@@ -40,8 +39,8 @@ B0:
 	2: MoveLoc[0](loc0: EnumWithThreeVariants<Ty0>)
 	3: Call f<Ty0>(EnumWithThreeVariants<Ty0>): Ty0
 	4: Ret
-
 }
+
 f<Ty0>(Arg0: EnumWithThreeVariants<Ty0>): Ty0 {
 B0:
 	0: ImmBorrowLoc[0](Arg0: EnumWithThreeVariants<Ty0>)
@@ -59,7 +58,9 @@ Jump tables:
 		Variant2 => jump 2
 	}
 }
+
 }
+
 
 task 3, line 101:
 //# run 0x6::Enums::call_fail_1 --type-args u64

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/enum_variant_mismatch.exp
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/enum_variant_mismatch.exp
@@ -5,7 +5,6 @@ task 0, lines 1-24:
 // Move bytecode v7
 module 6.MonomorphicEnums {
 
-
 enum EnumWithTwoVariants<Ty0> {
 	One {  },
 	Two { x: Ty0 }
@@ -35,7 +34,9 @@ Jump tables:
 		Variant1 => jump 5
 	}
 }
+
 }
+
 
 task 2, lines 51-61:
 //# run

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/mono/enum_decl_monomorphic.exp
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/mono/enum_decl_monomorphic.exp
@@ -5,14 +5,15 @@ task 0, lines 1-33:
 // Move bytecode v7
 module 6.MonomorphicEnums {
 
-
 enum EnumWithOneVariant {
 	One {  }
 }
+
 enum EnumWithTwoVariants {
 	One {  },
 	Two { x: u64 }
 }
+
 enum EnumWithTwoVariantsPlusAbilities has copy, drop, store, key {
 	One {  },
 	Two { x: u64 }
@@ -44,4 +45,6 @@ Jump tables:
 		Variant1 => jump 9
 	}
 }
+
 }
+

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/mono/mut_ref_update.exp
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/mono/mut_ref_update.exp
@@ -5,7 +5,6 @@ task 0, lines 3-50:
 // Move bytecode v7
 module 6.MonomorphicEnums {
 
-
 enum EnumWithTwoVariants has drop {
 	One { x: u64 },
 	Two { x: u64, y: u64 }
@@ -19,8 +18,8 @@ B0:
 	3: MoveLoc[1](loc0: u64)
 	4: PackVariant(VariantHandleIndex(0))
 	5: Ret
-
 }
+
 public mutate(Arg0: &mut EnumWithTwoVariants, Arg1: u64) {
 B0:
 	0: CopyLoc[0](Arg0: &mut EnumWithTwoVariants)
@@ -49,6 +48,7 @@ Jump tables:
 		Variant1 => jump 10
 	}
 }
+
 public get(Arg0: &EnumWithTwoVariants): &u64 {
 L0:	loc1: &u64
 B0:
@@ -73,4 +73,6 @@ Jump tables:
 		Variant1 => jump 7
 	}
 }
+
 }
+

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/mono/mut_ref_update_variant.exp
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/mono/mut_ref_update_variant.exp
@@ -5,7 +5,6 @@ task 0, lines 3-34:
 // Move bytecode v7
 module 6.MonomorphicEnums {
 
-
 enum EnumWithTwoVariants has drop {
 	One { x: u64 },
 	Two { x: u64, y: u64 }
@@ -16,8 +15,8 @@ B0:
 	0: MoveLoc[0](Arg0: u64)
 	1: PackVariant(VariantHandleIndex(0))
 	2: Ret
-
 }
+
 public mutate(Arg0: &mut EnumWithTwoVariants, Arg1: u64, Arg2: u64) {
 B0:
 	0: MoveLoc[1](Arg1: u64)
@@ -26,8 +25,8 @@ B0:
 	3: MoveLoc[0](Arg0: &mut EnumWithTwoVariants)
 	4: WriteRef
 	5: Ret
-
 }
+
 public is_variant_two(Arg0: &EnumWithTwoVariants): bool {
 L0:	loc1: &u64
 B0:
@@ -45,4 +44,6 @@ Jump tables:
 		Variant1 => jump 4
 	}
 }
+
 }
+

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/poly/basic_poly_enum.exp
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/poly/basic_poly_enum.exp
@@ -5,7 +5,6 @@ task 0, lines 1-24:
 // Move bytecode v7
 module 6.MonomorphicEnums {
 
-
 enum EnumWithTwoVariants<Ty0> {
 	One {  },
 	Two { x: Ty0 }
@@ -36,4 +35,6 @@ Jump tables:
 		Variant1 => jump 9
 	}
 }
+
 }
+

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/poly/poly_mut_ref_update.exp
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/poly/poly_mut_ref_update.exp
@@ -5,7 +5,6 @@ task 0, lines 3-50:
 // Move bytecode v7
 module 6.PolymorphicEnums {
 
-
 enum EnumWithTwoVariants<Ty0: drop> has drop {
 	One { x: Ty0 },
 	Two { x: Ty0, y: u64 }
@@ -19,8 +18,8 @@ B0:
 	3: MoveLoc[1](loc0: u64)
 	4: PackVariantGeneric(VariantInstantiationHandleIndex(0))
 	5: Ret
-
 }
+
 public mutate<Ty0: drop>(Arg0: &mut EnumWithTwoVariants<Ty0>, Arg1: Ty0) {
 B0:
 	0: CopyLoc[0](Arg0: &mut EnumWithTwoVariants<Ty0>)
@@ -49,6 +48,7 @@ Jump tables:
 		Variant1 => jump 10
 	}
 }
+
 public get<Ty0: drop>(Arg0: &EnumWithTwoVariants<Ty0>): &Ty0 {
 L0:	loc1: &u64
 B0:
@@ -73,4 +73,6 @@ Jump tables:
 		Variant1 => jump 7
 	}
 }
+
 }
+

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/poly/poly_mut_ref_update_variant.exp
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/poly/poly_mut_ref_update_variant.exp
@@ -5,7 +5,6 @@ task 0, lines 3-34:
 // Move bytecode v7
 module 6.PolymorphicEnums {
 
-
 enum EnumWithTwoVariants<Ty0> has drop {
 	One { x: Ty0 },
 	Two { x: Ty0, y: Ty0 }
@@ -16,8 +15,8 @@ B0:
 	0: MoveLoc[0](Arg0: u64)
 	1: PackVariantGeneric(VariantInstantiationHandleIndex(0))
 	2: Ret
-
 }
+
 public mutate(Arg0: &mut EnumWithTwoVariants<u64>, Arg1: u64, Arg2: u64) {
 B0:
 	0: MoveLoc[1](Arg1: u64)
@@ -26,8 +25,8 @@ B0:
 	3: MoveLoc[0](Arg0: &mut EnumWithTwoVariants<u64>)
 	4: WriteRef
 	5: Ret
-
 }
+
 public is_variant_two(Arg0: &EnumWithTwoVariants<u64>): bool {
 L0:	loc1: &u64
 B0:
@@ -45,4 +44,6 @@ Jump tables:
 		Variant1 => jump 4
 	}
 }
+
 }
+

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/variant_switch_loop.exp
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/variant_switch_loop.exp
@@ -5,7 +5,6 @@ task 0, lines 1-22:
 // Move bytecode v7
 module 6.InfiniteSwith {
 
-
 enum EnumWithOneVariant {
 	One {  }
 }
@@ -21,6 +20,7 @@ Jump tables:
 		Variant0 => jump 0
 	}
 }
+
 public start(): EnumWithOneVariant {
 L0:	loc0: EnumWithOneVariant
 B0:
@@ -28,9 +28,10 @@ B0:
 	1: StLoc[0](loc0: EnumWithOneVariant)
 	2: MoveLoc[0](loc0: EnumWithOneVariant)
 	3: Ret
+}
 
 }
-}
+
 
 task 2, lines 48-58:
 //# run --gas-budget 10000

--- a/external-crates/tests.sh
+++ b/external-crates/tests.sh
@@ -1,4 +1,5 @@
 # Run tests for external crates
+set -e
 echo "Running Move tests in external-crates"
 cd move
 echo "Excluding prover Move tests"


### PR DESCRIPTION
## Description 

Fix CI runner for CI for Move (using `set -e` in `test.sh`).

Fix formatting issues for enums in the disassembler. 

## Test plan 

CI + ran Move tests locally (including failing tests to make sure the tests fail if any fail)

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
