### PR TITLE
Remove `GetSharedLocks` trait

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1265,7 +1265,7 @@ impl AuthorityState {
             .start_timer();
         let input_objects = &certificate.data().transaction_data().input_objects()?;
         self.input_loader.read_objects_for_execution(
-            epoch_store.as_ref(),
+            epoch_store,
             &certificate.key(),
             tx_lock,
             input_objects,

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -588,13 +588,13 @@ impl CheckpointExecutor {
 
         if change_epoch_tx.contains_shared_object() {
             epoch_store
-                .acquire_shared_locks_from_effects(
+                .acquire_shared_version_assignments_from_effects(
                     &change_epoch_tx,
                     &change_epoch_fx,
                     self.object_cache_reader.as_ref(),
                 )
                 .await
-                .expect("Acquiring shared locks for change_epoch tx cannot fail");
+                .expect("Acquiring shared version assignments for change_epoch tx cannot fail");
         }
 
         self.tx_manager.enqueue_with_expected_effects_digest(
@@ -1237,7 +1237,7 @@ async fn execute_transactions(
     for (tx, _) in &executable_txns {
         if tx.contains_shared_object() {
             epoch_store
-                .acquire_shared_locks_from_effects(
+                .acquire_shared_version_assignments_from_effects(
                     tx,
                     digest_to_effects.get(tx.digest()).unwrap(),
                     object_cache_reader,

--- a/crates/sui-core/src/unit_tests/congestion_control_tests.rs
+++ b/crates/sui-core/src/unit_tests/congestion_control_tests.rs
@@ -350,7 +350,7 @@ async fn test_congestion_control_execution_cancellation() {
         .unwrap();
     authority_state_2
         .epoch_store_for_testing()
-        .acquire_shared_locks_from_effects(
+        .acquire_shared_version_assignments_from_effects(
             &VerifiedExecutableTransaction::new_from_certificate(cert.clone()),
             &effects,
             authority_state_2.get_object_cache_reader().as_ref(),

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -192,7 +192,7 @@ impl SingleValidator {
     ) -> TransactionEffects {
         let input_objects = transaction.transaction_data().input_objects().unwrap();
         let objects = store
-            .read_objects_for_execution(&*self.epoch_store, &transaction.key(), &input_objects)
+            .read_objects_for_execution(&self.epoch_store, &transaction.key(), &input_objects)
             .unwrap();
 
         let executable = VerifiedExecutableTransaction::new_from_certificate(

--- a/crates/sui-types/src/storage/mod.rs
+++ b/crates/sui-types/src/storage/mod.rs
@@ -7,12 +7,12 @@ mod read_store;
 mod shared_in_memory_store;
 mod write_store;
 
-use crate::base_types::{ConsensusObjectSequenceKey, TransactionDigest, VersionNumber};
+use crate::base_types::{TransactionDigest, VersionNumber};
 use crate::committee::EpochId;
 use crate::error::{ExecutionError, SuiError};
 use crate::execution::{DynamicallyLoadedObjectMetadata, ExecutionResults};
 use crate::move_package::MovePackage;
-use crate::transaction::{SenderSignedData, TransactionDataAPI, TransactionKey};
+use crate::transaction::{SenderSignedData, TransactionDataAPI};
 use crate::{
     base_types::{ObjectID, ObjectRef, SequenceNumber},
     error::SuiResult,
@@ -592,13 +592,4 @@ where
     fn as_object_store(&self) -> &dyn ObjectStore {
         self
     }
-}
-
-pub trait GetSharedLocks: Send + Sync {
-    fn get_shared_locks(
-        &self,
-        key: &TransactionKey,
-    ) -> SuiResult<Option<Vec<(ConsensusObjectSequenceKey, SequenceNumber)>>>;
-
-    fn is_initial_shared_version_unknown(&self) -> bool;
 }


### PR DESCRIPTION
## Description 

It's only ever populated with `AuthorityPerEpochStore`.

Also corrects the misnomer of "shared locks" everywhere to "shared version assignments".

## Test plan 

No behavior changes

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
