### PR TITLE
Add a short wait at the beginning of randomized workload

### DIFF
--- a/crates/sui-benchmark/src/workloads/randomized_transaction.rs
+++ b/crates/sui-benchmark/src/workloads/randomized_transaction.rs
@@ -14,6 +14,7 @@ use async_trait::async_trait;
 use futures::future::join_all;
 use rand::Rng;
 use std::sync::Arc;
+use std::time::Duration;
 use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress};
 use sui_types::crypto::{get_key_pair, AccountKeyPair};
@@ -406,6 +407,10 @@ impl Workload<dyn Payload> for RandomizedTransactionWorkload {
         proxy: Arc<dyn ValidatorProxy + Sync + Send>,
         system_state_observer: Arc<SystemStateObserver>,
     ) {
+        // We observed that randomness may need a few seconds until DKG completion, and this may
+        // causing randomness transaction fail with `TooOldTransactionPendingOnObject` error.
+        // Therefore, wait a few seconds at the beginning to give DKG some time.
+        tokio::time::sleep(Duration::from_secs(5)).await;
         if self.basics_package_id.is_some() {
             return;
         }


### PR DESCRIPTION
## Description 

DKG may take seconds to complete, which cause randomness transaction experiencing `TooOldTransactionPendingOnObject`, which has 500ms queue age limit.

Thanks @aschran for the insight!

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
