### PR TITLE
rpc: convert Client error to tonic::Status

### DIFF
--- a/crates/sui-rpc-api/src/client/mod.rs
+++ b/crates/sui-rpc-api/src/client/mod.rs
@@ -6,13 +6,17 @@ pub use response_ext::ResponseExt;
 
 pub mod sdk;
 use sdk::BoxError;
-use sdk::Error;
-use sdk::Result;
 
 pub use reqwest;
 use tap::Pipe;
+use tonic::metadata::MetadataMap;
 
 use crate::proto::node::node_client::NodeClient;
+use crate::proto::node::{
+    ExecuteTransactionResponse, GetCheckpointResponse, GetFullCheckpointResponse, GetObjectResponse,
+};
+use crate::proto::types::Bcs;
+use crate::proto::TryFromProtoError;
 use crate::types::ExecuteTransactionOptions;
 use sui_types::base_types::{ObjectID, SequenceNumber};
 use sui_types::effects::{TransactionEffects, TransactionEvents};
@@ -20,6 +24,11 @@ use sui_types::full_checkpoint_content::CheckpointData;
 use sui_types::messages_checkpoint::{CertifiedCheckpointSummary, CheckpointSequenceNumber};
 use sui_types::object::Object;
 use sui_types::transaction::Transaction;
+
+pub type Result<T, E = tonic::Status> = std::result::Result<T, E>;
+
+use tonic::transport::channel::ClientTlsConfig;
+use tonic::Status;
 
 #[derive(Clone)]
 pub struct Client {
@@ -34,12 +43,16 @@ impl Client {
         T: TryInto<http::Uri>,
         T::Error: Into<BoxError>,
     {
-        let uri = uri.try_into().map_err(Error::from_error)?;
+        let uri = uri
+            .try_into()
+            .map_err(Into::into)
+            .map_err(Status::from_error)?;
         let mut endpoint = tonic::transport::Endpoint::from(uri.clone());
         if uri.scheme() == Some(&http::uri::Scheme::HTTPS) {
             endpoint = endpoint
-                .tls_config(tonic::transport::channel::ClientTlsConfig::new().with_enabled_roots())
-                .map_err(Error::from_error)?;
+                .tls_config(ClientTlsConfig::new().with_enabled_roots())
+                .map_err(Into::into)
+                .map_err(Status::from_error)?;
         }
         let channel = endpoint.connect_lazy();
 
@@ -77,31 +90,22 @@ impl Client {
             }),
         };
 
-        let crate::proto::node::GetCheckpointResponse {
-            summary_bcs,
-            signature,
-            ..
-        } = self
+        let (
+            metadata,
+            GetCheckpointResponse {
+                summary_bcs,
+                signature,
+                ..
+            },
+            _extentions,
+        ) = self
             .raw_client()
             .get_checkpoint(request)
-            .await
-            .map_err(Error::from_error)?
-            .into_inner();
+            .await?
+            .into_parts();
 
-        let summary = summary_bcs
-            .ok_or_else(|| Error::from_error("missing summary"))?
-            .deserialize()?;
-
-        let signature = sui_types::crypto::AuthorityStrongQuorumSignInfo::from(
-            sui_sdk_types::types::ValidatorAggregatedSignature::try_from(
-                &signature.ok_or_else(|| Error::from_error("missing signautre"))?,
-            )
-            .map_err(Error::from_error)?,
-        );
-
-        Ok(CertifiedCheckpointSummary::new_from_data_and_sig(
-            summary, signature,
-        ))
+        certified_checkpoint_summary_try_from_proto(summary_bcs, signature)
+            .map_err(|e| status_from_error_with_metadata(e, metadata))
     }
 
     pub async fn get_full_checkpoint(
@@ -130,106 +134,14 @@ impl Client {
             }),
         };
 
-        let crate::proto::node::GetFullCheckpointResponse {
-            summary_bcs,
-            signature,
-            contents_bcs,
-            transactions,
-            ..
-        } = self
+        let (metadata, response, _extentions) = self
             .raw_client()
             .get_full_checkpoint(request)
-            .await
-            .map_err(Error::from_error)?
-            .into_inner();
+            .await?
+            .into_parts();
 
-        let summary = summary_bcs
-            .ok_or_else(|| Error::from_error("missing summary"))?
-            .deserialize()?;
-        let signature = sui_types::crypto::AuthorityStrongQuorumSignInfo::from(
-            sui_sdk_types::types::ValidatorAggregatedSignature::try_from(
-                &signature.ok_or_else(|| Error::from_error("missing signautre"))?,
-            )
-            .map_err(Error::from_error)?,
-        );
-        let checkpoint_summary =
-            CertifiedCheckpointSummary::new_from_data_and_sig(summary, signature);
-
-        let checkpoint_contents = contents_bcs
-            .ok_or_else(|| Error::from_error("missing contents"))?
-            .deserialize::<sui_types::messages_checkpoint::CheckpointContents>()?;
-
-        let transactions = transactions
-            .into_iter()
-            .zip(
-                checkpoint_contents
-                    .clone()
-                    .into_iter_with_signatures()
-                    .map(|(_digests, signatures)| signatures),
-            )
-            .map(
-                |(
-                    crate::proto::node::FullCheckpointTransaction {
-                        transaction_bcs,
-                        effects_bcs,
-                        events_bcs,
-                        input_objects,
-                        output_objects,
-                        ..
-                    },
-                    signatures,
-                )| {
-                    let transaction = transaction_bcs
-                        .ok_or_else(|| Error::from_error("missing transaction"))?
-                        .deserialize()?;
-                    let transaction = Transaction::from_generic_sig_data(transaction, signatures);
-                    let effects = effects_bcs
-                        .ok_or_else(|| Error::from_error("missing effects"))?
-                        .deserialize()?;
-                    let events = events_bcs.map(|bcs| bcs.deserialize()).transpose()?;
-                    let input_objects = input_objects
-                        .ok_or_else(|| Error::from_error("missing input_objects"))?
-                        .objects
-                        .into_iter()
-                        .map(|object| {
-                            object
-                                .object_bcs
-                                .as_ref()
-                                .ok_or_else(|| Error::from_error("missing object"))?
-                                .deserialize::<Object>()
-                                .map_err(Into::into)
-                        })
-                        .collect::<Result<_>>()?;
-
-                    let output_objects = output_objects
-                        .ok_or_else(|| Error::from_error("missing output_objects"))?
-                        .objects
-                        .into_iter()
-                        .map(|object| {
-                            object
-                                .object_bcs
-                                .ok_or_else(|| Error::from_error("missing object"))?
-                                .deserialize::<Object>()
-                                .map_err(Into::into)
-                        })
-                        .collect::<Result<_>>()?;
-
-                    Result::<_>::Ok(sui_types::full_checkpoint_content::CheckpointTransaction {
-                        transaction,
-                        effects,
-                        events,
-                        input_objects,
-                        output_objects,
-                    })
-                },
-            )
-            .collect::<Result<_, _>>()?;
-
-        Ok(CheckpointData {
-            checkpoint_summary,
-            checkpoint_contents,
-            transactions,
-        })
+        checkpoint_data_try_from_proto(response)
+            .map_err(|e| status_from_error_with_metadata(e, metadata))
     }
 
     pub async fn get_object(&self, object_id: ObjectID) -> Result<Object> {
@@ -259,17 +171,10 @@ impl Client {
             }),
         };
 
-        let crate::proto::node::GetObjectResponse { object_bcs, .. } = self
-            .raw_client()
-            .get_object(request)
-            .await
-            .map_err(Error::from_error)?
-            .into_inner();
+        let (metadata, GetObjectResponse { object_bcs, .. }, _extentions) =
+            self.raw_client().get_object(request).await?.into_parts();
 
-        object_bcs
-            .ok_or_else(|| Error::from_error("missing object"))?
-            .deserialize()
-            .map_err(Into::into)
+        object_try_from_proto(object_bcs).map_err(|e| status_from_error_with_metadata(e, metadata))
     }
 
     pub async fn execute_transaction(
@@ -283,13 +188,15 @@ impl Client {
             .clone()
             .into_iter()
             .map(sui_sdk_types::types::UserSignature::try_from)
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| Status::from_error(e.into()))?;
 
         let request = crate::proto::node::ExecuteTransactionRequest {
             transaction: None,
-            transaction_bcs: Some(crate::proto::types::Bcs::serialize(
-                &transaction.inner().intent_message.value,
-            )?),
+            transaction_bcs: Some(
+                crate::proto::types::Bcs::serialize(&transaction.inner().intent_message.value)
+                    .map_err(|e| Status::from_error(e.into()))?,
+            ),
             signatures: signatures.into_iter().map(Into::into).collect(),
 
             options: Some(crate::proto::node::ExecuteTransactionOptions {
@@ -301,48 +208,14 @@ impl Client {
             }),
         };
 
-        let crate::proto::node::ExecuteTransactionResponse {
-            finality,
-            effects_bcs,
-            events_bcs,
-            balance_changes,
-            ..
-        } = self
+        let (metadata, response, _extentions) = self
             .raw_client()
             .execute_transaction(request)
-            .await
-            .map_err(Error::from_error)?
-            .into_inner();
+            .await?
+            .into_parts();
 
-        let finality = finality
-            .as_ref()
-            .ok_or_else(|| Error::from_error("missing finality"))?
-            .pipe(TryInto::try_into)
-            .map_err(Error::from_error)?;
-
-        let effects = effects_bcs
-            .ok_or_else(|| Error::from_error("missing effects"))?
-            .deserialize()?;
-        let events = events_bcs.map(|bcs| bcs.deserialize()).transpose()?;
-
-        let balance_changes = balance_changes
-            .map(|balance_changes| {
-                balance_changes
-                    .balance_changes
-                    .iter()
-                    .map(TryInto::try_into)
-                    .collect::<Result<_, _>>()
-            })
-            .transpose()
-            .map_err(Error::from_error)?;
-
-        TransactionExecutionResponse {
-            finality,
-            effects,
-            events,
-            balance_changes,
-        }
-        .pipe(Ok)
+        execute_transaction_response_try_from_proto(response)
+            .map_err(|e| status_from_error_with_metadata(e, metadata))
     }
 }
 
@@ -353,4 +226,170 @@ pub struct TransactionExecutionResponse {
     pub effects: TransactionEffects,
     pub events: Option<TransactionEvents>,
     pub balance_changes: Option<Vec<sui_sdk_types::types::BalanceChange>>,
+}
+
+/// Attempts to parse `CertifiedCheckpointSummary` from the bcs fields in `GetCheckpointResponse`
+fn certified_checkpoint_summary_try_from_proto(
+    summary_bcs: Option<Bcs>,
+    signature: Option<crate::proto::types::ValidatorAggregatedSignature>,
+) -> Result<CertifiedCheckpointSummary, TryFromProtoError> {
+    let summary = summary_bcs
+        .ok_or_else(|| TryFromProtoError::missing("summary_bcs"))?
+        .deserialize()
+        .map_err(TryFromProtoError::from_error)?;
+
+    let signature = sui_types::crypto::AuthorityStrongQuorumSignInfo::from(
+        sui_sdk_types::types::ValidatorAggregatedSignature::try_from(
+            signature
+                .as_ref()
+                .ok_or_else(|| TryFromProtoError::missing("signature"))?,
+        )
+        .map_err(TryFromProtoError::from_error)?,
+    );
+
+    Ok(CertifiedCheckpointSummary::new_from_data_and_sig(
+        summary, signature,
+    ))
+}
+
+/// Attempts to parse `CheckpointData` from the bcs fields in `GetFullCheckpointResponse`
+fn checkpoint_data_try_from_proto(
+    GetFullCheckpointResponse {
+        summary_bcs,
+        signature,
+        contents_bcs,
+        transactions,
+        ..
+    }: GetFullCheckpointResponse,
+) -> Result<CheckpointData, TryFromProtoError> {
+    let checkpoint_summary = certified_checkpoint_summary_try_from_proto(summary_bcs, signature)?;
+
+    let checkpoint_contents = contents_bcs
+        .ok_or_else(|| TryFromProtoError::missing("contents_bcs"))?
+        .deserialize::<sui_types::messages_checkpoint::CheckpointContents>()
+        .map_err(TryFromProtoError::from_error)?;
+
+    let transactions = transactions
+        .into_iter()
+        .zip(
+            checkpoint_contents
+                .clone()
+                .into_iter_with_signatures()
+                .map(|(_digests, signatures)| signatures),
+        )
+        .map(
+            |(
+                crate::proto::node::FullCheckpointTransaction {
+                    transaction_bcs,
+                    effects_bcs,
+                    events_bcs,
+                    input_objects,
+                    output_objects,
+                    ..
+                },
+                signatures,
+            )| {
+                let transaction = transaction_bcs
+                    .ok_or_else(|| TryFromProtoError::missing("transaction_bcs"))?
+                    .deserialize()
+                    .map_err(TryFromProtoError::from_error)?;
+                let transaction = Transaction::from_generic_sig_data(transaction, signatures);
+                let effects = effects_bcs
+                    .ok_or_else(|| TryFromProtoError::missing("effects_bcs"))?
+                    .deserialize()
+                    .map_err(TryFromProtoError::from_error)?;
+                let events = events_bcs
+                    .map(|bcs| bcs.deserialize())
+                    .transpose()
+                    .map_err(TryFromProtoError::from_error)?;
+                let input_objects = input_objects
+                    .ok_or_else(|| TryFromProtoError::missing("input_objects"))?
+                    .objects
+                    .into_iter()
+                    .map(|object| object_try_from_proto(object.object_bcs))
+                    .collect::<Result<_, TryFromProtoError>>()?;
+
+                let output_objects = output_objects
+                    .ok_or_else(|| TryFromProtoError::missing("output_objects"))?
+                    .objects
+                    .into_iter()
+                    .map(|object| object_try_from_proto(object.object_bcs))
+                    .collect::<Result<_, TryFromProtoError>>()?;
+
+                Result::<_, TryFromProtoError>::Ok(
+                    sui_types::full_checkpoint_content::CheckpointTransaction {
+                        transaction,
+                        effects,
+                        events,
+                        input_objects,
+                        output_objects,
+                    },
+                )
+            },
+        )
+        .collect::<Result<_, _>>()?;
+
+    Ok(CheckpointData {
+        checkpoint_summary,
+        checkpoint_contents,
+        transactions,
+    })
+}
+
+/// Attempts to parse `Object` from the bcs fields in `GetObjectResponse`
+fn object_try_from_proto(object_bcs: Option<Bcs>) -> Result<Object, TryFromProtoError> {
+    object_bcs
+        .as_ref()
+        .ok_or_else(|| TryFromProtoError::missing("object_bcs"))?
+        .deserialize()
+        .map_err(TryFromProtoError::from_error)
+}
+
+/// Attempts to parse `TransactionExecutionResponse` from the fields in `TransactionExecutionResponse`
+fn execute_transaction_response_try_from_proto(
+    ExecuteTransactionResponse {
+        finality,
+        effects_bcs,
+        events_bcs,
+        balance_changes,
+        ..
+    }: ExecuteTransactionResponse,
+) -> Result<TransactionExecutionResponse, TryFromProtoError> {
+    let finality = finality
+        .as_ref()
+        .ok_or_else(|| TryFromProtoError::missing("finality"))?
+        .try_into()?;
+
+    let effects = effects_bcs
+        .ok_or_else(|| TryFromProtoError::missing("effects_bcs"))?
+        .deserialize()
+        .map_err(TryFromProtoError::from_error)?;
+    let events = events_bcs
+        .map(|bcs| bcs.deserialize())
+        .transpose()
+        .map_err(TryFromProtoError::from_error)?;
+
+    let balance_changes = balance_changes
+        .map(|balance_changes| {
+            balance_changes
+                .balance_changes
+                .iter()
+                .map(TryInto::try_into)
+                .collect::<Result<_, _>>()
+        })
+        .transpose()?;
+
+    TransactionExecutionResponse {
+        finality,
+        effects,
+        events,
+        balance_changes,
+    }
+    .pipe(Ok)
+}
+
+fn status_from_error_with_metadata<T: Into<BoxError>>(err: T, metadata: MetadataMap) -> Status {
+    let mut status = Status::from_error(err.into());
+    *status.metadata_mut() = metadata;
+    status
 }

--- a/crates/sui-rpc-api/src/client/mod.rs
+++ b/crates/sui-rpc-api/src/client/mod.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+mod response_ext;
+pub use response_ext::ResponseExt;
+
 pub mod sdk;
 use sdk::BoxError;
 use sdk::Error;

--- a/crates/sui-rpc-api/src/client/response_ext.rs
+++ b/crates/sui-rpc-api/src/client/response_ext.rs
@@ -1,0 +1,118 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_sdk_types::types::CheckpointDigest;
+
+/// Extension trait used to facilitate retrieval of Sui specific data from responses
+pub trait ResponseExt {
+    fn chain_id(&self) -> Option<CheckpointDigest>;
+    fn chain(&self) -> Option<&str>;
+    fn epoch(&self) -> Option<u64>;
+    fn checkpoint_height(&self) -> Option<u64>;
+    fn timestamp_ms(&self) -> Option<u64>;
+    fn lowest_available_checkpoint(&self) -> Option<u64>;
+    fn lowest_available_checkpoint_objects(&self) -> Option<u64>;
+}
+
+impl ResponseExt for tonic::metadata::MetadataMap {
+    fn chain_id(&self) -> Option<CheckpointDigest> {
+        self.get(crate::types::X_SUI_CHAIN_ID)
+            .map(tonic::metadata::MetadataValue::as_bytes)
+            .and_then(|s| CheckpointDigest::from_base58(s).ok())
+    }
+
+    fn chain(&self) -> Option<&str> {
+        self.get(crate::types::X_SUI_CHAIN)
+            .and_then(|h| h.to_str().ok())
+    }
+
+    fn epoch(&self) -> Option<u64> {
+        self.get(crate::types::X_SUI_EPOCH)
+            .and_then(|h| h.to_str().ok())
+            .and_then(|s| s.parse().ok())
+    }
+
+    fn checkpoint_height(&self) -> Option<u64> {
+        self.get(crate::types::X_SUI_CHECKPOINT_HEIGHT)
+            .and_then(|h| h.to_str().ok())
+            .and_then(|s| s.parse().ok())
+    }
+
+    fn timestamp_ms(&self) -> Option<u64> {
+        self.get(crate::types::X_SUI_TIMESTAMP_MS)
+            .and_then(|h| h.to_str().ok())
+            .and_then(|s| s.parse().ok())
+    }
+
+    fn lowest_available_checkpoint(&self) -> Option<u64> {
+        self.get(crate::types::X_SUI_LOWEST_AVAILABLE_CHECKPOINT)
+            .and_then(|h| h.to_str().ok())
+            .and_then(|s| s.parse().ok())
+    }
+
+    fn lowest_available_checkpoint_objects(&self) -> Option<u64> {
+        self.get(crate::types::X_SUI_LOWEST_AVAILABLE_CHECKPOINT_OBJECTS)
+            .and_then(|h| h.to_str().ok())
+            .and_then(|s| s.parse().ok())
+    }
+}
+
+impl<T> ResponseExt for tonic::Response<T> {
+    fn chain_id(&self) -> Option<CheckpointDigest> {
+        self.metadata().chain_id()
+    }
+
+    fn chain(&self) -> Option<&str> {
+        self.metadata().chain()
+    }
+
+    fn epoch(&self) -> Option<u64> {
+        self.metadata().epoch()
+    }
+
+    fn checkpoint_height(&self) -> Option<u64> {
+        self.metadata().checkpoint_height()
+    }
+
+    fn timestamp_ms(&self) -> Option<u64> {
+        self.metadata().timestamp_ms()
+    }
+
+    fn lowest_available_checkpoint(&self) -> Option<u64> {
+        self.metadata().lowest_available_checkpoint()
+    }
+
+    fn lowest_available_checkpoint_objects(&self) -> Option<u64> {
+        self.metadata().lowest_available_checkpoint_objects()
+    }
+}
+
+impl ResponseExt for tonic::Status {
+    fn chain_id(&self) -> Option<CheckpointDigest> {
+        self.metadata().chain_id()
+    }
+
+    fn chain(&self) -> Option<&str> {
+        self.metadata().chain()
+    }
+
+    fn epoch(&self) -> Option<u64> {
+        self.metadata().epoch()
+    }
+
+    fn checkpoint_height(&self) -> Option<u64> {
+        self.metadata().checkpoint_height()
+    }
+
+    fn timestamp_ms(&self) -> Option<u64> {
+        self.metadata().timestamp_ms()
+    }
+
+    fn lowest_available_checkpoint(&self) -> Option<u64> {
+        self.metadata().lowest_available_checkpoint()
+    }
+
+    fn lowest_available_checkpoint_objects(&self) -> Option<u64> {
+        self.metadata().lowest_available_checkpoint_objects()
+    }
+}


### PR DESCRIPTION
 Convert Client error type to be a tonic::Status. In addition, ensure
that if http headers (which are wrapped in a
tonic::metadata::MetadataMap) are received, that they are included in
either the response or the error Status so that callers can retrieve
header information even in the event of an error.
