### PR TITLE
fix(sui): fix Option<address> serialization in client_ptb

### DIFF
--- a/crates/sui/src/client_ptb/ast.rs
+++ b/crates/sui/src/client_ptb/ast.rs
@@ -202,6 +202,21 @@ impl Argument {
             {
                 MoveValue::Vector(s.bytes().map(MoveValue::U8).collect::<Vec<_>>())
             }
+            (Argument::Option(sp!(loc, o)), TypeTag::Vector(ty)) => {
+                if let Some(v) = o {
+                    let v = v
+                        .as_ref()
+                        .checked_to_pure_move_value(*loc, ty)
+                        .map_err(|e| {
+                            e.with_help(
+                                "Literal option values cannot contain object values.".to_string(),
+                            )
+                        })?;
+                    MoveValue::Vector(vec![v])
+                } else {
+                    MoveValue::Vector(vec![])
+                }
+            }
             (Argument::Option(sp!(loc, o)), TypeTag::Struct(stag))
                 if (
                     &stag.address,


### PR DESCRIPTION
# Description of change

Handle serialization for Option< address > in a PTB, since `TypeTag` for an Option is a `vector<T>` it needed to be handled extra

Porting over https://github.com/iotaledger/iota/pull/5143

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Running this command connected to the testnet
```
cargo run client ptb \
--assign addr "some(@0x2d4b94541bbfcce2ed51e5b0fb73e02bd809e04f1a0601797a6028e6a00b6607)" \
--move-call 0xc9586aae0485f0975167ef0261db81a4011d3255cfa0128dc2f7cc3b72135aaf::example::optional_address_param addr \
--dry-run
```