### PR TITLE
[Traffic Control] Add dynamic config via admin api

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1593,11 +1593,14 @@ impl AuthorityState {
     pub async fn reconfigure_traffic_control(
         &self,
         params: TrafficControlReconfigParams,
-    ) -> Result<(), SuiError> {
+    ) -> Result<TrafficControlReconfigParams, SuiError> {
         if let Some(traffic_controller) = self.traffic_controller.as_ref() {
-            traffic_controller.admin_reconfigure(params).await?;
+            traffic_controller.admin_reconfigure(params).await
+        } else {
+            Err(SuiError::InvalidAdminRequest(
+                "Traffic controller is not configured on this node".to_string(),
+            ))
         }
-        Ok(())
     }
 
     #[instrument(level = "trace", skip_all)]

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3001,6 +3001,7 @@ impl AuthorityState {
     }
 
     #[allow(clippy::disallowed_methods)] // allow unbounded_channel()
+    #[allow(clippy::too_many_arguments)]
     pub async fn new(
         name: AuthorityName,
         secret: StableSyncAuthoritySigner,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -11,6 +11,8 @@ use crate::execution_scheduler::ExecutionSchedulerWrapper;
 use crate::execution_scheduler::SchedulingSource;
 use crate::jsonrpc_index::CoinIndexKey2;
 use crate::rpc_index::RpcIndexStore;
+use crate::traffic_controller::metrics::TrafficControllerMetrics;
+use crate::traffic_controller::TrafficController;
 use crate::transaction_outputs::TransactionOutputs;
 use crate::verify_indexes::{fix_indexes, verify_indexes};
 use anyhow::anyhow;
@@ -65,6 +67,8 @@ use sui_types::layout_resolver::into_struct_layout;
 use sui_types::layout_resolver::LayoutResolver;
 use sui_types::messages_consensus::{AuthorityCapabilitiesV1, AuthorityCapabilitiesV2};
 use sui_types::object::bounded_visitor::BoundedVisitor;
+use sui_types::traffic_control::PolicyConfig;
+use sui_types::traffic_control::RemoteFirewallConfig;
 use sui_types::transaction_executor::SimulateTransactionResult;
 use tap::TapFallible;
 use tokio::sync::mpsc::unbounded_channel;
@@ -864,6 +868,9 @@ pub struct AuthorityState {
     chain_identifier: ChainIdentifier,
 
     pub(crate) congestion_tracker: Arc<CongestionTracker>,
+
+    /// Traffic controller for Sui core servers (json-rpc, validator service)
+    pub traffic_controller: Option<Arc<TrafficController>>,
 }
 
 /// The authority state encapsulates all state, drives execution, and ensures safety.
@@ -1580,6 +1587,22 @@ impl AuthorityState {
                 .observe(effects.gas_cost_summary().computation_cost as f64 / elapsed);
         };
         Ok((effects, execution_error_opt))
+    }
+
+    pub fn reconfigure_traffic_control(
+        &self,
+        error_threshold: Option<u64>,
+        spam_threshold: Option<u64>,
+        dry_run: Option<bool>,
+    ) -> SuiResult<()> {
+        self.traffic_controller
+            .as_ref()
+            .map(|traffic_controller| {
+                traffic_controller.reconfigure_no_clear(error_threshold, spam_threshold, dry_run)
+            })
+            .unwrap_or(Err(SuiError::InvalidAdminRequest(
+                "traffic controller not enabled".to_string(),
+            )))
     }
 
     #[instrument(level = "trace", skip_all)]
@@ -2996,6 +3019,8 @@ impl AuthorityState {
         validator_tx_finalizer: Option<Arc<ValidatorTxFinalizer<NetworkAuthorityClient>>>,
         chain_identifier: ChainIdentifier,
         pruner_db: Option<Arc<AuthorityPrunerTables>>,
+        policy_config: Option<PolicyConfig>,
+        firewall_config: Option<RemoteFirewallConfig>,
     ) -> Arc<Self> {
         Self::check_protocol_version(supported_protocol_versions, epoch_store.protocol_version());
 
@@ -3030,6 +3055,14 @@ impl AuthorityState {
         let input_loader =
             TransactionInputLoader::new(execution_cache_trait_pointers.object_cache_reader.clone());
         let epoch = epoch_store.epoch();
+        let traffic_controller_metrics = TrafficControllerMetrics::new(prometheus_registry);
+        let traffic_controller = policy_config.clone().map(|policy| {
+            Arc::new(TrafficController::init(
+                policy,
+                traffic_controller_metrics,
+                firewall_config.clone(),
+            ))
+        });
         let state = Arc::new(AuthorityState {
             name,
             secret,
@@ -3053,6 +3086,7 @@ impl AuthorityState {
             validator_tx_finalizer,
             chain_identifier,
             congestion_tracker: Arc::new(CongestionTracker::new()),
+            traffic_controller,
         });
 
         let state_clone = Arc::downgrade(&state);

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -348,6 +348,8 @@ impl<'a> TestAuthorityBuilder<'a> {
         config.authority_store_pruning_config = pruning_config;
 
         let chain_identifier = ChainIdentifier::from(*genesis.checkpoint().digest());
+        let policy_config = config.policy_config.clone();
+        let firewall_config = config.firewall_config.clone();
 
         let state = AuthorityState::new(
             name,
@@ -367,6 +369,8 @@ impl<'a> TestAuthorityBuilder<'a> {
             None,
             chain_identifier,
             pruner_db,
+            policy_config,
+            firewall_config,
         )
         .await;
 

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -64,6 +64,7 @@ use tokio::time::timeout;
 use tonic::metadata::{Ascii, MetadataValue};
 use tracing::{debug, error, error_span, info, Instrument};
 
+use crate::consensus_adapter::ConnectionMonitorStatusForTests;
 use crate::{
     authority::{
         authority_per_epoch_store::AuthorityPerEpochStore,
@@ -80,10 +81,6 @@ use crate::{
     authority::{consensus_tx_status_cache::ConsensusTxStatus, AuthorityState},
     consensus_adapter::{ConsensusAdapter, ConsensusAdapterMetrics},
     traffic_controller::{parse_ip, policies::TrafficTally, TrafficController},
-};
-use crate::{
-    consensus_adapter::ConnectionMonitorStatusForTests,
-    traffic_controller::metrics::TrafficControllerMetrics,
 };
 use nonempty::{nonempty, NonEmpty};
 use sui_config::local_ip_utils::new_local_tcp_address_for_testing;
@@ -401,22 +398,15 @@ impl ValidatorService {
         state: Arc<AuthorityState>,
         consensus_adapter: Arc<ConsensusAdapter>,
         validator_metrics: Arc<ValidatorServiceMetrics>,
-        traffic_controller_metrics: TrafficControllerMetrics,
-        policy_config: Option<PolicyConfig>,
-        firewall_config: Option<RemoteFirewallConfig>,
+        client_id_source: Option<ClientIdSource>,
     ) -> Self {
+        let traffic_controller = state.traffic_controller.as_ref().cloned();
         Self {
             state,
             consensus_adapter,
             metrics: validator_metrics,
-            traffic_controller: policy_config.clone().map(|policy| {
-                Arc::new(TrafficController::init(
-                    policy,
-                    traffic_controller_metrics,
-                    firewall_config,
-                ))
-            }),
-            client_id_source: policy_config.map(|policy| policy.client_id_source),
+            traffic_controller,
+            client_id_source,
         }
     }
 

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -1559,7 +1559,7 @@ impl ValidatorService {
         }
     }
 
-    async fn handle_traffic_resp<T>(
+    fn handle_traffic_resp<T>(
         &self,
         client: Option<IpAddr>,
         wrapped_response: WrappedServiceResponse<T>,
@@ -1574,19 +1574,17 @@ impl ValidatorService {
         };
 
         if let Some(traffic_controller) = self.traffic_controller.clone() {
-            traffic_controller
-                .tally(TrafficTally {
-                    direct: client,
-                    through_fullnode: None,
-                    error_info: error.map(|e| {
-                        let error_type = String::from(e.clone().as_ref());
-                        let error_weight = normalize(e);
-                        (error_weight, error_type)
-                    }),
-                    spam_weight,
-                    timestamp: SystemTime::now(),
-                })
-                .await;
+            traffic_controller.tally(TrafficTally {
+                direct: client,
+                through_fullnode: None,
+                error_info: error.map(|e| {
+                    let error_type = String::from(e.clone().as_ref());
+                    let error_weight = normalize(e);
+                    (error_weight, error_type)
+                }),
+                spam_weight,
+                timestamp: SystemTime::now(),
+            });
         }
         unwrapped_response
     }
@@ -1637,7 +1635,7 @@ macro_rules! handle_with_decoration {
 
         // handle traffic tallying
         let wrapped_response = $self.$func_name($request).await;
-        $self.handle_traffic_resp(client, wrapped_response).await
+        $self.handle_traffic_resp(client, wrapped_response)
     }};
 }
 

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use arc_swap::ArcSwapAny;
 use async_trait::async_trait;
 use fastcrypto::traits::KeyPair;
 use futures::TryFutureExt;
@@ -25,7 +24,7 @@ use sui_network::{
     tonic,
 };
 use sui_types::sui_system_state::SuiSystemState;
-use sui_types::traffic_control::{ClientIdSource, PolicyConfig, RemoteFirewallConfig, Weight};
+use sui_types::traffic_control::{ClientIdSource, Weight};
 use sui_types::{
     effects::TransactionEffects,
     messages_grpc::{
@@ -390,7 +389,7 @@ pub struct ValidatorService {
     state: Arc<AuthorityState>,
     consensus_adapter: Arc<ConsensusAdapter>,
     metrics: Arc<ValidatorServiceMetrics>,
-    traffic_controller: Option<Arc<ArcSwapAny<Arc<TrafficController>>>>,
+    traffic_controller: Option<Arc<TrafficController>>,
     client_id_source: Option<ClientIdSource>,
 }
 
@@ -1549,7 +1548,7 @@ impl ValidatorService {
 
     async fn handle_traffic_req(&self, client: Option<IpAddr>) -> Result<(), tonic::Status> {
         if let Some(traffic_controller) = &self.traffic_controller {
-            if !traffic_controller.load().check(&client, &None).await {
+            if !traffic_controller.check(&client, &None).await {
                 // Entity in blocklist
                 Err(tonic::Status::from_error(SuiError::TooManyRequests.into()))
             } else {
@@ -1560,7 +1559,7 @@ impl ValidatorService {
         }
     }
 
-    fn handle_traffic_resp<T>(
+    async fn handle_traffic_resp<T>(
         &self,
         client: Option<IpAddr>,
         wrapped_response: WrappedServiceResponse<T>,
@@ -1575,17 +1574,19 @@ impl ValidatorService {
         };
 
         if let Some(traffic_controller) = self.traffic_controller.clone() {
-            traffic_controller.load().tally(TrafficTally {
-                direct: client,
-                through_fullnode: None,
-                error_info: error.map(|e| {
-                    let error_type = String::from(e.clone().as_ref());
-                    let error_weight = normalize(e);
-                    (error_weight, error_type)
-                }),
-                spam_weight,
-                timestamp: SystemTime::now(),
-            })
+            traffic_controller
+                .tally(TrafficTally {
+                    direct: client,
+                    through_fullnode: None,
+                    error_info: error.map(|e| {
+                        let error_type = String::from(e.clone().as_ref());
+                        let error_weight = normalize(e);
+                        (error_weight, error_type)
+                    }),
+                    spam_weight,
+                    timestamp: SystemTime::now(),
+                })
+                .await;
         }
         unwrapped_response
     }
@@ -1636,7 +1637,7 @@ macro_rules! handle_with_decoration {
 
         // handle traffic tallying
         let wrapped_response = $self.$func_name($request).await;
-        $self.handle_traffic_resp(client, wrapped_response)
+        $self.handle_traffic_resp(client, wrapped_response).await
     }};
 }
 

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -1584,7 +1584,7 @@ impl ValidatorService {
                 }),
                 spam_weight,
                 timestamp: SystemTime::now(),
-            });
+            })
         }
         unwrapped_response
     }

--- a/crates/sui-core/src/traffic_controller/mod.rs
+++ b/crates/sui-core/src/traffic_controller/mod.rs
@@ -479,9 +479,15 @@ async fn run_tally_loop(
             }
             // process channel for receiving new policy config
             Ok(config) = reconfigure_rx.recv() => {
+                info!(
+                    "Received new traffic control policy. Reconfiguring traffic \
+                    controller with the following: {:?}",
+                    config,
+                );
                 // mutate the policy config
                 spam_policy = TrafficControlPolicy::from_spam_config(config.clone()).await;
                 error_policy = TrafficControlPolicy::from_error_config(config.clone()).await;
+                info!("Traffic controller reconfiguration complete");
             }
         }
 

--- a/crates/sui-core/src/traffic_controller/mod.rs
+++ b/crates/sui-core/src/traffic_controller/mod.rs
@@ -233,6 +233,9 @@ impl TrafficController {
             dry_run,
         } = params;
         if let Some(error_threshold) = error_threshold {
+            self.metrics
+                .error_client_threshold
+                .set(error_threshold as i64);
             Self::update_policy_threshold(
                 self.error_policy.as_ref().unwrap(),
                 error_threshold,
@@ -241,6 +244,9 @@ impl TrafficController {
             .await?;
         }
         if let Some(spam_threshold) = spam_threshold {
+            self.metrics
+                .spam_client_threshold
+                .set(spam_threshold as i64);
             Self::update_policy_threshold(
                 self.spam_policy.as_ref().unwrap(),
                 spam_threshold,
@@ -249,6 +255,7 @@ impl TrafficController {
             .await?;
         }
         if let Some(dry_run) = dry_run {
+            self.metrics.dry_run_enabled.set(dry_run as i64);
             self.policy_config.write().await.dry_run = dry_run;
         }
 

--- a/crates/sui-core/src/traffic_controller/mod.rs
+++ b/crates/sui-core/src/traffic_controller/mod.rs
@@ -8,6 +8,7 @@ pub mod policies;
 
 use dashmap::DashMap;
 use fs::File;
+use mysten_common::{debug_fatal, fatal};
 use prometheus::IntGauge;
 use std::fs;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -97,7 +98,7 @@ impl TrafficController {
                     .into_iter()
                     .map(|ip_str| {
                         parse_ip(&ip_str).unwrap_or_else(|| {
-                            panic!("Failed to parse allowlist IP address: {:?}", ip_str)
+                            fatal!("Failed to parse allowlist IP address: {:?}", ip_str)
                         })
                     })
                     .collect();
@@ -162,7 +163,7 @@ impl TrafficController {
             .set(mem_drainfile_present as i64);
         let blocklists = match self.acl.clone() {
             Acl::Blocklists(blocklists) => blocklists,
-            Acl::Allowlist(_) => panic!("Allowlist ACL should not exist on spawn"),
+            Acl::Allowlist(_) => fatal!("Allowlist ACL should not exist on spawn"),
         };
         let tally_loop_blocklists = blocklists.clone();
         let clear_loop_blocklists = blocklists.clone();
@@ -322,7 +323,7 @@ impl TrafficController {
                     // that clearly the system is overloaded
                 }
                 Err(TrySendError::Closed(_)) => {
-                    panic!("TrafficController tally channel closed unexpectedly");
+                    debug_fatal!("TrafficController tally channel closed unexpectedly");
                 }
                 Ok(_) => {}
             }

--- a/crates/sui-core/src/traffic_controller/policies.rs
+++ b/crates/sui-core/src/traffic_controller/policies.rs
@@ -14,7 +14,7 @@ use std::hash::Hash;
 use std::time::Duration;
 use std::time::{Instant, SystemTime};
 use sui_types::traffic_control::{FreqThresholdConfig, PolicyConfig, PolicyType, Weight};
-use tracing::{info, trace};
+use tracing::{info, trace, warn};
 
 const HIGHEST_RATES_CAPACITY: usize = 20;
 
@@ -271,6 +271,19 @@ pub enum TrafficControlPolicy {
     TestPanicOnInvocation(TestPanicOnInvocationPolicy),
 }
 
+// impl CloneToUnit for TrafficControlPolicy {
+//     fn clone_to_unit(&self) -> Self {
+//         match self {
+//             Self::FreqThreshold(_) => Self::FreqThreshold(FreqThresholdPolicy::default()),
+//             Self::NoOp(_) => Self::NoOp(NoOpPolicy::default()),
+//             Self::TestNConnIP(_) => Self::TestNConnIP(TestNConnIPPolicy::default()),
+//             Self::TestPanicOnInvocation(_) => {
+//                 Self::TestPanicOnInvocation(TestPanicOnInvocationPolicy::default())
+//             }
+//         }
+//     }
+// }
+
 impl Policy for TrafficControlPolicy {
     fn handle_tally(&mut self, tally: TrafficTally) -> PolicyResponse {
         match self {
@@ -317,10 +330,10 @@ impl TrafficControlPolicy {
 ////////////// *** Policy definitions *** //////////////
 
 pub struct FreqThresholdPolicy {
-    config: PolicyConfig,
+    pub config: PolicyConfig,
+    pub client_threshold: u64,
+    pub proxied_client_threshold: u64,
     sketch: TrafficSketch,
-    client_threshold: u64,
-    proxied_client_threshold: u64,
     /// Unique salt to be added to all keys in the sketch. This
     /// ensures that false positives are not correlated across
     /// all nodes at the same time. For Sui validators for example,
@@ -439,13 +452,14 @@ impl NoOpPolicy {
 
 #[derive(Clone)]
 pub struct TestNConnIPPolicy {
-    config: PolicyConfig,
+    pub threshold: u64,
+    pub config: PolicyConfig,
     frequencies: Arc<RwLock<HashMap<IpAddr, u64>>>,
-    threshold: u64,
 }
 
 impl TestNConnIPPolicy {
     pub async fn new(config: PolicyConfig, threshold: u64) -> Self {
+        warn!("TESTING -- Creating new TestNConnIPPolicy");
         let frequencies = Arc::new(RwLock::new(HashMap::new()));
         let frequencies_clone = frequencies.clone();
         spawn_monitored_task!(run_clear_frequencies(
@@ -461,8 +475,10 @@ impl TestNConnIPPolicy {
 
     fn handle_tally(&mut self, tally: TrafficTally) -> PolicyResponse {
         let client = if let Some(client) = tally.direct {
+            warn!("TESTING -- Handling tally for client: {:?}", client);
             client
         } else {
+            warn!("TESTING -- No client to handle tally for");
             return PolicyResponse::default();
         };
 
@@ -470,10 +486,16 @@ impl TestNConnIPPolicy {
         let mut frequencies = self.frequencies.write();
         let count = frequencies.entry(client).or_insert(0);
         *count += 1;
+        warn!(
+            "TESTING -- Count for client: {:?}, count: {:?}",
+            client, *count
+        );
         PolicyResponse {
             block_client: if *count >= self.threshold {
+                warn!("TESTING -- Blocking client: {:?}", client);
                 Some(client)
             } else {
+                warn!("TESTING -- Not blocking client: {:?}", client);
                 None
             },
             block_proxied_client: None,
@@ -488,6 +510,7 @@ impl TestNConnIPPolicy {
 async fn run_clear_frequencies(frequencies: Arc<RwLock<HashMap<IpAddr, u64>>>, window_secs: u64) {
     loop {
         tokio::time::sleep(tokio::time::Duration::from_secs(window_secs)).await;
+        warn!("TESTING -- Clearing frequencies");
         frequencies.write().clear();
     }
 }

--- a/crates/sui-e2e-tests/tests/traffic_control_tests.rs
+++ b/crates/sui-e2e-tests/tests/traffic_control_tests.rs
@@ -668,7 +668,7 @@ async fn test_traffic_control_dead_mans_switch() -> Result<(), anyhow::Error> {
 #[tokio::test]
 async fn test_traffic_control_manual_set_dead_mans_switch() -> Result<(), anyhow::Error> {
     telemetry_subscribers::init_for_testing();
-    let drain_path = tempfile::tempdir().unwrap().into_path().join("drain");
+    let drain_path = tempfile::tempdir().unwrap().keep().join("drain");
     assert!(!drain_path.exists(), "Expected drain file to not yet exist",);
     File::create(&drain_path).expect("Failed to touch nodefw drain file");
     assert!(drain_path.exists(), "Expected drain file to exist",);

--- a/crates/sui-e2e-tests/tests/traffic_control_tests.rs
+++ b/crates/sui-e2e-tests/tests/traffic_control_tests.rs
@@ -34,6 +34,7 @@ use test_cluster::{TestCluster, TestClusterBuilder};
 
 #[tokio::test]
 async fn test_validator_traffic_control_noop() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
     let policy_config = PolicyConfig {
         connection_blocklist_ttl_sec: 1,
         proxy_blocklist_ttl_sec: 5,
@@ -58,6 +59,7 @@ async fn test_validator_traffic_control_noop() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn test_fullnode_traffic_control_noop() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
     let policy_config = PolicyConfig {
         connection_blocklist_ttl_sec: 1,
         proxy_blocklist_ttl_sec: 5,
@@ -77,6 +79,7 @@ async fn test_fullnode_traffic_control_noop() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn test_validator_traffic_control_ok() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
     let policy_config = PolicyConfig {
         connection_blocklist_ttl_sec: 1,
         proxy_blocklist_ttl_sec: 5,
@@ -102,6 +105,7 @@ async fn test_validator_traffic_control_ok() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn test_fullnode_traffic_control_ok() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
     let policy_config = PolicyConfig {
         connection_blocklist_ttl_sec: 1,
         proxy_blocklist_ttl_sec: 5,
@@ -122,6 +126,7 @@ async fn test_fullnode_traffic_control_ok() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn test_validator_traffic_control_dry_run() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
     let n = 5;
     let policy_config = PolicyConfig {
         connection_blocklist_ttl_sec: 1,
@@ -148,6 +153,7 @@ async fn test_validator_traffic_control_dry_run() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn test_fullnode_traffic_control_dry_run() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
     let txn_count = 15;
     let policy_config = PolicyConfig {
         connection_blocklist_ttl_sec: 1,
@@ -211,6 +217,7 @@ async fn test_fullnode_traffic_control_dry_run() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn test_validator_traffic_control_error_blocked() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
     let n = 5;
     let policy_config = PolicyConfig {
         connection_blocklist_ttl_sec: 1,
@@ -255,7 +262,78 @@ async fn test_validator_traffic_control_error_blocked() -> Result<(), anyhow::Er
 }
 
 #[tokio::test]
+async fn test_validator_traffic_control_error_blocked_with_policy_reconfig(
+) -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
+    let n = 5;
+    let policy_config = PolicyConfig {
+        connection_blocklist_ttl_sec: 100,
+        // Test that any N requests will cause an IP to be added to the blocklist.
+        error_policy_type: PolicyType::TestNConnIP(n - 1),
+        dry_run: true,
+        ..Default::default()
+    };
+    let network_config = ConfigBuilder::new_with_temp_dir()
+        .committee_size(NonZeroUsize::new(4).unwrap())
+        .with_policy_config(Some(policy_config))
+        .build();
+    let committee = network_config.committee_with_network();
+    let test_cluster = TestClusterBuilder::new()
+        .set_network_config(network_config)
+        .build()
+        .await;
+    let local_clients = make_network_authority_clients_with_network_config(
+        &committee,
+        &default_mysten_network_config(),
+    );
+    let (_, auth_client) = local_clients.first_key_value().unwrap();
+
+    let mut txns = batch_make_transfer_transactions(&test_cluster.wallet, n as usize).await;
+    let mut tx = txns.swap_remove(0);
+    let signatures = tx.tx_signatures_mut_for_testing();
+    signatures.pop();
+    signatures.push(GenericSignature::Signature(
+        sui_types::crypto::Signature::Ed25519SuiSignature(Ed25519SuiSignature::default()),
+    ));
+
+    // Before reconfiguring the policy, we should not block any requests due to dry run mode,
+    // even after far exceeding the threshold. However the blocklist should be updated.
+    for _ in 0..(2 * n) {
+        let response = auth_client.handle_transaction(tx.clone(), None).await;
+        if let Err(err) = response {
+            assert!(
+                !err.to_string().contains("Too many requests"),
+                "Expected no blocked requests due to dry run mode"
+            );
+        }
+    }
+    // Reconfigure traffic control to disable dry run mode
+    for node in test_cluster.all_validator_handles() {
+        node.with(|node| {
+            node.state()
+                .reconfigure_traffic_control(TrafficControlReconfigParams {
+                    policy_config: None,
+                    fw_config: None,
+                    dry_run: Some(false),
+                })
+                .unwrap();
+        });
+    }
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    // If Node and TrafficController has not crashed, blocklist and policy freq state should still
+    // be intact. A single additional erroneous request from the client should trigger enforcement.
+    let response = auth_client.handle_transaction(tx.clone(), None).await;
+    if let Err(err) = response {
+        if err.to_string().contains("Too many requests") {
+            return Ok(());
+        }
+    }
+    panic!("Expected error policy to trigger on next requests after reconfiguration");
+}
+
+#[tokio::test]
 async fn test_fullnode_traffic_control_spam_blocked() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
     let txn_count = 15;
     let policy_config = PolicyConfig {
         connection_blocklist_ttl_sec: 3,
@@ -324,6 +402,7 @@ async fn test_fullnode_traffic_control_spam_blocked() -> Result<(), anyhow::Erro
 
 #[tokio::test]
 async fn test_fullnode_traffic_control_error_blocked() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
     let txn_count = 5;
     let policy_config = PolicyConfig {
         connection_blocklist_ttl_sec: 3,
@@ -381,6 +460,7 @@ async fn test_fullnode_traffic_control_error_blocked() -> Result<(), anyhow::Err
 
 #[tokio::test]
 async fn test_validator_traffic_control_error_delegated() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
     let n = 5;
     let port = 65000;
     let policy_config = PolicyConfig {
@@ -450,6 +530,7 @@ async fn test_validator_traffic_control_error_delegated() -> Result<(), anyhow::
 
 #[tokio::test]
 async fn test_fullnode_traffic_control_spam_delegated() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
     let txn_count = 10;
     let port = 65001;
     let policy_config = PolicyConfig {
@@ -530,6 +611,7 @@ async fn test_fullnode_traffic_control_spam_delegated() -> Result<(), anyhow::Er
 
 #[tokio::test]
 async fn test_traffic_control_dead_mans_switch() -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
     let policy_config = PolicyConfig {
         connection_blocklist_ttl_sec: 3,
         spam_policy_type: PolicyType::TestNConnIP(10),
@@ -586,7 +668,8 @@ async fn test_traffic_control_dead_mans_switch() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn test_traffic_control_manual_set_dead_mans_switch() -> Result<(), anyhow::Error> {
-    let drain_path = tempfile::tempdir().unwrap().keep().join("drain");
+    telemetry_subscribers::init_for_testing();
+    let drain_path = tempfile::tempdir().unwrap().into_path().join("drain");
     assert!(!drain_path.exists(), "Expected drain file to not yet exist",);
     File::create(&drain_path).expect("Failed to touch nodefw drain file");
     assert!(drain_path.exists(), "Expected drain file to exist",);
@@ -597,6 +680,7 @@ async fn test_traffic_control_manual_set_dead_mans_switch() -> Result<(), anyhow
 
 #[sim_test]
 async fn test_traffic_sketch_no_blocks() {
+    telemetry_subscribers::init_for_testing();
     let sketch_config = FreqThresholdConfig {
         client_threshold: 10_100,
         proxied_client_threshold: 10_100,
@@ -637,6 +721,7 @@ async fn test_traffic_sketch_no_blocks() {
 #[ignore]
 #[sim_test]
 async fn test_traffic_sketch_with_slow_blocks() {
+    telemetry_subscribers::init_for_testing();
     let sketch_config = FreqThresholdConfig {
         client_threshold: 9_900,
         proxied_client_threshold: 9_900,
@@ -676,6 +761,7 @@ async fn test_traffic_sketch_with_slow_blocks() {
 
 #[sim_test]
 async fn test_traffic_sketch_with_sampled_spam() {
+    telemetry_subscribers::init_for_testing();
     let sketch_config = FreqThresholdConfig {
         client_threshold: 4_500,
         proxied_client_threshold: 4_500,
@@ -713,6 +799,7 @@ async fn test_traffic_sketch_with_sampled_spam() {
 
 #[sim_test]
 async fn test_traffic_sketch_allowlist_mode() {
+    telemetry_subscribers::init_for_testing();
     let policy_config = PolicyConfig {
         connection_blocklist_ttl_sec: 1,
         proxy_blocklist_ttl_sec: 1,
@@ -738,6 +825,7 @@ async fn test_traffic_sketch_allowlist_mode() {
 }
 
 async fn assert_traffic_control_ok(mut test_cluster: TestCluster) -> Result<(), anyhow::Error> {
+    telemetry_subscribers::init_for_testing();
     let context = &mut test_cluster.wallet;
     let jsonrpc_client = &test_cluster.fullnode_handle.rpc_client;
 

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -14,7 +14,6 @@ use std::time::Duration;
 use sui_core::traffic_controller::metrics::TrafficControllerMetrics;
 use sui_core::traffic_controller::TrafficController;
 use sui_types::traffic_control::PolicyConfig;
-use sui_types::traffic_control::RemoteFirewallConfig;
 use tokio::runtime::Handle;
 use tokio_util::sync::CancellationToken;
 use tower::ServiceBuilder;
@@ -53,8 +52,8 @@ pub struct JsonRpcServerBuilder {
     module: RpcModule<()>,
     rpc_doc: Project,
     registry: Registry,
+    traffic_controller: Option<Arc<TrafficController>>,
     policy_config: Option<PolicyConfig>,
-    firewall_config: Option<RemoteFirewallConfig>,
 }
 
 pub fn sui_rpc_doc(version: &str) -> Project {
@@ -74,15 +73,15 @@ impl JsonRpcServerBuilder {
     pub fn new(
         version: &str,
         prometheus_registry: &Registry,
+        traffic_controller: Option<Arc<TrafficController>>,
         policy_config: Option<PolicyConfig>,
-        firewall_config: Option<RemoteFirewallConfig>,
     ) -> Self {
         Self {
             module: RpcModule::new(()),
             rpc_doc: sui_rpc_doc(version),
             registry: prometheus_registry.clone(),
+            traffic_controller,
             policy_config,
-            firewall_config,
         }
     }
 
@@ -136,14 +135,6 @@ impl JsonRpcServerBuilder {
         let methods_names = module.method_names().collect::<Vec<_>>();
 
         let metrics = Arc::new(Metrics::new(&self.registry, &methods_names));
-        let traffic_controller_metrics = TrafficControllerMetrics::new(&self.registry);
-        let traffic_controller = self.policy_config.clone().map(|policy| {
-            Arc::new(TrafficController::init(
-                policy,
-                traffic_controller_metrics,
-                self.firewall_config.clone(),
-            ))
-        });
         let client_id_source = self
             .policy_config
             .clone()
@@ -168,10 +159,14 @@ impl JsonRpcServerBuilder {
             .and_then(|value| value.parse::<u64>().ok())
             .unwrap_or(60);
 
+        let traffic_controller = self.traffic_controller.clone();
         let rpc_middleware = jsonrpsee::server::middleware::rpc::RpcServiceBuilder::new()
             .layer_fn(move |s| TimeoutLayer::new(s, Duration::from_secs(timeout)))
             .layer_fn(move |s| MetricsLayer::new(s, metrics.clone()))
-            .layer_fn(move |s| TrafficControllerService::new(s, traffic_controller.clone()));
+            .layer_fn({
+                let traffic_controller = traffic_controller.clone();
+                move |s| TrafficControllerService::new(s, traffic_controller.clone())
+            });
         let service_builder = jsonrpsee::server::ServerBuilder::new()
             // Since we're not using jsonrpsee's server to actually handle connections this value
             // is instead limiting the number of concurrent requests and has no impact on the

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -4,7 +4,6 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use arc_swap::ArcSwapAny;
 use axum::body::Body;
 use axum::http;
 use hyper::Request;
@@ -12,10 +11,7 @@ use jsonrpsee::RpcModule;
 use metrics::Metrics;
 use metrics::MetricsLayer;
 use prometheus::Registry;
-use std::net::SocketAddr;
-use std::sync::Arc;
 use std::time::Duration;
-use sui_core::traffic_controller::metrics::TrafficControllerMetrics;
 use sui_core::traffic_controller::TrafficController;
 use sui_types::traffic_control::PolicyConfig;
 use tokio::runtime::Handle;
@@ -56,7 +52,7 @@ pub struct JsonRpcServerBuilder {
     module: RpcModule<()>,
     rpc_doc: Project,
     registry: Registry,
-    traffic_controller: Option<Arc<ArcSwapAny<Arc<TrafficController>>>>,
+    traffic_controller: Option<Arc<TrafficController>>,
     policy_config: Option<PolicyConfig>,
 }
 
@@ -77,7 +73,7 @@ impl JsonRpcServerBuilder {
     pub fn new(
         version: &str,
         prometheus_registry: &Registry,
-        traffic_controller: Option<Arc<ArcSwapAny<Arc<TrafficController>>>>,
+        traffic_controller: Option<Arc<TrafficController>>,
         policy_config: Option<PolicyConfig>,
     ) -> Self {
         Self {

--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -1,6 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use arc_swap::ArcSwapAny;
 use axum::body::Body;
 use axum::http;
 use hyper::Request;
@@ -52,7 +56,7 @@ pub struct JsonRpcServerBuilder {
     module: RpcModule<()>,
     rpc_doc: Project,
     registry: Registry,
-    traffic_controller: Option<Arc<TrafficController>>,
+    traffic_controller: Option<Arc<ArcSwapAny<Arc<TrafficController>>>>,
     policy_config: Option<PolicyConfig>,
 }
 
@@ -73,7 +77,7 @@ impl JsonRpcServerBuilder {
     pub fn new(
         version: &str,
         prometheus_registry: &Registry,
-        traffic_controller: Option<Arc<TrafficController>>,
+        traffic_controller: Option<Arc<ArcSwapAny<Arc<TrafficController>>>>,
         policy_config: Option<PolicyConfig>,
     ) -> Self {
         Self {

--- a/crates/sui-json-rpc/src/traffic_control.rs
+++ b/crates/sui-json-rpc/src/traffic_control.rs
@@ -81,26 +81,24 @@ async fn handle_traffic_resp(
     response: &MethodResponse,
 ) {
     let error = response.as_error_code().map(ErrorCode::from);
-    traffic_controller
-        .tally(TrafficTally {
-            direct: client,
-            through_fullnode: None,
-            error_info: error.map(|e| {
-                let error_type = e.to_string();
-                let error_weight = normalize(e);
-                (error_weight, error_type)
-            }),
-            // For now, count everything as spam with equal weight
-            // on the rpc node side, including gas-charging endpoints
-            // such as `sui_executeTransactionBlock`, as this can enable
-            // node operators who wish to rate limit their transcation
-            // traffic and incentivize high volume clients to choose a
-            // suitable rpc provider (or run their own). Later we may want
-            // to provide a weight distribution based on the method being called.
-            spam_weight: Weight::one(),
-            timestamp: SystemTime::now(),
-        })
-        .await;
+    traffic_controller.tally(TrafficTally {
+        direct: client,
+        through_fullnode: None,
+        error_info: error.map(|e| {
+            let error_type = e.to_string();
+            let error_weight = normalize(e);
+            (error_weight, error_type)
+        }),
+        // For now, count everything as spam with equal weight
+        // on the rpc node side, including gas-charging endpoints
+        // such as `sui_executeTransactionBlock`, as this can enable
+        // node operators who wish to rate limit their transcation
+        // traffic and incentivize high volume clients to choose a
+        // suitable rpc provider (or run their own). Later we may want
+        // to provide a weight distribution based on the method being called.
+        spam_weight: Weight::one(),
+        timestamp: SystemTime::now(),
+    });
 }
 
 // TODO: refine error matching here

--- a/crates/sui-node/src/admin.rs
+++ b/crates/sui-node/src/admin.rs
@@ -87,7 +87,7 @@ const RANDOMNESS_INJECT_PARTIAL_SIGS_ROUTE: &str = "/randomness-inject-partial-s
 const RANDOMNESS_INJECT_FULL_SIG_ROUTE: &str = "/randomness-inject-full-sig";
 const GET_TX_COST_ROUTE: &str = "/get-tx-cost";
 const DUMP_CONSENSUS_TX_COST_ESTIMATES_ROUTE: &str = "/dump-consensus-tx-cost-estimates";
-const RECONFIGURE_TRAFFIC_CONTROL: &str = "/reconfigure-traffic-control";
+const TRAFFIC_CONTROL: &str = "/traffic-control";
 
 struct AppState {
     node: Arc<SuiNode>,
@@ -132,10 +132,7 @@ pub async fn run_admin_server(node: Arc<SuiNode>, port: u16, tracing_handle: Tra
             DUMP_CONSENSUS_TX_COST_ESTIMATES_ROUTE,
             get(dump_consensus_tx_cost_estimates),
         )
-        .route(
-            RECONFIGURE_TRAFFIC_CONTROL,
-            post(reconfigure_traffic_control),
-        )
+        .route(TRAFFIC_CONTROL, post(traffic_control))
         .with_state(Arc::new(app_state));
 
     let socket_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
@@ -510,7 +507,7 @@ struct TrafficControlConfig {
     dry_run: Option<bool>,
 }
 
-async fn reconfigure_traffic_control(
+async fn traffic_control(
     State(state): State<Arc<AppState>>,
     args: Query<TrafficControlConfig>,
 ) -> (StatusCode, String) {

--- a/crates/sui-node/src/admin.rs
+++ b/crates/sui-node/src/admin.rs
@@ -504,16 +504,6 @@ async fn dump_consensus_tx_cost_estimates(
     (StatusCode::OK, format!("{:#?}", estimates))
 }
 
-<<<<<<< HEAD
-#[derive(Deserialize)]
-struct TrafficControlConfig {
-    error_threshold: Option<u64>,
-    spam_threshold: Option<u64>,
-    dry_run: Option<bool>,
-}
-
-=======
->>>>>>> 28e5bffc0f (Change in approach - use arcswap to exfiltrate state, atomic swap references with a new instance containing old data, then shutdown old instance)
 async fn traffic_control(
     State(state): State<Arc<AppState>>,
     args: Query<TrafficControlReconfigParams>,

--- a/crates/sui-node/src/admin.rs
+++ b/crates/sui-node/src/admin.rs
@@ -510,7 +510,16 @@ async fn traffic_control(
 ) -> (StatusCode, String) {
     let Query(params) = args;
     match state.node.state().reconfigure_traffic_control(params).await {
-        Ok(()) => (StatusCode::OK, "traffic control configured\n".to_string()),
+        Ok(updated_state) => (
+            StatusCode::OK,
+            format!(
+                "Traffic control configured with:\n\
+                 Error threshold: {:?}\n\
+                 Spam threshold: {:?}\n\
+                 Dry run: {:?}\n",
+                updated_state.error_threshold, updated_state.spam_threshold, updated_state.dry_run
+            ),
+        ),
         Err(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
     }
 }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -39,7 +39,6 @@ use sui_core::execution_cache::build_execution_cache;
 use sui_core::execution_scheduler::SchedulingSource;
 use sui_core::global_state_hasher::GlobalStateHashMetrics;
 use sui_core::storage::RestReadStore;
-use sui_core::traffic_controller::metrics::TrafficControllerMetrics;
 use sui_json_rpc::bridge_api::BridgeReadApi;
 use sui_json_rpc_api::JsonRpcMetrics;
 use sui_network::randomness;
@@ -740,6 +739,8 @@ impl SuiNode {
             validator_tx_finalizer,
             chain_identifier,
             pruner_db,
+            config.policy_config.clone(),
+            config.firewall_config.clone(),
         )
         .await;
         // ensure genesis txn was executed
@@ -1518,9 +1519,7 @@ impl SuiNode {
             state.clone(),
             consensus_adapter,
             Arc::new(ValidatorServiceMetrics::new(prometheus_registry)),
-            TrafficControllerMetrics::new(prometheus_registry),
-            config.policy_config.clone(),
-            config.firewall_config.clone(),
+            config.policy_config.clone().map(|p| p.client_id_source),
         );
 
         let mut server_conf = mysten_network::config::Config::new();
@@ -2221,11 +2220,12 @@ async fn build_http_servers(
     let mut router = axum::Router::new();
 
     let json_rpc_router = {
+        let traffic_controller = state.traffic_controller.as_ref().cloned();
         let mut server = JsonRpcServerBuilder::new(
             env!("CARGO_PKG_VERSION"),
             prometheus_registry,
+            traffic_controller,
             config.policy_config.clone(),
-            config.firewall_config.clone(),
         );
 
         let kv_store = build_kv_store(&state, config, prometheus_registry)?;

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -2220,7 +2220,7 @@ async fn build_http_servers(
     let mut router = axum::Router::new();
 
     let json_rpc_router = {
-        let traffic_controller = state.traffic_controller.as_ref().cloned();
+        let traffic_controller = state.traffic_controller.clone();
         let mut server = JsonRpcServerBuilder::new(
             env!("CARGO_PKG_VERSION"),
             prometheus_registry,

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -716,6 +716,8 @@ pub enum SuiError {
         round: u64,
         last_committed_round: u64,
     },
+    #[error("Invalid admin request: {0}")]
+    InvalidAdminRequest(String),
 }
 
 #[repr(u64)]

--- a/crates/sui-types/src/traffic_control.rs
+++ b/crates/sui-types/src/traffic_control.rs
@@ -72,6 +72,13 @@ pub enum ClientIdSource {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TrafficControlReconfigParams {
+    pub error_threshold: Option<u64>,
+    pub spam_threshold: Option<u64>,
+    pub dry_run: Option<bool>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Weight(f32);
 
 impl Weight {


### PR DESCRIPTION
## Description 

Implement an admin API endpoint to do a hot reconfiguration of the traffic control policy without clearing blocklists or existing count min sketch.

To facilitate this, the PR introduces a refactor that allows AuthorityState to hold a reference to TrafficController, and for all sui callsites to reference this rather than instantiating separately. This is ok for our purposes (and indeed is much cleaner) because sui-node enforces that validators do not run json rpc server. Additionally, we need to make the policy a member of the traffic controller struct in order to reference it from the main thread.

Things to note:
For now, this only works when the node is previously running traffic controller with a blocklist policy. i.e. it will fail if used to enable traffic control on a node that did not already have it enabled. It will also fail if called when the node is running an allowlist policy. 

Given the above, there are two intended use patterns: 

1. Before being called, the node is running traffic controller in dry-run mode with some non-allowlist policy config so that tallying and metrics collection occurs. In such a case, it can be called with the appropriate flag to disable dry-run mode. Note that it can also be called to enable dry-run mode where the node previously had it running in active mode.
2. Before being called, the node is running traffic controller in active mode, but the node operator wants to elevate the policy restriction by adjusting the threshold values. 

Note also that this currently is supported for rpc node and validator server traffic control use cases. Bridge node is not yet supported.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
