### PR TITLE
rest: remove bcs content type responses

### DIFF
--- a/crates/sui-e2e-tests/tests/rpc/checkpoints.rs
+++ b/crates/sui-e2e-tests/tests/rpc/checkpoints.rs
@@ -4,8 +4,6 @@
 use sui_macros::sim_test;
 use sui_rpc_api::client::sdk::Client;
 use sui_rpc_api::client::Client as CoreClient;
-use sui_rpc_api::CheckpointResponse;
-use sui_sdk_types::types::SignedCheckpointSummary;
 use test_cluster::TestClusterBuilder;
 
 use crate::transfer_coin;
@@ -30,34 +28,6 @@ async fn list_checkpoint() {
     let _latest = client.get_latest_checkpoint().await.unwrap().into_inner();
 
     let _latest = core_client.get_latest_checkpoint().await.unwrap();
-
-    let client = reqwest::Client::new();
-    let url = format!("{}/v2/checkpoints", test_cluster.rpc_url());
-    // Make sure list works with json
-    let _checkpoints = client
-        .get(&url)
-        .header(reqwest::header::ACCEPT, sui_rpc_api::rest::APPLICATION_JSON)
-        .send()
-        .await
-        .unwrap()
-        .json::<Vec<CheckpointResponse>>()
-        .await
-        .unwrap();
-
-    // TODO remove this once the BCS format is no longer supported by the rest endpoint and clients
-    // wanting binary have migrated to grpc
-    //
-    // Make sure list works with BCS and the old format of only a SignedCheckpoint with no contents
-    let bytes = client
-        .get(&url)
-        .header(reqwest::header::ACCEPT, sui_rpc_api::rest::APPLICATION_BCS)
-        .send()
-        .await
-        .unwrap()
-        .bytes()
-        .await
-        .unwrap();
-    let _checkpoints = bcs::from_bytes::<Vec<SignedCheckpointSummary>>(&bytes).unwrap();
 }
 
 #[sim_test]

--- a/crates/sui-e2e-tests/tests/rpc/checkpoints.rs
+++ b/crates/sui-e2e-tests/tests/rpc/checkpoints.rs
@@ -55,33 +55,8 @@ async fn get_full_checkpoint() {
     let core_client = CoreClient::new(test_cluster.rpc_url()).unwrap();
 
     let latest = client.get_latest_checkpoint().await.unwrap().into_inner();
-    let _ = client
-        .get_full_checkpoint(latest.checkpoint.sequence_number)
-        .await
-        .unwrap();
     let _ = core_client
         .get_full_checkpoint(latest.checkpoint.sequence_number)
         .await
         .unwrap();
-
-    let client = reqwest::Client::new();
-    let url = format!(
-        "{}/v2/checkpoints/{}/full",
-        test_cluster.rpc_url(),
-        latest.checkpoint.sequence_number
-    );
-
-    // TODO remove this once the BCS format is no longer supported by the rest endpoint and clients
-    // wanting binary have migrated to grpc
-    let bytes = client
-        .get(&url)
-        .header(reqwest::header::ACCEPT, sui_rpc_api::rest::APPLICATION_BCS)
-        .send()
-        .await
-        .unwrap()
-        .bytes()
-        .await
-        .unwrap();
-    let _checkpoints =
-        bcs::from_bytes::<sui_types::full_checkpoint_content::CheckpointData>(&bytes).unwrap();
 }

--- a/crates/sui-e2e-tests/tests/rpc/objects.rs
+++ b/crates/sui-e2e-tests/tests/rpc/objects.rs
@@ -4,8 +4,6 @@
 use sui_macros::sim_test;
 use sui_rpc_api::client::sdk::Client;
 use sui_rpc_api::client::Client as CoreClient;
-use sui_rpc_api::ObjectResponse;
-use sui_sdk_types::types::Object;
 use test_cluster::TestClusterBuilder;
 
 #[sim_test]
@@ -29,38 +27,4 @@ async fn get_object() {
         .get_object_with_version("0x5".parse().unwrap(), 1.into())
         .await
         .unwrap();
-
-    async fn raw_request(url: &str) {
-        let client = reqwest::Client::new();
-
-        // Make sure list works with json
-        let _object = client
-            .get(url)
-            .header(reqwest::header::ACCEPT, sui_rpc_api::rest::APPLICATION_JSON)
-            .send()
-            .await
-            .unwrap()
-            .json::<ObjectResponse>()
-            .await
-            .unwrap();
-
-        // TODO remove this once the BCS format is no longer supported by the rest endpoint and clients
-        // wanting binary have migrated to grpc
-        let bytes = client
-            .get(url)
-            .header(reqwest::header::ACCEPT, sui_rpc_api::rest::APPLICATION_BCS)
-            .send()
-            .await
-            .unwrap()
-            .bytes()
-            .await
-            .unwrap();
-        let _object = bcs::from_bytes::<Object>(&bytes).unwrap();
-    }
-
-    let url = format!("{}/v2/objects/0x5", test_cluster.rpc_url());
-    raw_request(&url).await;
-
-    let url = format!("{}/v2/objects/0x5/version/1", test_cluster.rpc_url());
-    raw_request(&url).await;
 }

--- a/crates/sui-rpc-api/openapi/openapi.json
+++ b/crates/sui-rpc-api/openapi/openapi.json
@@ -539,43 +539,6 @@
         }
       }
     },
-    "/checkpoints/{checkpoint}/full": {
-      "get": {
-        "tags": [
-          "Checkpoint"
-        ],
-        "description": "[![unstable](https://img.shields.io/badge/api-unstable-red?style=for-the-badge)](#) _Api subject to change; use at your own risk_\n\nFetch a Full Checkpoint\n\nRequest a checkpoint and all data associated with it including:\n- CheckpointSummary\n- Validator Signature\n- CheckpointContents\n- Transactions, Effects, Events, as well as all input and output objects\n\nIf the requested checkpoint is below the Node's `lowest_available_checkpoint_objects`, a 410\nwill be returned.",
-        "operationId": "Get Full Checkpoint",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "checkpoint",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/CheckpointId"
-            },
-            "style": "simple"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/bcs": {}
-            }
-          },
-          "404": {
-            "description": ""
-          },
-          "410": {
-            "description": ""
-          },
-          "500": {
-            "description": ""
-          }
-        }
-      }
-    },
     "/transactions/{transaction}": {
       "get": {
         "tags": [

--- a/crates/sui-rpc-api/openapi/openapi.json
+++ b/crates/sui-rpc-api/openapi/openapi.json
@@ -275,8 +275,7 @@
                 "schema": {
                   "$ref": "#/components/schemas/ObjectResponse"
                 }
-              },
-              "application/bcs": {}
+              }
             }
           },
           "404": {
@@ -342,8 +341,7 @@
                 "schema": {
                   "$ref": "#/components/schemas/ObjectResponse"
                 }
-              },
-              "application/bcs": {}
+              }
             }
           },
           "404": {
@@ -529,8 +527,7 @@
                     "$ref": "#/components/schemas/CheckpointResponse"
                   }
                 }
-              },
-              "application/bcs": {}
+              }
             }
           },
           "410": {

--- a/crates/sui-rpc-api/src/response.rs
+++ b/crates/sui-rpc-api/src/response.rs
@@ -108,25 +108,6 @@ impl axum::response::IntoResponse for BcsRejection {
     }
 }
 
-#[derive(Debug)]
-pub enum ResponseContent<T, J = T> {
-    Bcs(T),
-    Json(J),
-}
-
-impl<T, J> axum::response::IntoResponse for ResponseContent<T, J>
-where
-    T: serde::Serialize,
-    J: serde::Serialize,
-{
-    fn into_response(self) -> axum::response::Response {
-        match self {
-            ResponseContent::Bcs(inner) => Bcs(inner).into_response(),
-            ResponseContent::Json(inner) => axum::Json(inner).into_response(),
-        }
-    }
-}
-
 pub async fn append_info_headers(
     State(state): State<RpcService>,
     response: Response,

--- a/crates/sui-rpc-api/src/rest/checkpoints.rs
+++ b/crates/sui-rpc-api/src/rest/checkpoints.rs
@@ -8,16 +8,13 @@ use sui_sdk_types::types::{CheckpointSequenceNumber, SignedCheckpointSummary};
 use sui_types::storage::ReadStore;
 
 use crate::reader::StateReader;
-use crate::response::Bcs;
 use crate::rest::openapi::{ApiEndpoint, OperationBuilder, ResponseBuilder, RouteHandler};
 use crate::rest::PageCursor;
-use crate::service::checkpoints::{CheckpointId, CheckpointNotFoundError};
+use crate::service::checkpoints::CheckpointId;
 use crate::types::{CheckpointResponse, GetCheckpointOptions};
+use crate::Result;
 use crate::{Direction, RpcService};
-use crate::{Result, RpcServiceError};
 use documented::Documented;
-
-use super::accept::AcceptFormat;
 
 /// Fetch a Checkpoint
 ///
@@ -232,99 +229,4 @@ impl ListCheckpointsPaginationParameters {
     pub fn direction(&self) -> Direction {
         self.direction.unwrap_or(Direction::Descending)
     }
-}
-
-/// Fetch a Full Checkpoint
-///
-/// Request a checkpoint and all data associated with it including:
-/// - CheckpointSummary
-/// - Validator Signature
-/// - CheckpointContents
-/// - Transactions, Effects, Events, as well as all input and output objects
-///
-/// If the requested checkpoint is below the Node's `lowest_available_checkpoint_objects`, a 410
-/// will be returned.
-#[derive(Documented)]
-pub struct GetFullCheckpoint;
-
-impl ApiEndpoint<RpcService> for GetFullCheckpoint {
-    fn method(&self) -> axum::http::Method {
-        axum::http::Method::GET
-    }
-
-    fn path(&self) -> &'static str {
-        "/checkpoints/{checkpoint}/full"
-    }
-
-    fn stable(&self) -> bool {
-        // TODO transactions are serialized with an intent message, do we want to change this
-        // format to remove it (and remove user signature duplication) prior to stabalizing the
-        // format?
-        false
-    }
-
-    fn operation(
-        &self,
-        generator: &mut schemars::gen::SchemaGenerator,
-    ) -> openapiv3::v3_1::Operation {
-        OperationBuilder::new()
-            .tag("Checkpoint")
-            .operation_id("Get Full Checkpoint")
-            .description(Self::DOCS)
-            .path_parameter::<CheckpointId>("checkpoint", generator)
-            .response(200, ResponseBuilder::new().bcs_content().build())
-            .response(404, ResponseBuilder::new().build())
-            .response(410, ResponseBuilder::new().build())
-            .response(500, ResponseBuilder::new().build())
-            .build()
-    }
-
-    fn handler(&self) -> RouteHandler<RpcService> {
-        RouteHandler::new(self.method(), get_full_checkpoint)
-    }
-}
-
-async fn get_full_checkpoint(
-    Path(checkpoint_id): Path<CheckpointId>,
-    accept: AcceptFormat,
-    State(state): State<StateReader>,
-) -> Result<Bcs<sui_types::full_checkpoint_content::CheckpointData>> {
-    match accept {
-        AcceptFormat::Bcs => {}
-        _ => {
-            return Err(RpcServiceError::new(
-                axum::http::StatusCode::BAD_REQUEST,
-                "invalid accept type; only 'application/bcs' is supported",
-            ))
-        }
-    }
-
-    let verified_summary = match checkpoint_id {
-        CheckpointId::SequenceNumber(s) => {
-            // Since we need object contents we need to check for the lowest available checkpoint
-            // with objects that hasn't been pruned
-            let oldest_checkpoint = state.inner().get_lowest_available_checkpoint_objects()?;
-            if s < oldest_checkpoint {
-                return Err(crate::RpcServiceError::new(
-                    axum::http::StatusCode::GONE,
-                    "Old checkpoints have been pruned",
-                ));
-            }
-
-            state.inner().get_checkpoint_by_sequence_number(s)
-        }
-        CheckpointId::Digest(d) => state.inner().get_checkpoint_by_digest(&d.into()),
-    }
-    .ok_or(CheckpointNotFoundError(checkpoint_id))?;
-
-    let checkpoint_contents = state
-        .inner()
-        .get_checkpoint_contents_by_digest(&verified_summary.content_digest)
-        .ok_or(CheckpointNotFoundError(checkpoint_id))?;
-
-    let checkpoint_data = state
-        .inner()
-        .get_checkpoint_data(verified_summary, checkpoint_contents)?;
-
-    Ok(Bcs(checkpoint_data))
 }

--- a/crates/sui-rpc-api/src/rest/mod.rs
+++ b/crates/sui-rpc-api/src/rest/mod.rs
@@ -40,7 +40,6 @@ pub const ENDPOINTS: &[&dyn ApiEndpoint<RpcService>] = &[
     &objects::GetObjectWithVersion,
     &objects::ListDynamicFields,
     &checkpoints::ListCheckpoints,
-    &checkpoints::GetFullCheckpoint,
     &transactions::GetTransaction,
     &transactions::ListTransactions,
     &committee::GetCommittee,

--- a/crates/sui-rpc-api/src/rest/mod.rs
+++ b/crates/sui-rpc-api/src/rest/mod.rs
@@ -9,7 +9,7 @@ use axum::{
     Router,
 };
 
-use crate::{reader::StateReader, response, RpcService};
+use crate::{reader::StateReader, RpcService};
 use openapi::ApiEndpoint;
 
 pub mod accept;
@@ -75,12 +75,6 @@ pub fn build_rest_router(service: RpcService) -> axum::Router {
         .route("/rest/", get(|| async { Redirect::permanent("/v2/") }))
 }
 
-#[derive(Debug)]
-pub struct Page<T, C> {
-    pub entries: response::ResponseContent<Vec<T>>,
-    pub cursor: Option<C>,
-}
-
 pub struct PageCursor<C>(pub Option<C>);
 
 impl<C: std::fmt::Display> axum::response::IntoResponseParts for PageCursor<C> {
@@ -105,16 +99,6 @@ impl<C: std::fmt::Display> axum::response::IntoResponse for PageCursor<C> {
 
 pub const DEFAULT_PAGE_SIZE: usize = 50;
 pub const MAX_PAGE_SIZE: usize = 100;
-
-impl<T: serde::Serialize, C: std::fmt::Display> axum::response::IntoResponse for Page<T, C> {
-    fn into_response(self) -> axum::response::Response {
-        let cursor = self
-            .cursor
-            .map(|cursor| [(crate::types::X_SUI_CURSOR, cursor.to_string())]);
-
-        (cursor, self.entries).into_response()
-    }
-}
 
 // Enable StateReader to be used as axum::extract::State
 impl axum::extract::FromRef<RpcService> for StateReader {

--- a/crates/sui-rpc-api/src/rest/openapi.rs
+++ b/crates/sui-rpc-api/src/rest/openapi.rs
@@ -648,10 +648,6 @@ impl ResponseBuilder {
         self.content(mime::APPLICATION_JSON.as_ref(), media_type)
     }
 
-    pub fn bcs_content(&mut self) -> &mut Self {
-        self.content(crate::rest::APPLICATION_BCS, MediaType::default())
-    }
-
     pub fn text_content(&mut self) -> &mut Self {
         self.content(mime::TEXT_PLAIN_UTF_8.as_ref(), MediaType::default())
     }


### PR DESCRIPTION
## Description 

Now that the new gRPC endpoint handles binary wire formatted requests/responses, the only BCS based wire formatted support can be removed from the experimental rest api. 

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
