### PR TITLE
[suiop][pulumi] handle non-poetry projects

### DIFF
--- a/crates/suiop-cli/src/cli/pulumi/deps.rs
+++ b/crates/suiop-cli/src/cli/pulumi/deps.rs
@@ -20,7 +20,13 @@ fn update_dependencies(path: &Path, runtime: &str) -> Result<()> {
     let output = match runtime {
         "go" => run_cmd(vec!["go", "get", "-u"], Some(cmd_opts.clone()))
             .and_then(|_o| run_cmd(vec!["go", "mod", "tidy"], Some(cmd_opts))),
-        "python" => run_cmd(vec!["poetry", "update"], Some(cmd_opts)),
+        "python" => {
+            if !path.join("pyproject.toml").exists() {
+                run_cmd(vec!["pulumi", "install"], Some(cmd_opts))
+            } else {
+                run_cmd(vec!["poetry", "update"], Some(cmd_opts))
+            }
+        }
         "typescript" => run_cmd(vec!["pnpm", "update"], Some(cmd_opts)),
         _ => unreachable!(),
     }?;


### PR DESCRIPTION
## Description 

Some projects don't use poetry

## Test plan 

Ran locally successfully on the services dir, which includes non-poetry python projects.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
