### PR TITLE
[quorum driver] Remove conflicting tx retry logic

### DIFF
--- a/crates/sui-core/src/quorum_driver/metrics.rs
+++ b/crates/sui-core/src/quorum_driver/metrics.rs
@@ -28,10 +28,6 @@ pub struct QuorumDriverMetrics {
     // TODO: add histogram of attempt that tx succeeds
     pub(crate) current_requests_in_flight: IntGauge,
 
-    pub(crate) total_err_process_tx_responses_with_nonzero_conflicting_transactions: IntCounter,
-    pub(crate) total_attempts_retrying_conflicting_transaction: IntCounter,
-    pub(crate) total_successful_attempts_retrying_conflicting_transaction: IntCounter,
-    pub(crate) total_times_conflicting_transaction_already_finalized_when_retrying: IntCounter,
     pub(crate) total_retryable_overload_errors: IntCounter,
     pub(crate) transaction_retry_count: Histogram,
     pub(crate) current_transactions_in_retry: IntGauge,
@@ -72,34 +68,11 @@ impl QuorumDriverMetrics {
                 "Total attempt times of ok response",
                 mysten_metrics::COUNT_BUCKETS.to_vec(),
                 registry,
-            ).unwrap(),
+            )
+            .unwrap(),
             current_requests_in_flight: register_int_gauge_with_registry!(
                 "current_requests_in_flight",
                 "Current number of requests being processed in QuorumDriver",
-                registry,
-            )
-            .unwrap(),
-            total_err_process_tx_responses_with_nonzero_conflicting_transactions: register_int_counter_with_registry!(
-                "quorum_driver_total_err_process_tx_responses_with_nonzero_conflicting_transactions",
-                "Total number of err process_tx responses with non empty conflicting transactions",
-                registry,
-            )
-            .unwrap(),
-            total_attempts_retrying_conflicting_transaction: register_int_counter_with_registry!(
-                "quorum_driver_total_attempts_trying_conflicting_transaction",
-                "Total number of attempts to retry a conflicting transaction",
-                registry,
-            )
-            .unwrap(),
-            total_successful_attempts_retrying_conflicting_transaction: register_int_counter_with_registry!(
-                "quorum_driver_total_successful_attempts_trying_conflicting_transaction",
-                "Total number of successful attempts to retry a conflicting transaction",
-                registry,
-            )
-            .unwrap(),
-            total_times_conflicting_transaction_already_finalized_when_retrying: register_int_counter_with_registry!(
-                "quorum_driver_total_times_conflicting_transaction_already_finalized_when_retrying",
-                "Total number of times the conflicting transaction is already finalized when retrying",
                 registry,
             )
             .unwrap(),
@@ -114,7 +87,8 @@ impl QuorumDriverMetrics {
                 "Histogram of transaction retry count",
                 mysten_metrics::COUNT_BUCKETS.to_vec(),
                 registry,
-            ).unwrap(),
+            )
+            .unwrap(),
             current_transactions_in_retry: register_int_gauge_with_registry!(
                 "current_transactions_in_retry",
                 "Current number of transactions in retry loop in QuorumDriver",

--- a/crates/sui-core/src/quorum_driver/tests.rs
+++ b/crates/sui-core/src/quorum_driver/tests.rs
@@ -294,12 +294,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
     // there are not enough retryable errors to push the original tx or the most staked
     // conflicting tx >= 2f+1 stake. Neither transaction can be retried due to client
     // double spend and this is a fatal error.
-    if let Err(QuorumDriverError::ObjectsDoubleUsed {
-        conflicting_txes,
-        retried_tx_status,
-    }) = res
-    {
-        assert_eq!(retried_tx_status, None);
+    if let Err(QuorumDriverError::ObjectsDoubleUsed { conflicting_txes }) = res {
         assert_eq!(conflicting_txes.len(), 1);
         assert_eq!(conflicting_txes.iter().next().unwrap().0, tx.digest());
     } else {
@@ -334,12 +329,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
         .unwrap()
         .await;
     // Aggregator gets three bad responses, and tries tx, which should succeed.
-    if let Err(QuorumDriverError::ObjectsDoubleUsed {
-        conflicting_txes,
-        retried_tx_status,
-    }) = res
-    {
-        assert_eq!(retried_tx_status, Some((*tx.digest(), true)));
+    if let Err(QuorumDriverError::ObjectsDoubleUsed { conflicting_txes }) = res {
         assert_eq!(conflicting_txes.len(), 1);
         assert_eq!(conflicting_txes.iter().next().unwrap().0, tx.digest());
     } else {
@@ -397,12 +387,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
         .unwrap()
         .await;
 
-    if let Err(QuorumDriverError::ObjectsDoubleUsed {
-        conflicting_txes,
-        retried_tx_status,
-    }) = res
-    {
-        assert_eq!(retried_tx_status, None);
+    if let Err(QuorumDriverError::ObjectsDoubleUsed { conflicting_txes }) = res {
         assert_eq!(conflicting_txes.len(), 2);
         let tx_stake = conflicting_txes.get(tx.digest()).unwrap().1;
         assert!(tx_stake == 2500 || tx_stake == 5000);
@@ -436,12 +421,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
         .unwrap()
         .await;
 
-    if let Err(QuorumDriverError::ObjectsDoubleUsed {
-        conflicting_txes,
-        retried_tx_status,
-    }) = res
-    {
-        assert_eq!(retried_tx_status, None);
+    if let Err(QuorumDriverError::ObjectsDoubleUsed { conflicting_txes }) = res {
         assert_eq!(conflicting_txes.len(), 1);
         assert_eq!(conflicting_txes.get(tx.digest()).unwrap().1, 5000);
     } else {
@@ -505,12 +485,7 @@ async fn test_quorum_driver_object_locked() -> Result<(), anyhow::Error> {
         .unwrap()
         .await;
 
-    if let Err(QuorumDriverError::ObjectsDoubleUsed {
-        conflicting_txes,
-        retried_tx_status,
-    }) = res
-    {
-        assert_eq!(retried_tx_status, None);
+    if let Err(QuorumDriverError::ObjectsDoubleUsed { conflicting_txes }) = res {
         assert!(conflicting_txes.len() == 3 || conflicting_txes.len() == 2);
         assert!(conflicting_txes
             .iter()

--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -421,7 +421,11 @@ mod tests {
                 Error::QuorumDriverError(quorum_driver_error).into();
             let expected_code = expect!["-32002"];
             expected_code.assert_eq(&error_object.code().to_string());
-            let expected_message = expect!["Failed to sign transaction by a quorum of validators because one or more of its objects is reserved for another transaction. Retried transaction 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi (succeeded) because it was able to gather the necessary votes. Other transactions locking these objects:\n- 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi (stake 80.0)\n- 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR (stake 5.0)"];
+            println!("error_object.message() {}", error_object.message());
+            let expected_message = expect![[r#"
+                Failed to sign transaction by a quorum of validators because one or more of its objects is reserved for another transaction. Other transactions locking these objects:
+                - 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi (stake 80.0)
+                - 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR (stake 5.0)"#]];
             expected_message.assert_eq(error_object.message());
             let expected_data = expect![[
                 r#"{"4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]],"8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]]}"#
@@ -457,7 +461,10 @@ mod tests {
                 Error::QuorumDriverError(quorum_driver_error).into();
             let expected_code = expect!["-32002"];
             expected_code.assert_eq(&error_object.code().to_string());
-            let expected_message = expect!["Failed to sign transaction by a quorum of validators because one or more of its objects is equivocated until the next epoch.  Other transactions locking these objects:\n- 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR (stake 50.0)\n- 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi (stake 40.0)"];
+            let expected_message = expect![[r#"
+                Failed to sign transaction by a quorum of validators because one or more of its objects is equivocated until the next epoch. Other transactions locking these objects:
+                - 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR (stake 50.0)
+                - 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi (stake 40.0)"#]];
             expected_message.assert_eq(error_object.message());
             let expected_data = expect![[
                 r#"{"4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]],"8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]]}"#

--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -163,10 +163,7 @@ impl From<Error> for ErrorObjectOwned {
                     | QuorumDriverError::FailedWithTransientErrorAfterMaximumAttempts { .. } => {
                             ErrorObject::owned(TRANSIENT_ERROR_CODE, err.to_string(), None::<()>)
                     }
-                    QuorumDriverError::ObjectsDoubleUsed {
-                        conflicting_txes,
-                        retried_tx_status,
-                    } => {
+                    QuorumDriverError::ObjectsDoubleUsed { conflicting_txes } => {
                         let weights: Vec<u64> =
                             conflicting_txes.values().map(|(_, stake)| *stake).collect();
                         let remaining: u64 = TOTAL_VOTING_POWER - weights.iter().sum::<u64>();
@@ -178,20 +175,8 @@ impl From<Error> for ErrorObjectOwned {
                             "reserved for another transaction"
                         };
 
-                        let retried_info = match retried_tx_status {
-                            Some((digest, success)) => {
-                                format!(
-                                    "Retried transaction {} ({}) because it was able to gather the necessary votes.",
-                                    digest, if success { "succeeded" } else { "failed" }
-                                )
-                            }
-                            None => "".to_string(),
-                        };
-
                         let error_message = format!(
-                            "Failed to sign transaction by a quorum of validators because one or more of its objects is {}. {} Other transactions locking these objects:\n{}",
-                            reason,
-                            retried_info,
+                            "Failed to sign transaction by a quorum of validators because one or more of its objects is {reason}. Other transactions locking these objects:\n{}",
                             conflicting_txes
                                 .iter()
                                 .sorted_by(|(_, (_, a)), (_, (_, b))| b.cmp(a))
@@ -430,10 +415,7 @@ mod tests {
             let authority_name = AuthorityPublicKeyBytes([1; AuthorityPublicKey::LENGTH]);
             conflicting_txes.insert(tx_digest, (vec![(authority_name, object_ref)], stake_unit));
 
-            let quorum_driver_error = QuorumDriverError::ObjectsDoubleUsed {
-                conflicting_txes,
-                retried_tx_status: Some((TransactionDigest::from([1; 32]), true)),
-            };
+            let quorum_driver_error = QuorumDriverError::ObjectsDoubleUsed { conflicting_txes };
 
             let error_object: ErrorObjectOwned =
                 Error::QuorumDriverError(quorum_driver_error).into();
@@ -469,11 +451,7 @@ mod tests {
             let authority_name = AuthorityPublicKeyBytes([1; AuthorityPublicKey::LENGTH]);
             conflicting_txes.insert(tx_digest, (vec![(authority_name, object_ref)], stake_unit));
 
-            let quorum_driver_error = QuorumDriverError::ObjectsDoubleUsed {
-                conflicting_txes,
-                // below threshold
-                retried_tx_status: None,
-            };
+            let quorum_driver_error = QuorumDriverError::ObjectsDoubleUsed { conflicting_txes };
 
             let error_object: ErrorObjectOwned =
                 Error::QuorumDriverError(quorum_driver_error).into();

--- a/crates/sui-rpc-api/src/error.rs
+++ b/crates/sui-rpc-api/src/error.rs
@@ -106,10 +106,7 @@ impl From<sui_types::quorum_driver_types::QuorumDriverError> for RpcServiceError
             QuorumDriverInternalError(err) => {
                 RpcServiceError::new(StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
             }
-            ObjectsDoubleUsed {
-                conflicting_txes,
-                retried_tx_status,
-            } => {
+            ObjectsDoubleUsed { conflicting_txes } => {
                 let new_map = conflicting_txes
                     .into_iter()
                     .map(|(digest, (pairs, _))| {
@@ -121,10 +118,7 @@ impl From<sui_types::quorum_driver_types::QuorumDriverError> for RpcServiceError
                     .collect::<std::collections::BTreeMap<_, Vec<_>>>();
 
                 let message = format!(
-                        "Failed to sign transaction by a quorum of validators because of locked objects. Retried a conflicting transaction {:?}, success: {:?}. Conflicting Transactions:\n{:#?}",
-                        retried_tx_status.map(|(tx, _)| tx),
-                        retried_tx_status.map(|(_, success)| success),
-                        new_map,
+                        "Failed to sign transaction by a quorum of validators because of locked objects. Conflicting Transactions:\n{new_map:#?}",  
                     );
 
                 RpcServiceError::new(StatusCode::CONFLICT, message)

--- a/crates/sui-types/src/quorum_driver_types.rs
+++ b/crates/sui-types/src/quorum_driver_types.rs
@@ -36,14 +36,10 @@ pub enum QuorumDriverError {
     #[error("Invalid user signature: {0}.")]
     InvalidUserSignature(SuiError),
     #[error(
-        "Failed to sign transaction by a quorum of validators because of locked objects: {:?}, retried a conflicting transaction {:?}, success: {:?}",
-        conflicting_txes,
-        .retried_tx_status.map(|(tx, success)| tx),
-        .retried_tx_status.map(|(tx, success)| success),
+        "Failed to sign transaction by a quorum of validators because of locked objects: {conflicting_txes:?}",
     )]
     ObjectsDoubleUsed {
         conflicting_txes: BTreeMap<TransactionDigest, (Vec<(AuthorityName, ObjectRef)>, StakeUnit)>,
-        retried_tx_status: Option<(TransactionDigest, bool)>,
     },
     #[error("Transaction timed out before reaching finality")]
     TimeoutBeforeFinality,


### PR DESCRIPTION
## Description 

The logic in quorum driver to retry conflicting transactions can end up in a situation where it is waiting for responses from all validators which can clog up QD and limit the throughput of our fullnodes. Additionally with `ValidatorTransactionFinalizer` component added recently we no longer need to rely on QD to do this retry of conflicting tx. We still track the conflicting tx digest so that we can return a more useful error to the user in the case that those conflicting tx digests exist.