### PR TITLE
Revert "[kv store] add watermark table to bigtable (#20390)"

### DIFF
--- a/crates/sui-data-ingestion/src/lib.rs
+++ b/crates/sui-data-ingestion/src/lib.rs
@@ -4,7 +4,7 @@
 mod progress_store;
 mod workers;
 
-pub use progress_store::IngestionWorkflowsProgressStore;
+pub use progress_store::DynamoDBProgressStore;
 pub use workers::{
     ArchivalConfig, ArchivalReducer, ArchivalWorker, BlobTaskConfig, BlobWorker, KVStoreTaskConfig,
     KVStoreWorker,

--- a/crates/sui-data-ingestion/src/main.rs
+++ b/crates/sui-data-ingestion/src/main.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 use sui_data_ingestion::{
     ArchivalConfig, ArchivalReducer, ArchivalWorker, BlobTaskConfig, BlobWorker,
-    IngestionWorkflowsProgressStore, KVStoreTaskConfig, KVStoreWorker,
+    DynamoDBProgressStore, KVStoreTaskConfig, KVStoreWorker,
 };
 use sui_data_ingestion_core::{DataIngestionMetrics, ReaderOptions};
 use sui_data_ingestion_core::{IndexerExecutor, WorkerPool};
@@ -119,27 +119,12 @@ async fn main() -> Result<()> {
     mysten_metrics::init_metrics(&registry);
     let metrics = DataIngestionMetrics::new(&registry);
 
-    let mut bigtable_client = None;
-    for task in &config.tasks {
-        if let Task::BigTableKV(kv_config) = &task.task {
-            bigtable_client = Some(
-                BigTableClient::new_remote(
-                    kv_config.instance_id.clone(),
-                    false,
-                    Some(Duration::from_secs(kv_config.timeout_secs as u64)),
-                )
-                .await?,
-            );
-        }
-    }
-
-    let progress_store = IngestionWorkflowsProgressStore::new(
+    let progress_store = DynamoDBProgressStore::new(
         &config.progress_store.aws_access_key_id,
         &config.progress_store.aws_secret_access_key,
         config.progress_store.aws_region,
         config.progress_store.table_name,
         config.is_backfill,
-        bigtable_client,
     )
     .await;
     let mut executor = IndexerExecutor::new(progress_store, config.tasks.len(), metrics);

--- a/crates/sui-kvstore/src/bigtable/client.rs
+++ b/crates/sui-kvstore/src/bigtable/client.rs
@@ -35,11 +35,9 @@ const OBJECTS_TABLE: &str = "objects";
 const TRANSACTIONS_TABLE: &str = "transactions";
 const CHECKPOINTS_TABLE: &str = "checkpoints";
 const CHECKPOINTS_BY_DIGEST_TABLE: &str = "checkpoints_by_digest";
-const WATERMARK_TABLE: &str = "watermark";
 
 const COLUMN_FAMILY_NAME: &str = "sui";
 const DEFAULT_COLUMN_QUALIFIER: &str = "";
-const AGGREGATED_WATERMARK_NAME: &str = "bigtable";
 const CHECKPOINT_SUMMARY_COLUMN_QUALIFIER: &str = "s";
 const CHECKPOINT_SIGNATURES_COLUMN_QUALIFIER: &str = "sg";
 const CHECKPOINT_CONTENTS_COLUMN_QUALIFIER: &str = "c";
@@ -130,21 +128,6 @@ impl KeyValueStoreWriter for BigTableClient {
                 checkpoint.checkpoint_summary.digest().inner().to_vec(),
                 vec![(DEFAULT_COLUMN_QUALIFIER, key)],
             )],
-        )
-        .await
-    }
-
-    async fn save_watermark(
-        &mut self,
-        name: &str,
-        watermark: CheckpointSequenceNumber,
-    ) -> Result<()> {
-        let key = name.as_bytes().to_vec();
-        let value = watermark.to_be_bytes().to_vec();
-        self.multi_set_with_timestamp(
-            WATERMARK_TABLE,
-            [(key, vec![(DEFAULT_COLUMN_QUALIFIER, value)])],
-            watermark as i64,
         )
         .await
     }
@@ -254,7 +237,15 @@ impl KeyValueStoreReader for BigTableClient {
     }
 
     async fn get_latest_checkpoint(&mut self) -> Result<CheckpointSequenceNumber> {
-        self.get_watermark(AGGREGATED_WATERMARK_NAME).await
+        let upper_limit = u64::MAX.to_be_bytes().to_vec();
+        match self
+            .reversed_scan(CHECKPOINTS_TABLE, upper_limit)
+            .await?
+            .pop()
+        {
+            Some((key_bytes, _)) => Ok(u64::from_be_bytes(key_bytes.as_slice().try_into()?)),
+            None => Ok(0),
+        }
     }
 
     async fn get_latest_object(&mut self, object_id: &ObjectID) -> Result<Option<Object>> {
@@ -265,17 +256,6 @@ impl KeyValueStoreReader for BigTableClient {
             }
         }
         Ok(None)
-    }
-
-    async fn get_watermark(&mut self, watermark_name: &str) -> Result<CheckpointSequenceNumber> {
-        let key = watermark_name.as_bytes().to_vec();
-        let mut response = self.multi_get(WATERMARK_TABLE, vec![key]).await?;
-        if let Some(row) = response.pop() {
-            if let Some((_, value)) = row.into_iter().next() {
-                return Ok(u64::from_be_bytes(value.as_slice().try_into()?));
-            }
-        }
-        Ok(0)
     }
 }
 
@@ -403,15 +383,6 @@ impl BigTableClient {
         table_name: &str,
         values: impl IntoIterator<Item = (Bytes, Vec<(&str, Bytes)>)> + std::marker::Send,
     ) -> Result<()> {
-        self.multi_set_with_timestamp(table_name, values, -1).await
-    }
-
-    async fn multi_set_with_timestamp(
-        &mut self,
-        table_name: &str,
-        values: impl IntoIterator<Item = (Bytes, Vec<(&str, Bytes)>)> + std::marker::Send,
-        timestamp: i64,
-    ) -> Result<()> {
         let mut entries = vec![];
         for (row_key, cells) in values {
             let mutations = cells
@@ -422,7 +393,7 @@ impl BigTableClient {
                         column_qualifier: column_name.to_owned().into_bytes(),
                         // The timestamp of the cell into which new data should be written.
                         // Use -1 for current Bigtable server time.
-                        timestamp_micros: timestamp,
+                        timestamp_micros: -1,
                         value,
                     })),
                 })

--- a/crates/sui-kvstore/src/bigtable/init.sh
+++ b/crates/sui-kvstore/src/bigtable/init.sh
@@ -10,7 +10,7 @@ if [[ -n $BIGTABLE_EMULATOR_HOST ]]; then
   command+=(-project emulator)
 fi
 
-for table in objects transactions checkpoints checkpoints_by_digest watermark; do
+for table in objects transactions checkpoints checkpoints_by_digest; do
   (
     set -x
     "${command[@]}" createtable $table

--- a/crates/sui-kvstore/src/lib.rs
+++ b/crates/sui-kvstore/src/lib.rs
@@ -34,7 +34,6 @@ pub trait KeyValueStoreReader {
     ) -> Result<Option<Checkpoint>>;
     async fn get_latest_checkpoint(&mut self) -> Result<CheckpointSequenceNumber>;
     async fn get_latest_object(&mut self, object_id: &ObjectID) -> Result<Option<Object>>;
-    async fn get_watermark(&mut self, task_name: &str) -> Result<u64>;
 }
 
 #[async_trait]
@@ -42,11 +41,6 @@ pub trait KeyValueStoreWriter {
     async fn save_objects(&mut self, objects: &[&Object]) -> Result<()>;
     async fn save_transactions(&mut self, transactions: &[TransactionData]) -> Result<()>;
     async fn save_checkpoint(&mut self, checkpoint: &CheckpointData) -> Result<()>;
-    async fn save_watermark(
-        &mut self,
-        name: &str,
-        watermark: CheckpointSequenceNumber,
-    ) -> Result<()>;
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This reverts commit 7eadb135535da670a73b4c1dd790cf829586dbb9.

## Description 

The hot row-hot cell pattern significantly slows down writes to Bigtable, impacting the ingestion speed of core pipelines



---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
