### PR TITLE
sui-http: support http upgrades

### DIFF
--- a/crates/sui-http/src/connection_handler.rs
+++ b/crates/sui-http/src/connection_handler.rs
@@ -21,14 +21,14 @@ pub async fn serve_connection<IO, S, B, C>(
     B: http_body::Body + Send + 'static,
     B::Data: Send,
     B::Error: Into<BoxError>,
-    IO: hyper::rt::Read + hyper::rt::Write + Unpin + 'static,
+    IO: hyper::rt::Read + hyper::rt::Write + Send + Unpin + 'static,
     S: hyper::service::Service<Request<hyper::body::Incoming>, Response = Response<B>> + 'static,
     S::Future: Send + 'static,
     S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
     let mut sig = pin!(Fuse::new(graceful_shutdown_token.cancelled_owned()));
 
-    let mut conn = pin!(builder.serve_connection(hyper_io, hyper_svc));
+    let mut conn = pin!(builder.serve_connection_with_upgrades(hyper_io, hyper_svc));
 
     let sleep = sleep_or_pending(max_connection_age);
     tokio::pin!(sleep);


### PR DESCRIPTION
Change sui-http to serve an http connection that supports http upgrades.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
