### PR TITLE
sui-rosetta: fix panic when setting usize::MAX max_concurrent_requests

### DIFF
--- a/crates/sui-rosetta/src/main.rs
+++ b/crates/sui-rosetta/src/main.rs
@@ -186,11 +186,7 @@ impl RosettaServerCommand {
 
 async fn wait_for_sui_client(rpc_address: String) -> SuiClient {
     loop {
-        match SuiClientBuilder::default()
-            .max_concurrent_requests(usize::MAX)
-            .build(&rpc_address)
-            .await
-        {
+        match SuiClientBuilder::default().build(&rpc_address).await {
             Ok(client) => return client,
             Err(e) => {
                 warn!("Error connecting to Sui RPC server [{rpc_address}]: {e}, retrying in 5 seconds.");


### PR DESCRIPTION
This fixes a panic that was seen when rosetta constructs a jsonrpc client with max_concurrent_requests of usize::MAX by changing how client construction happens to have the default be to disable any limit in concurrent requests (which is essentially what rosetta was trying to do).

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
