### PR TITLE
DEEP Supply Endpoint

### DIFF
--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -54,7 +54,8 @@ pub const DEEPBOOK_PACKAGE_ID: &str =
     "0x2c8d603bc51326b8c13cef9dd07031a408a48dddb541963357661df5d3204809";
 pub const DEEP_TOKEN_PACKAGE_ID: &str =
     "0xdeeb7a4662eec9f2f3def03fb937a663dddaa2e215b8078a284d026b7946c270";
-pub const DEEP_TREASURY_ID: &str = "0x032abf8948dda67a271bcc18e776dbbcfb0d58c8d288a700ff0d5521e57a1ffe";
+pub const DEEP_TREASURY_ID: &str =
+    "0x032abf8948dda67a271bcc18e776dbbcfb0d58c8d288a700ff0d5521e57a1ffe";
 pub const DEEP_SUPPLY_MODULE: &str = "deep";
 pub const DEEP_SUPPLY_FUNCTION: &str = "total_supply";
 pub const DEEP_SUPPLY_PATH: &str = "/deep_supply";
@@ -1125,18 +1126,18 @@ async fn orderbook(
     Ok(Json(result))
 }
 
-
 /// DEEP total supply
 async fn deep_supply() -> Result<Json<u64>, DeepBookError> {
     let sui_client = SuiClientBuilder::default().build(SUI_MAINNET_URL).await?;
     let mut ptb = ProgrammableTransactionBuilder::new();
 
-    let deep_treasury_object_id = ObjectID::from_hex_literal(
-        DEEP_TREASURY_ID
-    )?;
+    let deep_treasury_object_id = ObjectID::from_hex_literal(DEEP_TREASURY_ID)?;
     let deep_treasury_object: SuiObjectResponse = sui_client
         .read_api()
-        .get_object_with_options(deep_treasury_object_id, SuiObjectDataOptions::full_content())
+        .get_object_with_options(
+            deep_treasury_object_id,
+            SuiObjectDataOptions::full_content(),
+        )
         .await?;
     let deep_treasury_data: &SuiObjectData =
         deep_treasury_object
@@ -1146,14 +1147,18 @@ async fn deep_supply() -> Result<Json<u64>, DeepBookError> {
                 "Incorrect Treasury ID".to_string(),
             ))?;
 
-    let deep_treasury_ref: ObjectRef =
-        (deep_treasury_data.object_id, deep_treasury_data.version, deep_treasury_data.digest);
+    let deep_treasury_ref: ObjectRef = (
+        deep_treasury_data.object_id,
+        deep_treasury_data.version,
+        deep_treasury_data.digest,
+    );
 
     let deep_treasury_input = CallArg::Object(ObjectArg::ImmOrOwnedObject(deep_treasury_ref));
     ptb.input(deep_treasury_input)?;
 
-    let package = ObjectID::from_hex_literal(DEEP_TOKEN_PACKAGE_ID)
-        .map_err(|e| DeepBookError::InternalError(format!("Invalid deep token package ID: {}", e)))?;
+    let package = ObjectID::from_hex_literal(DEEP_TOKEN_PACKAGE_ID).map_err(|e| {
+        DeepBookError::InternalError(format!("Invalid deep token package ID: {}", e))
+    })?;
     let module = DEEP_SUPPLY_MODULE.to_string();
     let function = DEEP_SUPPLY_FUNCTION.to_string();
 
@@ -1176,7 +1181,6 @@ async fn deep_supply() -> Result<Json<u64>, DeepBookError> {
     let mut binding = result.results.ok_or(DeepBookError::InternalError(
         "No results from dev_inspect_transaction_block".to_string(),
     ))?;
-
 
     // Extract the total supply (assuming it's the first value returned)
     let total_supply = &binding

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -1182,7 +1182,6 @@ async fn deep_supply() -> Result<Json<u64>, DeepBookError> {
         "No results from dev_inspect_transaction_block".to_string(),
     ))?;
 
-    // Extract the total supply (assuming it's the first value returned)
     let total_supply = &binding
         .first_mut()
         .ok_or(DeepBookError::InternalError(
@@ -1195,12 +1194,10 @@ async fn deep_supply() -> Result<Json<u64>, DeepBookError> {
         ))?
         .0;
 
-    // Assuming `total_supply` is returned as a byte array that can be converted to a number
     let total_supply_value: u64 = bcs::from_bytes(total_supply).map_err(|_| {
         DeepBookError::InternalError("Failed to deserialize total supply".to_string())
     })?;
 
-    // Return the total supply as a single JSON number
     Ok(Json(total_supply_value))
 }
 

--- a/crates/sui-deepbook-indexer/src/server.rs
+++ b/crates/sui-deepbook-indexer/src/server.rs
@@ -52,6 +52,12 @@ pub const LEVEL2_MODULE: &str = "pool";
 pub const LEVEL2_FUNCTION: &str = "get_level2_ticks_from_mid";
 pub const DEEPBOOK_PACKAGE_ID: &str =
     "0x2c8d603bc51326b8c13cef9dd07031a408a48dddb541963357661df5d3204809";
+pub const DEEP_TOKEN_PACKAGE_ID: &str =
+    "0xdeeb7a4662eec9f2f3def03fb937a663dddaa2e215b8078a284d026b7946c270";
+pub const DEEP_TREASURY_ID: &str = "0x032abf8948dda67a271bcc18e776dbbcfb0d58c8d288a700ff0d5521e57a1ffe";
+pub const DEEP_SUPPLY_MODULE: &str = "deep";
+pub const DEEP_SUPPLY_FUNCTION: &str = "total_supply";
+pub const DEEP_SUPPLY_PATH: &str = "/deep_supply";
 
 pub fn run_server(socket_address: SocketAddr, state: PgDeepbookPersistent) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -80,6 +86,7 @@ pub(crate) fn make_router(state: PgDeepbookPersistent) -> Router {
         .route(TRADES_PATH, get(trades))
         .route(ASSETS_PATH, get(assets))
         .route(SUMMARY_PATH, get(summary))
+        .route(DEEP_SUPPLY_PATH, get(deep_supply))
         .with_state(state)
 }
 
@@ -1116,6 +1123,81 @@ async fn orderbook(
     result.insert("asks".to_string(), Value::Array(asks));
 
     Ok(Json(result))
+}
+
+
+/// DEEP total supply
+async fn deep_supply() -> Result<Json<u64>, DeepBookError> {
+    let sui_client = SuiClientBuilder::default().build(SUI_MAINNET_URL).await?;
+    let mut ptb = ProgrammableTransactionBuilder::new();
+
+    let deep_treasury_object_id = ObjectID::from_hex_literal(
+        DEEP_TREASURY_ID
+    )?;
+    let deep_treasury_object: SuiObjectResponse = sui_client
+        .read_api()
+        .get_object_with_options(deep_treasury_object_id, SuiObjectDataOptions::full_content())
+        .await?;
+    let deep_treasury_data: &SuiObjectData =
+        deep_treasury_object
+            .data
+            .as_ref()
+            .ok_or(DeepBookError::InternalError(
+                "Incorrect Treasury ID".to_string(),
+            ))?;
+
+    let deep_treasury_ref: ObjectRef =
+        (deep_treasury_data.object_id, deep_treasury_data.version, deep_treasury_data.digest);
+
+    let deep_treasury_input = CallArg::Object(ObjectArg::ImmOrOwnedObject(deep_treasury_ref));
+    ptb.input(deep_treasury_input)?;
+
+    let package = ObjectID::from_hex_literal(DEEP_TOKEN_PACKAGE_ID)
+        .map_err(|e| DeepBookError::InternalError(format!("Invalid deep token package ID: {}", e)))?;
+    let module = DEEP_SUPPLY_MODULE.to_string();
+    let function = DEEP_SUPPLY_FUNCTION.to_string();
+
+    ptb.command(Command::MoveCall(Box::new(ProgrammableMoveCall {
+        package,
+        module,
+        function,
+        type_arguments: vec![],
+        arguments: vec![Argument::Input(0)],
+    })));
+
+    let builder = ptb.finish();
+    let tx = TransactionKind::ProgrammableTransaction(builder);
+
+    let result = sui_client
+        .read_api()
+        .dev_inspect_transaction_block(SuiAddress::default(), tx, None, None, None)
+        .await?;
+
+    let mut binding = result.results.ok_or(DeepBookError::InternalError(
+        "No results from dev_inspect_transaction_block".to_string(),
+    ))?;
+
+
+    // Extract the total supply (assuming it's the first value returned)
+    let total_supply = &binding
+        .first_mut()
+        .ok_or(DeepBookError::InternalError(
+            "No return values for total supply".to_string(),
+        ))?
+        .return_values
+        .first_mut()
+        .ok_or(DeepBookError::InternalError(
+            "No total supply data found".to_string(),
+        ))?
+        .0;
+
+    // Assuming `total_supply` is returned as a byte array that can be converted to a number
+    let total_supply_value: u64 = bcs::from_bytes(total_supply).map_err(|_| {
+        DeepBookError::InternalError("Failed to deserialize total supply".to_string())
+    })?;
+
+    // Return the total supply as a single JSON number
+    Ok(Json(total_supply_value))
 }
 
 async fn get_net_deposits(


### PR DESCRIPTION
## Description 

DEEP Supply Endpoint: /deep_supply

Returns: 9997742312719287 (represents 9,997,742,312 DEEP)

## Test plan 

How did you test the new or updated feature?

Tested locally

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [x] Indexer: Deepbook Indexer
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
