### PR TITLE
[exp-to-insta][14/14] Cleanup of insta_assert macro

### DIFF
--- a/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
+++ b/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
@@ -522,9 +522,7 @@ fn move_ide_testsuite(test_path: &Path) -> datatest_stable::Result<()> {
         } => hint_test_suite(project, file_tests),
     }?;
 
-    let test_name = test_path.file_stem().unwrap().to_str().unwrap();
     insta_assert! {
-        name: test_name,
         input_path: test_path,
         contents: output,
     };

--- a/external-crates/move/crates/move-command-line-common/src/testing.rs
+++ b/external-crates/move/crates/move-command-line-common/src/testing.rs
@@ -24,6 +24,7 @@ pub struct InstaOptions {
     info_set: bool,
     suffix_set: bool,
     settings: insta::Settings,
+    test_name: Option<String>,
 }
 
 impl InstaOptions {
@@ -33,6 +34,7 @@ impl InstaOptions {
             info_set: false,
             suffix_set: false,
             settings: insta::Settings::clone_current(),
+            test_name: None,
         }
     }
 
@@ -48,9 +50,19 @@ impl InstaOptions {
         self.suffix_set = true;
     }
 
+    pub fn name<Name: Into<String>>(&mut self, name: Name) {
+        assert!(self.test_name.is_none());
+        self.test_name = Some(name.into());
+    }
+
     #[doc(hidden)]
-    pub fn into_settings(self) -> insta::Settings {
-        self.settings
+    pub fn into_settings(self) -> (Option<String>, insta::Settings) {
+        let Self {
+            test_name,
+            settings,
+            ..
+        } = self;
+        (test_name, settings)
     }
 }
 
@@ -100,26 +112,28 @@ pub use insta;
 /// See https://docs.rs/insta/latest/insta/#updating-snapshots for more information.
 macro_rules! insta_assert {
     {
-        name: $name:expr,
         input_path: $input:expr,
         contents: $contents:expr,
         options: $options:expr
         $(,)?
     } => {{
-        let name: String = $name.into();
         let i: &std::path::Path = $input.as_ref();
         let i = i.canonicalize().unwrap();
         let c = $contents;
-        let mut settings = $options.into_settings();
+        let (name_opt, mut settings) = $options.into_settings();
         settings.set_snapshot_path(i.parent().unwrap());
         settings.set_prepend_module_to_snapshot(false);
         settings.set_omit_expression(true);
+        let name = if let Some(name) = &name_opt {
+          name
+        } else {
+            i.file_stem().unwrap().to_str().unwrap()
+        };
         settings.bind(|| {
             $crate::testing::insta::assert_snapshot!(name, c);
         });
     }};
     {
-        name: $name:expr,
         input_path: $input:expr,
         contents: $contents:expr,
         $($k:ident: $v:expr),*$(,)?
@@ -129,7 +143,6 @@ macro_rules! insta_assert {
             opts.$k($v);
         )*
         insta_assert! {
-            name: $name,
             input_path: $input,
             contents: $contents,
             options: opts

--- a/external-crates/move/crates/move-command-line-common/src/testing.rs
+++ b/external-crates/move/crates/move-command-line-common/src/testing.rs
@@ -86,8 +86,6 @@ pub use insta;
 /// # Arguments
 /// The macro has three required arguments:
 ///
-/// - `name`: The name of the test. This will be used to name the snapshot file. For datatest this
-///           should likely be the file name.
 /// - `input_path`: The path to the input file. This is used to determine the snapshot path.
 /// - `contents`: The contents to snapshot.
 ///
@@ -96,6 +94,8 @@ pub use insta;
 /// the snapshot. If needed the `InstaOptions` struct can be used directly by specifying the
 /// `options` argument. Options include:
 ///
+///  - `name`: The name of the test. This will be used to name the snapshot file. By default, the
+///            file stem (the name without the extension) of the input path is used.
 ///  - `info`: Additional information to include in the header of the snapshot file. This can be
 ///           useful for debugging tests. The value can be any type that implements
 ///           `serde::Serialize`.

--- a/external-crates/move/crates/move-compiler/tests/move_check_testsuite.rs
+++ b/external-crates/move/crates/move-compiler/tests/move_check_testsuite.rs
@@ -248,8 +248,8 @@ pub fn run_test(path: &Path) -> datatest_stable::Result<()> {
     if let Some(suffix) = suffix {
         options.suffix(suffix);
     }
+    options.name(test_name);
     insta_assert! {
-        name: test_name,
         input_path: move_path,
         contents: rendered_diags,
         options: options,

--- a/external-crates/move/crates/move-docgen-tests/tests/testsuite.rs
+++ b/external-crates/move/crates/move-docgen-tests/tests/testsuite.rs
@@ -67,9 +67,9 @@ fn test_impl(toml_path: &Path, flags: DocgenFlags, test_case: &str) -> datatest_
         .try_into()
         .expect("Test infra supports only one output file currently");
     insta_assert! {
-        name: path,
         input_path: toml_path,
         contents: contents,
+        name: path,
         info: &options.flags,
         suffix: test_case,
     };

--- a/external-crates/move/crates/move-model/tests/testsuite.rs
+++ b/external-crates/move/crates/move-model/tests/testsuite.rs
@@ -62,9 +62,7 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
 
         "All good, no errors!".to_string()
     };
-    let test_name = path.file_stem().unwrap().to_str().unwrap();
     insta_assert! {
-        name: test_name,
         input_path: path,
         contents: diags,
     };

--- a/external-crates/move/crates/move-package/tests/test_runner.rs
+++ b/external-crates/move/crates/move-package/tests/test_runner.rs
@@ -31,7 +31,6 @@ pub fn run_test(path: &Path) -> datatest_stable::Result<()> {
 }
 
 struct Test<'a> {
-    test_name: String,
     kind: &'a str,
     toml_path: &'a Path,
     output_dir: TempDir,
@@ -43,9 +42,7 @@ impl Test<'_> {
         kind: &'a str,
     ) -> datatest_stable::Result<Test<'a>> {
         dbg!(&toml_path);
-        let name = toml_path.file_stem().unwrap().to_string_lossy().to_string();
         Ok(Test {
-            test_name: name,
             toml_path,
             kind,
             output_dir: tempdir()?,
@@ -56,7 +53,6 @@ impl Test<'_> {
         package_hooks::register_package_hooks(Box::new(TestHooks()));
         let output = self.output().unwrap_or_else(|err| format!("{:#}\n", err));
         insta_assert! {
-            name: &self.test_name,
             input_path: self.toml_path,
             contents: output,
             suffix: self.kind,

--- a/external-crates/move/crates/move-stackless-bytecode/tests/testsuite.rs
+++ b/external-crates/move/crates/move-stackless-bytecode/tests/testsuite.rs
@@ -191,9 +191,7 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
         }
         text
     };
-    let test_name = path.file_stem().unwrap().to_str().unwrap();
     insta_assert! {
-        name: test_name,
         input_path: path,
         contents: out,
     };

--- a/external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/framework.rs
@@ -806,7 +806,10 @@ where
         handle_known_task(&mut output, &mut adapter, task).await;
     }
 
-    insta_snapshot(path, output);
+    insta_assert! {
+        input_path: path,
+        contents: output,
+    }
     Ok(())
 }
 
@@ -867,14 +870,4 @@ async fn handle_known_task<'a, Adapter: MoveTestAdapter<'a>>(
         "\ntask {task_number}, {line_number}:\n{task_text}\n{result_string}"
     )
     .unwrap();
-}
-
-fn insta_snapshot(test_path: &Path, output: impl AsRef<str>) {
-    let test_name = test_path.file_stem().unwrap().to_string_lossy();
-    let contents = output.as_ref();
-    insta_assert! {
-        name: test_name,
-        input_path: test_path,
-        contents: contents,
-    }
 }

--- a/external-crates/move/crates/move-unit-test/tests/move_unit_test_testsuite.rs
+++ b/external-crates/move/crates/move-unit-test/tests/move_unit_test_testsuite.rs
@@ -39,9 +39,7 @@ fn run_test_impl(path: &Path) -> anyhow::Result<()> {
     let base_output = String::from_utf8(buffer)?;
     let cleaned_output = regex.replacen(&base_output, 0, r"$1$2");
 
-    let test_name = path.file_stem().unwrap().to_str().unwrap();
     insta_assert! {
-        name: test_name,
         input_path: path,
         contents: cleaned_output,
     };


### PR DESCRIPTION
## Description 

- Stacked on #21113 
- The name field was the same in all but two cases, as such I made it optional

## Test plan 

- ran the tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
