### PR TITLE
[gql] Watermark task reads from watermarks table, use watermarks for `Event::paginate`

### DIFF
--- a/crates/sui-graphql-e2e-tests/tests/stable/prune/events.move
+++ b/crates/sui-graphql-e2e-tests/tests/stable/prune/events.move
@@ -1,0 +1,150 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test that we handle pruned events. When paginating on a cursor, it should be bounded by
+// checkpoint consistency. Last graphql query checks that newer events exist.
+
+//# init --protocol-version 51 --addresses Test=0x0 --accounts A B --simulator --epochs-to-keep 1
+
+//# publish
+module Test::M1 {
+    use sui::event;
+
+    public struct EventA has copy, drop {
+        new_value: u64
+    }
+
+    public struct EventB<phantom T> has copy, drop {
+        new_value: u64
+    }
+
+    public struct Object has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public entry fun create(value: u64, recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Object { id: object::new(ctx), value },
+            recipient
+        )
+    }
+
+    public entry fun emit_a(o1: &mut Object, value: u64) {
+        o1.value = value;
+        event::emit(EventA { new_value: value })
+    }
+}
+
+//# run Test::M1::create --sender A --args 0 @A
+
+//# run Test::M1::emit_a --sender A --args object(2,0) 0
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# run Test::M1::emit_a --sender A --args object(2,0) 1
+
+//# create-checkpoint
+
+//# run-graphql --wait-for-checkpoint-pruned 1
+{
+  events(filter: {sender: "@{A}"}) {
+    edges {
+      cursor
+      node {
+        transactionBlock {
+          effects {
+            checkpoint {
+              sequenceNumber
+            }
+          }
+        }
+        sendingModule {
+          name
+        }
+        sender {
+          address
+        }
+        contents {
+          type {
+            repr
+          }
+          json
+          bcs
+        }
+      }
+    }
+  }
+}
+
+//# create-checkpoint
+
+//# run Test::M1::emit_a --sender A --args object(2,0) 2
+
+//# run Test::M1::emit_a --sender A --args object(2,0) 3
+
+//# create-checkpoint
+
+//# run-graphql --cursors {"tx":5,"e":0,"c":3}
+{
+  events(filter: {sender: "@{A}"}, after: "@{cursor_0}") {
+    edges {
+      cursor
+      node {
+        transactionBlock {
+          effects {
+            checkpoint {
+              sequenceNumber
+            }
+          }
+        }
+        sendingModule {
+          name
+        }
+        sender {
+          address
+        }
+        contents {
+          type {
+            repr
+          }
+          json
+          bcs
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  events(filter: {sender: "@{A}"}) {
+    edges {
+      cursor
+      node {
+        transactionBlock {
+          effects {
+            checkpoint {
+              sequenceNumber
+            }
+          }
+        }
+        sendingModule {
+          name
+        }
+        sender {
+          address
+        }
+        contents {
+          type {
+            repr
+          }
+          json
+          bcs
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-graphql-e2e-tests/tests/stable/prune/events.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/prune/events.snap
@@ -1,0 +1,203 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 15 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 9-37:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 6657600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 39:
+//# run Test::M1::create --sender A --args 0 @A
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 41:
+//# run Test::M1::emit_a --sender A --args object(2,0) 0
+events: Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [0, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 4, line 43:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, line 45:
+//# advance-epoch
+Epoch advanced: 0
+
+task 6, line 47:
+//# run Test::M1::emit_a --sender A --args object(2,0) 1
+events: Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [1, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 7, line 49:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 8, lines 51-80:
+//# run-graphql --wait-for-checkpoint-pruned 1
+Response: {
+  "data": {
+    "events": {
+      "edges": [
+        {
+          "cursor": "eyJ0eCI6NSwiZSI6MCwiYyI6M30",
+          "node": {
+            "transactionBlock": {
+              "effects": {
+                "checkpoint": {
+                  "sequenceNumber": 3
+                }
+              }
+            },
+            "sendingModule": {
+              "name": "M1"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xa286f296f0fbc2828616670adc9108817eefaa7a440106a2ed54c144582c9401::M1::EventA"
+              },
+              "json": {
+                "new_value": "1"
+              },
+              "bcs": "AQAAAAAAAAA="
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 9, line 82:
+//# create-checkpoint
+Checkpoint created: 4
+
+task 10, line 84:
+//# run Test::M1::emit_a --sender A --args object(2,0) 2
+events: Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [2, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 11, line 86:
+//# run Test::M1::emit_a --sender A --args object(2,0) 3
+events: Event { package_id: Test, transaction_module: Identifier("M1"), sender: A, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("EventA"), type_params: [] }, contents: [3, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 2279772, non_refundable_storage_fee: 23028
+
+task 12, line 88:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 13, lines 90-119:
+//# run-graphql --cursors {"tx":5,"e":0,"c":3}
+Response: {
+  "data": {
+    "events": {
+      "edges": []
+    }
+  }
+}
+
+task 14, lines 121-150:
+//# run-graphql
+Response: {
+  "data": {
+    "events": {
+      "edges": [
+        {
+          "cursor": "eyJ0eCI6NSwiZSI6MCwiYyI6NX0",
+          "node": {
+            "transactionBlock": {
+              "effects": {
+                "checkpoint": {
+                  "sequenceNumber": 3
+                }
+              }
+            },
+            "sendingModule": {
+              "name": "M1"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xa286f296f0fbc2828616670adc9108817eefaa7a440106a2ed54c144582c9401::M1::EventA"
+              },
+              "json": {
+                "new_value": "1"
+              },
+              "bcs": "AQAAAAAAAAA="
+            }
+          }
+        },
+        {
+          "cursor": "eyJ0eCI6NiwiZSI6MCwiYyI6NX0",
+          "node": {
+            "transactionBlock": {
+              "effects": {
+                "checkpoint": {
+                  "sequenceNumber": 5
+                }
+              }
+            },
+            "sendingModule": {
+              "name": "M1"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xa286f296f0fbc2828616670adc9108817eefaa7a440106a2ed54c144582c9401::M1::EventA"
+              },
+              "json": {
+                "new_value": "2"
+              },
+              "bcs": "AgAAAAAAAAA="
+            }
+          }
+        },
+        {
+          "cursor": "eyJ0eCI6NywiZSI6MCwiYyI6NX0",
+          "node": {
+            "transactionBlock": {
+              "effects": {
+                "checkpoint": {
+                  "sequenceNumber": 5
+                }
+              }
+            },
+            "sendingModule": {
+              "name": "M1"
+            },
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "contents": {
+              "type": {
+                "repr": "0xa286f296f0fbc2828616670adc9108817eefaa7a440106a2ed54c144582c9401::M1::EventA"
+              },
+              "json": {
+                "new_value": "3"
+              },
+              "bcs": "AwAAAAAAAAA="
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -736,6 +736,7 @@ pub mod tests {
         let watermark = Watermark {
             hi_cp: 1,
             hi_cp_timestamp_ms: 1,
+            hi_tx: 1,
             epoch: 0,
             lo_cp: 0,
             lo_tx: 0,

--- a/crates/sui-graphql-rpc/src/server/builder.rs
+++ b/crates/sui-graphql-rpc/src/server/builder.rs
@@ -1148,6 +1148,10 @@ pub mod tests {
     pub async fn test_health_check() {
         let cluster = prep_executor_cluster().await;
 
+        cluster
+            .wait_for_checkpoint_catchup(6, Duration::from_secs(60))
+            .await;
+
         let url = format!(
             "http://{}:{}/health",
             cluster.graphql_connection_config.host, cluster.graphql_connection_config.port

--- a/crates/sui-graphql-rpc/src/server/watermark_task.rs
+++ b/crates/sui-graphql-rpc/src/server/watermark_task.rs
@@ -6,15 +6,12 @@ use crate::error::Error;
 use crate::metrics::Metrics;
 use crate::types::chain_identifier::ChainIdentifier;
 use async_graphql::ServerError;
-use diesel::{
-    query_dsl::positional_order_dsl::PositionalOrderDsl, CombineDsl, ExpressionMethods,
-    OptionalExtension, QueryDsl,
-};
+use diesel::{ExpressionMethods, JoinOnDsl, OptionalExtension, QueryDsl};
 use diesel_async::scoped_futures::ScopedFutureExt;
 use std::mem;
 use std::sync::Arc;
 use std::time::Duration;
-use sui_indexer::schema::checkpoints;
+use sui_indexer::schema::{checkpoints, watermarks};
 use tokio::sync::{watch, RwLock};
 use tokio::time::Interval;
 use tokio_util::sync::CancellationToken;
@@ -43,14 +40,18 @@ pub(crate) type WatermarkLock = Arc<RwLock<Watermark>>;
 /// changes.
 #[derive(Clone, Copy, Default)]
 pub(crate) struct Watermark {
-    /// The inclusive checkpoint upper-bound for the query.
-    pub hi_cp: u64,
-    /// The timestamp of the inclusive upper-bound checkpoint for the query.
-    pub hi_cp_timestamp_ms: u64,
     /// The current epoch.
     pub epoch: u64,
+    /// The timestamp of the inclusive upper-bound checkpoint for the query. This is used for the
+    /// health check.
+    pub hi_cp_timestamp_ms: u64,
+    /// The inclusive checkpoint upper-bound for the query.
+    pub hi_cp: u64,
+    /// The inclusive tx_sequence_number upper-bound for the query.
+    pub hi_tx: u64,
     /// Smallest queryable checkpoint - checkpoints below this value are pruned.
     pub lo_cp: u64,
+    /// Smallest queryable tx_sequence_number - tx_sequence_numbers below this value are pruned.
     pub lo_tx: u64,
 }
 
@@ -89,7 +90,7 @@ impl WatermarkTask {
                     return;
                 },
                 _ = interval.tick() => {
-                    let Watermark { lo_cp, lo_tx, hi_cp, hi_cp_timestamp_ms, epoch } = match Watermark::query(&self.db).await {
+                    let Watermark {epoch, hi_cp_timestamp_ms, hi_cp, hi_tx, lo_cp, lo_tx } = match Watermark::query(&self.db).await {
                         Ok(Some(watermark)) => watermark,
                         Ok(None) => continue,
                         Err(e) => {
@@ -103,6 +104,7 @@ impl WatermarkTask {
                     let prev_epoch = {
                         let mut w = self.watermark.write().await;
                         w.hi_cp = hi_cp;
+                        w.hi_tx = hi_tx;
                         w.hi_cp_timestamp_ms = hi_cp_timestamp_ms;
                         w.lo_cp = lo_cp;
                         w.lo_tx = lo_tx;
@@ -166,41 +168,38 @@ impl Watermark {
         Self {
             hi_cp: w.hi_cp,
             hi_cp_timestamp_ms: w.hi_cp_timestamp_ms,
+            hi_tx: w.hi_tx,
             epoch: w.epoch,
             lo_cp: w.lo_cp,
             lo_tx: w.lo_tx,
         }
     }
 
+    /// Queries the watermarks table for the `checkpoints` pipeline to determine the available range
+    /// of checkpoints and tx_sequence_numbers. We don't query tables directly as pruning may be in
+    /// progress, which means the lower bound of data will constantly change. The watermarks table
+    /// has a `tx_hi` value, but not a `tx_lo` value, so the query also joins on the `checkpoints`
+    /// table to get the `min_tx_sequence_number` for that lower bound.
     #[allow(clippy::type_complexity)]
     pub(crate) async fn query(db: &Db) -> Result<Option<Watermark>, Error> {
-        use checkpoints::dsl;
-        let Some(result): Option<Vec<(i64, i64, i64, Option<i64>)>> = db
+        use checkpoints::dsl as c;
+        use watermarks::dsl as w;
+
+        let Some(result): Option<(i64, i64, i64, i64, i64, Option<i64>)> = db
             .execute(move |conn| {
                 async {
-                    conn.results(move || {
-                        let min_cp = dsl::checkpoints
+                    conn.result(move || {
+                        w::watermarks
+                            .inner_join(c::checkpoints.on(w::reader_lo.eq(c::sequence_number)))
+                            .filter(w::pipeline.eq("checkpoints"))
                             .select((
-                                dsl::sequence_number,
-                                dsl::timestamp_ms,
-                                dsl::epoch,
-                                dsl::min_tx_sequence_number,
+                                c::epoch,
+                                c::timestamp_ms,
+                                w::checkpoint_hi_inclusive,
+                                w::tx_hi,
+                                w::reader_lo,
+                                c::min_tx_sequence_number,
                             ))
-                            .order_by(dsl::sequence_number.asc())
-                            .limit(1);
-
-                        let max_cp = dsl::checkpoints
-                            .select((
-                                dsl::sequence_number,
-                                dsl::timestamp_ms,
-                                dsl::epoch,
-                                dsl::min_tx_sequence_number,
-                            ))
-                            .order_by(dsl::sequence_number.desc())
-                            .limit(1);
-
-                        // Order by sequence_number, which is in the 1st position
-                        min_cp.union_all(max_cp).positional_order_by(1)
                     })
                     .await
                     .optional()
@@ -210,36 +209,26 @@ impl Watermark {
             .await
             .map_err(|e| Error::Internal(format!("Failed to fetch watermark data: {e}")))?
         else {
-            // An empty response from the db is valid when indexer has not written any checkpoints
-            // to the db yet.
+            // An empty response from the db is valid when indexer has not committed data to the db
+            // yet.
             return Ok(None);
         };
 
-        let (lo_cp, lo_tx) = if let Some((cp, _, _, Some(tx))) = result.first() {
-            (cp, tx)
+        if let (epoch, hi_cp_timestamp_ms, hi_cp, hi_tx, lo_cp, Some(lo_tx)) = result {
+            Ok(Some(Watermark {
+                hi_cp: hi_cp as u64,
+                hi_cp_timestamp_ms: hi_cp_timestamp_ms as u64,
+                hi_tx: hi_tx as u64,
+                epoch: epoch as u64,
+                lo_cp: lo_cp as u64,
+                lo_tx: lo_tx as u64,
+            }))
         } else {
             return Err(Error::Internal(
                 "Expected entry for tx lower bound and min_tx_sequence_number to be non-null"
                     .to_string(),
             ));
-        };
-
-        let (hi_cp, hi_cp_timestamp_ms, epoch) =
-            if let Some((cp, timestamp_ms, epoch, _)) = result.last() {
-                (cp, timestamp_ms, epoch)
-            } else {
-                return Err(Error::Internal(
-                    "Expected entry for tx upper bound".to_string(),
-                ));
-            };
-
-        Ok(Some(Watermark {
-            hi_cp: *hi_cp as u64,
-            hi_cp_timestamp_ms: *hi_cp_timestamp_ms as u64,
-            epoch: *epoch as u64,
-            lo_cp: *lo_cp as u64,
-            lo_tx: *lo_tx as u64,
-        }))
+        }
     }
 }
 

--- a/crates/sui-graphql-rpc/src/types/event/lookups.rs
+++ b/crates/sui-graphql-rpc/src/types/event/lookups.rs
@@ -120,9 +120,14 @@ pub(crate) fn add_bounds(
     mut query: RawQuery,
     tx_digest_filter: &Option<Digest>,
     page: &Page<Cursor>,
+    tx_lo: i64,
     tx_hi: i64,
 ) -> RawQuery {
-    query = filter!(query, format!("tx_sequence_number < {}", tx_hi));
+    // Temporally bounds the query to the unpruned data range
+    query = filter!(
+        query,
+        format!("tx_sequence_number BETWEEN {} AND {}", tx_lo, tx_hi)
+    );
 
     if let Some(after) = page.after() {
         query = filter!(

--- a/crates/sui-graphql-rpc/src/types/event/lookups.rs
+++ b/crates/sui-graphql-rpc/src/types/event/lookups.rs
@@ -126,7 +126,10 @@ pub(crate) fn add_bounds(
     // Temporally bounds the query to the unpruned data range
     query = filter!(
         query,
-        format!("tx_sequence_number BETWEEN {} AND {}", tx_lo, tx_hi)
+        format!(
+            "tx_sequence_number >= {} AND tx_sequence_number < {}",
+            tx_lo, tx_hi
+        )
     );
 
     if let Some(after) = page.after() {

--- a/crates/sui-graphql-rpc/src/types/event/mod.rs
+++ b/crates/sui-graphql-rpc/src/types/event/mod.rs
@@ -134,8 +134,8 @@ impl Event {
         db: &Db,
         page: Page<Cursor>,
         filter: EventFilter,
-        checkpoint_viewed_at: u64,
         tx_lo: u64,
+        checkpoint_viewed_at: u64,
     ) -> Result<Connection<String, Event>, Error> {
         let cursor_viewed_at = page.validate_cursor_consistency()?;
         let checkpoint_viewed_at = cursor_viewed_at.unwrap_or(checkpoint_viewed_at);

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -461,14 +461,12 @@ impl Query {
         before: Option<event::Cursor>,
         filter: Option<EventFilter>,
     ) -> Result<Connection<String, Event>> {
-        let Watermark { hi_cp, .. } = *ctx.data()?;
-
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
         Event::paginate(
             ctx.data_unchecked(),
             page,
             filter.unwrap_or_default(),
-            hi_cp,
+            ctx.data_unchecked(),
         )
         .await
         .extend()

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -462,11 +462,13 @@ impl Query {
         filter: Option<EventFilter>,
     ) -> Result<Connection<String, Event>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
+        let Watermark { hi_cp, lo_tx, .. } = *ctx.data()?;
         Event::paginate(
             ctx.data_unchecked(),
             page,
             filter.unwrap_or_default(),
-            ctx.data_unchecked(),
+            hi_cp,
+            lo_tx,
         )
         .await
         .extend()

--- a/crates/sui-graphql-rpc/src/types/query.rs
+++ b/crates/sui-graphql-rpc/src/types/query.rs
@@ -462,13 +462,13 @@ impl Query {
         filter: Option<EventFilter>,
     ) -> Result<Connection<String, Event>> {
         let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
-        let Watermark { hi_cp, lo_tx, .. } = *ctx.data()?;
+        let Watermark { lo_tx, hi_cp, .. } = *ctx.data()?;
         Event::paginate(
             ctx.data_unchecked(),
             page,
             filter.unwrap_or_default(),
-            hi_cp,
             lo_tx,
+            hi_cp,
         )
         .await
         .extend()


### PR DESCRIPTION
## Description 

Watermark task now reads from watermarks table instead of checkpoints table. This is used for Event::paginate, so we can correctly bound the available range of data

## Test plan 

Pointed local graphql to current mainnet db. Ran the query below:
```
query Event {
  events(filter:{eventType:"0x3::validator::StakingRequestEvent"})
  {
    pageInfo {
      hasNextPage
      endCursor
    }
    nodes {
      sendingModule {
        name
        package {
          address
        }
      }
      sender {
        address
      }
      contents {
        json
      }
      
      timestamp
    }
  }
}
```

Received expected page of results instead of erroneous result,
```
{
  "data": {
    "events": {
      "pageInfo": {
        "hasNextPage": true,
        "endCursor": null
      },
      "nodes": []
    }
  }
}
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
