### PR TITLE
fix(sui-keys): enforce alias uniqueness in `AccountKeystore::update_alias_value`

### DIFF
--- a/crates/sui-keys/src/keystore.rs
+++ b/crates/sui-keys/src/keystore.rs
@@ -82,16 +82,7 @@ pub trait AccountKeystore: Send + Sync {
         if !self.alias_exists(old_alias) {
             bail!("The provided alias {old_alias} does not exist");
         }
-        let new_alias_name = match new_alias {
-            Some(x) => validate_alias(x)?,
-            None => random_name(
-                &self
-                    .alias_names()
-                    .into_iter()
-                    .map(|x| x.to_string())
-                    .collect::<HashSet<_>>(),
-            ),
-        };
+        let new_alias_name = self.create_alias(new_alias.map(str::to_string))?;
         for a in self.aliases_mut() {
             if a.alias == old_alias {
                 let pk = &a.public_key_base64;

--- a/crates/sui-keys/tests/tests.rs
+++ b/crates/sui-keys/tests/tests.rs
@@ -163,6 +163,19 @@ fn update_alias_test() {
     let update = keystore.update_alias("o", None).unwrap();
     let aliases = keystore.alias_names();
     assert_eq!(vec![&update], aliases);
+
+    // check that updating alias does not allow duplicates
+    keystore
+        .generate_and_add_new_key(
+            SignatureScheme::ED25519,
+            Some("my_alias_test".to_string()),
+            None,
+            None,
+        )
+        .unwrap();
+    assert!(keystore
+        .update_alias("my_alias_test", Some(&update))
+        .is_err());
 }
 
 #[test]


### PR DESCRIPTION
## Description 

Key aliases uniqueness is enforced by `sui client new-address` but not by `sui keytool update-alias`.
This patch reuses `AccountKeystore::create_alias` in `AccountKeystore::update_alias_value` as it has the exact same body + the uniqueness check.

Porting of https://github.com/iotaledger/iota/pull/4957.

## Test plan 

### Before

```
thibault@Thibaults-MacBook-Pro-2 ~/i/sui (testnet)> ./target/debug/sui client new-address ed25519 tibo
╭────────────────────────────────────────────────────────────────────────────────────────╮
│ Created new keypair and saved it to keystore.                                          │
├────────────────┬───────────────────────────────────────────────────────────────────────┤
│ alias          │ tibo                                                                  │
│ address        │ 0x824de7ba15a8d4418b076b7c559ab9f961c8408ba483e6cfb95e5e3c62ccbe3a    │
│ keyScheme      │ ed25519                                                               │
│ recoveryPhrase │ pulse pitch climb horse fancy pottery trim behind latin man off owner │
╰────────────────┴───────────────────────────────────────────────────────────────────────╯

thibault@Thibaults-MacBook-Pro-2 ~/i/sui (testnet)> ./target/debug/sui client new-address ed25519
╭─────────────────────────────────────────────────────────────────────────────────────────╮
│ Created new keypair and saved it to keystore.                                           │
├────────────────┬────────────────────────────────────────────────────────────────────────┤
│ alias          │ jovial-sunstone                                                        │
│ address        │ 0x9922cf533eb226319fcb881248abb0275e222102fae5d885712a8592bffa6cfe     │
│ keyScheme      │ ed25519                                                                │
│ recoveryPhrase │ seven taxi off supreme long where cube pond urban bacon vendor inquiry │
╰────────────────┴────────────────────────────────────────────────────────────────────────╯

thibault@Thibaults-MacBook-Pro-2 ~/i/sui (testnet)> ./target/debug/sui keytool update-alias jovial-sunstone tibo
Old alias jovial-sunstone was updated to tibo

thibault@Thibaults-MacBook-Pro-2 ~/i/sui (testnet)> ./target/debug/sui keytool list
╭────────────────────────────────────────────────────────────────────────────────────────────╮
│ ╭─────────────────┬──────────────────────────────────────────────────────────────────────╮ │
│ │ alias           │  eloquent-sapphire                                                   │ │
│ │ suiAddress      │  0x431462e54270a0f122cffb8763668636b3b9494a32ceb19e2c4feeb25aff68d8  │ │
│ │ publicBase64Key │  APWU7kcr0zoyajawSZW+P19hEtbQeXHlF4nNRaeadjBn                        │ │
│ │ keyScheme       │  ed25519                                                             │ │
│ │ flag            │  0                                                                   │ │
│ │ peerId          │  f594ee472bd33a326a36b04995be3f5f6112d6d07971e51789cd45a79a763067    │ │
│ ╰─────────────────┴──────────────────────────────────────────────────────────────────────╯ │
│ ╭─────────────────┬──────────────────────────────────────────────────────────────────────╮ │
│ │ alias           │  tibo                                                                │ │
│ │ suiAddress      │  0x824de7ba15a8d4418b076b7c559ab9f961c8408ba483e6cfb95e5e3c62ccbe3a  │ │
│ │ publicBase64Key │  AEjuRwtqQZDH1qzle37XZkLSMvaiTebH714NmLACgLlb                        │ │
│ │ keyScheme       │  ed25519                                                             │ │
│ │ flag            │  0                                                                   │ │
│ │ peerId          │  48ee470b6a4190c7d6ace57b7ed76642d232f6a24de6c7ef5e0d98b00280b95b    │ │
│ ╰─────────────────┴──────────────────────────────────────────────────────────────────────╯ │
│ ╭─────────────────┬──────────────────────────────────────────────────────────────────────╮ │
│ │ alias           │  tibo                                                                │ │
│ │ suiAddress      │  0x9922cf533eb226319fcb881248abb0275e222102fae5d885712a8592bffa6cfe  │ │
│ │ publicBase64Key │  AObvWmDSBDjvGfbqFuhzpTd2Lucr9RRIhPRw/s5j74Yx                        │ │
│ │ keyScheme       │  ed25519                                                             │ │
│ │ flag            │  0                                                                   │ │
│ │ peerId          │  e6ef5a60d20438ef19f6ea16e873a537762ee72bf5144884f470fece63ef8631    │ │
│ ╰─────────────────┴──────────────────────────────────────────────────────────────────────╯ │
╰────────────────────────────────────────────────────────────────────────────────────────────╯
```

### After

```
thibault@7f037d7e-e260-4d40-8338-8f1c07fb52d4 ~/i/sui (testnet)> ./target/debug/sui client new-address ed25519 tibo
╭───────────────────────────────────────────────────────────────────────────────────────────────╮
│ Created new keypair and saved it to keystore.                                                 │
├────────────────┬──────────────────────────────────────────────────────────────────────────────┤
│ alias          │ tibo                                                                         │
│ address        │ 0x2a25b9deee5c30f492006d64724469e5fd0e229826d5bcfe0c101b2809f6926b           │
│ keyScheme      │ ed25519                                                                      │
│ recoveryPhrase │ version pitch iron onion hire diamond film recycle update stem subject fault │
╰────────────────┴──────────────────────────────────────────────────────────────────────────────╯

thibault@7f037d7e-e260-4d40-8338-8f1c07fb52d4 ~/i/sui (testnet)> ./target/debug/sui client new-address ed25519
╭───────────────────────────────────────────────────────────────────────────────────────╮
│ Created new keypair and saved it to keystore.                                         │
├────────────────┬──────────────────────────────────────────────────────────────────────┤
│ alias          │ competent-alexandrite                                                │
│ address        │ 0x9123e41292c8774c23aa6dbd2a9baccc670c8df8a5330065aa3dd0fa60ba5c54   │
│ keyScheme      │ ed25519                                                              │
│ recoveryPhrase │ gauge slam flush shove catalog front orient split try fee tone essay │
╰────────────────┴──────────────────────────────────────────────────────────────────────╯

thibault@7f037d7e-e260-4d40-8338-8f1c07fb52d4 ~/i/sui (testnet)> ./target/debug/sui keytool update-alias competent-alexandrite tibo
Alias tibo already exists. Please choose another alias.
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Fixed the CLI `keytool update-alias` command to not allow duplicate aliases.
- [ ] Rust SDK:
