### PR TITLE
add build_mainnet for easy use sui-sdk

### DIFF
--- a/crates/sui-sdk/README.md
+++ b/crates/sui-sdk/README.md
@@ -27,6 +27,10 @@ async fn main() -> Result<(), anyhow::Error> {
     let sui_devnet = SuiClientBuilder::default().build_devnet().await?;
     println!("Sui devnet version: {}", sui_devnet.api_version());
 
+    // Sui mainnet -- https://fullnode.mainnet.sui.io:443
+    let sui_mainnet = SuiClientBuilder::default().build_mainnet().await?;
+    println!("Sui mainnet version: {}", sui_mainnet.api_version());
+
     Ok(())
 }
 

--- a/crates/sui-sdk/examples/sui_client.rs
+++ b/crates/sui-sdk/examples/sui_client.rs
@@ -32,8 +32,15 @@ async fn main() -> Result<(), anyhow::Error> {
     let sui_testnet = SuiClientBuilder::default().build_testnet().await?;
     println!("Sui testnet version: {}", sui_testnet.api_version());
 
-    println!("{:?}", sui_local.available_rpc_methods());
-    println!("{:?}", sui_local.available_subscriptions());
+    // Sui mainnet -- https://fullnode.mainnet.sui.io:443
+    let sui_mainnet = SuiClientBuilder::default().build_mainnet().await?;
+    println!("Sui mainnet version: {}", sui_mainnet.api_version());
+
+    println!("rpc methods: {:?}", sui_testnet.available_rpc_methods());
+    println!(
+        "available subscriptions: {:?}",
+        sui_testnet.available_subscriptions()
+    );
 
     Ok(())
 }

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -112,6 +112,7 @@ pub const SUI_LOCAL_NETWORK_URL_0: &str = "http://0.0.0.0:9000";
 pub const SUI_LOCAL_NETWORK_GAS_URL: &str = "http://127.0.0.1:5003/gas";
 pub const SUI_DEVNET_URL: &str = "https://fullnode.devnet.sui.io:443";
 pub const SUI_TESTNET_URL: &str = "https://fullnode.testnet.sui.io:443";
+pub const SUI_MAINNET_URL: &str = "https://fullnode.mainnet.sui.io:443";
 
 /// A Sui client builder for connecting to the Sui network
 ///
@@ -342,6 +343,29 @@ impl SuiClientBuilder {
     /// ```
     pub async fn build_testnet(self) -> SuiRpcResult<SuiClient> {
         self.build(SUI_TESTNET_URL).await
+    }
+
+    /// Returns a [SuiClient] object that is ready to interact with the Sui mainnet.
+    ///
+    /// For connecting to a custom URI, use the `build` function instead.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use sui_sdk::SuiClientBuilder;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), anyhow::Error> {
+    ///     let sui = SuiClientBuilder::default()
+    ///         .build_mainnet()
+    ///         .await?;
+    ///
+    ///     println!("{:?}", sui.api_version());
+    ///     Ok(())
+    /// }
+    /// ```
+    pub async fn build_mainnet(self) -> SuiRpcResult<SuiClient> {
+        self.build(SUI_MAINNET_URL).await
     }
 
     /// Return the server information as a `ServerInfo` structure.


### PR DESCRIPTION
## Description 

This PR adds a new function `build_mainnet` corresponding to the mainnet RPC node for the `SuiClientBuilder` type.

## Test plan 

How did you test the new or updated feature?

```rust
let sui_mainnet = SuiClientBuilder::default().build_mainnet().await?;
println!("Sui mainnet version: {}", sui_mainnet.api_version());
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [x] Rust SDK: Added a `build_mainnet` function to the `SuiClientBuilder`.
- [ ] REST API:
