### PR TITLE
[indexer-alt] - make migration optional

### DIFF
--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -121,7 +121,7 @@ impl Indexer {
         indexer_args: IndexerArgs,
         client_args: ClientArgs,
         ingestion_config: IngestionConfig,
-        migrations: &'static EmbeddedMigrations,
+        migrations: Option<&'static EmbeddedMigrations>,
         registry: &Registry,
         cancel: CancellationToken,
     ) -> Result<Self> {
@@ -184,7 +184,7 @@ impl Indexer {
                 local_ingestion_path: Some(tempdir().unwrap().into_path()),
             },
             IngestionConfig::default(),
-            migrations,
+            Some(migrations),
             &Registry::new(),
             CancellationToken::new(),
         )
@@ -355,13 +355,15 @@ impl Indexer {
     /// the database's schema is up-to-date for both the indexer framework and the specific
     /// indexer.
     pub fn migrations(
-        migrations: &'static EmbeddedMigrations,
+        migrations: Option<&'static EmbeddedMigrations>,
     ) -> impl MigrationSource<Pg> + Send + Sync + 'static {
-        struct Migrations(&'static EmbeddedMigrations);
+        struct Migrations(Option<&'static EmbeddedMigrations>);
         impl MigrationSource<Pg> for Migrations {
             fn migrations(&self) -> migration::Result<Vec<Box<dyn Migration<Pg>>>> {
                 let mut migrations = MIGRATIONS.migrations()?;
-                migrations.extend(self.0.migrations()?);
+                if let Some(more_migrations) = self.0 {
+                    migrations.extend(more_migrations.migrations()?);
+                }
                 Ok(migrations)
             }
         }

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -110,9 +110,9 @@ impl Indexer {
     /// - Where to download checkpoints from,
     /// - Concurrency and buffering parameters for downloading checkpoints.
     ///
-    /// `migrations` contains the SQL to run in order to bring the database schema up-to-date for
+    /// Optional `migrations` contains the SQL to run in order to bring the database schema up-to-date for
     /// the specific instance of the indexer, generated using diesel's `embed_migrations!` macro.
-    /// These migrations will be run as part of initializing the indexer.
+    /// These migrations will be run as part of initializing the indexer if provided.
     ///
     /// After initialization, at least one pipeline must be added using [Self::concurrent_pipeline]
     /// or [Self::sequential_pipeline], before the indexer is started using [Self::run].

--- a/crates/sui-indexer-alt/src/benchmark.rs
+++ b/crates/sui-indexer-alt/src/benchmark.rs
@@ -39,7 +39,11 @@ pub async fn run_benchmark(
     let last_checkpoint = *ingestion_data.keys().last().unwrap();
     let num_transactions: usize = ingestion_data.values().map(|c| c.transactions.len()).sum();
 
-    reset_database(db_args.clone(), Some(Indexer::migrations(&MIGRATIONS))).await?;
+    reset_database(
+        db_args.clone(),
+        Some(Indexer::migrations(Some(&MIGRATIONS))),
+    )
+    .await?;
 
     let indexer_args = IndexerArgs {
         first_checkpoint: Some(first_checkpoint),

--- a/crates/sui-indexer-alt/src/lib.rs
+++ b/crates/sui-indexer-alt/src/lib.rs
@@ -95,7 +95,7 @@ pub async fn start_indexer(
         indexer_args,
         client_args,
         ingestion,
-        &MIGRATIONS,
+        Some(&MIGRATIONS),
         registry,
         cancel.clone(),
     )

--- a/crates/sui-indexer-alt/src/main.rs
+++ b/crates/sui-indexer-alt/src/main.rs
@@ -99,7 +99,7 @@ async fn main() -> Result<()> {
         Command::ResetDatabase { skip_migrations } => {
             reset_database(
                 args.db_args,
-                (!skip_migrations).then(|| Indexer::migrations(&MIGRATIONS)),
+                (!skip_migrations).then(|| Indexer::migrations(Some(&MIGRATIONS))),
             )
             .await?;
         }


### PR DESCRIPTION
## Description 

Apps indexer might not be managing the DB schema, making migration optional to cater that use case.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
