### PR TITLE
[CLI] Fix dev inspect in sui client ptb

### DIFF
--- a/crates/sui/src/client_ptb/ptb.rs
+++ b/crates/sui/src/client_ptb/ptb.rs
@@ -173,6 +173,10 @@ impl PTB {
                 return Ok(());
             }
             SuiClientCommandResult::TransactionBlock(response) => response,
+            SuiClientCommandResult::DevInspect(response) => {
+                println!("{}", Pretty(&response));
+                return Ok(());
+            }
             _ => anyhow::bail!("Internal error, unexpected response from PTB execution."),
         };
 

--- a/crates/sui/src/displays/dev_inspect.rs
+++ b/crates/sui/src/displays/dev_inspect.rs
@@ -24,19 +24,29 @@ impl<'a> Display for Pretty<'a, DevInspectResults> {
         write!(f, "{}", response.events)?;
 
         if let Some(results) = &response.results {
+            if results.is_empty() {
+                writeln!(f, "No execution results")?;
+                return Ok(());
+            }
+
+            writeln!(f, "Execution Result")?;
             for result in results {
-                writeln!(f, "Execution Result")?;
-                writeln!(f, "  Mutable Reference Outputs")?;
-                for m in result.mutable_reference_outputs.iter() {
-                    writeln!(f, "    Sui Argument: {}", m.0)?;
-                    writeln!(f, "    Sui TypeTag: {:?}", m.2)?;
-                    writeln!(f, "    Bytes: {:?}", m.1)?;
+                if !result.mutable_reference_outputs.is_empty() {
+                    writeln!(f, "  Mutable Reference Outputs")?;
+                    for m in result.mutable_reference_outputs.iter() {
+                        writeln!(f, "    Sui Argument: {}", m.0)?;
+                        writeln!(f, "    Sui TypeTag: {:?}", m.2)?;
+                        writeln!(f, "    Bytes: {:?}", m.1)?;
+                    }
                 }
 
-                writeln!(f, "  Return values")?;
-                for val in result.return_values.iter() {
-                    writeln!(f, "    Sui TypeTag: {:?}", val.1)?;
-                    writeln!(f, "    Bytes: {:?}", val.0)?;
+                if !result.return_values.is_empty() {
+                    writeln!(f, "  Return values")?;
+
+                    for val in result.return_values.iter() {
+                        writeln!(f, "    Sui TypeTag: {:?}", val.1)?;
+                        writeln!(f, "    Bytes: {:?}", val.0)?;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description 

This PR fixes the `sui client ptb --dev-inspect` command to correctly display the result of the dev inspect.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Fixed `sui client ptb --dev-inspect` to correctly display the result of the dev inspect.
- [ ] Rust SDK:
- [ ] REST API:
