### PR TITLE
jsonrpc: disable batches and unlimit response sizes

### DIFF
--- a/crates/sui-json-rpc/src/lib.rs
+++ b/crates/sui-json-rpc/src/lib.rs
@@ -212,6 +212,10 @@ impl JsonRpcServerBuilder {
             // number of connections. As such, for now we can just set this to a very high value to
             // disable it artificially limiting us to ~100 conncurrent requests.
             .max_connections(u32::MAX)
+            // Before we updated jsonrpsee, batches were disabled so lets keep them disabled.
+            .set_batch_request_config(jsonrpsee::server::BatchRequestConfig::Disabled)
+            // We don't limit response body sizes.
+            .max_response_body_size(u32::MAX)
             .set_rpc_middleware(rpc_middleware);
 
         let mut router = axum::Router::new();


### PR DESCRIPTION
When we updated the `jsonrpsee` dependency a few configuration changes were made unintentially. Specifically batches were re-enabled and response bodies were limited to 10MB. This patch reverts both these semantic changes to the service by disabling batches and removing the cap on response sizes.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
