### PR TITLE
BaseCommitter declarative tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94087b935a822949d3291a9989ad2b2051ea141eda0fd4e478a75f6aa3e604b"
+checksum = "4378725facc195f1a538864863f6de233b500a8862747e7f165078a419d5e874"
 dependencies = [
  "cc",
  "glob",

--- a/consensus/core/src/base_committer.rs
+++ b/consensus/core/src/base_committer.rs
@@ -19,6 +19,10 @@ use crate::{
 #[path = "tests/base_committer_tests.rs"]
 mod base_committer_tests;
 
+#[cfg(test)]
+#[path = "tests/base_committer_declarative_tests.rs"]
+mod base_committer_declarative_tests;
+
 pub(crate) struct BaseCommitterOptions {
     /// TODO: Re-evaluate if we want this to be configurable after running experiments.
     /// The length of a wave (minimum 3)

--- a/consensus/core/src/tests/base_committer_declarative_tests.rs
+++ b/consensus/core/src/tests/base_committer_declarative_tests.rs
@@ -6,8 +6,8 @@ use parking_lot::RwLock;
 use std::sync::Arc;
 
 use crate::{
-    base_committer::base_committer_builder::BaseCommitterBuilder, commit::LeaderStatus,
-    context::Context, dag_state::DagState, storage::mem_store::MemStore,
+    base_committer::base_committer_builder::BaseCommitterBuilder, block::BlockAPI,
+    commit::LeaderStatus, context::Context, dag_state::DagState, storage::mem_store::MemStore,
     test_dag_parser::parse_dag,
 };
 
@@ -57,6 +57,50 @@ async fn direct_commit() {
         tracing::info!("Committed: {leader_status}");
     } else {
         panic!("Expected a committed leader, got {leader_status}");
+    }
+}
+
+#[tokio::test]
+async fn direct_skip() {
+    telemetry_subscribers::init_for_testing();
+    let context = Arc::new(Context::new_for_test(4).0);
+    let dag_state = Arc::new(RwLock::new(DagState::new(
+        context.clone(),
+        Arc::new(MemStore::new()),
+    )));
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // Round 3 is a leader round
+    // D3 is an elected leader for wave 1
+    // Round 4 is a voting round
+    // Round 5 is a decision round (acknowledge)
+    let dag_str = "DAG {
+        Round 0 : { 4 },
+        Round 1 : { },
+        Round 2 : { },
+        Round 3 : { * },
+        Round 4 : { 
+            A -> [D3],
+            B -> [],
+            C -> [],
+            D -> [], 
+        },
+        Round 5 : { * },
+        }";
+
+    let (_, dag_builder) = parse_dag(dag_str).expect("a DAG should be valid");
+    dag_builder.persist_all_blocks(dag_state.clone());
+
+    let leader_round = committer.leader_round(1);
+    tracing::info!("Leader round at wave 1: {leader_round}");
+    let leader = committer
+        .elect_leader(leader_round)
+        .expect("there should be a leader at wave 1");
+    let leader_status = committer.try_direct_decide(leader);
+    if let LeaderStatus::Skip(_) = leader_status {
+        tracing::info!("Skip: {leader_status}");
+    } else {
+        panic!("Expected a skipped leader, got {leader_status}");
     }
 }
 
@@ -165,4 +209,115 @@ async fn indirect_commit() {
     };
 }
 
-// TODO: direct_skip, indirect_skip, undecided
+/// Commit the first leader, indirectly skip the 2nd, and commit the 3rd leader.
+#[tokio::test]
+async fn indirect_skip() {
+    telemetry_subscribers::init_for_testing();
+    let context = Arc::new(Context::new_for_test(4).0);
+    let dag_state = Arc::new(RwLock::new(DagState::new(
+        context.clone(),
+        Arc::new(MemStore::new()),
+    )));
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // There are 3 rounds. Every block is connected exept
+    // that only f+1 validators connect to the leader of wave 2
+    let dag_str = "DAG {
+        Round 0 : { 4 },
+        Round 1 : { },
+        Round 2 : { },
+        Round 3 : { * },
+        Round 4 : { * },
+        Round 5 : { * },
+        Round 6 : { * },
+        Round 7 : { 
+            A -> [C6],
+            B -> [C6],
+            C -> [-C6],
+            D -> [-C6], 
+        },
+        Round 8 : { * },
+        Round 9 : { * },
+        Round 10 : { * },
+        Round 11 : { * },
+    }";
+
+    let (_, dag_builder) = parse_dag(dag_str).expect("a DAG should be valid");
+    dag_builder.persist_all_blocks(dag_state.clone());
+
+    let leader_round = committer.leader_round(1);
+    tracing::info!("Leader round wave 1: {leader_round}");
+    let leader = committer
+        .elect_leader(leader_round)
+        .expect("there should be a leader for wave 1");
+    let leader_index = leader.authority;
+    tracing::info!("Leader index wave 1: {leader_index}");
+
+    let leader_status_wave1 = committer.try_direct_decide(leader);
+    if let LeaderStatus::Commit(commited) = leader_status_wave1 {
+        tracing::info!("Direct undecided leader at wave 1: {commited}");
+    } else {
+        panic!("Expected LeaderStatus::Commit for a leader in wave 1, applying a direct decicion rule, got {leader_status_wave1}");
+    }
+
+    let leader_round_wave_2 = committer.leader_round(2);
+    tracing::info!("Leader round wave 2: {leader_round_wave_2}");
+    let leader_wave2 = committer
+        .elect_leader(leader_round_wave_2)
+        .expect("there should be a leader for wave 2");
+    let leader_index_wave_2 = leader_wave2.authority;
+    tracing::info!("Leader index wave 2: {leader_index_wave_2}");
+
+    let leader_status_wave_2 = committer.try_direct_decide(leader_wave2);
+    if let LeaderStatus::Undecided(undecided) = leader_status_wave_2.clone() {
+        tracing::info!("Direct committed leader at wave 2: {undecided}");
+    } else {
+        panic!(
+            "Expected LeaderStatus::Undecided for a leader in wave 2, applying a direct decicion rule, got {leader_status_wave_2}"
+        );
+    };
+
+    // Ensure we commit the leaders of wave 1 and 3 and skip the leader of wave 2
+
+    // 1. Ensure we commit the leader of wave 3.
+    let leader_round_wave_3 = committer.leader_round(3);
+    let leader_wave_3 = committer
+        .elect_leader(leader_round_wave_3)
+        .expect("should have elected leader");
+    tracing::info!("Try direct commit for leader {leader_wave_3}");
+    let leader_status = committer.try_direct_decide(leader_wave_3);
+    tracing::info!("Leader commit status: {leader_status}");
+
+    let mut decided_leaders = vec![];
+    if let LeaderStatus::Commit(ref committed_block) = leader_status {
+        assert_eq!(committed_block.author(), leader_wave_3.authority);
+        decided_leaders.push(leader_status);
+    } else {
+        panic!("Expected a committed leader")
+    };
+
+    // 2. Ensure we directly mark leader of wave 2 undecided.
+    let leader_wave_2 = committer
+        .elect_leader(leader_round_wave_2)
+        .expect("should have elected leader");
+    tracing::info!("Try direct commit for leader {leader_wave_2}");
+    let leader_status = committer.try_direct_decide(leader_wave_2);
+    tracing::info!("Leader commit status: {leader_status}");
+
+    if let LeaderStatus::Undecided(undecided_slot) = leader_status {
+        assert_eq!(undecided_slot, leader_wave_2)
+    } else {
+        panic!("Expected an undecided leader")
+    };
+
+    // 3. Ensure we skip leader of wave 2 indirectly.
+    tracing::info!("Try indirect commit for leader {leader_wave_2}",);
+    let leader_status = committer.try_indirect_decide(leader_wave_2, decided_leaders.iter());
+    tracing::info!("Leader commit status: {leader_status}");
+
+    if let LeaderStatus::Skip(skipped_slot) = leader_status {
+        assert_eq!(skipped_slot, leader_wave_2)
+    } else {
+        panic!("Expected a skipped leader")
+    };
+}

--- a/consensus/core/src/tests/base_committer_declarative_tests.rs
+++ b/consensus/core/src/tests/base_committer_declarative_tests.rs
@@ -1,0 +1,168 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::panic;
+use parking_lot::RwLock;
+use std::sync::Arc;
+
+use crate::{
+    base_committer::base_committer_builder::BaseCommitterBuilder, commit::LeaderStatus,
+    context::Context, dag_state::DagState, storage::mem_store::MemStore,
+    test_dag_parser::parse_dag,
+};
+
+#[tokio::test]
+async fn direct_commit() {
+    telemetry_subscribers::init_for_testing();
+    let context = Arc::new(Context::new_for_test(4).0);
+    let dag_state = Arc::new(RwLock::new(DagState::new(
+        context.clone(),
+        Arc::new(MemStore::new()),
+    )));
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // Round 3 is a leader round
+    // D3 is an elected leader for wave 1
+    // Round 4 is a voting round
+    // Round 5 is a decision round (acknowledge)
+    let dag_str = "DAG {
+        Round 0 : { 4 },
+        Round 1 : { },
+        Round 2 : { },
+        Round 3 : { * },
+        Round 4 : { 
+            A -> [D3],
+            B -> [D3],
+            C -> [D3],
+            D -> [], 
+        },
+        Round 5 : { 
+            A -> [A4, B4, C4],
+            B -> [A4, B4, C4],
+            C -> [A4, B4, C4],
+            D -> [], 
+        },
+        }";
+
+    let (_, dag_builder) = parse_dag(dag_str).expect("a DAG should be valid");
+    dag_builder.persist_all_blocks(dag_state.clone());
+
+    let leader_round = committer.leader_round(1);
+    tracing::info!("Leader round at wave 1: {leader_round}");
+    let leader = committer
+        .elect_leader(leader_round)
+        .expect("there should be a leader at wave 1");
+    let leader_status = committer.try_direct_decide(leader);
+    if let LeaderStatus::Commit(_) = leader_status {
+        tracing::info!("Committed: {leader_status}");
+    } else {
+        panic!("Expected a committed leader, got {leader_status}");
+    }
+}
+
+#[tokio::test]
+async fn indirect_commit() {
+    telemetry_subscribers::init_for_testing();
+    let context = Arc::new(Context::new_for_test(4).0);
+    let dag_state = Arc::new(RwLock::new(DagState::new(
+        context.clone(),
+        Arc::new(MemStore::new()),
+    )));
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    // Wave 1
+    // Round 3 is a leader round
+    // D3 is an elected leader for wave 1
+    // Round 4 is a voting round
+    // Round 5 is a decision round (acknowledge)
+    //
+    // Wave 2
+    // Round 6 is a leader round
+    // C6 is an elected leader for wave 2
+    // Round 7 is a voting round
+    // Round 8 is a decision round (acknowledge)
+    let dag_str = "DAG {
+        Round 0 : { 4 },
+        Round 1 : { },
+        Round 2 : { },
+        Round 3 : { * },
+        Round 4 : { 
+            A -> [D3],
+            B -> [D3],
+            C -> [D3],
+            D -> [], 
+        },
+        Round 5 : { 
+            A -> [A4, B4, C4],
+            B -> [],
+            C -> [],
+            D -> [], 
+        },
+        Round 6 : { 
+            A -> [],
+            B -> [],
+            C -> [A5],
+            D -> [], 
+        },
+        Round 7 : { 
+            A -> [C6],
+            B -> [C6],
+            C -> [],
+            D -> [C6], 
+        },
+        Round 8 : { 
+            A -> [A7, B7, D7],
+            B -> [A7, B7, D7],
+            C -> [],
+            D -> [A7, B7, D7], 
+        },
+    }";
+
+    let (_, dag_builder) = parse_dag(dag_str).expect("a DAG should be valid");
+    dag_builder.persist_all_blocks(dag_state.clone());
+
+    let leader_round = committer.leader_round(1);
+    tracing::info!("Leader round wave 1: {leader_round}");
+    let leader = committer
+        .elect_leader(leader_round)
+        .expect("there should be a leader for wave 1");
+    let leader_index = leader.authority;
+    tracing::info!("Leader index wave 1: {leader_index}");
+
+    let leader_status_wave1 = committer.try_direct_decide(leader);
+    if let LeaderStatus::Undecided(direct_undecided) = leader_status_wave1 {
+        tracing::info!("Direct undecided leader at wave 1: {direct_undecided}");
+    } else {
+        panic!("Expected LeaderStatus::Undecided for a leader in wave 1, applying a direct decicion rule, got {leader_status_wave1}");
+    }
+
+    let leader_round_wave2 = committer.leader_round(2);
+    tracing::info!("Leader round wave 2: {leader_round_wave2}");
+    let leader_wave2 = committer
+        .elect_leader(leader_round_wave2)
+        .expect("there should be a leader for wave 2");
+    let leader_index_wave2 = leader_wave2.authority;
+    tracing::info!("Leader index wave 2: {leader_index_wave2}");
+
+    let leader_status_wave_2 = committer.try_direct_decide(leader_wave2);
+    if let LeaderStatus::Commit(committed) = leader_status_wave_2.clone() {
+        tracing::info!("Direct committed leader at wave 2: {committed}");
+    } else {
+        panic!(
+            "Expected LeaderStatus::Commit for a leader in wave 2, applying a direct decicion rule, got {leader_status_wave_2}"
+        );
+    };
+
+    let leader_status_wave1_indirect =
+        committer.try_indirect_decide(leader, vec![leader_status_wave_2].iter());
+
+    if let LeaderStatus::Commit(committed) = leader_status_wave1_indirect {
+        tracing::info!("Indirect committed leader at wave 1: {committed}");
+    } else {
+        panic!(
+            "Expected LeaderStatus::Commit for a leader in wave 1, applying an indirect decicion rule, got {leader_status_wave1_indirect}"
+        );
+    };
+}
+
+// TODO: direct_skip, indirect_skip, undecided

--- a/consensus/core/src/tests/base_committer_declarative_tests.rs
+++ b/consensus/core/src/tests/base_committer_declarative_tests.rs
@@ -275,8 +275,8 @@ async fn indirect_skip() {
         Round 5 : { * },
         Round 6 : { * },
         Round 7 : { 
-            A -> [C6],
-            B -> [C6],
+            A -> [*],
+            B -> [*],
             C -> [-C6],
             D -> [-C6], 
         },

--- a/consensus/core/src/tests/base_committer_declarative_tests.rs
+++ b/consensus/core/src/tests/base_committer_declarative_tests.rs
@@ -27,8 +27,8 @@ async fn direct_commit() {
     // Round 5 is a decision round (acknowledge)
     let dag_str = "DAG {
         Round 0 : { 4 },
-        Round 1 : { },
-        Round 2 : { },
+        Round 1 : { * },
+        Round 2 : { * },
         Round 3 : { * },
         Round 4 : { 
             A -> [D3],
@@ -76,8 +76,8 @@ async fn direct_skip() {
     // Round 5 is a decision round (acknowledge)
     let dag_str = "DAG {
         Round 0 : { 4 },
-        Round 1 : { },
-        Round 2 : { },
+        Round 1 : { * },
+        Round 2 : { * },
         Round 3 : { * },
         Round 4 : { 
             A -> [D3],
@@ -120,8 +120,8 @@ async fn direct_undecided() {
     // Round 5 is a decision round (acknowledge)
     let dag_str = "DAG {
         Round 0 : { 4 },
-        Round 1 : { },
-        Round 2 : { },
+        Round 1 : { * },
+        Round 2 : { * },
         Round 3 : { * },
         Round 4 : { 
             A -> [D3],
@@ -171,8 +171,8 @@ async fn indirect_commit() {
     // Round 8 is a decision round (acknowledge)
     let dag_str = "DAG {
         Round 0 : { 4 },
-        Round 1 : { },
-        Round 2 : { },
+        Round 1 : { * },
+        Round 2 : { * },
         Round 3 : { * },
         Round 4 : { 
             A -> [D3],
@@ -268,8 +268,8 @@ async fn indirect_skip() {
     // that only f+1 validators connect to the leader of wave 2
     let dag_str = "DAG {
         Round 0 : { 4 },
-        Round 1 : { },
-        Round 2 : { },
+        Round 1 : { * },
+        Round 2 : { * },
         Round 3 : { * },
         Round 4 : { * },
         Round 5 : { * },

--- a/consensus/core/src/tests/base_committer_declarative_tests.rs
+++ b/consensus/core/src/tests/base_committer_declarative_tests.rs
@@ -242,7 +242,7 @@ async fn indirect_commit() {
     };
 
     let leader_status_wave1_indirect =
-        committer.try_indirect_decide(leader, vec![leader_status_wave_2].iter());
+        committer.try_indirect_decide(leader, [leader_status_wave_2].iter());
 
     if let LeaderStatus::Commit(committed) = leader_status_wave1_indirect {
         tracing::info!("Indirect committed leader at wave 1: {committed}");


### PR DESCRIPTION
## Description 
While reviewing [base_committer_tests](https://github.com/MystenLabs/sui/blob/main/consensus/core/src/tests/base_committer_tests.rs), I noticed that that it seems to have been written before DagBuilder and DagParser were introduced by @arun-koshy. Using these tools allows to describe DAG state in a declaratively, making tests both easier to understand and maintain.

By covering key DAG patterns, this PR aims to:
- serve as a useful learning reference for those exploring Sui’s consensus mechanism
- provide a more declarative and maintainable approach to testing

### Next steps
The plan is to continue to cover more cases and also to do the same for UniversalCommitter in the subsequent PRs.

## Test plan 
not applicable

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
