### PR TITLE
rpc: improve metrics for grpc endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8342,6 +8342,7 @@ dependencies = [
  "eyre",
  "futures",
  "http 1.1.0",
+ "http-body 1.0.1",
  "hyper-rustls 0.27.2",
  "hyper-util",
  "multiaddr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -366,6 +366,7 @@ hyper = "1"
 hyper-util = "0.1.6"
 hyper-rustls = { version = "0.27", default-features = false, features = [
     "webpki-roots",
+    "http1",
     "http2",
     "ring",
     "tls12",

--- a/consensus/core/src/network/anemo_network.rs
+++ b/consensus/core/src/network/anemo_network.rs
@@ -725,12 +725,12 @@ impl MakeCallbackHandler for MetricsCallbackMaker {
 }
 
 impl ResponseHandler for MetricsResponseCallback {
-    fn on_response(self, response: &anemo::Response<bytes::Bytes>) {
-        self.on_response(response)
+    fn on_response(mut self, response: &anemo::Response<bytes::Bytes>) {
+        MetricsResponseCallback::on_response(&mut self, response)
     }
 
-    fn on_error<E>(self, err: &E) {
-        self.on_error(err)
+    fn on_error<E>(mut self, err: &E) {
+        MetricsResponseCallback::on_error(&mut self, err)
     }
 }
 

--- a/consensus/core/src/network/metrics_layer.rs
+++ b/consensus/core/src/network/metrics_layer.rs
@@ -85,7 +85,7 @@ pub(crate) struct MetricsResponseCallback {
 
 impl MetricsResponseCallback {
     // Update response metrics.
-    pub(crate) fn on_response(self, response: &dyn SizedResponse) {
+    pub(crate) fn on_response(&mut self, response: &dyn SizedResponse) {
         let response_size = response.size();
         if response_size > 0 {
             self.metrics
@@ -108,7 +108,7 @@ impl MetricsResponseCallback {
         }
     }
 
-    pub(crate) fn on_error<E>(self, _error: &E) {
+    pub(crate) fn on_error<E>(&mut self, _error: &E) {
         self.metrics
             .errors
             .with_label_values(&[&self.route, "unknown"])

--- a/consensus/core/src/network/tonic_network.rs
+++ b/consensus/core/src/network/tonic_network.rs
@@ -1115,12 +1115,12 @@ impl MakeCallbackHandler for MetricsCallbackMaker {
 }
 
 impl ResponseHandler for MetricsResponseCallback {
-    fn on_response(self, response: &http::response::Parts) {
-        self.on_response(response)
+    fn on_response(&mut self, response: &http::response::Parts) {
+        MetricsResponseCallback::on_response(self, response)
     }
 
-    fn on_error<E>(self, err: &E) {
-        self.on_error(err)
+    fn on_error<E>(&mut self, err: &E) {
+        MetricsResponseCallback::on_error(self, err)
     }
 }
 

--- a/crates/mysten-network/Cargo.toml
+++ b/crates/mysten-network/Cargo.toml
@@ -16,6 +16,7 @@ bytes.workspace = true
 eyre.workspace = true
 futures.workspace = true
 http.workspace = true
+http-body.workspace = true
 multiaddr.workspace = true
 prometheus.workspace = true
 serde.workspace = true

--- a/crates/mysten-network/src/callback/body.rs
+++ b/crates/mysten-network/src/callback/body.rs
@@ -1,0 +1,80 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::ResponseHandler;
+use http_body::{Body, Frame};
+use pin_project_lite::pin_project;
+use std::{
+    fmt,
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
+
+pin_project! {
+    /// Response body for [`Callback`].
+    ///
+    /// [`Callback`]: super::Callback
+    pub struct ResponseBody<B, ResponseHandler> {
+        #[pin]
+        pub(crate) inner: B,
+        pub(crate) handler: ResponseHandler,
+    }
+}
+
+impl<B, ResponseHandlerT> Body for ResponseBody<B, ResponseHandlerT>
+where
+    B: Body,
+    B::Error: fmt::Display + 'static,
+    ResponseHandlerT: ResponseHandler,
+{
+    type Data = B::Data;
+    type Error = B::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        let this = self.project();
+        let result = ready!(this.inner.poll_frame(cx));
+
+        match result {
+            Some(Ok(frame)) => {
+                let frame = match frame.into_data() {
+                    Ok(chunk) => {
+                        this.handler.on_body_chunk(&chunk);
+                        Frame::data(chunk)
+                    }
+                    Err(frame) => frame,
+                };
+
+                let frame = match frame.into_trailers() {
+                    Ok(trailers) => {
+                        this.handler.on_end_of_stream(Some(&trailers));
+                        Frame::trailers(trailers)
+                    }
+                    Err(frame) => frame,
+                };
+
+                Poll::Ready(Some(Ok(frame)))
+            }
+            Some(Err(err)) => {
+                this.handler.on_error(&err);
+
+                Poll::Ready(Some(Err(err)))
+            }
+            None => {
+                this.handler.on_end_of_stream(None);
+
+                Poll::Ready(None)
+            }
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.size_hint()
+    }
+}

--- a/crates/mysten-network/src/callback/mod.rs
+++ b/crates/mysten-network/src/callback/mod.rs
@@ -1,13 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use http::{request, response};
+use http::{request, response, HeaderMap};
 
+mod body;
 mod future;
 mod layer;
 mod service;
 
-pub use self::{future::ResponseFuture, layer::CallbackLayer, service::Callback};
+pub use self::{
+    body::ResponseBody, future::ResponseFuture, layer::CallbackLayer, service::Callback,
+};
 
 pub trait MakeCallbackHandler {
     type Handler: ResponseHandler;
@@ -16,6 +19,19 @@ pub trait MakeCallbackHandler {
 }
 
 pub trait ResponseHandler {
-    fn on_response(self, response: &response::Parts);
-    fn on_error<E>(self, error: &E);
+    fn on_response(&mut self, response: &response::Parts);
+    fn on_error<E>(&mut self, error: &E)
+    where
+        E: std::fmt::Display + 'static;
+
+    fn on_body_chunk<B>(&mut self, _chunk: &B)
+    where
+        B: bytes::Buf,
+    {
+        // do nothing
+    }
+
+    fn on_end_of_stream(&mut self, _trailers: Option<&HeaderMap>) {
+        // do nothing
+    }
 }

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -580,13 +580,13 @@ struct MetricsCallbackHandler {
 }
 
 impl ResponseHandler for MetricsCallbackHandler {
-    fn on_response(self, response: &http::response::Parts) {
+    fn on_response(&mut self, response: &http::response::Parts) {
         if let Some(errors) = response.extensions.get::<GraphqlErrors>() {
             self.metrics.inc_errors(&errors.0);
         }
     }
 
-    fn on_error<E>(self, _error: &E) {
+    fn on_error<E>(&mut self, _error: &E) {
         // Do nothing if the whole service errored
         //
         // in Axum this isn't possible since all services are required to have an error type of

--- a/crates/sui-mvr-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-mvr-graphql-rpc/src/server/builder.rs
@@ -580,13 +580,13 @@ struct MetricsCallbackHandler {
 }
 
 impl ResponseHandler for MetricsCallbackHandler {
-    fn on_response(self, response: &http::response::Parts) {
+    fn on_response(&mut self, response: &http::response::Parts) {
         if let Some(errors) = response.extensions.get::<GraphqlErrors>() {
             self.metrics.inc_errors(&errors.0);
         }
     }
 
-    fn on_error<E>(self, _error: &E) {
+    fn on_error<E>(&mut self, _error: &E) {
         // Do nothing if the whole service errored
         //
         // in Axum this isn't possible since all services are required to have an error type of

--- a/crates/sui-rpc-api/src/metrics.rs
+++ b/crates/sui-rpc-api/src/metrics.rs
@@ -113,8 +113,15 @@ impl ResponseHandler for RpcMetricsCallbackHandler {
         let status = if response
             .headers
             .get(&http::header::CONTENT_TYPE)
-            .is_some_and(|header| header == tonic::metadata::GRPC_CONTENT_TYPE)
-        {
+            .is_some_and(|content_type| {
+                content_type
+                    .as_bytes()
+                    // check if the content-type starts_with 'application/grpc' in order to
+                    // consider this as a gRPC request. A prefix comparison is done instead of a
+                    // full equality check in order to account for the various types of
+                    // content-types that are considered as gRPC traffic.
+                    .starts_with(tonic::metadata::GRPC_CONTENT_TYPE.as_bytes())
+            }) {
             let code = response
                 .headers
                 .get(&GRPC_STATUS)

--- a/crates/sui-rpc-api/src/metrics.rs
+++ b/crates/sui-rpc-api/src/metrics.rs
@@ -98,7 +98,7 @@ pub struct RpcMetricsCallbackHandler {
 }
 
 impl ResponseHandler for RpcMetricsCallbackHandler {
-    fn on_response(mut self, response: &http::response::Parts) {
+    fn on_response(&mut self, response: &http::response::Parts) {
         self.metrics
             .num_requests
             .with_label_values(&[self.path.as_ref(), response.status.as_str()])
@@ -107,7 +107,7 @@ impl ResponseHandler for RpcMetricsCallbackHandler {
         self.counted_response = true;
     }
 
-    fn on_error<E>(self, _error: &E) {
+    fn on_error<E>(&mut self, _error: &E) {
         // Do nothing if the whole service errored
         //
         // in Axum this isn't possible since all services are required to have an error type of

--- a/crates/x/src/lint.rs
+++ b/crates/x/src/lint.rs
@@ -83,6 +83,8 @@ pub fn run(args: Args) -> crate::Result<()> {
             // as the opentelemetry crates.
             "prost".to_owned(),
             "tonic".to_owned(),
+            // jsonrpsee uses an older version of http-body
+            "http-body".to_owned(),
         ],
     };
 


### PR DESCRIPTION
* extend the lifetime of callback handlers in order to get a more accurate measurement of inflight requests, since now the handler will be held until the body has been fully exhausted and sent on the wire (or at least fully handed off to hyper).
* updates the path label for metrics to account for gRPC routes
* updates the status label for metrics to use gRPC status codes for grpc requests