### PR TITLE
rpc-alt: initial scaffold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14036,6 +14036,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sui-indexer-alt-jsonrpc"
+version = "1.40.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum 0.7.5",
+ "clap",
+ "diesel",
+ "diesel-async",
+ "jsonrpsee",
+ "sui-indexer-alt-schema",
+ "sui-pg-db",
+ "sui-types",
+ "telemetry-subscribers",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "sui-indexer-alt-schema"
 version = "1.40.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ members = [
     "crates/sui-indexer",
     "crates/sui-indexer-alt",
     "crates/sui-indexer-alt-framework",
+    "crates/sui-indexer-alt-jsonrpc",
     "crates/sui-indexer-alt-schema",
     "crates/sui-indexer-builder",
     "crates/sui-json",
@@ -641,6 +642,7 @@ sui-graphql-rpc-headers = { path = "crates/sui-graphql-rpc-headers" }
 sui-genesis-builder = { path = "crates/sui-genesis-builder" }
 sui-indexer = { path = "crates/sui-indexer" }
 sui-indexer-alt-framework = { path = "crates/sui-indexer-alt-framework" }
+sui-indexer-alt-jsonrpc = { path = "crates/sui-indexer-alt-jsonrpc" }
 sui-indexer-alt-schema = { path = "crates/sui-indexer-alt-schema" }
 sui-indexer-builder = { path = "crates/sui-indexer-builder" }
 sui-json = { path = "crates/sui-json" }

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -135,7 +135,7 @@ impl Indexer {
             metrics_address,
         } = indexer_args;
 
-        let db = Db::new(db_args)
+        let db = Db::for_write(db_args)
             .await
             .context("Failed to connect to database")?;
 

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/committer.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/committer.rs
@@ -103,11 +103,13 @@ pub(super) fn committer<H: Handler + 'static>(
                                     pipeline = H::NAME,
                                     "Committed failed to get connection for DB"
                                 );
+
                                 metrics
                                     .total_committer_batches_failed
                                     .with_label_values(&[H::NAME])
                                     .inc();
-                                BE::transient(Break::Err(e.into()))
+
+                                BE::transient(Break::Err(e))
                             })?;
 
                             let affected = H::commit(values.as_slice(), &mut conn).await;

--- a/crates/sui-indexer-alt-jsonrpc/Cargo.toml
+++ b/crates/sui-indexer-alt-jsonrpc/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "sui-indexer-alt-jsonrpc"
+version.workspace = true
+authors = ["Mysten Labs <build@mystenlabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[[bin]]
+name = "sui-indexer-alt-jsonrpc"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+async-trait.workspace = true
+axum.workspace = true
+clap.workspace = true
+diesel = { workspace = true, features = ["chrono"] }
+diesel-async = { workspace = true, features = ["bb8", "postgres", "async-connection-wrapper"] }
+jsonrpsee = { workspace = true, features = ["macros", "server"] }
+telemetry-subscribers.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+url.workspace = true
+
+sui-indexer-alt-schema.workspace = true
+sui-pg-db.workspace = true
+sui-types.workspace = true

--- a/crates/sui-indexer-alt-jsonrpc/src/api/governance.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/governance.rs
@@ -1,0 +1,38 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use diesel::{ExpressionMethods, QueryDsl};
+
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use sui_indexer_alt_schema::schema::kv_epoch_starts;
+use sui_pg_db::Db;
+use sui_types::sui_serde::BigInt;
+
+use super::Connection;
+
+#[rpc(server, namespace = "suix")]
+trait Governance {
+    /// Return the reference gas price for the network as of the latest epoch.
+    #[method(name = "getReferenceGasPrice")]
+    async fn get_reference_gas_price(&self) -> RpcResult<BigInt<u64>>;
+}
+
+pub(crate) struct GovernanceImpl(pub Db);
+
+#[async_trait::async_trait]
+impl GovernanceServer for GovernanceImpl {
+    async fn get_reference_gas_price(&self) -> RpcResult<BigInt<u64>> {
+        use kv_epoch_starts::dsl as e;
+
+        let mut conn = Connection::get(&self.0).await?;
+        let rgp: i64 = conn
+            .first(
+                e::kv_epoch_starts
+                    .select(e::reference_gas_price)
+                    .order(e::epoch.desc()),
+            )
+            .await?;
+
+        Ok((rgp as u64).into())
+    }
+}

--- a/crates/sui-indexer-alt-jsonrpc/src/api/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/mod.rs
@@ -7,7 +7,6 @@ use diesel::query_builder::QueryFragment;
 use diesel::query_dsl::methods::LimitDsl;
 use diesel::result::Error as DieselError;
 use diesel_async::methods::LoadQuery;
-use diesel_async::pooled_connection::bb8::RunError;
 use diesel_async::RunQueryDsl;
 use jsonrpsee::core::Error as RpcError;
 use jsonrpsee::types::{
@@ -26,7 +25,7 @@ struct Connection<'p>(db::Connection<'p>);
 #[derive(thiserror::Error, Debug)]
 enum DbError {
     #[error(transparent)]
-    Connect(#[from] RunError),
+    Connect(anyhow::Error),
 
     #[error(transparent)]
     RunQuery(#[from] DieselError),
@@ -34,7 +33,7 @@ enum DbError {
 
 impl<'p> Connection<'p> {
     async fn get(db: &'p db::Db) -> Result<Self, DbError> {
-        Ok(Self(db.connect().await?))
+        Ok(Self(db.connect().await.map_err(DbError::Connect)?))
     }
 
     async fn first<'q, Q, U>(&mut self, query: Q) -> Result<U, DbError>

--- a/crates/sui-indexer-alt-jsonrpc/src/api/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/mod.rs
@@ -1,0 +1,69 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use diesel::dsl::Limit;
+use diesel::pg::Pg;
+use diesel::query_builder::QueryFragment;
+use diesel::query_dsl::methods::LimitDsl;
+use diesel::result::Error as DieselError;
+use diesel_async::methods::LoadQuery;
+use diesel_async::pooled_connection::bb8::RunError;
+use diesel_async::RunQueryDsl;
+use jsonrpsee::core::Error as RpcError;
+use jsonrpsee::types::{
+    error::{CallError, INTERNAL_ERROR_CODE},
+    ErrorObject,
+};
+use sui_pg_db as db;
+use tracing::debug;
+
+pub(crate) mod governance;
+
+/// This wrapper type exists to perform error conversion between the data fetching layer and the
+/// RPC layer, and to handle debug logging of database queries.
+struct Connection<'p>(db::Connection<'p>);
+
+#[derive(thiserror::Error, Debug)]
+enum DbError {
+    #[error(transparent)]
+    Connect(#[from] RunError),
+
+    #[error(transparent)]
+    RunQuery(#[from] DieselError),
+}
+
+impl<'p> Connection<'p> {
+    async fn get(db: &'p db::Db) -> Result<Self, DbError> {
+        Ok(Self(db.connect().await?))
+    }
+
+    async fn first<'q, Q, U>(&mut self, query: Q) -> Result<U, DbError>
+    where
+        U: Send,
+        Q: RunQueryDsl<db::ManagedConnection> + 'q,
+        Q: LimitDsl,
+        Limit<Q>: LoadQuery<'q, db::ManagedConnection, U> + QueryFragment<Pg> + Send,
+    {
+        let query = query.limit(1);
+        debug!("{}", diesel::debug_query(&query));
+        Ok(query.get_result(&mut self.0).await?)
+    }
+}
+
+impl From<DbError> for RpcError {
+    fn from(err: DbError) -> RpcError {
+        match err {
+            DbError::Connect(err) => RpcError::Call(CallError::Custom(ErrorObject::owned(
+                INTERNAL_ERROR_CODE,
+                err.to_string(),
+                None::<()>,
+            ))),
+
+            DbError::RunQuery(err) => RpcError::Call(CallError::Custom(ErrorObject::owned(
+                INTERNAL_ERROR_CODE,
+                err.to_string(),
+                None::<()>,
+            ))),
+        }
+    }
+}

--- a/crates/sui-indexer-alt-jsonrpc/src/args.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/args.rs
@@ -1,0 +1,15 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_pg_db::DbArgs;
+
+use crate::RpcArgs;
+
+#[derive(clap::Parser, Debug, Clone)]
+pub struct Args {
+    #[command(flatten)]
+    pub db_args: DbArgs,
+
+    #[command(flatten)]
+    pub rpc_args: RpcArgs,
+}

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -1,0 +1,256 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::net::SocketAddr;
+
+use anyhow::Context;
+use jsonrpsee::server::{RpcModule, Server, ServerBuilder};
+use sui_pg_db::Db;
+use tokio::task::JoinHandle;
+use tracing::info;
+
+use crate::api::governance::{GovernanceImpl, GovernanceServer};
+use crate::args::Args;
+
+mod api;
+pub mod args;
+
+#[derive(clap::Args, Debug, Clone)]
+pub struct RpcArgs {
+    /// Address to listen to for incoming JSON-RPC connections.
+    #[clap(long)]
+    listen_address: SocketAddr,
+}
+
+pub struct RpcService {
+    /// The JSON-RPC server.
+    server: Server,
+
+    /// All the methods added to the server so far.
+    modules: RpcModule<()>,
+}
+
+impl RpcService {
+    /// Create a new instance of the JSON-RPC service, configured by `rpc_args`. The service will
+    /// bind to its socket upon construction (and will fail if this is not possible), but will not
+    /// accept connections until [Self::run] is called.
+    pub async fn new(rpc_args: RpcArgs) -> anyhow::Result<Self> {
+        let RpcArgs { listen_address } = rpc_args;
+
+        let server = ServerBuilder::new()
+            .http_only()
+            .build(listen_address)
+            .await
+            .context("Failed to bind server")?;
+
+        Ok(Self {
+            server,
+            modules: RpcModule::new(()),
+        })
+    }
+
+    /// Add an [RpcModule] to the service. The module's methods are combined with the existing
+    /// methods registered on the service, and the operation will fail if there is any overlap.
+    pub fn add_module<M>(&mut self, module: RpcModule<M>) -> anyhow::Result<()> {
+        self.modules
+            .merge(module.remove_context())
+            .context("Failed to add module because of a name conflict")
+    }
+
+    /// Start the service (it will accept connections) and return a handle that will resolve when
+    /// the service stops.
+    pub async fn run(self) -> anyhow::Result<JoinHandle<()>> {
+        let Self { server, modules } = self;
+
+        let listen_address = server
+            .local_addr()
+            .context("Can't start RPC service without listen address")?;
+
+        info!("Starting JSON-RPC service on {listen_address}",);
+
+        let handle = server
+            .start(modules)
+            .context("Failed to start JSON-RPC service")?;
+
+        Ok(tokio::spawn(async move {
+            handle.stopped().await;
+        }))
+    }
+}
+
+pub async fn start_rpc(args: Args) -> anyhow::Result<()> {
+    let Args { db_args, rpc_args } = args;
+
+    let mut rpc = RpcService::new(rpc_args)
+        .await
+        .context("Failed to start RPC service")?;
+
+    let db = Db::new(db_args)
+        .await
+        .context("Failed to connect to database")?;
+
+    rpc.add_module(GovernanceImpl(db.clone()).into_rpc())?;
+
+    let h_rpc = rpc.run().await.context("Failed to start RPC service")?;
+    let _ = h_rpc.await;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::BTreeSet,
+        net::{IpAddr, Ipv4Addr, SocketAddr},
+    };
+
+    use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+    use sui_pg_db::temp::get_available_port;
+
+    use super::*;
+
+    fn test_listen_address() -> SocketAddr {
+        let port = get_available_port();
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port)
+    }
+
+    async fn test_service() -> RpcService {
+        let listen_address = test_listen_address();
+        RpcService::new(RpcArgs { listen_address })
+            .await
+            .expect("Failed to create test JSON-RPC service")
+    }
+
+    #[tokio::test]
+    async fn test_add_module() {
+        let mut rpc = test_service().await;
+
+        #[rpc(server, namespace = "test")]
+        trait Foo {
+            #[method(name = "bar")]
+            fn bar(&self) -> RpcResult<u64>;
+        }
+
+        struct FooImpl;
+
+        impl FooServer for FooImpl {
+            fn bar(&self) -> RpcResult<u64> {
+                Ok(42)
+            }
+        }
+
+        rpc.add_module(FooImpl.into_rpc()).unwrap();
+
+        assert_eq!(
+            BTreeSet::from_iter(rpc.modules.method_names()),
+            BTreeSet::from_iter(["test_bar"]),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_add_module_multiple_methods() {
+        let mut rpc = test_service().await;
+
+        #[rpc(server, namespace = "test")]
+        trait Foo {
+            #[method(name = "bar")]
+            fn bar(&self) -> RpcResult<u64>;
+
+            #[method(name = "baz")]
+            fn baz(&self) -> RpcResult<u64>;
+        }
+
+        struct FooImpl;
+
+        impl FooServer for FooImpl {
+            fn bar(&self) -> RpcResult<u64> {
+                Ok(42)
+            }
+
+            fn baz(&self) -> RpcResult<u64> {
+                Ok(43)
+            }
+        }
+
+        rpc.add_module(FooImpl.into_rpc()).unwrap();
+
+        assert_eq!(
+            BTreeSet::from_iter(rpc.modules.method_names()),
+            BTreeSet::from_iter(["test_bar", "test_baz"]),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_add_multiple_modules() {
+        let mut rpc = test_service().await;
+
+        #[rpc(server, namespace = "test")]
+        trait Foo {
+            #[method(name = "bar")]
+            fn bar(&self) -> RpcResult<u64>;
+        }
+
+        #[rpc(server, namespace = "test")]
+        trait Bar {
+            #[method(name = "baz")]
+            fn baz(&self) -> RpcResult<u64>;
+        }
+
+        struct FooImpl;
+        struct BarImpl;
+
+        impl FooServer for FooImpl {
+            fn bar(&self) -> RpcResult<u64> {
+                Ok(42)
+            }
+        }
+
+        impl BarServer for BarImpl {
+            fn baz(&self) -> RpcResult<u64> {
+                Ok(43)
+            }
+        }
+
+        rpc.add_module(FooImpl.into_rpc()).unwrap();
+        rpc.add_module(BarImpl.into_rpc()).unwrap();
+
+        assert_eq!(
+            BTreeSet::from_iter(rpc.modules.method_names()),
+            BTreeSet::from_iter(["test_bar", "test_baz"]),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_add_module_conflict() {
+        let mut rpc = test_service().await;
+
+        #[rpc(server, namespace = "test")]
+        trait Foo {
+            #[method(name = "bar")]
+            fn bar(&self) -> RpcResult<u64>;
+        }
+
+        #[rpc(server, namespace = "test")]
+        trait Bar {
+            #[method(name = "bar")]
+            fn bar(&self) -> RpcResult<u64>;
+        }
+
+        struct FooImpl;
+        struct BarImpl;
+
+        impl FooServer for FooImpl {
+            fn bar(&self) -> RpcResult<u64> {
+                Ok(42)
+            }
+        }
+
+        impl BarServer for BarImpl {
+            fn bar(&self) -> RpcResult<u64> {
+                Ok(43)
+            }
+        }
+
+        rpc.add_module(FooImpl.into_rpc()).unwrap();
+        assert!(rpc.add_module(BarImpl.into_rpc()).is_err(),)
+    }
+}

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -85,7 +85,7 @@ pub async fn start_rpc(args: Args) -> anyhow::Result<()> {
         .await
         .context("Failed to start RPC service")?;
 
-    let db = Db::new(db_args)
+    let db = Db::for_read(db_args)
         .await
         .context("Failed to connect to database")?;
 

--- a/crates/sui-indexer-alt-jsonrpc/src/main.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/main.rs
@@ -1,0 +1,17 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Parser;
+use sui_indexer_alt_jsonrpc::{args::Args, start_rpc};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+
+    // Enable tracing, configured by environment variables.
+    let _guard = telemetry_subscribers::TelemetryConfig::new()
+        .with_env()
+        .init();
+
+    start_rpc(args).await
+}

--- a/crates/sui-pg-db/src/lib.rs
+++ b/crates/sui-pg-db/src/lib.rs
@@ -38,7 +38,8 @@ pub struct Db {
     pool: Pool<AsyncPgConnection>,
 }
 
-pub type Connection<'p> = PooledConnection<'p, AsyncPgConnection>;
+pub type ManagedConnection = AsyncPgConnection;
+pub type Connection<'p> = PooledConnection<'p, ManagedConnection>;
 
 impl DbArgs {
     pub fn connection_timeout(&self) -> Duration {

--- a/crates/sui-pg-db/src/lib.rs
+++ b/crates/sui-pg-db/src/lib.rs
@@ -25,8 +25,8 @@ pub struct DbArgs {
     database_url: Url,
 
     /// Number of connections to keep in the pool.
-    #[arg(long, default_value_t = Self::default().connection_pool_size)]
-    connection_pool_size: u32,
+    #[arg(long, default_value_t = Self::default().db_connection_pool_size)]
+    db_connection_pool_size: u32,
 
     /// Time spent waiting for a connection from the pool to become available, in milliseconds.
     #[arg(long, default_value_t = Self::default().connection_timeout_ms)]
@@ -169,7 +169,7 @@ impl Default for DbArgs {
                 "postgres://postgres:postgrespw@localhost:5432/sui_indexer_alt",
             )
             .unwrap(),
-            connection_pool_size: 100,
+            db_connection_pool_size: 100,
             connection_timeout_ms: 60_000,
         }
     }
@@ -193,7 +193,7 @@ async fn pool(args: DbArgs) -> anyhow::Result<Pool<AsyncPgConnection>> {
     let manager = AsyncDieselConnectionManager::new(args.database_url.as_str());
 
     Ok(Pool::builder()
-        .max_size(args.connection_pool_size)
+        .max_size(args.db_connection_pool_size)
         .connection_timeout(args.connection_timeout())
         .build(manager)
         .await?)

--- a/crates/sui-pg-db/src/lib.rs
+++ b/crates/sui-pg-db/src/lib.rs
@@ -35,6 +35,7 @@ pub struct DbArgs {
 
 #[derive(Clone)]
 pub struct Db {
+    read_only: bool,
     pool: Pool<AsyncPgConnection>,
 }
 
@@ -48,24 +49,35 @@ impl DbArgs {
 }
 
 impl Db {
-    /// Construct a new DB connection pool. Instances of [Db] can be cloned to share access to the
-    /// same pool.
-    pub async fn new(config: DbArgs) -> anyhow::Result<Self> {
-        let manager = AsyncDieselConnectionManager::new(config.database_url.as_str());
+    /// Construct a new DB connection pool that supports write and reads. Instances of [Db] can be
+    /// cloned to share access to the same pool.
+    pub async fn for_write(config: DbArgs) -> anyhow::Result<Self> {
+        Ok(Self {
+            read_only: false,
+            pool: pool(config).await?,
+        })
+    }
 
-        let pool = Pool::builder()
-            .max_size(config.connection_pool_size)
-            .connection_timeout(config.connection_timeout())
-            .build(manager)
-            .await?;
-
-        Ok(Self { pool })
+    /// Construct a new DB connection pool that defaults to read-only transactions. Instances of
+    /// [Db] can be cloned to share access to the same pool.
+    pub async fn for_read(config: DbArgs) -> anyhow::Result<Self> {
+        Ok(Self {
+            read_only: true,
+            pool: pool(config).await?,
+        })
     }
 
     /// Retrieves a connection from the pool. Can fail with a timeout if a connection cannot be
     /// established before the [DbArgs::connection_timeout] has elapsed.
     pub async fn connect(&self) -> anyhow::Result<Connection<'_>> {
-        Ok(self.pool.get().await?)
+        let mut conn = self.pool.get().await?;
+        if self.read_only {
+            diesel::sql_query("SET default_transaction_read_only = 'on'")
+                .execute(&mut conn)
+                .await?;
+        }
+
+        Ok(conn)
     }
 
     /// Statistics about the connection pool
@@ -168,13 +180,23 @@ pub async fn reset_database<S: MigrationSource<Pg> + Send + Sync + 'static>(
     db_config: DbArgs,
     migrations: Option<S>,
 ) -> anyhow::Result<()> {
-    let db = Db::new(db_config).await?;
+    let db = Db::for_write(db_config).await?;
     db.clear_database().await?;
     if let Some(migrations) = migrations {
         db.run_migrations(migrations).await?;
     }
 
     Ok(())
+}
+
+async fn pool(args: DbArgs) -> anyhow::Result<Pool<AsyncPgConnection>> {
+    let manager = AsyncDieselConnectionManager::new(args.database_url.as_str());
+
+    Ok(Pool::builder()
+        .max_size(args.connection_pool_size)
+        .connection_timeout(args.connection_timeout())
+        .build(manager)
+        .await?)
 }
 
 #[cfg(test)]
@@ -196,7 +218,7 @@ mod tests {
             ..Default::default()
         };
 
-        let db = Db::new(db_args).await.unwrap();
+        let db = Db::for_write(db_args).await.unwrap();
         let mut conn = db.connect().await.unwrap();
 
         // Run a simple query to verify the db can properly be queried
@@ -224,7 +246,7 @@ mod tests {
             ..Default::default()
         };
 
-        let db = Db::new(db_args.clone()).await.unwrap();
+        let db = Db::for_write(db_args.clone()).await.unwrap();
         let mut conn = db.connect().await.unwrap();
         diesel::sql_query("CREATE TABLE test_table (id INTEGER PRIMARY KEY)")
             .execute(&mut conn)
@@ -243,12 +265,75 @@ mod tests {
             .unwrap();
 
         let mut conn = db.connect().await.unwrap();
-        let cnt = diesel::sql_query(
+        let cnt: CountResult = diesel::sql_query(
             "SELECT COUNT(*) as cnt FROM information_schema.tables WHERE table_name = 'test_table'",
         )
-        .get_result::<CountResult>(&mut conn)
+        .get_result(&mut conn)
         .await
         .unwrap();
         assert_eq!(cnt.cnt, 0);
+    }
+
+    #[tokio::test]
+    async fn test_read_only() {
+        let temp_db = temp::TempDb::new().unwrap();
+        let url = temp_db.database().url();
+
+        let db_args = DbArgs {
+            database_url: url.clone(),
+            ..Default::default()
+        };
+
+        let writer = Db::for_write(db_args.clone()).await.unwrap();
+        let reader = Db::for_read(db_args).await.unwrap();
+
+        {
+            // Create a table
+            let mut conn = writer.connect().await.unwrap();
+            diesel::sql_query("CREATE TABLE test_table (id INTEGER PRIMARY KEY)")
+                .execute(&mut conn)
+                .await
+                .unwrap();
+        }
+
+        {
+            // Try an insert into it using the read-only connection, which should fail
+            let mut conn = reader.connect().await.unwrap();
+            let result = diesel::sql_query("INSERT INTO test_table (id) VALUES (1)")
+                .execute(&mut conn)
+                .await;
+            assert!(result.is_err());
+        }
+
+        {
+            // Try and select from it using the read-only connection, which should succeed, but
+            // return no results.
+            let mut conn = reader.connect().await.unwrap();
+            let cnt: CountResult = diesel::sql_query("SELECT COUNT(*) as cnt FROM test_table")
+                .get_result(&mut conn)
+                .await
+                .unwrap();
+            assert_eq!(cnt.cnt, 0);
+        }
+
+        {
+            // Then try to write to it using the write connection, which should succeed
+            let mut conn = writer.connect().await.unwrap();
+            diesel::sql_query("INSERT INTO test_table (id) VALUES (1)")
+                .execute(&mut conn)
+                .await
+                .unwrap();
+        }
+
+        {
+            // Finally, try to read from it using the read-only connection, which should now return
+            // results.
+            let mut conn = reader.connect().await.unwrap();
+            let cnt: CountResult = diesel::sql_query("SELECT COUNT(*) as cnt FROM test_table")
+                .get_result(&mut conn)
+                .await
+                .unwrap();
+            assert_eq!(cnt.cnt, 1);
+        }
     }
 }


### PR DESCRIPTION
## Description 

Initial scaffolding for a JSONRPC service that talks to the indexer-alt schema. This service only responds to `suix_getReferenceGasPrice` currently, and tries to take as few dependencies as possible on the existing JSONRPC infra, so that it will not hold-up its deprecation and eventual clean up.

We also introduce some clean-ups to supporting crates, in their own commits -- these commits will be landed unsquashed.

## Test plan 

Some new unit tests:

```
sui$ cargo nextest run -p sui-indexer-alt-jsonrpc
sui$ cargo nextest run -p sui-pg-db -- test_read_only
```

Run the service:

```
sui$ RUST_LOG="INFO,sui_indexer_alt_jsonrpc=DEBUG" cargo run -p sui-indexer-alt-jsonrpc -- \
  --database-url $DB_URL --listen-address 127.0.0.1:5000
```

And query the method:

```
sui$ curl -LX POST  "http://localhost:5000" \
    --header 'Content-Type: application/json' \
    --data '{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "suix_getReferenceGasPrice",
  "params": []
}' | jq .
{
  "jsonrpc": "2.0",
  "result": "750",
  "id": 1
}
```

E2E testing support will be a fast follow.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
