### PR TITLE
fix broken tokenomics.pdf links in docs

### DIFF
--- a/docs/content/concepts/tokenomics.mdx
+++ b/docs/content/concepts/tokenomics.mdx
@@ -54,7 +54,7 @@ At the end of each epoch, the protocol distributes stake rewards to participants
 - The total amount of stake rewards is calculated as the sum of computation fees accrued throughout the epoch plus the epoch's stake reward subsidies. The latter component is temporary in that it will only exist in the network's first years and disappear in the long run as the amount of SUI in circulation reaches its total supply.
 - The total amount of stake rewards is distributed across various entities. The storage fund is taken into account in the calculation of the epoch total stake, which is not owned by any entities in the way that staked SUI is. Instead, the Sui economic model distributes the stake rewards accruing to the storage fund to validators for compensation of their storage costs.
 
-The distribution mechanisms built into Sui tokenomics encourages a healthy competition for fair prices where validators set low gas fees while operating with viable business models. Refer to the https://docs.sui.io/assets/files/tokenomics-87c5e5545e70702a338016edee57dfd9.pdf whitepaper for in-depth review of the mathematical proofs that support this structure.
+The distribution mechanisms built into Sui tokenomics encourages a healthy competition for fair prices where validators set low gas fees while operating with viable business models. Refer to the https://docs.sui.io/paper/tokenomics.pdf whitepaper for in-depth review of the mathematical proofs that support this structure.
 
 ### Unlocking schedules
 
@@ -119,5 +119,5 @@ The distinction between third-party owned vs validator-owned rewards and stake i
 
 ## Related links
 
-- [The Sui Smart Contracts Platform: Economics and Incentives](https://docs.sui.io/assets/files/tokenomics-87c5e5545e70702a338016edee57dfd9.pdf): Whitepaper that details Sui tokenomics.
+- [The Sui Smart Contracts Platform: Economics and Incentives](https://docs.sui.io/paper/tokenomics.pdf): Whitepaper that details Sui tokenomics.
 - [Gas fees](https://docs.sui.io/concepts/tokenomics/gas-in-sui): Gas fees are charged on all network operations and used to reward participants of the proof-of-stake mechanism and prevent spam and denial-of-service attacks.


### PR DESCRIPTION
## Description 

Fix a broken link in the docs regarding the tokenomics pdf.

## Test plan 

Untested.

No release impact.