### PR TITLE
[indexer-alt] pruning tests for pipelines that depend on `CpSequenceNumbers` for tx intervals

### DIFF
--- a/crates/sui-indexer-alt-framework/src/models/cp_sequence_numbers.rs
+++ b/crates/sui-indexer-alt-framework/src/models/cp_sequence_numbers.rs
@@ -40,7 +40,7 @@ pub async fn epoch_interval(conn: &mut Connection<'_>, cps: Range<u64>) -> Resul
 
 /// Gets the tx and epoch mappings for the given checkpoint range.
 ///
-/// The values are expected to exist since the cp_mapping table must have enough information to
+/// The values are expected to exist since the cp_sequence_numbers table must have enough information to
 /// encompass the retention of other tables.
 pub(crate) async fn get_range(
     conn: &mut Connection<'_>,

--- a/crates/sui-indexer-alt-schema/src/events.rs
+++ b/crates/sui-indexer-alt-schema/src/events.rs
@@ -5,7 +5,7 @@ use crate::schema::{ev_emit_mod, ev_struct_inst};
 use diesel::prelude::*;
 use sui_field_count::FieldCount;
 
-#[derive(Insertable, Debug, Clone, Eq, PartialEq, Ord, PartialOrd, FieldCount)]
+#[derive(Insertable, Debug, Clone, Eq, PartialEq, Ord, PartialOrd, FieldCount, Queryable)]
 #[diesel(table_name = ev_emit_mod)]
 pub struct StoredEvEmitMod {
     pub package: Vec<u8>,
@@ -14,7 +14,7 @@ pub struct StoredEvEmitMod {
     pub sender: Vec<u8>,
 }
 
-#[derive(Insertable, Debug, Clone, Eq, PartialEq, Ord, PartialOrd, FieldCount)]
+#[derive(Insertable, Debug, Clone, Eq, PartialEq, Ord, PartialOrd, FieldCount, Queryable)]
 #[diesel(table_name = ev_struct_inst)]
 pub struct StoredEvStructInst {
     pub package: Vec<u8>,

--- a/crates/sui-indexer-alt-schema/src/transactions.rs
+++ b/crates/sui-indexer-alt-schema/src/transactions.rs
@@ -32,7 +32,7 @@ pub enum BalanceChange {
     },
 }
 
-#[derive(Insertable, Debug, Clone, FieldCount)]
+#[derive(Insertable, Debug, Clone, FieldCount, Queryable)]
 #[diesel(table_name = kv_transactions)]
 pub struct StoredTransaction {
     pub tx_digest: Vec<u8>,
@@ -43,7 +43,7 @@ pub struct StoredTransaction {
     pub events: Vec<u8>,
 }
 
-#[derive(Insertable, Debug, Clone, FieldCount)]
+#[derive(Insertable, Debug, Clone, FieldCount, Queryable)]
 #[diesel(table_name = tx_affected_addresses)]
 pub struct StoredTxAffectedAddress {
     pub tx_sequence_number: i64,
@@ -53,7 +53,7 @@ pub struct StoredTxAffectedAddress {
     pub sender: Vec<u8>,
 }
 
-#[derive(Insertable, Debug, Clone, FieldCount)]
+#[derive(Insertable, Debug, Clone, FieldCount, Queryable)]
 #[diesel(table_name = tx_affected_objects)]
 pub struct StoredTxAffectedObject {
     pub tx_sequence_number: i64,
@@ -63,24 +63,24 @@ pub struct StoredTxAffectedObject {
     pub sender: Vec<u8>,
 }
 
-#[derive(Insertable, Debug, Clone, FieldCount)]
+#[derive(Insertable, Debug, Clone, FieldCount, Queryable)]
 #[diesel(table_name = tx_balance_changes)]
 pub struct StoredTxBalanceChange {
     pub tx_sequence_number: i64,
     pub balance_changes: Vec<u8>,
 }
 
-#[derive(Insertable, Debug, Clone, FieldCount)]
+#[derive(Insertable, Debug, Clone, FieldCount, Queryable)]
 #[diesel(table_name = tx_calls)]
 pub struct StoredTxCalls {
-    pub tx_sequence_number: i64,
     pub package: Vec<u8>,
     pub module: String,
     pub function: String,
+    pub tx_sequence_number: i64,
     pub sender: Vec<u8>,
 }
 
-#[derive(Insertable, Debug, Clone, FieldCount)]
+#[derive(Insertable, Debug, Clone, FieldCount, Queryable)]
 #[diesel(table_name = tx_digests)]
 pub struct StoredTxDigest {
     pub tx_sequence_number: i64,
@@ -95,7 +95,7 @@ pub enum StoredKind {
     ProgrammableTransaction = 1,
 }
 
-#[derive(Insertable, Debug, Clone, FieldCount)]
+#[derive(Insertable, Debug, Clone, FieldCount, Queryable)]
 #[diesel(table_name = tx_kinds)]
 pub struct StoredTxKind {
     pub tx_sequence_number: i64,

--- a/crates/sui-indexer-alt/src/handlers/ev_struct_inst.rs
+++ b/crates/sui-indexer-alt/src/handlers/ev_struct_inst.rs
@@ -82,3 +82,131 @@ impl Handler for EvStructInst {
         Ok(diesel::delete(filter).execute(conn).await?)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use diesel_async::RunQueryDsl;
+    use sui_indexer_alt_framework::handlers::cp_sequence_numbers::CpSequenceNumbers;
+    use sui_indexer_alt_framework::Indexer;
+    use sui_indexer_alt_schema::MIGRATIONS;
+    use sui_types::event::Event;
+    use sui_types::test_checkpoint_data_builder::TestCheckpointDataBuilder;
+
+    async fn get_all_ev_struct_inst(
+        conn: &mut db::Connection<'_>,
+    ) -> Result<Vec<StoredEvStructInst>> {
+        let query = ev_struct_inst::table
+            .order_by((
+                ev_struct_inst::tx_sequence_number,
+                ev_struct_inst::sender,
+                ev_struct_inst::package,
+                ev_struct_inst::module,
+                ev_struct_inst::name,
+                ev_struct_inst::instantiation,
+            ))
+            .load(conn)
+            .await?;
+        Ok(query)
+    }
+
+    #[tokio::test]
+    async fn test_ev_struct_inst_pruning_complains_if_no_mapping() {
+        let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
+        let mut conn = indexer.db().connect().await.unwrap();
+
+        let result = EvStructInst.prune(0, 2, &mut conn).await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "No checkpoint mapping found for checkpoint 0"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ev_struct_inst_process_no_events() {
+        let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
+        let mut conn = indexer.db().connect().await.unwrap();
+
+        let checkpoint = Arc::new(
+            TestCheckpointDataBuilder::new(0)
+                .start_transaction(0)
+                .finish_transaction()
+                .build_checkpoint(),
+        );
+
+        let values = EvStructInst.process(&checkpoint).unwrap();
+        EvStructInst::commit(&values, &mut conn).await.unwrap();
+
+        assert_eq!(values.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_ev_struct_inst_process_single_event() {
+        let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
+        let mut conn = indexer.db().connect().await.unwrap();
+
+        let checkpoint = Arc::new(
+            TestCheckpointDataBuilder::new(0)
+                .start_transaction(0)
+                .with_events(vec![Event::random_for_testing()])
+                .finish_transaction()
+                .build_checkpoint(),
+        );
+
+        // Process checkpoint with one event
+        let values = EvStructInst.process(&checkpoint).unwrap();
+        EvStructInst::commit(&values, &mut conn).await.unwrap();
+
+        let events = get_all_ev_struct_inst(&mut conn).await.unwrap();
+        assert_eq!(events.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_ev_struct_inst_prune_events() {
+        let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
+        let mut conn = indexer.db().connect().await.unwrap();
+
+        // 0th checkpoint has no events
+        let mut builder = TestCheckpointDataBuilder::new(0);
+        builder = builder.start_transaction(0).finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = EvStructInst.process(&checkpoint).unwrap();
+        EvStructInst::commit(&values, &mut conn).await.unwrap();
+        let values = CpSequenceNumbers.process(&checkpoint).unwrap();
+        CpSequenceNumbers::commit(&values, &mut conn).await.unwrap();
+
+        // 1st checkpoint has 1 event
+        builder = builder
+            .start_transaction(0)
+            .with_events(vec![Event::random_for_testing()])
+            .finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = EvStructInst.process(&checkpoint).unwrap();
+        EvStructInst::commit(&values, &mut conn).await.unwrap();
+        let values = CpSequenceNumbers.process(&checkpoint).unwrap();
+        CpSequenceNumbers::commit(&values, &mut conn).await.unwrap();
+
+        // 2nd checkpoint has 2 events
+        builder = builder
+            .start_transaction(0)
+            .with_events(vec![
+                Event::random_for_testing(),
+                Event::random_for_testing(),
+            ])
+            .finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = EvStructInst.process(&checkpoint).unwrap();
+        EvStructInst::commit(&values, &mut conn).await.unwrap();
+        let values = CpSequenceNumbers.process(&checkpoint).unwrap();
+        CpSequenceNumbers::commit(&values, &mut conn).await.unwrap();
+
+        // Prune checkpoints from `[0, 2)`, expect 2 events remaining
+        let rows_pruned = EvStructInst.prune(0, 2, &mut conn).await.unwrap();
+        assert_eq!(rows_pruned, 1);
+
+        let remaining_events = get_all_ev_struct_inst(&mut conn).await.unwrap();
+        assert_eq!(remaining_events.len(), 2);
+    }
+}

--- a/crates/sui-indexer-alt/src/handlers/obj_info.rs
+++ b/crates/sui-indexer-alt/src/handlers/obj_info.rs
@@ -192,7 +192,8 @@ mod tests {
 
     use super::*;
 
-    // A helper function to return all entries in the obj_info table sorted by object_id and cp_sequence_number.
+    // A helper function to return all entries in the obj_info table sorted by object_id and
+    // cp_sequence_number.
     async fn get_all_obj_info(conn: &mut db::Connection<'_>) -> Result<Vec<StoredObjInfo>> {
         let query = obj_info::table.load(conn).await?;
         Ok(query)

--- a/crates/sui-indexer-alt/src/handlers/tx_affected_addresses.rs
+++ b/crates/sui-indexer-alt/src/handlers/tx_affected_addresses.rs
@@ -92,3 +92,86 @@ impl Handler for TxAffectedAddresses {
         Ok(diesel::delete(filter).execute(conn).await?)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use diesel_async::RunQueryDsl;
+    use sui_indexer_alt_framework::{handlers::cp_sequence_numbers::CpSequenceNumbers, Indexer};
+    use sui_indexer_alt_schema::MIGRATIONS;
+    use sui_types::test_checkpoint_data_builder::TestCheckpointDataBuilder;
+
+    async fn get_all_tx_affected_addresses(conn: &mut db::Connection<'_>) -> Result<Vec<i64>> {
+        Ok(tx_affected_addresses::table
+            .select(tx_affected_addresses::tx_sequence_number)
+            .order_by(tx_affected_addresses::tx_sequence_number)
+            .load(conn)
+            .await?)
+    }
+
+    #[tokio::test]
+    async fn test_tx_affected_addresses_pruning_complains_if_no_mapping() {
+        let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
+        let mut conn = indexer.db().connect().await.unwrap();
+
+        let result = TxAffectedAddresses.prune(0, 2, &mut conn).await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "No checkpoint mapping found for checkpoint 0"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tx_affected_addresses_pruning() {
+        let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
+        let mut conn = indexer.db().connect().await.unwrap();
+
+        // 0th checkpoint has 1 transaction
+        let mut builder = TestCheckpointDataBuilder::new(0);
+        builder = builder.start_transaction(0).finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = TxAffectedAddresses.process(&checkpoint).unwrap();
+        TxAffectedAddresses::commit(&values, &mut conn)
+            .await
+            .unwrap();
+        let values = CpSequenceNumbers.process(&checkpoint).unwrap();
+        CpSequenceNumbers::commit(&values, &mut conn).await.unwrap();
+
+        // 1st checkpoint has 2 transactions
+        builder = builder.start_transaction(0).finish_transaction();
+        builder = builder.start_transaction(1).finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = TxAffectedAddresses.process(&checkpoint).unwrap();
+        TxAffectedAddresses::commit(&values, &mut conn)
+            .await
+            .unwrap();
+        let values = CpSequenceNumbers.process(&checkpoint).unwrap();
+        CpSequenceNumbers::commit(&values, &mut conn).await.unwrap();
+
+        // 2nd checkpoint has 4 transactions
+        builder = builder.start_transaction(0).finish_transaction();
+        builder = builder.start_transaction(1).finish_transaction();
+        builder = builder.start_transaction(2).finish_transaction();
+        builder = builder.start_transaction(3).finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = TxAffectedAddresses.process(&checkpoint).unwrap();
+        TxAffectedAddresses::commit(&values, &mut conn)
+            .await
+            .unwrap();
+        let values = CpSequenceNumbers.process(&checkpoint).unwrap();
+        CpSequenceNumbers::commit(&values, &mut conn).await.unwrap();
+
+        let fetched_results = get_all_tx_affected_addresses(&mut conn).await.unwrap();
+        assert_eq!(fetched_results.len(), 7);
+
+        // Prune checkpoints from `[0, 2)`, expect 4 transactions remaining
+        let rows_pruned = TxAffectedAddresses.prune(0, 2, &mut conn).await.unwrap();
+        assert_eq!(rows_pruned, 3);
+        let remaining_tx_affected_addresses =
+            get_all_tx_affected_addresses(&mut conn).await.unwrap();
+        assert_eq!(remaining_tx_affected_addresses.len(), 4);
+        assert_eq!(remaining_tx_affected_addresses, vec![3, 4, 5, 6]);
+    }
+}

--- a/crates/sui-indexer-alt/src/handlers/tx_affected_objects.rs
+++ b/crates/sui-indexer-alt/src/handlers/tx_affected_objects.rs
@@ -82,3 +82,78 @@ impl Handler for TxAffectedObjects {
         Ok(diesel::delete(filter).execute(conn).await?)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use diesel_async::RunQueryDsl;
+    use sui_indexer_alt_framework::{handlers::cp_sequence_numbers::CpSequenceNumbers, Indexer};
+    use sui_indexer_alt_schema::MIGRATIONS;
+    use sui_types::test_checkpoint_data_builder::TestCheckpointDataBuilder;
+
+    async fn get_all_tx_affected_objects(conn: &mut db::Connection<'_>) -> Result<Vec<i64>> {
+        Ok(tx_affected_objects::table
+            .select(tx_affected_objects::tx_sequence_number)
+            .order_by(tx_affected_objects::tx_sequence_number)
+            .load(conn)
+            .await?)
+    }
+
+    #[tokio::test]
+    async fn test_tx_affected_objects_pruning_complains_if_no_mapping() {
+        let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
+        let mut conn = indexer.db().connect().await.unwrap();
+
+        let result = TxAffectedObjects.prune(0, 2, &mut conn).await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "No checkpoint mapping found for checkpoint 0"
+        );
+    }
+
+    /// The kv_checkpoints pruner does not require cp_sequence_numbers, it can prune directly with the
+    /// checkpoint sequence number range.
+    #[tokio::test]
+    async fn test_tx_affected_objects_pruning() {
+        let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
+        let mut conn = indexer.db().connect().await.unwrap();
+
+        let mut builder = TestCheckpointDataBuilder::new(0);
+        builder = builder.start_transaction(0).finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = TxAffectedObjects.process(&checkpoint).unwrap();
+        TxAffectedObjects::commit(&values, &mut conn).await.unwrap();
+        let values = CpSequenceNumbers.process(&checkpoint).unwrap();
+        CpSequenceNumbers::commit(&values, &mut conn).await.unwrap();
+
+        builder = builder.start_transaction(0).finish_transaction();
+        builder = builder.start_transaction(1).finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = TxAffectedObjects.process(&checkpoint).unwrap();
+        TxAffectedObjects::commit(&values, &mut conn).await.unwrap();
+        let values = CpSequenceNumbers.process(&checkpoint).unwrap();
+        CpSequenceNumbers::commit(&values, &mut conn).await.unwrap();
+
+        builder = builder.start_transaction(0).finish_transaction();
+        builder = builder.start_transaction(1).finish_transaction();
+        builder = builder.start_transaction(2).finish_transaction();
+        builder = builder.start_transaction(3).finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = TxAffectedObjects.process(&checkpoint).unwrap();
+        TxAffectedObjects::commit(&values, &mut conn).await.unwrap();
+        let values = CpSequenceNumbers.process(&checkpoint).unwrap();
+        CpSequenceNumbers::commit(&values, &mut conn).await.unwrap();
+
+        let fetched_results = get_all_tx_affected_objects(&mut conn).await.unwrap();
+        assert_eq!(fetched_results.len(), 7);
+
+        // Prune checkpoints from `[0, 2)`, expect 4 tx_affected_objects remaining
+        let rows_pruned = TxAffectedObjects.prune(0, 2, &mut conn).await.unwrap();
+        assert_eq!(rows_pruned, 3);
+        let remaining_tx_affected_objects = get_all_tx_affected_objects(&mut conn).await.unwrap();
+        assert_eq!(remaining_tx_affected_objects.len(), 4);
+        assert_eq!(remaining_tx_affected_objects, vec![3, 4, 5, 6]);
+    }
+}

--- a/crates/sui-indexer-alt/src/handlers/tx_balance_changes.rs
+++ b/crates/sui-indexer-alt/src/handlers/tx_balance_changes.rs
@@ -122,3 +122,78 @@ fn balance_changes(transaction: &CheckpointTransaction) -> Result<Vec<BalanceCha
         })
         .collect())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use diesel_async::RunQueryDsl;
+    use sui_indexer_alt_framework::{handlers::cp_sequence_numbers::CpSequenceNumbers, Indexer};
+    use sui_indexer_alt_schema::MIGRATIONS;
+    use sui_types::test_checkpoint_data_builder::TestCheckpointDataBuilder;
+
+    async fn get_all_tx_balance_changes(conn: &mut db::Connection<'_>) -> Result<Vec<i64>> {
+        Ok(tx_balance_changes::table
+            .select(tx_balance_changes::tx_sequence_number)
+            .order_by(tx_balance_changes::tx_sequence_number)
+            .load(conn)
+            .await?)
+    }
+
+    #[tokio::test]
+    async fn test_tx_balance_changes_pruning_complains_if_no_mapping() {
+        let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
+        let mut conn = indexer.db().connect().await.unwrap();
+
+        let result = TxBalanceChanges.prune(0, 2, &mut conn).await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "No checkpoint mapping found for checkpoint 0"
+        );
+    }
+
+    /// The kv_checkpoints pruner does not require cp_sequence_numbers, it can prune directly with the
+    /// checkpoint sequence number range.
+    #[tokio::test]
+    async fn test_tx_balance_changes_pruning() {
+        let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
+        let mut conn = indexer.db().connect().await.unwrap();
+
+        let mut builder = TestCheckpointDataBuilder::new(0);
+        builder = builder.start_transaction(0).finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = TxBalanceChanges.process(&checkpoint).unwrap();
+        TxBalanceChanges::commit(&values, &mut conn).await.unwrap();
+        let values = CpSequenceNumbers.process(&checkpoint).unwrap();
+        CpSequenceNumbers::commit(&values, &mut conn).await.unwrap();
+
+        builder = builder.start_transaction(0).finish_transaction();
+        builder = builder.start_transaction(1).finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = TxBalanceChanges.process(&checkpoint).unwrap();
+        TxBalanceChanges::commit(&values, &mut conn).await.unwrap();
+        let values = CpSequenceNumbers.process(&checkpoint).unwrap();
+        CpSequenceNumbers::commit(&values, &mut conn).await.unwrap();
+
+        builder = builder.start_transaction(0).finish_transaction();
+        builder = builder.start_transaction(1).finish_transaction();
+        builder = builder.start_transaction(2).finish_transaction();
+        builder = builder.start_transaction(3).finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = TxBalanceChanges.process(&checkpoint).unwrap();
+        TxBalanceChanges::commit(&values, &mut conn).await.unwrap();
+        let values = CpSequenceNumbers.process(&checkpoint).unwrap();
+        CpSequenceNumbers::commit(&values, &mut conn).await.unwrap();
+
+        let fetched_results = get_all_tx_balance_changes(&mut conn).await.unwrap();
+        assert_eq!(fetched_results.len(), 7);
+
+        // Prune checkpoints from `[0, 2)`, expect 4 tx_balance_changes remaining
+        let rows_pruned = TxBalanceChanges.prune(0, 2, &mut conn).await.unwrap();
+        assert_eq!(rows_pruned, 3);
+        let remaining_tx_balance_changes = get_all_tx_balance_changes(&mut conn).await.unwrap();
+        assert_eq!(remaining_tx_balance_changes.len(), 4);
+        assert_eq!(remaining_tx_balance_changes, vec![3, 4, 5, 6]);
+    }
+}

--- a/crates/sui-indexer-alt/src/handlers/tx_calls.rs
+++ b/crates/sui-indexer-alt/src/handlers/tx_calls.rs
@@ -84,3 +84,108 @@ impl Handler for TxCalls {
         Ok(diesel::delete(filter).execute(conn).await?)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use diesel_async::RunQueryDsl;
+    use sui_indexer_alt_framework::{handlers::cp_sequence_numbers::CpSequenceNumbers, Indexer};
+    use sui_indexer_alt_schema::MIGRATIONS;
+    use sui_types::{
+        base_types::ObjectID, test_checkpoint_data_builder::TestCheckpointDataBuilder,
+    };
+
+    async fn get_all_tx_calls(conn: &mut db::Connection<'_>) -> Result<Vec<StoredTxCalls>> {
+        Ok(tx_calls::table
+            .order_by((
+                tx_calls::tx_sequence_number,
+                tx_calls::sender,
+                tx_calls::package,
+                tx_calls::module,
+                tx_calls::function,
+            ))
+            .load(conn)
+            .await?)
+    }
+
+    #[tokio::test]
+    async fn test_tx_calls_pruning_complains_if_no_mapping() {
+        let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
+        let mut conn = indexer.db().connect().await.unwrap();
+
+        let result = TxCalls.prune(0, 2, &mut conn).await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "No checkpoint mapping found for checkpoint 0"
+        );
+    }
+
+    /// The kv_checkpoints pruner does not require cp_sequence_numbers, it can prune directly with the
+    /// checkpoint sequence number range.
+    #[tokio::test]
+    async fn test_tx_calls_pruning() {
+        let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
+        let mut conn = indexer.db().connect().await.unwrap();
+
+        let mut builder = TestCheckpointDataBuilder::new(0);
+        builder = builder
+            .start_transaction(0)
+            .add_move_call(ObjectID::random(), "module", "function")
+            .finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = TxCalls.process(&checkpoint).unwrap();
+        TxCalls::commit(&values, &mut conn).await.unwrap();
+        let values = CpSequenceNumbers.process(&checkpoint).unwrap();
+        CpSequenceNumbers::commit(&values, &mut conn).await.unwrap();
+
+        builder = builder
+            .start_transaction(0)
+            .add_move_call(ObjectID::random(), "module", "function")
+            .add_move_call(ObjectID::random(), "module", "function")
+            .finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = TxCalls.process(&checkpoint).unwrap();
+        TxCalls::commit(&values, &mut conn).await.unwrap();
+        let values = CpSequenceNumbers.process(&checkpoint).unwrap();
+        CpSequenceNumbers::commit(&values, &mut conn).await.unwrap();
+
+        let reuse_package_id = ObjectID::random();
+        builder = builder
+            .start_transaction(0)
+            .add_move_call(reuse_package_id, "donut", "prune")
+            .add_move_call(reuse_package_id, "donut", "prune2")
+            .add_move_call(reuse_package_id, "donut", "prune3")
+            .add_move_call(reuse_package_id, "donut", "prune4")
+            .finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = TxCalls.process(&checkpoint).unwrap();
+        TxCalls::commit(&values, &mut conn).await.unwrap();
+        let values = CpSequenceNumbers.process(&checkpoint).unwrap();
+        CpSequenceNumbers::commit(&values, &mut conn).await.unwrap();
+
+        let fetched_results = get_all_tx_calls(&mut conn).await.unwrap();
+        assert_eq!(fetched_results.len(), 7);
+
+        // Prune checkpoints from `[0, 2)`, expect 4 tx_calls remaining
+        let rows_pruned = TxCalls.prune(0, 2, &mut conn).await.unwrap();
+        assert_eq!(rows_pruned, 3);
+        let remaining_tx_calls = get_all_tx_calls(&mut conn).await.unwrap();
+        assert_eq!(remaining_tx_calls.len(), 4);
+        assert_eq!(
+            remaining_tx_calls
+                .iter()
+                .map(|tx_call| (tx_call.module.clone(), tx_call.function.clone()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("donut".to_string(), "prune".to_string()),
+                ("donut".to_string(), "prune2".to_string()),
+                ("donut".to_string(), "prune3".to_string()),
+                ("donut".to_string(), "prune4".to_string())
+            ]
+            .into_iter()
+            .collect::<Vec<_>>()
+        );
+    }
+}

--- a/crates/sui-indexer-alt/src/handlers/tx_digests.rs
+++ b/crates/sui-indexer-alt/src/handlers/tx_digests.rs
@@ -71,3 +71,76 @@ impl Handler for TxDigests {
         Ok(diesel::delete(filter).execute(conn).await?)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use diesel_async::RunQueryDsl;
+    use sui_indexer_alt_framework::{handlers::cp_sequence_numbers::CpSequenceNumbers, Indexer};
+    use sui_indexer_alt_schema::MIGRATIONS;
+    use sui_types::test_checkpoint_data_builder::TestCheckpointDataBuilder;
+
+    async fn get_all_tx_digests(conn: &mut db::Connection<'_>) -> Result<Vec<i64>> {
+        Ok(tx_digests::table
+            .select(tx_digests::tx_sequence_number)
+            .load(conn)
+            .await?)
+    }
+
+    #[tokio::test]
+    async fn test_tx_digests_pruning_complains_if_no_mapping() {
+        let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
+        let mut conn = indexer.db().connect().await.unwrap();
+
+        let result = TxDigests.prune(0, 2, &mut conn).await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "No checkpoint mapping found for checkpoint 0"
+        );
+    }
+
+    /// The kv_checkpoints pruner does not require cp_sequence_numbers, it can prune directly with the
+    /// checkpoint sequence number range.
+    #[tokio::test]
+    async fn test_tx_digests_pruning() {
+        let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
+        let mut conn = indexer.db().connect().await.unwrap();
+
+        let mut builder = TestCheckpointDataBuilder::new(0);
+        builder = builder.start_transaction(0).finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = TxDigests.process(&checkpoint).unwrap();
+        TxDigests::commit(&values, &mut conn).await.unwrap();
+        let values = CpSequenceNumbers.process(&checkpoint).unwrap();
+        CpSequenceNumbers::commit(&values, &mut conn).await.unwrap();
+
+        builder = builder.start_transaction(0).finish_transaction();
+        builder = builder.start_transaction(1).finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = TxDigests.process(&checkpoint).unwrap();
+        TxDigests::commit(&values, &mut conn).await.unwrap();
+        let values = CpSequenceNumbers.process(&checkpoint).unwrap();
+        CpSequenceNumbers::commit(&values, &mut conn).await.unwrap();
+
+        builder = builder.start_transaction(0).finish_transaction();
+        builder = builder.start_transaction(1).finish_transaction();
+        builder = builder.start_transaction(2).finish_transaction();
+        builder = builder.start_transaction(3).finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = TxDigests.process(&checkpoint).unwrap();
+        TxDigests::commit(&values, &mut conn).await.unwrap();
+        let values = CpSequenceNumbers.process(&checkpoint).unwrap();
+        CpSequenceNumbers::commit(&values, &mut conn).await.unwrap();
+
+        let fetched_results = get_all_tx_digests(&mut conn).await.unwrap();
+        assert_eq!(fetched_results.len(), 7);
+
+        // Prune checkpoints from `[0, 2)`, expect 4 tx_digests remaining
+        let rows_pruned = TxDigests.prune(0, 2, &mut conn).await.unwrap();
+        assert_eq!(rows_pruned, 3);
+        let remaining_tx_digests = get_all_tx_digests(&mut conn).await.unwrap();
+        assert_eq!(remaining_tx_digests.len(), 4);
+    }
+}

--- a/crates/sui-pg-db/src/lib.rs
+++ b/crates/sui-pg-db/src/lib.rs
@@ -22,11 +22,11 @@ pub mod temp;
 pub struct DbArgs {
     /// The URL of the database to connect to.
     #[arg(long, default_value_t = Self::default().database_url)]
-    database_url: Url,
+    pub database_url: Url,
 
     /// Number of connections to keep in the pool.
     #[arg(long, default_value_t = Self::default().db_connection_pool_size)]
-    db_connection_pool_size: u32,
+    pub db_connection_pool_size: u32,
 
     /// Time spent waiting for a connection from the pool to become available, in milliseconds.
     #[arg(long, default_value_t = Self::default().connection_timeout_ms)]

--- a/crates/sui-types/src/test_checkpoint_data_builder.rs
+++ b/crates/sui-types/src/test_checkpoint_data_builder.rs
@@ -53,6 +53,8 @@ struct CheckpointBuilder {
     checkpoint: u64,
     /// Epoch number for the current checkpoint we are building.
     epoch: u64,
+    /// Counter for the total number of transactions added to the builder.
+    network_total_transactions: u64,
     /// Transactions that have been added to the current checkpoint.
     transactions: Vec<CheckpointTransaction>,
     /// The current transaction being built.
@@ -96,6 +98,7 @@ impl TestCheckpointDataBuilder {
             checkpoint_builder: CheckpointBuilder {
                 checkpoint,
                 epoch: 0,
+                network_total_transactions: 0,
                 transactions: vec![],
                 next_transaction: None,
             },
@@ -462,11 +465,12 @@ impl TestCheckpointDataBuilder {
                 .iter()
                 .map(|tx| ExecutionDigests::new(*tx.transaction.digest(), tx.effects.digest())),
         );
+        self.checkpoint_builder.network_total_transactions += transactions.len() as u64;
         let checkpoint_summary = CheckpointSummary::new(
             &ProtocolConfig::get_for_max_version_UNSAFE(),
             self.checkpoint_builder.epoch,
             self.checkpoint_builder.checkpoint,
-            transactions.len() as u64,
+            self.checkpoint_builder.network_total_transactions,
             &contents,
             None,
             Default::default(),


### PR DESCRIPTION
## Description 

pruning tests for pipelines that depend on `CpSequenceNumbers` for tx intervals

## Test plan 

All tests!

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
