### PR TITLE
[mvr] add external dns lookup metric to track resolving mvr from non-mainnet graphql

### DIFF
--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -469,7 +469,10 @@ impl ServerBuilder {
             .context_data(metrics.clone())
             .context_data(config.clone())
             .context_data(move_registry_config.clone())
-            .context_data(MoveRegistryDataLoader::new(move_registry_config));
+            .context_data(MoveRegistryDataLoader::new(
+                move_registry_config,
+                metrics.clone(),
+            ));
 
         if config.internal_features.feature_gate {
             builder = builder.extension(FeatureGate);

--- a/crates/sui-mvr-graphql-rpc/README.md
+++ b/crates/sui-mvr-graphql-rpc/README.md
@@ -1,5 +1,15 @@
 # sui-mvr-graphql-rpc
 
+## Maintaining parity with sui-graphql-rpc crate
+Generates a series of patch files from the named commit to the current HEAD, and rewrites the paths to the destination crate.
+```
+# Create patch with stripped paths
+git format-patch <commit-hash>..HEAD --stdout -- ./crates/sui-mvr-graphql-rpc | sed 's|crates/sui-mvr-graphql-rpc/|crates/sui-graphql-rpc/|g' > patches.diff
+
+# Apply the patch
+git apply patches.diff
+```
+
 ## Dev setup
 Note that we use compilation flags to determine the backend for Diesel. If you're using VS Code, make sure to update settings.json with the appropriate features - there should at least be a "pg_backend" (or other backend.)
 ```

--- a/crates/sui-mvr-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-mvr-graphql-rpc/src/server/builder.rs
@@ -469,7 +469,10 @@ impl ServerBuilder {
             .context_data(metrics.clone())
             .context_data(config.clone())
             .context_data(move_registry_config.clone())
-            .context_data(MoveRegistryDataLoader::new(move_registry_config));
+            .context_data(MoveRegistryDataLoader::new(
+                move_registry_config,
+                metrics.clone(),
+            ));
 
         if config.internal_features.feature_gate {
             builder = builder.extension(FeatureGate);


### PR DESCRIPTION
## Description 

To resolve the mvr table on testnet, we consult the mainnet graphql service. We previously observed some slowness around dns lookup, so this metric will help track whether the issue persists. Also added to `sui-graphql-rpc` crate.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
