### PR TITLE
[GraphQL] Try to remove objectKeys

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/multi_get_objects.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/multi_get_objects.move
@@ -6,10 +6,9 @@
 
 // cp | object_id | owner
 // ----------------------
-// 1  | obj_2_0   | A
 // 1  | obj_3_0   | A
+// 2  | obj_5_0   | A
 // 2  | obj_6_0   | A
-// 2  | obj_7_0   | A
 // All owned by B after checkpoint 3.
 
 //# publish
@@ -33,36 +32,6 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --cursors bcs(@{obj_2_0},@{highest_checkpoint}) bcs(@{obj_3_0},@{highest_checkpoint})
-{
-  one_of_these_will_yield_an_object: address(address: "@{A}") {
-    objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
-      nodes {
-        version
-        contents {
-          type {
-            repr
-          }
-          json
-        }
-      }
-    }
-  }
-  if_the_other_does_not: objects(filter: {type: "@{Test}"}, after: "@{cursor_1}") {
-    nodes {
-      version
-      asMoveObject {
-        contents {
-          type {
-            repr
-          }
-          json
-        }
-      }
-    }
-  }
-}
-
 //# run Test::M1::create --args 2 @A
 
 //# run Test::M1::create --args 3 @A
@@ -75,8 +44,8 @@ module Test::M1 {
   objects_at_version: multiGetObjects(keys: [
             {objectId: "@{obj_2_0}", version: 3},
             {objectId: "@{obj_3_0}", version: 4},
-            {objectId: "@{obj_6_0}", version: 5},
-            {objectId: "@{obj_7_0}", version: 6}
+            {objectId: "@{obj_5_0}", version: 5},
+            {objectId: "@{obj_6_0}", version: 6}
   ]) {
         version
         asMoveObject {
@@ -90,44 +59,10 @@ module Test::M1 {
       }
 }
 
-//# programmable --sender A --inputs object(2,0) object(3,0) object(6,0) object(7,0) @B
+//# programmable --sender A --inputs object(2,0) object(3,0) object(5,0) object(6,0) @B
 //> TransferObjects([Input(0), Input(1), Input(2), Input(3)], Input(4))
 
 //# create-checkpoint
-
-//# advance-clock --duration-ns 1
-
-//# create-checkpoint
-
-//# advance-clock --duration-ns 1
-
-//# create-checkpoint
-
-//# advance-clock --duration-ns 1
-
-//# create-checkpoint
-
-//# advance-clock --duration-ns 1
-
-//# create-checkpoint
-
-//# run-graphql
-# Should have all the objects
-{
-  owned_by_address_b_latest: address(address: "@{B}") {
-    objects(filter: {type: "@{Test}"}) {
-      nodes {
-        version
-        contents {
-          type {
-            repr
-          }
-          json
-        }
-      }
-    }
-  }
-}
 
 //# run-graphql
 # Fetch specific versions of objects.
@@ -135,8 +70,8 @@ module Test::M1 {
   objects_at_version: multiGetObjects(keys: [
       {objectId: "@{obj_2_0}", version: 3},
       {objectId: "@{obj_3_0}", version: 4},
-      {objectId: "@{obj_6_0}", version: 5},
-      {objectId: "@{obj_7_0}", version: 6}
+      {objectId: "@{obj_5_0}", version: 5},
+      {objectId: "@{obj_6_0}", version: 6}
   ]) {
         version
         asMoveObject {

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/multi_get_objects.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/multi_get_objects.move
@@ -65,13 +65,13 @@ module Test::M1 {
 //# create-checkpoint
 
 //# run-graphql
-# Fetch specific versions of objects.
+# Fetch specific versions of objects including a non existing object.
 {
   objects_at_version: multiGetObjects(keys: [
-      {objectId: "@{obj_2_0}", version: 3},
+      {objectId: "0x1", version: 1},
       {objectId: "@{obj_3_0}", version: 4},
       {objectId: "@{obj_5_0}", version: 5},
-      {objectId: "@{obj_6_0}", version: 6}
+      {objectId: "0xabc", version: 1}
   ]) {
         version
         asMoveObject {

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/multi_get_objects.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/multi_get_objects.move
@@ -1,0 +1,152 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 51 --addresses Test=0x0 --accounts A B --simulator --objects-snapshot-min-checkpoint-lag 4
+
+
+// cp | object_id | owner
+// ----------------------
+// 1  | obj_2_0   | A
+// 1  | obj_3_0   | A
+// 2  | obj_6_0   | A
+// 2  | obj_7_0   | A
+// All owned by B after checkpoint 3.
+
+//# publish
+module Test::M1 {
+    public struct Object has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public entry fun create(value: u64, recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Object { id: object::new(ctx), value },
+            recipient
+        )
+    }
+}
+
+//# run Test::M1::create --args 0 @A
+
+//# run Test::M1::create --args 1 @A
+
+//# create-checkpoint
+
+//# run-graphql --cursors bcs(@{obj_2_0},@{highest_checkpoint}) bcs(@{obj_3_0},@{highest_checkpoint})
+{
+  one_of_these_will_yield_an_object: address(address: "@{A}") {
+    objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+  if_the_other_does_not: objects(filter: {type: "@{Test}"}, after: "@{cursor_1}") {
+    nodes {
+      version
+      asMoveObject {
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+}
+
+//# run Test::M1::create --args 2 @A
+
+//# run Test::M1::create --args 3 @A
+
+//# create-checkpoint
+
+//# run-graphql
+# Fetch specific versions of objects.
+{
+  objects_at_version: multiGetObjects(keys: [
+            {objectId: "@{obj_2_0}", version: 3},
+            {objectId: "@{obj_3_0}", version: 4},
+            {objectId: "@{obj_6_0}", version: 5},
+            {objectId: "@{obj_7_0}", version: 6}
+  ]) {
+        version
+        asMoveObject {
+          contents {
+            type {
+              repr
+            }
+            json
+          }
+        }
+      }
+}
+
+//# programmable --sender A --inputs object(2,0) object(3,0) object(6,0) object(7,0) @B
+//> TransferObjects([Input(0), Input(1), Input(2), Input(3)], Input(4))
+
+//# create-checkpoint
+
+//# advance-clock --duration-ns 1
+
+//# create-checkpoint
+
+//# advance-clock --duration-ns 1
+
+//# create-checkpoint
+
+//# advance-clock --duration-ns 1
+
+//# create-checkpoint
+
+//# advance-clock --duration-ns 1
+
+//# create-checkpoint
+
+//# run-graphql
+# Should have all the objects
+{
+  owned_by_address_b_latest: address(address: "@{B}") {
+    objects(filter: {type: "@{Test}"}) {
+      nodes {
+        version
+        contents {
+          type {
+            repr
+          }
+          json
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+# Fetch specific versions of objects.
+{
+  objects_at_version: multiGetObjects(keys: [
+      {objectId: "@{obj_2_0}", version: 3},
+      {objectId: "@{obj_3_0}", version: 4},
+      {objectId: "@{obj_6_0}", version: 5},
+      {objectId: "@{obj_7_0}", version: 6}
+  ]) {
+        version
+        asMoveObject {
+          contents {
+            type {
+              repr
+            }
+            json
+          }
+       }
+    }
+}
+

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/multi_get_objects.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/multi_get_objects.snap
@@ -1,80 +1,50 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 22 tasks
+processed 12 tasks
 
 init:
 A: object(0,0), B: object(0,1)
 
-task 1, lines 15-28:
+task 1, lines 14-27:
 //# publish
 created: object(1,0)
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 5175600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, line 30:
+task 2, line 29:
 //# run Test::M1::create --args 0 @A
 created: object(2,0)
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 3, line 32:
+task 3, line 31:
 //# run Test::M1::create --args 1 @A
 created: object(3,0)
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 4, line 34:
+task 4, line 33:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 5, lines 36-64:
-//# run-graphql --cursors bcs(@{obj_2_0},@{highest_checkpoint}) bcs(@{obj_3_0},@{highest_checkpoint})
-Response: {
-  "data": {
-    "one_of_these_will_yield_an_object": {
-      "objects": {
-        "nodes": []
-      }
-    },
-    "if_the_other_does_not": {
-      "nodes": [
-        {
-          "version": 3,
-          "asMoveObject": {
-            "contents": {
-              "type": {
-                "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
-              },
-              "json": {
-                "id": "0xc4e6c824c72af97ed831b666173a96111e573e0162b205b51c23ae242757e8d2",
-                "value": "0"
-              }
-            }
-          }
-        }
-      ]
-    }
-  }
-}
-
-task 6, line 66:
+task 5, line 35:
 //# run Test::M1::create --args 2 @A
+created: object(5,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, line 37:
+//# run Test::M1::create --args 3 @A
 created: object(6,0)
 mutated: object(0,2)
 gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 7, line 68:
-//# run Test::M1::create --args 3 @A
-created: object(7,0)
-mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
-
-task 8, line 70:
+task 7, line 39:
 //# create-checkpoint
 Checkpoint created: 2
 
-task 9, lines 72-91:
+task 8, lines 41-60:
 //# run-graphql
 Response: {
   "data": {
@@ -139,94 +109,17 @@ Response: {
   }
 }
 
-task 10, lines 93-94:
-//# programmable --sender A --inputs object(2,0) object(3,0) object(6,0) object(7,0) @B
+task 9, lines 62-63:
+//# programmable --sender A --inputs object(2,0) object(3,0) object(5,0) object(6,0) @B
 //> TransferObjects([Input(0), Input(1), Input(2), Input(3)], Input(4))
-mutated: object(0,0), object(2,0), object(3,0), object(6,0), object(7,0)
+mutated: object(0,0), object(2,0), object(3,0), object(5,0), object(6,0)
 gas summary: computation_cost: 1000000, storage_cost: 6247200,  storage_rebate: 5206608, non_refundable_storage_fee: 52592
 
-task 11, line 96:
+task 10, line 65:
 //# create-checkpoint
 Checkpoint created: 3
 
-task 13, line 100:
-//# create-checkpoint
-Checkpoint created: 4
-
-task 15, line 104:
-//# create-checkpoint
-Checkpoint created: 5
-
-task 17, line 108:
-//# create-checkpoint
-Checkpoint created: 6
-
-task 19, line 112:
-//# create-checkpoint
-Checkpoint created: 7
-
-task 20, lines 114-130:
-//# run-graphql
-Response: {
-  "data": {
-    "owned_by_address_b_latest": {
-      "objects": {
-        "nodes": [
-          {
-            "version": 7,
-            "contents": {
-              "type": {
-                "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
-              },
-              "json": {
-                "id": "0x0f2ff2731e04cef60e75403b02f31721406c99cb05eb3029f697de89a3d70a71",
-                "value": "1"
-              }
-            }
-          },
-          {
-            "version": 7,
-            "contents": {
-              "type": {
-                "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
-              },
-              "json": {
-                "id": "0x44864f8c6cad831f338516aa3ebeacf00c60a13fb4a5a4200b35f376af227cf3",
-                "value": "3"
-              }
-            }
-          },
-          {
-            "version": 7,
-            "contents": {
-              "type": {
-                "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
-              },
-              "json": {
-                "id": "0xc4e6c824c72af97ed831b666173a96111e573e0162b205b51c23ae242757e8d2",
-                "value": "0"
-              }
-            }
-          },
-          {
-            "version": 7,
-            "contents": {
-              "type": {
-                "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
-              },
-              "json": {
-                "id": "0xd0a70e7cf1fa823e6bf035f878cc33ee3d221d7f956da78e572bb52574482471",
-                "value": "2"
-              }
-            }
-          }
-        ]
-      }
-    }
-  }
-}
-
-task 21, lines 132-151:
+task 11, lines 67-86:
 //# run-graphql
 Response: {
   "data": {

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/multi_get_objects.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/multi_get_objects.snap
@@ -125,18 +125,8 @@ Response: {
   "data": {
     "objects_at_version": [
       {
-        "version": 3,
-        "asMoveObject": {
-          "contents": {
-            "type": {
-              "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
-            },
-            "json": {
-              "id": "0xc4e6c824c72af97ed831b666173a96111e573e0162b205b51c23ae242757e8d2",
-              "value": "0"
-            }
-          }
-        }
+        "version": 1,
+        "asMoveObject": null
       },
       {
         "version": 4,
@@ -166,20 +156,7 @@ Response: {
           }
         }
       },
-      {
-        "version": 6,
-        "asMoveObject": {
-          "contents": {
-            "type": {
-              "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
-            },
-            "json": {
-              "id": "0x44864f8c6cad831f338516aa3ebeacf00c60a13fb4a5a4200b35f376af227cf3",
-              "value": "3"
-            }
-          }
-        }
-      }
+      null
     ]
   }
 }

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/multi_get_objects.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/multi_get_objects.snap
@@ -1,0 +1,292 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 22 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 15-28:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 5175600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 30:
+//# run Test::M1::create --args 0 @A
+created: object(2,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, line 32:
+//# run Test::M1::create --args 1 @A
+created: object(3,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, line 34:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, lines 36-64:
+//# run-graphql --cursors bcs(@{obj_2_0},@{highest_checkpoint}) bcs(@{obj_3_0},@{highest_checkpoint})
+Response: {
+  "data": {
+    "one_of_these_will_yield_an_object": {
+      "objects": {
+        "nodes": []
+      }
+    },
+    "if_the_other_does_not": {
+      "nodes": [
+        {
+          "version": 3,
+          "asMoveObject": {
+            "contents": {
+              "type": {
+                "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
+              },
+              "json": {
+                "id": "0xc4e6c824c72af97ed831b666173a96111e573e0162b205b51c23ae242757e8d2",
+                "value": "0"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 6, line 66:
+//# run Test::M1::create --args 2 @A
+created: object(6,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7, line 68:
+//# run Test::M1::create --args 3 @A
+created: object(7,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 8, line 70:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 9, lines 72-91:
+//# run-graphql
+Response: {
+  "data": {
+    "objects_at_version": [
+      {
+        "version": 3,
+        "asMoveObject": {
+          "contents": {
+            "type": {
+              "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
+            },
+            "json": {
+              "id": "0xc4e6c824c72af97ed831b666173a96111e573e0162b205b51c23ae242757e8d2",
+              "value": "0"
+            }
+          }
+        }
+      },
+      {
+        "version": 4,
+        "asMoveObject": {
+          "contents": {
+            "type": {
+              "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
+            },
+            "json": {
+              "id": "0x0f2ff2731e04cef60e75403b02f31721406c99cb05eb3029f697de89a3d70a71",
+              "value": "1"
+            }
+          }
+        }
+      },
+      {
+        "version": 5,
+        "asMoveObject": {
+          "contents": {
+            "type": {
+              "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
+            },
+            "json": {
+              "id": "0xd0a70e7cf1fa823e6bf035f878cc33ee3d221d7f956da78e572bb52574482471",
+              "value": "2"
+            }
+          }
+        }
+      },
+      {
+        "version": 6,
+        "asMoveObject": {
+          "contents": {
+            "type": {
+              "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
+            },
+            "json": {
+              "id": "0x44864f8c6cad831f338516aa3ebeacf00c60a13fb4a5a4200b35f376af227cf3",
+              "value": "3"
+            }
+          }
+        }
+      }
+    ]
+  }
+}
+
+task 10, lines 93-94:
+//# programmable --sender A --inputs object(2,0) object(3,0) object(6,0) object(7,0) @B
+//> TransferObjects([Input(0), Input(1), Input(2), Input(3)], Input(4))
+mutated: object(0,0), object(2,0), object(3,0), object(6,0), object(7,0)
+gas summary: computation_cost: 1000000, storage_cost: 6247200,  storage_rebate: 5206608, non_refundable_storage_fee: 52592
+
+task 11, line 96:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 13, line 100:
+//# create-checkpoint
+Checkpoint created: 4
+
+task 15, line 104:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 17, line 108:
+//# create-checkpoint
+Checkpoint created: 6
+
+task 19, line 112:
+//# create-checkpoint
+Checkpoint created: 7
+
+task 20, lines 114-130:
+//# run-graphql
+Response: {
+  "data": {
+    "owned_by_address_b_latest": {
+      "objects": {
+        "nodes": [
+          {
+            "version": 7,
+            "contents": {
+              "type": {
+                "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
+              },
+              "json": {
+                "id": "0x0f2ff2731e04cef60e75403b02f31721406c99cb05eb3029f697de89a3d70a71",
+                "value": "1"
+              }
+            }
+          },
+          {
+            "version": 7,
+            "contents": {
+              "type": {
+                "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
+              },
+              "json": {
+                "id": "0x44864f8c6cad831f338516aa3ebeacf00c60a13fb4a5a4200b35f376af227cf3",
+                "value": "3"
+              }
+            }
+          },
+          {
+            "version": 7,
+            "contents": {
+              "type": {
+                "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
+              },
+              "json": {
+                "id": "0xc4e6c824c72af97ed831b666173a96111e573e0162b205b51c23ae242757e8d2",
+                "value": "0"
+              }
+            }
+          },
+          {
+            "version": 7,
+            "contents": {
+              "type": {
+                "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
+              },
+              "json": {
+                "id": "0xd0a70e7cf1fa823e6bf035f878cc33ee3d221d7f956da78e572bb52574482471",
+                "value": "2"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 21, lines 132-151:
+//# run-graphql
+Response: {
+  "data": {
+    "objects_at_version": [
+      {
+        "version": 3,
+        "asMoveObject": {
+          "contents": {
+            "type": {
+              "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
+            },
+            "json": {
+              "id": "0xc4e6c824c72af97ed831b666173a96111e573e0162b205b51c23ae242757e8d2",
+              "value": "0"
+            }
+          }
+        }
+      },
+      {
+        "version": 4,
+        "asMoveObject": {
+          "contents": {
+            "type": {
+              "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
+            },
+            "json": {
+              "id": "0x0f2ff2731e04cef60e75403b02f31721406c99cb05eb3029f697de89a3d70a71",
+              "value": "1"
+            }
+          }
+        }
+      },
+      {
+        "version": 5,
+        "asMoveObject": {
+          "contents": {
+            "type": {
+              "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
+            },
+            "json": {
+              "id": "0xd0a70e7cf1fa823e6bf035f878cc33ee3d221d7f956da78e572bb52574482471",
+              "value": "2"
+            }
+          }
+        }
+      },
+      {
+        "version": 6,
+        "asMoveObject": {
+          "contents": {
+            "type": {
+              "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
+            },
+            "json": {
+              "id": "0x44864f8c6cad831f338516aa3ebeacf00c60a13fb4a5a4200b35f376af227cf3",
+              "value": "3"
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/objects_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/objects_pagination.move
@@ -116,33 +116,6 @@ module Test::M1 {
   }
 }
 
-//# run-graphql
-{
-  objects_at_version: address(address: "@{A}") {
-    objects(
-      filter: {
-        type: "@{Test}",
-        objectKeys: [
-            {objectId: "@{obj_2_0}", version: 3},
-            {objectId: "@{obj_3_0}", version: 4},
-            {objectId: "@{obj_6_0}", version: 5},
-            {objectId: "@{obj_7_0}", version: 6}
-            ]
-      }
-    ) {
-      nodes {
-        version
-        contents {
-          type {
-            repr
-          }
-          json
-        }
-      }
-    }
-  }
-}
-
 //# programmable --sender A --inputs object(2,0) object(3,0) object(6,0) object(7,0) @B
 //> TransferObjects([Input(0), Input(1), Input(2), Input(3)], Input(4))
 
@@ -272,30 +245,3 @@ module Test::M1 {
   }
 }
 
-//# run-graphql
-# Historical lookups will still return results at version.
-{
-  objects_at_version: address(address: "@{A}") {
-    objects(
-      filter: {
-        type: "@{Test}",
-        objectKeys: [
-            {objectId: "@{obj_2_0}", version: 3},
-            {objectId: "@{obj_3_0}", version: 4},
-            {objectId: "@{obj_6_0}", version: 5},
-            {objectId: "@{obj_7_0}", version: 6}
-            ]
-      }
-    ) {
-      nodes {
-        version
-        contents {
-          type {
-            repr
-          }
-          json
-        }
-      }
-    }
-  }
-}

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/objects_pagination.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/objects_pagination.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 26 tasks
+processed 24 tasks
 
 init:
 A: object(0,0), B: object(0,1)
@@ -165,78 +165,17 @@ Response: {
   }
 }
 
-task 11, lines 119-144:
-//# run-graphql
-Response: {
-  "data": {
-    "objects_at_version": {
-      "objects": {
-        "nodes": [
-          {
-            "version": 4,
-            "contents": {
-              "type": {
-                "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
-              },
-              "json": {
-                "id": "0x0f2ff2731e04cef60e75403b02f31721406c99cb05eb3029f697de89a3d70a71",
-                "value": "1"
-              }
-            }
-          },
-          {
-            "version": 6,
-            "contents": {
-              "type": {
-                "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
-              },
-              "json": {
-                "id": "0x44864f8c6cad831f338516aa3ebeacf00c60a13fb4a5a4200b35f376af227cf3",
-                "value": "3"
-              }
-            }
-          },
-          {
-            "version": 3,
-            "contents": {
-              "type": {
-                "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
-              },
-              "json": {
-                "id": "0xc4e6c824c72af97ed831b666173a96111e573e0162b205b51c23ae242757e8d2",
-                "value": "0"
-              }
-            }
-          },
-          {
-            "version": 5,
-            "contents": {
-              "type": {
-                "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
-              },
-              "json": {
-                "id": "0xd0a70e7cf1fa823e6bf035f878cc33ee3d221d7f956da78e572bb52574482471",
-                "value": "2"
-              }
-            }
-          }
-        ]
-      }
-    }
-  }
-}
-
-task 12, lines 146-147:
+task 11, lines 119-120:
 //# programmable --sender A --inputs object(2,0) object(3,0) object(6,0) object(7,0) @B
 //> TransferObjects([Input(0), Input(1), Input(2), Input(3)], Input(4))
 mutated: object(0,0), object(2,0), object(3,0), object(6,0), object(7,0)
 gas summary: computation_cost: 1000000, storage_cost: 6247200,  storage_rebate: 5206608, non_refundable_storage_fee: 52592
 
-task 13, line 149:
+task 12, line 122:
 //# create-checkpoint
 Checkpoint created: 3
 
-task 14, lines 151-213:
+task 13, lines 124-186:
 //# run-graphql --cursors bcs(@{obj_6_0},2)
 Response: {
   "data": {
@@ -504,23 +443,23 @@ Response: {
   }
 }
 
-task 16, line 217:
+task 15, line 190:
 //# create-checkpoint
 Checkpoint created: 4
 
-task 18, line 221:
+task 17, line 194:
 //# create-checkpoint
 Checkpoint created: 5
 
-task 20, line 225:
+task 19, line 198:
 //# create-checkpoint
 Checkpoint created: 6
 
-task 22, line 229:
+task 21, line 202:
 //# create-checkpoint
 Checkpoint created: 7
 
-task 23, lines 231-255:
+task 22, lines 204-228:
 //# run-graphql --cursors bcs(@{obj_6_0},2)
 Response: {
   "data": null,
@@ -543,7 +482,7 @@ Response: {
   ]
 }
 
-task 24, lines 257-273:
+task 23, lines 230-246:
 //# run-graphql
 Response: {
   "data": {
@@ -588,67 +527,6 @@ Response: {
           },
           {
             "version": 7,
-            "contents": {
-              "type": {
-                "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
-              },
-              "json": {
-                "id": "0xd0a70e7cf1fa823e6bf035f878cc33ee3d221d7f956da78e572bb52574482471",
-                "value": "2"
-              }
-            }
-          }
-        ]
-      }
-    }
-  }
-}
-
-task 25, lines 275-301:
-//# run-graphql
-Response: {
-  "data": {
-    "objects_at_version": {
-      "objects": {
-        "nodes": [
-          {
-            "version": 4,
-            "contents": {
-              "type": {
-                "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
-              },
-              "json": {
-                "id": "0x0f2ff2731e04cef60e75403b02f31721406c99cb05eb3029f697de89a3d70a71",
-                "value": "1"
-              }
-            }
-          },
-          {
-            "version": 6,
-            "contents": {
-              "type": {
-                "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
-              },
-              "json": {
-                "id": "0x44864f8c6cad831f338516aa3ebeacf00c60a13fb4a5a4200b35f376af227cf3",
-                "value": "3"
-              }
-            }
-          },
-          {
-            "version": 3,
-            "contents": {
-              "type": {
-                "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"
-              },
-              "json": {
-                "id": "0xc4e6c824c72af97ed831b666173a96111e573e0162b205b51c23ae242757e8d2",
-                "value": "0"
-              }
-            }
-          },
-          {
-            "version": 5,
             "contents": {
               "type": {
                 "repr": "0xf8ecbba416b85769db9b3425d240e9e350c2994bc68d944ac19ebecffb7e0c60::M1::Object"

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/performance/many_objects.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/performance/many_objects.move
@@ -175,48 +175,44 @@ module Test::M1 {
       }
     }
   }
-  objects_a: objects(filter: {objectKeys: [
+  objects_a: multiGetObjects(keys: [
     {objectId: "@{obj_2_499}", version: 2},
     {objectId: "@{obj_2_498}", version: 2},
     {objectId: "@{obj_2_497}", version: 2},
-    ]}) {
-    nodes {
-      asMoveObject {
-        owner {
-          ... on AddressOwner {
-            owner {
-              address
-            }
+    ]) {
+    asMoveObject {
+      owner {
+        ... on AddressOwner {
+          owner {
+            address
           }
         }
-        contents {
-          json
-          type {
-            repr
-          }
+      }
+      contents {
+        json
+        type {
+          repr
         }
       }
     }
   }
-  objects_b: objects(filter: {objectKeys: [
+  objects_b: multiGetObjects(keys: [
     {objectId: "@{obj_2_499}", version: 3},
     {objectId: "@{obj_2_498}", version: 4},
     {objectId: "@{obj_2_497}", version: 5},
-    ]}) {
-    nodes {
-      asMoveObject {
-        owner {
-          ... on AddressOwner {
-            owner {
-              address
-            }
+    ]) {
+    asMoveObject {
+      owner {
+        ... on AddressOwner {
+          owner {
+            address
           }
         }
-        contents {
-          json
-          type {
-            repr
-          }
+      }
+      contents {
+        json
+        type {
+          repr
         }
       }
     }

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/performance/many_objects.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/performance/many_objects.snap
@@ -277,7 +277,7 @@ Response: {
   }
 }
 
-task 12, lines 140-244:
+task 12, lines 140-240:
 //# run-graphql
 Response: {
   "data": {
@@ -317,122 +317,118 @@ Response: {
         }
       }
     },
-    "objects_a": {
-      "nodes": [
-        {
-          "asMoveObject": {
+    "objects_a": [
+      {
+        "asMoveObject": {
+          "owner": {
             "owner": {
-              "owner": {
-                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-              }
-            },
-            "contents": {
-              "json": {
-                "id": "0xfef205520684c9953fac1dee89681b03fc8cd19d8574f660202972b95bb7a5a8",
-                "value": "275"
-              },
-              "type": {
-                "repr": "0x361adca72b31788356405445166ccc9c01ab86b80ab7a28fc7aff4da14b0bbb7::M1::Object"
-              }
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             }
-          }
-        },
-        {
-          "asMoveObject": {
-            "owner": {
-              "owner": {
-                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-              }
+          },
+          "contents": {
+            "json": {
+              "id": "0xfffc711287a6c859f0855d276c5439941b0a916bcdb4f31a62547bf94b073682",
+              "value": "107"
             },
-            "contents": {
-              "json": {
-                "id": "0xff7f5ef9e5a7b5b6265b414ddc0f76a1daa5677e6333d10c280223d036a7038f",
-                "value": "6"
-              },
-              "type": {
-                "repr": "0x361adca72b31788356405445166ccc9c01ab86b80ab7a28fc7aff4da14b0bbb7::M1::Object"
-              }
-            }
-          }
-        },
-        {
-          "asMoveObject": {
-            "owner": {
-              "owner": {
-                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
-              }
-            },
-            "contents": {
-              "json": {
-                "id": "0xfffc711287a6c859f0855d276c5439941b0a916bcdb4f31a62547bf94b073682",
-                "value": "107"
-              },
-              "type": {
-                "repr": "0x361adca72b31788356405445166ccc9c01ab86b80ab7a28fc7aff4da14b0bbb7::M1::Object"
-              }
+            "type": {
+              "repr": "0x361adca72b31788356405445166ccc9c01ab86b80ab7a28fc7aff4da14b0bbb7::M1::Object"
             }
           }
         }
-      ]
-    },
-    "objects_b": {
-      "nodes": [
-        {
-          "asMoveObject": {
+      },
+      {
+        "asMoveObject": {
+          "owner": {
             "owner": {
-              "owner": {
-                "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
-              }
-            },
-            "contents": {
-              "json": {
-                "id": "0xfef205520684c9953fac1dee89681b03fc8cd19d8574f660202972b95bb7a5a8",
-                "value": "275"
-              },
-              "type": {
-                "repr": "0x361adca72b31788356405445166ccc9c01ab86b80ab7a28fc7aff4da14b0bbb7::M1::Object"
-              }
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             }
-          }
-        },
-        {
-          "asMoveObject": {
-            "owner": {
-              "owner": {
-                "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
-              }
+          },
+          "contents": {
+            "json": {
+              "id": "0xff7f5ef9e5a7b5b6265b414ddc0f76a1daa5677e6333d10c280223d036a7038f",
+              "value": "6"
             },
-            "contents": {
-              "json": {
-                "id": "0xff7f5ef9e5a7b5b6265b414ddc0f76a1daa5677e6333d10c280223d036a7038f",
-                "value": "6"
-              },
-              "type": {
-                "repr": "0x361adca72b31788356405445166ccc9c01ab86b80ab7a28fc7aff4da14b0bbb7::M1::Object"
-              }
-            }
-          }
-        },
-        {
-          "asMoveObject": {
-            "owner": {
-              "owner": {
-                "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
-              }
-            },
-            "contents": {
-              "json": {
-                "id": "0xfffc711287a6c859f0855d276c5439941b0a916bcdb4f31a62547bf94b073682",
-                "value": "107"
-              },
-              "type": {
-                "repr": "0x361adca72b31788356405445166ccc9c01ab86b80ab7a28fc7aff4da14b0bbb7::M1::Object"
-              }
+            "type": {
+              "repr": "0x361adca72b31788356405445166ccc9c01ab86b80ab7a28fc7aff4da14b0bbb7::M1::Object"
             }
           }
         }
-      ]
-    },
+      },
+      {
+        "asMoveObject": {
+          "owner": {
+            "owner": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            }
+          },
+          "contents": {
+            "json": {
+              "id": "0xfef205520684c9953fac1dee89681b03fc8cd19d8574f660202972b95bb7a5a8",
+              "value": "275"
+            },
+            "type": {
+              "repr": "0x361adca72b31788356405445166ccc9c01ab86b80ab7a28fc7aff4da14b0bbb7::M1::Object"
+            }
+          }
+        }
+      }
+    ],
+    "objects_b": [
+      {
+        "asMoveObject": {
+          "owner": {
+            "owner": {
+              "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+            }
+          },
+          "contents": {
+            "json": {
+              "id": "0xfffc711287a6c859f0855d276c5439941b0a916bcdb4f31a62547bf94b073682",
+              "value": "107"
+            },
+            "type": {
+              "repr": "0x361adca72b31788356405445166ccc9c01ab86b80ab7a28fc7aff4da14b0bbb7::M1::Object"
+            }
+          }
+        }
+      },
+      {
+        "asMoveObject": {
+          "owner": {
+            "owner": {
+              "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+            }
+          },
+          "contents": {
+            "json": {
+              "id": "0xff7f5ef9e5a7b5b6265b414ddc0f76a1daa5677e6333d10c280223d036a7038f",
+              "value": "6"
+            },
+            "type": {
+              "repr": "0x361adca72b31788356405445166ccc9c01ab86b80ab7a28fc7aff4da14b0bbb7::M1::Object"
+            }
+          }
+        }
+      },
+      {
+        "asMoveObject": {
+          "owner": {
+            "owner": {
+              "address": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+            }
+          },
+          "contents": {
+            "json": {
+              "id": "0xfef205520684c9953fac1dee89681b03fc8cd19d8574f660202972b95bb7a5a8",
+              "value": "275"
+            },
+            "type": {
+              "repr": "0x361adca72b31788356405445166ccc9c01ab86b80ab7a28fc7aff4da14b0bbb7::M1::Object"
+            }
+          }
+        }
+      }
+    ],
     "owned_by_b": {
       "objects": {
         "nodes": [

--- a/crates/sui-graphql-rpc/schema.graphql
+++ b/crates/sui-graphql-rpc/schema.graphql
@@ -3323,7 +3323,7 @@ type Query {
 	"""
 	Fetch a list of objects by their IDs and versions.
 	"""
-	multiGetObjects(keys: [ObjectKey!]!): [Object!]!
+	multiGetObjects(keys: [ObjectKey!]!): [Object]!
 	"""
 	The coin objects that exist in the network.
 	

--- a/crates/sui-graphql-rpc/schema.graphql
+++ b/crates/sui-graphql-rpc/schema.graphql
@@ -2879,7 +2879,7 @@ objects are ones whose
 
 - Type matches the `type` filter,
 - AND, whose owner matches the `owner` filter,
-- AND, whose ID is in `objectIds` OR whose ID and version is in `objectKeys`.
+- AND, whose ID is in `objectIds`.
 """
 input ObjectFilter {
 	"""
@@ -2898,12 +2898,6 @@ input ObjectFilter {
 	Filter for live objects by their IDs.
 	"""
 	objectIds: [SuiAddress!]
-	"""
-	Filter for live objects by their ID and version. NOTE:  this input filter has been
-	deprecated in favor of `multiGetObjects` query as it does not make sense to query for live
-	objects by their versions. This filter will be removed with v1.42.0 release.
-	"""
-	objectKeys: [ObjectKey!]
 }
 
 input ObjectKey {

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -114,7 +114,7 @@ pub(crate) struct ObjectRef {
 ///
 /// - Type matches the `type` filter,
 /// - AND, whose owner matches the `owner` filter,
-/// - AND, whose ID is in `objectIds` OR whose ID and version is in `objectKeys`.
+/// - AND, whose ID is in `objectIds`.
 #[derive(InputObject, Default, Debug, Clone, Eq, PartialEq)]
 pub(crate) struct ObjectFilter {
     /// Filter objects by their type's `package`, `package::module`, or their fully qualified type
@@ -129,11 +129,6 @@ pub(crate) struct ObjectFilter {
 
     /// Filter for live objects by their IDs.
     pub object_ids: Option<Vec<SuiAddress>>,
-
-    /// Filter for live objects by their ID and version. NOTE:  this input filter has been
-    /// deprecated in favor of `multiGetObjects` query as it does not make sense to query for live
-    /// objects by their versions. This filter will be removed with v1.42.0 release.
-    pub object_keys: Option<Vec<ObjectKey>>,
 }
 
 #[derive(InputObject, Debug, Clone, Eq, PartialEq)]
@@ -812,7 +807,7 @@ impl Object {
     ) -> Result<Vec<Self>, Error> {
         let DataLoader(loader) = &ctx.data_unchecked();
 
-        let keys: Vec<PointLookupKey> = keys
+        let keys: Vec<_> = keys
             .into_iter()
             .map(|key| PointLookupKey {
                 id: key.object_id,
@@ -820,21 +815,16 @@ impl Object {
             })
             .collect();
 
-        let data = loader.load_many(keys).await?;
-        let objects: Vec<_> = data
+        let data = loader.load_many(keys.clone()).await?;
+        Ok(keys
             .into_iter()
-            .filter_map(|(lookup_key, bcs)| {
-                Object::new_serialized(
-                    lookup_key.id,
-                    lookup_key.version,
-                    bcs,
-                    checkpoint_viewed_at,
-                    lookup_key.version,
-                )
+            .filter_map(|k| {
+                data.get(&k).cloned().map(|bcs| {
+                    Object::new_serialized(k.id, k.version, bcs, checkpoint_viewed_at, k.version)
+                })
             })
-            .collect();
-
-        Ok(objects)
+            .flatten()
+            .collect())
     }
 
     /// Query the database for a `page` of objects, optionally `filter`-ed.
@@ -1082,77 +1072,32 @@ impl ObjectFilter {
             };
         }
 
-        // Treat `object_ids` and `object_keys` as a single filter on IDs, and optionally versions,
-        // and compute the intersection of that.
-        let keys = intersect::field(self.keys(), other.keys(), |k, l| {
-            let mut combined = BTreeMap::new();
-
-            for (id, v) in k {
-                if let Some(w) = l.get(&id).copied() {
-                    combined.insert(id, intersect::field(v, w, intersect::by_eq)?);
-                }
-            }
-
-            // If the intersection is empty, it means, there were some ID or Key filters in both
-            // `self` and `other`, but they don't overlap, so the final result is inconsistent.
-            (!combined.is_empty()).then_some(combined)
-        })?;
-
-        // Extract the ID and Key filters back out. At this point, we know that if there were ID/Key
-        // filters in both `self` and `other`, then they intersected to form a consistent set of
-        // constraints, so it is safe to interpret the lack of any ID/Key filters respectively as a
-        // lack of that kind of constraint, rather than a constraint on the empty set.
-
         let object_ids = {
-            let partition: Vec<_> = keys
-                .iter()
-                .flatten()
-                .filter_map(|(id, v)| v.is_none().then_some(*id))
-                .collect();
+            match (self.object_ids, other.object_ids) {
+                (Some(obj_ids), Some(other_obj_ids)) => {
+                    let set_a: BTreeSet<_> = obj_ids.iter().cloned().collect();
+                    let set_b: BTreeSet<_> = other_obj_ids.iter().cloned().collect();
+                    let intersection: Vec<_> = set_a.intersection(&set_b).cloned().collect();
 
-            (!partition.is_empty()).then_some(partition)
-        };
+                    if intersection.is_empty() {
+                        return None;
+                    }
 
-        let object_keys = {
-            let partition: Vec<_> = keys
-                .iter()
-                .flatten()
-                .filter_map(|(id, v)| {
-                    Some(ObjectKey {
-                        object_id: *id,
-                        version: (*v)?.into(),
-                    })
-                })
-                .collect();
-
-            (!partition.is_empty()).then_some(partition)
+                    Some(intersection)
+                }
+                (Some(obj_ids), None) => intersect::field(Some(obj_ids), None, intersect::by_eq)?,
+                (None, Some(other_obj_ids)) => {
+                    intersect::field(Some(other_obj_ids), None, intersect::by_eq)?
+                }
+                _ => None,
+            }
         };
 
         Some(Self {
             type_: intersect!(type_, TypeFilter::intersect)?,
             owner: intersect!(owner, intersect::by_eq)?,
             object_ids,
-            object_keys,
         })
-    }
-
-    /// Extract the Object ID and Key filters into one combined map from Object IDs in this filter,
-    /// to the versions they should have (or None if the filter mentions the ID but no version for
-    /// it).
-    fn keys(&self) -> Option<BTreeMap<SuiAddress, Option<u64>>> {
-        if self.object_keys.is_none() && self.object_ids.is_none() {
-            return None;
-        }
-
-        Some(BTreeMap::from_iter(
-            self.object_keys
-                .iter()
-                .flatten()
-                .map(|key| (key.object_id, Some(key.version.into())))
-                // Chain ID filters after Key filters so if there is overlap, we overwrite the key
-                // filter with the ID filter.
-                .chain(self.object_ids.iter().flatten().map(|id| (*id, None))),
-        ))
     }
 
     /// Applies ObjectFilter to the input `RawQuery` and returns a new `RawQuery`.
@@ -1175,29 +1120,6 @@ impl ObjectFilter {
                     )
                     .unwrap();
                     prefix = ", ";
-                }
-                inner.push(')');
-                query = or_filter!(query, inner);
-            }
-        }
-
-        if let Some(object_keys) = &self.object_keys {
-            // Maximally strict - match a vec of 0 elements
-            if object_keys.is_empty() {
-                query = or_filter!(query, "1=0");
-            } else {
-                let mut inner = String::new();
-                let mut prefix = "(";
-                for ObjectKey { object_id, version } in object_keys {
-                    // SAFETY: Writing to a `String` cannot fail.
-                    write!(
-                        &mut inner,
-                        "{prefix}(object_id = '\\x{}'::bytea AND object_version = {})",
-                        hex::encode(object_id.into_vec()),
-                        version
-                    )
-                    .unwrap();
-                    prefix = " OR ";
                 }
                 inner.push(')');
                 query = or_filter!(query, inner);
@@ -1682,66 +1604,22 @@ pub(crate) async fn deserialize_move_struct(
 }
 
 /// Constructs a raw query to fetch objects from the database. Objects are filtered out if they
-/// satisfy the criteria but have a later version in the same checkpoint. If object keys are
-/// provided, or no filters are specified at all, then this final condition is not applied.
+/// satisfy the criteria but have a later version in the same checkpoint. If no filters are
+/// specified at all, then this final condition is not applied.
 fn objects_query(filter: &ObjectFilter, range: AvailableRange, page: &Page<Cursor>) -> RawQuery
 where
 {
-    if let (Some(_), Some(_)) = (&filter.object_ids, &filter.object_keys) {
-        // If both object IDs and object keys are specified, then we need to query in
-        // both historical and consistent views, and then union the results.
-        let ids_only_filter = ObjectFilter {
-            object_keys: None,
-            ..filter.clone()
-        };
-        let (id_query, id_bindings) = build_objects_query(
-            View::Consistent,
-            range,
-            page,
-            move |query| ids_only_filter.apply(query),
-            move |newer| newer,
-        )
-        .finish();
-
-        let keys_only_filter = ObjectFilter {
-            object_ids: None,
-            ..filter.clone()
-        };
-        let (key_query, key_bindings) = build_objects_query(
-            View::Historical,
-            range,
-            page,
-            move |query| keys_only_filter.apply(query),
-            move |newer| newer,
-        )
-        .finish();
-
-        RawQuery::new(
-            format!(
-                "SELECT * FROM (({id_query}) UNION ALL ({key_query})) AS candidates",
-                id_query = id_query,
-                key_query = key_query,
-            ),
-            id_bindings.into_iter().chain(key_bindings).collect(),
-        )
-        .order_by("object_id")
-        .limit(page.limit() as i64)
-    } else {
-        // Only one of object IDs or object keys is specified, or neither are specified.
-        let view = if filter.object_keys.is_some() || !filter.has_filters() {
+    build_objects_query(
+        if !filter.has_filters() {
             View::Historical
         } else {
             View::Consistent
-        };
-
-        build_objects_query(
-            view,
-            range,
-            page,
-            move |query| filter.apply(query),
-            move |newer| newer,
-        )
-    }
+        },
+        range,
+        page,
+        move |query| filter.apply(query),
+        move |newer| newer,
+    )
 }
 
 #[cfg(test)]
@@ -1766,33 +1644,18 @@ mod tests {
     }
 
     #[test]
-    fn test_key_filter_intersection() {
+    fn test_object_filter_intersection() {
         let i1 = SuiAddress::from_str("0x1").unwrap();
         let i2 = SuiAddress::from_str("0x2").unwrap();
         let i3 = SuiAddress::from_str("0x3").unwrap();
-        let i4 = SuiAddress::from_str("0x4").unwrap();
 
         let f0 = ObjectFilter {
             object_ids: Some(vec![i1, i3]),
-            object_keys: Some(vec![
-                ObjectKey {
-                    object_id: i2,
-                    version: 1.into(),
-                },
-                ObjectKey {
-                    object_id: i4,
-                    version: 2.into(),
-                },
-            ]),
             ..Default::default()
         };
 
         let f1 = ObjectFilter {
             object_ids: Some(vec![i1, i2]),
-            object_keys: Some(vec![ObjectKey {
-                object_id: i4,
-                version: 2.into(),
-            }]),
             ..Default::default()
         };
 
@@ -1802,16 +1665,11 @@ mod tests {
         };
 
         let f3 = ObjectFilter {
-            object_keys: Some(vec![
-                ObjectKey {
-                    object_id: i2,
-                    version: 2.into(),
-                },
-                ObjectKey {
-                    object_id: i4,
-                    version: 2.into(),
-                },
-            ]),
+            ..Default::default()
+        };
+
+        let f4 = ObjectFilter {
+            object_ids: Some(vec![i3]),
             ..Default::default()
         };
 
@@ -1819,16 +1677,6 @@ mod tests {
             f0.clone().intersect(f1.clone()),
             Some(ObjectFilter {
                 object_ids: Some(vec![i1]),
-                object_keys: Some(vec![
-                    ObjectKey {
-                        object_id: i2,
-                        version: 1.into(),
-                    },
-                    ObjectKey {
-                        object_id: i4,
-                        version: 2.into(),
-                    },
-                ]),
                 ..Default::default()
             })
         );
@@ -1841,27 +1689,21 @@ mod tests {
             })
         );
 
+        assert_eq!(f1.clone().intersect(f3.clone()), Some(f1.clone()));
+
         assert_eq!(
-            f1.clone().intersect(f3.clone()),
+            f0.clone().intersect(f2.clone()),
             Some(ObjectFilter {
-                object_keys: Some(vec![
-                    ObjectKey {
-                        object_id: i2,
-                        version: 2.into(),
-                    },
-                    ObjectKey {
-                        object_id: i4,
-                        version: 2.into(),
-                    },
-                ]),
+                object_ids: Some(vec![i1, i3]),
                 ..Default::default()
             })
         );
 
-        // i2 got a conflicting version assignment
-        assert_eq!(f0.clone().intersect(f3.clone()), None);
+        assert_eq!(
+            f3.clone().intersect(f3.clone()),
+            Some(ObjectFilter::default())
+        );
 
-        // No overlap between these two.
-        assert_eq!(f2.clone().intersect(f3.clone()), None);
+        assert_eq!(f1.clone().intersect(f4.clone()), None);
     }
 }

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -819,18 +819,9 @@ impl Object {
         Ok(keys
             .into_iter()
             .map(|k| {
-                data.get(&k)
-                    .cloned()
-                    .map(|bcs| {
-                        Object::new_serialized(
-                            k.id,
-                            k.version,
-                            bcs,
-                            checkpoint_viewed_at,
-                            k.version,
-                        )
-                    })
-                    .flatten()
+                data.get(&k).cloned().and_then(|bcs| {
+                    Object::new_serialized(k.id, k.version, bcs, checkpoint_viewed_at, k.version)
+                })
             })
             .collect())
     }

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -333,7 +333,7 @@ impl Query {
         &self,
         ctx: &Context<'_>,
         keys: Vec<ObjectKey>,
-    ) -> Result<Vec<Object>> {
+    ) -> Result<Vec<Option<Object>>> {
         let cfg: &ServiceConfig = ctx.data_unchecked();
         if keys.len() > cfg.limits.max_multi_get_objects_keys as usize {
             return Err(Error::Client(format!(

--- a/crates/sui-graphql-rpc/staging.graphql
+++ b/crates/sui-graphql-rpc/staging.graphql
@@ -3323,7 +3323,7 @@ type Query {
 	"""
 	Fetch a list of objects by their IDs and versions.
 	"""
-	multiGetObjects(keys: [ObjectKey!]!): [Object!]!
+	multiGetObjects(keys: [ObjectKey!]!): [Object]!
 	"""
 	The coin objects that exist in the network.
 	

--- a/crates/sui-graphql-rpc/staging.graphql
+++ b/crates/sui-graphql-rpc/staging.graphql
@@ -2879,7 +2879,7 @@ objects are ones whose
 
 - Type matches the `type` filter,
 - AND, whose owner matches the `owner` filter,
-- AND, whose ID is in `objectIds` OR whose ID and version is in `objectKeys`.
+- AND, whose ID is in `objectIds`.
 """
 input ObjectFilter {
 	"""
@@ -2898,12 +2898,6 @@ input ObjectFilter {
 	Filter for live objects by their IDs.
 	"""
 	objectIds: [SuiAddress!]
-	"""
-	Filter for live objects by their ID and version. NOTE:  this input filter has been
-	deprecated in favor of `multiGetObjects` query as it does not make sense to query for live
-	objects by their versions. This filter will be removed with v1.42.0 release.
-	"""
-	objectKeys: [ObjectKey!]
 }
 
 input ObjectKey {

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema.graphql.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema.graphql.snap
@@ -2883,7 +2883,7 @@ objects are ones whose
 
 - Type matches the `type` filter,
 - AND, whose owner matches the `owner` filter,
-- AND, whose ID is in `objectIds` OR whose ID and version is in `objectKeys`.
+- AND, whose ID is in `objectIds`.
 """
 input ObjectFilter {
 	"""
@@ -2902,12 +2902,6 @@ input ObjectFilter {
 	Filter for live objects by their IDs.
 	"""
 	objectIds: [SuiAddress!]
-	"""
-	Filter for live objects by their ID and version. NOTE:  this input filter has been
-	deprecated in favor of `multiGetObjects` query as it does not make sense to query for live
-	objects by their versions. This filter will be removed with v1.42.0 release.
-	"""
-	objectKeys: [ObjectKey!]
 }
 
 input ObjectKey {

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema.graphql.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__schema.graphql.snap
@@ -3327,7 +3327,7 @@ type Query {
 	"""
 	Fetch a list of objects by their IDs and versions.
 	"""
-	multiGetObjects(keys: [ObjectKey!]!): [Object!]!
+	multiGetObjects(keys: [ObjectKey!]!): [Object]!
 	"""
 	The coin objects that exist in the network.
 	

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
@@ -2883,7 +2883,7 @@ objects are ones whose
 
 - Type matches the `type` filter,
 - AND, whose owner matches the `owner` filter,
-- AND, whose ID is in `objectIds` OR whose ID and version is in `objectKeys`.
+- AND, whose ID is in `objectIds`.
 """
 input ObjectFilter {
 	"""
@@ -2902,12 +2902,6 @@ input ObjectFilter {
 	Filter for live objects by their IDs.
 	"""
 	objectIds: [SuiAddress!]
-	"""
-	Filter for live objects by their ID and version. NOTE:  this input filter has been
-	deprecated in favor of `multiGetObjects` query as it does not make sense to query for live
-	objects by their versions. This filter will be removed with v1.42.0 release.
-	"""
-	objectKeys: [ObjectKey!]
 }
 
 input ObjectKey {

--- a/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
+++ b/crates/sui-graphql-rpc/tests/snapshots/snapshot_tests__staging.graphql.snap
@@ -3327,7 +3327,7 @@ type Query {
 	"""
 	Fetch a list of objects by their IDs and versions.
 	"""
-	multiGetObjects(keys: [ObjectKey!]!): [Object!]!
+	multiGetObjects(keys: [ObjectKey!]!): [Object]!
 	"""
 	The coin objects that exist in the network.
 	


### PR DESCRIPTION
## Description 

This PR removes the `objectKeys` field from `ObjectFilter` as per the previous deprecation notice. Use `multiGetObjects` instead.

## Test plan 

Updated tests accordingly and ensured all existing tests pass.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [x] GraphQL: Removed the `objectKeys` field from `ObjectFilter` as per the previous deprecation notice. Use `multiGetObjects` instead to fetch multiple objects.
- [ ] CLI: 
- [ ] Rust SDK:
