### PR TITLE
Change p2p default port to 8084

### DIFF
--- a/crates/sui-config/src/p2p.rs
+++ b/crates/sui-config/src/p2p.rs
@@ -40,7 +40,7 @@ pub struct P2pConfig {
 }
 
 fn default_listen_address() -> SocketAddr {
-    "0.0.0.0:8080".parse().unwrap()
+    "0.0.0.0:8084".parse().unwrap()
 }
 
 impl Default for P2pConfig {


### PR DESCRIPTION
## Description 

8084 is mentioned to be the default p2p port in docs: https://docs.sui.io/guides/operator/validator-tasks#connectivity
And validator / transaction RPC port defaults to 8080 already.
So changing the default p2p port from 8080 to 8084 in `P2pConfig`.
I believe the change is backward compatible but lmk otherwise.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
