### PR TITLE
fix(simtests): pass env vars to cargo-simtest

### DIFF
--- a/scripts/simtest/simtest-run.sh
+++ b/scripts/simtest/simtest-run.sh
@@ -98,7 +98,7 @@ echo "Using MSIM_TEST_SEED=$SEED, logging to $LOG_FILE"
 MSIM_TEST_SEED="$SEED" \
 MSIM_TEST_NUM=1 \
 MSIM_WATCHDOG_TIMEOUT_MS=60000 \
-MSIM_TEST_CHECK_DETERMINISM=1
+MSIM_TEST_CHECK_DETERMINISM=1 \
 scripts/simtest/cargo-simtest simtest \
   --color always \
   --test-threads "$NUM_CPUS" \


### PR DESCRIPTION
## Description 

Seems like env vars weren't passed to `cargo-simtest` in `scripts/simtest/simtest-run.sh`
This PR fixes passing env vars to cargo-simtest

## Test plan 

Tested simtests only
Ran the simtest script locally

