### PR TITLE
fix: Fixed missing article in rentable description Update workspace.dsl

### DIFF
--- a/examples/move/nft-rental/c4-architecture/workspace.dsl
+++ b/examples/move/nft-rental/c4-architecture/workspace.dsl
@@ -25,7 +25,7 @@ workspace {
                 borrow -> item "Grants access temporarily to"
                 borrow -> promise "Produces a"
                 reclaim -> item "Releases the"
-                rentable -> rent "Is transferred to borrower's Kiosk Extension"
+                rentable -> rent "Is transferred to the borrower's Kiosk Extension"
 
                 # person relationships
                 renter -> install "Invokes"


### PR DESCRIPTION
## Description 
 
I noticed a typo in the code where the word "the" was missing before "borrower's" in the description. This has been corrected to:  
```plaintext  
rentable -> rent "Is transferred to the borrower's Kiosk Extension"  
```  

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
