### PR TITLE
fix:[doc] useSignTransaction example error

### DIFF
--- a/sdk/docs/pages/dapp-kit/wallet-hooks/useSignTransaction.mdx
+++ b/sdk/docs/pages/dapp-kit/wallet-hooks/useSignTransaction.mdx
@@ -29,23 +29,28 @@ function MyComponent() {
 					<div>
 						<button
 							onClick={async () => {
-								const { bytes, signature, reportTransactionEffects } = await signTransaction({
-									transaction: new Transaction(),
-									chain: 'sui:devnet',
-								});
-
-								const executeResult = await client.executeTransactionBlock({
-									transactionBlock: bytes,
-									signature,
-									options: {
-										showRawEffects: true,
+								signTransaction(
+									{
+										transaction: new Transaction(),
+										chain: 'sui:devnet',
 									},
-								});
+									{
+										onSuccess: async ({ bytes, signature, reportTransactionEffects }) => {
+											const executeResult = await client.executeTransactionBlock({
+												transactionBlock: bytes,
+												signature,
+												options: {
+													showRawEffects: true,
+												},
+											});
 
-								// Always report transaction effects to the wallet after execution
-								reportTransactionEffects(executeResult.rawEffects!);
+											// Always report transaction effects to the wallet after execution
+											reportTransactionEffects(executeResult.rawEffects!);
 
-								console.log(executeResult);
+											console.log(executeResult);
+										}
+									}
+								);
 							}}
 						>
 							Sign empty transaction


### PR DESCRIPTION
## Description 

the [useSignTransaction doc](https://sdk.mystenlabs.com/dapp-kit/wallet-hooks/useSignTransaction) has a error. 
In the code `const { bytes, signature, reportTransactionEffects } = await signTransaction`, `signTransaction` will return void, so need to use `onSuccess` to get these params.

```ts
signTransaction(
  {
    transaction: new Transaction(),
    chain: 'sui:devnet',
  },
  {
    onSuccess: async ({ bytes, signature, reportTransactionEffects }) => {
       // do something
    })
  }
)
```

## Test plan 

this code is true: https://github.com/MystenLabs/sui/blob/main/sdk/docs/examples/wallet-hooks.tsx#L241-L254
but the doc is error, it will confuse developers

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
