### PR TITLE
[Consensus] enable consensus gc and the new linearizer logic for simtests

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1714,7 +1714,12 @@ impl ProtocolConfig {
     }
 
     pub fn gc_depth(&self) -> u32 {
-        self.consensus_gc_depth.unwrap_or(0)
+        if cfg!(msim) {
+            // exercise a very low gc_depth
+            5
+        } else {
+            self.consensus_gc_depth.unwrap_or(0)
+        }
     }
 
     pub fn mysticeti_fastpath(&self) -> bool {
@@ -1751,7 +1756,11 @@ impl ProtocolConfig {
     }
 
     pub fn consensus_linearize_subdag_v2(&self) -> bool {
-        let res = self.feature_flags.consensus_linearize_subdag_v2;
+        let res = if cfg!(msim) {
+            true
+        } else {
+            self.feature_flags.consensus_linearize_subdag_v2
+        };
         assert!(
             !res || self.gc_depth() > 0,
             "The consensus linearize sub dag V2 requires GC to be enabled"


### PR DESCRIPTION
## Description 

The plan is to enable for simtest only for a few days. If everything is ok then we can enable for testing & devnet environments https://github.com/MystenLabs/sui/pull/20258

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
