### PR TITLE
sdk: add passkey recovery option

### DIFF
--- a/sdk/typescript/src/keypairs/passkey/keypair.ts
+++ b/sdk/typescript/src/keypairs/passkey/keypair.ts
@@ -99,7 +99,7 @@ export class BrowserPasskeyProvider implements PasskeyProvider {
  * A passkey signer used for signing transactions. This is a client side implementation for [SIP-9](https://github.com/sui-foundation/sips/blob/main/sips/sip-9.md).
  */
 export class PasskeyKeypair extends Signer {
-	private publicKey?: Uint8Array;
+	private publicKey: Uint8Array;
 	private provider: PasskeyProvider;
 
 	/**
@@ -123,7 +123,7 @@ export class PasskeyKeypair extends Signer {
 	 * If there are existing passkey wallet, use `signAndRecover` to identify the correct
 	 * public key and then initialize the instance. See usage in `signAndRecover`.
 	 */
-	constructor(provider: PasskeyProvider, publicKey?: Uint8Array) {
+	constructor(publicKey: Uint8Array, provider: PasskeyProvider) {
 		super();
 		this.publicKey = publicKey;
 		this.provider = provider;
@@ -148,7 +148,7 @@ export class PasskeyKeypair extends Signer {
 			const pubkeyUncompressed = parseDerSPKI(new Uint8Array(derSPKI));
 			const pubkey = secp256r1.ProjectivePoint.fromHex(pubkeyUncompressed);
 			const pubkeyCompressed = pubkey.toRawBytes(true);
-			return new PasskeyKeypair(provider, pubkeyCompressed);
+			return new PasskeyKeypair(pubkeyCompressed, provider);
 		}
 	}
 
@@ -156,7 +156,7 @@ export class PasskeyKeypair extends Signer {
 	 * Return the public key for this passkey.
 	 */
 	getPublicKey(): PublicKey {
-		return new PasskeyPublicKey(this.publicKey!);
+		return new PasskeyPublicKey(this.publicKey);
 	}
 
 	/**

--- a/sdk/typescript/test/unit/cryptography/passkey.test.ts
+++ b/sdk/typescript/test/unit/cryptography/passkey.test.ts
@@ -348,7 +348,7 @@ describe('passkey signer E2E testing', () => {
 		const possiblePks2 = await PasskeyKeypair.signAndRecover(mockProvider, testMessage2);
 
 		const uniquePk = findUniquePublicKey(possiblePks, possiblePks2);
-		const signer2 = new PasskeyKeypair(mockProvider, uniquePk.toRawBytes());
+		const signer2 = new PasskeyKeypair(uniquePk.toRawBytes(), mockProvider);
 
 		// the address from recovered pk is the same as the one constructed from the same mock provider
 		expect(signer2.getPublicKey().toSuiAddress()).toEqual(address);


### PR DESCRIPTION
## Description 

after thinking about https://github.com/MystenLabs/passkey-example?tab=readme-ov-file#notes-on-wallet-storage i realize we should provide the recovery ability in our sdk since getPasskeyInstance is a bit unflexible and create a new credential every time when called. we should also allow user to find its existing passkey wallet without creating a new one. similar to "log in to existing" vs "create new". since there are more than one way to "recover/log in" to an wallet, i leave the flexibility to the wallet implementer (to sign once vs sign twice). 

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
