### PR TITLE
[cli] Allow to switch from localnet that is not running to another network

### DIFF
--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -456,6 +456,14 @@ impl SuiCommand {
                 prompt_if_no_config(&config_path, accept_defaults).await?;
                 if let Some(cmd) = cmd {
                     let mut context = WalletContext::new(&config_path, None, None)?;
+                    // we need to allow switching from localnet to another network; if a local
+                    // network is not running and we want to switch to another network, the code
+                    // will throw a low level network error because it cannot connect to the
+                    // network to fetch the api version.
+                    if let SuiClientCommands::Switch { .. } = cmd {
+                        cmd.execute(&mut context).await?.print(!json);
+                        return Ok(());
+                    }
                     if let Err(e) = context.get_client().await?.check_api_version() {
                         eprintln!("{}", format!("[warning] {e}").yellow().bold());
                     }


### PR DESCRIPTION
## Description 

When CLI is set to localnet and a local network is not running, switching to another network in the CLI throws an error. This PR fixes that.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
