### PR TITLE
Tweak fee calculation for kiosks

### DIFF
--- a/.changeset/rude-doors-retire.md
+++ b/.changeset/rude-doors-retire.md
@@ -1,0 +1,5 @@
+---
+'@mysten/kiosk': minor
+---
+
+Update fee calculation to happen via dry runs to improve the display of transactions within the wallet.

--- a/sdk/kiosk/src/client/kiosk-transaction.ts
+++ b/sdk/kiosk/src/client/kiosk-transaction.ts
@@ -372,7 +372,7 @@ export class KioskTransaction {
 
 			if (ruleDefinition.hasLockingRule) canTransferOutsideKiosk = false;
 
-			ruleDefinition.resolveRuleFunction({
+			await ruleDefinition.resolveRuleFunction({
 				packageId: ruleDefinition.packageId,
 				transactionBlock: this.transaction,
 				transaction: this.transaction,
@@ -386,6 +386,7 @@ export class KioskTransaction {
 				kiosk: this.kiosk!,
 				kioskCap: this.kioskCap!,
 				extraArgs: extraArgs || {},
+				kioskClient: this.kioskClient,
 			});
 		}
 

--- a/sdk/kiosk/src/constants.ts
+++ b/sdk/kiosk/src/constants.ts
@@ -27,7 +27,9 @@ export type BaseRulePackageIds = {
 export type TransferPolicyRule = {
 	rule: string;
 	packageId: string;
-	resolveRuleFunction: (rule: RuleResolvingParams) => ObjectArgument | void;
+	resolveRuleFunction: (
+		rule: RuleResolvingParams,
+	) => ObjectArgument | void | Promise<ObjectArgument | void>;
 	hasLockingRule?: boolean;
 };
 
@@ -64,7 +66,7 @@ export function getBaseRules({
 	personalKioskRulePackageId,
 	floorPriceRulePackageId,
 }: BaseRulePackageIds): TransferPolicyRule[] {
-	const rules = [];
+	const rules: TransferPolicyRule[] = [];
 
 	if (royaltyRulePackageId) {
 		rules.push({

--- a/sdk/kiosk/src/types/transfer-policy.ts
+++ b/sdk/kiosk/src/types/transfer-policy.ts
@@ -4,6 +4,7 @@
 import type { ObjectOwner } from '@mysten/sui/client';
 import type { Transaction, TransactionObjectArgument } from '@mysten/sui/transactions';
 
+import type { KioskClient } from '../client/kiosk-client.js';
 import type { ObjectArgument } from './index.js';
 
 /** The Transfer Policy module. */
@@ -66,4 +67,6 @@ export type RuleResolvingParams = {
 	purchasedItem: TransactionObjectArgument;
 	packageId: string;
 	extraArgs: Record<string, any>; // extraParams contains more possible {key, values} to pass for custom rules.
+
+	kioskClient: KioskClient;
 };


### PR DESCRIPTION
## Description 

Updates the fee calculation for kiosks to happen in a separate dry-run transaction so that the split amount is known statically.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
