### PR TITLE
easy(indexer-alt): small clean-ups

### DIFF
--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/collector.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/collector.rs
@@ -31,9 +31,7 @@ impl<H: Handler> Pending<H> {
     /// Whether there are values left to commit from this indexed checkpoint.
     fn is_empty(&self) -> bool {
         let empty = self.values.is_empty();
-        if empty {
-            debug_assert!(self.watermark.batch_rows == 0);
-        }
+        debug_assert!(!empty || self.watermark.batch_rows == 0);
         empty
     }
 

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
@@ -257,9 +257,9 @@ pub(crate) fn pipeline<H: Handler + Send + Sync + 'static>(
 }
 
 const fn max_chunk_rows<H: Handler>() -> usize {
-    // Handle division by zero
     if H::Value::FIELD_COUNT == 0 {
-        return 0;
+        i16::MAX as usize
+    } else {
+        i16::MAX as usize / H::Value::FIELD_COUNT
     }
-    i16::MAX as usize / H::Value::FIELD_COUNT
 }


### PR DESCRIPTION
## Description

- Row chunk size should default to `i16::MAX` if the field count is `0`.
- Fold the `if empty { ... }` check into the `debug_assert` so "nothing gets left behind" when we're building for release (in reality the compiler will probably not have a problem with compiling this out, but it's good practice to fold the full condition into assert body).

## Test plan

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
