### PR TITLE
Sending to the subscription handler should not block execution

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2656,7 +2656,6 @@ impl AuthorityState {
             // Emit events
             self.subscription_handler
                 .process_tx(certificate.data().transaction_data(), &effects, &events)
-                .await
                 .tap_ok(|_| {
                     self.metrics
                         .post_processing_total_tx_had_event_processed


### PR DESCRIPTION
Subscriptions are already not 100% reliable, and this allows a slow
subscription handler to block execution indefinitely, which we don't
want.
