### PR TITLE
jsonrpc: make coin_api cursors opaque

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14297,6 +14297,7 @@ dependencies = [
  "async-trait",
  "axum 0.7.5",
  "backoff",
+ "base64 0.21.7",
  "bcs",
  "cached",
  "chrono",

--- a/crates/sui-cluster-test/src/test_case/coin_index_test.rs
+++ b/crates/sui-cluster-test/src/test_case/coin_index_test.rs
@@ -523,16 +523,12 @@ impl TestCaseImpl for CoinIndexTest {
             sui_coins_with_managed_coin_1.data.len(),
             sui_coins.len() + 1
         );
-        assert_eq!(
-            sui_coins_with_managed_coin_1.next_cursor,
-            Some(first_managed_coin)
-        );
         assert!(sui_coins_with_managed_coin_1.has_next_page);
         let cursor = sui_coins_with_managed_coin_1.next_cursor;
 
         let managed_coins_2_11 = client
             .coin_read_api()
-            .get_all_coins(account, cursor, Some(10))
+            .get_all_coins(account, cursor.clone(), Some(10))
             .await
             .unwrap();
         assert_eq!(
@@ -554,14 +550,14 @@ impl TestCaseImpl for CoinIndexTest {
 
         let managed_coins_12_40 = client
             .coin_read_api()
-            .get_all_coins(account, cursor, None)
+            .get_all_coins(account, cursor.clone(), None)
             .await
             .unwrap();
         assert_eq!(
             managed_coins_12_40,
             client
                 .coin_read_api()
-                .get_coins(account, Some(coin_type_str.clone()), cursor, None)
+                .get_coins(account, Some(coin_type_str.clone()), cursor.clone(), None)
                 .await
                 .unwrap(),
         );
@@ -574,14 +570,19 @@ impl TestCaseImpl for CoinIndexTest {
 
         let managed_coins_12_40 = client
             .coin_read_api()
-            .get_all_coins(account, cursor, Some(30))
+            .get_all_coins(account, cursor.clone(), Some(30))
             .await
             .unwrap();
         assert_eq!(
             managed_coins_12_40,
             client
                 .coin_read_api()
-                .get_coins(account, Some(coin_type_str.clone()), cursor, Some(30))
+                .get_coins(
+                    account,
+                    Some(coin_type_str.clone()),
+                    cursor.clone(),
+                    Some(30)
+                )
                 .await
                 .unwrap(),
         );
@@ -597,7 +598,7 @@ impl TestCaseImpl for CoinIndexTest {
         let _ = add_to_envelope(ctx, package.0, envelope.0, removed_coin_id).await;
         let managed_coins_12_39 = client
             .coin_read_api()
-            .get_all_coins(account, cursor, Some(40))
+            .get_all_coins(account, cursor.clone(), Some(40))
             .await
             .unwrap();
         assert_eq!(

--- a/crates/sui-json-rpc-api/src/coin.rs
+++ b/crates/sui-json-rpc-api/src/coin.rs
@@ -6,7 +6,7 @@ use jsonrpsee::proc_macros::rpc;
 use sui_json_rpc_types::{Balance, CoinPage, SuiCoinMetadata};
 use sui_open_rpc_macros::open_rpc;
 use sui_types::balance::Supply;
-use sui_types::base_types::{ObjectID, SuiAddress};
+use sui_types::base_types::SuiAddress;
 
 #[open_rpc(namespace = "suix", tag = "Coin Query API")]
 #[rpc(server, client, namespace = "suix")]
@@ -20,7 +20,7 @@ pub trait CoinReadApi {
         /// optional type name for the coin (e.g., 0x168da5bf1f48dafc111b0a488fa454aca95e0b5e::usdc::USDC), default to 0x2::sui::SUI if not specified.
         coin_type: Option<String>,
         /// optional paging cursor
-        cursor: Option<ObjectID>,
+        cursor: Option<String>,
         /// maximum number of items per page
         limit: Option<usize>,
     ) -> RpcResult<CoinPage>;
@@ -32,7 +32,7 @@ pub trait CoinReadApi {
         /// the owner's Sui address
         owner: SuiAddress,
         /// optional paging cursor
-        cursor: Option<ObjectID>,
+        cursor: Option<String>,
         /// maximum number of items per page
         limit: Option<usize>,
     ) -> RpcResult<CoinPage>;

--- a/crates/sui-json-rpc-tests/tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/rpc_server_tests.rs
@@ -389,17 +389,6 @@ async fn test_get_coins() -> Result<(), anyhow::Error> {
     assert_eq!(2, result.data.len(), "{:?}", result);
     assert!(!result.has_next_page);
 
-    let result: CoinPage = http_client
-        .get_coins(
-            address,
-            Some("0x2::sui::SUI".into()),
-            result.next_cursor,
-            None,
-        )
-        .await?;
-    assert_eq!(0, result.data.len(), "{:?}", result);
-    assert!(!result.has_next_page);
-
     Ok(())
 }
 

--- a/crates/sui-json-rpc-types/src/sui_coin.rs
+++ b/crates/sui-json-rpc-types/src/sui_coin.rs
@@ -17,7 +17,7 @@ use sui_types::object::Object;
 use sui_types::sui_serde::BigInt;
 use sui_types::sui_serde::SequenceNumber as AsSequenceNumber;
 
-pub type CoinPage = Page<Coin, ObjectID>;
+pub type CoinPage = Page<Coin, String>;
 
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug, JsonSchema, PartialEq, Eq, Clone)]

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -37,6 +37,7 @@ bcs.workspace = true
 eyre.workspace = true
 once_cell.workspace = true
 serde_json.workspace = true
+base64.workspace = true
 
 tap.workspace = true
 

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -79,6 +79,40 @@ impl SuiRpcModule for CoinReadApi {
     }
 }
 
+#[derive(serde::Serialize, serde::Deserialize)]
+struct CoinCursor {
+    coin_type: String,
+    inverted_balance: u64,
+    object_id: ObjectID,
+}
+
+impl CoinCursor {
+    fn new(coin_type: String, balance: u64, object_id: ObjectID) -> Self {
+        Self {
+            coin_type,
+            inverted_balance: !balance,
+            object_id,
+        }
+    }
+
+    fn encode(&self) -> String {
+        use base64::prelude::BASE64_STANDARD;
+        use base64::Engine;
+
+        let json = serde_json::to_string(self).unwrap();
+
+        BASE64_STANDARD.encode(json.as_bytes())
+    }
+
+    fn decode(cursor: &str) -> Option<Self> {
+        use base64::prelude::BASE64_STANDARD;
+        use base64::Engine;
+
+        let bytes = BASE64_STANDARD.decode(cursor).ok()?;
+        serde_json::from_slice(&bytes).ok()
+    }
+}
+
 #[async_trait]
 impl CoinReadApiServer for CoinReadApi {
     #[instrument(skip(self))]
@@ -87,7 +121,7 @@ impl CoinReadApiServer for CoinReadApi {
         owner: SuiAddress,
         coin_type: Option<String>,
         // exclusive cursor if `Some`, otherwise start from the beginning
-        cursor: Option<ObjectID>,
+        cursor: Option<String>,
         limit: Option<usize>,
     ) -> RpcResult<CoinPage> {
         with_tracing!(async move {
@@ -95,13 +129,20 @@ impl CoinReadApiServer for CoinReadApi {
 
             let cursor = match cursor {
                 Some(c) => {
-                    let obj = self.internal.get_object(&c).await?.ok_or_else(|| {
-                        SuiRpcInputError::GenericInvalid("cursor not found".to_string())
+                    let decoded = CoinCursor::decode(&c).ok_or_else(|| {
+                        SuiRpcInputError::GenericInvalid("invalid cursor".to_string())
                     })?;
-                    let coin = obj.as_coin_maybe().ok_or_else(|| {
-                        SuiRpcInputError::GenericInvalid("cursor is not a coin".to_string())
-                    })?;
-                    (coin_type_tag.to_string(), !coin.balance.value(), c)
+
+                    if coin_type_tag.to_string() != decoded.coin_type {
+                        return Err(
+                            SuiRpcInputError::GenericInvalid("invalid cursor".to_string()).into(),
+                        );
+                    }
+                    (
+                        decoded.coin_type,
+                        decoded.inverted_balance,
+                        decoded.object_id,
+                    )
                 }
                 // If cursor is not specified, we need to start from the beginning of the coin type, which is the minimal possible ObjectID.
                 None => (coin_type_tag.to_string(), 0, ObjectID::ZERO),
@@ -120,47 +161,30 @@ impl CoinReadApiServer for CoinReadApi {
         &self,
         owner: SuiAddress,
         // exclusive cursor if `Some`, otherwise start from the beginning
-        cursor: Option<ObjectID>,
+        cursor: Option<String>,
         limit: Option<usize>,
     ) -> RpcResult<CoinPage> {
         with_tracing!(async move {
             let cursor = match cursor {
-                Some(object_id) => {
-                    let obj = self.internal.get_object(&object_id).await?;
-                    match obj {
-                        Some(obj) => {
-                            let coin_type = obj.coin_type_maybe();
-                            if coin_type.is_none() {
-                                Err(SuiRpcInputError::GenericInvalid(
-                                    "cursor is not a coin".to_string(),
-                                ))
-                            } else {
-                                let coin = obj.as_coin_maybe().ok_or_else(|| {
-                                    SuiRpcInputError::GenericInvalid(
-                                        "cursor is not a coin".to_string(),
-                                    )
-                                })?;
-                                Ok((
-                                    coin_type.unwrap().to_string(),
-                                    !coin.balance.value(),
-                                    object_id,
-                                ))
-                            }
-                        }
-                        None => Err(SuiRpcInputError::GenericInvalid(
-                            "cursor not found".to_string(),
-                        )),
-                    }
+                Some(c) => {
+                    let decoded = CoinCursor::decode(&c).ok_or_else(|| {
+                        SuiRpcInputError::GenericInvalid("invalid cursor".to_string())
+                    })?;
+                    (
+                        decoded.coin_type,
+                        decoded.inverted_balance,
+                        decoded.object_id,
+                    )
                 }
                 None => {
                     // If cursor is None, start from the beginning
-                    Ok((
+                    (
                         String::from_utf8([0u8].to_vec()).unwrap(),
                         0,
                         ObjectID::ZERO,
-                    ))
+                    )
                 }
-            }?;
+            };
 
             let coins = self
                 .internal
@@ -408,7 +432,14 @@ impl CoinReadInternal for CoinReadInternalImpl {
         self.metrics
             .get_coins_result_size_total
             .inc_by(data.len() as u64);
-        let next_cursor = data.last().map(|coin| coin.coin_object_id);
+        let next_cursor = has_next_page
+            .then(|| {
+                data.last().map(|coin| {
+                    CoinCursor::new(coin.coin_type.clone(), coin.balance, coin.coin_object_id)
+                        .encode()
+                })
+            })
+            .flatten();
         Ok(CoinPage {
             data,
             next_cursor,
@@ -620,7 +651,7 @@ mod tests {
                 result,
                 CoinPage {
                     data: vec![gas_coin.clone()],
-                    next_cursor: Some(gas_coin.coin_object_id),
+                    next_cursor: None,
                     has_next_page: false,
                 }
             );
@@ -656,16 +687,29 @@ mod tests {
                 .return_once(|_| Ok(Some(get_test_coin(Some("0xA"), CoinType::Gas).0)));
 
             let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state), None);
+            let cursor = CoinCursor::new(
+                coins[0].coin_type.clone(),
+                coins[0].balance,
+                coins[0].coin_object_id,
+            )
+            .encode();
             let response = coin_read_api
-                .get_coins(owner, None, Some(coins[0].coin_object_id), Some(limit))
+                .get_coins(owner, None, Some(cursor), Some(limit))
                 .await;
             assert!(response.is_ok());
             let result = response.unwrap();
+
+            let expected_cursor = CoinCursor::new(
+                coins[limit - 1].coin_type.clone(),
+                coins[limit - 1].balance,
+                coins[limit - 1].coin_object_id,
+            )
+            .encode();
             assert_eq!(
                 result,
                 CoinPage {
                     data: coins[..limit].to_vec(),
-                    next_cursor: Some(coins[limit - 1].coin_object_id),
+                    next_cursor: Some(expected_cursor),
                     has_next_page: true,
                 }
             );
@@ -703,7 +747,7 @@ mod tests {
                 result,
                 CoinPage {
                     data: vec![coin.clone()],
-                    next_cursor: Some(coin.coin_object_id),
+                    next_cursor: None,
                     has_next_page: false,
                 }
             );
@@ -720,7 +764,12 @@ mod tests {
             // Build request params
             let owner = get_test_owner();
             let coin_type = coins[0].coin_type.clone();
-            let cursor = coins[0].coin_object_id;
+            let cursor = CoinCursor::new(
+                coins[0].coin_type.clone(),
+                coins[0].balance,
+                coins[0].coin_object_id,
+            )
+            .encode();
             let limit = 2;
 
             let coin_type_tag =
@@ -751,11 +800,17 @@ mod tests {
 
             assert!(response.is_ok());
             let result = response.unwrap();
+            let expected_cursor = CoinCursor::new(
+                coins[limit - 1].coin_type.clone(),
+                coins[limit - 1].balance,
+                coins[limit - 1].coin_object_id,
+            )
+            .encode();
             assert_eq!(
                 result,
                 CoinPage {
                     data: coins[..limit].to_vec(),
-                    next_cursor: Some(coins[limit - 1].coin_object_id),
+                    next_cursor: Some(expected_cursor),
                     has_next_page: true,
                 }
             );
@@ -926,8 +981,14 @@ mod tests {
                 )
                 .return_once(move |_, _, _, _| Ok(coins_clone));
             let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state), None);
+            let cursor = CoinCursor::new(
+                coins[0].coin_type.clone(),
+                coins[0].balance,
+                coins[0].coin_object_id,
+            )
+            .encode();
             let response = coin_read_api
-                .get_all_coins(owner, Some(coins[0].coin_object_id), Some(limit))
+                .get_all_coins(owner, Some(cursor), Some(limit))
                 .await
                 .unwrap();
             assert_eq!(response.data.len(), limit);
@@ -950,7 +1011,7 @@ mod tests {
             });
             let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state), None);
             let response = coin_read_api
-                .get_all_coins(owner, Some(object_id), None)
+                .get_all_coins(owner, Some(object_id.to_string()), None)
                 .await;
 
             assert!(response.is_err());
@@ -958,7 +1019,7 @@ mod tests {
             assert_eq!(error_object.code(), -32602);
             let expected = expect!["-32602"];
             expected.assert_eq(&error_object.code().to_string());
-            let expected = expect!["cursor is not a coin"];
+            let expected = expect!["invalid cursor"];
             expected.assert_eq(error_object.message());
         }
 
@@ -971,14 +1032,14 @@ mod tests {
 
             let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state), None);
             let response = coin_read_api
-                .get_all_coins(owner, Some(object_id), None)
+                .get_all_coins(owner, Some(object_id.to_string()), None)
                 .await;
 
             assert!(response.is_err());
             let error_object = response.unwrap_err();
             let expected = expect!["-32602"];
             expected.assert_eq(&error_object.code().to_string());
-            let expected = expect!["cursor not found"];
+            let expected = expect!["invalid cursor"];
             expected.assert_eq(error_object.message());
         }
     }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -880,7 +880,7 @@
           "params": [
             {
               "name": "package",
-              "value": "0x9c4eb6769ca8b6a23efeb7298cf0a8d0b837b78749c2cfc711c42036cc6b7621"
+              "value": "0xa0a7b108f5023b7356f2c6a4be6f058e267aae38e08260c7d519d8641897490c"
             },
             {
               "name": "module",
@@ -960,7 +960,7 @@
           "params": [
             {
               "name": "package",
-              "value": "0x1639f3606a53f61f3a566963b3eac49fe3bb57d304a454ed2f4859b44f4e4918"
+              "value": "0x9c4eb6769ca8b6a23efeb7298cf0a8d0b837b78749c2cfc711c42036cc6b7621"
             },
             {
               "name": "module_name",
@@ -1032,7 +1032,7 @@
           "params": [
             {
               "name": "package",
-              "value": "0x800105867da4655eca6d9eb1258bfd1ad92af329a07781ee71e60065e00f2de9"
+              "value": "0x0047d5fa0a823e7d0ff4d55c32b09995a0ae1eedfee9c7b1354e805ed10ee3d0"
             },
             {
               "name": "module_name",
@@ -1043,7 +1043,7 @@
             "name": "Result",
             "value": {
               "fileFormatVersion": 6,
-              "address": "0x0047d5fa0a823e7d0ff4d55c32b09995a0ae1eedfee9c7b1354e805ed10ee3d0",
+              "address": "0x1639f3606a53f61f3a566963b3eac49fe3bb57d304a454ed2f4859b44f4e4918",
               "name": "module",
               "friends": [],
               "structs": {},
@@ -1086,14 +1086,14 @@
           "params": [
             {
               "name": "package",
-              "value": "0xc95b9e341bc3aba1654bdbad707dcd773bd6309363447ef3fe58a960de92aa93"
+              "value": "0x61630d3505f8905a0f4d42c6ff39a78a6ba2b28f68a3299ec3417bbabc6717dc"
             }
           ],
           "result": {
             "name": "Result",
             "value": {
               "fileFormatVersion": 6,
-              "address": "0x61630d3505f8905a0f4d42c6ff39a78a6ba2b28f68a3299ec3417bbabc6717dc",
+              "address": "0x800105867da4655eca6d9eb1258bfd1ad92af329a07781ee71e60065e00f2de9",
               "name": "module",
               "friends": [],
               "structs": {},
@@ -1147,7 +1147,7 @@
           "params": [
             {
               "name": "package",
-              "value": "0x77b3482580ee8d5bdc5b824808df54bfec4fc817622e5add0e48f749f01def98"
+              "value": "0xc95b9e341bc3aba1654bdbad707dcd773bd6309363447ef3fe58a960de92aa93"
             },
             {
               "name": "module_name",
@@ -2225,11 +2225,11 @@
             {
               "name": "object_ids",
               "value": [
-                "0x504d411325e3c7f89d412044fe99007efb0f94f1e64d2e8090c619a39299d87e",
-                "0x23618df6438d21a48040e6bb568cafc13246bd847c60448160e0358cac4a1134",
-                "0x8b95b4eaa9fd3b22b43f6b2c8e92090bd6d16522a6fd4fa83ec70a5f197ad656",
-                "0x3fbbd3ebef7dbcc7b02346cdf05674452cc61f316af5d5d7c02b94b023242685",
-                "0x9b5cd5df0df2a168259b7115a41ccc0a372b6fd0026e0c63043492ce4d0c19a6"
+                "0x77b3482580ee8d5bdc5b824808df54bfec4fc817622e5add0e48f749f01def98",
+                "0x9060d87664c26a3f9a509228c21b16dc6797cf787c839a07edc03e6338421091",
+                "0xb37379c527753c5c8ab783f697e7b61439368cd75ebe63d633af32ffb4a022d1",
+                "0xee309e94ff5c9f6b02c5637f018f6ea7bed8f6c3d80f2a595c2305e12dd6d07c",
+                "0x29bc7c8d230db3b417edb1184cf075da5e934f672d3da3e003d989075efaecc7"
               ]
             },
             {
@@ -2250,14 +2250,14 @@
             "value": [
               {
                 "data": {
-                  "objectId": "0x504d411325e3c7f89d412044fe99007efb0f94f1e64d2e8090c619a39299d87e",
+                  "objectId": "0x77b3482580ee8d5bdc5b824808df54bfec4fc817622e5add0e48f749f01def98",
                   "version": "1",
-                  "digest": "AibMqH69gKT5t7rVTsDZFy2X5iHtoNDobKaZ62mg3FCU",
+                  "digest": "2QwXW3qzMEZPAyyP9VHtXbC2tp7iomypQc5XnkyPsu5d",
                   "type": "0x2::coin::Coin<0x2::sui::SUI>",
                   "owner": {
-                    "AddressOwner": "0xe8070b5f56bb10bafa0e2261d819b2582f82ab308bf9c96dfb22ec7345db1b5f"
+                    "AddressOwner": "0x504d411325e3c7f89d412044fe99007efb0f94f1e64d2e8090c619a39299d87e"
                   },
-                  "previousTransaction": "2QwXW3qzMEZPAyyP9VHtXbC2tp7iomypQc5XnkyPsu5d",
+                  "previousTransaction": "GcjpL3GJBoiqc7RNwfV1R4411dFPYz4hTNyXQchsq6Sa",
                   "storageRebate": "100",
                   "content": {
                     "dataType": "moveObject",
@@ -2266,7 +2266,7 @@
                     "fields": {
                       "balance": "100000000",
                       "id": {
-                        "id": "0x504d411325e3c7f89d412044fe99007efb0f94f1e64d2e8090c619a39299d87e"
+                        "id": "0x77b3482580ee8d5bdc5b824808df54bfec4fc817622e5add0e48f749f01def98"
                       }
                     }
                   }
@@ -2274,14 +2274,14 @@
               },
               {
                 "data": {
-                  "objectId": "0x23618df6438d21a48040e6bb568cafc13246bd847c60448160e0358cac4a1134",
+                  "objectId": "0x9060d87664c26a3f9a509228c21b16dc6797cf787c839a07edc03e6338421091",
                   "version": "1",
-                  "digest": "D5W76mT1A3tqCmE1Z5MdV5obNzesMXLfLKpRDHSp1fyz",
+                  "digest": "5itvhMFvtJcV6fY2VY4x7F9Ex18q2N4Rr5WU4FXTJsFU",
                   "type": "0x2::coin::Coin<0x2::sui::SUI>",
                   "owner": {
-                    "AddressOwner": "0x5594d02890c986dbf328d28d21acece356d10d89e75f565b0934851ba8d5bc59"
+                    "AddressOwner": "0x23618df6438d21a48040e6bb568cafc13246bd847c60448160e0358cac4a1134"
                   },
-                  "previousTransaction": "5itvhMFvtJcV6fY2VY4x7F9Ex18q2N4Rr5WU4FXTJsFU",
+                  "previousTransaction": "6m5GPm6XurdzRcEBd7epcnn4rDv8s3fVUK7dN6vYiYk8",
                   "storageRebate": "100",
                   "content": {
                     "dataType": "moveObject",
@@ -2290,7 +2290,7 @@
                     "fields": {
                       "balance": "100000000",
                       "id": {
-                        "id": "0x23618df6438d21a48040e6bb568cafc13246bd847c60448160e0358cac4a1134"
+                        "id": "0x9060d87664c26a3f9a509228c21b16dc6797cf787c839a07edc03e6338421091"
                       }
                     }
                   }
@@ -2298,14 +2298,14 @@
               },
               {
                 "data": {
-                  "objectId": "0x8b95b4eaa9fd3b22b43f6b2c8e92090bd6d16522a6fd4fa83ec70a5f197ad656",
+                  "objectId": "0xb37379c527753c5c8ab783f697e7b61439368cd75ebe63d633af32ffb4a022d1",
                   "version": "1",
-                  "digest": "H2o2pWgceQgTtYrMacR4xnCi4vqGiuozDA6k2rBc4m3q",
+                  "digest": "8rsTRNPs13DZvD2xneZEtf2nAAipep6uHXPXWVXfzDBr",
                   "type": "0x2::coin::Coin<0x2::sui::SUI>",
                   "owner": {
-                    "AddressOwner": "0xda104dde1de9880be827a1a753e502ebcdfec53f33e745e3f021366b7bc47c2b"
+                    "AddressOwner": "0x8b95b4eaa9fd3b22b43f6b2c8e92090bd6d16522a6fd4fa83ec70a5f197ad656"
                   },
-                  "previousTransaction": "8rsTRNPs13DZvD2xneZEtf2nAAipep6uHXPXWVXfzDBr",
+                  "previousTransaction": "FgEJG8uwH2z3e5e4d2QGeVDYH5tdhbR3vKyXsXWf2zqY",
                   "storageRebate": "100",
                   "content": {
                     "dataType": "moveObject",
@@ -2314,7 +2314,7 @@
                     "fields": {
                       "balance": "100000000",
                       "id": {
-                        "id": "0x8b95b4eaa9fd3b22b43f6b2c8e92090bd6d16522a6fd4fa83ec70a5f197ad656"
+                        "id": "0xb37379c527753c5c8ab783f697e7b61439368cd75ebe63d633af32ffb4a022d1"
                       }
                     }
                   }
@@ -2322,14 +2322,14 @@
               },
               {
                 "data": {
-                  "objectId": "0x3fbbd3ebef7dbcc7b02346cdf05674452cc61f316af5d5d7c02b94b023242685",
+                  "objectId": "0xee309e94ff5c9f6b02c5637f018f6ea7bed8f6c3d80f2a595c2305e12dd6d07c",
                   "version": "1",
-                  "digest": "3ovR1s3bZt6AN1AQ7QhGUfX9BSwgjJPvL6XaczgeSKXU",
+                  "digest": "3w6ars2tmgBST4ozGxPWzSpEGyn4AdxMBv3K9sdkCWfR",
                   "type": "0x2::coin::Coin<0x2::sui::SUI>",
                   "owner": {
-                    "AddressOwner": "0x00a65bf5fdccb50582333b61721e6963a25f25ac8ead5916a83f49a7b372eae7"
+                    "AddressOwner": "0x3fbbd3ebef7dbcc7b02346cdf05674452cc61f316af5d5d7c02b94b023242685"
                   },
-                  "previousTransaction": "3w6ars2tmgBST4ozGxPWzSpEGyn4AdxMBv3K9sdkCWfR",
+                  "previousTransaction": "13Y8Ukebq34DkeL6dKEdr6ySSzeRMUpqhQXtZC9KmtTQ",
                   "storageRebate": "100",
                   "content": {
                     "dataType": "moveObject",
@@ -2338,7 +2338,7 @@
                     "fields": {
                       "balance": "100000000",
                       "id": {
-                        "id": "0x3fbbd3ebef7dbcc7b02346cdf05674452cc61f316af5d5d7c02b94b023242685"
+                        "id": "0xee309e94ff5c9f6b02c5637f018f6ea7bed8f6c3d80f2a595c2305e12dd6d07c"
                       }
                     }
                   }
@@ -2346,14 +2346,14 @@
               },
               {
                 "data": {
-                  "objectId": "0x9b5cd5df0df2a168259b7115a41ccc0a372b6fd0026e0c63043492ce4d0c19a6",
+                  "objectId": "0x29bc7c8d230db3b417edb1184cf075da5e934f672d3da3e003d989075efaecc7",
                   "version": "1",
-                  "digest": "25QdFqrh9FgxhGQyAxZsNEakYmHezqmU3FMPud7JGRB5",
+                  "digest": "BE9GoMd7Mr8fGte3EdsXxUMwYjcErW71n6Gsm4iPvDmv",
                   "type": "0x2::coin::Coin<0x2::sui::SUI>",
                   "owner": {
-                    "AddressOwner": "0x3e7f360c51d035a6470f09c8d23716e4085025b89d176840d61dde92a452a72f"
+                    "AddressOwner": "0x9b5cd5df0df2a168259b7115a41ccc0a372b6fd0026e0c63043492ce4d0c19a6"
                   },
-                  "previousTransaction": "BE9GoMd7Mr8fGte3EdsXxUMwYjcErW71n6Gsm4iPvDmv",
+                  "previousTransaction": "5CxnSSi2hCEo7beFke1fCp23W1rCKKRfPJrAELCpxiHc",
                   "storageRebate": "100",
                   "content": {
                     "dataType": "moveObject",
@@ -2362,7 +2362,7 @@
                     "fields": {
                       "balance": "100000000",
                       "id": {
-                        "id": "0x9b5cd5df0df2a168259b7115a41ccc0a372b6fd0026e0c63043492ce4d0c19a6"
+                        "id": "0x29bc7c8d230db3b417edb1184cf075da5e934f672d3da3e003d989075efaecc7"
                       }
                     }
                   }
@@ -2418,9 +2418,9 @@
             {
               "name": "digests",
               "value": [
-                "CKzxe1mN72xVrq5BadAzVu1Lk61AYzuRSEQ3zWK2zbGs",
-                "2jinTmZQ8aModigpcbYcKELwRrTcqosbMmqsiEopvMy9",
-                "BCyCzV64UgrX5vr2kdtzhrojLwaZ9gasnhVV8TQeY1EA"
+                "EMqJqkQip6UaTkdff493ewAQNHGQFJwXDDn6m9CTgZzo",
+                "Hn3B25vTQNTFAdThFkWvfkiAAUZxzwTaj4uEengu1ACX",
+                "9vLSG9a4QcLcMdG1xCu6FRdXAjWWqvJHoHBCJfPMKkR9"
               ]
             },
             {
@@ -2440,7 +2440,7 @@
             "name": "Result",
             "value": [
               {
-                "digest": "CKzxe1mN72xVrq5BadAzVu1Lk61AYzuRSEQ3zWK2zbGs",
+                "digest": "EMqJqkQip6UaTkdff493ewAQNHGQFJwXDDn6m9CTgZzo",
                 "transaction": {
                   "data": {
                     "messageVersion": "v1",
@@ -2450,14 +2450,14 @@
                         {
                           "type": "pure",
                           "valueType": "address",
-                          "value": "0x7a8e9a0d074f90fddb42cd928f74b986c6f539a734f3d7c9a75a9cb227ec3157"
+                          "value": "0x751b2dd4de1138554a9ff7b4f6b59f9426c321c8013afed093481dd4ef1267c6"
                         },
                         {
                           "type": "object",
                           "objectType": "immOrOwnedObject",
-                          "objectId": "0x24962ee4193c8c0d2fb28bbe0eb4ba5fc87a2c6d1a7c12c9454872c5ea06d5e1",
+                          "objectId": "0x7a8e9a0d074f90fddb42cd928f74b986c6f539a734f3d7c9a75a9cb227ec3157",
                           "version": "2",
-                          "digest": "3gmeyj5oEdE8A4PvjWsDSHchC6tb6YQj18gnD7xnDqGz"
+                          "digest": "JAgYeYMPm5VLzBYcYxxQUEatfG9gHdFqSNwmBBS41Bri"
                         }
                       ],
                       "transactions": [
@@ -2475,25 +2475,25 @@
                         }
                       ]
                     },
-                    "sender": "0x576f8e1fdc514e8cf2e0453a0b29ade149b33004c56deab5428239942aef9ec2",
+                    "sender": "0x5e52f7bcaae1fd72a7c420c1e68537e485d215b1e8ea45572b1b2980408ff9b5",
                     "gasData": {
                       "payment": [
                         {
-                          "objectId": "0x9585d5591521bfd12dec3a372efd539108ba807a0dabed6e5da0f174efc3f58e",
+                          "objectId": "0x24962ee4193c8c0d2fb28bbe0eb4ba5fc87a2c6d1a7c12c9454872c5ea06d5e1",
                           "version": 2,
-                          "digest": "JAgYeYMPm5VLzBYcYxxQUEatfG9gHdFqSNwmBBS41Bri"
+                          "digest": "B4g7NgvgmCFYzG2BPH6nT6kM5bPaRMD76LVJ4LWysq5w"
                         }
                       ],
-                      "owner": "0x576f8e1fdc514e8cf2e0453a0b29ade149b33004c56deab5428239942aef9ec2",
+                      "owner": "0x5e52f7bcaae1fd72a7c420c1e68537e485d215b1e8ea45572b1b2980408ff9b5",
                       "price": "10",
                       "budget": "100000"
                     }
                   },
                   "txSignatures": [
-                    "AAjABbK1jtt2/3ixW3D0YWrDscRT5oevWGf1yJD4KNqudiehykWXtHx7aipTKNx+5dbpTtEwPLI2dTB0CyORlg+nSicGHWn+0mf3oSb/LUa5i+dDAEb1qsgy7LkQ8hbr+w=="
+                    "ADCkpLtz9B6h6by9gst01e1ap3M9XyCjZ75pT59rvq6esYIxNzb7+KWZb+L5uZ7xsmzUtxR9ayYrSkXO99Rj5gkHrX7t0yuVOWkkiOMuz7HdUZsfbMy0efpXac3VZ8UVmA=="
                   ]
                 },
-                "rawTransaction": "AQAAAAAAAgAgeo6aDQdPkP3bQs2Sj3S5hsb1Oac089fJp1qcsifsMVcBACSWLuQZPIwNL7KLvg60ul/IeixtGnwSyUVIcsXqBtXhAgAAAAAAAAAgJ+eEST+x3M3niTo6xcZ80sTidUC1LugoCWsqpf5Qp+8BAQEBAQABAABXb44f3FFOjPLgRToLKa3hSbMwBMVt6rVCgjmUKu+ewgGVhdVZFSG/0S3sOjcu/VORCLqAeg2r7W5doPF078P1jgIAAAAAAAAAIP8RnpL1eudNGyUNXfLLUXB4KopDj79oHt7U0eCizX37V2+OH9xRTozy4EU6Cymt4UmzMATFbeq1QoI5lCrvnsIKAAAAAAAAAKCGAQAAAAAAAAFhAAjABbK1jtt2/3ixW3D0YWrDscRT5oevWGf1yJD4KNqudiehykWXtHx7aipTKNx+5dbpTtEwPLI2dTB0CyORlg+nSicGHWn+0mf3oSb/LUa5i+dDAEb1qsgy7LkQ8hbr+w==",
+                "rawTransaction": "AQAAAAAAAgAgdRst1N4ROFVKn/e09rWflCbDIcgBOv7Qk0gd1O8SZ8YBAHqOmg0HT5D920LNko90uYbG9TmnNPPXyadanLIn7DFXAgAAAAAAAAAg/xGekvV6500bJQ1d8stRcHgqikOPv2ge3tTR4KLNffsBAQEBAQABAABeUve8quH9cqfEIMHmhTfkhdIVsejqRVcrGymAQI/5tQEkli7kGTyMDS+yi74OtLpfyHosbRp8EslFSHLF6gbV4QIAAAAAAAAAIJWF1VkVIb/RLew6Ny79U5EIuoB6Davtbl2g8XTvw/WOXlL3vKrh/XKnxCDB5oU35IXSFbHo6kVXKxspgECP+bUKAAAAAAAAAKCGAQAAAAAAAAFhADCkpLtz9B6h6by9gst01e1ap3M9XyCjZ75pT59rvq6esYIxNzb7+KWZb+L5uZ7xsmzUtxR9ayYrSkXO99Rj5gkHrX7t0yuVOWkkiOMuz7HdUZsfbMy0efpXac3VZ8UVmA==",
                 "effects": {
                   "messageVersion": "v1",
                   "status": {
@@ -2506,57 +2506,57 @@
                     "storageRebate": "10",
                     "nonRefundableStorageFee": "0"
                   },
-                  "transactionDigest": "2SY11dmdTQv6JLD2wqcsMiJNqXbXUkn87Rzw5NHib8Mf",
+                  "transactionDigest": "J4k64LwycebB7TQhKrPaZ954yCK64rwbDJMSrSUW4Ba4",
                   "mutated": [
                     {
                       "owner": {
-                        "AddressOwner": "0x576f8e1fdc514e8cf2e0453a0b29ade149b33004c56deab5428239942aef9ec2"
-                      },
-                      "reference": {
-                        "objectId": "0x9585d5591521bfd12dec3a372efd539108ba807a0dabed6e5da0f174efc3f58e",
-                        "version": 2,
-                        "digest": "JAgYeYMPm5VLzBYcYxxQUEatfG9gHdFqSNwmBBS41Bri"
-                      }
-                    },
-                    {
-                      "owner": {
-                        "AddressOwner": "0x7a8e9a0d074f90fddb42cd928f74b986c6f539a734f3d7c9a75a9cb227ec3157"
+                        "AddressOwner": "0x5e52f7bcaae1fd72a7c420c1e68537e485d215b1e8ea45572b1b2980408ff9b5"
                       },
                       "reference": {
                         "objectId": "0x24962ee4193c8c0d2fb28bbe0eb4ba5fc87a2c6d1a7c12c9454872c5ea06d5e1",
                         "version": 2,
-                        "digest": "3gmeyj5oEdE8A4PvjWsDSHchC6tb6YQj18gnD7xnDqGz"
+                        "digest": "B4g7NgvgmCFYzG2BPH6nT6kM5bPaRMD76LVJ4LWysq5w"
+                      }
+                    },
+                    {
+                      "owner": {
+                        "AddressOwner": "0x751b2dd4de1138554a9ff7b4f6b59f9426c321c8013afed093481dd4ef1267c6"
+                      },
+                      "reference": {
+                        "objectId": "0x7a8e9a0d074f90fddb42cd928f74b986c6f539a734f3d7c9a75a9cb227ec3157",
+                        "version": 2,
+                        "digest": "JAgYeYMPm5VLzBYcYxxQUEatfG9gHdFqSNwmBBS41Bri"
                       }
                     }
                   ],
                   "gasObject": {
                     "owner": {
-                      "ObjectOwner": "0x576f8e1fdc514e8cf2e0453a0b29ade149b33004c56deab5428239942aef9ec2"
+                      "ObjectOwner": "0x5e52f7bcaae1fd72a7c420c1e68537e485d215b1e8ea45572b1b2980408ff9b5"
                     },
                     "reference": {
-                      "objectId": "0x9585d5591521bfd12dec3a372efd539108ba807a0dabed6e5da0f174efc3f58e",
+                      "objectId": "0x24962ee4193c8c0d2fb28bbe0eb4ba5fc87a2c6d1a7c12c9454872c5ea06d5e1",
                       "version": 2,
-                      "digest": "JAgYeYMPm5VLzBYcYxxQUEatfG9gHdFqSNwmBBS41Bri"
+                      "digest": "B4g7NgvgmCFYzG2BPH6nT6kM5bPaRMD76LVJ4LWysq5w"
                     }
                   },
-                  "eventsDigest": "DkaTtjSfULiQ7FT48kzuS7yKj2JUAWGgjDBXddqn1z9o"
+                  "eventsDigest": "2SY11dmdTQv6JLD2wqcsMiJNqXbXUkn87Rzw5NHib8Mf"
                 },
                 "objectChanges": [
                   {
                     "type": "transferred",
-                    "sender": "0x576f8e1fdc514e8cf2e0453a0b29ade149b33004c56deab5428239942aef9ec2",
+                    "sender": "0x5e52f7bcaae1fd72a7c420c1e68537e485d215b1e8ea45572b1b2980408ff9b5",
                     "recipient": {
-                      "AddressOwner": "0x7a8e9a0d074f90fddb42cd928f74b986c6f539a734f3d7c9a75a9cb227ec3157"
+                      "AddressOwner": "0x751b2dd4de1138554a9ff7b4f6b59f9426c321c8013afed093481dd4ef1267c6"
                     },
                     "objectType": "0x2::example::Object",
-                    "objectId": "0x24962ee4193c8c0d2fb28bbe0eb4ba5fc87a2c6d1a7c12c9454872c5ea06d5e1",
+                    "objectId": "0x7a8e9a0d074f90fddb42cd928f74b986c6f539a734f3d7c9a75a9cb227ec3157",
                     "version": "2",
-                    "digest": "J4k64LwycebB7TQhKrPaZ954yCK64rwbDJMSrSUW4Ba4"
+                    "digest": "3gmeyj5oEdE8A4PvjWsDSHchC6tb6YQj18gnD7xnDqGz"
                   }
                 ]
               },
               {
-                "digest": "2jinTmZQ8aModigpcbYcKELwRrTcqosbMmqsiEopvMy9",
+                "digest": "Hn3B25vTQNTFAdThFkWvfkiAAUZxzwTaj4uEengu1ACX",
                 "transaction": {
                   "data": {
                     "messageVersion": "v1",
@@ -2566,14 +2566,14 @@
                         {
                           "type": "pure",
                           "valueType": "address",
-                          "value": "0xc3e4f846a282754946e181e00f4341a53b5e895ef8ec3c73d2378a0a11825e23"
+                          "value": "0x7cbab4983e180ad2c31e8c3681aa4f7d35488cf6bf1135d2fc8703690e085797"
                         },
                         {
                           "type": "object",
                           "objectType": "immOrOwnedObject",
-                          "objectId": "0x2fac1a70e20e146fb1303bd60eb4bea9bd453e50690b423241f0e2e9beabd601",
+                          "objectId": "0xc3e4f846a282754946e181e00f4341a53b5e895ef8ec3c73d2378a0a11825e23",
                           "version": "2",
-                          "digest": "HyJbrm9Th6ox4oU9vrrRzgZSaCu1n3omMJ1fAcHswvvo"
+                          "digest": "snEA8RNnDvsYjKJx2NMUP49TMjoAuQXx3LJgwe4qo9B"
                         }
                       ],
                       "transactions": [
@@ -2591,25 +2591,25 @@
                         }
                       ]
                     },
-                    "sender": "0x994b906032a82b0d9f48030d74c092647d92266b13a63049e6027468c199666e",
+                    "sender": "0x62d4daf6e506989ba7a25b0d8915142e81252c859e8cd22db530ae213eec1925",
                     "gasData": {
                       "payment": [
                         {
-                          "objectId": "0xbbdabf2828ee9ca7e4227a61cff851fef9fb6a08ae444c96f9810275d6af973c",
+                          "objectId": "0x2fac1a70e20e146fb1303bd60eb4bea9bd453e50690b423241f0e2e9beabd601",
                           "version": 2,
-                          "digest": "snEA8RNnDvsYjKJx2NMUP49TMjoAuQXx3LJgwe4qo9B"
+                          "digest": "DeJhcQ3CmMPwyhVct22PP7hYaVny6zbz8V7gnTw3yoAT"
                         }
                       ],
-                      "owner": "0x994b906032a82b0d9f48030d74c092647d92266b13a63049e6027468c199666e",
+                      "owner": "0x62d4daf6e506989ba7a25b0d8915142e81252c859e8cd22db530ae213eec1925",
                       "price": "10",
                       "budget": "100000"
                     }
                   },
                   "txSignatures": [
-                    "AFumlgf6FRg/Hav9rJrEtmSzVW1iHCGixLA/lxj4ojn5ati0aXW8NnOwYe97d68oG1vjFfmid20XrO69XUh6eQULoJG5hufQ9rzjXn1UVSbD7HyPVZykOZAICGCiqQMgGw=="
+                    "AND+G9umCSLK1La6UWAgniuJWhkB3BNqVfk66Fj+f2hK1qIT2uJUWRYSwWYky6TO0unNN8egfzwvLJjFCMXU9gRy3O9A+7GacyYQAw/at8erjWXdUi4gR/xfdp6t5wPBDg=="
                   ]
                 },
-                "rawTransaction": "AQAAAAAAAgAgw+T4RqKCdUlG4YHgD0NBpTteiV747Dxz0jeKChGCXiMBAC+sGnDiDhRvsTA71g60vqm9RT5QaQtCMkHw4um+q9YBAgAAAAAAAAAg/Cdq6qc8DsEltgkKJ7uvql/DLnVzYS0husigmreRU3QBAQEBAQABAACZS5BgMqgrDZ9IAw10wJJkfZImaxOmMEnmAnRowZlmbgG72r8oKO6cp+QiemHP+FH++ftqCK5ETJb5gQJ11q+XPAIAAAAAAAAAIA0CLbniGg8JvLiQdz0RwavXF2ex9nqAQCZ3iCA/OXcimUuQYDKoKw2fSAMNdMCSZH2SJmsTpjBJ5gJ0aMGZZm4KAAAAAAAAAKCGAQAAAAAAAAFhAFumlgf6FRg/Hav9rJrEtmSzVW1iHCGixLA/lxj4ojn5ati0aXW8NnOwYe97d68oG1vjFfmid20XrO69XUh6eQULoJG5hufQ9rzjXn1UVSbD7HyPVZykOZAICGCiqQMgGw==",
+                "rawTransaction": "AQAAAAAAAgAgfLq0mD4YCtLDHow2gapPfTVIjPa/ETXS/IcDaQ4IV5cBAMPk+EaignVJRuGB4A9DQaU7Xole+Ow8c9I3igoRgl4jAgAAAAAAAAAgDQItueIaDwm8uJB3PRHBq9cXZ7H2eoBAJneIID85dyIBAQEBAQABAABi1Nr25QaYm6eiWw2JFRQugSUshZ6M0i21MK4hPuwZJQEvrBpw4g4Ub7EwO9YOtL6pvUU+UGkLQjJB8OLpvqvWAQIAAAAAAAAAILvavygo7pyn5CJ6Yc/4Uf75+2oIrkRMlvmBAnXWr5c8YtTa9uUGmJunolsNiRUULoElLIWejNIttTCuIT7sGSUKAAAAAAAAAKCGAQAAAAAAAAFhAND+G9umCSLK1La6UWAgniuJWhkB3BNqVfk66Fj+f2hK1qIT2uJUWRYSwWYky6TO0unNN8egfzwvLJjFCMXU9gRy3O9A+7GacyYQAw/at8erjWXdUi4gR/xfdp6t5wPBDg==",
                 "effects": {
                   "messageVersion": "v1",
                   "status": {
@@ -2622,57 +2622,57 @@
                     "storageRebate": "10",
                     "nonRefundableStorageFee": "0"
                   },
-                  "transactionDigest": "69bh3Q9RhRgMFKwmQn8LYE8vYujFTpYyUSVBht3oYkm6",
+                  "transactionDigest": "CHia3BiES8mt5kqMYhzBpjAeLRpjcsMNDMFakBAdcVAg",
                   "mutated": [
                     {
                       "owner": {
-                        "AddressOwner": "0x994b906032a82b0d9f48030d74c092647d92266b13a63049e6027468c199666e"
-                      },
-                      "reference": {
-                        "objectId": "0xbbdabf2828ee9ca7e4227a61cff851fef9fb6a08ae444c96f9810275d6af973c",
-                        "version": 2,
-                        "digest": "snEA8RNnDvsYjKJx2NMUP49TMjoAuQXx3LJgwe4qo9B"
-                      }
-                    },
-                    {
-                      "owner": {
-                        "AddressOwner": "0xc3e4f846a282754946e181e00f4341a53b5e895ef8ec3c73d2378a0a11825e23"
+                        "AddressOwner": "0x62d4daf6e506989ba7a25b0d8915142e81252c859e8cd22db530ae213eec1925"
                       },
                       "reference": {
                         "objectId": "0x2fac1a70e20e146fb1303bd60eb4bea9bd453e50690b423241f0e2e9beabd601",
                         "version": 2,
-                        "digest": "HyJbrm9Th6ox4oU9vrrRzgZSaCu1n3omMJ1fAcHswvvo"
+                        "digest": "DeJhcQ3CmMPwyhVct22PP7hYaVny6zbz8V7gnTw3yoAT"
+                      }
+                    },
+                    {
+                      "owner": {
+                        "AddressOwner": "0x7cbab4983e180ad2c31e8c3681aa4f7d35488cf6bf1135d2fc8703690e085797"
+                      },
+                      "reference": {
+                        "objectId": "0xc3e4f846a282754946e181e00f4341a53b5e895ef8ec3c73d2378a0a11825e23",
+                        "version": 2,
+                        "digest": "snEA8RNnDvsYjKJx2NMUP49TMjoAuQXx3LJgwe4qo9B"
                       }
                     }
                   ],
                   "gasObject": {
                     "owner": {
-                      "ObjectOwner": "0x994b906032a82b0d9f48030d74c092647d92266b13a63049e6027468c199666e"
+                      "ObjectOwner": "0x62d4daf6e506989ba7a25b0d8915142e81252c859e8cd22db530ae213eec1925"
                     },
                     "reference": {
-                      "objectId": "0xbbdabf2828ee9ca7e4227a61cff851fef9fb6a08ae444c96f9810275d6af973c",
+                      "objectId": "0x2fac1a70e20e146fb1303bd60eb4bea9bd453e50690b423241f0e2e9beabd601",
                       "version": 2,
-                      "digest": "snEA8RNnDvsYjKJx2NMUP49TMjoAuQXx3LJgwe4qo9B"
+                      "digest": "DeJhcQ3CmMPwyhVct22PP7hYaVny6zbz8V7gnTw3yoAT"
                     }
                   },
-                  "eventsDigest": "4Vh6HmG6PwdbZbMiMwj9YnKvsMnP3gfhLmAd288eujv4"
+                  "eventsDigest": "69bh3Q9RhRgMFKwmQn8LYE8vYujFTpYyUSVBht3oYkm6"
                 },
                 "objectChanges": [
                   {
                     "type": "transferred",
-                    "sender": "0x994b906032a82b0d9f48030d74c092647d92266b13a63049e6027468c199666e",
+                    "sender": "0x62d4daf6e506989ba7a25b0d8915142e81252c859e8cd22db530ae213eec1925",
                     "recipient": {
-                      "AddressOwner": "0xc3e4f846a282754946e181e00f4341a53b5e895ef8ec3c73d2378a0a11825e23"
+                      "AddressOwner": "0x7cbab4983e180ad2c31e8c3681aa4f7d35488cf6bf1135d2fc8703690e085797"
                     },
                     "objectType": "0x2::example::Object",
-                    "objectId": "0x2fac1a70e20e146fb1303bd60eb4bea9bd453e50690b423241f0e2e9beabd601",
+                    "objectId": "0xc3e4f846a282754946e181e00f4341a53b5e895ef8ec3c73d2378a0a11825e23",
                     "version": "2",
-                    "digest": "CHia3BiES8mt5kqMYhzBpjAeLRpjcsMNDMFakBAdcVAg"
+                    "digest": "HyJbrm9Th6ox4oU9vrrRzgZSaCu1n3omMJ1fAcHswvvo"
                   }
                 ]
               },
               {
-                "digest": "BCyCzV64UgrX5vr2kdtzhrojLwaZ9gasnhVV8TQeY1EA",
+                "digest": "9vLSG9a4QcLcMdG1xCu6FRdXAjWWqvJHoHBCJfPMKkR9",
                 "transaction": {
                   "data": {
                     "messageVersion": "v1",
@@ -2682,14 +2682,14 @@
                         {
                           "type": "pure",
                           "valueType": "address",
-                          "value": "0x0388c28ddd5977a58e206acd19639c875a4fbecf3342b825c8384300ac7e3bad"
+                          "value": "0x385b00a1a8902e84e81f871c47c3149e27b12500da884afdf5c30b19c017a0d1"
                         },
                         {
                           "type": "object",
                           "objectType": "immOrOwnedObject",
-                          "objectId": "0xc820a75b574224b920aa9b005093b820df24ef8b43715499f4fff4e056c0cd5c",
+                          "objectId": "0x0388c28ddd5977a58e206acd19639c875a4fbecf3342b825c8384300ac7e3bad",
                           "version": "2",
-                          "digest": "6jsxetsBSZJ5ozgZuDmHXJzn9ZBp8emivfYHe6tnHg7C"
+                          "digest": "9CpH2aW4XPVxaZBGHRwHueXEQUvN3Pf7JQpASHiEsNCw"
                         }
                       ],
                       "transactions": [
@@ -2707,25 +2707,25 @@
                         }
                       ]
                     },
-                    "sender": "0xb6c36d992a3b50f3acf8e3c9a0fb909eacbfc249eaf66616ad6712409d2ee563",
+                    "sender": "0x9b7489accb55a928190cfa87f52022d722c0686eda7677b3595dcd6167a4b4e5",
                     "gasData": {
                       "payment": [
                         {
-                          "objectId": "0xd8024b4b39a7fed27134b073da8638454111396519379e888c83abaf0e600504",
+                          "objectId": "0xc820a75b574224b920aa9b005093b820df24ef8b43715499f4fff4e056c0cd5c",
                           "version": 2,
-                          "digest": "9CpH2aW4XPVxaZBGHRwHueXEQUvN3Pf7JQpASHiEsNCw"
+                          "digest": "FYD6KHzkQnbwS52WA8rYS9WbJza1K583ootS5MK9BR2T"
                         }
                       ],
-                      "owner": "0xb6c36d992a3b50f3acf8e3c9a0fb909eacbfc249eaf66616ad6712409d2ee563",
+                      "owner": "0x9b7489accb55a928190cfa87f52022d722c0686eda7677b3595dcd6167a4b4e5",
                       "price": "10",
                       "budget": "100000"
                     }
                   },
                   "txSignatures": [
-                    "ALp3VT1YKzOOGLARJCrDqBbMScEPcFq2vWNJ68Zzr3+v5sEK+44cfPlQfMY0UZWyhA86viiG8yd4eLWmnzzU2gXBLYrHKlE7PwRVuJjmBwbiSpqS0m/j+PFnALfPM5bN1Q=="
+                    "AIPB1qErFsOHPUI/MJO9d5n2tTpG6fhxRumDT54vvkGYqtiHX9nlqhyujSbprdl0Th2qM/n3z18p/tLCmnjWMgR0l3KzifzaD4mmOjFLz1qKIB/e8f9eE9s+E+w2jwNGDQ=="
                   ]
                 },
-                "rawTransaction": "AQAAAAAAAgAgA4jCjd1Zd6WOIGrNGWOch1pPvs8zQrglyDhDAKx+O60BAMggp1tXQiS5IKqbAFCTuCDfJO+LQ3FUmfT/9OBWwM1cAgAAAAAAAAAgVUZy4Te1Cxp8iyTYMxDI9sRo5v6QbaCnpymsaNySaNMBAQEBAQABAAC2w22ZKjtQ86z448mg+5CerL/CSer2ZhatZxJAnS7lYwHYAktLOaf+0nE0sHPahjhFQRE5ZRk3noiMg6uvDmAFBAIAAAAAAAAAIHnkVv8BP1ZT2rttbJXd19NaQtMfOpvru2g9tm6KBnBotsNtmSo7UPOs+OPJoPuQnqy/wknq9mYWrWcSQJ0u5WMKAAAAAAAAAKCGAQAAAAAAAAFhALp3VT1YKzOOGLARJCrDqBbMScEPcFq2vWNJ68Zzr3+v5sEK+44cfPlQfMY0UZWyhA86viiG8yd4eLWmnzzU2gXBLYrHKlE7PwRVuJjmBwbiSpqS0m/j+PFnALfPM5bN1Q==",
+                "rawTransaction": "AQAAAAAAAgAgOFsAoaiQLoToH4ccR8MUniexJQDaiEr99cMLGcAXoNEBAAOIwo3dWXeljiBqzRljnIdaT77PM0K4Jcg4QwCsfjutAgAAAAAAAAAgeeRW/wE/VlPau21sld3X01pC0x86m+u7aD22booGcGgBAQEBAQABAACbdImsy1WpKBkM+of1ICLXIsBobtp2d7NZXc1hZ6S05QHIIKdbV0IkuSCqmwBQk7gg3yTvi0NxVJn0//TgVsDNXAIAAAAAAAAAINgCS0s5p/7ScTSwc9qGOEVBETllGTeeiIyDq68OYAUEm3SJrMtVqSgZDPqH9SAi1yLAaG7adnezWV3NYWektOUKAAAAAAAAAKCGAQAAAAAAAAFhAIPB1qErFsOHPUI/MJO9d5n2tTpG6fhxRumDT54vvkGYqtiHX9nlqhyujSbprdl0Th2qM/n3z18p/tLCmnjWMgR0l3KzifzaD4mmOjFLz1qKIB/e8f9eE9s+E+w2jwNGDQ==",
                 "effects": {
                   "messageVersion": "v1",
                   "status": {
@@ -2738,52 +2738,52 @@
                     "storageRebate": "10",
                     "nonRefundableStorageFee": "0"
                   },
-                  "transactionDigest": "DzJWHtFNHttaBdpECZGDMF7tcx5NYZfNfCk5NsaaRgmn",
+                  "transactionDigest": "HaFQHEJugXDGh95A9Ye1tp7GikbuAQNiEanrQuVLvpfz",
                   "mutated": [
                     {
                       "owner": {
-                        "AddressOwner": "0xb6c36d992a3b50f3acf8e3c9a0fb909eacbfc249eaf66616ad6712409d2ee563"
-                      },
-                      "reference": {
-                        "objectId": "0xd8024b4b39a7fed27134b073da8638454111396519379e888c83abaf0e600504",
-                        "version": 2,
-                        "digest": "9CpH2aW4XPVxaZBGHRwHueXEQUvN3Pf7JQpASHiEsNCw"
-                      }
-                    },
-                    {
-                      "owner": {
-                        "AddressOwner": "0x0388c28ddd5977a58e206acd19639c875a4fbecf3342b825c8384300ac7e3bad"
+                        "AddressOwner": "0x9b7489accb55a928190cfa87f52022d722c0686eda7677b3595dcd6167a4b4e5"
                       },
                       "reference": {
                         "objectId": "0xc820a75b574224b920aa9b005093b820df24ef8b43715499f4fff4e056c0cd5c",
                         "version": 2,
-                        "digest": "6jsxetsBSZJ5ozgZuDmHXJzn9ZBp8emivfYHe6tnHg7C"
+                        "digest": "FYD6KHzkQnbwS52WA8rYS9WbJza1K583ootS5MK9BR2T"
+                      }
+                    },
+                    {
+                      "owner": {
+                        "AddressOwner": "0x385b00a1a8902e84e81f871c47c3149e27b12500da884afdf5c30b19c017a0d1"
+                      },
+                      "reference": {
+                        "objectId": "0x0388c28ddd5977a58e206acd19639c875a4fbecf3342b825c8384300ac7e3bad",
+                        "version": 2,
+                        "digest": "9CpH2aW4XPVxaZBGHRwHueXEQUvN3Pf7JQpASHiEsNCw"
                       }
                     }
                   ],
                   "gasObject": {
                     "owner": {
-                      "ObjectOwner": "0xb6c36d992a3b50f3acf8e3c9a0fb909eacbfc249eaf66616ad6712409d2ee563"
+                      "ObjectOwner": "0x9b7489accb55a928190cfa87f52022d722c0686eda7677b3595dcd6167a4b4e5"
                     },
                     "reference": {
-                      "objectId": "0xd8024b4b39a7fed27134b073da8638454111396519379e888c83abaf0e600504",
+                      "objectId": "0xc820a75b574224b920aa9b005093b820df24ef8b43715499f4fff4e056c0cd5c",
                       "version": 2,
-                      "digest": "9CpH2aW4XPVxaZBGHRwHueXEQUvN3Pf7JQpASHiEsNCw"
+                      "digest": "FYD6KHzkQnbwS52WA8rYS9WbJza1K583ootS5MK9BR2T"
                     }
                   },
-                  "eventsDigest": "Bbh3U8fCxVzdX6uZUNWRzZrUktcUfWcydhWCMyWJSPpt"
+                  "eventsDigest": "DzJWHtFNHttaBdpECZGDMF7tcx5NYZfNfCk5NsaaRgmn"
                 },
                 "objectChanges": [
                   {
                     "type": "transferred",
-                    "sender": "0xb6c36d992a3b50f3acf8e3c9a0fb909eacbfc249eaf66616ad6712409d2ee563",
+                    "sender": "0x9b7489accb55a928190cfa87f52022d722c0686eda7677b3595dcd6167a4b4e5",
                     "recipient": {
-                      "AddressOwner": "0x0388c28ddd5977a58e206acd19639c875a4fbecf3342b825c8384300ac7e3bad"
+                      "AddressOwner": "0x385b00a1a8902e84e81f871c47c3149e27b12500da884afdf5c30b19c017a0d1"
                     },
                     "objectType": "0x2::example::Object",
-                    "objectId": "0xc820a75b574224b920aa9b005093b820df24ef8b43715499f4fff4e056c0cd5c",
+                    "objectId": "0x0388c28ddd5977a58e206acd19639c875a4fbecf3342b825c8384300ac7e3bad",
                     "version": "2",
-                    "digest": "HaFQHEJugXDGh95A9Ye1tp7GikbuAQNiEanrQuVLvpfz"
+                    "digest": "6jsxetsBSZJ5ozgZuDmHXJzn9ZBp8emivfYHe6tnHg7C"
                   }
                 ]
               }
@@ -2934,11 +2934,11 @@
               "name": "past_objects",
               "value": [
                 {
-                  "objectId": "0xceaf9ee4582d3a233101e322a22cb2a5bea2e681ea5af4e59bd1abb0bb4fcb27",
+                  "objectId": "0x38b3186a7bb26a1ab2c982a0a9b482aa70f5a010fffc60f20194ef0f597474e8",
                   "version": "4"
                 },
                 {
-                  "objectId": "0x47866ff92885a3c21a7703f564721c198308aa0c71b771ada6b96c16fc9c0fa7",
+                  "objectId": "0xceaf9ee4582d3a233101e322a22cb2a5bea2e681ea5af4e59bd1abb0bb4fcb27",
                   "version": "12"
                 }
               ]
@@ -2962,14 +2962,14 @@
               {
                 "status": "VersionFound",
                 "details": {
-                  "objectId": "0xceaf9ee4582d3a233101e322a22cb2a5bea2e681ea5af4e59bd1abb0bb4fcb27",
+                  "objectId": "0x38b3186a7bb26a1ab2c982a0a9b482aa70f5a010fffc60f20194ef0f597474e8",
                   "version": "4",
-                  "digest": "CE9bNT96Sa2BxQQH2id4PRxTgW5TW7zm6VVhDeRNBegW",
+                  "digest": "hvBGBXvKVhC7XYgVPujuiLjxASR6UGAkSFrCRtVxX1F",
                   "type": "0x2::coin::Coin<0x2::sui::SUI>",
                   "owner": {
-                    "AddressOwner": "0x54b3c61936f77fcfdaa213c2f7b4fb1b51ef9f3ed66000c0e45697dbee095479"
+                    "AddressOwner": "0x47866ff92885a3c21a7703f564721c198308aa0c71b771ada6b96c16fc9c0fa7"
                   },
-                  "previousTransaction": "hvBGBXvKVhC7XYgVPujuiLjxASR6UGAkSFrCRtVxX1F",
+                  "previousTransaction": "6heEteheiLZcS8iVNXsNUnU7oVjzT7UHYzprGcuWQ4gG",
                   "storageRebate": "100",
                   "content": {
                     "dataType": "moveObject",
@@ -2978,7 +2978,7 @@
                     "fields": {
                       "balance": "10000",
                       "id": {
-                        "id": "0xceaf9ee4582d3a233101e322a22cb2a5bea2e681ea5af4e59bd1abb0bb4fcb27"
+                        "id": "0x38b3186a7bb26a1ab2c982a0a9b482aa70f5a010fffc60f20194ef0f597474e8"
                       }
                     }
                   }
@@ -2987,14 +2987,14 @@
               {
                 "status": "VersionFound",
                 "details": {
-                  "objectId": "0x47866ff92885a3c21a7703f564721c198308aa0c71b771ada6b96c16fc9c0fa7",
+                  "objectId": "0xceaf9ee4582d3a233101e322a22cb2a5bea2e681ea5af4e59bd1abb0bb4fcb27",
                   "version": "12",
-                  "digest": "3pRSYsCdrDkfMDwecvKZ1zgSEpwUo52VcLE95iK9ap1N",
+                  "digest": "B5z4YkAgTi78fdxMbxG3fv2V4YBkhpc8PRCPz8MzLtbf",
                   "type": "0x2::coin::Coin<0x2::sui::SUI>",
                   "owner": {
-                    "AddressOwner": "0x998aaf3d11da24c49e014d4ccb1d7d0cd09d3cc1679290f1df2803b32b76ba03"
+                    "AddressOwner": "0xa6ced287081357950315a8842c3870f2d83f980fe0996a92d351d6749a0a0b47"
                   },
-                  "previousTransaction": "B5z4YkAgTi78fdxMbxG3fv2V4YBkhpc8PRCPz8MzLtbf",
+                  "previousTransaction": "BLN2oUCHmwmaAXXCxbojTcozUqZYfvXx4Bkgi7xcgyVc",
                   "storageRebate": "100",
                   "content": {
                     "dataType": "moveObject",
@@ -3003,7 +3003,7 @@
                     "fields": {
                       "balance": "20000",
                       "id": {
-                        "id": "0xceaf9ee4582d3a233101e322a22cb2a5bea2e681ea5af4e59bd1abb0bb4fcb27"
+                        "id": "0x38b3186a7bb26a1ab2c982a0a9b482aa70f5a010fffc60f20194ef0f597474e8"
                       }
                     }
                   }
@@ -3086,7 +3086,7 @@
           "name": "cursor",
           "description": "optional paging cursor",
           "schema": {
-            "$ref": "#/components/schemas/ObjectID"
+            "type": "string"
           }
         },
         {
@@ -3103,7 +3103,7 @@
         "name": "CoinPage",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/Page_for_Coin_and_ObjectID"
+          "$ref": "#/components/schemas/Page_for_Coin_and_String"
         }
       },
       "examples": [
@@ -3129,30 +3129,30 @@
               "data": [
                 {
                   "coinType": "0x2::sui::SUI",
-                  "coinObjectId": "0x91825debff541cf4e08b5c5f7296ff9840e6f0b185af93984cde8cf3870302c0",
+                  "coinObjectId": "0x861c5e055605b2bb1199faf653a8771e448930bc95a0369fad43a9870a2e5878",
                   "version": "103626",
-                  "digest": "7dp5WtTmtGp83EXYYFMzjBJRFeSgR67AzqMETLrfgeFx",
+                  "digest": "Ao1QyN9UTmYzb2ead3D5xhSBk7TvACRvmnJW8gRbwP99",
                   "balance": "200000000",
-                  "previousTransaction": "9WfFUVhjbbh4tWkyUse1QxzbKX952cyXScH7xJNPB2vQ"
+                  "previousTransaction": "7dp5WtTmtGp83EXYYFMzjBJRFeSgR67AzqMETLrfgeFx"
                 },
                 {
                   "coinType": "0x2::sui::SUI",
-                  "coinObjectId": "0x48a53f22e2e901ea2a5bf44fdd5bb94a1d83b6efc4dd779f0890ca3b1f6ba997",
+                  "coinObjectId": "0x7e769678d059761bff8a8f3944642e4c33a6e4fb0b55f8face36fadaa22f2a0d",
                   "version": "103626",
-                  "digest": "9xLdMXezY8d1yRA2TtN6pYjapyy2EVKHWNriGPFGCFvd",
+                  "digest": "5taVxHU9QLQD5cNdqxt8kNGAab93GMG4vX7zYDxEaohx",
                   "balance": "200000000",
-                  "previousTransaction": "Byq9SyV7x6fvzaf88YRA9JM8vLbVLJAqUX8pESDmKcgw"
+                  "previousTransaction": "9xLdMXezY8d1yRA2TtN6pYjapyy2EVKHWNriGPFGCFvd"
                 },
                 {
                   "coinType": "0x2::sui::SUI",
-                  "coinObjectId": "0x6867fcc63161269c5c0c73b02229486bbaff319209dfb8299ced3b8609037997",
+                  "coinObjectId": "0xa323d541ba5cf9e34919d2644cda38a263f69f47ae954dec65295231e0d2c7c8",
                   "version": "103626",
-                  "digest": "5xexWFq6QpGHBQyC9P2cbAJXq9qm2EjzfuRM9NwS1uyG",
+                  "digest": "82ZNKSSueWUQkpFNbBZGHSr3sUL5Rxfr7ucVRsvgQzz2",
                   "balance": "200000000",
-                  "previousTransaction": "CEjwHmo98nAiYhSMfKoSDvUMtfKJ6ge6Uj4wKotK4MPZ"
+                  "previousTransaction": "5xexWFq6QpGHBQyC9P2cbAJXq9qm2EjzfuRM9NwS1uyG"
                 }
               ],
-              "nextCursor": "0x861c5e055605b2bb1199faf653a8771e448930bc95a0369fad43a9870a2e5878",
+              "nextCursor": "abcd",
               "hasNextPage": true
             }
           }
@@ -3197,7 +3197,7 @@
           "params": [
             {
               "name": "owner",
-              "value": "0x51ceab2edc89f74730e683ebee65578cb3bc9237ba6fca019438a9737cf156ae"
+              "value": "0xa6f5a7953a75dc632e696cabe60560522a017bf2fb0bd930d1ec22c06f1ee4e4"
             },
             {
               "name": "coin_type",
@@ -3257,7 +3257,7 @@
               "symbol": "USDC",
               "description": "Stable coin.",
               "iconUrl": null,
-              "id": "0x6d907beaa3a49db57bdfdb3557e6d405cbf01c293a53e01457d65e92b5d8dd68"
+              "id": "0x51ceab2edc89f74730e683ebee65578cb3bc9237ba6fca019438a9737cf156ae"
             }
           }
         }
@@ -3291,7 +3291,7 @@
           "name": "cursor",
           "description": "optional paging cursor",
           "schema": {
-            "$ref": "#/components/schemas/ObjectID"
+            "type": "string"
           }
         },
         {
@@ -3308,7 +3308,7 @@
         "name": "CoinPage",
         "required": true,
         "schema": {
-          "$ref": "#/components/schemas/Page_for_Coin_and_ObjectID"
+          "$ref": "#/components/schemas/Page_for_Coin_and_String"
         }
       },
       "examples": [
@@ -3317,7 +3317,7 @@
           "params": [
             {
               "name": "owner",
-              "value": "0xd62ca040aba24f862a763851c54908cd2a0ee7d709c11b93d4a2083747b76856"
+              "value": "0x6d907beaa3a49db57bdfdb3557e6d405cbf01c293a53e01457d65e92b5d8dd68"
             },
             {
               "name": "coin_type",
@@ -3325,7 +3325,7 @@
             },
             {
               "name": "cursor",
-              "value": "0xe5c651321915b06c81838c2e370109b554a448a78d3a56220f798398dde66eab"
+              "value": "0xee6b5173afedb35330f60397c2cbb48196ba41921246c304be7b490cee0904eb"
             },
             {
               "name": "limit",
@@ -3338,30 +3338,30 @@
               "data": [
                 {
                   "coinType": "0x2::sui::SUI",
-                  "coinObjectId": "0xa5a8e30db5a798a7354340b6ea78a66f50921841ab5359ec7a3dc01f282420ae",
+                  "coinObjectId": "0xd62ca040aba24f862a763851c54908cd2a0ee7d709c11b93d4a2083747b76856",
                   "version": "103626",
-                  "digest": "tw5DzJTfdxTn4f3rekFrhN7dQTUezBgsEhycDobTBLb",
+                  "digest": "C9fdokK19BpDCgUgWsJv3cfd4LDyk7WGYBeGhFHbEL2Z",
                   "balance": "200000000",
-                  "previousTransaction": "HSein75AFXgdsnbABWLQ5mvjFmPFWrBFi9CMVsNn7gJr"
+                  "previousTransaction": "tw5DzJTfdxTn4f3rekFrhN7dQTUezBgsEhycDobTBLb"
                 },
                 {
                   "coinType": "0x2::sui::SUI",
-                  "coinObjectId": "0x47dfa99496428c65b2054ad7db1872b87ff05b1047bb5e3adf5257cceb08ecb4",
+                  "coinObjectId": "0xf44d295a385dc3544d211411b865e8bc4f01f49186970c7cf61e1cc829cc0be7",
                   "version": "103626",
-                  "digest": "AfgFe7ZfjJ5dWV6VAy2LbtvBFhcABkvdvwEjLrRcFqtr",
+                  "digest": "5qZkmtN5J5uGHURtiy9BtBhnXATPR2Wa6BJBDLrMzCaf",
                   "balance": "200000000",
-                  "previousTransaction": "5WHnm9jUZEtDvSvsj7HBrP5BoxA3UY6R57qqumXJXboV"
+                  "previousTransaction": "AfgFe7ZfjJ5dWV6VAy2LbtvBFhcABkvdvwEjLrRcFqtr"
                 },
                 {
                   "coinType": "0x2::sui::SUI",
-                  "coinObjectId": "0xd4f062dbcfc3bf73f5861945592222ff7b090ac21c8a3cf840abdc5b743da778",
+                  "coinObjectId": "0x42ef9314ccc792dd4401a88e69c66b4c5e43f21e9e57f4abe3c702649d3a7dd0",
                   "version": "103626",
-                  "digest": "9er6jxigfuQEKsn9gtPV2oW1zGQRcFtKNijHVe88GUJD",
+                  "digest": "FLE2nB2Wio3oUyTx6HyzkrMsWiZxDg9Kk8s7ivvuoBbD",
                   "balance": "200000000",
-                  "previousTransaction": "H3gwoKE2FSLx3BwvNTTKqCsNHmg6ARzm345icHhXUAEW"
+                  "previousTransaction": "9er6jxigfuQEKsn9gtPV2oW1zGQRcFtKNijHVe88GUJD"
                 }
               ],
-              "nextCursor": "0xd4f062dbcfc3bf73f5861945592222ff7b090ac21c8a3cf840abdc5b743da778",
+              "nextCursor": "abcd",
               "hasNextPage": true
             }
           }
@@ -3467,7 +3467,7 @@
           "params": [
             {
               "name": "parent_object_id",
-              "value": "0x5ea6f7a348f4a7bd1a9ab069eb7f63865de3075cc5a4e62432f634b50fd2bb2b"
+              "value": "0x3ddea0f8c3da994d9ead562ce76e36fdef6a382da344930c73d1298b0e9644b8"
             },
             {
               "name": "name",
@@ -3481,14 +3481,14 @@
             "name": "Result",
             "value": {
               "data": {
-                "objectId": "0x5ea6f7a348f4a7bd1a9ab069eb7f63865de3075cc5a4e62432f634b50fd2bb2b",
+                "objectId": "0x3ddea0f8c3da994d9ead562ce76e36fdef6a382da344930c73d1298b0e9644b8",
                 "version": "1",
-                "digest": "FnxePMX8y7AqX5mRL4nCcK4xecSrpHrd85c3sJDmh5uG",
+                "digest": "Faiv4yqGR4HjAW8WhMN1NHHNStxXgP3u22dVPyvLad2z",
                 "type": "0x0000000000000000000000000000000000000000000000000000000000000009::test::TestField",
                 "owner": {
-                  "AddressOwner": "0x013d1eb156edcc1bedc3b1af1be1fe41671856fd3450dc5574abd53c793c9f22"
+                  "AddressOwner": "0x5ea6f7a348f4a7bd1a9ab069eb7f63865de3075cc5a4e62432f634b50fd2bb2b"
                 },
-                "previousTransaction": "Faiv4yqGR4HjAW8WhMN1NHHNStxXgP3u22dVPyvLad2z",
+                "previousTransaction": "5qTpesGST3v9NmMTkzV7HHNZRJh52BSqUTErc6L6XGm",
                 "storageRebate": "100",
                 "content": {
                   "dataType": "moveObject",
@@ -3549,11 +3549,11 @@
           "params": [
             {
               "name": "parent_object_id",
-              "value": "0xcfd10bca4d517e9452ad5486d69ee482b758c2399039dbbedd5db24385e934d6"
+              "value": "0x5612581eba57ebe7e594b809ccceec2be4dac6ff6945d49b3ecc043d049611f6"
             },
             {
               "name": "cursor",
-              "value": "0x3ddea0f8c3da994d9ead562ce76e36fdef6a382da344930c73d1298b0e9644b8"
+              "value": "0x671832358f25bfacde706e528df4e15bb8de6dadd21835dfe44f4973139c15f9"
             },
             {
               "name": "limit",
@@ -3573,9 +3573,9 @@
                   "bcsName": "FDB4OTo6dGVzdDo6VGVzdEZpZWxk",
                   "type": "DynamicField",
                   "objectType": "test",
-                  "objectId": "0x82b2fd67344691abd0efc771941b948ad35360b08e449fbbc28b0641175bf60b",
+                  "objectId": "0xcfd10bca4d517e9452ad5486d69ee482b758c2399039dbbedd5db24385e934d6",
                   "version": 1,
-                  "digest": "P2fGrUFbsF576cFxXYXrp1PskZHo2XKvbEoxL14qtnr"
+                  "digest": "9oCJR2QHVThbwWtSYwmWv6oSFw26PuxXkLyFrUbNqpU2"
                 },
                 {
                   "name": {
@@ -3586,9 +3586,9 @@
                   "bcsName": "FDB4OTo6dGVzdDo6VGVzdEZpZWxk",
                   "type": "DynamicField",
                   "objectType": "test",
-                  "objectId": "0x21564fc5a68ace997461b098c1d1f3ccbde241d8fdf562db36bc1423ee10cecb",
+                  "objectId": "0x05a4a796534a1833ca2c4df8fda7d073bbbf2715d2cd82ed40dc051dd5e05f7f",
                   "version": 1,
-                  "digest": "8Nmpatir33R88Xow2td3dpezMm1gsQJD19VThwR1Y8T5"
+                  "digest": "3F8njMJQe6DNxeuvUnHPVjuR9Lt3RNwfsBoxDcB9SXAa"
                 },
                 {
                   "name": {
@@ -3599,12 +3599,12 @@
                   "bcsName": "FDB4OTo6dGVzdDo6VGVzdEZpZWxk",
                   "type": "DynamicField",
                   "objectType": "test",
-                  "objectId": "0x7e00acf5386662fa062483ba507b1e9e3039750f0a270f2e12441ad7f611a5f7",
+                  "objectId": "0x6d95af2033dd243fe6bdc6886d51b7d1cb695b9491893f88a5ae1b9d4f235b3c",
                   "version": 1,
-                  "digest": "J2n2gEG8R9P9nMep8mRVLjttxcDXQnWSH9KmrRsnGSg2"
+                  "digest": "9Ury7TXnLtHDrxreKjv5eMJpDAU4wZRuev4JJ1UnJBMp"
                 }
               ],
-              "nextCursor": "0x671832358f25bfacde706e528df4e15bb8de6dadd21835dfe44f4973139c15f9",
+              "nextCursor": "0xfd0b2c4326c56b1fec231d73038dba0f0885b97982f5fcac3ec6f5c8cae16743",
               "hasNextPage": true
             }
           }
@@ -3692,7 +3692,7 @@
           "params": [
             {
               "name": "address",
-              "value": "0x0cd4bb4d4f520fe9bbf0cf1cebe3f2549412826c3c9261bff9786c240123749f"
+              "value": "0xdbc9abc01a87906b033a75750e741edb2df5ea5d55c96a611371d22799d26827"
             },
             {
               "name": "query",
@@ -3703,7 +3703,7 @@
                       "StructType": "0x2::coin::Coin<0x2::sui::SUI>"
                     },
                     {
-                      "AddressOwner": "0x0cd4bb4d4f520fe9bbf0cf1cebe3f2549412826c3c9261bff9786c240123749f"
+                      "AddressOwner": "0xdbc9abc01a87906b033a75750e741edb2df5ea5d55c96a611371d22799d26827"
                     },
                     {
                       "Version": "13488"
@@ -3723,7 +3723,7 @@
             },
             {
               "name": "cursor",
-              "value": "0x8a417a09c971859f8f2b8ec279438a25d8876ea3c60e345ac3861444136b4a1b"
+              "value": "0x0cd4bb4d4f520fe9bbf0cf1cebe3f2549412826c3c9261bff9786c240123749f"
             },
             {
               "name": "limit",
@@ -3736,45 +3736,45 @@
               "data": [
                 {
                   "data": {
-                    "objectId": "0xd87765d1aadec2db8cc24c312542c8359b6b5e3bfeab524e5edaad3a204b4053",
+                    "objectId": "0x0b37a91692359a98496738a58c17a9334aeacc435c70ab9635e47a277d8f8dd9",
                     "version": "13488",
-                    "digest": "8qCvxDHh5LtDfF95Ci9G7vvQN2P6y4v55S9xoKBYp7FM",
+                    "digest": "FZzfCnKCSRW2jN9AwkiarjYQapViUQAh799aiRMZ4YC2",
                     "type": "0x2::coin::Coin<0x2::sui::SUI>",
                     "owner": {
-                      "AddressOwner": "0x0cd4bb4d4f520fe9bbf0cf1cebe3f2549412826c3c9261bff9786c240123749f"
+                      "AddressOwner": "0xdbc9abc01a87906b033a75750e741edb2df5ea5d55c96a611371d22799d26827"
                     },
-                    "previousTransaction": "kniF9zCBVYevxq3ZmtKxDDJk27N1qEgwkDtPiyeve4Y",
+                    "previousTransaction": "AJhAseKLEndWYT45FbvYGgCJQTqZP537xqNnthY9FqSa",
                     "storageRebate": "100"
                   }
                 },
                 {
                   "data": {
-                    "objectId": "0x26ed170e0427f9416a614d23284116375c16bd317738fd2c7a885362e04923f5",
+                    "objectId": "0xd4feace07fc863a2eef286c3e95ed48e2c181bb65db5beaf7ea664b4ca6b744c",
                     "version": "13488",
-                    "digest": "5Ka3vDaDy9h5UYk3Maz3vssWHrhbcGXQgwg8fL2ygyTi",
+                    "digest": "3cxBDcfnkVgtXWhnMnKKkMGtZdiEorUhb1vdp2DkVyfi",
                     "type": "0x2::coin::Coin<0x2::sui::SUI>",
                     "owner": {
-                      "AddressOwner": "0x0cd4bb4d4f520fe9bbf0cf1cebe3f2549412826c3c9261bff9786c240123749f"
+                      "AddressOwner": "0xdbc9abc01a87906b033a75750e741edb2df5ea5d55c96a611371d22799d26827"
                     },
-                    "previousTransaction": "FLSfkL1pVTxv724z5kfPbTq2KsWP1HEKBwZQ57uRZU11",
+                    "previousTransaction": "8qCvxDHh5LtDfF95Ci9G7vvQN2P6y4v55S9xoKBYp7FM",
                     "storageRebate": "100"
                   }
                 },
                 {
                   "data": {
-                    "objectId": "0x2aea16d6fb49b7d1ae51f33b01ed8e1ac66916858610c124bb6fd73bb13e141c",
+                    "objectId": "0xe26860fac6839ce2d7ed7e6f29d276a1b4c23f2d9a9b6f0d8b2c17beace292b7",
                     "version": "13488",
-                    "digest": "D3hfhfecVcmRcqNEkxkoFMzbuXvBqWj1JkCNU9zbnYMo",
+                    "digest": "3tX9sgYC4A6nVKGjKEE5xxW6t4zkvDL9BwjuaxMg8arP",
                     "type": "0x2::coin::Coin<0x2::sui::SUI>",
                     "owner": {
-                      "AddressOwner": "0x0cd4bb4d4f520fe9bbf0cf1cebe3f2549412826c3c9261bff9786c240123749f"
+                      "AddressOwner": "0xdbc9abc01a87906b033a75750e741edb2df5ea5d55c96a611371d22799d26827"
                     },
-                    "previousTransaction": "GEoTGQuWicnPLM9Rg3vW1Q2y3kvnAgEkbyn8Z3RnAYai",
+                    "previousTransaction": "5Ka3vDaDy9h5UYk3Maz3vssWHrhbcGXQgwg8fL2ygyTi",
                     "storageRebate": "100"
                   }
                 }
               ],
-              "nextCursor": "0x2aea16d6fb49b7d1ae51f33b01ed8e1ac66916858610c124bb6fd73bb13e141c",
+              "nextCursor": "0xe26860fac6839ce2d7ed7e6f29d276a1b4c23f2d9a9b6f0d8b2c17beace292b7",
               "hasNextPage": true
             }
           }
@@ -3841,18 +3841,18 @@
           "params": [
             {
               "name": "owner",
-              "value": "0x3befb84f03a24386492bd3b05b1fd386172eb450e5059ce7df0ea6d9d6cefcaa"
+              "value": "0x9c76d5157eaa77c41a7bfda8db98a8e8080f7cb53b7313088ed085c73f866f21"
             }
           ],
           "result": {
             "name": "Result",
             "value": [
               {
-                "validatorAddress": "0x9a95cf69368e31b4dbe8ee9bdb3c0587bbc79d8fc6edf4007e185a962fd906df",
-                "stakingPool": "0xb4eeb46b70f0bebcae832aeef9f7c5db76052ab656e5f81853d0cf701cdbc8eb",
+                "validatorAddress": "0x3befb84f03a24386492bd3b05b1fd386172eb450e5059ce7df0ea6d9d6cefcaa",
+                "stakingPool": "0x9a95cf69368e31b4dbe8ee9bdb3c0587bbc79d8fc6edf4007e185a962fd906df",
                 "stakes": [
                   {
-                    "stakedSuiId": "0xf27ab513fc6ef8c344406c78da3d5ad3a5fcc295dc8803c15989a62d33ee8590",
+                    "stakedSuiId": "0xb4eeb46b70f0bebcae832aeef9f7c5db76052ab656e5f81853d0cf701cdbc8eb",
                     "stakeRequestEpoch": "62",
                     "stakeActiveEpoch": "63",
                     "principal": "200000000000",
@@ -3860,7 +3860,7 @@
                     "estimatedReward": "520000000"
                   },
                   {
-                    "stakedSuiId": "0x14cfd5e91c13a481370240e392464c329a203fb9f0a8158aaab9b2a90044b26e",
+                    "stakedSuiId": "0xf27ab513fc6ef8c344406c78da3d5ad3a5fcc295dc8803c15989a62d33ee8590",
                     "stakeRequestEpoch": "142",
                     "stakeActiveEpoch": "143",
                     "principal": "200000000000",
@@ -3869,11 +3869,11 @@
                 ]
               },
               {
-                "validatorAddress": "0x14cc7fee4100fdcabda6d15c63c4b49c45ae23f2b936495cd38b1a4b04010295",
-                "stakingPool": "0xbaa75ac72e548aeecf2ce8b4e88530651d6e8f93e0fb79b4bc65a512beb5b9f3",
+                "validatorAddress": "0x14cfd5e91c13a481370240e392464c329a203fb9f0a8158aaab9b2a90044b26e",
+                "stakingPool": "0x14cc7fee4100fdcabda6d15c63c4b49c45ae23f2b936495cd38b1a4b04010295",
                 "stakes": [
                   {
-                    "stakedSuiId": "0x378423de90ed03b694cecf443c72b5387b29a731d26d98108d7abc4902107d7d",
+                    "stakedSuiId": "0xbaa75ac72e548aeecf2ce8b4e88530651d6e8f93e0fb79b4bc65a512beb5b9f3",
                     "stakeRequestEpoch": "244",
                     "stakeActiveEpoch": "245",
                     "principal": "200000000000",
@@ -3923,19 +3923,19 @@
             {
               "name": "staked_sui_ids",
               "value": [
-                "0x6a8e0f8fea6fda5488462e58724c034462b6064a08845e2ae2942fe7c4ee816d",
-                "0x754eb2eed23e6c6bb32c89fe1f21ab588374445e72e0402aea014b2956105799"
+                "0x378423de90ed03b694cecf443c72b5387b29a731d26d98108d7abc4902107d7d",
+                "0x6a8e0f8fea6fda5488462e58724c034462b6064a08845e2ae2942fe7c4ee816d"
               ]
             }
           ],
           "result": {
             "name": "Result",
             "value": {
-              "validatorAddress": "0x63ee67e81398729f87d81d62f399c041b0f8d0938923ea7e3917608ee62df437",
-              "stakingPool": "0x6710024f81dd33ab6833482ee8034e779a48e6ef635c7f856df4905022458bfb",
+              "validatorAddress": "0x754eb2eed23e6c6bb32c89fe1f21ab588374445e72e0402aea014b2956105799",
+              "stakingPool": "0x63ee67e81398729f87d81d62f399c041b0f8d0938923ea7e3917608ee62df437",
               "stakes": [
                 {
-                  "stakedSuiId": "0x6a8e0f8fea6fda5488462e58724c034462b6064a08845e2ae2942fe7c4ee816d",
+                  "stakedSuiId": "0x378423de90ed03b694cecf443c72b5387b29a731d26d98108d7abc4902107d7d",
                   "stakeRequestEpoch": "62",
                   "stakeActiveEpoch": "63",
                   "principal": "200000000000",
@@ -3943,7 +3943,7 @@
                   "estimatedReward": "520000000"
                 },
                 {
-                  "stakedSuiId": "0x754eb2eed23e6c6bb32c89fe1f21ab588374445e72e0402aea014b2956105799",
+                  "stakedSuiId": "0x6a8e0f8fea6fda5488462e58724c034462b6064a08845e2ae2942fe7c4ee816d",
                   "stakeRequestEpoch": "244",
                   "stakeActiveEpoch": "245",
                   "principal": "200000000000",
@@ -3986,7 +3986,7 @@
           "params": [
             {
               "name": "coin_type",
-              "value": "0x0a52124e2d53af3bef7959609efa51761ad155441a1b73bdaeecce7c56488b13::acoin::ACOIN"
+              "value": "0xe5c651321915b06c81838c2e370109b554a448a78d3a56220f798398dde66eab::acoin::ACOIN"
             }
           ],
           "result": {
@@ -4023,15 +4023,15 @@
             "value": {
               "apys": [
                 {
-                  "address": "0x27838b06db0346808ffb0676099de0408b31759f57b69c52e09410a66f9a23c3",
+                  "address": "0x9d77e49d53f92bc8310f0ccc3257dcc85bada4a729d650f77622264321297809",
                   "apy": 0.06
                 },
                 {
-                  "address": "0x4be9913b6697a5e83e02e2a0fc747057ba0901e4d9b1e04de75ea2699a441321",
+                  "address": "0x27838b06db0346808ffb0676099de0408b31759f57b69c52e09410a66f9a23c3",
                   "apy": 0.02
                 },
                 {
-                  "address": "0x5612581eba57ebe7e594b809ccceec2be4dac6ff6945d49b3ecc043d049611f6",
+                  "address": "0x4be9913b6697a5e83e02e2a0fc747057ba0901e4d9b1e04de75ea2699a441321",
                   "apy": 0.05
                 }
               ],
@@ -4097,7 +4097,7 @@
               "name": "query",
               "value": {
                 "MoveModule": {
-                  "package": "0x9c76d5157eaa77c41a7bfda8db98a8e8080f7cb53b7313088ed085c73f866f21",
+                  "package": "0xa395759ca37c6e1ffc179184e98a6f9a2da5d78f6e34b0e5044ed52a6bc0a1bc",
                   "module": "test"
                 }
               }
@@ -4105,7 +4105,7 @@
             {
               "name": "cursor",
               "value": {
-                "txDigest": "EnySDWe22mnp35umt47kifqXvvchBqTzAoyoPXaH3rfK",
+                "txDigest": "Eg3ynETJfTfPKyvJzq3VLG6MngURYHPMjjUJ3Xt1t7tf",
                 "eventSeq": "1"
               }
             },
@@ -4124,10 +4124,23 @@
               "data": [
                 {
                   "id": {
+                    "txDigest": "FFwCMgC7FHBLEwfL9JeSeR2EhMAZMykUPVW1kE3HgTMe",
+                    "eventSeq": "1"
+                  },
+                  "packageId": "0xb2fd632992b01aa25900867288b63d6255ff8223c12b0fd985c49d5777a0d65a",
+                  "transactionModule": "test",
+                  "sender": "0xcceee09f44d558691334ec0aff47af033f57162a2f33056e2585e2c46863ac02",
+                  "type": "0x3::test::Test<0x3::test::Test>",
+                  "parsedJson": "some_value",
+                  "bcsEncoding": "base64",
+                  "bcs": ""
+                },
+                {
+                  "id": {
                     "txDigest": "FUMhRSj76es8MYeaRYeaBnppk56cuEehKwL2CiU82U7B",
                     "eventSeq": "1"
                   },
-                  "packageId": "0xd3d707164b2a378eee639ebc2690873d2f7dd97d60bdd8f0b9935a5c791b096d",
+                  "packageId": "0xb2fd632992b01aa25900867288b63d6255ff8223c12b0fd985c49d5777a0d65a",
                   "transactionModule": "test",
                   "sender": "0x84bd999f9ff7a1804872957fafa528628a24386298faa98850887f64da841b87",
                   "type": "0x3::test::Test<0x3::test::Test>",
@@ -4140,7 +4153,7 @@
                     "txDigest": "CkEYWW2zxTCGBLvUcTARhyX92fu2uc7cnCUXfCiqAypp",
                     "eventSeq": "1"
                   },
-                  "packageId": "0xd3d707164b2a378eee639ebc2690873d2f7dd97d60bdd8f0b9935a5c791b096d",
+                  "packageId": "0xb2fd632992b01aa25900867288b63d6255ff8223c12b0fd985c49d5777a0d65a",
                   "transactionModule": "test",
                   "sender": "0x279efd098d59a66a3d9adc87cce81fe9ec69dc8105b2b60140589ec8be44c29f",
                   "type": "0x3::test::Test<0x3::test::Test>",
@@ -4153,22 +4166,9 @@
                     "txDigest": "Eg3ynETJfTfPKyvJzq3VLG6MngURYHPMjjUJ3Xt1t7tf",
                     "eventSeq": "1"
                   },
-                  "packageId": "0xd3d707164b2a378eee639ebc2690873d2f7dd97d60bdd8f0b9935a5c791b096d",
+                  "packageId": "0xb2fd632992b01aa25900867288b63d6255ff8223c12b0fd985c49d5777a0d65a",
                   "transactionModule": "test",
                   "sender": "0x289be027d2a94f744b4c59fda7b528f9c59f430eaba84b8bee9b43a30f9cc83f",
-                  "type": "0x3::test::Test<0x3::test::Test>",
-                  "parsedJson": "some_value",
-                  "bcsEncoding": "base64",
-                  "bcs": ""
-                },
-                {
-                  "id": {
-                    "txDigest": "EnySDWe22mnp35umt47kifqXvvchBqTzAoyoPXaH3rfK",
-                    "eventSeq": "1"
-                  },
-                  "packageId": "0xd3d707164b2a378eee639ebc2690873d2f7dd97d60bdd8f0b9935a5c791b096d",
-                  "transactionModule": "test",
-                  "sender": "0xa395759ca37c6e1ffc179184e98a6f9a2da5d78f6e34b0e5044ed52a6bc0a1bc",
                   "type": "0x3::test::Test<0x3::test::Test>",
                   "parsedJson": "some_value",
                   "bcsEncoding": "base64",
@@ -4176,7 +4176,7 @@
                 }
               ],
               "nextCursor": {
-                "txDigest": "EnySDWe22mnp35umt47kifqXvvchBqTzAoyoPXaH3rfK",
+                "txDigest": "Eg3ynETJfTfPKyvJzq3VLG6MngURYHPMjjUJ3Xt1t7tf",
                 "eventSeq": "1"
               },
               "hasNextPage": false
@@ -4318,7 +4318,7 @@
           ],
           "result": {
             "name": "Result",
-            "value": "0xd22bbb46f892c42d9ec0ae4de93e02c75973a51c17180798237326a58694a2cf"
+            "value": "0x6710024f81dd33ab6833482ee8034e779a48e6ef635c7f856df4905022458bfb"
           }
         }
       ]
@@ -4368,11 +4368,11 @@
           "params": [
             {
               "name": "address",
-              "value": "0x38b3186a7bb26a1ab2c982a0a9b482aa70f5a010fffc60f20194ef0f597474e8"
+              "value": "0x5cd6fa76ed1d18f05f15e35075252ddec4fb83621d55952d9172fcfcb72feae2"
             },
             {
               "name": "cursor",
-              "value": "0x5cd6fa76ed1d18f05f15e35075252ddec4fb83621d55952d9172fcfcb72feae2"
+              "value": "0xd22bbb46f892c42d9ec0ae4de93e02c75973a51c17180798237326a58694a2cf"
             },
             {
               "name": "limit",
@@ -4385,7 +4385,7 @@
               "data": [
                 "example.sui"
               ],
-              "nextCursor": "0x5cd6fa76ed1d18f05f15e35075252ddec4fb83621d55952d9172fcfcb72feae2",
+              "nextCursor": "0xd22bbb46f892c42d9ec0ae4de93e02c75973a51c17180798237326a58694a2cf",
               "hasNextPage": false
             }
           }
@@ -7831,7 +7831,7 @@
           }
         }
       },
-      "Page_for_Coin_and_ObjectID": {
+      "Page_for_Coin_and_String": {
         "description": "`next_cursor` points to the last item in the page; Reading with `next_cursor` will start from the next item after `next_cursor` if `next_cursor` is `Some`, otherwise it will start from the first item.",
         "type": "object",
         "required": [
@@ -7849,13 +7849,9 @@
             "type": "boolean"
           },
           "nextCursor": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ObjectID"
-              },
-              {
-                "type": "null"
-              }
+            "type": [
+              "string",
+              "null"
             ]
           }
         }

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -854,7 +854,6 @@ impl RpcExampleProvider {
         let limit = 3;
         let owner = SuiAddress::from(ObjectID::new(self.rng.gen()));
         let cursor = ObjectID::new(self.rng.gen());
-        let next = ObjectID::new(self.rng.gen());
         let coins = (0..3)
             .map(|_| Coin {
                 coin_type: "0x2::sui::SUI".to_string(),
@@ -868,7 +867,7 @@ impl RpcExampleProvider {
             .collect::<Vec<_>>();
         let page = CoinPage {
             data: coins,
-            next_cursor: Some(next),
+            next_cursor: Some("abcd".to_string()),
             has_next_page: true,
         };
 
@@ -956,11 +955,9 @@ impl RpcExampleProvider {
             })
             .collect::<Vec<_>>();
 
-        let next_cursor = coins.last().unwrap().coin_object_id;
-
         let page = CoinPage {
             data: coins,
-            next_cursor: Some(next_cursor),
+            next_cursor: Some("abcd".to_string()),
             has_next_page: true,
         };
 

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -748,7 +748,7 @@ impl CoinReadApi {
         &self,
         owner: SuiAddress,
         coin_type: Option<String>,
-        cursor: Option<ObjectID>,
+        cursor: Option<String>,
         limit: Option<usize>,
     ) -> SuiRpcResult<CoinPage> {
         Ok(self
@@ -782,7 +782,7 @@ impl CoinReadApi {
     pub async fn get_all_coins(
         &self,
         owner: SuiAddress,
-        cursor: Option<ObjectID>,
+        cursor: Option<String>,
         limit: Option<usize>,
     ) -> SuiRpcResult<CoinPage> {
         Ok(self.api.http.get_all_coins(owner, cursor, limit).await?)

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -824,7 +824,7 @@ impl CoinReadApi {
             ),
             move |(mut data, cursor, has_next_page, coin_type)| async move {
                 if let Some(item) = data.pop() {
-                    Some((item, (data, cursor, /* has_next_page */ true, coin_type)))
+                    Some((item, (data, cursor, has_next_page, coin_type)))
                 } else if has_next_page {
                     let page = self
                         .get_coins(owner, coin_type.clone(), cursor, Some(100))


### PR DESCRIPTION
Explicitly make the cursors for get_coins and get_all_coins to be an opaque string instead of an ObjectId encoded as a string.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [x] JSON-RPC: 

Explicitly make the cursors for GetCoins and GetAllCoins to be an opaque string instead of an ObjectId encoded as a string.

- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
