### PR TITLE
fix: add missing comma to sim_test macro

### DIFF
--- a/crates/sui-proc-macros/src/lib.rs
+++ b/crates/sui-proc-macros/src/lib.rs
@@ -200,7 +200,7 @@ pub fn sim_test(args: TokenStream, item: TokenStream) -> TokenStream {
         let return_type = &sig.output;
         let body = &input.block;
         quote! {
-            #[::sui_simulator::sim_test(crate = "sui_simulator", #(#args)*)]
+            #[::sui_simulator::sim_test(crate = "sui_simulator", #(#args),*)]
             #[::sui_macros::init_static_initializers]
             #ignore
             #sig {


### PR DESCRIPTION
## Description 

This adds a missing comma to the `sim_test` procedural macro. Without this, the arguments to the `sim_test` attribute are parsed correctly but propagated without commas, causing an error "error: expected `,`".

## Test plan 

All the existing simtests should continue to work.