### PR TITLE
Remove unnecessary config fields in examples

### DIFF
--- a/docs/content/guides/operator/data-management.mdx
+++ b/docs/content/guides/operator/data-management.mdx
@@ -180,20 +180,10 @@ This configuration keeps disk usage to a minimum. It is suitable for most valida
 enable-index-processing: false
 
 authority-store-pruning-config:
-  # default values
-  num-latest-epoch-dbs-to-retain: 3
-  epoch-db-pruning-period-secs: 3600
-  max-checkpoints-in-batch: 10
-  max-transactions-in-batch: 1000
-  # end of default values
-
   # Prune historic object versions as soon as possible.
   num-epochs-to-retain: 0
   # Prune historic transactions of the past epochs
   num-epochs-to-retain-for-checkpoints: 2
-  periodic-compaction-threshold-days: 1
-  # Smooth pruning traffic throughout an epoch
-  smooth: true
 ```
 
 ### Full node with indexing but no history
@@ -207,20 +197,10 @@ This setup manages secondary indexing in addition to the latest state, but aggre
 
 ```yaml
 authority-store-pruning-config:
-  # default values
-  num-latest-epoch-dbs-to-retain: 3
-  epoch-db-pruning-period-secs: 3600
-  max-checkpoints-in-batch: 10
-  max-transactions-in-batch: 1000
-  # end of default values
-
   # Prune historic object versions
   num-epochs-to-retain: 0
   # Prune historic transactions of the past epochs
   num-epochs-to-retain-for-checkpoints: 2
-  periodic-compaction-threshold-days: 1
-  # Smooth pruning traffic throughout an epoch
-  smooth: true
 ```
 
 ### Full node with full object history but pruned transaction history
@@ -233,18 +213,9 @@ In addition to the regular (pruned) snapshots, Mysten Labs also maintains specia
 
 ```yaml
 authority-store-pruning-config:
-  # default values
-  num-latest-epoch-dbs-to-retain: 3
-  epoch-db-pruning-period-secs: 3600
-  max-checkpoints-in-batch: 10
-  max-transactions-in-batch: 1000
-  # end of default values
-
-  # No pruning of object versions (use u64::max for num of epochs)
+  # No pruning of object versions with u64::max for num of epochs.
+  # Set a lower value for a smaller objects history.
   num-epochs-to-retain: 18446744073709551615
   # Prune historic transactions of the past epochs
   num-epochs-to-retain-for-checkpoints: 2
-  periodic-compaction-threshold-days: 1
-  # Smooth pruning traffic throughout an epoch
-  smooth: true
 ```

--- a/nre/config/validator.yaml
+++ b/nre/config/validator.yaml
@@ -10,25 +10,7 @@ network-address: /ip4/0.0.0.0/tcp/8080/http
 metrics-address: 0.0.0.0:9184
 admin-interface-port: 1337
 consensus-config:
-  address: /ip4/127.0.0.1/tcp/8083/http
   db-path: /opt/sui/db/consensus_db
-  internal-worker-address: null
-  narwhal-config:
-    header_num_of_batches_threshold: 32
-    max_header_num_of_batches: 1000
-    max_header_delay: 1000ms
-    gc_depth: 50
-    sync_retry_delay: 5000ms
-    sync_retry_nodes: 3
-    batch_size: 500000
-    max_batch_delay: 100ms
-    max_concurrent_requests: 500000
-    prometheus_metrics:
-      socket_addr: /ip4/127.0.0.1/tcp/33291/http
-    network_admin_server:
-      primary_network_admin_server_port: 41303
-      worker_network_admin_server_base_port: 41669
-enable-event-processing: false
 p2p-config:
   listen-address: 0.0.0.0:8084
   external-address: /dns/$HOSTNAME/udp/8084 # UPDATE THIS
@@ -36,13 +18,10 @@ p2p-config:
     max-concurrent-connections: 0
 genesis:
   genesis-file-location: /opt/sui/config/genesis.blob
+enable-index-processing: false
 authority-store-pruning-config:
-  num-latest-epoch-dbs-to-retain: 3
-  epoch-db-pruning-period-secs: 3600
-  num-epochs-to-retain: 1
-  max-checkpoints-in-batch: 5
-  max-transactions-in-batch: 1000
-end-of-epoch-broadcast-channel-capacity: 128
+  num-epochs-to-retain: 0
+  num-epochs-to-retain-for-checkpoints: 2
 checkpoint-executor-config:
   checkpoint-execution-max-concurrency: 200
   local-execution-timeout-sec: 10


### PR DESCRIPTION
## Description 

- Most of consensus configs do not need to be set explicitly or have been deprecated.
- Many fields in the pruning config do not need to be set because they are already the default.

## Test plan 

👀

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
