### PR TITLE
[suins-indexer] add logging init

### DIFF
--- a/crates/suins-indexer/src/main.rs
+++ b/crates/suins-indexer/src/main.rs
@@ -125,6 +125,7 @@ impl Worker for SuinsIndexerWorker {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let _guard = mysten_service::logging::init();
     dotenv().ok();
     let (remote_storage, registry_id, subdomain_wrapper_type, name_record_type) = (
         env::var("REMOTE_STORAGE").ok(),
@@ -174,5 +175,6 @@ async fn main() -> Result<()> {
             exit_receiver,
         )
         .await?;
+    drop(_guard);
     Ok(())
 }


### PR DESCRIPTION
## Description 

Add initialization so logs actually end up in stdout

## Test plan 

logs are flowing
```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.69s
     Running `/Users/jordankylejensen/mysten/sui/target/debug/suins-indexer`
Starting indexer with checkpoints dir: /tmp/checkpoints
2025-01-08T22:17:08.413416Z  INFO sui_data_ingestion_core::reader: cleaning processed files, watermark is 99438042
2025-01-08T22:17:08.413325Z  INFO sui_data_ingestion_core::worker_pool: Starting indexing pipeline suins_indexing with concurrency 100. Current watermark is 99438042.
2025-01-08T22:17:08.515215Z  INFO sui_data_ingestion_core::reader: Read from local. Current checkpoint number: 99438042, pruning watermark: 99438042, new updates: 0
2025-01-08T22:17:08.618230Z  INFO sui_data_ingestion_core::reader: Read from local. Current checkpoint number: 99438042, pruning watermark: 99438042, new updates: 0
2025-01-08T22:17:08.719356Z  INFO sui_data_ingestion_core::reader: Read from local. Current checkpoint number: 99438042, pruning watermark: 99438042, new updates: 0
2025-01-08T22:17:08.822170Z  INFO sui_data_ingestion_core::reader: Read from local. Current checkpoint number: 99438042, pruning watermark: 99438042, new updates: 0
2025-01-08T22:17:08.924724Z  INFO sui_data_ingestion_core::reader: Read from local. Current checkpoint number: 99438042, pruning watermark: 99438042, new updates: 0
2025-01-08T22:17:09.026985Z  INFO sui_data_ingestion_core::reader: Read from local. Current checkpoint number: 99438042, pruning watermark: 99438042, new updates: 0
2025-01-08T22:17:09.129247Z  INFO sui_data_ingestion_core::reader: Read from local. Current checkpoint number: 99438042, pruning watermark: 99438042, new updates: 0
2025-01-08T22:17:09.230280Z  INFO sui_data_ingestion_core::reader: Read from local. Current checkpoint number: 99438042, pruning watermark: 99438042, new updates: 0
2025-01-08T22:17:09.332760Z  INFO sui_data_ingestion_core::reader: Read from local. Current checkpoint number: 99438042, pruning watermark: 99438042, new updates: 0
2025-01-08T22:17:09.435161Z  INFO sui_data_ingestion_core::reader: Read from local. Current checkpoint number: 99438042, pruning watermark: 99438042, new updates: 0
2025-01-08T22:17:09.537393Z  INFO sui_data_ingestion_core::reader: Read from local. Current checkpoint number: 99438042, pruning watermark: 99438042, new updates: 0
2025-01-08T22:17:09.639200Z  INFO sui_data_ingestion_core::reader: Read from local. Current checkpoint number: 99438042, pruning watermark: 99438042, new updates: 0
2025-01-08T22:17:09.741509Z  INFO sui_data_ingestion_core::reader: Read from local. Current checkpoint number: 99438042, pruning watermark: 99438042, new updates: 0
2025-01-08T22:17:09.844328Z  INFO sui_data_ingestion_core::reader: Read from local. Current checkpoint number: 99438042, pruning watermark: 99438042, new updates: 0
2025-01-08T22:17:09.946500Z  INFO sui_data_ingestion_core::reader: Read from local. Current checkpoint number: 99438042, pruning watermark: 99438042, new updates: 0
2025-01-08T22:17:10.048789Z  INFO sui_data_ingestion_core::reader: Read from local. Current checkpoint number: 99438042, pruning watermark: 99438042, new updates: 0
2025-01-08T22:17:10.151922Z  INFO sui_data_ingestion_core::reader: Read from local. Current checkpoint number: 99438042, pruning watermark: 99438042, new updates: 0
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
