### PR TITLE
sui-http: properly set TCP_NODELAY by default

### DIFF
--- a/crates/sui-http/src/config.rs
+++ b/crates/sui-http/src/config.rs
@@ -31,7 +31,7 @@ impl Default for Config {
             init_connection_window_size: None,
             max_concurrent_streams: None,
             tcp_keepalive: None,
-            tcp_nodelay: false,
+            tcp_nodelay: true,
             http2_keepalive_interval: None,
             http2_keepalive_timeout: None,
             http2_adaptive_window: None,


### PR DESCRIPTION
The configuration documentation stated that TCP_NODELAY was enabled by default but the actual default had it disabled. This patch corrects that and enables TCP_NODELAY by default.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
