### PR TITLE
[1/n][vm-rewrite][Move] Updates to VM: some bugfixes, and query functions on vm instances needed for the adapter.

### DIFF
--- a/external-crates/move/crates/move-cli/src/sandbox/commands/publish.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/commands/publish.rs
@@ -72,7 +72,7 @@ pub fn publish(
 
     // use the publish_module API from the VM since we don't allow breaking changes
     let natives = NativeFunctions::new(natives)?;
-    let mut runtime = MoveRuntime::new_with_default_config(natives);
+    let runtime = MoveRuntime::new_with_default_config(natives);
 
     let mut gas_status = get_gas_status(cost_table, None)?;
 

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/functions/shadow_call.exp
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/functions/shadow_call.exp
@@ -1,0 +1,1 @@
+processed 4 tasks

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/functions/shadow_call.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/functions/shadow_call.move
@@ -1,0 +1,24 @@
+//# init --edition 2024.alpha
+
+//# publish
+module 0x42::m {
+    public fun y() { }
+}
+
+//# publish
+module 0x43::m{
+    use 0x42::m;
+
+    public fun y() {
+        m::y();
+    }
+}
+
+//# run
+module 0x44::main {
+    use 0x43::m;
+
+    fun main() {
+        m::y();
+    }
+}

--- a/external-crates/move/crates/move-core-types/src/vm_status.rs
+++ b/external-crates/move/crates/move-core-types/src/vm_status.rs
@@ -398,6 +398,7 @@ pub enum StatusCode {
     VARIANT_TAG_MISMATCH = 4030,
     PACKAGE_ARENA_LIMIT_REACHED = 4031,
     INTERNER_LIMIT_REACHED = 4032,
+    EXTERNAL_RESOLUTION_REQUEST_ERROR = 4033,
 
     // A reserved status to represent an unknown vm status.
     // this is std::u64::MAX, but we can't pattern match on that, so put the hardcoded value in

--- a/external-crates/move/crates/move-trace-format/src/format.rs
+++ b/external-crates/move/crates/move-trace-format/src/format.rs
@@ -5,8 +5,8 @@
 
 use crate::interface::{NopTracer, Tracer, Writer};
 use move_binary_format::{
-    file_format::{Bytecode, FunctionDefinitionIndex as BinaryFunctionDefinitionIndex},
-    file_format_common::{instruction_opcode, Opcodes},
+    file_format::FunctionDefinitionIndex as BinaryFunctionDefinitionIndex,
+    file_format_common::Opcodes,
 };
 use move_core_types::{
     annotated_value::MoveValue,

--- a/external-crates/move/crates/move-vm-runtime/src/cache/move_cache.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/cache/move_cache.rs
@@ -70,13 +70,16 @@ impl MoveCache {
         verified: verification::ast::Package,
         runtime: jit::execution::ast::Package,
     ) {
-        assert!(!self.package_cache.read().contains_key(&package_key));
+        // NB: We grab a write lock here to ensure that we don't double-insert a package.
+        let mut package_cache = self.package_cache.write();
+
+        if package_cache.contains_key(&package_key) {
+            return;
+        }
         let verified = Arc::new(verified);
         let runtime = Arc::new(runtime);
         let package = Package { verified, runtime };
-        self.package_cache()
-            .write()
-            .insert(package_key, Arc::new(package));
+        package_cache.insert(package_key, Arc::new(package));
     }
 
     pub fn cached_package_at(&self, package_key: PackageStorageId) -> Option<Arc<Package>> {

--- a/external-crates/move/crates/move-vm-runtime/src/execution/mod.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/mod.rs
@@ -6,3 +6,4 @@ pub mod interpreter;
 pub mod tracing;
 pub mod values;
 pub mod vm;
+pub use crate::jit::execution::ast::Type;

--- a/external-crates/move/crates/move-vm-runtime/src/execution/vm.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/vm.rs
@@ -18,13 +18,15 @@ use crate::{
     string_interner,
 };
 use move_binary_format::{
-    errors::{Location, PartialVMError, PartialVMResult, VMResult},
-    file_format::LocalIndex,
+    errors::{Location, PartialVMError, PartialVMResult, VMError, VMResult},
+    file_format::{AbilitySet, CodeOffset, FunctionDefinitionIndex, LocalIndex, Visibility},
 };
 use move_core_types::{
+    annotated_value,
     identifier::IdentStr,
     language_storage::{ModuleId, TypeTag},
-    vm_status::StatusCode,
+    runtime_value,
+    vm_status::{StatusCode, StatusType},
 };
 use move_trace_format::format::MoveTraceBuilder;
 use move_vm_config::runtime::VMConfig;
@@ -59,10 +61,21 @@ pub struct MoveVM<'extensions> {
     pub(crate) base_heap: BaseHeap,
 }
 
-pub struct MoveVMFunction {
+pub(crate) struct MoveVMFunction {
     function: VMPointer<Function>,
+    pub(crate) parameters: Vec<Type>,
+    pub(crate) return_type: Vec<Type>,
+}
+
+/// Externally visibile information about a function that can be asked and the VM will answer.
+pub struct LoadedFunctionInformation {
+    pub is_entry: bool,
+    pub is_native: bool,
+    pub visibility: Visibility,
+    pub index: FunctionDefinitionIndex,
+    pub instruction_count: CodeOffset,
     pub parameters: Vec<Type>,
-    pub return_type: Vec<Type>,
+    pub return_: Vec<Type>,
 }
 
 impl<'extensions> MoveVM<'extensions> {
@@ -188,12 +201,93 @@ impl<'extensions> MoveVM<'extensions> {
         )
     }
 
+    // -------------------------------------------
+    // External Queries
+    // -------------------------------------------
+
+    pub fn function_information(
+        &self,
+        // NB: The module ID is using the _runtime_ ID.
+        module_id: &ModuleId,
+        function_name: &IdentStr,
+        ty_args: &[Type],
+    ) -> VMResult<LoadedFunctionInformation> {
+        let MoveVMFunction {
+            function,
+            parameters,
+            return_type,
+        } = self.find_function(module_id, function_name, ty_args)?;
+
+        Ok(LoadedFunctionInformation {
+            is_entry: function.to_ref().is_entry,
+            is_native: function.to_ref().def_is_native,
+            visibility: function.to_ref().visibility,
+            index: function.to_ref().index,
+            instruction_count: function.to_ref().code.len() as CodeOffset,
+            parameters,
+            return_: return_type,
+        })
+    }
+
     pub fn vm_config(&self) -> &move_vm_config::runtime::VMConfig {
         &self.vm_config
     }
 
+    pub fn type_abilities(&self, ty: &Type) -> VMResult<AbilitySet> {
+        self.virtual_tables
+            .abilities(ty)
+            .map_err(|e| e.finish(Location::Undefined))
+    }
+
+    pub fn type_tag_for_type_defining_ids(&self, ty: &Type) -> VMResult<TypeTag> {
+        self.virtual_tables
+            .type_to_type_tag(ty)
+            .map_err(|e| e.finish(Location::Undefined))
+    }
+
+    /// Resolve a `TypeTag` to a `Type` using the VM's virtual tables.
+    /// NB: the `TypeTag` is coming from outside and therefore _may_ not represent a valid type
+    /// (e.g., an undefined type). Therefore any errors in resolution should be treated as runtime
+    /// errors and not anything else.
     pub fn load_type(&self, tag: &TypeTag) -> VMResult<Type> {
-        self.virtual_tables.load_type(tag)
+        self.virtual_tables
+            .load_type(tag)
+            .map_err(|e| Self::convert_to_external_type_tag_error(e, tag))
+    }
+
+    /// Resolve a `TypeTag` to a runtime type layout using the VM's virtual tables.
+    /// NB: the `TypeTag` is coming from outside and therefore _may_ not represent a valid type
+    /// (e.g., an undefined type). Therefore any errors in resolution should be treated as runtime
+    /// errors and not anything else.
+    pub fn runtime_type_layout(&self, ty: &TypeTag) -> VMResult<runtime_value::MoveTypeLayout> {
+        self.virtual_tables
+            .get_type_layout(ty)
+            .map_err(|e| Self::convert_to_external_type_tag_error(e, ty))
+    }
+
+    /// Resolve a `TypeTag` to an annotated type layout using the VM's virtual tables.
+    /// NB: the `TypeTag` is coming from outside and therefore _may_ not represent a valid type
+    /// (e.g., an undefined type). Therefore any errors in resolution should be treated as runtime
+    /// errors and not anything else.
+    pub fn annotated_type_layout(&self, ty: &TypeTag) -> VMResult<annotated_value::MoveTypeLayout> {
+        self.virtual_tables
+            .get_fully_annotated_type_layout(ty)
+            .map_err(|e| Self::convert_to_external_type_tag_error(e, ty))
+    }
+
+    fn convert_to_external_type_tag_error(err: VMError, tag: &TypeTag) -> VMError {
+        if err.major_status().status_type() == StatusType::InvariantViolation {
+            PartialVMError::new(StatusCode::EXTERNAL_RESOLUTION_REQUEST_ERROR)
+                .with_message(format!(
+                    "Failed to resolve external type tag{tag}{}",
+                    err.message()
+                        .map(|s| format!(": {}", s))
+                        .unwrap_or_else(|| "".to_string())
+                ))
+                .finish(Location::Undefined)
+        } else {
+            err
+        }
     }
 
     // -------------------------------------------
@@ -369,6 +463,10 @@ impl<'extensions> MoveVM<'extensions> {
 
     pub fn into_extensions(self) -> NativeContextExtensions<'extensions> {
         self.native_extensions
+    }
+
+    pub fn extensions(&self) -> &NativeContextExtensions<'extensions> {
+        &self.native_extensions
     }
 }
 

--- a/external-crates/move/crates/move-vm-runtime/src/execution/vm.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/vm.rs
@@ -205,9 +205,9 @@ impl<'extensions> MoveVM<'extensions> {
     // External Queries
     // -------------------------------------------
 
+    /// NB: The `module_id` is using the _runtime_ ID.
     pub fn function_information(
         &self,
-        // NB: The module ID is using the _runtime_ ID.
         module_id: &ModuleId,
         function_name: &IdentStr,
         ty_args: &[Type],

--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
@@ -20,7 +20,7 @@ use move_binary_format::{
     errors::{PartialVMError, PartialVMResult},
     file_format::{
         AbilitySet, CodeOffset, DatatypeTyParameter, FunctionDefinitionIndex, LocalIndex,
-        SignatureToken, VariantTag,
+        SignatureToken, VariantTag, Visibility,
     },
     file_format_common::Opcodes,
 };
@@ -130,6 +130,7 @@ pub struct Function {
     #[allow(unused)]
     pub file_format_version: u32,
     pub is_entry: bool,
+    pub visibility: Visibility,
     pub index: FunctionDefinitionIndex,
     pub code: ArenaVec<Bytecode>,
     pub parameters: ArenaVec<ArenaType>,

--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
@@ -122,6 +122,9 @@ impl PackageContext<'_> {
     }
 
     fn try_resolve_function(&self, vtable_entry: &VirtualTableKey) -> Option<VMPointer<Function>> {
+        if vtable_entry.package_key != self.runtime_id {
+            return None;
+        }
         self.vtable
             .functions
             .get(&vtable_entry.inner_pkg_key)
@@ -965,6 +968,7 @@ fn alloc_function(
         file_format_version: module.version(),
         index,
         is_entry,
+        visibility: def.visibility,
         // replaced in the next step of compilation
         code: ArenaVec::empty(),
         parameters,

--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
@@ -121,10 +121,18 @@ impl PackageContext<'_> {
         Ok(())
     }
 
-    fn try_resolve_function(&self, vtable_entry: &VirtualTableKey) -> Option<VMPointer<Function>> {
+    /// Try to resolve a function call (vtable entry) to a direct call (i.e. a call to a function
+    /// in the same package). If the vtable key represents an inter-package call this function
+    /// will return `None` as the call cannot be resolved to a direct call.
+    fn try_resolve_direct_function_call(
+        &self,
+        vtable_entry: &VirtualTableKey,
+    ) -> Option<VMPointer<Function>> {
+        // We are calling into a different package so we cannot resolve this to a direct call.
         if vtable_entry.package_key != self.runtime_id {
             return None;
         }
+        // TODO(vm-rewrite): Have this return an error if the function was not found.
         self.vtable
             .functions
             .get(&vtable_entry.inner_pkg_key)
@@ -1254,10 +1262,12 @@ fn call(
         },
     };
     dbg_println!(flag: function_resolution, "Resolving function: {:?}", vtable_key);
-    Ok(match package_context.try_resolve_function(&vtable_key) {
-        Some(func) => CallType::Direct(func),
-        None => CallType::Virtual(vtable_key),
-    })
+    Ok(
+        match package_context.try_resolve_direct_function_call(&vtable_key) {
+            Some(func) => CallType::Direct(func),
+            None => CallType::Virtual(vtable_key),
+        },
+    )
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/external-crates/move/crates/move-vm-runtime/src/natives/functions.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/natives/functions.rs
@@ -25,7 +25,7 @@ use crate::{
     natives::extensions::NativeContextExtensions,
 };
 pub use move_binary_format::errors::PartialVMError;
-use move_binary_format::errors::PartialVMResult;
+use move_binary_format::{errors::PartialVMResult, file_format::AbilitySet};
 pub use move_core_types::vm_status::StatusCode;
 use move_core_types::{
     account_address::AccountAddress, annotated_value as A, gas_algebra::InternalGas,
@@ -264,12 +264,42 @@ impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
         self.vtables.type_to_runtime_type_tag(ty)
     }
 
+    pub fn typetag_to_type_layout(
+        &self,
+        ty: &TypeTag,
+    ) -> PartialVMResult<Option<R::MoveTypeLayout>> {
+        match self.vtables.get_type_layout(ty) {
+            Ok(ty_layout) => Ok(Some(ty_layout)),
+            Err(e) if e.major_status().status_type() == StatusType::InvariantViolation => {
+                Err(e.to_partial())
+            }
+            Err(_) => Ok(None),
+        }
+    }
+
+    pub fn typetag_to_annotated_type_layout(
+        &self,
+        ty: &TypeTag,
+    ) -> PartialVMResult<Option<A::MoveTypeLayout>> {
+        match self.vtables.get_fully_annotated_type_layout(ty) {
+            Ok(ty_layout) => Ok(Some(ty_layout)),
+            Err(e) if e.major_status().status_type() == StatusType::InvariantViolation => {
+                Err(e.to_partial())
+            }
+            Err(_) => Ok(None),
+        }
+    }
+
     pub fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<Option<R::MoveTypeLayout>> {
         match self.vtables.type_to_type_layout(ty) {
             Ok(ty_layout) => Ok(Some(ty_layout)),
             Err(e) if e.major_status().status_type() == StatusType::InvariantViolation => Err(e),
             Err(_) => Ok(None),
         }
+    }
+
+    pub fn type_to_abilities(&self, ty: &Type) -> PartialVMResult<AbilitySet> {
+        self.vtables.abilities(ty)
     }
 
     pub fn type_to_fully_annotated_layout(

--- a/external-crates/move/crates/move-vm-runtime/src/natives/functions.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/natives/functions.rs
@@ -264,7 +264,7 @@ impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
         self.vtables.type_to_runtime_type_tag(ty)
     }
 
-    pub fn typetag_to_type_layout(
+    pub fn type_tag_to_type_layout(
         &self,
         ty: &TypeTag,
     ) -> PartialVMResult<Option<R::MoveTypeLayout>> {
@@ -277,7 +277,7 @@ impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
         }
     }
 
-    pub fn typetag_to_annotated_type_layout(
+    pub fn type_tag_to_annotated_type_layout(
         &self,
         ty: &TypeTag,
     ) -> PartialVMResult<Option<A::MoveTypeLayout>> {

--- a/external-crates/move/crates/move-vm-runtime/src/runtime/package_resolution.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/runtime/package_resolution.rs
@@ -110,7 +110,7 @@ pub fn jit_package_for_publish(
 ) -> VMResult<Arc<move_cache::Package>> {
     let storage_id = verified_pkg.storage_id;
     if cache.cached_package_at(storage_id).is_some() {
-        panic!("Attempting to re-jit a package, which should be impossible -- we already checked.");
+        return Ok(cache.cached_package_at(storage_id).unwrap());
     }
 
     let runtime_pkg = jit::translate_package(
@@ -135,8 +135,11 @@ pub fn jit_and_cache_package(
     verified_pkg: verification::ast::Package,
 ) -> VMResult<Arc<move_cache::Package>> {
     let storage_id = verified_pkg.storage_id;
+    // If the package is already in the cache, return it.
+    // This is possible since the cache is shared and may be inserted into concurrently by other
+    // VMs working over the same cache.
     if cache.cached_package_at(storage_id).is_some() {
-        panic!("Attempting to re-jit a package, which should be impossible -- we already checked.");
+        return Ok(cache.cached_package_at(storage_id).unwrap());
     }
 
     let runtime_pkg = jit::translate_package(

--- a/external-crates/tests.sh
+++ b/external-crates/tests.sh
@@ -4,5 +4,5 @@ echo "Running Move tests in external-crates"
 cd move
 echo "Excluding prover Move tests"
 cargo nextest run -E '!package(move-prover) and !test(prove) and !test(run_all::simple_build_with_docs/args.txt) and !test(run_test::nested_deps_bad_parent/Move.toml)' --workspace --no-fail-fast
-echo "SKIP Running tracing-specific tests"
-# cargo nextest run -p move-cli --features tracing
+echo "Running tracing-specific tests"
+cargo nextest run -p move-cli --features tracing


### PR DESCRIPTION
This adds various "query" functions that the Sui adapter will need to the VM (e.g., resolving a typetag to a loaded type, getting type layouts, abilities, etc). As part of this it adds a `LoadedFunctionInformation` struct that allows VM runtime `Type`s to flow out of the VM.  The adapter and object runtime will need to (and does) take care to not allow these VM runtime types to flow across VM instance boundaries.

The code in the PR may not be working as future PRs will build on top of this.

