### PR TITLE
Stabilize MVP of the new Fullnode gRPC api

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -63,8 +63,6 @@ pub struct NodeConfig {
     #[serde(default = "default_json_rpc_address")]
     pub json_rpc_address: SocketAddr,
 
-    #[serde(default)]
-    pub enable_experimental_rest_api: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rpc: Option<sui_rpc_api::Config>,
 

--- a/crates/sui-e2e-tests/tests/rpc/checkpoints.rs
+++ b/crates/sui-e2e-tests/tests/rpc/checkpoints.rs
@@ -5,10 +5,14 @@ use sui_macros::sim_test;
 use sui_rpc_api::client::sdk::Client;
 use sui_rpc_api::client::Client as CoreClient;
 use sui_rpc_api::proto::node::node_client::NodeClient;
-use sui_rpc_api::proto::node::{GetCheckpointOptions, GetCheckpointRequest, GetCheckpointResponse};
+use sui_rpc_api::proto::node::{
+    FullCheckpointObject, FullCheckpointTransaction, GetCheckpointOptions, GetCheckpointRequest,
+    GetCheckpointResponse, GetFullCheckpointOptions, GetFullCheckpointRequest,
+    GetFullCheckpointResponse,
+};
 use test_cluster::TestClusterBuilder;
 
-use crate::transfer_coin;
+use crate::{stake_with_validator, transfer_coin};
 
 #[sim_test]
 async fn list_checkpoint() {
@@ -162,7 +166,7 @@ async fn get_checkpoint() {
 async fn get_full_checkpoint() {
     let test_cluster = TestClusterBuilder::new().build().await;
 
-    let _transaction_digest = transfer_coin(&test_cluster.wallet).await;
+    let transaction_digest = stake_with_validator(&test_cluster).await;
 
     let client = Client::new(test_cluster.rpc_url()).unwrap();
     let core_client = CoreClient::new(test_cluster.rpc_url()).unwrap();
@@ -172,4 +176,244 @@ async fn get_full_checkpoint() {
         .get_full_checkpoint(latest.checkpoint.sequence_number)
         .await
         .unwrap();
+
+    let mut grpc_client = NodeClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
+
+    // A Checkpoint that we know has a transaction that emitted an event
+    let checkpoint = grpc_client
+        .get_transaction(sui_rpc_api::proto::node::GetTransactionRequest::new(
+            transaction_digest,
+        ))
+        .await
+        .unwrap()
+        .into_inner()
+        .checkpoint
+        .unwrap();
+
+    // Request default fields
+    let GetFullCheckpointResponse {
+        sequence_number,
+        digest,
+        summary,
+        summary_bcs,
+        signature,
+        contents,
+        contents_bcs,
+        transactions,
+    } = grpc_client
+        .get_full_checkpoint(GetFullCheckpointRequest::by_sequence_number(checkpoint))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(sequence_number.is_some());
+    assert!(digest.is_some());
+    assert!(summary.is_some());
+    assert!(summary_bcs.is_none());
+    assert!(signature.is_some());
+    assert!(contents.is_none());
+    assert!(contents_bcs.is_none());
+
+    let mut found_transaction = false;
+    for FullCheckpointTransaction {
+        digest,
+        transaction,
+        transaction_bcs,
+        effects,
+        effects_bcs,
+        events,
+        events_bcs,
+        input_objects,
+        output_objects,
+    } in transactions
+    {
+        assert!(digest.is_some());
+        assert!(transaction.is_some());
+        assert!(transaction_bcs.is_none());
+        assert!(effects.is_some());
+        assert!(effects_bcs.is_none());
+        if digest == Some(transaction_digest.into()) {
+            found_transaction = true;
+            assert!(events.is_some());
+        }
+        assert!(events_bcs.is_none());
+        assert!(input_objects.is_none());
+        assert!(output_objects.is_none());
+    }
+    // Ensure we found the transaction we used for picking the checkpoint to test against
+    assert!(found_transaction);
+
+    // Request no fields
+    let GetFullCheckpointResponse {
+        sequence_number,
+        digest,
+        summary,
+        summary_bcs,
+        signature,
+        contents,
+        contents_bcs,
+        transactions,
+    } = grpc_client
+        .get_full_checkpoint(
+            GetFullCheckpointRequest::by_sequence_number(checkpoint)
+                .with_options(GetFullCheckpointOptions::none()),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(sequence_number.is_some());
+    assert!(digest.is_some());
+    assert!(summary.is_none());
+    assert!(summary_bcs.is_none());
+    assert!(signature.is_none());
+    assert!(contents.is_none());
+    assert!(contents_bcs.is_none());
+
+    let mut found_transaction = false;
+    for FullCheckpointTransaction {
+        digest,
+        transaction,
+        transaction_bcs,
+        effects,
+        effects_bcs,
+        events,
+        events_bcs,
+        input_objects,
+        output_objects,
+    } in transactions
+    {
+        assert!(digest.is_some());
+        assert!(transaction.is_none());
+        assert!(transaction_bcs.is_none());
+        assert!(effects.is_none());
+        assert!(effects_bcs.is_none());
+        if digest == Some(transaction_digest.into()) {
+            found_transaction = true;
+        }
+        assert!(events.is_none());
+        assert!(events_bcs.is_none());
+        assert!(input_objects.is_none());
+        assert!(output_objects.is_none());
+    }
+    // Ensure we found the transaction we used for picking the checkpoint to test against
+    assert!(found_transaction);
+
+    // Request all fields
+    let response = grpc_client
+        .get_full_checkpoint(
+            GetFullCheckpointRequest::by_sequence_number(checkpoint)
+                .with_options(GetFullCheckpointOptions::all()),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+    let GetFullCheckpointResponse {
+        sequence_number,
+        digest,
+        summary,
+        summary_bcs,
+        signature,
+        contents,
+        contents_bcs,
+        transactions,
+    } = &response;
+
+    assert!(sequence_number.is_some());
+    assert!(digest.is_some());
+    assert!(summary.is_some());
+    assert!(summary_bcs.is_some());
+    assert!(signature.is_some());
+    assert!(contents.is_some());
+    assert!(contents_bcs.is_some());
+
+    let mut found_transaction = false;
+    for FullCheckpointTransaction {
+        digest,
+        transaction,
+        transaction_bcs,
+        effects,
+        effects_bcs,
+        events,
+        events_bcs,
+        input_objects,
+        output_objects,
+    } in transactions
+    {
+        assert!(digest.is_some());
+        assert!(transaction.is_some());
+        assert!(transaction_bcs.is_some());
+        assert!(effects.is_some());
+        assert!(effects_bcs.is_some());
+        if digest == &Some(transaction_digest.into()) {
+            found_transaction = true;
+            assert!(events.is_some());
+            assert!(events_bcs.is_some());
+        }
+        assert!(input_objects.is_some());
+        assert!(output_objects.is_some());
+
+        for FullCheckpointObject {
+            object_id,
+            version,
+            digest,
+            object,
+            object_bcs,
+        } in input_objects
+            .iter()
+            .flat_map(|objects| objects.objects.iter())
+            .chain(
+                output_objects
+                    .iter()
+                    .flat_map(|objects| objects.objects.iter()),
+            )
+        {
+            assert!(object_id.is_some());
+            assert!(version.is_some());
+            assert!(digest.is_some());
+            assert!(object.is_some());
+            assert!(object_bcs.is_some());
+        }
+    }
+    // Ensure we found the transaction we used for picking the checkpoint to test against
+    assert!(found_transaction);
+
+    // ensure we can convert proto GetFullCheckpointResponse type to rust CheckpointData
+    sui_rpc_api::types::FullCheckpointResponse::try_from(&response).unwrap();
+
+    // Request by digest
+    let response = grpc_client
+        .get_full_checkpoint(
+            GetFullCheckpointRequest::by_digest(digest.clone().unwrap())
+                .with_options(GetFullCheckpointOptions::none()),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(response.digest, digest.to_owned());
+
+    // Request by sequence_number
+    let response = grpc_client
+        .get_full_checkpoint(
+            GetFullCheckpointRequest::by_sequence_number(sequence_number.unwrap())
+                .with_options(GetFullCheckpointOptions::none()),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(response.sequence_number, sequence_number.to_owned());
+    assert_eq!(response.digest, digest.to_owned());
+
+    // Request by digest and sequence_number results in an error
+    grpc_client
+        .get_full_checkpoint(GetFullCheckpointRequest {
+            sequence_number: Some(sequence_number.unwrap()),
+            digest: Some(digest.clone().unwrap()),
+            options: None,
+        })
+        .await
+        .unwrap_err();
 }

--- a/crates/sui-e2e-tests/tests/rpc/checkpoints.rs
+++ b/crates/sui-e2e-tests/tests/rpc/checkpoints.rs
@@ -4,6 +4,8 @@
 use sui_macros::sim_test;
 use sui_rpc_api::client::sdk::Client;
 use sui_rpc_api::client::Client as CoreClient;
+use sui_rpc_api::proto::node::node_client::NodeClient;
+use sui_rpc_api::proto::node::{GetCheckpointOptions, GetCheckpointRequest, GetCheckpointResponse};
 use test_cluster::TestClusterBuilder;
 
 use crate::transfer_coin;
@@ -43,6 +45,117 @@ async fn get_checkpoint() {
         .get_checkpoint(latest.checkpoint.sequence_number)
         .await
         .unwrap();
+
+    let mut grpc_client = NodeClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
+
+    // Request default fields
+    let GetCheckpointResponse {
+        sequence_number,
+        digest,
+        summary,
+        summary_bcs,
+        signature,
+        contents,
+        contents_bcs,
+    } = grpc_client
+        .get_checkpoint(GetCheckpointRequest::latest())
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(sequence_number.is_some());
+    assert!(digest.is_some());
+    assert!(summary.is_some());
+    assert!(summary_bcs.is_none());
+    assert!(signature.is_some());
+    assert!(contents.is_none());
+    assert!(contents_bcs.is_none());
+
+    // Request no fields
+    let GetCheckpointResponse {
+        sequence_number,
+        digest,
+        summary,
+        summary_bcs,
+        signature,
+        contents,
+        contents_bcs,
+    } = grpc_client
+        .get_checkpoint(GetCheckpointRequest::latest().with_options(GetCheckpointOptions::none()))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(sequence_number.is_some());
+    assert!(digest.is_some());
+    assert!(summary.is_none());
+    assert!(summary_bcs.is_none());
+    assert!(signature.is_none());
+    assert!(contents.is_none());
+    assert!(contents_bcs.is_none());
+
+    // Request all fields
+    let response = grpc_client
+        .get_checkpoint(GetCheckpointRequest::latest().with_options(GetCheckpointOptions::all()))
+        .await
+        .unwrap()
+        .into_inner();
+
+    let GetCheckpointResponse {
+        sequence_number,
+        digest,
+        summary,
+        summary_bcs,
+        signature,
+        contents,
+        contents_bcs,
+    } = &response;
+
+    assert!(sequence_number.is_some());
+    assert!(digest.is_some());
+    assert!(summary.is_some());
+    assert!(summary_bcs.is_some());
+    assert!(signature.is_some());
+    assert!(contents.is_some());
+    assert!(contents_bcs.is_some());
+
+    // ensure we can convert proto GetCheckpointResponse type to rust CheckpointResponse
+    sui_rpc_api::types::CheckpointResponse::try_from(&response).unwrap();
+
+    // Request by digest
+    let response = grpc_client
+        .get_checkpoint(
+            GetCheckpointRequest::by_digest(digest.clone().unwrap())
+                .with_options(GetCheckpointOptions::none()),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(response.digest, digest.to_owned());
+
+    // Request by sequence_number
+    let response = grpc_client
+        .get_checkpoint(
+            GetCheckpointRequest::by_sequence_number(sequence_number.unwrap())
+                .with_options(GetCheckpointOptions::none()),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(response.sequence_number, sequence_number.to_owned());
+    assert_eq!(response.digest, digest.to_owned());
+
+    // Request by digest and sequence_number results in an error
+    grpc_client
+        .get_checkpoint(GetCheckpointRequest {
+            sequence_number: Some(sequence_number.unwrap()),
+            digest: Some(digest.clone().unwrap()),
+            options: None,
+        })
+        .await
+        .unwrap_err();
 }
 
 #[sim_test]

--- a/crates/sui-e2e-tests/tests/rpc/checkpoints.rs
+++ b/crates/sui-e2e-tests/tests/rpc/checkpoints.rs
@@ -71,9 +71,9 @@ async fn get_checkpoint() {
 
     assert!(sequence_number.is_some());
     assert!(digest.is_some());
-    assert!(summary.is_some());
+    assert!(summary.is_none());
     assert!(summary_bcs.is_none());
-    assert!(signature.is_some());
+    assert!(signature.is_none());
     assert!(contents.is_none());
     assert!(contents_bcs.is_none());
 
@@ -210,9 +210,9 @@ async fn get_full_checkpoint() {
 
     assert!(sequence_number.is_some());
     assert!(digest.is_some());
-    assert!(summary.is_some());
+    assert!(summary.is_none());
     assert!(summary_bcs.is_none());
-    assert!(signature.is_some());
+    assert!(signature.is_none());
     assert!(contents.is_none());
     assert!(contents_bcs.is_none());
 
@@ -230,14 +230,14 @@ async fn get_full_checkpoint() {
     } in transactions
     {
         assert!(digest.is_some());
-        assert!(transaction.is_some());
+        assert!(transaction.is_none());
         assert!(transaction_bcs.is_none());
-        assert!(effects.is_some());
+        assert!(effects.is_none());
         assert!(effects_bcs.is_none());
         if digest == Some(transaction_digest.into()) {
             found_transaction = true;
-            assert!(events.is_some());
         }
+        assert!(events.is_none());
         assert!(events_bcs.is_none());
         assert!(input_objects.is_none());
         assert!(output_objects.is_none());

--- a/crates/sui-e2e-tests/tests/rpc/committee.rs
+++ b/crates/sui-e2e-tests/tests/rpc/committee.rs
@@ -3,6 +3,8 @@
 
 use sui_macros::sim_test;
 use sui_rpc_api::client::sdk::Client;
+use sui_rpc_api::proto::node::node_client::NodeClient;
+use sui_rpc_api::proto::node::GetCommitteeRequest;
 use test_cluster::TestClusterBuilder;
 
 #[sim_test]
@@ -10,7 +12,31 @@ async fn get_committee() {
     let test_cluster = TestClusterBuilder::new().build().await;
 
     let client = Client::new(test_cluster.rpc_url()).unwrap();
+    let mut grpc_client = NodeClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
 
     let _committee = client.get_committee(0).await.unwrap();
     let _committee = client.get_current_committee().await.unwrap();
+
+    let latest_committee = grpc_client
+        .get_committee(GetCommitteeRequest { epoch: None })
+        .await
+        .unwrap()
+        .into_inner()
+        .committee
+        .unwrap();
+
+    let epoch_0_committee = grpc_client
+        .get_committee(GetCommitteeRequest { epoch: Some(0) })
+        .await
+        .unwrap()
+        .into_inner()
+        .committee
+        .unwrap();
+
+    assert_eq!(latest_committee, epoch_0_committee);
+
+    // ensure we can convert proto committee type to sdk_types committee
+    sui_sdk_types::types::ValidatorCommittee::try_from(&latest_committee).unwrap();
 }

--- a/crates/sui-e2e-tests/tests/rpc/main.rs
+++ b/crates/sui-e2e-tests/tests/rpc/main.rs
@@ -26,3 +26,22 @@ async fn transfer_coin(
     let resp = context.execute_transaction_must_succeed(txn).await;
     resp.digest.into()
 }
+
+async fn stake_with_validator(
+    cluster: &test_cluster::TestCluster,
+) -> sui_sdk_types::types::TransactionDigest {
+    let context = &cluster.wallet;
+    let gas_price = context.get_reference_gas_price().await.unwrap();
+    let accounts_and_objs = context.get_all_accounts_and_gas_objects().await.unwrap();
+    let sender = accounts_and_objs[0].0;
+    let gas_object = accounts_and_objs[0].1[0];
+    let coin_to_stake = accounts_and_objs[0].1[1];
+    let validator_address = cluster.swarm.config().validator_configs()[0].sui_address();
+    let txn = context.sign_transaction(
+        &sui_test_transaction_builder::TestTransactionBuilder::new(sender, gas_object, gas_price)
+            .call_staking(coin_to_stake, validator_address)
+            .build(),
+    );
+    let resp = context.execute_transaction_must_succeed(txn).await;
+    resp.digest.into()
+}

--- a/crates/sui-e2e-tests/tests/rpc/main.rs
+++ b/crates/sui-e2e-tests/tests/rpc/main.rs
@@ -4,6 +4,7 @@
 mod checkpoints;
 mod committee;
 mod execute;
+mod node_info;
 mod objects;
 mod resolve;
 mod transactions;

--- a/crates/sui-e2e-tests/tests/rpc/node_info.rs
+++ b/crates/sui-e2e-tests/tests/rpc/node_info.rs
@@ -1,0 +1,36 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_macros::sim_test;
+use sui_rpc_api::proto::node::node_client::NodeClient;
+use sui_rpc_api::proto::node::GetNodeInfoResponse;
+use test_cluster::TestClusterBuilder;
+
+#[sim_test]
+async fn get_node_info() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+
+    let mut grpc_client = NodeClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
+
+    let GetNodeInfoResponse {
+        chain_id,
+        chain,
+        epoch,
+        checkpoint_height,
+        timestamp,
+        lowest_available_checkpoint,
+        lowest_available_checkpoint_objects,
+        software_version,
+    } = grpc_client.get_node_info(()).await.unwrap().into_inner();
+
+    assert!(chain_id.is_some());
+    assert!(chain.is_some());
+    assert!(epoch.is_some());
+    assert!(checkpoint_height.is_some());
+    assert!(timestamp.is_some());
+    assert!(lowest_available_checkpoint.is_some());
+    assert!(lowest_available_checkpoint_objects.is_some());
+    assert!(software_version.is_some());
+}

--- a/crates/sui-e2e-tests/tests/rpc/objects.rs
+++ b/crates/sui-e2e-tests/tests/rpc/objects.rs
@@ -4,27 +4,96 @@
 use sui_macros::sim_test;
 use sui_rpc_api::client::sdk::Client;
 use sui_rpc_api::client::Client as CoreClient;
+use sui_rpc_api::proto::node::node_client::NodeClient;
+use sui_rpc_api::proto::node::GetObjectOptions;
+use sui_rpc_api::proto::node::GetObjectRequest;
+use sui_rpc_api::proto::node::GetObjectResponse;
+use sui_sdk_types::types::ObjectId;
 use test_cluster::TestClusterBuilder;
 
 #[sim_test]
 async fn get_object() {
     let test_cluster = TestClusterBuilder::new().build().await;
 
+    let id: ObjectId = "0x5".parse().unwrap();
+
     let client = Client::new(test_cluster.rpc_url()).unwrap();
     let core_client = CoreClient::new(test_cluster.rpc_url()).unwrap();
-
-    let _object = client.get_object("0x5".parse().unwrap()).await.unwrap();
-    let _object = core_client
-        .get_object("0x5".parse().unwrap())
+    let mut grpc_client = NodeClient::connect(test_cluster.rpc_url().to_owned())
         .await
         .unwrap();
 
-    let _object = client
-        .get_object_with_version("0x5".parse().unwrap(), 1)
-        .await
-        .unwrap();
+    let _object = client.get_object(id).await.unwrap();
+    let _object = core_client.get_object(id.into()).await.unwrap();
+
+    let _object = client.get_object_with_version(id, 1).await.unwrap();
     let _object = core_client
-        .get_object_with_version("0x5".parse().unwrap(), 1.into())
+        .get_object_with_version(id.into(), 1.into())
         .await
         .unwrap();
+
+    let GetObjectResponse {
+        object_id,
+        version,
+        digest,
+        object,
+        object_bcs,
+    } = grpc_client
+        .get_object(GetObjectRequest::new(id))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(object_id, Some(id.into()));
+    assert!(version.is_some());
+    assert!(digest.is_some());
+    assert!(object.is_some());
+    assert!(object_bcs.is_none()); // By default object_bcs isn't returned
+
+    let GetObjectResponse {
+        object_id,
+        version,
+        digest,
+        object,
+        object_bcs,
+    } = grpc_client
+        .get_object(
+            GetObjectRequest::new(id)
+                .with_version(1)
+                .with_options(GetObjectOptions::none()),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(object_id, Some(id.into()));
+    assert_eq!(version, Some(1));
+    assert!(digest.is_some());
+
+    // These fields were not requested
+    assert!(object.is_none());
+    assert!(object_bcs.is_none());
+
+    let response = grpc_client
+        .get_object(GetObjectRequest::new(id).with_options(GetObjectOptions::all()))
+        .await
+        .unwrap()
+        .into_inner();
+
+    let GetObjectResponse {
+        object_id,
+        version,
+        digest,
+        object,
+        object_bcs,
+    } = &response;
+
+    assert!(object_id.is_some());
+    assert!(version.is_some());
+    assert!(digest.is_some());
+    assert!(object.is_some());
+    assert!(object_bcs.is_some());
+
+    // ensure we can convert proto ObjectResponse type to rust ObjectResponse
+    sui_rpc_api::types::ObjectResponse::try_from(&response).unwrap();
 }

--- a/crates/sui-e2e-tests/tests/rpc/objects.rs
+++ b/crates/sui-e2e-tests/tests/rpc/objects.rs
@@ -47,7 +47,7 @@ async fn get_object() {
     assert_eq!(object_id, Some(id.into()));
     assert!(version.is_some());
     assert!(digest.is_some());
-    assert!(object.is_some());
+    assert!(object.is_none());
     assert!(object_bcs.is_none()); // By default object_bcs isn't returned
 
     let GetObjectResponse {

--- a/crates/sui-e2e-tests/tests/rpc/transactions.rs
+++ b/crates/sui-e2e-tests/tests/rpc/transactions.rs
@@ -46,13 +46,13 @@ async fn get_transaction() {
         .into_inner();
 
     assert!(digest.is_some());
-    assert!(transaction.is_some());
+    assert!(transaction.is_none());
     assert!(transaction_bcs.is_none());
-    assert!(signatures.is_some());
+    assert!(signatures.is_none());
     assert!(signatures_bytes.is_none());
-    assert!(effects.is_some());
+    assert!(effects.is_none());
     assert!(effects_bcs.is_none());
-    assert!(events.is_some());
+    assert!(events.is_none());
     assert!(events_bcs.is_none());
     assert!(checkpoint.is_some());
     assert!(timestamp.is_some());

--- a/crates/sui-e2e-tests/tests/rpc/transactions.rs
+++ b/crates/sui-e2e-tests/tests/rpc/transactions.rs
@@ -3,24 +3,136 @@
 
 use sui_macros::sim_test;
 use sui_rpc_api::client::sdk::Client;
+use sui_rpc_api::proto::node::node_client::NodeClient;
+use sui_rpc_api::proto::node::{
+    GetTransactionOptions, GetTransactionRequest, GetTransactionResponse,
+};
 use sui_rpc_api::rest::transactions::ListTransactionsCursorParameters;
 use test_cluster::TestClusterBuilder;
 
-use crate::transfer_coin;
+use crate::{stake_with_validator, transfer_coin};
 
 #[sim_test]
 async fn get_transaction() {
     let test_cluster = TestClusterBuilder::new().build().await;
 
-    let transaction_digest = transfer_coin(&test_cluster.wallet).await;
+    let transaction_digest = stake_with_validator(&test_cluster).await;
 
     let client = Client::new(test_cluster.rpc_url()).unwrap();
 
     let _transaction = client.get_transaction(&transaction_digest).await.unwrap();
+
+    let mut grpc_client = NodeClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
+
+    // Request default fields
+    let GetTransactionResponse {
+        digest,
+        transaction,
+        transaction_bcs,
+        signatures,
+        signatures_bytes,
+        effects,
+        effects_bcs,
+        events,
+        events_bcs,
+        checkpoint,
+        timestamp,
+    } = grpc_client
+        .get_transaction(GetTransactionRequest::new(transaction_digest))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(digest.is_some());
+    assert!(transaction.is_some());
+    assert!(transaction_bcs.is_none());
+    assert!(signatures.is_some());
+    assert!(signatures_bytes.is_none());
+    assert!(effects.is_some());
+    assert!(effects_bcs.is_none());
+    assert!(events.is_some());
+    assert!(events_bcs.is_none());
+    assert!(checkpoint.is_some());
+    assert!(timestamp.is_some());
+
+    // Request no fields
+    let GetTransactionResponse {
+        digest,
+        transaction,
+        transaction_bcs,
+        signatures,
+        signatures_bytes,
+        effects,
+        effects_bcs,
+        events,
+        events_bcs,
+        checkpoint,
+        timestamp,
+    } = grpc_client
+        .get_transaction(
+            GetTransactionRequest::new(transaction_digest)
+                .with_options(GetTransactionOptions::none()),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(digest.is_some());
+    assert!(transaction.is_none());
+    assert!(transaction_bcs.is_none());
+    assert!(signatures.is_none());
+    assert!(signatures_bytes.is_none());
+    assert!(effects.is_none());
+    assert!(effects_bcs.is_none());
+    assert!(events.is_none());
+    assert!(events_bcs.is_none());
+    assert!(checkpoint.is_some());
+    assert!(timestamp.is_some());
+
+    // Request all fields
+    let response = grpc_client
+        .get_transaction(
+            GetTransactionRequest::new(transaction_digest)
+                .with_options(GetTransactionOptions::all()),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+
+    let GetTransactionResponse {
+        digest,
+        transaction,
+        transaction_bcs,
+        signatures,
+        signatures_bytes,
+        effects,
+        effects_bcs,
+        events,
+        events_bcs,
+        checkpoint,
+        timestamp,
+    } = &response;
+
+    assert!(digest.is_some());
+    assert!(transaction.is_some());
+    assert!(transaction_bcs.is_some());
+    assert!(signatures.is_some());
+    assert!(signatures_bytes.is_some());
+    assert!(effects.is_some());
+    assert!(effects_bcs.is_some());
+    assert!(events.is_some());
+    assert!(events_bcs.is_some());
+    assert!(checkpoint.is_some());
+    assert!(timestamp.is_some());
+
+    // ensure we can convert proto GetTransactionResponse type to rust TransactionResponse
+    sui_rpc_api::types::TransactionResponse::try_from(&response).unwrap();
 }
 
 #[sim_test]
-async fn list_checkpoint() {
+async fn list_transactions() {
     let test_cluster = TestClusterBuilder::new().build().await;
 
     let _transaction_digest = transfer_coin(&test_cluster.wallet).await;

--- a/crates/sui-rpc-api/openapi/openapi.json
+++ b/crates/sui-rpc-api/openapi/openapi.json
@@ -117,9 +117,9 @@
           {
             "in": "query",
             "name": "signature",
-            "description": "Request `ValidatorAggregatedSignature` be included in the response\n\nDefaults to `true` if not provided.",
+            "description": "Request `ValidatorAggregatedSignature` be included in the response\n\nDefaults to `false` if not provided.",
             "schema": {
-              "description": "Request `ValidatorAggregatedSignature` be included in the response\n\nDefaults to `true` if not provided.",
+              "description": "Request `ValidatorAggregatedSignature` be included in the response\n\nDefaults to `false` if not provided.",
               "type": "boolean"
             },
             "style": "form"
@@ -127,9 +127,9 @@
           {
             "in": "query",
             "name": "summary",
-            "description": "Request `CheckpointSummary` be included in the response\n\nDefaults to `true` if not provided.",
+            "description": "Request `CheckpointSummary` be included in the response\n\nDefaults to `false` if not provided.",
             "schema": {
-              "description": "Request `CheckpointSummary` be included in the response\n\nDefaults to `true` if not provided.",
+              "description": "Request `CheckpointSummary` be included in the response\n\nDefaults to `false` if not provided.",
               "type": "boolean"
             },
             "style": "form"
@@ -249,9 +249,9 @@
           {
             "in": "query",
             "name": "object",
-            "description": "Request that `Object` be included in the response\n\nDefaults to `true` if not provided.",
+            "description": "Request that `Object` be included in the response\n\nDefaults to `false` if not provided.",
             "schema": {
-              "description": "Request that `Object` be included in the response\n\nDefaults to `true` if not provided.",
+              "description": "Request that `Object` be included in the response\n\nDefaults to `false` if not provided.",
               "type": "boolean"
             },
             "style": "form"
@@ -315,9 +315,9 @@
           {
             "in": "query",
             "name": "object",
-            "description": "Request that `Object` be included in the response\n\nDefaults to `true` if not provided.",
+            "description": "Request that `Object` be included in the response\n\nDefaults to `false` if not provided.",
             "schema": {
-              "description": "Request that `Object` be included in the response\n\nDefaults to `true` if not provided.",
+              "description": "Request that `Object` be included in the response\n\nDefaults to `false` if not provided.",
               "type": "boolean"
             },
             "style": "form"
@@ -480,9 +480,9 @@
           {
             "in": "query",
             "name": "signature",
-            "description": "Request `ValidatorAggregatedSignature` be included in the response\n\nDefaults to `true` if not provided.",
+            "description": "Request `ValidatorAggregatedSignature` be included in the response\n\nDefaults to `false` if not provided.",
             "schema": {
-              "description": "Request `ValidatorAggregatedSignature` be included in the response\n\nDefaults to `true` if not provided.",
+              "description": "Request `ValidatorAggregatedSignature` be included in the response\n\nDefaults to `false` if not provided.",
               "type": "boolean"
             },
             "style": "form"
@@ -490,9 +490,9 @@
           {
             "in": "query",
             "name": "summary",
-            "description": "Request `CheckpointSummary` be included in the response\n\nDefaults to `true` if not provided.",
+            "description": "Request `CheckpointSummary` be included in the response\n\nDefaults to `false` if not provided.",
             "schema": {
-              "description": "Request `CheckpointSummary` be included in the response\n\nDefaults to `true` if not provided.",
+              "description": "Request `CheckpointSummary` be included in the response\n\nDefaults to `false` if not provided.",
               "type": "boolean"
             },
             "style": "form"
@@ -559,9 +559,9 @@
           {
             "in": "query",
             "name": "effects",
-            "description": "Request `TransactionEffects` be included in the response\n\nDefaults to `true` if not provided.",
+            "description": "Request `TransactionEffects` be included in the response\n\nDefaults to `false` if not provided.",
             "schema": {
-              "description": "Request `TransactionEffects` be included in the response\n\nDefaults to `true` if not provided.",
+              "description": "Request `TransactionEffects` be included in the response\n\nDefaults to `false` if not provided.",
               "type": "boolean"
             },
             "style": "form"
@@ -579,9 +579,9 @@
           {
             "in": "query",
             "name": "events",
-            "description": "Request `TransactionEvents` be included in the response\n\nDefaults to `true` if not provided.",
+            "description": "Request `TransactionEvents` be included in the response\n\nDefaults to `false` if not provided.",
             "schema": {
-              "description": "Request `TransactionEvents` be included in the response\n\nDefaults to `true` if not provided.",
+              "description": "Request `TransactionEvents` be included in the response\n\nDefaults to `false` if not provided.",
               "type": "boolean"
             },
             "style": "form"
@@ -599,9 +599,9 @@
           {
             "in": "query",
             "name": "signatures",
-            "description": "Request `Vec<UserSignature>` be included in the response\n\nDefaults to `true` if not provided.",
+            "description": "Request `Vec<UserSignature>` be included in the response\n\nDefaults to `false` if not provided.",
             "schema": {
-              "description": "Request `Vec<UserSignature>` be included in the response\n\nDefaults to `true` if not provided.",
+              "description": "Request `Vec<UserSignature>` be included in the response\n\nDefaults to `false` if not provided.",
               "type": "boolean"
             },
             "style": "form"
@@ -619,9 +619,9 @@
           {
             "in": "query",
             "name": "transaction",
-            "description": "Request `Transaction` be included in the response\n\nDefaults to `true` if not provided.",
+            "description": "Request `Transaction` be included in the response\n\nDefaults to `false` if not provided.",
             "schema": {
-              "description": "Request `Transaction` be included in the response\n\nDefaults to `true` if not provided.",
+              "description": "Request `Transaction` be included in the response\n\nDefaults to `false` if not provided.",
               "type": "boolean"
             },
             "style": "form"
@@ -691,9 +691,9 @@
           {
             "in": "query",
             "name": "effects",
-            "description": "Request `TransactionEffects` be included in the response\n\nDefaults to `true` if not provided.",
+            "description": "Request `TransactionEffects` be included in the response\n\nDefaults to `false` if not provided.",
             "schema": {
-              "description": "Request `TransactionEffects` be included in the response\n\nDefaults to `true` if not provided.",
+              "description": "Request `TransactionEffects` be included in the response\n\nDefaults to `false` if not provided.",
               "type": "boolean"
             },
             "style": "form"
@@ -711,9 +711,9 @@
           {
             "in": "query",
             "name": "events",
-            "description": "Request `TransactionEvents` be included in the response\n\nDefaults to `true` if not provided.",
+            "description": "Request `TransactionEvents` be included in the response\n\nDefaults to `false` if not provided.",
             "schema": {
-              "description": "Request `TransactionEvents` be included in the response\n\nDefaults to `true` if not provided.",
+              "description": "Request `TransactionEvents` be included in the response\n\nDefaults to `false` if not provided.",
               "type": "boolean"
             },
             "style": "form"
@@ -731,9 +731,9 @@
           {
             "in": "query",
             "name": "signatures",
-            "description": "Request `Vec<UserSignature>` be included in the response\n\nDefaults to `true` if not provided.",
+            "description": "Request `Vec<UserSignature>` be included in the response\n\nDefaults to `false` if not provided.",
             "schema": {
-              "description": "Request `Vec<UserSignature>` be included in the response\n\nDefaults to `true` if not provided.",
+              "description": "Request `Vec<UserSignature>` be included in the response\n\nDefaults to `false` if not provided.",
               "type": "boolean"
             },
             "style": "form"
@@ -751,9 +751,9 @@
           {
             "in": "query",
             "name": "transaction",
-            "description": "Request `Transaction` be included in the response\n\nDefaults to `true` if not provided.",
+            "description": "Request `Transaction` be included in the response\n\nDefaults to `false` if not provided.",
             "schema": {
-              "description": "Request `Transaction` be included in the response\n\nDefaults to `true` if not provided.",
+              "description": "Request `Transaction` be included in the response\n\nDefaults to `false` if not provided.",
               "type": "boolean"
             },
             "style": "form"
@@ -816,9 +816,9 @@
           {
             "in": "query",
             "name": "effects",
-            "description": "Request `TransactionEffects` be included in the Response.\n\nDefaults to `true` if not provided.",
+            "description": "Request `TransactionEffects` be included in the Response.\n\nDefaults to `false` if not provided.",
             "schema": {
-              "description": "Request `TransactionEffects` be included in the Response.\n\nDefaults to `true` if not provided.",
+              "description": "Request `TransactionEffects` be included in the Response.\n\nDefaults to `false` if not provided.",
               "type": "boolean"
             },
             "style": "form"
@@ -836,9 +836,9 @@
           {
             "in": "query",
             "name": "events",
-            "description": "Request `TransactionEvents` be included in the Response.\n\nDefaults to `true` if not provided.",
+            "description": "Request `TransactionEvents` be included in the Response.\n\nDefaults to `false` if not provided.",
             "schema": {
-              "description": "Request `TransactionEvents` be included in the Response.\n\nDefaults to `true` if not provided.",
+              "description": "Request `TransactionEvents` be included in the Response.\n\nDefaults to `false` if not provided.",
               "type": "boolean"
             },
             "style": "form"

--- a/crates/sui-rpc-api/proto/sui.node.v2.proto
+++ b/crates/sui-rpc-api/proto/sui.node.v2.proto
@@ -64,35 +64,35 @@ message GetTransactionRequest {
 message GetTransactionOptions {
   // Include the sui.types.Transaction message in the response.
   //
-  // Defaults to true if not included
+  // Defaults to `false` if not included
   optional bool transaction = 1;
   // Include the Transaction formatted as BCS in the response.
   //
-  // Defaults to false if not included
+  // Defaults to `false` if not included
   optional bool transaction_bcs = 2;
   // Include the set of sui.types.UserSignature's in the response.
   //
-  // Defaults to true if not included
+  // Defaults to `false` if not included
   optional bool signatures = 3;
   // Include the set of UserSignature's encoded as bytes in the response.
   //
-  // Defaults to false if not included
+  // Defaults to `false` if not included
   optional bool signatures_bytes = 8;
   // Include the sui.types.TransactionEffects message in the response.
   //
-  // Defaults to true if not included
+  // Defaults to `false` if not included
   optional bool effects = 4;
   // Include the TransactionEffects formatted as BCS in the response.
   //
-  // Defaults to false if not included
+  // Defaults to `false` if not included
   optional bool effects_bcs = 5;
   // Include the sui.types.TransactionEvents message in the response.
   //
-  // Defaults to true if not included
+  // Defaults to `false` if not included
   optional bool events = 6;
   // Include the TransactionEvents formatted as BCS in the response.
   //
-  // Defaults to false if not included
+  // Defaults to `false` if not included
   optional bool events_bcs = 7;
 }
 
@@ -129,11 +129,11 @@ message GetObjectRequest {
 message GetObjectOptions {
   // Include the sui.types.Object message in the response.
   //
-  // Defaults to true if not included
+  // Defaults to `false` if not included
   optional bool object = 1;
   // Include the Object formatted as BCS in the response.
   //
-  // Defaults to false if not included
+  // Defaults to `false` if not included
   optional bool object_bcs = 2;
 }
 
@@ -157,23 +157,23 @@ message GetCheckpointRequest {
 message GetCheckpointOptions {
   // Include the sui.types.CheckpointSummary in the response.
   //
-  // Defaults to true if not included
+  // Defaults to `false` if not included
   optional bool summary = 3;
   // Include the CheckpointSummary formatted as BCS in the response.
   //
-  // Defaults to false if not included
+  // Defaults to `false` if not included
   optional bool summary_bcs = 4;
   // Include the sui.types.ValidatorAggregatedSignature in the response.
   //
-  // Defaults to true if not included
+  // Defaults to `false` if not included
   optional bool signature = 5;
   // Include the sui.types.CheckpointContents message in the response.
   //
-  // Defaults to false if not included
+  // Defaults to `false` if not included
   optional bool contents = 6;
   // Include the CheckpointContents formatted as BCS in the response.
   //
-  // Defaults to false if not included
+  // Defaults to `false` if not included
   optional bool contents_bcs = 7;
 }
 
@@ -200,60 +200,67 @@ message GetFullCheckpointRequest {
 message GetFullCheckpointOptions {
   // Include the sui.types.CheckpointSummary in the response.
   //
-  // Defaults to true if not included
+  // Defaults to `false` if not included
   optional bool summary = 3;
   // Include the CheckpointSummary formatted as BCS in the response.
   //
-  // Defaults to false if not included
+  // Defaults to `false` if not included
   optional bool summary_bcs = 4;
   // Include the sui.types.ValidatorAggregatedSignature in the response.
   //
-  // Defaults to true if not included
+  // Defaults to `false` if not included
   optional bool signature = 5;
   // Include the sui.types.CheckpointContents message in the response.
   //
-  // Defaults to false if not included
+  // Defaults to `false` if not included
   optional bool contents = 6;
   // Include the CheckpointContents formatted as BCS in the response.
   //
-  // Defaults to false if not included
+  // Defaults to `false` if not included
   optional bool contents_bcs = 7;
 
   // Include the sui.types.Transaction message in the response.
   //
-  // Defaults to true if not included
+  // Defaults to `false` if not included
   optional bool transaction = 8;
   // Include the Transaction formatted as BCS in the response.
   //
-  // Defaults to false if not included
+  // Defaults to `false` if not included
   optional bool transaction_bcs = 9;
   // Include the sui.types.TransactionEffects message in the response.
   //
-  // Defaults to true if not included
+  // Defaults to `false` if not included
   optional bool effects = 10;
   // Include the TransactionEffects formatted as BCS in the response.
   //
-  // Defaults to false if not included
+  // Defaults to `false` if not included
   optional bool effects_bcs = 11;
   // Include the sui.types.TransactionEvents message in the response.
   //
-  // Defaults to true if not included
+  // Defaults to `false` if not included
   optional bool events = 12;
   // Include the TransactionEvents formatted as BCS in the response.
   //
-  // Defaults to false if not included
+  // Defaults to `false` if not included
   optional bool events_bcs = 13;
 
+  // Include the input objects for transactions in the response.
+  //
+  // Defaults to `false` if not included
   optional bool input_objects = 14;
+
+  // Include the output objects for transactions in the response.
+  //
+  // Defaults to `false` if not included
   optional bool output_objects = 15;
 
   // Include the sui.types.Object message in the response.
   //
-  // Defaults to true if not included
+  // Defaults to `false` if not included
   optional bool object = 16;
   // Include the Object formatted as BCS in the response.
   //
-  // Defaults to false if not included
+  // Defaults to `false` if not included
   optional bool object_bcs = 17;
 }
 
@@ -340,23 +347,23 @@ message ExecuteTransactionRequest {
 message ExecuteTransactionOptions {
   // Include the sui.types.TransactionEffects message in the response.
   //
-  // Defaults to true if not included
+  // Defaults to `false` if not included
   optional bool effects = 4;
   // Include the TransactionEffects formatted as BCS in the response.
   //
-  // Defaults to false if not included
+  // Defaults to `false` if not included
   optional bool effects_bcs = 5;
   // Include the sui.types.TransactionEvents message in the response.
   //
-  // Defaults to true if not included
+  // Defaults to `false` if not included
   optional bool events = 6;
   // Include the TransactionEvents formatted as BCS in the response.
   //
-  // Defaults to false if not included
+  // Defaults to `false` if not included
   optional bool events_bcs = 7;
 
   // Include the BalanceChanges in the response.
   //
-  // Defaults to false if not included
+  // Defaults to `false` if not included
   optional bool balance_changes = 8;
 }

--- a/crates/sui-rpc-api/src/client/sdk.rs
+++ b/crates/sui-rpc-api/src/client/sdk.rs
@@ -126,7 +126,10 @@ impl Client {
     pub async fn get_object(&self, object_id: ObjectId) -> Result<Response<Object>> {
         let url = self.url().join(&format!("objects/{object_id}"))?;
 
-        let request = self.inner.get(url);
+        let request = self.inner.get(url).query(&crate::types::GetObjectOptions {
+            object: Some(true),
+            object_bcs: None,
+        });
 
         self.json::<crate::ObjectResponse>(request)
             .await?
@@ -142,7 +145,10 @@ impl Client {
             .url()
             .join(&format!("objects/{object_id}/version/{version}"))?;
 
-        let request = self.inner.get(url);
+        let request = self.inner.get(url).query(&crate::types::GetObjectOptions {
+            object: Some(true),
+            object_bcs: None,
+        });
 
         self.json::<crate::ObjectResponse>(request)
             .await?

--- a/crates/sui-rpc-api/src/config.rs
+++ b/crates/sui-rpc-api/src/config.rs
@@ -4,11 +4,11 @@
 #[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
-    /// Enable serving of unstable APIs
+    /// Enable the experimental REST api
     ///
-    /// Defaults to `false`, with unstable APIs being disabled
+    /// Defaults to `false`
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub enable_unstable_apis: Option<bool>,
+    pub enable_experimental_rest_api: Option<bool>,
 
     /// Enable indexing of transactions and objects
     ///
@@ -30,11 +30,8 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn enable_unstable_apis(&self) -> bool {
-        // TODO
-        // Until the rest service as a whole is "stabalized" with a sane set of default stable
-        // apis, have the default be to enable all apis
-        self.enable_unstable_apis.unwrap_or(true)
+    pub fn enable_experimental_rest_api(&self) -> bool {
+        self.enable_experimental_rest_api.unwrap_or(false)
     }
 
     pub fn enable_indexing(&self) -> bool {

--- a/crates/sui-rpc-api/src/lib.rs
+++ b/crates/sui-rpc-api/src/lib.rs
@@ -79,9 +79,7 @@ impl RpcService {
     pub async fn into_router(self) -> axum::Router {
         let metrics = self.metrics.clone();
 
-        let rest_router = build_rest_router(self.clone());
-
-        let grpc_router = {
+        let mut router = {
             let node_service = crate::proto::node::node_server::NodeServer::new(self.clone());
 
             let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
@@ -117,8 +115,11 @@ impl RpcService {
                 .into_router()
         };
 
-        rest_router
-            .merge(grpc_router)
+        if self.config.enable_experimental_rest_api() {
+            router = router.merge(build_rest_router(self.clone()));
+        }
+
+        router
             .layer(axum::middleware::map_response_with_state(
                 self,
                 response::append_info_headers,

--- a/crates/sui-rpc-api/src/lib.rs
+++ b/crates/sui-rpc-api/src/lib.rs
@@ -119,7 +119,12 @@ impl RpcService {
             router = router.merge(build_rest_router(self.clone()));
         }
 
+        let health_endpoint = axum::Router::new()
+            .route("/health", axum::routing::get(rest::health::health))
+            .with_state(self.clone());
+
         router
+            .merge(health_endpoint)
             .layer(axum::middleware::map_response_with_state(
                 self,
                 response::append_info_headers,

--- a/crates/sui-rpc-api/src/proto/generated/sui.node.v2.rs
+++ b/crates/sui-rpc-api/src/proto/generated/sui.node.v2.rs
@@ -46,42 +46,42 @@ pub struct GetTransactionRequest {
 pub struct GetTransactionOptions {
     /// Include the sui.types.Transaction message in the response.
     ///
-    /// Defaults to true if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "1")]
     pub transaction: ::core::option::Option<bool>,
     /// Include the Transaction formatted as BCS in the response.
     ///
-    /// Defaults to false if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "2")]
     pub transaction_bcs: ::core::option::Option<bool>,
     /// Include the set of sui.types.UserSignature's in the response.
     ///
-    /// Defaults to true if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "3")]
     pub signatures: ::core::option::Option<bool>,
     /// Include the set of UserSignature's encoded as bytes in the response.
     ///
-    /// Defaults to false if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "8")]
     pub signatures_bytes: ::core::option::Option<bool>,
     /// Include the sui.types.TransactionEffects message in the response.
     ///
-    /// Defaults to true if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "4")]
     pub effects: ::core::option::Option<bool>,
     /// Include the TransactionEffects formatted as BCS in the response.
     ///
-    /// Defaults to false if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "5")]
     pub effects_bcs: ::core::option::Option<bool>,
     /// Include the sui.types.TransactionEvents message in the response.
     ///
-    /// Defaults to true if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "6")]
     pub events: ::core::option::Option<bool>,
     /// Include the TransactionEvents formatted as BCS in the response.
     ///
-    /// Defaults to false if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "7")]
     pub events_bcs: ::core::option::Option<bool>,
 }
@@ -134,12 +134,12 @@ pub struct GetObjectRequest {
 pub struct GetObjectOptions {
     /// Include the sui.types.Object message in the response.
     ///
-    /// Defaults to true if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "1")]
     pub object: ::core::option::Option<bool>,
     /// Include the Object formatted as BCS in the response.
     ///
-    /// Defaults to false if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "2")]
     pub object_bcs: ::core::option::Option<bool>,
 }
@@ -170,27 +170,27 @@ pub struct GetCheckpointRequest {
 pub struct GetCheckpointOptions {
     /// Include the sui.types.CheckpointSummary in the response.
     ///
-    /// Defaults to true if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "3")]
     pub summary: ::core::option::Option<bool>,
     /// Include the CheckpointSummary formatted as BCS in the response.
     ///
-    /// Defaults to false if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "4")]
     pub summary_bcs: ::core::option::Option<bool>,
     /// Include the sui.types.ValidatorAggregatedSignature in the response.
     ///
-    /// Defaults to true if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "5")]
     pub signature: ::core::option::Option<bool>,
     /// Include the sui.types.CheckpointContents message in the response.
     ///
-    /// Defaults to false if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "6")]
     pub contents: ::core::option::Option<bool>,
     /// Include the CheckpointContents formatted as BCS in the response.
     ///
-    /// Defaults to false if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "7")]
     pub contents_bcs: ::core::option::Option<bool>,
 }
@@ -228,71 +228,77 @@ pub struct GetFullCheckpointRequest {
 pub struct GetFullCheckpointOptions {
     /// Include the sui.types.CheckpointSummary in the response.
     ///
-    /// Defaults to true if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "3")]
     pub summary: ::core::option::Option<bool>,
     /// Include the CheckpointSummary formatted as BCS in the response.
     ///
-    /// Defaults to false if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "4")]
     pub summary_bcs: ::core::option::Option<bool>,
     /// Include the sui.types.ValidatorAggregatedSignature in the response.
     ///
-    /// Defaults to true if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "5")]
     pub signature: ::core::option::Option<bool>,
     /// Include the sui.types.CheckpointContents message in the response.
     ///
-    /// Defaults to false if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "6")]
     pub contents: ::core::option::Option<bool>,
     /// Include the CheckpointContents formatted as BCS in the response.
     ///
-    /// Defaults to false if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "7")]
     pub contents_bcs: ::core::option::Option<bool>,
     /// Include the sui.types.Transaction message in the response.
     ///
-    /// Defaults to true if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "8")]
     pub transaction: ::core::option::Option<bool>,
     /// Include the Transaction formatted as BCS in the response.
     ///
-    /// Defaults to false if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "9")]
     pub transaction_bcs: ::core::option::Option<bool>,
     /// Include the sui.types.TransactionEffects message in the response.
     ///
-    /// Defaults to true if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "10")]
     pub effects: ::core::option::Option<bool>,
     /// Include the TransactionEffects formatted as BCS in the response.
     ///
-    /// Defaults to false if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "11")]
     pub effects_bcs: ::core::option::Option<bool>,
     /// Include the sui.types.TransactionEvents message in the response.
     ///
-    /// Defaults to true if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "12")]
     pub events: ::core::option::Option<bool>,
     /// Include the TransactionEvents formatted as BCS in the response.
     ///
-    /// Defaults to false if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "13")]
     pub events_bcs: ::core::option::Option<bool>,
+    /// Include the input objects for transactions in the response.
+    ///
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "14")]
     pub input_objects: ::core::option::Option<bool>,
+    /// Include the output objects for transactions in the response.
+    ///
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "15")]
     pub output_objects: ::core::option::Option<bool>,
     /// Include the sui.types.Object message in the response.
     ///
-    /// Defaults to true if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "16")]
     pub object: ::core::option::Option<bool>,
     /// Include the Object formatted as BCS in the response.
     ///
-    /// Defaults to false if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "17")]
     pub object_bcs: ::core::option::Option<bool>,
 }
@@ -423,27 +429,27 @@ pub struct ExecuteTransactionRequest {
 pub struct ExecuteTransactionOptions {
     /// Include the sui.types.TransactionEffects message in the response.
     ///
-    /// Defaults to true if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "4")]
     pub effects: ::core::option::Option<bool>,
     /// Include the TransactionEffects formatted as BCS in the response.
     ///
-    /// Defaults to false if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "5")]
     pub effects_bcs: ::core::option::Option<bool>,
     /// Include the sui.types.TransactionEvents message in the response.
     ///
-    /// Defaults to true if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "6")]
     pub events: ::core::option::Option<bool>,
     /// Include the TransactionEvents formatted as BCS in the response.
     ///
-    /// Defaults to false if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "7")]
     pub events_bcs: ::core::option::Option<bool>,
     /// Include the BalanceChanges in the response.
     ///
-    /// Defaults to false if not included
+    /// Defaults to `false` if not included
     #[prost(bool, optional, tag = "8")]
     pub balance_changes: ::core::option::Option<bool>,
 }

--- a/crates/sui-rpc-api/src/proto/node.rs
+++ b/crates/sui-rpc-api/src/proto/node.rs
@@ -152,6 +152,42 @@ impl TryFrom<&GetNodeInfoResponse> for crate::types::NodeInfo {
 // GetObjectOptions
 //
 
+impl GetObjectOptions {
+    pub fn all() -> Self {
+        Self {
+            object: Some(true),
+            object_bcs: Some(true),
+        }
+    }
+
+    pub fn none() -> Self {
+        Self {
+            object: Some(false),
+            object_bcs: Some(false),
+        }
+    }
+
+    pub fn with_object(mut self) -> Self {
+        self.object = Some(true);
+        self
+    }
+
+    pub fn without_object(mut self) -> Self {
+        self.object = Some(false);
+        self
+    }
+
+    pub fn with_object_bcs(mut self) -> Self {
+        self.object_bcs = Some(true);
+        self
+    }
+
+    pub fn without_object_bcs(mut self) -> Self {
+        self.object = Some(false);
+        self
+    }
+}
+
 impl From<crate::types::GetObjectOptions> for GetObjectOptions {
     fn from(
         crate::types::GetObjectOptions { object, object_bcs }: crate::types::GetObjectOptions,
@@ -163,6 +199,30 @@ impl From<crate::types::GetObjectOptions> for GetObjectOptions {
 impl From<GetObjectOptions> for crate::types::GetObjectOptions {
     fn from(GetObjectOptions { object, object_bcs }: GetObjectOptions) -> Self {
         Self { object, object_bcs }
+    }
+}
+
+//
+// GetObjectRequest
+//
+
+impl GetObjectRequest {
+    pub fn new<T: Into<super::types::ObjectId>>(object_id: T) -> Self {
+        Self {
+            object_id: Some(object_id.into()),
+            version: None,
+            options: None,
+        }
+    }
+
+    pub fn with_version(mut self, version: u64) -> Self {
+        self.version = Some(version);
+        self
+    }
+
+    pub fn with_options(mut self, options: GetObjectOptions) -> Self {
+        self.options = Some(options);
+        self
     }
 }
 

--- a/crates/sui-rpc-api/src/proto/node.rs
+++ b/crates/sui-rpc-api/src/proto/node.rs
@@ -334,6 +334,114 @@ impl From<GetCheckpointOptions> for crate::types::GetCheckpointOptions {
 // GetTransactionOptions
 //
 
+impl GetTransactionOptions {
+    pub fn all() -> Self {
+        Self {
+            transaction: Some(true),
+            transaction_bcs: Some(true),
+            signatures: Some(true),
+            signatures_bytes: Some(true),
+            effects: Some(true),
+            effects_bcs: Some(true),
+            events: Some(true),
+            events_bcs: Some(true),
+        }
+    }
+
+    pub fn none() -> Self {
+        Self {
+            transaction: Some(false),
+            transaction_bcs: Some(false),
+            signatures: Some(false),
+            signatures_bytes: Some(false),
+            effects: Some(false),
+            effects_bcs: Some(false),
+            events: Some(false),
+            events_bcs: Some(false),
+        }
+    }
+
+    pub fn with_transaction(mut self) -> Self {
+        self.transaction = Some(true);
+        self
+    }
+
+    pub fn without_transaction(mut self) -> Self {
+        self.transaction = Some(false);
+        self
+    }
+
+    pub fn with_transaction_bcs(mut self) -> Self {
+        self.transaction_bcs = Some(true);
+        self
+    }
+
+    pub fn without_transaction_bcs(mut self) -> Self {
+        self.transaction_bcs = Some(false);
+        self
+    }
+
+    pub fn with_signatures(mut self) -> Self {
+        self.signatures = Some(true);
+        self
+    }
+
+    pub fn without_signatures(mut self) -> Self {
+        self.signatures = Some(false);
+        self
+    }
+
+    pub fn with_signatures_bytes(mut self) -> Self {
+        self.signatures_bytes = Some(true);
+        self
+    }
+
+    pub fn without_signatures_bytes(mut self) -> Self {
+        self.signatures_bytes = Some(false);
+        self
+    }
+
+    pub fn with_effects(mut self) -> Self {
+        self.effects = Some(true);
+        self
+    }
+
+    pub fn without_effects(mut self) -> Self {
+        self.effects = Some(false);
+        self
+    }
+
+    pub fn with_effects_bcs(mut self) -> Self {
+        self.effects_bcs = Some(true);
+        self
+    }
+
+    pub fn without_effects_bcs(mut self) -> Self {
+        self.effects_bcs = Some(false);
+        self
+    }
+
+    pub fn with_events(mut self) -> Self {
+        self.events = Some(true);
+        self
+    }
+
+    pub fn without_events(mut self) -> Self {
+        self.events = Some(false);
+        self
+    }
+
+    pub fn with_events_bcs(mut self) -> Self {
+        self.events_bcs = Some(true);
+        self
+    }
+
+    pub fn without_events_bcs(mut self) -> Self {
+        self.events_bcs = Some(false);
+        self
+    }
+}
+
 impl From<crate::types::GetTransactionOptions> for GetTransactionOptions {
     fn from(
         crate::types::GetTransactionOptions {
@@ -383,6 +491,24 @@ impl From<GetTransactionOptions> for crate::types::GetTransactionOptions {
             events,
             events_bcs,
         }
+    }
+}
+
+//
+// GetTransactionRequest
+//
+
+impl GetTransactionRequest {
+    pub fn new<T: Into<super::types::Digest>>(digest: T) -> Self {
+        Self {
+            digest: Some(digest.into()),
+            options: None,
+        }
+    }
+
+    pub fn with_options(mut self, options: GetTransactionOptions) -> Self {
+        self.options = Some(options);
+        self
     }
 }
 

--- a/crates/sui-rpc-api/src/proto/node.rs
+++ b/crates/sui-rpc-api/src/proto/node.rs
@@ -290,6 +290,78 @@ impl TryFrom<&GetObjectResponse> for crate::types::ObjectResponse {
 // GetCheckpointOptions
 //
 
+impl GetCheckpointOptions {
+    pub fn all() -> Self {
+        Self {
+            summary: Some(true),
+            summary_bcs: Some(true),
+            signature: Some(true),
+            contents: Some(true),
+            contents_bcs: Some(true),
+        }
+    }
+
+    pub fn none() -> Self {
+        Self {
+            summary: Some(false),
+            summary_bcs: Some(false),
+            signature: Some(false),
+            contents: Some(false),
+            contents_bcs: Some(false),
+        }
+    }
+
+    pub fn with_summary(mut self) -> Self {
+        self.summary = Some(true);
+        self
+    }
+
+    pub fn without_summary(mut self) -> Self {
+        self.summary = Some(false);
+        self
+    }
+
+    pub fn with_summary_bcs(mut self) -> Self {
+        self.summary_bcs = Some(true);
+        self
+    }
+
+    pub fn without_summary_bcs(mut self) -> Self {
+        self.summary_bcs = Some(false);
+        self
+    }
+
+    pub fn with_signature(mut self) -> Self {
+        self.signature = Some(true);
+        self
+    }
+
+    pub fn without_signature(mut self) -> Self {
+        self.signature = Some(false);
+        self
+    }
+
+    pub fn with_contents(mut self) -> Self {
+        self.contents = Some(true);
+        self
+    }
+
+    pub fn without_contents(mut self) -> Self {
+        self.contents = Some(false);
+        self
+    }
+
+    pub fn with_contents_bcs(mut self) -> Self {
+        self.contents_bcs = Some(true);
+        self
+    }
+
+    pub fn without_contents_bcs(mut self) -> Self {
+        self.contents_bcs = Some(false);
+        self
+    }
+}
+
 impl From<crate::types::GetCheckpointOptions> for GetCheckpointOptions {
     fn from(
         crate::types::GetCheckpointOptions {
@@ -327,6 +399,41 @@ impl From<GetCheckpointOptions> for crate::types::GetCheckpointOptions {
             contents,
             contents_bcs,
         }
+    }
+}
+
+//
+// GetCheckpointRequest
+//
+
+impl GetCheckpointRequest {
+    pub fn latest() -> Self {
+        Self {
+            sequence_number: None,
+            digest: None,
+            options: None,
+        }
+    }
+
+    pub fn by_digest<T: Into<super::types::Digest>>(digest: T) -> Self {
+        Self {
+            sequence_number: None,
+            digest: Some(digest.into()),
+            options: None,
+        }
+    }
+
+    pub fn by_sequence_number(sequence_number: u64) -> Self {
+        Self {
+            sequence_number: Some(sequence_number),
+            digest: None,
+            options: None,
+        }
+    }
+
+    pub fn with_options(mut self, options: GetCheckpointOptions) -> Self {
+        self.options = Some(options);
+        self
     }
 }
 

--- a/crates/sui-rpc-api/src/proto/node.rs
+++ b/crates/sui-rpc-api/src/proto/node.rs
@@ -667,6 +667,198 @@ impl From<ExecuteTransactionOptions> for crate::types::ExecuteTransactionOptions
 // GetFullCheckpointOptions
 //
 
+impl GetFullCheckpointOptions {
+    pub fn all() -> Self {
+        Self {
+            summary: Some(true),
+            summary_bcs: Some(true),
+            signature: Some(true),
+            contents: Some(true),
+            contents_bcs: Some(true),
+            transaction: Some(true),
+            transaction_bcs: Some(true),
+            effects: Some(true),
+            effects_bcs: Some(true),
+            events: Some(true),
+            events_bcs: Some(true),
+            input_objects: Some(true),
+            output_objects: Some(true),
+            object: Some(true),
+            object_bcs: Some(true),
+        }
+    }
+
+    pub fn none() -> Self {
+        Self {
+            summary: Some(false),
+            summary_bcs: Some(false),
+            signature: Some(false),
+            contents: Some(false),
+            contents_bcs: Some(false),
+            transaction: Some(false),
+            transaction_bcs: Some(false),
+            effects: Some(false),
+            effects_bcs: Some(false),
+            events: Some(false),
+            events_bcs: Some(false),
+            input_objects: Some(false),
+            output_objects: Some(false),
+            object: Some(false),
+            object_bcs: Some(false),
+        }
+    }
+
+    pub fn with_summary(mut self) -> Self {
+        self.summary = Some(true);
+        self
+    }
+
+    pub fn without_summary(mut self) -> Self {
+        self.summary = Some(false);
+        self
+    }
+
+    pub fn with_summary_bcs(mut self) -> Self {
+        self.summary_bcs = Some(true);
+        self
+    }
+
+    pub fn without_summary_bcs(mut self) -> Self {
+        self.summary_bcs = Some(false);
+        self
+    }
+
+    pub fn with_signature(mut self) -> Self {
+        self.signature = Some(true);
+        self
+    }
+
+    pub fn without_signature(mut self) -> Self {
+        self.signature = Some(false);
+        self
+    }
+
+    pub fn with_contents(mut self) -> Self {
+        self.contents = Some(true);
+        self
+    }
+
+    pub fn without_contents(mut self) -> Self {
+        self.contents = Some(false);
+        self
+    }
+
+    pub fn with_contents_bcs(mut self) -> Self {
+        self.contents_bcs = Some(true);
+        self
+    }
+
+    pub fn without_contents_bcs(mut self) -> Self {
+        self.contents_bcs = Some(false);
+        self
+    }
+
+    pub fn with_transaction(mut self) -> Self {
+        self.transaction = Some(true);
+        self
+    }
+
+    pub fn without_transaction(mut self) -> Self {
+        self.transaction = Some(false);
+        self
+    }
+
+    pub fn with_transaction_bcs(mut self) -> Self {
+        self.transaction_bcs = Some(true);
+        self
+    }
+
+    pub fn without_transaction_bcs(mut self) -> Self {
+        self.transaction_bcs = Some(false);
+        self
+    }
+
+    pub fn with_effects(mut self) -> Self {
+        self.effects = Some(true);
+        self
+    }
+
+    pub fn without_effects(mut self) -> Self {
+        self.effects = Some(false);
+        self
+    }
+
+    pub fn with_effects_bcs(mut self) -> Self {
+        self.effects_bcs = Some(true);
+        self
+    }
+
+    pub fn without_effects_bcs(mut self) -> Self {
+        self.effects_bcs = Some(false);
+        self
+    }
+
+    pub fn with_events(mut self) -> Self {
+        self.events = Some(true);
+        self
+    }
+
+    pub fn without_events(mut self) -> Self {
+        self.events = Some(false);
+        self
+    }
+
+    pub fn with_events_bcs(mut self) -> Self {
+        self.events_bcs = Some(true);
+        self
+    }
+
+    pub fn without_events_bcs(mut self) -> Self {
+        self.events_bcs = Some(false);
+        self
+    }
+
+    pub fn with_input_objects(mut self) -> Self {
+        self.input_objects = Some(true);
+        self
+    }
+
+    pub fn without_input_objects(mut self) -> Self {
+        self.input_objects = Some(false);
+        self
+    }
+
+    pub fn with_output_objects(mut self) -> Self {
+        self.output_objects = Some(true);
+        self
+    }
+
+    pub fn without_output_objects(mut self) -> Self {
+        self.output_objects = Some(false);
+        self
+    }
+
+    pub fn with_object(mut self) -> Self {
+        self.object = Some(true);
+        self
+    }
+
+    pub fn without_object(mut self) -> Self {
+        self.object = Some(false);
+        self
+    }
+
+    pub fn with_object_bcs(mut self) -> Self {
+        self.object_bcs = Some(true);
+        self
+    }
+
+    pub fn without_object_bcs(mut self) -> Self {
+        self.object = Some(false);
+        self
+    }
+}
+
 impl From<crate::types::GetFullCheckpointOptions> for GetFullCheckpointOptions {
     fn from(
         crate::types::GetFullCheckpointOptions {
@@ -744,6 +936,41 @@ impl From<GetFullCheckpointOptions> for crate::types::GetFullCheckpointOptions {
             object,
             object_bcs,
         }
+    }
+}
+
+//
+// GetFullCheckpointRequest
+//
+
+impl GetFullCheckpointRequest {
+    pub fn latest() -> Self {
+        Self {
+            sequence_number: None,
+            digest: None,
+            options: None,
+        }
+    }
+
+    pub fn by_digest<T: Into<super::types::Digest>>(digest: T) -> Self {
+        Self {
+            sequence_number: None,
+            digest: Some(digest.into()),
+            options: None,
+        }
+    }
+
+    pub fn by_sequence_number(sequence_number: u64) -> Self {
+        Self {
+            sequence_number: Some(sequence_number),
+            digest: None,
+            options: None,
+        }
+    }
+
+    pub fn with_options(mut self, options: GetFullCheckpointOptions) -> Self {
+        self.options = Some(options);
+        self
     }
 }
 

--- a/crates/sui-rpc-api/src/rest/health.rs
+++ b/crates/sui-rpc-api/src/rest/health.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     rest::openapi::{ApiEndpoint, OperationBuilder, ResponseBuilder, RouteHandler},
-    Result, RpcService,
+    RpcService,
 };
 use axum::extract::{Query, State};
 use documented::Documented;
@@ -58,9 +58,12 @@ pub struct Threshold {
     pub threshold_seconds: Option<u32>,
 }
 
-async fn health(
+pub async fn health(
     Query(Threshold { threshold_seconds }): Query<Threshold>,
     State(state): State<RpcService>,
-) -> Result<()> {
-    state.health_check(threshold_seconds)
+) -> impl axum::response::IntoResponse {
+    match state.health_check(threshold_seconds) {
+        Ok(()) => (axum::http::StatusCode::OK, "up"),
+        Err(_) => (axum::http::StatusCode::SERVICE_UNAVAILABLE, "down"),
+    }
 }

--- a/crates/sui-rpc-api/src/rest/mod.rs
+++ b/crates/sui-rpc-api/src/rest/mod.rs
@@ -57,12 +57,7 @@ pub const ENDPOINTS: &[&dyn ApiEndpoint<RpcService>] = &[
 pub fn build_rest_router(service: RpcService) -> axum::Router {
     let mut api = openapi::Api::new(info(service.software_version()));
 
-    api.register_endpoints(
-        ENDPOINTS
-            .iter()
-            .copied()
-            .filter(|endpoint| endpoint.stable() || service.config.enable_unstable_apis()),
-    );
+    api.register_endpoints(ENDPOINTS.iter().copied());
 
     Router::new()
         .nest("/v2/", api.to_router().with_state(service))

--- a/crates/sui-rpc-api/src/types.rs
+++ b/crates/sui-rpc-api/src/types.rs
@@ -528,19 +528,19 @@ pub struct GetFullCheckpointOptions {
 
     /// Request that input objects be included in the response
     ///
-    /// Defaults to `true` if not provided.
+    /// Defaults to `false` if not provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input_objects: Option<bool>,
 
     /// Request that output objects be included in the response
     ///
-    /// Defaults to `true` if not provided.
+    /// Defaults to `false` if not provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub output_objects: Option<bool>,
 
     /// Request that `Object` be included in the response
     ///
-    /// Defaults to `true` if not provided.
+    /// Defaults to `false` if not provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub object: Option<bool>,
 
@@ -597,15 +597,15 @@ impl GetFullCheckpointOptions {
     }
 
     pub fn include_input_objects(&self) -> bool {
-        self.input_objects.unwrap_or(true)
+        self.input_objects.unwrap_or(false)
     }
 
     pub fn include_output_objects(&self) -> bool {
-        self.output_objects.unwrap_or(true)
+        self.output_objects.unwrap_or(false)
     }
 
     pub fn include_object(&self) -> bool {
-        self.object.unwrap_or(true)
+        self.object.unwrap_or(false)
     }
 
     pub fn include_object_bcs(&self) -> bool {

--- a/crates/sui-rpc-api/src/types.rs
+++ b/crates/sui-rpc-api/src/types.rs
@@ -96,7 +96,7 @@ pub struct ObjectResponse {
 pub struct GetObjectOptions {
     /// Request that `Object` be included in the response
     ///
-    /// Defaults to `true` if not provided.
+    /// Defaults to `false` if not provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub object: Option<bool>,
     /// Request that `Object` formated as BCS be included in the response
@@ -108,7 +108,7 @@ pub struct GetObjectOptions {
 
 impl GetObjectOptions {
     pub fn include_object(&self) -> bool {
-        self.object.unwrap_or(true)
+        self.object.unwrap_or(false)
     }
 
     pub fn include_object_bcs(&self) -> bool {
@@ -149,7 +149,7 @@ pub struct CheckpointResponse {
 pub struct GetCheckpointOptions {
     /// Request `CheckpointSummary` be included in the response
     ///
-    /// Defaults to `true` if not provided.
+    /// Defaults to `false` if not provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<bool>,
 
@@ -161,7 +161,7 @@ pub struct GetCheckpointOptions {
 
     /// Request `ValidatorAggregatedSignature` be included in the response
     ///
-    /// Defaults to `true` if not provided.
+    /// Defaults to `false` if not provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signature: Option<bool>,
 
@@ -180,7 +180,7 @@ pub struct GetCheckpointOptions {
 
 impl GetCheckpointOptions {
     pub fn include_summary(&self) -> bool {
-        self.summary.unwrap_or(true)
+        self.summary.unwrap_or(false)
     }
 
     pub fn include_summary_bcs(&self) -> bool {
@@ -188,7 +188,7 @@ impl GetCheckpointOptions {
     }
 
     pub fn include_signature(&self) -> bool {
-        self.signature.unwrap_or(true)
+        self.signature.unwrap_or(false)
     }
 
     pub fn include_contents(&self) -> bool {
@@ -256,7 +256,7 @@ pub struct TransactionResponse {
 pub struct GetTransactionOptions {
     /// Request `Transaction` be included in the response
     ///
-    /// Defaults to `true` if not provided.
+    /// Defaults to `false` if not provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction: Option<bool>,
 
@@ -268,7 +268,7 @@ pub struct GetTransactionOptions {
 
     /// Request `Vec<UserSignature>` be included in the response
     ///
-    /// Defaults to `true` if not provided.
+    /// Defaults to `false` if not provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signatures: Option<bool>,
 
@@ -280,7 +280,7 @@ pub struct GetTransactionOptions {
 
     /// Request `TransactionEffects` be included in the response
     ///
-    /// Defaults to `true` if not provided.
+    /// Defaults to `false` if not provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub effects: Option<bool>,
 
@@ -292,7 +292,7 @@ pub struct GetTransactionOptions {
 
     /// Request `TransactionEvents` be included in the response
     ///
-    /// Defaults to `true` if not provided.
+    /// Defaults to `false` if not provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub events: Option<bool>,
 
@@ -305,7 +305,7 @@ pub struct GetTransactionOptions {
 
 impl GetTransactionOptions {
     pub fn include_transaction(&self) -> bool {
-        self.transaction.unwrap_or(true)
+        self.transaction.unwrap_or(false)
     }
 
     pub fn include_transaction_bcs(&self) -> bool {
@@ -313,7 +313,7 @@ impl GetTransactionOptions {
     }
 
     pub fn include_signatures(&self) -> bool {
-        self.signatures.unwrap_or(true)
+        self.signatures.unwrap_or(false)
     }
 
     pub fn include_signatures_bytes(&self) -> bool {
@@ -321,7 +321,7 @@ impl GetTransactionOptions {
     }
 
     pub fn include_effects(&self) -> bool {
-        self.effects.unwrap_or(true)
+        self.effects.unwrap_or(false)
     }
 
     pub fn include_effects_bcs(&self) -> bool {
@@ -329,7 +329,7 @@ impl GetTransactionOptions {
     }
 
     pub fn include_events(&self) -> bool {
-        self.events.unwrap_or(true)
+        self.events.unwrap_or(false)
     }
 
     pub fn include_events_bcs(&self) -> bool {
@@ -342,7 +342,7 @@ impl GetTransactionOptions {
 pub struct ExecuteTransactionOptions {
     /// Request `TransactionEffects` be included in the Response.
     ///
-    /// Defaults to `true` if not provided.
+    /// Defaults to `false` if not provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub effects: Option<bool>,
 
@@ -354,7 +354,7 @@ pub struct ExecuteTransactionOptions {
 
     /// Request `TransactionEvents` be included in the Response.
     ///
-    /// Defaults to `true` if not provided.
+    /// Defaults to `false` if not provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub events: Option<bool>,
 
@@ -369,24 +369,11 @@ pub struct ExecuteTransactionOptions {
     /// Defaults to `false` if not provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub balance_changes: Option<bool>,
-    // TODO determine if we want to provide the same level of options for Objects here as we do in
-    // the get_object apis
-    // /// Request input `Object`s be included in the Response.
-    // ///
-    // /// Defaults to `false` if not provided.
-    // #[serde(skip_serializing_if = "Option::is_none")]
-    // pub input_objects: Option<bool>,
-
-    // /// Request output `Object`s be included in the Response.
-    // ///
-    // /// Defaults to `false` if not provided.
-    // #[serde(skip_serializing_if = "Option::is_none")]
-    // pub output_objects: Option<bool>,
 }
 
 impl ExecuteTransactionOptions {
     pub fn include_effects(&self) -> bool {
-        self.effects.unwrap_or(true)
+        self.effects.unwrap_or(false)
     }
 
     pub fn include_effects_bcs(&self) -> bool {
@@ -394,7 +381,7 @@ impl ExecuteTransactionOptions {
     }
 
     pub fn include_events(&self) -> bool {
-        self.events.unwrap_or(true)
+        self.events.unwrap_or(false)
     }
 
     pub fn include_events_bcs(&self) -> bool {
@@ -462,7 +449,7 @@ pub enum EffectsFinality {
 pub struct GetFullCheckpointOptions {
     /// Request `CheckpointSummary` be included in the response
     ///
-    /// Defaults to `true` if not provided.
+    /// Defaults to `false` if not provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<bool>,
 
@@ -474,7 +461,7 @@ pub struct GetFullCheckpointOptions {
 
     /// Request `ValidatorAggregatedSignature` be included in the response
     ///
-    /// Defaults to `true` if not provided.
+    /// Defaults to `false` if not provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signature: Option<bool>,
 
@@ -492,7 +479,7 @@ pub struct GetFullCheckpointOptions {
 
     /// Request `Transaction` be included in the response
     ///
-    /// Defaults to `true` if not provided.
+    /// Defaults to `false` if not provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction: Option<bool>,
 
@@ -504,7 +491,7 @@ pub struct GetFullCheckpointOptions {
 
     /// Request `TransactionEffects` be included in the response
     ///
-    /// Defaults to `true` if not provided.
+    /// Defaults to `false` if not provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub effects: Option<bool>,
 
@@ -516,7 +503,7 @@ pub struct GetFullCheckpointOptions {
 
     /// Request `TransactionEvents` be included in the response
     ///
-    /// Defaults to `true` if not provided.
+    /// Defaults to `false` if not provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub events: Option<bool>,
 
@@ -553,7 +540,7 @@ pub struct GetFullCheckpointOptions {
 
 impl GetFullCheckpointOptions {
     pub fn include_summary(&self) -> bool {
-        self.summary.unwrap_or(true)
+        self.summary.unwrap_or(false)
     }
 
     pub fn include_summary_bcs(&self) -> bool {
@@ -561,7 +548,7 @@ impl GetFullCheckpointOptions {
     }
 
     pub fn include_signature(&self) -> bool {
-        self.signature.unwrap_or(true)
+        self.signature.unwrap_or(false)
     }
 
     pub fn include_contents(&self) -> bool {
@@ -573,7 +560,7 @@ impl GetFullCheckpointOptions {
     }
 
     pub fn include_transaction(&self) -> bool {
-        self.transaction.unwrap_or(true)
+        self.transaction.unwrap_or(false)
     }
 
     pub fn include_transaction_bcs(&self) -> bool {
@@ -581,7 +568,7 @@ impl GetFullCheckpointOptions {
     }
 
     pub fn include_effects(&self) -> bool {
-        self.effects.unwrap_or(true)
+        self.effects.unwrap_or(false)
     }
 
     pub fn include_effects_bcs(&self) -> bool {
@@ -589,7 +576,7 @@ impl GetFullCheckpointOptions {
     }
 
     pub fn include_events(&self) -> bool {
-        self.events.unwrap_or(true)
+        self.events.unwrap_or(false)
     }
 
     pub fn include_events_bcs(&self) -> bool {

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -217,10 +217,8 @@ impl ValidatorConfigBuilder {
             indexer_max_subscriptions: Default::default(),
             transaction_kv_store_read_config: Default::default(),
             transaction_kv_store_write_config: None,
-            enable_experimental_rest_api: true,
             rpc: Some(sui_rpc_api::Config {
-                enable_unstable_apis: Some(true),
-                enable_indexing: Some(true),
+                enable_experimental_rest_api: Some(true),
                 ..Default::default()
             }),
             jwk_fetch_interval_seconds: self
@@ -520,9 +518,8 @@ impl FullnodeConfigBuilder {
             indexer_max_subscriptions: Default::default(),
             transaction_kv_store_read_config: Default::default(),
             transaction_kv_store_write_config: Default::default(),
-            enable_experimental_rest_api: true,
             rpc: Some(sui_rpc_api::Config {
-                enable_unstable_apis: Some(true),
+                enable_experimental_rest_api: Some(true),
                 enable_indexing: Some(true),
                 ..Default::default()
             }),

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -14,10 +14,8 @@ validator_configs:
     db-path: /tmp/foo/
     network-address: ""
     json-rpc-address: "0.0.0.0:1"
-    enable-experimental-rest-api: true
     rpc:
-      enable-unstable-apis: true
-      enable-indexing: true
+      enable-experimental-rest-api: true
     metrics-address: "0.0.0.0:1"
     admin-interface-port: 8888
     consensus-config:
@@ -179,10 +177,8 @@ validator_configs:
     db-path: /tmp/foo/
     network-address: ""
     json-rpc-address: "0.0.0.0:1"
-    enable-experimental-rest-api: true
     rpc:
-      enable-unstable-apis: true
-      enable-indexing: true
+      enable-experimental-rest-api: true
     metrics-address: "0.0.0.0:1"
     admin-interface-port: 8888
     consensus-config:
@@ -344,10 +340,8 @@ validator_configs:
     db-path: /tmp/foo/
     network-address: ""
     json-rpc-address: "0.0.0.0:1"
-    enable-experimental-rest-api: true
     rpc:
-      enable-unstable-apis: true
-      enable-indexing: true
+      enable-experimental-rest-api: true
     metrics-address: "0.0.0.0:1"
     admin-interface-port: 8888
     consensus-config:
@@ -509,10 +503,8 @@ validator_configs:
     db-path: /tmp/foo/
     network-address: ""
     json-rpc-address: "0.0.0.0:1"
-    enable-experimental-rest-api: true
     rpc:
-      enable-unstable-apis: true
-      enable-indexing: true
+      enable-experimental-rest-api: true
     metrics-address: "0.0.0.0:1"
     admin-interface-port: 8888
     consensus-config:
@@ -674,10 +666,8 @@ validator_configs:
     db-path: /tmp/foo/
     network-address: ""
     json-rpc-address: "0.0.0.0:1"
-    enable-experimental-rest-api: true
     rpc:
-      enable-unstable-apis: true
-      enable-indexing: true
+      enable-experimental-rest-api: true
     metrics-address: "0.0.0.0:1"
     admin-interface-port: 8888
     consensus-config:
@@ -839,10 +829,8 @@ validator_configs:
     db-path: /tmp/foo/
     network-address: ""
     json-rpc-address: "0.0.0.0:1"
-    enable-experimental-rest-api: true
     rpc:
-      enable-unstable-apis: true
-      enable-indexing: true
+      enable-experimental-rest-api: true
     metrics-address: "0.0.0.0:1"
     admin-interface-port: 8888
     consensus-config:
@@ -1004,10 +992,8 @@ validator_configs:
     db-path: /tmp/foo/
     network-address: ""
     json-rpc-address: "0.0.0.0:1"
-    enable-experimental-rest-api: true
     rpc:
-      enable-unstable-apis: true
-      enable-indexing: true
+      enable-experimental-rest-api: true
     metrics-address: "0.0.0.0:1"
     admin-interface-port: 8888
     consensus-config:


### PR DESCRIPTION
## Description 

Stabilize the MVP of the new Fullnode gRPC api which is intended to eventually obsolesce the existing JSON-RPC api on Fullnodes.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [x] gRPC:

Stabilize the MVP of the new Fullnode gRPC api which is intended to eventually obsolesce the existing JSON-RPC api on Fullnodes.

- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: