### PR TITLE
[2/n][vm-rewrite][Move] Update runtime value representation to support global references.

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/execution/values/values_impl.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/values/values_impl.rs
@@ -103,6 +103,9 @@ pub enum Reference {
 pub struct FixedSizeVec(Box<[Value]>);
 
 // XXX/TODO(vm-rewrite): Remove this and replace with proper value dirtying.
+#[deprecated(
+    note = "This is a temporary shim for the new VM. It _MUST_ be removed before final rollout."
+)]
 #[derive(Debug)]
 pub struct GlobalFingerprint(Option<String>);
 


### PR DESCRIPTION
This updates the VM value representation to support global values, and "fingerprinting" of the global values so that they can be properly dirtied at the end of execution.

## IMPORTANT

Additional work is needed to make the fingerprinting of global values actually something we'd want to use in prod, but the underlying logic of what a fingerprint is, and how it is computed has been abstracted away into a newtype so we can update this fairly easily hopefully.

## Semantic changes

This changes the semantics of execution around global values. Previously a global value would always be counted as mutated if the reference was written, even with the same value. In the implementation here this is no longer the case -- if the value is the same at time of read and the conclusion of execution, the value will not be viewed as mutated. As an example of a program that would exhibit this change in behavior:

```move
module 0x42::a;

public struct X has key, store {
    id: UID,
    x: u64,
}

public fun update1(x: &mut UID) {
    let s: &mut X = dynamic_field::borrow_mut(x, 0);
    assert!(s.x == 10);
    s.x = 11;
    s.x = 12;
    s.x = 10;
}

public fun update2(x: &mut UID) {
    let s: &mut X = dynamic_field::borrow_mut(x, 0);
    assert!(s.x == 10);
    s.x = 10;
}
```

In the previous semantics, the borrowed dynamic field would show as a mutated output of the transaction, in the new semantics it will not show up as mutated as extensionally the value was unchanged.

Note however, that for `move_from` and `move_to` operations, we _always_ view this as a dirtying operation. Eventually this logic for global value dirtying will be moved out and will be tracked in the object runtime, but for now we use this implementation to unblock the adapter updates.

NB: The code in the PR may not be working as future PRs will build on top of this.

