### PR TITLE
[indexer-alt] Add total_committer_batches_failed metric

### DIFF
--- a/crates/sui-indexer-alt-framework/src/metrics.rs
+++ b/crates/sui-indexer-alt-framework/src/metrics.rs
@@ -91,6 +91,7 @@ pub(crate) struct IndexerMetrics {
     pub total_collector_batches_created: IntCounterVec,
     pub total_committer_batches_attempted: IntCounterVec,
     pub total_committer_batches_succeeded: IntCounterVec,
+    pub total_committer_batches_failed: IntCounterVec,
     pub total_committer_rows_committed: IntCounterVec,
     pub total_committer_rows_affected: IntCounterVec,
     pub total_watermarks_out_of_order: IntCounterVec,
@@ -338,6 +339,13 @@ impl IndexerMetrics {
             total_committer_batches_succeeded: register_int_counter_vec_with_registry!(
                 "indexer_total_committer_batches_succeeded",
                 "Total number of successful batches writes by this committer",
+                &["pipeline"],
+                registry,
+            )
+            .unwrap(),
+            total_committer_batches_failed: register_int_counter_vec_with_registry!(
+                "indexer_total_committer_batches_failed",
+                "Total number of failed batches writes by this committer",
                 &["pipeline"],
                 registry,
             )

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/committer.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/committer.rs
@@ -92,6 +92,10 @@ pub(super) fn committer<H: Handler + 'static>(
                                     pipeline = H::NAME,
                                     "Committed failed to get connection for DB"
                                 );
+                                metrics
+                                    .total_committer_batches_failed
+                                    .with_label_values(&[H::NAME])
+                                    .inc();
                                 BE::transient(Break::Err(e.into()))
                             })?;
 
@@ -138,6 +142,11 @@ pub(super) fn committer<H: Handler + 'static>(
                                         committed = values.len(),
                                         "Error writing batch: {e}",
                                     );
+
+                                    metrics
+                                        .total_committer_batches_failed
+                                        .with_label_values(&[H::NAME])
+                                        .inc();
 
                                     Err(BE::transient(Break::Err(e)))
                                 }

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
@@ -219,6 +219,10 @@ pub(super) fn committer<H: Handler + 'static>(
 
                     let Ok(mut conn) = db.connect().await else {
                         warn!(pipeline = H::NAME, "Failed to get connection for DB");
+                        metrics
+                            .total_committer_batches_failed
+                            .with_label_values(&[H::NAME])
+                            .inc();
                         continue;
                     };
 
@@ -250,6 +254,11 @@ pub(super) fn committer<H: Handler + 'static>(
                                 pending = pending_rows,
                                 "Error writing batch: {e}",
                             );
+
+                            metrics
+                                .total_committer_batches_failed
+                                .with_label_values(&[H::NAME])
+                                .inc();
 
                             attempt += 1;
                             continue;


### PR DESCRIPTION
## Description 

Adds a metric that tracks the number of failed commits.
While we track the number of attempts and number of successes, they cannot be used to track number of errors, because any at moment, the delta can exist but they don't necessarily mean errors.
So if we want to track error rate, we need a dedicated metric.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
