### PR TITLE
[move] Update versions of toml and toml_edit crates

### DIFF
--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -610,16 +610,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,7 +1785,7 @@ dependencies = [
  "move-vm-types",
  "serde_yaml",
  "tempfile",
- "toml_edit 0.14.4",
+ "toml_edit 0.22.22",
  "walkdir",
 ]
 
@@ -2068,7 +2058,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "toml",
- "toml_edit 0.14.4",
+ "toml_edit 0.22.22",
  "treeline",
  "vfs",
  "walkdir",
@@ -3366,6 +3356,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3851,11 +3850,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
  "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.22",
 ]
 
 [[package]]
@@ -3863,16 +3865,7 @@ name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
-
-[[package]]
-name = "toml_edit"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
 dependencies = [
- "combine",
- "indexmap 1.9.3",
- "itertools",
  "serde",
 ]
 
@@ -3884,7 +3877,20 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.5.0",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap 2.5.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.20",
 ]
 
 [[package]]
@@ -4394,6 +4400,15 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -117,8 +117,8 @@ tera = "1.16.0"
 thiserror = "1.0.24"
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 tokio = { version = "1.18.2", features = ["full"] }
-toml = "0.5.8"
-toml_edit =  { version = "0.14.3", features = ["easy"] }
+toml = "0.8.19"
+toml_edit =  { version = "0.22.22", features = ["serde"] }
 tracing = "0.1.26"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 treeline = "0.1.0"

--- a/external-crates/move/crates/move-package/src/compilation/build_plan.rs
+++ b/external-crates/move/crates/move-package/src/compilation/build_plan.rs
@@ -25,7 +25,7 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
 };
-use toml_edit::{value, Document};
+use toml_edit::{value, DocumentMut};
 use vfs::VfsPath;
 
 use super::{
@@ -273,7 +273,7 @@ impl BuildPlan {
     pub fn record_package_edition(&self, edition: Edition) -> anyhow::Result<()> {
         let move_toml_path = resolve_move_manifest_path(&self.root_package_path());
         let mut toml = std::fs::read_to_string(move_toml_path.clone())?
-            .parse::<Document>()
+            .parse::<DocumentMut>()
             .expect("Failed to read TOML file to update edition");
         toml[PACKAGE_NAME][EDITION_NAME] = value(edition.to_string());
         std::fs::write(move_toml_path, toml.to_string())?;

--- a/external-crates/move/crates/move-package/src/lock_file/schema.rs
+++ b/external-crates/move/crates/move-package/src/lock_file/schema.rs
@@ -249,7 +249,7 @@ pub fn update_dependency_graph(
     use toml_edit::value;
     let mut toml_string = String::new();
     file.read_to_string(&mut toml_string)?;
-    let mut toml = toml_string.parse::<toml_edit::Document>()?;
+    let mut toml = toml_string.parse::<toml_edit::DocumentMut>()?;
     let move_table = toml
         .entry("move")
         .or_insert(Item::Table(toml_edit::Table::new()))
@@ -297,7 +297,7 @@ pub fn update_compiler_toolchain(
 ) -> Result<()> {
     let mut toml_string = String::new();
     file.read_to_string(&mut toml_string)?;
-    let mut toml = toml_string.parse::<toml_edit::Document>()?;
+    let mut toml = toml_string.parse::<toml_edit::DocumentMut>()?;
     let move_table = toml["move"].as_table_mut().ok_or(std::fmt::Error)?;
     let toolchain_version = toml::Value::try_from(ToolchainVersion {
         compiler_version,
@@ -355,10 +355,10 @@ pub enum ManagedAddressUpdate {
 /// for preparing package publishing and package upgrades. Invariant: callers maintain a valid
 /// hex `id`.
 pub fn set_original_id(file: &mut LockFile, environment: &str, id: &str) -> Result<()> {
-    use toml_edit::{value, Document};
+    use toml_edit::{value, DocumentMut};
     let mut toml_string = String::new();
     file.read_to_string(&mut toml_string)?;
-    let mut toml = toml_string.parse::<Document>()?;
+    let mut toml = toml_string.parse::<DocumentMut>()?;
     let env_table = toml
         .get_mut(ENV_TABLE_NAME)
         .and_then(|item| item.as_table_mut())
@@ -382,11 +382,11 @@ pub fn update_managed_address(
     environment: &str,
     managed_address_update: ManagedAddressUpdate,
 ) -> Result<()> {
-    use toml_edit::{value, Document, Table};
+    use toml_edit::{value, DocumentMut, Table};
 
     let mut toml_string = String::new();
     file.read_to_string(&mut toml_string)?;
-    let mut toml = toml_string.parse::<Document>()?;
+    let mut toml = toml_string.parse::<DocumentMut>()?;
 
     let env_table = toml
         .entry(ENV_TABLE_NAME)

--- a/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
@@ -1246,10 +1246,10 @@ impl DependencyGraph {
         for (id, pkg) in &self.package_table {
             writeln!(writer, "\n[[move.package]]")?;
 
-            writeln!(writer, "id = {}", str_escape(id.as_str())?)?;
+            writeln!(writer, "id = {}", str_escape(id.as_str()))?;
             writeln!(writer, "source = {}", PackageTOML(pkg))?;
             if let Some(version) = &pkg.version {
-                writeln!(writer, "version = {}", str_escape(version.as_str())?)?;
+                writeln!(writer, "version = {}", str_escape(version.as_str()))?;
             }
 
             self.write_dependencies_to_lock(*id, &mut writer)?;
@@ -1259,7 +1259,7 @@ impl DependencyGraph {
         let mut dev_dependencies = None;
         let mut packages = None;
         if !writer.is_empty() {
-            let toml = writer.parse::<toml_edit::Document>()?;
+            let toml = writer.parse::<toml_edit::DocumentMut>()?;
             if let Some(value) = toml.get("dependencies").and_then(|v| v.as_value()) {
                 dependencies = Some(value.clone());
             }
@@ -1572,10 +1572,10 @@ impl fmt::Display for Package {
                 subdir,
             }) => {
                 write!(f, "git = ")?;
-                f.write_str(&str_escape(git_url.as_str())?)?;
+                f.write_str(&str_escape(git_url.as_str()))?;
 
                 write!(f, ", rev = ")?;
-                f.write_str(&str_escape(git_rev.as_str())?)?;
+                f.write_str(&str_escape(git_rev.as_str()))?;
 
                 write!(f, ", subdir = ")?;
                 f.write_str(&path_escape(subdir)?)?;
@@ -1583,7 +1583,7 @@ impl fmt::Display for Package {
 
             PM::DependencyKind::OnChain(PM::OnChainInfo { id }) => {
                 write!(f, "id = ")?;
-                f.write_str(&str_escape(id.as_str())?)?;
+                f.write_str(&str_escape(id.as_str()))?;
             }
         }
 
@@ -1628,14 +1628,14 @@ impl<'a> fmt::Display for DependencyTOML<'a> {
         f.write_str("{ ")?;
 
         write!(f, "id = ")?;
-        f.write_str(&str_escape(id.as_str())?)?;
+        f.write_str(&str_escape(id.as_str()))?;
 
         write!(f, ", name = ")?;
-        f.write_str(&str_escape(dep_name.as_str())?)?;
+        f.write_str(&str_escape(dep_name.as_str()))?;
 
         if let Some(digest) = digest {
             write!(f, ", digest = ")?;
-            f.write_str(&str_escape(digest.as_str())?)?;
+            f.write_str(&str_escape(digest.as_str()))?;
         }
 
         if let Some(subst) = subst {
@@ -1655,18 +1655,18 @@ impl<'a> fmt::Display for SubstTOML<'a> {
             addr: &PM::NamedAddress,
             subst: &PM::SubstOrRename,
         ) -> fmt::Result {
-            f.write_str(&str_escape(addr.as_str())?)?;
+            f.write_str(&str_escape(addr.as_str()))?;
             write!(f, " = ")?;
 
             match subst {
                 PM::SubstOrRename::RenameFrom(named) => {
-                    f.write_str(&str_escape(named.as_str())?)?;
+                    f.write_str(&str_escape(named.as_str()))?;
                 }
 
                 PM::SubstOrRename::Assign(account) => {
                     f.write_str(&str_escape(
                         &account.to_canonical_string(/* with_prefix */ false),
-                    )?)?;
+                    ))?;
                 }
             }
 
@@ -1694,13 +1694,13 @@ impl<'a> fmt::Display for SubstTOML<'a> {
 }
 
 /// Escape a string to output in a TOML file.
-fn str_escape(s: &str) -> Result<String, fmt::Error> {
-    toml::to_string(s).map_err(|_| fmt::Error)
+fn str_escape(s: &str) -> String {
+    format!("\"{}\"", s)
 }
 
 /// Escape a path to output in a TOML file.
 fn path_escape(p: &Path) -> Result<String, fmt::Error> {
-    str_escape(p.to_str().ok_or(fmt::Error)?)
+    Ok(str_escape(p.to_str().ok_or(fmt::Error)?))
 }
 
 fn format_deps(

--- a/external-crates/move/crates/move-package/tests/test_sources/conflicting_dependencies/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/conflicting_dependencies/Move.resolved
@@ -1,1 +1,6 @@
-Unable to parse Move package manifest: duplicate key: `OtherDep` for key `dependencies` at line 4 column 1
+Unable to parse Move package manifest: TOML parse error at line 6, column 1
+  |
+6 | OtherDep = { local = "./deps_only/different_dep" }
+  | ^
+duplicate key `OtherDep` in table `dependencies`
+

--- a/external-crates/move/crates/move-package/tests/test_sources/external_broken/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_broken/Move.resolved
@@ -1,1 +1,6 @@
-Failed to resolve dependencies for package 'Root': Parsing response from '../resolvers/broken.sh' for dependency 'A' of package 'Root': Deserializing packages: expected an equals, found an identifier at line 1 column 8
+Failed to resolve dependencies for package 'Root': Parsing response from '../resolvers/broken.sh' for dependency 'A' of package 'Root': Deserializing packages: TOML parse error at line 1, column 8
+  |
+1 | Broken response (not a lock file) from resolver for dependencies of A.
+  |        ^
+expected `.`, `=`
+

--- a/external-crates/move/crates/move-package/tests/test_sources/external_resolver_invalid_resolver/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_resolver_invalid_resolver/Move.resolved
@@ -1,3 +1,1 @@
-Error parsing '[dependencies]' section of manifest: Malformed external resolver declaration for dependency r.baz = "quz"
-foo = "bar"
-
+Error parsing '[dependencies]' section of manifest: Malformed external resolver declaration for dependency r.{ baz = "quz", foo = "bar" }

--- a/external-crates/move/crates/move-package/tests/test_sources/external_resolver_invalid_resolver_invalid_target/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_resolver_invalid_resolver_invalid_target/Move.resolved
@@ -1,3 +1,1 @@
-Error parsing '[dependencies]' section of manifest: Malformed external resolver declaration for dependency r.[foo]
-bar = "baz"
-
+Error parsing '[dependencies]' section of manifest: Malformed external resolver declaration for dependency r.{ foo = { bar = "baz" } }

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_duplicate_address_names/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_duplicate_address_names/Move.resolved
@@ -1,1 +1,6 @@
-Unable to parse Move package manifest: duplicate key: `a` for key `addresses` at line 4 column 1
+Unable to parse Move package manifest: TOML parse error at line 6, column 1
+  |
+6 | a = "0x2"
+  | ^
+duplicate key `a` in table `addresses`
+

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_duplicate_top_level_field/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_duplicate_top_level_field/Move.resolved
@@ -1,1 +1,7 @@
-Unable to parse Move package manifest: redefinition of table `package` for key `package` at line 4 column 1
+Unable to parse Move package manifest: TOML parse error at line 4, column 1
+  |
+4 | [package]
+  | ^
+invalid table header
+duplicate key `package` in document root
+

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_non_string_address_name/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_non_string_address_name/Move.resolved
@@ -1,2 +1,1 @@
-Error parsing '[addresses]' section of manifest: Invalid address name b = "0x1"
- encountered. Expected a string but found a table
+Error parsing '[addresses]' section of manifest: Invalid address name { b = "0x1" } encountered. Expected a string but found a table

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_too_many_entries_renaming_instantiation/Move.resolved
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_too_many_entries_renaming_instantiation/Move.resolved
@@ -1,3 +1,1 @@
-Error parsing '[dependencies]' section of manifest: Malformed dependency substitution B = "0x1"
-R = "0x2"
-. Expected a string, but encountered a table
+Error parsing '[dependencies]' section of manifest: Malformed dependency substitution { B = "0x1", R = "0x2" }. Expected a string, but encountered a table


### PR DESCRIPTION
## Description 

Update the versions for `toml` and `toml_edit` crates in anticipation for adding source spans. 

## Test plan 

Existing tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: `Move.toml` parsing errors format has changed slightly. 
- [ ] Rust SDK:
- [ ] REST API:
