### PR TITLE
Revert "types: use base64 for display"

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_event.rs
+++ b/crates/sui-json-rpc-types/src/sui_event.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use fastcrypto::encoding::Base64;
+use fastcrypto::encoding::{Base58, Base64};
 use move_core_types::annotated_value::MoveDatatypeLayout;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::StructTag;
@@ -51,9 +51,9 @@ pub struct SuiEvent {
     pub type_: StructTag,
     /// Parsed json value of the event
     pub parsed_json: Value,
-    #[serde_as(as = "Base64")]
-    #[schemars(with = "Base64")]
-    /// Base64 encoded bcs bytes of the move event
+    #[serde_as(as = "Base58")]
+    #[schemars(with = "Base58")]
+    /// Base 58 encoded bcs bytes of the move event
     pub bcs: Vec<u8>,
     /// UTC timestamp in milliseconds since epoch (1/1/1970)
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -3555,7 +3555,7 @@
                     "type": "0x0000000000000000000000000000000000000000000000000000000000000009::test::TestField",
                     "value": "some_value"
                   },
-                  "bcsName": "FDB4OTo6dGVzdDo6VGVzdEZpZWxk",
+                  "bcsName": "2F1KQ3miNpBx1RzoRr1MVYMraK7RV",
                   "type": "DynamicField",
                   "objectType": "test",
                   "objectId": "0x82b2fd67344691abd0efc771941b948ad35360b08e449fbbc28b0641175bf60b",
@@ -3567,7 +3567,7 @@
                     "type": "0x0000000000000000000000000000000000000000000000000000000000000009::test::TestField",
                     "value": "some_value"
                   },
-                  "bcsName": "FDB4OTo6dGVzdDo6VGVzdEZpZWxk",
+                  "bcsName": "2F1KQ3miNpBx1RzoRr1MVYMraK7RV",
                   "type": "DynamicField",
                   "objectType": "test",
                   "objectId": "0x21564fc5a68ace997461b098c1d1f3ccbde241d8fdf562db36bc1423ee10cecb",
@@ -3579,7 +3579,7 @@
                     "type": "0x0000000000000000000000000000000000000000000000000000000000000009::test::TestField",
                     "value": "some_value"
                   },
-                  "bcsName": "FDB4OTo6dGVzdDo6VGVzdEZpZWxk",
+                  "bcsName": "2F1KQ3miNpBx1RzoRr1MVYMraK7RV",
                   "type": "DynamicField",
                   "objectType": "test",
                   "objectId": "0x7e00acf5386662fa062483ba507b1e9e3039750f0a270f2e12441ad7f611a5f7",
@@ -5962,7 +5962,7 @@
         ],
         "properties": {
           "bcsName": {
-            "$ref": "#/components/schemas/Base64"
+            "$ref": "#/components/schemas/Base58"
           },
           "digest": {
             "$ref": "#/components/schemas/ObjectDigest"
@@ -6081,10 +6081,10 @@
         ],
         "properties": {
           "bcs": {
-            "description": "Base64 encoded bcs bytes of the move event",
+            "description": "Base 58 encoded bcs bytes of the move event",
             "allOf": [
               {
-                "$ref": "#/components/schemas/Base64"
+                "$ref": "#/components/schemas/Base58"
               }
             ]
           },

--- a/crates/sui-types/src/dynamic_field.rs
+++ b/crates/sui-types/src/dynamic_field.rs
@@ -10,7 +10,7 @@ use crate::storage::ObjectStore;
 use crate::sui_serde::Readable;
 use crate::sui_serde::SuiTypeTag;
 use crate::{MoveTypeTagTrait, ObjectID, SequenceNumber, SUI_FRAMEWORK_ADDRESS};
-use fastcrypto::encoding::Base64;
+use fastcrypto::encoding::Base58;
 use fastcrypto::hash::HashFunction;
 use move_core_types::annotated_value::{MoveStruct, MoveValue};
 use move_core_types::ident_str;
@@ -65,8 +65,8 @@ where
 #[serde(rename_all = "camelCase")]
 pub struct DynamicFieldInfo {
     pub name: DynamicFieldName,
-    #[schemars(with = "Base64")]
-    #[serde_as(as = "Readable<Base64, _>")]
+    #[schemars(with = "Base58")]
+    #[serde_as(as = "Readable<Base58, _>")]
     pub bcs_name: Vec<u8>,
     pub type_: DynamicFieldType,
     pub object_type: String,


### PR DESCRIPTION
This reverts commit 327afdfbd34a90e42e3da71c13c2ec6c76a1281c which is not compatible with previous versions 

## Test plan 

```
Example query on Testnet:
sui client dynamic-field 0x37c0e4d7b36a2f64d51bba262a1791f844cfd88f31379f1b7c04244061d43914
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
