### PR TITLE
[vm-rewrite] Rootless linkage

### DIFF
--- a/external-crates/move/crates/move-cli/src/sandbox/commands/publish.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/commands/publish.rs
@@ -77,7 +77,7 @@ pub fn publish(
     let mut gas_status = get_gas_status(cost_table, None)?;
 
     // Create a `LinkageContext`
-    let linkage_context = LinkageContext::new(package_storage_id, dependency_map);
+    let linkage_context = LinkageContext::new(dependency_map);
 
     // Serialize the modules into a package to prepare them for publishing
     let pkg = StoredPackage::from_module_for_testing_with_linkage(

--- a/external-crates/move/crates/move-cli/src/sandbox/commands/publish.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/commands/publish.rs
@@ -14,7 +14,7 @@ use move_vm_runtime::{
     runtime::MoveRuntime,
     shared::{linkage_context::LinkageContext, types::PackageStorageId},
 };
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 
 pub fn publish(
     natives: impl IntoIterator<Item = NativeFunctionRecord>,
@@ -55,7 +55,7 @@ pub fn publish(
         .collect::<Vec<_>>();
 
     // Build the dependency map from the package
-    let mut dependency_map = HashMap::new();
+    let mut dependency_map = BTreeMap::new();
     for (name, unit) in package.deps_compiled_units.iter() {
         let unit_address = *unit.unit.module.self_id().address();
         if let Some(other) = dependency_map.insert(unit_address, unit_address) {

--- a/external-crates/move/crates/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -411,7 +411,6 @@ impl OnDiskStateView {
             "Found circular dependencies during dependency generation."
         );
         let linkage_context = LinkageContext::new(
-            *package_address,
             all_dependencies
                 .into_iter()
                 .map(|id| (id, id))

--- a/external-crates/move/crates/move-transactional-test-runner/src/vm_test_harness.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/vm_test_harness.rs
@@ -98,14 +98,13 @@ impl PublishLinkageArgs {
         linkage: &LinkageContext,
     ) -> AccountAddress {
         // 1. Use location if specified; otherwise
-        // 2. Use the sender address (remapped if it exists in the linkage table); otherwise
-        // 3. Use the sender address
+        // 2. Use the sender address (remapped if it exists in the linkage table).
         self.location.unwrap_or(
             linkage
                 .linkage_table
                 .get(&sender)
                 .copied()
-                .unwrap_or(sender),
+                .expect("Sender address not found in linkage table"),
         )
     }
 }

--- a/external-crates/move/crates/move-transactional-test-runner/src/vm_test_harness.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/vm_test_harness.rs
@@ -41,11 +41,7 @@ use move_vm_runtime::{
 };
 use once_cell::sync::Lazy;
 
-use std::{
-    collections::{BTreeMap, HashMap},
-    path::Path,
-    sync::Arc,
-};
+use std::{collections::BTreeMap, path::Path, sync::Arc};
 
 const STD_ADDR: AccountAddress = AccountAddress::ONE;
 
@@ -219,7 +215,7 @@ impl<'a> MoveTestAdapter<'a> for SimpleRuntimeTestAdapter {
                 let sender = *move_stdlib.first().unwrap().self_id().address();
                 println!("generating stdlib linkage");
                 let linkage_context =
-                    LinkageContext::new(sender, HashMap::from([(sender, sender)]));
+                    LinkageContext::new(sender, BTreeMap::from([(sender, sender)]));
                 println!("calling stdlib publish with address {sender:?}");
                 let pkg = StoredPackage::from_module_for_testing_with_linkage(
                     sender,

--- a/external-crates/move/crates/move-vm-runtime/src/dev_utils/compilation_utils.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/dev_utils/compilation_utils.rs
@@ -114,6 +114,6 @@ pub fn compile_packages(
 ) -> BTreeMap<RuntimePackageId, StoredPackage> {
     compile_packages_in_file(filename, dependencies)
         .into_iter()
-        .map(|p| (p.linkage_context.root_package(), p))
+        .map(|p| (p.package_id, p))
         .collect()
 }

--- a/external-crates/move/crates/move-vm-runtime/src/dev_utils/in_memory_test_adapter.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/dev_utils/in_memory_test_adapter.rs
@@ -123,7 +123,7 @@ impl VMTestAdapter<InMemoryStorage> for InMemoryTestAdapter {
             // TODO: VM error instead?
             panic!("Did not find runtime ID {runtime_id} in linkage context.");
         };
-        assert!(storage_id == package.storage_id);
+        assert_eq!(storage_id, package.storage_id);
         let mut gas_meter = GasStatus::new_unmetered();
         self.runtime.validate_package(
             &self.storage,
@@ -204,7 +204,6 @@ impl VMTestAdapter<InMemoryStorage> for InMemoryTestAdapter {
             "Found circular dependencies during linkage generation."
         );
         let linkage_context = LinkageContext::new(
-            storage_id,
             all_dependencies
                 .into_iter()
                 .map(|id| (id, id))

--- a/external-crates/move/crates/move-vm-runtime/src/dev_utils/storage.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/dev_utils/storage.rs
@@ -15,7 +15,7 @@ use move_core_types::{
     language_storage::ModuleId,
     resolver::{ModuleResolver, MoveResolver, SerializedPackage, TypeOrigin},
 };
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 // -------------------------------------------------------------------------------------------------
 // Types
@@ -71,7 +71,7 @@ impl StoredPackage {
     fn empty(storage_id: AccountAddress) -> Self {
         Self {
             modules: BTreeMap::new(),
-            linkage_context: LinkageContext::new(storage_id, HashMap::new()),
+            linkage_context: LinkageContext::new(storage_id, BTreeMap::new()),
             type_origin_table: vec![],
         }
     }
@@ -83,7 +83,7 @@ impl StoredPackage {
         assert!(!modules.is_empty());
         // Map the modules in this package to `storage_id` and generate the identity linkage for
         // all deps.
-        let mut linkage_table = HashMap::new();
+        let mut linkage_table = BTreeMap::new();
         let type_origin_table = generate_type_origins(storage_id, &modules);
         let modules: BTreeMap<_, _> = modules
             .into_iter()

--- a/external-crates/move/crates/move-vm-runtime/src/dev_utils/vm_test_adapter.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/dev_utils/vm_test_adapter.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use move_binary_format::{errors::VMResult, file_format::CompiledModule};
 use move_core_types::resolver::{MoveResolver, SerializedPackage};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 // FIXME(cswords): support gas
 
@@ -78,7 +78,7 @@ pub trait VMTestAdapter<Storage: MoveResolver + Sync + Send> {
         let pkg = self.get_package_from_store(&package_id)?;
         Ok(LinkageContext::new(
             package_id,
-            HashMap::from_iter(pkg.linkage_table),
+            BTreeMap::from_iter(pkg.linkage_table),
         ))
     }
 

--- a/external-crates/move/crates/move-vm-runtime/src/dev_utils/vm_test_adapter.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/dev_utils/vm_test_adapter.rs
@@ -76,10 +76,7 @@ pub trait VMTestAdapter<Storage: MoveResolver + Sync + Send> {
     /// Retrieve the linkage context for the given package in `Storage`.
     fn get_linkage_context(&self, package_id: PackageStorageId) -> VMResult<LinkageContext> {
         let pkg = self.get_package_from_store(&package_id)?;
-        Ok(LinkageContext::new(
-            package_id,
-            BTreeMap::from_iter(pkg.linkage_table),
-        ))
+        Ok(LinkageContext::new(BTreeMap::from_iter(pkg.linkage_table)))
     }
 
     fn get_package_from_store(&self, package_id: &PackageStorageId) -> VMResult<SerializedPackage>;

--- a/external-crates/move/crates/move-vm-runtime/src/runtime/mod.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/runtime/mod.rs
@@ -120,7 +120,7 @@ impl MoveRuntime {
             .map(|pkg| (pkg.runtime.runtime_id, Arc::clone(&pkg.runtime)))
             .collect::<BTreeMap<RuntimePackageId, Arc<jit::execution::ast::Package>>>();
 
-        let virtual_tables = VMDispatchTables::new(runtime_packages)?;
+        let virtual_tables = VMDispatchTables::new(self.vm_config.clone(), runtime_packages)?;
 
         let base_heap = BaseHeap::new();
 
@@ -200,7 +200,7 @@ impl MoveRuntime {
             .map(|pkg| (pkg.runtime.runtime_id, Arc::clone(&pkg.runtime)))
             .collect::<BTreeMap<RuntimePackageId, Arc<jit::execution::ast::Package>>>();
 
-        let virtual_tables = VMDispatchTables::new(runtime_packages)?;
+        let virtual_tables = VMDispatchTables::new(self.vm_config.clone(), runtime_packages)?;
 
         let base_heap = BaseHeap::new();
 

--- a/external-crates/move/crates/move-vm-runtime/src/runtime/mod.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/runtime/mod.rs
@@ -15,10 +15,7 @@ use move_binary_format::errors::VMResult;
 use move_core_types::resolver::{MoveResolver, SerializedPackage};
 use move_vm_config::runtime::VMConfig;
 
-use std::{
-    collections::{BTreeMap, HashMap},
-    sync::Arc,
-};
+use std::{collections::BTreeMap, sync::Arc};
 
 // FIXME(cswords): This is only public for testing...
 pub mod package_resolution;
@@ -167,7 +164,7 @@ impl MoveRuntime {
         let data_cache = TransactionDataCache::new(data_cache);
         let link_context = LinkageContext::new(
             pkg.storage_id,
-            HashMap::from_iter(pkg.linkage_table.clone()),
+            BTreeMap::from_iter(pkg.linkage_table.clone()),
         );
 
         // Verify a provided serialized package. This will validate the provided serialized

--- a/external-crates/move/crates/move-vm-runtime/src/runtime/mod.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/runtime/mod.rs
@@ -162,10 +162,7 @@ impl MoveRuntime {
         dbg_println!("\n\nPublishing module at {storage_id} (=> {pkg_runtime_id})\n\n");
 
         let data_cache = TransactionDataCache::new(data_cache);
-        let link_context = LinkageContext::new(
-            pkg.storage_id,
-            BTreeMap::from_iter(pkg.linkage_table.clone()),
-        );
+        let link_context = LinkageContext::new(BTreeMap::from_iter(pkg.linkage_table.clone()));
 
         // Verify a provided serialized package. This will validate the provided serialized
         // package, including attempting to jit-compile the package and verify linkage with its
@@ -178,7 +175,7 @@ impl MoveRuntime {
             &self.vm_config,
             &data_cache,
             &link_context,
-            link_context.all_package_dependencies()?,
+            link_context.all_package_dependencies_except(pkg.storage_id)?,
         )?;
         let verified_pkg = {
             let deps = pkg_dependencies

--- a/external-crates/move/crates/move-vm-runtime/src/shared/constants.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/shared/constants.rs
@@ -22,7 +22,7 @@ pub const VALUE_DEPTH_MAX: u64 = 128;
 /// fields for struct types.
 /// Maximal nodes which are allowed when converting to layout. This includes the types of
 /// fields for datatypes.
-pub const MAX_TYPE_TO_LAYOUT_NODES: u64 = 256;
+pub const HISTORICAL_MAX_TYPE_TO_LAYOUT_NODES: u64 = 256;
 
 /// Maximal nodes which are all allowed when instantiating a generic type. This does not include
 /// field types of datatypes.

--- a/external-crates/move/crates/move-vm-runtime/src/shared/linkage_context.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/shared/linkage_context.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 
 use move_binary_format::errors::{PartialVMError, PartialVMResult, VMResult};
 use move_core_types::{
@@ -25,13 +25,13 @@ pub struct LinkageContext {
     // All calls to P in the root package will call 0xCAFE as the Runtime ID, but during loading
     // and JIT compilation we need to rewrite these. The linkage table here will redirect 0xCAFE to
     // 0xDEAD for this purpose.
-    pub linkage_table: HashMap<RuntimePackageId, PackageStorageId>,
+    pub linkage_table: BTreeMap<RuntimePackageId, PackageStorageId>,
 }
 
 impl LinkageContext {
     pub fn new(
         root_package: PackageStorageId,
-        linkage_table: HashMap<RuntimePackageId, PackageStorageId>,
+        linkage_table: BTreeMap<RuntimePackageId, PackageStorageId>,
     ) -> Self {
         Self {
             root_package,

--- a/external-crates/move/crates/move-vm-runtime/src/shared/serialization.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/shared/serialization.rs
@@ -14,7 +14,6 @@ use move_binary_format::{
     file_format::LocalIndex,
 };
 use move_core_types::{runtime_value::MoveTypeLayout, vm_status::StatusCode};
-use move_vm_config::runtime::VMConfig;
 
 use tracing::warn;
 
@@ -68,7 +67,6 @@ pub fn deserialize_value(
 /// Returns the list of mutable references plus the vector of values.
 pub fn deserialize_args(
     vtables: &VMDispatchTables,
-    _vm_config: &VMConfig,
     heap: &mut BaseHeap,
     arg_tys: Vec<Type>,
     serialized_args: Vec<impl Borrow<[u8]>>,
@@ -106,7 +104,6 @@ pub fn deserialize_args(
 
 pub fn serialize_return_value(
     vtables: &VMDispatchTables,
-    vm_config: &VMConfig,
     ty: &Type,
     value: Value,
 ) -> PartialVMResult<(Vec<u8>, MoveTypeLayout)> {
@@ -123,7 +120,7 @@ pub fn serialize_return_value(
         _ => (ty, value),
     };
 
-    let layout = if vm_config.rethrow_serialization_type_layout_errors {
+    let layout = if vtables.vm_config.rethrow_serialization_type_layout_errors {
         vtables.type_to_type_layout(ty)?
     } else {
         vtables.type_to_type_layout(ty).map_err(|_err| {
@@ -142,7 +139,6 @@ pub fn serialize_return_value(
 
 pub fn serialize_return_values(
     vtables: &VMDispatchTables,
-    vm_config: &VMConfig,
     return_types: &[Type],
     return_values: Vec<Value>,
 ) -> PartialVMResult<Vec<(Vec<u8>, MoveTypeLayout)>> {
@@ -161,6 +157,6 @@ pub fn serialize_return_values(
     return_types
         .iter()
         .zip(return_values)
-        .map(|(ty, value)| serialize_return_value(vtables, vm_config, ty, value))
+        .map(|(ty, value)| serialize_return_value(vtables, ty, value))
         .collect()
 }

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/bad_entry_point_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/bad_entry_point_tests.rs
@@ -18,14 +18,14 @@ use move_core_types::{
     runtime_value::{serialize_values, MoveValue},
     vm_status::StatusType,
 };
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
 
 #[test]
 fn call_non_existent_module() {
     let adapter = InMemoryTestAdapter::new();
-    let linkage = LinkageContext::new(TEST_ADDR, HashMap::new());
+    let linkage = LinkageContext::new(TEST_ADDR, BTreeMap::new());
     let mut vm = adapter.make_vm(linkage).unwrap();
 
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("M").unwrap());

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/bad_entry_point_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/bad_entry_point_tests.rs
@@ -25,7 +25,7 @@ const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGT
 #[test]
 fn call_non_existent_module() {
     let adapter = InMemoryTestAdapter::new();
-    let linkage = LinkageContext::new(TEST_ADDR, BTreeMap::new());
+    let linkage = LinkageContext::new(BTreeMap::new());
     let mut vm = adapter.make_vm(linkage).unwrap();
 
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("M").unwrap());

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/bad_storage_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/bad_storage_tests.rs
@@ -78,7 +78,6 @@ fn test_malformed_module() {
             blob,
         );
         let linkage = LinkageContext {
-            root_package: TEST_ADDR,
             linkage_table: [(TEST_ADDR, TEST_ADDR)].into_iter().collect(),
         };
 
@@ -200,8 +199,7 @@ fn test_missing_module_dependency() {
             StoredPackage::from_modules_for_testing(TEST_ADDR, vec![n]).unwrap(),
         );
 
-        let linkage =
-            LinkageContext::new(TEST_ADDR, [(TEST_ADDR, TEST_ADDR)].into_iter().collect());
+        let linkage = LinkageContext::new([(TEST_ADDR, TEST_ADDR)].into_iter().collect());
         let Err(err) = adapter.make_vm(linkage) else {
             panic!("Expected an error, but passed");
         };
@@ -269,8 +267,7 @@ fn test_malformed_module_dependency() {
             StoredPackage::from_modules_for_testing(TEST_ADDR, vec![n.clone()]).unwrap(),
         );
 
-        let linkage =
-            LinkageContext::new(TEST_ADDR, [(TEST_ADDR, TEST_ADDR)].into_iter().collect());
+        let linkage = LinkageContext::new([(TEST_ADDR, TEST_ADDR)].into_iter().collect());
         adapter.storage.publish_or_overwrite_module(
             *n.self_id().address(),
             n.self_id().name().to_owned(),
@@ -342,8 +339,7 @@ fn test_unverifiable_module_dependency() {
             StoredPackage::from_modules_for_testing(TEST_ADDR, vec![n.clone()]).unwrap(),
         );
 
-        let linkage =
-            LinkageContext::new(TEST_ADDR, [(TEST_ADDR, TEST_ADDR)].into_iter().collect());
+        let linkage = LinkageContext::new([(TEST_ADDR, TEST_ADDR)].into_iter().collect());
         adapter.storage.publish_or_overwrite_module(
             *n.self_id().address(),
             n.self_id().name().to_owned(),

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/instantiation_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/instantiation_tests.rs
@@ -521,7 +521,6 @@ fn make_module(
     let module_id = module.self_id();
     let mut pkg = StoredPackage::from_modules_for_testing(addr, vec![module.clone()]).unwrap();
     pkg.linkage_context = LinkageContext::new(
-        addr,
         [(addr, addr)]
             .into_iter()
             .chain(module.module_handles().iter().map(|mhandle| {

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/loader_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/loader_tests.rs
@@ -42,13 +42,7 @@ use move_core_types::{
 use move_vm_config::{runtime::VMConfig, verifier::VerifierConfig};
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
-use std::{
-    collections::{BTreeMap, HashMap},
-    path::PathBuf,
-    str::FromStr,
-    sync::Arc,
-    thread,
-};
+use std::{collections::BTreeMap, path::PathBuf, str::FromStr, sync::Arc, thread};
 
 const ADDR2: AccountAddress = {
     let mut address = [0u8; AccountAddress::LENGTH];
@@ -126,7 +120,7 @@ impl Adapter {
         let vm = Arc::new(RwLock::new(
             InMemoryTestAdapter::new_with_runtime_and_storage(runtime, store),
         ));
-        let linkage = LinkageContext::new(ADDR2, HashMap::new());
+        let linkage = LinkageContext::new(ADDR2, BTreeMap::new());
         Self {
             store: {
                 RelinkingStore {
@@ -141,7 +135,7 @@ impl Adapter {
     fn with_linkage(
         &self,
         context: PackageStorageId,
-        linkage: HashMap<RuntimePackageId, PackageStorageId>,
+        linkage: BTreeMap<RuntimePackageId, PackageStorageId>,
         type_origin: Vec<((&IdentStr, &IdentStr), PackageStorageId)>,
     ) -> Self {
         Self {
@@ -362,7 +356,7 @@ fn load() {
     let data_store = InMemoryStorage::new();
 
     let mut adapter =
-        Adapter::new(data_store).with_linkage(ADDR2, HashMap::from([(ADDR2, ADDR2)]), vec![]);
+        Adapter::new(data_store).with_linkage(ADDR2, BTreeMap::from([(ADDR2, ADDR2)]), vec![]);
     let pkg = get_loader_tests_modules();
     adapter.publish_package(pkg);
     // calls all functions sequentially
@@ -373,7 +367,7 @@ fn load() {
 fn test_depth() {
     let data_store = InMemoryStorage::new();
     let mut adapter =
-        Adapter::new(data_store).with_linkage(ADDR2, HashMap::from([(ADDR2, ADDR2)]), vec![]);
+        Adapter::new(data_store).with_linkage(ADDR2, BTreeMap::from([(ADDR2, ADDR2)]), vec![]);
     let modules = get_depth_tests_modules();
     let structs = vec![
         (
@@ -576,7 +570,7 @@ fn test_depth() {
 fn load_concurrent() {
     let data_store = InMemoryStorage::new();
     let mut adapter =
-        Adapter::new(data_store).with_linkage(ADDR2, HashMap::from([(ADDR2, ADDR2)]), vec![]);
+        Adapter::new(data_store).with_linkage(ADDR2, BTreeMap::from([(ADDR2, ADDR2)]), vec![]);
     let modules = get_loader_tests_modules();
     adapter.publish_package(modules);
     // makes 15 threads
@@ -587,7 +581,7 @@ fn load_concurrent() {
 fn load_concurrent_many() {
     let data_store = InMemoryStorage::new();
     let mut adapter =
-        Adapter::new(data_store).with_linkage(ADDR2, HashMap::from([(ADDR2, ADDR2)]), vec![]);
+        Adapter::new(data_store).with_linkage(ADDR2, BTreeMap::from([(ADDR2, ADDR2)]), vec![]);
     let modules = get_loader_tests_modules();
     adapter.publish_package(modules);
     // makes 150 threads
@@ -598,7 +592,7 @@ fn load_concurrent_many() {
 fn relink() {
     let data_store = InMemoryStorage::new();
     let mut adapter =
-        Adapter::new(data_store).with_linkage(ADDR2, HashMap::from([(ADDR2, ADDR2)]), vec![]);
+        Adapter::new(data_store).with_linkage(ADDR2, BTreeMap::from([(ADDR2, ADDR2)]), vec![]);
 
     let a0 = ModuleId::new(ADDR4, ident_str!("a").to_owned());
     let b0 = ModuleId::new(ADDR3, ident_str!("b").to_owned());
@@ -615,7 +609,7 @@ fn relink() {
     adapter
         .with_linkage(
             ADDR3,
-            HashMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
+            BTreeMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
             vec![],
         )
         .publish_package(b0_modules);
@@ -625,7 +619,7 @@ fn relink() {
         adapter
             .with_linkage(
                 ADDR3,
-                HashMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3),]),
+                BTreeMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3),]),
                 vec![],
             )
             .call_function_with_return(&b0, ident_str!("b")),
@@ -633,7 +627,7 @@ fn relink() {
 
     let mut adapter = adapter.with_linkage(
         ADDR5,
-        /* linkage */ HashMap::from_iter([(ADDR2, ADDR5)]),
+        /* linkage */ BTreeMap::from_iter([(ADDR2, ADDR5)]),
         /* type origin */
         vec![
             ((c0.name(), ident_str!("S")), *c0.address()),
@@ -646,7 +640,7 @@ fn relink() {
     adapter.publish_package(c1_modules);
     let mut adapter = adapter.with_linkage(
         ADDR4,
-        HashMap::from([(ADDR2, ADDR5), (ADDR3, ADDR3), (ADDR4, ADDR4)]),
+        BTreeMap::from([(ADDR2, ADDR5), (ADDR3, ADDR3), (ADDR4, ADDR4)]),
         vec![],
     );
     adapter.publish_package(a0_modules);
@@ -661,7 +655,7 @@ fn relink() {
 fn relink_publish_err() {
     let data_store = InMemoryStorage::new();
     let mut adapter =
-        Adapter::new(data_store).with_linkage(ADDR2, HashMap::from([(ADDR2, ADDR2)]), vec![]);
+        Adapter::new(data_store).with_linkage(ADDR2, BTreeMap::from([(ADDR2, ADDR2)]), vec![]);
 
     let c0_modules = get_relinker_tests_modules_with_deps(ADDR2, "c_v0", []).unwrap();
     let b1_modules = get_relinker_tests_modules_with_deps(ADDR3, "b_v1", ["c_v1"]).unwrap();
@@ -672,7 +666,7 @@ fn relink_publish_err() {
     adapter
         .with_linkage(
             ADDR3,
-            HashMap::from_iter([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
+            BTreeMap::from_iter([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
             vec![],
         )
         .publish_package_with_error(b1_modules);
@@ -697,13 +691,13 @@ fn relink_load_err() {
     adapter
         .with_linkage(
             *c0.address(),
-            HashMap::from([(*c0.address(), *c0.address())]),
+            BTreeMap::from([(*c0.address(), *c0.address())]),
             vec![],
         )
         .publish_package(c0_modules);
     let mut adapter = adapter.with_linkage(
         *b0.address(),
-        HashMap::from([
+        BTreeMap::from([
             (*c0.address(), *c0.address()),
             (*b0.address(), *b0.address()),
         ]),
@@ -720,7 +714,7 @@ fn relink_load_err() {
         .with_linkage(
             *c1.address(),
             /* linkage */
-            HashMap::from_iter([(*c0.address(), *c1.address())]),
+            BTreeMap::from_iter([(*c0.address(), *c1.address())]),
             /* type origin */
             vec![
                 ((c0.name(), ident_str!("S")), *c0.address()),
@@ -733,7 +727,7 @@ fn relink_load_err() {
     let mut adapter = adapter.with_linkage(
         *b1.address(),
         /* linkage */
-        HashMap::from_iter([
+        BTreeMap::from_iter([
             (*b0.address(), *b1.address()),
             (*c0.address(), *c1.address()),
         ]),
@@ -756,7 +750,7 @@ fn relink_load_err() {
         .with_linkage(
             *b1.address(),
             /* linkage */
-            HashMap::from_iter([
+            BTreeMap::from_iter([
                 (*b0.address(), *b1.address()),
                 (*c0.address(), *c0.address()),
             ]),
@@ -785,7 +779,7 @@ fn relink_type_identity() {
 
     let mut adapter = adapter.with_linkage(
         *c0.address(),
-        HashMap::from([(*c0.address(), *c0.address())]),
+        BTreeMap::from([(*c0.address(), *c0.address())]),
         vec![],
     );
     adapter.publish_package(c0_modules);
@@ -795,7 +789,7 @@ fn relink_type_identity() {
         .with_linkage(
             *c1.address(),
             /* linkage */
-            HashMap::from_iter([(*c0.address(), *c1.address())]),
+            BTreeMap::from_iter([(*c0.address(), *c1.address())]),
             /* type origin */
             vec![
                 ((c0.name(), ident_str!("S")), *c0.address()),
@@ -807,7 +801,7 @@ fn relink_type_identity() {
     let mut adapter = adapter.with_linkage(
         *b1.address(),
         /* linkage */
-        HashMap::from_iter([
+        BTreeMap::from_iter([
             (*b0.address(), *b1.address()),
             (*c0.address(), *c1.address()),
         ]),
@@ -837,7 +831,7 @@ fn relink_defining_module_successive() {
     let data_store = InMemoryStorage::new();
     let mut adapter = Adapter::new(data_store).with_linkage(
         *c0.address(),
-        HashMap::from([(ADDR2, ADDR2)]),
+        BTreeMap::from([(ADDR2, ADDR2)]),
         vec![((c0.name(), ident_str!("S")), *c0.address())],
     );
 
@@ -850,7 +844,7 @@ fn relink_defining_module_successive() {
 
     let mut adapter = adapter.with_linkage(
         *c1.address(),
-        /* linkage */ HashMap::from_iter([(*c0.address(), *c1.address())]),
+        /* linkage */ BTreeMap::from_iter([(*c0.address(), *c1.address())]),
         /* type origin */
         vec![
             ((c0.name(), ident_str!("S")), *c0.address()),
@@ -864,7 +858,7 @@ fn relink_defining_module_successive() {
 
     let mut adapter = adapter.with_linkage(
         *c2.address(),
-        /* linkage */ HashMap::from_iter([(*c0.address(), *c2.address())]),
+        /* linkage */ BTreeMap::from_iter([(*c0.address(), *c2.address())]),
         /* type origin */
         vec![
             ((c0.name(), ident_str!("S")), *c0.address()),
@@ -919,7 +913,7 @@ fn relink_defining_module_oneshot() {
 
     let mut adapter = Adapter::new(data_store).with_linkage(
         *c2.address(),
-        /* linkage */ HashMap::from_iter([(*c0.address(), *c2.address())]),
+        /* linkage */ BTreeMap::from_iter([(*c0.address(), *c2.address())]),
         /* type origin */
         vec![
             ((c0.name(), ident_str!("S")), *c0.address()),
@@ -971,9 +965,9 @@ fn relink_defining_module_oneshot() {
 //         .linkage(
 //             *c0.address(),
 //             /* linkage */
-//             HashMap::from_iter([(*c0.address(), *c0.address())]),
+//             BTreeMap::from_iter([(*c0.address(), *c0.address())]),
 //             /* type origin */
-//             HashMap::from_iter([((c0.clone(), ident_str!("S").to_owned()), c0.clone())]),
+//             BTreeMap::from_iter([((c0.clone(), ident_str!("S").to_owned()), c0.clone())]),
 //         )
 //         .publish_modules(c0_modules);
 //
@@ -982,12 +976,12 @@ fn relink_defining_module_oneshot() {
 //     let mut adapter = adapter.linkage(
 //         *b0.address(),
 //         /* linkage */
-//         HashMap::from_iter([
+//         BTreeMap::from_iter([
 //             (*b0.address(), *b1.address()),
 //             (*c0.address(), *c0.address()),
 //         ]),
 //         /* type origin */
-//         HashMap::from_iter([
+//         BTreeMap::from_iter([
 //             ((c0.clone(), ident_str!("S").to_owned()), c0.clone()),
 //             ((b0.clone(), ident_str!("S").to_owned()), b1.clone()),
 //         ]),
@@ -1012,20 +1006,20 @@ fn publish_bundle_and_load() {
     let a0_modules = get_relinker_tests_modules_with_deps(ADDR4, "a_v0", ["b_v0", "c_v1"]).unwrap();
 
     adapter
-        .with_linkage(ADDR2, HashMap::from([(ADDR2, ADDR2)]), vec![])
+        .with_linkage(ADDR2, BTreeMap::from([(ADDR2, ADDR2)]), vec![])
         .publish_package(c1_modules);
 
     adapter
         .with_linkage(
             ADDR3,
-            HashMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
+            BTreeMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
             vec![],
         )
         .publish_package(b0_modules);
 
     let mut adapter = adapter.with_linkage(
         ADDR4,
-        HashMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3), (ADDR4, ADDR4)]),
+        BTreeMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3), (ADDR4, ADDR4)]),
         vec![],
     );
     adapter.publish_package(a0_modules);
@@ -1040,7 +1034,7 @@ fn publish_bundle_and_load() {
 fn publish_bundle_with_err_retry() {
     let data_store = InMemoryStorage::new();
     let adapter =
-        Adapter::new(data_store).with_linkage(ADDR2, HashMap::from([(ADDR2, ADDR2)]), vec![]);
+        Adapter::new(data_store).with_linkage(ADDR2, BTreeMap::from([(ADDR2, ADDR2)]), vec![]);
 
     let a0 = ModuleId::new(ADDR4, ident_str!("a").to_owned());
     let c0_modules = get_relinker_tests_modules_with_deps(ADDR2, "c_v0", []).unwrap();
@@ -1049,13 +1043,13 @@ fn publish_bundle_with_err_retry() {
     let a0_modules = get_relinker_tests_modules_with_deps(ADDR4, "a_v0", ["b_v0", "c_v1"]).unwrap();
 
     adapter
-        .with_linkage(ADDR2, HashMap::from([(ADDR2, ADDR2)]), vec![])
+        .with_linkage(ADDR2, BTreeMap::from([(ADDR2, ADDR2)]), vec![])
         .publish_package(c0_modules);
 
     adapter
         .with_linkage(
             ADDR3,
-            HashMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
+            BTreeMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
             vec![],
         )
         .publish_package(b0_modules);
@@ -1064,19 +1058,19 @@ fn publish_bundle_with_err_retry() {
     adapter
         .with_linkage(
             ADDR4,
-            HashMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3), (ADDR4, ADDR4)]),
+            BTreeMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3), (ADDR4, ADDR4)]),
             vec![],
         )
         .publish_package_with_error(a0_modules.clone());
 
     // publish the upgrade of c0 to ADDR5
     adapter
-        .with_linkage(ADDR5, HashMap::from([(ADDR2, ADDR5)]), vec![])
+        .with_linkage(ADDR5, BTreeMap::from([(ADDR2, ADDR5)]), vec![])
         .publish_package(c1_modules);
 
     let mut adapter = adapter.with_linkage(
         ADDR4,
-        HashMap::from([(ADDR2, ADDR5), (ADDR3, ADDR3), (ADDR4, ADDR4)]),
+        BTreeMap::from([(ADDR2, ADDR5), (ADDR3, ADDR3), (ADDR4, ADDR4)]),
         vec![],
     );
 
@@ -1094,7 +1088,7 @@ fn publish_bundle_with_err_retry() {
 fn deep_dependency_list_0() {
     let data_store = InMemoryStorage::new();
     let mut adapter =
-        Adapter::new(data_store).with_linkage(ADDR2, HashMap::from([(ADDR2, ADDR2)]), vec![]);
+        Adapter::new(data_store).with_linkage(ADDR2, BTreeMap::from([(ADDR2, ADDR2)]), vec![]);
 
     let mut modules = vec![];
 
@@ -1106,7 +1100,7 @@ fn deep_dependency_list_0() {
 
     let mut adapter = adapter.with_linkage(
         ADDR3,
-        HashMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
+        BTreeMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
         vec![],
     );
     let name = format!("A{}", max);
@@ -1121,7 +1115,7 @@ fn deep_dependency_list_0() {
 fn deep_dependency_list_1() {
     let data_store = InMemoryStorage::new();
     let mut adapter =
-        Adapter::new(data_store).with_linkage(ADDR2, HashMap::from([(ADDR2, ADDR2)]), vec![]);
+        Adapter::new(data_store).with_linkage(ADDR2, BTreeMap::from([(ADDR2, ADDR2)]), vec![]);
 
     let mut modules = vec![];
 
@@ -1133,7 +1127,7 @@ fn deep_dependency_list_1() {
 
     let mut adapter = adapter.with_linkage(
         ADDR3,
-        HashMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
+        BTreeMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
         vec![],
     );
     let name = format!("A{}", max);
@@ -1148,7 +1142,7 @@ fn deep_dependency_list_1() {
 fn deep_dependency_list_ok_0() {
     let data_store = InMemoryStorage::new();
     let mut adapter =
-        Adapter::new(data_store).with_linkage(ADDR2, HashMap::from([(ADDR2, ADDR2)]), vec![]);
+        Adapter::new(data_store).with_linkage(ADDR2, BTreeMap::from([(ADDR2, ADDR2)]), vec![]);
 
     let mut modules = vec![];
 
@@ -1160,7 +1154,7 @@ fn deep_dependency_list_ok_0() {
 
     let mut adapter = adapter.with_linkage(
         ADDR3,
-        HashMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
+        BTreeMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
         vec![],
     );
     let name = format!("A{}", max);
@@ -1175,7 +1169,7 @@ fn deep_dependency_list_ok_0() {
 fn deep_dependency_list_ok_1() {
     let data_store = InMemoryStorage::new();
     let mut adapter =
-        Adapter::new(data_store).with_linkage(ADDR2, HashMap::from([(ADDR2, ADDR2)]), vec![]);
+        Adapter::new(data_store).with_linkage(ADDR2, BTreeMap::from([(ADDR2, ADDR2)]), vec![]);
 
     let mut modules = vec![];
 
@@ -1187,7 +1181,7 @@ fn deep_dependency_list_ok_1() {
 
     let mut adapter = adapter.with_linkage(
         ADDR3,
-        HashMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
+        BTreeMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
         vec![],
     );
     let name = format!("A{}", max);
@@ -1202,7 +1196,7 @@ fn deep_dependency_list_ok_1() {
 fn deep_dependency_tree_0() {
     let data_store = InMemoryStorage::new();
     let mut adapter =
-        Adapter::new(data_store).with_linkage(ADDR2, HashMap::from([(ADDR2, ADDR2)]), vec![]);
+        Adapter::new(data_store).with_linkage(ADDR2, BTreeMap::from([(ADDR2, ADDR2)]), vec![]);
 
     let mut modules = vec![];
 
@@ -1216,7 +1210,7 @@ fn deep_dependency_tree_0() {
     // use one of the module in the tree
     let mut adapter = adapter.with_linkage(
         ADDR3,
-        HashMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
+        BTreeMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
         vec![],
     );
     let name = "ASome".to_string();
@@ -1231,7 +1225,7 @@ fn deep_dependency_tree_0() {
 fn deep_dependency_tree_1() {
     let data_store = InMemoryStorage::new();
     let mut adapter =
-        Adapter::new(data_store).with_linkage(ADDR2, HashMap::from([(ADDR2, ADDR2)]), vec![]);
+        Adapter::new(data_store).with_linkage(ADDR2, BTreeMap::from([(ADDR2, ADDR2)]), vec![]);
 
     let mut modules = vec![];
 
@@ -1245,7 +1239,7 @@ fn deep_dependency_tree_1() {
     // use one of the module in the tree
     let mut adapter = adapter.with_linkage(
         ADDR3,
-        HashMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
+        BTreeMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
         vec![],
     );
     let name = "ASome".to_string();
@@ -1260,7 +1254,7 @@ fn deep_dependency_tree_1() {
 fn deep_dependency_tree_ok_0() {
     let data_store = InMemoryStorage::new();
     let mut adapter =
-        Adapter::new(data_store).with_linkage(ADDR2, HashMap::from([(ADDR2, ADDR2)]), vec![]);
+        Adapter::new(data_store).with_linkage(ADDR2, BTreeMap::from([(ADDR2, ADDR2)]), vec![]);
 
     let mut modules = vec![];
 
@@ -1274,7 +1268,7 @@ fn deep_dependency_tree_ok_0() {
     // use one of the module in the tree
     let mut adapter = adapter.with_linkage(
         ADDR3,
-        HashMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
+        BTreeMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
         vec![],
     );
     let name = "ASome".to_string();
@@ -1289,7 +1283,7 @@ fn deep_dependency_tree_ok_0() {
 fn deep_dependency_tree_ok_1() {
     let data_store = InMemoryStorage::new();
     let mut adapter =
-        Adapter::new(data_store).with_linkage(ADDR2, HashMap::from([(ADDR2, ADDR2)]), vec![]);
+        Adapter::new(data_store).with_linkage(ADDR2, BTreeMap::from([(ADDR2, ADDR2)]), vec![]);
 
     let mut modules = vec![];
 
@@ -1303,7 +1297,7 @@ fn deep_dependency_tree_ok_1() {
     // use one of the module in the tree
     let mut adapter = adapter.with_linkage(
         ADDR3,
-        HashMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
+        BTreeMap::from([(ADDR2, ADDR2), (ADDR3, ADDR3)]),
         vec![],
     );
     let name = "ASome".to_string();

--- a/external-crates/move/crates/move-vm-runtime/src/validation/deserialization/translate.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/validation/deserialization/translate.rs
@@ -13,12 +13,7 @@ pub(crate) fn package(vm_config: &VMConfig, pkg: SerializedPackage) -> VMResult<
     let mut modules = BTreeMap::new();
     for module in pkg.modules.iter() {
         let module = CompiledModule::deserialize_with_config(module, &vm_config.binary_config)
-            .map_err(|err| -> move_binary_format::errors::VMError {
-                let msg = format!("Deserialization error: {:?}", err);
-                PartialVMError::new(StatusCode::CODE_DESERIALIZATION_ERROR)
-                    .with_message(msg)
-                    .finish(Location::Undefined) // TODO(tzakian): add Location::Package
-            })?;
+            .map_err(|err| err.finish(Location::Undefined))?; // TODO: add Location::Package
         modules.insert(module.self_id(), module);
     }
 


### PR DESCRIPTION
## Description 

Two commits:
- Lower commit switches the inner `HashMap` for linkage to a `BTreeMap` (for determinism purposes/paranoia). This transformation is pretty mechanical.
- The top commit removes the `root_package` from the linkage context, as in the new linkage story this does not make much sense.

## Test plan 

Make sure existing tests pass. 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
