### PR TITLE
[Consensus] enable the new linearize logic for devnet.

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -216,6 +216,7 @@ const MAX_PROTOCOL_VERSION: u64 = 74;
 // Version 74: Enable load_nitro_attestation move function in sui framework in devnet.
 //             Enable all gas costs for load_nitro_attestation.
 //             Enable zstd compression for consensus tonic network in mainnet.
+//             Enable the new commit rule for devnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -3240,6 +3241,10 @@ impl ProtocolConfig {
 
                     // Enable zstd compression for consensus in mainnet
                     cfg.feature_flags.consensus_zstd_compression = true;
+
+                    if chain != Chain::Mainnet && chain != Chain::Testnet {
+                        cfg.feature_flags.consensus_linearize_subdag_v2 = true;
+                    }
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_74.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_74.snap
@@ -76,6 +76,7 @@ feature_flags:
   consensus_smart_ancestor_selection: true
   consensus_round_prober_probe_accepted_rounds: true
   native_charging_v2: true
+  consensus_linearize_subdag_v2: true
   convert_type_argument_error: true
   variant_nodes: true
   consensus_zstd_compression: true


### PR DESCRIPTION
## Description 

Enables the new linearize logic for devnet. Although it had been previously enabled it got later [disabled](https://github.com/MystenLabs/sui/pull/21019) during a regression investigation which appeared to be though unrelated to this logic. 

## Test plan 

CI/PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
