### PR TITLE
[gql] Increase EPOCH_DURATION_MS to reduce tests interacting with reconfiguration

### DIFF
--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -32,7 +32,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 const VALIDATOR_COUNT: usize = 4;
-const EPOCH_DURATION_MS: u64 = 30000;
+/// Set default epoch duration to 300s. This high value is to turn the TestCluster into a lockstep
+/// network of sorts. Tests should call `trigger_reconfiguration` to advance the network's epoch.
+const EPOCH_DURATION_MS: u64 = 300_000;
 
 const ACCOUNT_NUM: usize = 20;
 const GAS_OBJECT_COUNT: usize = 3;

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -32,7 +32,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 const VALIDATOR_COUNT: usize = 4;
-const EPOCH_DURATION_MS: u64 = 10000;
+const EPOCH_DURATION_MS: u64 = 30000;
 
 const ACCOUNT_NUM: usize = 20;
 const GAS_OBJECT_COUNT: usize = 3;

--- a/crates/sui-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-graphql-rpc/tests/e2e_tests.rs
@@ -391,6 +391,7 @@ async fn test_zklogin_sig_verify() {
     let cluster = start_cluster(ServiceConfig::test_defaults()).await;
 
     let test_cluster = &cluster.network.validator_fullnode_handle;
+    test_cluster.trigger_reconfiguration().await;
     test_cluster.wait_for_epoch_all_nodes(1).await;
     test_cluster.wait_for_authenticator_state_update().await;
 

--- a/crates/sui-mvr-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-mvr-graphql-rpc/src/test_infra/cluster.rs
@@ -32,7 +32,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 const VALIDATOR_COUNT: usize = 4;
-const EPOCH_DURATION_MS: u64 = 10000;
+const EPOCH_DURATION_MS: u64 = 30_000;
 
 const ACCOUNT_NUM: usize = 20;
 const GAS_OBJECT_COUNT: usize = 3;

--- a/crates/sui-mvr-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-mvr-graphql-rpc/src/test_infra/cluster.rs
@@ -32,7 +32,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 const VALIDATOR_COUNT: usize = 4;
-const EPOCH_DURATION_MS: u64 = 30_000;
+/// Set default epoch duration to 300s. This high value is to turn the TestCluster into a lockstep
+/// network of sorts. Tests should call `trigger_reconfiguration` to advance the network's epoch.
+const EPOCH_DURATION_MS: u64 = 300_000;
 
 const ACCOUNT_NUM: usize = 20;
 const GAS_OBJECT_COUNT: usize = 3;

--- a/crates/sui-mvr-graphql-rpc/tests/e2e_tests.rs
+++ b/crates/sui-mvr-graphql-rpc/tests/e2e_tests.rs
@@ -290,6 +290,7 @@ async fn test_zklogin_sig_verify() {
     let cluster = start_cluster(ServiceConfig::test_defaults()).await;
 
     let test_cluster = &cluster.network.validator_fullnode_handle;
+    test_cluster.trigger_reconfiguration().await;
     test_cluster.wait_for_epoch_all_nodes(1).await;
     test_cluster.wait_for_authenticator_state_update().await;
 


### PR DESCRIPTION
## Description 

When we submit a transaction to the test cluster while the nodes are reconfiguring for the new epoch, they will likely time out, causing several tests to frequently flake out.

## Test plan 

Flakey tests pass without multiple retries

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] Indexer: 
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] REST API:
