### PR TITLE
Update "blst" from "0.3.11" to "0.3.13" to fix build on x86 Mac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2129,9 +2129,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94087b935a822949d3291a9989ad2b2051ea141eda0fd4e478a75f6aa3e604b"
+checksum = "4378725facc195f1a538864863f6de233b500a8862747e7f165078a419d5e874"
 dependencies = [
  "cc",
  "glob",


### PR DESCRIPTION
## Description 
In order to successfully build on my Intel Mac I had to update a `blst` dependency to  "0.3.13". With  the version "0.3.11" I'm getting the following:
```
warning: blst@0.3.11: /var/folders/6v/s4b4wws53_j3ym0gc4wgmzqr0000gn/T/assembly-71e81e.s:8561:1: error: invalid CFI advance_loc expression
warning: blst@0.3.11: .cfi_adjust_cfa_offset 8
warning: blst@0.3.11: ^
warning: blst@0.3.11: ToolExecError: Command env -u IPHONEOS_DEPLOYMENT_TARGET "cc" "-O2" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-2" "-fno-omit-frame-pointer" "-m64" "--target=x86_64-apple-darwin" "-mmacosx-version-min=15.2" "-Wall" "-Wextra" "-mno-avx" "-fno-builtin" "-Wno-unused-function" "-Wno-unused-command-line-argument" "-D__ADX__" "-o" "/var/folders/6v/s4b4wws53_j3ym0gc4wgmzqr0000gn/T/cargo-installTiPaPX/release/build/blst-36b169cb32bec89f/out/ef1d644edca660a8-assembly.o" "-c" "/Users/d/.cargo/registry/src/index.crates.io-6f17d22bba15001f/blst-0.3.11/blst/build/assembly.S" with args cc did not execute successfully (status code exit status: 1).

error: failed to run custom build command for `blst v0.3.11`

Caused by:
  process didn't exit successfully: `/var/folders/6v/s4b4wws53_j3ym0gc4wgmzqr0000gn/T/cargo-installTiPaPX/release/build/blst-e5a2897cd01ae6e7/build-script-build` (exit status: 1)
  --- stdout
  cargo:rustc-cfg=feature="std"
  cargo:rerun-if-env-changed=BLST_TEST_NO_STD
  Using blst source directory /Users/d/.cargo/registry/src/index.crates.io-6f17d22bba15001f/blst-0.3.11/blst
  cargo:rerun-if-changed=/Users/d/.cargo/registry/src/index.crates.io-6f17d22bba15001f/blst-0.3.11/blst/src
  cargo:rerun-if-changed=/Users/d/.cargo/registry/src/index.crates.io-6f17d22bba15001f/blst-0.3.11/blst/build
```

The problem was discussed there: https://github.com/ethereum/go-ethereum/issues/30494.

## Test plan 
Running a current test suite. 

---

## Release notes
- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
