### PR TITLE
[rpc-alt] add getAllBalances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2071,9 +2071,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.13"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4378725facc195f1a538864863f6de233b500a8862747e7f165078a419d5e874"
+checksum = "c94087b935a822949d3291a9989ad2b2051ea141eda0fd4e478a75f6aa3e604b"
 dependencies = [
  "cc",
  "glob",

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/get_all_balances.exp
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/get_all_balances.exp
@@ -1,0 +1,95 @@
+processed 9 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-65:
+//# publish --sender A
+created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5), object(1,6), object(1,7), object(1,8), object(1,9), object(1,10), object(1,11), object(1,12)
+mutated: object(0,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 31707200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 67:
+//# transfer-object 1,2 --sender A --recipient B
+mutated: object(0,0), object(1,2)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 2310400,  storage_rebate: 2287296, non_refundable_storage_fee: 23104
+
+task 3, line 69:
+//# transfer-object 1,1 --sender A --recipient B
+mutated: object(0,0), object(1,1)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 2310400,  storage_rebate: 2287296, non_refundable_storage_fee: 23104
+
+task 4, line 71:
+//# transfer-object 1,6 --sender A --recipient B
+mutated: object(0,0), object(1,6)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 2310400,  storage_rebate: 2287296, non_refundable_storage_fee: 23104
+
+task 5, lines 73-75:
+//# programmable --sender A --inputs 500 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, line 77:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 7, lines 79-83:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": [
+    {
+      "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+      "coinObjectCount": 2,
+      "totalBalance": "299999962225608",
+      "lockedBalance": {}
+    },
+    {
+      "coinType": "0xa6628f77d4a14f62ba1e2e8b24d99c19ca9948e8925f97367ce6f597f6b3085c::fake::FAKE",
+      "coinObjectCount": 2,
+      "totalBalance": "4100",
+      "lockedBalance": {}
+    },
+    {
+      "coinType": "0xa6628f77d4a14f62ba1e2e8b24d99c19ca9948e8925f97367ce6f597f6b3085c::real::REAL",
+      "coinObjectCount": 3,
+      "totalBalance": "25003742",
+      "lockedBalance": {}
+    }
+  ]
+}
+
+task 8, lines 85-89:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": [
+    {
+      "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+      "coinObjectCount": 1,
+      "totalBalance": "300000000000000",
+      "lockedBalance": {}
+    },
+    {
+      "coinType": "0xa6628f77d4a14f62ba1e2e8b24d99c19ca9948e8925f97367ce6f597f6b3085c::fake::FAKE",
+      "coinObjectCount": 2,
+      "totalBalance": "3020",
+      "lockedBalance": {}
+    },
+    {
+      "coinType": "0xa6628f77d4a14f62ba1e2e8b24d99c19ca9948e8925f97367ce6f597f6b3085c::real::REAL",
+      "coinObjectCount": 1,
+      "totalBalance": "1000000",
+      "lockedBalance": {}
+    }
+  ]
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/get_all_balances.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/get_all_balances.move
@@ -87,3 +87,19 @@ module Test::real {
   "method": "suix_getAllBalances",
   "params": ["@{B}"]
 }
+
+//# transfer-object 1,6 --sender B --recipient A
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "suix_getAllBalances",
+  "params": ["@{A}"]
+}
+
+//# run-jsonrpc
+{
+  "method": "suix_getAllBalances",
+  "params": ["@{B}"]
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/get_all_balances.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/get_all_balances.move
@@ -1,0 +1,89 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --addresses Test=0x0 --accounts A B --simulator --objects-snapshot-min-checkpoint-lag 2
+
+//# publish --sender A
+module Test::fake {
+    use sui::coin;
+
+    public struct FAKE has drop {}
+
+    fun init(witness: FAKE, ctx: &mut TxContext){
+        let (mut treasury_cap, metadata) = coin::create_currency(
+            witness,
+            2,
+            b"FAKE",
+            b"",
+            b"",
+            option::none(),
+            ctx,
+        );
+
+        let c1 = coin::mint(&mut treasury_cap, 100, ctx);
+        let c2 = coin::mint(&mut treasury_cap, 20, ctx);
+        let c3 = coin::mint(&mut treasury_cap, 3000, ctx);
+        let c4 = coin::mint(&mut treasury_cap, 4000, ctx);
+
+        transfer::public_freeze_object(metadata);
+        transfer::public_transfer(treasury_cap, tx_context::sender(ctx));
+        transfer::public_transfer(c1, tx_context::sender(ctx));
+        transfer::public_transfer(c2, tx_context::sender(ctx));
+        transfer::public_transfer(c3, tx_context::sender(ctx));
+        transfer::public_transfer(c4, tx_context::sender(ctx));
+    }
+}
+
+module Test::real {
+    use sui::coin;
+
+    public struct REAL has drop {}
+
+    fun init(witness: REAL, ctx: &mut TxContext){
+        let (mut treasury_cap, metadata) = coin::create_currency(
+            witness,
+            2,
+            b"REAL",
+            b"",
+            b"",
+            option::none(),
+            ctx,
+        );
+
+        let c5 = coin::mint(&mut treasury_cap, 42, ctx);
+        let c6 = coin::mint(&mut treasury_cap, 3700, ctx);
+        let c7 = coin::mint(&mut treasury_cap, 1000000, ctx);
+        let c8 = coin::mint(&mut treasury_cap, 25000000, ctx);
+
+        transfer::public_freeze_object(metadata);
+        transfer::public_transfer(treasury_cap, tx_context::sender(ctx));
+        transfer::public_transfer(c5, tx_context::sender(ctx));
+        transfer::public_transfer(c6, tx_context::sender(ctx));
+        transfer::public_transfer(c7, tx_context::sender(ctx));
+        transfer::public_transfer(c8, tx_context::sender(ctx));
+    }
+}
+
+//# transfer-object 1,2 --sender A --recipient B
+
+//# transfer-object 1,1 --sender A --recipient B
+
+//# transfer-object 1,6 --sender A --recipient B
+
+//# programmable --sender A --inputs 500 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "suix_getAllBalances",
+  "params": ["@{A}"]
+}
+
+//# run-jsonrpc
+{
+  "method": "suix_getAllBalances",
+  "params": ["@{B}"]
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/get_all_balances.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/get_all_balances.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 9 tasks
+processed 13 tasks
 
 init:
 A: object(0,0), B: object(0,1)
@@ -92,6 +92,64 @@ Response: {
       "coinType": "0xa6628f77d4a14f62ba1e2e8b24d99c19ca9948e8925f97367ce6f597f6b3085c::real::REAL",
       "coinObjectCount": 1,
       "totalBalance": "1000000",
+      "lockedBalance": {}
+    }
+  ]
+}
+
+task 9, line 91:
+//# transfer-object 1,6 --sender B --recipient A
+mutated: object(0,1), object(1,6)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 2310400,  storage_rebate: 1309176, non_refundable_storage_fee: 13224
+
+task 10, line 93:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 11, lines 95-99:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": [
+    {
+      "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+      "coinObjectCount": 2,
+      "totalBalance": "299999962225608",
+      "lockedBalance": {}
+    },
+    {
+      "coinType": "0xa6628f77d4a14f62ba1e2e8b24d99c19ca9948e8925f97367ce6f597f6b3085c::fake::FAKE",
+      "coinObjectCount": 2,
+      "totalBalance": "4100",
+      "lockedBalance": {}
+    },
+    {
+      "coinType": "0xa6628f77d4a14f62ba1e2e8b24d99c19ca9948e8925f97367ce6f597f6b3085c::real::REAL",
+      "coinObjectCount": 4,
+      "totalBalance": "26003742",
+      "lockedBalance": {}
+    }
+  ]
+}
+
+task 12, lines 101-105:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": [
+    {
+      "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+      "coinObjectCount": 1,
+      "totalBalance": "299999997998776",
+      "lockedBalance": {}
+    },
+    {
+      "coinType": "0xa6628f77d4a14f62ba1e2e8b24d99c19ca9948e8925f97367ce6f597f6b3085c::fake::FAKE",
+      "coinObjectCount": 2,
+      "totalBalance": "3020",
       "lockedBalance": {}
     }
   ]

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/get_all_balances.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/coin/get_all_balances.snap
@@ -1,0 +1,98 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 9 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-65:
+//# publish --sender A
+created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5), object(1,6), object(1,7), object(1,8), object(1,9), object(1,10), object(1,11), object(1,12)
+mutated: object(0,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 31707200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 67:
+//# transfer-object 1,2 --sender A --recipient B
+mutated: object(0,0), object(1,2)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 2310400,  storage_rebate: 2287296, non_refundable_storage_fee: 23104
+
+task 3, line 69:
+//# transfer-object 1,1 --sender A --recipient B
+mutated: object(0,0), object(1,1)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 2310400,  storage_rebate: 2287296, non_refundable_storage_fee: 23104
+
+task 4, line 71:
+//# transfer-object 1,6 --sender A --recipient B
+mutated: object(0,0), object(1,6)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 2310400,  storage_rebate: 2287296, non_refundable_storage_fee: 23104
+
+task 5, lines 73-75:
+//# programmable --sender A --inputs 500 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, line 77:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 7, lines 79-83:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": [
+    {
+      "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+      "coinObjectCount": 2,
+      "totalBalance": "299999962225608",
+      "lockedBalance": {}
+    },
+    {
+      "coinType": "0xa6628f77d4a14f62ba1e2e8b24d99c19ca9948e8925f97367ce6f597f6b3085c::fake::FAKE",
+      "coinObjectCount": 2,
+      "totalBalance": "4100",
+      "lockedBalance": {}
+    },
+    {
+      "coinType": "0xa6628f77d4a14f62ba1e2e8b24d99c19ca9948e8925f97367ce6f597f6b3085c::real::REAL",
+      "coinObjectCount": 3,
+      "totalBalance": "25003742",
+      "lockedBalance": {}
+    }
+  ]
+}
+
+task 8, lines 85-89:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": [
+    {
+      "coinType": "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+      "coinObjectCount": 1,
+      "totalBalance": "300000000000000",
+      "lockedBalance": {}
+    },
+    {
+      "coinType": "0xa6628f77d4a14f62ba1e2e8b24d99c19ca9948e8925f97367ce6f597f6b3085c::fake::FAKE",
+      "coinObjectCount": 2,
+      "totalBalance": "3020",
+      "lockedBalance": {}
+    },
+    {
+      "coinType": "0xa6628f77d4a14f62ba1e2e8b24d99c19ca9948e8925f97367ce6f597f6b3085c::real::REAL",
+      "coinObjectCount": 1,
+      "totalBalance": "1000000",
+      "lockedBalance": {}
+    }
+  ]
+}

--- a/crates/sui-indexer-alt-jsonrpc/src/api/coin.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/coin.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::{BTreeMap, HashMap};
+
 use anyhow::Context as _;
 use futures::future;
 
@@ -17,7 +19,7 @@ use move_core_types::language_storage::TypeTag;
 use serde::{Deserialize, Serialize};
 use sui_indexer_alt_schema::objects::StoredCoinOwnerKind;
 use sui_indexer_alt_schema::schema::coin_balance_buckets;
-use sui_json_rpc_types::{Coin, Page as PageResponse};
+use sui_json_rpc_types::{Balance, Coin, Page as PageResponse};
 use sui_open_rpc::Module;
 use sui_open_rpc_macros::open_rpc;
 use sui_types::{
@@ -42,6 +44,14 @@ trait CoinsApi {
         /// maximum number of items per page
         limit: Option<usize>,
     ) -> RpcResult<PageResponse<Coin, String>>;
+
+    /// Return the total coin balance for all coin type, owned by the address owner.
+    #[method(name = "getAllBalances")]
+    async fn get_all_balances(
+        &self,
+        /// the owner's Sui address
+        owner: SuiAddress,
+    ) -> RpcResult<Vec<Balance>>;
 }
 
 pub(crate) struct Coins(pub Context, pub CoinsConfig);
@@ -102,7 +112,7 @@ impl CoinsApiServer for Coins {
         )?;
 
         // We get all the qualified coin ids first.
-        let coin_id_page = filter_coins(ctx, owner, coin_type_tag, page).await?;
+        let coin_id_page = filter_coins(ctx, owner, Some(coin_type_tag), Some(page)).await?;
 
         let coin_futures = coin_id_page.data.iter().map(|id| coin_response(ctx, *id));
 
@@ -118,6 +128,40 @@ impl CoinsApiServer for Coins {
             next_cursor: coin_id_page.next_cursor,
             has_next_page: coin_id_page.has_next_page,
         })
+    }
+
+    async fn get_all_balances(&self, owner: SuiAddress) -> RpcResult<Vec<Balance>> {
+        let Self(ctx, _) = self;
+        let coin_ids = filter_coins(ctx, owner, None, None).await?;
+        let coin_futures = coin_ids.data.iter().map(|id| coin_response(ctx, *id));
+        let coins = future::join_all(coin_futures)
+            .await
+            .into_iter()
+            .zip(coin_ids.data)
+            .map(|(r, c)| {
+                let id = c;
+                r.with_internal_context(|| format!("Failed to get object {id}"))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Using a BTreeMap so that the ordering of keys is deterministic.
+        let mut balance_map: BTreeMap<String, (usize, u128)> = BTreeMap::new();
+        for coin in coins {
+            let entry = balance_map.entry(coin.coin_type).or_insert((0, 0));
+            entry.0 += 1;
+            entry.1 += coin.balance as u128;
+        }
+        let balances: Vec<Balance> = balance_map
+            .into_iter()
+            .map(|(coin_type, (coin_object_count, total_balance))| Balance {
+                coin_type,
+                coin_object_count,
+                total_balance,
+                // LockedCoin is deprecated
+                locked_balance: HashMap::new(),
+            })
+            .collect();
+        Ok(balances)
     }
 }
 
@@ -143,8 +187,8 @@ impl Default for CoinsConfig {
 async fn filter_coins(
     ctx: &Context,
     owner: SuiAddress,
-    coin_type_tag: TypeTag,
-    page: Page<Cursor>,
+    coin_type_tag: Option<TypeTag>,
+    page: Option<Page<Cursor>>,
 ) -> Result<PageResponse<ObjectID, String>, RpcError<Error>> {
     use coin_balance_buckets::dsl as cb;
 
@@ -153,11 +197,6 @@ async fn filter_coins(
         .connect()
         .await
         .context("Failed to connect to database")?;
-
-    let limit = page.limit;
-
-    let serialized_coin_type =
-        bcs::to_bytes(&coin_type_tag).context("Failed to serialize coin type tag")?;
 
     // We use two aliases of coin_balance_buckets to make the query more readable.
     let (candidates, newer) = diesel::alias!(
@@ -193,11 +232,18 @@ async fn filter_coins(
         .filter(newer!(object_id).is_null())
         .filter(candidates!(owner_kind).eq(StoredCoinOwnerKind::Fastpath))
         .filter(candidates!(owner_id).eq(owner.to_vec()))
-        .filter(candidates!(coin_type).eq(serialized_coin_type))
         .into_boxed();
 
+    if let Some(coin_type_tag) = coin_type_tag {
+        let serialized_coin_type =
+            bcs::to_bytes(&coin_type_tag).context("Failed to serialize coin type tag")?;
+        query = query.filter(candidates!(coin_type).eq(serialized_coin_type));
+    }
+
+    let (cursor, limit) = page.map_or((None, None), |p| (p.cursor, Some(p.limit)));
+
     // If the cursor is specified, we filter by it.
-    if let Some(c) = page.cursor {
+    if let Some(c) = cursor {
         query = query.filter(
             sql::<Bool>(r"(candidates.coin_balance_bucket, candidates.cp_sequence_number, candidates.object_id) < (")
                 .bind::<SmallInt, _>(c.coin_balance_bucket as i16)
@@ -213,16 +259,23 @@ async fn filter_coins(
     query = query
         .order_by(candidates!(coin_balance_bucket).desc())
         .then_order_by(candidates!(cp_sequence_number).desc())
-        .then_order_by(candidates!(object_id).desc())
-        .limit(limit + 1);
+        .then_order_by(candidates!(object_id).desc());
+
+    if let Some(limit) = limit {
+        query = query.limit(limit + 1);
+    }
 
     let mut buckets: Vec<(Vec<u8>, i64, i16)> =
         conn.results(query).await.context("Failed to query coins")?;
 
-    // Now gather pagination info.
-    let has_next_page = buckets.len() > limit as usize;
-    if has_next_page {
-        buckets.truncate(limit as usize);
+    let mut has_next_page = false;
+
+    if let Some(limit) = limit {
+        // Now gather pagination info.
+        has_next_page = buckets.len() > limit as usize;
+        if has_next_page {
+            buckets.truncate(limit as usize);
+        }
     }
 
     let next_cursor = buckets


### PR DESCRIPTION
## Description 

Add initial implementation for `getAllBalances`, reusing most of the infra already built for other APIs. Note that this method does not support pagination and we may have to add optimizations later to improve performance when fetching whale's balances, based on benchmarking results.

## Test plan 

Added e2e tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
