### PR TITLE
[indexer-alt] - add rpc api ingestion to indexer-alt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13792,6 +13792,7 @@ dependencies = [
  "sui-field-count",
  "sui-indexer-alt-metrics",
  "sui-pg-db",
+ "sui-rpc-api",
  "sui-sql-macro",
  "sui-storage",
  "sui-synthetic-ingestion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13802,6 +13802,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tonic 0.12.3",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -118,6 +118,8 @@ impl FullCluster {
             local_ingestion_path: Some(temp_dir.path().to_owned()),
             remote_store_url: None,
             rpc_api_url: None,
+            rpc_username: None,
+            rpc_password: None,
         };
 
         let offchain = OffchainCluster::new(

--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -117,6 +117,7 @@ impl FullCluster {
         let client_args = ClientArgs {
             local_ingestion_path: Some(temp_dir.path().to_owned()),
             remote_store_url: None,
+            rpc_api_url: None,
         };
 
         let offchain = OffchainCluster::new(

--- a/crates/sui-indexer-alt-e2e-tests/tests/transactional_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/transactional_tests.rs
@@ -106,6 +106,7 @@ async fn cluster(config: &OffChainConfig) -> Arc<OffchainCluster> {
     let client_args = ClientArgs {
         local_ingestion_path: Some(config.data_ingestion_path.clone()),
         remote_store_url: None,
+        rpc_api_url: None,
     };
 
     // This configuration controls how often the RPC service checks for changes to system packages.

--- a/crates/sui-indexer-alt-e2e-tests/tests/transactional_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/transactional_tests.rs
@@ -107,6 +107,8 @@ async fn cluster(config: &OffChainConfig) -> Arc<OffchainCluster> {
         local_ingestion_path: Some(config.data_ingestion_path.clone()),
         remote_store_url: None,
         rpc_api_url: None,
+        rpc_username: None,
+        rpc_password: None,
     };
 
     // This configuration controls how often the RPC service checks for changes to system packages.

--- a/crates/sui-indexer-alt-framework/Cargo.toml
+++ b/crates/sui-indexer-alt-framework/Cargo.toml
@@ -13,7 +13,7 @@ axum.workspace = true
 backoff.workspace = true
 bb8 = "0.8.5"
 chrono.workspace = true
-clap.workspace = true
+clap = { workspace = true, features = ["env"] }
 diesel = { workspace = true, features = ["chrono"] }
 diesel-async = { workspace = true, features = ["bb8", "postgres", "async-connection-wrapper"] }
 diesel_migrations.workspace = true
@@ -37,7 +37,7 @@ sui-sql-macro.workspace = true
 sui-storage.workspace = true
 sui-types.workspace = true
 sui-rpc-api.workspace = true
-bytes = "1.8.0"
+tonic.workspace = true
 
 [dev-dependencies]
 rand.workspace = true

--- a/crates/sui-indexer-alt-framework/Cargo.toml
+++ b/crates/sui-indexer-alt-framework/Cargo.toml
@@ -36,6 +36,8 @@ sui-pg-db.workspace = true
 sui-sql-macro.workspace = true
 sui-storage.workspace = true
 sui-types.workspace = true
+sui-rpc-api.workspace = true
+bytes = "1.8.0"
 
 [dev-dependencies]
 rand.workspace = true

--- a/crates/sui-indexer-alt-framework/src/cluster.rs
+++ b/crates/sui-indexer-alt-framework/src/cluster.rs
@@ -258,6 +258,7 @@ mod tests {
             client_args: ClientArgs {
                 local_ingestion_path: Some(checkpoint_dir.path().to_owned()),
                 remote_store_url: None,
+                rpc_api_url: None,
             },
             indexer_args: IndexerArgs {
                 first_checkpoint: Some(0),

--- a/crates/sui-indexer-alt-framework/src/cluster.rs
+++ b/crates/sui-indexer-alt-framework/src/cluster.rs
@@ -259,6 +259,8 @@ mod tests {
                 local_ingestion_path: Some(checkpoint_dir.path().to_owned()),
                 remote_store_url: None,
                 rpc_api_url: None,
+                rpc_username: None,
+                rpc_password: None,
             },
             indexer_args: IndexerArgs {
                 first_checkpoint: Some(0),

--- a/crates/sui-indexer-alt-framework/src/ingestion/client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/client.rs
@@ -171,9 +171,8 @@ impl IngestionClient {
                         })?
                     }
                     FetchData::CheckPointData(data) => {
-                        self.metrics
-                            .total_ingested_bytes
-                            .inc_by(size_of_val(&data) as u64);
+                        // We are not recording size metric for Checkpoint data (from RPC client).
+                        // TODO: Record the metric when we have a good way to get the size information
                         data
                     }
                 })

--- a/crates/sui-indexer-alt-framework/src/ingestion/client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/client.rs
@@ -85,8 +85,7 @@ impl IngestionClient {
         metrics: Arc<IndexerMetrics>,
     ) -> IngestionResult<Self> {
         let client = Arc::new(
-            RpcIngestionClient::new(url, basic_auth)
-                .map_err(|e| IngestionError::RpcClientError(e))?,
+            RpcIngestionClient::new(url, basic_auth).map_err(IngestionError::RpcClientError)?,
         );
         Ok(Self::new_impl(client, metrics))
     }

--- a/crates/sui-indexer-alt-framework/src/ingestion/client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/client.rs
@@ -16,6 +16,7 @@ use url::Url;
 
 use crate::ingestion::local_client::LocalIngestionClient;
 use crate::ingestion::remote_client::RemoteIngestionClient;
+use crate::ingestion::rpc_client::RpcIngestionClient;
 use crate::ingestion::Error as IngestionError;
 use crate::ingestion::Result as IngestionResult;
 use crate::metrics::CheckpointLagMetricReporter;
@@ -76,6 +77,18 @@ impl IngestionClient {
             metrics,
             checkpoint_lag_reporter,
         }
+    }
+
+    pub(crate) fn new_rpc(
+        url: Url,
+        basic_auth: Option<(String, String)>,
+        metrics: Arc<IndexerMetrics>,
+    ) -> IngestionResult<Self> {
+        let client = Arc::new(
+            RpcIngestionClient::new(url, basic_auth)
+                .map_err(|e| IngestionError::RpcClientError(e))?,
+        );
+        Ok(Self::new_impl(client, metrics))
     }
 
     /// Fetch checkpoint data by sequence number.

--- a/crates/sui-indexer-alt-framework/src/ingestion/client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/client.rs
@@ -5,23 +5,23 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use backoff::backoff::Constant;
-use backoff::Error as BE;
-use backoff::ExponentialBackoff;
-use sui_storage::blob::Blob;
-use tokio_util::bytes::Bytes;
-use tokio_util::sync::CancellationToken;
-use tracing::debug;
-use url::Url;
-
 use crate::ingestion::local_client::LocalIngestionClient;
 use crate::ingestion::remote_client::RemoteIngestionClient;
-use crate::ingestion::rpc_client::RpcIngestionClient;
 use crate::ingestion::Error as IngestionError;
 use crate::ingestion::Result as IngestionResult;
 use crate::metrics::CheckpointLagMetricReporter;
 use crate::metrics::IndexerMetrics;
 use crate::types::full_checkpoint_content::CheckpointData;
+use backoff::backoff::Constant;
+use backoff::Error as BE;
+use backoff::ExponentialBackoff;
+use sui_rpc_api::client::AuthInterceptor;
+use sui_rpc_api::Client;
+use sui_storage::blob::Blob;
+use tokio_util::bytes::Bytes;
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
+use url::Url;
 
 /// Wait at most this long between retries for transient errors.
 const MAX_TRANSIENT_RETRY_INTERVAL: Duration = Duration::from_secs(60);

--- a/crates/sui-indexer-alt-framework/src/ingestion/error.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/error.rs
@@ -22,4 +22,7 @@ pub enum Error {
 
     #[error("Shutdown signal received, stopping ingestion service")]
     Cancelled,
+
+    #[error(transparent)]
+    RpcClientError(anyhow::Error),
 }

--- a/crates/sui-indexer-alt-framework/src/ingestion/error.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/error.rs
@@ -24,5 +24,5 @@ pub enum Error {
     Cancelled,
 
     #[error(transparent)]
-    RpcClientError(anyhow::Error),
+    RpcClientError(#[from] tonic::Status),
 }

--- a/crates/sui-indexer-alt-framework/src/ingestion/local_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/local_client.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ingestion::client::{FetchError, FetchResult, IngestionClientTrait};
+use crate::ingestion::client::{FetchData, FetchError, FetchResult, IngestionClientTrait};
 use axum::body::Bytes;
 use std::path::PathBuf;
 
@@ -31,7 +31,7 @@ impl IngestionClientTrait for LocalIngestionClient {
                 }
             }
         })?;
-        Ok(Bytes::from(bytes))
+        Ok(FetchData::Raw(Bytes::from(bytes)))
     }
 }
 

--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -31,19 +31,20 @@ mod rpc_client;
 mod test_utils;
 
 #[derive(clap::Args, Clone, Debug)]
+#[group(required = true)]
 pub struct ClientArgs {
     /// Remote Store to fetch checkpoints from.
-    #[clap(long, required = true, group = "source")]
+    #[clap(long, group = "source")]
     pub remote_store_url: Option<Url>,
 
     /// Path to the local ingestion directory.
     /// If both remote_store_url and local_ingestion_path are provided, remote_store_url will be used.
-    #[clap(long, required = true, group = "source")]
+    #[clap(long, group = "source")]
     pub local_ingestion_path: Option<PathBuf>,
 
     /// Path to the local ingestion directory.
     /// If all remote_store_url, local_ingestion_path and rpc_api_url are provided, remote_store_url will be used.
-    #[clap(long, required = true, group = "source")]
+    #[clap(long, group = "source")]
     pub rpc_api_url: Option<Url>,
 
     #[clap(long)]

--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -44,11 +44,8 @@ pub struct ClientArgs {
 
     /// Path to the local ingestion directory.
     /// If all remote_store_url, local_ingestion_path and rpc_api_url are provided, remote_store_url will be used.
-    #[clap(long, group = "source")]
+    #[clap(long, env, group = "source")]
     pub rpc_api_url: Option<Url>,
-
-    #[clap(long)]
-    pub basic_auth: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -93,12 +90,7 @@ impl IngestionService {
         } else if let Some(path) = args.local_ingestion_path.as_ref() {
             IngestionClient::new_local(path.clone(), metrics.clone())
         } else if let Some(rpc_api_url) = args.rpc_api_url.as_ref() {
-            let basic_auth = args.basic_auth.map(|s| {
-                let split = s.split(":").collect::<Vec<_>>();
-                assert_eq!(2, split.len());
-                (split[0].to_string(), split[1].to_string())
-            });
-            IngestionClient::new_rpc(rpc_api_url.clone(), basic_auth, metrics.clone())?
+            IngestionClient::new_rpc(rpc_api_url.clone(), metrics.clone())?
         } else {
             panic!("One of remote_store_url, local_ingestion_path or rpc_api_url must be provided");
         };
@@ -222,7 +214,6 @@ mod tests {
                 remote_store_url: Some(Url::parse(&uri).unwrap()),
                 local_ingestion_path: None,
                 rpc_api_url: None,
-                basic_auth: None,
             },
             IngestionConfig {
                 checkpoint_buffer_size,

--- a/crates/sui-indexer-alt-framework/src/ingestion/remote_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/remote_client.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ingestion::client::{FetchError, FetchResult, IngestionClientTrait};
+use crate::ingestion::client::{FetchData, FetchError, FetchResult, IngestionClientTrait};
 use crate::ingestion::Result as IngestionResult;
 use reqwest::{Client, StatusCode};
 use tracing::{debug, error};
@@ -65,10 +65,14 @@ impl IngestionClientTrait for RemoteIngestionClient {
                 // checkpoint from them is considered a transient error -- the store being
                 // fetched from needs to be corrected, and ingestion will keep retrying it
                 // until it is.
-                response.bytes().await.map_err(|e| FetchError::Transient {
-                    reason: "bytes",
-                    error: e.into(),
-                })
+                response
+                    .bytes()
+                    .await
+                    .map_err(|e| FetchError::Transient {
+                        reason: "bytes",
+                        error: e.into(),
+                    })
+                    .map(FetchData::Raw)
             }
 
             // Treat 404s as a special case so we can match on this error type.

--- a/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
@@ -1,0 +1,49 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::ingestion::client::{FetchError, FetchResult, IngestionClientTrait};
+use anyhow::anyhow;
+use bytes::Bytes;
+use sui_rpc_api::Client;
+use sui_storage::blob::{Blob, BlobEncoding};
+use url::Url;
+
+pub(crate) struct RpcIngestionClient {
+    client: Client,
+}
+
+impl RpcIngestionClient {
+    pub(crate) fn new(
+        url: Url,
+        basic_auth: Option<(String, String)>,
+    ) -> Result<Self, anyhow::Error> {
+        let mut client = Client::new(url.to_string())?;
+        if let Some(basic_auth) = basic_auth {
+            client = client.with_basic_auth(basic_auth)?;
+        }
+        Ok(Self { client })
+    }
+}
+
+#[async_trait::async_trait]
+impl IngestionClientTrait for RpcIngestionClient {
+    async fn fetch(&self, checkpoint: u64) -> FetchResult {
+        let data = self
+            .client
+            .get_full_checkpoint(checkpoint)
+            .await
+            .map_err(|e| {
+                if e.message().contains("not found") {
+                    FetchError::NotFound
+                } else {
+                    FetchError::Transient {
+                        reason: "io_error",
+                        error: anyhow!(e),
+                    }
+                }
+            })?;
+        Ok(Bytes::from(
+            Blob::encode(&data, BlobEncoding::Bcs)?.to_bytes(),
+        ))
+    }
+}

--- a/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
@@ -4,20 +4,21 @@
 use crate::ingestion::client::{FetchData, FetchError, FetchResult, IngestionClientTrait};
 use anyhow::anyhow;
 use sui_rpc_api::Client as RpcClient;
+use tonic::Code;
 
 #[async_trait::async_trait]
 impl IngestionClientTrait for RpcClient {
     async fn fetch(&self, checkpoint: u64) -> FetchResult {
-        let data = self.get_full_checkpoint(checkpoint).await.map_err(|e| {
-            if e.message().contains("not found") {
-                FetchError::NotFound
-            } else {
-                FetchError::Transient {
+        let data = self
+            .get_full_checkpoint(checkpoint)
+            .await
+            .map_err(|status| match status.code() {
+                Code::NotFound => FetchError::NotFound,
+                _ => FetchError::Transient {
                     reason: "get_full_checkpoint",
-                    error: anyhow!(e),
-                }
-            }
-        })?;
+                    error: anyhow!(status),
+                },
+            })?;
         Ok(FetchData::CheckPointData(data))
     }
 }

--- a/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
@@ -4,6 +4,7 @@
 use crate::ingestion::client::{FetchError, FetchResult, IngestionClientTrait};
 use anyhow::anyhow;
 use bytes::Bytes;
+use sui_rpc_api::client::AuthInterceptor;
 use sui_rpc_api::Client;
 use sui_storage::blob::{Blob, BlobEncoding};
 use url::Url;
@@ -18,8 +19,8 @@ impl RpcIngestionClient {
         basic_auth: Option<(String, String)>,
     ) -> Result<Self, anyhow::Error> {
         let mut client = Client::new(url.to_string())?;
-        if let Some(basic_auth) = basic_auth {
-            client = client.with_basic_auth(basic_auth)?;
+        if let Some((username, password)) = basic_auth {
+            client = client.with_auth(AuthInterceptor::basic(username, Some(password)));
         }
         Ok(Self { client })
     }

--- a/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
@@ -13,7 +13,7 @@ impl IngestionClientTrait for RpcClient {
                 FetchError::NotFound
             } else {
                 FetchError::Transient {
-                    reason: "io_error",
+                    reason: "get_full_checkpoint",
                     error: anyhow!(e),
                 }
             }

--- a/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
@@ -1,50 +1,23 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ingestion::client::{FetchError, FetchResult, IngestionClientTrait};
+use crate::ingestion::client::{FetchData, FetchError, FetchResult, IngestionClientTrait};
 use anyhow::anyhow;
-use bytes::Bytes;
-use sui_rpc_api::client::AuthInterceptor;
-use sui_rpc_api::Client;
-use sui_storage::blob::{Blob, BlobEncoding};
-use url::Url;
-
-pub(crate) struct RpcIngestionClient {
-    client: Client,
-}
-
-impl RpcIngestionClient {
-    pub(crate) fn new(
-        url: Url,
-        basic_auth: Option<(String, String)>,
-    ) -> Result<Self, anyhow::Error> {
-        let mut client = Client::new(url.to_string())?;
-        if let Some((username, password)) = basic_auth {
-            client = client.with_auth(AuthInterceptor::basic(username, Some(password)));
-        }
-        Ok(Self { client })
-    }
-}
+use sui_rpc_api::Client as RpcClient;
 
 #[async_trait::async_trait]
-impl IngestionClientTrait for RpcIngestionClient {
+impl IngestionClientTrait for RpcClient {
     async fn fetch(&self, checkpoint: u64) -> FetchResult {
-        let data = self
-            .client
-            .get_full_checkpoint(checkpoint)
-            .await
-            .map_err(|e| {
-                if e.message().contains("not found") {
-                    FetchError::NotFound
-                } else {
-                    FetchError::Transient {
-                        reason: "io_error",
-                        error: anyhow!(e),
-                    }
+        let data = self.get_full_checkpoint(checkpoint).await.map_err(|e| {
+            if e.message().contains("not found") {
+                FetchError::NotFound
+            } else {
+                FetchError::Transient {
+                    reason: "io_error",
+                    error: anyhow!(e),
                 }
-            })?;
-        Ok(Bytes::from(
-            Blob::encode(&data, BlobEncoding::Bcs)?.to_bytes(),
-        ))
+            }
+        })?;
+        Ok(FetchData::CheckPointData(data))
     }
 }

--- a/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/rpc_client.rs
@@ -19,6 +19,6 @@ impl IngestionClientTrait for RpcClient {
                     error: anyhow!(status),
                 },
             })?;
-        Ok(FetchData::CheckPointData(data))
+        Ok(FetchData::CheckpointData(data))
     }
 }

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -194,6 +194,8 @@ impl Indexer {
                 remote_store_url: None,
                 local_ingestion_path: Some(tempdir().unwrap().into_path()),
                 rpc_api_url: None,
+                rpc_username: None,
+                rpc_password: None,
             },
             IngestionConfig::default(),
             Some(migrations),

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -194,7 +194,6 @@ impl Indexer {
                 remote_store_url: None,
                 local_ingestion_path: Some(tempdir().unwrap().into_path()),
                 rpc_api_url: None,
-                basic_auth: None,
             },
             IngestionConfig::default(),
             Some(migrations),

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -193,6 +193,8 @@ impl Indexer {
             ClientArgs {
                 remote_store_url: None,
                 local_ingestion_path: Some(tempdir().unwrap().into_path()),
+                rpc_api_url: None,
+                basic_auth: None,
             },
             IngestionConfig::default(),
             Some(migrations),

--- a/crates/sui-indexer-alt-framework/src/metrics.rs
+++ b/crates/sui-indexer-alt-framework/src/metrics.rs
@@ -179,7 +179,8 @@ impl IndexerMetrics {
             .unwrap(),
             total_ingested_bytes: register_int_counter_with_registry!(
                 "indexer_total_ingested_bytes",
-                "Total number of bytes fetched from the remote store",
+                "Total number of bytes fetched from the remote store, this metric will not \
+                be updated when data are fetched over gRPC.",
                 registry,
             )
             .unwrap(),

--- a/crates/sui-indexer-alt/src/benchmark.rs
+++ b/crates/sui-indexer-alt/src/benchmark.rs
@@ -62,7 +62,6 @@ pub async fn run_benchmark(
         remote_store_url: None,
         local_ingestion_path: Some(ingestion_path.clone()),
         rpc_api_url: None,
-        basic_auth: None,
     };
 
     let cur_time = Instant::now();

--- a/crates/sui-indexer-alt/src/benchmark.rs
+++ b/crates/sui-indexer-alt/src/benchmark.rs
@@ -62,6 +62,8 @@ pub async fn run_benchmark(
         remote_store_url: None,
         local_ingestion_path: Some(ingestion_path.clone()),
         rpc_api_url: None,
+        rpc_username: None,
+        rpc_password: None,
     };
 
     let cur_time = Instant::now();

--- a/crates/sui-indexer-alt/src/benchmark.rs
+++ b/crates/sui-indexer-alt/src/benchmark.rs
@@ -61,6 +61,8 @@ pub async fn run_benchmark(
     let client_args = ClientArgs {
         remote_store_url: None,
         local_ingestion_path: Some(ingestion_path.clone()),
+        rpc_api_url: None,
+        basic_auth: None,
     };
 
     let cur_time = Instant::now();

--- a/crates/sui-rpc-api/Cargo.toml
+++ b/crates/sui-rpc-api/Cargo.toml
@@ -43,7 +43,6 @@ tonic.workspace = true
 prost.workspace = true
 prost-types = "0.13.3"
 bytes.workspace = true
-base64.workspace = true
 
 tonic-health.workspace = true
 tonic-reflection.workspace = true

--- a/crates/sui-rpc-api/Cargo.toml
+++ b/crates/sui-rpc-api/Cargo.toml
@@ -43,7 +43,7 @@ tonic.workspace = true
 prost.workspace = true
 prost-types = "0.13.3"
 bytes.workspace = true
-base64 = "0.22.1"
+base64.workspace = true
 
 tonic-health.workspace = true
 tonic-reflection.workspace = true

--- a/crates/sui-rpc-api/Cargo.toml
+++ b/crates/sui-rpc-api/Cargo.toml
@@ -43,6 +43,7 @@ tonic.workspace = true
 prost.workspace = true
 prost-types = "0.13.3"
 bytes.workspace = true
+base64 = "0.22.1"
 
 tonic-health.workspace = true
 tonic-reflection.workspace = true

--- a/crates/sui-rpc-api/src/client/mod.rs
+++ b/crates/sui-rpc-api/src/client/mod.rs
@@ -50,11 +50,7 @@ impl Client {
         let mut endpoint = tonic::transport::Endpoint::from(uri.clone());
         if uri.scheme() == Some(&http::uri::Scheme::HTTPS) {
             endpoint = endpoint
-                .tls_config(
-                    ClientTlsConfig::new()
-                        .with_enabled_roots()
-                        .assume_http2(true),
-                )
+                .tls_config(ClientTlsConfig::new().with_enabled_roots())
                 .map_err(Into::into)
                 .map_err(Status::from_error)?;
         }

--- a/crates/sui-rpc-api/src/client/mod.rs
+++ b/crates/sui-rpc-api/src/client/mod.rs
@@ -50,7 +50,11 @@ impl Client {
         let mut endpoint = tonic::transport::Endpoint::from(uri.clone());
         if uri.scheme() == Some(&http::uri::Scheme::HTTPS) {
             endpoint = endpoint
-                .tls_config(ClientTlsConfig::new().with_enabled_roots())
+                .tls_config(
+                    ClientTlsConfig::new()
+                        .with_enabled_roots()
+                        .assume_http2(true),
+                )
                 .map_err(Into::into)
                 .map_err(Status::from_error)?;
         }

--- a/crates/sui-rpc-api/src/client/mod.rs
+++ b/crates/sui-rpc-api/src/client/mod.rs
@@ -141,7 +141,7 @@ impl Client {
 
         let (metadata, response, _extentions) = self
             .raw_client()
-            .max_decoding_message_size(64 * 1024 * 1024)
+            .max_decoding_message_size(128 * 1024 * 1024)
             .get_full_checkpoint(request)
             .await?
             .into_parts();


### PR DESCRIPTION
## Description 

add rpc api ingestion to indexer-alt, this is to unblock a private-net app indexer.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
