### PR TITLE
fix: Fix pipeline starting checkpoint sequence number

### DIFF
--- a/crates/sui-analytics-indexer/src/lib.rs
+++ b/crates/sui-analytics-indexer/src/lib.rs
@@ -887,17 +887,16 @@ pub async fn get_starting_checkpoint_seq_num(
     config: AnalyticsIndexerConfig,
     file_type: FileType,
 ) -> Result<u64> {
-    let checkpoint = if let Some(starting_checkpoint_seq_num) = config.starting_checkpoint_seq_num {
-        starting_checkpoint_seq_num
-    } else {
-        read_store_for_checkpoint(
-            config.remote_store_config.clone(),
-            file_type,
-            config.remote_store_path_prefix,
-        )
-        .await?
-    };
-    Ok(checkpoint)
+    let remote_latest = read_store_for_checkpoint(
+        config.remote_store_config,
+        file_type,
+        config.remote_store_path_prefix,
+    )
+    .await?;
+
+    Ok(config
+        .starting_checkpoint_seq_num
+        .map_or(remote_latest, |start| start.max(remote_latest)))
 }
 
 pub async fn make_analytics_processor(


### PR DESCRIPTION
## Description 

When a pipeline is provided starting checkpoint sequence number as an arg, we keep going back and start processing from the starting checkpoint upon every restart. This PR fixes that by checking the remote store, and using that if it is ahead.
