### PR TITLE
[kv store] json rpc: remove leftover call sites to old events API

### DIFF
--- a/crates/sui-json-rpc/src/authority_state.rs
+++ b/crates/sui-json-rpc/src/authority_state.rs
@@ -24,7 +24,7 @@ use sui_types::base_types::{
 };
 use sui_types::bridge::Bridge;
 use sui_types::committee::{Committee, EpochId};
-use sui_types::digests::{ChainIdentifier, TransactionDigest, TransactionEventsDigest};
+use sui_types::digests::{ChainIdentifier, TransactionDigest};
 use sui_types::dynamic_field::DynamicFieldInfo;
 use sui_types::effects::TransactionEffects;
 use sui_types::error::{SuiError, UserInputError};
@@ -57,7 +57,6 @@ pub trait StateRead: Send + Sync {
         &self,
         transactions: &[TransactionDigest],
         effects: &[TransactionDigest],
-        events: &[TransactionEventsDigest],
     ) -> StateReadResult<KVStoreTransactionData>;
 
     fn get_object_read(&self, object_id: &ObjectID) -> StateReadResult<ObjectRead>;
@@ -235,14 +234,12 @@ impl StateRead for AuthorityState {
         &self,
         transactions: &[TransactionDigest],
         effects: &[TransactionDigest],
-        events: &[TransactionEventsDigest],
     ) -> StateReadResult<KVStoreTransactionData> {
         Ok(
             <AuthorityState as TransactionKeyValueStoreTrait>::multi_get(
                 self,
                 transactions,
                 effects,
-                events,
             )
             .await?,
         )

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -435,7 +435,7 @@ mod tests {
     use sui_types::balance::Supply;
     use sui_types::base_types::{ObjectID, SequenceNumber, SuiAddress};
     use sui_types::coin::TreasuryCap;
-    use sui_types::digests::{ObjectDigest, TransactionDigest, TransactionEventsDigest};
+    use sui_types::digests::{ObjectDigest, TransactionDigest};
     use sui_types::effects::{TransactionEffects, TransactionEvents};
     use sui_types::error::{SuiError, SuiResult};
     use sui_types::gas_coin::GAS;
@@ -455,7 +455,6 @@ mod tests {
                 &self,
                 transactions: &[TransactionDigest],
                 effects: &[TransactionDigest],
-                events: &[TransactionEventsDigest],
             ) -> SuiResult<KVStoreTransactionData>;
 
             async fn multi_get_checkpoints(
@@ -1399,7 +1398,7 @@ mod tests {
                 .return_once(move |_| Ok(transaction_digest));
             mock_state
                 .expect_multi_get()
-                .return_once(move |_, _, _| Ok((vec![], vec![Some(transaction_effects)], vec![])));
+                .return_once(move |_, _| Ok((vec![], vec![Some(transaction_effects)])));
 
             let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state), None);
             let response = coin_read_api.get_total_supply(coin_name.clone()).await;

--- a/crates/sui-storage/src/bin/http_kv_tool.rs
+++ b/crates/sui-storage/src/bin/http_kv_tool.rs
@@ -8,7 +8,7 @@ use sui_storage::http_key_value_store::*;
 use sui_storage::key_value_store::TransactionKeyValueStore;
 use sui_storage::key_value_store_metrics::KeyValueStoreMetrics;
 use sui_types::base_types::ObjectID;
-use sui_types::digests::{CheckpointDigest, TransactionDigest, TransactionEventsDigest};
+use sui_types::digests::{CheckpointDigest, TransactionDigest};
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 
 #[derive(Parser)]
@@ -83,21 +83,6 @@ impl Command {
                             for (digest, fx) in digests.iter().zip(fx.iter()) {
                                 println!("fetched fx: {:?} {:?}", digest, fx);
                             }
-                        }
-                    }
-
-                    "events" => {
-                        let digests: Vec<_> = digest
-                            .into_iter()
-                            .map(|digest| {
-                                TransactionEventsDigest::from_str(&digest)
-                                    .expect("invalid events digest")
-                            })
-                            .collect();
-
-                        let tx = kv.multi_get_events(&digests).await.unwrap();
-                        for (digest, ev) in digests.iter().zip(tx.iter()) {
-                            println!("fetched events: {:?} {:?}", digest, ev);
                         }
                     }
 

--- a/crates/sui-storage/tests/key_value_tests.rs
+++ b/crates/sui-storage/tests/key_value_tests.rs
@@ -13,14 +13,11 @@ use sui_types::base_types::{
 use sui_types::committee::Committee;
 use sui_types::crypto::KeypairTraits;
 use sui_types::crypto::{get_key_pair, AccountKeyPair};
-use sui_types::digests::{
-    CheckpointContentsDigest, CheckpointDigest, TransactionDigest, TransactionEventsDigest,
-};
+use sui_types::digests::{CheckpointContentsDigest, CheckpointDigest, TransactionDigest};
 use sui_types::effects::{
     TestEffectsBuilder, TransactionEffects, TransactionEffectsAPI, TransactionEvents,
 };
 use sui_types::error::SuiResult;
-use sui_types::event::Event;
 use sui_types::messages_checkpoint::{
     CertifiedCheckpointSummary, CheckpointContents, CheckpointSequenceNumber, CheckpointSummary,
     SignedCheckpointSummary,
@@ -46,16 +43,10 @@ fn random_fx() -> TransactionEffects {
     TestEffectsBuilder::new(tx.data()).build()
 }
 
-fn random_events() -> TransactionEvents {
-    let event = Event::random_for_testing();
-    TransactionEvents { data: vec![event] }
-}
-
 #[derive(Default)]
 struct MockTxStore {
     txs: HashMap<TransactionDigest, Transaction>,
     fxs: HashMap<TransactionDigest, TransactionEffects>,
-    events: HashMap<TransactionEventsDigest, TransactionEvents>,
     checkpoint_summaries: HashMap<CheckpointSequenceNumber, CertifiedCheckpointSummary>,
     checkpoint_contents: HashMap<CheckpointSequenceNumber, CheckpointContents>,
     checkpoint_summaries_by_digest: HashMap<CheckpointDigest, CertifiedCheckpointSummary>,
@@ -79,10 +70,6 @@ impl MockTxStore {
         self.fxs.insert(*fx.transaction_digest(), fx);
     }
 
-    fn add_events(&mut self, events: TransactionEvents) {
-        self.events.insert(events.digest(), events);
-    }
-
     fn add_random_tx(&mut self) -> Transaction {
         let tx = random_tx();
         self.add_tx(tx.clone());
@@ -93,12 +80,6 @@ impl MockTxStore {
         let fx = random_fx();
         self.add_fx(fx.clone());
         fx
-    }
-
-    fn add_random_events(&mut self) -> TransactionEvents {
-        let events = random_events();
-        self.add_events(events.clone());
-        events
     }
 
     fn add_random_checkpoint(&mut self) -> (CertifiedCheckpointSummary, CheckpointContents) {
@@ -161,12 +142,7 @@ impl TransactionKeyValueStoreTrait for MockTxStore {
         &self,
         transactions: &[TransactionDigest],
         effects: &[TransactionDigest],
-        events: &[TransactionEventsDigest],
-    ) -> SuiResult<(
-        Vec<Option<Transaction>>,
-        Vec<Option<TransactionEffects>>,
-        Vec<Option<TransactionEvents>>,
-    )> {
+    ) -> SuiResult<(Vec<Option<Transaction>>, Vec<Option<TransactionEffects>>)> {
         let mut txs = Vec::new();
         for digest in transactions {
             txs.push(self.txs.get(digest).cloned());
@@ -177,12 +153,7 @@ impl TransactionKeyValueStoreTrait for MockTxStore {
             fxs.push(self.fxs.get(digest).cloned());
         }
 
-        let mut evts = Vec::new();
-        for digest in events {
-            evts.push(self.events.get(digest).cloned());
-        }
-
-        Ok((txs, fxs, evts))
+        Ok((txs, fxs))
     }
 
     async fn multi_get_checkpoints(
@@ -285,26 +256,6 @@ async fn test_get_fx() {
 }
 
 #[tokio::test]
-async fn test_get_events() {
-    let mut store = MockTxStore::new();
-    let events = random_events();
-    store.add_events(events.clone());
-    let store = TransactionKeyValueStore::from(store);
-
-    let result = store
-        .multi_get_events(&[events.digest()])
-        .now_or_never()
-        .unwrap();
-    assert_eq!(result.unwrap(), vec![Some(events)]);
-
-    let result = store
-        .multi_get_events(&[TransactionEventsDigest::random()])
-        .now_or_never()
-        .unwrap();
-    assert_eq!(result.unwrap(), vec![None]);
-}
-
-#[tokio::test]
 async fn test_multi_get() {
     let mut store = MockTxStore::new();
     let txns = vec![store.add_random_tx(), store.add_random_tx()];
@@ -313,8 +264,6 @@ async fn test_multi_get() {
         store.add_random_fx(),
         store.add_random_fx(),
     ];
-    let events = vec![store.add_random_events(), store.add_random_events()];
-
     let store = TransactionKeyValueStore::from(store);
 
     let result = store
@@ -323,25 +272,13 @@ async fn test_multi_get() {
             &fxs.iter()
                 .map(|fx| *fx.transaction_digest())
                 .collect::<Vec<_>>(),
-            &events
-                .iter()
-                .map(|events| events.digest())
-                .collect::<Vec<_>>(),
         )
         .now_or_never()
         .unwrap();
 
     let txns = txns.into_iter().map(Some).collect::<Vec<_>>();
     let fxs = fxs.into_iter().map(Some).collect::<Vec<_>>();
-    let events = events.into_iter().map(Some).collect::<Vec<_>>();
-
-    assert_eq!(result.unwrap(), (txns, fxs, events));
-
-    let result = store
-        .multi_get_events(&[TransactionEventsDigest::random()])
-        .now_or_never()
-        .unwrap();
-    assert_eq!(result.unwrap(), vec![None]);
+    assert_eq!(result.unwrap(), (txns, fxs));
 }
 
 #[tokio::test]
@@ -412,7 +349,6 @@ async fn test_get_tx_from_fallback() {
         .multi_get(
             &[*fallback_tx.digest(), *tx.digest()],
             &[*fx.transaction_digest(), *fallback_fx.transaction_digest()],
-            &[],
         )
         .now_or_never()
         .unwrap();
@@ -421,7 +357,6 @@ async fn test_get_tx_from_fallback() {
         (
             vec![Some(fallback_tx), Some(tx)],
             vec![Some(fx), Some(fallback_fx)],
-            vec![]
         )
     );
 }
@@ -490,7 +425,6 @@ mod simtests {
         let tx = random_tx();
         let random_digest = TransactionDigest::random();
         let fx = random_fx();
-        let events = random_events();
 
         {
             let bytes = bcs::to_bytes(&tx).unwrap();
@@ -498,12 +432,6 @@ mod simtests {
 
             let bytes = bcs::to_bytes(&fx).unwrap();
             assert_eq!(fx, bcs::from_bytes::<TransactionEffects>(&bytes).unwrap());
-
-            let bytes = bcs::to_bytes(&events).unwrap();
-            assert_eq!(
-                events,
-                bcs::from_bytes::<TransactionEvents>(&bytes).unwrap()
-            );
         }
 
         data.insert(
@@ -513,10 +441,6 @@ mod simtests {
         data.insert(
             format!("{}/fx", encode_digest(fx.transaction_digest())),
             bcs::to_bytes(&fx).unwrap(),
-        );
-        data.insert(
-            format!("{}/ev", encode_digest(&events.digest())),
-            bcs::to_bytes(&events).unwrap(),
         );
 
         // a bogus entry with the wrong digest
@@ -532,14 +456,13 @@ mod simtests {
         let store = HttpKVStore::new("http://10.10.10.10:8080", 1000, metrics.clone()).unwrap();
 
         // send one request to warm up the client (and open a connection)
-        store.multi_get(&[*tx.digest()], &[], &[]).await.unwrap();
+        store.multi_get(&[*tx.digest()], &[]).await.unwrap();
 
         let start_time = Instant::now();
         let result = store
             .multi_get(
                 &[*tx.digest(), *random_tx().digest()],
                 &[*fx.transaction_digest()],
-                &[events.digest()],
             )
             .await
             .unwrap();
@@ -548,10 +471,7 @@ mod simtests {
         // i.e. test that pipelining or multiplexing is working.
         assert!(start_time.elapsed() < Duration::from_millis(600));
 
-        assert_eq!(
-            result,
-            (vec![Some(tx), None], vec![Some(fx)], vec![Some(events)])
-        );
+        assert_eq!(result, (vec![Some(tx), None], vec![Some(fx)]));
 
         // the tx was fetched twice, so there should be one cache hit
         assert_eq!(
@@ -563,8 +483,8 @@ mod simtests {
             1
         );
 
-        let result = store.multi_get(&[random_digest], &[], &[]).await.unwrap();
-        assert_eq!(result, (vec![None], vec![], vec![]));
+        let result = store.multi_get(&[random_digest], &[]).await.unwrap();
+        assert_eq!(result, (vec![None], vec![]));
     }
 }
 
@@ -579,14 +499,6 @@ fn test_key_to_path_and_back() {
     );
 
     let key = Key::Fx(TransactionDigest::random());
-    let path_elts = key.to_path_elements();
-    assert_eq!(
-        path_elements_to_key(path_elts.0.as_str(), path_elts.1).unwrap(),
-        key
-    );
-
-    let events = TransactionEventsDigest::random();
-    let key = Key::Events(events);
     let path_elts = key.to_path_elements();
     assert_eq!(
         path_elements_to_key(path_elts.0.as_str(), path_elts.1).unwrap(),


### PR DESCRIPTION
## Description 

query events still accesses old events key  

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
