### PR TITLE
Reduce logging verbosity 

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -723,7 +723,7 @@ impl AuthorityEpochTables {
         impl Iterator<Item = ((CheckpointSequenceNumber, u64), CheckpointSignatureMessage)> + '_,
     > {
         let key = (checkpoint_seq, starting_index);
-        debug!("Scanning pending checkpoint signatures from {:?}", key);
+        trace!("Scanning pending checkpoint signatures from {:?}", key);
         let iter = self
             .pending_checkpoint_signatures
             .unbounded_iter()
@@ -2658,7 +2658,7 @@ impl AuthorityPerEpochStore {
             .is_consensus_message_processed(&transaction.transaction.key())
             .expect("Storage error")
         {
-            debug!(
+            trace!(
                 consensus_index=?transaction.consensus_index.transaction_index,
                 tracking_id=?transaction.transaction.get_tracking_id(),
                 "handle_consensus_transaction UserTransaction [skip]",

--- a/docker/sui-antithesis/Dockerfile
+++ b/docker/sui-antithesis/Dockerfile
@@ -13,12 +13,14 @@ WORKDIR /
 
 ARG SUI_NODE_A_TAG
 ARG SUI_NODE_B_TAG
+ARG SUI_RUST_LOG
 ENV SUI_NODE_A_TAG=$SUI_NODE_A_TAG
 ENV SUI_NODE_B_TAG=$SUI_NODE_B_TAG
 
 RUN ./new-genesis.sh
 RUN echo "SUI_NODE_A_TAG=$SUI_NODE_A_TAG" >> /.env
 RUN echo "SUI_NODE_B_TAG=$SUI_NODE_B_TAG" >> /.env
+RUN echo "SUI_RUST_LOG=$SUI_RUST_LOG" >> /.env
 
 COPY ./docker-compose-antithesis.yaml /docker-compose.yaml
 

--- a/docker/sui-antithesis/docker-compose-antithesis.yaml
+++ b/docker/sui-antithesis/docker-compose-antithesis.yaml
@@ -11,7 +11,7 @@ services:
     environment:
       - ENABLE_WRITEBACK_CACHE=1
       - RUST_BACKTRACE=1
-      - RUST_LOG=info,sui_core=debug,sui_node=debug,jsonrpsee=error
+      - RUST_LOG=${SUI_RUST_LOG:-info}
       - RPC_WORKER_THREAD=12
       - NEW_CHECKPOINT_WARNING_TIMEOUT_MS=30000
       - NEW_CHECKPOINT_PANIC_TIMEOUT_MS=60000
@@ -39,7 +39,7 @@ services:
     environment:
       - ENABLE_WRITEBACK_CACHE=1
       - RUST_BACKTRACE=1
-      - RUST_LOG=info,sui_core=debug,sui_node=debug,jsonrpsee=error
+      - RUST_LOG=${SUI_RUST_LOG:-info}
       - RPC_WORKER_THREAD=12
       - NEW_CHECKPOINT_WARNING_TIMEOUT_MS=30000
       - NEW_CHECKPOINT_PANIC_TIMEOUT_MS=60000
@@ -67,7 +67,7 @@ services:
     environment:
       - DISABLE_WRITEBACK_CACHE=1
       - RUST_BACKTRACE=1
-      - RUST_LOG=info,sui_core=debug,sui_node=debug,jsonrpsee=error
+      - RUST_LOG=${SUI_RUST_LOG:-info}
       - RPC_WORKER_THREAD=12
       - NEW_CHECKPOINT_WARNING_TIMEOUT_MS=30000
       - NEW_CHECKPOINT_PANIC_TIMEOUT_MS=60000
@@ -95,7 +95,7 @@ services:
     environment:
       - DISABLE_WRITEBACK_CACHE=1
       - RUST_BACKTRACE=1
-      - RUST_LOG=info,sui_core=debug,sui_node=debug,jsonrpsee=error
+      - RUST_LOG=${SUI_RUST_LOG:-info}
       - RPC_WORKER_THREAD=12
       - NEW_CHECKPOINT_WARNING_TIMEOUT_MS=30000
       - NEW_CHECKPOINT_PANIC_TIMEOUT_MS=60000
@@ -123,7 +123,7 @@ services:
     environment:
       - ENABLE_WRITEBACK_CACHE=1
       - RUST_BACKTRACE=1
-      - RUST_LOG=info,sui_core=debug,sui_node=debug,jsonrpsee=error
+      - RUST_LOG=${SUI_RUST_LOG:-info}
       - RPC_WORKER_THREAD=12
       - NEW_CHECKPOINT_WARNING_TIMEOUT_MS=30000
       - NEW_CHECKPOINT_PANIC_TIMEOUT_MS=60000

--- a/docker/sui-antithesis/docker-compose-antithesis.yaml
+++ b/docker/sui-antithesis/docker-compose-antithesis.yaml
@@ -11,7 +11,7 @@ services:
     environment:
       - ENABLE_WRITEBACK_CACHE=1
       - RUST_BACKTRACE=1
-      - RUST_LOG=info,sui_core=debug,consensus=debug,jsonrpsee=error
+      - RUST_LOG=info,sui_core=debug,sui_node=debug,jsonrpsee=error
       - RPC_WORKER_THREAD=12
       - NEW_CHECKPOINT_WARNING_TIMEOUT_MS=30000
       - NEW_CHECKPOINT_PANIC_TIMEOUT_MS=60000
@@ -39,7 +39,7 @@ services:
     environment:
       - ENABLE_WRITEBACK_CACHE=1
       - RUST_BACKTRACE=1
-      - RUST_LOG=info,sui_core=debug,sui_network=debug,sui_node=debug,consensus=debug,jsonrpsee=error
+      - RUST_LOG=info,sui_core=debug,sui_node=debug,jsonrpsee=error
       - RPC_WORKER_THREAD=12
       - NEW_CHECKPOINT_WARNING_TIMEOUT_MS=30000
       - NEW_CHECKPOINT_PANIC_TIMEOUT_MS=60000
@@ -67,7 +67,7 @@ services:
     environment:
       - DISABLE_WRITEBACK_CACHE=1
       - RUST_BACKTRACE=1
-      - RUST_LOG=info,sui_core=debug,sui_network=debug,sui_node=debug,consensus=debug,jsonrpsee=error
+      - RUST_LOG=info,sui_core=debug,sui_node=debug,jsonrpsee=error
       - RPC_WORKER_THREAD=12
       - NEW_CHECKPOINT_WARNING_TIMEOUT_MS=30000
       - NEW_CHECKPOINT_PANIC_TIMEOUT_MS=60000
@@ -95,7 +95,7 @@ services:
     environment:
       - DISABLE_WRITEBACK_CACHE=1
       - RUST_BACKTRACE=1
-      - RUST_LOG=info,sui_core=debug,sui_network=debug,sui_node=debug,consensus=debug,jsonrpsee=error
+      - RUST_LOG=info,sui_core=debug,sui_node=debug,jsonrpsee=error
       - RPC_WORKER_THREAD=12
       - NEW_CHECKPOINT_WARNING_TIMEOUT_MS=30000
       - NEW_CHECKPOINT_PANIC_TIMEOUT_MS=60000
@@ -123,7 +123,7 @@ services:
     environment:
       - ENABLE_WRITEBACK_CACHE=1
       - RUST_BACKTRACE=1
-      - RUST_LOG=info,jsonrpsee=error
+      - RUST_LOG=info,sui_core=debug,sui_node=debug,jsonrpsee=error
       - RPC_WORKER_THREAD=12
       - NEW_CHECKPOINT_WARNING_TIMEOUT_MS=30000
       - NEW_CHECKPOINT_PANIC_TIMEOUT_MS=60000


### PR DESCRIPTION
This PR
- Reduces logging vebosity in general - this was an ad hoc change based on taking high-volume debug logs and changing them to trace if I didn't personally recall looking at them while debugging.
- Reduce log levels for antithesis tests - Attempts to remove a lot of unnecessary logs in antithesis runs.
