### PR TITLE
[6/n][vm-rewrite][sui-execution] Update object runtime to use type tags instead of runtime VM types

### DIFF
--- a/sui-execution/latest/sui-move-natives/Cargo.toml
+++ b/sui-execution/latest/sui-move-natives/Cargo.toml
@@ -19,9 +19,7 @@ fastcrypto-vdf.workspace = true
 fastcrypto.workspace = true
 move-binary-format.workspace = true
 move-core-types.workspace = true
-move-vm-types.workspace = true
 
-move-stdlib-natives = { path = "../../../external-crates/move/crates/move-stdlib-natives" }
 move-vm-runtime = { path = "../../../external-crates/move/crates/move-vm-runtime" }
 
 sui-protocol-config.workspace = true

--- a/sui-execution/latest/sui-move-natives/src/address.rs
+++ b/sui-execution/latest/sui-move-natives/src/address.rs
@@ -4,10 +4,12 @@
 use crate::NativesCostTable;
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::{account_address::AccountAddress, gas_algebra::InternalGas, u256::U256};
-use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
-use move_vm_types::{
-    loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
+use move_vm_runtime::{
+    execution::{values::Value, Type},
+    natives::functions::NativeResult,
+    pop_arg,
 };
+use move_vm_runtime::{native_charge_gas_early_exit, natives::functions::NativeContext};
 use smallvec::smallvec;
 use std::collections::VecDeque;
 

--- a/sui-execution/latest/sui-move-natives/src/config.rs
+++ b/sui-execution/latest/sui-move-natives/src/config.rs
@@ -8,14 +8,18 @@ use move_core_types::{
     runtime_value as R, vm_status::StatusCode,
 };
 use move_vm_runtime::native_charge_gas_early_exit;
-use move_vm_runtime::native_functions::NativeContext;
-use move_vm_types::{
-    loaded_data::runtime_types::Type,
-    natives::function::NativeResult,
+use move_vm_runtime::natives::extensions::NativeContextMut;
+use move_vm_runtime::natives::functions::NativeContext;
+use move_vm_runtime::{
+    execution::{
+        values::{Struct, Value, Vector},
+        Type,
+    },
+    natives::functions::NativeResult,
     pop_arg,
-    values::{Struct, Value, Vector},
 };
 use smallvec::smallvec;
+use std::cell::RefMut;
 use std::collections::VecDeque;
 use sui_types::{base_types::MoveObjectType, TypeTag};
 use tracing::{error, instrument};
@@ -83,11 +87,13 @@ pub fn read_setting_impl(
             E_BCS_SERIALIZATION_FAILURE,
         ));
     };
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: RefMut<ObjectRuntime> = context
+        .extensions_mut()
+        .get::<NativeContextMut<ObjectRuntime>>()
+        .get_mut();
 
     let read_value_opt = consistent_value_before_current_epoch(
         object_runtime,
-        &field_setting_ty,
         field_setting_tag,
         &field_setting_layout,
         &setting_value_ty,
@@ -110,8 +116,7 @@ pub fn read_setting_impl(
 }
 
 fn consistent_value_before_current_epoch(
-    object_runtime: &mut ObjectRuntime,
-    field_setting_ty: &Type,
+    mut object_runtime: RefMut<ObjectRuntime>,
     field_setting_tag: StructTag,
     field_setting_layout: &R::MoveTypeLayout,
     _setting_value_ty: &Type,
@@ -125,7 +130,6 @@ fn consistent_value_before_current_epoch(
     let Some(field) = object_runtime.config_setting_unsequenced_read(
         config_addr.into(),
         name_df_addr.into(),
-        field_setting_ty,
         field_setting_layout,
         &field_setting_obj_ty,
     ) else {
@@ -150,8 +154,8 @@ fn consistent_value_before_current_epoch(
     let [newer_value_epoch, newer_value, older_value_opt]: [Value; 3] = unpack_struct(data)?;
     let newer_value_epoch: u64 = newer_value_epoch.value_as()?;
     debug_assert!(
-        unpack_option(newer_value.copy_value()?, value_ty)?.is_some()
-            || unpack_option(older_value_opt.copy_value()?, value_ty)?.is_some()
+        unpack_option(newer_value.copy_value(), value_ty)?.is_some()
+            || unpack_option(older_value_opt.copy_value(), value_ty)?.is_some()
     );
     Ok(if current_epoch > newer_value_epoch {
         newer_value

--- a/sui-execution/latest/sui-move-natives/src/crypto/bls12381.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/bls12381.rs
@@ -6,13 +6,15 @@ use fastcrypto::{
 };
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::gas_algebra::InternalGas;
-use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
-use move_vm_types::{
-    loaded_data::runtime_types::Type,
-    natives::function::NativeResult,
+use move_vm_runtime::{
+    execution::{
+        values::{Value, VectorRef},
+        Type,
+    },
+    natives::functions::NativeResult,
     pop_arg,
-    values::{Value, VectorRef},
 };
+use move_vm_runtime::{native_charge_gas_early_exit, natives::functions::NativeContext};
 use smallvec::smallvec;
 use std::collections::VecDeque;
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_k1.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_k1.rs
@@ -14,13 +14,15 @@ use fastcrypto::{
 };
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::gas_algebra::InternalGas;
-use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
-use move_vm_types::{
-    loaded_data::runtime_types::Type,
-    natives::function::NativeResult,
+use move_vm_runtime::{
+    execution::{
+        values::{self, Value, VectorRef},
+        Type,
+    },
+    natives::functions::NativeResult,
     pop_arg,
-    values::{self, Value, VectorRef},
 };
+use move_vm_runtime::{native_charge_gas_early_exit, natives::functions::NativeContext};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use smallvec::smallvec;

--- a/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_r1.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_r1.rs
@@ -13,12 +13,14 @@ use fastcrypto::{
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::gas_algebra::InternalGas;
 use move_vm_runtime::native_charge_gas_early_exit;
-use move_vm_runtime::native_functions::NativeContext;
-use move_vm_types::{
-    loaded_data::runtime_types::Type,
-    natives::function::NativeResult,
+use move_vm_runtime::natives::functions::NativeContext;
+use move_vm_runtime::{
+    execution::{
+        values::{Value, VectorRef},
+        Type,
+    },
+    natives::functions::NativeResult,
     pop_arg,
-    values::{Value, VectorRef},
 };
 use smallvec::smallvec;
 use std::collections::VecDeque;

--- a/sui-execution/latest/sui-move-natives/src/crypto/ecvrf.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/ecvrf.rs
@@ -5,13 +5,15 @@ use fastcrypto::vrf::ecvrf::{ECVRFProof, ECVRFPublicKey};
 use fastcrypto::vrf::VRFProof;
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::gas_algebra::InternalGas;
-use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
-use move_vm_types::{
-    loaded_data::runtime_types::Type,
-    natives::function::NativeResult,
+use move_vm_runtime::{
+    execution::{
+        values::{Value, VectorRef},
+        Type,
+    },
+    natives::functions::NativeResult,
     pop_arg,
-    values::{Value, VectorRef},
 };
+use move_vm_runtime::{native_charge_gas_early_exit, natives::functions::NativeContext};
 use smallvec::smallvec;
 use std::collections::VecDeque;
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/ed25519.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/ed25519.rs
@@ -7,13 +7,15 @@ use fastcrypto::{
 };
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::gas_algebra::InternalGas;
-use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
-use move_vm_types::{
-    loaded_data::runtime_types::Type,
-    natives::function::NativeResult,
+use move_vm_runtime::{
+    execution::{
+        values::{Value, VectorRef},
+        Type,
+    },
+    natives::functions::NativeResult,
     pop_arg,
-    values::{Value, VectorRef},
 };
+use move_vm_runtime::{native_charge_gas_early_exit, natives::functions::NativeContext};
 use smallvec::smallvec;
 use std::collections::VecDeque;
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/groth16.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/groth16.rs
@@ -3,13 +3,15 @@
 use crate::{object_runtime::ObjectRuntime, NativesCostTable};
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::gas_algebra::InternalGas;
-use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
-use move_vm_types::{
-    loaded_data::runtime_types::Type,
-    natives::function::NativeResult,
+use move_vm_runtime::{
+    execution::{
+        values::{self, Value, VectorRef},
+        Type,
+    },
+    natives::functions::NativeResult,
     pop_arg,
-    values::{self, Value, VectorRef},
 };
+use move_vm_runtime::{native_charge_gas_early_exit, natives::functions::NativeContext};
 use smallvec::smallvec;
 use std::collections::VecDeque;
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/group_ops.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/group_ops.rs
@@ -12,12 +12,14 @@ use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::gas_algebra::InternalGas;
 use move_core_types::vm_status::StatusCode;
 use move_vm_runtime::native_charge_gas_early_exit;
-use move_vm_runtime::native_functions::NativeContext;
-use move_vm_types::{
-    loaded_data::runtime_types::Type,
-    natives::function::NativeResult,
+use move_vm_runtime::natives::functions::NativeContext;
+use move_vm_runtime::{
+    execution::{
+        values::{Value, VectorRef},
+        Type,
+    },
+    natives::functions::NativeResult,
     pop_arg,
-    values::{Value, VectorRef},
 };
 use smallvec::smallvec;
 use std::collections::VecDeque;

--- a/sui-execution/latest/sui-move-natives/src/crypto/hash.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/hash.rs
@@ -4,13 +4,15 @@ use crate::NativesCostTable;
 use fastcrypto::hash::{Blake2b256, HashFunction, Keccak256};
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::gas_algebra::InternalGas;
-use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
-use move_vm_types::{
-    loaded_data::runtime_types::Type,
-    natives::function::NativeResult,
+use move_vm_runtime::{
+    execution::{
+        values::{Value, VectorRef},
+        Type,
+    },
+    natives::functions::NativeResult,
     pop_arg,
-    values::{Value, VectorRef},
 };
+use move_vm_runtime::{native_charge_gas_early_exit, natives::functions::NativeContext};
 use smallvec::smallvec;
 use std::{collections::VecDeque, ops::Mul};
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/hmac.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/hmac.rs
@@ -4,13 +4,15 @@ use crate::NativesCostTable;
 use fastcrypto::{hmac, traits::ToFromBytes};
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::gas_algebra::InternalGas;
-use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
-use move_vm_types::{
-    loaded_data::runtime_types::Type,
-    natives::function::NativeResult,
+use move_vm_runtime::{
+    execution::{
+        values::{Value, VectorRef},
+        Type,
+    },
+    natives::functions::NativeResult,
     pop_arg,
-    values::{Value, VectorRef},
 };
+use move_vm_runtime::{native_charge_gas_early_exit, natives::functions::NativeContext};
 use smallvec::smallvec;
 use std::collections::VecDeque;
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/poseidon.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/poseidon.rs
@@ -6,14 +6,15 @@ use fastcrypto_zkp::bn254::poseidon::poseidon_bytes;
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::gas_algebra::InternalGas;
 use move_core_types::vm_status::StatusCode;
-use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
-use move_vm_types::natives::function::PartialVMError;
-use move_vm_types::{
-    loaded_data::runtime_types::Type,
-    natives::function::NativeResult,
+use move_vm_runtime::{
+    execution::{
+        values::{Value, VectorRef},
+        Type,
+    },
+    natives::functions::{NativeResult, PartialVMError},
     pop_arg,
-    values::{Value, VectorRef},
 };
+use move_vm_runtime::{native_charge_gas_early_exit, natives::functions::NativeContext};
 use smallvec::smallvec;
 use std::collections::VecDeque;
 use std::ops::Mul;

--- a/sui-execution/latest/sui-move-natives/src/crypto/vdf.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/vdf.rs
@@ -9,14 +9,15 @@ use fastcrypto_vdf::vdf::VDF;
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::gas_algebra::InternalGas;
 use move_core_types::vm_status::StatusCode;
-use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
-use move_vm_types::natives::function::PartialVMError;
-use move_vm_types::{
-    loaded_data::runtime_types::Type,
-    natives::function::NativeResult,
+use move_vm_runtime::{
+    execution::{
+        values::{Value, VectorRef},
+        Type,
+    },
+    natives::functions::{NativeResult, PartialVMError},
     pop_arg,
-    values::{Value, VectorRef},
 };
+use move_vm_runtime::{native_charge_gas_early_exit, natives::functions::NativeContext};
 use smallvec::smallvec;
 use std::collections::VecDeque;
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/zklogin.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/zklogin.rs
@@ -7,12 +7,15 @@ use move_core_types::account_address::AccountAddress;
 use move_core_types::gas_algebra::InternalGas;
 use move_core_types::u256::U256;
 use move_core_types::vm_status::StatusCode;
-use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
-use move_vm_types::natives::function::PartialVMError;
-use move_vm_types::values::VectorRef;
-use move_vm_types::{
-    loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
+use move_vm_runtime::{
+    execution::{
+        values::{Value, VectorRef},
+        Type,
+    },
+    natives::functions::{NativeResult, PartialVMError},
+    pop_arg,
 };
+use move_vm_runtime::{native_charge_gas_early_exit, natives::functions::NativeContext};
 use smallvec::smallvec;
 use std::collections::VecDeque;
 

--- a/sui-execution/latest/sui-move-natives/src/dynamic_field.rs
+++ b/sui-execution/latest/sui-move-natives/src/dynamic_field.rs
@@ -24,7 +24,7 @@ use move_vm_runtime::{
 };
 use move_vm_runtime::{native_charge_gas_early_exit, natives::extensions::NativeContextMut};
 use smallvec::smallvec;
-use std::{cell::RefMut, collections::VecDeque};
+use std::collections::VecDeque;
 use sui_types::{base_types::MoveObjectType, dynamic_field::derive_dynamic_field_id};
 use tracing::instrument;
 
@@ -231,10 +231,10 @@ pub fn add_child_object(
     );
 
     {
-        let mut object_runtime: RefMut<ObjectRuntime> = context
+        let object_runtime: &mut ObjectRuntime = &mut context
             .extensions_mut()
             .get::<NativeContextMut<ObjectRuntime>>()
-            .get_mut();
+            .borrow_mut();
         object_runtime.add_child_object(parent, child_id, MoveObjectType::from(tag), child)?;
     };
     Ok(NativeResult::ok(context.gas_used(), smallvec![]))
@@ -290,7 +290,7 @@ pub fn borrow_child_object(
     // `get_or_fetch_object` so that the lifetime of the returned object is tied to the lifetime of
     // the runtime reference we are creating here and the borrow checker will be happy with us.
     let object_runtime: &NativeContextMut<'_, ObjectRuntime<'_>> = context.extensions().get();
-    let mut object_runtime_mut: RefMut<ObjectRuntime> = object_runtime.get_mut();
+    let object_runtime_mut: &mut ObjectRuntime = &mut object_runtime.borrow_mut();
     let global_value_result = get_or_fetch_object!(
         context,
         object_runtime_mut,
@@ -364,7 +364,7 @@ pub fn remove_child_object(
     // `get_or_fetch_object` so that the lifetime of the returned object is tied to the lifetime of
     // the runtime reference we are creating here and the borrow checker will be happy with us.
     let object_runtime: &NativeContextMut<'_, ObjectRuntime<'_>> = context.extensions().get();
-    let mut object_runtime_mut: RefMut<ObjectRuntime> = object_runtime.get_mut();
+    let object_runtime_mut: &mut ObjectRuntime = &mut object_runtime.borrow_mut();
     let global_value_result = get_or_fetch_object!(
         context,
         object_runtime_mut,
@@ -429,7 +429,7 @@ pub fn has_child_object(
     let child_id = pop_arg!(args, AccountAddress).into();
     let parent = pop_arg!(args, AccountAddress).into();
     let has_child = {
-        let mut object_runtime: RefMut<ObjectRuntime> = context.extensions().get::<NativeContextMut<ObjectRuntime>>().get_mut();
+        let object_runtime: &mut ObjectRuntime = &mut context.extensions().get::<NativeContextMut<ObjectRuntime>>().borrow_mut();
         object_runtime.child_object_exists(parent, child_id)?
     };
 
@@ -502,7 +502,7 @@ pub fn has_child_object_with_ty(
     );
 
     let has_child = {
-        let mut object_runtime: RefMut<ObjectRuntime> = context.extensions().get::<NativeContextMut<ObjectRuntime>>().get_mut();
+        let object_runtime: &mut ObjectRuntime = &mut context.extensions().get::<NativeContextMut<ObjectRuntime>>().borrow_mut();
         object_runtime.child_object_exists_and_has_type(parent, child_id, &MoveObjectType::from(tag))?
     };
 

--- a/sui-execution/latest/sui-move-natives/src/event.rs
+++ b/sui-execution/latest/sui-move-natives/src/event.rs
@@ -10,7 +10,7 @@ use move_vm_runtime::{
 };
 use move_vm_runtime::{native_charge_gas_early_exit, natives::functions::NativeContext};
 use smallvec::smallvec;
-use std::{cell::RefMut, collections::VecDeque};
+use std::collections::VecDeque;
 use sui_types::error::VMMemoryLimitExceededSubStatusCode;
 
 #[derive(Clone, Debug)]
@@ -75,10 +75,10 @@ pub fn emit(
             * u64::from(tag_size).into()
     );
 
-    let mut obj_runtime: RefMut<ObjectRuntime> = context
+    let obj_runtime: &mut ObjectRuntime = &mut context
         .extensions()
         .get::<NativeContextMut<ObjectRuntime>>()
-        .get_mut();
+        .borrow_mut();
     let max_event_emit_size = obj_runtime.protocol_config.max_event_emit_size();
     let ev_size = u64::from(tag_size + event_value_size);
     // Check if the event size is within the limit

--- a/sui-execution/latest/sui-move-natives/src/lib.rs
+++ b/sui-execution/latest/sui-move-natives/src/lib.rs
@@ -51,12 +51,16 @@ use move_core_types::{
     runtime_value as R,
     vm_status::StatusCode,
 };
-use move_stdlib_natives::{self as MSN, GasParameters};
-use move_vm_runtime::native_functions::{NativeContext, NativeFunction, NativeFunctionTable};
-use move_vm_types::{
-    loaded_data::runtime_types::Type,
-    natives::function::NativeResult,
-    values::{Struct, Value},
+use move_vm_runtime::natives::{
+    functions::{NativeContext, NativeFunction, NativeFunctionTable},
+    move_stdlib::{self as MSN, GasParameters},
+};
+use move_vm_runtime::{
+    execution::{
+        values::{Struct, Value},
+        Type,
+    },
+    natives::functions::NativeResult,
 };
 use std::sync::Arc;
 use sui_protocol_config::ProtocolConfig;
@@ -1093,11 +1097,13 @@ pub fn all_natives(silent: bool, protocol_config: &ProtocolConfig) -> NativeFunc
             )
         })
         .chain(sui_framework_natives_iter)
-        .chain(move_stdlib_natives::all_natives(
-            MOVE_STDLIB_ADDRESS,
-            make_stdlib_gas_params_for_protocol_config(protocol_config),
-            silent,
-        ))
+        .chain(
+            move_vm_runtime::natives::move_stdlib::stdlib_native_function_table(
+                MOVE_STDLIB_ADDRESS,
+                make_stdlib_gas_params_for_protocol_config(protocol_config),
+                silent,
+            ),
+        )
         .collect()
 }
 

--- a/sui-execution/latest/sui-move-natives/src/object.rs
+++ b/sui-execution/latest/sui-move-natives/src/object.rs
@@ -4,15 +4,17 @@
 use crate::{object_runtime::ObjectRuntime, NativesCostTable};
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::{account_address::AccountAddress, gas_algebra::InternalGas};
-use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
-use move_vm_types::{
-    loaded_data::runtime_types::Type,
-    natives::function::NativeResult,
+use move_vm_runtime::{
+    execution::{
+        values::{StructRef, Value},
+        Type,
+    },
+    natives::{extensions::NativeContextMut, functions::NativeResult},
     pop_arg,
-    values::{StructRef, Value},
 };
+use move_vm_runtime::{native_charge_gas_early_exit, natives::functions::NativeContext};
 use smallvec::smallvec;
-use std::collections::VecDeque;
+use std::{cell::RefMut, collections::VecDeque};
 
 #[derive(Clone)]
 pub struct BorrowUidCostParams {
@@ -78,7 +80,10 @@ pub fn delete_impl(
     // unwrap safe because the interface of native function guarantees it.
     let uid_bytes = pop_arg!(args, AccountAddress);
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let mut obj_runtime: RefMut<ObjectRuntime> = context
+        .extensions()
+        .get::<NativeContextMut<ObjectRuntime>>()
+        .get_mut();
     obj_runtime.delete_id(uid_bytes.into())?;
     Ok(NativeResult::ok(context.gas_used(), smallvec![]))
 }
@@ -115,7 +120,10 @@ pub fn record_new_uid(
     // unwrap safe because the interface of native function guarantees it.
     let uid_bytes = pop_arg!(args, AccountAddress);
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let mut obj_runtime: RefMut<ObjectRuntime> = context
+        .extensions()
+        .get::<NativeContextMut<ObjectRuntime>>()
+        .get_mut();
     obj_runtime.new_id(uid_bytes.into())?;
     Ok(NativeResult::ok(context.gas_used(), smallvec![]))
 }

--- a/sui-execution/latest/sui-move-natives/src/object.rs
+++ b/sui-execution/latest/sui-move-natives/src/object.rs
@@ -14,7 +14,7 @@ use move_vm_runtime::{
 };
 use move_vm_runtime::{native_charge_gas_early_exit, natives::functions::NativeContext};
 use smallvec::smallvec;
-use std::{cell::RefMut, collections::VecDeque};
+use std::collections::VecDeque;
 
 #[derive(Clone)]
 pub struct BorrowUidCostParams {
@@ -80,10 +80,10 @@ pub fn delete_impl(
     // unwrap safe because the interface of native function guarantees it.
     let uid_bytes = pop_arg!(args, AccountAddress);
 
-    let mut obj_runtime: RefMut<ObjectRuntime> = context
+    let obj_runtime: &mut ObjectRuntime = &mut context
         .extensions()
         .get::<NativeContextMut<ObjectRuntime>>()
-        .get_mut();
+        .borrow_mut();
     obj_runtime.delete_id(uid_bytes.into())?;
     Ok(NativeResult::ok(context.gas_used(), smallvec![]))
 }
@@ -120,10 +120,10 @@ pub fn record_new_uid(
     // unwrap safe because the interface of native function guarantees it.
     let uid_bytes = pop_arg!(args, AccountAddress);
 
-    let mut obj_runtime: RefMut<ObjectRuntime> = context
+    let obj_runtime: &mut ObjectRuntime = &mut context
         .extensions()
         .get::<NativeContextMut<ObjectRuntime>>()
-        .get_mut();
+        .borrow_mut();
     obj_runtime.new_id(uid_bytes.into())?;
     Ok(NativeResult::ok(context.gas_used(), smallvec![]))
 }

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
@@ -18,8 +18,7 @@ use move_core_types::{
     runtime_value as R,
     vm_status::StatusCode,
 };
-use move_vm_types::{
-    loaded_data::runtime_types::Type,
+use move_vm_runtime::execution::{
     values::{GlobalValue, Value},
 };
 use object_store::{ActiveChildObject, ChildObjectStore};
@@ -37,7 +36,7 @@ use sui_types::{
     metrics::LimitsMetrics,
     object::{MoveObject, Owner},
     storage::ChildObjectResolver,
-    SUI_AUTHENTICATOR_STATE_OBJECT_ID, SUI_BRIDGE_OBJECT_ID, SUI_CLOCK_OBJECT_ID,
+    TypeTag, SUI_AUTHENTICATOR_STATE_OBJECT_ID, SUI_BRIDGE_OBJECT_ID, SUI_CLOCK_OBJECT_ID,
     SUI_DENY_LIST_OBJECT_ID, SUI_RANDOMNESS_STATE_OBJECT_ID, SUI_SYSTEM_STATE_OBJECT_ID,
 };
 use tracing::error;
@@ -55,11 +54,11 @@ type Set<K> = IndexSet<K>;
 pub(crate) struct TestInventories {
     pub(crate) objects: BTreeMap<ObjectID, Value>,
     // address inventories. Most recent objects are at the back of the set
-    pub(crate) address_inventories: BTreeMap<SuiAddress, BTreeMap<Type, Set<ObjectID>>>,
+    pub(crate) address_inventories: BTreeMap<SuiAddress, BTreeMap<TypeTag, Set<ObjectID>>>,
     // global inventories.Most recent objects are at the back of the set
-    pub(crate) shared_inventory: BTreeMap<Type, Set<ObjectID>>,
-    pub(crate) immutable_inventory: BTreeMap<Type, Set<ObjectID>>,
-    pub(crate) taken_immutable_values: BTreeMap<Type, BTreeMap<ObjectID, Value>>,
+    pub(crate) shared_inventory: BTreeMap<TypeTag, Set<ObjectID>>,
+    pub(crate) immutable_inventory: BTreeMap<TypeTag, Set<ObjectID>>,
+    pub(crate) taken_immutable_values: BTreeMap<TypeTag, BTreeMap<ObjectID, Value>>,
     // object has been taken from the inventory
     pub(crate) taken: BTreeMap<ObjectID, Owner>,
     // allocated receiving tickets
@@ -72,8 +71,8 @@ pub struct LoadedRuntimeObject {
 }
 
 pub struct RuntimeResults {
-    pub writes: IndexMap<ObjectID, (Owner, Type, Value)>,
-    pub user_events: Vec<(Type, StructTag, Value)>,
+    pub writes: IndexMap<ObjectID, (Owner, MoveObjectType, Value)>,
+    pub user_events: Vec<(StructTag, Value)>,
     // Loaded child objects, their loaded version/digest and whether they were modified.
     pub loaded_child_objects: BTreeMap<ObjectID, LoadedRuntimeObject>,
     pub created_object_ids: Set<ObjectID>,
@@ -89,8 +88,8 @@ pub(crate) struct ObjectRuntimeState {
     deleted_ids: Set<ObjectID>,
     // transfers to a new owner (shared, immutable, object, or account address)
     // TODO these struct tags can be removed if type_to_type_tag was exposed in the session
-    transfers: IndexMap<ObjectID, (Owner, Type, Value)>,
-    events: Vec<(Type, StructTag, Value)>,
+    transfers: IndexMap<ObjectID, (Owner, MoveObjectType, Value)>,
+    events: Vec<(StructTag, Value)>,
     // total size of events emitted so far
     total_events_size: u64,
     received: IndexMap<ObjectID, DynamicallyLoadedObjectMetadata>,
@@ -240,10 +239,10 @@ impl<'a> ObjectRuntime<'a> {
     pub fn transfer(
         &mut self,
         owner: Owner,
-        ty: Type,
+        ty: MoveObjectType,
         obj: Value,
     ) -> PartialVMResult<TransferResult> {
-        let id: ObjectID = get_object_id(obj.copy_value()?)?
+        let id: ObjectID = get_object_id(obj.copy_value())?
             .value_as::<AccountAddress>()?
             .into();
         // - An object is new if it is contained in the new ids or if it is one of the objects
@@ -300,15 +299,15 @@ impl<'a> ObjectRuntime<'a> {
         Ok(transfer_result)
     }
 
-    pub fn emit_event(&mut self, ty: Type, tag: StructTag, event: Value) -> PartialVMResult<()> {
+    pub fn emit_event(&mut self, tag: StructTag, event: Value) -> PartialVMResult<()> {
         if self.state.events.len() >= (self.protocol_config.max_num_event_emit() as usize) {
             return Err(max_event_error(self.protocol_config.max_num_event_emit()));
         }
-        self.state.events.push((ty, tag, event));
+        self.state.events.push((tag, event));
         Ok(())
     }
 
-    pub fn take_user_events(&mut self) -> Vec<(Type, StructTag, Value)> {
+    pub fn take_user_events(&mut self) -> Vec<(StructTag, Value)> {
         std::mem::take(&mut self.state.events)
     }
 
@@ -335,7 +334,6 @@ impl<'a> ObjectRuntime<'a> {
         parent: ObjectID,
         child: ObjectID,
         child_version: SequenceNumber,
-        child_ty: &Type,
         child_layout: &R::MoveTypeLayout,
         child_fully_annotated_layout: &MoveTypeLayout,
         child_move_type: MoveObjectType,
@@ -344,7 +342,6 @@ impl<'a> ObjectRuntime<'a> {
             parent,
             child,
             child_version,
-            child_ty,
             child_layout,
             child_fully_annotated_layout,
             child_move_type,
@@ -371,7 +368,6 @@ impl<'a> ObjectRuntime<'a> {
         &mut self,
         parent: ObjectID,
         child: ObjectID,
-        child_ty: &Type,
         child_layout: &R::MoveTypeLayout,
         child_fully_annotated_layout: &MoveTypeLayout,
         child_move_type: MoveObjectType,
@@ -379,7 +375,6 @@ impl<'a> ObjectRuntime<'a> {
         let res = self.child_object_store.get_or_fetch_object(
             parent,
             child,
-            child_ty,
             child_layout,
             child_fully_annotated_layout,
             child_move_type,
@@ -394,26 +389,23 @@ impl<'a> ObjectRuntime<'a> {
         &mut self,
         parent: ObjectID,
         child: ObjectID,
-        child_ty: &Type,
         child_move_type: MoveObjectType,
         child_value: Value,
     ) -> PartialVMResult<()> {
         self.child_object_store
-            .add_object(parent, child, child_ty, child_move_type, child_value)
+            .add_object(parent, child, child_move_type, child_value)
     }
 
     pub(crate) fn config_setting_unsequenced_read(
         &mut self,
         config_id: ObjectID,
         name_df_id: ObjectID,
-        field_setting_ty: &Type,
         field_setting_layout: &R::MoveTypeLayout,
         field_setting_object_type: &MoveObjectType,
     ) -> Option<Value> {
         match self.child_object_store.config_setting_unsequenced_read(
             config_id,
             name_df_id,
-            field_setting_ty,
             field_setting_layout,
             field_setting_object_type,
         ) {
@@ -641,7 +633,7 @@ impl ObjectRuntimeState {
         })
     }
 
-    pub fn events(&self) -> &[(Type, StructTag, Value)] {
+    pub fn events(&self) -> &[(StructTag, Value)] {
         &self.events
     }
 

--- a/sui-execution/latest/sui-move-natives/src/random.rs
+++ b/sui-execution/latest/sui-move-natives/src/random.rs
@@ -3,10 +3,8 @@
 
 use crate::legacy_test_cost;
 use move_binary_format::errors::PartialVMResult;
-use move_vm_runtime::native_functions::NativeContext;
-use move_vm_types::{
-    loaded_data::runtime_types::Type, natives::function::NativeResult, values::Value,
-};
+use move_vm_runtime::execution::{values::Value, Type};
+use move_vm_runtime::natives::functions::{NativeContext, NativeResult};
 use rand::Rng;
 use smallvec::smallvec;
 use std::collections::VecDeque;

--- a/sui-execution/latest/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/latest/sui-move-natives/src/test_scenario.rs
@@ -1012,13 +1012,13 @@ fn find_all_wrapped_objects<'a, 'i>(
 
     let uid = UID::layout();
     for (_id, ty, value) in new_object_values {
-        let Ok(Some(layout)) = context.typetag_to_type_layout(&ty.clone().into()) else {
+        let Ok(Some(layout)) = context.type_tag_to_type_layout(&ty.clone().into()) else {
             debug_assert!(false);
             continue;
         };
 
         let Ok(Some(annotated_layout)) =
-            context.typetag_to_annotated_type_layout(&ty.clone().into())
+            context.type_tag_to_annotated_type_layout(&ty.clone().into())
         else {
             debug_assert!(false);
             continue;

--- a/sui-execution/latest/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/latest/sui-move-natives/src/test_scenario.rs
@@ -29,7 +29,7 @@ use move_vm_runtime::{
 use smallvec::smallvec;
 use std::{
     borrow::Borrow,
-    cell::{RefCell, RefMut},
+    cell::RefCell,
     collections::{BTreeMap, BTreeSet, VecDeque},
     thread::LocalKey,
 };
@@ -100,10 +100,10 @@ pub fn end_transaction(
 ) -> PartialVMResult<NativeResult> {
     assert!(ty_args.is_empty());
     assert!(args.is_empty());
-    let mut object_runtime_ref: RefMut<ObjectRuntime> = context
+    let object_runtime_ref: &mut ObjectRuntime = &mut context
         .extensions()
         .get::<NativeContextMut<ObjectRuntime>>()
-        .get_mut();
+        .borrow_mut();
     let taken_shared_or_imm: BTreeMap<_, _> = object_runtime_ref
         .test_inventories
         .taken
@@ -275,10 +275,10 @@ pub fn end_transaction(
     }
     // find all wrapped objects
     let mut all_wrapped = BTreeSet::new();
-    let mut object_runtime_ref: RefMut<ObjectRuntime> = context
+    let object_runtime_ref: &mut ObjectRuntime = &mut context
         .extensions()
         .get::<NativeContextMut<ObjectRuntime>>()
-        .get_mut();
+        .borrow_mut();
     find_all_wrapped_objects(
         context,
         &mut all_wrapped,
@@ -392,7 +392,7 @@ pub fn take_from_address_by_id(
     let object_runtime: &mut ObjectRuntime = &mut context
         .extensions()
         .get::<NativeContextMut<ObjectRuntime>>()
-        .get_mut();
+        .borrow_mut();
     let inventories = &mut object_runtime.test_inventories;
     let res = take_from_inventory(
         |x| {
@@ -425,10 +425,10 @@ pub fn ids_for_address(
     let account: SuiAddress = pop_arg!(args, AccountAddress).into();
     assert!(args.is_empty());
     let specified_obj_ty = context.type_to_type_tag(&specified_ty)?;
-    let mut object_runtime: RefMut<ObjectRuntime> = context
+    let object_runtime: &mut ObjectRuntime = &mut context
         .extensions()
         .get::<NativeContextMut<ObjectRuntime>>()
-        .get_mut();
+        .borrow_mut();
     let inventories = &mut object_runtime.test_inventories;
     let ids = inventories
         .address_inventories
@@ -450,10 +450,10 @@ pub fn most_recent_id_for_address(
     let account: SuiAddress = pop_arg!(args, AccountAddress).into();
     assert!(args.is_empty());
     let specified_obj_ty = context.type_to_type_tag(&specified_ty)?;
-    let mut object_runtime: RefMut<ObjectRuntime> = context
+    let object_runtime: &mut ObjectRuntime = &mut context
         .extensions()
         .get::<NativeContextMut<ObjectRuntime>>()
-        .get_mut();
+        .borrow_mut();
     let inventories = &mut object_runtime.test_inventories;
     let most_recent_id = match inventories.address_inventories.get(&account) {
         None => pack_option(None),
@@ -475,10 +475,10 @@ pub fn was_taken_from_address(
     let id = pop_id(&mut args)?;
     let account: SuiAddress = pop_arg!(args, AccountAddress).into();
     assert!(args.is_empty());
-    let mut object_runtime: RefMut<ObjectRuntime> = context
+    let object_runtime: &mut ObjectRuntime = &mut context
         .extensions()
         .get::<NativeContextMut<ObjectRuntime>>()
-        .get_mut();
+        .borrow_mut();
     let inventories = &mut object_runtime.test_inventories;
     let was_taken = inventories
         .taken
@@ -505,7 +505,7 @@ pub fn take_immutable_by_id(
     let object_runtime: &mut ObjectRuntime = &mut context
         .extensions()
         .get::<NativeContextMut<ObjectRuntime>>()
-        .get_mut();
+        .borrow_mut();
     let inventories = &mut object_runtime.test_inventories;
     let res = take_from_inventory(
         |x| {
@@ -543,10 +543,10 @@ pub fn most_recent_immutable_id(
     let specified_ty = get_specified_ty(ty_args);
     assert!(args.is_empty());
     let specified_obj_ty = context.type_to_type_tag(&specified_ty)?;
-    let mut object_runtime: RefMut<ObjectRuntime> = context
+    let object_runtime: &mut ObjectRuntime = &mut context
         .extensions()
         .get::<NativeContextMut<ObjectRuntime>>()
-        .get_mut();
+        .borrow_mut();
     let inventories = &mut object_runtime.test_inventories;
     let most_recent_id = most_recent_at_ty(
         &inventories.taken,
@@ -568,10 +568,10 @@ pub fn was_taken_immutable(
     assert!(ty_args.is_empty());
     let id = pop_id(&mut args)?;
     assert!(args.is_empty());
-    let mut object_runtime: RefMut<ObjectRuntime> = context
+    let object_runtime: &mut ObjectRuntime = &mut context
         .extensions()
         .get::<NativeContextMut<ObjectRuntime>>()
-        .get_mut();
+        .borrow_mut();
     let inventories = &mut object_runtime.test_inventories;
     let was_taken = inventories
         .taken
@@ -598,7 +598,7 @@ pub fn take_shared_by_id(
     let object_runtime: &mut ObjectRuntime = &mut context
         .extensions()
         .get::<NativeContextMut<ObjectRuntime>>()
-        .get_mut();
+        .borrow_mut();
     let inventories = &mut object_runtime.test_inventories;
     let res = take_from_inventory(
         |x| {
@@ -629,10 +629,10 @@ pub fn most_recent_id_shared(
     let specified_ty = get_specified_ty(ty_args);
     assert!(args.is_empty());
     let specified_obj_ty = context.type_to_type_tag(&specified_ty)?;
-    let mut object_runtime: RefMut<ObjectRuntime> = context
+    let object_runtime: &mut ObjectRuntime = &mut context
         .extensions()
         .get::<NativeContextMut<ObjectRuntime>>()
-        .get_mut();
+        .borrow_mut();
     let inventories = &mut object_runtime.test_inventories;
     let most_recent_id = most_recent_at_ty(
         &inventories.taken,
@@ -654,10 +654,10 @@ pub fn was_taken_shared(
     assert!(ty_args.is_empty());
     let id = pop_id(&mut args)?;
     assert!(args.is_empty());
-    let mut object_runtime: RefMut<ObjectRuntime> = context
+    let object_runtime: &mut ObjectRuntime = &mut context
         .extensions()
         .get::<NativeContextMut<ObjectRuntime>>()
-        .get_mut();
+        .borrow_mut();
     let inventories = &mut object_runtime.test_inventories;
     let was_taken = inventories
         .taken
@@ -685,10 +685,10 @@ pub fn allocate_receiving_ticket_for_object(
             E_UNABLE_TO_ALLOCATE_RECEIVING_TICKET,
         ));
     };
-    let mut object_runtime: RefMut<ObjectRuntime> = context
+    let object_runtime: &mut ObjectRuntime = &mut context
         .extensions()
         .get::<NativeContextMut<ObjectRuntime>>()
-        .get_mut();
+        .borrow_mut();
     let object_version = SequenceNumber::new();
     let inventories = &mut object_runtime.test_inventories;
     if inventories.allocated_tickets.contains_key(&id) {
@@ -765,10 +765,10 @@ pub fn deallocate_receiving_ticket_for_object(
 ) -> PartialVMResult<NativeResult> {
     let id = pop_id(&mut args)?;
 
-    let mut object_runtime: RefMut<ObjectRuntime> = context
+    let object_runtime: &mut ObjectRuntime = &mut context
         .extensions()
         .get::<NativeContextMut<ObjectRuntime>>()
-        .get_mut();
+        .borrow_mut();
     let inventories = &mut object_runtime.test_inventories;
     // Deallocate the ticket -- we should never hit this scenario
     let Some((_, value)) = inventories.allocated_tickets.remove(&id) else {

--- a/sui-execution/latest/sui-move-natives/src/test_utils.rs
+++ b/sui-execution/latest/sui-move-natives/src/test_utils.rs
@@ -4,10 +4,11 @@
 use crate::{legacy_test_cost, types::is_otw_struct};
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::{gas_algebra::InternalGas, runtime_value::MoveTypeLayout};
-use move_vm_runtime::native_functions::NativeContext;
-use move_vm_types::{
-    loaded_data::runtime_types::Type, natives::function::NativeResult, values::Value,
+use move_vm_runtime::execution::{
+    values::{Struct, Value},
+    Type,
 };
+use move_vm_runtime::natives::functions::{NativeContext, NativeResult};
 use smallvec::smallvec;
 use std::collections::VecDeque;
 
@@ -40,9 +41,7 @@ pub fn create_one_time_witness(
     if is_otw_struct(&struct_layout, &type_tag, hardened_check) {
         Ok(NativeResult::ok(
             legacy_test_cost(),
-            smallvec![Value::struct_(move_vm_types::values::Struct::pack(vec![
-                Value::bool(true)
-            ]))],
+            smallvec![Value::struct_(Struct::pack(vec![Value::bool(true)]))],
         ))
     } else {
         Ok(NativeResult::err(InternalGas::new(1), 1))

--- a/sui-execution/latest/sui-move-natives/src/transfer.rs
+++ b/sui-execution/latest/sui-move-natives/src/transfer.rs
@@ -17,7 +17,6 @@ use move_vm_runtime::{
 };
 use move_vm_runtime::{native_charge_gas_early_exit, natives::functions::NativeContext};
 use smallvec::smallvec;
-use std::cell::RefMut;
 use std::collections::VecDeque;
 use sui_types::{
     base_types::{MoveObjectType, ObjectID, SequenceNumber},
@@ -76,10 +75,10 @@ pub fn receive_object_internal(
         ));
     };
 
-    let mut object_runtime: RefMut<ObjectRuntime> = context
+    let object_runtime: &mut ObjectRuntime = &mut context
         .extensions()
         .get::<NativeContextMut<ObjectRuntime>>()
-        .get_mut();
+        .borrow_mut();
     let child = match object_runtime.receive_object(
         parent,
         child_id,
@@ -248,9 +247,9 @@ fn object_runtime_transfer(
         }
     };
 
-    let mut obj_runtime: RefMut<ObjectRuntime> = context
+    let obj_runtime: &mut ObjectRuntime = &mut context
         .extensions()
         .get::<NativeContextMut<ObjectRuntime>>()
-        .get_mut();
+        .borrow_mut();
     obj_runtime.transfer(owner, object_type, obj)
 }

--- a/sui-execution/latest/sui-move-natives/src/tx_context.rs
+++ b/sui-execution/latest/sui-move-natives/src/tx_context.rs
@@ -10,7 +10,7 @@ use move_vm_runtime::{
 };
 use move_vm_runtime::{native_charge_gas_early_exit, natives::functions::NativeContext};
 use smallvec::smallvec;
-use std::{cell::RefMut, collections::VecDeque, convert::TryFrom};
+use std::{collections::VecDeque, convert::TryFrom};
 use sui_types::base_types::{ObjectID, TransactionDigest};
 
 use crate::{object_runtime::ObjectRuntime, NativesCostTable};
@@ -48,10 +48,10 @@ pub fn derive_id(
     // unwrap safe because all digests in Move are serialized from the Rust `TransactionDigest`
     let digest = TransactionDigest::try_from(tx_hash.as_slice()).unwrap();
     let address = AccountAddress::from(ObjectID::derive_id(digest, ids_created));
-    let mut obj_runtime: RefMut<ObjectRuntime> = context
+    let obj_runtime: &mut ObjectRuntime = &mut context
         .extensions()
         .get::<NativeContextMut<ObjectRuntime>>()
-        .get_mut();
+        .borrow_mut();
     obj_runtime.new_id(address.into())?;
 
     Ok(NativeResult::ok(

--- a/sui-execution/latest/sui-move-natives/src/types.rs
+++ b/sui-execution/latest/sui-move-natives/src/types.rs
@@ -7,10 +7,10 @@ use move_core_types::{
     language_storage::TypeTag,
     runtime_value::{MoveStructLayout, MoveTypeLayout},
 };
-use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
-use move_vm_types::{
-    loaded_data::runtime_types::Type, natives::function::NativeResult, values::Value,
+use move_vm_runtime::{
+    execution::values::Value, execution::Type, natives::functions::NativeResult,
 };
+use move_vm_runtime::{native_charge_gas_early_exit, natives::functions::NativeContext};
 use smallvec::smallvec;
 use std::collections::VecDeque;
 

--- a/sui-execution/latest/sui-move-natives/src/validator.rs
+++ b/sui-execution/latest/sui-move-natives/src/validator.rs
@@ -4,10 +4,10 @@
 use crate::NativesCostTable;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{gas_algebra::InternalGas, vm_status::StatusCode};
-use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
-use move_vm_types::{
-    loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
+use move_vm_runtime::{
+    execution::values::Value, execution::Type, natives::functions::NativeResult, pop_arg,
 };
+use move_vm_runtime::{native_charge_gas_early_exit, natives::functions::NativeContext};
 use smallvec::smallvec;
 use std::collections::VecDeque;
 use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorMetadataV1;


### PR DESCRIPTION
Since the VM instance no longer will live across commands/the entire lifetime of the object runtime, this replaces all VM runtime `Type`s with `TypeTag`s or `MoveObjectType`s where appropriate. This also updates the natives and runtime to handle the new
`NativeContextExtensions` model.

NB: The code in the PR may not be working as future PRs will build on top of this.
