### PR TITLE
[12/n][vm-rewrite] Update and cleanup linkage generation

### DIFF
--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -166,18 +166,6 @@ mod checked {
         }
 
         //---------------------------------------------------------------------------
-        // Package Resolution
-        //---------------------------------------------------------------------------
-
-        pub fn runtime_id_for_storage_id(&self, storage_id: &ObjectID) -> Option<ObjectID> {
-            self.linkage.reverse_linkage.get(storage_id).copied()
-        }
-
-        pub fn storage_id_for_runtime_id(&self, runtime_id: &ObjectID) -> Option<ObjectID> {
-            self.linkage.linkage.get(runtime_id).copied()
-        }
-
-        //---------------------------------------------------------------------------
         // Type Resolution
         //---------------------------------------------------------------------------
 
@@ -222,6 +210,7 @@ mod checked {
         ) -> Result<TypeTag, ExecutionError> {
             self.ctx
                 .linkage_analyzer
+                .resolver()
                 .runtime_type_tag(type_tag, &SuiDataStore::new(&self.ctx.state_view, &[]))
         }
 
@@ -654,6 +643,7 @@ mod checked {
             let linkage = self
                 .ctx
                 .linkage_analyzer
+                .resolver()
                 .publication_linkage(vm.linkage_context(), &data_store)?;
             let [pkg] = new_packages;
             Ok((
@@ -1477,7 +1467,7 @@ mod checked {
             .flat_map(|tag| tag.all_addresses())
             .map(ObjectID::from)
             .collect();
-        linkage_analyzer.type_linkage(&tags, store)
+        linkage_analyzer.resolver().type_linkage(&tags, store)
     }
 
     fn identity_linkage_for_struct_tags<'a>(
@@ -1490,7 +1480,7 @@ mod checked {
             .flat_map(|tag| tag.all_addresses())
             .map(ObjectID::from)
             .collect();
-        linkage_analyzer.type_linkage(&tags, store)
+        linkage_analyzer.resolver().type_linkage(&tags, store)
     }
 
     // NB: The typetag must be defining ID based

--- a/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
@@ -30,7 +30,17 @@ struct NullSuiResolver<'state>(Box<dyn TypeLayoutStore + 'state>);
 impl<'state, 'vm> TypeLayoutResolver<'state, 'vm> {
     pub fn new(vm: &'vm MoveRuntime, state_view: Box<dyn TypeLayoutStore + 'state>) -> Self {
         let resolver = NullSuiResolver(state_view);
-        let linkage_resolver = UnifiedLinkage::new(vm.vm_config().binary_config.clone());
+        // Since we do not include system packages by default, we can set this to false as no
+        // loading will be done when creating the linkage resolver.
+        let always_include_system_packages = false;
+        let Some(linkage_resolver) = UnifiedLinkage::new(
+            always_include_system_packages,
+            vm.vm_config().binary_config.clone(),
+            &resolver,
+        )
+        .ok() else {
+            unreachable!()
+        };
         Self {
             vm,
             resolver,


### PR DESCRIPTION
This updates linkage generation to almost always include system packages (other than in genesis/system transaction mode -- so basically when we're updating the system packages). This is primarily since we rely on access to these packages at places in the adapter (e.g., when resolving the type for the upgrade capability when upgrading or publishing a package).

This also cleans up the interfaces around linkage

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
