### PR TITLE
[rpc-alt] set up bigtable kvstore and use it for objects + checkpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14223,6 +14223,7 @@ dependencies = [
  "sui-indexer-alt-schema",
  "sui-json",
  "sui-json-rpc-types",
+ "sui-kvstore",
  "sui-name-service",
  "sui-open-rpc",
  "sui-open-rpc-macros",

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_get_past_object.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_get_past_object.snap
@@ -82,12 +82,11 @@ Response: {
   "jsonrpc": "2.0",
   "id": 3,
   "result": {
-    "status": "ObjectDeleted",
-    "details": {
-      "objectId": "0xc442f9431f789a6c80078a63e707de84c7815c3150e08f1e44be256bd05a2b81",
-      "version": 4,
-      "digest": "7gyGAp71YXQRoxmFBaHxofQXAipvgHyBKPyxmdSJxyvz"
-    }
+    "status": "VersionNotFound",
+    "details": [
+      "0xc442f9431f789a6c80078a63e707de84c7815c3150e08f1e44be256bd05a2b81",
+      4
+    ]
   }
 }
 
@@ -132,11 +131,10 @@ Response: {
   "jsonrpc": "2.0",
   "id": 6,
   "result": {
-    "status": "ObjectDeleted",
-    "details": {
-      "objectId": "0xc442f9431f789a6c80078a63e707de84c7815c3150e08f1e44be256bd05a2b81",
-      "version": 4,
-      "digest": "7gyGAp71YXQRoxmFBaHxofQXAipvgHyBKPyxmdSJxyvz"
-    }
+    "status": "VersionNotFound",
+    "details": [
+      "0xc442f9431f789a6c80078a63e707de84c7815c3150e08f1e44be256bd05a2b81",
+      4
+    ]
   }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_multi_get_past_objects.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/objects/try_multi_get_past_objects.snap
@@ -119,12 +119,11 @@ Response: {
       }
     },
     {
-      "status": "ObjectDeleted",
-      "details": {
-        "objectId": "0x0dfe3bf8505600c374ecc59e9580d3504a37a14f65b53084ef86c5861f39cc3f",
-        "version": 8,
-        "digest": "7gyGAp71YXQRoxmFBaHxofQXAipvgHyBKPyxmdSJxyvz"
-      }
+      "status": "VersionNotFound",
+      "details": [
+        "0x0dfe3bf8505600c374ecc59e9580d3504a37a14f65b53084ef86c5861f39cc3f",
+        8
+      ]
     },
     {
       "status": "VersionNotFound",
@@ -227,12 +226,11 @@ Response: {
       }
     },
     {
-      "status": "ObjectDeleted",
-      "details": {
-        "objectId": "0x0dfe3bf8505600c374ecc59e9580d3504a37a14f65b53084ef86c5861f39cc3f",
-        "version": 8,
-        "digest": "7gyGAp71YXQRoxmFBaHxofQXAipvgHyBKPyxmdSJxyvz"
-      }
+      "status": "VersionNotFound",
+      "details": [
+        "0x0dfe3bf8505600c374ecc59e9580d3504a37a14f65b53084ef86c5861f39cc3f",
+        8
+      ]
     },
     {
       "status": "VersionNotFound",

--- a/crates/sui-indexer-alt-jsonrpc/Cargo.toml
+++ b/crates/sui-indexer-alt-jsonrpc/Cargo.toml
@@ -46,6 +46,7 @@ sui-indexer-alt-schema.workspace = true
 sui-json.workspace = true
 sui-json-rpc-types.workspace = true
 sui-name-service.workspace = true
+sui-kvstore.workspace = true
 sui-open-rpc.workspace = true
 sui-open-rpc-macros.workspace = true
 sui-package-resolver.workspace = true

--- a/crates/sui-indexer-alt-jsonrpc/src/api/checkpoints.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/checkpoints.rs
@@ -11,7 +11,6 @@ use sui_types::sui_serde::BigInt;
 
 use crate::{
     context::Context,
-    data::checkpoints::CheckpointKey,
     error::{invalid_params, InternalContext, RpcError},
 };
 
@@ -61,7 +60,7 @@ impl RpcModule for Checkpoints {
 async fn response(ctx: &Context, seq: u64) -> Result<Checkpoint, RpcError<Error>> {
     let (summary, contents, signature) = ctx
         .kv_loader()
-        .load_one_checkpoint(CheckpointKey(seq))
+        .load_one_checkpoint(seq)
         .await
         .context("Failed to load checkpoint")?
         .ok_or_else(|| invalid_params(Error::NotFound(seq)))?;

--- a/crates/sui-indexer-alt-jsonrpc/src/api/checkpoints.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/checkpoints.rs
@@ -4,15 +4,10 @@
 use anyhow::Context as _;
 
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use sui_indexer_alt_schema::checkpoints::StoredCheckpoint;
 use sui_json_rpc_types::Checkpoint;
 use sui_open_rpc::Module;
 use sui_open_rpc_macros::open_rpc;
-use sui_types::{
-    crypto::AuthorityQuorumSignInfo,
-    messages_checkpoint::{CheckpointContents, CheckpointSummary},
-    sui_serde::BigInt,
-};
+use sui_types::sui_serde::BigInt;
 
 use crate::{
     context::Context,
@@ -64,21 +59,12 @@ impl RpcModule for Checkpoints {
 
 /// Load a checkpoint and prepare it for presentation as a JSON-RPC response.
 async fn response(ctx: &Context, seq: u64) -> Result<Checkpoint, RpcError<Error>> {
-    let stored: StoredCheckpoint = ctx
-        .pg_loader()
-        .load_one(CheckpointKey(seq))
+    let (summary, contents, signature) = ctx
+        .kv_loader()
+        .load_one_checkpoint(CheckpointKey(seq))
         .await
         .context("Failed to load checkpoint")?
         .ok_or_else(|| invalid_params(Error::NotFound(seq)))?;
-
-    let summary: CheckpointSummary = bcs::from_bytes(&stored.checkpoint_summary)
-        .context("Failed to deserialize checkpoint summary")?;
-
-    let contents: CheckpointContents = bcs::from_bytes(&stored.checkpoint_contents)
-        .context("Failed to deserialize checkpoint contents")?;
-
-    let signature: AuthorityQuorumSignInfo<true> = bcs::from_bytes(&stored.validator_signatures)
-        .context("Failed to deserialize validator signatures")?;
 
     Ok(Checkpoint::from((summary, contents, signature.signature)))
 }

--- a/crates/sui-indexer-alt-jsonrpc/src/api/checkpoints.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/checkpoints.rs
@@ -65,7 +65,7 @@ impl RpcModule for Checkpoints {
 /// Load a checkpoint and prepare it for presentation as a JSON-RPC response.
 async fn response(ctx: &Context, seq: u64) -> Result<Checkpoint, RpcError<Error>> {
     let stored: StoredCheckpoint = ctx
-        .loader()
+        .pg_loader()
         .load_one(CheckpointKey(seq))
         .await
         .context("Failed to load checkpoint")?

--- a/crates/sui-indexer-alt-jsonrpc/src/api/dynamic_fields.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/dynamic_fields.rs
@@ -144,7 +144,7 @@ async fn dynamic_field_object_response(
     use RpcError as E;
 
     Ok(SuiObjectResponse::new_with_data(
-        objects::response::object(ctx, object, &options)
+        objects::response::object_data_with_options(ctx, object, &options)
             .await
             .map_err(|e| match e {
                 E::InvalidParams(e) => match e {},
@@ -164,7 +164,7 @@ async fn load_df(
     let id = derive_dynamic_field_id(parent_id, type_, value)
         .context("Failed to derive dynamic field ID")?;
 
-    Ok(load_latest(ctx.loader(), id)
+    Ok(load_latest(ctx, id)
         .await
         .context("Failed to load dynamic field")?)
 }
@@ -184,7 +184,7 @@ async fn load_dof(
     let id = derive_dynamic_field_id(parent_id, &wrapper, name)
         .context("Failed to derive dynamic object field ID")?;
 
-    let Some(object) = load_latest(ctx.loader(), id)
+    let Some(object) = load_latest(ctx, id)
         .await
         .context("Failed to load dynamic object field")?
     else {
@@ -199,7 +199,7 @@ async fn load_dof(
     let value = ObjectID::from_bytes(&move_object.contents()[ObjectID::LENGTH + name.len()..])
         .context("Failed to extract object ID from dynamic object field")?;
 
-    Ok(load_latest(ctx.loader(), value)
+    Ok(load_latest(ctx, value)
         .await
         .context("Failed to load dynamic field object")?)
 }

--- a/crates/sui-indexer-alt-jsonrpc/src/api/governance.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/governance.rs
@@ -68,7 +68,7 @@ async fn rgp_response(ctx: &Context) -> Result<BigInt<u64>, RpcError> {
     use kv_epoch_starts::dsl as e;
 
     let mut conn = ctx
-        .reader()
+        .pg_reader()
         .connect()
         .await
         .context("Failed to connect to the database")?;
@@ -89,9 +89,8 @@ async fn rgp_response(ctx: &Context) -> Result<BigInt<u64>, RpcError> {
 async fn latest_sui_system_state_response(
     ctx: &Context,
 ) -> Result<SuiSystemStateSummary, RpcError> {
-    let loader = ctx.loader();
     let wrapper: SuiSystemStateWrapper =
-        load_latest_deserialized(loader, SUI_SYSTEM_STATE_OBJECT_ID)
+        load_latest_deserialized(ctx, SUI_SYSTEM_STATE_OBJECT_ID)
             .await
             .context("Failed to fetch system state wrapper object")?;
 
@@ -103,12 +102,12 @@ async fn latest_sui_system_state_response(
     .context("Failed to derive inner system state field ID")?;
 
     Ok(match wrapper.version {
-        1 => load_latest_deserialized::<Field<u64, SuiSystemStateInnerV1>>(loader, inner_id)
+        1 => load_latest_deserialized::<Field<u64, SuiSystemStateInnerV1>>(ctx, inner_id)
             .await
             .context("Failed to fetch inner system state object")?
             .value
             .into_sui_system_state_summary(),
-        2 => load_latest_deserialized::<Field<u64, SuiSystemStateInnerV2>>(loader, inner_id)
+        2 => load_latest_deserialized::<Field<u64, SuiSystemStateInnerV2>>(ctx, inner_id)
             .await
             .context("Failed to fetch inner system state object")?
             .value

--- a/crates/sui-indexer-alt-jsonrpc/src/api/governance.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/governance.rs
@@ -89,10 +89,9 @@ async fn rgp_response(ctx: &Context) -> Result<BigInt<u64>, RpcError> {
 async fn latest_sui_system_state_response(
     ctx: &Context,
 ) -> Result<SuiSystemStateSummary, RpcError> {
-    let wrapper: SuiSystemStateWrapper =
-        load_latest_deserialized(ctx, SUI_SYSTEM_STATE_OBJECT_ID)
-            .await
-            .context("Failed to fetch system state wrapper object")?;
+    let wrapper: SuiSystemStateWrapper = load_latest_deserialized(ctx, SUI_SYSTEM_STATE_OBJECT_ID)
+        .await
+        .context("Failed to fetch system state wrapper object")?;
 
     let inner_id = derive_dynamic_field_id(
         SUI_SYSTEM_STATE_OBJECT_ID,

--- a/crates/sui-indexer-alt-jsonrpc/src/api/name_service/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/name_service/response.rs
@@ -33,10 +33,10 @@ pub(super) async fn resolved_address(
     let domain_record_id = config.record_field_id(&domain);
     let parent_record_id = config.record_field_id(&domain.parent());
 
-    let domain_object = load_live(ctx.loader(), domain_record_id);
+    let domain_object = load_live(ctx, domain_record_id);
     let parent_object: OptionFuture<_> = domain
         .is_subdomain()
-        .then(|| load_live(ctx.loader(), parent_record_id))
+        .then(|| load_live(ctx, parent_record_id))
         .into();
 
     // Fetch the current timestamp, the domain record. If the domain being resolved is a
@@ -98,7 +98,7 @@ async fn latest_timestamp_ms(ctx: &Context) -> Result<u64, RpcError<Error>> {
     use watermarks::dsl as w;
 
     let mut conn = ctx
-        .reader()
+        .pg_reader()
         .connect()
         .await
         .context("Failed to connect to database")?;

--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/filter.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/filter.rs
@@ -181,7 +181,7 @@ pub(super) async fn owned_objects(
     }
 
     let mut results: Vec<(Vec<u8>, i64)> = ctx
-        .reader()
+        .pg_reader()
         .connect()
         .await
         .context("Failed to connect to the database")?

--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
@@ -5,12 +5,11 @@ use anyhow::Context as _;
 use futures::future::OptionFuture;
 use move_core_types::annotated_value::MoveTypeLayout;
 use sui_json_rpc_types::{
-    SuiData, SuiObjectData, SuiObjectDataOptions, SuiObjectRef, SuiObjectResponse, SuiParsedData,
+    SuiData, SuiObjectData, SuiObjectDataOptions, SuiObjectResponse, SuiParsedData,
     SuiPastObjectResponse, SuiRawData,
 };
 use sui_types::{
     base_types::{ObjectID, ObjectType, SequenceNumber},
-    digests::ObjectDigest,
     error::SuiObjectResponseError,
     object::{Data, Object},
     TypeTag,
@@ -34,7 +33,7 @@ pub(super) async fn live_object(
     options: &SuiObjectDataOptions,
 ) -> Result<SuiObjectResponse, RpcError> {
     let Some(info) = ctx
-        .loader()
+        .pg_loader()
         .load_one(LatestObjectInfoKey(object_id))
         .await
         .context("Failed to load object ownership information from store")?
@@ -69,13 +68,13 @@ pub(super) async fn latest_object(
     // object does exist, so the following calls should find a valid latest version for the object,
     // and that version is expected to have content, so if either of those things don't happen,
     // it's an internal error.
-    let o = load_latest(ctx.loader(), object_id)
+    let object = load_latest(ctx, object_id)
         .await
         .context("Failed to load latest object")?
         .context("Could not find latest content for live object")?;
 
     Ok(SuiObjectResponse::new_with_data(
-        object(ctx, o, options).await?,
+        object_data_with_options(ctx, object, options).await?,
     ))
 }
 
@@ -87,32 +86,22 @@ pub(super) async fn past_object(
     version: SequenceNumber,
     options: &SuiObjectDataOptions,
 ) -> Result<SuiPastObjectResponse, RpcError> {
-    let Some(stored) = ctx
-        .loader()
-        .load_one(VersionedObjectKey(object_id, version.value()))
+    let Some(object) = ctx
+        .kv_loader()
+        .load_one_object(VersionedObjectKey(object_id, version.value()))
         .await
         .context("Failed to load object from store")?
     else {
         return Ok(SuiPastObjectResponse::VersionNotFound(object_id, version));
     };
 
-    let Some(bytes) = &stored.serialized_object else {
-        return Ok(SuiPastObjectResponse::ObjectDeleted(SuiObjectRef {
-            object_id,
-            version,
-            digest: ObjectDigest::OBJECT_DIGEST_DELETED,
-        }));
-    };
-
-    let o: Object = bcs::from_bytes(bytes).context("Failed to deserialize object")?;
-
     Ok(SuiPastObjectResponse::VersionFound(
-        object(ctx, o, options).await?,
+        object_data_with_options(ctx, object, options).await?,
     ))
 }
 
-/// Extract a representation of the object from its stored form, according to its response options.
-pub(crate) async fn object(
+/// Extract a representation of the object according to its response options.
+pub(crate) async fn object_data_with_options(
     ctx: &Context,
     object: Object,
     options: &SuiObjectDataOptions,

--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
@@ -18,10 +18,7 @@ use tokio::join;
 
 use crate::{
     context::Context,
-    data::{
-        object_info::LatestObjectInfoKey,
-        objects::{load_latest, VersionedObjectKey},
-    },
+    data::{object_info::LatestObjectInfoKey, objects::load_latest},
     error::{rpc_bail, RpcError},
 };
 
@@ -88,7 +85,7 @@ pub(super) async fn past_object(
 ) -> Result<SuiPastObjectResponse, RpcError> {
     let Some(object) = ctx
         .kv_loader()
-        .load_one_object(VersionedObjectKey(object_id, version.value()))
+        .load_one_object(object_id, version.value())
         .await
         .context("Failed to load object from store")?
     else {

--- a/crates/sui-indexer-alt-jsonrpc/src/api/transactions/filter.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/transactions/filter.rs
@@ -128,7 +128,7 @@ async fn all_transactions(ctx: &Context, page: &Page<Cursor>) -> Result<Digests,
         .into_boxed();
 
     let results: Vec<(i64, Vec<u8>)> = ctx
-        .reader()
+        .pg_reader()
         .connect()
         .await
         .context("Failed to connect to the database")?
@@ -146,7 +146,7 @@ async fn by_checkpoint(
     checkpoint: u64,
 ) -> Result<Digests, RpcError<Error>> {
     let Some(checkpoint) = ctx
-        .loader()
+        .pg_loader()
         .load_one(CheckpointKey(checkpoint))
         .await
         .context("Failed to load checkpoint")?
@@ -238,7 +238,7 @@ async fn tx_calls(
     }
 
     let results: Vec<i64> = ctx
-        .reader()
+        .pg_reader()
         .connect()
         .await
         .context("Failed to connect to the database")?
@@ -264,7 +264,7 @@ async fn tx_affected_objects(
         .into_boxed();
 
     let results: Vec<i64> = ctx
-        .reader()
+        .pg_reader()
         .connect()
         .await
         .context("Failed to connect to the database")?
@@ -304,7 +304,7 @@ async fn tx_affected_addresses(
     }
 
     let results: Vec<i64> = ctx
-        .reader()
+        .pg_reader()
         .connect()
         .await
         .context("Failed to connect to the database")?
@@ -395,7 +395,7 @@ async fn from_sequence_numbers(
         .context("Failed to encode next cursor")?;
 
     let digests = ctx
-        .loader()
+        .pg_loader()
         .load_many(rows.iter().map(|&seq| TxDigestKey(seq as u64)))
         .await
         .context("Failed to load transaction digests")?;

--- a/crates/sui-indexer-alt-jsonrpc/src/api/transactions/filter.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/transactions/filter.rs
@@ -23,11 +23,12 @@ use sui_json_rpc_types::{Page as PageResponse, SuiTransactionBlockResponseOption
 use sui_types::{
     base_types::{ObjectID, SuiAddress},
     digests::TransactionDigest,
+    messages_checkpoint::CheckpointSequenceNumber,
     sui_serde::{BigInt, Readable},
 };
 
 use crate::{
-    data::{checkpoints::CheckpointKey, tx_digests::TxDigestKey},
+    data::tx_digests::TxDigestKey,
     error::{invalid_params, RpcError},
     paginate::{Cursor as _, JsonCursor, Page},
 };
@@ -146,7 +147,7 @@ async fn by_checkpoint(
 ) -> Result<Digests, RpcError<Error>> {
     let Some((summary, contents, _)) = ctx
         .kv_loader()
-        .load_one_checkpoint(CheckpointKey(checkpoint))
+        .load_one_checkpoint(checkpoint)
         .await
         .context("Failed to load checkpoint")?
     else {

--- a/crates/sui-indexer-alt-jsonrpc/src/config.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/config.rs
@@ -22,6 +22,9 @@ pub struct RpcConfig {
 
     /// Configuration for SuiNS related RPC methods.
     pub name_service: NameServiceLayer,
+    /// Configuration for bigtable kv store, if it is used..
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bigtable_config: Option<BigtableConfig>,
 
     #[serde(flatten)]
     pub extra: toml::Table,
@@ -59,6 +62,13 @@ pub struct NameServiceLayer {
     pub extra: toml::Table,
 }
 
+#[DefaultConfig]
+#[derive(Clone, Default, Debug)]
+pub struct BigtableConfig {
+    pub instance_id: String,
+    pub credentials: String,
+}
+
 impl RpcConfig {
     /// Generate an example configuration, suitable for demonstrating the fields available to
     /// configure.
@@ -67,6 +77,7 @@ impl RpcConfig {
             objects: ObjectsConfig::default().into(),
             transactions: TransactionsConfig::default().into(),
             name_service: NameServiceConfig::default().into(),
+            bigtable_config: None,
             extra: Default::default(),
         }
     }

--- a/crates/sui-indexer-alt-jsonrpc/src/config.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/config.rs
@@ -22,7 +22,8 @@ pub struct RpcConfig {
 
     /// Configuration for SuiNS related RPC methods.
     pub name_service: NameServiceLayer,
-    /// Configuration for bigtable kv store, if it is used..
+
+    /// Configuration for bigtable kv store, if it is used.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bigtable_config: Option<BigtableConfig>,
 
@@ -65,8 +66,8 @@ pub struct NameServiceLayer {
 #[DefaultConfig]
 #[derive(Clone, Default, Debug)]
 pub struct BigtableConfig {
+    /// The instance id of the Bigtable instance to connect to.
     pub instance_id: String,
-    pub credentials: String,
 }
 
 impl RpcConfig {

--- a/crates/sui-indexer-alt-jsonrpc/src/context.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/context.rs
@@ -9,9 +9,13 @@ use sui_package_resolver::Resolver;
 use sui_pg_db::DbArgs;
 
 use crate::{
+    config::BigtableConfig,
     data::{
+        bigtable_reader::BigtableReader,
+        kv_loader::KVLoader,
         package_resolver::{DbPackageStore, PackageCache, PackageResolver},
-        reader::{ReadError, Reader},
+        pg_reader::PgReader,
+        read_error::ReadError,
     },
     metrics::RpcMetrics,
 };
@@ -20,12 +24,16 @@ use crate::{
 #[derive(Clone)]
 pub(crate) struct Context {
     /// Direct access to the database, for running SQL queries.
-    reader: Reader,
+    pg_reader: PgReader,
 
     /// Access to the database for performing point look-ups. Access is through the same connection
     /// pool as `reader`, but this interface groups multiple point lookups into a single database
     /// query.
-    loader: Arc<DataLoader<Reader>>,
+    pg_loader: Arc<DataLoader<PgReader>>,
+
+    /// Access to the kv store for performing point look-ups. This may either be backed by Bigtable
+    /// or Postgres db, depending on the configuration.
+    kv_loader: KVLoader,
 
     /// Access to the database for accessing information about types from their packages (again
     /// through the same connection pool as `reader`).
@@ -36,30 +44,45 @@ impl Context {
     /// Set-up access to the database through all the interfaces available in the context.
     pub(crate) async fn new(
         db_args: DbArgs,
+        bigtable_config: Option<BigtableConfig>,
         metrics: Arc<RpcMetrics>,
         registry: &Registry,
     ) -> Result<Self, ReadError> {
-        let reader = Reader::new(db_args, metrics, registry).await?;
-        let loader = Arc::new(reader.as_data_loader());
+        let pg_reader = PgReader::new(db_args, metrics, registry).await?;
+        let pg_loader = Arc::new(pg_reader.as_data_loader());
 
-        let store = PackageCache::new(DbPackageStore::new(loader.clone()));
+        let kv_loader = if let Some(config) = bigtable_config {
+            let bigtable_reader =
+                BigtableReader::new(config.instance_id, config.credentials).await?;
+            KVLoader::new_with_bigtable(bigtable_reader)
+        } else {
+            KVLoader::new_with_pg(pg_reader.clone())
+        };
+
+        let store = PackageCache::new(DbPackageStore::new(pg_loader.clone()));
         let package_resolver = Arc::new(Resolver::new(store));
 
         Ok(Self {
-            reader,
-            loader,
+            pg_reader,
+            pg_loader,
+            kv_loader,
             package_resolver,
         })
     }
 
     /// For performing arbitrary SQL queries.
-    pub(crate) fn reader(&self) -> &Reader {
-        &self.reader
+    pub(crate) fn pg_reader(&self) -> &PgReader {
+        &self.pg_reader
     }
 
     /// For performing point look-ups.
-    pub(crate) fn loader(&self) -> &Arc<DataLoader<Reader>> {
-        &self.loader
+    pub(crate) fn pg_loader(&self) -> &Arc<DataLoader<PgReader>> {
+        &self.pg_loader
+    }
+
+    /// For performing point look-ups on the kv store.
+    pub(crate) fn kv_loader(&self) -> &KVLoader {
+        &self.kv_loader
     }
 
     /// For querying type and function signature information.

--- a/crates/sui-indexer-alt-jsonrpc/src/data/bigtable_reader.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/bigtable_reader.rs
@@ -1,19 +1,31 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::data::read_error::ReadError;
+use crate::data::error::Error;
+use async_graphql::dataloader::DataLoader;
 use sui_kvstore::BigTableClient;
 
+/// A reader backed by Bigtable kv store.
+/// In order to use this reader, the environment variable `GOOGLE_APPLICATION_CREDENTIALS`
+/// must be set to the path of the credentials file.
+#[derive(Clone)]
 pub struct BigtableReader(pub(crate) BigTableClient);
 
 impl BigtableReader {
-    pub(crate) async fn new(instance_id: String, credentials: String) -> Result<Self, ReadError> {
-        std::env::set_var("GOOGLE_APPLICATION_CREDENTIALS", credentials);
-
+    pub(crate) async fn new(instance_id: String) -> Result<Self, Error> {
+        if std::env::var("GOOGLE_APPLICATION_CREDENTIALS").is_err() {
+            return Err(Error::BigtableCreate(anyhow::anyhow!(
+                "Environment variable GOOGLE_APPLICATION_CREDENTIALS is not set"
+            )));
+        }
         let client = BigTableClient::new_remote(instance_id, true, None)
             .await
-            .map_err(|e| ReadError::BigtableCreate(e.into()))?;
-
+            .map_err(|e| Error::BigtableCreate(e.into()))?;
         Ok(Self(client))
+    }
+
+    /// Create a data loader backed by this reader.
+    pub(crate) fn as_data_loader(&self) -> DataLoader<Self> {
+        DataLoader::new(self.clone(), tokio::spawn)
     }
 }

--- a/crates/sui-indexer-alt-jsonrpc/src/data/bigtable_reader.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/bigtable_reader.rs
@@ -20,7 +20,7 @@ impl BigtableReader {
         }
         let client = BigTableClient::new_remote(instance_id, true, None)
             .await
-            .map_err(|e| Error::BigtableCreate(e.into()))?;
+            .map_err(Error::BigtableCreate)?;
         Ok(Self(client))
     }
 

--- a/crates/sui-indexer-alt-jsonrpc/src/data/bigtable_reader.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/bigtable_reader.rs
@@ -1,0 +1,19 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::data::read_error::ReadError;
+use sui_kvstore::BigTableClient;
+
+pub struct BigtableReader(pub(crate) BigTableClient);
+
+impl BigtableReader {
+    pub(crate) async fn new(instance_id: String, credentials: String) -> Result<Self, ReadError> {
+        std::env::set_var("GOOGLE_APPLICATION_CREDENTIALS", credentials);
+
+        let client = BigTableClient::new_remote(instance_id, true, None)
+            .await
+            .map_err(|e| ReadError::BigtableCreate(e.into()))?;
+
+        Ok(Self(client))
+    }
+}

--- a/crates/sui-indexer-alt-jsonrpc/src/data/checkpoints.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/checkpoints.rs
@@ -10,14 +10,15 @@ use async_graphql::dataloader::Loader;
 use diesel::{ExpressionMethods, QueryDsl};
 use sui_indexer_alt_schema::{checkpoints::StoredCheckpoint, schema::kv_checkpoints};
 
-use super::reader::{ReadError, Reader};
+use super::pg_reader::PgReader;
+use super::read_error::ReadError;
 
 /// Key for fetching a checkpoint's content by its sequence number.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct CheckpointKey(pub u64);
 
 #[async_trait::async_trait]
-impl Loader<CheckpointKey> for Reader {
+impl Loader<CheckpointKey> for PgReader {
     type Value = StoredCheckpoint;
     type Error = Arc<ReadError>;
 

--- a/crates/sui-indexer-alt-jsonrpc/src/data/checkpoints.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/checkpoints.rs
@@ -9,9 +9,14 @@ use std::{
 use async_graphql::dataloader::Loader;
 use diesel::{ExpressionMethods, QueryDsl};
 use sui_indexer_alt_schema::{checkpoints::StoredCheckpoint, schema::kv_checkpoints};
+use sui_kvstore::KeyValueStoreReader;
+use sui_types::{
+    crypto::AuthorityQuorumSignInfo,
+    messages_checkpoint::{CheckpointContents, CheckpointSequenceNumber, CheckpointSummary},
+};
 
-use super::pg_reader::PgReader;
 use super::read_error::ReadError;
+use super::{bigtable_reader::BigtableReader, pg_reader::PgReader};
 
 /// Key for fetching a checkpoint's content by its sequence number.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -43,6 +48,44 @@ impl Loader<CheckpointKey> for PgReader {
         Ok(checkpoints
             .into_iter()
             .map(|c| (CheckpointKey(c.sequence_number as u64), c))
+            .collect())
+    }
+}
+
+#[async_trait::async_trait]
+impl Loader<CheckpointKey> for BigtableReader {
+    type Value = (
+        CheckpointSummary,
+        CheckpointContents,
+        AuthorityQuorumSignInfo<true>,
+    );
+    type Error = Arc<ReadError>;
+
+    async fn load(
+        &self,
+        keys: &[CheckpointKey],
+    ) -> Result<HashMap<CheckpointKey, Self::Value>, Self::Error> {
+        if keys.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let checkpoint_keys: Vec<CheckpointSequenceNumber> = keys.iter().map(|k| k.0).collect();
+
+        let checkpoints = self
+            .0
+            .clone()
+            .get_checkpoints(&checkpoint_keys)
+            .await
+            .map_err(|e| Arc::new(ReadError::BigtableRead(e.into())))?;
+
+        Ok(checkpoints
+            .into_iter()
+            .map(|c| {
+                (
+                    CheckpointKey(c.summary.sequence_number),
+                    (c.summary, c.contents, c.signatures),
+                )
+            })
             .collect())
     }
 }

--- a/crates/sui-indexer-alt-jsonrpc/src/data/checkpoints.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/checkpoints.rs
@@ -76,7 +76,7 @@ impl Loader<CheckpointKey> for BigtableReader {
             .clone()
             .get_checkpoints(&checkpoint_keys)
             .await
-            .map_err(|e| Arc::new(Error::BigtableRead(e.into())))?;
+            .map_err(|e| Arc::new(Error::BigtableRead(e)))?;
 
         Ok(checkpoints
             .into_iter()

--- a/crates/sui-indexer-alt-jsonrpc/src/data/checkpoints.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/checkpoints.rs
@@ -15,7 +15,7 @@ use sui_types::{
     messages_checkpoint::{CheckpointContents, CheckpointSequenceNumber, CheckpointSummary},
 };
 
-use super::read_error::ReadError;
+use super::error::Error;
 use super::{bigtable_reader::BigtableReader, pg_reader::PgReader};
 
 /// Key for fetching a checkpoint's content by its sequence number.
@@ -25,7 +25,7 @@ pub(crate) struct CheckpointKey(pub u64);
 #[async_trait::async_trait]
 impl Loader<CheckpointKey> for PgReader {
     type Value = StoredCheckpoint;
-    type Error = Arc<ReadError>;
+    type Error = Arc<Error>;
 
     async fn load(
         &self,
@@ -59,7 +59,7 @@ impl Loader<CheckpointKey> for BigtableReader {
         CheckpointContents,
         AuthorityQuorumSignInfo<true>,
     );
-    type Error = Arc<ReadError>;
+    type Error = Arc<Error>;
 
     async fn load(
         &self,
@@ -76,7 +76,7 @@ impl Loader<CheckpointKey> for BigtableReader {
             .clone()
             .get_checkpoints(&checkpoint_keys)
             .await
-            .map_err(|e| Arc::new(ReadError::BigtableRead(e.into())))?;
+            .map_err(|e| Arc::new(Error::BigtableRead(e.into())))?;
 
         Ok(checkpoints
             .into_iter()

--- a/crates/sui-indexer-alt-jsonrpc/src/data/error.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/error.rs
@@ -4,7 +4,7 @@
 use diesel::result::Error as DieselError;
 
 #[derive(thiserror::Error, Debug)]
-pub(crate) enum ReadError {
+pub(crate) enum Error {
     #[error(transparent)]
     PgCreate(anyhow::Error),
 

--- a/crates/sui-indexer-alt-jsonrpc/src/data/kv_loader.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/kv_loader.rs
@@ -1,13 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::error::Error;
 use super::objects::VersionedObjectKey;
 use super::pg_reader::PgReader;
-use super::read_error::ReadError;
 use super::{bigtable_reader::BigtableReader, checkpoints::CheckpointKey};
 use async_graphql::dataloader::DataLoader;
 use std::collections::HashMap;
 use std::sync::Arc;
+use sui_types::base_types::ObjectID;
 use sui_types::{
     crypto::AuthorityQuorumSignInfo,
     messages_checkpoint::{CheckpointContents, CheckpointSummary},
@@ -20,34 +21,38 @@ use sui_types::{
 /// - Checkpoints by sequence number
 /// - Transactions by digest
 #[derive(Clone)]
-pub(crate) enum KVLoader {
+pub(crate) enum KvLoader {
     Bigtable(Arc<DataLoader<BigtableReader>>),
     Pg(Arc<DataLoader<PgReader>>),
 }
 
-impl KVLoader {
-    pub(crate) fn new_with_bigtable(bigtable_reader: BigtableReader) -> Self {
-        Self::Bigtable(Arc::new(DataLoader::new(bigtable_reader, tokio::spawn)))
+impl KvLoader {
+    pub(crate) fn new_with_bigtable(bigtable_loader: Arc<DataLoader<BigtableReader>>) -> Self {
+        Self::Bigtable(bigtable_loader)
     }
 
-    pub(crate) fn new_with_pg(pg_reader: PgReader) -> Self {
-        Self::Pg(Arc::new(DataLoader::new(pg_reader, tokio::spawn)))
+    pub(crate) fn new_with_pg(pg_loader: Arc<DataLoader<PgReader>>) -> Self {
+        Self::Pg(pg_loader)
     }
 
     pub(crate) async fn load_one_object(
         &self,
-        key: VersionedObjectKey,
-    ) -> Result<Option<Object>, Arc<ReadError>> {
+        id: ObjectID,
+        version: u64,
+    ) -> Result<Option<Object>, Arc<Error>> {
+        let key = VersionedObjectKey(id, version);
         match self {
             Self::Bigtable(loader) => loader.load_one(key).await,
             Self::Pg(loader) => loader
                 .load_one(key)
                 .await?
                 .and_then(|stored| {
-                    stored.serialized_object.map(|serialized_object| {
-                        Ok(bcs::from_bytes(&serialized_object)
-                            .map_err(|e| ReadError::Serde(e.into()))?)
-                    })
+                    stored.serialized_object.map(
+                        |serialized_object| -> Result<Object, Arc<Error>> {
+                            bcs::from_bytes(serialized_object.as_slice())
+                                .map_err(|e| Arc::new(Error::Serde(e.into())))
+                        },
+                    )
                 })
                 .transpose(),
         }
@@ -56,7 +61,7 @@ impl KVLoader {
     pub(crate) async fn load_many_objects(
         &self,
         keys: Vec<VersionedObjectKey>,
-    ) -> Result<HashMap<VersionedObjectKey, Object>, Arc<ReadError>> {
+    ) -> Result<HashMap<VersionedObjectKey, Object>, Arc<Error>> {
         match self {
             Self::Bigtable(loader) => loader.load_many(keys).await,
             Self::Pg(loader) => loader
@@ -64,13 +69,15 @@ impl KVLoader {
                 .await?
                 .into_iter()
                 .flat_map(|(key, stored)| {
-                    stored.serialized_object.map(|serialized_object| {
-                        Ok((
-                            key,
-                            bcs::from_bytes(&serialized_object)
-                                .map_err(|e| ReadError::Serde(e.into()))?,
-                        ))
-                    })
+                    stored.serialized_object.map(
+                        |serialized_object| -> Result<(VersionedObjectKey, Object), Arc<Error>> {
+                            Ok((
+                                key,
+                                bcs::from_bytes(serialized_object.as_slice())
+                                    .map_err(|e| Arc::new(Error::Serde(e.into())))?,
+                            ))
+                        },
+                    )
                 })
                 .collect(),
         }
@@ -78,15 +85,16 @@ impl KVLoader {
 
     pub(crate) async fn load_one_checkpoint(
         &self,
-        key: CheckpointKey,
+        sequence_number: u64,
     ) -> Result<
         Option<(
             CheckpointSummary,
             CheckpointContents,
             AuthorityQuorumSignInfo<true>,
         )>,
-        Arc<ReadError>,
+        Arc<Error>,
     > {
+        let key = CheckpointKey(sequence_number);
         match self {
             Self::Bigtable(loader) => loader.load_one(key).await,
             Self::Pg(loader) => loader
@@ -94,14 +102,14 @@ impl KVLoader {
                 .await?
                 .map(|stored| {
                     let summary: CheckpointSummary = bcs::from_bytes(&stored.checkpoint_summary)
-                        .map_err(|e| ReadError::Serde(e.into()))?;
+                        .map_err(|e| Error::Serde(e.into()))?;
 
                     let contents: CheckpointContents = bcs::from_bytes(&stored.checkpoint_contents)
-                        .map_err(|e| ReadError::Serde(e.into()))?;
+                        .map_err(|e| Error::Serde(e.into()))?;
 
                     let signature: AuthorityQuorumSignInfo<true> =
                         bcs::from_bytes(&stored.validator_signatures)
-                            .map_err(|e| ReadError::Serde(e.into()))?;
+                            .map_err(|e| Error::Serde(e.into()))?;
 
                     Ok((summary, contents, signature))
                 })

--- a/crates/sui-indexer-alt-jsonrpc/src/data/kv_loader.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/kv_loader.rs
@@ -1,0 +1,69 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::bigtable_reader::BigtableReader;
+use super::objects::VersionedObjectKey;
+use super::pg_reader::PgReader;
+use super::read_error::ReadError;
+use async_graphql::dataloader::DataLoader;
+use std::collections::HashMap;
+use std::sync::Arc;
+use sui_types::object::Object;
+
+#[derive(Clone)]
+pub(crate) enum KVLoader {
+    Bigtable(Arc<DataLoader<BigtableReader>>),
+    Pg(Arc<DataLoader<PgReader>>),
+}
+
+impl KVLoader {
+    pub(crate) fn new_with_bigtable(bigtable_reader: BigtableReader) -> Self {
+        Self::Bigtable(Arc::new(DataLoader::new(bigtable_reader, tokio::spawn)))
+    }
+
+    pub(crate) fn new_with_pg(pg_reader: PgReader) -> Self {
+        Self::Pg(Arc::new(DataLoader::new(pg_reader, tokio::spawn)))
+    }
+
+    pub(crate) async fn load_one_object(
+        &self,
+        key: VersionedObjectKey,
+    ) -> Result<Option<Object>, Arc<ReadError>> {
+        match self {
+            Self::Bigtable(loader) => loader.load_one(key).await,
+            Self::Pg(loader) => loader
+                .load_one(key)
+                .await?
+                .and_then(|stored| {
+                    stored.serialized_object.map(|serialized_object| {
+                        Ok(bcs::from_bytes(&serialized_object)
+                            .map_err(|e| ReadError::Serde(e.into()))?)
+                    })
+                })
+                .transpose(),
+        }
+    }
+
+    pub(crate) async fn load_many_objects(
+        &self,
+        keys: Vec<VersionedObjectKey>,
+    ) -> Result<HashMap<VersionedObjectKey, Object>, Arc<ReadError>> {
+        match self {
+            Self::Bigtable(loader) => loader.load_many(keys).await,
+            Self::Pg(loader) => loader
+                .load_many(keys)
+                .await?
+                .into_iter()
+                .flat_map(|(key, stored)| {
+                    stored.serialized_object.map(|serialized_object| {
+                        Ok((
+                            key,
+                            bcs::from_bytes(&serialized_object)
+                                .map_err(|e| ReadError::Serde(e.into()))?,
+                        ))
+                    })
+                })
+                .collect(),
+        }
+    }
+}

--- a/crates/sui-indexer-alt-jsonrpc/src/data/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/mod.rs
@@ -1,12 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod bigtable_reader;
 pub(crate) mod checkpoints;
+pub(crate) mod kv_loader;
 pub(crate) mod object_info;
 pub(crate) mod object_versions;
 pub(crate) mod objects;
 pub(crate) mod package_resolver;
-pub(crate) mod reader;
+pub(crate) mod pg_reader;
+pub(crate) mod read_error;
 pub mod system_package_task;
 pub(crate) mod transactions;
 pub(crate) mod tx_balance_changes;

--- a/crates/sui-indexer-alt-jsonrpc/src/data/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/mod.rs
@@ -3,13 +3,13 @@
 
 pub(crate) mod bigtable_reader;
 pub(crate) mod checkpoints;
+pub(crate) mod error;
 pub(crate) mod kv_loader;
 pub(crate) mod object_info;
 pub(crate) mod object_versions;
 pub(crate) mod objects;
 pub(crate) mod package_resolver;
 pub(crate) mod pg_reader;
-pub(crate) mod read_error;
 pub mod system_package_task;
 pub(crate) mod transactions;
 pub(crate) mod tx_balance_changes;

--- a/crates/sui-indexer-alt-jsonrpc/src/data/object_info.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/object_info.rs
@@ -11,7 +11,8 @@ use diesel::{ExpressionMethods, QueryDsl};
 use sui_indexer_alt_schema::{objects::StoredObjInfo, schema::obj_info};
 use sui_types::base_types::ObjectID;
 
-use super::reader::{ReadError, Reader};
+use super::pg_reader::PgReader;
+use crate::data::read_error::ReadError;
 
 /// Key for fetching the latest object info record for an object. This record corresponds to the
 /// last time the object's ownership information changed.
@@ -19,7 +20,7 @@ use super::reader::{ReadError, Reader};
 pub(crate) struct LatestObjectInfoKey(pub ObjectID);
 
 #[async_trait::async_trait]
-impl Loader<LatestObjectInfoKey> for Reader {
+impl Loader<LatestObjectInfoKey> for PgReader {
     type Value = StoredObjInfo;
     type Error = Arc<ReadError>;
 

--- a/crates/sui-indexer-alt-jsonrpc/src/data/object_info.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/object_info.rs
@@ -12,7 +12,7 @@ use sui_indexer_alt_schema::{objects::StoredObjInfo, schema::obj_info};
 use sui_types::base_types::ObjectID;
 
 use super::pg_reader::PgReader;
-use crate::data::read_error::ReadError;
+use crate::data::error::Error;
 
 /// Key for fetching the latest object info record for an object. This record corresponds to the
 /// last time the object's ownership information changed.
@@ -22,7 +22,7 @@ pub(crate) struct LatestObjectInfoKey(pub ObjectID);
 #[async_trait::async_trait]
 impl Loader<LatestObjectInfoKey> for PgReader {
     type Value = StoredObjInfo;
-    type Error = Arc<ReadError>;
+    type Error = Arc<Error>;
 
     async fn load(
         &self,

--- a/crates/sui-indexer-alt-jsonrpc/src/data/object_versions.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/object_versions.rs
@@ -11,7 +11,8 @@ use diesel::{ExpressionMethods, QueryDsl};
 use sui_indexer_alt_schema::{objects::StoredObjVersion, schema::obj_versions};
 use sui_types::base_types::ObjectID;
 
-use super::reader::{ReadError, Reader};
+use super::pg_reader::PgReader;
+use crate::data::read_error::ReadError;
 
 /// Key for fetching the latest version of an object, not accounting for deletions or wraps. If the
 /// object has been deleted or wrapped, the version before the delete/wrap is returned.
@@ -19,7 +20,7 @@ use super::reader::{ReadError, Reader};
 pub(crate) struct LatestObjectVersionKey(pub ObjectID);
 
 #[async_trait::async_trait]
-impl Loader<LatestObjectVersionKey> for Reader {
+impl Loader<LatestObjectVersionKey> for PgReader {
     type Value = StoredObjVersion;
     type Error = Arc<ReadError>;
 

--- a/crates/sui-indexer-alt-jsonrpc/src/data/object_versions.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/object_versions.rs
@@ -12,7 +12,7 @@ use sui_indexer_alt_schema::{objects::StoredObjVersion, schema::obj_versions};
 use sui_types::base_types::ObjectID;
 
 use super::pg_reader::PgReader;
-use crate::data::read_error::ReadError;
+use crate::data::error::Error;
 
 /// Key for fetching the latest version of an object, not accounting for deletions or wraps. If the
 /// object has been deleted or wrapped, the version before the delete/wrap is returned.
@@ -22,7 +22,7 @@ pub(crate) struct LatestObjectVersionKey(pub ObjectID);
 #[async_trait::async_trait]
 impl Loader<LatestObjectVersionKey> for PgReader {
     type Value = StoredObjVersion;
-    type Error = Arc<ReadError>;
+    type Error = Arc<Error>;
 
     async fn load(
         &self,

--- a/crates/sui-indexer-alt-jsonrpc/src/data/objects.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/objects.rs
@@ -93,7 +93,7 @@ impl Loader<VersionedObjectKey> for BigtableReader {
             .clone()
             .get_objects(&object_keys)
             .await
-            .map_err(|e| Arc::new(Error::BigtableRead(e.into())))?;
+            .map_err(|e| Arc::new(Error::BigtableRead(e)))?;
 
         Ok(objects
             .into_iter()

--- a/crates/sui-indexer-alt-jsonrpc/src/data/package_resolver.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/package_resolver.rs
@@ -14,19 +14,19 @@ use sui_package_resolver::{
     error::Error, Package, PackageStore, PackageStoreWithLruCache, Resolver, Result,
 };
 
-use super::reader::Reader;
+use super::pg_reader::PgReader;
 
 const STORE: &str = "PostgreSQL";
 
 pub(crate) type PackageCache = PackageStoreWithLruCache<DbPackageStore>;
 pub(crate) type PackageResolver = Arc<Resolver<PackageCache>>;
-pub(crate) struct DbPackageStore(Arc<DataLoader<Reader>>);
+pub(crate) struct DbPackageStore(Arc<DataLoader<PgReader>>);
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
 struct PackageKey(AccountAddress);
 
 impl DbPackageStore {
-    pub fn new(loader: Arc<DataLoader<Reader>>) -> Self {
+    pub fn new(loader: Arc<DataLoader<PgReader>>) -> Self {
         Self(loader)
     }
 }
@@ -44,7 +44,7 @@ impl PackageStore for DbPackageStore {
 }
 
 #[async_trait::async_trait]
-impl Loader<PackageKey> for Reader {
+impl Loader<PackageKey> for PgReader {
     type Value = Arc<Package>;
     type Error = Error;
 

--- a/crates/sui-indexer-alt-jsonrpc/src/data/pg_reader.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/pg_reader.rs
@@ -10,19 +10,18 @@ use diesel::pg::Pg;
 use diesel::query_builder::{Query, QueryFragment, QueryId};
 use diesel::query_dsl::methods::LimitDsl;
 use diesel::query_dsl::CompatibleType;
-use diesel::result::Error as DieselError;
 use diesel_async::RunQueryDsl;
 use prometheus::Registry;
 use sui_indexer_alt_metrics::db::DbConnectionStatsCollector;
 use sui_pg_db as db;
 use tracing::debug;
 
+use crate::data::read_error::ReadError;
 use crate::metrics::RpcMetrics;
-
 /// This wrapper type exists to perform error conversion between the data fetching layer and the
 /// RPC layer, metrics collection, and debug logging of database queries.
 #[derive(Clone)]
-pub(crate) struct Reader {
+pub(crate) struct PgReader {
     db: db::Db,
     metrics: Arc<RpcMetrics>,
 }
@@ -32,32 +31,22 @@ pub(crate) struct Connection<'p> {
     metrics: Arc<RpcMetrics>,
 }
 
-#[derive(thiserror::Error, Debug)]
-pub(crate) enum ReadError {
-    #[error(transparent)]
-    Create(anyhow::Error),
-
-    #[error(transparent)]
-    Connect(anyhow::Error),
-
-    #[error(transparent)]
-    RunQuery(#[from] DieselError),
-}
-
-impl Reader {
+impl PgReader {
     pub(crate) async fn new(
         db_args: db::DbArgs,
         metrics: Arc<RpcMetrics>,
         registry: &Registry,
     ) -> Result<Self, ReadError> {
-        let db = db::Db::for_read(db_args).await.map_err(ReadError::Create)?;
+        let db = db::Db::for_read(db_args)
+            .await
+            .map_err(ReadError::PgCreate)?;
 
         registry
             .register(Box::new(DbConnectionStatsCollector::new(
                 Some("rpc_db"),
                 db.clone(),
             )))
-            .map_err(|e| ReadError::Create(e.into()))?;
+            .map_err(|e| ReadError::PgCreate(e.into()))?;
 
         Ok(Self { db, metrics })
     }
@@ -69,7 +58,7 @@ impl Reader {
 
     pub(crate) async fn connect(&self) -> Result<Connection<'_>, ReadError> {
         Ok(Connection {
-            conn: self.db.connect().await.map_err(ReadError::Connect)?,
+            conn: self.db.connect().await.map_err(ReadError::PgConnect)?,
             metrics: self.metrics.clone(),
         })
     }

--- a/crates/sui-indexer-alt-jsonrpc/src/data/read_error.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/read_error.rs
@@ -1,0 +1,25 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use diesel::result::Error as DieselError;
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum ReadError {
+    #[error(transparent)]
+    PgCreate(anyhow::Error),
+
+    #[error(transparent)]
+    PgConnect(anyhow::Error),
+
+    #[error(transparent)]
+    PgRunQuery(#[from] DieselError),
+
+    #[error(transparent)]
+    BigtableCreate(anyhow::Error),
+
+    #[error(transparent)]
+    BigtableRead(anyhow::Error),
+
+    #[error(transparent)]
+    Serde(anyhow::Error),
+}

--- a/crates/sui-indexer-alt-jsonrpc/src/data/system_package_task.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/system_package_task.rs
@@ -73,7 +73,7 @@ impl SystemPackageTask {
                     }
 
                     _ = interval.tick() => {
-                        let mut conn = match context.reader().connect().await {
+                        let mut conn = match context.pg_reader().connect().await {
                             Ok(conn) => conn,
                             Err(e) => {
                                 error!("Failed to connect to database: {:?}", e);

--- a/crates/sui-indexer-alt-jsonrpc/src/data/transactions.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/transactions.rs
@@ -11,14 +11,15 @@ use diesel::{ExpressionMethods, QueryDsl};
 use sui_indexer_alt_schema::{schema::kv_transactions, transactions::StoredTransaction};
 use sui_types::digests::TransactionDigest;
 
-use super::reader::{ReadError, Reader};
+use super::pg_reader::PgReader;
+use crate::data::read_error::ReadError;
 
 /// Key for fetching transaction contents (TransactionData, Effects, and Events) by digest.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct TransactionKey(pub TransactionDigest);
 
 #[async_trait::async_trait]
-impl Loader<TransactionKey> for Reader {
+impl Loader<TransactionKey> for PgReader {
     type Value = StoredTransaction;
     type Error = Arc<ReadError>;
 

--- a/crates/sui-indexer-alt-jsonrpc/src/data/transactions.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/transactions.rs
@@ -12,7 +12,7 @@ use sui_indexer_alt_schema::{schema::kv_transactions, transactions::StoredTransa
 use sui_types::digests::TransactionDigest;
 
 use super::pg_reader::PgReader;
-use crate::data::read_error::ReadError;
+use crate::data::error::Error;
 
 /// Key for fetching transaction contents (TransactionData, Effects, and Events) by digest.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -21,7 +21,7 @@ pub(crate) struct TransactionKey(pub TransactionDigest);
 #[async_trait::async_trait]
 impl Loader<TransactionKey> for PgReader {
     type Value = StoredTransaction;
-    type Error = Arc<ReadError>;
+    type Error = Arc<Error>;
 
     async fn load(
         &self,

--- a/crates/sui-indexer-alt-jsonrpc/src/data/tx_balance_changes.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/tx_balance_changes.rs
@@ -15,7 +15,7 @@ use sui_indexer_alt_schema::{
 use sui_types::digests::TransactionDigest;
 
 use super::pg_reader::PgReader;
-use crate::data::read_error::ReadError;
+use crate::data::error::Error;
 
 /// Key for fetching a transaction's balance changes by digest.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -24,7 +24,7 @@ pub(crate) struct TxBalanceChangeKey(pub TransactionDigest);
 #[async_trait::async_trait]
 impl Loader<TxBalanceChangeKey> for PgReader {
     type Value = StoredTxBalanceChange;
-    type Error = Arc<ReadError>;
+    type Error = Arc<Error>;
 
     async fn load(
         &self,

--- a/crates/sui-indexer-alt-jsonrpc/src/data/tx_balance_changes.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/tx_balance_changes.rs
@@ -14,14 +14,15 @@ use sui_indexer_alt_schema::{
 };
 use sui_types::digests::TransactionDigest;
 
-use super::reader::{ReadError, Reader};
+use super::pg_reader::PgReader;
+use crate::data::read_error::ReadError;
 
 /// Key for fetching a transaction's balance changes by digest.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct TxBalanceChangeKey(pub TransactionDigest);
 
 #[async_trait::async_trait]
-impl Loader<TxBalanceChangeKey> for Reader {
+impl Loader<TxBalanceChangeKey> for PgReader {
     type Value = StoredTxBalanceChange;
     type Error = Arc<ReadError>;
 

--- a/crates/sui-indexer-alt-jsonrpc/src/data/tx_digests.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/tx_digests.rs
@@ -10,14 +10,15 @@ use async_graphql::dataloader::Loader;
 use diesel::{ExpressionMethods, QueryDsl};
 use sui_indexer_alt_schema::{schema::tx_digests, transactions::StoredTxDigest};
 
-use super::reader::{ReadError, Reader};
+use super::pg_reader::PgReader;
+use super::read_error::ReadError;
 
 /// Key for fetching a transaction's digest by its sequence number.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct TxDigestKey(pub u64);
 
 #[async_trait::async_trait]
-impl Loader<TxDigestKey> for Reader {
+impl Loader<TxDigestKey> for PgReader {
     type Value = StoredTxDigest;
     type Error = Arc<ReadError>;
 

--- a/crates/sui-indexer-alt-jsonrpc/src/data/tx_digests.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/tx_digests.rs
@@ -10,8 +10,8 @@ use async_graphql::dataloader::Loader;
 use diesel::{ExpressionMethods, QueryDsl};
 use sui_indexer_alt_schema::{schema::tx_digests, transactions::StoredTxDigest};
 
+use super::error::Error;
 use super::pg_reader::PgReader;
-use super::read_error::ReadError;
 
 /// Key for fetching a transaction's digest by its sequence number.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -20,7 +20,7 @@ pub(crate) struct TxDigestKey(pub u64);
 #[async_trait::async_trait]
 impl Loader<TxDigestKey> for PgReader {
     type Value = StoredTxDigest;
-    type Error = Arc<ReadError>;
+    type Error = Arc<Error>;
 
     async fn load(
         &self,

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -217,6 +217,7 @@ pub async fn start_rpc(
         objects,
         transactions,
         name_service,
+        bigtable_config,
         extra: _,
     } = rpc_config.finish();
 
@@ -227,7 +228,7 @@ pub async fn start_rpc(
     let mut rpc = RpcService::new(rpc_args, registry, cancel.child_token())
         .context("Failed to create RPC service")?;
 
-    let context = Context::new(db_args, rpc.metrics(), registry).await?;
+    let context = Context::new(db_args, bigtable_config, rpc.metrics(), registry).await?;
 
     let system_package_task = SystemPackageTask::new(
         context.clone(),


### PR DESCRIPTION
## Description 

This PR adds the support for point lookups backed by Bigtable kv store and use it for objects and checkpoints.
Support for transactions is coming in another commit/PR. 

## Test plan 

Connected to Bigtable and tested locally.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
