### PR TITLE
[move-analyzer] Cache user program

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/analyzer.rs
+++ b/external-crates/move/crates/move-analyzer/src/analyzer.rs
@@ -45,10 +45,9 @@ pub fn run() {
 
     let (connection, io_threads) = Connection::stdio();
     let symbols_map = Arc::new(Mutex::new(BTreeMap::new()));
-    let pkg_deps = Arc::new(Mutex::new(BTreeMap::<
-        PathBuf,
-        symbols::PrecomputedPkgDepsInfo,
-    >::new()));
+    let pkg_deps = Arc::new(Mutex::new(
+        BTreeMap::<PathBuf, symbols::PrecomputedPkgInfo>::new(),
+    ));
     let ide_files_root: VfsPath = MemoryFS::new().into();
 
     let (id, client_response) = connection
@@ -154,6 +153,7 @@ pub fn run() {
                 Arc::new(Mutex::new(BTreeMap::new())),
                 ide_files_root.clone(),
                 p.as_path(),
+                None,
                 lint,
                 None,
             ) {
@@ -279,7 +279,7 @@ fn on_request(
     context: &Context,
     request: &Request,
     ide_files_root: VfsPath,
-    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, symbols::PrecomputedPkgDepsInfo>>>,
+    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, symbols::PrecomputedPkgInfo>>>,
     shutdown_request_received: bool,
 ) -> bool {
     if shutdown_request_received {

--- a/external-crates/move/crates/move-analyzer/src/completions/mod.rs
+++ b/external-crates/move/crates/move-analyzer/src/completions/mod.rs
@@ -10,7 +10,7 @@ use crate::{
         utils::{completion_item, PRIMITIVE_TYPE_COMPLETIONS},
     },
     context::Context,
-    symbols::{self, CursorContext, PrecomputedPkgDepsInfo, SymbolicatorRunner, Symbols},
+    symbols::{self, CursorContext, PrecomputedPkgInfo, SymbolicatorRunner, Symbols},
 };
 use lsp_server::Request;
 use lsp_types::{CompletionItem, CompletionItemKind, CompletionParams, Position};
@@ -78,7 +78,7 @@ pub fn on_completion_request(
     context: &Context,
     request: &Request,
     ide_files_root: VfsPath,
-    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgDepsInfo>>>,
+    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgInfo>>>,
 ) {
     eprintln!("handling completion request");
     let parameters = serde_json::from_value::<CompletionParams>(request.params.clone())
@@ -119,7 +119,7 @@ pub fn on_completion_request(
 fn completions(
     context: &Context,
     ide_files_root: VfsPath,
-    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgDepsInfo>>>,
+    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgInfo>>>,
     path: &Path,
     pos: Position,
 ) -> Option<Vec<CompletionItem>> {
@@ -143,7 +143,7 @@ fn completions(
 pub fn compute_completions(
     current_symbols: &Symbols,
     ide_files_root: VfsPath,
-    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgDepsInfo>>>,
+    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgInfo>>>,
     path: &Path,
     pos: Position,
 ) -> Vec<CompletionItem> {
@@ -156,7 +156,7 @@ pub fn compute_completions(
 /// view of the code (returns `None` if the symbols could not be re-computed).
 fn compute_completions_new_symbols(
     ide_files_root: VfsPath,
-    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgDepsInfo>>>,
+    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgInfo>>>,
     path: &Path,
     cursor_position: Position,
 ) -> Option<Vec<CompletionItem>> {
@@ -170,6 +170,7 @@ fn compute_completions_new_symbols(
         pkg_dependencies,
         ide_files_root,
         &pkg_path,
+        Some(vec![path.to_path_buf()]),
         LintLevel::None,
         cursor_info,
     )

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -79,6 +79,7 @@ use std::{
     sync::{Arc, Condvar, Mutex},
     thread,
     time::Instant,
+    vec,
 };
 use tempfile::tempdir;
 use url::Url;
@@ -106,10 +107,7 @@ use move_compiler::{
         NamedAddressMaps,
     },
     typing::{
-        ast::{
-            self as T, Exp, ExpListItem, ModuleDefinition, SequenceItem, SequenceItem_,
-            UnannotatedExp_,
-        },
+        ast::{Exp, ExpListItem, ModuleDefinition, SequenceItem, SequenceItem_, UnannotatedExp_},
         visitor::TypingVisitorContext,
     },
     unit_test::filter_test_members::UNIT_TEST_POISON_FUN_NAME,
@@ -120,28 +118,30 @@ use move_ir_types::location::*;
 use move_package::{
     compilation::{build_plan::BuildPlan, compiled_package::ModuleFormat},
     resolution::resolution_graph::ResolvedGraph,
-    source_package::parsed_manifest::FileName,
 };
 use move_symbol_pool::Symbol;
 
 const MANIFEST_FILE_NAME: &str = "Move.toml";
 const STD_LIB_PKG_ADDRESS: &str = "0x1";
-type SourceFiles = BTreeMap<FileHash, (FileName, String, bool)>;
 
 /// Information about compiled program (ASTs at different levels)
 #[derive(Clone)]
-struct CompiledProgram {
-    parsed: P::Program,
-    typed: T::Program,
+pub struct CompiledProgram {
+    pub parsed: P::Program,
+    pub typed_modules: UniqueMap<ModuleIdent, ModuleDefinition>,
 }
 
-/// Information about cached dependencies used during compilation and analysis
+/// Package data used during compilation and analysis
 #[derive(Clone)]
-struct CachedDeps {
+struct AnalyzedPkgInfo {
     /// Cached fully compiled program representing dependencies
-    compiled_program: Arc<FullyCompiledProgram>,
+    program_deps: Arc<FullyCompiledProgram>,
     /// Cached symbols computation data for dependencies
     symbols_data: Option<Arc<SymbolsComputationData>>,
+    /// Compiled user program
+    program: Option<Arc<CompiledProgram>>,
+    /// Mapping from file paths to file hashes
+    file_hashes: Arc<BTreeMap<PathBuf, FileHash>>,
 }
 
 /// Information about the compiled package and data structures
@@ -155,11 +155,9 @@ pub struct CompiledPkgInfo {
     /// A combined hash for manifest files of the dependencies
     deps_hash: String,
     /// Information about cached dependencies
-    cached_deps: Option<CachedDeps>,
+    cached_deps: Option<AnalyzedPkgInfo>,
     /// Compiled user program
     program: CompiledProgram,
-    /// Source files
-    source_files: SourceFiles,
     /// Maped files
     mapped_files: MappedFiles,
     /// Edition of the compiler
@@ -200,9 +198,10 @@ impl SymbolsComputationData {
     }
 }
 
-/// Precomputed information about package dependencies.
+/// Precomputed information about the package and its dependencies
+/// cached with the purpose of being re-used during the analysis.
 #[derive(Clone)]
-pub struct PrecomputedPkgDepsInfo {
+pub struct PrecomputedPkgInfo {
     /// Hash of the manifest file for a given package
     manifest_hash: Option<FileHash>,
     /// Hash of dependency source files
@@ -211,6 +210,10 @@ pub struct PrecomputedPkgDepsInfo {
     deps: Arc<FullyCompiledProgram>,
     /// Symbols computation data
     deps_symbols_data: Arc<SymbolsComputationData>,
+    /// Compiled user program
+    program: Arc<CompiledProgram>,
+    /// Mapping from file paths to file hashes
+    file_hashes: Arc<BTreeMap<PathBuf, FileHash>>,
 }
 
 /// Location of a use's identifier
@@ -1365,7 +1368,7 @@ impl SymbolicatorRunner {
     pub fn new(
         ide_files_root: VfsPath,
         symbols_map: Arc<Mutex<BTreeMap<PathBuf, Symbols>>>,
-        pkg_deps: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgDepsInfo>>>,
+        packages_info: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgInfo>>>,
         sender: Sender<Result<BTreeMap<PathBuf, Vec<Diagnostic>>>>,
         lint: LintLevel,
     ) -> Self {
@@ -1406,10 +1409,10 @@ impl SymbolicatorRunner {
                         }
                     };
                     if let Some(all_starting_paths) = all_starting_paths_opt {
-                        let mut pkgs_to_analyze = BTreeMap::new();
+                        let mut pkgs_to_analyze: BTreeMap<PathBuf, BTreeSet<Option<PathBuf>>> = BTreeMap::new();
                         for starting_path in &all_starting_paths {
-                            let root_dir = Self::root_dir(starting_path);
-                            if root_dir.is_none() {
+                            let root_dir_opt = Self::root_dir(starting_path);
+                            if root_dir_opt.is_none() {
                                 if !missing_manifests.contains(starting_path) {
                                     eprintln!("reporting missing manifest");
 
@@ -1427,17 +1430,42 @@ impl SymbolicatorRunner {
                                 }
                                 continue;
                             }
-                            pkgs_to_analyze
-                                .entry(root_dir.unwrap())
-                                .or_insert_with(BTreeSet::new)
-                                .insert(starting_path.clone());
+                            // we want to collect either all modified Move files (as BTreeSet<Some(PathBuf)> or,
+                            // if one of the paths for a package is not a Move file, have aonly one BTreeSet
+                            // None entry. This will be later passed to symbolicator as Some(Vec<PathBuf>) or
+                            // None, to indicated if incremental symbolication is possible or not.
+                            let root_dir = root_dir_opt.unwrap();
+                            if let Some(mut modified_files) = pkgs_to_analyze.remove(&root_dir) {
+                                if modified_files.len() != 1 || modified_files.first() != None {
+                                    // keep adding modfied Move files if any
+                                    let is_move_file = starting_path.is_file() &&
+                                            starting_path
+                                                .extension()
+                                                .map_or(false, |ext| ext == "move");
+                                    if is_move_file {
+                                        // add move file to existing set
+                                        modified_files.insert(Some(starting_path.clone()));
+                                        pkgs_to_analyze.insert(root_dir, modified_files);
+                                    } else {
+                                        // reset to a single None entry
+                                        pkgs_to_analyze.insert(root_dir,  BTreeSet::from_iter(vec![None]));
+                                    }
+                                } // else we already seen this package with a non-Move-file path so nothing to do
+                            } else {
+                                pkgs_to_analyze.insert(root_dir,  BTreeSet::from_iter(vec![Some(starting_path.clone())]));
+                            }
                         }
-                        for pkg_path in pkgs_to_analyze.keys() {
+                        for (pkg_path, modified_files) in pkgs_to_analyze.into_iter() {
                             eprintln!("symbolication started");
                             match get_symbols(
-                                pkg_deps.clone(),
+                                packages_info.clone(),
                                 ide_files_root.clone(),
                                 pkg_path.as_path(),
+                                if modified_files.len() == 1 && modified_files.first() == None {
+                                    None
+                                } else {
+                                    Some(modified_files.into_iter().filter_map(|p| p).collect())
+                                },
                                 lint,
                                 None,
                             ) {
@@ -1763,18 +1791,96 @@ impl Symbols {
 
 fn has_precompiled_deps(
     pkg_path: &Path,
-    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgDepsInfo>>>,
+    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgInfo>>>,
 ) -> bool {
     let pkg_deps = pkg_dependencies.lock().unwrap();
     pkg_deps.contains_key(pkg_path)
 }
 
+fn is_parsed_pkg_modified(
+    pkg_def: &P::PackageDefinition,
+    files_to_compile: &BTreeSet<PathBuf>,
+    file_hashes: Arc<BTreeMap<PathBuf, FileHash>>,
+) -> bool {
+    files_to_compile.iter().any(|fpath| {
+        if let Some(fhash) = file_hashes.get(fpath) {
+            if let P::Definition::Module(mdef) = &pkg_def.def {
+                return mdef.loc.file_hash() == *fhash;
+            }
+        }
+        false
+    })
+}
+
+fn is_typed_mod_modified(
+    mdef: &ModuleDefinition,
+    files_to_compile: &BTreeSet<PathBuf>,
+    file_hashes: Arc<BTreeMap<PathBuf, FileHash>>,
+) -> bool {
+    files_to_compile.iter().any(|fpath| {
+        if let Some(fhash) = file_hashes.get(fpath) {
+            return mdef.loc.file_hash() == *fhash;
+        }
+        false
+    })
+}
+
+/// Merges a cached compiled program with newly computed compiled program
+/// In the newly computed program, only modified files are fully compiled
+/// and these files are mereged with the cached compiled program.
+fn merge_user_programs(
+    cached_info_opt: Option<AnalyzedPkgInfo>,
+    parsed_program_new: P::Program,
+    typed_program_modules_new: UniqueMap<ModuleIdent, ModuleDefinition>,
+    file_hashes_new: Arc<BTreeMap<PathBuf, FileHash>>,
+    files_to_compile: BTreeSet<PathBuf>,
+) -> (P::Program, UniqueMap<ModuleIdent, ModuleDefinition>) {
+    // unraps are safe as this function only called when cached compiled program exists
+    let cached_info = cached_info_opt.unwrap();
+    let compiled_program = cached_info.program.unwrap();
+    let file_hashes_cached = cached_info.file_hashes;
+    let mut parsed_program_cached = compiled_program.parsed.clone();
+    let mut typed_modules_cached = compiled_program.typed_modules.clone();
+    // address maps might have changed but all would be computed in full during
+    // incremental compilation as only function bodies are omitted
+    parsed_program_cached.named_address_maps = parsed_program_new.named_address_maps;
+    // remove modules from user code that belong to modified files (use cached
+    // file hashes as we are comparing with hashes in cached modules)
+    parsed_program_cached.source_definitions.retain(|pkg_def| {
+        !is_parsed_pkg_modified(pkg_def, &files_to_compile, file_hashes_cached.clone())
+    });
+    let mut typed_modules_cached_filtered = UniqueMap::new();
+    for (mident, mdef) in typed_modules_cached.into_iter() {
+        if !is_typed_mod_modified(&mdef, &files_to_compile, file_hashes_cached.clone()) {
+            _ = typed_modules_cached_filtered.add(mident, mdef);
+        }
+    }
+    typed_modules_cached = typed_modules_cached_filtered;
+    // add new modules from user code (use new file hashes as we are comparing with
+    // hashes in new modules)
+    for pkg_def in parsed_program_new.source_definitions {
+        if is_parsed_pkg_modified(&pkg_def, &files_to_compile, file_hashes_new.clone()) {
+            parsed_program_cached.source_definitions.push(pkg_def);
+        }
+    }
+    for (mident, mdef) in typed_program_modules_new.into_iter() {
+        if is_typed_mod_modified(&mdef, &files_to_compile, file_hashes_new.clone()) {
+            typed_modules_cached.remove(&mident); // in case new file has new definition of the module
+            _ = typed_modules_cached.add(mident, mdef);
+        }
+    }
+
+    (parsed_program_cached, typed_modules_cached)
+}
+
 /// Builds a package at a given path and, if successful, returns parsed AST
 /// and typed AST as well as (regardless of success) diagnostics.
+/// See `get_symbols` for explanation of what `modified_files` parameter is.
 pub fn get_compiled_pkg(
-    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgDepsInfo>>>,
+    packages_info: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgInfo>>>,
     ide_files_root: VfsPath,
     pkg_path: &Path,
+    modified_files: Option<Vec<PathBuf>>,
     lint: LintLevel,
 ) -> Result<(Option<CompiledPkgInfo>, BTreeMap<PathBuf, Vec<Diagnostic>>)> {
     let build_config = move_package::BuildConfig {
@@ -1782,7 +1888,7 @@ pub fn get_compiled_pkg(
         install_dir: Some(tempdir().unwrap().path().to_path_buf()),
         default_flavor: Some(Flavor::Sui),
         lint_flag: lint.into(),
-        skip_fetch_latest_git_deps: has_precompiled_deps(pkg_path, pkg_dependencies.clone()),
+        skip_fetch_latest_git_deps: has_precompiled_deps(pkg_path, packages_info.clone()),
         ..Default::default()
     };
 
@@ -1813,17 +1919,16 @@ pub fn get_compiled_pkg(
         None
     };
 
-    let mut mapped_files: MappedFiles = MappedFiles::empty();
-
     // Hash dependencies so we can check if something has changed.
-    let source_files = file_sources(&resolution_graph, overlay_fs_root.clone());
-    let mut hasher = Sha256::new();
-    source_files
-        .iter()
-        .filter(|(_, (_, _, is_dep))| *is_dep)
-        .for_each(|(fhash, _)| hasher.update(fhash.0));
-    let deps_hash = format!("{:X}", hasher.finalize());
-
+    let (mapped_files, deps_hash) =
+        compute_mapped_files(&resolution_graph, overlay_fs_root.clone());
+    let file_hashes: Arc<BTreeMap<PathBuf, FileHash>> = Arc::new(
+        mapped_files
+            .file_name_mapping()
+            .iter()
+            .map(|(fhash, fpath)| (fpath.clone(), fhash.clone()))
+            .collect(),
+    );
     let compiler_flags = resolution_graph.build_options.compiler_flags().clone();
     let build_plan =
         BuildPlan::create(resolution_graph)?.set_compiler_vfs_root(overlay_fs_root.clone());
@@ -1833,7 +1938,7 @@ pub fn get_compiled_pkg(
     let mut diagnostics = None;
 
     let mut dependencies = build_plan.compute_dependencies();
-    let cached_deps = if let Ok(deps_package_paths) = dependencies.make_deps_for_compiler() {
+    let cached_info_opt = if let Ok(deps_package_paths) = dependencies.make_deps_for_compiler() {
         // Partition deps_package according whether src is available
         let src_deps = deps_package_paths
             .iter()
@@ -1851,18 +1956,19 @@ pub fn get_compiled_pkg(
             .filter_map(|p| p.name.as_ref().map(|(n, _)| *n))
             .collect::<BTreeSet<_>>();
 
-        let pkg_deps = pkg_dependencies.lock().unwrap();
-        let pkg_cached_deps = match pkg_deps.get(pkg_path) {
+        let pkg_info = packages_info.lock().unwrap();
+        let pkg_cached_deps = match pkg_info.get(pkg_path) {
             Some(d)
                 if manifest_hash.is_some()
                     && manifest_hash == d.manifest_hash
                     && deps_hash == d.deps_hash =>
             {
                 eprintln!("found cached deps for {:?}", pkg_path);
-                mapped_files.extend_with_duplicates(d.deps.files.clone());
-                Some(CachedDeps {
-                    compiled_program: d.deps.clone(),
+                Some(AnalyzedPkgInfo {
+                    program_deps: d.deps.clone(),
                     symbols_data: Some(d.deps_symbols_data.clone()),
+                    program: Some(d.program.clone()),
+                    file_hashes: d.file_hashes.clone(),
                 })
             }
             _ => construct_pre_compiled_lib(
@@ -1875,10 +1981,11 @@ pub fn get_compiled_pkg(
             .and_then(|pprog_and_comments_res| pprog_and_comments_res.ok())
             .map(|libs| {
                 eprintln!("created pre-compiled libs for {:?}", pkg_path);
-                mapped_files.extend_with_duplicates(libs.files.clone());
-                CachedDeps {
-                    compiled_program: Arc::new(libs),
+                AnalyzedPkgInfo {
+                    program_deps: Arc::new(libs),
                     symbols_data: None,
+                    program: None,
+                    file_hashes: file_hashes.clone(),
                 }
             }),
         };
@@ -1892,16 +1999,35 @@ pub fn get_compiled_pkg(
         None
     };
 
+    let (full_compilation, files_to_compile) = if let Some(chached_info) = &cached_info_opt {
+        if chached_info.program.is_some() {
+            // we already have cached user program, consider incremental compilation
+            match modified_files {
+                Some(files) => (false, BTreeSet::from_iter(files)),
+                None => (true, BTreeSet::new()),
+            }
+        } else {
+            (true, BTreeSet::new())
+        }
+    } else {
+        (true, BTreeSet::new())
+    };
+
     let mut edition = None;
     let mut comments = None;
-    let compiled_libs = cached_deps
+    let compiled_libs = cached_info_opt
         .clone()
-        .map(|deps| deps.compiled_program.clone());
+        .map(|deps| deps.program_deps.clone());
     build_plan.compile_with_driver_and_deps(dependencies, &mut std::io::sink(), |compiler| {
         let compiler = compiler.set_ide_mode();
         // extract expansion AST
         let (files, compilation_result) = compiler
             .set_pre_compiled_lib_opt(compiled_libs.clone())
+            .set_files_to_compile(if full_compilation {
+                None
+            } else {
+                Some(files_to_compile.clone())
+            })
             .run::<PASS_PARSER>()?;
         let (comments_map, compiler) = match compilation_result {
             Ok(v) => v,
@@ -1916,7 +2042,6 @@ pub fn get_compiled_pkg(
         eprintln!("compiled to parsed AST");
         let (compiler, parsed_program) = compiler.into_ast();
         parsed_ast = Some(parsed_program.clone());
-        mapped_files.extend_with_duplicates(compiler.compilation_env().mapped_files().clone());
 
         // extract typed AST
         let compilation_result = compiler.at_parser(parsed_program).run::<PASS_TYPING>();
@@ -1974,8 +2099,17 @@ pub fn get_compiled_pkg(
 
     // uwrap's are safe - this function returns earlier (during diagnostics processing)
     // when failing to produce the ASTs
-    let parsed_program = parsed_ast.unwrap();
-    let typed_program = typed_ast.clone().unwrap();
+    let (parsed_program, typed_program_modules) = if full_compilation {
+        (parsed_ast.unwrap(), typed_ast.unwrap().modules)
+    } else {
+        merge_user_programs(
+            cached_info_opt.clone(),
+            parsed_ast.unwrap(),
+            typed_ast.unwrap().modules,
+            file_hashes,
+            files_to_compile,
+        )
+    };
     let mut all_comments = comments.unwrap();
     if let Some(libs) = &compiled_libs {
         all_comments.extend(libs.comments.clone());
@@ -1984,12 +2118,11 @@ pub fn get_compiled_pkg(
         path: pkg_path.into(),
         manifest_hash,
         deps_hash,
-        cached_deps,
+        cached_deps: cached_info_opt,
         program: CompiledProgram {
             parsed: parsed_program,
-            typed: typed_program,
+            typed_modules: typed_program_modules,
         },
-        source_files,
         mapped_files,
         edition,
         compiler_info,
@@ -2007,12 +2140,12 @@ pub fn compute_symbols_pre_process(
 ) -> Option<CursorContext> {
     let mut fields_order_info = FieldOrderInfo::new();
     let parsed_program = &compiled_pkg_info.program.parsed;
-    let typed_program = &compiled_pkg_info.program.typed;
+    let typed_program_modules = &compiled_pkg_info.program.typed_modules;
     pre_process_parsed_program(parsed_program, &mut fields_order_info);
 
     let mut cursor_context = compute_cursor_context(&compiled_pkg_info.mapped_files, cursor_info);
     pre_process_typed_modules(
-        &typed_program.modules,
+        &typed_program_modules,
         &fields_order_info,
         &compiled_pkg_info.mapped_files,
         &mut computation_data.mod_outer_defs,
@@ -2037,7 +2170,7 @@ pub fn compute_symbols_pre_process(
                 // No cached dependency symbols data but we still have cached compilation results.
                 // Fill out dependency symbols from compiled package info to cache them at the end of analysis
                 pre_process_typed_modules(
-                    &cached_deps.compiled_program.typing.modules,
+                    &cached_deps.program_deps.typing.modules,
                     &FieldOrderInfo::new(),
                     &compiled_pkg_info.mapped_files,
                     &mut computation_data_deps.mod_outer_defs,
@@ -2110,7 +2243,7 @@ pub fn compute_symbols_parsed_program(
                 computation_data_deps,
                 compiled_pkg_info,
                 None,
-                &cached_deps.compiled_program.parser,
+                &cached_deps.program_deps.parser,
             );
         }
     }
@@ -2122,7 +2255,7 @@ fn run_typing_analysis(
     mut computation_data: SymbolsComputationData,
     mapped_files: &MappedFiles,
     compiler_info: &mut CompilerInfo,
-    typed_program: &T::Program,
+    typed_program_modules: &UniqueMap<ModuleIdent, ModuleDefinition>,
 ) -> SymbolsComputationData {
     let mut typing_symbolicator = typing_analysis::TypingAnalysisContext {
         mod_outer_defs: &mut computation_data.mod_outer_defs,
@@ -2139,7 +2272,7 @@ fn run_typing_analysis(
     };
 
     process_typed_modules(
-        &typed_program.modules,
+        typed_program_modules,
         &computation_data.mod_to_alias_lengths,
         &mut typing_symbolicator,
         &mut computation_data.mod_use_defs,
@@ -2151,7 +2284,7 @@ fn run_typing_analysis(
 // use-def map
 fn update_file_use_defs(
     computation_data: &SymbolsComputationData,
-    source_files: &SourceFiles,
+    mapped_files: &MappedFiles,
     file_use_defs: &mut FileUseDefs,
 ) {
     for (module_ident_str, use_defs) in &computation_data.mod_use_defs {
@@ -2161,13 +2294,13 @@ fn update_file_use_defs(
             .mod_outer_defs
             .get(module_ident_str)
             .unwrap();
-        let fpath = match source_files.get(&module_defs.fhash) {
-            Some((p, _, _)) => p,
+        let fpath = match mapped_files.file_name_mapping().get(&module_defs.fhash) {
+            Some(p) => p.as_path().to_string_lossy().to_string(),
             None => return,
         };
 
         let fpath_buffer =
-            dunce::canonicalize(fpath.as_str()).unwrap_or_else(|_| PathBuf::from(fpath.as_str()));
+            dunce::canonicalize(fpath.clone()).unwrap_or_else(|_| PathBuf::from(fpath.as_str()));
 
         file_use_defs
             .entry(fpath_buffer)
@@ -2176,25 +2309,31 @@ fn update_file_use_defs(
     }
 }
 
-/// Process typed program for symbols computation.
+/// Process typed program for symbols computation. Returns:
+/// - computed symbols
+/// - optional cacheable symbols data (obtained either from cache or recomputed)
+/// - compiled user program
 pub fn compute_symbols_typed_program(
     computation_data: SymbolsComputationData,
     computation_data_deps: SymbolsComputationData,
     mut compiled_pkg_info: CompiledPkgInfo,
     cursor_context: Option<CursorContext>,
-) -> (Symbols, Option<Arc<SymbolsComputationData>>) {
+) -> (
+    Symbols,
+    Option<Arc<SymbolsComputationData>>,
+    CompiledProgram,
+) {
     // run typing analysis for the main user program
     let compiler_info = &mut compiled_pkg_info.compiler_info.as_mut().unwrap();
     let mapped_files = &compiled_pkg_info.mapped_files;
-    let source_files = &compiled_pkg_info.source_files;
     let mut computation_data = run_typing_analysis(
         computation_data,
         mapped_files,
         compiler_info,
-        &compiled_pkg_info.program.typed,
+        &compiled_pkg_info.program.typed_modules,
     );
     let mut file_use_defs = BTreeMap::new();
-    update_file_use_defs(&computation_data, source_files, &mut file_use_defs);
+    update_file_use_defs(&computation_data, mapped_files, &mut file_use_defs);
 
     let cacheable_symbols_data_opt =
         if let Some(cached_deps) = compiled_pkg_info.cached_deps.clone() {
@@ -2209,14 +2348,14 @@ pub fn compute_symbols_typed_program(
                     computation_data_deps,
                     mapped_files,
                     compiler_info,
-                    &cached_deps.compiled_program.typing,
+                    &cached_deps.program_deps.typing.modules,
                 );
                 Arc::new(computation_data_deps)
             };
             // create `file_use_defs` map and merge references to produce complete symbols data
             // (mod_outer_defs and def_info have already been merged to facilitate user program
             // analysis)
-            update_file_use_defs(&deps_symbols_data, source_files, &mut file_use_defs);
+            update_file_use_defs(&deps_symbols_data, mapped_files, &mut file_use_defs);
             for (def_loc, uses) in &deps_symbols_data.references {
                 computation_data
                     .references
@@ -2246,13 +2385,14 @@ pub fn compute_symbols_typed_program(
             cursor_context,
         },
         cacheable_symbols_data_opt,
+        compiled_pkg_info.program,
     )
 }
 
 /// Compute symbols for a given package from the parsed and typed ASTs,
 /// as well as other auxiliary data provided in `compiled_pkg_info`.
 pub fn compute_symbols(
-    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgDepsInfo>>>,
+    packages_info: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgInfo>>>,
     mut compiled_pkg_info: CompiledPkgInfo,
     cursor_info: Option<(&PathBuf, Position)>,
 ) -> Symbols {
@@ -2260,6 +2400,12 @@ pub fn compute_symbols(
     let manifest_hash = compiled_pkg_info.manifest_hash;
     let cached_dep_opt = compiled_pkg_info.cached_deps.clone();
     let deps_hash = compiled_pkg_info.deps_hash.clone();
+    let file_hashes = compiled_pkg_info
+        .mapped_files
+        .file_name_mapping()
+        .into_iter()
+        .map(|(fhash, fpath)| (fpath.clone(), fhash.clone()))
+        .collect::<BTreeMap<_, _>>();
     let mut symbols_computation_data = SymbolsComputationData::new();
     let mut symbols_computation_data_deps = SymbolsComputationData::new();
     let cursor_context = compute_symbols_pre_process(
@@ -2275,34 +2421,33 @@ pub fn compute_symbols(
         cursor_context,
     );
 
-    let (symbols, cacheable_symbols_data_opt) = compute_symbols_typed_program(
+    let (symbols, cacheable_symbols_data_opt, program) = compute_symbols_typed_program(
         symbols_computation_data,
         symbols_computation_data_deps,
         compiled_pkg_info,
         cursor_context,
     );
 
-    let mut pkg_deps = pkg_dependencies.lock().unwrap();
+    let mut pkg_deps = packages_info.lock().unwrap();
 
     if let Some(cached_deps) = cached_dep_opt {
         // we have at least compiled program available, either already cached
         // or created for the purpose of this analysis
-        if cached_deps.symbols_data.is_none() {
-            // if no symbols computation data was cached, it means that
-            // compiled program was created for the purpose of this analysis
-            // and we need to cache both
-            if let Some(deps_symbols_data) = cacheable_symbols_data_opt {
-                eprintln!("caching pre-compiled program and pre-computed symbols");
-                pkg_deps.insert(
-                    pkg_path,
-                    PrecomputedPkgDepsInfo {
-                        manifest_hash,
-                        deps_hash,
-                        deps: cached_deps.compiled_program.clone(),
-                        deps_symbols_data,
-                    },
-                );
-            }
+        if let Some(deps_symbols_data) = cacheable_symbols_data_opt {
+            // dependencies migh have changed or not, but we still need to update the cache
+            // with new file hashes and user program info
+            eprintln!("caching pre-compiled program and pre-computed symbols");
+            pkg_deps.insert(
+                pkg_path,
+                PrecomputedPkgInfo {
+                    manifest_hash,
+                    deps_hash,
+                    deps: cached_deps.program_deps.clone(),
+                    deps_symbols_data,
+                    program: Arc::new(program),
+                    file_hashes: Arc::new(file_hashes),
+                },
+            );
         }
     }
     symbols
@@ -2312,22 +2457,34 @@ pub fn compute_symbols(
 /// correctly computed symbols should be a replacement for the old set - if symbols are not
 /// actually (re)computed and the diagnostics are returned, the old symbolic information should
 /// be retained even if it's getting out-of-date.
+///
+/// Takes `modified_files` as an argument to indicate if we can retain (portion of) the cached
+/// user code. If `modified_files` is `None`, we can't retain any cached user code (need to recompute)
+/// everything. If `modified_files` is `Some`, we can retain cached user code for all Move files other than
+/// the ones in `modified_files` (if `modified_paths` contains a path not representing
+/// a Move file but rather a directory, then we conservatively do not re-use any cached info).
 pub fn get_symbols(
-    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgDepsInfo>>>,
+    packages_info: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgInfo>>>,
     ide_files_root: VfsPath,
     pkg_path: &Path,
+    modified_files: Option<Vec<PathBuf>>,
     lint: LintLevel,
     cursor_info: Option<(&PathBuf, Position)>,
 ) -> Result<(Option<Symbols>, BTreeMap<PathBuf, Vec<Diagnostic>>)> {
     let compilation_start = Instant::now();
-    let (compiled_pkg_info_opt, ide_diagnostics) =
-        get_compiled_pkg(pkg_dependencies.clone(), ide_files_root, pkg_path, lint)?;
+    let (compiled_pkg_info_opt, ide_diagnostics) = get_compiled_pkg(
+        packages_info.clone(),
+        ide_files_root,
+        pkg_path,
+        modified_files,
+        lint,
+    )?;
     eprintln!("compilation complete in: {:?}", compilation_start.elapsed());
     let Some(compiled_pkg_info) = compiled_pkg_info_opt else {
         return Ok((None, ide_diagnostics));
     };
     let analysis_start = Instant::now();
-    let symbols = compute_symbols(pkg_dependencies, compiled_pkg_info, cursor_info);
+    let symbols = compute_symbols(packages_info, compiled_pkg_info, cursor_info);
     eprintln!("analysis complete in {:?}", analysis_start.elapsed());
     eprintln!("get_symbols load complete");
 
@@ -2462,38 +2619,43 @@ fn process_typed_modules<'a>(
     }
 }
 
-fn file_sources(resolved_graph: &ResolvedGraph, overlay_fs: VfsPath) -> SourceFiles {
-    resolved_graph
-        .package_table
-        .iter()
-        .flat_map(|(_, rpkg)| {
-            rpkg.get_sources(&resolved_graph.build_options)
-                .unwrap()
-                .iter()
-                .map(|f| {
-                    let is_dep = rpkg.package_path != resolved_graph.graph.root_path;
-                    // dunce does a better job of canonicalization on Windows
-                    let fname = dunce::canonicalize(f.as_str())
-                        .map(|p| p.to_string_lossy().to_string())
-                        .unwrap_or_else(|_| f.to_string());
-                    let mut contents = String::new();
-                    // there is a fair number of unwraps here but if we can't read the files
-                    // that by all accounts should be in the file system, then there is not much
-                    // we can do so it's better to fail so that we can investigate
-                    let vfs_file_path = overlay_fs.join(fname.as_str()).unwrap();
-                    let mut vfs_file = vfs_file_path.open_file().unwrap();
-                    let _ = vfs_file.read_to_string(&mut contents);
-                    let fhash = FileHash::new(&contents);
-                    // write to top layer of the overlay file system so that the content
-                    // is immutable for the duration of compilation and symbolication
-                    let _ = vfs_file_path.parent().create_dir_all();
-                    let mut vfs_file = vfs_file_path.create_file().unwrap();
-                    let _ = vfs_file.write_all(contents.as_bytes());
-                    (fhash, (Symbol::from(fname), contents, is_dep))
-                })
-                .collect::<BTreeMap<_, _>>()
-        })
-        .collect()
+fn compute_mapped_files(
+    resolved_graph: &ResolvedGraph,
+    overlay_fs: VfsPath,
+) -> (MappedFiles, String) {
+    let mut mapped_files: MappedFiles = MappedFiles::empty();
+    let mut hasher = Sha256::new();
+    for rpkg in resolved_graph.package_table.values() {
+        for f in rpkg.get_sources(&resolved_graph.build_options).unwrap() {
+            let is_dep = rpkg.package_path != resolved_graph.graph.root_path;
+            // dunce does a better job of canonicalization on Windows
+            let fname = dunce::canonicalize(f.as_str())
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|_| f.to_string());
+            let mut contents = String::new();
+            // there is a fair number of unwraps here but if we can't read the files
+            // that by all accounts should be in the file system, then there is not much
+            // we can do so it's better to fail so that we can investigate
+            let vfs_file_path = overlay_fs.join(fname.as_str()).unwrap();
+            let mut vfs_file = vfs_file_path.open_file().unwrap();
+            let _ = vfs_file.read_to_string(&mut contents);
+            let fhash = FileHash::new(&contents);
+            if is_dep {
+                hasher.update(fhash.0);
+            }
+            // write to top layer of the overlay file system so that the content
+            // is immutable for the duration of compilation and symbolication
+            let _ = vfs_file_path.parent().create_dir_all();
+            let mut vfs_file = vfs_file_path.create_file().unwrap();
+            let _ = vfs_file.write_all(contents.as_bytes());
+            mapped_files.add(
+                fhash.clone(),
+                fname.into(),
+                Arc::from(contents.into_boxed_str()),
+            );
+        }
+    }
+    (mapped_files, format!("{:X}", hasher.finalize()))
 }
 
 /// Produces module ident string of the form pkg::module to be used as a map key
@@ -2924,7 +3086,7 @@ pub fn add_member_use_def(
     alias_lengths: &BTreeMap<Position, usize>,
 ) -> Option<UseDef> {
     let Some(name_file_start) = files.start_position_opt(use_loc) else {
-        debug_assert!(false);
+        //        debug_assert!(false);
         return None;
     };
     let name_start = Position {

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -1486,9 +1486,7 @@ impl SymbolicatorRunner {
             // The mutext value is only set by the `on_text_document_sync_notification` handler
             // and can only contain a valid Move file path, so we simply collect a set of Move
             // file paths here to pass them to the symbolicator.
-            let modfied_files = pkgs_to_analyze
-                .entry(root_dir.clone())
-                .or_insert(BTreeSet::new());
+            let modfied_files = pkgs_to_analyze.entry(root_dir.clone()).or_default();
             modfied_files.insert(starting_path.clone());
         }
         pkgs_to_analyze

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -2434,7 +2434,7 @@ pub fn compute_symbols(
         // we have at least compiled program available, either already cached
         // or created for the purpose of this analysis
         if let Some(deps_symbols_data) = cacheable_symbols_data_opt {
-            // dependencies migh have changed or not, but we still need to update the cache
+            // dependencies may have changed or not, but we still need to update the cache
             // with new file hashes and user program info
             eprintln!("caching pre-compiled program and pre-computed symbols");
             pkg_deps.insert(
@@ -3086,7 +3086,7 @@ pub fn add_member_use_def(
     alias_lengths: &BTreeMap<Position, usize>,
 ) -> Option<UseDef> {
     let Some(name_file_start) = files.start_position_opt(use_loc) else {
-        //        debug_assert!(false);
+        debug_assert!(false);
         return None;
     };
     let name_start = Position {

--- a/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
+++ b/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     fs::{self, File},
     io::{self, BufWriter},
     path::{Path, PathBuf},
@@ -369,6 +369,7 @@ fn check_expected(expected_path: &Path, result: &str) -> anyhow::Result<()> {
 
 fn initial_symbols(
     project: String,
+    files: &BTreeSet<&String>,
 ) -> datatest_stable::Result<(PathBuf, CompiledPkgInfo, Symbols)> {
     let base_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let mut project_path = base_path.clone();
@@ -377,7 +378,7 @@ fn initial_symbols(
     let ide_files_root: VfsPath = MemoryFS::new().into();
     let pkg_deps = Arc::new(Mutex::new(BTreeMap::new()));
 
-    let (compiled_pkg_info_opt, _) = get_compiled_pkg(
+    let (mut compiled_pkg_info_opt, _) = get_compiled_pkg(
         pkg_deps.clone(),
         ide_files_root.clone(),
         project_path.as_path(),
@@ -385,12 +386,19 @@ fn initial_symbols(
         LintLevel::None,
     )?;
 
+    if let Some(f) = files.first() {
+        let mod_file = project_path.join("sources").join(f);
+        (compiled_pkg_info_opt, _) = get_compiled_pkg(
+            pkg_deps.clone(),
+            ide_files_root.clone(),
+            project_path.as_path(),
+            Some(vec![mod_file]),
+            LintLevel::None,
+        )?;
+    }
+
     let compiled_pkg_info = compiled_pkg_info_opt.ok_or("PACKAGE COMPILATION FAILED")?;
-    let symbols = compute_symbols(
-        Arc::new(Mutex::new(BTreeMap::new())),
-        compiled_pkg_info.clone(),
-        None,
-    );
+    let symbols = compute_symbols(pkg_deps.clone(), compiled_pkg_info.clone(), None);
 
     Ok((project_path, compiled_pkg_info, symbols))
 }
@@ -399,7 +407,7 @@ fn use_def_test_suite(
     project: String,
     file_tests: BTreeMap<String, Vec<UseDefTest>>,
 ) -> datatest_stable::Result<String> {
-    let (project_path, _, symbols) = initial_symbols(project)?;
+    let (project_path, _, symbols) = initial_symbols(project, &file_tests.keys().collect())?;
 
     let mut output: BufWriter<_> = BufWriter::new(Vec::new());
     let writer: &mut dyn io::Write = output.get_mut();
@@ -433,7 +441,8 @@ fn completion_test_suite(
     project: String,
     file_tests: BTreeMap<String, Vec<CompletionTest>>,
 ) -> datatest_stable::Result<String> {
-    let (project_path, compiled_pkg_info, mut symbols) = initial_symbols(project)?;
+    let (project_path, compiled_pkg_info, mut symbols) =
+        initial_symbols(project, &file_tests.keys().collect())?;
 
     let mut output: BufWriter<_> = BufWriter::new(Vec::new());
     let writer: &mut dyn io::Write = output.get_mut();
@@ -462,7 +471,8 @@ fn cursor_test_suite(
     project: String,
     file_tests: BTreeMap<String, Vec<CursorTest>>,
 ) -> datatest_stable::Result<String> {
-    let (project_path, compiled_pkg_info, mut symbols) = initial_symbols(project)?;
+    let (project_path, compiled_pkg_info, mut symbols) =
+        initial_symbols(project, &file_tests.keys().collect())?;
 
     let mut output: BufWriter<_> = BufWriter::new(Vec::new());
     let writer: &mut dyn io::Write = output.get_mut();
@@ -490,7 +500,7 @@ fn hint_test_suite(
     project: String,
     file_tests: BTreeMap<String, Vec<HintTest>>,
 ) -> datatest_stable::Result<String> {
-    let (project_path, _, symbols) = initial_symbols(project)?;
+    let (project_path, _, symbols) = initial_symbols(project, &file_tests.keys().collect())?;
 
     let mut output: BufWriter<_> = BufWriter::new(Vec::new());
     let writer: &mut dyn io::Write = output.get_mut();

--- a/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
+++ b/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
@@ -381,6 +381,7 @@ fn initial_symbols(
         pkg_deps.clone(),
         ide_files_root.clone(),
         project_path.as_path(),
+        None,
         LintLevel::None,
     )?;
 


### PR DESCRIPTION
## Description 

This PR builds upon the compiler changes supporting partial compilation of of user code (skipping function bodies when compiling specific files designated by the user) to deliver the performance improvements described in the [PR](https://github.com/MystenLabs/sui/pull/20588) containing the compiler changes (reducing compilation time in the IDE for the Deepbook package from over 1s to less than 200ms).

In this PR, in addition to caching dependencies, we also cache user code, fully compile only modified files, and merge result of this compilation with the cached data


## Test plan 

All tests must pass. Also tested manually to verify correctness and performance improvements
