### PR TITLE
fix(typos): Correct spelling errors in exchange rates task and transaction processor

### DIFF
--- a/crates/sui-graphql-rpc/src/server/exchange_rates_task.rs
+++ b/crates/sui-graphql-rpc/src/server/exchange_rates_task.rs
@@ -39,14 +39,14 @@ impl TriggerExchangeRatesTask {
 
                 _ = self.epoch_rx.changed() => {
                     info!("Detected epoch boundary, triggering call to exchange rates");
-                    let latest_sui_sytem_state = self.db.inner
+                    let latest_sui_system_state = self.db.inner
                         .get_latest_sui_system_state()
                         .await.map_err(|_| error!("Failed to fetch latest Sui system state"));
 
-                    if let Ok(latest_sui_sytem_state) = latest_sui_sytem_state {
+                    if let Ok(latest_sui_system_state) = latest_sui_system_state {
                         let db = self.db.clone();
                         let governance_api = GovernanceReadApi::new(db.inner) ;
-                        exchange_rates(&governance_api, &latest_sui_sytem_state)
+                        exchange_rates(&governance_api, &latest_sui_system_state)
                             .await
                             .map_err(|e| error!("Failed to fetch exchange rates: {:?}", e))
                             .ok();

--- a/crates/sui-indexer/src/handlers/tx_processor.rs
+++ b/crates/sui-indexer/src/handlers/tx_processor.rs
@@ -102,7 +102,7 @@ impl TxChangesProcessor {
             effects,
             tx.input_objects().unwrap_or_else(|e| {
                 panic!(
-                    "Checkpointed tx {:?} has inavlid input objects: {e}",
+                    "Checkpointed tx {:?} has invalid input objects: {e}",
                     tx_digest,
                 )
             }),

--- a/crates/sui-mvr-graphql-rpc/src/server/exchange_rates_task.rs
+++ b/crates/sui-mvr-graphql-rpc/src/server/exchange_rates_task.rs
@@ -39,14 +39,14 @@ impl TriggerExchangeRatesTask {
 
                 _ = self.epoch_rx.changed() => {
                     info!("Detected epoch boundary, triggering call to exchange rates");
-                    let latest_sui_sytem_state = self.db.inner
+                    let latest_sui_system_state = self.db.inner
                         .get_latest_sui_system_state()
                         .await.map_err(|_| error!("Failed to fetch latest Sui system state"));
 
-                    if let Ok(latest_sui_sytem_state) = latest_sui_sytem_state {
+                    if let Ok(latest_sui_system_state) = latest_sui_system_state {
                         let db = self.db.clone();
                         let governance_api = GovernanceReadApi::new(db.inner) ;
-                        exchange_rates(&governance_api, &latest_sui_sytem_state)
+                        exchange_rates(&governance_api, &latest_sui_system_state)
                             .await
                             .map_err(|e| error!("Failed to fetch exchange rates: {:?}", e))
                             .ok();


### PR DESCRIPTION
- Fixed `sui_sytem_state` → `sui_system_state` in `exchange_rates_task.rs` (multiple occurrences).  
- Fixed `inavlid` → `invalid` in `tx_processor.rs`.  