### PR TITLE
[Consensus] add metric for missing ancestors when processing blocks via commit sync

### DIFF
--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -308,6 +308,19 @@ impl<C: NetworkClient> CommitSyncer<C> {
                             missing, fetched_commit_range
                         );
                     }
+                    for block_ref in missing {
+                        let hostname = self
+                            .inner
+                            .context
+                            .committee
+                            .authority(block_ref.author)
+                            .hostname
+                            .clone();
+                        metrics
+                            .commit_sync_fetch_missing_blocks
+                            .with_label_values(&[&hostname])
+                            .inc();
+                    }
                 }
                 Err(e) => {
                     info!("Failed to add blocks, shutting down: {}", e);

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -309,16 +309,15 @@ impl<C: NetworkClient> CommitSyncer<C> {
                         );
                     }
                     for block_ref in missing {
-                        let hostname = self
+                        let hostname = &self
                             .inner
                             .context
                             .committee
                             .authority(block_ref.author)
-                            .hostname
-                            .clone();
+                            .hostname;
                         metrics
                             .commit_sync_fetch_missing_blocks
-                            .with_label_values(&[&hostname])
+                            .with_label_values(&[hostname])
                             .inc();
                     }
                 }

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -184,6 +184,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) commit_sync_fetch_loop_latency: Histogram,
     pub(crate) commit_sync_fetch_once_latency: Histogram,
     pub(crate) commit_sync_fetch_once_errors: IntCounterVec,
+    pub(crate) commit_sync_fetch_missing_blocks: IntCounterVec,
     pub(crate) round_prober_received_quorum_round_gaps: IntGaugeVec,
     pub(crate) round_prober_accepted_quorum_round_gaps: IntGaugeVec,
     pub(crate) round_prober_low_received_quorum_round: IntGaugeVec,
@@ -690,6 +691,12 @@ impl NodeMetrics {
                 "commit_sync_fetch_once_errors",
                 "Number of errors when attempting to fetch commits and blocks from single authority during commit sync.",
                 &["authority", "error"],
+                registry
+            ).unwrap(),
+            commit_sync_fetch_missing_blocks: register_int_counter_vec_with_registry!(
+                "commit_sync_fetch_missing_blocks",
+                "Number of ancestor blocks that are missing when processing blocks via commit sync.",
+                &["authority"],
                 registry
             ).unwrap(),
             round_prober_received_quorum_round_gaps: register_int_gauge_vec_with_registry!(


### PR DESCRIPTION
## Description 

An additional metric to better track the missing ancestors exclusively coming from the commit sync.

Will cherry pick in 1.43

## Test plan 

CI/PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
