### PR TITLE
[move][move-vm][rewrite][cleanup] Replace type info with a datatype descriptor pointers in VTables

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/cache/arena.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/cache/arena.rs
@@ -51,6 +51,14 @@ impl Arena {
             Err(PartialVMError::new(StatusCode::PACKAGE_ARENA_LIMIT_REACHED))
         }
     }
+
+    pub fn alloc_item<T>(&self, item: T) -> PartialVMResult<*const T> {
+        if let Ok(value) = self.0.try_alloc(item) {
+            Ok(value)
+        } else {
+            Err(PartialVMError::new(StatusCode::PACKAGE_ARENA_LIMIT_REACHED))
+        }
+    }
 }
 
 // -----------------------------------------------

--- a/external-crates/move/crates/move-vm-runtime/src/cache/move_cache.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/cache/move_cache.rs
@@ -103,7 +103,7 @@ impl Package {
     /// Used for testing that the correct number of types are loaded
     #[allow(dead_code)]
     pub(crate) fn loaded_types_len(&self) -> usize {
-        self.runtime.vtable.types.cached_types.len()
+        self.runtime.vtable.types.len()
     }
 }
 

--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/eval.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/eval.rs
@@ -45,7 +45,7 @@ enum StepStatus {
 }
 
 struct RunContext<'vm_cache, 'native, 'native_lifetimes, 'tracer, 'trace_builder> {
-    vtables: &'vm_cache VMDispatchTables,
+    vtables: &'vm_cache mut VMDispatchTables,
     vm_config: Arc<VMConfig>,
     extensions: &'native mut NativeContextExtensions<'native_lifetimes>,
     // TODO: consider making this `Option<&mut VMTracer<'_>>` and passing it like that everywhere?
@@ -66,7 +66,7 @@ impl RunContext<'_, '_, '_, '_, '_> {
 /// calling `step`, until the call stack is empty.
 pub(super) fn run(
     start_state: MachineState,
-    vtables: &VMDispatchTables,
+    vtables: &mut VMDispatchTables,
     vm_config: Arc<VMConfig>,
     extensions: &mut NativeContextExtensions,
     tracer: &mut Option<VMTracer<'_>>,
@@ -1207,7 +1207,7 @@ fn partial_error_to_error<T>(
     })
 }
 
-fn check_depth_of_type(run_context: &RunContext, ty: &Type) -> PartialVMResult<u64> {
+fn check_depth_of_type(run_context: &mut RunContext, ty: &Type) -> PartialVMResult<u64> {
     let Some(max_depth) = run_context
         .vm_config
         .runtime_limits_config
@@ -1219,7 +1219,7 @@ fn check_depth_of_type(run_context: &RunContext, ty: &Type) -> PartialVMResult<u
 }
 
 fn check_depth_of_type_impl(
-    run_context: &RunContext,
+    run_context: &mut RunContext,
     ty: &Type,
     current_depth: u64,
     max_depth: u64,

--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/mod.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/mod.rs
@@ -24,7 +24,7 @@ pub(crate) mod state;
 /// Entrypoint into the interpreter. All external calls need to be routed through this
 /// function.
 pub(crate) fn run(
-    vtables: &VMDispatchTables,
+    vtables: &mut VMDispatchTables,
     vm_config: Arc<VMConfig>,
     extensions: &mut NativeContextExtensions,
     tracer: &mut Option<VMTracer<'_>>,

--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/state.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/state.rs
@@ -192,7 +192,7 @@ impl MachineState {
         // a verification error cannot happen at runtime so change it into an invariant violation.
         let err = if err.status_type() == StatusType::Verification {
             error!("Verification error during runtime: {:?}", err);
-            let new_err = PartialVMError::new(StatusCode::VERIFICATION_ERROR);
+            let new_err = PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR);
             let new_err = match err.message() {
                 None => new_err.with_message("No message provided for core dump".to_owned()),
                 Some(msg) => new_err.with_message(msg.to_owned()),

--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/state.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/state.rs
@@ -189,7 +189,6 @@ impl MachineState {
     /// Given an `VMStatus` generate a core dump if the error is an `InvariantViolation`. Uses the
     /// `current_frame` on the state to perform the core dump.
     pub fn maybe_core_dump(&self, err: VMError) -> VMError {
-        // a verification error cannot happen at runtime so change it into an invariant violation.
         let err = if err.status_type() == StatusType::Verification {
             error!("Verification error during runtime: {:?}", err);
             let new_err = PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR);

--- a/external-crates/move/crates/move-vm-runtime/src/execution/vm.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/vm.rs
@@ -337,7 +337,7 @@ impl<'extensions> MoveVM<'extensions> {
             .map_err(|err| err.finish(Location::Undefined))?;
 
         let return_values = interpreter::run(
-            &self.virtual_tables,
+            &mut self.virtual_tables,
             self.vm_config.clone(),
             &mut self.native_extensions,
             tracer,

--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
@@ -45,6 +45,7 @@ pub struct Package {
 
     // NB: this is under the package's context so we don't need to further resolve by
     // address in this table.
+    // TODO(vm-rewrite): IdentifierKey
     pub loaded_modules: BinaryCache<Identifier, Module>,
 
     // NB: Package functions and code are allocated into this arena.
@@ -136,6 +137,7 @@ pub struct Function {
     pub native: Option<NativeFunction>,
     pub def_is_native: bool,
     pub module: ModuleId,
+    // TODO(vm-rewrite): IdentifierKey
     pub name: Identifier,
     pub locals_len: usize,
     pub jump_tables: Vec<VariantJumpTable>,
@@ -257,6 +259,7 @@ pub enum Type {
 pub struct DatatypeDescriptor {
     pub abilities: AbilitySet,
     pub type_parameters: Vec<DatatypeTyParameter>,
+    // TODO(vm-rewrite): IdentifierKey
     pub name: Identifier,
     pub defining_id: ModuleId,
     pub runtime_id: ModuleId,
@@ -279,6 +282,7 @@ pub struct EnumType {
 
 #[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct VariantType {
+    // TODO(vm-rewrite): IdentifierKey
     pub variant_name: Identifier,
     pub fields: Vec<Type>,
     pub field_names: Vec<Identifier>,

--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
@@ -289,10 +289,8 @@ fn record_module_types_in_vtable(
 ) {
     for (key, descriptor) in datatype_descriptors {
         let descriptor_ptr = VMPointer::from_ref(descriptor);
-        debug_assert!(
-            vtable.types.insert(*key, descriptor_ptr).is_none(),
-            "Double insert for datatype"
-        );
+        let _prev = vtable.types.insert(*key, descriptor_ptr);
+        debug_assert!(_prev.is_none(), "Double insert for datatype");
     }
 }
 
@@ -328,9 +326,7 @@ fn structs(
         .iter()
         .map(|struct_def| {
             let key = type_refs[struct_def.struct_handle.0 as usize];
-            let Some(type_) = datatype_descriptors.get(&key) else {
-                panic!("did not find struct {}", key.to_string()?);
-            };
+            let type_ = &datatype_descriptors[&key];
             let struct_type = type_.get_struct()?;
             let field_count = struct_type.fields.len() as u16;
             Ok(StructDef {
@@ -380,9 +376,7 @@ fn enums(
         .iter()
         .map(|enum_def| {
             let key = type_refs[enum_def.enum_handle.0 as usize];
-            let Some(type_) = datatype_descriptors.get(&key) else {
-                panic!("did not find enum {}", key.to_string()?);
-            };
+            let type_ = &datatype_descriptors[&key];
             let enum_type = type_.get_enum()?;
             let variant_count = enum_type.variants.len() as u16;
             let variants = enum_type
@@ -952,10 +946,9 @@ fn load_module_types(
             module_key: module_name,
             member_key: member_name,
         };
+        let _prev = datatype_descriptors.insert(struct_key, datatype_descriptor);
         debug_assert!(
-            datatype_descriptors
-                .insert(struct_key, datatype_descriptor)
-                .is_none(),
+            _prev.is_none(),
             "double-insert of datatype {}",
             struct_key.to_string()?
         );
@@ -1027,10 +1020,9 @@ fn load_module_types(
             module_key: module_name,
             member_key: member_name,
         };
+        let _prev = datatype_descriptors.insert(enum_key, datatype_descriptor);
         debug_assert!(
-            datatype_descriptors
-                .insert(enum_key, datatype_descriptor)
-                .is_none(),
+            _prev.is_none(),
             "double-insert of datatype {}",
             enum_key.to_string()?
         );

--- a/external-crates/move/crates/move-vm-runtime/src/shared/vm_pointer.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/shared/vm_pointer.rs
@@ -112,14 +112,15 @@ impl<T: ::std::fmt::Debug> ::std::fmt::Debug for VMPointer<T> {
     }
 }
 
-// Pointer equality
-impl<T> PartialEq for VMPointer<T> {
+// VMPointer equality first checks pointer equality, then full equality
+impl<T: PartialEq> PartialEq for VMPointer<T> {
     fn eq(&self, other: &Self) -> bool {
-        self.ptr_eq(other)
+        self.ptr_eq(other) || self.to_ref().eq(other.to_ref())
     }
 }
 
-impl<T> Eq for VMPointer<T> {}
+// VMPointer equality first checks pointer equality, then full equality
+impl<T: Eq> Eq for VMPointer<T> {}
 
 impl<T> Clone for VMPointer<T> {
     #[allow(clippy::non_canonical_clone_impl)]
@@ -137,5 +138,23 @@ impl<T> From<Box<T>> for VMPointer<T> {
 
         // Create an `ArenaPointer` from the raw pointer.
         VMPointer(raw_ptr)
+    }
+}
+
+impl<T: PartialOrd> PartialOrd for VMPointer<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.to_ref().partial_cmp(other.to_ref())
+    }
+}
+
+impl<T: Ord> Ord for VMPointer<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.to_ref().cmp(other.to_ref())
+    }
+}
+
+impl<T: std::hash::Hash> std::hash::Hash for VMPointer<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.to_ref().hash(state)
     }
 }

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/loader_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/loader_tests.rs
@@ -201,7 +201,7 @@ impl Adapter {
         struct_name: &IdentStr,
     ) -> DepthFormula {
         let vm = self.runtime_adapter.write();
-        let session = vm.make_vm(self.store.linkage.clone()).unwrap();
+        let mut session = vm.make_vm(self.store.linkage.clone()).unwrap();
         session
             .virtual_tables
             .calculate_depth_of_type(&VirtualTableKey {
@@ -229,6 +229,7 @@ impl Adapter {
 
     fn call_functions(&self, functions: &[(ModuleId, Identifier)]) {
         for (module_id, name) in functions {
+            println!("calling {name}");
             self.call_function(module_id, name);
         }
     }

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/package_cache_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/package_cache_tests.rs
@@ -138,7 +138,7 @@ fn load_package_internal_package_calls_only_with_types() {
     assert_eq!(l_pkg.runtime.loaded_modules.binaries.len(), 3);
     assert_eq!(l_pkg.runtime.storage_id, package_address);
     assert_eq!(l_pkg.runtime.vtable.functions.len(), 3);
-    assert_eq!(l_pkg.runtime.vtable.types.cached_types.len(), 0);
+    assert_eq!(l_pkg.runtime.vtable.types.len(), 0);
 }
 
 #[test]


### PR DESCRIPTION
## Description 

Toward arena values everywhere, and to mirror the current situation for the function pointers in the virtual tables, we swap out types with a `DatatypeDescriptor`.

Two notes:
1. This deletes the type instantiation cache, as planned. We can reintroduce something later with more runtime elegance.
2. The previous implementation would update type depth formulae during execution by grabbing `Arc` locks to do that. We no longer do this, and instead the `VMDispatchTables` struct holds the formulae separately. This is toward future-proofing for signatures and type ugradability.

## Test plan 

Tests all still pass.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
