### PR TITLE
[move][move-vm][rewrite][cleanup 1/n]  Replace signature index references with VM Pointers

### DIFF
--- a/external-crates/move/crates/move-cli/tests/sandbox_tests/print_stack_trace/args.exp
+++ b/external-crates/move/crates/move-cli/tests/sandbox_tests/print_stack_trace/args.exp
@@ -21,7 +21,7 @@ Call Stack:
 
         Code:
             [10] LdU64(1)
-            [11] VecImmBorrow(2)
+            [11] VecImmBorrow(Bool)
             [12] StLoc(0)
           > [13] CallGeneric(0)
             [14] StLoc(2)

--- a/external-crates/move/crates/move-vm-runtime/src/cache/arena.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/cache/arena.rs
@@ -34,6 +34,14 @@ impl Arena {
         let slice = self.0.alloc_slice_fill_iter(items);
         slice as *mut [T]
     }
+
+    /// SAFETY: it is the caller's responsibility to ensure that `self` is not shared across
+    /// threads during this call. This should be fine as the translation step that uses an arena
+    /// should happen in a thread that holds that arena, with no other contention for allocation
+    /// into it, and nothing should allocate into a LoadedModule after it is loaded.
+    pub fn alloc_item<T>(&self, item: T) -> *mut T {
+        self.0.alloc(item) as *mut T
+    }
 }
 
 // -----------------------------------------------

--- a/external-crates/move/crates/move-vm-runtime/src/dev_utils/in_memory_test_adapter.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/dev_utils/in_memory_test_adapter.rs
@@ -120,7 +120,8 @@ impl VMTestAdapter<InMemoryStorage> for InMemoryTestAdapter {
         package: SerializedPackage,
     ) -> VMResult<(verif_ast::Package, MoveVM<'extensions>)> {
         let Some(storage_id) = package.linkage_table.get(&runtime_id).cloned() else {
-            // TODO: VM error instead?
+            // NB: This is a panic because it means something went really wrong -- we should always
+            // panic if we expect a package to exist and it is not there.
             panic!("Did not find runtime ID {runtime_id} in linkage context.");
         };
         assert_eq!(storage_id, package.storage_id);
@@ -140,7 +141,8 @@ impl VMTestAdapter<InMemoryStorage> for InMemoryTestAdapter {
         package: verif_ast::Package,
     ) -> VMResult<()> {
         let Some(storage_id) = package.linkage_table.get(&runtime_id).cloned() else {
-            // TODO: VM error instead?
+            // NB: This is a panic because it means something went really wrong -- we should always
+            // panic if we expect a package to exist and it is not there.
             panic!("Did not find runtime ID {runtime_id} in linkage context.");
         };
         assert!(storage_id == package.storage_id);

--- a/external-crates/move/crates/move-vm-runtime/src/execution/vm.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/vm.rs
@@ -277,9 +277,9 @@ impl<'extensions> MoveVM<'extensions> {
         let fun_ref = function.to_ref();
 
         // See TODO on LoadedModule to avoid this work
-        let parameters = fun_ref.parameters.clone();
+        let parameters = fun_ref.parameters.to_ref().clone();
 
-        let return_ = fun_ref.return_.clone();
+        let return_ = fun_ref.return_.to_ref().clone();
 
         // verify type arguments
         self.virtual_tables

--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
@@ -1131,6 +1131,30 @@ impl Type {
 }
 
 // -------------------------------------------------------------------------------------------------
+// Equality
+// -------------------------------------------------------------------------------------------------
+
+impl PartialEq for Function {
+    fn eq(&self, other: &Self) -> bool {
+        self.file_format_version == other.file_format_version
+            && self.is_entry == other.is_entry
+            && self.index == other.index
+            && std::ptr::eq(self.code, other.code) // Compare raw pointers for equality
+            && self.parameters == other.parameters
+            && self.locals == other.locals
+            && self.return_ == other.return_
+            && self.type_parameters == other.type_parameters
+            && self.def_is_native == other.def_is_native
+            && self.module == other.module
+            && self.name == other.name
+            && self.locals_len == other.locals_len
+            && self.jump_tables == other.jump_tables
+    }
+}
+
+impl Eq for Function { }
+
+// -------------------------------------------------------------------------------------------------
 // Into
 // -------------------------------------------------------------------------------------------------
 

--- a/external-crates/move/crates/move-vm-runtime/src/shared/linkage_context.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/shared/linkage_context.rs
@@ -17,8 +17,8 @@ use crate::shared::types::{PackageStorageId, RuntimePackageId};
 pub struct LinkageContext {
     // Linkage Table. This is a table indicating, for a given Address, how it should be linked.
     // This is purely for versioning. Assume some Package P is published at V1 and V2 as:
-    //  P V1 -> 0xCAFE
-    //  P V2 -> 0xDEAD
+    //   P V1 -> 0xCAFE
+    //   P V2 -> 0xDEAD
     // All calls to P in the root package will call 0xCAFE as the Runtime ID, but during loading
     // and JIT compilation we need to rewrite these. The linkage table here will redirect 0xCAFE to
     // 0xDEAD for this purpose.
@@ -88,7 +88,6 @@ impl LinkageContext {
 
     /// Translate the runtime fully-qualified struct name to the on-chain `ModuleId` that originally
     /// defined that type.
-    /// TODO: FIX THIS WHEN THE TYPE ORIGIN TABLE EXISTS
     pub fn defining_module(
         &self,
         module_id: &ModuleId,

--- a/external-crates/move/crates/move-vm-runtime/src/shared/vm_pointer.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/shared/vm_pointer.rs
@@ -113,13 +113,13 @@ impl<T: ::std::fmt::Debug> ::std::fmt::Debug for VMPointer<T> {
 }
 
 // Pointer equality
-impl<T> PartialEq for VMPointer<T> {
+impl<T: PartialEq> PartialEq for VMPointer<T> {
     fn eq(&self, other: &Self) -> bool {
-        self.ptr_eq(other)
+        self.ptr_eq(other) || self.to_ref().eq(other.to_ref())
     }
 }
 
-impl<T> Eq for VMPointer<T> {}
+impl<T: Eq> Eq for VMPointer<T> {}
 
 impl<T> Clone for VMPointer<T> {
     #[allow(clippy::non_canonical_clone_impl)]
@@ -137,5 +137,23 @@ impl<T> From<Box<T>> for VMPointer<T> {
 
         // Create an `ArenaPointer` from the raw pointer.
         VMPointer(raw_ptr)
+    }
+}
+
+impl<T: PartialOrd> PartialOrd for VMPointer<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.to_ref().partial_cmp(other.to_ref())
+    }
+}
+
+impl<T: Ord> Ord for VMPointer<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.to_ref().cmp(other.to_ref())
+    }
+}
+
+impl<T: std::hash::Hash> std::hash::Hash for VMPointer<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.to_ref().hash(state)
     }
 }


### PR DESCRIPTION
## Description 

What it says on the tin: in the runtime AST all `SignatureIndex` forms are now `VMPointer<Type>` or `VMPointer<Vec<Type>>` as appropriate, with those allocated on the arena.

## Test plan 

Tests all still pass

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
