### PR TITLE
rpc-alt: getObject, multiGetObjects

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/get_object.exp
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/get_object.exp
@@ -1,0 +1,185 @@
+processed 18 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 13-15:
+//# programmable --sender A --inputs @A
+//> 0: sui::table::new<u64, sui::coin::Coin<sui::sui::SUI>>();
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2979200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 17-19:
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, line 21:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 23-27:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": {
+    "data": {
+      "objectId": "0xa305393e33fd6731559f651b5718c817eb91aee862fd203bd85e46b08c456c5d",
+      "version": "3",
+      "digest": "7xrrTER6S874SBJBszf4CDxmF79DpGELaMbi9xnNx9yC",
+      "content": {
+        "dataType": "moveObject",
+        "type": "0x2::coin::Coin<0x2::sui::SUI>",
+        "hasPublicTransfer": true,
+        "fields": {
+          "balance": "42",
+          "id": {
+            "id": "0xa305393e33fd6731559f651b5718c817eb91aee862fd203bd85e46b08c456c5d"
+          }
+        }
+      }
+    }
+  }
+}
+
+task 5, lines 29-31:
+//# programmable --sender A --inputs object(2,0) 21
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 6, line 33:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 7, lines 35-39:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "data": {
+      "objectId": "0xa305393e33fd6731559f651b5718c817eb91aee862fd203bd85e46b08c456c5d",
+      "version": "4",
+      "digest": "4ChF24sgkRSajSk9i9mwjTKXgyJPnb2PMxiAdUoAZLKH",
+      "content": {
+        "dataType": "moveObject",
+        "type": "0x2::coin::Coin<0x2::sui::SUI>",
+        "hasPublicTransfer": true,
+        "fields": {
+          "balance": "21",
+          "id": {
+            "id": "0xa305393e33fd6731559f651b5718c817eb91aee862fd203bd85e46b08c456c5d"
+          }
+        }
+      }
+    }
+  }
+}
+
+task 8, lines 41-42:
+//# programmable --sender A --inputs object(1,0) 0 object(2,0)
+//> 0: sui::table::add<u64, sui::coin::Coin<sui::sui::SUI>>(Input(0), Input(1), Input(2));
+created: object(8,0)
+mutated: object(0,0), object(1,0)
+wrapped: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 5335200,  storage_rebate: 3927528, non_refundable_storage_fee: 39672
+
+task 9, line 44:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 10, lines 46-50:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "error": {
+      "code": "notExists",
+      "object_id": "0xa305393e33fd6731559f651b5718c817eb91aee862fd203bd85e46b08c456c5d"
+    }
+  }
+}
+
+task 11, lines 52-54:
+//# programmable --sender A --inputs object(1,0) 0 @A
+//> 0: sui::table::remove<u64, sui::coin::Coin<sui::sui::SUI>>(Input(0), Input(1));
+//> 1: TransferObjects([Result(0)], Input(2))
+mutated: object(0,0), object(1,0)
+unwrapped: object(2,0)
+deleted: object(8,0)
+gas summary: computation_cost: 1000000, storage_cost: 3967200,  storage_rebate: 5281848, non_refundable_storage_fee: 53352
+
+task 12, line 56:
+//# create-checkpoint
+Checkpoint created: 4
+
+task 13, lines 58-62:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "data": {
+      "objectId": "0xa305393e33fd6731559f651b5718c817eb91aee862fd203bd85e46b08c456c5d",
+      "version": "6",
+      "digest": "EgjhvDZUPAmiGDmZZgqVWRyfjsAc88wua5jnTbjwidQ1",
+      "content": {
+        "dataType": "moveObject",
+        "type": "0x2::coin::Coin<0x2::sui::SUI>",
+        "hasPublicTransfer": true,
+        "fields": {
+          "balance": "21",
+          "id": {
+            "id": "0xa305393e33fd6731559f651b5718c817eb91aee862fd203bd85e46b08c456c5d"
+          }
+        }
+      }
+    }
+  }
+}
+
+task 14, lines 64-65:
+//# programmable --sender A --inputs object(2,0)
+//> 0: MergeCoins(Gas, [Input(0)])
+mutated: object(0,0)
+deleted: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 15, line 67:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 16, lines 69-73:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 4,
+  "result": {
+    "error": {
+      "code": "notExists",
+      "object_id": "0xa305393e33fd6731559f651b5718c817eb91aee862fd203bd85e46b08c456c5d"
+    }
+  }
+}
+
+task 17, lines 75-79:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 5,
+  "result": {
+    "error": {
+      "code": "notExists",
+      "object_id": "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/get_object.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/get_object.move
@@ -1,0 +1,79 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --addresses test=0x0 --simulator
+
+// 1. Fetching a freshly created object
+// 2. ...the same object after it has been modified
+// 3. ...after it has been wrapped
+// 4. ...after it has been unwrapped
+// 5. ...after it has been deleted
+// 6. Fetching an object that just doesn't exist
+
+//# programmable --sender A --inputs @A
+//> 0: sui::table::new<u64, sui::coin::Coin<sui::sui::SUI>>();
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "sui_getObject",
+  "params": ["@{obj_2_0}", { "showContent": true }]
+}
+
+//# programmable --sender A --inputs object(2,0) 21
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "sui_getObject",
+  "params": ["@{obj_2_0}", { "showContent": true }]
+}
+
+//# programmable --sender A --inputs object(1,0) 0 object(2,0)
+//> 0: sui::table::add<u64, sui::coin::Coin<sui::sui::SUI>>(Input(0), Input(1), Input(2));
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "sui_getObject",
+  "params": ["@{obj_2_0}", { "showContent": true }]
+}
+
+//# programmable --sender A --inputs object(1,0) 0 @A
+//> 0: sui::table::remove<u64, sui::coin::Coin<sui::sui::SUI>>(Input(0), Input(1));
+//> 1: TransferObjects([Result(0)], Input(2))
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "sui_getObject",
+  "params": ["@{obj_2_0}", { "showContent": true }]
+}
+
+//# programmable --sender A --inputs object(2,0)
+//> 0: MergeCoins(Gas, [Input(0)])
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "sui_getObject",
+  "params": ["@{obj_2_0}", { "showContent": true }]
+}
+
+//# run-jsonrpc
+{
+  "method": "sui_getObject",
+  "params": ["0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"]
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/multi_get_objects.exp
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/multi_get_objects.exp
@@ -1,0 +1,288 @@
+processed 15 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 11-13:
+//# programmable --sender A --inputs @A
+//> 0: sui::table::new<u64, sui::coin::Coin<sui::sui::SUI>>();
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2979200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 15-17:
+//# programmable --sender A --inputs @A 42 43 44
+//> 0: SplitCoins(Gas, [Input(1), Input(2), Input(3)]);
+//> 1: TransferObjects([NestedResult(0,0), NestedResult(0,1), NestedResult(0,2)], Input(0))
+created: object(2,0), object(2,1), object(2,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3952000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 19-21:
+//# programmable --sender A --inputs @A 45 46 47
+//> 0: SplitCoins(Gas, [Input(1), Input(2), Input(3)]);
+//> 1: TransferObjects([NestedResult(0,0), NestedResult(0,1), NestedResult(0,2)], Input(0))
+created: object(3,0), object(3,1), object(3,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3952000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, line 23:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, lines 25-39:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": [
+    {
+      "data": {
+        "objectId": "0x8f6a9e2ab5d577014e24a3da8c8f3ca4b037132e3586cd4a25c5fd26d01b9965",
+        "version": "3",
+        "digest": "Hv8Uz2Jr45bANWHnEHukUdd6XzxnqYTKgrR7PQuowyp7",
+        "previousTransaction": "39cbD6LsWG38baffyLj8mHXt5RXFNzks9FCE9aJ6ZvCb"
+      }
+    },
+    {
+      "data": {
+        "objectId": "0x9413fd1f69f1d9310ad6a23fc1c45634c658cdd06187bdfa25f6a7e4c56361da",
+        "version": "3",
+        "digest": "Ee6o7whthmVr2mA1WfPWV7pcwbJDHXEfmeRTDFQwzN7t",
+        "previousTransaction": "39cbD6LsWG38baffyLj8mHXt5RXFNzks9FCE9aJ6ZvCb"
+      }
+    },
+    {
+      "data": {
+        "objectId": "0xba0168804d275bf0e06d07d80af8e9217ba9ef544e7ea44fe91af30b9b0deabd",
+        "version": "3",
+        "digest": "F4HyAA7rcGZjYrpBwVrJ5H7jjtuSiWSbp2Yyvvacb2CK",
+        "previousTransaction": "39cbD6LsWG38baffyLj8mHXt5RXFNzks9FCE9aJ6ZvCb"
+      }
+    },
+    {
+      "data": {
+        "objectId": "0x22dc0e3ece8fff96d44adcdc4df625fb83d59cef839b9f753bdf09de5ad73c7d",
+        "version": "4",
+        "digest": "8kZPFg4X6tTYQD5hYWo3m6Tabw8mVUWgCYZFQ6DDCbnN",
+        "previousTransaction": "5FXfQ5B9shMYaXaJsqR4B3z4jDzVHw7bwCGabN1kJdir"
+      }
+    },
+    {
+      "data": {
+        "objectId": "0x9d8aed2d1c9ce29699db57bc37be56812257c92b15e17326fcd9a4fd693b8121",
+        "version": "4",
+        "digest": "CZtu4tdm685KfBMFMZz6NFgaKXagktQYsBeztGsEgE9C",
+        "previousTransaction": "5FXfQ5B9shMYaXaJsqR4B3z4jDzVHw7bwCGabN1kJdir"
+      }
+    },
+    {
+      "data": {
+        "objectId": "0xd974de1faf8d949dcd839f8c489cc5bbf8dcd65255ce55988ddcd1d0e6a6911a",
+        "version": "4",
+        "digest": "5CgQpv3fyy7z87aLhw8x5L9FC5qtJerM1YPuEsqgUD7D",
+        "previousTransaction": "5FXfQ5B9shMYaXaJsqR4B3z4jDzVHw7bwCGabN1kJdir"
+      }
+    }
+  ]
+}
+
+task 6, lines 41-43:
+//# programmable --sender A --inputs object(2,0) 21
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 7, line 45:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 8, lines 47-61:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": [
+    {
+      "data": {
+        "objectId": "0x8f6a9e2ab5d577014e24a3da8c8f3ca4b037132e3586cd4a25c5fd26d01b9965",
+        "version": "5",
+        "digest": "J4X6cWTUYDeTKmpYBBmwvjKTA46tHeHnCSF2fPJmhadJ",
+        "previousTransaction": "2iS5PyX2Bxd3r7aHHDNtLVM3EJuRPQVAaWhJyjvYH4YZ"
+      }
+    },
+    {
+      "data": {
+        "objectId": "0x9413fd1f69f1d9310ad6a23fc1c45634c658cdd06187bdfa25f6a7e4c56361da",
+        "version": "3",
+        "digest": "Ee6o7whthmVr2mA1WfPWV7pcwbJDHXEfmeRTDFQwzN7t",
+        "previousTransaction": "39cbD6LsWG38baffyLj8mHXt5RXFNzks9FCE9aJ6ZvCb"
+      }
+    },
+    {
+      "data": {
+        "objectId": "0xba0168804d275bf0e06d07d80af8e9217ba9ef544e7ea44fe91af30b9b0deabd",
+        "version": "3",
+        "digest": "F4HyAA7rcGZjYrpBwVrJ5H7jjtuSiWSbp2Yyvvacb2CK",
+        "previousTransaction": "39cbD6LsWG38baffyLj8mHXt5RXFNzks9FCE9aJ6ZvCb"
+      }
+    },
+    {
+      "data": {
+        "objectId": "0x22dc0e3ece8fff96d44adcdc4df625fb83d59cef839b9f753bdf09de5ad73c7d",
+        "version": "4",
+        "digest": "8kZPFg4X6tTYQD5hYWo3m6Tabw8mVUWgCYZFQ6DDCbnN",
+        "previousTransaction": "5FXfQ5B9shMYaXaJsqR4B3z4jDzVHw7bwCGabN1kJdir"
+      }
+    },
+    {
+      "data": {
+        "objectId": "0x9d8aed2d1c9ce29699db57bc37be56812257c92b15e17326fcd9a4fd693b8121",
+        "version": "4",
+        "digest": "CZtu4tdm685KfBMFMZz6NFgaKXagktQYsBeztGsEgE9C",
+        "previousTransaction": "5FXfQ5B9shMYaXaJsqR4B3z4jDzVHw7bwCGabN1kJdir"
+      }
+    },
+    {
+      "data": {
+        "objectId": "0xd974de1faf8d949dcd839f8c489cc5bbf8dcd65255ce55988ddcd1d0e6a6911a",
+        "version": "4",
+        "digest": "5CgQpv3fyy7z87aLhw8x5L9FC5qtJerM1YPuEsqgUD7D",
+        "previousTransaction": "5FXfQ5B9shMYaXaJsqR4B3z4jDzVHw7bwCGabN1kJdir"
+      }
+    }
+  ]
+}
+
+task 9, lines 63-64:
+//# programmable --sender A --inputs object(1,0) 0 object(3,0)
+//> 0: sui::table::add<u64, sui::coin::Coin<sui::sui::SUI>>(Input(0), Input(1), Input(2))
+created: object(9,0)
+mutated: object(0,0), object(1,0)
+wrapped: object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 5335200,  storage_rebate: 3927528, non_refundable_storage_fee: 39672
+
+task 10, line 66:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 11, lines 68-82:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": [
+    {
+      "data": {
+        "objectId": "0x8f6a9e2ab5d577014e24a3da8c8f3ca4b037132e3586cd4a25c5fd26d01b9965",
+        "version": "5",
+        "digest": "J4X6cWTUYDeTKmpYBBmwvjKTA46tHeHnCSF2fPJmhadJ",
+        "previousTransaction": "2iS5PyX2Bxd3r7aHHDNtLVM3EJuRPQVAaWhJyjvYH4YZ"
+      }
+    },
+    {
+      "data": {
+        "objectId": "0x9413fd1f69f1d9310ad6a23fc1c45634c658cdd06187bdfa25f6a7e4c56361da",
+        "version": "3",
+        "digest": "Ee6o7whthmVr2mA1WfPWV7pcwbJDHXEfmeRTDFQwzN7t",
+        "previousTransaction": "39cbD6LsWG38baffyLj8mHXt5RXFNzks9FCE9aJ6ZvCb"
+      }
+    },
+    {
+      "data": {
+        "objectId": "0xba0168804d275bf0e06d07d80af8e9217ba9ef544e7ea44fe91af30b9b0deabd",
+        "version": "3",
+        "digest": "F4HyAA7rcGZjYrpBwVrJ5H7jjtuSiWSbp2Yyvvacb2CK",
+        "previousTransaction": "39cbD6LsWG38baffyLj8mHXt5RXFNzks9FCE9aJ6ZvCb"
+      }
+    },
+    {
+      "error": {
+        "code": "notExists",
+        "object_id": "0x22dc0e3ece8fff96d44adcdc4df625fb83d59cef839b9f753bdf09de5ad73c7d"
+      }
+    },
+    {
+      "data": {
+        "objectId": "0x9d8aed2d1c9ce29699db57bc37be56812257c92b15e17326fcd9a4fd693b8121",
+        "version": "4",
+        "digest": "CZtu4tdm685KfBMFMZz6NFgaKXagktQYsBeztGsEgE9C",
+        "previousTransaction": "5FXfQ5B9shMYaXaJsqR4B3z4jDzVHw7bwCGabN1kJdir"
+      }
+    },
+    {
+      "data": {
+        "objectId": "0xd974de1faf8d949dcd839f8c489cc5bbf8dcd65255ce55988ddcd1d0e6a6911a",
+        "version": "4",
+        "digest": "5CgQpv3fyy7z87aLhw8x5L9FC5qtJerM1YPuEsqgUD7D",
+        "previousTransaction": "5FXfQ5B9shMYaXaJsqR4B3z4jDzVHw7bwCGabN1kJdir"
+      }
+    }
+  ]
+}
+
+task 12, lines 84-85:
+//# programmable --sender A --inputs object(2,1)
+//> MergeCoins(Gas, [Input(0)])
+mutated: object(0,0)
+deleted: object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 13, line 87:
+//# create-checkpoint
+Checkpoint created: 4
+
+task 14, lines 89-103:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": [
+    {
+      "data": {
+        "objectId": "0x8f6a9e2ab5d577014e24a3da8c8f3ca4b037132e3586cd4a25c5fd26d01b9965",
+        "version": "5",
+        "digest": "J4X6cWTUYDeTKmpYBBmwvjKTA46tHeHnCSF2fPJmhadJ",
+        "previousTransaction": "2iS5PyX2Bxd3r7aHHDNtLVM3EJuRPQVAaWhJyjvYH4YZ"
+      }
+    },
+    {
+      "error": {
+        "code": "notExists",
+        "object_id": "0x9413fd1f69f1d9310ad6a23fc1c45634c658cdd06187bdfa25f6a7e4c56361da"
+      }
+    },
+    {
+      "data": {
+        "objectId": "0xba0168804d275bf0e06d07d80af8e9217ba9ef544e7ea44fe91af30b9b0deabd",
+        "version": "3",
+        "digest": "F4HyAA7rcGZjYrpBwVrJ5H7jjtuSiWSbp2Yyvvacb2CK",
+        "previousTransaction": "39cbD6LsWG38baffyLj8mHXt5RXFNzks9FCE9aJ6ZvCb"
+      }
+    },
+    {
+      "error": {
+        "code": "notExists",
+        "object_id": "0x22dc0e3ece8fff96d44adcdc4df625fb83d59cef839b9f753bdf09de5ad73c7d"
+      }
+    },
+    {
+      "data": {
+        "objectId": "0x9d8aed2d1c9ce29699db57bc37be56812257c92b15e17326fcd9a4fd693b8121",
+        "version": "4",
+        "digest": "CZtu4tdm685KfBMFMZz6NFgaKXagktQYsBeztGsEgE9C",
+        "previousTransaction": "5FXfQ5B9shMYaXaJsqR4B3z4jDzVHw7bwCGabN1kJdir"
+      }
+    },
+    {
+      "data": {
+        "objectId": "0xd974de1faf8d949dcd839f8c489cc5bbf8dcd65255ce55988ddcd1d0e6a6911a",
+        "version": "4",
+        "digest": "5CgQpv3fyy7z87aLhw8x5L9FC5qtJerM1YPuEsqgUD7D",
+        "previousTransaction": "5FXfQ5B9shMYaXaJsqR4B3z4jDzVHw7bwCGabN1kJdir"
+      }
+    }
+  ]
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/multi_get_objects.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/multi_get_objects.move
@@ -1,0 +1,103 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --addresses test=0x0 --simulator
+
+// 1. Multi-get newly created objects
+// 2. ...after some have been modified
+// 3. ...after some have been wrapped
+// 4. ...after some have been deleted
+
+//# programmable --sender A --inputs @A
+//> 0: sui::table::new<u64, sui::coin::Coin<sui::sui::SUI>>();
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# programmable --sender A --inputs @A 42 43 44
+//> 0: SplitCoins(Gas, [Input(1), Input(2), Input(3)]);
+//> 1: TransferObjects([NestedResult(0,0), NestedResult(0,1), NestedResult(0,2)], Input(0))
+
+//# programmable --sender A --inputs @A 45 46 47
+//> 0: SplitCoins(Gas, [Input(1), Input(2), Input(3)]);
+//> 1: TransferObjects([NestedResult(0,0), NestedResult(0,1), NestedResult(0,2)], Input(0))
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "sui_multiGetObjects",
+  "params": [
+    [
+      "@{obj_2_0}",
+      "@{obj_2_1}",
+      "@{obj_2_2}",
+      "@{obj_3_0}",
+      "@{obj_3_1}",
+      "@{obj_3_2}"
+    ],
+    { "showPreviousTransaction": true }
+  ]
+}
+
+//# programmable --sender A --inputs object(2,0) 21
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "sui_multiGetObjects",
+  "params": [
+    [
+      "@{obj_2_0}",
+      "@{obj_2_1}",
+      "@{obj_2_2}",
+      "@{obj_3_0}",
+      "@{obj_3_1}",
+      "@{obj_3_2}"
+    ],
+    { "showPreviousTransaction": true }
+  ]
+}
+
+//# programmable --sender A --inputs object(1,0) 0 object(3,0)
+//> 0: sui::table::add<u64, sui::coin::Coin<sui::sui::SUI>>(Input(0), Input(1), Input(2))
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "sui_multiGetObjects",
+  "params": [
+    [
+      "@{obj_2_0}",
+      "@{obj_2_1}",
+      "@{obj_2_2}",
+      "@{obj_3_0}",
+      "@{obj_3_1}",
+      "@{obj_3_2}"
+    ],
+    { "showPreviousTransaction": true }
+  ]
+}
+
+//# programmable --sender A --inputs object(2,1)
+//> MergeCoins(Gas, [Input(0)])
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "sui_multiGetObjects",
+  "params": [
+    [
+      "@{obj_2_0}",
+      "@{obj_2_1}",
+      "@{obj_2_2}",
+      "@{obj_3_0}",
+      "@{obj_3_1}",
+      "@{obj_3_2}"
+    ],
+    { "showPreviousTransaction": true }
+  ]
+}

--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/mod.rs
@@ -4,7 +4,9 @@
 use futures::future;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use serde::{Deserialize, Serialize};
-use sui_json_rpc_types::{SuiGetPastObjectRequest, SuiObjectDataOptions, SuiPastObjectResponse};
+use sui_json_rpc_types::{
+    SuiGetPastObjectRequest, SuiObjectDataOptions, SuiObjectResponse, SuiPastObjectResponse,
+};
 use sui_open_rpc::Module;
 use sui_open_rpc_macros::open_rpc;
 use sui_types::base_types::{ObjectID, SequenceNumber};
@@ -24,6 +26,16 @@ mod response;
 #[open_rpc(namespace = "sui", tag = "Objects API")]
 #[rpc(server, namespace = "sui")]
 trait ObjectsApi {
+    /// Return the object information for the latest version of an object.
+    #[method(name = "getObject")]
+    async fn get_object(
+        &self,
+        /// The ID of the queried obect
+        object_id: ObjectID,
+        /// Options for specifying the content to be returned
+        options: Option<SuiObjectDataOptions>,
+    ) -> RpcResult<SuiObjectResponse>;
+
     /// Return the object information for a specified version.
     ///
     /// Note that past versions of an object may be pruned from the system, even if they once
@@ -65,6 +77,20 @@ pub struct ObjectsConfig {
 
 #[async_trait::async_trait]
 impl ObjectsApiServer for Objects {
+    async fn get_object(
+        &self,
+        object_id: ObjectID,
+        options: Option<SuiObjectDataOptions>,
+    ) -> RpcResult<SuiObjectResponse> {
+        let Self(ctx, _) = self;
+        let options = options.unwrap_or_default();
+        Ok(response::live_object(ctx, object_id, &options)
+            .await
+            .with_internal_context(|| {
+                format!("Failed to get object {object_id} at latest version")
+            })?)
+    }
+
     async fn try_get_past_object(
         &self,
         object_id: ObjectID,
@@ -73,7 +99,14 @@ impl ObjectsApiServer for Objects {
     ) -> RpcResult<SuiPastObjectResponse> {
         let Self(ctx, _) = self;
         let options = options.unwrap_or_default();
-        Ok(response::past_object(ctx, object_id, version, &options).await?)
+        Ok(response::past_object(ctx, object_id, version, &options)
+            .await
+            .with_internal_context(|| {
+                format!(
+                    "Failed to get object {object_id} at version {}",
+                    version.value()
+                )
+            })?)
     }
 
     async fn try_multi_get_past_objects(

--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/mod.rs
@@ -36,6 +36,16 @@ trait ObjectsApi {
         options: Option<SuiObjectDataOptions>,
     ) -> RpcResult<SuiObjectResponse>;
 
+    /// Return the object information for the latest versions of multiple objects.
+    #[method(name = "multiGetObjects")]
+    async fn multi_get_objects(
+        &self,
+        /// the IDs of the queried objects
+        object_ids: Vec<ObjectID>,
+        /// Options for specifying the content to be returned
+        options: Option<SuiObjectDataOptions>,
+    ) -> RpcResult<Vec<SuiObjectResponse>>;
+
     /// Return the object information for a specified version.
     ///
     /// Note that past versions of an object may be pruned from the system, even if they once
@@ -91,6 +101,36 @@ impl ObjectsApiServer for Objects {
             })?)
     }
 
+    async fn multi_get_objects(
+        &self,
+        object_ids: Vec<ObjectID>,
+        options: Option<SuiObjectDataOptions>,
+    ) -> RpcResult<Vec<SuiObjectResponse>> {
+        let Self(ctx, config) = self;
+        if object_ids.len() > config.max_multi_get_objects {
+            return Err(invalid_params(Error::TooManyKeys {
+                requested: object_ids.len(),
+                max: config.max_multi_get_objects,
+            })
+            .into());
+        }
+
+        let options = options.unwrap_or_default();
+
+        let obj_futures = object_ids
+            .iter()
+            .map(|id| response::live_object(ctx, *id, &options));
+
+        Ok(future::join_all(obj_futures)
+            .await
+            .into_iter()
+            .zip(object_ids)
+            .map(|(r, o)| {
+                r.with_internal_context(|| format!("Failed to get object {o} at latest version"))
+            })
+            .collect::<Result<Vec<_>, _>>()?)
+    }
+
     async fn try_get_past_object(
         &self,
         object_id: ObjectID,
@@ -134,7 +174,7 @@ impl ObjectsApiServer for Objects {
             .into_iter()
             .zip(past_objects)
             .map(|(r, o)| {
-                let id = o.object_id.to_canonical_display(/* with_prefix */ true);
+                let id = o.object_id;
                 let v = o.version;
                 r.with_internal_context(|| format!("Failed to get object {id} at version {v}"))
             })

--- a/crates/sui-indexer-alt-jsonrpc/src/data/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod object_info;
 pub(crate) mod object_versions;
 pub(crate) mod objects;
 pub(crate) mod package_resolver;

--- a/crates/sui-indexer-alt-jsonrpc/src/data/object_info.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/object_info.rs
@@ -1,0 +1,62 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::{BTreeSet, HashMap},
+    sync::Arc,
+};
+
+use async_graphql::dataloader::Loader;
+use diesel::{ExpressionMethods, QueryDsl};
+use sui_indexer_alt_schema::{objects::StoredObjInfo, schema::obj_info};
+use sui_types::base_types::ObjectID;
+
+use super::reader::{ReadError, Reader};
+
+/// Key for fetching the latest object info record for an object. This record corresponds to the
+/// last time the object's ownership information changed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct LatestObjectInfoKey(pub ObjectID);
+
+#[async_trait::async_trait]
+impl Loader<LatestObjectInfoKey> for Reader {
+    type Value = StoredObjInfo;
+    type Error = Arc<ReadError>;
+
+    async fn load(
+        &self,
+        keys: &[LatestObjectInfoKey],
+    ) -> Result<HashMap<LatestObjectInfoKey, StoredObjInfo>, Self::Error> {
+        use obj_info::dsl as i;
+
+        if keys.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let mut conn = self.connect().await.map_err(Arc::new)?;
+
+        let ids: BTreeSet<_> = keys.iter().map(|k| k.0.into_bytes()).collect();
+        let obj_info: Vec<StoredObjInfo> = conn
+            .results(
+                i::obj_info
+                    .filter(i::object_id.eq_any(ids))
+                    .distinct_on(i::object_id)
+                    .order((i::object_id, i::cp_sequence_number.desc())),
+            )
+            .await
+            .map_err(Arc::new)?;
+
+        let id_to_stored: HashMap<_, _> = obj_info
+            .into_iter()
+            .map(|stored| (stored.object_id.clone(), stored))
+            .collect();
+
+        Ok(keys
+            .iter()
+            .filter_map(|key| {
+                let slice: &[u8] = key.0.as_ref();
+                Some((*key, id_to_stored.get(slice).cloned()?))
+            })
+            .collect())
+    }
+}


### PR DESCRIPTION
## Description 

Implement unfiltered live object set look-ups. They are built on top of an `obj_info` data loader which detects whether the object exists in the live object set at that version.

This PR also pulls out the common loading logic from `fetch_latest_for_system_state` to be used for generally loading latest content by object ID.

## Test plan 

New E2E tests:

```
sui$ cargo nextest run -p sui-indexer-alt-e2e-tests \
  -- objects/get_object objects/multi_get_objects
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
