### PR TITLE
[rust-sdk] add pretty print formatting and fix compiling issue

### DIFF
--- a/crates/sui-sdk/README.md
+++ b/crates/sui-sdk/README.md
@@ -130,7 +130,7 @@ async fn main() -> Result<(), anyhow::Error> {
       .coin_read_api()
       .get_all_balances(active_address)
       .await?;
-   println!("The balances for all coins owned by address: {active_address} are {}", total_balance);
+   println!("The balances for all coins owned by address: {active_address} are {:#?}", total_balance);
    Ok(())
 }
 ```


### PR DESCRIPTION
Description
This PR fixes a minor issue in the coin-read example of the Sui Rust SDK documentation. The previous code used {} to print total_balance, which caused a compilation error. The fix changes it to {:#?} to properly format the output, ensuring the example compiles and runs correctly when copied and pasted.

Original line:

println!("The balances for all coins owned by address: {active_address} are {}", total_balance);

Updated line:
println!("The balances for all coins owned by address: {active_address} are {:#?}", total_balance);

Test plan
The updated example has been tested by copying and running it, verifying that the compilation error is resolved and that the output correctly displays the balances.

Release notes
 Protocol:
 Nodes (Validators and Full nodes):
 gRPC:
 JSON-RPC:
 GraphQL:
 CLI:
 Rust SDK: Fixes a formatting issue in the coin-read example that previously caused a compiler error. The example now works as intended when copied and pasted.