### PR TITLE
[consensus] Enable zstd compression for consensus tonic network in mainnet

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -215,7 +215,7 @@ const MAX_PROTOCOL_VERSION: u64 = 74;
 //             Enable probing for accepted rounds in round prober in mainnet
 // Version 74: Enable load_nitro_attestation move function in sui framework in devnet.
 //             Enable all gas costs for load_nitro_attestation.
-//
+//             Enable zstd compression for consensus tonic network in mainnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -3237,6 +3237,9 @@ impl ProtocolConfig {
                     cfg.nitro_attestation_parse_cost_per_byte = Some(50);
                     cfg.nitro_attestation_verify_base_cost = Some(49632 * 50);
                     cfg.nitro_attestation_verify_cost_per_cert = Some(52369 * 50);
+
+                    // Enable zstd compression for consensus in mainnet
+                    cfg.feature_flags.consensus_zstd_compression = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_74.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_74.snap
@@ -70,6 +70,7 @@ feature_flags:
   native_charging_v2: true
   convert_type_argument_error: true
   variant_nodes: true
+  consensus_zstd_compression: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000


### PR DESCRIPTION
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [X] Protocol: Enable zstd compression for consensus tonic network in mainnet
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
