### PR TITLE
[3/n][vm-rewrite][Move] Update native context extensions to support Cloning

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/natives/extensions.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/natives/extensions.rs
@@ -7,7 +7,6 @@ use std::{
     any::TypeId,
     cell::{Ref, RefCell, RefMut},
     collections::HashMap,
-    ops::{Deref, DerefMut},
     rc::Rc,
 };
 
@@ -38,19 +37,6 @@ impl<'a, T: Tid<'a>> NativeContextMut<'a, T> {
 
     pub fn into_inner(self) -> T {
         self.0.into_inner()
-    }
-}
-
-impl<'a, T: Tid<'a>> Deref for NativeContextMut<'a, T> {
-    type Target = RefCell<T>;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<'a, T: Tid<'a>> DerefMut for NativeContextMut<'a, T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }
 


### PR DESCRIPTION
This updates the `NativeContextExtensions` struct to be `Clone`able. This updates the `Box<dyn Tid<'a>>` to a `Rc<dyn Tid<'a>>` and the extension is responsible for handling interior mutability.

As a helper struct the `NativeContextMut` was added to allow for easy writing/handling of native extensions that need interior mutability.

NB: The code in the PR may not be working as future PRs will build on top of this. In particular, for this PR, the changes to the object runtime/sui-adapter/sui-execution natives will be needed.

