### PR TITLE
rpc benchmark: json rpc benchmark

### DIFF
--- a/crates/sui-rpc-benchmark/src/config.rs
+++ b/crates/sui-rpc-benchmark/src/config.rs
@@ -3,19 +3,22 @@
 
 use std::time::Duration;
 
+#[derive(Debug, Clone)]
 pub struct BenchmarkConfig {
     /// Number of concurrent clients
     pub concurrency: usize,
-    /// All queries will execute if they finish within the specified timeout.
-    /// Otherwise, the binary will stop at that time and report collected metrics.
-    pub timeout: Duration,
+    /// Duration to run the benchmark in seconds
+    pub duration: Duration,
+    /// Optional path to JSON RPC file for JSON RPC benchmarks
+    pub json_rpc_file_path: Option<String>,
 }
 
 impl Default for BenchmarkConfig {
     fn default() -> Self {
         Self {
             concurrency: 50,
-            timeout: Duration::from_secs(30),
+            duration: Duration::from_secs(30),
+            json_rpc_file_path: None,
         }
     }
 }

--- a/crates/sui-rpc-benchmark/src/config.rs
+++ b/crates/sui-rpc-benchmark/src/config.rs
@@ -9,7 +9,9 @@ pub struct BenchmarkConfig {
     pub concurrency: usize,
     /// Duration to run the benchmark in seconds
     pub duration: Duration,
-    /// Optional path to JSON RPC file for JSON RPC benchmarks
+    /// Optional path to a jsonl file for JSON RPC benchmark.
+    /// The file contains a list of JSON RPC requests that are collected from Grafana,
+    /// and will be run concurrently by the JSON RPC benchmark runner.
     pub json_rpc_file_path: Option<String>,
 }
 

--- a/crates/sui-rpc-benchmark/src/direct/mod.rs
+++ b/crates/sui-rpc-benchmark/src/direct/mod.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod benchmark_config;
 pub mod metrics;
 pub mod query_enricher;
 pub mod query_executor;

--- a/crates/sui-rpc-benchmark/src/direct/query_executor.rs
+++ b/crates/sui-rpc-benchmark/src/direct/query_executor.rs
@@ -16,7 +16,7 @@ use tokio_postgres::{types::ToSql, NoTls};
 use tracing::info;
 use url::Url;
 
-use crate::direct::benchmark_config::BenchmarkConfig;
+use crate::config::BenchmarkConfig;
 use crate::direct::metrics::{BenchmarkResult, MetricsCollector};
 use crate::direct::query_enricher::{EnrichedBenchmarkQuery, SqlValue};
 
@@ -95,7 +95,7 @@ impl QueryExecutor {
         );
 
         let start = Instant::now();
-        let deadline = start + self.config.timeout;
+        let deadline = start + self.config.duration;
         let (concurrency, metrics, pool, queries) = (
             self.config.concurrency,
             self.metrics.clone(),

--- a/crates/sui-rpc-benchmark/src/json_rpc/mod.rs
+++ b/crates/sui-rpc-benchmark/src/json_rpc/mod.rs
@@ -1,0 +1,59 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::config::BenchmarkConfig;
+use anyhow::Result;
+use request_loader::load_json_rpc_requests;
+use runner::run_queries;
+use std::time::Duration;
+use tracing::info;
+
+pub mod request_loader;
+pub mod runner;
+
+pub async fn run_benchmark(
+    endpoint: &str,
+    file_path: &str,
+    concurrency: usize,
+    duration_secs: u64,
+) -> Result<()> {
+    let config = BenchmarkConfig {
+        concurrency,
+        duration: Duration::from_secs(duration_secs),
+        json_rpc_file_path: Some(file_path.to_string()),
+    };
+
+    info!("Loading JSON RPC requests from {}", file_path);
+    let requests = load_json_rpc_requests(file_path)?;
+    info!("Loaded {} requests", requests.len());
+
+    let metrics = run_queries(endpoint, &requests, &config).await?;
+    info!("Benchmark results:");
+    info!("=== Overall Statistics ===");
+    info!("Total requests sent: {}", metrics.total_sent);
+    info!("Total errors: {}", metrics.total_errors);
+    if metrics.total_sent > 0 {
+        let avg_latency = metrics.total_latency_ms / metrics.total_sent as f64;
+        info!("Average latency: {:.2}ms", avg_latency);
+        let success_rate = ((metrics.total_sent - metrics.total_errors) as f64
+            / metrics.total_sent as f64)
+            * 100.0;
+        info!("Success rate: {:.1}%", success_rate);
+    }
+    info!("=== Per-Method Statistics ===");
+    let mut methods: Vec<_> = metrics.per_method.iter().collect();
+    methods.sort_by_key(|(method, _)| *method);
+    for (method, stats) in methods {
+        info!("Method: {}", method);
+        info!("  Requests: {}", stats.total_sent);
+        info!("  Errors: {}", stats.total_errors);
+        if stats.total_sent > 0 {
+            let method_avg_latency = stats.total_latency_ms / stats.total_sent as f64;
+            let method_success_rate =
+                ((stats.total_sent - stats.total_errors) as f64 / stats.total_sent as f64) * 100.0;
+            info!("  Avg latency: {:.2}ms", method_avg_latency);
+            info!("  Success rate: {:.1}%", method_success_rate);
+        }
+    }
+    Ok(())
+}

--- a/crates/sui-rpc-benchmark/src/json_rpc/request_loader.rs
+++ b/crates/sui-rpc-benchmark/src/json_rpc/request_loader.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// This module implements the request loader, which is used to load
+/// the JSON RPC requests from a jsonl file.
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::{
+    fs::File,
+    io::{BufRead, BufReader},
+};
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct JsonRpcRequestLine {
+    pub method: String,
+    #[serde(rename = "body")]
+    pub body_json: serde_json::Value,
+}
+
+pub fn load_json_rpc_requests(file_path: &str) -> Result<Vec<JsonRpcRequestLine>> {
+    let file = File::open(file_path)
+        .with_context(|| format!("Could not open JSON RPC file at {}", file_path))?;
+    let reader = BufReader::new(file);
+
+    let mut requests = Vec::new();
+    for line in reader.lines() {
+        let line = line?;
+        let request_line: JsonRpcRequestLine =
+            serde_json::from_str(&line).with_context(|| "Failed to parse JSON RPC line")?;
+        requests.push(request_line);
+    }
+
+    Ok(requests)
+}

--- a/crates/sui-rpc-benchmark/src/json_rpc/runner.rs
+++ b/crates/sui-rpc-benchmark/src/json_rpc/runner.rs
@@ -1,0 +1,98 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// This module implements the JSON RPC benchmark runner.
+/// The main function is `run_queries`, which runs the queries concurrently
+/// and records the metrics.
+use anyhow::Result;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::Instant,
+};
+use sui_indexer_alt_framework::task::TrySpawnStreamExt;
+use tokio::time::timeout;
+
+use super::request_loader::JsonRpcRequestLine;
+use crate::config::BenchmarkConfig;
+
+#[derive(Clone, Default)]
+pub struct MethodMetrics {
+    pub total_sent: usize,
+    pub total_errors: usize,
+    // record total latency and calculate average latency later to avoid duplicate calculations
+    pub total_latency_ms: f64,
+}
+
+#[derive(Clone, Default)]
+pub struct JsonRpcMetrics {
+    pub total_sent: usize,
+    pub total_errors: usize,
+    // record total latency and calculate average latency to avoid duplicate calculations
+    pub total_latency_ms: f64,
+    pub per_method: HashMap<String, MethodMetrics>,
+}
+
+impl JsonRpcMetrics {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn record_request(&mut self, method: &str, latency_ms: f64, is_error: bool) {
+        self.total_sent += 1;
+        self.total_latency_ms += latency_ms;
+        if is_error {
+            self.total_errors += 1;
+        }
+
+        let method_metrics = self.per_method.entry(method.to_string()).or_default();
+        method_metrics.total_sent += 1;
+        method_metrics.total_latency_ms += latency_ms;
+        if is_error {
+            method_metrics.total_errors += 1;
+        }
+    }
+}
+
+pub async fn run_queries(
+    endpoint: &str,
+    requests: &[JsonRpcRequestLine],
+    config: &BenchmarkConfig,
+) -> Result<JsonRpcMetrics> {
+    let concurrency = config.concurrency;
+    let shared_metrics = Arc::new(Mutex::new(JsonRpcMetrics::new()));
+    let client = reqwest::Client::new();
+    let endpoint = endpoint.to_owned();
+    let requests = requests.to_vec();
+    let metrics = shared_metrics.clone();
+    futures::stream::iter(requests.into_iter().map(move |request_line| {
+        let task_metrics = metrics.clone();
+        let client = client.clone();
+        let endpoint = endpoint.clone();
+        async move {
+            let now = Instant::now();
+            let res = timeout(
+                std::time::Duration::from_secs(10),
+                client.post(&endpoint).json(&request_line.body_json).send(),
+            )
+            .await;
+
+            let elapsed_ms = now.elapsed().as_millis() as f64;
+            let is_error = !matches!(res, Ok(Ok(ref resp)) if resp.status().is_success());
+
+            let mut metrics = task_metrics
+                .lock()
+                .map_err(|e| anyhow::anyhow!("Failed to acquire metrics lock: {}", e))?;
+            metrics.record_request(&request_line.method, elapsed_ms, is_error);
+            Ok::<(), anyhow::Error>(())
+        }
+    }))
+    .try_for_each_spawned(concurrency, |fut| fut)
+    .await?;
+
+    let final_metrics = shared_metrics
+        .lock()
+        .map_err(|e| anyhow::anyhow!("Failed to acquire metrics lock for final results: {}", e))?
+        .clone();
+    Ok(final_metrics)
+}


### PR DESCRIPTION
## Description 

- load requests from jsonl file
- generate and file JSON RPC requests concurrently
- collect total and per-method metrics

will collect more logs from production and stress test with logs pulled from loki API

## Test plan 

local run and verify on report
```
Benchmark results:
=== Overall Statistics ===
Total requests sent: 3
Total errors: 0
Average latency: 1360.67ms
Success rate: 100.0%

=== Per-Method Statistics ===
Method: sui_getLatestCheckpointSequenceNumber
  Requests: 1
  Errors: 0
  Avg latency: 1298.00ms
  Success rate: 100.0%
Method: sui_multiGetTransactionBlocks
  Requests: 1
  Errors: 0
  Avg latency: 1486.00ms
  Success rate: 100.0%
Method: suix_queryTransactionBlocks
  Requests: 1
  Errors: 0
  Avg latency: 1298.00ms
  Success rate: 100.0%
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
