### PR TITLE
[trace-view] Fixed displaying of compound reference values

### DIFF
--- a/external-crates/move/crates/move-analyzer/trace-adapter/tests/references_deep/test.exp
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/tests/references_deep/test.exp
@@ -25,14 +25,10 @@ current frame stack:
 
   function: bar (m.move:13)
     scope 0 :
-      vec_ref : (0x0::m::SomeStruct) {
-        struct_field : (0x0::m::VecStruct) {
-          vec_field : [
-            0 : 0
-            1 : 7
-          ]
-        }
-      }
+      vec_ref : [
+        0 : 0
+        1 : 7
+      ]
       type: &mut vector<u64>
 
 current frame stack:
@@ -62,13 +58,9 @@ current frame stack:
 
   function: bar (m.move:15)
     scope 0 :
-      vec_ref : (0x0::m::SomeStruct) {
-        struct_field : (0x0::m::VecStruct) {
-          vec_field : [
-            0 : 42
-            1 : 7
-          ]
-        }
-      }
+      vec_ref : [
+        0 : 42
+        1 : 7
+      ]
       type: &mut vector<u64>
 


### PR DESCRIPTION
## Description 

When displaying references to structs/enums, we need to store the index path to a specific portion of the struct/enum so that we can display only the "innermost" portion of the whole referenced values. Consider the following code:
```move
public struct SomeStruct has drop {
    struct_field: VecStruct,
}

public struct VecStruct has drop, copy {
    vec_field: vector<u64>,
}

fun bar(vec_ref: &mut vector<u64>): u64 {
    let e = vector::borrow_mut(vec_ref, 0);
    *e = 42;
    vec_ref[0]
}

fun foo(some_struct_ref: &mut SomeStruct): u64 {
    let res = bar(&mut some_struct_ref.struct_field.vec_field);
    res + some_struct_ref.struct_field.vec_field[0]
}

fun some_struct(): SomeStruct {
    SomeStruct {
        struct_field: VecStruct { vec_field: vector::singleton(0) }
    }
}

#[test]
fun test() {
    let mut some_struct = some_struct();
    some_struct.struct_field.vec_field.push_back(7);
    foo(&mut some_struct);
}
```

In `bar`, we want to display just the vector and its values even though this vector is part of a larger nested struct. Previously, without index paths being available, we would see the entire struct:
![image](https://github.com/user-attachments/assets/3eb58ee7-9780-4bf8-814d-aa7e6c50323a)

After changes in this PR, we will correctly only show the content of the vector:
![image](https://github.com/user-attachments/assets/9024012b-8eb9-47f8-a892-9e44bf09dca2)


## Test plan 

All tests (including the updated ones) must pass
