### PR TITLE
[CLI] Make source verification opt-in instead of opt-out (dvx-699)

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1749,7 +1749,7 @@ fn check_dep_verification_flags(
         }
 
         (true, false) => {
-            eprintln!("{}: Dependency sources are no longer verificed automatically during publication and upgrade, \
+            eprintln!("{}: Dependency sources are no longer verified automatically during publication and upgrade, \
                 so the `--skip-dependency-verification` flag is no longer necessary.",
                 "[Warning]".bold().yellow());
             Ok(verify_dependencies)

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1737,17 +1737,25 @@ fn check_dep_verification_flags(
     verify_dependencies: bool,
 ) -> anyhow::Result<bool> {
     match (skip_dependency_verification, verify_dependencies) {
-        (true, true) => bail!("[error]: --skip_dependency_verification and --verify_dependencies are mutually exclusive"),
+        (true, true) => bail!(
+            "[error]: --skip-dependency-verification and --verify-deps are mutually exclusive"
+        ),
 
         (false, false) => {
-            eprintln!("{}: In a future release, dependency source code will no longer be verified by default during publication and upgrade. \
-                You can opt in to source verification using `--verify-deps` or disable this warning using `--skip-dependency-verification`. \
-                You can also manually verify dependencies using `sui client verify-source`.",
-                "[warning]".bold().yellow());
-            Ok(true)
-        },
+            eprintln!("{}: Dependency sources are no longer verified automatically during publication and upgrade. \
+                You can pass the `--verify-deps` option if you would like to verify them as part of publication or upgrade.",
+                "[Note]".bold().yellow());
+            Ok(verify_dependencies)
+        }
 
-        _ => Ok(verify_dependencies),
+        (true, false) => {
+            eprintln!("{}: Dependency sources are no longer verificed automatically during publication and upgrade, \
+                so the `--skip-dependency-verification` flag is no longer necessary.",
+                "[Warning]".bold().yellow());
+            Ok(verify_dependencies)
+        }
+
+        (false, true) => Ok(verify_dependencies),
     }
 }
 

--- a/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/both_flags.sh
+++ b/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/both_flags.sh
@@ -3,8 +3,8 @@
 
 # test that we get an error if we supply both `--skip-dependency-verification` and `--verify-deps`
 
-echo "=== publish ===" | tee /dev/stderr
+echo "=== publish (should fail) ===" | tee /dev/stderr
 sui client --client.config $CONFIG publish example --skip-dependency-verification --verify-deps
 
-echo "=== upgrade ===" | tee /dev/stderr
+echo "=== upgrade (should fail) ===" | tee /dev/stderr
 sui client --client.config $CONFIG upgrade example --upgrade-capability 0x1234 --skip-dependency-verification --verify-deps

--- a/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/no_flags.sh
+++ b/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/no_flags.sh
@@ -15,11 +15,11 @@ echo "=== publish dependency ===" | tee /dev/stderr
 sui client --client.config $CONFIG publish "dependency" \
   --json | jq '.effects.status'
 
-echo "=== publish package v0 (should warn) ===" | tee /dev/stderr
+echo "=== publish package v0 (should note deprecation) ===" | tee /dev/stderr
 UPGRADE_CAP=$(sui client --client.config $CONFIG publish "example" \
   --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
 
-echo "=== upgrade package (should warn) ===" | tee /dev/stderr
+echo "=== upgrade package (should note deprecation) ===" | tee /dev/stderr
 sui client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example \
   --json | jq '.effects.status'
 
@@ -27,10 +27,10 @@ echo "=== modify dependency ===" | tee /dev/stderr
 cat dependency/sources/dependency.move | sed 's#0#1#g' > dependency.move
 mv dependency.move dependency/sources/dependency.move
 
-echo "=== try to publish with modified dep (should fail) ===" | tee /dev/stderr
+echo "=== try to publish with modified dep (should succeed) ===" | tee /dev/stderr
 sui client --client.config $CONFIG publish "example" \
-  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'
+  --json | jq '.effects.status'
 
-echo "=== try to upgrade with modified dep (should fail) ===" | tee /dev/stderr
+echo "=== try to upgrade with modified dep (should succeed) ===" | tee /dev/stderr
 sui client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example \
-  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'
+  --json | jq '.effects.status'

--- a/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/no_flags.sh
+++ b/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/no_flags.sh
@@ -28,8 +28,8 @@ cat dependency/sources/dependency.move | sed 's#0#1#g' > dependency.move
 mv dependency.move dependency/sources/dependency.move
 
 echo "=== try to publish with modified dep (should succeed) ===" | tee /dev/stderr
-sui client --client.config $CONFIG publish "example" \
-  --json | jq '.effects.status'
+UPGRADE_CAP=$(sui client --client.config $CONFIG publish "example" \
+  --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
 
 echo "=== try to upgrade with modified dep (should succeed) ===" | tee /dev/stderr
 sui client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example \

--- a/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/skip_dep_verif.sh
+++ b/crates/sui/tests/shell_tests/with_network/source_verification_deprecation/skip_dep_verif.sh
@@ -11,15 +11,15 @@ do
     && mv Move.toml $i
 done
 
-echo "=== publish dependency ===" | tee /dev/stderr
+echo "=== publish dependency (should warn about deprecation) ===" | tee /dev/stderr
 sui client --client.config $CONFIG publish "dependency" --skip-dependency-verification \
   --json | jq '.effects.status'
 
-echo "=== publish package v0 (should NOT warn) ===" | tee /dev/stderr
+echo "=== publish package v0 (should warn about deprecation) ===" | tee /dev/stderr
 UPGRADE_CAP=$(sui client --client.config $CONFIG publish "example" --skip-dependency-verification \
   --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
 
-echo "=== upgrade package (should NOT warn) ===" | tee /dev/stderr
+echo "=== upgrade package (should warn about deprecation) ===" | tee /dev/stderr
 sui client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example --skip-dependency-verification \
   --json | jq '.effects.status'
 

--- a/crates/sui/tests/snapshots/shell_tests__with_network__source_verification_deprecation__both_flags.sh.snap
+++ b/crates/sui/tests/snapshots/shell_tests__with_network__source_verification_deprecation__both_flags.sh.snap
@@ -8,27 +8,27 @@ description: tests/shell_tests/with_network/source_verification_deprecation/both
 
 # test that we get an error if we supply both `--skip-dependency-verification` and `--verify-deps`
 
-echo "=== publish ===" | tee /dev/stderr
+echo "=== publish (should fail) ===" | tee /dev/stderr
 sui client --client.config $CONFIG publish example --skip-dependency-verification --verify-deps
 
-echo "=== upgrade ===" | tee /dev/stderr
+echo "=== upgrade (should fail) ===" | tee /dev/stderr
 sui client --client.config $CONFIG upgrade example --upgrade-capability 0x1234 --skip-dependency-verification --verify-deps
 
 ----- results -----
 success: false
 exit_code: 2
 ----- stdout -----
-=== publish ===
-=== upgrade ===
+=== publish (should fail) ===
+=== upgrade (should fail) ===
 
 ----- stderr -----
-=== publish ===
+=== publish (should fail) ===
 error: the argument '--skip-dependency-verification' cannot be used with '--verify-deps'
 
 Usage: sui client publish --skip-dependency-verification <package_path>
 
 For more information, try '--help'.
-=== upgrade ===
+=== upgrade (should fail) ===
 error: the argument '--skip-dependency-verification' cannot be used with '--verify-deps'
 
 Usage: sui client upgrade --upgrade-capability <UPGRADE_CAPABILITY> --skip-dependency-verification <package_path>

--- a/crates/sui/tests/snapshots/shell_tests__with_network__source_verification_deprecation__no_flags.sh.snap
+++ b/crates/sui/tests/snapshots/shell_tests__with_network__source_verification_deprecation__no_flags.sh.snap
@@ -33,16 +33,16 @@ cat dependency/sources/dependency.move | sed 's#0#1#g' > dependency.move
 mv dependency.move dependency/sources/dependency.move
 
 echo "=== try to publish with modified dep (should succeed) ===" | tee /dev/stderr
-sui client --client.config $CONFIG publish "example" \
-  --json | jq '.effects.status'
+UPGRADE_CAP=$(sui client --client.config $CONFIG publish "example" \
+  --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
 
 echo "=== try to upgrade with modified dep (should succeed) ===" | tee /dev/stderr
 sui client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example \
   --json | jq '.effects.status'
 
 ----- results -----
-success: false
-exit_code: 5
+success: true
+exit_code: 0
 ----- stdout -----
 === munge Move.toml files ===
 === publish dependency ===
@@ -56,10 +56,10 @@ exit_code: 5
 }
 === modify dependency ===
 === try to publish with modified dep (should succeed) ===
+=== try to upgrade with modified dep (should succeed) ===
 {
   "status": "success"
 }
-=== try to upgrade with modified dep (should succeed) ===
 
 ----- stderr -----
 === munge Move.toml files ===
@@ -88,4 +88,3 @@ Skipping dependency verification
 INCLUDING DEPENDENCY dependency
 BUILDING example
 Skipping dependency verification
-jq: parse error: Invalid numeric literal at line 1, column 6

--- a/crates/sui/tests/snapshots/shell_tests__with_network__source_verification_deprecation__no_flags.sh.snap
+++ b/crates/sui/tests/snapshots/shell_tests__with_network__source_verification_deprecation__no_flags.sh.snap
@@ -20,11 +20,11 @@ echo "=== publish dependency ===" | tee /dev/stderr
 sui client --client.config $CONFIG publish "dependency" \
   --json | jq '.effects.status'
 
-echo "=== publish package v0 (should warn) ===" | tee /dev/stderr
+echo "=== publish package v0 (should note deprecation) ===" | tee /dev/stderr
 UPGRADE_CAP=$(sui client --client.config $CONFIG publish "example" \
   --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
 
-echo "=== upgrade package (should warn) ===" | tee /dev/stderr
+echo "=== upgrade package (should note deprecation) ===" | tee /dev/stderr
 sui client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example \
   --json | jq '.effects.status'
 
@@ -32,64 +32,60 @@ echo "=== modify dependency ===" | tee /dev/stderr
 cat dependency/sources/dependency.move | sed 's#0#1#g' > dependency.move
 mv dependency.move dependency/sources/dependency.move
 
-echo "=== try to publish with modified dep (should fail) ===" | tee /dev/stderr
+echo "=== try to publish with modified dep (should succeed) ===" | tee /dev/stderr
 sui client --client.config $CONFIG publish "example" \
-  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'
+  --json | jq '.effects.status'
 
-echo "=== try to upgrade with modified dep (should fail) ===" | tee /dev/stderr
+echo "=== try to upgrade with modified dep (should succeed) ===" | tee /dev/stderr
 sui client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example \
-  | sed 's/at .*::dependency::dependency/at [[package address]]::dependency::dependency/g'
+  --json | jq '.effects.status'
 
 ----- results -----
-success: true
-exit_code: 0
+success: false
+exit_code: 5
 ----- stdout -----
 === munge Move.toml files ===
 === publish dependency ===
 {
   "status": "success"
 }
-=== publish package v0 (should warn) ===
-=== upgrade package (should warn) ===
+=== publish package v0 (should note deprecation) ===
+=== upgrade package (should note deprecation) ===
 {
   "status": "success"
 }
 === modify dependency ===
-=== try to publish with modified dep (should fail) ===
-Failed to publish the Move module(s), reason: [warning] Local dependency did not match its on-chain version at [[package address]]::dependency::dependency
-
-This may indicate that the on-chain version(s) of your package's dependencies may behave differently than the source version(s) your package was built against.
-
-Fix this by rebuilding your packages with source versions matching on-chain versions of dependencies, or ignore this warning by re-running with the --skip-dependency-verification flag.
-=== try to upgrade with modified dep (should fail) ===
-Failed to publish the Move module(s), reason: [warning] Local dependency did not match its on-chain version at [[package address]]::dependency::dependency
-
-This may indicate that the on-chain version(s) of your package's dependencies may behave differently than the source version(s) your package was built against.
-
-Fix this by rebuilding your packages with source versions matching on-chain versions of dependencies, or ignore this warning by re-running with the --skip-dependency-verification flag.
+=== try to publish with modified dep (should succeed) ===
+{
+  "status": "success"
+}
+=== try to upgrade with modified dep (should succeed) ===
 
 ----- stderr -----
 === munge Move.toml files ===
 === publish dependency ===
-[warning]: In a future release, dependency source code will no longer be verified by default during publication and upgrade. You can opt in to source verification using `--verify-deps` or disable this warning using `--skip-dependency-verification`. You can also manually verify dependencies using `sui client verify-source`.
+[Note]: Dependency sources are no longer verified automatically during publication and upgrade. You can pass the `--verify-deps` option if you would like to verify them as part of publication or upgrade.
 BUILDING dependency
-Successfully verified dependencies on-chain against source.
-=== publish package v0 (should warn) ===
-[warning]: In a future release, dependency source code will no longer be verified by default during publication and upgrade. You can opt in to source verification using `--verify-deps` or disable this warning using `--skip-dependency-verification`. You can also manually verify dependencies using `sui client verify-source`.
+Skipping dependency verification
+=== publish package v0 (should note deprecation) ===
+[Note]: Dependency sources are no longer verified automatically during publication and upgrade. You can pass the `--verify-deps` option if you would like to verify them as part of publication or upgrade.
 INCLUDING DEPENDENCY dependency
 BUILDING example
-Successfully verified dependencies on-chain against source.
-=== upgrade package (should warn) ===
-[warning]: In a future release, dependency source code will no longer be verified by default during publication and upgrade. You can opt in to source verification using `--verify-deps` or disable this warning using `--skip-dependency-verification`. You can also manually verify dependencies using `sui client verify-source`.
+Skipping dependency verification
+=== upgrade package (should note deprecation) ===
+[Note]: Dependency sources are no longer verified automatically during publication and upgrade. You can pass the `--verify-deps` option if you would like to verify them as part of publication or upgrade.
 INCLUDING DEPENDENCY dependency
 BUILDING example
-Successfully verified dependencies on-chain against source.
+Skipping dependency verification
 === modify dependency ===
-=== try to publish with modified dep (should fail) ===
-[warning]: In a future release, dependency source code will no longer be verified by default during publication and upgrade. You can opt in to source verification using `--verify-deps` or disable this warning using `--skip-dependency-verification`. You can also manually verify dependencies using `sui client verify-source`.
+=== try to publish with modified dep (should succeed) ===
+[Note]: Dependency sources are no longer verified automatically during publication and upgrade. You can pass the `--verify-deps` option if you would like to verify them as part of publication or upgrade.
 INCLUDING DEPENDENCY dependency
 BUILDING example
-=== try to upgrade with modified dep (should fail) ===
-[warning]: In a future release, dependency source code will no longer be verified by default during publication and upgrade. You can opt in to source verification using `--verify-deps` or disable this warning using `--skip-dependency-verification`. You can also manually verify dependencies using `sui client verify-source`.
+Skipping dependency verification
+=== try to upgrade with modified dep (should succeed) ===
+[Note]: Dependency sources are no longer verified automatically during publication and upgrade. You can pass the `--verify-deps` option if you would like to verify them as part of publication or upgrade.
 INCLUDING DEPENDENCY dependency
 BUILDING example
+Skipping dependency verification
+jq: parse error: Invalid numeric literal at line 1, column 6

--- a/crates/sui/tests/snapshots/shell_tests__with_network__source_verification_deprecation__skip_dep_verif.sh.snap
+++ b/crates/sui/tests/snapshots/shell_tests__with_network__source_verification_deprecation__skip_dep_verif.sh.snap
@@ -64,27 +64,27 @@ exit_code: 0
 ----- stderr -----
 === munge Move.toml files ===
 === publish dependency (should warn about deprecation) ===
-[Warning]: Dependency sources are no longer verificed automatically during publication and upgrade, so the `--skip-dependency-verification` flag is no longer necessary.
+[Warning]: Dependency sources are no longer verified automatically during publication and upgrade, so the `--skip-dependency-verification` flag is no longer necessary.
 BUILDING dependency
 Skipping dependency verification
 === publish package v0 (should warn about deprecation) ===
-[Warning]: Dependency sources are no longer verificed automatically during publication and upgrade, so the `--skip-dependency-verification` flag is no longer necessary.
+[Warning]: Dependency sources are no longer verified automatically during publication and upgrade, so the `--skip-dependency-verification` flag is no longer necessary.
 INCLUDING DEPENDENCY dependency
 BUILDING example
 Skipping dependency verification
 === upgrade package (should warn about deprecation) ===
-[Warning]: Dependency sources are no longer verificed automatically during publication and upgrade, so the `--skip-dependency-verification` flag is no longer necessary.
+[Warning]: Dependency sources are no longer verified automatically during publication and upgrade, so the `--skip-dependency-verification` flag is no longer necessary.
 INCLUDING DEPENDENCY dependency
 BUILDING example
 Skipping dependency verification
 === modify dependency ===
 === try to publish with modified dep (should succeed) ===
-[Warning]: Dependency sources are no longer verificed automatically during publication and upgrade, so the `--skip-dependency-verification` flag is no longer necessary.
+[Warning]: Dependency sources are no longer verified automatically during publication and upgrade, so the `--skip-dependency-verification` flag is no longer necessary.
 INCLUDING DEPENDENCY dependency
 BUILDING example
 Skipping dependency verification
 === try to upgrade with modified dep (should succeed) ===
-[Warning]: Dependency sources are no longer verificed automatically during publication and upgrade, so the `--skip-dependency-verification` flag is no longer necessary.
+[Warning]: Dependency sources are no longer verified automatically during publication and upgrade, so the `--skip-dependency-verification` flag is no longer necessary.
 INCLUDING DEPENDENCY dependency
 BUILDING example
 Skipping dependency verification

--- a/crates/sui/tests/snapshots/shell_tests__with_network__source_verification_deprecation__skip_dep_verif.sh.snap
+++ b/crates/sui/tests/snapshots/shell_tests__with_network__source_verification_deprecation__skip_dep_verif.sh.snap
@@ -16,15 +16,15 @@ do
     && mv Move.toml $i
 done
 
-echo "=== publish dependency ===" | tee /dev/stderr
+echo "=== publish dependency (should warn about deprecation) ===" | tee /dev/stderr
 sui client --client.config $CONFIG publish "dependency" --skip-dependency-verification \
   --json | jq '.effects.status'
 
-echo "=== publish package v0 (should NOT warn) ===" | tee /dev/stderr
+echo "=== publish package v0 (should warn about deprecation) ===" | tee /dev/stderr
 UPGRADE_CAP=$(sui client --client.config $CONFIG publish "example" --skip-dependency-verification \
   --json | jq -r '.objectChanges[] | select(.objectType == "0x2::package::UpgradeCap") | .objectId')
 
-echo "=== upgrade package (should NOT warn) ===" | tee /dev/stderr
+echo "=== upgrade package (should warn about deprecation) ===" | tee /dev/stderr
 sui client --client.config $CONFIG upgrade --upgrade-capability $UPGRADE_CAP example --skip-dependency-verification \
   --json | jq '.effects.status'
 
@@ -45,12 +45,12 @@ success: true
 exit_code: 0
 ----- stdout -----
 === munge Move.toml files ===
-=== publish dependency ===
+=== publish dependency (should warn about deprecation) ===
 {
   "status": "success"
 }
-=== publish package v0 (should NOT warn) ===
-=== upgrade package (should NOT warn) ===
+=== publish package v0 (should warn about deprecation) ===
+=== upgrade package (should warn about deprecation) ===
 {
   "status": "success"
 }
@@ -63,23 +63,28 @@ exit_code: 0
 
 ----- stderr -----
 === munge Move.toml files ===
-=== publish dependency ===
+=== publish dependency (should warn about deprecation) ===
+[Warning]: Dependency sources are no longer verificed automatically during publication and upgrade, so the `--skip-dependency-verification` flag is no longer necessary.
 BUILDING dependency
 Skipping dependency verification
-=== publish package v0 (should NOT warn) ===
+=== publish package v0 (should warn about deprecation) ===
+[Warning]: Dependency sources are no longer verificed automatically during publication and upgrade, so the `--skip-dependency-verification` flag is no longer necessary.
 INCLUDING DEPENDENCY dependency
 BUILDING example
 Skipping dependency verification
-=== upgrade package (should NOT warn) ===
+=== upgrade package (should warn about deprecation) ===
+[Warning]: Dependency sources are no longer verificed automatically during publication and upgrade, so the `--skip-dependency-verification` flag is no longer necessary.
 INCLUDING DEPENDENCY dependency
 BUILDING example
 Skipping dependency verification
 === modify dependency ===
 === try to publish with modified dep (should succeed) ===
+[Warning]: Dependency sources are no longer verificed automatically during publication and upgrade, so the `--skip-dependency-verification` flag is no longer necessary.
 INCLUDING DEPENDENCY dependency
 BUILDING example
 Skipping dependency verification
 === try to upgrade with modified dep (should succeed) ===
+[Warning]: Dependency sources are no longer verificed automatically during publication and upgrade, so the `--skip-dependency-verification` flag is no longer necessary.
 INCLUDING DEPENDENCY dependency
 BUILDING example
 Skipping dependency verification


### PR DESCRIPTION
## Description 

Switch source dependency verification from opt-out to opt-in; update warnings and tests accordingly.

## Test plan 

Existing integration tests are updated.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: Source verification for publish/upgrade commands is now opt-in instead of opt-out.
- [ ] Rust SDK:
