### PR TITLE
changed error behavior for `sui::framework_versions::framework_for_protocol`

### DIFF
--- a/crates/sui/src/framework_versions.rs
+++ b/crates/sui/src/framework_versions.rs
@@ -53,6 +53,7 @@ pub fn latest_framework() -> &'static FrameworkVersion {
 /// 1. the framework did not change when `version` was released, or
 /// 2. this binary is older than the requested version and therefore doesn't know about the latest
 ///    framework version
+///
 /// You can distinguish these cases by comparing `version` with [ProtocolVersion::MAX].
 pub fn framework_for_protocol(
     version: ProtocolVersion,


### PR DESCRIPTION
## Description 

This changes the behavior of `sui::framework_version::framework_for_protocol` when the requested protocol is newer than the binary (it no longer returns an error - instead it returns a tuple with a differing protocol version)

## Test plan 

Existing unit tests were updated.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
