### PR TITLE
Move static OnceCell ChainIdentifier into AuthorityState

### DIFF
--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -311,6 +311,8 @@ impl<'a> TestAuthorityBuilder<'a> {
         config.authority_overload_config = authority_overload_config;
         config.authority_store_pruning_config = pruning_config;
 
+        let chain_identifier = ChainIdentifier::from(*genesis.checkpoint().digest());
+
         let state = AuthorityState::new(
             name,
             secret,
@@ -329,6 +331,7 @@ impl<'a> TestAuthorityBuilder<'a> {
             usize::MAX,
             ArchiveReaderBalancer::default(),
             None,
+            chain_identifier,
         )
         .await;
 

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -51,10 +51,7 @@ pub async fn execution_process(
             return;
         };
 
-        state
-            .get_chain_identifier()
-            .map(|chain_id| chain_id.chain())
-            == Some(Chain::Mainnet)
+        state.get_chain_identifier().chain() == Chain::Mainnet
     };
 
     // Loop whenever there is a signal that a new transactions is ready to process.

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -462,12 +462,8 @@ impl RpcStateReader for RestReadStore {
         }
     }
 
-    fn get_chain_identifier(
-        &self,
-    ) -> sui_types::storage::error::Result<sui_types::digests::ChainIdentifier> {
-        self.state
-            .get_chain_identifier()
-            .ok_or_else(|| StorageError::missing("unable to query chain identifier"))
+    fn get_chain_identifier(&self) -> Result<sui_types::digests::ChainIdentifier> {
+        Ok(self.state.get_chain_identifier())
     }
 
     fn indexes(&self) -> Option<&dyn RpcIndexes> {

--- a/crates/sui-json-rpc/src/authority_state.rs
+++ b/crates/sui-json-rpc/src/authority_state.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::anyhow;
 use arc_swap::Guard;
 use async_trait::async_trait;
 use move_core_types::language_storage::TypeTag;
@@ -531,9 +530,7 @@ impl StateRead for AuthorityState {
     }
 
     fn get_chain_identifier(&self) -> StateReadResult<ChainIdentifier> {
-        Ok(self
-            .get_chain_identifier()
-            .ok_or(anyhow!("Chain identifier not found"))?)
+        Ok(self.get_chain_identifier())
     }
 }
 

--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -149,11 +149,7 @@ fn main() {
     let node_once_cell_clone = node_once_cell.clone();
     runtimes.metrics.spawn(async move {
         let node = node_once_cell_clone.get().await;
-        let chain_identifier = match node.state().get_chain_identifier() {
-            Some(chain_identifier) => chain_identifier.to_string(),
-            None => "unknown".to_string(),
-        };
-
+        let chain_identifier = node.state().get_chain_identifier().to_string();
         info!("Sui chain identifier: {chain_identifier}");
         prometheus_registry
             .register(mysten_metrics::uptime_metric(

--- a/crates/sui-snapshot/src/writer.rs
+++ b/crates/sui-snapshot/src/writer.rs
@@ -7,7 +7,7 @@ use crate::{
     ManifestV1, FILE_MAX_BYTES, MAGIC_BYTES, MANIFEST_FILE_MAGIC, OBJECT_FILE_MAGIC,
     OBJECT_REF_BYTES, REFERENCE_FILE_MAGIC, SEQUENCE_NUM_BYTES,
 };
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use byteorder::{BigEndian, ByteOrder};
 use fastcrypto::hash::MultisetHash;
 use futures::StreamExt;
@@ -24,13 +24,13 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use sui_config::object_storage_config::ObjectStoreConfig;
 use sui_core::authority::authority_store_tables::{AuthorityPerpetualTables, LiveObject};
-use sui_core::authority::CHAIN_IDENTIFIER;
 use sui_core::state_accumulator::StateAccumulator;
 use sui_protocol_config::{ProtocolConfig, ProtocolVersion};
 use sui_storage::blob::{Blob, BlobEncoding, BLOB_ENCODING_BYTES};
 use sui_storage::object_store::util::{copy_file, delete_recursively, path_to_filesystem};
 use sui_types::accumulator::Accumulator;
 use sui_types::base_types::{ObjectID, ObjectRef};
+use sui_types::digests::ChainIdentifier;
 use sui_types::messages_checkpoint::ECMHLiveObjectSetDigest;
 use sui_types::sui_system_state::get_sui_system_state;
 use sui_types::sui_system_state::SuiSystemStateTrait;
@@ -260,13 +260,11 @@ impl StateSnapshotWriterV1 {
         epoch: u64,
         perpetual_db: Arc<AuthorityPerpetualTables>,
         root_state_hash: ECMHLiveObjectSetDigest,
+        chain_identifier: ChainIdentifier,
     ) -> Result<()> {
         let system_state_object = get_sui_system_state(&perpetual_db)?;
 
         let protocol_version = system_state_object.protocol_version();
-        let chain_identifier = CHAIN_IDENTIFIER
-            .get()
-            .ok_or(anyhow!("No chain identifier found"))?;
         let protocol_config = ProtocolConfig::get_for_version(
             ProtocolVersion::new(protocol_version),
             chain_identifier.chain(),

--- a/crates/sui-telemetry/src/lib.rs
+++ b/crates/sui-telemetry/src/lib.rs
@@ -41,10 +41,7 @@ struct IpResponse {
 pub async fn send_telemetry_event(state: Arc<AuthorityState>, is_validator: bool) {
     let git_rev = env!("CARGO_PKG_VERSION").to_string();
     let ip_address = get_ip().await;
-    let chain_identifier = match state.get_chain_identifier() {
-        Some(chain_identifier) => chain_identifier.to_string(),
-        None => "Unknown".to_string(),
-    };
+    let chain_identifier = state.get_chain_identifier().to_string();
     let since_the_epoch = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("Now should be later than epoch!");


### PR DESCRIPTION
## Description 

As part of fixing flakey graphql tests, I observed an inconsistency in how the fullnode rpc in TestCluster was reporting chain_identifier. The nodes wrote `0.chk` to file with a particular checkpoint digest->chain_id, but the rpc would report a different chain_id. Conspicuously, the chain_id was the same across tests.

The issue stemmed from using a global static OnceCell<ChainIdentifier>. This global state meant that if the `test_simple_client_validator_cluster` test did not set the `chain_id`, then it would fail. I suppose there might be some production issues as well, for example if someone were to run multiple nodes in the same process to different networks.

To address, I moved chain_identifier into AuthorityState, and modified SuiNode to explicitly pass the chain_identifier to components that need it, which is basically just StateSnapshotUploader today.

By eagerly setting `chain_identifier`, we can also simplify some logic around existing callsites

## Test plan 

Existing tests pass

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
