### PR TITLE
[Traffic Control] Add metrics for policy config settings

### DIFF
--- a/crates/sui-core/src/traffic_controller/metrics.rs
+++ b/crates/sui-core/src/traffic_controller/metrics.rs
@@ -24,6 +24,10 @@ pub struct TrafficControllerMetrics {
     pub highest_proxied_spam_rate: IntGauge,
     pub highest_direct_error_rate: IntGauge,
     pub highest_proxied_error_rate: IntGauge,
+    pub spam_client_threshold: IntGauge,
+    pub error_client_threshold: IntGauge,
+    pub spam_proxied_client_threshold: IntGauge,
+    pub error_proxied_client_threshold: IntGauge,
 }
 
 impl TrafficControllerMetrics {
@@ -126,6 +130,30 @@ impl TrafficControllerMetrics {
             highest_proxied_error_rate: register_int_gauge_with_registry!(
                 "highest_proxied_error_rate",
                 "Highest proxied error rate seen recently",
+                registry
+            )
+            .unwrap(),
+            spam_client_threshold: register_int_gauge_with_registry!(
+                "spam_client_threshold",
+                "Spam client threshold",
+                registry
+            )
+            .unwrap(),
+            error_client_threshold: register_int_gauge_with_registry!(
+                "error_client_threshold",
+                "Error client threshold",
+                registry
+            )
+            .unwrap(),
+            spam_proxied_client_threshold: register_int_gauge_with_registry!(
+                "spam_proxied_client_threshold",
+                "Spam proxied client threshold",
+                registry
+            )
+            .unwrap(),
+            error_proxied_client_threshold: register_int_gauge_with_registry!(
+                "error_proxied_client_threshold",
+                "Error proxied client threshold",
                 registry
             )
             .unwrap(),


### PR DESCRIPTION
## Description 

This will allow us to contextualize blocked request metrics from community nodes given that they control their own configuration.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
