### PR TITLE
feat: Make analytics pipeline handle upgraded packages while filtering

### DIFF
--- a/crates/sui-analytics-indexer/src/handlers/object_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/object_handler.rs
@@ -188,9 +188,17 @@ impl ObjectHandler {
         let object_type = move_obj_opt.map(|o| o.type_());
 
         let is_match = if let Some(package_id) = self.package_filter {
+            let original_package_id = state
+                .package_store
+                .get_original_package_id(package_id.into())
+                .await?;
             if let Some(move_object_type) = object_type {
                 let object_package_id: ObjectID = move_object_type.address().into();
-                object_package_id == package_id
+                let object_original_package_id = state
+                    .package_store
+                    .get_original_package_id(object_package_id.into())
+                    .await?;
+                object_original_package_id == original_package_id
             } else {
                 false
             }

--- a/crates/sui-analytics-indexer/src/package_store.rs
+++ b/crates/sui-analytics-indexer/src/package_store.rs
@@ -2,17 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
+use move_core_types::account_address::AccountAddress;
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
-
-use move_core_types::account_address::AccountAddress;
 use sui_package_resolver::{
     error::Error as PackageResolverError, Package, PackageStore, PackageStoreWithLruCache, Result,
 };
 use sui_rpc_api::Client;
 use sui_types::base_types::ObjectID;
-use sui_types::object::Object;
+use sui_types::object::{Data, Object};
 use thiserror::Error;
+use tokio::sync::RwLock;
 use typed_store::rocks::{DBMap, MetricConf};
 use typed_store::traits::TableSummary;
 use typed_store::traits::TypedStoreDebug;
@@ -70,6 +71,7 @@ impl PackageStoreTables {
 pub struct LocalDBPackageStore {
     package_store_tables: Arc<PackageStoreTables>,
     fallback_client: Client,
+    original_id_cache: Arc<RwLock<HashMap<AccountAddress, ObjectID>>>,
 }
 
 impl LocalDBPackageStore {
@@ -77,6 +79,7 @@ impl LocalDBPackageStore {
         Self {
             package_store_tables: PackageStoreTables::new(path),
             fallback_client: Client::new(rest_url).unwrap(),
+            original_id_cache: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -106,6 +109,24 @@ impl LocalDBPackageStore {
             object
         };
         Ok(object)
+    }
+
+    /// Gets the original package id for the given package id.
+    pub async fn get_original_package_id(&self, id: AccountAddress) -> Result<ObjectID> {
+        if let Some(&original_id) = self.original_id_cache.read().await.get(&id) {
+            return Ok(original_id);
+        }
+
+        let object = self.get(id).await?;
+        let Data::Package(package) = &object.data else {
+            return Err(PackageResolverError::PackageNotFound(id));
+        };
+
+        let original_id = package.original_package_id();
+
+        self.original_id_cache.write().await.insert(id, original_id);
+
+        Ok(original_id)
     }
 }
 


### PR DESCRIPTION
## Description 

Today, we have to restart analytics pipelines with updated package id filter arg when walrus packages are upgraded. This PR fixes the problem by filtering on object's original package id. This means we can provide *any* version of walrus package id as the filter arg and pipeline can filter out objects across *all* versions of the package.
