### PR TITLE
[trace-view] Start debugging in disassembly

### DIFF
--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/runtime.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/runtime.ts
@@ -268,15 +268,16 @@ export class Runtime extends EventEmitter {
     /**
      * Start a trace viewing session and set up the initial state of the runtime.
      *
-     * @param source  path to the Move source file whose traces are to be viewed.
+     * @param openedFilePath path to the Move source file (or disassembled bytecode file)
+     * whose traces are to be viewed.
      * @param traceInfo  trace selected for viewing.
      * @throws Error with a descriptive error message if starting runtime has failed.
      *
      */
-    public async start(source: string, traceInfo: string, stopOnEntry: boolean): Promise<void> {
-        const pkgRoot = await findPkgRoot(source);
+    public async start(openedFilePath: string, traceInfo: string, stopOnEntry: boolean): Promise<void> {
+        const pkgRoot = await findPkgRoot(openedFilePath);
         if (!pkgRoot) {
-            throw new Error(`Cannot find package root for file: ${source}`);
+            throw new Error(`Cannot find package root for file: ${openedFilePath}`);
         }
         const manifest_path = path.join(pkgRoot, 'Move.toml');
 
@@ -286,6 +287,12 @@ export class Runtime extends EventEmitter {
         if (!pkg_name) {
             throw Error(`Cannot find package name in manifest file: ${manifest_path}`);
         }
+
+        const opendFileExt = path.extname(openedFilePath);
+        if (opendFileExt !== MOVE_FILE_EXT && opendFileExt !== BCODE_FILE_EXT) {
+            throw new Error(`File extension: ${opendFileExt} is not supported by trace debugger`);
+        }
+        const showDisassembly = opendFileExt === BCODE_FILE_EXT;
 
         // create file maps for all files in the `sources` directory, including both package source
         // files and source files for dependencies
@@ -335,6 +342,7 @@ export class Runtime extends EventEmitter {
                 currentEvent.optimizedSrcLines,
                 currentEvent.optimizedBcodeLines
             );
+        newFrame.showDisassembly = showDisassembly;
         this.frameStack = {
             frames: [newFrame],
             globals: new Map<number, RuntimeValueType>()

--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/runtime.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/runtime.ts
@@ -289,7 +289,9 @@ export class Runtime extends EventEmitter {
         }
 
         const opendFileExt = path.extname(openedFilePath);
-        if (opendFileExt !== MOVE_FILE_EXT && opendFileExt !== BCODE_FILE_EXT) {
+        if (opendFileExt !== MOVE_FILE_EXT
+            && opendFileExt !== BCODE_FILE_EXT
+            && opendFileExt !== JSON_FILE_EXT) {
             throw new Error(`File extension: ${opendFileExt} is not supported by trace debugger`);
         }
         const showDisassembly = opendFileExt === BCODE_FILE_EXT;

--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/runtime.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/runtime.ts
@@ -288,13 +288,13 @@ export class Runtime extends EventEmitter {
             throw Error(`Cannot find package name in manifest file: ${manifest_path}`);
         }
 
-        const opendFileExt = path.extname(openedFilePath);
-        if (opendFileExt !== MOVE_FILE_EXT
-            && opendFileExt !== BCODE_FILE_EXT
-            && opendFileExt !== JSON_FILE_EXT) {
-            throw new Error(`File extension: ${opendFileExt} is not supported by trace debugger`);
+        const openedFileExt = path.extname(openedFilePath);
+        if (openedFileExt !== MOVE_FILE_EXT
+            && openedFileExt !== BCODE_FILE_EXT
+            && openedFileExt !== JSON_FILE_EXT) {
+            throw new Error(`File extension: ${openedFileExt} is not supported by trace debugger`);
         }
-        const showDisassembly = opendFileExt === BCODE_FILE_EXT;
+        const showDisassembly = openedFileExt === BCODE_FILE_EXT;
 
         // create file maps for all files in the `sources` directory, including both package source
         // files and source files for dependencies

--- a/external-crates/move/crates/move-analyzer/trace-debug/package.json
+++ b/external-crates/move/crates/move-analyzer/trace-debug/package.json
@@ -55,6 +55,16 @@
           "extensions": [
             ".mvb"
           ]
+        },
+        {
+          "id": "mtrace",
+          "aliases": [
+            "mtrace"
+          ],
+          "extensions": [
+            ".json",
+            ".JSON"
+          ]
         }
       ],
     "breakpoints": [{ "language": "move" }, { "language": "mvb" }],
@@ -69,7 +79,8 @@
         ],
         "languages": [
           "move",
-          "mvb"
+          "mvb",
+          "mtrace"
         ],
         "configurationAttributes": {
           "launch": {

--- a/external-crates/move/crates/move-analyzer/trace-debug/package.json
+++ b/external-crates/move/crates/move-analyzer/trace-debug/package.json
@@ -5,7 +5,7 @@
   "publisher": "mysten",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "preview": true,
   "repository": {
     "url": "https://github.com/MystenLabs/sui.git",

--- a/external-crates/move/crates/move-analyzer/trace-debug/src/extension.ts
+++ b/external-crates/move/crates/move-analyzer/trace-debug/src/extension.ts
@@ -23,6 +23,10 @@ const LOG_LEVEL = 'log';
  */
 const DEBUGGER_TYPE = 'move-debug';
 
+const MOVE_FILE_EXT = ".move";
+const BCODE_FILE_EXT = ".mvb";
+
+
 /**
  * Provider of on-hover information during debug session.
  */
@@ -84,10 +88,6 @@ export function activate(context: vscode.ExtensionContext) {
                     const stackFrame: StackFrame = stackTraceResponse.stackFrames[0];
                     if (stackFrame && stackFrame.source && stackFrame.source.path !== previousSourcePath) {
                         previousSourcePath = stackFrame.source.path;
-                        const source = stackFrame.source;
-                        const line = stackFrame.line;
-                        console.log(`Frame details: ${source?.name} at line ${line}`);
-
                         const editor = vscode.window.activeTextEditor;
                         if (editor) {
                             const optimized_lines = stackTraceResponse.optimizedLines;
@@ -227,13 +227,13 @@ async function findTraceInfo(editor: vscode.TextEditor): Promise<string> {
     }
 
     let tracedFunctions: string[] = [];
-    if (path.extname(editor.document.uri.fsPath) === '.move') {
+    if (path.extname(editor.document.uri.fsPath) === MOVE_FILE_EXT) {
         const pkgModules = findSrcModules(editor.document.getText());
         if (pkgModules.length === 0) {
             throw new Error(`Cannot find any modules in file '${editor.document.uri.fsPath}'`);
         }
         tracedFunctions = findTracedFunctionsFromPath(pkgRoot, pkgModules);
-    } else if (path.extname(editor.document.uri.fsPath) === '.mvb') {
+    } else if (path.extname(editor.document.uri.fsPath) === BCODE_FILE_EXT) {
         const modulePattern = /\bmodule\s+\d+\.\w+\b/g;
         const moduleSequences = editor.document.getText().match(modulePattern);
         if (!moduleSequences || moduleSequences.length === 0) {


### PR DESCRIPTION
## Description 

This PR adds the ability to start trace debugging a unit test with an assembly file (rather than a source file) in active editor


## Test plan 

Tested manually that one can start debugging with a disassembly file opened
