### PR TITLE
fix(vscode-extension): stop lsp before extension deactivation #20478

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/src/main.ts
+++ b/external-crates/move/crates/move-analyzer/editors/code/src/main.ts
@@ -144,3 +144,8 @@ export async function activate(extensionContext: Readonly<vscode.ExtensionContex
 
     context.registerOnDidChangeConfiguration();
 }
+
+export async function deactivate(extensionContext: Readonly<vscode.ExtensionContext>): Promise<void> {
+    const context = new Context(extensionContext);
+    return context.stopClient();
+}


### PR DESCRIPTION
## Description 
Every time the vscode extension started the `move analyzer` never terminated.
Added deactivation of the client interacting with the language server.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
