### PR TITLE
easy(move-build): assorted clean ups

### DIFF
--- a/crates/sui-core/src/unit_tests/auth_unit_test_utils.rs
+++ b/crates/sui-core/src/unit_tests/auth_unit_test_utils.rs
@@ -130,7 +130,7 @@ pub async fn upgrade_package_on_single_authority(
         gas_payment,
         package_id,
         modules,
-        package.published_dependency_ids(),
+        package.get_dependency_storage_package_ids(),
         (upgrade_cap, Owner::AddressOwner(sender)),
         UpgradePolicy::COMPATIBLE,
         digest,

--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -607,10 +607,6 @@ impl CompiledPackage {
             error: error_message.join("\n"),
         })
     }
-
-    pub fn published_dependency_ids(&self) -> Vec<ObjectID> {
-        self.dependency_ids.published.values().cloned().collect()
-    }
 }
 
 impl Default for BuildConfig {

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -1274,7 +1274,7 @@ fn merge_output(left: Option<String>, right: Option<String>) -> Option<String> {
     }
 }
 
-impl<'a> SuiTestAdapter {
+impl SuiTestAdapter {
     pub fn with_offchain_reader(&mut self, offchain_reader: Box<dyn OffchainStateReader>) {
         self.offchain_reader = Some(offchain_reader);
     }

--- a/external-crates/move/crates/move-bytecode-utils/src/lib.rs
+++ b/external-crates/move/crates/move-bytecode-utils/src/lib.rs
@@ -25,10 +25,12 @@ impl<'a> Modules<'a> {
     pub fn new(modules: impl IntoIterator<Item = &'a CompiledModule>) -> Self {
         let mut map = BTreeMap::new();
         for m in modules {
-            assert!(
-                map.insert(m.self_id(), m).is_none(),
-                "Duplicate module found"
-            );
+            if let Some(prev) = map.insert(m.self_id(), m) {
+                panic!(
+                    "Duplicate module found: {}",
+                    prev.self_id().to_canonical_display(/* with_prefix */ true)
+                )
+            }
         }
         Modules(map)
     }


### PR DESCRIPTION
## Description 

A couple of small clean-ups in Move-related code that I noticed while working on other things:

- Removing an unnecessary lifetime parameter on `SuiAdapter` impl block.
- Removing a duplicate function on `CompiledPackage`.
- Richer error message when `Modules` detects a duplicate Module by ID.

## Test plan 

CI

## Stack

- #21010 
- #21085 
- #21119

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
