### PR TITLE
Consensus Data Quarantining

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -22,6 +22,7 @@ use move_binary_format::binary_config::BinaryConfig;
 use move_binary_format::CompiledModule;
 use move_core_types::annotated_value::MoveStructLayout;
 use move_core_types::language_storage::ModuleId;
+use mysten_common::fatal;
 use mysten_metrics::{TX_TYPE_SHARED_OBJ_TX, TX_TYPE_SINGLE_WRITER_TX};
 use parking_lot::Mutex;
 use prometheus::{
@@ -3152,6 +3153,7 @@ impl AuthorityState {
         epoch_start_configuration: EpochStartConfiguration,
         accumulator: Arc<StateAccumulator>,
         expensive_safety_check_config: &ExpensiveSafetyCheckConfig,
+        epoch_last_checkpoint: CheckpointSequenceNumber,
     ) -> SuiResult<Arc<AuthorityPerEpochStore>> {
         Self::check_protocol_version(
             supported_protocol_versions,
@@ -3167,6 +3169,26 @@ impl AuthorityState {
 
         // Terminate all epoch-specific tasks (those started with within_alive_epoch).
         cur_epoch_store.epoch_terminated().await;
+
+        let highest_locally_built_checkpoint_seq = self
+            .checkpoint_store
+            .get_latest_locally_computed_checkpoint()
+            .map(|c| *c.sequence_number())
+            .unwrap_or(0);
+
+        assert!(epoch_last_checkpoint >= highest_locally_built_checkpoint_seq);
+        if highest_locally_built_checkpoint_seq == epoch_last_checkpoint {
+            // if we built the last checkpoint locally (as opposed to receiving it from a peer),
+            // then all shared_version_assignments except the one for the ChangeEpoch transaction
+            // should have been removed
+            let num_shared_version_assignments = cur_epoch_store.num_shared_version_assignments();
+            // Note that while 1 is the typical value, 0 is possible if the node restarts after
+            // committing the last checkpoint but before reconfiguring.
+            if num_shared_version_assignments > 1 {
+                // If this happens in prod, we have a memory leak, but not a correctness issue.
+                debug_fatal!("all shared_version_assignments should have been removed (num_shared_version_assignments: {num_shared_version_assignments})");
+            }
+        }
 
         // Safe to being reconfiguration now. No transactions are being executed,
         // and no epoch-specific tasks are running.
@@ -3217,6 +3239,7 @@ impl AuthorityState {
                 new_committee,
                 epoch_start_configuration,
                 expensive_safety_check_config,
+                epoch_last_checkpoint,
             )
             .await?;
         assert_eq!(new_epoch_store.epoch(), new_epoch);
@@ -3247,6 +3270,11 @@ impl AuthorityState {
             self.get_backing_package_store().clone(),
             self.get_object_store().clone(),
             &self.config.expensive_safety_check_config,
+            self.checkpoint_store
+                .get_epoch_last_checkpoint(epoch_store.epoch())
+                .unwrap()
+                .map(|c| *c.sequence_number())
+                .unwrap_or_default(),
         );
         let new_epoch = new_epoch_store.epoch();
         self.transaction_manager.reconfigure(new_epoch);
@@ -5164,6 +5192,7 @@ impl AuthorityState {
         new_committee: Committee,
         epoch_start_configuration: EpochStartConfiguration,
         expensive_safety_check_config: &ExpensiveSafetyCheckConfig,
+        epoch_last_checkpoint: CheckpointSequenceNumber,
     ) -> SuiResult<Arc<AuthorityPerEpochStore>> {
         let new_epoch = new_committee.epoch;
         info!(new_epoch = ?new_epoch, "re-opening AuthorityEpochTables for new epoch");
@@ -5180,6 +5209,7 @@ impl AuthorityState {
             self.get_object_store().clone(),
             expensive_safety_check_config,
             cur_epoch_store.get_chain_identifier(),
+            epoch_last_checkpoint,
         );
         self.epoch_store.store(new_epoch_store.clone());
         Ok(new_epoch_store)
@@ -5279,6 +5309,14 @@ impl RandomnessRoundReceiver {
         let transaction = VerifiedExecutableTransaction::new_system(transaction, epoch);
         let digest = *transaction.digest();
 
+        // Randomness state updates contain the full bls signature for the random round,
+        // which cannot necessarily be reconstructed again later. Therefore we must immediately
+        // persist this transaction. If we crash before its outputs are committed, this
+        // ensures we will be able to re-execute it.
+        self.authority_state
+            .get_cache_commit()
+            .persist_transaction(&transaction);
+
         // Send transaction to TransactionManager for execution.
         self.authority_state
             .transaction_manager()
@@ -5318,7 +5356,7 @@ impl RandomnessRoundReceiver {
 
             let effects = effects.pop().expect("should return effects");
             if *effects.status() != ExecutionStatus::Success {
-                panic!("failed to execute randomness state update transaction at epoch {epoch}, round {round}: {effects:?}");
+                fatal!("failed to execute randomness state update transaction at epoch {epoch}, round {round}: {effects:?}");
             }
             debug!("successfully executed randomness state update transaction at epoch {epoch}, round {round}");
         });

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3176,7 +3176,10 @@ impl AuthorityState {
             .map(|c| *c.sequence_number())
             .unwrap_or(0);
 
-        assert!(epoch_last_checkpoint >= highest_locally_built_checkpoint_seq);
+        assert!(
+            epoch_last_checkpoint >= highest_locally_built_checkpoint_seq,
+            "{epoch_last_checkpoint} >= {highest_locally_built_checkpoint_seq}"
+        );
         if highest_locally_built_checkpoint_seq == epoch_last_checkpoint {
             // if we built the last checkpoint locally (as opposed to receiving it from a peer),
             // then all shared_version_assignments except the one for the ChangeEpoch transaction

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1688,12 +1688,7 @@ impl AuthorityPerEpochStore {
         let next_versions = self
             .consensus_quarantine
             .read()
-            .get_next_shared_object_versions(
-                self.epoch_start_config(),
-                &tables,
-                &db_transaction,
-                objects_to_init,
-            )?;
+            .get_next_shared_object_versions(self.epoch_start_config(), &tables, objects_to_init)?;
 
         let uninitialized_objects: Vec<ConsensusObjectSequenceKey> = next_versions
             .iter()

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -111,10 +111,10 @@ use crate::consensus_handler::{
 use crate::epoch::epoch_metrics::EpochMetrics;
 use crate::epoch::randomness::{
     DkgStatus, RandomnessManager, RandomnessReporter, VersionedProcessedMessage,
-    VersionedUsedProcessedMessages,
+    VersionedUsedProcessedMessages, SINGLETON_KEY,
 };
 use crate::epoch::reconfiguration::ReconfigState;
-use crate::execution_cache::ObjectCacheRead;
+use crate::execution_cache::{ObjectCacheRead, TransactionCacheRead};
 use crate::module_cache_metrics::ResolverMetrics;
 use crate::post_consensus_tx_reorder::PostConsensusTxReorder;
 use crate::signature_verifier::*;
@@ -135,6 +135,8 @@ pub(crate) type EncG = bls12381::G2Element;
 pub(crate) mod consensus_quarantine;
 
 use consensus_quarantine::ConsensusCommitOutput;
+use consensus_quarantine::ConsensusEphemeralOutput;
+use consensus_quarantine::ConsensusOutputQuarantine;
 
 // CertLockGuard and CertTxGuard are functionally identical right now, but we retain a distinction
 // anyway. If we need to support distributed object storage, having this distinction will be
@@ -317,6 +319,9 @@ pub struct AuthorityPerEpochStore {
     /// and it needs to be cleared at the end of the epoch.
     tables: ArcSwapOption<AuthorityEpochTables>,
 
+    consensus_quarantine: RwLock<ConsensusOutputQuarantine>,
+    consensus_output_cache: ConsensusEphemeralOutput,
+
     protocol_config: ProtocolConfig,
 
     // needed for re-opening epoch db.
@@ -434,40 +439,17 @@ pub struct AuthorityEpochTables {
     /// Transactions that were executed in the current epoch.
     executed_in_epoch: DBMap<TransactionDigest, ()>,
 
-    /// The tables below manage shared object locks / versions. There are three ways they can be
-    /// updated:
-    /// 1. (validators only): Upon receiving a certified transaction from consensus, the authority
-    ///     assigns the next version to each shared object of the transaction. The next versions of
-    ///     the shared objects are updated as well.
-    /// 2. (validators only): Upon receiving a new consensus commit, the authority assigns the
-    ///     next version of the randomness state object to an expected future transaction to be
-    ///     generated after the next random value is available. The next version of the randomness
-    ///     state object is updated as well.
-    /// 3. (fullnodes + validators): Upon receiving a certified effect from state sync, or
-    ///     transaction orchestrator fast execution path, the node assigns the shared object
-    ///     versions from the transaction effect. Next object versions are not updated.
-    ///
-    /// REQUIRED: all authorities must assign the same shared object versions for each transaction.
+    #[allow(dead_code)]
     assigned_shared_object_versions_v2: DBMap<TransactionKey, Vec<(ObjectID, SequenceNumber)>>,
+    #[allow(dead_code)]
     assigned_shared_object_versions_v3:
         DBMap<TransactionKey, Vec<(ConsensusObjectSequenceKey, SequenceNumber)>>,
+
+    /// Next available shared object versions for each shared object.
     next_shared_object_versions: DBMap<ObjectID, SequenceNumber>,
     next_shared_object_versions_v2: DBMap<ConsensusObjectSequenceKey, SequenceNumber>,
 
-    /// Deprecated table for pre-random-beacon shared object versions.
-    #[allow(dead_code)]
-    assigned_shared_object_versions: DBMap<TransactionDigest, Vec<(ObjectID, SequenceNumber)>>,
-
-    /// Certificates that have been received from clients or received from consensus, but not yet
-    /// executed. Entries are cleared after execution.
-    /// This table is critical for crash recovery, because usually the consensus output progress
-    /// is updated after a certificate is committed into this table.
-    ///
-    /// In theory, this table may be superseded by storing consensus and checkpoint execution
-    /// progress. But it is more complex, because it would be necessary to track inflight
-    /// executions not ordered by indices. For now, tracking inflight certificates as a map
-    /// seems easier.
-    #[default_options_override_fn = "pending_execution_table_default_config"]
+    // TODO: delete after DQ is rolled out
     pub(crate) pending_execution: DBMap<TransactionDigest, TrustedExecutableTransaction>,
 
     /// Track which transactions have been processed in handle_consensus_transaction. We must be
@@ -512,15 +494,7 @@ pub struct AuthorityEpochTables {
     #[allow(dead_code)]
     final_epoch_checkpoint: DBMap<u64, u64>,
 
-    /// This table has information for the checkpoints for which we constructed all the data
-    /// from consensus, but not yet constructed actual checkpoint.
-    ///
-    /// Key in this table is the consensus commit height and not a checkpoint sequence number.
-    ///
-    /// Non-empty list of transactions here might result in empty list when we are forming checkpoint.
-    /// Because we don't want to create checkpoints with empty content(see CheckpointBuilder::write_checkpoint),
-    /// the sequence number of checkpoint does not match height here.
-    #[default_options_override_fn = "pending_checkpoints_table_default_config"]
+    #[allow(dead_code)]
     pending_checkpoints_v2: DBMap<CheckpointHeight, PendingCheckpointV2>,
 
     /// Deprecated table for pre-random-beacon checkpoints.
@@ -539,8 +513,8 @@ pub struct AuthorityEpochTables {
     pending_checkpoint_signatures:
         DBMap<(CheckpointSequenceNumber, u64), CheckpointSignatureMessage>,
 
-    /// When we see certificate through consensus for the first time, we record
-    /// user signature for this transaction here. This will be included in the checkpoint later.
+    /// Deprecated - pending signatures are now stored in memory.
+    #[allow(dead_code)]
     user_signatures_for_checkpoints: DBMap<TransactionDigest, Vec<GenericSignature>>,
 
     /// This table is not used
@@ -651,19 +625,7 @@ fn owned_object_transaction_locks_table_default_config() -> DBOptions {
     }
 }
 
-fn pending_execution_table_default_config() -> DBOptions {
-    default_db_options()
-        .optimize_for_write_throughput()
-        .optimize_for_large_values_no_scan(1 << 10)
-}
-
 fn pending_consensus_transactions_table_default_config() -> DBOptions {
-    default_db_options()
-        .optimize_for_write_throughput()
-        .optimize_for_large_values_no_scan(1 << 10)
-}
-
-fn pending_checkpoints_table_default_config() -> DBOptions {
     default_db_options()
         .optimize_for_write_throughput()
         .optimize_for_large_values_no_scan(1 << 10)
@@ -789,68 +751,22 @@ impl AuthorityEpochTables {
         Ok(())
     }
 
-    pub fn load_initial_object_debts(
+    fn get_all_deferred_transactions(
         &self,
-        current_round: Round,
-        for_randomness: bool,
-        protocol_config: &ProtocolConfig,
-        transactions: &[VerifiedSequencedConsensusTransaction],
-    ) -> SuiResult<impl IntoIterator<Item = (ObjectID, u64)>> {
-        let default_per_commit_budget = protocol_config
-            .max_accumulated_txn_cost_per_object_in_mysticeti_commit_as_option()
-            .unwrap_or(0);
-        let (table, per_commit_budget) = if for_randomness {
-            (
-                &self.congestion_control_randomness_object_debts,
-                protocol_config
-                    .max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit_as_option()
-                    .unwrap_or(default_per_commit_budget),
-            )
-        } else {
-            (
-                &self.congestion_control_object_debts,
-                default_per_commit_budget,
-            )
-        };
+    ) -> SuiResult<BTreeMap<DeferralKey, Vec<VerifiedSequencedConsensusTransaction>>> {
+        Ok(self
+            .deferred_transactions
+            .safe_iter()
+            .collect::<Result<_, _>>()?)
+    }
 
-        let shared_input_object_ids: BTreeSet<_> = transactions
-            .iter()
-            .filter_map(|tx| match &tx.0.transaction {
-                SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                    kind: ConsensusTransactionKind::CertifiedTransaction(tx),
-                    ..
-                }) => Some(
-                    tx.shared_input_objects()
-                        .map(|obj| obj.id)
-                        .collect::<Vec<_>>(),
-                ),
-                SequencedConsensusTransactionKind::External(ConsensusTransaction {
-                    kind: ConsensusTransactionKind::UserTransaction(tx),
-                    ..
-                }) => Some(
-                    tx.shared_input_objects()
-                        .map(|obj| obj.id)
-                        .collect::<Vec<_>>(),
-                ),
-                _ => None,
-            })
-            .flatten()
-            .collect();
-        Ok(table
-            .multi_get(shared_input_object_ids.iter())?
-            .into_iter()
-            .zip(shared_input_object_ids)
-            .filter_map(|(debt, object_id)| debt.map(|debt| (debt, object_id)))
-            .map(move |(debt, object_id)| {
-                let (round, debt) = debt.into_v1();
-                (
-                    object_id,
-                    // Stored debts already account for the budget of the round in which
-                    // they were accumulated. Application of budget from future rounds to
-                    // the debt is handled here.
-                    debt.saturating_sub(per_commit_budget * (current_round - round - 1)),
-                )
-            }))
+    fn get_all_user_signatures_for_checkpoints(
+        &self,
+    ) -> SuiResult<HashMap<TransactionDigest, Vec<GenericSignature>>> {
+        Ok(self
+            .user_signatures_for_checkpoints
+            .safe_iter()
+            .collect::<Result<_, _>>()?)
     }
 }
 
@@ -871,6 +787,7 @@ impl AuthorityPerEpochStore {
         signature_verifier_metrics: Arc<SignatureVerifierMetrics>,
         expensive_safety_check_config: &ExpensiveSafetyCheckConfig,
         chain_identifier: ChainIdentifier,
+        highest_executed_checkpoint: CheckpointSequenceNumber,
     ) -> Arc<Self> {
         let current_time = Instant::now();
         let epoch_id = committee.epoch;
@@ -970,11 +887,18 @@ impl AuthorityPerEpochStore {
 
         let jwk_aggregator = Mutex::new(jwk_aggregator);
 
+        let consensus_output_cache =
+            ConsensusEphemeralOutput::new(&epoch_start_configuration, &tables);
+
         let s = Arc::new(Self {
             name,
             committee: committee.clone(),
             protocol_config,
             tables: ArcSwapOption::new(Some(Arc::new(tables))),
+            consensus_output_cache,
+            consensus_quarantine: RwLock::new(ConsensusOutputQuarantine::new(
+                highest_executed_checkpoint,
+            )),
             parent_path: parent_path.to_path_buf(),
             db_options,
             reconfig_state_mem: RwLock::new(reconfig_state),
@@ -1122,6 +1046,7 @@ impl AuthorityPerEpochStore {
         object_store: Arc<dyn ObjectStore + Send + Sync>,
         expensive_safety_check_config: &ExpensiveSafetyCheckConfig,
         chain_identifier: ChainIdentifier,
+        previous_epoch_last_checkpoint: CheckpointSequenceNumber,
     ) -> Arc<Self> {
         assert_eq!(self.epoch() + 1, new_committee.epoch);
         self.record_reconfig_halt_duration_metric();
@@ -1139,6 +1064,7 @@ impl AuthorityPerEpochStore {
             self.signature_verifier.metrics.clone(),
             expensive_safety_check_config,
             chain_identifier,
+            previous_epoch_last_checkpoint,
         )
     }
 
@@ -1147,6 +1073,7 @@ impl AuthorityPerEpochStore {
         backing_package_store: Arc<dyn BackingPackageStore + Send + Sync>,
         object_store: Arc<dyn ObjectStore + Send + Sync>,
         expensive_safety_check_config: &ExpensiveSafetyCheckConfig,
+        previous_epoch_last_checkpoint: CheckpointSequenceNumber,
     ) -> Arc<Self> {
         let next_epoch = self.epoch() + 1;
         let next_committee = Committee::new(
@@ -1162,6 +1089,7 @@ impl AuthorityPerEpochStore {
             object_store,
             expensive_safety_check_config,
             self.chain_identifier,
+            previous_epoch_last_checkpoint,
         )
     }
 
@@ -1377,6 +1305,21 @@ impl AuthorityPerEpochStore {
         Ok(())
     }
 
+    pub(crate) fn remove_shared_version_assignments<'a>(
+        &self,
+        keys: impl IntoIterator<Item = &'a TransactionKey>,
+    ) {
+        for tx_key in keys {
+            self.consensus_output_cache
+                .shared_version_assignments
+                .remove(tx_key);
+        }
+    }
+
+    pub fn num_shared_version_assignments(&self) -> usize {
+        self.consensus_output_cache.shared_version_assignments.len()
+    }
+
     pub fn revert_executed_transaction(&self, tx_digest: &TransactionDigest) -> SuiResult {
         let tables = self.tables()?;
         let mut batch = tables.effects_signatures.batch();
@@ -1458,7 +1401,6 @@ impl AuthorityPerEpochStore {
                         let assigned_shared_versions = assigned_shared_versions
                             .get_or_init(|| {
                                 self.get_assigned_shared_object_versions(key)
-                                    .expect("reading assigned shared versions should not fail")
                                     .map(|versions| versions.into_iter().collect())
                             })
                             .as_ref()
@@ -1501,6 +1443,10 @@ impl AuthorityPerEpochStore {
     }
 
     pub fn get_last_consensus_stats(&self) -> SuiResult<ExecutionIndicesWithStats> {
+        assert!(
+            self.consensus_quarantine.read().is_empty(),
+            "get_last_consensus_stats should only be called at startup"
+        );
         match self
             .tables()?
             .get_last_consensus_stats()
@@ -1569,8 +1515,6 @@ impl AuthorityPerEpochStore {
         Ok(result)
     }
 
-    /// `pending_certificates` table related methods. Should only be used from TransactionManager.
-
     /// Gets all pending certificates. Used during recovery.
     pub fn all_pending_execution(&self) -> SuiResult<Vec<VerifiedExecutableTransaction>> {
         Ok(self
@@ -1583,7 +1527,11 @@ impl AuthorityPerEpochStore {
 
     /// Called when transaction outputs are committed to disk
     #[instrument(level = "trace", skip_all)]
-    pub fn handle_committed_transactions(&self, digests: &[TransactionDigest]) -> SuiResult<()> {
+    pub fn handle_finalized_checkpoint(
+        &self,
+        checkpoint: &CheckpointSummary,
+        digests: &[TransactionDigest],
+    ) -> SuiResult<()> {
         let tables = match self.tables() {
             Ok(tables) => tables,
             // After Epoch ends, it is no longer necessary to remove pending transactions
@@ -1591,34 +1539,18 @@ impl AuthorityPerEpochStore {
             Err(SuiError::EpochEnded(_)) => return Ok(()),
             Err(e) => return Err(e),
         };
-        let mut batch = tables.pending_execution.batch();
-        // pending_execution stores transactions received from consensus which may not have
-        // been executed yet. At this point, they have been committed to the db durably and
-        // can be removed.
-        // After end-to-end quarantining, we will not need pending_execution since the consensus
-        // log itself will be used for recovery.
-        batch.delete_batch(&tables.pending_execution, digests)?;
+        let mut batch = tables.signed_effects_digests.batch();
 
         // Now that the transaction effects are committed, we will never re-execute, so we
         // don't need to worry about equivocating.
         batch.delete_batch(&tables.signed_effects_digests, digests)?;
 
-        // Note that this does not delete keys for random transactions. The worst case result
-        // of this is that we restart at the end of the epoch and load about 160k keys into
-        // memory.
-        if self.epoch_start_config().use_version_assignment_tables_v3() {
-            batch.delete_batch(
-                &tables.assigned_shared_object_versions_v3,
-                digests.iter().map(|d| TransactionKey::Digest(*d)),
-            )?;
-        } else {
-            batch.delete_batch(
-                &tables.assigned_shared_object_versions_v2,
-                digests.iter().map(|d| TransactionKey::Digest(*d)),
-            )?;
-        }
+        let seq = *checkpoint.sequence_number();
 
+        let mut quarantine = self.consensus_quarantine.write();
+        quarantine.update_highest_executed_checkpoint(seq, self, &mut batch)?;
         batch.write()?;
+
         Ok(())
     }
 
@@ -1652,21 +1584,14 @@ impl AuthorityPerEpochStore {
     pub fn set_shared_object_versions_for_testing(
         &self,
         tx_digest: &TransactionDigest,
-        assigned_versions: Vec<(ConsensusObjectSequenceKey, SequenceNumber)>,
+        assigned_versions: &[(ConsensusObjectSequenceKey, SequenceNumber)],
     ) -> SuiResult {
-        if self.epoch_start_config().use_version_assignment_tables_v3() {
-            self.tables()?
-                .assigned_shared_object_versions_v3
-                .insert(&TransactionKey::Digest(*tx_digest), &assigned_versions)?;
-        } else {
-            self.tables()?.assigned_shared_object_versions_v2.insert(
-                &TransactionKey::Digest(*tx_digest),
-                &assigned_versions
-                    .into_iter()
-                    .map(|(k, v)| (k.0, v))
-                    .collect(),
-            )?;
-        }
+        self.consensus_output_cache
+            .shared_version_assignments
+            .insert(
+                TransactionKey::Digest(*tx_digest),
+                assigned_versions.to_owned(),
+            );
         Ok(())
     }
 
@@ -1761,15 +1686,15 @@ impl AuthorityPerEpochStore {
             .acquire_locks(objects_to_init.iter().map(|(id, _)| *id));
         let tables = self.tables()?;
 
-        let next_versions = if self.epoch_start_config().use_version_assignment_tables_v3() {
-            tables
-                .next_shared_object_versions_v2
-                .multi_get(objects_to_init)?
-        } else {
-            tables
-                .next_shared_object_versions
-                .multi_get(objects_to_init.iter().map(|(id, _)| *id))?
-        };
+        let next_versions = self
+            .consensus_quarantine
+            .read()
+            .get_next_shared_object_versions(
+                self.epoch_start_config(),
+                &tables,
+                &db_transaction,
+                objects_to_init,
+            )?;
 
         let uninitialized_objects: Vec<ConsensusObjectSequenceKey> = next_versions
             .iter()
@@ -1844,46 +1769,20 @@ impl AuthorityPerEpochStore {
     pub fn get_assigned_shared_object_versions(
         &self,
         key: &TransactionKey,
-    ) -> SuiResult<Option<Vec<(ConsensusObjectSequenceKey, SequenceNumber)>>> {
-        if self.epoch_start_config().use_version_assignment_tables_v3() {
-            Ok(self.tables()?.assigned_shared_object_versions_v3.get(key)?)
-        } else {
-            Ok(self
-                .tables()?
-                .assigned_shared_object_versions_v2
-                .get(key)?
-                .map(|result| {
-                    result
-                        .into_iter()
-                        .map(|(id, v)| ((id, SequenceNumber::UNKNOWN), v))
-                        .collect()
-                }))
-        }
+    ) -> Option<Vec<(ConsensusObjectSequenceKey, SequenceNumber)>> {
+        self.consensus_output_cache
+            .shared_version_assignments
+            .get(key)
+            .map(|locks| locks.clone())
     }
 
-    fn set_assigned_shared_object_versions_with_db_batch(
-        &self,
-        versions: AssignedTxAndVersions,
-        db_batch: &mut DBBatch,
-    ) -> SuiResult {
+    fn set_assigned_shared_object_versions(&self, versions: AssignedTxAndVersions) {
         debug!("set_assigned_shared_object_versions: {:?}", versions);
-        if self.epoch_start_config().use_version_assignment_tables_v3() {
-            db_batch.insert_batch(&self.tables()?.assigned_shared_object_versions_v3, versions)?;
-        } else {
-            db_batch.insert_batch(
-                &self.tables()?.assigned_shared_object_versions_v2,
-                versions.into_iter().map(|(key, versions)| {
-                    (
-                        key,
-                        versions
-                            .into_iter()
-                            .map(|(id, v)| (id.0, v))
-                            .collect::<Vec<_>>(),
-                    )
-                }),
-            )?;
+        for (key, value) in &versions {
+            self.consensus_output_cache
+                .shared_version_assignments
+                .insert(*key, value.clone());
         }
-        Ok(())
     }
 
     /// Given list of certificates, assign versions for all shared objects used in them.
@@ -1897,7 +1796,6 @@ impl AuthorityPerEpochStore {
         cache_reader: &dyn ObjectCacheRead,
         certificates: &[VerifiedExecutableTransaction],
     ) -> SuiResult {
-        let mut db_batch = self.tables()?.assigned_shared_object_versions_v2.batch();
         let assigned_versions = SharedObjVerManager::assign_versions_from_consensus(
             self,
             cache_reader,
@@ -1906,8 +1804,7 @@ impl AuthorityPerEpochStore {
             &BTreeMap::new(),
         )?
         .assigned_versions;
-        self.set_assigned_shared_object_versions_with_db_batch(assigned_versions, &mut db_batch)?;
-        db_batch.write()?;
+        self.set_assigned_shared_object_versions(assigned_versions);
         Ok(())
     }
 
@@ -1966,22 +1863,18 @@ impl AuthorityPerEpochStore {
         debug!("Query epoch store to load deferred txn {:?} {:?}", min, max);
         let mut keys = Vec::new();
         let mut txns = Vec::new();
-        self.tables()?
-            .deferred_transactions
-            .safe_iter_with_bounds(Some(min), Some(max))
-            .try_for_each(|result| match result {
-                Ok((key, txs)) => {
-                    debug!(
-                        "Loaded {:?} deferred txn with deferral key {:?}",
-                        txs.len(),
-                        key
-                    );
-                    keys.push(key);
-                    txns.push((key, txs));
-                    Ok(())
-                }
-                Err(err) => Err(err),
-            })?;
+
+        let mut deferred_transactions = self.consensus_output_cache.deferred_transactions.lock();
+
+        for (key, transactions) in deferred_transactions.range(min..max) {
+            debug!(
+                "Loaded {:?} deferred txn with deferral key {:?}",
+                transactions.len(),
+                key
+            );
+            keys.push(*key);
+            txns.push((*key, transactions.clone()));
+        }
 
         // verify that there are no duplicates - should be impossible due to
         // is_consensus_message_processed
@@ -1995,6 +1888,10 @@ impl AuthorityPerEpochStore {
             }
         }
 
+        for key in &keys {
+            deferred_transactions.remove(key);
+        }
+
         output.delete_loaded_deferred_transactions(&keys);
 
         Ok(txns)
@@ -2002,12 +1899,13 @@ impl AuthorityPerEpochStore {
 
     pub fn get_all_deferred_transactions_for_test(
         &self,
-    ) -> SuiResult<Vec<(DeferralKey, Vec<VerifiedSequencedConsensusTransaction>)>> {
-        Ok(self
-            .tables()?
+    ) -> Vec<(DeferralKey, Vec<VerifiedSequencedConsensusTransaction>)> {
+        self.consensus_output_cache
             .deferred_transactions
-            .safe_iter()
-            .collect::<Result<Vec<_>, _>>()?)
+            .lock()
+            .iter()
+            .map(|(key, txs)| (*key, txs.clone()))
+            .collect()
     }
 
     fn should_defer(
@@ -2071,9 +1969,7 @@ impl AuthorityPerEpochStore {
             self,
             cache_reader,
         )?;
-        let mut db_batch = self.tables()?.assigned_shared_object_versions_v2.batch();
-        self.set_assigned_shared_object_versions_with_db_batch(versions, &mut db_batch)?;
-        db_batch.write()?;
+        self.set_assigned_shared_object_versions(versions);
         Ok(())
     }
 
@@ -2147,9 +2043,9 @@ impl AuthorityPerEpochStore {
     }
 
     pub fn deferred_transactions_empty(&self) -> bool {
-        self.tables()
-            .expect("deferred transactions should not be read past end of epoch")
+        self.consensus_output_cache
             .deferred_transactions
+            .lock()
             .is_empty()
     }
 
@@ -2187,19 +2083,53 @@ impl AuthorityPerEpochStore {
         key: &SequencedConsensusTransactionKey,
     ) -> SuiResult<bool> {
         Ok(self
-            .tables()?
-            .consensus_message_processed
-            .contains_key(key)?)
+            .consensus_quarantine
+            .read()
+            .is_consensus_message_processed(key)
+            || self
+                .tables()?
+                .consensus_message_processed
+                .contains_key(key)?)
     }
 
     pub fn check_consensus_messages_processed(
         &self,
         keys: impl Iterator<Item = SequencedConsensusTransactionKey>,
     ) -> SuiResult<Vec<bool>> {
-        Ok(self
+        let size_hint = keys.size_hint().0;
+        let mut results = Vec::with_capacity(size_hint);
+        let mut fallback_keys = Vec::with_capacity(size_hint);
+        let mut fallback_indices = Vec::with_capacity(size_hint);
+
+        {
+            let consensus_quarantine = self.consensus_quarantine.read();
+
+            for (i, key) in keys.enumerate() {
+                if consensus_quarantine.is_consensus_message_processed(&key) {
+                    results.push(true);
+                } else {
+                    results.push(false);
+                    fallback_keys.push(key);
+                    fallback_indices.push(i);
+                }
+            }
+        }
+
+        let fallback_results = self
             .tables()?
             .consensus_message_processed
-            .multi_contains_keys(keys)?)
+            .multi_contains_keys(fallback_keys)?;
+
+        assert_eq!(fallback_results.len(), fallback_indices.len());
+
+        for (result, i) in fallback_results
+            .into_iter()
+            .zip(fallback_indices.into_iter())
+        {
+            results[i] = result;
+        }
+
+        Ok(results)
     }
 
     pub async fn consensus_messages_processed_notify(
@@ -2327,10 +2257,15 @@ impl AuthorityPerEpochStore {
         digests: &[TransactionDigest],
     ) -> SuiResult<Vec<Vec<GenericSignature>>> {
         assert_eq!(transactions.len(), digests.len());
-        let signatures = self
-            .tables()?
-            .user_signatures_for_checkpoints
-            .multi_get(digests)?;
+
+        let signatures: Vec<_> = {
+            let mut user_sigs = self
+                .consensus_output_cache
+                .user_signatures_for_checkpoints
+                .lock();
+            digests.iter().map(|d| user_sigs.remove(d)).collect()
+        };
+
         let mut result = Vec::with_capacity(digests.len());
         for (signatures, transaction) in signatures.into_iter().zip(transactions.iter()) {
             let signatures = if let Some(signatures) = signatures {
@@ -2523,29 +2458,7 @@ impl AuthorityPerEpochStore {
     }
 
     pub(crate) fn get_new_jwks(&self, round: u64) -> SuiResult<Vec<ActiveJwk>> {
-        let epoch = self.epoch();
-
-        let empty_jwk_id = JwkId::new(String::new(), String::new());
-        let empty_jwk = JWK {
-            kty: String::new(),
-            e: String::new(),
-            n: String::new(),
-            alg: String::new(),
-        };
-
-        let start = (round, (empty_jwk_id.clone(), empty_jwk.clone()));
-        let end = (round + 1, (empty_jwk_id, empty_jwk));
-
-        // TODO: use a safe iterator
-        Ok(self
-            .tables()?
-            .active_jwks
-            .safe_iter_with_bounds(Some(start), Some(end))
-            .map_ok(|((r, (jwk_id, jwk)), _)| {
-                debug_assert!(round == r);
-                ActiveJwk { jwk_id, jwk, epoch }
-            })
-            .collect::<Result<Vec<_>, _>>()?)
+        self.consensus_quarantine.read().get_new_jwks(self, round)
     }
 
     pub fn jwk_active_in_current_epoch(&self, jwk_id: &JwkId, jwk: &JWK) -> bool {
@@ -2553,46 +2466,70 @@ impl AuthorityPerEpochStore {
         jwk_aggregator.has_quorum_for_key(&(jwk_id.clone(), jwk.clone()))
     }
 
+    pub(crate) fn get_randomness_last_round_timestamp(&self) -> SuiResult<Option<TimestampMs>> {
+        if let Some(ts) = self
+            .consensus_quarantine
+            .read()
+            .get_randomness_last_round_timestamp()
+        {
+            Ok(Some(ts))
+        } else {
+            Ok(self
+                .tables()?
+                .randomness_last_round_timestamp
+                .get(&SINGLETON_KEY)?)
+        }
+    }
+
+    #[cfg(test)]
     pub fn test_insert_user_signature(
         &self,
         digest: TransactionDigest,
         signatures: Vec<GenericSignature>,
     ) {
-        self.tables()
-            .expect("test should not cross epoch boundary")
+        self.consensus_output_cache
             .user_signatures_for_checkpoints
-            .insert(&digest, &signatures)
-            .unwrap();
+            .lock()
+            .insert(digest, signatures);
         let key = ConsensusTransactionKey::Certificate(digest);
         let key = SequencedConsensusTransactionKey::External(key);
-        self.tables()
-            .expect("test should not cross epoch boundary")
-            .consensus_message_processed
-            .insert(&key, &true)
-            .unwrap();
+
+        let mut output = ConsensusCommitOutput::default();
+        output.record_consensus_message_processed(key.clone());
+        output.set_default_commit_stats_for_testing();
+        self.consensus_quarantine
+            .write()
+            .push_consensus_output(output);
         self.consensus_notify_read.notify(&key, &());
+    }
+
+    #[cfg(test)]
+    pub(crate) fn push_consensus_output_for_tests(&self, output: ConsensusCommitOutput) {
+        self.consensus_quarantine
+            .write()
+            .push_consensus_output(output);
     }
 
     fn finish_consensus_certificate_process_with_batch(
         &self,
-        output: &mut ConsensusCommitOutput,
         certificates: &[VerifiedExecutableTransaction],
-    ) -> SuiResult {
-        output.insert_pending_execution(certificates);
-        output.insert_user_signatures_for_checkpoints(certificates);
+    ) {
+        let sigs: Vec<_> = certificates
+            .iter()
+            .map(|certificate| (*certificate.digest(), certificate.tx_signatures().to_vec()))
+            .collect();
 
-        if cfg!(debug_assertions) {
-            for certificate in certificates {
-                // User signatures are written in the same batch as consensus certificate processed flag,
-                // which means we won't attempt to insert this twice for the same tx digest
-                assert!(!self
-                    .tables()?
-                    .user_signatures_for_checkpoints
-                    .contains_key(certificate.digest())
-                    .unwrap());
-            }
+        let mut user_sigs = self
+            .consensus_output_cache
+            .user_signatures_for_checkpoints
+            .lock();
+
+        user_sigs.reserve(certificates.len());
+        for (digest, sigs) in sigs {
+            // User signatures are written in the same batch as consensus certificate processed flag,
+            // which means we won't attempt to insert this twice for the same tx digest
+            assert!(user_sigs.insert(digest, sigs).is_none());
         }
-        Ok(())
     }
 
     pub fn get_reconfig_state_read_lock_guard(&self) -> RwLockReadGuard<ReconfigState> {
@@ -2828,7 +2765,6 @@ impl AuthorityPerEpochStore {
 
     #[instrument(level = "debug", skip_all)]
     pub(crate) async fn process_consensus_transactions_and_commit_boundary<
-        'a,
         C: CheckpointServiceNotify,
     >(
         &self,
@@ -2836,6 +2772,7 @@ impl AuthorityPerEpochStore {
         consensus_stats: &ExecutionIndicesWithStats,
         checkpoint_service: &Arc<C>,
         cache_reader: &dyn ObjectCacheRead,
+        tx_reader: &dyn TransactionCacheRead,
         consensus_commit_info: &ConsensusCommitInfo,
         authority_metrics: &Arc<AuthorityMetrics>,
     ) -> SuiResult<Vec<VerifiedExecutableTransaction>> {
@@ -3029,21 +2966,26 @@ impl AuthorityPerEpochStore {
 
         // We track transaction execution cost separately for regular transactions and transactions using randomness, since
         // they will be in different PendingCheckpoints.
-        let tables = self.tables()?;
         let shared_object_congestion_tracker = SharedObjectCongestionTracker::from_protocol_config(
-            &tables,
+            self.consensus_quarantine.read().load_initial_object_debts(
+                self,
+                consensus_commit_info.round,
+                false,
+                &sequenced_transactions,
+            )?,
             self.protocol_config(),
-            consensus_commit_info.round,
             false,
-            &sequenced_transactions,
         )?;
         let shared_object_using_randomness_congestion_tracker =
             SharedObjectCongestionTracker::from_protocol_config(
-                &tables,
+                self.consensus_quarantine.read().load_initial_object_debts(
+                    self,
+                    consensus_commit_info.round,
+                    true,
+                    &sequenced_transactions,
+                )?,
                 self.protocol_config(),
-                consensus_commit_info.round,
                 true,
-                &sequenced_randomness_transactions,
             )?;
 
         // We always order transactions using randomness last.
@@ -3079,8 +3021,10 @@ impl AuthorityPerEpochStore {
                 authority_metrics,
             )
             .await?;
-        self.finish_consensus_certificate_process_with_batch(&mut output, &verified_transactions)?;
+        self.finish_consensus_certificate_process_with_batch(&verified_transactions);
         output.record_consensus_commit_stats(consensus_stats.clone());
+
+        let mut verified_transactions = verified_transactions;
 
         // Create pending checkpoints if we are still accepting tx.
         let should_accept_tx = if let Some(lock) = &lock {
@@ -3116,10 +3060,21 @@ impl AuthorityPerEpochStore {
             checkpoint_roots.extend(roots.into_iter());
 
             if let Some(randomness_round) = randomness_round {
-                randomness_roots.insert(TransactionKey::RandomnessRound(
-                    self.epoch(),
-                    randomness_round,
-                ));
+                let key = TransactionKey::RandomnessRound(self.epoch(), randomness_round);
+
+                // During crash recovery, the randomness update transaction may already have been
+                // created and executed before the crash. If it is available locally, we need to
+                // ensure it is executed.
+                if let Some(digest) = self.tables()?.transaction_key_to_digest.get(&key)? {
+                    if let Some(tx) = tx_reader.get_transaction_block(&digest) {
+                        info!("Randomness update transaction {:?} already exists, scheduling for execution", digest);
+                        let tx =
+                            VerifiedExecutableTransaction::new_system((*tx).clone(), self.epoch());
+                        verified_transactions.push(tx);
+                    }
+                }
+
+                randomness_roots.insert(key);
             }
 
             // Determine whether to write pending checkpoint for user tx with randomness.
@@ -3154,9 +3109,14 @@ impl AuthorityPerEpochStore {
             }
         }
 
-        let mut batch = self.db_batch()?;
-        output.write_to_batch(self, &mut batch)?;
-        batch.write()?;
+        {
+            let mut consensus_quarantine = self.consensus_quarantine.write();
+            consensus_quarantine.push_consensus_output(output);
+
+            // we may already have observed the certified checkpoint for this round, if state sync is running
+            // ahead of consensus, so there may be data to commit right away.
+            consensus_quarantine.commit(self)?;
+        }
 
         // Only after batch is written, notify checkpoint service to start building any new
         // pending checkpoints.
@@ -3278,18 +3238,21 @@ impl AuthorityPerEpochStore {
             randomness_round,
             cancelled_txns,
         )?;
-        output.set_assigned_shared_object_versions(assigned_versions, shared_input_next_versions);
+
+        for (tx_key, objects) in &assigned_versions {
+            self.consensus_output_cache
+                .shared_version_assignments
+                .insert(*tx_key, objects.clone());
+        }
+
+        output.set_next_shared_object_versions(shared_input_next_versions);
         Ok(())
     }
 
     pub fn get_highest_pending_checkpoint_height(&self) -> CheckpointHeight {
-        self.tables()
-            .expect("test should not cross epoch boundary")
-            .pending_checkpoints_v2
-            .unbounded_iter()
-            .skip_to_last()
-            .next()
-            .map(|(key, _)| key)
+        self.consensus_quarantine
+            .read()
+            .get_highest_pending_checkpoint_height()
             .unwrap_or_default()
     }
 
@@ -3302,6 +3265,7 @@ impl AuthorityPerEpochStore {
         transactions: Vec<SequencedConsensusTransaction>,
         checkpoint_service: &Arc<C>,
         cache_reader: &dyn ObjectCacheRead,
+        tx_reader: &dyn TransactionCacheRead,
         authority_metrics: &Arc<AuthorityMetrics>,
         skip_consensus_commit_prologue_in_test: bool,
     ) -> SuiResult<Vec<VerifiedExecutableTransaction>> {
@@ -3310,6 +3274,7 @@ impl AuthorityPerEpochStore {
             &ExecutionIndicesWithStats::default(),
             checkpoint_service,
             cache_reader,
+            tx_reader,
             &ConsensusCommitInfo::new_for_test(
                 if self.randomness_state_enabled() {
                     self.get_highest_pending_checkpoint_height() / 2 + 1
@@ -3338,6 +3303,7 @@ impl AuthorityPerEpochStore {
             &mut output,
         )?;
         let mut batch = self.db_batch()?;
+        output.set_default_commit_stats_for_testing();
         output.write_to_batch(self, &mut batch)?;
         batch.write()?;
         Ok(())
@@ -3496,10 +3462,16 @@ impl AuthorityPerEpochStore {
 
         let commit_has_deferred_txns = !deferred_txns.is_empty();
         let mut total_deferred_txns = 0;
-        for (key, txns) in deferred_txns.into_iter() {
-            total_deferred_txns += txns.len();
-            output.defer_transactions(key, txns);
+        {
+            let mut deferred_transactions =
+                self.consensus_output_cache.deferred_transactions.lock();
+            for (key, txns) in deferred_txns.into_iter() {
+                total_deferred_txns += txns.len();
+                deferred_transactions.insert(key, txns.clone());
+                output.defer_transactions(key, txns);
+            }
         }
+
         authority_metrics
             .consensus_handler_deferred_transactions
             .inc_by(total_deferred_txns as u64);
@@ -4062,7 +4034,7 @@ impl AuthorityPerEpochStore {
         checkpoint: &PendingCheckpointV2,
     ) -> SuiResult {
         assert!(
-            self.get_pending_checkpoint(&checkpoint.height())?.is_none(),
+            !self.pending_checkpoint_exists(&checkpoint.height())?,
             "Duplicate pending checkpoint notification at height {:?}",
             checkpoint.height()
         );
@@ -4088,30 +4060,41 @@ impl AuthorityPerEpochStore {
         last: Option<CheckpointHeight>,
     ) -> SuiResult<Vec<(CheckpointHeight, PendingCheckpointV2)>> {
         let tables = self.tables()?;
-        let mut iter = tables.pending_checkpoints_v2.unbounded_iter();
+        let mut db_iter = tables.pending_checkpoints_v2.unbounded_iter();
         if let Some(last_processed_height) = last {
-            iter = iter.skip_to(&(last_processed_height + 1))?;
+            db_iter = db_iter.skip_to(&(last_processed_height + 1))?;
         }
-        Ok(iter.collect())
+
+        let db_results: Vec<_> = db_iter.collect();
+
+        let mut quarantine_results = self
+            .consensus_quarantine
+            .read()
+            .get_pending_checkpoints(last);
+
+        // retain only the checkpoints with heights greater than the highest height in the db
+        if let Some(db_highest_height) = db_results.last().map(|(h, _)| h) {
+            quarantine_results.retain(|(h, _)| h > db_highest_height);
+        }
+
+        let mut db_results = db_results;
+        db_results.extend(quarantine_results);
+        Ok(db_results)
     }
 
-    pub fn get_pending_checkpoint(
-        &self,
-        index: &CheckpointHeight,
-    ) -> SuiResult<Option<PendingCheckpointV2>> {
-        Ok(self.tables()?.pending_checkpoints_v2.get(index)?)
+    pub fn pending_checkpoint_exists(&self, index: &CheckpointHeight) -> SuiResult<bool> {
+        Ok(self
+            .consensus_quarantine
+            .read()
+            .pending_checkpoint_exists(index))
     }
 
     pub fn process_pending_checkpoint(
         &self,
         commit_height: CheckpointHeight,
         content_info: NonEmpty<(CheckpointSummary, CheckpointContents)>,
-    ) -> SuiResult<()> {
-        let tables = self.tables()?;
-        // All created checkpoints are inserted in builder_checkpoint_summary in a single batch.
-        // This means that upon restart we can use BuilderCheckpointSummary::commit_height
-        // from the last built summary to resume building checkpoints.
-        let mut batch = tables.pending_checkpoints_v2.batch();
+    ) {
+        let mut consensus_quarantine = self.consensus_quarantine.write();
         for (position_in_commit, (summary, transactions)) in content_info.into_iter().enumerate() {
             let sequence_number = summary.sequence_number;
             let summary = BuilderCheckpointSummary {
@@ -4119,34 +4102,14 @@ impl AuthorityPerEpochStore {
                 checkpoint_height: Some(commit_height),
                 position_in_commit,
             };
-            batch.insert_batch(
-                &tables.builder_checkpoint_summary_v2,
-                [(&sequence_number, summary)],
-            )?;
-            batch.insert_batch(
-                &tables.builder_digest_to_checkpoint,
-                transactions
-                    .iter()
-                    .map(|tx| (tx.transaction, sequence_number)),
-            )?;
 
-            batch.delete_batch(
-                &tables.user_signatures_for_checkpoints,
-                transactions.iter().map(|tx| tx.transaction),
-            )?;
+            consensus_quarantine.insert_builder_summary(sequence_number, summary, transactions);
         }
 
-        // find all pending checkpoints <= commit_height and remove them
-        let iter = tables
-            .pending_checkpoints_v2
-            .safe_range_iter(0..=commit_height);
-        let keys = iter
-            .map(|c| c.map(|(h, _)| h))
-            .collect::<Result<Vec<_>, _>>()?;
-
-        batch.delete_batch(&tables.pending_checkpoints_v2, &keys)?;
-
-        Ok(batch.write()?)
+        // Because builder can run behind state sync, the data may be immediately ready to be committed.
+        consensus_quarantine
+            .commit(self)
+            .expect("commit cannot fail");
     }
 
     /// Register genesis checkpoint in builder DB
@@ -4180,6 +4143,10 @@ impl AuthorityPerEpochStore {
     pub fn last_built_checkpoint_builder_summary(
         &self,
     ) -> SuiResult<Option<BuilderCheckpointSummary>> {
+        if let Some(summary) = self.consensus_quarantine.read().last_built_summary() {
+            return Ok(Some(summary.clone()));
+        }
+
         Ok(self
             .tables()?
             .builder_checkpoint_summary_v2
@@ -4192,19 +4159,41 @@ impl AuthorityPerEpochStore {
     pub fn last_built_checkpoint_summary(
         &self,
     ) -> SuiResult<Option<(CheckpointSequenceNumber, CheckpointSummary)>> {
-        Ok(self
-            .tables()?
-            .builder_checkpoint_summary_v2
-            .unbounded_iter()
-            .skip_to_last()
-            .next()
-            .map(|(seq, s)| (seq, s.summary)))
+        if let Some(BuilderCheckpointSummary { summary, .. }) =
+            self.consensus_quarantine.read().last_built_summary()
+        {
+            let seq = *summary.sequence_number();
+            debug!(
+                "returning last_built_summary from consensus quarantine: {:?}",
+                seq
+            );
+            Ok(Some((seq, summary.clone())))
+        } else {
+            let seq = self
+                .tables()?
+                .builder_checkpoint_summary_v2
+                .unbounded_iter()
+                .skip_to_last()
+                .next()
+                .map(|(seq, s)| (seq, s.summary));
+            debug!(
+                "returning last_built_summary from builder_checkpoint_summary_v2: {:?}",
+                seq
+            );
+            Ok(seq)
+        }
     }
 
     pub fn get_built_checkpoint_summary(
         &self,
         sequence: CheckpointSequenceNumber,
     ) -> SuiResult<Option<CheckpointSummary>> {
+        if let Some(BuilderCheckpointSummary { summary, .. }) =
+            self.consensus_quarantine.read().get_built_summary(sequence)
+        {
+            return Ok(Some(summary.clone()));
+        }
+
         Ok(self
             .tables()?
             .builder_checkpoint_summary_v2
@@ -4216,10 +4205,40 @@ impl AuthorityPerEpochStore {
         &self,
         digests: impl Iterator<Item = &'a TransactionDigest>,
     ) -> SuiResult<Vec<bool>> {
-        Ok(self
+        let size_hint = digests.size_hint().0;
+        let mut results = Vec::with_capacity(size_hint);
+        let mut fallback_keys = Vec::with_capacity(size_hint);
+        let mut fallback_indices = Vec::with_capacity(size_hint);
+
+        {
+            let consensus_quarantine = self.consensus_quarantine.read();
+
+            for (i, digest) in digests.enumerate() {
+                if consensus_quarantine.included_transaction_in_checkpoint(digest) {
+                    results.push(true);
+                } else {
+                    results.push(false);
+                    fallback_keys.push(digest);
+                    fallback_indices.push(i);
+                }
+            }
+        }
+
+        let fallback_results = self
             .tables()?
             .builder_digest_to_checkpoint
-            .multi_contains_keys(digests)?)
+            .multi_contains_keys(fallback_keys)?;
+
+        assert_eq!(fallback_results.len(), fallback_indices.len());
+
+        for (result, i) in fallback_results
+            .into_iter()
+            .zip(fallback_indices.into_iter())
+        {
+            results[i] = result;
+        }
+
+        Ok(results)
     }
 
     pub fn get_last_checkpoint_signature_index(&self) -> SuiResult<u64> {

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -4034,16 +4034,21 @@ impl AuthorityPerEpochStore {
         &self,
         last: Option<CheckpointHeight>,
     ) -> SuiResult<Vec<(CheckpointHeight, PendingCheckpointV2)>> {
-        // TODO: Delete the db reads.
-        // Reading from the db table is only need when upgrading to data quarantining
-        // for the first time.
-        let tables = self.tables()?;
-        let mut db_iter = tables.pending_checkpoints_v2.unbounded_iter();
-        if let Some(last_processed_height) = last {
-            db_iter = db_iter.skip_to(&(last_processed_height + 1))?;
-        }
-
-        let db_results: Vec<_> = db_iter.collect();
+        let db_results = if !self
+            .epoch_start_config()
+            .is_data_quarantine_active_from_beginning_of_epoch()
+        {
+            // Reading from the db table is only need when upgrading to data quarantining
+            // for the first time.
+            let tables = self.tables()?;
+            let mut db_iter = tables.pending_checkpoints_v2.unbounded_iter();
+            if let Some(last_processed_height) = last {
+                db_iter = db_iter.skip_to(&(last_processed_height + 1))?;
+            }
+            db_iter.collect()
+        } else {
+            vec![]
+        };
 
         let mut quarantine_results = self
             .consensus_quarantine

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -823,6 +823,10 @@ impl AuthorityPerEpochStore {
             epoch_id
         );
         let epoch_start_configuration = Arc::new(epoch_start_configuration);
+        assert!(
+            epoch_start_configuration.use_version_assignment_tables_v3(),
+            "use_version_assignment_tables_v3 must be already be enabled for DataQuarantining"
+        );
         info!("epoch flags: {:?}", epoch_start_configuration.flags());
         metrics.current_epoch.set(epoch_id as i64);
         metrics

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -403,6 +403,7 @@ pub async fn send_consensus(authority: &AuthorityState, cert: &VerifiedCertifica
             vec![transaction],
             &Arc::new(CheckpointServiceNoop {}),
             authority.get_object_cache_reader().as_ref(),
+            authority.get_transaction_cache_reader().as_ref(),
             &authority.metrics,
             true,
         )
@@ -427,6 +428,7 @@ pub async fn send_consensus_no_execution(authority: &AuthorityState, cert: &Veri
             vec![transaction],
             &Arc::new(CheckpointServiceNoop {}),
             authority.get_object_cache_reader().as_ref(),
+            authority.get_transaction_cache_reader().as_ref(),
             &authority.metrics,
             true,
         )
@@ -457,6 +459,7 @@ pub async fn send_batch_consensus_no_execution(
             transactions,
             &Arc::new(CheckpointServiceNoop {}),
             authority.get_object_cache_reader().as_ref(),
+            authority.get_transaction_cache_reader().as_ref(),
             &authority.metrics,
             skip_consensus_commit_prologue_in_test,
         )

--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -1,31 +1,44 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{hash_map, BTreeMap, BTreeSet, HashMap, VecDeque};
 
-use crate::authority::authority_per_epoch_store::{EncG, ExecutionIndicesWithStats, PkG};
+use crate::authority::authority_per_epoch_store::{
+    AuthorityEpochTables, EncG, ExecutionIndicesWithStats, PkG,
+};
 use crate::authority::transaction_deferral::DeferralKey;
+use crate::checkpoints::BuilderCheckpointSummary;
+use crate::consensus_handler::SequencedConsensusTransactionKind;
 use crate::epoch::randomness::SINGLETON_KEY;
+use dashmap::DashMap;
 use fastcrypto_tbls::{dkg_v1, nodes::PartyId};
 use fastcrypto_zkp::bn254::zk_login::{JwkId, JWK};
+use mysten_common::fatal;
+use parking_lot::Mutex;
+use sui_types::authenticator_state::ActiveJwk;
 use sui_types::base_types::{AuthorityName, SequenceNumber};
 use sui_types::crypto::RandomnessRound;
 use sui_types::error::SuiResult;
+use sui_types::messages_checkpoint::{CheckpointContents, CheckpointSequenceNumber};
+use sui_types::messages_consensus::{ConsensusTransaction, ConsensusTransactionKind};
 use sui_types::{
     base_types::{ConsensusObjectSequenceKey, ObjectID},
     digests::TransactionDigest,
     messages_consensus::{Round, TimestampMs, VersionedDkgConfirmation},
     signature::GenericSignature,
+    transaction::TransactionKey,
 };
-use typed_store::rocks::DBBatch;
+use tracing::{debug, info};
+use typed_store::rocks::{DBBatch, DBTransaction};
+use typed_store::Map;
 
 use crate::{
     authority::{
         authority_per_epoch_store::AuthorityPerEpochStore,
-        epoch_start_configuration::EpochStartConfigTrait,
+        epoch_start_configuration::{EpochStartConfigTrait, EpochStartConfiguration},
         shared_object_congestion_tracker::CongestionPerObjectDebt,
     },
-    checkpoints::PendingCheckpointV2,
+    checkpoints::{CheckpointHeight, PendingCheckpointV2},
     consensus_handler::{SequencedConsensusTransactionKey, VerifiedSequencedConsensusTransaction},
     epoch::{
         randomness::{VersionedProcessedMessage, VersionedUsedProcessedMessages},
@@ -39,24 +52,21 @@ use super::*;
 pub(crate) struct ConsensusCommitOutput {
     // Consensus and reconfig state
     consensus_round: Round,
-    consensus_messages_processed: BTreeSet<SequencedConsensusTransactionKey>,
-    end_of_publish: BTreeSet<AuthorityName>,
-    reconfig_state: Option<ReconfigState>,
-    consensus_commit_stats: Option<ExecutionIndicesWithStats>,
-    pending_execution: Vec<VerifiedExecutableTransaction>,
+    consensus_messages_processed: BTreeSet<SequencedConsensusTransactionKey>, // done
+    end_of_publish: BTreeSet<AuthorityName>,                                  // done
+    reconfig_state: Option<ReconfigState>,                                    // done
+    consensus_commit_stats: Option<ExecutionIndicesWithStats>,                // done
 
     // transaction scheduling state
-    shared_object_versions: Option<(
-        AssignedTxAndVersions,
-        HashMap<ConsensusObjectSequenceKey, SequenceNumber>,
-    )>,
+    next_shared_object_versions: Option<HashMap<ConsensusObjectSequenceKey, SequenceNumber>>,
 
+    // TODO: If we delay committing consensus output until after all deferrals have been loaded,
+    // we can move deferred_txns to the ConsensusEphemeralOutput and save disk bandwidth.
     deferred_txns: Vec<(DeferralKey, Vec<VerifiedSequencedConsensusTransaction>)>,
     // deferred txns that have been loaded and can be removed
     deleted_deferred_txns: BTreeSet<DeferralKey>,
 
     // checkpoint state
-    user_signatures_for_checkpoints: Vec<(TransactionDigest, Vec<GenericSignature>)>,
     pending_checkpoints: Vec<PendingCheckpointV2>,
 
     // random beacon state
@@ -84,28 +94,51 @@ impl ConsensusCommitOutput {
         }
     }
 
+    fn get_randomness_last_round_timestamp(&self) -> Option<TimestampMs> {
+        self.next_randomness_round.as_ref().map(|(_, ts)| *ts)
+    }
+
+    fn get_highest_pending_checkpoint_height(&self) -> Option<CheckpointHeight> {
+        // TODO: can we simply get the height of the last checkpoint in the list?
+        self.pending_checkpoints.iter().map(|cp| cp.height()).max()
+    }
+
+    fn get_pending_checkpoints(
+        &self,
+        last: Option<CheckpointHeight>,
+    ) -> impl Iterator<Item = &PendingCheckpointV2> {
+        self.pending_checkpoints.iter().filter(move |cp| {
+            if let Some(last) = last {
+                cp.height() > last
+            } else {
+                true
+            }
+        })
+    }
+
+    fn pending_checkpoint_exists(&self, index: &CheckpointHeight) -> bool {
+        self.pending_checkpoints
+            .iter()
+            .any(|cp| cp.height() == *index)
+    }
+
+    fn get_round(&self) -> Option<u64> {
+        self.consensus_commit_stats
+            .as_ref()
+            .map(|stats| stats.index.last_committed_round)
+    }
+
     pub fn insert_end_of_publish(&mut self, authority: AuthorityName) {
         self.end_of_publish.insert(authority);
     }
 
-    pub fn insert_pending_execution(&mut self, transactions: &[VerifiedExecutableTransaction]) {
-        self.pending_execution.reserve(transactions.len());
-        self.pending_execution.extend_from_slice(transactions);
-    }
-
-    pub fn insert_user_signatures_for_checkpoints(
-        &mut self,
-        transactions: &[VerifiedExecutableTransaction],
-    ) {
-        self.user_signatures_for_checkpoints.extend(
-            transactions
-                .iter()
-                .map(|tx| (*tx.digest(), tx.tx_signatures().to_vec())),
-        );
-    }
-
-    pub fn record_consensus_commit_stats(&mut self, stats: ExecutionIndicesWithStats) {
+    pub(crate) fn record_consensus_commit_stats(&mut self, stats: ExecutionIndicesWithStats) {
         self.consensus_commit_stats = Some(stats);
+    }
+
+    // in testing code we often need to write to the db outside of a consensus commit
+    pub(crate) fn set_default_commit_stats_for_testing(&mut self) {
+        self.record_consensus_commit_stats(Default::default());
     }
 
     pub fn store_reconfig_state(&mut self, state: ReconfigState) {
@@ -116,13 +149,12 @@ impl ConsensusCommitOutput {
         self.consensus_messages_processed.insert(key);
     }
 
-    pub fn set_assigned_shared_object_versions(
+    pub fn set_next_shared_object_versions(
         &mut self,
-        versions: AssignedTxAndVersions,
         next_versions: HashMap<ConsensusObjectSequenceKey, SequenceNumber>,
     ) {
-        assert!(self.shared_object_versions.is_none());
-        self.shared_object_versions = Some((versions, next_versions));
+        assert!(self.next_shared_object_versions.is_none());
+        self.next_shared_object_versions = Some(next_versions);
     }
 
     pub fn defer_transactions(
@@ -212,64 +244,32 @@ impl ConsensusCommitOutput {
             )?;
         }
 
-        if let Some(consensus_commit_stats) = &self.consensus_commit_stats {
-            batch.insert_batch(
-                &tables.last_consensus_stats,
-                [(LAST_CONSENSUS_STATS_ADDR, consensus_commit_stats)],
-            )?;
-        }
+        let consensus_commit_stats = self
+            .consensus_commit_stats
+            .expect("consensus_commit_stats must be set");
+        let round = consensus_commit_stats.index.last_committed_round;
 
         batch.insert_batch(
-            &tables.pending_execution,
-            self.pending_execution
-                .into_iter()
-                .map(|tx| (*tx.inner().digest(), tx.serializable())),
+            &tables.last_consensus_stats,
+            [(LAST_CONSENSUS_STATS_ADDR, consensus_commit_stats)],
         )?;
 
-        if let Some((assigned_versions, next_versions)) = self.shared_object_versions {
+        if let Some(next_versions) = self.next_shared_object_versions {
             if epoch_store
                 .epoch_start_config()
                 .use_version_assignment_tables_v3()
             {
-                batch.insert_batch(
-                    &tables.assigned_shared_object_versions_v3,
-                    assigned_versions,
-                )?;
                 batch.insert_batch(&tables.next_shared_object_versions_v2, next_versions)?;
             } else {
                 batch.insert_batch(
-                    &tables.assigned_shared_object_versions_v2,
-                    assigned_versions.into_iter().map(|(key, versions)| {
-                        (
-                            key,
-                            versions
-                                .into_iter()
-                                .map(|(id, v)| (id.0, v))
-                                .collect::<Vec<_>>(),
-                        )
-                    }),
-                )?;
-                batch.insert_batch(
                     &tables.next_shared_object_versions,
-                    next_versions.into_iter().map(|(key, v)| (key.0, v)),
+                    next_versions.into_iter().map(|((id, _), v)| (id, v)),
                 )?;
             }
         }
 
         batch.delete_batch(&tables.deferred_transactions, self.deleted_deferred_txns)?;
         batch.insert_batch(&tables.deferred_transactions, self.deferred_txns)?;
-
-        batch.insert_batch(
-            &tables.user_signatures_for_checkpoints,
-            self.user_signatures_for_checkpoints,
-        )?;
-
-        batch.insert_batch(
-            &tables.pending_checkpoints_v2,
-            self.pending_checkpoints
-                .into_iter()
-                .map(|cp| (cp.height(), cp)),
-        )?;
 
         if let Some((round, commit_timestamp)) = self.next_randomness_round {
             batch.insert_batch(&tables.randomness_next_round, [(SINGLETON_KEY, round)])?;
@@ -301,7 +301,11 @@ impl ConsensusCommitOutput {
         )?;
         batch.insert_batch(
             &tables.active_jwks,
-            self.active_jwks.into_iter().map(|j| (j, ())),
+            self.active_jwks.into_iter().map(|j| {
+                // TODO: we don't need to store the round in this map if it is invariant
+                assert_eq!(j.0, round);
+                (j, ())
+            }),
         )?;
 
         batch.insert_batch(
@@ -328,5 +332,649 @@ impl ConsensusCommitOutput {
         )?;
 
         Ok(())
+    }
+}
+
+/// ConsensusOutputCache holds outputs of consensus processing that do not need to be committed to disk.
+/// Data quarantining guarantees that all of this data will be used (e.g. for building checkpoints)
+/// before the consensus commit from which it originated is marked as processed. Therefore we can rely
+/// on replay of consensus commits to recover this data.
+pub(crate) struct ConsensusEphemeralOutput {
+    // shared version assignments is a DashMap because it is read from execution so we don't
+    // want contention.
+    pub(super) shared_version_assignments:
+        DashMap<TransactionKey, Vec<(ConsensusObjectSequenceKey, SequenceNumber)>>,
+
+    // deferred transactions is only used by consensus handler so there should never be lock contention
+    // - hence no need for a DashMap.
+    pub(super) deferred_transactions:
+        Mutex<BTreeMap<DeferralKey, Vec<VerifiedSequencedConsensusTransaction>>>,
+    // user_signatures_for_checkpoints is written to by consensus handler and read from by checkpoint builder
+    // The critical sections are small in both cases so a DashMap is probably not helpful.
+    pub(super) user_signatures_for_checkpoints:
+        Mutex<HashMap<TransactionDigest, Vec<GenericSignature>>>,
+}
+
+impl ConsensusEphemeralOutput {
+    pub(crate) fn new(
+        epoch_start_configuration: &EpochStartConfiguration,
+        tables: &AuthorityEpochTables,
+    ) -> Self {
+        let shared_version_assignments =
+            Self::get_all_shared_version_assignments(epoch_start_configuration, tables);
+
+        let deferred_transactions = tables
+            .get_all_deferred_transactions()
+            .expect("load deferred transactions cannot fail");
+
+        let user_signatures_for_checkpoints = tables
+            .get_all_user_signatures_for_checkpoints()
+            .expect("load user signatures for checkpoints cannot fail");
+
+        Self {
+            shared_version_assignments: shared_version_assignments.into_iter().collect(),
+            deferred_transactions: Mutex::new(deferred_transactions),
+            user_signatures_for_checkpoints: Mutex::new(user_signatures_for_checkpoints),
+        }
+    }
+
+    // Used to read pre-existing shared object versions from the database after a crash.
+    // TODO: remove this once all nodes have upgraded to data-quarantining.
+    fn get_all_shared_version_assignments(
+        epoch_start_configuration: &EpochStartConfiguration,
+        tables: &AuthorityEpochTables,
+    ) -> Vec<(
+        TransactionKey,
+        Vec<(ConsensusObjectSequenceKey, SequenceNumber)>,
+    )> {
+        if epoch_start_configuration.use_version_assignment_tables_v3() {
+            tables
+                .assigned_shared_object_versions_v3
+                .safe_iter()
+                .collect::<Result<_, _>>()
+                .expect("db error")
+        } else {
+            tables
+                .assigned_shared_object_versions_v2
+                .safe_iter()
+                .collect::<Result<Vec<_>, _>>()
+                .expect("db error")
+                .into_iter()
+                .map(|(key, value)| {
+                    (
+                        key,
+                        value
+                            .into_iter()
+                            .map(|(id, v)| ((id, SequenceNumber::UNKNOWN), v))
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect()
+        }
+    }
+}
+
+/// ConsensusOutputQuarantine holds outputs of consensus processing in memory until the checkpoints
+/// for the commit have been certified.
+pub(crate) struct ConsensusOutputQuarantine {
+    // Output from consensus handler
+    output_queue: VecDeque<ConsensusCommitOutput>,
+
+    // Highest known certified checkpoint sequence number
+    highest_executed_checkpoint: CheckpointSequenceNumber,
+
+    // Checkpoint Builder output
+    builder_checkpoint_summary:
+        BTreeMap<CheckpointSequenceNumber, (BuilderCheckpointSummary, CheckpointContents)>,
+
+    builder_digest_to_checkpoint: HashMap<TransactionDigest, CheckpointSequenceNumber>,
+
+    // Any un-committed next versions are stored here.
+    shared_object_next_versions: RefCountedHashMap<ConsensusObjectSequenceKey, SequenceNumber>,
+
+    // The most recent congestion control debts for objects. Uses a ref-count to track
+    // which objects still exist in some element of output_queue.
+    congestion_control_randomness_object_debts:
+        RefCountedHashMap<ObjectID, CongestionPerObjectDebt>,
+    congestion_control_object_debts: RefCountedHashMap<ObjectID, CongestionPerObjectDebt>,
+
+    processed_consensus_messages: RefCountedHashMap<SequencedConsensusTransactionKey, ()>,
+}
+
+impl ConsensusOutputQuarantine {
+    pub(super) fn new(highest_executed_checkpoint: CheckpointSequenceNumber) -> Self {
+        Self {
+            highest_executed_checkpoint,
+
+            output_queue: VecDeque::new(),
+            builder_checkpoint_summary: BTreeMap::new(),
+            builder_digest_to_checkpoint: HashMap::new(),
+            shared_object_next_versions: RefCountedHashMap::new(),
+            processed_consensus_messages: RefCountedHashMap::new(),
+            congestion_control_randomness_object_debts: RefCountedHashMap::new(),
+            congestion_control_object_debts: RefCountedHashMap::new(),
+        }
+    }
+}
+
+// Write methods - all methods in this block insert new data into the quarantine.
+// There are only two sources! ConsensusHandler and CheckpointBuilder.
+impl ConsensusOutputQuarantine {
+    // Push all data gathered from a consensus commit into the quarantine.
+    pub(super) fn push_consensus_output(&mut self, output: ConsensusCommitOutput) {
+        self.insert_shared_object_next_versions(&output);
+        self.insert_congestion_control_debts(&output);
+        self.insert_processed_consensus_messages(&output);
+        self.output_queue.push_back(output);
+    }
+
+    // Record a newly built checkpoint.
+    pub(super) fn insert_builder_summary(
+        &mut self,
+        sequence_number: CheckpointSequenceNumber,
+        summary: BuilderCheckpointSummary,
+        contents: CheckpointContents,
+    ) {
+        debug!(?sequence_number, "inserting builder summary {:?}", summary);
+        for tx in contents.iter() {
+            self.builder_digest_to_checkpoint
+                .insert(tx.transaction, sequence_number);
+        }
+        self.builder_checkpoint_summary
+            .insert(sequence_number, (summary, contents));
+    }
+}
+
+// Commit methods.
+impl ConsensusOutputQuarantine {
+    /// Update the highest executed checkpoint and commit any data which is now
+    /// below the watermark.
+    pub(super) fn update_highest_executed_checkpoint(
+        &mut self,
+        checkpoint: CheckpointSequenceNumber,
+        epoch_store: &AuthorityPerEpochStore,
+        batch: &mut DBBatch,
+    ) -> SuiResult {
+        self.highest_executed_checkpoint = checkpoint;
+        self.commit_with_batch(epoch_store, batch)
+    }
+
+    pub(super) fn commit(&mut self, epoch_store: &AuthorityPerEpochStore) -> SuiResult {
+        let mut batch = epoch_store.db_batch()?;
+        self.commit_with_batch(epoch_store, &mut batch)?;
+        batch.write()?;
+        Ok(())
+    }
+
+    /// Commit all data below the watermark.
+    fn commit_with_batch(
+        &mut self,
+        epoch_store: &AuthorityPerEpochStore,
+        batch: &mut DBBatch,
+    ) -> SuiResult {
+        // The commit algorithm is simple:
+        // 1. First commit all checkpoint builder state which is below the watermark.
+        // 2. Determine the consensus commit height that corresponds to the highest committed
+        //    checkpoint.
+        // 3. Commit all consensus output at that height or below.
+
+        let tables = epoch_store.tables()?;
+
+        let mut highest_committed_height = None;
+
+        while self
+            .builder_checkpoint_summary
+            .first_key_value()
+            .map(|(seq, _)| *seq <= self.highest_executed_checkpoint)
+            == Some(true)
+        {
+            let (seq, (builder_summary, contents)) =
+                self.builder_checkpoint_summary.pop_first().unwrap();
+
+            for tx in contents.iter() {
+                let digest = &tx.transaction;
+                assert_eq!(
+                    self.builder_digest_to_checkpoint
+                        .remove(digest)
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "transaction {:?} not found in builder_digest_to_checkpoint",
+                                digest
+                            )
+                        }),
+                    seq
+                );
+            }
+
+            batch.insert_batch(
+                &tables.builder_digest_to_checkpoint,
+                contents.iter().map(|tx| (tx.transaction, seq)),
+            )?;
+
+            batch.insert_batch(
+                &tables.builder_checkpoint_summary_v2,
+                [(seq, &builder_summary)],
+            )?;
+
+            let checkpoint_height = builder_summary
+                .checkpoint_height
+                .expect("non-genesis checkpoint must have height");
+            if let Some(highest) = highest_committed_height {
+                assert!(checkpoint_height > highest);
+            }
+
+            highest_committed_height = Some(checkpoint_height);
+        }
+
+        let Some(highest_committed_height) = highest_committed_height else {
+            return Ok(());
+        };
+
+        while !self.output_queue.is_empty() {
+            // A consensus commit can have more than one pending checkpoint (a regular one and a randomnes one).
+            // We can only write the consensus commit if the highest pending checkpoint associated with it has
+            // been processed by the builder.
+            let Some(highest_in_commit) = self
+                .output_queue
+                .front()
+                .unwrap()
+                .get_highest_pending_checkpoint_height()
+            else {
+                // if highest is none, we have already written the pending checkpoint for the final epoch,
+                // so there is no more data that needs to be committed.
+                break;
+            };
+
+            if highest_in_commit <= highest_committed_height {
+                info!(
+                    "committing output with highest pending checkpoint height {:?}",
+                    highest_in_commit
+                );
+                let output = self.output_queue.pop_front().unwrap();
+                self.remove_shared_object_next_versions(&output);
+                self.remove_processed_consensus_messages(&output);
+                self.remove_congestion_control_debts(&output);
+                epoch_store.remove_shared_version_assignments(
+                    output
+                        .pending_checkpoints
+                        .iter()
+                        .flat_map(|c| c.roots().iter()),
+                );
+                output.write_to_batch(epoch_store, batch)?;
+            } else {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// Read methods - all methods in this block return data from the quarantine which would otherwise
+// by found in the database.
+impl ConsensusOutputQuarantine {
+    pub(super) fn last_built_summary(&self) -> Option<&BuilderCheckpointSummary> {
+        self.builder_checkpoint_summary
+            .values()
+            .last()
+            .map(|(summary, _)| summary)
+    }
+
+    pub(super) fn get_built_summary(
+        &self,
+        sequence: CheckpointSequenceNumber,
+    ) -> Option<&BuilderCheckpointSummary> {
+        self.builder_checkpoint_summary
+            .get(&sequence)
+            .map(|(summary, _)| summary)
+    }
+
+    pub(super) fn included_transaction_in_checkpoint(&self, digest: &TransactionDigest) -> bool {
+        self.builder_digest_to_checkpoint.contains_key(digest)
+    }
+
+    pub(super) fn is_consensus_message_processed(
+        &self,
+        key: &SequencedConsensusTransactionKey,
+    ) -> bool {
+        self.processed_consensus_messages.contains_key(key)
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.output_queue.is_empty()
+    }
+
+    pub(super) fn get_next_shared_object_versions(
+        &self,
+        epoch_start_config: &EpochStartConfiguration,
+        tables: &AuthorityEpochTables,
+        db_transaction: &DBTransaction<'_>,
+        objects_to_init: &[ConsensusObjectSequenceKey],
+    ) -> SuiResult<Vec<Option<SequenceNumber>>> {
+        let mut results = Vec::with_capacity(objects_to_init.len());
+        let mut fallback_keys = Vec::with_capacity(objects_to_init.len());
+        let mut fallback_indices = Vec::with_capacity(objects_to_init.len());
+
+        for (i, object_key) in objects_to_init.iter().enumerate() {
+            if let Some(next_version) = self.shared_object_next_versions.get(object_key) {
+                results.push(Some(*next_version));
+            } else {
+                results.push(None);
+                fallback_keys.push(object_key);
+                fallback_indices.push(i);
+            }
+        }
+
+        let fallback_results = if epoch_start_config.use_version_assignment_tables_v3() {
+            db_transaction.multi_get(&tables.next_shared_object_versions_v2, fallback_keys)?
+        } else {
+            db_transaction.multi_get(
+                &tables.next_shared_object_versions,
+                fallback_keys.iter().map(|(id, _)| *id),
+            )?
+        };
+
+        assert_eq!(fallback_results.len(), fallback_indices.len());
+        for (i, result) in fallback_indices.into_iter().zip(fallback_results) {
+            results[i] = result;
+        }
+
+        Ok(results)
+    }
+
+    fn insert_shared_object_next_versions(&mut self, output: &ConsensusCommitOutput) {
+        if let Some(next_versions) = output.next_shared_object_versions.as_ref() {
+            for (object_id, next_version) in next_versions {
+                self.shared_object_next_versions
+                    .insert(*object_id, *next_version);
+            }
+        }
+    }
+
+    fn insert_congestion_control_debts(&mut self, output: &ConsensusCommitOutput) {
+        let current_round = output.consensus_round;
+
+        for (object_id, debt) in output.congestion_control_object_debts.iter() {
+            self.congestion_control_object_debts.insert(
+                *object_id,
+                CongestionPerObjectDebt::new(current_round, *debt),
+            );
+        }
+
+        for (object_id, debt) in output.congestion_control_randomness_object_debts.iter() {
+            self.congestion_control_randomness_object_debts.insert(
+                *object_id,
+                CongestionPerObjectDebt::new(current_round, *debt),
+            );
+        }
+    }
+
+    fn remove_congestion_control_debts(&mut self, output: &ConsensusCommitOutput) {
+        for (object_id, _) in output.congestion_control_object_debts.iter() {
+            self.congestion_control_object_debts.remove(object_id);
+        }
+        for (object_id, _) in output.congestion_control_randomness_object_debts.iter() {
+            self.congestion_control_randomness_object_debts
+                .remove(object_id);
+        }
+    }
+
+    fn insert_processed_consensus_messages(&mut self, output: &ConsensusCommitOutput) {
+        for tx_key in output.consensus_messages_processed.iter() {
+            self.processed_consensus_messages.insert(tx_key.clone(), ());
+        }
+    }
+
+    fn remove_processed_consensus_messages(&mut self, output: &ConsensusCommitOutput) {
+        for tx_key in output.consensus_messages_processed.iter() {
+            self.processed_consensus_messages.remove(tx_key);
+        }
+    }
+
+    pub(super) fn remove_shared_object_next_versions(&mut self, output: &ConsensusCommitOutput) {
+        if let Some(next_versions) = output.next_shared_object_versions.as_ref() {
+            for object_id in next_versions.keys() {
+                if !self.shared_object_next_versions.remove(object_id) {
+                    fatal!(
+                        "Shared object next version not found in quarantine: {:?}",
+                        object_id
+                    );
+                }
+            }
+        }
+    }
+
+    pub(super) fn get_highest_pending_checkpoint_height(&self) -> Option<CheckpointHeight> {
+        self.output_queue
+            .back()
+            .and_then(|output| output.get_highest_pending_checkpoint_height())
+    }
+
+    pub(super) fn get_pending_checkpoints(
+        &self,
+        last: Option<CheckpointHeight>,
+    ) -> Vec<(CheckpointHeight, PendingCheckpointV2)> {
+        let mut checkpoints = Vec::new();
+        for output in &self.output_queue {
+            checkpoints.extend(
+                output
+                    .get_pending_checkpoints(last)
+                    .map(|cp| (cp.height(), cp.clone())),
+            );
+        }
+        if cfg!(debug_assertions) {
+            let mut prev = None;
+            for (height, _) in &checkpoints {
+                if let Some(prev) = prev {
+                    assert!(prev < *height);
+                }
+                prev = Some(*height);
+            }
+        }
+        checkpoints
+    }
+
+    pub(super) fn pending_checkpoint_exists(&self, index: &CheckpointHeight) -> bool {
+        self.output_queue
+            .iter()
+            .any(|output| output.pending_checkpoint_exists(index))
+    }
+
+    pub(super) fn get_new_jwks(
+        &self,
+        epoch_store: &AuthorityPerEpochStore,
+        round: u64,
+    ) -> SuiResult<Vec<ActiveJwk>> {
+        let epoch = epoch_store.epoch();
+
+        // Check if the requested round is in memory
+        for output in self.output_queue.iter().rev() {
+            // unwrap safe because output will always have last consensus stats set before being added
+            // to the quarantine
+            let output_round = output.get_round().unwrap();
+            if round == output_round {
+                return Ok(output
+                    .active_jwks
+                    .iter()
+                    .map(|(_, (jwk_id, jwk))| ActiveJwk {
+                        jwk_id: jwk_id.clone(),
+                        jwk: jwk.clone(),
+                        epoch,
+                    })
+                    .collect());
+            }
+        }
+
+        // Fall back to reading from database
+        let empty_jwk_id = JwkId::new(String::new(), String::new());
+        let empty_jwk = JWK {
+            kty: String::new(),
+            e: String::new(),
+            n: String::new(),
+            alg: String::new(),
+        };
+
+        let start = (round, (empty_jwk_id.clone(), empty_jwk.clone()));
+        let end = (round + 1, (empty_jwk_id, empty_jwk));
+
+        Ok(epoch_store
+            .tables()?
+            .active_jwks
+            .safe_iter_with_bounds(Some(start), Some(end))
+            .map_ok(|((r, (jwk_id, jwk)), _)| {
+                debug_assert!(round == r);
+                ActiveJwk { jwk_id, jwk, epoch }
+            })
+            .collect::<Result<Vec<_>, _>>()?)
+    }
+
+    pub(super) fn get_randomness_last_round_timestamp(&self) -> Option<TimestampMs> {
+        self.output_queue
+            .iter()
+            .rev()
+            .filter_map(|output| output.get_randomness_last_round_timestamp())
+            .next()
+    }
+
+    pub(super) fn load_initial_object_debts(
+        &self,
+        epoch_store: &AuthorityPerEpochStore,
+        current_round: Round,
+        for_randomness: bool,
+        transactions: &[VerifiedSequencedConsensusTransaction],
+    ) -> SuiResult<impl IntoIterator<Item = (ObjectID, u64)>> {
+        let protocol_config = epoch_store.protocol_config();
+        let tables = epoch_store.tables()?;
+        let default_per_commit_budget = protocol_config
+            .max_accumulated_txn_cost_per_object_in_mysticeti_commit_as_option()
+            .unwrap_or(0);
+        let (hash_table, db_table, per_commit_budget) = if for_randomness {
+            (
+                &self.congestion_control_randomness_object_debts,
+                &tables.congestion_control_randomness_object_debts,
+                protocol_config
+                    .max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit_as_option()
+                    .unwrap_or(default_per_commit_budget),
+            )
+        } else {
+            (
+                &self.congestion_control_object_debts,
+                &tables.congestion_control_object_debts,
+                default_per_commit_budget,
+            )
+        };
+        let shared_input_object_ids: BTreeSet<_> = transactions
+            .iter()
+            .filter_map(|tx| {
+                if let SequencedConsensusTransactionKind::External(ConsensusTransaction {
+                    kind: ConsensusTransactionKind::CertifiedTransaction(tx),
+                    ..
+                }) = &tx.0.transaction
+                {
+                    Some(tx.shared_input_objects().map(|obj| obj.id))
+                } else {
+                    None
+                }
+            })
+            .flatten()
+            .collect();
+
+        let num_ids = shared_input_object_ids.len();
+        let mut results = Vec::with_capacity(num_ids);
+        let mut fallback_keys = Vec::with_capacity(num_ids);
+        let mut fallback_indices = Vec::with_capacity(num_ids);
+
+        for (i, object_id) in shared_input_object_ids.iter().enumerate() {
+            if let Some(debt) = hash_table.get(object_id) {
+                results.push(Some(debt.into_v1()));
+            } else {
+                results.push(None);
+                fallback_keys.push(object_id);
+                fallback_indices.push(i);
+            }
+        }
+
+        let fallback_results = db_table.multi_get(fallback_keys)?;
+        assert_eq!(fallback_results.len(), fallback_indices.len());
+        for (i, result) in fallback_indices.into_iter().zip(fallback_results) {
+            results[i] = result.map(|debt| debt.into_v1());
+        }
+
+        Ok(results
+            .into_iter()
+            .zip(shared_input_object_ids)
+            .filter_map(|(debt, object_id)| debt.map(|debt| (debt, object_id)))
+            .map(move |((round, debt), object_id)| {
+                // Stored debts already account for the budget of the round in which
+                // they were accumulated. Application of budget from future rounds to
+                // the debt is handled here.
+                assert!(current_round > round);
+                let num_rounds = current_round - round - 1;
+                let debt = debt.saturating_sub(per_commit_budget * num_rounds);
+                (object_id, debt)
+            }))
+    }
+}
+
+// A wrapper around HashMap that uses refcounts to keep entries alive until
+// they are no longer needed.
+//
+// If there are N inserts for the same key, the key will not be removed until
+// there are N removes.
+//
+// It is intended to track the *latest* value for a given key, so duplicate
+// inserts are intended to overwrite any prior value.
+#[derive(Debug, Default)]
+struct RefCountedHashMap<K, V> {
+    map: HashMap<K, (usize, V)>,
+}
+
+impl<K, V> RefCountedHashMap<K, V>
+where
+    K: Clone + Eq + std::hash::Hash,
+{
+    pub fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+        }
+    }
+
+    pub fn insert(&mut self, key: K, value: V) {
+        let entry = self.map.entry(key);
+        match entry {
+            hash_map::Entry::Occupied(mut entry) => {
+                let (ref_count, v) = entry.get_mut();
+                *ref_count += 1;
+                *v = value;
+            }
+            hash_map::Entry::Vacant(entry) => {
+                entry.insert((1, value));
+            }
+        }
+    }
+
+    // Returns true if the key was present, false otherwise.
+    // Note that the key may not be removed if present, as it may have a refcount > 1.
+    pub fn remove(&mut self, key: &K) -> bool {
+        let entry = self.map.entry(key.clone());
+        match entry {
+            hash_map::Entry::Occupied(mut entry) => {
+                let (ref_count, _) = entry.get_mut();
+                *ref_count -= 1;
+                if *ref_count == 0 {
+                    entry.remove();
+                }
+                true
+            }
+            hash_map::Entry::Vacant(_) => false,
+        }
+    }
+
+    pub fn get(&self, key: &K) -> Option<&V> {
+        self.map.get(key).map(|(_, v)| v)
+    }
+
+    pub fn contains_key(&self, key: &K) -> bool {
+        self.map.contains_key(key)
     }
 }

--- a/crates/sui-core/src/authority/epoch_start_configuration.rs
+++ b/crates/sui-core/src/authority/epoch_start_configuration.rs
@@ -34,6 +34,11 @@ pub trait EpochStartConfigTrait {
         self.flags()
             .contains(&EpochFlag::UseVersionAssignmentTablesV3)
     }
+
+    fn is_data_quarantine_active_from_beginning_of_epoch(&self) -> bool {
+        self.flags()
+            .contains(&EpochFlag::DataQuarantineFromBeginningOfEpoch)
+    }
 }
 
 // IMPORTANT: Assign explicit values to each variant to ensure that the values are stable.
@@ -59,6 +64,10 @@ pub enum EpochFlag {
     _ExecutedInEpochTableDeprecated = 7,
 
     UseVersionAssignmentTablesV3 = 8,
+
+    // This flag indicates whether data quarantining has been enabled from the
+    // beginning of the epoch.
+    DataQuarantineFromBeginningOfEpoch = 9,
 }
 
 impl EpochFlag {
@@ -74,7 +83,10 @@ impl EpochFlag {
     }
 
     fn default_flags_impl() -> Vec<Self> {
-        vec![EpochFlag::UseVersionAssignmentTablesV3]
+        vec![
+            EpochFlag::UseVersionAssignmentTablesV3,
+            EpochFlag::DataQuarantineFromBeginningOfEpoch,
+        ]
     }
 }
 
@@ -108,6 +120,9 @@ impl fmt::Display for EpochFlag {
             }
             EpochFlag::UseVersionAssignmentTablesV3 => {
                 write!(f, "UseVersionAssignmentTablesV3")
+            }
+            EpochFlag::DataQuarantineFromBeginningOfEpoch => {
+                write!(f, "DataQuarantineFromBeginningOfEpoch")
             }
         }
     }

--- a/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
+++ b/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::authority_per_epoch_store::AuthorityEpochTables;
 use super::execution_time_estimator::ExecutionTimeEstimator;
 use crate::authority::transaction_deferral::DeferralKey;
 use serde::{Deserialize, Serialize};

--- a/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
+++ b/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
@@ -4,7 +4,6 @@
 use super::authority_per_epoch_store::AuthorityEpochTables;
 use super::execution_time_estimator::ExecutionTimeEstimator;
 use crate::authority::transaction_deferral::DeferralKey;
-use crate::consensus_handler::VerifiedSequencedConsensusTransaction;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use sui_protocol_config::{PerObjectCongestionControlMode, ProtocolConfig};
@@ -88,21 +87,14 @@ impl SharedObjectCongestionTracker {
     }
 
     pub fn from_protocol_config(
-        tables: &AuthorityEpochTables,
+        initial_object_debts: impl IntoIterator<Item = (ObjectID, u64)>,
         protocol_config: &ProtocolConfig,
-        round: Round,
         for_randomness: bool,
-        transactions: &[VerifiedSequencedConsensusTransaction],
     ) -> SuiResult<Self> {
         let max_accumulated_txn_cost_per_object_in_commit =
             protocol_config.max_accumulated_txn_cost_per_object_in_mysticeti_commit_as_option();
         Ok(Self::new(
-            tables.load_initial_object_debts(
-                round,
-                for_randomness,
-                protocol_config,
-                transactions,
-            )?,
+            initial_object_debts,
             protocol_config.per_object_congestion_control_mode(),
             if for_randomness {
                 protocol_config
@@ -303,7 +295,7 @@ impl SharedObjectCongestionTracker {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub enum CongestionPerObjectDebt {
     V1(Round, u64),
 }

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -273,6 +273,10 @@ impl<'a> TestAuthorityBuilder<'a> {
             signature_verifier_metrics,
             &expensive_safety_checks,
             ChainIdentifier::from(*genesis.checkpoint().digest()),
+            checkpoint_store
+                .get_highest_executed_checkpoint_seq_number()
+                .unwrap()
+                .unwrap_or(0),
         );
         let committee_store = Arc::new(CommitteeStore::new(
             path.join("epochs"),

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -28,6 +28,7 @@ use std::{
 use either::Either;
 use futures::stream::FuturesOrdered;
 use itertools::izip;
+use mysten_common::fatal;
 use mysten_metrics::spawn_monitored_task;
 use sui_config::node::{CheckpointExecutorConfig, RunWithRange};
 use sui_macros::{fail_point, fail_point_async};
@@ -462,7 +463,7 @@ impl CheckpointExecutor {
             .await;
 
         epoch_store
-            .handle_committed_transactions(all_tx_digests)
+            .handle_finalized_checkpoint(checkpoint.data(), all_tx_digests)
             .expect("cannot fail");
 
         // Once the checkpoint is finalized, we know that any randomness contained in this checkpoint has
@@ -1240,7 +1241,7 @@ fn get_unexecuted_transactions(
             .enumerate()
             .map(|(i, (tx, expected_effects_digest))| {
                 let tx = tx.unwrap_or_else(||
-                    panic!(
+                    fatal!(
                         "state-sync should have ensured that transaction with digest {:?} exists for checkpoint: {checkpoint:?}",
                         unexecuted_txns[i]
                     )

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -27,7 +27,6 @@ use serde::{Deserialize, Serialize};
 use sui_macros::fail_point;
 use sui_network::default_mysten_network_config;
 use sui_types::base_types::ConciseableName;
-use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::messages_checkpoint::CheckpointCommitment;
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
 use tokio::sync::watch;
@@ -747,106 +746,6 @@ impl CheckpointStore {
         self.watermarks.rocksdb.flush()?;
         Ok(())
     }
-
-    /// Re-executes all transactions from all local, uncertified checkpoints for crash recovery.
-    /// All transactions thus re-executed are guaranteed to not have any missing dependencies,
-    /// because we start from the highest executed checkpoint, and proceed through checkpoints in
-    /// order.
-    #[instrument(level = "debug", skip_all)]
-    pub async fn reexecute_local_checkpoints(
-        &self,
-        state: &AuthorityState,
-        epoch_store: &AuthorityPerEpochStore,
-    ) {
-        info!("rexecuting locally computed checkpoints for crash recovery");
-        let epoch = epoch_store.epoch();
-        let highest_executed = self
-            .get_highest_executed_checkpoint_seq_number()
-            .expect("get_highest_executed_checkpoint_seq_number should not fail")
-            .unwrap_or(0);
-
-        let Some(highest_built) = self.get_latest_locally_computed_checkpoint() else {
-            info!("no locally built checkpoints to verify");
-            return;
-        };
-
-        for seq in highest_executed + 1..=*highest_built.sequence_number() {
-            info!(?seq, "Re-executing locally computed checkpoint");
-            let Some(checkpoint) = self
-                .get_locally_computed_checkpoint(seq)
-                .expect("get_locally_computed_checkpoint should not fail")
-            else {
-                panic!("locally computed checkpoint {:?} not found", seq);
-            };
-
-            let Some(contents) = self
-                .get_checkpoint_contents(&checkpoint.content_digest)
-                .expect("get_checkpoint_contents should not fail")
-            else {
-                panic!("checkpoint contents not found for locally computed checkpoint {:?} (digest: {:?})", seq, checkpoint.content_digest);
-            };
-
-            let cache = state.get_transaction_cache_reader();
-
-            let tx_digests: Vec<_> = contents.iter().map(|digests| digests.transaction).collect();
-            let fx_digests: Vec<_> = contents.iter().map(|digests| digests.effects).collect();
-            let txns = cache.multi_get_transaction_blocks(&tx_digests);
-            for (tx, digest) in txns.iter().zip(tx_digests.iter()) {
-                if tx.is_none() {
-                    panic!("transaction {:?} not found", digest);
-                }
-            }
-
-            let txns: Vec<_> = txns
-                .into_iter()
-                .map(|tx| tx.unwrap())
-                .zip(fx_digests.into_iter())
-                // end of epoch transaction can only be executed by CheckpointExecutor
-                .filter(|(tx, _)| !tx.data().transaction_data().is_end_of_epoch_tx())
-                .map(|(tx, fx)| {
-                    (
-                        VerifiedExecutableTransaction::new_from_checkpoint(
-                            (*tx).clone(),
-                            epoch,
-                            seq,
-                        ),
-                        fx,
-                    )
-                })
-                .collect();
-
-            let tx_digests: Vec<_> = txns.iter().map(|(tx, _)| *tx.digest()).collect();
-
-            info!(
-                ?seq,
-                ?tx_digests,
-                "Re-executing transactions for locally built checkpoint"
-            );
-            // this will panic if any re-execution diverges from the previously recorded effects digest
-            state.enqueue_with_expected_effects_digest(txns, epoch_store);
-
-            // a task that logs every so often until it is cancelled
-            // This should normally finish very quickly, so seeing this log more than once or twice is
-            // likely a sign of a problem.
-            let waiting_logger = tokio::task::spawn(async move {
-                let mut interval = tokio::time::interval(Duration::from_secs(1));
-                loop {
-                    interval.tick().await;
-                    warn!(?seq, "Still waiting for re-execution to complete");
-                }
-            });
-
-            cache
-                .notify_read_executed_effects_digests(&tx_digests)
-                .await;
-
-            waiting_logger.abort();
-            waiting_logger.await.ok();
-            info!(?seq, "Re-execution completed for locally built checkpoint");
-        }
-
-        info!("Re-execution of locally built checkpoints completed");
-    }
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
@@ -998,6 +897,7 @@ impl CheckpointBuilder {
             {
                 Ok(seq) => {
                     self.last_built.send_if_modified(|cur| {
+                        // when rebuilding checkpoints at startup, seq can be for an old checkpoint
                         if seq > *cur {
                             *cur = seq;
                             true
@@ -1104,6 +1004,15 @@ impl CheckpointBuilder {
 
                 // No other dependencies of this consensus commit prologue that haven't been included
                 // in any previous checkpoint.
+                if unsorted_ccp.len() != 1 {
+                    fatal!(
+                        "Expected 1 consensus commit prologue, got {:?}",
+                        unsorted_ccp
+                            .iter()
+                            .map(|e| e.transaction_digest())
+                            .collect::<Vec<_>>()
+                    );
+                }
                 assert_eq!(unsorted_ccp.len(), 1);
                 assert_eq!(unsorted_ccp[0].transaction_digest(), ccp_digest);
             }
@@ -1183,23 +1092,6 @@ impl CheckpointBuilder {
         let mut all_tx_digests =
             Vec::with_capacity(new_checkpoints.iter().map(|(_, c)| c.size()).sum());
 
-        // When upgrading to a data-quarantining build, we need to persist the transactions and effects
-        // to the database for crash recovery. After the upgrade this is no longer needed, because recovery
-        // is driven by replay of consensus commits.
-        // This only updates the content-addressed stores (similar to state sync), it does not mark any
-        // transactions as executed.
-        self.state
-            .get_cache_commit()
-            .persist_transactions_and_effects(
-                &new_checkpoints
-                    .iter()
-                    .flat_map(|(_, c)| {
-                        c.iter()
-                            .map(|digests| (digests.transaction, digests.effects))
-                    })
-                    .collect::<Vec<_>>(),
-            );
-
         for (summary, contents) in &new_checkpoints {
             debug!(
                 checkpoint_commit_height = height,
@@ -1207,11 +1099,24 @@ impl CheckpointBuilder {
                 contents_digest = ?contents.digest(),
                 "writing checkpoint",
             );
-            all_tx_digests.extend(contents.iter().map(|digests| digests.transaction));
 
-            self.output
-                .checkpoint_created(summary, contents, &self.epoch_store, &self.tables)
-                .await?;
+            if let Some(previously_computed_summary) = self
+                .tables
+                .locally_computed_checkpoints
+                .get(&summary.sequence_number)?
+            {
+                if previously_computed_summary != *summary {
+                    // Panic so that we don't send out an equivocating checkpoint sig.
+                    fatal!(
+                        "Checkpoint {} was previously built with a different result: {:?} vs {:?}",
+                        summary.sequence_number,
+                        previously_computed_summary,
+                        summary
+                    );
+                }
+            }
+
+            all_tx_digests.extend(contents.iter().map(|digests| digests.transaction));
 
             self.metrics
                 .transactions_included_in_checkpoint
@@ -1232,22 +1137,14 @@ impl CheckpointBuilder {
             )?;
         }
 
-        // Durably commit transactions (but not their outputs) to the database.
-        // Called before writing a locally built checkpoint to the CheckpointStore, so that
-        // the inputs of the checkpoint cannot be lost.
-        // These transactions are guaranteed to be final unless this validator
-        // forks (i.e. constructs a checkpoint which will never be certified). In this case
-        // some non-final transactions could be left in the database.
-        //
-        // This is an intermediate solution until we delay commits to the epoch db. After
-        // we have done that, crash recovery will be done by re-processing consensus commits
-        // and pending_consensus_transactions, and this method can be removed.
-        self.state
-            .get_cache_commit()
-            .persist_transactions(&all_tx_digests)
-            .await;
-
         batch.write()?;
+
+        // Send all checkpoint sigs to consensus.
+        for (summary, contents) in &new_checkpoints {
+            self.output
+                .checkpoint_created(summary, contents, &self.epoch_store, &self.tables)
+                .await?;
+        }
 
         for (local_checkpoint, _) in &new_checkpoints {
             if let Some(certified_checkpoint) = self
@@ -1262,7 +1159,7 @@ impl CheckpointBuilder {
 
         self.notify_aggregator.notify_one();
         self.epoch_store
-            .process_pending_checkpoint(height, new_checkpoints)?;
+            .process_pending_checkpoint(height, new_checkpoints);
         Ok(())
     }
 
@@ -1318,20 +1215,16 @@ impl CheckpointBuilder {
         Ok(chunks)
     }
 
-    #[instrument(level = "debug", skip_all)]
-    async fn create_checkpoints(
-        &self,
-        all_effects: Vec<TransactionEffects>,
-        details: &PendingCheckpointInfo,
-    ) -> anyhow::Result<NonEmpty<(CheckpointSummary, CheckpointContents)>> {
-        let _scope = monitored_scope("CheckpointBuilder::create_checkpoints");
-        let total = all_effects.len();
-        let mut last_checkpoint = self.epoch_store.last_built_checkpoint_summary()?;
+    fn load_last_built_checkpoint_summary(
+        epoch_store: &AuthorityPerEpochStore,
+        tables: &CheckpointStore,
+    ) -> SuiResult<Option<(CheckpointSequenceNumber, CheckpointSummary)>> {
+        let mut last_checkpoint = epoch_store.last_built_checkpoint_summary()?;
         if last_checkpoint.is_none() {
-            let epoch = self.epoch_store.epoch();
+            let epoch = epoch_store.epoch();
             if epoch > 0 {
                 let previous_epoch = epoch - 1;
-                let last_verified = self.tables.get_epoch_last_checkpoint(previous_epoch)?;
+                let last_verified = tables.get_epoch_last_checkpoint(previous_epoch)?;
                 last_checkpoint = last_verified.map(VerifiedCheckpoint::into_summary_and_sequence);
                 if let Some((ref seq, _)) = last_checkpoint {
                     debug!("No checkpoints in builder DB, taking checkpoint from previous epoch with sequence {seq}");
@@ -1341,6 +1234,19 @@ impl CheckpointBuilder {
                 }
             }
         }
+        Ok(last_checkpoint)
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    async fn create_checkpoints(
+        &self,
+        all_effects: Vec<TransactionEffects>,
+        details: &PendingCheckpointInfo,
+    ) -> anyhow::Result<NonEmpty<(CheckpointSummary, CheckpointContents)>> {
+        let _scope = monitored_scope("CheckpointBuilder::create_checkpoints");
+        let total = all_effects.len();
+        let mut last_checkpoint =
+            Self::load_last_built_checkpoint_summary(&self.epoch_store, &self.tables)?;
         let last_checkpoint_seq = last_checkpoint.as_ref().map(|(seq, _)| *seq);
         info!(
             next_checkpoint_seq = last_checkpoint_seq.unwrap_or_default() + 1,
@@ -2283,13 +2189,19 @@ impl CheckpointService {
         let notify_builder = Arc::new(Notify::new());
         let notify_aggregator = Arc::new(Notify::new());
 
-        let highest_previously_built_seq = epoch_store
-            .last_built_checkpoint_builder_summary()
-            .expect("epoch should not have ended")
-            .map(|s| s.summary.sequence_number)
+        // We may have built higher checkpoint numbers before restarting.
+        let highest_previously_built_seq = checkpoint_store
+            .get_latest_locally_computed_checkpoint()
+            .map(|s| s.sequence_number)
             .unwrap_or(0);
 
-        let (highest_currently_built_seq_tx, _) = watch::channel(highest_previously_built_seq);
+        let highest_currently_built_seq =
+            CheckpointBuilder::load_last_built_checkpoint_summary(&epoch_store, &checkpoint_store)
+                .expect("epoch should not have ended")
+                .map(|(seq, _)| seq)
+                .unwrap_or(0);
+
+        let (highest_currently_built_seq_tx, _) = watch::channel(highest_currently_built_seq);
 
         let aggregator = CheckpointAggregator::new(
             checkpoint_store.clone(),
@@ -2384,9 +2296,8 @@ impl CheckpointService {
 
         let mut output = ConsensusCommitOutput::new(0);
         epoch_store.write_pending_checkpoint(&mut output, &checkpoint)?;
-        let mut batch = epoch_store.db_batch_for_test();
-        output.write_to_batch(epoch_store, &mut batch)?;
-        batch.write()?;
+        output.set_default_commit_stats_for_testing();
+        epoch_store.push_consensus_output_for_tests(output);
         self.notify_checkpoint()?;
         Ok(())
     }

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1159,7 +1159,7 @@ impl CheckpointBuilder {
 
         self.notify_aggregator.notify_one();
         self.epoch_store
-            .process_pending_checkpoint(height, new_checkpoints);
+            .process_constructed_checkpoint(height, new_checkpoints);
         Ok(())
     }
 

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -2277,12 +2277,17 @@ impl CheckpointService {
     pub async fn wait_for_rebuilt_checkpoints(&self) {
         let highest_previously_built_seq = self.highest_previously_built_seq;
         let mut rx = self.highest_currently_built_seq_tx.subscribe();
+        let mut highest_currently_built_seq = *rx.borrow_and_update();
+        info!(
+            "Waiting for checkpoints to be rebuilt, previously built seq: {highest_previously_built_seq}, currently built seq: {highest_currently_built_seq}"
+        );
         loop {
-            let highest_currently_built_seq = *rx.borrow_and_update();
             if highest_currently_built_seq >= highest_previously_built_seq {
+                info!("Checkpoint rebuild complete");
                 break;
             }
             rx.changed().await.unwrap();
+            highest_currently_built_seq = *rx.borrow_and_update();
         }
     }
 

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -27,6 +27,7 @@ use serde::{Deserialize, Serialize};
 use sui_macros::fail_point;
 use sui_network::default_mysten_network_config;
 use sui_types::base_types::ConciseableName;
+use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::messages_checkpoint::CheckpointCommitment;
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
 use tokio::sync::watch;
@@ -745,6 +746,112 @@ impl CheckpointStore {
         self.delete_highest_executed_checkpoint_test_only()?;
         self.watermarks.rocksdb.flush()?;
         Ok(())
+    }
+
+    /// TODO: this is only needed while upgrading from non-dataquarantine to
+    /// dataquarantine. After that it can be deleted.
+    ///
+    /// Re-executes all transactions from all local, uncertified checkpoints for crash recovery.
+    /// All transactions thus re-executed are guaranteed to not have any missing dependencies,
+    /// because we start from the highest executed checkpoint, and proceed through checkpoints in
+    /// order.
+    #[instrument(level = "debug", skip_all)]
+    pub async fn reexecute_local_checkpoints(
+        &self,
+        state: &AuthorityState,
+        epoch_store: &AuthorityPerEpochStore,
+    ) {
+        info!("rexecuting locally computed checkpoints for crash recovery");
+        let epoch = epoch_store.epoch();
+        let highest_executed = self
+            .get_highest_executed_checkpoint_seq_number()
+            .expect("get_highest_executed_checkpoint_seq_number should not fail")
+            .unwrap_or(0);
+
+        let Some(highest_built) = self.get_latest_locally_computed_checkpoint() else {
+            info!("no locally built checkpoints to verify");
+            return;
+        };
+
+        for seq in highest_executed + 1..=*highest_built.sequence_number() {
+            info!(?seq, "Re-executing locally computed checkpoint");
+            let Some(checkpoint) = self
+                .get_locally_computed_checkpoint(seq)
+                .expect("get_locally_computed_checkpoint should not fail")
+            else {
+                panic!("locally computed checkpoint {:?} not found", seq);
+            };
+
+            let Some(contents) = self
+                .get_checkpoint_contents(&checkpoint.content_digest)
+                .expect("get_checkpoint_contents should not fail")
+            else {
+                panic!("checkpoint contents not found for locally computed checkpoint {:?} (digest: {:?})", seq, checkpoint.content_digest);
+            };
+
+            let cache = state.get_transaction_cache_reader();
+
+            let tx_digests: Vec<_> = contents.iter().map(|digests| digests.transaction).collect();
+            let fx_digests: Vec<_> = contents.iter().map(|digests| digests.effects).collect();
+            let txns = cache.multi_get_transaction_blocks(&tx_digests);
+
+            let txns: Vec<_> = itertools::izip!(txns, tx_digests, fx_digests)
+                .filter_map(|(tx, digest, fx)| {
+                    if let Some(tx) = tx {
+                        Some((tx, fx))
+                    } else {
+                        info!(
+                            "transaction {:?} not found during checkpoint re-execution",
+                            digest
+                        );
+                        None
+                    }
+                })
+                // end of epoch transaction can only be executed by CheckpointExecutor
+                .filter(|(tx, _)| !tx.data().transaction_data().is_end_of_epoch_tx())
+                .map(|(tx, fx)| {
+                    (
+                        VerifiedExecutableTransaction::new_from_checkpoint(
+                            (*tx).clone(),
+                            epoch,
+                            seq,
+                        ),
+                        fx,
+                    )
+                })
+                .collect();
+
+            let tx_digests: Vec<_> = txns.iter().map(|(tx, _)| *tx.digest()).collect();
+
+            info!(
+                ?seq,
+                ?tx_digests,
+                "Re-executing transactions for locally built checkpoint"
+            );
+            // this will panic if any re-execution diverges from the previously recorded effects digest
+            state.enqueue_with_expected_effects_digest(txns, epoch_store);
+
+            // a task that logs every so often until it is cancelled
+            // This should normally finish very quickly, so seeing this log more than once or twice is
+            // likely a sign of a problem.
+            let waiting_logger = tokio::task::spawn(async move {
+                let mut interval = tokio::time::interval(Duration::from_secs(1));
+                loop {
+                    interval.tick().await;
+                    warn!(?seq, "Still waiting for re-execution to complete");
+                }
+            });
+
+            cache
+                .notify_read_executed_effects_digests(&tx_digests)
+                .await;
+
+            waiting_logger.abort();
+            waiting_logger.await.ok();
+            info!(?seq, "Re-execution completed for locally built checkpoint");
+        }
+
+        info!("Re-execution of locally built checkpoints completed");
     }
 }
 

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -2260,7 +2260,7 @@ impl CheckpointService {
 
         // If this times out, the validator may still start up. The worst that can
         // happen is that we will crash later on (due to missing transactions).
-        if tokio::time::timeout(Duration::from_secs(10), self.wait_for_rebuilt_checkpoints())
+        if tokio::time::timeout(Duration::from_secs(60), self.wait_for_rebuilt_checkpoints())
             .await
             .is_err()
         {

--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -215,7 +215,9 @@ impl ConsensusManagerTrait for MysticetiManager {
         *consensus_handler = Some(handler);
 
         // Wait until all locally available commits have been processed
+        info!("replaying commits at startup");
         registered_authority.0.replay_complete().await;
+        info!("Startup commit replay complete");
     }
 
     async fn shutdown(&self) {

--- a/crates/sui-core/src/epoch/epoch_metrics.rs
+++ b/crates/sui-core/src/epoch/epoch_metrics.rs
@@ -107,6 +107,12 @@ pub struct EpochMetrics {
 
     /// The number of execution time observations dropped due to backpressure from the observer.
     pub epoch_execution_time_observations_dropped: IntCounter,
+
+    /// The number of consensus output items in the quarantine.
+    pub consensus_quarantine_queue_size: IntGauge,
+
+    /// The number of shared object assignments in the quarantine.
+    pub shared_object_assignments_size: IntGauge,
 }
 
 impl EpochMetrics {
@@ -234,6 +240,18 @@ impl EpochMetrics {
             epoch_execution_time_observations_dropped: register_int_counter_with_registry!(
                 "epoch_execution_time_observations_dropped",
                 "The number of execution time observations dropped due to backpressure from the observer",
+                registry
+            )
+            .unwrap(),
+            consensus_quarantine_queue_size: register_int_gauge_with_registry!(
+                "consensus_quarantine_queue_size",
+                "The number of consensus output items in the quarantine",
+                registry
+            )
+            .unwrap(),
+            shared_object_assignments_size: register_int_gauge_with_registry!(
+                "shared_object_assignments_size",
+                "The number of shared object assignments in the quarantine",
                 registry
             )
             .unwrap(),

--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -23,6 +23,7 @@ use sui_types::base_types::{FullObjectID, VerifiedExecutionData};
 use sui_types::digests::{TransactionDigest, TransactionEffectsDigest, TransactionEventsDigest};
 use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::error::{SuiError, SuiResult, UserInputError};
+use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::object::Object;
 use sui_types::storage::{
@@ -151,27 +152,10 @@ pub trait ExecutionCacheCommit: Send + Sync {
         use_object_per_epoch_marker_table_v2: bool,
     ) -> BoxFuture<'a, ()>;
 
-    /// Durably commit transactions (but not their outputs) to the database.
-    /// Called before writing a locally built checkpoint to the CheckpointStore, so that
-    /// the inputs of the checkpoint cannot be lost.
-    /// These transactions are guaranteed to be final unless this validator
-    /// forks (i.e. constructs a checkpoint which will never be certified). In this case
-    /// some non-final transactions could be left in the database.
-    ///
-    /// This is an intermediate solution until we delay commits to the epoch db. After
-    /// we have done that, crash recovery will be done by re-processing consensus commits
-    /// and pending_consensus_transactions, and this method can be removed.
-    fn persist_transactions<'a>(&'a self, digests: &'a [TransactionDigest]) -> BoxFuture<'a, ()>;
-
-    /// Persist transactions and their effects to the database, but no other outputs.
-    /// Additionally this stores the content-addressed effects in the database but does
-    /// not add an executed_effects. This is required for recovery from a crash when
-    /// upgrading to data-quarantining.
-    /// TODO: remove this once all nodes have upgraded to data-quarantining.
-    fn persist_transactions_and_effects(
-        &self,
-        digests: &[(TransactionDigest, TransactionEffectsDigest)],
-    );
+    /// Durably commit a transaction to the database. Used to store any transactions
+    /// that cannot be reconstructed at start-up by consensus replay. Currently the only
+    /// case of this is RandomnessTransaction.
+    fn persist_transaction(&self, transaction: &VerifiedExecutableTransaction);
 
     // Number of pending uncommitted transactions
     fn approximate_pending_transaction_count(&self) -> u64;

--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -154,7 +154,7 @@ pub trait ExecutionCacheCommit: Send + Sync {
 
     /// Durably commit a transaction to the database. Used to store any transactions
     /// that cannot be reconstructed at start-up by consensus replay. Currently the only
-    /// case of this is RandomnessTransaction.
+    /// case of this is RandomnessStateUpdate.
     fn persist_transaction(&self, transaction: &VerifiedExecutableTransaction);
 
     // Number of pending uncommitted transactions

--- a/crates/sui-core/src/execution_cache/cache_types.rs
+++ b/crates/sui-core/src/execution_cache/cache_types.rs
@@ -12,6 +12,15 @@ use mysten_common::debug_fatal;
 use parking_lot::Mutex;
 use sui_types::base_types::SequenceNumber;
 
+pub enum CacheResult<T> {
+    /// Entry is in the cache
+    Hit(T),
+    /// Entry is not in the cache and is known to not exist
+    NegativeHit,
+    /// Entry is not in the cache and may or may not exist in the store
+    Miss,
+}
+
 /// CachedVersionMap is a map from version to value, with the additional contraints:
 /// - The key (SequenceNumber) must be monotonically increasing for each insert. If
 ///   a key is inserted that is less than the previous key, it results in an assertion

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -72,6 +72,7 @@ use sui_types::digests::{
 };
 use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::error::{SuiError, SuiResult, UserInputError};
+use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::message_envelope::Message;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::object::Object;
@@ -978,37 +979,6 @@ impl WritebackCache {
         self.set_backpressure(pending_count);
     }
 
-    fn persist_transactions_and_effects(
-        &self,
-        digests: &[(TransactionDigest, TransactionEffectsDigest)],
-    ) {
-        let mut transactions_and_effects = Vec::with_capacity(digests.len());
-        for (tx_digest, fx_digest) in digests {
-            let Some(outputs) = self
-                .dirty
-                .pending_transaction_writes
-                .get(tx_digest)
-                .map(|o| o.clone())
-            else {
-                debug!("transaction {:?} was already committed", tx_digest);
-                continue;
-            };
-
-            assert_eq!(
-                outputs.effects.digest(),
-                *fx_digest,
-                "effects digest mismatch"
-            );
-
-            transactions_and_effects
-                .push(((*outputs.transaction).clone(), outputs.effects.clone()));
-        }
-
-        self.store
-            .persist_transactions_and_effects(&transactions_and_effects)
-            .expect("db error");
-    }
-
     fn approximate_pending_transaction_count(&self) -> u64 {
         let num_commits = self
             .dirty
@@ -1152,33 +1122,6 @@ impl WritebackCache {
                 &ObjectEntry::Wrapped,
             );
         }
-    }
-
-    async fn persist_transactions(&self, digests: &[TransactionDigest]) {
-        let mut txns = Vec::with_capacity(digests.len());
-        for tx_digest in digests {
-            let Some(tx) = self
-                .dirty
-                .pending_transaction_writes
-                .get(tx_digest)
-                .map(|o| o.transaction.clone())
-            else {
-                // tx should exist in the db if it is not in dirty set.
-                debug_assert!(self
-                    .store
-                    .get_transaction_block(tx_digest)
-                    .unwrap()
-                    .is_some());
-                // If the transaction is not in dirty, it does not need to be committed.
-                // This situation can happen if we build a checkpoint locally which was just executed
-                // via state sync.
-                continue;
-            };
-
-            txns.push((*tx_digest, (*tx).clone()));
-        }
-
-        self.store.commit_transactions(&txns).expect("db error");
     }
 
     // Move the oldest/least entry from the dirty queue to the cache queue.
@@ -1333,19 +1276,12 @@ impl ExecutionCacheCommit for WritebackCache {
         .boxed()
     }
 
-    fn persist_transactions<'a>(&'a self, digests: &'a [TransactionDigest]) -> BoxFuture<'a, ()> {
-        WritebackCache::persist_transactions(self, digests).boxed()
+    fn persist_transaction(&self, tx: &VerifiedExecutableTransaction) {
+        self.store.persist_transaction(tx).expect("db error");
     }
 
     fn approximate_pending_transaction_count(&self) -> u64 {
         WritebackCache::approximate_pending_transaction_count(self)
-    }
-
-    fn persist_transactions_and_effects(
-        &self,
-        digests: &[(TransactionDigest, TransactionEffectsDigest)],
-    ) {
-        WritebackCache::persist_transactions_and_effects(self, digests);
     }
 }
 

--- a/crates/sui-core/src/fallback_fetch.rs
+++ b/crates/sui-core/src/fallback_fetch.rs
@@ -1,0 +1,61 @@
+// Copyright (c) 2021, Facebook, Inc. and its affiliates
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::execution_cache::cache_types::CacheResult;
+use sui_types::error::SuiResult;
+
+/// do_fallback_lookup is a helper function for multi-get operations.
+/// It takes a list of keys and first attempts to look up each key in the cache.
+/// The cache can return a hit, a miss, or a negative hit (if the object is known to not exist).
+/// Any keys that result in a miss are then looked up in the store.
+///
+/// The "get from cache" and "get from store" behavior are implemented by the caller and provided
+/// via the get_cached_key and multiget_fallback functions.
+pub fn do_fallback_lookup<K: Clone, V: Default + Clone>(
+    keys: &[K],
+    get_cached_key: impl Fn(&K) -> CacheResult<V>,
+    multiget_fallback: impl Fn(&[K]) -> Vec<V>,
+) -> Vec<V> {
+    do_fallback_lookup_fallible(
+        keys,
+        |key| Ok(get_cached_key(key)),
+        |keys| Ok(multiget_fallback(keys)),
+    )
+    .expect("cannot fail")
+}
+
+pub fn do_fallback_lookup_fallible<K: Clone, V: Default + Clone>(
+    keys: &[K],
+    get_cached_key: impl Fn(&K) -> SuiResult<CacheResult<V>>,
+    multiget_fallback: impl Fn(&[K]) -> SuiResult<Vec<V>>,
+) -> SuiResult<Vec<V>> {
+    let mut results = vec![V::default(); keys.len()];
+    let mut fallback_keys = Vec::with_capacity(keys.len());
+    let mut fallback_indices = Vec::with_capacity(keys.len());
+
+    for (i, key) in keys.iter().enumerate() {
+        match get_cached_key(key)? {
+            CacheResult::Miss => {
+                fallback_keys.push(key.clone());
+                fallback_indices.push(i);
+            }
+            CacheResult::NegativeHit => (),
+            CacheResult::Hit(value) => {
+                results[i] = value;
+            }
+        }
+    }
+
+    let fallback_results = multiget_fallback(&fallback_keys)?;
+    assert_eq!(fallback_results.len(), fallback_indices.len());
+    assert_eq!(fallback_results.len(), fallback_keys.len());
+
+    for (i, result) in fallback_indices
+        .into_iter()
+        .zip(fallback_results.into_iter())
+    {
+        results[i] = result;
+    }
+    Ok(results)
+}

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod db_checkpoint_handler;
 pub mod epoch;
 pub mod execution_cache;
 mod execution_driver;
+mod fallback_fetch;
 pub mod jsonrpc_index;
 pub mod metrics;
 pub mod mock_consensus;

--- a/crates/sui-core/src/mock_consensus.rs
+++ b/crates/sui-core/src/mock_consensus.rs
@@ -68,6 +68,7 @@ impl MockConsensusClient {
                             vec![SequencedConsensusTransaction::new_test(tx.clone())],
                             &checkpoint_service,
                             validator.get_object_cache_reader().as_ref(),
+                            validator.get_transaction_cache_reader().as_ref(),
                             &authority_metrics,
                             true,
                         )

--- a/crates/sui-core/src/transaction_input_loader.rs
+++ b/crates/sui-core/src/transaction_input_loader.rs
@@ -181,7 +181,6 @@ impl TransactionInputLoader {
                         .get_or_init(|| {
                             epoch_store
                                 .get_assigned_shared_object_versions(tx_key)
-                                .expect("loading assigned shared versions should not fail")
                                 .map(|versions| versions.into_iter().collect())
                         })
                         .as_ref()

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -4586,7 +4586,6 @@ async fn test_shared_object_transaction_ok() {
     let shared_object_version = authority
         .epoch_store_for_testing()
         .get_assigned_shared_object_versions(&certificate.key())
-        .expect("Reading shared version assignments should not fail")
         .expect("Versions should be set")
         .into_iter()
         .find_map(|((object_id, initial_shared_version), version)| {
@@ -4704,7 +4703,6 @@ async fn test_consensus_commit_prologue_generation() {
         authority_state
             .epoch_store_for_testing()
             .get_assigned_shared_object_versions(txn_key)
-            .unwrap()
             .expect("versions should be set")
             .iter()
             .filter_map(|((id, initial_shared_version), seq)| {
@@ -5832,9 +5830,7 @@ async fn test_consensus_handler_per_object_congestion_control(
     } else {
         epoch_store.get_highest_pending_checkpoint_height()
     };
-    let deferred_txns = epoch_store
-        .get_all_deferred_transactions_for_test()
-        .unwrap();
+    let deferred_txns = epoch_store.get_all_deferred_transactions_for_test();
     assert_eq!(deferred_txns.len(), 1);
     assert_eq!(deferred_txns[0].1.len(), 3);
     let deferral_key = deferred_txns[0].0;
@@ -5895,8 +5891,7 @@ async fn test_consensus_handler_per_object_congestion_control(
 
     let deferred_txns = authority
         .epoch_store_for_testing()
-        .get_all_deferred_transactions_for_test()
-        .unwrap();
+        .get_all_deferred_transactions_for_test();
     assert_eq!(deferred_txns.len(), 1);
     assert_eq!(deferred_txns[0].1.len(), 1);
     let deferral_key = deferred_txns[0].0;
@@ -5924,7 +5919,6 @@ async fn test_consensus_handler_per_object_congestion_control(
     assert!(authority
         .epoch_store_for_testing()
         .get_all_deferred_transactions_for_test()
-        .unwrap()
         .is_empty());
 }
 
@@ -6070,14 +6064,12 @@ async fn test_consensus_handler_congestion_control_transaction_cancellation() {
     assert!(authority
         .epoch_store_for_testing()
         .get_all_deferred_transactions_for_test()
-        .unwrap()
         .is_empty());
 
     // Check cancelled transaction shared locks.
     let shared_object_version = authority
         .epoch_store_for_testing()
         .get_assigned_shared_object_versions(&cancelled_txn.key())
-        .expect("Reading shared version assignments should not fail")
         .expect("Versions should be set")
         .into_iter()
         .collect::<HashMap<_, _>>();

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -221,6 +221,7 @@ pub fn make_consensus_adapter_for_test(
                                     vec![tx],
                                     &checkpoint_service,
                                     self.state.get_object_cache_reader().as_ref(),
+                                    self.state.get_transaction_cache_reader().as_ref(),
                                     &self.state.metrics,
                                     true,
                                 )
@@ -239,6 +240,7 @@ pub fn make_consensus_adapter_for_test(
                                 vec![tx],
                                 &checkpoint_service,
                                 self.state.get_object_cache_reader().as_ref(),
+                                self.state.get_transaction_cache_reader().as_ref(),
                                 &self.state.metrics,
                                 true,
                             )

--- a/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_manager_tests.rs
@@ -237,7 +237,7 @@ async fn transaction_manager_object_dependency() {
         .epoch_store_for_testing()
         .set_shared_object_versions_for_testing(
             transaction_read_0.digest(),
-            vec![(
+            &[(
                 (
                     shared_object.id(),
                     shared_object.owner().start_version().unwrap(),
@@ -250,7 +250,7 @@ async fn transaction_manager_object_dependency() {
         .epoch_store_for_testing()
         .set_shared_object_versions_for_testing(
             transaction_read_1.digest(),
-            vec![(
+            &[(
                 (
                     shared_object.id(),
                     shared_object.owner().start_version().unwrap(),
@@ -274,7 +274,7 @@ async fn transaction_manager_object_dependency() {
         .epoch_store_for_testing()
         .set_shared_object_versions_for_testing(
             transaction_default.digest(),
-            vec![(
+            &[(
                 (
                     shared_object.id(),
                     shared_object.owner().start_version().unwrap(),
@@ -302,7 +302,7 @@ async fn transaction_manager_object_dependency() {
         .epoch_store_for_testing()
         .set_shared_object_versions_for_testing(
             transaction_read_2.digest(),
-            vec![
+            &[
                 (
                     (
                         shared_object.id(),
@@ -827,7 +827,7 @@ async fn transaction_manager_with_cancelled_transactions() {
         .epoch_store_for_testing()
         .set_shared_object_versions_for_testing(
             cancelled_transaction.digest(),
-            vec![
+            &[
                 (
                     (
                         shared_object_1.id(),

--- a/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
@@ -737,8 +737,8 @@ async fn test_epoch_flag_upgrade() {
             return None;
         }
 
-        // start with no flags
-        let flags: Vec<EpochFlag> = vec![];
+        // start with only UseVersionAssignmentTablesV3
+        let flags: Vec<EpochFlag> = vec![EpochFlag::UseVersionAssignmentTablesV3];
         Some(flags)
     });
 

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -557,6 +557,10 @@ impl SuiNode {
             signature_verifier_metrics,
             &config.expensive_safety_check_config,
             ChainIdentifier::from(*genesis.checkpoint().digest()),
+            checkpoint_store
+                .get_highest_executed_checkpoint_seq_number()
+                .expect("checkpoint store read cannot fail")
+                .unwrap_or(0),
         );
 
         info!("created epoch store");
@@ -591,8 +595,6 @@ impl SuiNode {
                 "buffer_stake_for_protocol_upgrade_bps is currently overridden"
             );
         }
-
-        info!("creating checkpoint store");
 
         checkpoint_store.insert_genesis_checkpoint(
             genesis.checkpoint(),
@@ -759,10 +761,6 @@ impl SuiNode {
                 .await
                 .unwrap();
         }
-
-        checkpoint_store
-            .reexecute_local_checkpoints(&state, &epoch_store)
-            .await;
 
         // Start the loop that receives new randomness and generates transactions for it.
         RandomnessRoundReceiver::spawn(state.clone(), randomness_rx);
@@ -1401,6 +1399,8 @@ impl SuiNode {
             backpressure_manager,
         );
 
+        info!("Starting consensus manager");
+
         consensus_manager
             .start(
                 config,
@@ -1416,6 +1416,7 @@ impl SuiNode {
             )
             .await;
 
+        info!("Spawning checkpoint service");
         let checkpoint_service_tasks = checkpoint_service.spawn().await;
 
         if epoch_store.authenticator_state_enabled() {
@@ -1981,6 +1982,15 @@ impl SuiNode {
             .expect("Error loading last checkpoint for current epoch")
             .expect("Could not load last checkpoint for current epoch");
 
+        let last_checkpoint_seq = *last_checkpoint.sequence_number();
+
+        assert_eq!(
+            Some(last_checkpoint_seq),
+            self.checkpoint_store
+                .get_highest_executed_checkpoint_seq_number()
+                .expect("Error loading highest executed checkpoint sequence number")
+        );
+
         let epoch_start_configuration = EpochStartConfiguration::new(
             next_epoch_start_system_state,
             *last_checkpoint.digest(),
@@ -1998,6 +2008,7 @@ impl SuiNode {
                 epoch_start_configuration,
                 accumulator,
                 &self.config.expensive_safety_check_config,
+                last_checkpoint_seq,
             )
             .await
             .expect("Reconfigure authority state cannot fail");

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1339,7 +1339,7 @@ impl SuiNode {
         let checkpoint_service = Self::build_checkpoint_service(
             config,
             consensus_adapter.clone(),
-            checkpoint_store,
+            checkpoint_store.clone(),
             epoch_store.clone(),
             state.clone(),
             state_sync_handle,
@@ -1415,6 +1415,15 @@ impl SuiNode {
                 ),
             )
             .await;
+
+        if !epoch_store
+            .epoch_start_config()
+            .is_data_quarantine_active_from_beginning_of_epoch()
+        {
+            checkpoint_store
+                .reexecute_local_checkpoints(&state, &epoch_store)
+                .await;
+        }
 
         info!("Spawning checkpoint service");
         let checkpoint_service_tasks = checkpoint_service.spawn().await;

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1600,7 +1600,7 @@ impl SuiNode {
         // executed. This could confuse clients in some circumstances. However, the transactions
         // are still in pending_consensus_certificates, so we cannot lose any finality guarantees.
         if tokio::time::timeout(
-            std::time::Duration::from_secs(10),
+            std::time::Duration::from_secs(60),
             state
                 .get_transaction_cache_reader()
                 .notify_read_executed_effects_digests(&digests),

--- a/crates/sui-single-node-benchmark/src/mock_storage.rs
+++ b/crates/sui-single-node-benchmark/src/mock_storage.rs
@@ -68,7 +68,6 @@ impl InMemoryObjectStore {
                         .get_or_init(|| {
                             epoch_store
                                 .get_assigned_shared_object_versions(tx_key)
-                                .expect("get_assigned_shared_object_versions should not fail")
                                 .map(|l| l.into_iter().collect())
                         })
                         .as_ref()


### PR DESCRIPTION
## Description 

- All consensus output is held in memory until all checkpoints built from that output have been committed. This ensures that the epoch db is not corrupted in the event of a fork.
- Consensus therefor becomes the primary replay log for all crash recovery.
- Additionally this means there are several tables that we no longer need to write to, and their contents can live in memory.

## Test plan 

Extensive testing with both simtest and antithesis. In particular the upgrade flow (from non-DQ to DQ build) has been tested extensively with antithesis.
