### PR TITLE
fix: Increase max decoded size in grpc server to 10 MB

### DIFF
--- a/crates/sui-rpc-api/src/client/mod.rs
+++ b/crates/sui-rpc-api/src/client/mod.rs
@@ -136,6 +136,7 @@ impl Client {
 
         let (metadata, response, _extentions) = self
             .raw_client()
+            .max_decoding_message_size(64 * 1024 * 1024)
             .get_full_checkpoint(request)
             .await?
             .into_parts();


### PR DESCRIPTION
## Description 

Some checkpoints are over 4 MB in size as we noticed in Walrus:

```
{
    "timestamp": "2025-01-06T15:32:14.805931Z",
    "level": "WARN",
    "fields": {
        "message": "failed to read next checkpoint",
        "next_checkpoint": 128601037,
        "status": "Some(Status { code: OutOfRange, message: \"Error, decoded message length too large: found 4520056 bytes, the limit is: 4194304 bytes\", metadata: MetadataMap { headers: {\"content-type\": \"application/grpc\", \"x-sui-chain-id\": \"4c78adac\", \"x-sui-chain\": \"testnet\", \"x-sui-epoch\": \"606\", \"x-sui-checkpoint-height\": \"149661152\", \"x-sui-timestamp-ms\": \"1736177533698\", \"x-sui-lowest-available-checkpoint\": \"0\", \"x-sui-lowest-available-checkpoint-objects\": \"119169201\", \"server-timing\": \"finish_request;dur=186\", \"date\": \"Mon, 06 Jan 2025 15:32:14 GMT\", \"content-length\": \"4520061\", \"via\": \"1.1 google\", \"alt-svc\": \"h3=\\\":443\\\"; ma=2592000,h3-29=\\\":443\\\"; ma=2592000\"} }, source: None })"
    },
    "target": "walrus_utils::checkpoint_downloader",
    "filename": "crates/walrus-utils/src/checkpoint_downloader.rs",
    "line_number": 593
}
```
