### PR TITLE
rpc-alt: getOwnedObjects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14178,6 +14178,7 @@ dependencies = [
  "pin-project-lite",
  "prometheus",
  "reqwest 0.12.9",
+ "schemars",
  "serde",
  "serde_json",
  "sui-default-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14181,6 +14181,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serde_with 3.9.0",
  "sui-default-config",
  "sui-indexer-alt-metrics",
  "sui-indexer-alt-schema",

--- a/crates/sui-core/src/unit_tests/auth_unit_test_utils.rs
+++ b/crates/sui-core/src/unit_tests/auth_unit_test_utils.rs
@@ -130,7 +130,7 @@ pub async fn upgrade_package_on_single_authority(
         gas_payment,
         package_id,
         modules,
-        package.published_dependency_ids(),
+        package.get_dependency_storage_package_ids(),
         (upgrade_cap, Owner::AddressOwner(sender)),
         UpgradePolicy::COMPATIBLE,
         digest,

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_module.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_module.move
@@ -1,0 +1,108 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --addresses P=0x0 --simulator
+
+// 1. All the objects of a certain module, for a particular owner
+// 2. All the objects of another module, for that same owner
+// 3. ...limited
+// 4. ...limited, with a cursor
+
+//# publish
+module P::M {
+  public struct O1 has key, store {
+    id: UID,
+  }
+
+  public struct O2 has key, store {
+    id: UID,
+  }
+
+  public fun o1(ctx: &mut TxContext): O1 {
+    O1 { id: object::new(ctx) }
+  }
+
+  public fun o2(ctx: &mut TxContext): O2 {
+    O2 { id: object::new(ctx) }
+  }
+}
+
+module P::N {
+  public struct O1 has key, store {
+    id: UID,
+  }
+
+  public fun o1(ctx: &mut TxContext): O1 {
+    O1 { id: object::new(ctx) }
+  }
+}
+
+//# programmable --sender B --inputs @B
+//> 0: P::M::o1();
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# programmable --sender A --inputs @A
+//> 0: P::M::o1();
+//> 1: P::M::o2();
+//> 2: P::N::o1();
+//> 3: TransferObjects([Result(0), Result(1), Result(2)], Input(0))
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs @A
+//> 0: P::M::o1();
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "suix_getOwnedObjects",
+  "params": [
+    "@{A}",
+    {
+      "filter": { "MoveModule": ["@{P}", "M"] },
+      "options": { "showType": true }
+    }
+  ]
+}
+
+//# run-jsonrpc
+{
+  "method": "suix_getOwnedObjects",
+  "params": [
+    "@{A}",
+    {
+      "filter": { "MoveModule": ["@{P}", "N"] },
+      "options": { "showType": true }
+    }
+  ]
+}
+
+//# run-jsonrpc
+{
+  "method": "suix_getOwnedObjects",
+  "params": [
+    "@{A}",
+    {
+      "filter": { "MoveModule": ["@{P}", "M"] },
+      "options": { "showType": true }
+    },
+    null,
+    1
+  ]
+}
+
+//# run-jsonrpc --cursors @{obj_5_0,2}
+{
+  "method": "suix_getOwnedObjects",
+  "params": [
+    "@{A}",
+    {
+      "filter": { "MoveModule": ["@{P}", "M"] },
+      "options": { "showType": true }
+    },
+    "@{cursor_0}",
+    1
+  ]
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_module.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_module.snap
@@ -1,0 +1,147 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 11 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 11-38:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 6961600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 40-42:
+//# programmable --sender B --inputs @B
+//> 0: P::M::o1();
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(2,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 2204000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 44-48:
+//# programmable --sender A --inputs @A
+//> 0: P::M::o1();
+//> 1: P::M::o2();
+//> 2: P::N::o1();
+//> 3: TransferObjects([Result(0), Result(1), Result(2)], Input(0))
+created: object(3,0), object(3,1), object(3,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 4636000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 4, line 50:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, lines 52-54:
+//# programmable --sender A --inputs @A
+//> 0: P::M::o1();
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2204000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, line 56:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 7, lines 58-68:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": {
+    "data": [
+      {
+        "data": {
+          "objectId": "0x33606f6df49726da6eb459b42a99e5e9035f775d5fc67f4878ecebf7acd952a7",
+          "version": "3",
+          "digest": "HkMtbLn6X37sNutQWr87BCTnkkWzGjr4CkxMYAKRq6X5",
+          "type": "0xe1c6660ef31048dad1e41047f6fb9b7ed23973bfd4d5c2381c328eaf059b137d::M::O1"
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x7d1dd38797c8b44409ce173982e23be378dd849b77265513b89409b1ebb58f8a",
+          "version": "2",
+          "digest": "CvF9yM9tXXtYcLBdwBqBNXHGN9wtTHPogfsp2SqnzwJH",
+          "type": "0xe1c6660ef31048dad1e41047f6fb9b7ed23973bfd4d5c2381c328eaf059b137d::M::O2"
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x641bb5c9fe8c5c55141dc24b63197f610be62cbdf5de690d299ac04621cee5c6",
+          "version": "2",
+          "digest": "HXsWXDM5xFmP9HfPnyzXA7EinHANUwvAJZz8hwkyPR1A",
+          "type": "0xe1c6660ef31048dad1e41047f6fb9b7ed23973bfd4d5c2381c328eaf059b137d::M::O1"
+        }
+      }
+    ],
+    "nextCursor": "IGQbtcn+jFxVFB3CS2MZf2EL5iy99d5pDSmawEYhzuXGAQAAAAAAAAA=",
+    "hasNextPage": false
+  }
+}
+
+task 8, lines 70-80:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "data": [
+      {
+        "data": {
+          "objectId": "0xbd6943dd9a32bed6693ec36ae6526c4f195738bcb3c08484b035731b1dfc7fb9",
+          "version": "2",
+          "digest": "An1LvXhmnEHn2gJMSSkdGyun4u38i9oHDmAwXXb9AJJh",
+          "type": "0xe1c6660ef31048dad1e41047f6fb9b7ed23973bfd4d5c2381c328eaf059b137d::N::O1"
+        }
+      }
+    ],
+    "nextCursor": "IL1pQ92aMr7WaT7DauZSbE8ZVzi8s8CEhLA1cxsd/H+5AQAAAAAAAAA=",
+    "hasNextPage": false
+  }
+}
+
+task 9, lines 82-94:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "data": [
+      {
+        "data": {
+          "objectId": "0x33606f6df49726da6eb459b42a99e5e9035f775d5fc67f4878ecebf7acd952a7",
+          "version": "3",
+          "digest": "HkMtbLn6X37sNutQWr87BCTnkkWzGjr4CkxMYAKRq6X5",
+          "type": "0xe1c6660ef31048dad1e41047f6fb9b7ed23973bfd4d5c2381c328eaf059b137d::M::O1"
+        }
+      }
+    ],
+    "nextCursor": "IDNgb230lybabrRZtCqZ5ekDX3ddX8Z/SHjs6/es2VKnAgAAAAAAAAA=",
+    "hasNextPage": true
+  }
+}
+
+task 10, lines 96-108:
+//# run-jsonrpc --cursors @{obj_5_0,2}
+Response: {
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "data": [
+      {
+        "data": {
+          "objectId": "0x7d1dd38797c8b44409ce173982e23be378dd849b77265513b89409b1ebb58f8a",
+          "version": "2",
+          "digest": "CvF9yM9tXXtYcLBdwBqBNXHGN9wtTHPogfsp2SqnzwJH",
+          "type": "0xe1c6660ef31048dad1e41047f6fb9b7ed23973bfd4d5c2381c328eaf059b137d::M::O2"
+        }
+      }
+    ],
+    "nextCursor": "IH0d04eXyLRECc4XOYLiO+N43YSbdyZVE7iUCbHrtY+KAQAAAAAAAAA=",
+    "hasNextPage": true
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_name.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_name.move
@@ -1,0 +1,108 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --addresses P=0x0 --simulator
+
+// 1. All the objects of a generic type, for a particular owner
+// 2. All the objects of a non-generic type, for that same owner
+// 3. ...limited
+// 4. ...limited, with a cursor
+
+//# publish
+module P::M {
+  public struct O1<phantom T> has key, store {
+    id: UID,
+  }
+
+  public struct O2 has key, store {
+    id: UID,
+  }
+
+  public fun o1<T>(ctx: &mut TxContext): O1<T> {
+    O1 { id: object::new(ctx) }
+  }
+
+  public fun o2(ctx: &mut TxContext): O2 {
+    O2 { id: object::new(ctx) }
+  }
+}
+
+module P::N {
+  public struct O1 has key, store {
+    id: UID,
+  }
+
+  public fun o1(ctx: &mut TxContext): O1 {
+    O1 { id: object::new(ctx) }
+  }
+}
+
+//# programmable --sender B --inputs @B
+//> 0: P::M::o1<u64>();
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# programmable --sender A --inputs @A
+//> 0: P::M::o1<u32>();
+//> 1: P::M::o2();
+//> 2: P::N::o1();
+//> 3: TransferObjects([Result(0), Result(1), Result(2)], Input(0))
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs @A
+//> 0: P::M::o1<u16>();
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "suix_getOwnedObjects",
+  "params": [
+    "@{A}",
+    {
+      "filter": { "StructType": "@{P}::M::O1" },
+      "options": { "showType": true }
+    }
+  ]
+}
+
+//# run-jsonrpc
+{
+  "method": "suix_getOwnedObjects",
+  "params": [
+    "@{A}",
+    {
+      "filter": { "StructType": "@{P}::M::O2" },
+      "options": { "showType": true }
+    }
+  ]
+}
+
+//# run-jsonrpc
+{
+  "method": "suix_getOwnedObjects",
+  "params": [
+    "@{A}",
+    {
+      "filter": { "StructType": "@{P}::M::O1" },
+      "options": { "showType": true }
+    },
+    null,
+    1
+  ]
+}
+
+//# run-jsonrpc --cursors @{obj_5_0,2}
+{
+  "method": "suix_getOwnedObjects",
+  "params": [
+    "@{A}",
+    {
+      "filter": { "StructType": "@{P}::M::O1" },
+      "options": { "showType": true }
+    },
+    "@{cursor_0}",
+    1
+  ]
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_name.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_name.snap
@@ -1,0 +1,139 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 11 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 11-38:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 7075600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 40-42:
+//# programmable --sender B --inputs @B
+//> 0: P::M::o1<u64>();
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(2,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 2211600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 44-48:
+//# programmable --sender A --inputs @A
+//> 0: P::M::o1<u32>();
+//> 1: P::M::o2();
+//> 2: P::N::o1();
+//> 3: TransferObjects([Result(0), Result(1), Result(2)], Input(0))
+created: object(3,0), object(3,1), object(3,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 4643600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 4, line 50:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, lines 52-54:
+//# programmable --sender A --inputs @A
+//> 0: P::M::o1<u16>();
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2211600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, line 56:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 7, lines 58-68:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": {
+    "data": [
+      {
+        "data": {
+          "objectId": "0xa149cfb5a4d73dc0e453acf798b86ae510abc6ef0842bde71b79ac28846caad4",
+          "version": "3",
+          "digest": "8fBZV9wTyZLsfFpk6juQX599wMXGH2ELV7auRea72HDe",
+          "type": "0xea172d9fc530d31939523f79e455a7709df18773cf0e7194c9ef04fe8db0c634::M::O1<u16>"
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x72a1babb319e33c79676c8b6273887a6745c39e337e96379fe09e489338e9f44",
+          "version": "2",
+          "digest": "5ZzFto6F55thAMFLz9Q4rfQehjjJo3GQvUu5zhUo3DD8",
+          "type": "0xea172d9fc530d31939523f79e455a7709df18773cf0e7194c9ef04fe8db0c634::M::O1<u32>"
+        }
+      }
+    ],
+    "nextCursor": "IHKhursxnjPHlnbItic4h6Z0XDnjN+ljef4J5Ikzjp9EAQAAAAAAAAA=",
+    "hasNextPage": false
+  }
+}
+
+task 8, lines 70-80:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "data": [
+      {
+        "data": {
+          "objectId": "0x8e780346fb537c4dbfe2622b77b9179d6ff80b5b6cd30c746ec094576944a460",
+          "version": "2",
+          "digest": "8JdoHUTLVvnAdd9kpzep3Gm8uiJPNFdtarXSd8bAf84f",
+          "type": "0xea172d9fc530d31939523f79e455a7709df18773cf0e7194c9ef04fe8db0c634::M::O2"
+        }
+      }
+    ],
+    "nextCursor": "II54A0b7U3xNv+JiK3e5F51v+AtbbNMMdG7AlFdpRKRgAQAAAAAAAAA=",
+    "hasNextPage": false
+  }
+}
+
+task 9, lines 82-94:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "data": [
+      {
+        "data": {
+          "objectId": "0xa149cfb5a4d73dc0e453acf798b86ae510abc6ef0842bde71b79ac28846caad4",
+          "version": "3",
+          "digest": "8fBZV9wTyZLsfFpk6juQX599wMXGH2ELV7auRea72HDe",
+          "type": "0xea172d9fc530d31939523f79e455a7709df18773cf0e7194c9ef04fe8db0c634::M::O1<u16>"
+        }
+      }
+    ],
+    "nextCursor": "IKFJz7Wk1z3A5FOs95i4auUQq8bvCEK95xt5rCiEbKrUAgAAAAAAAAA=",
+    "hasNextPage": true
+  }
+}
+
+task 10, lines 96-108:
+//# run-jsonrpc --cursors @{obj_5_0,2}
+Response: {
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "data": [
+      {
+        "data": {
+          "objectId": "0x72a1babb319e33c79676c8b6273887a6745c39e337e96379fe09e489338e9f44",
+          "version": "2",
+          "digest": "5ZzFto6F55thAMFLz9Q4rfQehjjJo3GQvUu5zhUo3DD8",
+          "type": "0xea172d9fc530d31939523f79e455a7709df18773cf0e7194c9ef04fe8db0c634::M::O1<u32>"
+        }
+      }
+    ],
+    "nextCursor": "IHKhursxnjPHlnbItic4h6Z0XDnjN+ljef4J5Ikzjp9EAQAAAAAAAAA=",
+    "hasNextPage": false
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_package.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_package.move
@@ -1,0 +1,116 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --addresses P=0x0 --simulator
+
+// 1. All the objects of a certain type, for a particular owner
+// 2. All the objects of another type, for that same owner
+// 3. ...limited
+// 4. ...limited, with a cursor
+
+//# publish
+module P::M {
+  public struct O1 has key, store {
+    id: UID,
+  }
+
+  public struct O2 has key, store {
+    id: UID,
+  }
+
+  public fun o1(ctx: &mut TxContext): O1 {
+    O1 { id: object::new(ctx) }
+  }
+
+  public fun o2(ctx: &mut TxContext): O2 {
+    O2 { id: object::new(ctx) }
+  }
+}
+
+module P::N {
+  public struct O1 has key, store {
+    id: UID,
+  }
+
+  public fun o1(ctx: &mut TxContext): O1 {
+    O1 { id: object::new(ctx) }
+  }
+}
+
+//# programmable --sender B --inputs @B
+//> 0: P::M::o1();
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# programmable --sender A --inputs @A
+//> 0: P::M::o1();
+//> 1: P::M::o2();
+//> 2: P::N::o1();
+//> 3: TransferObjects([Result(0), Result(1), Result(2)], Input(0))
+
+//# programmable --sender A --inputs @A 42 43 44
+//> 0: SplitCoins(Gas, [Input(1), Input(2), Input(3)]);
+//> 1: TransferObjects([NestedResult(0,0), NestedResult(0,1), NestedResult(0,2)], Input(0))
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs @A
+//> 0: P::M::o1();
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# programmable --sender A --inputs @A 45
+//> 0: SplitCoins(Gas, [Input(1)]);
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "suix_getOwnedObjects",
+  "params": [
+    "@{A}",
+    {
+      "filter": { "Package": "@{P}" },
+      "options": { "showType": true }
+    }
+  ]
+}
+
+//# run-jsonrpc
+{
+  "method": "suix_getOwnedObjects",
+  "params": [
+    "@{A}",
+    {
+      "filter": { "Package": "0x2" },
+      "options": { "showType": true }
+    }
+  ]
+}
+
+//# run-jsonrpc
+{
+  "method": "suix_getOwnedObjects",
+  "params": [
+    "@{A}",
+    {
+      "filter": { "Package": "@{P}" },
+      "options": { "showType": true }
+    },
+    null,
+    2
+  ]
+}
+
+//# run-jsonrpc --cursors @{obj_3_2,1}
+{
+  "method": "suix_getOwnedObjects",
+  "params": [
+    "@{A}",
+    {
+      "filter": { "Package": "@{P}" },
+      "options": { "showType": true }
+    },
+    "@{cursor_0}",
+    2
+  ]
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_package.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_package.snap
@@ -1,0 +1,219 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 13 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 11-38:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 6961600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 40-42:
+//# programmable --sender B --inputs @B
+//> 0: P::M::o1();
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(2,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 2204000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 44-48:
+//# programmable --sender A --inputs @A
+//> 0: P::M::o1();
+//> 1: P::M::o2();
+//> 2: P::N::o1();
+//> 3: TransferObjects([Result(0), Result(1), Result(2)], Input(0))
+created: object(3,0), object(3,1), object(3,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 4636000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 4, lines 50-52:
+//# programmable --sender A --inputs @A 42 43 44
+//> 0: SplitCoins(Gas, [Input(1), Input(2), Input(3)]);
+//> 1: TransferObjects([NestedResult(0,0), NestedResult(0,1), NestedResult(0,2)], Input(0))
+created: object(4,0), object(4,1), object(4,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3952000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, line 54:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 6, lines 56-58:
+//# programmable --sender A --inputs @A
+//> 0: P::M::o1();
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(6,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2204000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 7, lines 60-62:
+//# programmable --sender A --inputs @A 45
+//> 0: SplitCoins(Gas, [Input(1)]);
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(7,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 8, line 64:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 9, lines 66-76:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": {
+    "data": [
+      {
+        "data": {
+          "objectId": "0xddde710d6f6bd5860dcb8abd5aef61d18c4490428a48ef82460f66918f0558e7",
+          "version": "4",
+          "digest": "E5Ve86CRPTDR9Un8kcmC9WPWGnNXfwYuWCEdqLJUTHCC",
+          "type": "0xe1c6660ef31048dad1e41047f6fb9b7ed23973bfd4d5c2381c328eaf059b137d::M::O1"
+        }
+      },
+      {
+        "data": {
+          "objectId": "0xbd6943dd9a32bed6693ec36ae6526c4f195738bcb3c08484b035731b1dfc7fb9",
+          "version": "2",
+          "digest": "An1LvXhmnEHn2gJMSSkdGyun4u38i9oHDmAwXXb9AJJh",
+          "type": "0xe1c6660ef31048dad1e41047f6fb9b7ed23973bfd4d5c2381c328eaf059b137d::N::O1"
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x7d1dd38797c8b44409ce173982e23be378dd849b77265513b89409b1ebb58f8a",
+          "version": "2",
+          "digest": "CvF9yM9tXXtYcLBdwBqBNXHGN9wtTHPogfsp2SqnzwJH",
+          "type": "0xe1c6660ef31048dad1e41047f6fb9b7ed23973bfd4d5c2381c328eaf059b137d::M::O2"
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x641bb5c9fe8c5c55141dc24b63197f610be62cbdf5de690d299ac04621cee5c6",
+          "version": "2",
+          "digest": "HXsWXDM5xFmP9HfPnyzXA7EinHANUwvAJZz8hwkyPR1A",
+          "type": "0xe1c6660ef31048dad1e41047f6fb9b7ed23973bfd4d5c2381c328eaf059b137d::M::O1"
+        }
+      }
+    ],
+    "nextCursor": "IGQbtcn+jFxVFB3CS2MZf2EL5iy99d5pDSmawEYhzuXGAQAAAAAAAAA=",
+    "hasNextPage": false
+  }
+}
+
+task 10, lines 78-88:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "data": [
+      {
+        "data": {
+          "objectId": "0xaa1f5c0190afe3d847aa2077a7802b7a1b49ee0f92d0f09fb9f5b721d4ba2372",
+          "version": "5",
+          "digest": "DXH2NGnZFPJxPbbu6z84EHZwDQX7JQ5CLja8ogjsQKgo",
+          "type": "0x2::coin::Coin<0x2::sui::SUI>"
+        }
+      },
+      {
+        "data": {
+          "objectId": "0xc5737f0f5cf7ccef056f1b658e7c60bdd1deab8a61130b441971051519f999af",
+          "version": "3",
+          "digest": "6AZB47gG7PBkLiJYEf5E5B2MibwqvVjmUTuUoJZsLam3",
+          "type": "0x2::coin::Coin<0x2::sui::SUI>"
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x80d40d685b717262b28552e3c46a961db3c7cfec8bc92a6566ca1e9e42e8eb0d",
+          "version": "3",
+          "digest": "6PWfMKpHkwJd4YbQob4hgx7mtn6aJcNXSE6CnQ3bsVEW",
+          "type": "0x2::coin::Coin<0x2::sui::SUI>"
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x384f5e9509f6e067de9646a84464620bfabeba8379d1fad5cd3e315c1c0a3809",
+          "version": "3",
+          "digest": "7KREW2AzGWrzc44gfkQywFz338Pk9JnKVdvMbJXu6scP",
+          "type": "0x2::coin::Coin<0x2::sui::SUI>"
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
+          "version": "5",
+          "digest": "Dgc8CWgN79ooHHMa3V4PhW8Xz5DsA6QTxr6gPG1WbnxH",
+          "type": "0x2::coin::Coin<0x2::sui::SUI>"
+        }
+      }
+    ],
+    "nextCursor": "ICg02F2/79zWbwSBEjG6gYiTeT6DqJXVNAL9meEy42ViAAAAAAAAAAA=",
+    "hasNextPage": false
+  }
+}
+
+task 11, lines 90-102:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "data": [
+      {
+        "data": {
+          "objectId": "0xddde710d6f6bd5860dcb8abd5aef61d18c4490428a48ef82460f66918f0558e7",
+          "version": "4",
+          "digest": "E5Ve86CRPTDR9Un8kcmC9WPWGnNXfwYuWCEdqLJUTHCC",
+          "type": "0xe1c6660ef31048dad1e41047f6fb9b7ed23973bfd4d5c2381c328eaf059b137d::M::O1"
+        }
+      },
+      {
+        "data": {
+          "objectId": "0xbd6943dd9a32bed6693ec36ae6526c4f195738bcb3c08484b035731b1dfc7fb9",
+          "version": "2",
+          "digest": "An1LvXhmnEHn2gJMSSkdGyun4u38i9oHDmAwXXb9AJJh",
+          "type": "0xe1c6660ef31048dad1e41047f6fb9b7ed23973bfd4d5c2381c328eaf059b137d::N::O1"
+        }
+      }
+    ],
+    "nextCursor": "IL1pQ92aMr7WaT7DauZSbE8ZVzi8s8CEhLA1cxsd/H+5AQAAAAAAAAA=",
+    "hasNextPage": true
+  }
+}
+
+task 12, lines 104-116:
+//# run-jsonrpc --cursors @{obj_3_2,1}
+Response: {
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "data": [
+      {
+        "data": {
+          "objectId": "0x7d1dd38797c8b44409ce173982e23be378dd849b77265513b89409b1ebb58f8a",
+          "version": "2",
+          "digest": "CvF9yM9tXXtYcLBdwBqBNXHGN9wtTHPogfsp2SqnzwJH",
+          "type": "0xe1c6660ef31048dad1e41047f6fb9b7ed23973bfd4d5c2381c328eaf059b137d::M::O2"
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x641bb5c9fe8c5c55141dc24b63197f610be62cbdf5de690d299ac04621cee5c6",
+          "version": "2",
+          "digest": "HXsWXDM5xFmP9HfPnyzXA7EinHANUwvAJZz8hwkyPR1A",
+          "type": "0xe1c6660ef31048dad1e41047f6fb9b7ed23973bfd4d5c2381c328eaf059b137d::M::O1"
+        }
+      }
+    ],
+    "nextCursor": "IGQbtcn+jFxVFB3CS2MZf2EL5iy99d5pDSmawEYhzuXGAQAAAAAAAAA=",
+    "hasNextPage": false
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_type_params.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_type_params.move
@@ -1,0 +1,90 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --addresses P=0x0 --simulator
+
+// 1. All the objects of a generic type instance, for a particular owner
+// 2. All the objects of another generic type instance, for that same owner
+// 3. ...limited
+// 4. ...limited, with a cursor
+
+//# publish
+module P::M {
+  public struct O1<phantom T> has key, store {
+    id: UID,
+  }
+
+  public fun o1<T>(ctx: &mut TxContext): O1<T> {
+    O1 { id: object::new(ctx) }
+  }
+}
+
+//# programmable --sender B --inputs @B
+//> 0: P::M::o1<u64>();
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# programmable --sender A --inputs @A
+//> 0: P::M::o1<u64>();
+//> 1: P::M::o1<u32>();
+//> 2: P::M::o1<u64>();
+//> 3: TransferObjects([Result(0), Result(1), Result(2)], Input(0))
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs @A
+//> 0: P::M::o1<u32>();
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "suix_getOwnedObjects",
+  "params": [
+    "@{A}",
+    {
+      "filter": { "StructType": "@{P}::M::O1<u64>" },
+      "options": { "showType": true }
+    }
+  ]
+}
+
+//# run-jsonrpc
+{
+  "method": "suix_getOwnedObjects",
+  "params": [
+    "@{A}",
+    {
+      "filter": { "StructType": "@{P}::M::O1<u32>" },
+      "options": { "showType": true }
+    }
+  ]
+}
+
+//# run-jsonrpc
+{
+  "method": "suix_getOwnedObjects",
+  "params": [
+    "@{A}",
+    {
+      "filter": { "StructType": "@{P}::M::O1<u32>" },
+      "options": { "showType": true }
+    },
+    null,
+    1
+  ]
+}
+
+//# run-jsonrpc --cursors @{obj_5_0,2}
+{
+  "method": "suix_getOwnedObjects",
+  "params": [
+    "@{A}",
+    {
+      "filter": { "StructType": "@{P}::M::O1<u32>" },
+      "options": { "showType": true }
+    },
+    "@{cursor_0}",
+    1
+  ]
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_type_params.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_type_params.snap
@@ -1,0 +1,147 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 11 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 11-20:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 4696800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 22-24:
+//# programmable --sender B --inputs @B
+//> 0: P::M::o1<u64>();
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(2,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 2211600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 26-30:
+//# programmable --sender A --inputs @A
+//> 0: P::M::o1<u64>();
+//> 1: P::M::o1<u32>();
+//> 2: P::M::o1<u64>();
+//> 3: TransferObjects([Result(0), Result(1), Result(2)], Input(0))
+created: object(3,0), object(3,1), object(3,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 4658800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 4, line 32:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, lines 34-36:
+//# programmable --sender A --inputs @A
+//> 0: P::M::o1<u32>();
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2211600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, line 38:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 7, lines 40-50:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": {
+    "data": [
+      {
+        "data": {
+          "objectId": "0x9a80dfcde4a045e027dceaa9f60cd0c170743fa029d775b8b77657432053ebe7",
+          "version": "2",
+          "digest": "EeN99ChrMgtWcwzfyXKmbePCRJdNqMUAEAynADFjRHLE",
+          "type": "0xb950fe2a124ab853efc3ee02166d1f5224b744789fdbdb16b4cc83bd25b1affa::M::O1<u64>"
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x09bd57395cac88fc79d52fa7914d7f6127370b7d2de860ccb71929beb5d7c869",
+          "version": "2",
+          "digest": "2gZHNT6i7iNRoizwG812drn3fy6AETK1VygZmYcPyHgH",
+          "type": "0xb950fe2a124ab853efc3ee02166d1f5224b744789fdbdb16b4cc83bd25b1affa::M::O1<u64>"
+        }
+      }
+    ],
+    "nextCursor": "IAm9VzlcrIj8edUvp5FNf2EnNwt9LehgzLcZKb6118hpAQAAAAAAAAA=",
+    "hasNextPage": false
+  }
+}
+
+task 8, lines 52-62:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "data": [
+      {
+        "data": {
+          "objectId": "0xa1f7fd756f61d5ddfac12633b350fedb6114dba40e2a42c20053bd011d8fb79f",
+          "version": "3",
+          "digest": "8DGH1AnMfXTs9ydGuR5RXhG1jF1PVD7kuAEewPYG8Zkr",
+          "type": "0xb950fe2a124ab853efc3ee02166d1f5224b744789fdbdb16b4cc83bd25b1affa::M::O1<u32>"
+        }
+      },
+      {
+        "data": {
+          "objectId": "0xeaeae71b228562e9813ebed88f1c019c39d1a24a4b35717817b00d80aa3b04b5",
+          "version": "2",
+          "digest": "Ai86Kt6S54Q7CXvjEGWmmjSQpT9sE4bLFVDwEc5ctjmt",
+          "type": "0xb950fe2a124ab853efc3ee02166d1f5224b744789fdbdb16b4cc83bd25b1affa::M::O1<u32>"
+        }
+      }
+    ],
+    "nextCursor": "IOrq5xsihWLpgT6+2I8cAZw50aJKSzVxeBewDYCqOwS1AQAAAAAAAAA=",
+    "hasNextPage": false
+  }
+}
+
+task 9, lines 64-76:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "data": [
+      {
+        "data": {
+          "objectId": "0xa1f7fd756f61d5ddfac12633b350fedb6114dba40e2a42c20053bd011d8fb79f",
+          "version": "3",
+          "digest": "8DGH1AnMfXTs9ydGuR5RXhG1jF1PVD7kuAEewPYG8Zkr",
+          "type": "0xb950fe2a124ab853efc3ee02166d1f5224b744789fdbdb16b4cc83bd25b1affa::M::O1<u32>"
+        }
+      }
+    ],
+    "nextCursor": "IKH3/XVvYdXd+sEmM7NQ/tthFNukDipCwgBTvQEdj7efAgAAAAAAAAA=",
+    "hasNextPage": true
+  }
+}
+
+task 10, lines 78-90:
+//# run-jsonrpc --cursors @{obj_5_0,2}
+Response: {
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "data": [
+      {
+        "data": {
+          "objectId": "0xeaeae71b228562e9813ebed88f1c019c39d1a24a4b35717817b00d80aa3b04b5",
+          "version": "2",
+          "digest": "Ai86Kt6S54Q7CXvjEGWmmjSQpT9sE4bLFVDwEc5ctjmt",
+          "type": "0xb950fe2a124ab853efc3ee02166d1f5224b744789fdbdb16b4cc83bd25b1affa::M::O1<u32>"
+        }
+      }
+    ],
+    "nextCursor": "IOrq5xsihWLpgT6+2I8cAZw50aJKSzVxeBewDYCqOwS1AQAAAAAAAAA=",
+    "hasNextPage": false
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/owner.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/owner.move
@@ -1,0 +1,84 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --simulator
+
+// 1. All objects owned by A
+// 2. ...owned by B
+// 3. Limited number of objects owned by A
+// 4. Limited and offset by a cursor
+// 5. Objects after they have been modified
+// 6. Objects after they have been transferred
+
+//# programmable --sender A --inputs @A 42 43 44
+//> 0: SplitCoins(Gas, [Input(1), Input(2), Input(3)]);
+//> 1: TransferObjects([NestedResult(0,0), NestedResult(0,1), NestedResult(0,2)], Input(0))
+
+//# programmable --sender B --inputs @B 45
+//> 0: SplitCoins(Gas, [Input(1)]);
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs @A 46 47 48
+//> 0: SplitCoins(Gas, [Input(1), Input(2), Input(3)]);
+//> 1: TransferObjects([NestedResult(0,0), NestedResult(0,1), NestedResult(0,2)], Input(0))
+
+//# programmable --sender B --inputs @B 49
+//> 0: SplitCoins(Gas, [Input(1)]);
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "suix_getOwnedObjects",
+  "params": ["@{A}", { "options": { "showOwner": true, "showContent": true } }]
+}
+
+//# run-jsonrpc
+{
+  "method": "suix_getOwnedObjects",
+  "params": ["@{B}", { "options": { "showOwner": true, "showContent": true } }]
+}
+
+//# run-jsonrpc
+{
+  "method": "suix_getOwnedObjects",
+  "params": ["@{A}", { "options": { "showContent": true } }, null, 2]
+}
+
+//# run-jsonrpc --cursors @{obj_4_1,2}
+{
+  "method": "suix_getOwnedObjects",
+  "params": ["@{A}", { "options": { "showContent": true } }, "@{cursor_0}", 2]
+}
+
+//# programmable --sender B --inputs @B object(2,0) 21
+//> 0: SplitCoins(Input(1), [Input(2)]);
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "suix_getOwnedObjects",
+  "params": ["@{B}", { "options": { "showContent": true } }]
+}
+
+//# programmable --sender B --inputs object(5,0) @A
+//> 0: TransferObjects([Input(0)], Input(1))
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "suix_getOwnedObjects",
+  "params": ["@{A}", { "options": { "showContent": true } }]
+}
+
+//# run-jsonrpc
+{
+  "method": "suix_getOwnedObjects",
+  "params": ["@{B}", { "options": { "showContent": true } }]
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/owner.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/owner.snap
@@ -1,0 +1,712 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 18 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 13-15:
+//# programmable --sender A --inputs @A 42 43 44
+//> 0: SplitCoins(Gas, [Input(1), Input(2), Input(3)]);
+//> 1: TransferObjects([NestedResult(0,0), NestedResult(0,1), NestedResult(0,2)], Input(0))
+created: object(1,0), object(1,1), object(1,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3952000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 17-19:
+//# programmable --sender B --inputs @B 45
+//> 0: SplitCoins(Gas, [Input(1)]);
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(2,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 21:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 23-25:
+//# programmable --sender A --inputs @A 46 47 48
+//> 0: SplitCoins(Gas, [Input(1), Input(2), Input(3)]);
+//> 1: TransferObjects([NestedResult(0,0), NestedResult(0,1), NestedResult(0,2)], Input(0))
+created: object(4,0), object(4,1), object(4,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3952000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 27-29:
+//# programmable --sender B --inputs @B 49
+//> 0: SplitCoins(Gas, [Input(1)]);
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(5,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, line 31:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 7, lines 33-37:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": {
+    "data": [
+      {
+        "data": {
+          "objectId": "0xe066da8ca52480b18f814164a3c939df886dae8d9825dec51a32a7639a4bb543",
+          "version": "3",
+          "digest": "Bq17sSAUHGu31dcX834notozn39ujPCPTEraVXahX7MB",
+          "owner": {
+            "AddressOwner": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+          },
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "47",
+              "id": {
+                "id": "0xe066da8ca52480b18f814164a3c939df886dae8d9825dec51a32a7639a4bb543"
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x6229558a2a5d8459cad0f20100c205ac70a6182432a1df70a317a459f909b69c",
+          "version": "3",
+          "digest": "H6Rr8kyrJPyPEwFyYbZvmSyVouN6n598wmcTUcvBRJVw",
+          "owner": {
+            "AddressOwner": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+          },
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "48",
+              "id": {
+                "id": "0x6229558a2a5d8459cad0f20100c205ac70a6182432a1df70a317a459f909b69c"
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x0d01104ae2ee2f7f4b2c9419f10c5459936690aee9c130b2b7fc417b2cd9c1d9",
+          "version": "3",
+          "digest": "DnK1jFMVh53uiV2kVcQQpekxHoKc7EMfTu1hPN4nLzXg",
+          "owner": {
+            "AddressOwner": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+          },
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "46",
+              "id": {
+                "id": "0x0d01104ae2ee2f7f4b2c9419f10c5459936690aee9c130b2b7fc417b2cd9c1d9"
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x9c656e2bd829e114b6be22bbe848fda3706779e659fe0ec8e4f0a1cdafbb0170",
+          "version": "2",
+          "digest": "H83YervcNEB7YzasFRN3u81qSUdgij48JiTstqnej75i",
+          "owner": {
+            "AddressOwner": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+          },
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "43",
+              "id": {
+                "id": "0x9c656e2bd829e114b6be22bbe848fda3706779e659fe0ec8e4f0a1cdafbb0170"
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x6d6e84695f8578b310c89591dce354b1dd973bfb0baf6006c734a345186844a3",
+          "version": "2",
+          "digest": "Fsqs9wUPNELQ1gTpBTpbLhgjs9kqcj5g3RLGuRz2E8fL",
+          "owner": {
+            "AddressOwner": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+          },
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "44",
+              "id": {
+                "id": "0x6d6e84695f8578b310c89591dce354b1dd973bfb0baf6006c734a345186844a3"
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x06d9ee78babebd2a923465538a1bd0803712145f275bfce5017e795a8a06bc2a",
+          "version": "2",
+          "digest": "BRK2ni4E7zT6DooqDPGE4i9DepEmvC5iTzbFb6ENjYkV",
+          "owner": {
+            "AddressOwner": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+          },
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "42",
+              "id": {
+                "id": "0x06d9ee78babebd2a923465538a1bd0803712145f275bfce5017e795a8a06bc2a"
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
+          "version": "3",
+          "digest": "3zsSqaBnACz5HyweWi93TYhLWKasMSvZCHrWAP5c9sZs",
+          "owner": {
+            "AddressOwner": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+          },
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "299999991073850",
+              "id": {
+                "id": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "nextCursor": "ICg02F2/79zWbwSBEjG6gYiTeT6DqJXVNAL9meEy42ViAAAAAAAAAAA=",
+    "hasNextPage": false
+  }
+}
+
+task 8, lines 39-43:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "data": [
+      {
+        "data": {
+          "objectId": "0x9d0d32458232bb477df29a9bc9a689b666d6a45ada1ebc32fc6f3cb474cc3f47",
+          "version": "3",
+          "digest": "BLzZRStLpS7tzrgWP6KPfELuyVHSFv6AhTif7s3qCRpJ",
+          "owner": {
+            "AddressOwner": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+          },
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "49",
+              "id": {
+                "id": "0x9d0d32458232bb477df29a9bc9a689b666d6a45ada1ebc32fc6f3cb474cc3f47"
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x8b3bb5e48bd643f5095a44fe76b3d3703573e91e07a202c3e151a9535f43a386",
+          "version": "2",
+          "digest": "3bNMzhsPGvFvkMKfmPrguob4SiQnXaeEeAVPtnowhPra",
+          "owner": {
+            "AddressOwner": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+          },
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "45",
+              "id": {
+                "id": "0x8b3bb5e48bd643f5095a44fe76b3d3703573e91e07a202c3e151a9535f43a386"
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "objectId": "0xfdc25bc3b2d2b3664199d08f5275c3a6bb360b0629ab5784672f083149163417",
+          "version": "3",
+          "digest": "8fRTgwdBqoAGbBDp2D55fvu3DYwa2y5TGw77C8NFj46g",
+          "owner": {
+            "AddressOwner": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
+          },
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "299999995026026",
+              "id": {
+                "id": "0xfdc25bc3b2d2b3664199d08f5275c3a6bb360b0629ab5784672f083149163417"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "nextCursor": "IP3CW8Oy0rNmQZnQj1J1w6a7NgsGKatXhGcvCDFJFjQXAAAAAAAAAAA=",
+    "hasNextPage": false
+  }
+}
+
+task 9, lines 45-49:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "data": [
+      {
+        "data": {
+          "objectId": "0xe066da8ca52480b18f814164a3c939df886dae8d9825dec51a32a7639a4bb543",
+          "version": "3",
+          "digest": "Bq17sSAUHGu31dcX834notozn39ujPCPTEraVXahX7MB",
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "47",
+              "id": {
+                "id": "0xe066da8ca52480b18f814164a3c939df886dae8d9825dec51a32a7639a4bb543"
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x6229558a2a5d8459cad0f20100c205ac70a6182432a1df70a317a459f909b69c",
+          "version": "3",
+          "digest": "H6Rr8kyrJPyPEwFyYbZvmSyVouN6n598wmcTUcvBRJVw",
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "48",
+              "id": {
+                "id": "0x6229558a2a5d8459cad0f20100c205ac70a6182432a1df70a317a459f909b69c"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "nextCursor": "IGIpVYoqXYRZytDyAQDCBaxwphgkMqHfcKMXpFn5CbacAgAAAAAAAAA=",
+    "hasNextPage": true
+  }
+}
+
+task 10, lines 51-55:
+//# run-jsonrpc --cursors @{obj_4_1,2}
+Response: {
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "data": [
+      {
+        "data": {
+          "objectId": "0x0d01104ae2ee2f7f4b2c9419f10c5459936690aee9c130b2b7fc417b2cd9c1d9",
+          "version": "3",
+          "digest": "DnK1jFMVh53uiV2kVcQQpekxHoKc7EMfTu1hPN4nLzXg",
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "46",
+              "id": {
+                "id": "0x0d01104ae2ee2f7f4b2c9419f10c5459936690aee9c130b2b7fc417b2cd9c1d9"
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x9c656e2bd829e114b6be22bbe848fda3706779e659fe0ec8e4f0a1cdafbb0170",
+          "version": "2",
+          "digest": "H83YervcNEB7YzasFRN3u81qSUdgij48JiTstqnej75i",
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "43",
+              "id": {
+                "id": "0x9c656e2bd829e114b6be22bbe848fda3706779e659fe0ec8e4f0a1cdafbb0170"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "nextCursor": "IJxlbivYKeEUtr4iu+hI/aNwZ3nmWf4OyOTwoc2vuwFwAQAAAAAAAAA=",
+    "hasNextPage": true
+  }
+}
+
+task 11, lines 57-59:
+//# programmable --sender B --inputs @B object(2,0) 21
+//> 0: SplitCoins(Input(1), [Input(2)]);
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(11,0)
+mutated: object(0,1), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2964000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 12, line 61:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 13, lines 63-67:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 4,
+  "result": {
+    "data": [
+      {
+        "data": {
+          "objectId": "0xefe81a3ecc38ebe214f98a659f34db44b4fb6bbe89de0aadec955518a97e0aee",
+          "version": "4",
+          "digest": "APkEyUbe9tKMm1ndy25odsxUKLhKJbmWiXZTzY3vdf8h",
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "21",
+              "id": {
+                "id": "0xefe81a3ecc38ebe214f98a659f34db44b4fb6bbe89de0aadec955518a97e0aee"
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x9d0d32458232bb477df29a9bc9a689b666d6a45ada1ebc32fc6f3cb474cc3f47",
+          "version": "3",
+          "digest": "BLzZRStLpS7tzrgWP6KPfELuyVHSFv6AhTif7s3qCRpJ",
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "49",
+              "id": {
+                "id": "0x9d0d32458232bb477df29a9bc9a689b666d6a45ada1ebc32fc6f3cb474cc3f47"
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x8b3bb5e48bd643f5095a44fe76b3d3703573e91e07a202c3e151a9535f43a386",
+          "version": "4",
+          "digest": "AVWvjj4vyn63Y9zmMNKxq8sM8VtvuGhNyaBCjorbPdj4",
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "24",
+              "id": {
+                "id": "0x8b3bb5e48bd643f5095a44fe76b3d3703573e91e07a202c3e151a9535f43a386"
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "objectId": "0xfdc25bc3b2d2b3664199d08f5275c3a6bb360b0629ab5784672f083149163417",
+          "version": "4",
+          "digest": "B9kLm4RWF1jJVRKJFDFwd1mrBuQajJqMQVUiNPvmFFpR",
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "299999993018266",
+              "id": {
+                "id": "0xfdc25bc3b2d2b3664199d08f5275c3a6bb360b0629ab5784672f083149163417"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "nextCursor": "IP3CW8Oy0rNmQZnQj1J1w6a7NgsGKatXhGcvCDFJFjQXAAAAAAAAAAA=",
+    "hasNextPage": false
+  }
+}
+
+task 14, lines 69-70:
+//# programmable --sender B --inputs object(5,0) @A
+//> 0: TransferObjects([Input(0)], Input(1))
+mutated: object(0,1), object(5,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 15, line 72:
+//# create-checkpoint
+Checkpoint created: 4
+
+task 16, lines 74-78:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 5,
+  "result": {
+    "data": [
+      {
+        "data": {
+          "objectId": "0x9d0d32458232bb477df29a9bc9a689b666d6a45ada1ebc32fc6f3cb474cc3f47",
+          "version": "5",
+          "digest": "7abSh3b1wEYk7r8JNbTDGzwXhJewf4jZgdzoezJPn1WC",
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "49",
+              "id": {
+                "id": "0x9d0d32458232bb477df29a9bc9a689b666d6a45ada1ebc32fc6f3cb474cc3f47"
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "objectId": "0xe066da8ca52480b18f814164a3c939df886dae8d9825dec51a32a7639a4bb543",
+          "version": "3",
+          "digest": "Bq17sSAUHGu31dcX834notozn39ujPCPTEraVXahX7MB",
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "47",
+              "id": {
+                "id": "0xe066da8ca52480b18f814164a3c939df886dae8d9825dec51a32a7639a4bb543"
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x6229558a2a5d8459cad0f20100c205ac70a6182432a1df70a317a459f909b69c",
+          "version": "3",
+          "digest": "H6Rr8kyrJPyPEwFyYbZvmSyVouN6n598wmcTUcvBRJVw",
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "48",
+              "id": {
+                "id": "0x6229558a2a5d8459cad0f20100c205ac70a6182432a1df70a317a459f909b69c"
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x0d01104ae2ee2f7f4b2c9419f10c5459936690aee9c130b2b7fc417b2cd9c1d9",
+          "version": "3",
+          "digest": "DnK1jFMVh53uiV2kVcQQpekxHoKc7EMfTu1hPN4nLzXg",
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "46",
+              "id": {
+                "id": "0x0d01104ae2ee2f7f4b2c9419f10c5459936690aee9c130b2b7fc417b2cd9c1d9"
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x9c656e2bd829e114b6be22bbe848fda3706779e659fe0ec8e4f0a1cdafbb0170",
+          "version": "2",
+          "digest": "H83YervcNEB7YzasFRN3u81qSUdgij48JiTstqnej75i",
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "43",
+              "id": {
+                "id": "0x9c656e2bd829e114b6be22bbe848fda3706779e659fe0ec8e4f0a1cdafbb0170"
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x6d6e84695f8578b310c89591dce354b1dd973bfb0baf6006c734a345186844a3",
+          "version": "2",
+          "digest": "Fsqs9wUPNELQ1gTpBTpbLhgjs9kqcj5g3RLGuRz2E8fL",
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "44",
+              "id": {
+                "id": "0x6d6e84695f8578b310c89591dce354b1dd973bfb0baf6006c734a345186844a3"
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x06d9ee78babebd2a923465538a1bd0803712145f275bfce5017e795a8a06bc2a",
+          "version": "2",
+          "digest": "BRK2ni4E7zT6DooqDPGE4i9DepEmvC5iTzbFb6ENjYkV",
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "42",
+              "id": {
+                "id": "0x06d9ee78babebd2a923465538a1bd0803712145f275bfce5017e795a8a06bc2a"
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
+          "version": "3",
+          "digest": "3zsSqaBnACz5HyweWi93TYhLWKasMSvZCHrWAP5c9sZs",
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "299999991073850",
+              "id": {
+                "id": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "nextCursor": "ICg02F2/79zWbwSBEjG6gYiTeT6DqJXVNAL9meEy42ViAAAAAAAAAAA=",
+    "hasNextPage": false
+  }
+}
+
+task 17, lines 80-84:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 6,
+  "result": {
+    "data": [
+      {
+        "data": {
+          "objectId": "0xefe81a3ecc38ebe214f98a659f34db44b4fb6bbe89de0aadec955518a97e0aee",
+          "version": "4",
+          "digest": "APkEyUbe9tKMm1ndy25odsxUKLhKJbmWiXZTzY3vdf8h",
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "21",
+              "id": {
+                "id": "0xefe81a3ecc38ebe214f98a659f34db44b4fb6bbe89de0aadec955518a97e0aee"
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "objectId": "0x8b3bb5e48bd643f5095a44fe76b3d3703573e91e07a202c3e151a9535f43a386",
+          "version": "4",
+          "digest": "AVWvjj4vyn63Y9zmMNKxq8sM8VtvuGhNyaBCjorbPdj4",
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "24",
+              "id": {
+                "id": "0x8b3bb5e48bd643f5095a44fe76b3d3703573e91e07a202c3e151a9535f43a386"
+              }
+            }
+          }
+        }
+      },
+      {
+        "data": {
+          "objectId": "0xfdc25bc3b2d2b3664199d08f5275c3a6bb360b0629ab5784672f083149163417",
+          "version": "5",
+          "digest": "JB1LcDwRzfSnBhFE9fqymjwrFA1YorfGFGYpNZLEep64",
+          "content": {
+            "dataType": "moveObject",
+            "type": "0x2::coin::Coin<0x2::sui::SUI>",
+            "hasPublicTransfer": true,
+            "fields": {
+              "balance": "299999991998506",
+              "id": {
+                "id": "0xfdc25bc3b2d2b3664199d08f5275c3a6bb360b0629ab5784672f083149163417"
+              }
+            }
+          }
+        }
+      }
+    ],
+    "nextCursor": "IP3CW8Oy0rNmQZnQj1J1w6a7NgsGKatXhGcvCDFJFjQXAAAAAAAAAAA=",
+    "hasNextPage": false
+  }
+}

--- a/crates/sui-indexer-alt-jsonrpc/Cargo.toml
+++ b/crates/sui-indexer-alt-jsonrpc/Cargo.toml
@@ -24,6 +24,7 @@ futures.workspace = true
 jsonrpsee = { workspace = true, features = ["macros", "server"] }
 pin-project-lite.workspace = true
 prometheus.workspace = true
+schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 telemetry-subscribers.workspace = true

--- a/crates/sui-indexer-alt-jsonrpc/Cargo.toml
+++ b/crates/sui-indexer-alt-jsonrpc/Cargo.toml
@@ -27,6 +27,7 @@ prometheus.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde_with.workspace = true
 telemetry-subscribers.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/error.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/error.rs
@@ -3,6 +3,9 @@
 
 #[derive(thiserror::Error, Debug)]
 pub(super) enum Error {
+    #[error("Pagination issue: {0}")]
+    Pagination(#[from] crate::paginate::Error),
+
     #[error("Requested {requested} keys, exceeding maximum {max}")]
     TooManyKeys { requested: usize, max: usize },
 }

--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/filter.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/filter.rs
@@ -1,0 +1,165 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Context as _;
+use diesel::{
+    dsl::sql,
+    sql_types::{BigInt, Bool, Bytea},
+    BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl,
+};
+use move_core_types::language_storage::StructTag;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use sui_indexer_alt_schema::{objects::StoredOwnerKind, schema::obj_info};
+use sui_json_rpc_types::{Page as PageResponse, SuiObjectDataOptions};
+use sui_types::{
+    base_types::{ObjectID, SuiAddress},
+    Identifier,
+};
+
+use crate::{
+    error::{rpc_bail, RpcError},
+    paginate::{BcsCursor, Cursor as _, Page},
+    Context,
+};
+
+use super::{error::Error, ObjectsConfig};
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Default)]
+#[serde(rename_all = "camelCase", rename = "ObjectResponseQuery", default)]
+pub(crate) struct SuiObjectResponseQuery {
+    /// If None, no filter will be applied
+    pub filter: Option<SuiObjectDataFilter>,
+    /// config which fields to include in the response, by default only digest is included
+    pub options: Option<SuiObjectDataOptions>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub(crate) enum SuiObjectDataFilter {
+    /// Query by the object type's package.
+    Package(ObjectID),
+    /// Query by the object type's module.
+    MoveModule {
+        /// The package that contains the module.
+        package: ObjectID,
+        /// The module name.
+        #[schemars(with = "String")]
+        module: Identifier,
+    },
+    /// Query by the object's type.
+    StructType(#[schemars(with = "String")] StructTag),
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct ObjectCursor {
+    object_id: Vec<u8>,
+    cp_sequence_number: u64,
+}
+
+type Cursor = BcsCursor<ObjectCursor>;
+type ObjectIDs = PageResponse<ObjectID, String>;
+
+/// Fetch ObjectIDs for a page of objects owned by `owner` that satisfy the given `filter` and
+/// pagination parameters. Returns the digests and a cursor point to the last result (if there are
+/// any results).
+pub(super) async fn owned_objects(
+    ctx: &Context,
+    config: &ObjectsConfig,
+    owner: SuiAddress,
+    filter: &Option<SuiObjectDataFilter>,
+    cursor: Option<String>,
+    limit: Option<usize>,
+) -> Result<ObjectIDs, RpcError<Error>> {
+    use obj_info::dsl as o;
+
+    let (candidates, newer) = diesel::alias!(obj_info as candidates, obj_info as newer);
+
+    macro_rules! candidates {
+        ($($field:ident),*) => {
+            candidates.fields(($(o::$field),*))
+        };
+    }
+
+    macro_rules! newer {
+        ($($field:ident),*) => {
+            newer.fields(($(o::$field),*))
+        };
+    }
+
+    let page: Page<Cursor> = Page::from_params(
+        config.default_page_size,
+        config.max_page_size,
+        cursor,
+        limit,
+        None,
+    )?;
+
+    let mut query = candidates
+        .select(candidates!(object_id, cp_sequence_number))
+        .left_join(
+            newer.on(candidates!(object_id)
+                .eq(newer!(object_id))
+                .and(candidates!(cp_sequence_number).lt(newer!(cp_sequence_number)))),
+        )
+        .filter(newer!(object_id).is_null())
+        .filter(candidates!(owner_kind).eq(StoredOwnerKind::Address))
+        .filter(candidates!(owner_id).eq(owner.to_inner()))
+        .order_by(candidates!(cp_sequence_number).desc())
+        .then_order_by(candidates!(object_id).desc())
+        .limit(page.limit + 1)
+        .into_boxed();
+
+    if let Some(c) = page.cursor {
+        query = query.filter(
+            sql::<Bool>(r#"("candidates"."cp_sequence_number", "candidates"."object_id") < ("#)
+                .bind::<BigInt, _>(c.cp_sequence_number as i64)
+                .sql(", ")
+                .bind::<Bytea, _>(c.object_id.clone())
+                .sql(")"),
+        );
+    }
+
+    match filter {
+        None => { /* nop */ }
+
+        Some(_) => rpc_bail!("unimplemented"),
+    }
+
+    let mut results: Vec<(Vec<u8>, i64)> = ctx
+        .reader()
+        .connect()
+        .await
+        .context("Failed to connect to the database")?
+        .results(query)
+        .await
+        .context("Failed to fetch object info")?;
+
+    let has_next_page = results.len() > page.limit as usize;
+    if has_next_page {
+        results.truncate(page.limit as usize);
+    }
+
+    let next_cursor = results
+        .last()
+        .map(|(o, c)| {
+            BcsCursor(ObjectCursor {
+                object_id: o.clone(),
+                cp_sequence_number: *c as u64,
+            })
+            .encode()
+        })
+        .transpose()
+        .context("Failed to encode next cursor")?;
+
+    let data: Vec<ObjectID> = results
+        .into_iter()
+        .map(|(o, _)| ObjectID::from_bytes(o))
+        .collect::<Result<Vec<_>, _>>()
+        .context("Failed to deserialize Object IDs")?;
+
+    Ok(PageResponse {
+        data,
+        next_cursor,
+        has_next_page,
+    })
+}

--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
@@ -54,6 +54,17 @@ pub(super) async fn live_object(
         ));
     }
 
+    latest_object(ctx, object_id, options).await
+}
+
+/// Assuming the latest version of this object exists, fetch it from the database and convert it
+/// into a response. This is intended to be used after checking with `obj_info` that the object is
+/// live.
+pub(super) async fn latest_object(
+    ctx: &Context,
+    object_id: ObjectID,
+    options: &SuiObjectDataOptions,
+) -> Result<SuiObjectResponse, RpcError> {
     // The fact that we found an `obj_info` record above means that the latest version of the
     // object does exist, so the following calls should find a valid latest version for the object,
     // and that version is expected to have content, so if either of those things don't happen,

--- a/crates/sui-indexer-alt-jsonrpc/src/config.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/config.rs
@@ -25,6 +25,8 @@ pub struct RpcConfig {
 #[derive(Clone, Default, Debug)]
 pub struct ObjectsLayer {
     pub max_multi_get_objects: Option<usize>,
+    pub default_page_size: Option<usize>,
+    pub max_page_size: Option<usize>,
 
     #[serde(flatten)]
     pub extra: toml::Table,
@@ -64,6 +66,8 @@ impl ObjectsLayer {
             max_multi_get_objects: self
                 .max_multi_get_objects
                 .unwrap_or(base.max_multi_get_objects),
+            default_page_size: self.default_page_size.unwrap_or(base.default_page_size),
+            max_page_size: self.max_page_size.unwrap_or(base.max_page_size),
         }
     }
 }
@@ -82,6 +86,8 @@ impl From<ObjectsConfig> for ObjectsLayer {
     fn from(config: ObjectsConfig) -> Self {
         Self {
             max_multi_get_objects: Some(config.max_multi_get_objects),
+            default_page_size: Some(config.default_page_size),
+            max_page_size: Some(config.max_page_size),
             extra: Default::default(),
         }
     }

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use anyhow::Context as _;
 use api::checkpoints::Checkpoints;
 use api::dynamic_fields::DynamicFields;
-use api::objects::{Objects, ObjectsConfig};
+use api::objects::{Objects, ObjectsConfig, QueryObjects};
 use api::rpc_module::RpcModule;
 use api::transactions::{QueryTransactions, Transactions, TransactionsConfig};
 use config::RpcConfig;
@@ -228,7 +228,8 @@ pub async fn start_rpc(
     rpc.add_module(Checkpoints(context.clone()))?;
     rpc.add_module(DynamicFields(context.clone()))?;
     rpc.add_module(Governance(context.clone()))?;
-    rpc.add_module(Objects(context.clone(), objects_config))?;
+    rpc.add_module(Objects(context.clone(), objects_config.clone()))?;
+    rpc.add_module(QueryObjects(context.clone(), objects_config))?;
     rpc.add_module(QueryTransactions(context.clone(), transactions_config))?;
     rpc.add_module(Transactions(context.clone()))?;
 

--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -607,10 +607,6 @@ impl CompiledPackage {
             error: error_message.join("\n"),
         })
     }
-
-    pub fn published_dependency_ids(&self) -> Vec<ObjectID> {
-        self.dependency_ids.published.values().cloned().collect()
-    }
 }
 
 impl Default for BuildConfig {

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -1274,7 +1274,7 @@ fn merge_output(left: Option<String>, right: Option<String>) -> Option<String> {
     }
 }
 
-impl<'a> SuiTestAdapter {
+impl SuiTestAdapter {
     pub fn with_offchain_reader(&mut self, offchain_reader: Box<dyn OffchainStateReader>) {
         self.offchain_reader = Some(offchain_reader);
     }

--- a/external-crates/move/crates/move-bytecode-utils/src/lib.rs
+++ b/external-crates/move/crates/move-bytecode-utils/src/lib.rs
@@ -25,10 +25,12 @@ impl<'a> Modules<'a> {
     pub fn new(modules: impl IntoIterator<Item = &'a CompiledModule>) -> Self {
         let mut map = BTreeMap::new();
         for m in modules {
-            assert!(
-                map.insert(m.self_id(), m).is_none(),
-                "Duplicate module found"
-            );
+            if let Some(prev) = map.insert(m.self_id(), m) {
+                panic!(
+                    "Duplicate module found: {}",
+                    prev.self_id().to_canonical_display(/* with_prefix */ true)
+                )
+            }
         }
         Modules(map)
     }


### PR DESCRIPTION
## Description 

Implement querying objects by owner and type. Also introduce BCS-serialized cursors (to keep size down).

## Test plan 

New E2E tests:

```
sui$ cargo nextest run -p sui-indexer-alt-e2e-tests \
  -- objects/query
```

## Stack

- #21010 
- #21085


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
