### PR TITLE
persist all transactions and effects during checkpoint construction

### DIFF
--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -163,6 +163,16 @@ pub trait ExecutionCacheCommit: Send + Sync {
     /// and pending_consensus_transactions, and this method can be removed.
     fn persist_transactions<'a>(&'a self, digests: &'a [TransactionDigest]) -> BoxFuture<'a, ()>;
 
+    /// Persist transactions and their effects to the database, but no other outputs.
+    /// Additionally this stores the content-addressed effects in the database but does
+    /// not add an executed_effects. This is required for recovery from a crash when
+    /// upgrading to data-quarantining.
+    /// TODO: remove this once all nodes have upgraded to data-quarantining.
+    fn persist_transactions_and_effects(
+        &self,
+        digests: &[(TransactionDigest, TransactionEffectsDigest)],
+    );
+
     // Number of pending uncommitted transactions
     fn approximate_pending_transaction_count(&self) -> u64;
 }


### PR DESCRIPTION
This is a temporary change needed to prepare for the upgrade to data quarantining. The data quarantining code will assume that any uncommitted transactions will be replayed from consensus. But upon upgrade, no replay will occur - the non-DQ build will have marked all commits as processed immediately. This change prevents the assert at https://github.com/MystenLabs/sui/blob/791ce9132d98cfff4874e9cff4278419e050d94c/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs#L1001 from firing during startup of a DQ build.
