### PR TITLE
[child effects refactor] Cleanup protocol config checks

### DIFF
--- a/sui-execution/latest/sui-move-natives/src/object_runtime/object_store.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/object_store.rs
@@ -595,20 +595,7 @@ impl<'a> ChildObjectStore<'a> {
                         ),
                 );
             }
-            if self.inner.protocol_config.loaded_child_object_format() {
-                // double check format did not change
-                if !self.inner.protocol_config.loaded_child_object_format_type() && child_ty != &ty
-                {
-                    let msg = format!("Type changed for child {child} when setting the value back");
-                    return Err(
-                        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                            .with_message(msg),
-                    );
-                }
-                value
-            } else {
-                GlobalValue::none()
-            }
+            value
         } else {
             GlobalValue::none()
         };

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/object_store.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/object_store.rs
@@ -582,7 +582,7 @@ impl<'a> ChildObjectStore<'a> {
                 ));
         };
 
-        let mut value = if let Some(ChildObject { ty, value, .. }) = self.store.remove(&child) {
+        let mut value = if let Some(ChildObject { value, .. }) = self.store.remove(&child) {
             if value.exists()? {
                 return Err(
                     PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)


### PR DESCRIPTION
## Description 

- `loaded_child_object_format` and `loaded_child_object_format_type` are always true in this execution version

## Test plan 

- Ran tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
