### PR TITLE
Execution layer reports timings of each executed command

### DIFF
--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -135,20 +135,22 @@ impl EpochState {
 
         let transaction_data = transaction.data().transaction_data();
         let (kind, signer, gas) = transaction_data.execution_parts();
-        Ok(self.executor.execute_transaction_to_effects(
-            store.backing_store(),
-            &self.protocol_config,
-            self.limits_metrics.clone(),
-            false,           // enable_expensive_checks
-            &HashSet::new(), // certificate_deny_set
-            &self.epoch_start_state.epoch(),
-            self.epoch_start_state.epoch_start_timestamp_ms(),
-            checked_input_objects,
-            gas,
-            gas_status,
-            kind,
-            signer,
-            tx_digest,
-        ))
+        let (inner_temp_store, gas_status, effects, _timings, result) =
+            self.executor.execute_transaction_to_effects(
+                store.backing_store(),
+                &self.protocol_config,
+                self.limits_metrics.clone(),
+                false,           // enable_expensive_checks
+                &HashSet::new(), // certificate_deny_set
+                &self.epoch_start_state.epoch(),
+                self.epoch_start_state.epoch_start_timestamp_ms(),
+                checked_input_objects,
+                gas,
+                gas_status,
+                kind,
+                signer,
+                tx_digest,
+            );
+        Ok((inner_temp_store, gas_status, effects, result))
     }
 }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1655,7 +1655,7 @@ impl AuthorityState {
         let (kind, signer, gas) = transaction_data.execution_parts();
 
         #[allow(unused_mut)]
-        let (inner_temp_store, _, mut effects, execution_error_opt) =
+        let (inner_temp_store, _, mut effects, _timings, execution_error_opt) =
             epoch_store.executor().execute_transaction_to_effects(
                 self.get_backing_store().as_ref(),
                 protocol_config,
@@ -1844,7 +1844,7 @@ impl AuthorityState {
             .expect("Creating an executor should not fail here");
 
         let expensive_checks = false;
-        let (inner_temp_store, _, effects, _execution_error) = executor
+        let (inner_temp_store, _, effects, _timings, _execution_error) = executor
             .execute_transaction_to_effects(
                 self.get_backing_store().as_ref(),
                 protocol_config,
@@ -2034,7 +2034,7 @@ impl AuthorityState {
             .expect("Creating an executor should not fail here");
 
         let expensive_checks = false;
-        let (inner_temp_store, _, effects, _execution_error) = executor
+        let (inner_temp_store, _, effects, _timings, _execution_error) = executor
             .execute_transaction_to_effects(
                 self.get_backing_store().as_ref(),
                 protocol_config,

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -925,7 +925,7 @@ fn create_genesis_transaction(
         let transaction_data = &genesis_transaction.data().intent_message().value;
         let (kind, signer, _) = transaction_data.execution_parts();
         let input_objects = CheckedInputObjects::new_for_genesis(vec![]);
-        let (inner_temp_store, _, effects, _execution_error) = executor
+        let (inner_temp_store, _, effects, _timings, _execution_error) = executor
             .execute_transaction_to_effects(
                 &InMemoryStorage::new(Vec::new()),
                 protocol_config,

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -764,21 +764,22 @@ impl LocalExec {
             )
             .expect("Failed to create gas status")
         };
-        let (inner_store, gas_status, effects, result) = executor.execute_transaction_to_effects(
-            &self,
-            protocol_config,
-            metrics.clone(),
-            expensive_checks,
-            &certificate_deny_set,
-            &tx_info.executed_epoch,
-            tx_info.epoch_start_timestamp,
-            CheckedInputObjects::new_for_replay(input_objects.clone()),
-            tx_info.gas.clone(),
-            gas_status,
-            transaction_kind.clone(),
-            tx_info.sender,
-            *tx_digest,
-        );
+        let (inner_store, gas_status, effects, _timings, result) = executor
+            .execute_transaction_to_effects(
+                &self,
+                protocol_config,
+                metrics.clone(),
+                expensive_checks,
+                &certificate_deny_set,
+                &tx_info.executed_epoch,
+                tx_info.epoch_start_timestamp,
+                CheckedInputObjects::new_for_replay(input_objects.clone()),
+                tx_info.gas.clone(),
+                gas_status,
+                transaction_kind.clone(),
+                tx_info.sender,
+                *tx_digest,
+            );
 
         if let Err(err) = self.pretty_print_for_tracing(
             &gas_status,
@@ -924,7 +925,7 @@ impl LocalExec {
         .unwrap();
         let (kind, signer, gas) = executable.transaction_data().execution_parts();
         let executor = sui_execution::executor(&protocol_config, true, None).unwrap();
-        let (_, _, effects, exec_res) = executor.execute_transaction_to_effects(
+        let (_, _, effects, _timings, exec_res) = executor.execute_transaction_to_effects(
             &store,
             &protocol_config,
             Arc::new(LimitsMetrics::new(&Registry::new())),

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -206,7 +206,7 @@ impl SingleValidator {
         )
         .unwrap();
         let (kind, signer, gas) = executable.transaction_data().execution_parts();
-        let (inner_temp_store, _, effects, _) =
+        let (inner_temp_store, _, effects, _timings, _) =
             self.epoch_store.executor().execute_transaction_to_effects(
                 &store,
                 self.epoch_store.protocol_config(),

--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -602,7 +602,7 @@ mod test {
         let (kind, signer, _) = transaction_data.execution_parts();
         let input_objects = CheckedInputObjects::new_for_genesis(vec![]);
 
-        let (_inner_temp_store, _, effects, _execution_error) = executor
+        let (_inner_temp_store, _, effects, _timings, _execution_error) = executor
             .execute_transaction_to_effects(
                 &InMemoryStorage::new(Vec::new()),
                 &protocol_config,

--- a/crates/sui-types/src/execution.rs
+++ b/crates/sui-types/src/execution.rs
@@ -14,6 +14,7 @@ use move_core_types::language_storage::TypeTag;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::time::Duration;
 
 /// A type containing all of the information needed to work with a deleted shared object in
 /// execution and when committing the execution effects of the transaction. This holds:
@@ -169,6 +170,12 @@ impl ExecutionResultsV2 {
         }
     }
 }
+
+pub enum ExecutionTiming {
+    Success(Duration),
+    Abort(Duration),
+}
+pub type TimingResult<R, E> = Result<(R, Vec<ExecutionTiming>), (E, Vec<ExecutionTiming>)>;
 
 /// If a transaction digest shows up in this list, when executing such transaction,
 /// we will always return `ExecutionError::CertificateDenied` without executing it (but still do

--- a/crates/sui-types/src/execution.rs
+++ b/crates/sui-types/src/execution.rs
@@ -175,7 +175,7 @@ pub enum ExecutionTiming {
     Success(Duration),
     Abort(Duration),
 }
-pub type TimingResult<R, E> = Result<(R, Vec<ExecutionTiming>), (E, Vec<ExecutionTiming>)>;
+pub type ResultWithTimings<R, E> = Result<(R, Vec<ExecutionTiming>), (E, Vec<ExecutionTiming>)>;
 
 /// If a transaction digest shows up in this list, when executing such transaction,
 /// we will always return `ExecutionError::CertificateDenied` without executing it (but still do

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -51,7 +51,7 @@ mod checked {
     };
     use sui_types::effects::TransactionEffects;
     use sui_types::error::{ExecutionError, ExecutionErrorKind};
-    use sui_types::execution::is_certificate_denied;
+    use sui_types::execution::{is_certificate_denied, ExecutionTiming, TimingResult};
     use sui_types::execution_config_utils::to_binary_config;
     use sui_types::execution_status::{CongestedObjects, ExecutionStatus};
     use sui_types::gas::GasCostSummary;
@@ -96,6 +96,7 @@ mod checked {
         InnerTemporaryStore,
         SuiGasStatus,
         TransactionEffects,
+        Vec<ExecutionTiming>,
         Result<Mode::ExecutionResults, ExecutionError>,
     ) {
         let input_objects = input_objects.into_inner();
@@ -132,7 +133,7 @@ mod checked {
         let is_epoch_change = transaction_kind.is_end_of_epoch_tx();
 
         let deny_cert = is_certificate_denied(&transaction_digest, certificate_deny_set);
-        let (gas_cost_summary, execution_result) = execute_transaction::<Mode>(
+        let (gas_cost_summary, execution_result, timings) = execute_transaction::<Mode>(
             &mut temporary_store,
             transaction_kind,
             &mut gas_charger,
@@ -229,6 +230,7 @@ mod checked {
             inner,
             gas_charger.into_gas_status(),
             effects,
+            timings,
             execution_result,
         )
     }
@@ -260,7 +262,8 @@ mod checked {
             tx_context,
             &mut gas_charger,
             pt,
-        )?;
+        )
+        .map_err(|(e, _)| e)?;
         temporary_store.update_object_version_and_prev_tx();
         Ok(temporary_store.into_inner())
     }
@@ -281,6 +284,7 @@ mod checked {
     ) -> (
         GasCostSummary,
         Result<Mode::ExecutionResults, ExecutionError>,
+        Vec<ExecutionTiming>,
     ) {
         gas_charger.smash_gas(temporary_store);
 
@@ -296,67 +300,77 @@ mod checked {
         // We must charge object read here during transaction execution, because if this fails
         // we must still ensure an effect is committed and all objects versions incremented
         let result = gas_charger.charge_input_objects(temporary_store);
-        let mut result = result.and_then(|()| {
-            let mut execution_result = if deny_cert {
-                Err(ExecutionError::new(
-                    ExecutionErrorKind::CertificateDenied,
-                    None,
-                ))
-            } else if contains_deleted_input {
-                Err(ExecutionError::new(
-                    ExecutionErrorKind::InputObjectDeleted,
-                    None,
-                ))
-            } else if let Some((cancelled_objects, reason)) = cancelled_objects {
-                match reason {
-                    SequenceNumber::CONGESTED => Err(ExecutionError::new(
-                        ExecutionErrorKind::ExecutionCancelledDueToSharedObjectCongestion {
-                            congested_objects: CongestedObjects(cancelled_objects),
-                        },
-                        None,
-                    )),
-                    SequenceNumber::RANDOMNESS_UNAVAILABLE => Err(ExecutionError::new(
-                        ExecutionErrorKind::ExecutionCancelledDueToRandomnessUnavailable,
-                        None,
-                    )),
-                    _ => panic!("invalid cancellation reason SequenceNumber: {reason}"),
-                }
-            } else {
-                execution_loop::<Mode>(
-                    temporary_store,
-                    transaction_kind,
-                    tx_ctx,
-                    move_vm,
-                    gas_charger,
-                    protocol_config,
-                    metrics.clone(),
-                )
-            };
 
-            let meter_check = check_meter_limit(
-                temporary_store,
-                gas_charger,
-                protocol_config,
-                metrics.clone(),
+        let result: TimingResult<Mode::ExecutionResults, ExecutionError> =
+            result.map_err(|e| (e, vec![])).and_then(
+                |()| -> TimingResult<Mode::ExecutionResults, ExecutionError> {
+                    let mut execution_result: TimingResult<Mode::ExecutionResults, ExecutionError> =
+                        if deny_cert {
+                            Err((
+                                ExecutionError::new(ExecutionErrorKind::CertificateDenied, None),
+                                vec![],
+                            ))
+                        } else if contains_deleted_input {
+                            Err((
+                                ExecutionError::new(ExecutionErrorKind::InputObjectDeleted, None),
+                                vec![],
+                            ))
+                        } else if let Some((cancelled_objects, reason)) = cancelled_objects {
+                            match reason {
+                            SequenceNumber::CONGESTED => Err((ExecutionError::new(
+                                ExecutionErrorKind::ExecutionCancelledDueToSharedObjectCongestion {
+                                    congested_objects: CongestedObjects(cancelled_objects),
+                                },
+                                None,
+                            ), vec![])),
+                            SequenceNumber::RANDOMNESS_UNAVAILABLE => Err((ExecutionError::new(
+                                ExecutionErrorKind::ExecutionCancelledDueToRandomnessUnavailable,
+                                None,
+                            ), vec![])),
+                            _ => panic!("invalid cancellation reason SequenceNumber: {reason}"),
+                        }
+                        } else {
+                            execution_loop::<Mode>(
+                                temporary_store,
+                                transaction_kind,
+                                tx_ctx,
+                                move_vm,
+                                gas_charger,
+                                protocol_config,
+                                metrics.clone(),
+                            )
+                        };
+
+                    let meter_check = check_meter_limit(
+                        temporary_store,
+                        gas_charger,
+                        protocol_config,
+                        metrics.clone(),
+                    );
+                    if let Err(e) = meter_check {
+                        execution_result = Err((e, vec![]));
+                    }
+
+                    if execution_result.is_ok() {
+                        let gas_check = check_written_objects_limit::<Mode>(
+                            temporary_store,
+                            gas_charger,
+                            protocol_config,
+                            metrics,
+                        );
+                        if let Err(e) = gas_check {
+                            execution_result = Err((e, vec![]));
+                        }
+                    }
+
+                    execution_result
+                },
             );
-            if let Err(e) = meter_check {
-                execution_result = Err(e);
-            }
 
-            if execution_result.is_ok() {
-                let gas_check = check_written_objects_limit::<Mode>(
-                    temporary_store,
-                    gas_charger,
-                    protocol_config,
-                    metrics,
-                );
-                if let Err(e) = gas_check {
-                    execution_result = Err(e);
-                }
-            }
-
-            execution_result
-        });
+        let (mut result, timings) = match result {
+            Ok((r, t)) => (Ok(r), t),
+            Err((e, t)) => (Err(e), t),
+        };
 
         let cost_summary = gas_charger.charge_gas(temporary_store, &mut result);
         // For advance epoch transaction, we need to provide epoch rewards and rebates as extra
@@ -383,7 +397,7 @@ mod checked {
             result = Err(e);
         }
 
-        (cost_summary, result)
+        (cost_summary, result, timings)
     }
 
     #[instrument(name = "run_conservation_checks", level = "debug", skip_all)]
@@ -550,7 +564,7 @@ mod checked {
         gas_charger: &mut GasCharger,
         protocol_config: &ProtocolConfig,
         metrics: Arc<LimitsMetrics>,
-    ) -> Result<Mode::ExecutionResults, ExecutionError> {
+    ) -> TimingResult<Mode::ExecutionResults, ExecutionError> {
         let result = match transaction_kind {
             TransactionKind::ChangeEpoch(change_epoch) => {
                 let builder = ProgrammableTransactionBuilder::new();
@@ -563,8 +577,9 @@ mod checked {
                     gas_charger,
                     protocol_config,
                     metrics,
-                )?;
-                Ok(Mode::empty_results())
+                )
+                .map_err(|e| (e, vec![]))?;
+                Ok((Mode::empty_results(), vec![]))
             }
             TransactionKind::Genesis(GenesisTransaction { objects }) => {
                 if tx_ctx.epoch() != 0 {
@@ -584,7 +599,7 @@ mod checked {
                         }
                     }
                 }
-                Ok(Mode::empty_results())
+                Ok((Mode::empty_results(), vec![]))
             }
             TransactionKind::ConsensusCommitPrologue(prologue) => {
                 setup_consensus_commit(
@@ -597,7 +612,7 @@ mod checked {
                     metrics,
                 )
                 .expect("ConsensusCommitPrologue cannot fail");
-                Ok(Mode::empty_results())
+                Ok((Mode::empty_results(), vec![]))
             }
             TransactionKind::ConsensusCommitPrologueV2(prologue) => {
                 setup_consensus_commit(
@@ -610,7 +625,7 @@ mod checked {
                     metrics,
                 )
                 .expect("ConsensusCommitPrologueV2 cannot fail");
-                Ok(Mode::empty_results())
+                Ok((Mode::empty_results(), vec![]))
             }
             TransactionKind::ConsensusCommitPrologueV3(prologue) => {
                 setup_consensus_commit(
@@ -623,7 +638,7 @@ mod checked {
                     metrics,
                 )
                 .expect("ConsensusCommitPrologueV3 cannot fail");
-                Ok(Mode::empty_results())
+                Ok((Mode::empty_results(), vec![]))
             }
             TransactionKind::ProgrammableTransaction(pt) => {
                 programmable_transactions::execution::execute::<Mode>(
@@ -652,8 +667,9 @@ mod checked {
                                 gas_charger,
                                 protocol_config,
                                 metrics,
-                            )?;
-                            return Ok(Mode::empty_results());
+                            )
+                            .map_err(|e| (e, vec![]))?;
+                            return Ok((Mode::empty_results(), vec![]));
                         }
                         EndOfEpochTransactionKind::AuthenticatorStateCreate => {
                             assert!(protocol_config.enable_jwk_consensus_updates());
@@ -696,8 +712,9 @@ mod checked {
                     gas_charger,
                     protocol_config,
                     metrics,
-                )?;
-                Ok(Mode::empty_results())
+                )
+                .map_err(|e| (e, vec![]))?;
+                Ok((Mode::empty_results(), vec![]))
             }
             TransactionKind::RandomnessStateUpdate(randomness_state_update) => {
                 setup_randomness_state_update(
@@ -708,11 +725,14 @@ mod checked {
                     gas_charger,
                     protocol_config,
                     metrics,
-                )?;
-                Ok(Mode::empty_results())
+                )
+                .map_err(|e| (e, vec![]))?;
+                Ok((Mode::empty_results(), vec![]))
             }
         }?;
-        temporary_store.check_execution_results_consistency()?;
+        temporary_store
+            .check_execution_results_consistency()
+            .map_err(|e| (e, vec![]))?;
         Ok(result)
     }
 
@@ -886,13 +906,13 @@ mod checked {
         #[cfg(msim)]
         let result = maybe_modify_result(result, change_epoch.epoch);
 
-        if result.is_err() {
+        if let Err(err) = &result {
             tracing::error!(
-            "Failed to execute advance epoch transaction. Switching to safe mode. Error: {:?}. Input objects: {:?}. Tx data: {:?}",
-            result.as_ref().err(),
-            temporary_store.objects(),
-            change_epoch,
-        );
+                "Failed to execute advance epoch transaction. Switching to safe mode. Error: {:?}. Input objects: {:?}. Tx data: {:?}",
+                err.0,
+                temporary_store.objects(),
+                change_epoch,
+            );
             temporary_store.drop_writes();
             // Must reset the storage rebate since we are re-executing.
             gas_charger.reset_storage_cost_and_rebate();
@@ -911,6 +931,7 @@ mod checked {
                     gas_charger,
                     advance_epoch_safe_mode_pt,
                 )
+                .map_err(|(e, _)| e)
                 .expect("Advance epoch with safe mode must succeed");
             }
         }
@@ -980,6 +1001,7 @@ mod checked {
                     gas_charger,
                     publish_pt,
                 )
+                .map_err(|(e, _)| e)
                 .expect("System Package Publish must succeed");
             } else {
                 let mut new_package = Object::new_system_package(
@@ -1048,6 +1070,8 @@ mod checked {
             gas_charger,
             pt,
         )
+        .map_err(|(e, _)| e)?;
+        Ok(())
     }
 
     fn setup_authenticator_state_create(
@@ -1189,6 +1213,8 @@ mod checked {
             gas_charger,
             pt,
         )
+        .map_err(|(e, _)| e)?;
+        Ok(())
     }
 
     fn setup_authenticator_state_expire(
@@ -1255,6 +1281,8 @@ mod checked {
             gas_charger,
             pt,
         )
+        .map_err(|(e, _)| e)?;
+        Ok(())
     }
 
     fn setup_coin_deny_list_state_create(

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
@@ -29,6 +29,7 @@ mod checked {
     };
     use move_vm_types::loaded_data::runtime_types::{CachedDatatype, Type};
     use serde::{de::DeserializeSeed, Deserialize};
+    use std::time::Instant;
     use std::{
         collections::{BTreeMap, BTreeSet},
         fmt,
@@ -36,6 +37,7 @@ mod checked {
     };
     use sui_move_natives::object_runtime::ObjectRuntime;
     use sui_protocol_config::ProtocolConfig;
+    use sui_types::execution::{ExecutionTiming, TimingResult};
     use sui_types::execution_config_utils::to_binary_config;
     use sui_types::execution_status::{CommandArgumentError, PackageUpgradeError};
     use sui_types::storage::{get_package_objects, PackageObject};
@@ -74,6 +76,34 @@ mod checked {
         tx_context: &mut TxContext,
         gas_charger: &mut GasCharger,
         pt: ProgrammableTransaction,
+    ) -> TimingResult<Mode::ExecutionResults, ExecutionError> {
+        let mut timings = vec![];
+        let result = execute_inner::<Mode>(
+            &mut timings,
+            protocol_config,
+            metrics,
+            vm,
+            state_view,
+            tx_context,
+            gas_charger,
+            pt,
+        );
+
+        match result {
+            Ok(result) => Ok((result, timings)),
+            Err(e) => Err((e, timings)),
+        }
+    }
+
+    pub fn execute_inner<Mode: ExecutionMode>(
+        timings: &mut Vec<ExecutionTiming>,
+        protocol_config: &ProtocolConfig,
+        metrics: Arc<LimitsMetrics>,
+        vm: &MoveVM,
+        state_view: &mut dyn ExecutionState,
+        tx_context: &mut TxContext,
+        gas_charger: &mut GasCharger,
+        pt: ProgrammableTransaction,
     ) -> Result<Mode::ExecutionResults, ExecutionError> {
         let ProgrammableTransaction { inputs, commands } = pt;
         let mut context = ExecutionContext::new(
@@ -88,6 +118,7 @@ mod checked {
         // execute commands
         let mut mode_results = Mode::empty_results();
         for (idx, command) in commands.into_iter().enumerate() {
+            let start = Instant::now();
             if let Err(err) = execute_command::<Mode>(&mut context, &mut mode_results, command) {
                 let object_runtime: &ObjectRuntime = context.object_runtime();
                 // We still need to record the loaded child objects for replay
@@ -95,8 +126,10 @@ mod checked {
                 // we do not save the wrapped objects since on error, they should not be modified
                 drop(context);
                 state_view.save_loaded_runtime_objects(loaded_runtime_objects);
+                timings.push(ExecutionTiming::Abort(start.elapsed()));
                 return Err(err.with_command_index(idx));
             };
+            timings.push(ExecutionTiming::Success(start.elapsed()));
         }
 
         // Save loaded objects table in case we fail in post execution

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
@@ -37,7 +37,7 @@ mod checked {
     };
     use sui_move_natives::object_runtime::ObjectRuntime;
     use sui_protocol_config::ProtocolConfig;
-    use sui_types::execution::{ExecutionTiming, TimingResult};
+    use sui_types::execution::{ExecutionTiming, ResultWithTimings};
     use sui_types::execution_config_utils::to_binary_config;
     use sui_types::execution_status::{CommandArgumentError, PackageUpgradeError};
     use sui_types::storage::{get_package_objects, PackageObject};
@@ -76,7 +76,7 @@ mod checked {
         tx_context: &mut TxContext,
         gas_charger: &mut GasCharger,
         pt: ProgrammableTransaction,
-    ) -> TimingResult<Mode::ExecutionResults, ExecutionError> {
+    ) -> ResultWithTimings<Mode::ExecutionResults, ExecutionError> {
         let mut timings = vec![];
         let result = execute_inner::<Mode>(
             &mut timings,

--- a/sui-execution/src/executor.rs
+++ b/sui-execution/src/executor.rs
@@ -3,6 +3,7 @@
 
 use std::{collections::HashSet, sync::Arc};
 use sui_protocol_config::ProtocolConfig;
+use sui_types::execution::ExecutionTiming;
 use sui_types::storage::BackingStore;
 use sui_types::{
     base_types::{ObjectRef, SuiAddress, TxContext},
@@ -44,6 +45,7 @@ pub trait Executor {
         InnerTemporaryStore,
         SuiGasStatus,
         TransactionEffects,
+        Vec<ExecutionTiming>,
         Result<(), ExecutionError>,
     );
 

--- a/sui-execution/src/latest.rs
+++ b/sui-execution/src/latest.rs
@@ -7,6 +7,7 @@ use std::{collections::HashSet, sync::Arc};
 use move_binary_format::CompiledModule;
 use move_vm_config::verifier::{MeterConfig, VerifierConfig};
 use sui_protocol_config::ProtocolConfig;
+use sui_types::execution::ExecutionTiming;
 use sui_types::{
     base_types::{ObjectRef, SuiAddress, TxContext},
     committee::EpochId,
@@ -83,6 +84,7 @@ impl executor::Executor for Executor {
         InnerTemporaryStore,
         SuiGasStatus,
         TransactionEffects,
+        Vec<ExecutionTiming>,
         Result<(), ExecutionError>,
     ) {
         execute_transaction_to_effects::<execution_mode::Normal>(
@@ -125,7 +127,7 @@ impl executor::Executor for Executor {
         TransactionEffects,
         Result<Vec<ExecutionResult>, ExecutionError>,
     ) {
-        if skip_all_checks {
+        let (inner_temp_store, gas_status, effects, _timings, result) = if skip_all_checks {
             execute_transaction_to_effects::<execution_mode::DevInspect<true>>(
                 store,
                 input_objects,
@@ -159,7 +161,8 @@ impl executor::Executor for Executor {
                 enable_expensive_checks,
                 certificate_deny_set,
             )
-        }
+        };
+        (inner_temp_store, gas_status, effects, result)
     }
 
     fn update_genesis_state(

--- a/sui-execution/src/v0.rs
+++ b/sui-execution/src/v0.rs
@@ -7,6 +7,7 @@ use std::{collections::HashSet, sync::Arc};
 use move_binary_format::CompiledModule;
 use move_vm_config::verifier::{MeterConfig, VerifierConfig};
 use sui_protocol_config::ProtocolConfig;
+use sui_types::execution::ExecutionTiming;
 use sui_types::{
     base_types::{ObjectRef, SuiAddress, TxContext},
     committee::EpochId,
@@ -83,24 +84,27 @@ impl executor::Executor for Executor {
         InnerTemporaryStore,
         SuiGasStatus,
         TransactionEffects,
+        Vec<ExecutionTiming>,
         Result<(), ExecutionError>,
     ) {
-        execute_transaction_to_effects::<execution_mode::Normal>(
-            store,
-            input_objects,
-            gas_coins,
-            gas_status,
-            transaction_kind,
-            transaction_signer,
-            transaction_digest,
-            &self.0,
-            epoch_id,
-            epoch_timestamp_ms,
-            protocol_config,
-            metrics,
-            enable_expensive_checks,
-            certificate_deny_set,
-        )
+        let (inner_temp_store, gas_status, effects, result) =
+            execute_transaction_to_effects::<execution_mode::Normal>(
+                store,
+                input_objects,
+                gas_coins,
+                gas_status,
+                transaction_kind,
+                transaction_signer,
+                transaction_digest,
+                &self.0,
+                epoch_id,
+                epoch_timestamp_ms,
+                protocol_config,
+                metrics,
+                enable_expensive_checks,
+                certificate_deny_set,
+            );
+        (inner_temp_store, gas_status, effects, vec![], result)
     }
 
     fn dev_inspect_transaction(

--- a/sui-execution/src/v0.rs
+++ b/sui-execution/src/v0.rs
@@ -104,6 +104,7 @@ impl executor::Executor for Executor {
                 enable_expensive_checks,
                 certificate_deny_set,
             );
+        // note: old versions do not report timings.
         (inner_temp_store, gas_status, effects, vec![], result)
     }
 

--- a/sui-execution/src/v1.rs
+++ b/sui-execution/src/v1.rs
@@ -7,6 +7,7 @@ use std::{collections::HashSet, sync::Arc};
 use move_binary_format::CompiledModule;
 use move_vm_config::verifier::{MeterConfig, VerifierConfig};
 use sui_protocol_config::ProtocolConfig;
+use sui_types::execution::ExecutionTiming;
 use sui_types::{
     base_types::{ObjectRef, SuiAddress, TxContext},
     committee::EpochId,
@@ -83,24 +84,27 @@ impl executor::Executor for Executor {
         InnerTemporaryStore,
         SuiGasStatus,
         TransactionEffects,
+        Vec<ExecutionTiming>,
         Result<(), ExecutionError>,
     ) {
-        execute_transaction_to_effects::<execution_mode::Normal>(
-            store,
-            input_objects,
-            gas_coins,
-            gas_status,
-            transaction_kind,
-            transaction_signer,
-            transaction_digest,
-            &self.0,
-            epoch_id,
-            epoch_timestamp_ms,
-            protocol_config,
-            metrics,
-            enable_expensive_checks,
-            certificate_deny_set,
-        )
+        let (inner_temp_store, gas_status, effects, result) =
+            execute_transaction_to_effects::<execution_mode::Normal>(
+                store,
+                input_objects,
+                gas_coins,
+                gas_status,
+                transaction_kind,
+                transaction_signer,
+                transaction_digest,
+                &self.0,
+                epoch_id,
+                epoch_timestamp_ms,
+                protocol_config,
+                metrics,
+                enable_expensive_checks,
+                certificate_deny_set,
+            );
+        (inner_temp_store, gas_status, effects, vec![], result)
     }
 
     fn dev_inspect_transaction(

--- a/sui-execution/src/v1.rs
+++ b/sui-execution/src/v1.rs
@@ -104,6 +104,7 @@ impl executor::Executor for Executor {
                 enable_expensive_checks,
                 certificate_deny_set,
             );
+        // note: old versions do not report timings.
         (inner_temp_store, gas_status, effects, vec![], result)
     }
 

--- a/sui-execution/src/v2.rs
+++ b/sui-execution/src/v2.rs
@@ -7,6 +7,7 @@ use std::{collections::HashSet, sync::Arc};
 use move_binary_format::CompiledModule;
 use move_vm_config::verifier::{MeterConfig, VerifierConfig};
 use sui_protocol_config::ProtocolConfig;
+use sui_types::execution::ExecutionTiming;
 use sui_types::{
     base_types::{ObjectRef, SuiAddress, TxContext},
     committee::EpochId,
@@ -83,24 +84,27 @@ impl executor::Executor for Executor {
         InnerTemporaryStore,
         SuiGasStatus,
         TransactionEffects,
+        Vec<ExecutionTiming>,
         Result<(), ExecutionError>,
     ) {
-        execute_transaction_to_effects::<execution_mode::Normal>(
-            store,
-            input_objects,
-            gas_coins,
-            gas_status,
-            transaction_kind,
-            transaction_signer,
-            transaction_digest,
-            &self.0,
-            epoch_id,
-            epoch_timestamp_ms,
-            protocol_config,
-            metrics,
-            enable_expensive_checks,
-            certificate_deny_set,
-        )
+        let (inner_temp_store, gas_status, effects, result) =
+            execute_transaction_to_effects::<execution_mode::Normal>(
+                store,
+                input_objects,
+                gas_coins,
+                gas_status,
+                transaction_kind,
+                transaction_signer,
+                transaction_digest,
+                &self.0,
+                epoch_id,
+                epoch_timestamp_ms,
+                protocol_config,
+                metrics,
+                enable_expensive_checks,
+                certificate_deny_set,
+            );
+        (inner_temp_store, gas_status, effects, vec![], result)
     }
 
     fn dev_inspect_transaction(

--- a/sui-execution/src/v2.rs
+++ b/sui-execution/src/v2.rs
@@ -104,6 +104,7 @@ impl executor::Executor for Executor {
                 enable_expensive_checks,
                 certificate_deny_set,
             );
+        // note: old versions do not report timings.
         (inner_temp_store, gas_status, effects, vec![], result)
     }
 

--- a/sui-execution/v0/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v0/sui-adapter/src/execution_engine.rs
@@ -36,7 +36,7 @@ mod checked {
     use sui_types::storage::BackingStore;
     use sui_types::storage::WriteKind;
     #[cfg(msim)]
-    use sui_types::sui_system_state::advance_epoch_result_injection::maybe_modify_result;
+    use sui_types::sui_system_state::advance_epoch_result_injection::maybe_modify_result_legacy;
     use sui_types::sui_system_state::{AdvanceEpochParams, ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME};
     use sui_types::transaction::CheckedInputObjects;
     use sui_types::transaction::{
@@ -657,7 +657,7 @@ mod checked {
         );
 
         #[cfg(msim)]
-        let result = maybe_modify_result(result, change_epoch.epoch);
+        let result = maybe_modify_result_legacy(result, change_epoch.epoch);
 
         if result.is_err() {
             tracing::error!(

--- a/sui-execution/v1/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v1/sui-adapter/src/execution_engine.rs
@@ -42,7 +42,7 @@ mod checked {
     use sui_types::inner_temporary_store::InnerTemporaryStore;
     use sui_types::storage::BackingStore;
     #[cfg(msim)]
-    use sui_types::sui_system_state::advance_epoch_result_injection::maybe_modify_result;
+    use sui_types::sui_system_state::advance_epoch_result_injection::maybe_modify_result_legacy;
     use sui_types::sui_system_state::{AdvanceEpochParams, ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME};
     use sui_types::transaction::CheckedInputObjects;
     use sui_types::transaction::{
@@ -839,7 +839,7 @@ mod checked {
         );
 
         #[cfg(msim)]
-        let result = maybe_modify_result(result, change_epoch.epoch);
+        let result = maybe_modify_result_legacy(result, change_epoch.epoch);
 
         if result.is_err() {
             tracing::error!(

--- a/sui-execution/v2/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v2/sui-adapter/src/execution_engine.rs
@@ -48,7 +48,7 @@ mod checked {
     use sui_types::inner_temporary_store::InnerTemporaryStore;
     use sui_types::storage::BackingStore;
     #[cfg(msim)]
-    use sui_types::sui_system_state::advance_epoch_result_injection::maybe_modify_result;
+    use sui_types::sui_system_state::advance_epoch_result_injection::maybe_modify_result_legacy;
     use sui_types::sui_system_state::{AdvanceEpochParams, ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME};
     use sui_types::transaction::{
         Argument, AuthenticatorStateExpire, AuthenticatorStateUpdate, CallArg, ChangeEpoch,
@@ -869,7 +869,7 @@ mod checked {
         );
 
         #[cfg(msim)]
-        let result = maybe_modify_result(result, change_epoch.epoch);
+        let result = maybe_modify_result_legacy(result, change_epoch.epoch);
 
         if result.is_err() {
             tracing::error!(


### PR DESCRIPTION
The timings are unused for now - they are intended for the congestion control execution time estimator.
