### PR TITLE
[consensus] lower propagation delay threshold to 5

### DIFF
--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -155,7 +155,7 @@ impl Parameters {
         if cfg!(msim) {
             2
         } else {
-            10
+            5
         }
     }
 

--- a/consensus/config/tests/snapshots/parameters_test__parameters.snap
+++ b/consensus/config/tests/snapshots/parameters_test__parameters.snap
@@ -17,7 +17,7 @@ sync_last_known_own_block_timeout:
   nanos: 0
 round_prober_interval_ms: 5000
 round_prober_request_timeout_ms: 2000
-propagation_delay_stop_proposal_threshold: 10
+propagation_delay_stop_proposal_threshold: 5
 dag_state_cached_rounds: 500
 commit_sync_parallel_fetches: 8
 commit_sync_batch_size: 100
@@ -31,4 +31,3 @@ tonic:
   connection_buffer_size: 33554432
   excessive_message_size: 16777216
   message_size_limit: 67108864
-


### PR DESCRIPTION
## Description 

It seems well functioning validators do not have delay > 3.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
