### PR TITLE
Add org support to suiop ci image command for image builds

### DIFF
--- a/crates/suiop-cli/src/cli/ci/image.rs
+++ b/crates/suiop-cli/src/cli/ci/image.rs
@@ -344,7 +344,7 @@ async fn send_image_request(token: &str, action: &ImageAction) -> Result<()> {
                 build_args: _,
                 force: _,
                 image_target,
-                org,
+                org: _,
             } => {
                 let ref_type = ref_type.clone().unwrap_or(RefType::Branch);
                 let ref_val = ref_val.clone().unwrap_or("main".to_string());

--- a/crates/suiop-cli/src/cli/ci/image.rs
+++ b/crates/suiop-cli/src/cli/ci/image.rs
@@ -131,6 +131,9 @@ pub enum ImageAction {
         /// Optional flag to target the image, used for multi-stage builds
         #[arg(short = 't', long)]
         image_target: Option<String>,
+        /// Optional arg to speciy the org to build the image for, default to "mystenlabs"
+        #[arg(short = 'o', long)]
+        org: Option<String>,
     },
     #[command(name = "query")]
     Query {
@@ -178,6 +181,7 @@ struct RequestBuildRequest {
     build_args: Vec<String>,
     force: bool,
     image_target: Option<String>,
+    org: String,
 }
 
 #[derive(serde::Serialize)]
@@ -340,6 +344,7 @@ async fn send_image_request(token: &str, action: &ImageAction) -> Result<()> {
                 build_args: _,
                 force: _,
                 image_target,
+                org,
             } => {
                 let ref_type = ref_type.clone().unwrap_or(RefType::Branch);
                 let ref_val = ref_val.clone().unwrap_or("main".to_string());
@@ -525,6 +530,7 @@ fn generate_image_request(token: &str, action: &ImageAction) -> reqwest::Request
             build_args,
             force,
             image_target,
+            org,
         } => {
             let full_url = format!("{}{}", api_server, ENDPOINT);
             debug!("full_url: {}", full_url);
@@ -573,6 +579,7 @@ fn generate_image_request(token: &str, action: &ImageAction) -> reqwest::Request
                 build_args: build_args.clone(),
                 force: *force,
                 image_target: image_target.clone(),
+                org: org.clone().unwrap_or("mystenlabs".to_string()),
             };
             debug!("req body: {:?}", body);
             req.json(&body).headers(generate_headers_with_auth(token))


### PR DESCRIPTION
## Description 

Add org optional arg to build from other github orgs

## Test plan 

Built from another org successfully 
```
suiop ci image query --repo-name another-repo
Requested query for repo: tomato-contracts
╭────────────────────────┬───────────┬─────────────────────────┬─────────────────────╮
│ name                   │ status    │ Start Time (Local Time) │ End Time            │
├────────────────────────┼───────────┼─────────────────────────┼─────────────────────┤
│ another-repo-pigyh │ Succeeded │ 2024-12-12 11:33:51     │ 2024-12-12 11:44:18 │
╰────────────────────────┴───────────┴─────────────────────────┴─────────────────────╯
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
