### PR TITLE
Display preflight warnings

### DIFF
--- a/apps/wallet/src/ui/app/components/known-scam-overlay/index.tsx
+++ b/apps/wallet/src/ui/app/components/known-scam-overlay/index.tsx
@@ -48,13 +48,11 @@ export function ScamOverlay({ preflight, onClickBack, onClickContinue }: ScamOve
 			>
 				<WarningSvg />
 
-				{block.enabled ? (
-					<Warning {...preflight.block} />
-				) : (
-					warnings?.map(({ title, subtitle }) => {
-						return <Warning title={title} subtitle={subtitle} />;
-					})
-				)}
+				{!!block.enabled && <Warning {...preflight.block} />}
+
+				{warnings?.map(({ title, subtitle }) => {
+					return <Warning title={title} subtitle={subtitle} />;
+				})}
 
 				<div className="flex flex-col gap-2 mt-auto w-full items-stretch">
 					<Button variant="primary" text="Return to safety" onClick={onClickBack} />

--- a/apps/wallet/src/ui/app/components/known-scam-overlay/index.tsx
+++ b/apps/wallet/src/ui/app/components/known-scam-overlay/index.tsx
@@ -42,7 +42,7 @@ export function ScamOverlay({ preflight, onClickBack, onClickContinue }: ScamOve
 		<Portal containerId="overlay-portal-container">
 			<div
 				className={cx(
-					'h-full w-full bg-warning-light flex flex-col p-4 justify-center items-center gap-4 absolute top-0 left-0 bottom-0 z-50',
+					'h-full w-full flex flex-col p-4 justify-center items-center gap-4 absolute top-0 left-0 bottom-0 z-50',
 					block.enabled ? 'bg-issue-light' : 'bg-warning-light',
 				)}
 			>
@@ -50,8 +50,9 @@ export function ScamOverlay({ preflight, onClickBack, onClickContinue }: ScamOve
 
 				{!!block.enabled && <Warning {...preflight.block} />}
 
-				{warnings?.map(({ title, subtitle }) => {
-					return <Warning title={title} subtitle={subtitle} />;
+				{warnings?.map(({ title, subtitle }, i) => {
+					// warnings list won't ever change, index key is fine
+					return <Warning key={i} title={title} subtitle={subtitle} />;
 				})}
 
 				<div className="flex flex-col gap-2 mt-auto w-full items-stretch">

--- a/apps/wallet/src/ui/app/components/known-scam-overlay/index.tsx
+++ b/apps/wallet/src/ui/app/components/known-scam-overlay/index.tsx
@@ -9,8 +9,6 @@ import { Portal } from '../../shared/Portal';
 import type { DappPreflightResponse } from './types';
 import WarningSvg from './warning.svg';
 
-// const scamOverlayStyles = cva
-
 export type ScamOverlayProps = {
 	preflight: DappPreflightResponse;
 	onClickBack(): void;

--- a/apps/wallet/src/ui/app/components/known-scam-overlay/index.tsx
+++ b/apps/wallet/src/ui/app/components/known-scam-overlay/index.tsx
@@ -1,38 +1,66 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+import { cx } from 'class-variance-authority';
+
 import { Button } from '../../shared/ButtonUI';
 import { Heading } from '../../shared/heading';
 import { Portal } from '../../shared/Portal';
+import type { DappPreflightResponse } from './types';
 import WarningSvg from './warning.svg';
 
+// const scamOverlayStyles = cva
+
 export type ScamOverlayProps = {
-	onDismiss(): void;
-	open: boolean;
-	title?: string;
-	subtitle?: string;
+	preflight: DappPreflightResponse;
+	onClickBack(): void;
+	onClickContinue(): void;
 };
 
-export function ScamOverlay({ open, onDismiss, title, subtitle }: ScamOverlayProps) {
-	if (!open) return null;
+function Warning({ title, subtitle }: { title: string; subtitle: string }) {
+	return (
+		<div className="flex flex-col gap-2 text-center pb-4">
+			<Heading variant="heading2" weight="semibold" color="gray-90">
+				{title || 'Malicious website'}
+			</Heading>
+			<div className="flex text-center font-medium text-pBody text-gray-90">
+				<div className="font-medium text-pBody text-gray-90">
+					{subtitle ||
+						'This website has been flagged for malicious behavior. To protect your wallet from potential threats, please return to safety.'}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export function ScamOverlay({ preflight, onClickBack, onClickContinue }: ScamOverlayProps) {
+	const { block, warnings } = preflight;
+
+	if (!block.enabled && !warnings?.length) return null;
+
 	return (
 		<Portal containerId="overlay-portal-container">
-			<div className="h-full w-full bg-issue-light flex flex-col p-4 justify-center items-center gap-4 absolute top-0 left-0 bottom-0 z-50">
+			<div
+				className={cx(
+					'h-full w-full bg-warning-light flex flex-col p-4 justify-center items-center gap-4 absolute top-0 left-0 bottom-0 z-50',
+					block.enabled ? 'bg-issue-light' : 'bg-warning-light',
+				)}
+			>
 				<WarningSvg />
-				<div className="flex flex-col gap-2 text-center pb-4">
-					<Heading variant="heading2" weight="semibold" color="gray-90">
-						{title || 'Malicious website'}
-					</Heading>
-					<div className="flex text-center font-medium text-pBody text-gray-90">
-						<div className="font-medium text-pBody text-gray-90">
-							{subtitle ||
-								'This website has been flagged for malicious behavior. To protect your wallet from potential threats, please return to safety.'}
-						</div>
-					</div>
-				</div>
 
-				<div className="gap-2 mt-auto w-full items-stretch">
-					<Button variant="primary" text="I understand" onClick={onDismiss} />
+				{block.enabled ? (
+					<Warning {...preflight.block} />
+				) : (
+					warnings?.map(({ title, subtitle }) => {
+						return <Warning title={title} subtitle={subtitle} />;
+					})
+				)}
+
+				<div className="flex flex-col gap-2 mt-auto w-full items-stretch">
+					<Button variant="primary" text="Return to safety" onClick={onClickBack} />
+					{!block.enabled && (
+						<Button variant="outlineWarning" text="Proceed" onClick={onClickContinue} />
+					)}
 				</div>
 			</div>
 		</Portal>

--- a/apps/wallet/src/ui/app/components/known-scam-overlay/types.ts
+++ b/apps/wallet/src/ui/app/components/known-scam-overlay/types.ts
@@ -15,6 +15,10 @@ export type DappPreflightResponse = {
 		title: string;
 		subtitle: string;
 	};
+	warnings?: {
+		title: string;
+		subtitle: string;
+	}[];
 };
 
 export type Network = 'mainnet' | 'testnet' | 'devnet' | 'local';

--- a/apps/wallet/src/ui/app/components/known-scam-overlay/useShowScamWarning.tsx
+++ b/apps/wallet/src/ui/app/components/known-scam-overlay/useShowScamWarning.tsx
@@ -37,7 +37,6 @@ export function useShowScamWarning({
 
 	return {
 		data,
-		isOpen: !!data?.block.enabled && !isError,
 		isPending,
 		isError,
 	};


### PR DESCRIPTION
## Description 

Displays optional warnings from the dapp preflight. Adds ability to dismiss the overlay to support the "Proceed" action. "Proceed" simply hides the overlay and allows the user to continue their action.

|With warnings (block disabled)|With hard block|
|-|-|
|<img width="472" alt="image" src="https://github.com/user-attachments/assets/bff4e62b-31da-4ca7-9ddb-c88ce26e0f28" />|<img width="472" alt="image" src="https://github.com/user-attachments/assets/edc65027-a71f-4989-8a2e-e958960da618" />|


## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
