### PR TITLE
[indexer-alt] pruning tests for kv_epoch_ends and pipelines that don't need `CpSeqeuenceNumbers`

### DIFF
--- a/crates/sui-indexer-alt-schema/src/checkpoints.rs
+++ b/crates/sui-indexer-alt-schema/src/checkpoints.rs
@@ -9,7 +9,7 @@ use sui_types::digests::{ChainIdentifier, CheckpointDigest};
 
 use crate::schema::{kv_checkpoints, kv_genesis};
 
-#[derive(Insertable, Debug, Clone, FieldCount)]
+#[derive(Insertable, Debug, Clone, FieldCount, Queryable)]
 #[diesel(table_name = kv_checkpoints)]
 pub struct StoredCheckpoint {
     pub sequence_number: i64,

--- a/crates/sui-indexer-alt-schema/src/epochs.rs
+++ b/crates/sui-indexer-alt-schema/src/epochs.rs
@@ -6,7 +6,7 @@ use sui_field_count::FieldCount;
 
 use crate::schema::{kv_epoch_ends, kv_epoch_starts, kv_feature_flags, kv_protocol_configs};
 
-#[derive(Insertable, Debug, Clone, FieldCount)]
+#[derive(Insertable, Debug, Clone, FieldCount, Queryable)]
 #[diesel(table_name = kv_epoch_ends)]
 #[diesel(treat_none_as_default_value = false)]
 pub struct StoredEpochEnd {

--- a/crates/sui-indexer-alt/src/handlers/kv_checkpoints.rs
+++ b/crates/sui-indexer-alt/src/handlers/kv_checkpoints.rs
@@ -11,7 +11,6 @@ use sui_indexer_alt_schema::{checkpoints::StoredCheckpoint, schema::kv_checkpoin
 use sui_pg_db as db;
 use sui_types::full_checkpoint_content::CheckpointData;
 
-#[derive(Default)]
 pub(crate) struct KvCheckpoints;
 
 impl Processor for KvCheckpoints {
@@ -75,27 +74,26 @@ mod tests {
     async fn test_kv_checkpoints_pruning() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
         let mut conn = indexer.db().connect().await.unwrap();
-        let kv_checkpoints = KvCheckpoints::default();
 
         // Create 3 checkpoints
         let mut builder = TestCheckpointDataBuilder::new(0);
         builder = builder.start_transaction(0).finish_transaction();
         let checkpoint = Arc::new(builder.build_checkpoint());
-        let values = kv_checkpoints.process(&checkpoint).unwrap();
+        let values = KvCheckpoints.process(&checkpoint).unwrap();
         KvCheckpoints::commit(&values, &mut conn).await.unwrap();
 
         builder = builder.start_transaction(0).finish_transaction();
         let checkpoint = Arc::new(builder.build_checkpoint());
-        let values = kv_checkpoints.process(&checkpoint).unwrap();
+        let values = KvCheckpoints.process(&checkpoint).unwrap();
         KvCheckpoints::commit(&values, &mut conn).await.unwrap();
 
         builder = builder.start_transaction(0).finish_transaction();
         let checkpoint = Arc::new(builder.build_checkpoint());
-        let values = kv_checkpoints.process(&checkpoint).unwrap();
+        let values = KvCheckpoints.process(&checkpoint).unwrap();
         KvCheckpoints::commit(&values, &mut conn).await.unwrap();
 
         // Prune checkpoints from `[0, 2)`
-        let rows_pruned = kv_checkpoints.prune(0, 2, &mut conn).await.unwrap();
+        let rows_pruned = KvCheckpoints.prune(0, 2, &mut conn).await.unwrap();
         assert_eq!(rows_pruned, 2);
 
         // Checkpoint 2 remains

--- a/crates/sui-indexer-alt/src/handlers/kv_checkpoints.rs
+++ b/crates/sui-indexer-alt/src/handlers/kv_checkpoints.rs
@@ -11,6 +11,7 @@ use sui_indexer_alt_schema::{checkpoints::StoredCheckpoint, schema::kv_checkpoin
 use sui_pg_db as db;
 use sui_types::full_checkpoint_content::CheckpointData;
 
+#[derive(Default)]
 pub(crate) struct KvCheckpoints;
 
 impl Processor for KvCheckpoints {
@@ -50,5 +51,55 @@ impl Handler for KvCheckpoints {
             .filter(kv_checkpoints::sequence_number.between(from as i64, to_exclusive as i64 - 1));
 
         Ok(diesel::delete(filter).execute(conn).await?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use diesel_async::RunQueryDsl;
+    use sui_indexer_alt_framework::Indexer;
+    use sui_indexer_alt_schema::MIGRATIONS;
+    use sui_types::test_checkpoint_data_builder::TestCheckpointDataBuilder;
+
+    async fn get_all_kv_checkpoints(
+        conn: &mut db::Connection<'_>,
+    ) -> Result<Vec<StoredCheckpoint>> {
+        let query = kv_checkpoints::table.load(conn).await?;
+        Ok(query)
+    }
+
+    /// The kv_checkpoints pruner does not require cp_sequence_numbers, it can prune directly with the
+    /// checkpoint sequence number range.
+    #[tokio::test]
+    async fn test_kv_checkpoints_pruning() {
+        let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
+        let mut conn = indexer.db().connect().await.unwrap();
+        let kv_checkpoints = KvCheckpoints::default();
+
+        // Create 3 checkpoints
+        let mut builder = TestCheckpointDataBuilder::new(0);
+        builder = builder.start_transaction(0).finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = kv_checkpoints.process(&checkpoint).unwrap();
+        KvCheckpoints::commit(&values, &mut conn).await.unwrap();
+
+        builder = builder.start_transaction(0).finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = kv_checkpoints.process(&checkpoint).unwrap();
+        KvCheckpoints::commit(&values, &mut conn).await.unwrap();
+
+        builder = builder.start_transaction(0).finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = kv_checkpoints.process(&checkpoint).unwrap();
+        KvCheckpoints::commit(&values, &mut conn).await.unwrap();
+
+        // Prune checkpoints from `[0, 2)`
+        let rows_pruned = kv_checkpoints.prune(0, 2, &mut conn).await.unwrap();
+        assert_eq!(rows_pruned, 2);
+
+        // Checkpoint 2 remains
+        let remaining_checkpoints = get_all_kv_checkpoints(&mut conn).await.unwrap();
+        assert_eq!(remaining_checkpoints.len(), 1);
     }
 }

--- a/crates/sui-indexer-alt/src/handlers/kv_epoch_ends.rs
+++ b/crates/sui-indexer-alt/src/handlers/kv_epoch_ends.rs
@@ -19,7 +19,6 @@ use sui_types::{
     transaction::{TransactionDataAPI, TransactionKind},
 };
 
-#[derive(Default)]
 pub(crate) struct KvEpochEnds;
 
 impl Processor for KvEpochEnds {

--- a/crates/sui-indexer-alt/src/handlers/kv_epoch_ends.rs
+++ b/crates/sui-indexer-alt/src/handlers/kv_epoch_ends.rs
@@ -161,21 +161,50 @@ mod tests {
     use sui_pg_db::Connection;
     use sui_types::test_checkpoint_data_builder::TestCheckpointDataBuilder;
 
-    async fn get_all_kv_epoch_ends(conn: &mut Connection<'_>) -> Result<Vec<i64>> {
+    async fn get_all_kv_epoch_ends(conn: &mut Connection<'_>) -> Result<Vec<StoredEpochEnd>> {
         let result = kv_epoch_ends::table
-            .select(kv_epoch_ends::epoch)
+            .order_by(kv_epoch_ends::epoch.asc())
             .load(conn)
             .await?;
         Ok(result)
     }
 
-    /// Epoch end table retention must be larger than one epoch's worth of checkpoints - otherwise
-    /// we'll prune the entry for the previous epoch at boundary shortly after writing it.
+    async fn get_epoch_num_of_all_kv_epoch_ends(conn: &mut Connection<'_>) -> Result<Vec<i64>> {
+        let epochs = get_all_kv_epoch_ends(conn).await?;
+        Ok(epochs.iter().map(|e| e.epoch).collect())
+    }
+
+    #[tokio::test]
+    pub async fn test_kv_epoch_ends_safe_mode() -> () {
+        let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
+        let mut conn = indexer.db().connect().await.unwrap();
+
+        let mut builder = TestCheckpointDataBuilder::new(0);
+        let checkpoint = Arc::new(builder.advance_epoch(true));
+        let values = KvEpochEnds.process(&checkpoint).unwrap();
+        KvEpochEnds::commit(&values, &mut conn).await.unwrap();
+
+        let epochs = get_all_kv_epoch_ends(&mut conn).await.unwrap();
+        assert_eq!(epochs.len(), 1);
+        assert_eq!(epochs[0].safe_mode, true);
+        assert_eq!(epochs[0].total_gas_fees, None);
+
+        let checkpoint = Arc::new(builder.advance_epoch(false));
+        let values = KvEpochEnds.process(&checkpoint).unwrap();
+        KvEpochEnds::commit(&values, &mut conn).await.unwrap();
+
+        let epochs = get_all_kv_epoch_ends(&mut conn).await.unwrap();
+        assert_eq!(epochs.len(), 2);
+        assert_eq!(epochs[1].safe_mode, false);
+        assert_eq!(epochs[1].total_gas_fees, Some(0));
+    }
+
     #[tokio::test]
     pub async fn test_kv_epoch_ends_same_epoch() -> () {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
         let mut conn = indexer.db().connect().await.unwrap();
 
+        // Test that there is nothing to commit while we haven't reached epoch end.
         let mut builder = TestCheckpointDataBuilder::new(0);
         let checkpoint = Arc::new(builder.build_checkpoint());
         let values = KvEpochEnds.process(&checkpoint).unwrap();
@@ -191,6 +220,7 @@ mod tests {
         let values = CpSequenceNumbers.process(&checkpoint).unwrap();
         CpSequenceNumbers::commit(&values, &mut conn).await.unwrap();
 
+        // When the advance epoch tx is detected, there should be an entry to commit.
         let checkpoint = Arc::new(builder.advance_epoch(false));
         let values = KvEpochEnds.process(&checkpoint).unwrap();
         KvEpochEnds::commit(&values, &mut conn).await.unwrap();
@@ -198,6 +228,8 @@ mod tests {
         let values = CpSequenceNumbers.process(&checkpoint).unwrap();
         CpSequenceNumbers::commit(&values, &mut conn).await.unwrap();
 
+        // Afterwards, kv_epoch_ends should not have anything to commit until the next advance epoch
+        // tx.
         let checkpoint = Arc::new(builder.build_checkpoint());
         let values = KvEpochEnds.process(&checkpoint).unwrap();
         KvEpochEnds::commit(&values, &mut conn).await.unwrap();
@@ -212,11 +244,11 @@ mod tests {
         let values = CpSequenceNumbers.process(&checkpoint).unwrap();
         CpSequenceNumbers::commit(&values, &mut conn).await.unwrap();
 
-        let epochs = get_all_kv_epoch_ends(&mut conn).await.unwrap();
+        let epochs = get_epoch_num_of_all_kv_epoch_ends(&mut conn).await.unwrap();
         assert_eq!(epochs, vec![0]);
 
         let rows_pruned = KvEpochEnds.prune(0, 4, &mut conn).await.unwrap();
-        let epochs = get_all_kv_epoch_ends(&mut conn).await.unwrap();
+        let epochs = get_epoch_num_of_all_kv_epoch_ends(&mut conn).await.unwrap();
         assert_eq!(epochs.len(), 0);
         assert_eq!(rows_pruned, 1);
     }
@@ -226,6 +258,7 @@ mod tests {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
         let mut conn = indexer.db().connect().await.unwrap();
 
+        // Advance epoch three times, 0, 1, 2
         let mut builder = TestCheckpointDataBuilder::new(0);
         let checkpoint = Arc::new(builder.advance_epoch(false));
         let values = KvEpochEnds.process(&checkpoint).unwrap();
@@ -245,11 +278,12 @@ mod tests {
         let values = CpSequenceNumbers.process(&checkpoint).unwrap();
         CpSequenceNumbers::commit(&values, &mut conn).await.unwrap();
 
-        let epochs = get_all_kv_epoch_ends(&mut conn).await.unwrap();
+        let epochs = get_epoch_num_of_all_kv_epoch_ends(&mut conn).await.unwrap();
         assert_eq!(epochs, vec![0, 1, 2]);
 
         let rows_pruned = KvEpochEnds.prune(0, 2, &mut conn).await.unwrap();
-        let epochs = get_all_kv_epoch_ends(&mut conn).await.unwrap();
+        let epochs = get_epoch_num_of_all_kv_epoch_ends(&mut conn).await.unwrap();
+        // Only epoch 2 remains, after pruning 0 and 1.
         assert_eq!(epochs, vec![2]);
         assert_eq!(rows_pruned, 2);
     }

--- a/crates/sui-indexer-alt/src/handlers/kv_epoch_ends.rs
+++ b/crates/sui-indexer-alt/src/handlers/kv_epoch_ends.rs
@@ -174,7 +174,7 @@ mod tests {
     }
 
     #[tokio::test]
-    pub async fn test_kv_epoch_ends_safe_mode() -> () {
+    pub async fn test_kv_epoch_ends_safe_mode() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
         let mut conn = indexer.db().connect().await.unwrap();
 
@@ -185,7 +185,7 @@ mod tests {
 
         let epochs = get_all_kv_epoch_ends(&mut conn).await.unwrap();
         assert_eq!(epochs.len(), 1);
-        assert_eq!(epochs[0].safe_mode, true);
+        assert!(epochs[0].safe_mode);
         assert_eq!(epochs[0].total_gas_fees, None);
 
         let checkpoint = Arc::new(builder.advance_epoch(false));
@@ -194,12 +194,12 @@ mod tests {
 
         let epochs = get_all_kv_epoch_ends(&mut conn).await.unwrap();
         assert_eq!(epochs.len(), 2);
-        assert_eq!(epochs[1].safe_mode, false);
+        assert!(!epochs[1].safe_mode);
         assert_eq!(epochs[1].total_gas_fees, Some(0));
     }
 
     #[tokio::test]
-    pub async fn test_kv_epoch_ends_same_epoch() -> () {
+    pub async fn test_kv_epoch_ends_same_epoch() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
         let mut conn = indexer.db().connect().await.unwrap();
 
@@ -253,7 +253,7 @@ mod tests {
     }
 
     #[tokio::test]
-    pub async fn test_kv_epoch_ends_advance_multiple_epochs() -> () {
+    pub async fn test_kv_epoch_ends_advance_multiple_epochs() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
         let mut conn = indexer.db().connect().await.unwrap();
 

--- a/crates/sui-indexer-alt/src/handlers/kv_transactions.rs
+++ b/crates/sui-indexer-alt/src/handlers/kv_transactions.rs
@@ -11,6 +11,7 @@ use sui_indexer_alt_schema::{schema::kv_transactions, transactions::StoredTransa
 use sui_pg_db as db;
 use sui_types::full_checkpoint_content::CheckpointData;
 
+#[derive(Default)]
 pub(crate) struct KvTransactions;
 
 impl Processor for KvTransactions {
@@ -74,12 +75,64 @@ impl Handler for KvTransactions {
         to_exclusive: u64,
         conn: &mut db::Connection<'_>,
     ) -> Result<usize> {
-        // TODO: use tx_interval. `tx_sequence_number` needs to be added to this table, and an index
-        // created as its primary key is on `tx_digest`.
         let filter = kv_transactions::table.filter(
             kv_transactions::cp_sequence_number.between(from as i64, to_exclusive as i64 - 1),
         );
 
         Ok(diesel::delete(filter).execute(conn).await?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use diesel_async::RunQueryDsl;
+    use sui_indexer_alt_framework::Indexer;
+    use sui_indexer_alt_schema::MIGRATIONS;
+    use sui_types::test_checkpoint_data_builder::TestCheckpointDataBuilder;
+
+    async fn get_all_kv_transactions(
+        conn: &mut db::Connection<'_>,
+    ) -> Result<Vec<StoredTransaction>> {
+        Ok(kv_transactions::table.load(conn).await?)
+    }
+
+    /// The kv_checkpoints pruner does not require cp_sequence_numbers, it can prune directly with the
+    /// checkpoint sequence number range.
+    #[tokio::test]
+    async fn test_kv_transactions_pruning() {
+        let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
+        let mut conn = indexer.db().connect().await.unwrap();
+        let kv_transactions = KvTransactions::default();
+
+        let mut builder = TestCheckpointDataBuilder::new(0);
+        builder = builder.start_transaction(0).finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = kv_transactions.process(&checkpoint).unwrap();
+        KvTransactions::commit(&values, &mut conn).await.unwrap();
+
+        builder = builder.start_transaction(0).finish_transaction();
+        builder = builder.start_transaction(1).finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = kv_transactions.process(&checkpoint).unwrap();
+        KvTransactions::commit(&values, &mut conn).await.unwrap();
+
+        builder = builder.start_transaction(0).finish_transaction();
+        builder = builder.start_transaction(1).finish_transaction();
+        builder = builder.start_transaction(2).finish_transaction();
+        builder = builder.start_transaction(3).finish_transaction();
+        let checkpoint = Arc::new(builder.build_checkpoint());
+        let values = kv_transactions.process(&checkpoint).unwrap();
+        KvTransactions::commit(&values, &mut conn).await.unwrap();
+
+        let transactions = get_all_kv_transactions(&mut conn).await.unwrap();
+        assert_eq!(transactions.len(), 7);
+
+        // Prune checkpoints from `[0, 2)`
+        let rows_pruned = kv_transactions.prune(0, 2, &mut conn).await.unwrap();
+        assert_eq!(rows_pruned, 3);
+
+        let remaining_transactions = get_all_kv_transactions(&mut conn).await.unwrap();
+        assert_eq!(remaining_transactions.len(), 4);
     }
 }

--- a/crates/sui-types/src/event.rs
+++ b/crates/sui-types/src/event.rs
@@ -160,7 +160,7 @@ impl Event {
 }
 
 // Event emitted in move code `fun advance_epoch`
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize, Default)]
 pub struct SystemEpochInfoEvent {
     pub epoch: u64,
     pub protocol_version: u64,

--- a/crates/sui-types/src/test_checkpoint_data_builder.rs
+++ b/crates/sui-types/src/test_checkpoint_data_builder.rs
@@ -522,11 +522,9 @@ impl TestCheckpointDataBuilder {
         }
     }
 
-    /// Creates a transaction that advances the epoch,
-    /// Build the checkpoint data with a transaction that advances the epoch in addition to all the
-    /// transactions added to the builder so far. This increments the stored checkpoint sequence
-    /// number and epoch. If `safe_mode` is true, the epoch end transaction will not include the
-    /// `SystemEpochInfoEvent`.
+    /// Creates a transaction that advances the epoch, adds it to the checkpoint, and then builds
+    /// the checkpoint. This increments the stored checkpoint sequence number and epoch. If
+    /// `safe_mode` is true, the epoch end transaction will not include the `SystemEpochInfoEvent`.
     pub fn advance_epoch(&mut self, safe_mode: bool) -> CheckpointData {
         let (committee, _) = Committee::new_simple_test_committee();
         let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();

--- a/crates/sui-types/src/test_checkpoint_data_builder.rs
+++ b/crates/sui-types/src/test_checkpoint_data_builder.rs
@@ -7,7 +7,6 @@ use move_core_types::{
     ident_str,
     language_storage::{StructTag, TypeTag},
 };
-use serde::Serialize;
 use sui_protocol_config::ProtocolConfig;
 use tap::Pipe;
 
@@ -20,7 +19,7 @@ use crate::{
     committee::Committee,
     digests::TransactionDigest,
     effects::{TestEffectsBuilder, TransactionEffectsAPI, TransactionEvents},
-    event::Event,
+    event::{Event, SystemEpochInfoEvent},
     full_checkpoint_content::{CheckpointData, CheckpointTransaction},
     gas_coin::GAS,
     message_envelope::Message,
@@ -84,23 +83,6 @@ struct TransactionBuilder {
     wrapped_objects: BTreeSet<ObjectID>,
     deleted_objects: BTreeSet<ObjectID>,
     events: Option<Vec<Event>>,
-}
-
-// Matches the SystemEpochInfoEvent
-#[derive(Serialize, Default)]
-struct TestSystemEpochInfoEvent {
-    pub epoch: u64,
-    pub protocol_version: u64,
-    pub reference_gas_price: u64,
-    pub total_stake: u64,
-    pub storage_fund_reinvestment: u64,
-    pub storage_charge: u64,
-    pub storage_rebate: u64,
-    pub storage_fund_balance: u64,
-    pub stake_subsidy_amount: u64,
-    pub total_gas_fees: u64,
-    pub total_stake_rewards_distributed: u64,
-    pub leftover_storage_fund_inflow: u64,
 }
 
 impl TransactionBuilder {
@@ -552,7 +534,7 @@ impl TestCheckpointDataBuilder {
         .pipe(Transaction::new);
 
         let events = if !safe_mode {
-            let system_epoch_info_event = TestSystemEpochInfoEvent {
+            let system_epoch_info_event = SystemEpochInfoEvent {
                 epoch: self.checkpoint_builder.epoch,
                 protocol_version: protocol_config.version.as_u64(),
                 ..Default::default()

--- a/crates/sui-types/src/test_checkpoint_data_builder.rs
+++ b/crates/sui-types/src/test_checkpoint_data_builder.rs
@@ -20,7 +20,7 @@ use crate::{
     committee::Committee,
     digests::TransactionDigest,
     effects::{TestEffectsBuilder, TransactionEffectsAPI, TransactionEvents},
-    event::{Event, SystemEpochInfoEvent},
+    event::Event,
     full_checkpoint_content::{CheckpointData, CheckpointTransaction},
     gas_coin::GAS,
     message_envelope::Message,
@@ -29,7 +29,6 @@ use crate::{
     },
     object::{MoveObject, Object, Owner, GAS_VALUE_FOR_TESTING},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    sui_system_state::SuiSystemStateWrapper,
     transaction::{
         EndOfEpochTransactionKind, SenderSignedData, Transaction, TransactionData, TransactionKind,
     },
@@ -85,6 +84,23 @@ struct TransactionBuilder {
     wrapped_objects: BTreeSet<ObjectID>,
     deleted_objects: BTreeSet<ObjectID>,
     events: Option<Vec<Event>>,
+}
+
+// Matches the SystemEpochInfoEvent
+#[derive(Serialize, Default)]
+struct TestSystemEpochInfoEvent {
+    pub epoch: u64,
+    pub protocol_version: u64,
+    pub reference_gas_price: u64,
+    pub total_stake: u64,
+    pub storage_fund_reinvestment: u64,
+    pub storage_charge: u64,
+    pub storage_rebate: u64,
+    pub storage_fund_balance: u64,
+    pub stake_subsidy_amount: u64,
+    pub total_gas_fees: u64,
+    pub total_stake_rewards_distributed: u64,
+    pub leftover_storage_fund_inflow: u64,
 }
 
 impl TransactionBuilder {
@@ -355,8 +371,8 @@ impl TestCheckpointDataBuilder {
         self
     }
 
-    /// Complete the current transaction and add it to the checkpoint.
-    /// This will also finalize all the object changes, and reflect them in the live object map.
+    /// Complete the current transaction and add it to the checkpoint. This will also finalize all
+    /// the object changes, and reflect them in the live object map.
     pub fn finish_transaction(mut self) -> Self {
         let TransactionBuilder {
             sender_idx,
@@ -506,14 +522,12 @@ impl TestCheckpointDataBuilder {
         }
     }
 
+    /// Creates a transaction that advances the epoch,
     /// Build the checkpoint data with a transaction that advances the epoch in addition to all the
     /// transactions added to the builder so far. This increments the stored checkpoint sequence
-    /// number and epoch.
+    /// number and epoch. If `safe_mode` is true, the epoch end transaction will not include the
+    /// `SystemEpochInfoEvent`.
     pub fn advance_epoch(&mut self, safe_mode: bool) -> CheckpointData {
-        // the input to `get_sui-system_state` from kv_epoch_starts is `&[Object]`
-        // the sui-system_state_object_id needs to be part of output objects ig
-        // and then get_dynamic_field_from_store(object_store, id, &wrapper.version)
-        // damn, why is this so involved?
         let (committee, _) = Committee::new_simple_test_committee();
         let protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
         let tx_kind = EndOfEpochTransactionKind::new_change_epoch(
@@ -527,32 +541,8 @@ impl TestCheckpointDataBuilder {
             Default::default(),
         );
 
-        // let wrapper = object from object store
-        // then try as move object
-        // and finally SuiSystemStateWrapper
-
-        // so we gotta go the other way by ... converting into a move object
-        // move_object.contents() = SuiSystemWrapper bcs::to_bytes
-        // and then tuck it into wrapper.data
-
-        // let data = Data::Move(MoveObject {
-        //     type_: TreasuryCap::type_(struct_tag).into(),
-        //     has_public_transfer: true,
-        //     version: OBJECT_START_VERSION,
-        //     contents: bcs::to_bytes(&treasury_cap).expect("Failed to serialize"),
-        // });
-        // let object: Object = ObjectInner {
-        //     owner: Owner::Immutable,
-        //     data,
-        //     previous_transaction: TransactionDigest::genesis_marker(),
-        //     storage_rebate: 0,
-        // }
-        // .into()
-
-        // let wrapper = SuiSystemStateWrapper::new(0, SUI_SYSTEM_STATE_OBJECT_ID, SuiSystemStateInnerV2::new(0, vec![]));
-        // let move_object = MoveObject::new_from_execution(SuiSystemStateWrapper::type_().into(), true, 0, bcs::to_bytes(&wrapper).unwrap(), &protocol_config).unwrap();
-        // let object = Object::new_move(move_object, Owner::Address(SUI_SYSTEM_STATE_OBJECT_ID), TransactionDigest::ZERO());
-
+        // TODO: need the system state object wrapper and dynamic field object to "correctly" mock
+        // advancing epoch, at least to satisfy kv_epoch_starts pipeline.
         let end_of_epoch_tx = TransactionData::new(
             TransactionKind::EndOfEpochTransaction(vec![tx_kind]),
             SuiAddress::default(),
@@ -563,63 +553,11 @@ impl TestCheckpointDataBuilder {
         .pipe(|data| SenderSignedData::new(data, vec![]))
         .pipe(Transaction::new);
 
-        // so basically htere needs to be two objects in the output_objects right
-        // the wrapper object
-        // and then the dynamic field object, the inner
-
-        // create fake sui system state object ...
-        // add it as output_objects somehow
-        // get_sui_system_state_wrapper
-        // needs to have SUI_SYSTEM_STATE_OBJECT_ID
-
-        // contenst are <Field<K, V>> = SuiSystemStateInnerV2? ah, K is wrapper.version
-        // So ... field: Field<u64, T>
-        // look at Self::advance_epoch_safe_mode_impl::<SuiSystemStateInnerV2>
-        // assumes move_object.contents() so ...
-
-        // let mut field: Field<u64, SuiSystemStateInnerV2> =
-        /*
-                let new_contents = bcs::to_bytes(&field).expect("bcs serialization should never fail");
-        move_object
-            .update_contents(new_contents, protocol_config)
-            .expect("Update sui system object content cannot fail since it should be small");
-
-         */
-
-        // let move_object = MoveObject::
-        // let object = Object::new_move(
-
-        // Matches the SystemEpochInfoEvent
-        #[derive(Serialize)]
-        pub struct TestSystemEpochInfoEvent {
-            pub epoch: u64,
-            pub protocol_version: u64,
-            pub reference_gas_price: u64,
-            pub total_stake: u64,
-            pub storage_fund_reinvestment: u64,
-            pub storage_charge: u64,
-            pub storage_rebate: u64,
-            pub storage_fund_balance: u64,
-            pub stake_subsidy_amount: u64,
-            pub total_gas_fees: u64,
-            pub total_stake_rewards_distributed: u64,
-            pub leftover_storage_fund_inflow: u64,
-        }
-
         let events = if !safe_mode {
             let system_epoch_info_event = TestSystemEpochInfoEvent {
                 epoch: self.checkpoint_builder.epoch,
                 protocol_version: protocol_config.version.as_u64(),
-                reference_gas_price: 0,
-                total_stake: 0,
-                storage_fund_reinvestment: 0,
-                storage_charge: 0,
-                storage_rebate: 0,
-                storage_fund_balance: 0,
-                stake_subsidy_amount: 0,
-                total_gas_fees: 0,
-                total_stake_rewards_distributed: 0,
-                leftover_storage_fund_inflow: 0,
+                ..Default::default()
             };
             let struct_tag = StructTag {
                 address: SUI_SYSTEM_ADDRESS,
@@ -640,6 +578,7 @@ impl TestCheckpointDataBuilder {
 
         let transaction_events = events.map(|events| TransactionEvents { data: events });
 
+        // Similar to calling self.finish_transaction()
         self.checkpoint_builder
             .transactions
             .push(CheckpointTransaction {
@@ -647,9 +586,11 @@ impl TestCheckpointDataBuilder {
                 effects: Default::default(),
                 events: transaction_events,
                 input_objects: vec![],
-                output_objects: vec![], // over here I think?
+                output_objects: vec![],
             });
 
+        // Call build_checkpoint() to finalize the checkpoint and then populate the checkpoint with
+        // additional end of epoch data.
         let mut checkpoint = self.build_checkpoint();
         let end_of_epoch_data = EndOfEpochData {
             next_epoch_committee: committee.voting_rights.clone(),
@@ -657,7 +598,6 @@ impl TestCheckpointDataBuilder {
             epoch_commitments: vec![],
         };
         checkpoint.checkpoint_summary.end_of_epoch_data = Some(end_of_epoch_data);
-
         self.checkpoint_builder.epoch += 1;
         checkpoint
     }


### PR DESCRIPTION
## Description 

Extend `TestCheckpointDataBuilder` to advance an epoch by creating an advance epoch tx with or without the SystemEpochInfoEvent depending on `safe_mode`. Usage:
```
        let mut builder = TestCheckpointDataBuilder::new(0);
        let checkpoint = Arc::new(builder.advance_epoch(true));
        let values = KvEpochEnds.process(&checkpoint).unwrap();
        KvEpochEnds::commit(&values, &mut conn).await.unwrap();
```

I had originally considered extending the current tx workflow of `builder.start_transaction()` to then `.advance_epoch().build_checkpoint()`, but ultimately kept it standalone as we'd largely be discarding modifications if any made to the current transaction. A user can still create multiple transactions for the checkpoint, and after `.finish_transaction()`, would call `advance_epoch()` instead of `build_checkpoint()`.

This saves us from having to use simulacrum to test epoch-boundary behavior (and dealing with potential flakiness)

## Test plan 

New tests written

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
