### PR TITLE
rpc-alt: (re-adding) `tryGetPastObject`, `tryMultiGetPastObjects`

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/contents.exp
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/contents.exp
@@ -1,0 +1,141 @@
+processed 8 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 10-19:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 4620800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 21-23:
+//# programmable --sender A --inputs @A
+//> 0: test::mod::new();
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 25-27:
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, line 29:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, lines 31-35:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": {
+    "status": "VersionFound",
+    "details": {
+      "objectId": "0xb1d114770bfc9968a2ad3da9c6d5bcbf32e4bcf3d0bf3eba674df5d907a83e73",
+      "version": "1",
+      "digest": "Sgp59rDKZRKoSZ2ZJKKcc5YQ7MrhEHDxbZLqqFjywcq",
+      "content": {
+        "dataType": "package",
+        "disassembled": {
+          "mod": "// Move bytecode v6\nmodule b1d114770bfc9968a2ad3da9c6d5bcbf32e4bcf3d0bf3eba674df5d907a83e73.mod {\nuse 0000000000000000000000000000000000000000000000000000000000000002::object;\nuse 0000000000000000000000000000000000000000000000000000000000000002::tx_context;\n\nstruct Foo has store, key {\n\tid: UID\n}\n\npublic new(Arg0: &mut TxContext): Foo {\nB0:\n\t0: MoveLoc[0](Arg0: &mut TxContext)\n\t1: Call object::new(&mut TxContext): UID\n\t2: Pack[0](Foo)\n\t3: Ret\n}\n\n}\n"
+        }
+      },
+      "bcs": {
+        "dataType": "package",
+        "id": "0xb1d114770bfc9968a2ad3da9c6d5bcbf32e4bcf3d0bf3eba674df5d907a83e73",
+        "version": 1,
+        "moduleMap": {
+          "mod": "oRzrCwYAAAAIAQAGAgYMAxIKBRwLBycvCFZACpYBBgycAQ0ABAEGAQcAAAwAAQIEAAIBAgAABQABAAEFAAMAAQcIAgEIAAABCAEDRm9vCVR4Q29udGV4dANVSUQCaWQDbW9kA25ldwZvYmplY3QKdHhfY29udGV4dLHRFHcL/Jlooq09qcbVvL8y5Lzz0L8+umdN9dkHqD5zAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAgEDCAEAAQAAAgQLABEBEgACAA=="
+        },
+        "typeOriginTable": [
+          {
+            "module_name": "mod",
+            "datatype_name": "Foo",
+            "package": "0xb1d114770bfc9968a2ad3da9c6d5bcbf32e4bcf3d0bf3eba674df5d907a83e73"
+          }
+        ],
+        "linkageTable": {
+          "0x0000000000000000000000000000000000000000000000000000000000000001": {
+            "upgraded_id": "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "upgraded_version": 1
+          },
+          "0x0000000000000000000000000000000000000000000000000000000000000002": {
+            "upgraded_id": "0x0000000000000000000000000000000000000000000000000000000000000002",
+            "upgraded_version": 1
+          }
+        }
+      }
+    }
+  }
+}
+
+task 6, lines 37-41:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "status": "VersionFound",
+    "details": {
+      "objectId": "0x5736caa914301b5f6bc2734fdd6ef4c0097ebf6f0b346ec0ce1119f3a86c8c37",
+      "version": "2",
+      "digest": "6pd5G7cgCu3ShFTxpyo7xJTsq5EwzbAnrmfNeR55roUH",
+      "content": {
+        "dataType": "moveObject",
+        "type": "0xb1d114770bfc9968a2ad3da9c6d5bcbf32e4bcf3d0bf3eba674df5d907a83e73::mod::Foo",
+        "hasPublicTransfer": true,
+        "fields": {
+          "id": {
+            "id": "0x5736caa914301b5f6bc2734fdd6ef4c0097ebf6f0b346ec0ce1119f3a86c8c37"
+          }
+        }
+      },
+      "bcs": {
+        "dataType": "moveObject",
+        "type": "0xb1d114770bfc9968a2ad3da9c6d5bcbf32e4bcf3d0bf3eba674df5d907a83e73::mod::Foo",
+        "hasPublicTransfer": true,
+        "version": 2,
+        "bcsBytes": "VzbKqRQwG19rwnNP3W70wAl+v28LNG7AzhEZ86hsjDc="
+      }
+    }
+  }
+}
+
+task 7, lines 43-47:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "status": "VersionFound",
+    "details": {
+      "objectId": "0xf2a6833ec5d2dd77e656a3fe62bdd4e4609b23fa0739312e384fdbb06080155e",
+      "version": "3",
+      "digest": "AeAb1PukmXSZNcUMrQmqqWeEwSwyoKXhSGogxN37Wdym",
+      "content": {
+        "dataType": "moveObject",
+        "type": "0x2::coin::Coin<0x2::sui::SUI>",
+        "hasPublicTransfer": true,
+        "fields": {
+          "balance": "42",
+          "id": {
+            "id": "0xf2a6833ec5d2dd77e656a3fe62bdd4e4609b23fa0739312e384fdbb06080155e"
+          }
+        }
+      },
+      "bcs": {
+        "dataType": "moveObject",
+        "type": "0x2::coin::Coin<0x2::sui::SUI>",
+        "hasPublicTransfer": true,
+        "version": 3,
+        "bcsBytes": "8qaDPsXS3XfmVqP+Yr3U5GCbI/oHOTEuOE/bsGCAFV4qAAAAAAAAAA=="
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/contents.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/contents.move
@@ -1,0 +1,47 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --addresses test=0x0 --simulator
+
+// 1. View the contents of a package
+// 2. View the contents of an arbitrary object
+// 3. View the contents of a coin
+
+//# publish
+module test::mod {
+  public struct Foo has key, store {
+    id: UID,
+  }
+
+  public fun new(ctx: &mut TxContext): Foo {
+    Foo { id: object::new(ctx) }
+  }
+}
+
+//# programmable --sender A --inputs @A
+//> 0: test::mod::new();
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "sui_tryGetPastObject",
+  "params": ["@{obj_1_0}", 1, { "showContent": true, "showBcs": true }]
+}
+
+//# run-jsonrpc
+{
+  "method": "sui_tryGetPastObject",
+  "params": ["@{obj_2_0}", 2, { "showContent": true, "showBcs": true }]
+}
+
+//# run-jsonrpc
+{
+  "method": "sui_tryGetPastObject",
+  "params": ["@{obj_3_0}", 3, { "showContent": true, "showBcs": true }]
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/show_owner.exp
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/show_owner.exp
@@ -1,0 +1,145 @@
+processed 13 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 12-14:
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 16-18:
+//# programmable --sender A --inputs 43 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 20-22:
+//# programmable --sender A --inputs 44
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::transfer::public_share_object<sui::coin::Coin<sui::sui::SUI>>(Result(0))
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 24-26:
+//# programmable --sender A --inputs 45
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::transfer::public_freeze_object<sui::coin::Coin<sui::sui::SUI>>(Result(0))
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 28-30:
+//# programmable --sender A --inputs @A
+//> 0: sui::table::new<u64, u64>();
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 32-33:
+//# programmable --sender A --inputs object(5,0) 46 47
+//> 0: sui::table::add<u64, u64>(Input(0), Input(1), Input(2))
+created: object(6,0)
+mutated: object(0,0), object(5,0)
+gas summary: computation_cost: 1000000, storage_cost: 3800000,  storage_rebate: 2309868, non_refundable_storage_fee: 23332
+
+task 7, line 35:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 8, lines 37-41:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": {
+    "status": "VersionFound",
+    "details": {
+      "objectId": "0xc442f9431f789a6c80078a63e707de84c7815c3150e08f1e44be256bd05a2b81",
+      "version": "2",
+      "digest": "4wV3VBJGNaMCv9zfjSna8c4as6EkuYoqTHHjueS6S745",
+      "owner": {
+        "AddressOwner": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+      }
+    }
+  }
+}
+
+task 9, lines 43-47:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "status": "VersionFound",
+    "details": {
+      "objectId": "0xf2945213c986e35d59aae258ef1b094e81ead5cc982b0d1519625bf3f81bee68",
+      "version": "3",
+      "digest": "9wMLcUMLvkbqNFyoPtUJ1GPuVuXVqpLA3GP2DHL2SyL6",
+      "owner": {
+        "AddressOwner": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+      }
+    }
+  }
+}
+
+task 10, lines 49-53:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "status": "VersionFound",
+    "details": {
+      "objectId": "0x0918a1917bda4d05f1cb4db824532a63476c57d65c548930406fe02051f22819",
+      "version": "4",
+      "digest": "8pirmp97ym3pzSCabaPsoPYVPbKYQHfnPqEbCyk32Au2",
+      "owner": {
+        "Shared": {
+          "initial_shared_version": 4
+        }
+      }
+    }
+  }
+}
+
+task 11, lines 55-59:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "status": "VersionFound",
+    "details": {
+      "objectId": "0xf079987ab8a34791ae4dd8b2d2a9af3485496a49b382b22239c4ca43902fe18a",
+      "version": "5",
+      "digest": "EEF6GF5DCZRZ4zxsubwzaQhYWysCdGJ63sLRLE15d9F",
+      "owner": "Immutable"
+    }
+  }
+}
+
+task 12, lines 61-65:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 4,
+  "result": {
+    "status": "VersionFound",
+    "details": {
+      "objectId": "0x0dfe3bf8505600c374ecc59e9580d3504a37a14f65b53084ef86c5861f39cc3f",
+      "version": "7",
+      "digest": "9rcnz8P9Eie7KZPUjTWnmTzyUxsBMaJcb9G3ncuG4BiC",
+      "owner": {
+        "ObjectOwner": "0x2867eee076a7f41efb3dc507f27531c26319dfbf0c9a6d92f6d1fd0f8d9bdeeb"
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/show_owner.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/show_owner.move
@@ -1,0 +1,65 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --addresses test=0x0 --simulator
+
+// 1. Show the owner of an object owned by one address
+// 2. ...owned by another address
+// 3. ...shared
+// 4. ...frozen
+// 5. ...owned by an object
+
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 43 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 44
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::transfer::public_share_object<sui::coin::Coin<sui::sui::SUI>>(Result(0))
+
+//# programmable --sender A --inputs 45
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::transfer::public_freeze_object<sui::coin::Coin<sui::sui::SUI>>(Result(0))
+
+//# programmable --sender A --inputs @A
+//> 0: sui::table::new<u64, u64>();
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# programmable --sender A --inputs object(5,0) 46 47
+//> 0: sui::table::add<u64, u64>(Input(0), Input(1), Input(2))
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "sui_tryGetPastObject",
+  "params": ["@{obj_1_0}", 2, { "showOwner": true }]
+}
+
+//# run-jsonrpc
+{
+  "method": "sui_tryGetPastObject",
+  "params": ["@{obj_2_0}", 3, { "showOwner": true }]
+}
+
+//# run-jsonrpc
+{
+  "method": "sui_tryGetPastObject",
+  "params": ["@{obj_3_0}", 4, { "showOwner": true }]
+}
+
+//# run-jsonrpc
+{
+  "method": "sui_tryGetPastObject",
+  "params": ["@{obj_4_0}", 5, { "showOwner": true }]
+}
+
+//# run-jsonrpc
+{
+  "method": "sui_tryGetPastObject",
+  "params": ["@{obj_6_0}", 7, { "showOwner": true }]
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_get_past_object.exp
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_get_past_object.exp
@@ -1,9 +1,9 @@
-processed 9 tasks
+processed 12 tasks
 
 init:
 A: object(0,0), B: object(0,1)
 
-task 1, lines 11-13:
+task 1, lines 15-17:
 //# programmable --sender A --inputs 42 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> 1: TransferObjects([Result(0)], Input(1))
@@ -11,25 +11,25 @@ created: object(1,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 15-17:
+task 2, lines 19-21:
 //# programmable --sender A --inputs 43 object(1,0)
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> 1: MergeCoins(Input(1), [Result(0)])
 mutated: object(0,0), object(1,0)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
 
-task 3, lines 19-20:
+task 3, lines 23-24:
 //# programmable --sender A --inputs object(1,0)
 //> 0: MergeCoins(Gas, [Input(0)])
 mutated: object(0,0)
 deleted: object(1,0)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
 
-task 4, line 22:
+task 4, line 26:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 5, lines 24-28:
+task 5, lines 28-32:
 //# run-jsonrpc
 Response: {
   "jsonrpc": "2.0",
@@ -43,7 +43,7 @@ Response: {
   }
 }
 
-task 6, lines 30-34:
+task 6, lines 34-38:
 //# run-jsonrpc
 Response: {
   "jsonrpc": "2.0",
@@ -58,7 +58,7 @@ Response: {
   }
 }
 
-task 7, lines 36-40:
+task 7, lines 40-44:
 //# run-jsonrpc
 Response: {
   "jsonrpc": "2.0",
@@ -73,11 +73,56 @@ Response: {
   }
 }
 
-task 8, lines 42-46:
+task 8, lines 46-50:
 //# run-jsonrpc
 Response: {
   "jsonrpc": "2.0",
   "id": 3,
+  "result": {
+    "status": "ObjectDeleted",
+    "details": {
+      "objectId": "0xc442f9431f789a6c80078a63e707de84c7815c3150e08f1e44be256bd05a2b81",
+      "version": 4,
+      "digest": "7gyGAp71YXQRoxmFBaHxofQXAipvgHyBKPyxmdSJxyvz"
+    }
+  }
+}
+
+task 9, lines 52-62:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 4,
+  "result": {
+    "status": "VersionNotFound",
+    "details": [
+      "0xc442f9431f789a6c80078a63e707de84c7815c3150e08f1e44be256bd05a2b81",
+      1
+    ]
+  }
+}
+
+task 10, lines 64-74:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 5,
+  "result": {
+    "status": "VersionFound",
+    "details": {
+      "objectId": "0xc442f9431f789a6c80078a63e707de84c7815c3150e08f1e44be256bd05a2b81",
+      "version": "2",
+      "digest": "4wV3VBJGNaMCv9zfjSna8c4as6EkuYoqTHHjueS6S745",
+      "type": "0x2::coin::Coin<0x2::sui::SUI>"
+    }
+  }
+}
+
+task 11, lines 76-86:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 6,
   "result": {
     "status": "ObjectDeleted",
     "details": {

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_get_past_object.exp
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_get_past_object.exp
@@ -3,7 +3,7 @@ processed 12 tasks
 init:
 A: object(0,0), B: object(0,1)
 
-task 1, lines 15-17:
+task 1, lines 14-16:
 //# programmable --sender A --inputs 42 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> 1: TransferObjects([Result(0)], Input(1))
@@ -11,25 +11,25 @@ created: object(1,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 19-21:
+task 2, lines 18-20:
 //# programmable --sender A --inputs 43 object(1,0)
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> 1: MergeCoins(Input(1), [Result(0)])
 mutated: object(0,0), object(1,0)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
 
-task 3, lines 23-24:
+task 3, lines 22-23:
 //# programmable --sender A --inputs object(1,0)
 //> 0: MergeCoins(Gas, [Input(0)])
 mutated: object(0,0)
 deleted: object(1,0)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
 
-task 4, line 26:
+task 4, line 25:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 5, lines 28-32:
+task 5, lines 27-31:
 //# run-jsonrpc
 Response: {
   "jsonrpc": "2.0",
@@ -43,7 +43,7 @@ Response: {
   }
 }
 
-task 6, lines 34-38:
+task 6, lines 33-37:
 //# run-jsonrpc
 Response: {
   "jsonrpc": "2.0",
@@ -58,7 +58,7 @@ Response: {
   }
 }
 
-task 7, lines 40-44:
+task 7, lines 39-43:
 //# run-jsonrpc
 Response: {
   "jsonrpc": "2.0",
@@ -73,7 +73,7 @@ Response: {
   }
 }
 
-task 8, lines 46-50:
+task 8, lines 45-49:
 //# run-jsonrpc
 Response: {
   "jsonrpc": "2.0",
@@ -88,7 +88,7 @@ Response: {
   }
 }
 
-task 9, lines 52-62:
+task 9, lines 51-62:
 //# run-jsonrpc
 Response: {
   "jsonrpc": "2.0",
@@ -102,7 +102,7 @@ Response: {
   }
 }
 
-task 10, lines 64-74:
+task 10, lines 64-75:
 //# run-jsonrpc
 Response: {
   "jsonrpc": "2.0",
@@ -113,12 +113,15 @@ Response: {
       "objectId": "0xc442f9431f789a6c80078a63e707de84c7815c3150e08f1e44be256bd05a2b81",
       "version": "2",
       "digest": "4wV3VBJGNaMCv9zfjSna8c4as6EkuYoqTHHjueS6S745",
-      "type": "0x2::coin::Coin<0x2::sui::SUI>"
+      "type": "0x2::coin::Coin<0x2::sui::SUI>",
+      "owner": {
+        "AddressOwner": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+      }
     }
   }
 }
 
-task 11, lines 76-86:
+task 11, lines 77-88:
 //# run-jsonrpc
 Response: {
   "jsonrpc": "2.0",

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_get_past_object.exp
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_get_past_object.exp
@@ -88,7 +88,7 @@ Response: {
   }
 }
 
-task 9, lines 51-63:
+task 9, lines 51-64:
 //# run-jsonrpc
 Response: {
   "jsonrpc": "2.0",
@@ -102,7 +102,7 @@ Response: {
   }
 }
 
-task 10, lines 65-77:
+task 10, lines 66-79:
 //# run-jsonrpc
 Response: {
   "jsonrpc": "2.0",
@@ -117,12 +117,13 @@ Response: {
       "owner": {
         "AddressOwner": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
       },
-      "previousTransaction": "ABo3jemYqdBWMRYqsaCYUKnGDp64tR7jK2fH1mKCoJLk"
+      "previousTransaction": "ABo3jemYqdBWMRYqsaCYUKnGDp64tR7jK2fH1mKCoJLk",
+      "storageRebate": "988000"
     }
   }
 }
 
-task 11, lines 79-91:
+task 11, lines 81-94:
 //# run-jsonrpc
 Response: {
   "jsonrpc": "2.0",

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_get_past_object.exp
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_get_past_object.exp
@@ -88,7 +88,7 @@ Response: {
   }
 }
 
-task 9, lines 51-62:
+task 9, lines 51-63:
 //# run-jsonrpc
 Response: {
   "jsonrpc": "2.0",
@@ -102,7 +102,7 @@ Response: {
   }
 }
 
-task 10, lines 64-75:
+task 10, lines 65-77:
 //# run-jsonrpc
 Response: {
   "jsonrpc": "2.0",
@@ -116,12 +116,13 @@ Response: {
       "type": "0x2::coin::Coin<0x2::sui::SUI>",
       "owner": {
         "AddressOwner": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-      }
+      },
+      "previousTransaction": "ABo3jemYqdBWMRYqsaCYUKnGDp64tR7jK2fH1mKCoJLk"
     }
   }
 }
 
-task 11, lines 77-88:
+task 11, lines 79-91:
 //# run-jsonrpc
 Response: {
   "jsonrpc": "2.0",

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_get_past_object.exp
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_get_past_object.exp
@@ -1,0 +1,89 @@
+processed 9 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 11-13:
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 15-17:
+//# programmable --sender A --inputs 43 object(1,0)
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: MergeCoins(Input(1), [Result(0)])
+mutated: object(0,0), object(1,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 3, lines 19-20:
+//# programmable --sender A --inputs object(1,0)
+//> 0: MergeCoins(Gas, [Input(0)])
+mutated: object(0,0)
+deleted: object(1,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 4, line 22:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, lines 24-28:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": {
+    "status": "VersionNotFound",
+    "details": [
+      "0xc442f9431f789a6c80078a63e707de84c7815c3150e08f1e44be256bd05a2b81",
+      1
+    ]
+  }
+}
+
+task 6, lines 30-34:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "status": "VersionFound",
+    "details": {
+      "objectId": "0xc442f9431f789a6c80078a63e707de84c7815c3150e08f1e44be256bd05a2b81",
+      "version": "2",
+      "digest": "4wV3VBJGNaMCv9zfjSna8c4as6EkuYoqTHHjueS6S745"
+    }
+  }
+}
+
+task 7, lines 36-40:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "status": "VersionFound",
+    "details": {
+      "objectId": "0xc442f9431f789a6c80078a63e707de84c7815c3150e08f1e44be256bd05a2b81",
+      "version": "3",
+      "digest": "5p2rFja4CnVp4TWPg2VuRYpDS6d2AUSTQL5mfWBoiVjh"
+    }
+  }
+}
+
+task 8, lines 42-46:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "status": "ObjectDeleted",
+    "details": {
+      "objectId": "0xc442f9431f789a6c80078a63e707de84c7815c3150e08f1e44be256bd05a2b81",
+      "version": 4,
+      "digest": "7gyGAp71YXQRoxmFBaHxofQXAipvgHyBKPyxmdSJxyvz"
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_get_past_object.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_get_past_object.move
@@ -1,0 +1,46 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --addresses test=0x0 --simulator
+
+// 1. Trying to fetch an object at too low a version
+// 2. ...at its first version
+// 3. ...after it has been modified
+// 4. ...after it has been deleted
+
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 43 object(1,0)
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: MergeCoins(Input(1), [Result(0)])
+
+//# programmable --sender A --inputs object(1,0)
+//> 0: MergeCoins(Gas, [Input(0)])
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "sui_tryGetPastObject",
+  "params": ["@{obj_1_0}", 1]
+}
+
+//# run-jsonrpc
+{
+  "method": "sui_tryGetPastObject",
+  "params": ["@{obj_1_0}", 2]
+}
+
+//# run-jsonrpc
+{
+  "method": "sui_tryGetPastObject",
+  "params": ["@{obj_1_0}", 3]
+}
+
+//# run-jsonrpc
+{
+  "method": "sui_tryGetPastObject",
+  "params": ["@{obj_1_0}", 4]
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_get_past_object.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_get_past_object.move
@@ -57,7 +57,8 @@
     {
       "showType": true,
       "showOwner": true,
-      "showPreviousTransaction": true
+      "showPreviousTransaction": true,
+      "showStorageRebate": true
     }
   ]
 }
@@ -71,7 +72,8 @@
     {
       "showType": true,
       "showOwner": true,
-      "showPreviousTransaction": true
+      "showPreviousTransaction": true,
+      "showStorageRebate": true
     }
   ]
 }
@@ -85,7 +87,8 @@
     {
       "showType": true,
       "showOwner": true,
-      "showPreviousTransaction": true
+      "showPreviousTransaction": true,
+      "showStorageRebate": true
     }
   ]
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_get_past_object.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_get_past_object.move
@@ -7,6 +7,10 @@
 // 2. ...at its first version
 // 3. ...after it has been modified
 // 4. ...after it has been deleted
+// 5. Show the type of a non-existent object verson
+// 6. Show the type of an object version
+// 7. Show the type of a deleted object version
+
 
 //# programmable --sender A --inputs 42 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
@@ -43,4 +47,40 @@
 {
   "method": "sui_tryGetPastObject",
   "params": ["@{obj_1_0}", 4]
+}
+
+//# run-jsonrpc
+{
+  "method": "sui_tryGetPastObject",
+  "params": [
+    "@{obj_1_0}",
+    1,
+    {
+      "showType": true
+    }
+  ]
+}
+
+//# run-jsonrpc
+{
+  "method": "sui_tryGetPastObject",
+  "params": [
+    "@{obj_1_0}",
+    2,
+    {
+      "showType": true
+    }
+  ]
+}
+
+//# run-jsonrpc
+{
+  "method": "sui_tryGetPastObject",
+  "params": [
+    "@{obj_1_0}",
+    4,
+    {
+      "showType": true
+    }
+  ]
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_get_past_object.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_get_past_object.move
@@ -7,10 +7,9 @@
 // 2. ...at its first version
 // 3. ...after it has been modified
 // 4. ...after it has been deleted
-// 5. Show the type of a non-existent object verson
-// 6. Show the type of an object version
-// 7. Show the type of a deleted object version
-
+// 5. Show the details of a non-existent object verson
+// 6. Show the details of an object version
+// 7. Show the details of a deleted object version
 
 //# programmable --sender A --inputs 42 @A
 //> 0: SplitCoins(Gas, [Input(0)]);
@@ -56,7 +55,8 @@
     "@{obj_1_0}",
     1,
     {
-      "showType": true
+      "showType": true,
+      "showOwner": true
     }
   ]
 }
@@ -68,7 +68,8 @@
     "@{obj_1_0}",
     2,
     {
-      "showType": true
+      "showType": true,
+      "showOwner": true
     }
   ]
 }
@@ -80,7 +81,8 @@
     "@{obj_1_0}",
     4,
     {
-      "showType": true
+      "showType": true,
+      "showOwner": true
     }
   ]
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_get_past_object.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_get_past_object.move
@@ -56,7 +56,8 @@
     1,
     {
       "showType": true,
-      "showOwner": true
+      "showOwner": true,
+      "showPreviousTransaction": true
     }
   ]
 }
@@ -69,7 +70,8 @@
     2,
     {
       "showType": true,
-      "showOwner": true
+      "showOwner": true,
+      "showPreviousTransaction": true
     }
   ]
 }
@@ -82,7 +84,8 @@
     4,
     {
       "showType": true,
-      "showOwner": true
+      "showOwner": true,
+      "showPreviousTransaction": true
     }
   ]
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_multi_get_past_objects.exp
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_multi_get_past_objects.exp
@@ -1,0 +1,242 @@
+processed 11 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 9-11:
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 13-15:
+//# programmable --sender A --inputs 43 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 17-19:
+//# programmable --sender A --inputs 44
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::transfer::public_share_object<sui::coin::Coin<sui::sui::SUI>>(Result(0))
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 21-23:
+//# programmable --sender A --inputs 45
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::transfer::public_freeze_object<sui::coin::Coin<sui::sui::SUI>>(Result(0))
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 25-27:
+//# programmable --sender A --inputs @A
+//> 0: sui::table::new<u64, u64>();
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 29-30:
+//# programmable --sender A --inputs object(5,0) 46 47
+//> 0: sui::table::add<u64, u64>(Input(0), Input(1), Input(2))
+created: object(6,0)
+mutated: object(0,0), object(5,0)
+gas summary: computation_cost: 1000000, storage_cost: 3800000,  storage_rebate: 2309868, non_refundable_storage_fee: 23332
+
+task 7, lines 32-33:
+//# programmable --sender A --inputs object(5,0) 46
+//> 0: sui::table::remove<u64, u64>(Input(0), Input(1))
+mutated: object(0,0), object(5,0)
+deleted: object(6,0)
+gas summary: computation_cost: 1000000, storage_cost: 2333200,  storage_rebate: 3762000, non_refundable_storage_fee: 38000
+
+task 8, line 35:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 9, lines 37-52:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": [
+    {
+      "status": "VersionFound",
+      "details": {
+        "objectId": "0xc442f9431f789a6c80078a63e707de84c7815c3150e08f1e44be256bd05a2b81",
+        "version": "2",
+        "digest": "4wV3VBJGNaMCv9zfjSna8c4as6EkuYoqTHHjueS6S745"
+      }
+    },
+    {
+      "status": "VersionFound",
+      "details": {
+        "objectId": "0xf2945213c986e35d59aae258ef1b094e81ead5cc982b0d1519625bf3f81bee68",
+        "version": "3",
+        "digest": "9wMLcUMLvkbqNFyoPtUJ1GPuVuXVqpLA3GP2DHL2SyL6"
+      }
+    },
+    {
+      "status": "VersionFound",
+      "details": {
+        "objectId": "0x0918a1917bda4d05f1cb4db824532a63476c57d65c548930406fe02051f22819",
+        "version": "4",
+        "digest": "8pirmp97ym3pzSCabaPsoPYVPbKYQHfnPqEbCyk32Au2"
+      }
+    },
+    {
+      "status": "VersionFound",
+      "details": {
+        "objectId": "0xf079987ab8a34791ae4dd8b2d2a9af3485496a49b382b22239c4ca43902fe18a",
+        "version": "5",
+        "digest": "EEF6GF5DCZRZ4zxsubwzaQhYWysCdGJ63sLRLE15d9F"
+      }
+    },
+    {
+      "status": "VersionFound",
+      "details": {
+        "objectId": "0x2867eee076a7f41efb3dc507f27531c26319dfbf0c9a6d92f6d1fd0f8d9bdeeb",
+        "version": "6",
+        "digest": "EtpqCkaW8jrLkvbeL9Mgy3REUMX73FrGxEjGiFCz8TSm"
+      }
+    },
+    {
+      "status": "VersionFound",
+      "details": {
+        "objectId": "0x0dfe3bf8505600c374ecc59e9580d3504a37a14f65b53084ef86c5861f39cc3f",
+        "version": "7",
+        "digest": "9rcnz8P9Eie7KZPUjTWnmTzyUxsBMaJcb9G3ncuG4BiC"
+      }
+    },
+    {
+      "status": "ObjectDeleted",
+      "details": {
+        "objectId": "0x0dfe3bf8505600c374ecc59e9580d3504a37a14f65b53084ef86c5861f39cc3f",
+        "version": 8,
+        "digest": "7gyGAp71YXQRoxmFBaHxofQXAipvgHyBKPyxmdSJxyvz"
+      }
+    },
+    {
+      "status": "VersionNotFound",
+      "details": [
+        "0x0dfe3bf8505600c374ecc59e9580d3504a37a14f65b53084ef86c5861f39cc3f",
+        9
+      ]
+    }
+  ]
+}
+
+task 10, lines 54-75:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": [
+    {
+      "status": "VersionFound",
+      "details": {
+        "objectId": "0xc442f9431f789a6c80078a63e707de84c7815c3150e08f1e44be256bd05a2b81",
+        "version": "2",
+        "digest": "4wV3VBJGNaMCv9zfjSna8c4as6EkuYoqTHHjueS6S745",
+        "type": "0x2::coin::Coin<0x2::sui::SUI>",
+        "owner": {
+          "AddressOwner": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+        },
+        "previousTransaction": "ABo3jemYqdBWMRYqsaCYUKnGDp64tR7jK2fH1mKCoJLk",
+        "storageRebate": "988000"
+      }
+    },
+    {
+      "status": "VersionFound",
+      "details": {
+        "objectId": "0xf2945213c986e35d59aae258ef1b094e81ead5cc982b0d1519625bf3f81bee68",
+        "version": "3",
+        "digest": "9wMLcUMLvkbqNFyoPtUJ1GPuVuXVqpLA3GP2DHL2SyL6",
+        "type": "0x2::coin::Coin<0x2::sui::SUI>",
+        "owner": {
+          "AddressOwner": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+        },
+        "previousTransaction": "DHGGkfgVSyMV4vZqbHe5jPcJLX5Wrp3m7d5mdLUn62dX",
+        "storageRebate": "988000"
+      }
+    },
+    {
+      "status": "VersionFound",
+      "details": {
+        "objectId": "0x0918a1917bda4d05f1cb4db824532a63476c57d65c548930406fe02051f22819",
+        "version": "4",
+        "digest": "8pirmp97ym3pzSCabaPsoPYVPbKYQHfnPqEbCyk32Au2",
+        "type": "0x2::coin::Coin<0x2::sui::SUI>",
+        "owner": {
+          "Shared": {
+            "initial_shared_version": 4
+          }
+        },
+        "previousTransaction": "FDCEMiaPqGUUFjB4sV1EMCFisw7W7WMJJ6nWTBwnoHcc",
+        "storageRebate": "988000"
+      }
+    },
+    {
+      "status": "VersionFound",
+      "details": {
+        "objectId": "0xf079987ab8a34791ae4dd8b2d2a9af3485496a49b382b22239c4ca43902fe18a",
+        "version": "5",
+        "digest": "EEF6GF5DCZRZ4zxsubwzaQhYWysCdGJ63sLRLE15d9F",
+        "type": "0x2::coin::Coin<0x2::sui::SUI>",
+        "owner": "Immutable",
+        "previousTransaction": "4ZmQdHopY1d8eg5zsTVciezKwhTbuQGaybXXBMWjs7ax",
+        "storageRebate": "988000"
+      }
+    },
+    {
+      "status": "VersionFound",
+      "details": {
+        "objectId": "0x2867eee076a7f41efb3dc507f27531c26319dfbf0c9a6d92f6d1fd0f8d9bdeeb",
+        "version": "6",
+        "digest": "EtpqCkaW8jrLkvbeL9Mgy3REUMX73FrGxEjGiFCz8TSm",
+        "type": "0x2::table::Table<u64, u64>",
+        "owner": {
+          "AddressOwner": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+        },
+        "previousTransaction": "7DxXXvjVgFuqLXPRaZKAVm12cQWopxbVySBdNqmUCRVJ",
+        "storageRebate": "1345200"
+      }
+    },
+    {
+      "status": "VersionFound",
+      "details": {
+        "objectId": "0x0dfe3bf8505600c374ecc59e9580d3504a37a14f65b53084ef86c5861f39cc3f",
+        "version": "7",
+        "digest": "9rcnz8P9Eie7KZPUjTWnmTzyUxsBMaJcb9G3ncuG4BiC",
+        "type": "0x2::dynamic_field::Field<u64, u64>",
+        "owner": {
+          "ObjectOwner": "0x2867eee076a7f41efb3dc507f27531c26319dfbf0c9a6d92f6d1fd0f8d9bdeeb"
+        },
+        "previousTransaction": "6mXaEAhjYrN5QF4mBX1bLK2T8h4XtmYqqi3FNvtsd3TY",
+        "storageRebate": "1466800"
+      }
+    },
+    {
+      "status": "ObjectDeleted",
+      "details": {
+        "objectId": "0x0dfe3bf8505600c374ecc59e9580d3504a37a14f65b53084ef86c5861f39cc3f",
+        "version": 8,
+        "digest": "7gyGAp71YXQRoxmFBaHxofQXAipvgHyBKPyxmdSJxyvz"
+      }
+    },
+    {
+      "status": "VersionNotFound",
+      "details": [
+        "0x0dfe3bf8505600c374ecc59e9580d3504a37a14f65b53084ef86c5861f39cc3f",
+        9
+      ]
+    }
+  ]
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_multi_get_past_objects.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_multi_get_past_objects.move
@@ -1,0 +1,75 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --addresses test=0x0 --simulator
+
+// 1. Multi-get objects (with found object, with non-existent object, with deleted object)
+// 2. Multi-get objects with options
+
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 43 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 44
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::transfer::public_share_object<sui::coin::Coin<sui::sui::SUI>>(Result(0))
+
+//# programmable --sender A --inputs 45
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: sui::transfer::public_freeze_object<sui::coin::Coin<sui::sui::SUI>>(Result(0))
+
+//# programmable --sender A --inputs @A
+//> 0: sui::table::new<u64, u64>();
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# programmable --sender A --inputs object(5,0) 46 47
+//> 0: sui::table::add<u64, u64>(Input(0), Input(1), Input(2))
+
+//# programmable --sender A --inputs object(5,0) 46
+//> 0: sui::table::remove<u64, u64>(Input(0), Input(1))
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "sui_tryMultiGetPastObjects",
+  "params": [
+    [
+      { "objectId": "@{obj_1_0}", "version": "2" },
+      { "objectId": "@{obj_2_0}", "version": "3" },
+      { "objectId": "@{obj_3_0}", "version": "4" },
+      { "objectId": "@{obj_4_0}", "version": "5" },
+      { "objectId": "@{obj_5_0}", "version": "6" },
+      { "objectId": "@{obj_6_0}", "version": "7" },
+      { "objectId": "@{obj_6_0}", "version": "8" },
+      { "objectId": "@{obj_6_0}", "version": "9" }
+    ]
+  ]
+}
+
+//# run-jsonrpc
+{
+  "method": "sui_tryMultiGetPastObjects",
+  "params": [
+    [
+      { "objectId": "@{obj_1_0}", "version": "2" },
+      { "objectId": "@{obj_2_0}", "version": "3" },
+      { "objectId": "@{obj_3_0}", "version": "4" },
+      { "objectId": "@{obj_4_0}", "version": "5" },
+      { "objectId": "@{obj_5_0}", "version": "6" },
+      { "objectId": "@{obj_6_0}", "version": "7" },
+      { "objectId": "@{obj_6_0}", "version": "8" },
+      { "objectId": "@{obj_6_0}", "version": "9" }
+    ],
+    {
+      "showType": true,
+      "showOwner": true,
+      "showPreviousTransaction": true,
+      "showStorageRebate": true
+    }
+  ]
+}

--- a/crates/sui-indexer-alt-jsonrpc/src/api/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/mod.rs
@@ -2,5 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub(crate) mod governance;
+pub(crate) mod objects;
 pub(crate) mod rpc_module;
 pub(crate) mod transactions;

--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/error.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/error.rs
@@ -1,0 +1,8 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[derive(thiserror::Error, Debug)]
+pub(super) enum Error {
+    #[error("Requested {requested} keys, exceeding maximum {max}")]
+    TooManyKeys { requested: usize, max: usize },
+}

--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/mod.rs
@@ -1,0 +1,60 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use sui_json_rpc_types::{SuiObjectDataOptions, SuiPastObjectResponse};
+use sui_open_rpc::Module;
+use sui_open_rpc_macros::open_rpc;
+use sui_types::base_types::{ObjectID, SequenceNumber};
+
+use crate::context::Context;
+
+use super::rpc_module::RpcModule;
+
+mod response;
+
+#[open_rpc(namespace = "sui", tag = "Objects API")]
+#[rpc(server, namespace = "sui")]
+trait ObjectsApi {
+    /// Return the object information for a specified version.
+    ///
+    /// Note that past versions of an object may be pruned from the system, even if they once
+    /// existed. Different RPC services may return different responses for the same request as a
+    /// result, based on their pruning policies.
+    #[method(name = "tryGetPastObject")]
+    async fn try_get_past_object(
+        &self,
+        /// The ID of the queried object
+        object_id: ObjectID,
+        /// The version of the queried object.
+        version: SequenceNumber,
+        /// Options for specifying the content to be returned
+        options: Option<SuiObjectDataOptions>,
+    ) -> RpcResult<SuiPastObjectResponse>;
+}
+
+pub(crate) struct Objects(pub Context);
+
+#[async_trait::async_trait]
+impl ObjectsApiServer for Objects {
+    async fn try_get_past_object(
+        &self,
+        object_id: ObjectID,
+        version: SequenceNumber,
+        options: Option<SuiObjectDataOptions>,
+    ) -> RpcResult<SuiPastObjectResponse> {
+        let Self(ctx) = self;
+        let options = options.unwrap_or_default();
+        Ok(response::past_object(ctx, object_id, version, &options).await?)
+    }
+}
+
+impl RpcModule for Objects {
+    fn schema(&self) -> Module {
+        ObjectsApiOpenRpc::module_doc()
+    }
+
+    fn into_impl(self) -> jsonrpsee::RpcModule<Self> {
+        self.into_rpc()
+    }
+}

--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/mod.rs
@@ -1,16 +1,24 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use futures::future;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use sui_json_rpc_types::{SuiObjectDataOptions, SuiPastObjectResponse};
+use serde::{Deserialize, Serialize};
+use sui_json_rpc_types::{SuiGetPastObjectRequest, SuiObjectDataOptions, SuiPastObjectResponse};
 use sui_open_rpc::Module;
 use sui_open_rpc_macros::open_rpc;
 use sui_types::base_types::{ObjectID, SequenceNumber};
 
-use crate::context::Context;
+use crate::{
+    context::Context,
+    error::{invalid_params, InternalContext},
+};
 
 use super::rpc_module::RpcModule;
 
+use self::error::Error;
+
+mod error;
 mod response;
 
 #[open_rpc(namespace = "sui", tag = "Objects API")]
@@ -31,9 +39,29 @@ trait ObjectsApi {
         /// Options for specifying the content to be returned
         options: Option<SuiObjectDataOptions>,
     ) -> RpcResult<SuiPastObjectResponse>;
+
+    /// Return the object information for multiple specified objects and versions.
+    ///
+    /// Note that past versions of an object may be pruned from the system, even if they once
+    /// existed. Different RPC services may return different responses for the same request as a
+    /// result, based on their pruning policies.
+    #[method(name = "tryMultiGetPastObjects")]
+    async fn try_multi_get_past_objects(
+        &self,
+        /// A vector of object and versions to be queried
+        past_objects: Vec<SuiGetPastObjectRequest>,
+        /// Options for specifying the content to be returned
+        options: Option<SuiObjectDataOptions>,
+    ) -> RpcResult<Vec<SuiPastObjectResponse>>;
 }
 
-pub(crate) struct Objects(pub Context);
+pub(crate) struct Objects(pub Context, pub ObjectsConfig);
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ObjectsConfig {
+    /// The maximum number of keys that can be queried in a single multi-get request.
+    pub max_multi_get_objects: usize,
+}
 
 #[async_trait::async_trait]
 impl ObjectsApiServer for Objects {
@@ -43,9 +71,41 @@ impl ObjectsApiServer for Objects {
         version: SequenceNumber,
         options: Option<SuiObjectDataOptions>,
     ) -> RpcResult<SuiPastObjectResponse> {
-        let Self(ctx) = self;
+        let Self(ctx, _) = self;
         let options = options.unwrap_or_default();
         Ok(response::past_object(ctx, object_id, version, &options).await?)
+    }
+
+    async fn try_multi_get_past_objects(
+        &self,
+        past_objects: Vec<SuiGetPastObjectRequest>,
+        options: Option<SuiObjectDataOptions>,
+    ) -> RpcResult<Vec<SuiPastObjectResponse>> {
+        let Self(ctx, config) = self;
+        if past_objects.len() > config.max_multi_get_objects {
+            return Err(invalid_params(Error::TooManyKeys {
+                requested: past_objects.len(),
+                max: config.max_multi_get_objects,
+            })
+            .into());
+        }
+
+        let options = options.unwrap_or_default();
+
+        let obj_futures = past_objects
+            .iter()
+            .map(|obj| response::past_object(ctx, obj.object_id, obj.version, &options));
+
+        Ok(future::join_all(obj_futures)
+            .await
+            .into_iter()
+            .zip(past_objects)
+            .map(|(r, o)| {
+                let id = o.object_id.to_canonical_display(/* with_prefix */ true);
+                let v = o.version;
+                r.with_internal_context(|| format!("Failed to get object {id} at version {v}"))
+            })
+            .collect::<Result<Vec<_>, _>>()?)
     }
 }
 
@@ -56,5 +116,13 @@ impl RpcModule for Objects {
 
     fn into_impl(self) -> jsonrpsee::RpcModule<Self> {
         self.into_rpc()
+    }
+}
+
+impl Default for ObjectsConfig {
+    fn default() -> Self {
+        Self {
+            max_multi_get_objects: 50,
+        }
     }
 }

--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
@@ -54,6 +54,9 @@ fn object(
 
     let type_ = options.show_type.then(|| ObjectType::from(&object));
     let owner = options.show_owner.then(|| object.owner().clone());
+    let previous_transaction = options
+        .show_previous_transaction
+        .then(|| object.previous_transaction);
 
     Ok(SuiObjectData {
         object_id,
@@ -61,7 +64,7 @@ fn object(
         digest: object.digest(),
         type_,
         owner,
-        previous_transaction: None,
+        previous_transaction,
         storage_rebate: None,
         display: None,
         content: None,

--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
@@ -6,7 +6,7 @@ use sui_json_rpc_types::{
     SuiObjectData, SuiObjectDataOptions, SuiObjectRef, SuiPastObjectResponse,
 };
 use sui_types::{
-    base_types::{ObjectID, SequenceNumber},
+    base_types::{ObjectID, ObjectType, SequenceNumber},
     digests::ObjectDigest,
     object::Object,
 };
@@ -48,15 +48,17 @@ fn object(
     object_id: ObjectID,
     version: SequenceNumber,
     bytes: &[u8],
-    _options: &SuiObjectDataOptions,
+    options: &SuiObjectDataOptions,
 ) -> Result<SuiObjectData, RpcError> {
     let object: Object = bcs::from_bytes(bytes).context("Failed to deserialize object")?;
+
+    let type_ = options.show_type.then(|| ObjectType::from(&object));
 
     Ok(SuiObjectData {
         object_id,
         version,
         digest: object.digest(),
-        type_: None,
+        type_,
         owner: None,
         previous_transaction: None,
         storage_rebate: None,

--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
@@ -57,6 +57,7 @@ fn object(
     let previous_transaction = options
         .show_previous_transaction
         .then(|| object.previous_transaction);
+    let storage_rebate = options.show_storage_rebate.then(|| object.storage_rebate);
 
     Ok(SuiObjectData {
         object_id,
@@ -65,7 +66,7 @@ fn object(
         type_,
         owner,
         previous_transaction,
-        storage_rebate: None,
+        storage_rebate,
         display: None,
         content: None,
         bcs: None,

--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
@@ -53,13 +53,14 @@ fn object(
     let object: Object = bcs::from_bytes(bytes).context("Failed to deserialize object")?;
 
     let type_ = options.show_type.then(|| ObjectType::from(&object));
+    let owner = options.show_owner.then(|| object.owner().clone());
 
     Ok(SuiObjectData {
         object_id,
         version,
         digest: object.digest(),
         type_,
-        owner: None,
+        owner,
         previous_transaction: None,
         storage_rebate: None,
         display: None,

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -5,6 +5,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use anyhow::Context as _;
+use api::objects::Objects;
 use api::rpc_module::RpcModule;
 use api::transactions::{QueryTransactions, Transactions, TransactionsConfig};
 use config::RpcConfig;
@@ -192,8 +193,8 @@ impl Default for RpcArgs {
 /// command-line). The service will continue to run until the cancellation token is triggered, and
 /// will signal cancellation on the token when it is shutting down.
 ///
-/// The service may spin up auxilliary services (such as the system package task) to support
-/// itself, and will clean these up on shutdown as well.
+/// The service may spin up auxiliary services (such as the system package task) to support itself,
+/// and will clean these up on shutdown as well.
 pub async fn start_rpc(
     db_args: DbArgs,
     rpc_args: RpcArgs,
@@ -221,6 +222,7 @@ pub async fn start_rpc(
     );
 
     rpc.add_module(Governance(context.clone()))?;
+    rpc.add_module(Objects(context.clone()))?;
     rpc.add_module(QueryTransactions(context.clone(), transactions_config))?;
     rpc.add_module(Transactions(context.clone()))?;
 


### PR DESCRIPTION
## Description

Initial support for `tryGetPastObject`, `tryMultiGetPastObjects` and most of the response options. Support for `showDisplay` will come in a follow-up PR.

This PR is a remix of #20962 as it was easier to redo it and fix it forward rather than rebase the stack below this PR on top of that change.

## Test plan

New E2E tests:

```
sui$ cargo nextest run -p sui-indexer-alt-e2e-tests -- objects
```

## Stack

- #20944 
- #20975 
- #20990 
- #20991 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
