### PR TITLE
Make 1.5s the total-tx estimated default time, not the per-command default

### DIFF
--- a/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
+++ b/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
@@ -1179,8 +1179,8 @@ mod object_cost_tests {
             PerObjectCongestionControlMode::TotalGasBudget => 60,
             PerObjectCongestionControlMode::TotalTxCount => 13,
             PerObjectCongestionControlMode::TotalGasBudgetWithCap => 45, // 3 objects, 7 commands
-            // previous cost 3_000_010 + 7 commands * 1.5M
-            PerObjectCongestionControlMode::ExecutionTimeEstimate => 13_500_010,
+            // previous cost 3_000_010 + (unknown-command default of 1.5M)
+            PerObjectCongestionControlMode::ExecutionTimeEstimate => 4_500_010,
         };
         shared_object_congestion_tracker
             .bump_object_execution_cost(&execution_time_estimator, &cert);

--- a/crates/sui-types/src/execution.rs
+++ b/crates/sui-types/src/execution.rs
@@ -232,20 +232,6 @@ impl ExecutionTimeObservationKey {
             Command::Upgrade(_, _, _, _) => ExecutionTimeObservationKey::Upgrade,
         }
     }
-
-    // Returns the default estimated execution duration for the given key, for use if no
-    // observations are available.
-    pub fn default_duration(&self) -> Duration {
-        match self {
-            ExecutionTimeObservationKey::MoveEntryPoint { .. } => Duration::from_millis(1_500),
-            ExecutionTimeObservationKey::TransferObjects => Duration::from_millis(1),
-            ExecutionTimeObservationKey::SplitCoins => Duration::from_millis(1),
-            ExecutionTimeObservationKey::MergeCoins => Duration::from_millis(1),
-            ExecutionTimeObservationKey::Publish => Duration::from_millis(1),
-            ExecutionTimeObservationKey::MakeMoveVec => Duration::from_millis(1),
-            ExecutionTimeObservationKey::Upgrade => Duration::from_millis(1),
-        }
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
