### PR TITLE
[nodes] compatibility checks merge name and address checking to "id" check

### DIFF
--- a/external-crates/move/crates/move-binary-format/src/compatibility.rs
+++ b/external-crates/move/crates/move-binary-format/src/compatibility.rs
@@ -376,13 +376,14 @@ impl InclusionCheck {
     ) -> Result<(), M::Error> {
         let mut context = M::default();
 
-        // Module checks
-        if old_module.name != new_module.name {
-            context.module_name_mismatch(&old_module.name, &new_module.name);
-        }
-
-        if old_module.address != new_module.address {
-            context.module_address_mismatch(&old_module.address, &new_module.address);
+        // module's name and address are unchanged
+        if old_module.address != new_module.address || old_module.name != new_module.name {
+            context.module_id_mismatch(
+                &old_module.address,
+                &old_module.name,
+                &new_module.address,
+                &new_module.name,
+            );
         }
 
         if old_module.file_format_version > new_module.file_format_version {

--- a/external-crates/move/crates/move-binary-format/src/inclusion_mode.rs
+++ b/external-crates/move/crates/move-binary-format/src/inclusion_mode.rs
@@ -1,15 +1,16 @@
 use crate::compatibility::InclusionCheck;
 use crate::normalized::{Enum, Function, Struct};
 use move_core_types::account_address::AccountAddress;
-use move_core_types::identifier::Identifier;
+use move_core_types::identifier::{IdentStr, Identifier};
 
 pub trait InclusionCheckMode: Default {
     type Error;
-    fn module_name_mismatch(&mut self, old_address: &Identifier, new_address: &Identifier);
-    fn module_address_mismatch(
+    fn module_id_mismatch(
         &mut self,
         old_address: &AccountAddress,
+        old_name: &IdentStr,
         new_address: &AccountAddress,
+        new_name: &IdentStr,
     );
     fn file_format_version_downgrade(&mut self, old_version: u32, new_version: u32);
     fn struct_new(&mut self, name: &Identifier, new_struct: &Struct);
@@ -45,15 +46,12 @@ impl Default for InclusionCheckExecutionMode {
 impl InclusionCheckMode for InclusionCheckExecutionMode {
     type Error = ();
 
-    fn module_name_mismatch(&mut self, _old_address: &Identifier, _new_address: &Identifier) {
-        self.is_subset = false;
-        self.is_equal = false;
-    }
-
-    fn module_address_mismatch(
+    fn module_id_mismatch(
         &mut self,
         _old_address: &AccountAddress,
+        _old_name: &IdentStr,
         _new_address: &AccountAddress,
+        _new_name: &IdentStr,
     ) {
         self.is_subset = false;
         self.is_equal = false;


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.

Follow the same patter as compatibility check 'compatible' within the inclusion check by flagging name and address differences with the same function to cut down on the size of the trait by one function. Individual checking does not appear to give any benefit and are ignored during client side upgrade checks since it is assumed that the module names are the same and addresses are not yet calculated.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
