### PR TITLE
[move][move-vm][rewrite][cleanup 2/n] Use arena allocation across the entire runtime AST

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/cache/arena.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/cache/arena.rs
@@ -51,6 +51,14 @@ impl Arena {
             Err(PartialVMError::new(StatusCode::PACKAGE_ARENA_LIMIT_REACHED))
         }
     }
+
+    pub fn alloc_item<T>(&self, item: T) -> PartialVMResult<*const T> {
+        if let Ok(value) = self.0.try_alloc(item) {
+            Ok(value)
+        } else {
+            Err(PartialVMError::new(StatusCode::PACKAGE_ARENA_LIMIT_REACHED))
+        }
+    }
 }
 
 // -----------------------------------------------

--- a/external-crates/move/crates/move-vm-runtime/src/cache/arena.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/cache/arena.rs
@@ -14,6 +14,16 @@ use bumpalo::Bump;
 
 pub struct Arena(Bump);
 
+/// An arena-allocated vector. Notably, `Drop` does not drop the elements it holds, as that is the
+/// perview of the arena it was allocated in.
+#[derive(Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ArenaVec<T>(std::mem::ManuallyDrop<Vec<T>>);
+
+/// An arena-allocated vector. Notably, `Drop` does not drop the value it holds, as that is the
+/// perview of the arena it was allocated in.
+#[derive(Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ArenaBox<T>(std::mem::ManuallyDrop<Box<T>>);
+
 /// Size of a package arena.
 /// This is 10 megabytes, which should be more than enough room for any pacakge on chain.
 /// FIXME: Test this limit and validate. See how large packages are in backtesting and double that
@@ -37,16 +47,35 @@ impl Arena {
         Arena(Bump::new())
     }
 
-    /// SAFETY: it is the caller's responsibility to ensure that `self` is not shared across
-    /// threads during this call. This should be fine as the translation step that uses an arena
-    /// should happen in a thread that holds that arena, with no other contention for allocation
-    /// into it, and nothing should allocate into a LoadedModule after it is loaded.
-    pub fn alloc_slice<T>(
+    /// SAFETY:
+    /// 1. It is the caller's responsibility to ensure that `self` is not shared across threads
+    ///    during this call.
+    /// 2. This vector is allocated in the arena, and thus even it is dropped its memory will not
+    ///    be reclaimed until the arena is discarded.
+    pub fn alloc_vec<T>(
         &self,
         items: impl ExactSizeIterator<Item = T>,
-    ) -> PartialVMResult<*mut [T]> {
+    ) -> PartialVMResult<ArenaVec<T>> {
+        let size = items.len();
         if let Ok(slice) = self.0.try_alloc_slice_fill_iter(items) {
-            Ok(slice)
+            Ok(ArenaVec(unsafe {
+                std::mem::ManuallyDrop::new(Vec::from_raw_parts(slice.as_mut_ptr(), size, size))
+            }))
+        } else {
+            Err(PartialVMError::new(StatusCode::PACKAGE_ARENA_LIMIT_REACHED))
+        }
+    }
+
+    /// SAFETY:
+    /// 1. It is the caller's responsibility to ensure that `self` is not shared across threads
+    ///    during this call.
+    /// 2. This box is allocated in the arena, and thus even it is dropped its memory will not be
+    ///    reclaimed until the arena is discarded.
+    pub fn alloc_box<T>(&self, item: T) -> PartialVMResult<ArenaBox<T>> {
+        if let Ok(slice) = self.0.try_alloc(item) {
+            Ok(ArenaBox(unsafe {
+                std::mem::ManuallyDrop::new(Box::from_raw(slice as *mut T))
+            }))
         } else {
             Err(PartialVMError::new(StatusCode::PACKAGE_ARENA_LIMIT_REACHED))
         }
@@ -61,12 +90,59 @@ impl Arena {
     }
 }
 
-// -----------------------------------------------
+impl<T> ArenaVec<T> {
+    pub fn iter(&self) -> std::slice::Iter<T> {
+        self.0.iter()
+    }
+
+    /// Returns an iterator over mutable references.
+    /// Crate-only because nobody else should be modifying arena values.
+    pub(crate) fn iter_mut(&mut self) -> std::slice::IterMut<T> {
+        self.0.iter_mut()
+    }
+
+    /// Make an empty ArenaVec
+    pub fn empty() -> Self {
+        ArenaVec(std::mem::ManuallyDrop::new(vec![]))
+    }
+}
+
+impl<T> ArenaBox<T> {
+    pub fn as_ref(&self) -> &T {
+        &self.0
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
 // Trait Implementations
-// -----------------------------------------------
+// -------------------------------------------------------------------------------------------------
 
 // SAFETY: these are okay, if callers follow the documented safety requirements for `Arena`'s
 // unsafe methods.
 
 unsafe impl Send for Arena {}
 unsafe impl Sync for Arena {}
+
+// -----------------------------------------------
+// ArenaVec Trait Implementations
+// -----------------------------------------------
+
+impl<T> std::ops::Deref for ArenaVec<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+// -----------------------------------------------
+// ArenaVec Trait Implementations
+// -----------------------------------------------
+
+impl<T> std::ops::Deref for ArenaBox<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/external-crates/move/crates/move-vm-runtime/src/cache/move_cache.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/cache/move_cache.rs
@@ -103,7 +103,7 @@ impl Package {
     /// Used for testing that the correct number of types are loaded
     #[allow(dead_code)]
     pub(crate) fn loaded_types_len(&self) -> usize {
-        self.runtime.vtable.types.cached_types.len()
+        self.runtime.vtable.types.len()
     }
 }
 

--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/eval.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/eval.rs
@@ -255,7 +255,7 @@ fn step(
                     None,
                 )
             });
-            call_function(state, run_context, gas_meter, *function, vec![])?;
+            call_function(state, run_context, gas_meter, function.ptr_clone(), vec![])?;
             Ok(StepStatus::Running)
         }
         _ => {
@@ -447,7 +447,7 @@ fn op_step_impl(
         Bytecode::LdConst(idx) => {
             let constant = state.call_stack.current_frame.resolver.constant_at(*idx);
             gas_meter.charge_ld_const(NumBytes::new(constant.size))?;
-            let val = constant.value.clone().to_value();
+            let val = constant.value.to_value();
             gas_meter.charge_ld_const_after_deserialization(&val)?;
             state.push_operand(val)?
         }
@@ -930,7 +930,7 @@ fn call_type_to_function(
     call_type: &CallType,
 ) -> PartialVMResult<VMPointer<Function>> {
     match call_type {
-        CallType::Direct(ptr) => Ok(*ptr),
+        CallType::Direct(ptr) => Ok(ptr.ptr_clone()),
         CallType::Virtual(vtable_key) => run_context.vtables.resolve_function(vtable_key),
     }
 }

--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/eval.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/eval.rs
@@ -45,7 +45,7 @@ enum StepStatus {
 }
 
 struct RunContext<'vm_cache, 'native, 'native_lifetimes, 'tracer, 'trace_builder> {
-    vtables: &'vm_cache VMDispatchTables,
+    vtables: &'vm_cache mut VMDispatchTables,
     vm_config: Arc<VMConfig>,
     extensions: &'native mut NativeContextExtensions<'native_lifetimes>,
     // TODO: consider making this `Option<&mut VMTracer<'_>>` and passing it like that everywhere?
@@ -66,7 +66,7 @@ impl RunContext<'_, '_, '_, '_, '_> {
 /// calling `step`, until the call stack is empty.
 pub(super) fn run(
     start_state: MachineState,
-    vtables: &VMDispatchTables,
+    vtables: &mut VMDispatchTables,
     vm_config: Arc<VMConfig>,
     extensions: &mut NativeContextExtensions,
     tracer: &mut Option<VMTracer<'_>>,
@@ -1207,7 +1207,7 @@ fn partial_error_to_error<T>(
     })
 }
 
-fn check_depth_of_type(run_context: &RunContext, ty: &Type) -> PartialVMResult<u64> {
+fn check_depth_of_type(run_context: &mut RunContext, ty: &Type) -> PartialVMResult<u64> {
     let Some(max_depth) = run_context
         .vm_config
         .runtime_limits_config
@@ -1219,7 +1219,7 @@ fn check_depth_of_type(run_context: &RunContext, ty: &Type) -> PartialVMResult<u
 }
 
 fn check_depth_of_type_impl(
-    run_context: &RunContext,
+    run_context: &mut RunContext,
     ty: &Type,
     current_depth: u64,
     max_depth: u64,

--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/mod.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/mod.rs
@@ -24,7 +24,7 @@ pub(crate) mod state;
 /// Entrypoint into the interpreter. All external calls need to be routed through this
 /// function.
 pub(crate) fn run(
-    vtables: &VMDispatchTables,
+    vtables: &mut VMDispatchTables,
     vm_config: Arc<VMConfig>,
     extensions: &mut NativeContextExtensions,
     tracer: &mut Option<VMTracer<'_>>,

--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/state.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/state.rs
@@ -192,7 +192,7 @@ impl MachineState {
         // a verification error cannot happen at runtime so change it into an invariant violation.
         let err = if err.status_type() == StatusType::Verification {
             error!("Verification error during runtime: {:?}", err);
-            let new_err = PartialVMError::new(StatusCode::VERIFICATION_ERROR);
+            let new_err = PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR);
             let new_err = match err.message() {
                 None => new_err.with_message("No message provided for core dump".to_owned()),
                 Some(msg) => new_err.with_message(msg.to_owned()),

--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/state.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/state.rs
@@ -189,7 +189,6 @@ impl MachineState {
     /// Given an `VMStatus` generate a core dump if the error is an `InvariantViolation`. Uses the
     /// `current_frame` on the state to perform the core dump.
     pub fn maybe_core_dump(&self, err: VMError) -> VMError {
-        // a verification error cannot happen at runtime so change it into an invariant violation.
         let err = if err.status_type() == StatusType::Verification {
             error!("Verification error during runtime: {:?}", err);
             let new_err = PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR);

--- a/external-crates/move/crates/move-vm-runtime/src/execution/tracing/tracer.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/tracing/tracer.rs
@@ -3,11 +3,10 @@
 
 use crate::{
     execution::{
-        dispatch_tables::{subst, VMDispatchTables},
-        interpreter::state::MachineState,
+        dispatch_tables::VMDispatchTables, interpreter::state::MachineState,
         values::Value as RuntimeValue,
     },
-    jit::execution::ast::{Function, Type},
+    jit::execution::ast::{ArenaType, Function, Type, TypeSubst},
 };
 use move_binary_format::{
     errors::{PartialVMError, VMError, VMResult},
@@ -1637,8 +1636,8 @@ impl FunctionTypeInfo {
             }
         }
 
-        let subst_and_layout_type = |ty: &Type| -> Option<TagWithLayoutInfoOpt> {
-            let subst_ty = subst(ty, ty_args).ok()?;
+        let subst_and_layout_type = |ty: &ArenaType| -> Option<TagWithLayoutInfoOpt> {
+            let subst_ty = ty.subst(ty_args).ok()?;
             let (ty, ref_type) = deref_ty(subst_ty);
             let tag = vtables.type_to_type_tag(&ty).ok()?;
             // NB: This may fail if the type represents a value greater than the max
@@ -1696,5 +1695,7 @@ fn get_constant_type_layout(
         .current_frame
         .resolver
         .constant_at(const_ndx);
-    vtables.type_to_fully_annotated_layout(&constant.type_).ok()
+    vtables
+        .arena_type_to_fully_annotated_layout(&constant.type_)
+        .ok()
 }

--- a/external-crates/move/crates/move-vm-runtime/src/execution/values/values_impl.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/values/values_impl.rs
@@ -206,7 +206,7 @@ pub struct VariantRef(VMPointer<Container>);
 
 /// Constant representation of a Move value.
 #[derive(Debug)]
-pub enum ConstantValue {
+pub(crate) enum ConstantValue {
     U8(u8),
     U16(u16),
     U32(u32),
@@ -221,7 +221,7 @@ pub enum ConstantValue {
 /// A container is a collection of constant values. It is used to represent data structures like a
 /// Move vector or struct.
 #[derive(Debug)]
-pub enum ConstantContainer {
+pub(crate) enum ConstantContainer {
     Vec(ArenaVec<ConstantValue>),
     Struct(ArenaVec<ConstantValue>),
     VecU8(ArenaVec<u8>),
@@ -442,7 +442,7 @@ impl Reference {
 
 impl Value {
     /// Allocates the constant in the provided arena
-    pub fn to_constant_value(self, arena: &Arena) -> PartialVMResult<ConstantValue> {
+    pub(crate) fn to_constant_value(self, arena: &Arena) -> PartialVMResult<ConstantValue> {
         match self {
             Value::Invalid => Err(PartialVMError::new(
                 StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
@@ -468,7 +468,7 @@ impl Value {
 
 impl Container {
     /// Allocates the constant in the provided arena
-    pub fn to_constant_value(self, arena: &Arena) -> PartialVMResult<ConstantValue> {
+    pub(crate) fn to_constant_value(self, arena: &Arena) -> PartialVMResult<ConstantValue> {
         macro_rules! alloc_vec {
             ($values:expr) => {
                 arena.alloc_vec($values.into_iter())?
@@ -517,7 +517,7 @@ impl Container {
 
 impl ConstantValue {
     /// Performs a deep copy of the constant value
-    pub fn to_value(&self) -> Value {
+    pub(crate) fn to_value(&self) -> Value {
         match self {
             // TODO: auto-gen this?
             ConstantValue::U8(value) => Value::U8(*value),
@@ -537,7 +537,7 @@ impl ConstantValue {
 
 impl ConstantContainer {
     /// Performs a deep copy of the constant value
-    pub fn to_container(&self) -> Container {
+    pub(crate) fn to_container(&self) -> Container {
         macro_rules! clone_vec {
             ($vec:expr) => {
                 $vec.iter().map(|v| *v).collect()

--- a/external-crates/move/crates/move-vm-runtime/src/execution/vm.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/vm.rs
@@ -7,7 +7,7 @@ use crate::{
         dispatch_tables::VMDispatchTables,
         interpreter::{self, locals::BaseHeap},
     },
-    jit::execution::ast::{Function, Type},
+    jit::execution::ast::{Function, Type, TypeSubst},
     natives::extensions::NativeContextExtensions,
     shared::{
         gas::GasMeter,
@@ -276,10 +276,13 @@ impl<'extensions> MoveVM<'extensions> {
 
         let fun_ref = function.to_ref();
 
-        // See TODO on LoadedModule to avoid this work
-        let parameters = fun_ref.parameters.clone();
+        let parameters = fun_ref
+            .parameters
+            .into_iter()
+            .map(|ty| ty.to_type())
+            .collect();
 
-        let return_ = fun_ref.return_.clone();
+        let return_ = fun_ref.return_.into_iter().map(|ty| ty.to_type()).collect();
 
         // verify type arguments
         self.virtual_tables

--- a/external-crates/move/crates/move-vm-runtime/src/execution/vm.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/vm.rs
@@ -337,7 +337,7 @@ impl<'extensions> MoveVM<'extensions> {
             .map_err(|err| err.finish(Location::Undefined))?;
 
         let return_values = interpreter::run(
-            &self.virtual_tables,
+            &mut self.virtual_tables,
             self.vm_config.clone(),
             &mut self.native_extensions,
             tracer,

--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
@@ -45,6 +45,7 @@ pub struct Package {
 
     // NB: this is under the package's context so we don't need to further resolve by
     // address in this table.
+    // TODO(vm-rewrite): IdentifierKey
     pub loaded_modules: BinaryCache<Identifier, Module>,
 
     // NB: Package functions and code are allocated into this arena.
@@ -136,6 +137,7 @@ pub struct Function {
     pub native: Option<NativeFunction>,
     pub def_is_native: bool,
     pub module: ModuleId,
+    // TODO(vm-rewrite): IdentifierKey
     pub name: Identifier,
     pub locals_len: usize,
     pub jump_tables: Vec<VariantJumpTable>,
@@ -257,6 +259,7 @@ pub enum Type {
 pub struct DatatypeDescriptor {
     pub abilities: AbilitySet,
     pub type_parameters: Vec<DatatypeTyParameter>,
+    // TODO(vm-rewrite): IdentifierKey
     pub name: Identifier,
     pub defining_id: ModuleId,
     pub runtime_id: ModuleId,
@@ -279,6 +282,7 @@ pub struct EnumType {
 
 #[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct VariantType {
+    // TODO(vm-rewrite): IdentifierKey
     pub variant_name: Identifier,
     pub fields: Vec<Type>,
     pub field_names: Vec<Identifier>,

--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
@@ -49,11 +49,11 @@ pub struct Package {
     // NB: this is under the package's context so we don't need to further resolve by
     // address in this table.
     // TODO(vm-rewrite): IdentifierKey
-    pub loaded_modules: BTreeMap<Identifier, Module>,
+    pub(crate) loaded_modules: BTreeMap<Identifier, Module>,
 
     // NB: Package functions and code are allocated into this arena.
-    pub package_arena: Arena,
-    pub vtable: PackageVirtualTable,
+    pub(crate) package_arena: Arena,
+    pub(crate) vtable: PackageVirtualTable,
 }
 
 // A LoadedModule is very similar to a CompiledModule but data is "transformed" to a representation
@@ -61,7 +61,7 @@ pub struct Package {
 // When code executes indexes in instructions are resolved against those runtime structure
 // so that any data needed for execution is immediately available
 #[derive(Debug)]
-pub struct Module {
+pub(crate) struct Module {
     #[allow(dead_code)]
     pub id: ModuleId,
 
@@ -132,7 +132,7 @@ pub struct Module {
 
 // A runtime constant
 #[derive(Debug)]
-pub struct Constant {
+pub(crate) struct Constant {
     pub value: ConstantValue,
     pub type_: ArenaType,
     // Size of constant -- used for gas charging.
@@ -142,7 +142,7 @@ pub struct Constant {
 // A runtime function
 // #[derive(Debug)]
 // https://github.com/rust-lang/rust/issues/70263
-pub struct Function {
+pub(crate) struct Function {
     #[allow(unused)]
     pub file_format_version: u32,
     pub is_entry: bool,
@@ -174,7 +174,7 @@ pub struct Function {
 //   (e.g., intra-package calls, or possibly calls to framework/well-known external packages).
 // - Virtual: the function is unknown and the index is the index in the global table of vtables
 //   that will be filled in at a later time before execution.
-pub enum CallType {
+pub(crate) enum CallType {
     Direct(VMPointer<Function>),
     Virtual(VirtualTableKey),
 }
@@ -254,7 +254,7 @@ pub struct VariantDef {
 // -------------------------------------------------------------------------------------------------
 
 #[derive(Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub enum ArenaType {
+pub(crate) enum ArenaType {
     Bool,
     U8,
     U64,
@@ -276,14 +276,14 @@ pub enum ArenaType {
 #[derive(Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct DatatypeDescriptor {
     pub abilities: AbilitySet,
-    pub type_parameters: ArenaVec<DatatypeTyParameter>,
+    pub(crate) type_parameters: ArenaVec<DatatypeTyParameter>,
     // TODO(vm-rewrite): IdentifierKey
     pub name: Identifier,
     pub defining_id: ModuleId,
     pub runtime_id: ModuleId,
     pub module_key: IdentifierKey,
     pub member_key: IdentifierKey,
-    pub datatype_info: VMPointer<Datatype>,
+    pub(crate) datatype_info: VMPointer<Datatype>,
 }
 
 #[derive(Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -294,7 +294,7 @@ pub enum Datatype {
 
 #[derive(Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct EnumType {
-    pub variants: ArenaVec<VariantType>,
+    pub(crate) variants: ArenaVec<VariantType>,
     pub enum_def: EnumDefinitionIndex,
 }
 
@@ -302,16 +302,16 @@ pub struct EnumType {
 pub struct VariantType {
     // TODO(vm-rewrite): IdentifierKey
     pub variant_name: Identifier,
-    pub fields: ArenaVec<ArenaType>,
-    pub field_names: ArenaVec<Identifier>,
+    pub(crate) fields: ArenaVec<ArenaType>,
+    pub(crate) field_names: ArenaVec<Identifier>,
     pub enum_def: EnumDefinitionIndex,
     pub variant_tag: VariantTag,
 }
 
 #[derive(Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct StructType {
-    pub fields: ArenaVec<ArenaType>,
-    pub field_names: ArenaVec<Identifier>,
+    pub(crate) fields: ArenaVec<ArenaType>,
+    pub(crate) field_names: ArenaVec<Identifier>,
     pub struct_def: StructDefinitionIndex,
 }
 
@@ -348,7 +348,7 @@ pub enum Type {
 /// Bytecodes operate on a stack machine and each bytecode has side effect on the stack and the
 /// instruction stream.
 #[derive(Eq, PartialEq)]
-pub enum Bytecode {
+pub(crate) enum Bytecode {
     /// Pop and discard the value at the top of the stack.
     /// The value on the stack must be an copyable type.
     ///

--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
@@ -289,10 +289,8 @@ fn record_module_types_in_vtable(
 ) {
     for (key, descriptor) in datatype_descriptors {
         let descriptor_ptr = VMPointer::from_ref(descriptor);
-        debug_assert!(
-            vtable.types.insert(*key, descriptor_ptr).is_none(),
-            "Double insert for datatype"
-        );
+        let _prev = vtable.types.insert(*key, descriptor_ptr);
+        debug_assert!(_prev.is_none(), "Double insert for datatype");
     }
 }
 
@@ -328,9 +326,7 @@ fn structs(
         .iter()
         .map(|struct_def| {
             let key = type_refs[struct_def.struct_handle.0 as usize];
-            let Some(type_) = datatype_descriptors.get(&key) else {
-                panic!("did not find struct {}", key.to_string()?);
-            };
+            let type_ = &datatype_descriptors[&key];
             let struct_type = type_.get_struct()?;
             let field_count = struct_type.fields.len() as u16;
             Ok(StructDef {
@@ -380,9 +376,7 @@ fn enums(
         .iter()
         .map(|enum_def| {
             let key = type_refs[enum_def.enum_handle.0 as usize];
-            let Some(type_) = datatype_descriptors.get(&key) else {
-                panic!("did not find enum {}", key.to_string()?);
-            };
+            let type_ = &datatype_descriptors[&key];
             let enum_type = type_.get_enum()?;
             let variant_count = enum_type.variants.len() as u16;
             let variants = enum_type
@@ -952,10 +946,9 @@ fn load_module_types(
             module_key: module_name,
             member_key: member_name,
         };
+        let _prev = datatype_descriptors.insert(struct_key, datatype_descriptor);
         debug_assert!(
-            datatype_descriptors
-                .insert(struct_key, datatype_descriptor)
-                .is_none(),
+            _prev.is_none(),
             "double-insert of datatype {}",
             struct_key.to_string()?
         );
@@ -1027,10 +1020,9 @@ fn load_module_types(
             module_key: module_name,
             member_key: member_name,
         };
+        let _prev = datatype_descriptors.insert(enum_key, datatype_descriptor);
         debug_assert!(
-            datatype_descriptors
-                .insert(enum_key, datatype_descriptor)
-                .is_none(),
+            _prev.is_none(),
             "double-insert of datatype {}",
             enum_key.to_string()?
         );

--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
@@ -223,7 +223,7 @@ fn module(
     // Initialize module data
     let type_refs = initialize_type_refs(package_context, &cmodule)?;
 
-    let (instantiation_signatures, _signature_map) = cache_signatures(package_context, &cmodule)?;
+    let instantiation_signatures = cache_signatures(package_context, &cmodule)?;
 
     let structs = structs(package_context, &cmodule, &type_refs, &descriptor_map)?;
     let enums = enums(package_context, &cmodule, &type_refs, &descriptor_map)?;
@@ -477,10 +477,9 @@ fn field_instantiations(
 fn cache_signatures(
     context: &mut PackageContext<'_>,
     module: &CompiledModule,
-) -> PartialVMResult<(
+) -> PartialVMResult<
     ArenaVec<ArenaVec<ArenaType>>,
-    BTreeMap<SignatureIndex, VMPointer<ArenaVec<ArenaType>>>,
-)> {
+> {
     let signatures = module
         .signatures()
         .iter()
@@ -494,12 +493,7 @@ fn cache_signatures(
         })
         .collect::<PartialVMResult<Vec<_>>>()?;
     let signatures = context.arena_vec(signatures.into_iter())?;
-    let signature_map = signatures
-        .iter()
-        .enumerate()
-        .map(|(ndx, entry)| (SignatureIndex::new(ndx as u16), VMPointer::from_ref(entry)))
-        .collect::<BTreeMap<_, _>>();
-    Ok((signatures, signature_map))
+    Ok(signatures)
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -983,7 +977,7 @@ fn load_module_types(
             module_key: module_name,
             member_key: member_name,
         };
-        let _prev = datatype_descriptors.push(datatype_descriptor);
+        datatype_descriptors.push(datatype_descriptor);
     }
 
     for (idx, enum_def) in module.enum_defs().iter().enumerate() {
@@ -1060,7 +1054,7 @@ fn load_module_types(
             module_key: module_name,
             member_key: member_name,
         };
-        let _prev = datatype_descriptors.push(datatype_descriptor);
+        datatype_descriptors.push(datatype_descriptor);
     }
 
     let datatype_descriptors = package_context.arena_vec(datatype_descriptors.into_iter())?;

--- a/external-crates/move/crates/move-vm-runtime/src/shared/mod.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/shared/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
+
 pub mod binary_cache;
 pub mod constants;
 pub mod data_store;
@@ -19,4 +21,19 @@ macro_rules! try_block {
             $($body)*
         })()
     }};
+}
+
+/// Either returns a BTreeMap of unique keys, or a repeated key if the input keys are not unique.
+pub fn unique_map<Key: Ord, Value>(
+    values: impl IntoIterator<Item = (Key, Value)>,
+) -> Result<BTreeMap<Key, Value>, Key> {
+    let mut map = BTreeMap::new();
+    for (k, v) in values {
+        if map.contains_key(&k) {
+            return Err(k);
+        } else {
+            map.insert(k, v);
+        }
+    }
+    Ok(map)
 }

--- a/external-crates/move/crates/move-vm-runtime/src/shared/vm_pointer.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/shared/vm_pointer.rs
@@ -112,14 +112,15 @@ impl<T: ::std::fmt::Debug> ::std::fmt::Debug for VMPointer<T> {
     }
 }
 
-// Pointer equality
-impl<T> PartialEq for VMPointer<T> {
+// VMPointer equality first checks pointer equality, then full equality
+impl<T: PartialEq> PartialEq for VMPointer<T> {
     fn eq(&self, other: &Self) -> bool {
-        self.ptr_eq(other)
+        self.ptr_eq(other) || self.to_ref().eq(other.to_ref())
     }
 }
 
-impl<T> Eq for VMPointer<T> {}
+// VMPointer equality first checks pointer equality, then full equality
+impl<T: Eq> Eq for VMPointer<T> {}
 
 impl<T> Clone for VMPointer<T> {
     #[allow(clippy::non_canonical_clone_impl)]
@@ -137,5 +138,23 @@ impl<T> From<Box<T>> for VMPointer<T> {
 
         // Create an `ArenaPointer` from the raw pointer.
         VMPointer(raw_ptr)
+    }
+}
+
+impl<T: PartialOrd> PartialOrd for VMPointer<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.to_ref().partial_cmp(other.to_ref())
+    }
+}
+
+impl<T: Ord> Ord for VMPointer<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.to_ref().cmp(other.to_ref())
+    }
+}
+
+impl<T: std::hash::Hash> std::hash::Hash for VMPointer<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.to_ref().hash(state)
     }
 }

--- a/external-crates/move/crates/move-vm-runtime/src/shared/vm_pointer.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/shared/vm_pointer.rs
@@ -29,13 +29,13 @@ impl<T> VMPointer<T> {
     }
 
     #[inline]
-    pub fn to_ref<'a>(self) -> &'a T {
-        to_ref(self.ptr_clone().0)
+    pub fn to_ref<'a>(&self) -> &'a T {
+        to_ref(self.0)
     }
 
     #[inline]
-    pub fn to_mut_ref<'a>(self) -> &'a mut T {
-        to_mut_ref(self.ptr_clone().0)
+    pub fn to_mut_ref<'a>(&self) -> &'a mut T {
+        to_mut_ref(self.0)
     }
 
     #[inline]
@@ -122,15 +122,6 @@ impl<T: PartialEq> PartialEq for VMPointer<T> {
 // VMPointer equality first checks pointer equality, then full equality
 impl<T: Eq> Eq for VMPointer<T> {}
 
-impl<T> Clone for VMPointer<T> {
-    #[allow(clippy::non_canonical_clone_impl)]
-    fn clone(&self) -> Self {
-        self.ptr_clone()
-    }
-}
-
-impl<T> Copy for VMPointer<T> {}
-
 impl<T> From<Box<T>> for VMPointer<T> {
     fn from(boxed: Box<T>) -> Self {
         // Use `Box::into_raw` to extract the raw pointer from the box.
@@ -156,5 +147,13 @@ impl<T: Ord> Ord for VMPointer<T> {
 impl<T: std::hash::Hash> std::hash::Hash for VMPointer<T> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.to_ref().hash(state)
+    }
+}
+
+impl<T> std::ops::Deref for VMPointer<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.to_ref()
     }
 }

--- a/external-crates/move/crates/move-vm-runtime/src/shared/vm_pointer.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/shared/vm_pointer.rs
@@ -132,17 +132,20 @@ impl<T> From<Box<T>> for VMPointer<T> {
     }
 }
 
+// Written in terms of the underlying pointers to ensure determinism.
 impl<T: PartialOrd> PartialOrd for VMPointer<T> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.to_ref().partial_cmp(other.to_ref())
     }
 }
 
+// Written in terms of the underlying pointers to ensure determinism.
 impl<T: Ord> Ord for VMPointer<T> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.to_ref().cmp(other.to_ref())
     }
 }
+// Written in terms of the underlying pointers to ensure determinism.
 
 impl<T: std::hash::Hash> std::hash::Hash for VMPointer<T> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/loader_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/loader_tests.rs
@@ -201,7 +201,7 @@ impl Adapter {
         struct_name: &IdentStr,
     ) -> DepthFormula {
         let vm = self.runtime_adapter.write();
-        let session = vm.make_vm(self.store.linkage.clone()).unwrap();
+        let mut session = vm.make_vm(self.store.linkage.clone()).unwrap();
         session
             .virtual_tables
             .calculate_depth_of_type(&VirtualTableKey {
@@ -229,6 +229,7 @@ impl Adapter {
 
     fn call_functions(&self, functions: &[(ModuleId, Identifier)]) {
         for (module_id, name) in functions {
+            println!("calling {name}");
             self.call_function(module_id, name);
         }
     }

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/loader_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/loader_tests.rs
@@ -229,7 +229,6 @@ impl Adapter {
 
     fn call_functions(&self, functions: &[(ModuleId, Identifier)]) {
         for (module_id, name) in functions {
-            println!("calling {name}");
             self.call_function(module_id, name);
         }
     }

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/package_cache_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/package_cache_tests.rs
@@ -1,4 +1,3 @@
-// Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
@@ -43,7 +42,7 @@ fn cache_package_internal_package_calls_only_no_types() {
     // Verify that we've loaded the package correctly
     let result = result.unwrap();
     let l_pkg = result.first_key_value().unwrap().1;
-    assert_eq!(l_pkg.runtime.loaded_modules.binaries.len(), 3);
+    assert_eq!(l_pkg.runtime.loaded_modules.len(), 3);
     assert_eq!(l_pkg.runtime.storage_id, package_address);
     assert_eq!(l_pkg.runtime.vtable.functions.len(), 3);
 }
@@ -62,7 +61,7 @@ fn cache_package_internal_package_calls_only_with_types() {
     // Verify that we've loaded the package correctly
     let result = result.unwrap();
     let l_pkg = result.first_key_value().unwrap().1;
-    assert_eq!(l_pkg.runtime.loaded_modules.binaries.len(), 3);
+    assert_eq!(l_pkg.runtime.loaded_modules.len(), 3);
     assert_eq!(l_pkg.runtime.storage_id, package_address);
     assert_eq!(l_pkg.runtime.vtable.functions.len(), 3);
 }
@@ -82,12 +81,12 @@ fn cache_package_external_package_calls_no_types() {
     // Verify that we've loaded the packages correctly
     let results = result.unwrap();
     let l_pkg = results.get(&package1_address).unwrap();
-    assert_eq!(l_pkg.runtime.loaded_modules.binaries.len(), 2);
+    assert_eq!(l_pkg.runtime.loaded_modules.len(), 2);
     assert_eq!(l_pkg.runtime.storage_id, package1_address);
     assert_eq!(l_pkg.runtime.vtable.functions.len(), 2);
 
     let l_pkg = results.get(&package2_address).unwrap();
-    assert_eq!(l_pkg.runtime.loaded_modules.binaries.len(), 1);
+    assert_eq!(l_pkg.runtime.loaded_modules.len(), 1);
     assert_eq!(l_pkg.runtime.storage_id, package2_address);
     assert_eq!(l_pkg.runtime.vtable.functions.len(), 1);
 }
@@ -115,7 +114,7 @@ fn load_package_internal_package_calls_only_no_types() {
     let l_pkg = result.unwrap();
     assert_eq!(l_pkg.len(), 1);
     let l_pkg = l_pkg.get(&package_address).unwrap();
-    assert_eq!(l_pkg.runtime.loaded_modules.binaries.len(), 3);
+    assert_eq!(l_pkg.runtime.loaded_modules.len(), 3);
     assert_eq!(l_pkg.runtime.storage_id, package_address);
     assert_eq!(l_pkg.runtime.vtable.functions.len(), 3);
 }
@@ -135,7 +134,7 @@ fn load_package_internal_package_calls_only_with_types() {
     let l_pkg = result.unwrap();
     assert_eq!(l_pkg.len(), 1);
     let l_pkg = l_pkg.get(&package_address).unwrap();
-    assert_eq!(l_pkg.runtime.loaded_modules.binaries.len(), 3);
+    assert_eq!(l_pkg.runtime.loaded_modules.len(), 3);
     assert_eq!(l_pkg.runtime.storage_id, package_address);
     assert_eq!(l_pkg.runtime.vtable.functions.len(), 3);
     assert_eq!(l_pkg.runtime.vtable.types.len(), 0);
@@ -156,7 +155,7 @@ fn load_package_external_package_calls_no_types() {
     let l_pkg = result.unwrap();
     assert_eq!(l_pkg.len(), 2);
     let l_pkg = l_pkg.get(&package2_address).unwrap();
-    assert_eq!(l_pkg.runtime.loaded_modules.binaries.len(), 1);
+    assert_eq!(l_pkg.runtime.loaded_modules.len(), 1);
     assert_eq!(l_pkg.runtime.storage_id, package2_address);
     assert_eq!(l_pkg.runtime.vtable.functions.len(), 1);
 

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/package_cache_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/package_cache_tests.rs
@@ -138,7 +138,7 @@ fn load_package_internal_package_calls_only_with_types() {
     assert_eq!(l_pkg.runtime.loaded_modules.binaries.len(), 3);
     assert_eq!(l_pkg.runtime.storage_id, package_address);
     assert_eq!(l_pkg.runtime.vtable.functions.len(), 3);
-    assert_eq!(l_pkg.runtime.vtable.types.cached_types.len(), 0);
+    assert_eq!(l_pkg.runtime.vtable.types.len(), 0);
 }
 
 #[test]


### PR DESCRIPTION
## Description 

This introduces ArenaVec and ArenaBox types and uses them across the execution AST. This is to ensure that the allocated module is correctly dropped when the `bumpalo` arena is discarded.

## Test plan 

All move tests still pass.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
