### PR TITLE
[tests] Fix expected failure type random selector

### DIFF
--- a/crates/sui-benchmark/src/workloads/workload.rs
+++ b/crates/sui-benchmark/src/workloads/workload.rs
@@ -47,7 +47,7 @@ impl TryFrom<u32> for ExpectedFailureType {
         match value {
             0 => {
                 let mut rng = rand::thread_rng();
-                let n = rng.gen_range(0..ExpectedFailureType::COUNT - 1);
+                let n = rng.gen_range(1..ExpectedFailureType::COUNT - 1);
                 Ok(ExpectedFailureType::iter().nth(n).unwrap())
             }
             _ => ExpectedFailureType::iter()


### PR DESCRIPTION
## Description 

The change of this code block from `Ok(rand::random())` to a custom selector logic overlooked the fact that we must avoid re-selecting variant `0`, as variant `0` is the random variant, causing the code to hit an `unreachable` block meant to avoid infinte recursion.

## Test plan 

Re-run test

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
