### PR TITLE
Enable burst mode for congestion control at 10x per-commit rate

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -3009,6 +3009,9 @@ impl ProtocolConfig {
                             .consensus_round_prober_probe_accepted_rounds = true;
                     }
 
+                    // Enable bursts for congestion control. (10x the per-commit budget)
+                    cfg.allowed_txn_cost_overage_burst_per_object_in_commit = Some(185_000_000);
+
                     cfg.poseidon_bn254_cost_per_block = Some(388);
 
                     cfg.gas_model_version = Some(9);

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_70.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_70.snap
@@ -331,6 +331,7 @@ consensus_voting_rounds: 40
 max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
 max_deferral_rounds_for_congestion_control: 10
 max_txn_cost_overage_per_object_in_commit: 18446744073709551615
+allowed_txn_cost_overage_burst_per_object_in_commit: 185000000
 min_checkpoint_interval_ms: 200
 checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_70.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_70.snap
@@ -334,6 +334,7 @@ consensus_voting_rounds: 40
 max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
 max_deferral_rounds_for_congestion_control: 10
 max_txn_cost_overage_per_object_in_commit: 18446744073709551615
+allowed_txn_cost_overage_burst_per_object_in_commit: 185000000
 min_checkpoint_interval_ms: 200
 checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_70.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_70.snap
@@ -343,6 +343,7 @@ consensus_voting_rounds: 40
 max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
 max_deferral_rounds_for_congestion_control: 10
 max_txn_cost_overage_per_object_in_commit: 18446744073709551615
+allowed_txn_cost_overage_burst_per_object_in_commit: 185000000
 min_checkpoint_interval_ms: 200
 checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5


### PR DESCRIPTION
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [x] Protocol: Allows bursts to exceed the normal per-commit congestion control limits on shared objects.
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
