### PR TITLE
fix: CSS variable formatting and remove duplicate styles

### DIFF
--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -90,10 +90,10 @@
   --sui-link-color-light: #1f98e9;
   --sui-ghost-white: #f8f8ff;
   --sui-ghost-dark: #282a36;
-  --sui-white: 255, 255, 255;
-  --sui-card-dark: 13, 20, 37;
-  --sui-card-darker: 0, 23, 49;
-  --sui-blue-primary: 77, 162, 255;
+  --sui-white: 255 255 255;
+  --sui-card-dark: 13 20 37;
+  --sui-card-darker: 0 23 49;
+  --sui-blue-primary: 77 162 255;
   --sui-gray: #ABBDCC;
   --sui-white: #f7f7f8;
   --sui-button-hover: #1a88ff;

--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -90,10 +90,10 @@
   --sui-link-color-light: #1f98e9;
   --sui-ghost-white: #f8f8ff;
   --sui-ghost-dark: #282a36;
-  --sui-white: 255 255 255;
-  --sui-card-dark: 13 20 37;
-  --sui-card-darker: 0 23 49;
-  --sui-blue-primary: 77 162 255;
+  --sui-white: 255, 255, 255;
+  --sui-card-dark: 13, 20, 37;
+  --sui-card-darker: 0, 23, 49;
+  --sui-blue-primary: 77, 162, 255;
   --sui-gray: #ABBDCC;
   --sui-white: #f7f7f8;
   --sui-button-hover: #1a88ff;

--- a/docs/site/src/pages/index.module.css
+++ b/docs/site/src/pages/index.module.css
@@ -13,7 +13,6 @@
   display: flex;
   flex-direction: column;
   row-gap: 2.5rem;
-  margin: 0 auto;
   text-align: center;
   width: 43.375rem;
   max-width: 95%;


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.

- **Fixed incorrect CSS variable values**:  
  Replaced space-separated RGB values with comma-separated values to ensure compatibility with `rgb(var(--color-variable))`.  

- **Removed redundant `margin: 0 auto;` in `index.module.css`**:  
  This style was duplicated and unnecessary.  
