### PR TITLE
Reduce thread stall log level from ERROR to WARN

### DIFF
--- a/crates/mysten-metrics/src/thread_stall_monitor.rs
+++ b/crates/mysten-metrics/src/thread_stall_monitor.rs
@@ -7,7 +7,7 @@ use std::sync::Once;
 use std::time::Duration;
 use std::time::Instant;
 
-use tracing::{error, info};
+use tracing::{info, warn};
 
 use crate::{get_metrics, spawn_logged_monitored_task};
 
@@ -40,12 +40,12 @@ const ALERT_THRESHOLD: Duration = Duration::from_millis(500);
 // The debugger will now print out all thread stacks every time a thread stall is detected.
 #[inline(never)]
 extern "C" fn thread_monitor_report_stall(duration_ms: u64) {
-    error!("Thread stalled for {}ms", duration_ms);
+    warn!("Thread stalled for {}ms", duration_ms);
 }
 
 #[inline(never)]
 extern "C" fn thread_monitor_report_stall_cleared(duration_ms: u64) {
-    error!("Thread stall cleared after {}ms", duration_ms);
+    warn!("Thread stall cleared after {}ms", duration_ms);
 }
 
 /// Monitors temporary stalls in tokio scheduling every MONITOR_INTERVAL.


### PR DESCRIPTION
## Description 

Thread stalls can happen spuriously. Most operators are not equipped to debug the error and it is hard to help them debug too. So downgrading to warn to be less distracting.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
