### PR TITLE
telemetry-subscribers: remove feature flags

### DIFF
--- a/crates/telemetry-subscribers/Cargo.toml
+++ b/crates/telemetry-subscribers/Cargo.toml
@@ -10,18 +10,18 @@ publish = false
 
 [dependencies]
 atomic_float.workspace = true
-console-subscriber = { workspace = true, optional = true }
+console-subscriber.workspace = true
 crossterm.workspace = true
 once_cell.workspace = true
 prometheus.workspace = true
 tracing.workspace = true
 tracing-appender.workspace = true
 tracing-subscriber.workspace = true
-opentelemetry = { version = "0.25.0", optional = true }
-opentelemetry_sdk = { version = "0.25.0", features = ["rt-tokio"], optional = true }
-opentelemetry-otlp = { version = "0.25.0", features = ["grpc-tonic"], optional = true }
-tracing-opentelemetry = { version = "0.26.0", optional = true }
-opentelemetry-proto = { version = "0.25", optional = true }
+opentelemetry = { version = "0.25.0" }
+opentelemetry_sdk = { version = "0.25.0", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.25.0", features = ["grpc-tonic"] }
+tracing-opentelemetry = { version = "0.26.0" }
+opentelemetry-proto = { version = "0.25" }
 tokio = { workspace = true, features = ["full"] }
 futures.workspace = true
 clap.workspace = true
@@ -32,17 +32,6 @@ bytes-varint = { version = "1" }
 # workspace
 tonic = { version = "0.12.3" }
 prost = "0.13"
-
-[features]
-default = ["otlp"]
-tokio-console = ["console-subscriber"]
-otlp = [
-  "tracing-opentelemetry",
-  "opentelemetry",
-  "opentelemetry-otlp",
-  "opentelemetry-proto",
-  "opentelemetry_sdk"
-]
 
 [dev-dependencies]
 camino.workspace = true

--- a/crates/telemetry-subscribers/src/lib.rs
+++ b/crates/telemetry-subscribers/src/lib.rs
@@ -363,7 +363,6 @@ impl TelemetryConfig {
         // tokio-console layer
         // Please see https://docs.rs/console-subscriber/latest/console_subscriber/struct.Builder.html#configuration
         // for environment vars/config options
-        #[cfg(feature = "tokio-console")]
         if config.tokio_console {
             layers.push(console_subscriber::spawn().boxed());
         }


### PR DESCRIPTION
Remove the feature flags from the `telemetry-subscribers` crate. The existing flags were not being proberly handled which could have lead to broken compilation if features were enabled/disabled and given we don't make use of feature flags in the sui repo it makes things easier to maintain with these removed.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
