### PR TITLE
[consensus increase round prober default timeout to 4s

### DIFF
--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -146,7 +146,7 @@ impl Parameters {
         if cfg!(msim) {
             800
         } else {
-            2000
+            4000
         }
     }
 

--- a/consensus/config/tests/snapshots/parameters_test__parameters.snap
+++ b/consensus/config/tests/snapshots/parameters_test__parameters.snap
@@ -16,7 +16,7 @@ sync_last_known_own_block_timeout:
   secs: 5
   nanos: 0
 round_prober_interval_ms: 5000
-round_prober_request_timeout_ms: 2000
+round_prober_request_timeout_ms: 4000
 propagation_delay_stop_proposal_threshold: 5
 dag_state_cached_rounds: 500
 commit_sync_parallel_fetches: 8


### PR DESCRIPTION
## Description 

It should be ok to exclude responses when they are taking >= 2s to return, for quorum round calculations. But it seems better to use a longer timeout to reduce variance in the computed quorum rounds among validators.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
