### PR TITLE
[test-adapter] refactor query interpolation and change format for bcs cursors

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/coins.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/coins.move
@@ -134,7 +134,7 @@ module P0::fake {
   }
 }
 
-//# run-graphql --cursors @{obj_1_1,2}
+//# run-graphql --cursors bcs(@{obj_1_1},2)
 # There should be two coins, and the coin owners should be the same as the owner of the first coin in the previous query
 {
   availableRange {
@@ -162,7 +162,7 @@ module P0::fake {
   }
 }
 
-//# run-graphql --cursors @{obj_1_1,1}
+//# run-graphql --cursors bcs(@{obj_1_1},1)
 # Outside of available range
 {
   availableRange {
@@ -190,7 +190,7 @@ module P0::fake {
   }
 }
 
-//# run-graphql --cursors @{obj_1_1,0}
+//# run-graphql --cursors bcs(@{obj_1_1},0)
 # Outside of available range
 {
   availableRange {

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/coins.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/coins.snap
@@ -242,7 +242,7 @@ Response: {
 }
 
 task 12, lines 137-163:
-//# run-graphql --cursors @{obj_1_1,2}
+//# run-graphql --cursors bcs(@{obj_1_1},2)
 Response: {
   "data": {
     "availableRange": {
@@ -293,7 +293,7 @@ Response: {
 }
 
 task 13, lines 165-191:
-//# run-graphql --cursors @{obj_1_1,1}
+//# run-graphql --cursors bcs(@{obj_1_1},1)
 Response: {
   "data": null,
   "errors": [
@@ -316,7 +316,7 @@ Response: {
 }
 
 task 14, lines 193-219:
-//# run-graphql --cursors @{obj_1_1,0}
+//# run-graphql --cursors bcs(@{obj_1_1},0)
 Response: {
   "data": null,
   "errors": [

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/dynamic_fields/dynamic_fields.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/dynamic_fields/dynamic_fields.move
@@ -173,7 +173,7 @@ fragment DynamicFieldsSelect on DynamicFieldConnection {
 
 //# create-checkpoint
 
-//# run-graphql --cursors @{obj_5_0,1} @{obj_5_0,2}
+//# run-graphql --cursors bcs(@{obj_5_0},1) bcs(@{obj_5_0},2)
 fragment DynamicFieldSelect on DynamicField {
   name {
     bcs
@@ -284,7 +284,7 @@ fragment DynamicFieldSelect on DynamicField {
 
 //# create-checkpoint
 
-//# run-graphql --cursors @{obj_5_0,2} @{obj_5_0,3}
+//# run-graphql --cursors bcs(@{obj_5_0},2) bcs(@{obj_5_0},3)
 fragment DynamicFieldSelect on DynamicField {
   name {
     bcs
@@ -345,7 +345,7 @@ fragment DynamicFieldsSelect on DynamicFieldConnection {
 
 //# create-checkpoint
 
-//# run-graphql --cursors @{obj_5_0,2} @{obj_5_0,4}
+//# run-graphql --cursors bcs(@{obj_5_0},2) bcs(@{obj_5_0},4)
 fragment DynamicFieldSelect on DynamicField {
   name {
     bcs
@@ -446,7 +446,7 @@ fragment DynamicFieldSelect on DynamicField {
 
 //# create-checkpoint
 
-//# run-graphql --cursors @{obj_5_0,2} @{obj_5_0,4}
+//# run-graphql --cursors bcs(@{obj_5_0},2) bcs(@{obj_5_0},4)
 fragment DynamicFieldSelect on DynamicField {
   name {
     bcs

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/dynamic_fields/dynamic_fields.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/dynamic_fields/dynamic_fields.snap
@@ -169,7 +169,7 @@ task 13, line 174:
 Checkpoint created: 2
 
 task 14, lines 176-236:
-//# run-graphql --cursors @{obj_5_0,1} @{obj_5_0,2}
+//# run-graphql --cursors bcs(@{obj_5_0},1) bcs(@{obj_5_0},2)
 Response: {
   "data": {
     "parent_version_4_show_dof_and_dfs": {
@@ -408,7 +408,7 @@ task 19, line 285:
 Checkpoint created: 3
 
 task 20, lines 287-337:
-//# run-graphql --cursors @{obj_5_0,2} @{obj_5_0,3}
+//# run-graphql --cursors bcs(@{obj_5_0},2) bcs(@{obj_5_0},3)
 Response: {
   "data": {
     "parent_version_4_has_4_children": {
@@ -737,7 +737,7 @@ task 24, line 346:
 Checkpoint created: 4
 
 task 25, lines 348-398:
-//# run-graphql --cursors @{obj_5_0,2} @{obj_5_0,4}
+//# run-graphql --cursors bcs(@{obj_5_0},2) bcs(@{obj_5_0},4)
 Response: {
   "data": {
     "parent_version_4_has_df1_2_3": {
@@ -999,7 +999,7 @@ task 34, line 447:
 Checkpoint created: 8
 
 task 35, lines 449-507:
-//# run-graphql --cursors @{obj_5_0,2} @{obj_5_0,4}
+//# run-graphql --cursors bcs(@{obj_5_0},2) bcs(@{obj_5_0},4)
 Response: {
   "data": {
     "availableRange": {

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/object_at_version.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/object_at_version.move
@@ -289,7 +289,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors @{obj_1_0,6}
+//# run-graphql --cursors bcs(@{obj_1_0},6)
 # But it would no longer be possible to try to paginate using a cursor that falls outside the available range
 {
   availableRange {

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/object_at_version.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/object_at_version.snap
@@ -279,7 +279,7 @@ Response: {
 }
 
 task 32, lines 292-312:
-//# run-graphql --cursors @{obj_1_0,6}
+//# run-graphql --cursors bcs(@{obj_1_0},6)
 Response: {
   "data": null,
   "errors": [

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/objects_pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/objects_pagination.move
@@ -33,7 +33,7 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --cursors @{obj_2_0} @{obj_3_0}
+//# run-graphql --cursors bcs(@{obj_2_0},@{highest_checkpoint}) bcs(@{obj_3_0},@{highest_checkpoint})
 {
   one_of_these_will_yield_an_object: address(address: "@{A}") {
     objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
@@ -69,7 +69,7 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --cursors @{obj_2_0,1} @{obj_3_0,1}
+//# run-graphql --cursors bcs(@{obj_2_0},1) bcs(@{obj_3_0},1)
 {
   paginating_on_checkpoint_1: address(address: "@{A}") {
     objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
@@ -148,7 +148,7 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --cursors @{obj_6_0,2}
+//# run-graphql --cursors bcs(@{obj_6_0},2)
 {
   after_obj_6_0_at_checkpoint_2: address(address: "@{A}") {
     objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
@@ -228,7 +228,7 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --cursors @{obj_6_0,2}
+//# run-graphql --cursors bcs(@{obj_6_0},2)
 # This query will error due to requesting data outside of available range
 {
   availableRange {

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/objects_pagination.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/objects_pagination.snap
@@ -29,7 +29,7 @@ task 4, line 34:
 Checkpoint created: 1
 
 task 5, lines 36-64:
-//# run-graphql --cursors @{obj_2_0} @{obj_3_0}
+//# run-graphql --cursors bcs(@{obj_2_0},@{highest_checkpoint}) bcs(@{obj_3_0},@{highest_checkpoint})
 Response: {
   "data": {
     "one_of_these_will_yield_an_object": {
@@ -75,7 +75,7 @@ task 8, line 70:
 Checkpoint created: 2
 
 task 9, lines 72-100:
-//# run-graphql --cursors @{obj_2_0,1} @{obj_3_0,1}
+//# run-graphql --cursors bcs(@{obj_2_0},1) bcs(@{obj_3_0},1)
 Response: {
   "data": {
     "paginating_on_checkpoint_1": {
@@ -237,7 +237,7 @@ task 13, line 149:
 Checkpoint created: 3
 
 task 14, lines 151-213:
-//# run-graphql --cursors @{obj_6_0,2}
+//# run-graphql --cursors bcs(@{obj_6_0},2)
 Response: {
   "data": {
     "after_obj_6_0_at_checkpoint_2": {
@@ -521,7 +521,7 @@ task 22, line 229:
 Checkpoint created: 7
 
 task 23, lines 231-255:
-//# run-graphql --cursors @{obj_6_0,2}
+//# run-graphql --cursors bcs(@{obj_6_0},2)
 Response: {
   "data": null,
   "errors": [

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/objects_pagination_single.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/objects_pagination_single.move
@@ -34,7 +34,7 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --cursors @{obj_3_0}
+//# run-graphql --cursors bcs(@{obj_3_0},@{highest_checkpoint})
 {
   after_obj_3_0: address(address: "@{A}") {
     objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
@@ -68,7 +68,7 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --cursors @{obj_3_0,1}
+//# run-graphql --cursors bcs(@{obj_3_0},1)
 # This query should yield the same results as the previous one.
 {
   after_obj_3_0_chkpt_1: address(address: "@{A}") {
@@ -99,7 +99,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors @{obj_3_0,2}
+//# run-graphql --cursors bcs(@{obj_3_0},2)
 {
   address(address: "@{A}") {
     objects(filter: {type: "@{Test}"}) {
@@ -180,7 +180,7 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --cursors @{obj_3_0,2}
+//# run-graphql --cursors bcs(@{obj_3_0},2)
 # This query should yield the same results as the previous one.
 {
     after_obj_3_0_chkpt_2: address(address: "@{A}") {
@@ -245,7 +245,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors @{obj_3_0,3}
+//# run-graphql --cursors bcs(@{obj_3_0},3)
 {
   address(address: "@{A}") {
     objects(filter: {type: "@{Test}"}) {

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/objects_pagination_single.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/objects_pagination_single.snap
@@ -34,7 +34,7 @@ task 5, line 35:
 Checkpoint created: 1
 
 task 6, lines 37-65:
-//# run-graphql --cursors @{obj_3_0}
+//# run-graphql --cursors bcs(@{obj_3_0},@{highest_checkpoint})
 Response: {
   "data": {
     "after_obj_3_0": {
@@ -73,7 +73,7 @@ task 8, line 69:
 Checkpoint created: 2
 
 task 9, lines 71-100:
-//# run-graphql --cursors @{obj_3_0,1}
+//# run-graphql --cursors bcs(@{obj_3_0},1)
 Response: {
   "data": {
     "after_obj_3_0_chkpt_1": {
@@ -103,7 +103,7 @@ Response: {
 }
 
 task 10, lines 102-177:
-//# run-graphql --cursors @{obj_3_0,2}
+//# run-graphql --cursors bcs(@{obj_3_0},2)
 Response: {
   "data": {
     "address": {
@@ -204,7 +204,7 @@ task 12, line 181:
 Checkpoint created: 3
 
 task 13, lines 183-246:
-//# run-graphql --cursors @{obj_3_0,2}
+//# run-graphql --cursors bcs(@{obj_3_0},2)
 Response: {
   "data": {
     "after_obj_3_0_chkpt_2": {
@@ -266,7 +266,7 @@ Response: {
 }
 
 task 14, lines 248-323:
-//# run-graphql --cursors @{obj_3_0,3}
+//# run-graphql --cursors bcs(@{obj_3_0},3)
 Response: {
   "data": {
     "address": {

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/staked_sui.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/staked_sui.move
@@ -55,7 +55,7 @@
   }
 }
 
-//# run-graphql --cursors @{obj_3_1,1} @{obj_7_0,1}
+//# run-graphql --cursors bcs(@{obj_3_1},1) bcs(@{obj_7_0},1)
 # Even though there is a stake created after the initial one, the cursor locks the upper bound to
 # checkpoint 1 - at that point in time, we did not have any additional stakes.
 {
@@ -101,7 +101,7 @@
   }
 }
 
-//# run-graphql --cursors @{obj_3_1,3} @{obj_7_0,3}
+//# run-graphql --cursors bcs(@{obj_3_1},3) bcs(@{obj_7_0},3)
 # The second stake was created at checkpoint 3, and thus will be visible.
 {
   coins_after_obj_3_1_chkpt_3: address(address: "@{C}") {

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/staked_sui.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/staked_sui.snap
@@ -130,7 +130,7 @@ Response: {
 }
 
 task 13, lines 58-102:
-//# run-graphql --cursors @{obj_3_1,1} @{obj_7_0,1}
+//# run-graphql --cursors bcs(@{obj_3_1},1) bcs(@{obj_7_0},1)
 Response: {
   "data": {
     "no_coins_after_obj_3_1_chkpt_1": {
@@ -157,7 +157,7 @@ Response: {
 }
 
 task 14, lines 104-147:
-//# run-graphql --cursors @{obj_3_1,3} @{obj_7_0,3}
+//# run-graphql --cursors bcs(@{obj_3_1},3) bcs(@{obj_7_0},3)
 Response: {
   "data": {
     "coins_after_obj_3_1_chkpt_3": {

--- a/crates/sui-graphql-e2e-tests/tests/stable/objects/pagination.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/objects/pagination.move
@@ -54,7 +54,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors @{obj_5_0}
+//# run-graphql --cursors bcs(@{obj_5_0},@{highest_checkpoint})
 {
   address(address: "@{A}") {
     # select the 2nd and 3rd objects
@@ -68,7 +68,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors @{obj_4_0}
+//# run-graphql --cursors bcs(@{obj_4_0},@{highest_checkpoint})
 {
   address(address: "@{A}") {
     # select 4th and last object
@@ -80,7 +80,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors @{obj_3_0}
+//# run-graphql --cursors bcs(@{obj_3_0},@{highest_checkpoint})
 {
   address(address: "@{A}") {
     # select 3rd and 4th object

--- a/crates/sui-graphql-e2e-tests/tests/stable/objects/pagination.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/objects/pagination.snap
@@ -91,7 +91,7 @@ Response: {
 }
 
 task 10, lines 57-69:
-//# run-graphql --cursors @{obj_5_0}
+//# run-graphql --cursors bcs(@{obj_5_0},@{highest_checkpoint})
 Response: {
   "data": {
     "address": {
@@ -103,7 +103,7 @@ Response: {
 }
 
 task 11, lines 71-81:
-//# run-graphql --cursors @{obj_4_0}
+//# run-graphql --cursors bcs(@{obj_4_0},@{highest_checkpoint})
 Response: {
   "data": {
     "address": {
@@ -122,7 +122,7 @@ Response: {
 }
 
 task 12, lines 83-93:
-//# run-graphql --cursors @{obj_3_0}
+//# run-graphql --cursors bcs(@{obj_3_0},@{highest_checkpoint})
 Response: {
   "data": {
     "address": {

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_module.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_module.move
@@ -93,7 +93,7 @@ module P::N {
   ]
 }
 
-//# run-jsonrpc --cursors @{obj_5_0,2}
+//# run-jsonrpc --cursors bcs(@{obj_5_0},2)
 {
   "method": "suix_getOwnedObjects",
   "params": [

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_module.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_module.snap
@@ -126,7 +126,7 @@ Response: {
 }
 
 task 10, lines 96-108:
-//# run-jsonrpc --cursors @{obj_5_0,2}
+//# run-jsonrpc --cursors bcs(@{obj_5_0},2)
 Response: {
   "jsonrpc": "2.0",
   "id": 3,

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_name.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_name.move
@@ -93,7 +93,7 @@ module P::N {
   ]
 }
 
-//# run-jsonrpc --cursors @{obj_5_0,2}
+//# run-jsonrpc --cursors bcs(@{obj_5_0},2)
 {
   "method": "suix_getOwnedObjects",
   "params": [

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_name.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_name.snap
@@ -118,7 +118,7 @@ Response: {
 }
 
 task 10, lines 96-108:
-//# run-jsonrpc --cursors @{obj_5_0,2}
+//# run-jsonrpc --cursors bcs(@{obj_5_0},2)
 Response: {
   "jsonrpc": "2.0",
   "id": 3,

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_package.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_package.move
@@ -101,7 +101,7 @@ module P::N {
   ]
 }
 
-//# run-jsonrpc --cursors @{obj_3_2,1}
+//# run-jsonrpc --cursors bcs(@{obj_3_2},1)
 {
   "method": "suix_getOwnedObjects",
   "params": [

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_package.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_package.snap
@@ -190,7 +190,7 @@ Response: {
 }
 
 task 12, lines 104-116:
-//# run-jsonrpc --cursors @{obj_3_2,1}
+//# run-jsonrpc --cursors bcs(@{obj_3_2},1)
 Response: {
   "jsonrpc": "2.0",
   "id": 3,

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_type_params.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_type_params.move
@@ -75,7 +75,7 @@ module P::M {
   ]
 }
 
-//# run-jsonrpc --cursors @{obj_5_0,2}
+//# run-jsonrpc --cursors bcs(@{obj_5_0},2)
 {
   "method": "suix_getOwnedObjects",
   "params": [

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_type_params.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/by_type_params.snap
@@ -126,7 +126,7 @@ Response: {
 }
 
 task 10, lines 78-90:
-//# run-jsonrpc --cursors @{obj_5_0,2}
+//# run-jsonrpc --cursors bcs(@{obj_5_0},2)
 Response: {
   "jsonrpc": "2.0",
   "id": 3,

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/owner.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/owner.move
@@ -48,7 +48,7 @@
   "params": ["@{A}", { "options": { "showContent": true } }, null, 2]
 }
 
-//# run-jsonrpc --cursors @{obj_4_1,2}
+//# run-jsonrpc --cursors bcs(@{obj_4_1},2)
 {
   "method": "suix_getOwnedObjects",
   "params": ["@{A}", { "options": { "showContent": true } }, "@{cursor_0}", 2]

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/owner.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/query/owner.snap
@@ -332,7 +332,7 @@ Response: {
 }
 
 task 10, lines 51-55:
-//# run-jsonrpc --cursors @{obj_4_1,2}
+//# run-jsonrpc --cursors bcs(@{obj_4_1},2)
 Response: {
   "jsonrpc": "2.0",
   "id": 3,

--- a/crates/sui-mvr-graphql-e2e-tests/tests/stable/consistency/objects_pagination.move
+++ b/crates/sui-mvr-graphql-e2e-tests/tests/stable/consistency/objects_pagination.move
@@ -33,7 +33,7 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --cursors @{obj_2_0} @{obj_3_0}
+//# run-graphql --cursors bcs(@{obj_2_0},@{highest_checkpoint}) bcs(@{obj_3_0},@{highest_checkpoint})
 {
   one_of_these_will_yield_an_object: address(address: "@{A}") {
     objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
@@ -69,7 +69,7 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --cursors @{obj_2_0,1} @{obj_3_0,1}
+//# run-graphql --cursors bcs(@{obj_2_0},1) bcs(@{obj_3_0},1)
 {
   paginating_on_checkpoint_1: address(address: "@{A}") {
     objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
@@ -148,7 +148,7 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --cursors @{obj_6_0,2}
+//# run-graphql --cursors bcs(@{obj_6_0},2)
 {
   after_obj_6_0_at_checkpoint_2: address(address: "@{A}") {
     objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
@@ -228,7 +228,7 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --cursors @{obj_6_0,2}
+//# run-graphql --cursors bcs(@{obj_6_0},2)
 # This query will error due to requesting data outside of available range
 {
   availableRange {

--- a/crates/sui-mvr-graphql-e2e-tests/tests/stable/consistency/objects_pagination.snap
+++ b/crates/sui-mvr-graphql-e2e-tests/tests/stable/consistency/objects_pagination.snap
@@ -29,7 +29,7 @@ task 4, line 34:
 Checkpoint created: 1
 
 task 5, lines 36-64:
-//# run-graphql --cursors @{obj_2_0} @{obj_3_0}
+//# run-graphql --cursors bcs(@{obj_2_0},@{highest_checkpoint}) bcs(@{obj_3_0},@{highest_checkpoint})
 Response: {
   "data": {
     "one_of_these_will_yield_an_object": {
@@ -75,7 +75,7 @@ task 8, line 70:
 Checkpoint created: 2
 
 task 9, lines 72-100:
-//# run-graphql --cursors @{obj_2_0,1} @{obj_3_0,1}
+//# run-graphql --cursors bcs(@{obj_2_0},1) bcs(@{obj_3_0},1)
 Response: {
   "data": {
     "paginating_on_checkpoint_1": {
@@ -237,7 +237,7 @@ task 13, line 149:
 Checkpoint created: 3
 
 task 14, lines 151-213:
-//# run-graphql --cursors @{obj_6_0,2}
+//# run-graphql --cursors bcs(@{obj_6_0},2)
 Response: {
   "data": {
     "after_obj_6_0_at_checkpoint_2": {
@@ -521,7 +521,7 @@ task 22, line 229:
 Checkpoint created: 7
 
 task 23, lines 231-255:
-//# run-graphql --cursors @{obj_6_0,2}
+//# run-graphql --cursors bcs(@{obj_6_0},2)
 Response: {
   "data": null,
   "errors": [

--- a/crates/sui-mvr-graphql-e2e-tests/tests/stable/consistency/objects_pagination_single.move
+++ b/crates/sui-mvr-graphql-e2e-tests/tests/stable/consistency/objects_pagination_single.move
@@ -34,7 +34,7 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --cursors @{obj_3_0}
+//# run-graphql --cursors bcs(@{obj_3_0},@{highest_checkpoint})
 {
   after_obj_3_0: address(address: "@{A}") {
     objects(filter: {type: "@{Test}"}, after: "@{cursor_0}") {
@@ -68,7 +68,7 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --cursors @{obj_3_0,1}
+//# run-graphql --cursors bcs(@{obj_3_0},1)
 # This query should yield the same results as the previous one.
 {
   after_obj_3_0_chkpt_1: address(address: "@{A}") {
@@ -99,7 +99,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors @{obj_3_0,2}
+//# run-graphql --cursors bcs(@{obj_3_0},2)
 {
   address(address: "@{A}") {
     objects(filter: {type: "@{Test}"}) {
@@ -180,7 +180,7 @@ module Test::M1 {
 
 //# create-checkpoint
 
-//# run-graphql --cursors @{obj_3_0,2}
+//# run-graphql --cursors bcs(@{obj_3_0},2)
 # This query should yield the same results as the previous one.
 {
     after_obj_3_0_chkpt_2: address(address: "@{A}") {
@@ -245,7 +245,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors @{obj_3_0,3}
+//# run-graphql --cursors bcs(@{obj_3_0},3)
 {
   address(address: "@{A}") {
     objects(filter: {type: "@{Test}"}) {

--- a/crates/sui-mvr-graphql-e2e-tests/tests/stable/consistency/objects_pagination_single.snap
+++ b/crates/sui-mvr-graphql-e2e-tests/tests/stable/consistency/objects_pagination_single.snap
@@ -34,7 +34,7 @@ task 5, line 35:
 Checkpoint created: 1
 
 task 6, lines 37-65:
-//# run-graphql --cursors @{obj_3_0}
+//# run-graphql --cursors bcs(@{obj_3_0},@{highest_checkpoint})
 Response: {
   "data": {
     "after_obj_3_0": {
@@ -73,7 +73,7 @@ task 8, line 69:
 Checkpoint created: 2
 
 task 9, lines 71-100:
-//# run-graphql --cursors @{obj_3_0,1}
+//# run-graphql --cursors bcs(@{obj_3_0},1)
 Response: {
   "data": {
     "after_obj_3_0_chkpt_1": {
@@ -103,7 +103,7 @@ Response: {
 }
 
 task 10, lines 102-177:
-//# run-graphql --cursors @{obj_3_0,2}
+//# run-graphql --cursors bcs(@{obj_3_0},2)
 Response: {
   "data": {
     "address": {
@@ -204,7 +204,7 @@ task 12, line 181:
 Checkpoint created: 3
 
 task 13, lines 183-246:
-//# run-graphql --cursors @{obj_3_0,2}
+//# run-graphql --cursors bcs(@{obj_3_0},2)
 Response: {
   "data": {
     "after_obj_3_0_chkpt_2": {
@@ -266,7 +266,7 @@ Response: {
 }
 
 task 14, lines 248-323:
-//# run-graphql --cursors @{obj_3_0,3}
+//# run-graphql --cursors bcs(@{obj_3_0},3)
 Response: {
   "data": {
     "address": {

--- a/crates/sui-mvr-graphql-e2e-tests/tests/stable/objects/pagination.move
+++ b/crates/sui-mvr-graphql-e2e-tests/tests/stable/objects/pagination.move
@@ -54,7 +54,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors @{obj_5_0}
+//# run-graphql --cursors bcs(@{obj_5_0},@{highest_checkpoint})
 {
   address(address: "@{A}") {
     # select the 2nd and 3rd objects
@@ -68,7 +68,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors @{obj_4_0}
+//# run-graphql --cursors bcs(@{obj_4_0},@{highest_checkpoint})
 {
   address(address: "@{A}") {
     # select 4th and last object
@@ -80,7 +80,7 @@ module Test::M1 {
   }
 }
 
-//# run-graphql --cursors @{obj_3_0}
+//# run-graphql --cursors bcs(@{obj_3_0},@{highest_checkpoint})
 {
   address(address: "@{A}") {
     # select 3rd and 4th object

--- a/crates/sui-mvr-graphql-e2e-tests/tests/stable/objects/pagination.snap
+++ b/crates/sui-mvr-graphql-e2e-tests/tests/stable/objects/pagination.snap
@@ -91,7 +91,7 @@ Response: {
 }
 
 task 10, lines 57-69:
-//# run-graphql --cursors @{obj_5_0}
+//# run-graphql --cursors bcs(@{obj_5_0},@{highest_checkpoint})
 Response: {
   "data": {
     "address": {
@@ -103,7 +103,7 @@ Response: {
 }
 
 task 11, lines 71-81:
-//# run-graphql --cursors @{obj_4_0}
+//# run-graphql --cursors bcs(@{obj_4_0},@{highest_checkpoint})
 Response: {
   "data": {
     "address": {
@@ -122,7 +122,7 @@ Response: {
 }
 
 task 12, lines 83-93:
-//# run-graphql --cursors @{obj_3_0}
+//# run-graphql --cursors bcs(@{obj_3_0},@{highest_checkpoint})
 Response: {
   "data": {
     "address": {


### PR DESCRIPTION

## Description 

This PR refactors the query interpolation part of transactional test adapter and changes the format for bcs cursors:
- If the cursor is prefixed with `bcs_obj:` then only an object id is expected and the test adapter will supplement with highest cp sequence number to be encoded together with the object id
- If the cursor is prefixed with `bcs:` then a tuple of an object id and at least one number is expected. And they will together be encoded. 
- Otherwise we interpolate the cursor content and encode directly

## Test plan 

modified existing tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
