### PR TITLE
Fix spelling error

### DIFF
--- a/crates/sui-types/src/multisig_legacy.rs
+++ b/crates/sui-types/src/multisig_legacy.rs
@@ -188,7 +188,7 @@ impl MultiSigLegacy {
             )?);
             if !inserted {
                 return Err(SuiError::InvalidSignature {
-                    error: "Duplicate sigature".to_string(),
+                    error: "Duplicate signature".to_string(),
                 });
             }
             sigs.push(s.to_compressed()?);

--- a/examples/move/nft-rental/c4-architecture/workspace.dsl
+++ b/examples/move/nft-rental/c4-architecture/workspace.dsl
@@ -13,7 +13,7 @@ workspace {
                 promise = component "Promise" "A Promise object given to the borrower when they want to use the borrowed item. Acts as a hot potato, requiring that the rentable be returned after use."
                 install = component "Install" "Allows for a borrower or renter to install the Rentables Extension to their Kiosk."
                 list = component "List" "Allows for a renter to list an item for renting."
-                delist = component "Delist" "Allows a renter to delist an item they are currenlty listing but not actively renting."
+                delist = component "Delist" "Allows a renter to delist an item they are currently listing but not actively renting."
                 rent = component "Rent" "Allows a borrower to rent an item that is being listed in one's Rentables Extension."
                 borrow = component "Borrow" "Enables the borrower to borrow the item either by value of by reference. Depending on the configuration defined by the renter."
                 reclaim = component "Reclaim" "Allows the renter to claim their item after the rental period has expired."

--- a/examples/move/nft-rental/c4-architecture/workspace.json
+++ b/examples/move/nft-rental/c4-architecture/workspace.json
@@ -202,7 +202,7 @@
           } ],
           "tags" : "Element,Component"
         }, {
-          "description" : "Allows a renter to delist an item they are currenlty listing but not actively renting.",
+          "description" : "Allows a renter to delist an item they are currently listing but not actively renting.",
           "documentation" : { },
           "id" : "14",
           "name" : "Delist",

--- a/examples/trading/frontend/src/components/escrows/CreateEscrow.tsx
+++ b/examples/trading/frontend/src/components/escrows/CreateEscrow.tsx
@@ -80,7 +80,7 @@ export function CreateEscrow({ locked }: { locked: ApiLockedObject }) {
                     <Select.Item
                       key={object.data?.objectId!}
                       value={object.data?.objectId!}
-                      className="h-auto w-full data-[state=checked]:bg-blue-50 whitespace-pre-wrap overlfow-hidden break-words hover:bg-blue-50 bg-white text-black cursor-pointer"
+                      className="h-auto w-full data-[state=checked]:bg-blue-50 whitespace-pre-wrap overflow-hidden break-words hover:bg-blue-50 bg-white text-black cursor-pointer"
                     >
                       <div className="flex items-center break-words">
                         <Avatar

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
@@ -547,7 +547,7 @@ mod checked {
         let package =
             context.new_package(&modules, dependencies.iter().map(|p| p.move_package()))?;
 
-        // Here we optimistacally push the package that is being published/upgraded
+        // Here we optimistically push the package that is being published/upgraded
         // and if there is an error of any kind (verification or module init) we
         // remove it.
         // The call to `pop_last_package` later is fine because we cannot re-enter and

--- a/sui-execution/v1/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/v1/sui-adapter/src/programmable_transactions/execution.rs
@@ -500,7 +500,7 @@ mod checked {
         let package =
             context.new_package(&modules, dependencies.iter().map(|p| p.move_package()))?;
 
-        // Here we optimistacally push the package that is being published/upgraded
+        // Here we optimistically push the package that is being published/upgraded
         // and if there is an error of any kind (verification or module init) we
         // remove it.
         // The call to `pop_last_package` later is fine because we cannot re-enter and

--- a/sui-execution/v2/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/v2/sui-adapter/src/programmable_transactions/execution.rs
@@ -506,7 +506,7 @@ mod checked {
         let package =
             context.new_package(&modules, dependencies.iter().map(|p| p.move_package()))?;
 
-        // Here we optimistacally push the package that is being published/upgraded
+        // Here we optimistically push the package that is being published/upgraded
         // and if there is an error of any kind (verification or module init) we
         // remove it.
         // The call to `pop_last_package` later is fine because we cannot re-enter and


### PR DESCRIPTION
- `"optimistacally"` → `"optimistically"`  
- `"sigature"` → `"signature"`  
- `"overlfow"` → `"overflow"`  
- `"currenlty"` → `"currently"`  
