### PR TITLE
[indexer-alt] add index on `cp_sequence_number` for `kv_transactions` for pruning

### DIFF
--- a/crates/sui-indexer-alt-schema/migrations/2025-01-02-201724_cp-sequence-number-index-on-kv-transactions/down.sql
+++ b/crates/sui-indexer-alt-schema/migrations/2025-01-02-201724_cp-sequence-number-index-on-kv-transactions/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS kv_transactions_cp_sequence_number;

--- a/crates/sui-indexer-alt-schema/migrations/2025-01-02-201724_cp-sequence-number-index-on-kv-transactions/up.sql
+++ b/crates/sui-indexer-alt-schema/migrations/2025-01-02-201724_cp-sequence-number-index-on-kv-transactions/up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS kv_transactions_cp_sequence_number
+ON kv_transactions (cp_sequence_number);


### PR DESCRIPTION
## Description 

add index on cp_sequence_number for kv_transactions, so that we can prune the table while still adhering to kv schema

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
