### PR TITLE
[suiop][env] move to pulumi env interactive for suiop env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10417,6 +10417,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "query-shell"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300d1c86e9638eceb24568649d5ad0f31b949ff11ff1ffbacbe3e382a4dfee25"
+dependencies = [
+ "sysinfo",
+ "thiserror 1.0.64",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15955,6 +15965,7 @@ dependencies = [
  "once_cell",
  "open",
  "prettytable-rs",
+ "query-shell",
  "rand 0.8.5",
  "regex",
  "reqwest 0.12.5",

--- a/crates/suiop-cli/Cargo.toml
+++ b/crates/suiop-cli/Cargo.toml
@@ -59,6 +59,7 @@ futures-timer = "3.0.3"
 tempfile.workspace = true
 kube = { version = "0.97.0", features = ["client"] }
 k8s-openapi = { version = "0.23.0", features = ["latest"] }
+query-shell = "0.3.0"
 
 
 [dev-dependencies]

--- a/crates/suiop-cli/src/cli/env/mod.rs
+++ b/crates/suiop-cli/src/cli/env/mod.rs
@@ -1,13 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::run_cmd;
+use crate::{command::CommandOptions, run_cmd};
 use anyhow::Result;
 use clap::Parser;
 use inquire::Select;
 use query_shell::get_shell_name;
-use std::io::Write;
-use tracing::{debug, info};
 
 /// Load an environment from pulumi
 ///
@@ -18,7 +16,7 @@ pub struct LoadEnvironmentArgs {
     environment_name: Option<String>,
 }
 
-pub fn load_environment_new(args: &LoadEnvironmentArgs) -> Result<()> {
+pub fn load_environment(args: &LoadEnvironmentArgs) -> Result<()> {
     // list envs from pulumi using `pulumi env ls`
     let env = args.environment_name.clone().unwrap_or_else(|| {
         let output = run_cmd(vec!["pulumi", "env", "ls"], None).expect("Running pulumi env ls");
@@ -35,64 +33,10 @@ pub fn load_environment_new(args: &LoadEnvironmentArgs) -> Result<()> {
             .to_owned()
     });
 
-    setup_pulumi_environment(&env);
-
     // get the user's shell
     let shell = get_shell_name()?;
     // use `pulumi env run <env_name> -i <shell>` to load the environment into the shell
-    run_cmd(vec!["pulumi", "env", "run", &env, "-i", &shell], None)?;
-    Ok(())
-}
-pub fn load_environment_cmd(args: &LoadEnvironmentArgs) -> Result<()> {
-    setup_pulumi_environment(&args.environment_name.clone().unwrap_or_else(|| {
-        let output = run_cmd(vec!["pulumi", "env", "ls"], None).expect("Running pulumi env ls");
-        let output_str = String::from_utf8_lossy(&output.stdout);
-        let options: Vec<&str> = output_str.lines().collect();
-
-        if options.is_empty() {
-            panic!("No environments found. Make sure you are logged into the correct pulumi org.");
-        }
-
-        Select::new("Select an environment:", options)
-            .prompt()
-            .expect("Failed to select environment")
-            .to_owned()
-    }))
-}
-
-pub fn setup_pulumi_environment(environment_name: &str) -> Result<()> {
-    let output = run_cmd(vec!["pulumi", "env", "open", environment_name], None)?;
-    let output_str = String::from_utf8_lossy(&output.stdout);
-    let output_json: serde_json::Value = serde_json::from_str(&output_str)?;
-    let env_vars = &output_json["environmentVariables"];
-    // Open a file to write environment variables
-    let home_dir = std::env::var("HOME").expect("HOME environment variable not set");
-    let suiop_dir = format!("{}/.suiop", home_dir);
-    std::fs::create_dir_all(&suiop_dir).expect("Failed to create .suiop directory");
-    let env_file_path = format!("{}/env_vars", suiop_dir);
-    let mut env_file =
-        std::fs::File::create(&env_file_path).expect("Failed to create env_vars file");
-
-    if let serde_json::Value::Object(env_vars) = env_vars {
-        for (key, value) in env_vars {
-            if let Some(value_str) = value.as_str() {
-                writeln!(env_file, "{}={}", key, value_str)?;
-                info!("writing environment variable {}", key);
-                debug!("={}", value_str);
-            } else {
-                info!(
-                    "Failed to set environment variable: {}. Value is not a string.",
-                    key
-                );
-            }
-        }
-    } else {
-        info!("Environment variables are not in the expected format.");
-        debug!("env: {:?}", output_json);
-    }
-    info!(
-        "finished loading environment. use `source {}` to load them into your shell",
-        env_file_path
-    );
+    let opts = CommandOptions::new(true, false);
+    run_cmd(vec!["pulumi", "env", "run", &env, "-i", &shell], Some(opts))?;
     Ok(())
 }

--- a/crates/suiop-cli/src/cli/mod.rs
+++ b/crates/suiop-cli/src/cli/mod.rs
@@ -14,7 +14,7 @@ mod slack;
 
 pub use ci::{ci_cmd, CIArgs};
 pub use docker::{docker_cmd, DockerArgs};
-pub use env::{load_environment_new, LoadEnvironmentArgs};
+pub use env::{load_environment, LoadEnvironmentArgs};
 pub use iam::{iam_cmd, IAMArgs};
 pub use incidents::{incidents_cmd, IncidentsArgs};
 pub use pulumi::{pulumi_cmd, PulumiArgs};

--- a/crates/suiop-cli/src/cli/mod.rs
+++ b/crates/suiop-cli/src/cli/mod.rs
@@ -14,7 +14,7 @@ mod slack;
 
 pub use ci::{ci_cmd, CIArgs};
 pub use docker::{docker_cmd, DockerArgs};
-pub use env::{load_environment_cmd, LoadEnvironmentArgs};
+pub use env::{load_environment_new, LoadEnvironmentArgs};
 pub use iam::{iam_cmd, IAMArgs};
 pub use incidents::{incidents_cmd, IncidentsArgs};
 pub use pulumi::{pulumi_cmd, PulumiArgs};

--- a/crates/suiop-cli/src/main.rs
+++ b/crates/suiop-cli/src/main.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use clap::Parser;
 use suioplib::{
     cli::{
-        ci_cmd, docker_cmd, iam_cmd, incidents_cmd, load_environment_new, pulumi_cmd,
+        ci_cmd, docker_cmd, iam_cmd, incidents_cmd, load_environment, pulumi_cmd,
         service::ServiceAction, service_cmd, CIArgs, DockerArgs, IAMArgs, IncidentsArgs,
         LoadEnvironmentArgs, PulumiArgs, ServiceArgs,
     },
@@ -100,7 +100,7 @@ async fn main() -> Result<()> {
             ci_cmd(&args).await?;
         }
         Resource::LoadEnvironment(args) => {
-            load_environment_new(&args)?;
+            load_environment(&args)?;
         }
         Resource::Logs => {
             service_cmd(&ServiceArgs {

--- a/crates/suiop-cli/src/main.rs
+++ b/crates/suiop-cli/src/main.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use clap::Parser;
 use suioplib::{
     cli::{
-        ci_cmd, docker_cmd, iam_cmd, incidents_cmd, load_environment_cmd, pulumi_cmd,
+        ci_cmd, docker_cmd, iam_cmd, incidents_cmd, load_environment_new, pulumi_cmd,
         service::ServiceAction, service_cmd, CIArgs, DockerArgs, IAMArgs, IncidentsArgs,
         LoadEnvironmentArgs, PulumiArgs, ServiceArgs,
     },
@@ -100,7 +100,7 @@ async fn main() -> Result<()> {
             ci_cmd(&args).await?;
         }
         Resource::LoadEnvironment(args) => {
-            load_environment_cmd(&args)?;
+            load_environment_new(&args)?;
         }
         Resource::Logs => {
             service_cmd(&ServiceArgs {


### PR DESCRIPTION
## Description 

Use `pulumi run -i` instead to start an interactive shell with the user's preexisting shell. ctrl + d to exit back out.

## Test plan 

How did you test the new or updated feature?

```
cargo run --bin suiop -- env mysten/default/gcp-app-env
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.64s
     Running `/Users/jordankylejensen/mysten/sui/target/debug/suiop env mysten/default/gcp-app-env`
done initializing 🎉

suiop-cli [jkj/suiop-env-esc] 
```

interactive:
```
cargo run --bin suiop -- env 
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.51s
     Running `/Users/jordankylejensen/mysten/sui/target/debug/suiop env`
> Select an environment: mysten/default/gcp-app-env-dev
done initializing 🎉

suiop-cli [jkj/suiop-env-esc] 
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
