### PR TITLE
[move] Remove unused dependency from move-trace-format's manifest

### DIFF
--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -2307,7 +2307,6 @@ name = "move-trace-format"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "arbitrary",
  "enum-compat-util",
  "getrandom 0.2.15",
  "move-binary-format",

--- a/external-crates/move/crates/move-trace-format/Cargo.toml
+++ b/external-crates/move/crates/move-trace-format/Cargo.toml
@@ -14,7 +14,6 @@ ref-cast.workspace = true
 variant_count.workspace = true
 move-core-types.workspace = true
 serde.workspace = true
-arbitrary = { workspace = true, optional = true, features = ["derive"] }
 enum-compat-util.workspace = true
 move-proc-macros.workspace = true
 move-binary-format.workspace = true
@@ -30,5 +29,5 @@ move-core-types = { workspace = true, features = ["fuzzing" ] }
 
 [features]
 default = []
-fuzzing = ["proptest", "proptest-derive", "arbitrary", "move-core-types/fuzzing"]
+fuzzing = ["proptest", "proptest-derive", "move-core-types/fuzzing"]
 wasm = ["getrandom"]


### PR DESCRIPTION
## Description 

What the title says
