### PR TITLE
[indexer-alt] modify coin balance bucket index to sort object id in descending order

### DIFF
--- a/crates/sui-indexer-alt-schema/migrations/2025-02-05-232254_coin_balance_buckets_object_id_desc/down.sql
+++ b/crates/sui-indexer-alt-schema/migrations/2025-02-05-232254_coin_balance_buckets_object_id_desc/down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS coin_balances_buckets_object_id_desc;
+
+CREATE INDEX IF NOT EXISTS coin_balances_buckets_owner_type
+ON coin_balance_buckets (owner_kind, owner_id, coin_type, coin_balance_bucket DESC, cp_sequence_number DESC, object_id);

--- a/crates/sui-indexer-alt-schema/migrations/2025-02-05-232254_coin_balance_buckets_object_id_desc/up.sql
+++ b/crates/sui-indexer-alt-schema/migrations/2025-02-05-232254_coin_balance_buckets_object_id_desc/up.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS coin_balances_buckets_owner_type;
+
+CREATE INDEX IF NOT EXISTS coin_balances_buckets_object_id_desc
+ON coin_balance_buckets (owner_kind, owner_id, coin_type, coin_balance_bucket DESC, cp_sequence_number DESC, object_id DESC);


### PR DESCRIPTION

## Description 

As titled. This way we can more efficiently fetch coin balances and use the index to its fullest potential like in #20931.
 
## Test plan 

Existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
