### PR TITLE
[indexer-alt] Fix comments in pruner `to`

### DIFF
--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
@@ -62,9 +62,13 @@ pub trait Handler: Processor<Value: FieldCount> {
     async fn commit(values: &[Self::Value], conn: &mut db::Connection<'_>)
         -> anyhow::Result<usize>;
 
-    /// Clean up data between checkpoints `_from` and `_to` (inclusive) in the database, returning
+    /// Clean up data between checkpoints `_from` and `_to_exclusive` (exclusive) in the database, returning
     /// the number of rows affected. This function is optional, and defaults to not pruning at all.
-    async fn prune(_from: u64, _to: u64, _conn: &mut db::Connection<'_>) -> anyhow::Result<usize> {
+    async fn prune(
+        _from: u64,
+        _to_exclusive: u64,
+        _conn: &mut db::Connection<'_>,
+    ) -> anyhow::Result<usize> {
         Ok(0)
     }
 }


### PR DESCRIPTION
## Description 

Clarified in the doc comment for `prune` that `to` should be exclusive instead of inclusive.
Also updated the prune loop to make it clearer.

## Test plan 

We probably want to write some tests.
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
