### PR TITLE
[consensus] Enable zstd compression in tonic network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17020,6 +17020,7 @@ dependencies = [
  "tower-service",
  "tracing",
  "webpki-roots 0.26.3",
+ "zstd 0.13.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -506,7 +506,7 @@ tokio-stream = { version = "0.1.14", features = ["sync", "net"] }
 tokio-util = "0.7.10"
 toml = { version = "0.7.4", features = ["preserve_order"] }
 toml_edit = { version = "0.19.10" }
-tonic = { version = "0.12", features = ["transport", "tls-webpki-roots"] }
+tonic = { version = "0.12", features = ["zstd", "transport", "tls-webpki-roots"] }
 tonic-build = { version = "0.12", features = ["prost", "transport"] }
 tonic-health = "0.12"
 tonic-reflection = "0.12"

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1311,6 +1311,7 @@
                 "consensus_round_prober": false,
                 "consensus_round_prober_probe_accepted_rounds": false,
                 "consensus_smart_ancestor_selection": false,
+                "consensus_zstd_compression": false,
                 "convert_type_argument_error": false,
                 "disable_invariant_violation_check_in_swap_loc": false,
                 "disallow_adding_abilities_on_upgrade": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -210,6 +210,7 @@ const MAX_PROTOCOL_VERSION: u64 = 73;
 //             Variants as type nodes.
 // Version 73: Enable new marker table version.
 //             Enable consensus garbage collection and new commit rule for devnet.
+//             Enable zstd compression for consensus tonic network in testnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -607,6 +608,10 @@ struct FeatureFlags {
     // Variants count as nodes
     #[serde(skip_serializing_if = "is_false")]
     variant_nodes: bool,
+
+    // If true, enable zstd compression for consensus tonic network.
+    #[serde(skip_serializing_if = "is_false")]
+    consensus_zstd_compression: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -1775,6 +1780,10 @@ impl ProtocolConfig {
 
     pub fn variant_nodes(&self) -> bool {
         self.feature_flags.variant_nodes
+    }
+
+    pub fn consensus_zstd_compression(&self) -> bool {
+        self.feature_flags.consensus_zstd_compression
     }
 }
 
@@ -3171,6 +3180,11 @@ impl ProtocolConfig {
                         // to be included before be considered garbage collected.
                         cfg.consensus_gc_depth = Some(60);
                         cfg.feature_flags.consensus_linearize_subdag_v2 = true;
+                    }
+
+                    if chain != Chain::Mainnet {
+                        // Enable zstd compression for consensus in testnet
+                        cfg.feature_flags.consensus_zstd_compression = true;
                     }
                 }
                 // Use this template when making changes:

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_73.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_73.snap
@@ -71,6 +71,7 @@ feature_flags:
   native_charging_v2: true
   convert_type_argument_error: true
   variant_nodes: true
+  consensus_zstd_compression: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_73.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_73.snap
@@ -78,6 +78,7 @@ feature_flags:
   consensus_linearize_subdag_v2: true
   convert_type_argument_error: true
   variant_nodes: true
+  consensus_zstd_compression: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000


### PR DESCRIPTION
## Description 

In an effort to save on network egress/ingress and potentially help with latency/throughput we will enable grpc compression for consensus.

Zstd was chosen over Gzip because it offers better compression and decompression speeds. Additionally it claims to achieve better compression ratios, allowing for more efficient use of bandwidth. The flexibility of Zstd in adjusting compression levels can also be explored further if needed.

## Test plan 

[With compression](https://metrics.sui.io/goto/u746UAONg?orgId=1)
![Screenshot 2025-01-24 at 9 58 55 PM](https://github.com/user-attachments/assets/4654f058-9055-4168-8e7f-5a4789e9d99d)

[Without compression](https://metrics.sui.io/goto/Aqr68AdHR?orgId=1)
![Screenshot 2025-01-24 at 10 00 04 PM](https://github.com/user-attachments/assets/973a90ef-81ac-48d0-a575-c85159dfda9d)


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [x] Protocol: Enable zstd compression for consensus tonic network in testnet.
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
