### PR TITLE
[move] Added support for generating bytecode disassembly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7710,6 +7710,7 @@ dependencies = [
  "move-prover",
  "move-stdlib",
  "move-stdlib-natives",
+ "move-symbol-pool",
  "move-unit-test",
  "move-vm-profiler",
  "move-vm-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7696,6 +7696,7 @@ dependencies = [
  "colored",
  "difference",
  "move-binary-format",
+ "move-bytecode-source-map",
  "move-bytecode-utils",
  "move-bytecode-verifier",
  "move-bytecode-viewer",
@@ -7836,6 +7837,7 @@ dependencies = [
  "move-core-types",
  "move-coverage",
  "move-ir-types",
+ "move-symbol-pool",
 ]
 
 [[package]]
@@ -14343,6 +14345,7 @@ dependencies = [
  "jemalloc-ctl",
  "jsonrpsee",
  "move-binary-format",
+ "move-bytecode-source-map",
  "move-cli",
  "move-compiler",
  "move-disassembler",

--- a/crates/sui-graphql-rpc/src/types/move_module.rs
+++ b/crates/sui-graphql-rpc/src/types/move_module.rs
@@ -415,18 +415,17 @@ impl MoveModule {
 
     /// Textual representation of the module's bytecode.
     async fn disassembly(&self) -> Result<Option<String>> {
-        Ok(Some(
-            Disassembler::from_module_with_max_size(
-                self.parsed.bytecode(),
-                Loc::invalid(),
-                *move_package::MAX_DISASSEMBLED_MODULE_SIZE,
-            )
-            .map_err(|e| Error::Internal(format!("Error creating disassembler: {e}")))
-            .extend()?
-            .disassemble()
-            .map_err(|e| Error::Internal(format!("Error creating disassembly: {e}")))
-            .extend()?,
-        ))
+        let (disassembled_string, _) = Disassembler::from_module_with_max_size(
+            self.parsed.bytecode(),
+            Loc::invalid(),
+            *move_package::MAX_DISASSEMBLED_MODULE_SIZE,
+        )
+        .map_err(|e| Error::Internal(format!("Error creating disassembler: {e}")))
+        .extend()?
+        .disassemble()
+        .map_err(|e| Error::Internal(format!("Error creating disassembly: {e}")))
+        .extend()?;
+        Ok(Some(disassembled_string))
     }
 }
 

--- a/crates/sui-move/Cargo.toml
+++ b/crates/sui-move/Cargo.toml
@@ -18,6 +18,7 @@ prometheus.workspace = true
 bin-version.workspace = true
 
 move-binary-format.workspace = true
+move-bytecode-source-map.workspace = true
 move-cli.workspace = true
 move-compiler.workspace = true
 move-disassembler.workspace = true

--- a/crates/sui-move/src/disassemble.rs
+++ b/crates/sui-move/src/disassemble.rs
@@ -3,6 +3,7 @@
 
 use clap::Parser;
 use move_binary_format::CompiledModule;
+use move_bytecode_source_map::utils::serialize_to_json_string;
 use move_cli::base;
 use move_disassembler::disassembler::Disassembler;
 use move_ir_types::location::Spanned;
@@ -69,7 +70,10 @@ impl Disassemble {
             println!("{module:#?}");
         } else {
             let d = Disassembler::from_module(&module, Spanned::unsafe_no_loc(()).loc)?;
-            println!("{}", d.disassemble()?);
+            let (disassembled_string, bytecode_map) = d.disassemble()?;
+            println!("{}", disassembled_string);
+            println!("%BYTECODE MAP%");
+            println!("{}", serialize_to_json_string(&bytecode_map)?);
         }
 
         Ok(())

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -625,11 +625,11 @@ where
         .map_err(|e| SuiError::ObjectSerializationError {
             error: e.to_string(),
         })?;
-        let bytecode_str = d
-            .disassemble()
-            .map_err(|e| SuiError::ObjectSerializationError {
-                error: e.to_string(),
-            })?;
+        let (bytecode_str, _) =
+            d.disassemble()
+                .map_err(|e| SuiError::ObjectSerializationError {
+                    error: e.to_string(),
+                })?;
         disassembled.insert(module.name().to_string(), Value::String(bytecode_str));
     }
     Ok(disassembled)

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -1788,6 +1788,7 @@ dependencies = [
  "move-prover",
  "move-stdlib",
  "move-stdlib-natives",
+ "move-symbol-pool",
  "move-unit-test",
  "move-vm-profiler",
  "move-vm-runtime",

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -1774,6 +1774,7 @@ dependencies = [
  "datatest-stable",
  "difference",
  "move-binary-format",
+ "move-bytecode-source-map",
  "move-bytecode-utils",
  "move-bytecode-verifier",
  "move-bytecode-viewer",
@@ -1927,6 +1928,7 @@ dependencies = [
  "move-core-types",
  "move-coverage",
  "move-ir-types",
+ "move-symbol-pool",
 ]
 
 [[package]]

--- a/external-crates/move/crates/move-bytecode-source-map/src/utils.rs
+++ b/external-crates/move/crates/move-bytecode-source-map/src/utils.rs
@@ -27,13 +27,16 @@ pub fn source_map_from_file(file_path: &Path) -> Result<SourceMap> {
         .map_err(|_| format_err!("Error deserializing into source map"))
 }
 
+pub fn serialize_to_json_string(map: &SourceMap) -> Result<String> {
+    serde_json::to_string_pretty(map).map_err(|e| format_err!("Error serializing to json: {}", e))
+}
+
 pub fn serialize_to_json(map: &SourceMap) -> Result<Vec<u8>> {
     serde_json::to_vec(map).map_err(|e| format_err!("Error serializing to json: {}", e))
 }
 
 pub fn serialize_to_json_file(map: &SourceMap, file_path: &Path) -> Result<()> {
-    let json = serde_json::to_string_pretty(map)
-        .map_err(|e| format_err!("Error serializing to json: {}", e))?;
+    let json = serialize_to_json_string(map)?;
     let mut f =
         std::fs::File::create(file_path).map_err(|e| format_err!("Error creating file: {}", e))?;
     f.write_all(json.as_bytes())

--- a/external-crates/move/crates/move-bytecode-viewer/src/bytecode_viewer.rs
+++ b/external-crates/move/crates/move-bytecode-viewer/src/bytecode_viewer.rs
@@ -32,7 +32,7 @@ impl<'a> BytecodeViewer<'a> {
             print_basic_blocks: true,
             ..Default::default()
         };
-        let disassembled_string = Disassembler::new(source_mapping, options)
+        let (disassembled_string, _) = Disassembler::new(source_mapping, options)
             .disassemble()
             .unwrap();
 

--- a/external-crates/move/crates/move-cli/Cargo.toml
+++ b/external-crates/move/crates/move-cli/Cargo.toml
@@ -33,6 +33,7 @@ move-ir-types.workspace = true
 move-compiler.workspace = true
 move-stdlib.workspace = true
 move-stdlib-natives.workspace = true
+move-symbol-pool.workspace = true
 move-vm-types.workspace = true
 move-vm-runtime.workspace = true
 move-vm-profiler.workspace = true

--- a/external-crates/move/crates/move-cli/Cargo.toml
+++ b/external-crates/move/crates/move-cli/Cargo.toml
@@ -26,6 +26,7 @@ move-bytecode-verifier.workspace = true
 move-disassembler.workspace = true
 move-docgen.workspace = true
 move-command-line-common.workspace = true
+move-bytecode-source-map.workspace = true
 move-bytecode-utils.workspace = true
 move-coverage.workspace = true
 move-core-types.workspace = true

--- a/external-crates/move/crates/move-cli/src/base/coverage.rs
+++ b/external-crates/move/crates/move-cli/src/base/coverage.rs
@@ -93,7 +93,8 @@ impl Coverage {
                 let unit = package.get_module_by_name_from_root(&module_name)?;
                 let mut disassembler = Disassembler::from_unit(&unit.unit);
                 disassembler.add_coverage_map(coverage_map.to_unified_exec_map());
-                println!("{}", disassembler.disassemble()?);
+                let (disassembled_string, _) = disassembler.disassemble()?;
+                println!("{}", disassembled_string);
             }
         }
         Ok(())

--- a/external-crates/move/crates/move-cli/src/base/disassemble.rs
+++ b/external-crates/move/crates/move-cli/src/base/disassemble.rs
@@ -66,7 +66,9 @@ impl Disassemble {
                         source_path,
                     )
                 } else {
-                    println!("{}", Disassembler::from_unit(&unit.unit).disassemble()?);
+                    let (disassembled_string, _) =
+                        Disassembler::from_unit(&unit.unit).disassemble()?;
+                    println!("{}", disassembled_string);
                     if debug {
                         println!("\n{:#?}", &unit.unit.module)
                     }

--- a/external-crates/move/crates/move-cli/src/base/test.rs
+++ b/external-crates/move/crates/move-cli/src/base/test.rs
@@ -6,6 +6,7 @@ use crate::NativeFunctionRecord;
 use anyhow::Result;
 use clap::*;
 use move_binary_format::CompiledModule;
+use move_bytecode_source_map::utils::serialize_to_json_string;
 use move_command_line_common::files::MOVE_COVERAGE_MAP_EXTENSION;
 use move_compiler::{
     diagnostics::{self, Diagnostics},
@@ -311,11 +312,16 @@ fn save_disassembly(
             .join(package_name.as_str())
     }
     .join(unit.unit.name.as_str());
+    let (disassembled_string, bytecode_map) = Disassembler::from_unit(&unit.unit).disassemble()?;
     compiled_package.save_under(
         bytecode_modules_dir.join(&file_path).with_extension("mvb"),
-        Disassembler::from_unit(&unit.unit)
-            .disassemble()?
-            .as_bytes(),
+        disassembled_string.as_bytes(),
+    )?;
+    compiled_package.save_under(
+        bytecode_modules_dir
+            .join(&file_path)
+            .with_extension("mvbsm"),
+        &serialize_to_json_string(&bytecode_map)?.as_bytes(),
     )
 }
 

--- a/external-crates/move/crates/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -152,7 +152,8 @@ impl OnDiskStateView {
                 // TODO: find or create source map and pass it to disassembler
                 let d: Disassembler =
                     Disassembler::from_module(&module, Spanned::unsafe_no_loc(()).loc)?;
-                Some(d.disassemble()?)
+                let (disassembled_string, _) = d.disassemble()?;
+                Some(disassembled_string)
             }
             None => None,
         })

--- a/external-crates/move/crates/move-disassembler/Cargo.toml
+++ b/external-crates/move/crates/move-disassembler/Cargo.toml
@@ -19,6 +19,7 @@ move-binary-format.workspace = true
 move-coverage.workspace = true
 move-compiler.workspace = true
 move-abstract-interpreter.workspace = true
+move-symbol-pool.workspace = true
 
 bcs.workspace = true
 clap.workspace = true

--- a/external-crates/move/crates/move-disassembler/src/main.rs
+++ b/external-crates/move/crates/move-disassembler/src/main.rs
@@ -107,7 +107,7 @@ fn main() {
         );
     }
 
-    let dissassemble_string = disassembler.disassemble().expect("Unable to dissassemble");
+    let (dissassemble_string, _) = disassembler.disassemble().expect("Unable to dissassemble");
 
     println!("{}", dissassemble_string);
 }

--- a/external-crates/move/crates/move-model/src/model.rs
+++ b/external-crates/move/crates/move-model/src/model.rs
@@ -2130,9 +2130,10 @@ impl<'env> ModuleEnv<'env> {
                 max_output_size: None,
             },
         );
-        disas
+        let (disassemble_string, _) = disas
             .disassemble()
-            .expect("Failed to disassemble a verified module")
+            .expect("Failed to disassemble a verified module");
+        disassemble_string
     }
 
     fn match_module_name(&self, module_name: &str) -> bool {

--- a/external-crates/move/crates/move-package/src/compilation/compiled_package.rs
+++ b/external-crates/move/crates/move-package/src/compilation/compiled_package.rs
@@ -252,7 +252,7 @@ impl OnDiskCompiledPackage {
     }
 
     /// Save `bytes` under `path_under` relative to the package on disk
-    pub(crate) fn save_under(&self, file: impl AsRef<Path>, bytes: &[u8]) -> Result<()> {
+    pub fn save_under(&self, file: impl AsRef<Path>, bytes: &[u8]) -> Result<()> {
         let path_to_save = self.root_path.join(file);
         let parent = path_to_save.parent().unwrap();
         std::fs::create_dir_all(parent)?;

--- a/external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/framework.rs
@@ -223,7 +223,8 @@ pub trait MoveTestAdapter<'a>: Sized + Send {
                     };
                     let disassembler =
                         Disassembler::new(source_mapping, DisassemblerOptions::new());
-                    merge_output(output, Some(disassembler.disassemble().unwrap()))
+                    let (disassembled_string, _) = disassembler.disassemble().unwrap();
+                    merge_output(output, Some(disassembled_string))
                 });
                 Ok(output)
             }


### PR DESCRIPTION
## Description 

This PR adds support for generating bytecode disassembly (and depositing it in the `build` directory) whenever a user runst tests with tracing enabled. The main reason is to to enable bytecode-level debugging in the Trace Viewer. This is particularly important due to discrepancy between source code and bytecode and resulting complications in mapping recorded trace events to source code (e.g., some variables and lines of code are optimized away). Providing the ability to switch to the bytecode view can provide necessary clarification in such cases and this PR is the first step to delivering this functionality.


## Test plan 

All tests must pass. Verified manually that disassembled bytecode is generated correctly
