### PR TITLE
[faucet] Do not log 429 errors

### DIFF
--- a/crates/sui-faucet/src/metrics_layer.rs
+++ b/crates/sui-faucet/src/metrics_layer.rs
@@ -175,10 +175,13 @@ impl MetricsGuard {
                     self.path, elapsed, err
                 );
             } else if let Some(status) = status {
-                error!(
-                    "Request failed for path {} in {:.2}s with status: {}",
-                    self.path, elapsed, status
-                );
+                // don't log too many requests as an error, as we're flooding the logs
+                if status != StatusCode::TOO_MANY_REQUESTS {
+                    error!(
+                        "Request failed for path {} in {:.2}s with status: {}",
+                        self.path, elapsed, status
+                    );
+                }
             } else {
                 warn!("Request failed for path {} in {:.2}s", self.path, elapsed);
             }


### PR DESCRIPTION
## Description 

This PR updates the logging of 429 errors, to skip them as it floods the logs with them after rate limiting the server.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
