### PR TITLE
[move-analyzer] Cached user program merge fix

### DIFF
--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -1020,6 +1020,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "erased-discriminant"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f74784b51403f16c5fa6dc667488389e629811329c1c6719c25874da2ba4f"
+dependencies = [
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3360,13 +3369,15 @@ dependencies = [
 
 [[package]]
 name = "serde-reflection"
-version = "0.3.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05a5f801ac62a51a49d378fdb3884480041b99aced450b28990673e8ff99895"
+checksum = "e5bef77b40d103fda6c10d29c21f5c78c980e8570e1a290a648a9ff5011f96e1"
 dependencies = [
+ "erased-discriminant",
  "once_cell",
  "serde",
  "thiserror",
+ "typeid",
 ]
 
 [[package]]
@@ -4006,6 +4017,12 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e"
 
 [[package]]
 name = "typenum"

--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
   "publisher": "mysten",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "preview": true,
   "repository": {
     "url": "https://github.com/MystenLabs/sui.git",

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -1782,37 +1782,73 @@ fn has_precompiled_deps(
     pkg_deps.contains_key(pkg_path)
 }
 
-fn is_parsed_pkg_modified(
-    pkg_def: &P::PackageDefinition,
-    files_to_compile: &BTreeSet<PathBuf>,
+/// Checks if a hash is included in the file hashes list.
+/// We only consider file hashes from files.
+fn hash_included_in_file_hashes(
+    hash: FileHash,
+    modified_files: &BTreeSet<PathBuf>,
     file_hashes: Arc<BTreeMap<PathBuf, FileHash>>,
 ) -> bool {
-    files_to_compile.iter().any(|fpath| {
-        file_hashes
-            .get(fpath)
-            .and_then(|fhash| match &pkg_def.def {
-                P::Definition::Module(mdef) => Some((mdef, fhash)),
-                _ => None,
-            })
-            .map_or(false, |(mdef, fhash)| mdef.loc.file_hash() == *fhash)
-    })
+    for fpath in modified_files {
+        let Some(fhash) = file_hashes.get(fpath) else {
+            debug_assert!(false);
+            continue;
+        };
+        if hash == *fhash {
+            return true;
+        }
+    }
+    false
 }
 
-fn is_typed_mod_modified(
-    mdef: &ModuleDefinition,
-    files_to_compile: &BTreeSet<PathBuf>,
+/// Checks if a parsed module has been modified by comparing
+/// file hash in the module with the file hashes provided
+/// as an argument to see if module hash is included in the
+/// hashes provided. We only consider file hashes from modified
+/// files.
+fn is_parsed_mod_modified(
+    mdef: &P::ModuleDefinition,
+    modified_files: &BTreeSet<PathBuf>,
     file_hashes: Arc<BTreeMap<PathBuf, FileHash>>,
 ) -> bool {
-    files_to_compile.iter().any(|fpath| {
-        file_hashes
-            .get(fpath)
-            .map_or(false, |fhash| mdef.loc.file_hash() == *fhash)
-    })
+    !hash_included_in_file_hashes(mdef.loc.file_hash(), modified_files, file_hashes)
+}
+
+/// Checks if a typed module has been modified by comparing
+/// file hash in the module with the file hashes provided
+/// as an argument to see if module hash is included in the
+/// hashes provided. We only consider file hashes from modified
+/// files.
+fn is_typed_mod_modified(
+    mdef: &ModuleDefinition,
+    modified_files: &BTreeSet<PathBuf>,
+    file_hashes: Arc<BTreeMap<PathBuf, FileHash>>,
+) -> bool {
+    !hash_included_in_file_hashes(mdef.loc.file_hash(), modified_files, file_hashes)
+}
+
+/// Checks if a parsed package has been modified by comparing
+/// file hash in the package's modules with the file hashes provided
+/// as an argument to see if all module hashes are included
+/// in the hashes provided. We only consider file hashes from modified
+/// files.
+fn is_parsed_pkg_modified(
+    pkg_def: &P::PackageDefinition,
+    modified_files: &BTreeSet<PathBuf>,
+    file_hashes: Arc<BTreeMap<PathBuf, FileHash>>,
+) -> bool {
+    match &pkg_def.def {
+        P::Definition::Module(mdef) => is_parsed_mod_modified(mdef, modified_files, file_hashes),
+        P::Definition::Address(adef) => adef
+            .modules
+            .iter()
+            .any(|mdef| is_parsed_mod_modified(mdef, modified_files, file_hashes.clone())),
+    }
 }
 
 /// Merges a cached compiled program with newly computed compiled program
 /// In the newly computed program, only modified files are fully compiled
-/// and these files are mereged with the cached compiled program.
+/// and these files are merged with the cached compiled program.
 fn merge_user_programs(
     cached_info_opt: Option<AnalyzedPkgInfo>,
     parsed_program_new: P::Program,
@@ -1829,27 +1865,28 @@ fn merge_user_programs(
     // address maps might have changed but all would be computed in full during
     // incremental compilation as only function bodies are omitted
     parsed_program_cached.named_address_maps = parsed_program_new.named_address_maps;
-    // remove modules from user code that belong to modified files (use cached
-    // file hashes as we are comparing with hashes in cached modules)
+    // remove modules from user code that belong to modified files (use new
+    // file hashes - if cached module's hash is on the list of new file hashes, it means
+    // that nothing changed)
     parsed_program_cached.source_definitions.retain(|pkg_def| {
-        !is_parsed_pkg_modified(pkg_def, &files_to_compile, file_hashes_cached.clone())
+        !is_parsed_pkg_modified(pkg_def, &files_to_compile, file_hashes_new.clone())
     });
     let mut typed_modules_cached_filtered = UniqueMap::new();
     for (mident, mdef) in typed_modules_cached.into_iter() {
-        if !is_typed_mod_modified(&mdef, &files_to_compile, file_hashes_cached.clone()) {
+        if !is_typed_mod_modified(&mdef, &files_to_compile, file_hashes_new.clone()) {
             _ = typed_modules_cached_filtered.add(mident, mdef);
         }
     }
     typed_modules_cached = typed_modules_cached_filtered;
-    // add new modules from user code (use new file hashes as we are comparing with
-    // hashes in new modules)
+    // add new modules from user code (use cached file hashes - if new module's hash is on the list of
+    // cached file hashes, it means that nothing' changed)
     for pkg_def in parsed_program_new.source_definitions {
-        if is_parsed_pkg_modified(&pkg_def, &files_to_compile, file_hashes_new.clone()) {
+        if is_parsed_pkg_modified(&pkg_def, &files_to_compile, file_hashes_cached.clone()) {
             parsed_program_cached.source_definitions.push(pkg_def);
         }
     }
     for (mident, mdef) in typed_program_modules_new.into_iter() {
-        if is_typed_mod_modified(&mdef, &files_to_compile, file_hashes_new.clone()) {
+        if is_typed_mod_modified(&mdef, &files_to_compile, file_hashes_cached.clone()) {
             typed_modules_cached.remove(&mident); // in case new file has new definition of the module
             _ = typed_modules_cached.add(mident, mdef);
         }

--- a/external-crates/move/crates/move-analyzer/src/symbols.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols.rs
@@ -1789,16 +1789,15 @@ fn hash_included_in_file_hashes(
     modified_files: &BTreeSet<PathBuf>,
     file_hashes: Arc<BTreeMap<PathBuf, FileHash>>,
 ) -> bool {
-    for fpath in modified_files {
-        let Some(fhash) = file_hashes.get(fpath) else {
-            debug_assert!(false);
-            continue;
-        };
-        if hash == *fhash {
-            return true;
-        }
-    }
-    false
+    modified_files.iter().any(|fpath| {
+        file_hashes.get(fpath).map_or_else(
+            || {
+                debug_assert!(false);
+                false
+            },
+            |fhash| hash == *fhash,
+        )
+    })
 }
 
 /// Checks if a parsed module has been modified by comparing


### PR DESCRIPTION
## Description 

The rules deciding on how to merge user package files between freshly computed and cached data were incorrect. Luckily (or not actually) they were not fatally incorrect and while the initial merge (when files were actually modified) would not succeed, the subsequent one (where no files were modified - resulting for example from inlay hint request) would, and ultimately the correct data would be generated.

The problem was spotted in the debug build where debug assertions would fail on the initial merge (though all would return to normal after `move-analyzer` restart upon the subsequent request).

I fixed the code and also made it a bit more verbose but also easier to follow the merge logic

## Test plan 

Verified that assertions are no longer failing in the debug build on code that was previously triggering them
