### PR TITLE
[Consensus] Disable the new linearizer logic

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -3179,7 +3179,6 @@ impl ProtocolConfig {
                         // Assuming a round rate of max 15/sec, then using a gc depth of 60 allow blocks within a window of ~4 seconds
                         // to be included before be considered garbage collected.
                         cfg.consensus_gc_depth = Some(60);
-                        cfg.feature_flags.consensus_linearize_subdag_v2 = true;
                     }
 
                     if chain != Chain::Mainnet {

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_73.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_73.snap
@@ -75,7 +75,6 @@ feature_flags:
   consensus_smart_ancestor_selection: true
   consensus_round_prober_probe_accepted_rounds: true
   native_charging_v2: true
-  consensus_linearize_subdag_v2: true
   convert_type_argument_error: true
   variant_nodes: true
   consensus_zstd_compression: true


### PR DESCRIPTION
## Description 

This is running on PT nightly for the past couple of days and a very small degradation in performance has been observed. It's not entirely clear whether is due to the new linearizer logic - metrics showcase an increase in the utilisation for the related function - but I am disabling for now until get better clarity. 

## Test plan 

CI/PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
