### PR TITLE
[CLI] cherry pick (#20977) Deprecation warnings for dependency verification 

### DIFF
--- a/crates/sui-source-validation-service/tests/tests.rs
+++ b/crates/sui-source-validation-service/tests/tests.rs
@@ -181,6 +181,7 @@ async fn run_publish(
         package_path: package_path.clone(),
         build_config,
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
     }
@@ -208,6 +209,7 @@ async fn run_upgrade(
         upgrade_capability: cap.reference.object_id,
         build_config,
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         verify_compatibility: true,

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -245,6 +245,7 @@ async fn test_ptb_publish_and_complex_arg_resolution() -> Result<(), anyhow::Err
         package_path: package_path.clone(),
         build_config,
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
     }
@@ -524,6 +525,7 @@ async fn test_move_call_args_linter_command() -> Result<(), anyhow::Error> {
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -788,6 +790,7 @@ async fn test_package_publish_command() -> Result<(), anyhow::Error> {
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -858,6 +861,7 @@ async fn test_package_management_on_publish_command() -> Result<(), anyhow::Erro
         build_config: build_config.clone(),
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -928,6 +932,7 @@ async fn test_delete_shared_object() -> Result<(), anyhow::Error> {
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -1032,6 +1037,7 @@ async fn test_receive_argument() -> Result<(), anyhow::Error> {
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -1156,6 +1162,7 @@ async fn test_receive_argument_by_immut_ref() -> Result<(), anyhow::Error> {
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -1280,6 +1287,7 @@ async fn test_receive_argument_by_mut_ref() -> Result<(), anyhow::Error> {
         build_config,
         skip_dependency_verification: false,
         with_unpublished_dependencies: false,
+        verify_deps: true,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
     }
     .execute(context)
@@ -1406,6 +1414,7 @@ async fn test_package_publish_command_with_unpublished_dependency_succeeds(
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies,
     }
     .execute(context)
@@ -1475,6 +1484,7 @@ async fn test_package_publish_command_with_unpublished_dependency_fails(
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies,
     }
     .execute(context)
@@ -1518,6 +1528,7 @@ async fn test_package_publish_command_non_zero_unpublished_dep_fails() -> Result
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies,
     }
     .execute(context)
@@ -1570,6 +1581,7 @@ async fn test_package_publish_command_failure_invalid() -> Result<(), anyhow::Er
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies,
     }
     .execute(context)
@@ -1609,6 +1621,7 @@ async fn test_package_publish_nonexistent_dependency() -> Result<(), anyhow::Err
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -1649,6 +1662,7 @@ async fn test_package_publish_test_flag() -> Result<(), anyhow::Error> {
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -1701,6 +1715,7 @@ async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
         build_config,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -1772,6 +1787,7 @@ async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         verify_compatibility: true,
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -1837,6 +1853,7 @@ async fn test_package_management_on_upgrade_command() -> Result<(), anyhow::Erro
         build_config: build_config.clone(),
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -1891,6 +1908,7 @@ async fn test_package_management_on_upgrade_command() -> Result<(), anyhow::Erro
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         verify_compatibility: true,
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -1971,6 +1989,7 @@ async fn test_package_management_on_upgrade_command_conflict() -> Result<(), any
         build_config: build_config_publish.clone(),
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -2039,6 +2058,7 @@ async fn test_package_management_on_upgrade_command_conflict() -> Result<(), any
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
         verify_compatibility: true,
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
     }
     .execute(context)
@@ -3808,6 +3828,7 @@ async fn test_clever_errors() -> Result<(), anyhow::Error> {
         package_path: package_path.clone(),
         build_config,
         skip_dependency_verification: false,
+        verify_deps: true,
         with_unpublished_dependencies: false,
         opts: OptsWithGas::for_testing(Some(gas_obj_id), rgp * TEST_ONLY_GAS_UNIT_FOR_PUBLISH),
     }

--- a/crates/sui/tests/shell_tests.rs
+++ b/crates/sui/tests/shell_tests.rs
@@ -48,6 +48,7 @@ async fn test_shell_snapshot(path: &Path) -> datatest_stable::Result<()> {
             "PATH",
             format!("{}:{}", get_sui_bin_path(), std::env::var("PATH")?),
         )
+        .env("RUST_BACKTRACE", "0")
         .current_dir(sandbox)
         .arg(path.file_name().unwrap());
 

--- a/crates/sui/tests/shell_tests/with_network/move_build_bytecode_with_address_resolution/move_build_bytecode_with_address_resolution.sh
+++ b/crates/sui/tests/shell_tests/with_network/move_build_bytecode_with_address_resolution/move_build_bytecode_with_address_resolution.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 sui client --client.config $CONFIG \
-  publish simple \
+  publish simple --verify-deps \
   --json | jq '.effects.status'
 
 sui move --client.config $CONFIG \

--- a/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/README.md
+++ b/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/README.md
@@ -1,0 +1,2 @@
+This test suite checks that the deprecation warnings for dependency verification during publication and the
+associated flags `--skip-dependency-verification` and `--verify-deps` are working correctly.

--- a/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/both_flags.sh
+++ b/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/both_flags.sh
@@ -1,0 +1,10 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# test that we get an error if we supply both `--skip-dependency-verification` and `--verify-deps`
+
+echo "=== publish ===" | tee /dev/stderr
+sui client --client.config $CONFIG publish example --skip-dependency-verification --verify-deps
+
+echo "=== upgrade ===" | tee /dev/stderr
+sui client --client.config $CONFIG upgrade example --upgrade-capability 0x1234 --skip-dependency-verification --verify-deps

--- a/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/dependency/Move.toml
+++ b/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/dependency/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "dependency"
+edition = "2024.beta"
+
+[dependencies]
+# Sui = { local = "FRAMEWORK_DIR", override = true }
+
+[addresses]
+dependency = "0x0"
+

--- a/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/dependency/sources/dependency.move
+++ b/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/dependency/sources/dependency.move
@@ -1,0 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module dependency::dependency;
+
+public fun f(): u64 { 0 }

--- a/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/example/Move.toml
+++ b/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/example/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "example"
+edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+
+[dependencies]
+# Sui = { local = "FRAMEWORK_DIR" }
+dependency = { local = "../dependency" }
+
+[addresses]
+example = "0x0"

--- a/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/example/sources/example.move
+++ b/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/example/sources/example.move
@@ -1,0 +1,9 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Module: example
+module example::example;
+
+use dependency::dependency::f;
+
+public fun g(): u64 { f() }

--- a/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/no_flags.sh
+++ b/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/no_flags.sh
@@ -1,0 +1,36 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# check that we get a deprecation warning when upgrading without any dependency verification flags
+
+echo "=== munge Move.toml files ===" | tee /dev/stderr
+FRAMEWORK_DIR=$(echo $CARGO_MANIFEST_DIR | sed 's#/crates/sui#/crates/sui-framework/packages/sui-framework#g')
+for i in dependency/Move.toml example/Move.toml
+do
+  cat $i | sed "s#FRAMEWORK_DIR#$FRAMEWORK_DIR#g" > Move.toml \
+    && mv Move.toml $i
+done
+
+echo "=== publish dependency ===" | tee /dev/stderr
+sui client --client.config $CONFIG publish "dependency" \
+  --json | jq '.effects.status'
+
+echo "=== publish package v0 (should warn) ===" | tee /dev/stderr
+UPGRADE_CAP=$(sui client --client.config $CONFIG publish "example" \
+  --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
+
+echo "=== upgrade package (should warn) ===" | tee /dev/stderr
+sui client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example \
+  --json | jq '.effects.status'
+
+echo "=== modify dependency ===" | tee /dev/stderr
+cat dependency/sources/dependency.move | sed 's#0#1#g' > dependency.move
+mv dependency.move dependency/sources/dependency.move
+
+echo "=== try to publish with modified dep (should fail) ===" | tee /dev/stderr
+sui client --client.config $CONFIG publish "example" \
+  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'
+
+echo "=== try to upgrade with modified dep (should fail) ===" | tee /dev/stderr
+sui client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example \
+  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'

--- a/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/skip_dep_verif.sh
+++ b/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/skip_dep_verif.sh
@@ -1,0 +1,36 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# check that --skip-dependency-verification has the right behavior on publish and upgrade
+
+echo "=== munge Move.toml files ===" | tee /dev/stderr
+FRAMEWORK_DIR=$(echo $CARGO_MANIFEST_DIR | sed 's#/crates/sui#/crates/sui-framework/packages/sui-framework#g')
+for i in dependency/Move.toml example/Move.toml
+do
+  cat $i | sed "s#FRAMEWORK_DIR#$FRAMEWORK_DIR#g" > Move.toml \
+    && mv Move.toml $i
+done
+
+echo "=== publish dependency ===" | tee /dev/stderr
+sui client --client.config $CONFIG publish "dependency" --skip-dependency-verification \
+  --json | jq '.effects.status'
+
+echo "=== publish package v0 (should NOT warn) ===" | tee /dev/stderr
+UPGRADE_CAP=$(sui client --client.config $CONFIG publish "example" --skip-dependency-verification \
+  --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
+
+echo "=== upgrade package (should NOT warn) ===" | tee /dev/stderr
+sui client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example --skip-dependency-verification \
+  --json | jq '.effects.status'
+
+echo "=== modify dependency ===" | tee /dev/stderr
+cat dependency/sources/dependency.move | sed 's#0#1#g' > dependency.move
+mv dependency.move dependency/sources/dependency.move
+
+echo "=== try to publish with modified dep (should succeed) ===" | tee /dev/stderr
+UPGRADE_CAP=$(sui client --client.config $CONFIG publish "example" --skip-dependency-verification \
+  --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
+
+echo "=== try to upgrade with modified dep (should succeed) ===" | tee /dev/stderr
+sui client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example --skip-dependency-verification \
+  --json | jq '.effects.status'

--- a/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/with_dep_verif.sh
+++ b/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/with_dep_verif.sh
@@ -1,0 +1,36 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# check that --verify-deps has the right behavior on publish and upgrade
+
+echo "=== munge Move.toml files ===" | tee /dev/stderr
+FRAMEWORK_DIR=$(echo $CARGO_MANIFEST_DIR | sed 's#/crates/sui#/crates/sui-framework/packages/sui-framework#g')
+for i in dependency/Move.toml example/Move.toml
+do
+  cat $i | sed "s#FRAMEWORK_DIR#$FRAMEWORK_DIR#g" > Move.toml \
+    && mv Move.toml $i
+done
+
+echo "=== publish dependency ===" | tee /dev/stderr
+sui client --client.config $CONFIG publish "dependency" --verify-deps \
+  --json | jq '.effects.status'
+
+echo "=== publish package v0 (should NOT warn) ===" | tee /dev/stderr
+UPGRADE_CAP=$(sui client --client.config $CONFIG publish "example" --verify-deps \
+  --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
+
+echo "=== upgrade package (should NOT warn) ===" | tee /dev/stderr
+sui client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example --verify-deps \
+  --json | jq '.effects.status'
+
+echo "=== modify dependency ===" | tee /dev/stderr
+cat dependency/sources/dependency.move | sed 's#0#1#g' > dependency.move
+mv dependency.move dependency/sources/dependency.move
+
+echo "=== try to publish with modified dep (should fail) ===" | tee /dev/stderr
+sui client --client.config $CONFIG publish "example" --verify-deps \
+  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'
+
+echo "=== try to upgrade with modified dep (should fail) ===" | tee /dev/stderr
+sui client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example --verify-deps \
+  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'

--- a/crates/sui/tests/snapshots/shell_tests__with_network__move_build_bytecode_with_address_resolution__move_build_bytecode_with_address_resolution.sh.snap
+++ b/crates/sui/tests/snapshots/shell_tests__with_network__move_build_bytecode_with_address_resolution__move_build_bytecode_with_address_resolution.sh.snap
@@ -7,7 +7,7 @@ description: tests/shell_tests/with_network/move_build_bytecode_with_address_res
 # SPDX-License-Identifier: Apache-2.0
 
 sui client --client.config $CONFIG \
-  publish simple \
+  publish simple --verify-deps \
   --json | jq '.effects.status'
 
 sui move --client.config $CONFIG \

--- a/crates/sui/tests/snapshots/shell_tests__with_network__source_verification_deprecation__both_flags.sh.snap
+++ b/crates/sui/tests/snapshots/shell_tests__with_network__source_verification_deprecation__both_flags.sh.snap
@@ -1,0 +1,36 @@
+---
+source: crates/sui/tests/shell_tests.rs
+description: tests/shell_tests/with_network/source_verification_deprecation/both_flags.sh
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# test that we get an error if we supply both `--skip-dependency-verification` and `--verify-deps`
+
+echo "=== publish ===" | tee /dev/stderr
+sui client --client.config $CONFIG publish example --skip-dependency-verification --verify-deps
+
+echo "=== upgrade ===" | tee /dev/stderr
+sui client --client.config $CONFIG upgrade example --upgrade-capability 0x1234 --skip-dependency-verification --verify-deps
+
+----- results -----
+success: false
+exit_code: 2
+----- stdout -----
+=== publish ===
+=== upgrade ===
+
+----- stderr -----
+=== publish ===
+error: the argument '--skip-dependency-verification' cannot be used with '--verify-deps'
+
+Usage: sui client publish --skip-dependency-verification <package_path>
+
+For more information, try '--help'.
+=== upgrade ===
+error: the argument '--skip-dependency-verification' cannot be used with '--verify-deps'
+
+Usage: sui client upgrade --upgrade-capability <UPGRADE_CAPABILITY> --skip-dependency-verification <package_path>
+
+For more information, try '--help'.

--- a/crates/sui/tests/snapshots/shell_tests__with_network__source_verification_deprecation__no_flags.sh.snap
+++ b/crates/sui/tests/snapshots/shell_tests__with_network__source_verification_deprecation__no_flags.sh.snap
@@ -1,0 +1,95 @@
+---
+source: crates/sui/tests/shell_tests.rs
+description: tests/shell_tests/with_network/source_verification_deprecation/no_flags.sh
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# check that we get a deprecation warning when upgrading without any dependency verification flags
+
+echo "=== munge Move.toml files ===" | tee /dev/stderr
+FRAMEWORK_DIR=$(echo $CARGO_MANIFEST_DIR | sed 's#/crates/sui#/crates/sui-framework/packages/sui-framework#g')
+for i in dependency/Move.toml example/Move.toml
+do
+  cat $i | sed "s#FRAMEWORK_DIR#$FRAMEWORK_DIR#g" > Move.toml \
+    && mv Move.toml $i
+done
+
+echo "=== publish dependency ===" | tee /dev/stderr
+sui client --client.config $CONFIG publish "dependency" \
+  --json | jq '.effects.status'
+
+echo "=== publish package v0 (should warn) ===" | tee /dev/stderr
+UPGRADE_CAP=$(sui client --client.config $CONFIG publish "example" \
+  --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
+
+echo "=== upgrade package (should warn) ===" | tee /dev/stderr
+sui client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example \
+  --json | jq '.effects.status'
+
+echo "=== modify dependency ===" | tee /dev/stderr
+cat dependency/sources/dependency.move | sed 's#0#1#g' > dependency.move
+mv dependency.move dependency/sources/dependency.move
+
+echo "=== try to publish with modified dep (should fail) ===" | tee /dev/stderr
+sui client --client.config $CONFIG publish "example" \
+  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'
+
+echo "=== try to upgrade with modified dep (should fail) ===" | tee /dev/stderr
+sui client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example \
+  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'
+
+----- results -----
+success: true
+exit_code: 0
+----- stdout -----
+=== munge Move.toml files ===
+=== publish dependency ===
+{
+  "status": "success"
+}
+=== publish package v0 (should warn) ===
+=== upgrade package (should warn) ===
+{
+  "status": "success"
+}
+=== modify dependency ===
+=== try to publish with modified dep (should fail) ===
+Failed to publish the Move module(s), reason: [warning] Local dependency did not match its on-chain version at [[package address]]::dependency::dependency
+
+This may indicate that the on-chain version(s) of your package's dependencies may behave differently than the source version(s) your package was built against.
+
+Fix this by rebuilding your packages with source versions matching on-chain versions of dependencies, or ignore this warning by re-running with the --skip-dependency-verification flag.
+=== try to upgrade with modified dep (should fail) ===
+Failed to publish the Move module(s), reason: [warning] Local dependency did not match its on-chain version at [[package address]]::dependency::dependency
+
+This may indicate that the on-chain version(s) of your package's dependencies may behave differently than the source version(s) your package was built against.
+
+Fix this by rebuilding your packages with source versions matching on-chain versions of dependencies, or ignore this warning by re-running with the --skip-dependency-verification flag.
+
+----- stderr -----
+=== munge Move.toml files ===
+=== publish dependency ===
+[warning]: In a future release, dependency source code will no longer be verified by default during publication and upgrade. You can opt in to source verification using `--verify-deps` or disable this warning using `--skip-dependency-verification`. You can also manually verify dependencies using `sui client verify-source`.
+BUILDING dependency
+Successfully verified dependencies on-chain against source.
+=== publish package v0 (should warn) ===
+[warning]: In a future release, dependency source code will no longer be verified by default during publication and upgrade. You can opt in to source verification using `--verify-deps` or disable this warning using `--skip-dependency-verification`. You can also manually verify dependencies using `sui client verify-source`.
+INCLUDING DEPENDENCY dependency
+BUILDING example
+Successfully verified dependencies on-chain against source.
+=== upgrade package (should warn) ===
+[warning]: In a future release, dependency source code will no longer be verified by default during publication and upgrade. You can opt in to source verification using `--verify-deps` or disable this warning using `--skip-dependency-verification`. You can also manually verify dependencies using `sui client verify-source`.
+INCLUDING DEPENDENCY dependency
+BUILDING example
+Successfully verified dependencies on-chain against source.
+=== modify dependency ===
+=== try to publish with modified dep (should fail) ===
+[warning]: In a future release, dependency source code will no longer be verified by default during publication and upgrade. You can opt in to source verification using `--verify-deps` or disable this warning using `--skip-dependency-verification`. You can also manually verify dependencies using `sui client verify-source`.
+INCLUDING DEPENDENCY dependency
+BUILDING example
+=== try to upgrade with modified dep (should fail) ===
+[warning]: In a future release, dependency source code will no longer be verified by default during publication and upgrade. You can opt in to source verification using `--verify-deps` or disable this warning using `--skip-dependency-verification`. You can also manually verify dependencies using `sui client verify-source`.
+INCLUDING DEPENDENCY dependency
+BUILDING example

--- a/crates/sui/tests/snapshots/shell_tests__with_network__source_verification_deprecation__skip_dep_verif.sh.snap
+++ b/crates/sui/tests/snapshots/shell_tests__with_network__source_verification_deprecation__skip_dep_verif.sh.snap
@@ -1,0 +1,85 @@
+---
+source: crates/sui/tests/shell_tests.rs
+description: tests/shell_tests/with_network/source_verification_deprecation/skip_dep_verif.sh
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# check that --skip-dependency-verification has the right behavior on publish and upgrade
+
+echo "=== munge Move.toml files ===" | tee /dev/stderr
+FRAMEWORK_DIR=$(echo $CARGO_MANIFEST_DIR | sed 's#/crates/sui#/crates/sui-framework/packages/sui-framework#g')
+for i in dependency/Move.toml example/Move.toml
+do
+  cat $i | sed "s#FRAMEWORK_DIR#$FRAMEWORK_DIR#g" > Move.toml \
+    && mv Move.toml $i
+done
+
+echo "=== publish dependency ===" | tee /dev/stderr
+sui client --client.config $CONFIG publish "dependency" --skip-dependency-verification \
+  --json | jq '.effects.status'
+
+echo "=== publish package v0 (should NOT warn) ===" | tee /dev/stderr
+UPGRADE_CAP=$(sui client --client.config $CONFIG publish "example" --skip-dependency-verification \
+  --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
+
+echo "=== upgrade package (should NOT warn) ===" | tee /dev/stderr
+sui client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example --skip-dependency-verification \
+  --json | jq '.effects.status'
+
+echo "=== modify dependency ===" | tee /dev/stderr
+cat dependency/sources/dependency.move | sed 's#0#1#g' > dependency.move
+mv dependency.move dependency/sources/dependency.move
+
+echo "=== try to publish with modified dep (should succeed) ===" | tee /dev/stderr
+UPGRADE_CAP=$(sui client --client.config $CONFIG publish "example" --skip-dependency-verification \
+  --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
+
+echo "=== try to upgrade with modified dep (should succeed) ===" | tee /dev/stderr
+sui client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example --skip-dependency-verification \
+  --json | jq '.effects.status'
+
+----- results -----
+success: true
+exit_code: 0
+----- stdout -----
+=== munge Move.toml files ===
+=== publish dependency ===
+{
+  "status": "success"
+}
+=== publish package v0 (should NOT warn) ===
+=== upgrade package (should NOT warn) ===
+{
+  "status": "success"
+}
+=== modify dependency ===
+=== try to publish with modified dep (should succeed) ===
+=== try to upgrade with modified dep (should succeed) ===
+{
+  "status": "success"
+}
+
+----- stderr -----
+=== munge Move.toml files ===
+=== publish dependency ===
+BUILDING dependency
+Skipping dependency verification
+=== publish package v0 (should NOT warn) ===
+INCLUDING DEPENDENCY dependency
+BUILDING example
+Skipping dependency verification
+=== upgrade package (should NOT warn) ===
+INCLUDING DEPENDENCY dependency
+BUILDING example
+Skipping dependency verification
+=== modify dependency ===
+=== try to publish with modified dep (should succeed) ===
+INCLUDING DEPENDENCY dependency
+BUILDING example
+Skipping dependency verification
+=== try to upgrade with modified dep (should succeed) ===
+INCLUDING DEPENDENCY dependency
+BUILDING example
+Skipping dependency verification

--- a/crates/sui/tests/snapshots/shell_tests__with_network__source_verification_deprecation__with_dep_verif.sh.snap
+++ b/crates/sui/tests/snapshots/shell_tests__with_network__source_verification_deprecation__with_dep_verif.sh.snap
@@ -1,0 +1,90 @@
+---
+source: crates/sui/tests/shell_tests.rs
+description: tests/shell_tests/with_network/source_verification_deprecation/with_dep_verif.sh
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# check that --verify-deps has the right behavior on publish and upgrade
+
+echo "=== munge Move.toml files ===" | tee /dev/stderr
+FRAMEWORK_DIR=$(echo $CARGO_MANIFEST_DIR | sed 's#/crates/sui#/crates/sui-framework/packages/sui-framework#g')
+for i in dependency/Move.toml example/Move.toml
+do
+  cat $i | sed "s#FRAMEWORK_DIR#$FRAMEWORK_DIR#g" > Move.toml \
+    && mv Move.toml $i
+done
+
+echo "=== publish dependency ===" | tee /dev/stderr
+sui client --client.config $CONFIG publish "dependency" --verify-deps \
+  --json | jq '.effects.status'
+
+echo "=== publish package v0 (should NOT warn) ===" | tee /dev/stderr
+UPGRADE_CAP=$(sui client --client.config $CONFIG publish "example" --verify-deps \
+  --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
+
+echo "=== upgrade package (should NOT warn) ===" | tee /dev/stderr
+sui client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example --verify-deps \
+  --json | jq '.effects.status'
+
+echo "=== modify dependency ===" | tee /dev/stderr
+cat dependency/sources/dependency.move | sed 's#0#1#g' > dependency.move
+mv dependency.move dependency/sources/dependency.move
+
+echo "=== try to publish with modified dep (should fail) ===" | tee /dev/stderr
+sui client --client.config $CONFIG publish "example" --verify-deps \
+  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'
+
+echo "=== try to upgrade with modified dep (should fail) ===" | tee /dev/stderr
+sui client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example --verify-deps \
+  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'
+
+----- results -----
+success: true
+exit_code: 0
+----- stdout -----
+=== munge Move.toml files ===
+=== publish dependency ===
+{
+  "status": "success"
+}
+=== publish package v0 (should NOT warn) ===
+=== upgrade package (should NOT warn) ===
+{
+  "status": "success"
+}
+=== modify dependency ===
+=== try to publish with modified dep (should fail) ===
+Failed to publish the Move module(s), reason: [warning] Local dependency did not match its on-chain version at [[package address]]::dependency::dependency
+
+This may indicate that the on-chain version(s) of your package's dependencies may behave differently than the source version(s) your package was built against.
+
+Fix this by rebuilding your packages with source versions matching on-chain versions of dependencies, or ignore this warning by re-running with the --skip-dependency-verification flag.
+=== try to upgrade with modified dep (should fail) ===
+Failed to publish the Move module(s), reason: [warning] Local dependency did not match its on-chain version at [[package address]]::dependency::dependency
+
+This may indicate that the on-chain version(s) of your package's dependencies may behave differently than the source version(s) your package was built against.
+
+Fix this by rebuilding your packages with source versions matching on-chain versions of dependencies, or ignore this warning by re-running with the --skip-dependency-verification flag.
+
+----- stderr -----
+=== munge Move.toml files ===
+=== publish dependency ===
+BUILDING dependency
+Successfully verified dependencies on-chain against source.
+=== publish package v0 (should NOT warn) ===
+INCLUDING DEPENDENCY dependency
+BUILDING example
+Successfully verified dependencies on-chain against source.
+=== upgrade package (should NOT warn) ===
+INCLUDING DEPENDENCY dependency
+BUILDING example
+Successfully verified dependencies on-chain against source.
+=== modify dependency ===
+=== try to publish with modified dep (should fail) ===
+INCLUDING DEPENDENCY dependency
+BUILDING example
+=== try to upgrade with modified dep (should fail) ===
+INCLUDING DEPENDENCY dependency
+BUILDING example


### PR DESCRIPTION

## Description 

This adds a warning that source verification will become opt-in instead of opt-out in a future release, along with the `--verify-deps` flag that currently disables the warning.

## Test plan 

Several shell tests that cover the behavior with no flags, with both flags, and with each flag independently, on a package with source that has changed since publication. See the snapshot files for the tests and expected output.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: publication and upgrade will now warn that source verification will become opt-in in a future release; the warning can be disabled with either `--skip-dependency-verification` or the new `--verify-deps` flags
- [ ] Rust SDK:

