### PR TITLE
[indexer-alt] add coin jsonrpc impl

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/deleted.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/deleted.move
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// This test is to verify that deleted coins are not included in the result of suix_getCoins.
+// We create two coins, of balances 12 and 34, call the rpc method to see both of them in the results.
+// Then we merge the coins and call the rpc method again to see that only the merged coin with
+// balance 46 is in the results.
+
+//# init --protocol-version 70 --addresses Test=0x0 --accounts A B --simulator --objects-snapshot-min-checkpoint-lag 2
+
+//# programmable --sender A --inputs 12 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 34 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# view-object 1,0
+
+//# view-object 2,0
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "suix_getCoins",
+  "params": ["@{A}"]
+}
+
+//# programmable --sender A --inputs object(1,0) object(2,0)
+//> 0: MergeCoins(Input(0), [Input(1)]);
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "suix_getCoins",
+  "params": ["@{A}"]
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/deleted.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/deleted.snap
@@ -1,0 +1,134 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 10 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 11-13:
+//# programmable --sender A --inputs 12 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 15-17:
+//# programmable --sender A --inputs 34 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, line 19:
+//# view-object 1,0
+Owner: Account Address ( A )
+Version: 2
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(1,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 12u64,
+    },
+}
+
+task 4, line 21:
+//# view-object 2,0
+Owner: Account Address ( A )
+Version: 3
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 34u64,
+    },
+}
+
+task 5, line 23:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 6, lines 25-29:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": {
+    "data": [
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
+        "version": "3",
+        "digest": "BGqvhSkz3SYePbLs4rwrKCGSjmZCQi98wj5XmPEZ3KAF",
+        "balance": "299999995026074",
+        "previousTransaction": "AasjzjtKdtrQeZqXEquUBDp3Wb8mbLziGxg6np4mhf56"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x57f42279a1d36e456374da161a332ad4f4fe7919fdb44dba456447a6f4d25e8e",
+        "version": "3",
+        "digest": "5edeWFmMJatCEtNanqj2Qx91HcBGyq9F1EzbCnbZtY69",
+        "balance": "34",
+        "previousTransaction": "AasjzjtKdtrQeZqXEquUBDp3Wb8mbLziGxg6np4mhf56"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x25c9a04c7ccfe4bba96596c73d14363121e0d6a6c979e65893877266f7f82074",
+        "version": "2",
+        "digest": "3xXGpcHsghX2BCcmWQ8CspNsWP8sD93LRdzzstTMt1Dx",
+        "balance": "12",
+        "previousTransaction": "Cuu9udTB5hRGQd5o37gNxaq4BjCU5qJiQEQzbuD7U6Y6"
+      }
+    ],
+    "nextCursor": "ICXJoEx8z+S7qWWWxz0UNjEh4NamyXnmWJOHcmb3+CB0AQAAAAAAAAABAAAAAAAAAA==",
+    "hasNextPage": false
+  }
+}
+
+task 7, lines 31-32:
+//# programmable --sender A --inputs object(1,0) object(2,0)
+//> 0: MergeCoins(Input(0), [Input(1)]);
+mutated: object(0,0), object(1,0)
+deleted: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 2934360, non_refundable_storage_fee: 29640
+
+task 8, line 34:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 9, lines 36-40:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "data": [
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
+        "version": "4",
+        "digest": "89vdJGrEidfnSQRpDXBTCzwcfueKzgbS9pvZKwP9zBzW",
+        "balance": "299999994984434",
+        "previousTransaction": "CftuBvsnseqKfCCcxHGX3bXPhzRJvvcLo16QTsgL3xPv"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x25c9a04c7ccfe4bba96596c73d14363121e0d6a6c979e65893877266f7f82074",
+        "version": "4",
+        "digest": "BCyJEa2eY66tdAiJsQi1z2bCkhNrJiUy2bhqzFrhTQnN",
+        "balance": "46",
+        "previousTransaction": "CftuBvsnseqKfCCcxHGX3bXPhzRJvvcLo16QTsgL3xPv"
+      }
+    ],
+    "nextCursor": "ICXJoEx8z+S7qWWWxz0UNjEh4NamyXnmWJOHcmb3+CB0AQAAAAAAAAABAAAAAAAAAA==",
+    "hasNextPage": false
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/inconsistency.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/inconsistency.move
@@ -1,0 +1,43 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// This illustrates the "inconsistency" of suix_getCoins, as opposed to graphql's consistency feature.
+// We have a coin with balance 3400 and another coin with balance 12000 at checkpoint 1.
+// We query with limit 2 and get a cursor specifying checkpoint 1 with the 12000 coin.
+// We update the 3400 coin's balance to 1400 at checkpoint 2.
+// We query the coin using the cursor we got from the first query and see a coin with balance 1400.
+// In graphql, the returned coin will be from checkpoint_viewed_at = 1, and has balance 3400.
+
+//# init --protocol-version 70 --addresses Test=0x0 --accounts A B --simulator --objects-snapshot-min-checkpoint-lag 2
+
+//# programmable --sender A --inputs 12000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 3400 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# view-object 1,0
+
+//# view-object 2,0
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "suix_getCoins",
+  "params": ["@{A}", null, null, 2]
+}
+
+//# programmable --sender A --inputs object(2,0) 2000 @A
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: TransferObjects([Result(0)], Input(2))
+
+//# create-checkpoint
+
+//# run-jsonrpc --cursors bcs(@{obj_1_0},1,4)
+{
+  "method": "suix_getCoins",
+  "params": ["@{A}", null, "@{cursor_0}"]
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/inconsistency.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/inconsistency.snap
@@ -1,0 +1,127 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 10 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 13-15:
+//# programmable --sender A --inputs 12000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 17-19:
+//# programmable --sender A --inputs 3400 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, line 21:
+//# view-object 1,0
+Owner: Account Address ( A )
+Version: 2
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(1,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 12000u64,
+    },
+}
+
+task 4, line 23:
+//# view-object 2,0
+Owner: Account Address ( A )
+Version: 3
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 3400u64,
+    },
+}
+
+task 5, line 25:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 6, lines 27-31:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": {
+    "data": [
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
+        "version": "3",
+        "digest": "D63GjQSUZQ6iuYP2hJfbAp9fTcjBramkoH4tDDmGFMCT",
+        "balance": "299999995010720",
+        "previousTransaction": "EK4m6HC3b7C2T7fZT9KjqugnkgPD7YsgBXGoG9WAFmQN"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0xe4a7de8e2336a34d8a4a544546eecffad748156a8fb62dd4e6c030424d49e259",
+        "version": "2",
+        "digest": "gMNG9ZADuKXKq5PoHpFbspGzEv9kZ4ifgvXXswLjthf",
+        "balance": "12000",
+        "previousTransaction": "3tfDJdUhJPunyaRVaMnTiLzHdyryECfepHu6LfUXUsDN"
+      }
+    ],
+    "nextCursor": "IOSn3o4jNqNNikpURUbuz/rXSBVqj7Yt1ObAMEJNSeJZAQAAAAAAAAAEAAAAAAAAAA==",
+    "hasNextPage": true
+  }
+}
+
+task 7, lines 33-35:
+//# programmable --sender A --inputs object(2,0) 2000 @A
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: TransferObjects([Result(0)], Input(2))
+created: object(7,0)
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2964000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 8, line 37:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 9, lines 39-43:
+//# run-jsonrpc --cursors bcs(@{obj_1_0},1,4)
+Response: {
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "data": [
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x8f30d8a369b4b9649bd1f018cb5c6fc84c19098aefb8d3d0cffb50aa1574251d",
+        "version": "4",
+        "digest": "AWvFXoUkm92HAZcAargDYsx68QS8arnJiqxjVUzXC7nk",
+        "balance": "2000",
+        "previousTransaction": "AXzgRv8bvNPQvMiETHqWkQ9oQhWb8QF2PUurfXeEFUyT"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0xa9a2c06be125dfa73fab40fdcca74eb80251de59c95a4baf07e13e1435fe19cd",
+        "version": "4",
+        "digest": "9DPCe86YYAHDNXptQhoXyJ5jxjew9BSJwT51W9MuBAFf",
+        "balance": "1400",
+        "previousTransaction": "AXzgRv8bvNPQvMiETHqWkQ9oQhWb8QF2PUurfXeEFUyT"
+      }
+    ],
+    "nextCursor": "IKmiwGvhJd+nP6tA/cynTrgCUd5ZyVpLrwfhPhQ1/hnNAQAAAAAAAAADAAAAAAAAAA==",
+    "hasNextPage": false
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/pagination.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/pagination.move
@@ -1,0 +1,84 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --addresses Test=0x0 --accounts A B --simulator --objects-snapshot-min-checkpoint-lag 2
+
+//# programmable --sender A --inputs 120000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 34000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 5600 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 780 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 90 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 10 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 20 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+
+//# programmable --sender A --inputs 30 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# view-object 4,0
+
+//# view-object 5,0
+
+//# view-object 6,0
+
+//# view-object 7,0
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "suix_getCoins",
+  "params": ["@{A}", null, null, 3]
+}
+
+//# run-jsonrpc --cursors bcs(@{obj_2_0},1,4)
+{
+  "method": "suix_getCoins",
+  "params": ["@{A}", null, "@{cursor_0}"]
+}
+
+//# run-jsonrpc --cursors bcs(@{obj_7_0},1,1)
+{
+  "method": "suix_getCoins",
+  "params": ["@{A}", null, "@{cursor_0}"]
+}
+
+//# programmable --sender A --inputs 500 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# run-jsonrpc --cursors bcs(@{obj_1_0},2,4)
+{
+  "method": "suix_getCoins",
+  "params": ["@{A}", null, "@{cursor_0}"]
+}
+
+//# run-jsonrpc --cursors bcs(@{obj_1_0},1,4)
+{
+  "method": "suix_getCoins",
+  "params": ["@{A}", null, "@{cursor_0}"]
+}
+

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/pagination.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/pagination.snap
@@ -1,0 +1,412 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 21 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-8:
+//# programmable --sender A --inputs 120000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 10-12:
+//# programmable --sender A --inputs 34000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 14-16:
+//# programmable --sender A --inputs 5600 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 18-20:
+//# programmable --sender A --inputs 780 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 22-24:
+//# programmable --sender A --inputs 90 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 26-28:
+//# programmable --sender A --inputs 10 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(6,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7, lines 30-32:
+//# programmable --sender A --inputs 20 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(7,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 8, lines 35-37:
+//# programmable --sender A --inputs 30 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(8,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 9, line 39:
+//# view-object 4,0
+Owner: Account Address ( A )
+Version: 5
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(4,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 780u64,
+    },
+}
+
+task 10, line 41:
+//# view-object 5,0
+Owner: Account Address ( A )
+Version: 6
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(5,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 90u64,
+    },
+}
+
+task 11, line 43:
+//# view-object 6,0
+Owner: Account Address ( A )
+Version: 7
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(6,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 10u64,
+    },
+}
+
+task 12, line 45:
+//# view-object 7,0
+Owner: Account Address ( A )
+Version: 8
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(7,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 20u64,
+    },
+}
+
+task 13, line 47:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 14, lines 49-53:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": {
+    "data": [
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
+        "version": "9",
+        "digest": "5usSL4ERL13WoLuoiF5kX8pi2tPurxYj2ERsR4LRKuwh",
+        "balance": "299999982878310",
+        "previousTransaction": "FLyLdcy3iVcMBCaNgJVmwbeYEd7ajuqmLM78XYn5R6f4"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x1f8c2ea789c2426feb2f978bee8ef2040357cdff57e40ca469d321975f9b1eea",
+        "version": "2",
+        "digest": "HrwLjPuZJqBKFNYHNS9rN5v8CNxG7BQDFNwcd3P8yoKa",
+        "balance": "120000",
+        "previousTransaction": "6STUxqkKd9kidCaCC8SgvP2xrtNPoW2CKUGS5zrPshHQ"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x7d068eefc97a634a8c71e9acec5edbb804d6e7627d5d148f82f7425deb355a4c",
+        "version": "3",
+        "digest": "DDhvgXrYkJC8ERVxY7grGxo3L8zGKBnL4kjXYD2S2XYW",
+        "balance": "34000",
+        "previousTransaction": "HT3v8ipX1BUP6po38Bq7VAYRAfby9KPoQSTDRxiufs3h"
+      }
+    ],
+    "nextCursor": "IH0Gju/JemNKjHHprOxe27gE1udifV0Uj4L3Ql3rNVpMAQAAAAAAAAAEAAAAAAAAAA==",
+    "hasNextPage": true
+  }
+}
+
+task 15, lines 55-59:
+//# run-jsonrpc --cursors bcs(@{obj_2_0},1,4)
+Response: {
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "data": [
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x22c10432a25aceb795a1b5bc78af3aadc5523691a8472b90ddacee8fe1b7bcd7",
+        "version": "4",
+        "digest": "4446xMC65fqJWnk2iLryPk5JTQ7juZkE63U6LbBoZmps",
+        "balance": "5600",
+        "previousTransaction": "HwMPiS9g2rbeaHrx44A2qbHB9XifujgHxuFgtmW7yEQ8"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x1adba5970dbbc5c6c0c9be3963ca04af329f69249c8a81243bf957a3e784bbeb",
+        "version": "5",
+        "digest": "EhVBeFBajM4ipwDUmfCCAnkuSW7fs2dgLyBWyrWUMq5P",
+        "balance": "780",
+        "previousTransaction": "9zpR1FozxwVpM12h2YdxYjuSGhPQUdMbCaF5kc7sFqDU"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x7c0f7f5e3998ae1dc0f651d700bb01333dc070d6fae03e23df128acb7137929f",
+        "version": "7",
+        "digest": "AHvTed6HDPKTK2EjCgbYvRUWhpcY8yw6umuXDsZcPRNQ",
+        "balance": "10",
+        "previousTransaction": "Dy8DZVxCLuXCF1mgCEiUnyuXqHwxgiSDdM44cda6utCP"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x51bed430062918953ee68916bfe9915a513693378e1b1e8b7d3eed4d4c02fbc9",
+        "version": "9",
+        "digest": "GJmZQkhnu5RENNvjKmzgq5DCRzwkKGTNNPL3XizEKoGC",
+        "balance": "30",
+        "previousTransaction": "FLyLdcy3iVcMBCaNgJVmwbeYEd7ajuqmLM78XYn5R6f4"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x3fcf4edca31d2a34adcc101e7b2440f724f625e90bf5c4333163997ae88f0997",
+        "version": "8",
+        "digest": "1Cp4hQxZ825Gur6sE6w6YETGu3jcWphvpAk5JRVvovt",
+        "balance": "20",
+        "previousTransaction": "J3qkn4d3YZQW9i8f8bPv9brSurg8y2ge4orwstySy9nW"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x2230dbb39cb72038491f8f158ecfcc4cd0ba38901a3cd3898acd4139b1a39641",
+        "version": "6",
+        "digest": "DvSWxQyyakRTPbJo5Fav8syomFi2bhFjNzG49cjUa6DF",
+        "balance": "90",
+        "previousTransaction": "2HZ5XDxzLeTbPaSk6j9TvXYCp5d7WE66Hjn5brLHm6YP"
+      }
+    ],
+    "nextCursor": "ICIw27OctyA4SR+PFY7PzEzQujiQGjzTiYrNQTmxo5ZBAQAAAAAAAAABAAAAAAAAAA==",
+    "hasNextPage": false
+  }
+}
+
+task 16, lines 61-65:
+//# run-jsonrpc --cursors bcs(@{obj_7_0},1,1)
+Response: {
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "data": [
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x2230dbb39cb72038491f8f158ecfcc4cd0ba38901a3cd3898acd4139b1a39641",
+        "version": "6",
+        "digest": "DvSWxQyyakRTPbJo5Fav8syomFi2bhFjNzG49cjUa6DF",
+        "balance": "90",
+        "previousTransaction": "2HZ5XDxzLeTbPaSk6j9TvXYCp5d7WE66Hjn5brLHm6YP"
+      }
+    ],
+    "nextCursor": "ICIw27OctyA4SR+PFY7PzEzQujiQGjzTiYrNQTmxo5ZBAQAAAAAAAAABAAAAAAAAAA==",
+    "hasNextPage": false
+  }
+}
+
+task 17, lines 67-69:
+//# programmable --sender A --inputs 500 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(17,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 18, line 71:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 19, lines 73-77:
+//# run-jsonrpc --cursors bcs(@{obj_1_0},2,4)
+Response: {
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "data": [
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x7d068eefc97a634a8c71e9acec5edbb804d6e7627d5d148f82f7425deb355a4c",
+        "version": "3",
+        "digest": "DDhvgXrYkJC8ERVxY7grGxo3L8zGKBnL4kjXYD2S2XYW",
+        "balance": "34000",
+        "previousTransaction": "HT3v8ipX1BUP6po38Bq7VAYRAfby9KPoQSTDRxiufs3h"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x22c10432a25aceb795a1b5bc78af3aadc5523691a8472b90ddacee8fe1b7bcd7",
+        "version": "4",
+        "digest": "4446xMC65fqJWnk2iLryPk5JTQ7juZkE63U6LbBoZmps",
+        "balance": "5600",
+        "previousTransaction": "HwMPiS9g2rbeaHrx44A2qbHB9XifujgHxuFgtmW7yEQ8"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0xc1db2503c7d914949414fe2bee5f7adf2f5e1d0e45637af0a2ae40600aa9762f",
+        "version": "10",
+        "digest": "FrG4cyrxyPGt8zJQGeKzakYpNfLyK11itiqTmhhRaeeo",
+        "balance": "500",
+        "previousTransaction": "Sf4SnHHzy8Rd8TWvqowRBvj5LpC3fTGRtfeFHRTbosi"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x1adba5970dbbc5c6c0c9be3963ca04af329f69249c8a81243bf957a3e784bbeb",
+        "version": "5",
+        "digest": "EhVBeFBajM4ipwDUmfCCAnkuSW7fs2dgLyBWyrWUMq5P",
+        "balance": "780",
+        "previousTransaction": "9zpR1FozxwVpM12h2YdxYjuSGhPQUdMbCaF5kc7sFqDU"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x7c0f7f5e3998ae1dc0f651d700bb01333dc070d6fae03e23df128acb7137929f",
+        "version": "7",
+        "digest": "AHvTed6HDPKTK2EjCgbYvRUWhpcY8yw6umuXDsZcPRNQ",
+        "balance": "10",
+        "previousTransaction": "Dy8DZVxCLuXCF1mgCEiUnyuXqHwxgiSDdM44cda6utCP"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x51bed430062918953ee68916bfe9915a513693378e1b1e8b7d3eed4d4c02fbc9",
+        "version": "9",
+        "digest": "GJmZQkhnu5RENNvjKmzgq5DCRzwkKGTNNPL3XizEKoGC",
+        "balance": "30",
+        "previousTransaction": "FLyLdcy3iVcMBCaNgJVmwbeYEd7ajuqmLM78XYn5R6f4"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x3fcf4edca31d2a34adcc101e7b2440f724f625e90bf5c4333163997ae88f0997",
+        "version": "8",
+        "digest": "1Cp4hQxZ825Gur6sE6w6YETGu3jcWphvpAk5JRVvovt",
+        "balance": "20",
+        "previousTransaction": "J3qkn4d3YZQW9i8f8bPv9brSurg8y2ge4orwstySy9nW"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x2230dbb39cb72038491f8f158ecfcc4cd0ba38901a3cd3898acd4139b1a39641",
+        "version": "6",
+        "digest": "DvSWxQyyakRTPbJo5Fav8syomFi2bhFjNzG49cjUa6DF",
+        "balance": "90",
+        "previousTransaction": "2HZ5XDxzLeTbPaSk6j9TvXYCp5d7WE66Hjn5brLHm6YP"
+      }
+    ],
+    "nextCursor": "ICIw27OctyA4SR+PFY7PzEzQujiQGjzTiYrNQTmxo5ZBAQAAAAAAAAABAAAAAAAAAA==",
+    "hasNextPage": false
+  }
+}
+
+task 20, lines 79-83:
+//# run-jsonrpc --cursors bcs(@{obj_1_0},1,4)
+Response: {
+  "jsonrpc": "2.0",
+  "id": 4,
+  "result": {
+    "data": [
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x22c10432a25aceb795a1b5bc78af3aadc5523691a8472b90ddacee8fe1b7bcd7",
+        "version": "4",
+        "digest": "4446xMC65fqJWnk2iLryPk5JTQ7juZkE63U6LbBoZmps",
+        "balance": "5600",
+        "previousTransaction": "HwMPiS9g2rbeaHrx44A2qbHB9XifujgHxuFgtmW7yEQ8"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0xc1db2503c7d914949414fe2bee5f7adf2f5e1d0e45637af0a2ae40600aa9762f",
+        "version": "10",
+        "digest": "FrG4cyrxyPGt8zJQGeKzakYpNfLyK11itiqTmhhRaeeo",
+        "balance": "500",
+        "previousTransaction": "Sf4SnHHzy8Rd8TWvqowRBvj5LpC3fTGRtfeFHRTbosi"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x1adba5970dbbc5c6c0c9be3963ca04af329f69249c8a81243bf957a3e784bbeb",
+        "version": "5",
+        "digest": "EhVBeFBajM4ipwDUmfCCAnkuSW7fs2dgLyBWyrWUMq5P",
+        "balance": "780",
+        "previousTransaction": "9zpR1FozxwVpM12h2YdxYjuSGhPQUdMbCaF5kc7sFqDU"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x7c0f7f5e3998ae1dc0f651d700bb01333dc070d6fae03e23df128acb7137929f",
+        "version": "7",
+        "digest": "AHvTed6HDPKTK2EjCgbYvRUWhpcY8yw6umuXDsZcPRNQ",
+        "balance": "10",
+        "previousTransaction": "Dy8DZVxCLuXCF1mgCEiUnyuXqHwxgiSDdM44cda6utCP"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x51bed430062918953ee68916bfe9915a513693378e1b1e8b7d3eed4d4c02fbc9",
+        "version": "9",
+        "digest": "GJmZQkhnu5RENNvjKmzgq5DCRzwkKGTNNPL3XizEKoGC",
+        "balance": "30",
+        "previousTransaction": "FLyLdcy3iVcMBCaNgJVmwbeYEd7ajuqmLM78XYn5R6f4"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x3fcf4edca31d2a34adcc101e7b2440f724f625e90bf5c4333163997ae88f0997",
+        "version": "8",
+        "digest": "1Cp4hQxZ825Gur6sE6w6YETGu3jcWphvpAk5JRVvovt",
+        "balance": "20",
+        "previousTransaction": "J3qkn4d3YZQW9i8f8bPv9brSurg8y2ge4orwstySy9nW"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x2230dbb39cb72038491f8f158ecfcc4cd0ba38901a3cd3898acd4139b1a39641",
+        "version": "6",
+        "digest": "DvSWxQyyakRTPbJo5Fav8syomFi2bhFjNzG49cjUa6DF",
+        "balance": "90",
+        "previousTransaction": "2HZ5XDxzLeTbPaSk6j9TvXYCp5d7WE66Hjn5brLHm6YP"
+      }
+    ],
+    "nextCursor": "ICIw27OctyA4SR+PFY7PzEzQujiQGjzTiYrNQTmxo5ZBAQAAAAAAAAABAAAAAAAAAA==",
+    "hasNextPage": false
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/transferred.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/transferred.move
@@ -1,0 +1,43 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Transfer an object from A to B and verify that the coin is now included in the result of suix_getCoins
+// for B and not included in the result for A.
+
+//# init --protocol-version 70 --addresses Test=0x0 --accounts A B --simulator --objects-snapshot-min-checkpoint-lag 2
+
+//# programmable --sender A --inputs 12 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 34 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# view-object 1,0
+
+//# view-object 2,0
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "suix_getCoins",
+  "params": ["@{A}"]
+}
+
+//# transfer-object 1,0 --sender A --recipient B
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "suix_getCoins",
+  "params": ["@{A}"]
+}
+
+//# run-jsonrpc
+{
+  "method": "suix_getCoins",
+  "params": ["@{B}"]
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/transferred.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/transferred.snap
@@ -1,0 +1,161 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 11 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 9-11:
+//# programmable --sender A --inputs 12 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 13-15:
+//# programmable --sender A --inputs 34 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, line 17:
+//# view-object 1,0
+Owner: Account Address ( A )
+Version: 2
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(1,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 12u64,
+    },
+}
+
+task 4, line 19:
+//# view-object 2,0
+Owner: Account Address ( A )
+Version: 3
+Contents: sui::coin::Coin<sui::sui::SUI> {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+    balance: sui::balance::Balance<sui::sui::SUI> {
+        value: 34u64,
+    },
+}
+
+task 5, line 21:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 6, lines 23-27:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": {
+    "data": [
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
+        "version": "3",
+        "digest": "BGqvhSkz3SYePbLs4rwrKCGSjmZCQi98wj5XmPEZ3KAF",
+        "balance": "299999995026074",
+        "previousTransaction": "AasjzjtKdtrQeZqXEquUBDp3Wb8mbLziGxg6np4mhf56"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x57f42279a1d36e456374da161a332ad4f4fe7919fdb44dba456447a6f4d25e8e",
+        "version": "3",
+        "digest": "5edeWFmMJatCEtNanqj2Qx91HcBGyq9F1EzbCnbZtY69",
+        "balance": "34",
+        "previousTransaction": "AasjzjtKdtrQeZqXEquUBDp3Wb8mbLziGxg6np4mhf56"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x25c9a04c7ccfe4bba96596c73d14363121e0d6a6c979e65893877266f7f82074",
+        "version": "2",
+        "digest": "3xXGpcHsghX2BCcmWQ8CspNsWP8sD93LRdzzstTMt1Dx",
+        "balance": "12",
+        "previousTransaction": "Cuu9udTB5hRGQd5o37gNxaq4BjCU5qJiQEQzbuD7U6Y6"
+      }
+    ],
+    "nextCursor": "ICXJoEx8z+S7qWWWxz0UNjEh4NamyXnmWJOHcmb3+CB0AQAAAAAAAAABAAAAAAAAAA==",
+    "hasNextPage": false
+  }
+}
+
+task 7, line 29:
+//# transfer-object 1,0 --sender A --recipient B
+mutated: object(0,0), object(1,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 8, line 31:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 9, lines 33-37:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "data": [
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
+        "version": "4",
+        "digest": "E3ZC4SDS6NLFuUt49XLDLakLKeRt3K5Z8vRi46VWS5WH",
+        "balance": "299999994006314",
+        "previousTransaction": "7NrtfspjR8UyxKK5hQMDnZmLEbgk9WnkLwSZjchzwPyH"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x57f42279a1d36e456374da161a332ad4f4fe7919fdb44dba456447a6f4d25e8e",
+        "version": "3",
+        "digest": "5edeWFmMJatCEtNanqj2Qx91HcBGyq9F1EzbCnbZtY69",
+        "balance": "34",
+        "previousTransaction": "AasjzjtKdtrQeZqXEquUBDp3Wb8mbLziGxg6np4mhf56"
+      }
+    ],
+    "nextCursor": "IFf0Inmh025FY3TaFhozKtT0/nkZ/bRNukVkR6b00l6OAQAAAAAAAAABAAAAAAAAAA==",
+    "hasNextPage": false
+  }
+}
+
+task 10, lines 39-43:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "data": [
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0xfdc25bc3b2d2b3664199d08f5275c3a6bb360b0629ab5784672f083149163417",
+        "version": "1",
+        "digest": "4hY6HbcSgDuyD5TcKhxom1cPPdPTQtcoNUStc8BYoZt5",
+        "balance": "300000000000000",
+        "previousTransaction": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr"
+      },
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x25c9a04c7ccfe4bba96596c73d14363121e0d6a6c979e65893877266f7f82074",
+        "version": "4",
+        "digest": "CWZpsBtv4atiPHN1gt3L162sWwNXQuotS82ob6vUWC6N",
+        "balance": "12",
+        "previousTransaction": "7NrtfspjR8UyxKK5hQMDnZmLEbgk9WnkLwSZjchzwPyH"
+      }
+    ],
+    "nextCursor": "ICXJoEx8z+S7qWWWxz0UNjEh4NamyXnmWJOHcmb3+CB0AgAAAAAAAAABAAAAAAAAAA==",
+    "hasNextPage": false
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/type_filter.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/type_filter.move
@@ -1,0 +1,67 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --addresses Test=0x0 --accounts A B --simulator --objects-snapshot-min-checkpoint-lag 2
+
+//# publish --sender A
+module Test::fake {
+    use sui::coin;
+
+    public struct FAKE has drop {}
+
+    fun init(witness: FAKE, ctx: &mut TxContext){
+        let (mut treasury_cap, metadata) = coin::create_currency(
+            witness,
+            2,
+            b"FAKE",
+            b"",
+            b"",
+            option::none(),
+            ctx,
+        );
+
+        let c1 = coin::mint(&mut treasury_cap, 100, ctx);
+        let c2 = coin::mint(&mut treasury_cap, 2, ctx);
+        let c3 = coin::mint(&mut treasury_cap, 3000, ctx);
+        let c4 = coin::mint(&mut treasury_cap, 4000, ctx); // same bucket as c3
+        let c5 = coin::mint(&mut treasury_cap, 5000, ctx); // another one with the same bucket
+
+        transfer::public_freeze_object(metadata);
+        transfer::public_transfer(treasury_cap, tx_context::sender(ctx));
+        transfer::public_transfer(c1, tx_context::sender(ctx));
+        transfer::public_transfer(c2, tx_context::sender(ctx));
+        transfer::public_transfer(c3, tx_context::sender(ctx));
+        transfer::public_transfer(c4, tx_context::sender(ctx));
+        transfer::public_transfer(c5, tx_context::sender(ctx));
+    }
+}
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "suix_getCoins",
+  "params": ["@{A}", "@{Test}::fake::FAKE"]
+}
+
+//# transfer-object 1,1 --sender A --recipient B
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "suix_getCoins",
+  "params": ["@{A}", "0x2::sui::SUI"]
+}
+
+//# run-jsonrpc
+{
+  "method": "suix_getCoins",
+  "params": ["@{A}", "@{Test}::fake::FAKE", null, 2]
+}
+
+//# run-jsonrpc
+{
+  "method": "suix_getCoins",
+  "params": ["@{B}", "@{Test}::fake::FAKE", null, 1]
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/type_filter.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/type_filter.snap
@@ -1,0 +1,152 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 9 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-37:
+//# publish --sender A
+created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5), object(1,6), object(1,7)
+mutated: object(0,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 18794800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 39:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 41-45:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": {
+    "data": [
+      {
+        "coinType": "0xf5ce206aa1fffb93935caae7f35123bf471173bc2b42f77c66a035043060c071::fake::FAKE",
+        "coinObjectId": "0x78ebc8177cb90d983dcafc9c5541a20dc33f44b6058be96dbb3069202532a20a",
+        "version": "2",
+        "digest": "BmJ8PfWvoR8xKBLFGhtfCewi9w13tjCTwwvvQ5k7xkmd",
+        "balance": "4000",
+        "previousTransaction": "4Mpg2JTgZa2pt8akvsiqazRZohAbsVBUVVemra6eAR3d"
+      },
+      {
+        "coinType": "0xf5ce206aa1fffb93935caae7f35123bf471173bc2b42f77c66a035043060c071::fake::FAKE",
+        "coinObjectId": "0x432c7c87c609b5c9e4cf20816a4d293ba11fd6c13613a13ffcc4b17220779072",
+        "version": "2",
+        "digest": "Fo22wjk5H3iVDc6xe9e22Rje2hApm5HBLn5roSyhTWsP",
+        "balance": "5000",
+        "previousTransaction": "4Mpg2JTgZa2pt8akvsiqazRZohAbsVBUVVemra6eAR3d"
+      },
+      {
+        "coinType": "0xf5ce206aa1fffb93935caae7f35123bf471173bc2b42f77c66a035043060c071::fake::FAKE",
+        "coinObjectId": "0x1c06fe536adc913b33082885c9deb5243f617a4810f4d6895d9ca78c5613b041",
+        "version": "2",
+        "digest": "CCUct1nMqHYvTWspP59DUSYH1sYYW129ckUuksahU9G",
+        "balance": "3000",
+        "previousTransaction": "4Mpg2JTgZa2pt8akvsiqazRZohAbsVBUVVemra6eAR3d"
+      },
+      {
+        "coinType": "0xf5ce206aa1fffb93935caae7f35123bf471173bc2b42f77c66a035043060c071::fake::FAKE",
+        "coinObjectId": "0xc6e3d02b9a0160f25578ec0f8f6de719fa642f647179dfbf057ff857d9f5c975",
+        "version": "2",
+        "digest": "Aje2LLNb1R3tpLnFcZ3P1UYs8afQ9XQhPKatPvp9LD6V",
+        "balance": "100",
+        "previousTransaction": "4Mpg2JTgZa2pt8akvsiqazRZohAbsVBUVVemra6eAR3d"
+      },
+      {
+        "coinType": "0xf5ce206aa1fffb93935caae7f35123bf471173bc2b42f77c66a035043060c071::fake::FAKE",
+        "coinObjectId": "0x89937febb73cf783a63724b12bdfdc8112aeaac78466b463710506aa72624317",
+        "version": "2",
+        "digest": "DEX2jGJyLHDkDSDNVA5iL8uubMZrk7SjDShPSdyVBsQN",
+        "balance": "2",
+        "previousTransaction": "4Mpg2JTgZa2pt8akvsiqazRZohAbsVBUVVemra6eAR3d"
+      }
+    ],
+    "nextCursor": "IImTf+u3PPeDpjcksSvf3IESrqrHhGa0Y3EFBqpyYkMXAQAAAAAAAAAAAAAAAAAAAA==",
+    "hasNextPage": false
+  }
+}
+
+task 4, line 47:
+//# transfer-object 1,1 --sender A --recipient B
+mutated: object(0,0), object(1,1)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 2310400,  storage_rebate: 2287296, non_refundable_storage_fee: 23104
+
+task 5, line 49:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 6, lines 51-55:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "data": [
+      {
+        "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+        "coinObjectId": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
+        "version": "3",
+        "digest": "Cy2yHmJFWTiwEBvNCi9XQRsh4eGgyw5UbcuToXEdvne3",
+        "balance": "299999979182096",
+        "previousTransaction": "B7wzuNdFRBBbPeMDHibh4rLLFvFsNHb4uAuoX4KVTxao"
+      }
+    ],
+    "nextCursor": "ICg02F2/79zWbwSBEjG6gYiTeT6DqJXVNAL9meEy42ViAAAAAAAAAAAOAAAAAAAAAA==",
+    "hasNextPage": false
+  }
+}
+
+task 7, lines 57-61:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "data": [
+      {
+        "coinType": "0xf5ce206aa1fffb93935caae7f35123bf471173bc2b42f77c66a035043060c071::fake::FAKE",
+        "coinObjectId": "0x78ebc8177cb90d983dcafc9c5541a20dc33f44b6058be96dbb3069202532a20a",
+        "version": "2",
+        "digest": "BmJ8PfWvoR8xKBLFGhtfCewi9w13tjCTwwvvQ5k7xkmd",
+        "balance": "4000",
+        "previousTransaction": "4Mpg2JTgZa2pt8akvsiqazRZohAbsVBUVVemra6eAR3d"
+      },
+      {
+        "coinType": "0xf5ce206aa1fffb93935caae7f35123bf471173bc2b42f77c66a035043060c071::fake::FAKE",
+        "coinObjectId": "0x432c7c87c609b5c9e4cf20816a4d293ba11fd6c13613a13ffcc4b17220779072",
+        "version": "2",
+        "digest": "Fo22wjk5H3iVDc6xe9e22Rje2hApm5HBLn5roSyhTWsP",
+        "balance": "5000",
+        "previousTransaction": "4Mpg2JTgZa2pt8akvsiqazRZohAbsVBUVVemra6eAR3d"
+      }
+    ],
+    "nextCursor": "IEMsfIfGCbXJ5M8ggWpNKTuhH9bBNhOhP/zEsXIgd5ByAQAAAAAAAAADAAAAAAAAAA==",
+    "hasNextPage": true
+  }
+}
+
+task 8, lines 63-67:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "data": [
+      {
+        "coinType": "0xf5ce206aa1fffb93935caae7f35123bf471173bc2b42f77c66a035043060c071::fake::FAKE",
+        "coinObjectId": "0x1c06fe536adc913b33082885c9deb5243f617a4810f4d6895d9ca78c5613b041",
+        "version": "3",
+        "digest": "7yfjHoKjSWC9hGFPCWR92aXGKNnfnLkRViVGtU6zw9CS",
+        "balance": "3000",
+        "previousTransaction": "B7wzuNdFRBBbPeMDHibh4rLLFvFsNHb4uAuoX4KVTxao"
+      }
+    ],
+    "nextCursor": "IBwG/lNq3JE7MwgohcnetSQ/YXpIEPTWiV2cp4xWE7BBAgAAAAAAAAADAAAAAAAAAA==",
+    "hasNextPage": false
+  }
+}

--- a/crates/sui-indexer-alt-jsonrpc/src/api/coin.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/coin.rs
@@ -1,0 +1,278 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Context as _;
+use futures::future;
+
+use super::rpc_module::RpcModule;
+use crate::context::Context;
+use crate::data::objects::load_latest;
+use crate::error::{invalid_params, InternalContext, RpcError};
+use crate::paginate::{BcsCursor, Cursor as _, Page};
+use diesel::dsl::sql;
+use diesel::prelude::*;
+use diesel::sql_types::{BigInt, Bool, Bytea, SmallInt};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use move_core_types::language_storage::TypeTag;
+use serde::{Deserialize, Serialize};
+use sui_indexer_alt_schema::objects::StoredCoinOwnerKind;
+use sui_indexer_alt_schema::schema::coin_balance_buckets;
+use sui_json_rpc_types::{Coin, Page as PageResponse};
+use sui_open_rpc::Module;
+use sui_open_rpc_macros::open_rpc;
+use sui_types::{
+    base_types::{ObjectID, SuiAddress},
+    gas_coin::GAS,
+};
+
+#[open_rpc(namespace = "suix", tag = "Coin API")]
+#[rpc(server, namespace = "suix")]
+trait CoinsApi {
+    /// Return Coin objects owned by an address with a specified coin type.
+    /// If no coin type is specified, SUI coins are returned.
+    #[method(name = "getCoins")]
+    async fn get_coins(
+        &self,
+        /// the owner's Sui address
+        owner: SuiAddress,
+        /// optional coin type
+        coin_type: Option<String>,
+        /// optional paging cursor
+        cursor: Option<String>,
+        /// maximum number of items per page
+        limit: Option<usize>,
+    ) -> RpcResult<PageResponse<Coin, String>>;
+}
+
+pub(crate) struct Coins(pub Context, pub CoinsConfig);
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CoinsConfig {
+    /// The default page size limit when querying coins, if none is provided.
+    pub default_page_size: usize,
+
+    /// The largest acceptable page size when querying coins. Requesting a page larger than
+    /// this is a user error.
+    pub max_page_size: usize,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum Error {
+    #[error("Pagination issue: {0}")]
+    Pagination(#[from] crate::paginate::Error),
+
+    #[error("Failed to parse type {0:?}: {1}")]
+    BadType(String, anyhow::Error),
+}
+
+#[derive(Queryable, Debug, Serialize, Deserialize)]
+#[diesel(table_name = coin_balance_buckets)]
+struct BalanceCursor {
+    object_id: Vec<u8>,
+    cp_sequence_number: u64,
+    coin_balance_bucket: u64,
+}
+
+type Cursor = BcsCursor<BalanceCursor>;
+
+#[async_trait::async_trait]
+impl CoinsApiServer for Coins {
+    async fn get_coins(
+        &self,
+        owner: SuiAddress,
+        coin_type: Option<String>,
+        cursor: Option<String>,
+        limit: Option<usize>,
+    ) -> RpcResult<PageResponse<Coin, String>> {
+        let coin_type_tag = if let Some(coin_type) = coin_type {
+            sui_types::parse_sui_type_tag(&coin_type)
+                .map_err(|e| invalid_params(Error::BadType(coin_type, e)))?
+        } else {
+            GAS::type_tag()
+        };
+
+        let Self(ctx, config) = self;
+
+        let page: Page<Cursor> = Page::from_params::<Error>(
+            config.default_page_size,
+            config.max_page_size,
+            cursor,
+            limit,
+            None,
+        )?;
+
+        // We get all the qualified coin ids first.
+        let coin_id_page = filter_coins(ctx, owner, coin_type_tag, page).await?;
+
+        let coin_futures = coin_id_page.data.iter().map(|id| coin_response(ctx, *id));
+
+        let coins = future::join_all(coin_futures)
+            .await
+            .into_iter()
+            .zip(coin_id_page.data)
+            .map(|(r, id)| r.with_internal_context(|| format!("Failed to get object {id}")))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(PageResponse {
+            data: coins,
+            next_cursor: coin_id_page.next_cursor,
+            has_next_page: coin_id_page.has_next_page,
+        })
+    }
+}
+
+impl RpcModule for Coins {
+    fn schema(&self) -> Module {
+        CoinsApiOpenRpc::module_doc()
+    }
+
+    fn into_impl(self) -> jsonrpsee::RpcModule<Self> {
+        self.into_rpc()
+    }
+}
+
+impl Default for CoinsConfig {
+    fn default() -> Self {
+        Self {
+            default_page_size: 50,
+            max_page_size: 100,
+        }
+    }
+}
+
+async fn filter_coins(
+    ctx: &Context,
+    owner: SuiAddress,
+    coin_type_tag: TypeTag,
+    page: Page<Cursor>,
+) -> Result<PageResponse<ObjectID, String>, RpcError<Error>> {
+    use coin_balance_buckets::dsl as cb;
+
+    let mut conn = ctx
+        .pg_reader()
+        .connect()
+        .await
+        .context("Failed to connect to database")?;
+
+    let limit = page.limit;
+
+    let serialized_coin_type =
+        bcs::to_bytes(&coin_type_tag).context("Failed to serialize coin type tag")?;
+
+    // We use two aliases of coin_balance_buckets to make the query more readable.
+    let (candidates, newer) = diesel::alias!(
+        coin_balance_buckets as candidates,
+        coin_balance_buckets as newer
+    );
+
+    // Macros to make the query more readable.
+    macro_rules! candidates {
+        ($field:ident) => {
+            candidates.field(cb::$field)
+        };
+    }
+
+    macro_rules! newer {
+        ($field:ident) => {
+            newer.field(cb::$field)
+        };
+    }
+
+    // Construct the basic query first to filter by owner, not deleted and newest rows.
+    let mut query = candidates
+        .select((
+            candidates!(object_id),
+            candidates!(cp_sequence_number),
+            candidates!(coin_balance_bucket).assume_not_null(),
+        ))
+        .left_join(
+            newer.on(candidates!(object_id)
+                .eq(newer!(object_id))
+                .and(candidates!(cp_sequence_number).lt(newer!(cp_sequence_number)))),
+        )
+        .filter(newer!(object_id).is_null())
+        .filter(candidates!(owner_kind).eq(StoredCoinOwnerKind::Fastpath))
+        .filter(candidates!(owner_id).eq(owner.to_vec()))
+        .filter(candidates!(coin_type).eq(serialized_coin_type))
+        .into_boxed();
+
+    // If the cursor is specified, we filter by it.
+    if let Some(c) = page.cursor {
+        query = query.filter(
+            sql::<Bool>(r"(candidates.coin_balance_bucket, candidates.cp_sequence_number, candidates.object_id) < (")
+                .bind::<SmallInt, _>(c.coin_balance_bucket as i16)
+                .sql(", ")
+                .bind::<BigInt, _>(c.cp_sequence_number as i64)
+                .sql(", ")
+                .bind::<Bytea, _>(c.object_id.clone())
+                .sql(")")
+        );
+    }
+
+    // Finally we order by coin_balance_bucket, then by cp_sequence_number, and then by object_id.
+    query = query
+        .order_by(candidates!(coin_balance_bucket).desc())
+        .then_order_by(candidates!(cp_sequence_number).desc())
+        .then_order_by(candidates!(object_id).desc())
+        .limit(limit + 1);
+
+    let mut buckets: Vec<(Vec<u8>, i64, i16)> =
+        conn.results(query).await.context("Failed to query coins")?;
+
+    // Now gather pagination info.
+    let has_next_page = buckets.len() > limit as usize;
+    if has_next_page {
+        buckets.truncate(limit as usize);
+    }
+
+    let next_cursor = buckets
+        .last()
+        .map(|(object_id, cp_sequence_number, coin_balance_bucket)| {
+            BcsCursor(BalanceCursor {
+                object_id: object_id.clone(),
+                cp_sequence_number: *cp_sequence_number as u64,
+                coin_balance_bucket: *coin_balance_bucket as u64,
+            })
+            .encode()
+        })
+        .transpose()
+        .context("Failed to encode cursor")?;
+
+    let ids = buckets
+        .iter()
+        .map(|(object_id, _, _)| ObjectID::from_bytes(object_id))
+        .collect::<Result<Vec<_>, _>>()
+        .context("Failed to parse object id")?;
+
+    Ok(PageResponse {
+        data: ids,
+        next_cursor,
+        has_next_page,
+    })
+}
+
+async fn coin_response(ctx: &Context, id: ObjectID) -> Result<Coin, RpcError<Error>> {
+    let object = load_latest(ctx, id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("Failed to load latest object {}", id))?;
+
+    let coin_object_id = object.id();
+    let digest = object.digest();
+    let version = object.version();
+    let previous_transaction = object.as_inner().previous_transaction;
+    let coin = object
+        .as_coin_maybe()
+        .context("Object is expected to be a coin")?;
+    let coin_type = object
+        .coin_type_maybe()
+        .context("Object is expected to have a coin type")?
+        .to_canonical_string(/* with_prefix */ true);
+    Ok(Coin {
+        coin_type,
+        coin_object_id,
+        version,
+        digest,
+        balance: coin.balance.value(),
+        previous_transaction,
+    })
+}

--- a/crates/sui-indexer-alt-jsonrpc/src/api/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub(crate) mod checkpoints;
+pub(crate) mod coin;
 pub(crate) mod dynamic_fields;
 pub(crate) mod governance;
 pub(crate) mod move_utils;

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use api::checkpoints::Checkpoints;
+use api::coin::{Coins, CoinsConfig};
 use api::dynamic_fields::DynamicFields;
 use api::move_utils::MoveUtils;
 use api::name_service::NameService;
@@ -217,6 +218,7 @@ pub async fn start_rpc(
         objects,
         transactions,
         name_service,
+        coins,
         bigtable_config,
         extra: _,
     } = rpc_config.finish();
@@ -224,6 +226,7 @@ pub async fn start_rpc(
     let objects_config = objects.finish(ObjectsConfig::default());
     let transactions_config = transactions.finish(TransactionsConfig::default());
     let name_service_config = name_service.finish(NameServiceConfig::default());
+    let coins_config = coins.finish(CoinsConfig::default());
 
     let mut rpc = RpcService::new(rpc_args, registry, cancel.child_token())
         .context("Failed to create RPC service")?;
@@ -237,6 +240,7 @@ pub async fn start_rpc(
     );
 
     rpc.add_module(Checkpoints(context.clone()))?;
+    rpc.add_module(Coins(context.clone(), coins_config))?;
     rpc.add_module(DynamicFields(context.clone()))?;
     rpc.add_module(Governance(context.clone()))?;
     rpc.add_module(MoveUtils(context.clone()))?;


### PR DESCRIPTION
## Description 

This PR added indexer alt jsonrpc reader implementation for `getCoins` and `getAllCoins`. I ported over `raw_query` from graphql crate for usage here.

## Test plan 

Added e2e tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
