### PR TITLE
snapshot reader: parallel checksum for speed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15306,6 +15306,7 @@ dependencies = [
  "serde_json",
  "sui-config",
  "sui-core",
+ "sui-indexer-alt-framework",
  "sui-protocol-config",
  "sui-storage",
  "sui-types",

--- a/crates/sui-snapshot/Cargo.toml
+++ b/crates/sui-snapshot/Cargo.toml
@@ -25,6 +25,7 @@ prometheus.workspace = true
 sui-types.workspace = true
 sui-config.workspace = true
 sui-core.workspace = true
+sui-indexer-alt-framework.workspace = true
 sui-storage.workspace = true
 sui-protocol-config.workspace = true
 fastcrypto = { workspace = true, features = ["copy_key"] }


### PR DESCRIPTION
## Description 

title, before the local run of checksum took about 30min, after it's about 4 min

## Test plan 

ci & local run 
before 
```
[00:33:57] 726 out of 726 ref files checksummed (Checksumming complete)
```
after 
```
[00:04:19] 726 out of 726 ref files checksummed (Checksumming complete)
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
