### PR TITLE
fix(sui-indexer): allow setting --gc-checkpoint-files=false

### DIFF
--- a/crates/sui-indexer/src/config.rs
+++ b/crates/sui-indexer/src/config.rs
@@ -142,7 +142,13 @@ pub struct IngestionConfig {
 
     /// Whether to delete processed checkpoint files from the local directory,
     /// when running Fullnode-colocated indexer.
-    #[arg(long, default_value_t = true)]
+    #[arg(
+        long,
+        default_value_t = true,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = false,
+    )]
     pub gc_checkpoint_files: bool,
 }
 


### PR DESCRIPTION
## Description 

Previously I was unable to turn off checkpoint file garbage collection,
since the default value was `true`, the `--gc-checkpoint-files` flag
didn't expect any values and the default `clap` action was to set the
value to `true` when the flag was present. I've tried all of:

- `--gc-checkpoint-files 0`
- `--gc-checkpoint-files false`
- `--gc-checkpoint-files=0`
- `--gc-checkpoint-files=false`

This changes that so that the `false` value is accepted by the argument, i.e., you can set `--gc-checkpoint-files=false`. Default behavior when the argument is missing remains the same as before.

It is based on this [comment](https://github.com/clap-rs/clap/issues/1649#issuecomment-2144879038)

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
