### PR TITLE
[Consensus] Optimistically accept certified commits votes.

### DIFF
--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -424,6 +424,17 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 certifier_block_refs = votes;
                 break 'commit;
             } else {
+                debug!(
+                    "Commit {} votes did not reach quorum to certify, {} < {}, skipping",
+                    index,
+                    stake_aggregator.stake(),
+                    stake_aggregator.threshold(&self.context.committee)
+                );
+                self.context
+                    .metrics
+                    .node_metrics
+                    .fetch_commits_skip_uncertified
+                    .inc();
                 commits.pop();
             }
         }

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -433,7 +433,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 self.context
                     .metrics
                     .node_metrics
-                    .fetch_commits_skip_uncertified
+                    .commit_sync_fetch_commits_handler_uncertified_skipped
                     .inc();
                 commits.pop();
             }
@@ -697,7 +697,7 @@ mod tests {
     use crate::{
         authority_service::AuthorityService,
         block::{BlockAPI, BlockRef, SignedBlock, TestBlock, VerifiedBlock},
-        commit::{CertifiedCommit, CommitRange},
+        commit::{CertifiedCommits, CommitRange},
         commit_vote_monitor::CommitVoteMonitor,
         context::Context,
         core_thread::{CoreError, CoreThreadDispatcher},
@@ -756,7 +756,7 @@ mod tests {
 
         async fn add_certified_commits(
             &self,
-            _commits: Vec<CertifiedCommit>,
+            _commits: CertifiedCommits,
         ) -> Result<BTreeSet<BlockRef>, CoreError> {
             todo!()
         }

--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -207,6 +207,8 @@ impl Deref for TrustedCommit {
     }
 }
 
+/// `CertifiedCommits` keeps the synchronized certified commits along with the corresponding votes received from the peer that provided these commits.
+/// The `votes` contain the blocks as those provided by the peer, and certify the tip of the synced commits.
 #[derive(Clone, Debug)]
 pub(crate) struct CertifiedCommits {
     commits: Vec<CertifiedCommit>,
@@ -227,9 +229,7 @@ impl CertifiedCommits {
     }
 }
 
-/// A commit that has been synced and certified by a quorum of authorities. It has to be noted that it is expected
-/// in the majority of the cases the `votes` vector to be empty as during the sync commit process we expect to certify
-/// the tip of the fetched commits from an authority which inherently certifies the previous commits.
+/// A commit that has been synced and certified by a quorum of authorities.
 #[derive(Clone, Debug)]
 pub(crate) struct CertifiedCommit {
     commit: Arc<TrustedCommit>,

--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -207,6 +207,26 @@ impl Deref for TrustedCommit {
     }
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct CertifiedCommits {
+    commits: Vec<CertifiedCommit>,
+    votes: Vec<VerifiedBlock>,
+}
+
+impl CertifiedCommits {
+    pub(crate) fn new(commits: Vec<CertifiedCommit>, votes: Vec<VerifiedBlock>) -> Self {
+        Self { commits, votes }
+    }
+
+    pub(crate) fn commits(&self) -> &[CertifiedCommit] {
+        &self.commits
+    }
+
+    pub(crate) fn votes(&self) -> &[VerifiedBlock] {
+        &self.votes
+    }
+}
+
 /// A commit that has been synced and certified by a quorum of authorities. It has to be noted that it is expected
 /// in the majority of the cases the `votes` vector to be empty as during the sync commit process we expect to certify
 /// the tip of the fetched commits from an authority which inherently certifies the previous commits.
@@ -214,30 +234,18 @@ impl Deref for TrustedCommit {
 pub(crate) struct CertifiedCommit {
     commit: Arc<TrustedCommit>,
     blocks: Vec<VerifiedBlock>,
-    #[allow(unused)]
-    votes: Vec<VerifiedBlock>,
 }
 
 impl CertifiedCommit {
-    pub(crate) fn new_certified(
-        commit: TrustedCommit,
-        blocks: Vec<VerifiedBlock>,
-        votes: Vec<VerifiedBlock>,
-    ) -> Self {
+    pub(crate) fn new_certified(commit: TrustedCommit, blocks: Vec<VerifiedBlock>) -> Self {
         Self {
             commit: Arc::new(commit),
             blocks,
-            votes,
         }
     }
 
     pub fn blocks(&self) -> &[VerifiedBlock] {
         &self.blocks
-    }
-
-    #[allow(unused)]
-    pub fn votes(&self) -> &[VerifiedBlock] {
-        &self.votes
     }
 }
 

--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -207,22 +207,37 @@ impl Deref for TrustedCommit {
     }
 }
 
+/// A commit that has been synced and certified by a quorum of authorities. It has to be noted that it is expected
+/// in the majority of the cases the `votes` vector to be empty as during the sync commit process we expect to certify
+/// the tip of the fetched commits from an authority which inherently certifies the previous commits.
 #[derive(Clone, Debug)]
 pub(crate) struct CertifiedCommit {
     commit: Arc<TrustedCommit>,
     blocks: Vec<VerifiedBlock>,
+    #[allow(unused)]
+    votes: Vec<VerifiedBlock>,
 }
 
 impl CertifiedCommit {
-    pub(crate) fn new_certified(commit: TrustedCommit, blocks: Vec<VerifiedBlock>) -> Self {
+    pub(crate) fn new_certified(
+        commit: TrustedCommit,
+        blocks: Vec<VerifiedBlock>,
+        votes: Vec<VerifiedBlock>,
+    ) -> Self {
         Self {
             commit: Arc::new(commit),
             blocks,
+            votes,
         }
     }
 
     pub fn blocks(&self) -> &[VerifiedBlock] {
         &self.blocks
+    }
+
+    #[allow(unused)]
+    pub fn votes(&self) -> &[VerifiedBlock] {
+        &self.votes
     }
 }
 

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -89,11 +89,11 @@ pub(crate) struct CommitSyncer<C: NetworkClient> {
     // States only used by the scheduler.
 
     // Inflight requests to fetch commits from different authorities.
-    inflight_fetches: JoinSet<(u32, Vec<TrustedCommit>, Vec<VerifiedBlock>)>,
+    inflight_fetches: JoinSet<(u32, Vec<CertifiedCommit>)>,
     // Additional ranges of commits to fetch.
     pending_fetches: BTreeSet<CommitRange>,
     // Fetched commits and blocks by commit range.
-    fetched_ranges: BTreeMap<CommitRange, (Vec<TrustedCommit>, Vec<VerifiedBlock>)>,
+    fetched_ranges: BTreeMap<CommitRange, Vec<CertifiedCommit>>,
     // Highest commit index among inflight and pending fetches.
     // Used to determine the start of new ranges to be fetched.
     highest_scheduled_index: Option<CommitIndex>,
@@ -166,8 +166,8 @@ impl<C: NetworkClient> CommitSyncer<C> {
                         self.inflight_fetches.shutdown().await;
                         return;
                     }
-                    let (target_end, commits, blocks) = result.unwrap();
-                    self.handle_fetch_result(target_end, commits, blocks).await;
+                    let (target_end, commits) = result.unwrap();
+                    self.handle_fetch_result(target_end, commits).await;
                 }
                 _ = &mut rx_shutdown => {
                     // Shutdown requested.
@@ -235,23 +235,32 @@ impl<C: NetworkClient> CommitSyncer<C> {
     async fn handle_fetch_result(
         &mut self,
         target_end: CommitIndex,
-        commits: Vec<TrustedCommit>,
-        blocks: Vec<VerifiedBlock>,
+        commits: Vec<CertifiedCommit>,
     ) {
         assert!(!commits.is_empty());
+
+        let (total_blocks_fetched, total_blocks_size_bytes) =
+            commits.iter().fold((0, 0), |(blocks, bytes), c| {
+                (
+                    blocks + c.blocks().len(),
+                    bytes
+                        + c.blocks()
+                            .iter()
+                            .map(|b| b.serialized().len())
+                            .sum::<usize>() as u64,
+                )
+            });
+
         let metrics = &self.inner.context.metrics.node_metrics;
         metrics
             .commit_sync_fetched_commits
             .inc_by(commits.len() as u64);
         metrics
             .commit_sync_fetched_blocks
-            .inc_by(blocks.len() as u64);
-        metrics.commit_sync_total_fetched_blocks_size.inc_by(
-            blocks
-                .iter()
-                .map(|b| b.serialized().len() as u64)
-                .sum::<u64>(),
-        );
+            .inc_by(total_blocks_fetched as u64);
+        metrics
+            .commit_sync_total_fetched_blocks_size
+            .inc_by(total_blocks_size_bytes);
 
         let (commit_start, commit_end) = (
             commits.first().unwrap().index(),
@@ -274,15 +283,13 @@ impl<C: NetworkClient> CommitSyncer<C> {
         // Only add new blocks if at least some of them are not already synced.
         if self.synced_commit_index < commit_end {
             self.fetched_ranges
-                .insert((commit_start..=commit_end).into(), (commits, blocks));
+                .insert((commit_start..=commit_end).into(), commits);
         }
         // Try to process as many fetched blocks as possible.
-        while let Some((fetched_commit_range, (_commits, _blocks))) =
-            self.fetched_ranges.first_key_value()
-        {
+        while let Some((fetched_commit_range, _commits)) = self.fetched_ranges.first_key_value() {
             // Only pop fetched_ranges if there is no gap with blocks already synced.
             // Note: start, end and synced_commit_index are all inclusive.
-            let (fetched_commit_range, (commits, blocks)) =
+            let (fetched_commit_range, commits) =
                 if fetched_commit_range.start() <= self.synced_commit_index + 1 {
                     self.fetched_ranges.pop_first().unwrap()
                 } else {
@@ -299,28 +306,12 @@ impl<C: NetworkClient> CommitSyncer<C> {
             debug!(
                 "Fetched certified blocks for commit range {:?}: {}",
                 fetched_commit_range,
-                blocks.iter().map(|b| b.reference().to_string()).join(","),
+                commits
+                    .iter()
+                    .flat_map(|c| c.blocks())
+                    .map(|b| b.reference().to_string())
+                    .join(","),
             );
-
-            let mut blocks_map = BTreeMap::new();
-            for block in blocks {
-                blocks_map.insert(block.reference(), block);
-            }
-
-            let certified_commits = commits
-                .into_iter()
-                .map(|commit| {
-                    let blocks = commit
-                        .blocks()
-                        .iter()
-                        .map(|block_ref| {
-                            // It's impossible for two different commits to sequence the same block so that operation should be safe.
-                            blocks_map.remove(block_ref).expect("Block should exist")
-                        })
-                        .collect::<Vec<_>>();
-                    CertifiedCommit::new_certified(commit, blocks)
-                })
-                .collect();
 
             // If core thread cannot handle the incoming blocks, it is ok to block here.
             // Also it is possible to have missing ancestors because an equivocating validator
@@ -329,7 +320,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
             match self
                 .inner
                 .core_thread_dispatcher
-                .add_certified_commits(certified_commits)
+                .add_certified_commits(commits)
                 .await
             {
                 Ok(missing) => {
@@ -421,7 +412,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
     async fn fetch_loop(
         inner: Arc<Inner<C>>,
         commit_range: CommitRange,
-    ) -> (CommitIndex, Vec<TrustedCommit>, Vec<VerifiedBlock>) {
+    ) -> (CommitIndex, Vec<CertifiedCommit>) {
         // Individual request base timeout.
         const TIMEOUT: Duration = Duration::from_secs(10);
         // Max per-request timeout will be base timeout times a multiplier.
@@ -476,9 +467,9 @@ impl<C: NetworkClient> CommitSyncer<C> {
                 )
                 .await
                 {
-                    Ok(Ok((commits, blocks))) => {
+                    Ok(Ok(commits)) => {
                         info!("Finished fetching commits in {commit_range:?}",);
-                        return (commit_range.end(), commits, blocks);
+                        return (commit_range.end(), commits);
                     }
                     Ok(Err(e)) => {
                         let hostname = inner
@@ -527,7 +518,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
         target_authority: AuthorityIndex,
         commit_range: CommitRange,
         timeout: Duration,
-    ) -> ConsensusResult<(Vec<TrustedCommit>, Vec<VerifiedBlock>)> {
+    ) -> ConsensusResult<Vec<CertifiedCommit>> {
         let _timer = inner
             .context
             .metrics
@@ -544,7 +535,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
         // 2. Verify the response contains blocks that can certify the last returned commit,
         // and the returned commits are chained by digest, so earlier commits are certified
         // as well.
-        let commits = Handle::current()
+        let (commits, votes) = Handle::current()
             .spawn_blocking({
                 let inner = inner.clone();
                 move || {
@@ -628,13 +619,15 @@ impl<C: NetworkClient> CommitSyncer<C> {
             })
             .collect();
 
-        let mut fetched_blocks = Vec::new();
+        let mut fetched_blocks = BTreeMap::new();
         while let Some(result) = requests.next().await {
-            fetched_blocks.extend(result?);
+            for block in result? {
+                fetched_blocks.insert(block.reference(), block);
+            }
         }
 
-        // 8. Make sure fetched block timestamps are lower than current time.
-        for block in &fetched_blocks {
+        // 8. Make sure fetched block (and votes) timestamps are lower than current time.
+        for block in fetched_blocks.values().chain(votes.iter()) {
             let now_ms = inner.context.clock.timestamp_utc_ms();
             let forward_drift = block.timestamp_ms().saturating_sub(now_ms);
             if forward_drift == 0 {
@@ -659,7 +652,31 @@ impl<C: NetworkClient> CommitSyncer<C> {
             sleep(forward_drift).await;
         }
 
-        Ok((commits, fetched_blocks))
+        // 9. Now create the Certified commits by assingning the blocks to each commit. The last commit will also bear the votes with it.
+        let mut certified_commits = Vec::new();
+        for (i, commit) in commits.iter().enumerate() {
+            let blocks = commit
+                .blocks()
+                .iter()
+                .map(|block_ref| {
+                    fetched_blocks
+                        .remove(block_ref)
+                        .expect("Block should exist")
+                })
+                .collect::<Vec<_>>();
+            let votes = if i == commits.len() - 1 {
+                votes.clone()
+            } else {
+                vec![]
+            };
+            certified_commits.push(CertifiedCommit::new_certified(
+                commit.clone(),
+                blocks,
+                votes,
+            ));
+        }
+
+        Ok(certified_commits)
     }
 
     fn unhandled_commits_threshold(&self) -> CommitIndex {
@@ -673,7 +690,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
     }
 
     #[cfg(test)]
-    fn fetched_ranges(&self) -> BTreeMap<CommitRange, (Vec<TrustedCommit>, Vec<VerifiedBlock>)> {
+    fn fetched_ranges(&self) -> BTreeMap<CommitRange, Vec<CertifiedCommit>> {
         self.fetched_ranges.clone()
     }
 
@@ -704,13 +721,15 @@ struct Inner<C: NetworkClient> {
 }
 
 impl<C: NetworkClient> Inner<C> {
+    /// Verifies the commits and also certifies them using the provided vote blocks for the last commit. The
+    /// method returns the verified commits and the votes as verified blocks.
     fn verify_commits(
         &self,
         peer: AuthorityIndex,
         commit_range: CommitRange,
         serialized_commits: Vec<Bytes>,
         serialized_blocks: Vec<Bytes>,
-    ) -> ConsensusResult<Vec<TrustedCommit>> {
+    ) -> ConsensusResult<(Vec<TrustedCommit>, Vec<VerifiedBlock>)> {
         // Parse and verify commits.
         let mut commits = Vec::new();
         for serialized in &serialized_commits {
@@ -753,6 +772,7 @@ impl<C: NetworkClient> Inner<C> {
         // Parse and verify blocks. Then accumulate votes on the end commit.
         let end_commit_ref = CommitRef::new(end_commit.index(), *end_commit_digest);
         let mut stake_aggregator = StakeAggregator::<QuorumThreshold>::new();
+        let mut votes = Vec::new();
         for serialized in serialized_blocks {
             let block: SignedBlock =
                 bcs::from_bytes(&serialized).map_err(ConsensusError::MalformedBlock)?;
@@ -764,6 +784,7 @@ impl<C: NetworkClient> Inner<C> {
                     stake_aggregator.add(block.author(), &self.context.committee);
                 }
             }
+            votes.push(VerifiedBlock::new_verified(block, serialized));
         }
 
         // Check if the end commit has enough votes.
@@ -775,11 +796,12 @@ impl<C: NetworkClient> Inner<C> {
             });
         }
 
-        Ok(commits
+        let trusted_commits = commits
             .into_iter()
             .zip(serialized_commits)
             .map(|((_d, c), s)| TrustedCommit::new_trusted(c, s))
-            .collect())
+            .collect();
+        Ok((trusted_commits, votes))
     }
 }
 

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -655,7 +655,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
             sleep(forward_drift).await;
         }
 
-        // 9. Now create the Certified commits by assigning the blocks to each commit. The last commit will also bear the votes with it.
+        // 9. Now create the Certified commits by assigning the blocks to each commit and retaining the commit votes history.
         let mut certified_commits = Vec::new();
         for commit in &commits {
             let blocks = commit
@@ -716,7 +716,7 @@ struct Inner<C: NetworkClient> {
 
 impl<C: NetworkClient> Inner<C> {
     /// Verifies the commits and also certifies them using the provided vote blocks for the last commit. The
-    /// method returns the verified commits and the votes as verified blocks.
+    /// method returns the trusted commits and the votes as verified blocks.
     fn verify_commits(
         &self,
         peer: AuthorityIndex,

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -321,6 +321,11 @@ impl Core {
             let commits = self
                 .validate_certified_commits(commits)
                 .expect("Certified commits validation failed");
+            
+            // Accept the certified commit votes. This is optimistically done to increase the chances of having votes available when this node
+            // will need to sync commits to other nodes.
+            self.block_manager
+                .try_accept_blocks(commits.iter().flat_map(|c| c.blocks()).cloned().collect());
 
             // Try to commit the new blocks. Take into account the trusted commit that has been provided.
             self.try_commit(commits)?;

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -22,7 +22,7 @@ use tracing::warn;
 
 use crate::{
     block::{BlockRef, Round, VerifiedBlock},
-    commit::CertifiedCommit,
+    commit::CertifiedCommits,
     context::Context,
     core::Core,
     core_thread::CoreError::Shutdown,
@@ -40,7 +40,7 @@ enum CoreThreadCommand {
     /// Checks if block refs exist locally and sync missing ones.
     CheckBlockRefs(Vec<BlockRef>, oneshot::Sender<BTreeSet<BlockRef>>),
     /// Add committed sub dag blocks for processing and acceptance.
-    AddCertifiedCommits(Vec<CertifiedCommit>, oneshot::Sender<BTreeSet<BlockRef>>),
+    AddCertifiedCommits(CertifiedCommits, oneshot::Sender<BTreeSet<BlockRef>>),
     /// Called when the min round has passed or the leader timeout occurred and a block should be produced.
     /// When the command is called with `force = true`, then the block will be created for `round` skipping
     /// any checks (ex leader existence of previous round). More information can be found on the `Core` component.
@@ -69,7 +69,7 @@ pub trait CoreThreadDispatcher: Sync + Send + 'static {
 
     async fn add_certified_commits(
         &self,
-        commits: Vec<CertifiedCommit>,
+        commits: CertifiedCommits,
     ) -> Result<BTreeSet<BlockRef>, CoreError>;
 
     async fn new_block(&self, round: Round, force: bool) -> Result<(), CoreError>;
@@ -325,9 +325,9 @@ impl CoreThreadDispatcher for ChannelCoreThreadDispatcher {
 
     async fn add_certified_commits(
         &self,
-        commits: Vec<CertifiedCommit>,
+        commits: CertifiedCommits,
     ) -> Result<BTreeSet<BlockRef>, CoreError> {
-        for commit in &commits {
+        for commit in commits.commits() {
             for block in commit.blocks() {
                 self.highest_received_rounds[block.author()]
                     .fetch_max(block.round(), Ordering::AcqRel);
@@ -446,7 +446,7 @@ impl CoreThreadDispatcher for MockCoreThreadDispatcher {
 
     async fn add_certified_commits(
         &self,
-        _commits: Vec<CertifiedCommit>,
+        _commits: CertifiedCommits,
     ) -> Result<BTreeSet<BlockRef>, CoreError> {
         todo!()
     }

--- a/consensus/core/src/leader_timeout.rs
+++ b/consensus/core/src/leader_timeout.rs
@@ -129,7 +129,7 @@ mod tests {
     use tokio::time::{sleep, Instant};
 
     use crate::block::{BlockRef, Round, VerifiedBlock};
-    use crate::commit::CertifiedCommit;
+    use crate::commit::CertifiedCommits;
     use crate::context::Context;
     use crate::core::CoreSignals;
     use crate::core_thread::{CoreError, CoreThreadDispatcher};
@@ -167,7 +167,7 @@ mod tests {
 
         async fn add_certified_commits(
             &self,
-            _commit: Vec<CertifiedCommit>,
+            _commits: CertifiedCommits,
         ) -> Result<BTreeSet<BlockRef>, CoreError> {
             todo!()
         }

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -125,6 +125,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) dag_state_store_write_count: IntCounter,
     pub(crate) fetch_blocks_scheduler_inflight: IntGauge,
     pub(crate) fetch_blocks_scheduler_skipped: IntCounterVec,
+    pub(crate) fetch_commits_skip_uncertified: IntCounter,
     pub(crate) synchronizer_fetched_blocks_by_peer: IntCounterVec,
     pub(crate) synchronizer_missing_blocks_by_authority: IntCounterVec,
     pub(crate) synchronizer_current_missing_blocks_by_authority: IntGaugeVec,
@@ -704,7 +705,12 @@ impl NodeMetrics {
                 "commit_sync_fetch_missing_blocks",
                 "Number of ancestor blocks that are missing when processing blocks via commit sync.",
                 &["authority"],
-                registry
+                registry,
+            ).unwrap(),
+            fetch_commits_skip_uncertified: register_int_counter_with_registry!(
+                "fetch_commits_skip_uncertified",
+                "Number of uncertified commits that got skipped to return when fetching commits",
+                registry,
             ).unwrap(),
             round_prober_received_quorum_round_gaps: register_int_gauge_vec_with_registry!(
                 "round_prober_received_quorum_round_gaps",

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -125,7 +125,6 @@ pub(crate) struct NodeMetrics {
     pub(crate) dag_state_store_write_count: IntCounter,
     pub(crate) fetch_blocks_scheduler_inflight: IntGauge,
     pub(crate) fetch_blocks_scheduler_skipped: IntCounterVec,
-    pub(crate) fetch_commits_skip_uncertified: IntCounter,
     pub(crate) synchronizer_fetched_blocks_by_peer: IntCounterVec,
     pub(crate) synchronizer_missing_blocks_by_authority: IntCounterVec,
     pub(crate) synchronizer_current_missing_blocks_by_authority: IntGaugeVec,
@@ -175,6 +174,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) subscribed_by: IntGaugeVec,
     pub(crate) commit_sync_inflight_fetches: IntGauge,
     pub(crate) commit_sync_pending_fetches: IntGauge,
+    pub(crate) commit_sync_fetch_commits_handler_uncertified_skipped: IntCounter,
     pub(crate) commit_sync_fetched_commits: IntCounter,
     pub(crate) commit_sync_fetched_blocks: IntCounter,
     pub(crate) commit_sync_total_fetched_blocks_size: IntCounter,
@@ -707,9 +707,9 @@ impl NodeMetrics {
                 &["authority"],
                 registry,
             ).unwrap(),
-            fetch_commits_skip_uncertified: register_int_counter_with_registry!(
-                "fetch_commits_skip_uncertified",
-                "Number of uncertified commits that got skipped to return when fetching commits",
+            commit_sync_fetch_commits_handler_uncertified_skipped: register_int_counter_with_registry!(
+                "commit_sync_fetch_commits_handler_uncertified_skipped",
+                "Number of uncertified commits that got skipped when fetching commits due to lack of votes",
                 registry,
             ).unwrap(),
             round_prober_received_quorum_round_gaps: register_int_gauge_vec_with_registry!(

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -110,6 +110,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) block_proposal_leader_wait_count: IntCounterVec,
     pub(crate) block_timestamp_drift_wait_ms: IntCounterVec,
     pub(crate) blocks_per_commit_count: Histogram,
+    pub(crate) blocks_pruned_on_commit: IntCounterVec,
     pub(crate) broadcaster_rtt_estimate_ms: IntGaugeVec,
     pub(crate) core_add_blocks_batch_size: Histogram,
     pub(crate) core_check_block_refs_batch_size: Histogram,
@@ -279,6 +280,12 @@ impl NodeMetrics {
                 "blocks_per_commit_count",
                 "The number of blocks per commit.",
                 NUM_BUCKETS.to_vec(),
+                registry,
+            ).unwrap(),
+            blocks_pruned_on_commit: register_int_counter_vec_with_registry!(
+                "blocks_pruned_on_commit",
+                "Number of blocks that got pruned due to garbage collection during a commit. This is not an accurate metric and measures the pruned blocks on the edge of the commit.",
+                &["authority"],
                 registry,
             ).unwrap(),
             broadcaster_rtt_estimate_ms: register_int_gauge_vec_with_registry!(

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -285,7 +285,7 @@ impl NodeMetrics {
             blocks_pruned_on_commit: register_int_counter_vec_with_registry!(
                 "blocks_pruned_on_commit",
                 "Number of blocks that got pruned due to garbage collection during a commit. This is not an accurate metric and measures the pruned blocks on the edge of the commit.",
-                &["authority"],
+                &["authority", "commit_status"],
                 registry,
             ).unwrap(),
             broadcaster_rtt_estimate_ms: register_int_gauge_vec_with_registry!(

--- a/consensus/core/src/round_prober.rs
+++ b/consensus/core/src/round_prober.rs
@@ -361,7 +361,7 @@ mod test {
     use super::QuorumRound;
     use crate::{
         block::BlockRef,
-        commit::{CertifiedCommit, CommitRange},
+        commit::{CertifiedCommits, CommitRange},
         context::Context,
         core_thread::{CoreError, CoreThreadDispatcher},
         dag_state::DagState,
@@ -420,7 +420,7 @@ mod test {
 
         async fn add_certified_commits(
             &self,
-            _commit: Vec<CertifiedCommit>,
+            _commits: CertifiedCommits,
         ) -> Result<BTreeSet<BlockRef>, CoreError> {
             unimplemented!()
         }

--- a/consensus/core/src/stake_aggregator.rs
+++ b/consensus/core/src/stake_aggregator.rs
@@ -7,6 +7,7 @@ use consensus_config::{AuthorityIndex, Committee, Stake};
 
 pub(crate) trait CommitteeThreshold {
     fn is_threshold(committee: &Committee, amount: Stake) -> bool;
+    fn threshold(committee: &Committee) -> Stake;
 }
 
 pub(crate) struct QuorumThreshold;
@@ -18,11 +19,17 @@ impl CommitteeThreshold for QuorumThreshold {
     fn is_threshold(committee: &Committee, amount: Stake) -> bool {
         committee.reached_quorum(amount)
     }
+    fn threshold(committee: &Committee) -> Stake {
+        committee.quorum_threshold()
+    }
 }
 
 impl CommitteeThreshold for ValidityThreshold {
     fn is_threshold(committee: &Committee, amount: Stake) -> bool {
         committee.reached_validity(amount)
+    }
+    fn threshold(committee: &Committee) -> Stake {
+        committee.validity_threshold()
     }
 }
 
@@ -57,6 +64,10 @@ impl<T: CommitteeThreshold> StakeAggregator<T> {
 
     pub(crate) fn reached_threshold(&self, committee: &Committee) -> bool {
         T::is_threshold(committee, self.stake)
+    }
+
+    pub(crate) fn threshold(&self, committee: &Committee) -> Stake {
+        T::threshold(committee)
     }
 
     pub(crate) fn clear(&mut self) {

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -274,7 +274,7 @@ impl DagBuilder {
             .into_iter()
             .map(|(sub_dag, commit)| {
                 let certified_commit =
-                    CertifiedCommit::new_certified(commit, sub_dag.blocks.clone(), vec![]);
+                    CertifiedCommit::new_certified(commit, sub_dag.blocks.clone());
                 (sub_dag, certified_commit)
             })
             .collect()

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -274,7 +274,7 @@ impl DagBuilder {
             .into_iter()
             .map(|(sub_dag, commit)| {
                 let certified_commit =
-                    CertifiedCommit::new_certified(commit, sub_dag.blocks.clone());
+                    CertifiedCommit::new_certified(commit, sub_dag.blocks.clone(), vec![]);
                 (sub_dag, certified_commit)
             })
             .collect()


### PR DESCRIPTION
## Description 

The PR is utilising further the `CertifiedCommit` struct to piggy back the votes that certify a commit. It is also extending the `CommitSyncer` so it does utilise now internally the `CertifiedCommit` and better manage the fetched blocks etc. The received votes are attempted to be optimistically accepted via the normal path of the block manager. Pay attention that in order to avoid kicking off the scheduled synchronizer due to missing dependencies, the earlier mechanism that was introduced which would allow missing ancestors to be fetched up to above a certain threshold from the highest accepted round, will now need to get disabled. This was added due to this https://github.com/MystenLabs/sui/pull/19763 . But now that we commit the certified commits directly, this won't be an issue.

## Test plan 

CI/PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
