### PR TITLE
Rewrite and simplify CheckpointExecutor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13370,6 +13370,7 @@ dependencies = [
  "anemo",
  "anyhow",
  "arc-swap",
+ "async-stream",
  "async-trait",
  "axum 0.7.5",
  "bcs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16516,6 +16516,7 @@ dependencies = [
  "futures",
  "jsonrpsee",
  "move-binary-format",
+ "mysten-common",
  "prometheus",
  "rand 0.8.5",
  "sui-config",

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -1415,4 +1415,11 @@ impl RunWithRange {
     pub fn matches_checkpoint(&self, seq_num: CheckpointSequenceNumber) -> bool {
         matches!(self, RunWithRange::Checkpoint(seq) if *seq == seq_num)
     }
+
+    pub fn into_checkpoint_bound(self) -> Option<CheckpointSequenceNumber> {
+        match self {
+            RunWithRange::Epoch(_) => None,
+            RunWithRange::Checkpoint(seq) => Some(seq),
+        }
+    }
 }

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -821,7 +821,7 @@ impl ExpensiveSafetyCheckConfig {
 }
 
 fn default_checkpoint_execution_max_concurrency() -> usize {
-    200
+    40
 }
 
 fn default_local_execution_timeout_sec() -> u64 {

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 anyhow = { workspace = true, features = ["backtrace"] }
 arc-swap.workspace = true
 async-trait.workspace = true
+async-stream.workspace = true
 axum.workspace = true
 bcs.workspace = true
 bincode.workspace = true

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -168,7 +168,7 @@ use crate::transaction_input_loader::TransactionInputLoader;
 use crate::transaction_manager::TransactionManager;
 
 #[cfg(msim)]
-pub use crate::checkpoints::checkpoint_executor::{
+pub use crate::checkpoints::checkpoint_executor::utils::{
     init_checkpoint_timeout_config, CheckpointTimeoutConfig,
 };
 

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1162,9 +1162,13 @@ impl AuthorityPerEpochStore {
 
     pub fn get_running_root_accumulator(
         &self,
-        checkpoint: &CheckpointSequenceNumber,
+        checkpoint: CheckpointSequenceNumber,
     ) -> SuiResult<Option<Accumulator>> {
-        Ok(self.tables()?.running_root_accumulators.get(checkpoint)?)
+        Ok(self
+            .tables()?
+            .running_root_accumulators
+            .get(&checkpoint)
+            .expect("db error"))
     }
 
     pub fn get_highest_running_root_accumulator(

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/data_ingestion_handler.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/data_ingestion_handler.rs
@@ -1,45 +1,23 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::checkpoints::CheckpointStore;
+use crate::checkpoints::checkpoint_executor::CheckpointExecutionData;
 use crate::execution_cache::{ObjectCacheRead, TransactionCacheRead};
 use std::collections::HashMap;
-use std::path::PathBuf;
-use std::sync::Arc;
+use std::path::Path;
 use sui_storage::blob::{Blob, BlobEncoding};
-use sui_types::digests::TransactionDigest;
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::error::{SuiError, SuiResult, UserInputError};
 use sui_types::full_checkpoint_content::{CheckpointData, CheckpointTransaction};
-use sui_types::messages_checkpoint::VerifiedCheckpoint;
 use sui_types::storage::ObjectKey;
 
 pub(crate) fn load_checkpoint_data(
-    checkpoint: VerifiedCheckpoint,
+    ckpt: &CheckpointExecutionData,
     object_cache_reader: &dyn ObjectCacheRead,
     transaction_cache_reader: &dyn TransactionCacheRead,
-    checkpoint_store: Arc<CheckpointStore>,
-    transaction_digests: &[TransactionDigest],
 ) -> SuiResult<CheckpointData> {
-    let checkpoint_contents = checkpoint_store
-        .get_checkpoint_contents(&checkpoint.content_digest)?
-        .expect("checkpoint content has to be stored");
-
-    let transactions = transaction_cache_reader
-        .multi_get_transaction_blocks(transaction_digests)
-        .into_iter()
-        .zip(transaction_digests)
-        .map(|(tx, digest)| tx.ok_or(SuiError::TransactionNotFound { digest: *digest }))
-        .collect::<SuiResult<Vec<_>>>()?;
-
-    let effects = transaction_cache_reader
-        .multi_get_executed_effects(transaction_digests)
-        .into_iter()
-        .zip(transaction_digests)
-        .map(|(effects, &digest)| effects.ok_or(SuiError::TransactionNotFound { digest }))
-        .collect::<SuiResult<Vec<_>>>()?;
-
-    let event_digests = effects
+    let event_digests = ckpt
+        .effects
         .iter()
         .flat_map(|fx| fx.events_digest().copied())
         .collect::<Vec<_>>();
@@ -52,8 +30,8 @@ pub(crate) fn load_checkpoint_data(
         .collect::<SuiResult<Vec<_>>>()?;
 
     let events: HashMap<_, _> = event_digests.into_iter().zip(events).collect();
-    let mut full_transactions = Vec::with_capacity(transactions.len());
-    for (tx, fx) in transactions.into_iter().zip(effects) {
+    let mut full_transactions = Vec::with_capacity(ckpt.transactions.len());
+    for (tx, fx) in ckpt.transactions.iter().zip(ckpt.effects.iter()) {
         let events = fx.events_digest().map(|event_digest| {
             events
                 .get(event_digest)
@@ -102,8 +80,8 @@ pub(crate) fn load_checkpoint_data(
             .collect::<SuiResult<Vec<_>>>()?;
 
         let full_transaction = CheckpointTransaction {
-            transaction: (*tx).clone().into(),
-            effects: fx,
+            transaction: (*tx).clone().into_unsigned().into(),
+            effects: fx.clone(),
             events,
             input_objects,
             output_objects,
@@ -111,20 +89,21 @@ pub(crate) fn load_checkpoint_data(
         full_transactions.push(full_transaction);
     }
     let checkpoint_data = CheckpointData {
-        checkpoint_summary: checkpoint.into(),
-        checkpoint_contents,
+        checkpoint_summary: ckpt.checkpoint.clone().into(),
+        checkpoint_contents: ckpt.checkpoint_contents.clone(),
         transactions: full_transactions,
     };
     Ok(checkpoint_data)
 }
 
 pub(crate) fn store_checkpoint_locally(
-    path: PathBuf,
+    path: impl AsRef<Path>,
     checkpoint_data: &CheckpointData,
 ) -> SuiResult {
+    let path = path.as_ref();
     let file_name = format!("{}.chk", checkpoint_data.checkpoint_summary.sequence_number);
 
-    std::fs::create_dir_all(&path).map_err(|err| {
+    std::fs::create_dir_all(path).map_err(|err| {
         SuiError::FileIOError(format!(
             "failed to save full checkpoint content locally {:?}",
             err

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -24,7 +24,7 @@ use parking_lot::Mutex;
 use std::{sync::Arc, time::Instant};
 use sui_types::crypto::RandomnessRound;
 use sui_types::inner_temporary_store::PackageStoreWithFallback;
-use sui_types::messages_checkpoint::CheckpointContents;
+use sui_types::messages_checkpoint::{CheckpointContents, CheckpointSequenceNumber};
 use sui_types::transaction::{TransactionDataAPI, TransactionKind};
 
 use sui_config::node::{CheckpointExecutorConfig, RunWithRange};
@@ -161,7 +161,7 @@ impl CheckpointExecutor {
 
     // Gets the next checkpoint to schedule for execution. If the epoch is already
     // completed, returns None.
-    fn get_next_to_schedule(&self) -> Option<u64> {
+    fn get_next_to_schedule(&self) -> Option<CheckpointSequenceNumber> {
         // Decide the first checkpoint to schedule for execution.
         // If we haven't executed anything in the past, we schedule checkpoint 0.
         // Otherwise we schedule the one after highest executed.

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -18,50 +18,33 @@
 //! CheckpointExecutor enforces the invariant that if `run` returns successfully, we have reached the
 //! end of epoch. This allows us to use it as a signal for reconfig.
 
-use std::path::PathBuf;
-use std::{
-    collections::HashMap,
-    sync::Arc,
-    time::{Duration, Instant},
-};
-
-use either::Either;
-use futures::stream::FuturesOrdered;
-use itertools::izip;
-use mysten_common::fatal;
-use mysten_metrics::spawn_monitored_task;
-use sui_config::node::{CheckpointExecutorConfig, RunWithRange};
-use sui_macros::{fail_point, fail_point_async};
-use sui_types::accumulator::Accumulator;
+use futures::StreamExt;
+use mysten_common::{debug_fatal, fatal};
+use parking_lot::Mutex;
+use std::{sync::Arc, time::Instant};
 use sui_types::crypto::RandomnessRound;
+use sui_types::inner_temporary_store::PackageStoreWithFallback;
+use sui_types::messages_checkpoint::CheckpointContents;
+use sui_types::transaction::{TransactionDataAPI, TransactionKind};
+
+use sui_config::node::{CheckpointExecutorConfig, RunWithRange};
+use sui_macros::fail_point;
+use sui_types::accumulator::Accumulator;
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::full_checkpoint_content::CheckpointData;
-use sui_types::inner_temporary_store::PackageStoreWithFallback;
 use sui_types::message_envelope::Message;
-use sui_types::transaction::TransactionKind;
 use sui_types::{
-    base_types::{ExecutionDigests, TransactionDigest, TransactionEffectsDigest},
-    messages_checkpoint::{CheckpointSequenceNumber, VerifiedCheckpoint},
+    base_types::{TransactionDigest, TransactionEffectsDigest},
+    messages_checkpoint::VerifiedCheckpoint,
     transaction::VerifiedTransaction,
 };
-use sui_types::{error::SuiResult, transaction::TransactionDataAPI};
 use tap::{TapFallible, TapOptional};
-use tokio::{
-    sync::broadcast::{self, error::RecvError},
-    task::JoinHandle,
-    time::timeout,
-};
-use tokio_stream::StreamExt;
-use tracing::{debug, error, info, instrument, trace, warn};
+use tracing::{debug, info, instrument, warn};
 
-use self::metrics::CheckpointExecutorMetrics;
 use crate::authority::authority_per_epoch_store::AuthorityPerEpochStore;
 use crate::authority::backpressure::BackpressureManager;
 use crate::authority::AuthorityState;
-use crate::checkpoints::checkpoint_executor::data_ingestion_handler::{
-    load_checkpoint_data, store_checkpoint_locally,
-};
 use crate::state_accumulator::StateAccumulator;
 use crate::transaction_manager::TransactionManager;
 use crate::{
@@ -71,66 +54,13 @@ use crate::{
 
 mod data_ingestion_handler;
 pub mod metrics;
+pub(crate) mod utils;
 
-type CheckpointExecutionBuffer = FuturesOrdered<
-    JoinHandle<(
-        VerifiedCheckpoint,
-        Option<Accumulator>,
-        Option<CheckpointData>,
-        Vec<TransactionDigest>,
-        Vec<RandomnessRound>,
-    )>,
->;
+use data_ingestion_handler::{load_checkpoint_data, store_checkpoint_locally};
+use metrics::CheckpointExecutorMetrics;
+use utils::*;
 
-/// The interval to log checkpoint progress, in # of checkpoints processed.
 const CHECKPOINT_PROGRESS_LOG_COUNT_INTERVAL: u64 = 5000;
-
-#[derive(Debug, Clone, Copy)]
-pub struct CheckpointTimeoutConfig {
-    pub panic_timeout: Option<Duration>,
-    pub warning_timeout: Duration,
-}
-
-// We use a thread local so that the config can be overridden on a per-test basis. This means
-// that get_scheduling_timeout() can be called multiple times in a multithreaded context, but
-// the function is still very cheap to call so this is okay.
-thread_local! {
-    static SCHEDULING_TIMEOUT: once_cell::sync::OnceCell<CheckpointTimeoutConfig> =
-        const { once_cell::sync::OnceCell::new() };
-}
-
-#[cfg(msim)]
-pub fn init_checkpoint_timeout_config(config: CheckpointTimeoutConfig) {
-    SCHEDULING_TIMEOUT.with(|s| {
-        s.set(config).expect("SchedulingTimeoutConfig already set");
-    });
-}
-
-fn get_scheduling_timeout() -> CheckpointTimeoutConfig {
-    fn inner() -> CheckpointTimeoutConfig {
-        let panic_timeout: Option<Duration> = if cfg!(msim) {
-            Some(Duration::from_secs(45))
-        } else {
-            std::env::var("NEW_CHECKPOINT_PANIC_TIMEOUT_MS")
-                .ok()
-                .and_then(|s| s.parse::<u64>().ok())
-                .map(Duration::from_millis)
-        };
-
-        let warning_timeout: Duration = std::env::var("NEW_CHECKPOINT_WARNING_TIMEOUT_MS")
-            .ok()
-            .and_then(|s| s.parse::<u64>().ok())
-            .map(Duration::from_millis)
-            .unwrap_or(Duration::from_secs(5));
-
-        CheckpointTimeoutConfig {
-            panic_timeout,
-            warning_timeout,
-        }
-    }
-
-    SCHEDULING_TIMEOUT.with(|s| *s.get_or_init(inner))
-}
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum StopReason {
@@ -138,10 +68,39 @@ pub enum StopReason {
     RunWithRangeCondition,
 }
 
+pub(crate) struct CheckpointExecutionData {
+    pub checkpoint: VerifiedCheckpoint,
+    pub checkpoint_contents: CheckpointContents,
+    pub tx_digests: Vec<TransactionDigest>,
+    pub fx_digests: Vec<TransactionEffectsDigest>,
+    pub transactions: Vec<VerifiedExecutableTransaction>,
+    pub effects: Vec<TransactionEffects>,
+}
+
+pub(crate) struct CheckpointExecutionState {
+    pub data: CheckpointExecutionData,
+
+    executed_fx_digests: Vec<Option<TransactionEffectsDigest>>,
+    accumulator: Option<Accumulator>,
+    full_data: Option<CheckpointData>,
+}
+
+impl CheckpointExecutionState {
+    pub fn new(
+        data: CheckpointExecutionData,
+        executed_fx_digests: Vec<Option<TransactionEffectsDigest>>,
+    ) -> Self {
+        Self {
+            data,
+            executed_fx_digests,
+            accumulator: None,
+            full_data: None,
+        }
+    }
+}
+
 pub struct CheckpointExecutor {
-    mailbox: broadcast::Receiver<VerifiedCheckpoint>,
-    // TODO: AuthorityState is only needed because we have to call deprecated_insert_finalized_transactions
-    // once that code is fully deprecated we can remove this
+    epoch_store: Arc<AuthorityPerEpochStore>,
     state: Arc<AuthorityState>,
     checkpoint_store: Arc<CheckpointStore>,
     object_cache_reader: Arc<dyn ObjectCacheRead>,
@@ -156,7 +115,7 @@ pub struct CheckpointExecutor {
 
 impl CheckpointExecutor {
     pub fn new(
-        mailbox: broadcast::Receiver<VerifiedCheckpoint>,
+        epoch_store: Arc<AuthorityPerEpochStore>,
         checkpoint_store: Arc<CheckpointStore>,
         state: Arc<AuthorityState>,
         accumulator: Arc<StateAccumulator>,
@@ -166,7 +125,7 @@ impl CheckpointExecutor {
         subscription_service_checkpoint_sender: Option<tokio::sync::mpsc::Sender<CheckpointData>>,
     ) -> Self {
         Self {
-            mailbox,
+            epoch_store,
             state: state.clone(),
             checkpoint_store,
             object_cache_reader: state.get_object_cache_reader().clone(),
@@ -181,13 +140,13 @@ impl CheckpointExecutor {
     }
 
     pub fn new_for_tests(
-        mailbox: broadcast::Receiver<VerifiedCheckpoint>,
+        epoch_store: Arc<AuthorityPerEpochStore>,
         checkpoint_store: Arc<CheckpointStore>,
         state: Arc<AuthorityState>,
         accumulator: Arc<StateAccumulator>,
     ) -> Self {
         Self::new(
-            mailbox,
+            epoch_store,
             checkpoint_store,
             state,
             accumulator,
@@ -198,182 +157,428 @@ impl CheckpointExecutor {
         )
     }
 
-    /// Ensure that all checkpoints in the current epoch will be executed.
-    /// We don't technically need &mut on self, but passing it to make sure only one instance is
-    /// running at one time.
-    pub async fn run_epoch(
-        &mut self,
-        epoch_store: Arc<AuthorityPerEpochStore>,
-        run_with_range: Option<RunWithRange>,
-    ) -> StopReason {
-        // check if we want to run this epoch based on RunWithRange condition value
-        // we want to be inclusive of the defined RunWithRangeEpoch::Epoch
-        // i.e Epoch(N) means we will execute epoch N and stop when reaching N+1
-        if run_with_range.map_or(false, |rwr| rwr.is_epoch_gt(epoch_store.epoch())) {
-            info!(
-                "RunWithRange condition satisfied at {:?}, run_epoch={:?}",
-                run_with_range,
-                epoch_store.epoch()
-            );
-            return StopReason::RunWithRangeCondition;
-        };
-
-        debug!(
-            "Checkpoint executor running for epoch {}",
-            epoch_store.epoch(),
-        );
-        self.metrics
-            .checkpoint_exec_epoch
-            .set(epoch_store.epoch() as i64);
-
+    // Gets the next checkpoint to schedule for execution. If the epoch is already
+    // completed, returns None.
+    fn get_next_to_schedule(&self) -> Option<u64> {
         // Decide the first checkpoint to schedule for execution.
         // If we haven't executed anything in the past, we schedule checkpoint 0.
         // Otherwise we schedule the one after highest executed.
-        let mut highest_executed = self
+        let highest_executed = self
             .checkpoint_store
             .get_highest_executed_checkpoint()
             .unwrap();
 
         if let Some(highest_executed) = &highest_executed {
-            if epoch_store.epoch() == highest_executed.epoch()
+            if self.epoch_store.epoch() == highest_executed.epoch()
                 && highest_executed.is_last_checkpoint_of_epoch()
             {
                 // We can arrive at this point if we bump the highest_executed_checkpoint watermark, and then
                 // crash before completing reconfiguration.
                 info!(seq = ?highest_executed.sequence_number, "final checkpoint of epoch has already been executed");
-                return StopReason::EpochComplete;
+                return None;
             }
         }
 
-        let mut next_to_schedule = highest_executed
-            .as_ref()
-            .map(|c| c.sequence_number() + 1)
-            .unwrap_or_else(|| {
-                // TODO this invariant may no longer hold once we introduce snapshots
-                assert_eq!(epoch_store.epoch(), 0);
-                0
-            });
-        let mut pending: CheckpointExecutionBuffer = FuturesOrdered::new();
+        Some(
+            highest_executed
+                .as_ref()
+                .map(|c| c.sequence_number() + 1)
+                .unwrap_or_else(|| {
+                    // TODO this invariant may no longer hold once we introduce snapshots
+                    assert_eq!(self.epoch_store.epoch(), 0);
+                    0
+                }),
+        )
+    }
 
-        let mut now_time = Instant::now();
-        let mut now_transaction_num = highest_executed
-            .as_ref()
-            .map(|c| c.network_total_transactions)
-            .unwrap_or(0);
-        let scheduling_timeout_config = get_scheduling_timeout();
+    /// Ensure that all checkpoints in the current epoch will be executed.
+    /// We don't technically need &mut on self, but passing it to make sure only one instance is
+    /// running at one time.
+    #[instrument(level = "error", skip_all, fields(epoch = ?self.epoch_store.epoch()))]
+    pub async fn run_epoch(self, run_with_range: Option<RunWithRange>) -> StopReason {
+        let _metrics_guard = mysten_metrics::monitored_scope("CheckpointExecutor::run_epoch");
+        debug!(?run_with_range, "CheckpointExecutor::run_epoch");
 
-        loop {
-            let schedule_scope = mysten_metrics::monitored_scope("ScheduleCheckpointExecution");
+        // check if we want to run this epoch based on RunWithRange condition value
+        // we want to be inclusive of the defined RunWithRangeEpoch::Epoch
+        // i.e Epoch(N) means we will execute epoch N and stop when reaching N+1
+        if run_with_range.map_or(false, |rwr| rwr.is_epoch_gt(self.epoch_store.epoch())) {
+            info!("RunWithRange condition satisfied at {:?}", run_with_range,);
+            return StopReason::RunWithRangeCondition;
+        };
 
-            // If we have executed the last checkpoint of the current epoch, stop.
-            // Note: when we arrive here with highest_executed == the final checkpoint of the epoch,
-            // we are in an edge case where highest_executed does not actually correspond to the watermark.
-            // The watermark is only bumped past the epoch final checkpoint after execution of the change
-            // epoch tx, and state accumulation.
-            if self
-                .check_epoch_last_checkpoint(epoch_store.clone(), &highest_executed)
-                .await
-            {
-                self.checkpoint_store
-                    .prune_local_summaries()
-                    .tap_err(|e| error!("Failed to prune local summaries: {}", e))
-                    .ok();
+        self.metrics
+            .checkpoint_exec_epoch
+            .set(self.epoch_store.epoch() as i64);
 
-                // be extra careful to ensure we don't have orphans
-                assert!(
-                    pending.is_empty(),
-                    "Pending checkpoint execution buffer should be empty after processing last checkpoint of epoch",
-                );
-                fail_point!("crash");
-                debug!(epoch = epoch_store.epoch(), "finished epoch");
-                return StopReason::EpochComplete;
-            }
+        let Some(next_to_schedule) = self.get_next_to_schedule() else {
+            return StopReason::EpochComplete;
+        };
 
-            self.schedule_synced_checkpoints(
-                &mut pending,
-                // next_to_schedule will be updated to the next checkpoint to schedule.
-                // This makes sure we don't re-schedule the same checkpoint multiple times.
-                &mut next_to_schedule,
-                epoch_store.clone(),
-                run_with_range,
-            );
+        let tps_estimator = Arc::new(Mutex::new(TPSEstimator::default()));
 
-            self.metrics
-                .checkpoint_exec_inflight
-                .set(pending.len() as i64);
+        let this = Arc::new(self);
 
-            let panic_timeout = scheduling_timeout_config.panic_timeout;
-            let warning_timeout = scheduling_timeout_config.warning_timeout;
+        let is_final_checkpoint = stream_synced_checkpoints(
+            this.checkpoint_store.clone(),
+            next_to_schedule,
+            run_with_range.and_then(|rwr| rwr.into_checkpoint_bound()),
+        )
+        // concurrent step
+        .map(|checkpoint| {
+            checkpoint.report_checkpoint_age(&this.metrics.checkpoint_contents_age, &this.metrics.checkpoint_contents_age_ms);
+            this.backpressure_manager.update_highest_certified_checkpoint(*checkpoint.sequence_number());
 
-            drop(schedule_scope);
-            tokio::select! {
-                // Check for completed workers and ratchet the highest_checkpoint_executed
-                // watermark accordingly. Note that given that checkpoints are guaranteed to
-                // be processed (added to FuturesOrdered) in seq_number order, using FuturesOrdered
-                // guarantees that we will also ratchet the watermarks in order.
-                Some(Ok((checkpoint, checkpoint_acc, checkpoint_data, tx_digests, randomness_rounds))) = pending.next() => {
-                    let _process_scope = mysten_metrics::monitored_scope("ProcessExecutedCheckpoint");
+            let this = this.clone();
 
-                    self.process_executed_checkpoint(&epoch_store, &checkpoint, checkpoint_acc, checkpoint_data, &tx_digests, randomness_rounds).await;
-                    self.backpressure_manager.update_highest_executed_checkpoint(*checkpoint.sequence_number());
-                    highest_executed = Some(checkpoint.clone());
+            async move {
+                let sequence_number = checkpoint.sequence_number;
+                if checkpoint.is_last_checkpoint_of_epoch() && sequence_number > 0 {
+                    info!(?sequence_number, "Reached end of epoch checkpoint, waiting for all previous checkpoints to be executed");
+                    this.checkpoint_store.notify_read_executed_checkpoint(sequence_number - 1).await;
+                }
+                let _parallel_step_guard = mysten_metrics::monitored_scope("CheckpointExecutor::parallel_step");
 
-                    // Estimate TPS every 10k transactions or 30 sec
-                    let elapsed = now_time.elapsed().as_millis();
-                    let current_transaction_num =  highest_executed.as_ref().map(|c| c.network_total_transactions).unwrap_or(0);
-                    if current_transaction_num - now_transaction_num > 10_000 || elapsed > 30_000 {
-                        let tps = (1000.0 * (current_transaction_num - now_transaction_num) as f64 / elapsed as f64) as i32;
-                        self.metrics.checkpoint_exec_sync_tps.set(tps as i64);
-                        now_time = Instant::now();
-                        now_transaction_num = current_transaction_num;
+                info!(?sequence_number, "executing checkpoint");
+
+                let (mut ckpt_state, unexecuted_tx_digests) = tokio::task::spawn_blocking({
+                    let this = this.clone();
+                    move || {
+                        let _scope = mysten_metrics::monitored_scope("CheckpointExecutor::execute_transactions");
+                        let ckpt_state = this.load_checkpoint_transactions(checkpoint);
+                        let unexecuted_tx_digests = this.execute_checkpoint(&ckpt_state);
+                        (ckpt_state, unexecuted_tx_digests)
                     }
-                     // we want to be inclusive of checkpoints in RunWithRange::Checkpoint type
-                    if run_with_range.map_or(false, |rwr| rwr.matches_checkpoint(checkpoint.sequence_number)) {
-                        info!(
-                            "RunWithRange condition satisfied after checkpoint sequence number {:?}",
-                            checkpoint.sequence_number
-                        );
-                        return StopReason::RunWithRangeCondition;
-                    }
+                }).await.unwrap();
+
+                this.transaction_cache_reader
+                    .notify_read_executed_effects_digests(&unexecuted_tx_digests)
+                    .await;
+
+                if ckpt_state.data.checkpoint.is_last_checkpoint_of_epoch() {
+                    this.execute_change_epoch_tx(&ckpt_state).await;
                 }
 
-                received = self.mailbox.recv() => match received {
-                    Ok(checkpoint) => {
-                        info!(
-                            sequence_number = ?checkpoint.sequence_number,
-                            "Received checkpoint summary from state sync"
-                        );
-                        checkpoint.report_checkpoint_age(&self.metrics.checkpoint_contents_age, &self.metrics.checkpoint_contents_age_ms);
-                        // Note: checkpoints arrive in increasing order by sequence number, but they are not
-                        // necessarily consecutive.
-                        self.backpressure_manager.update_highest_certified_checkpoint(*checkpoint.sequence_number());
-                    },
-                    Err(RecvError::Lagged(num_skipped)) => {
-                        debug!(
-                            "Checkpoint Execution Recv channel overflowed with {:?} messages",
-                            num_skipped,
+                tokio::task::spawn_blocking(move || {
+                    let _scope = mysten_metrics::monitored_scope("CheckpointExecutor::finalize_checkpoint");
+                    this.epoch_store
+                        .insert_finalized_transactions(&ckpt_state.data.tx_digests, sequence_number)
+                        .expect("failed to insert finalized transactions");
+
+                    if this.state.is_fullnode(&this.epoch_store) {
+                        this.state.congestion_tracker.process_checkpoint_effects(
+                            &*this.transaction_cache_reader,
+                            &ckpt_state.data.checkpoint,
+                            &ckpt_state.data.effects,
                         );
                     }
-                    Err(RecvError::Closed) => {
-                        panic!("Checkpoint Execution Sender (StateSync) closed channel unexpectedly");
-                    },
-                },
 
-                _ = tokio::time::sleep(warning_timeout) => {
-                    warn!(
-                        "Received no new synced checkpoints for {warning_timeout:?}. Next checkpoint to be scheduled: {next_to_schedule}",
+                    // TODO remove once we no longer need to support this table for read RPC
+                    this.state
+                        .get_checkpoint_cache()
+                        .deprecated_insert_finalized_transactions(
+                            &ckpt_state.data.tx_digests,
+                            this.epoch_store.epoch(),
+                            sequence_number,
+                        );
+
+                    // The early versions of the accumulator (prior to effectsv2) rely on db
+                    // state, so we must wait until all transactions have been executed
+                    // before accumulating the checkpoint.
+                    ckpt_state.accumulator = Some(
+                        this.accumulator
+                            .accumulate_checkpoint(
+                                &ckpt_state.data.effects,
+                                sequence_number,
+                                &this.epoch_store,
+                            )
+                            .expect("epoch cannot have ended"),
                     );
-                }
 
-                _ = panic_timeout
-                            .map(|d| Either::Left(tokio::time::sleep(d)))
-                            .unwrap_or_else(|| Either::Right(futures::future::pending())) => {
-                    panic!("No new synced checkpoints received for {panic_timeout:?} on node {:?}", self.state.name);
-                },
+                    ckpt_state.full_data = this.process_checkpoint_data(&ckpt_state);
+                    ckpt_state
+                }).await.unwrap()
             }
+        })
+        .buffered(10)
+        // sequential step
+        .map(|ckpt_state| {
+            let this = this.clone();
+            let tps_estimator = tps_estimator.clone();
+            async move {
+                let _sequential_step_guard = mysten_metrics::monitored_scope("CheckpointExecutor::sequential_step");
+
+                let tps = tps_estimator.lock().update(
+                    Instant::now(),
+                    ckpt_state.data.checkpoint.network_total_transactions,
+                );
+                this.metrics.checkpoint_exec_sync_tps.set(tps as i64);
+
+                this.backpressure_manager
+                    .update_highest_executed_checkpoint(
+                        *ckpt_state.data.checkpoint.sequence_number(),
+                    );
+
+                let is_final_checkpoint = ckpt_state.data.checkpoint.is_last_checkpoint_of_epoch();
+                this.process_executed_checkpoint(ckpt_state).await;
+                is_final_checkpoint
+            }
+        })
+        .fold(false, |state, is_final_checkpoint| {
+            assert!(!state, "fold can't be called again after the final checkpoint");
+            is_final_checkpoint
+        })
+        .await;
+
+        if is_final_checkpoint {
+            StopReason::EpochComplete
+        } else {
+            StopReason::RunWithRangeCondition
+        }
+    }
+}
+
+impl CheckpointExecutor {
+    fn checkpoint_data_enabled(&self) -> bool {
+        self.subscription_service_checkpoint_sender.is_some()
+            || self.state.rpc_index.is_some()
+            || self.config.data_ingestion_dir.is_some()
+    }
+
+    fn process_checkpoint_data(
+        &self,
+        ckpt_state: &CheckpointExecutionState,
+    ) -> Option<CheckpointData> {
+        if !self.checkpoint_data_enabled() {
+            return None;
+        }
+
+        let checkpoint_data = load_checkpoint_data(
+            &ckpt_state.data,
+            &*self.object_cache_reader,
+            &*self.transaction_cache_reader,
+        )
+        .expect("failed to load checkpoint data");
+
+        self.write_checkpoint_data(&checkpoint_data);
+        Some(checkpoint_data)
+    }
+
+    // Load all required transaction and effects data for the checkpoint.
+    fn load_checkpoint_transactions(
+        &self,
+        checkpoint: VerifiedCheckpoint,
+    ) -> CheckpointExecutionState {
+        let seq = checkpoint.sequence_number;
+        let epoch = checkpoint.epoch;
+
+        let checkpoint_contents = self
+            .checkpoint_store
+            .get_checkpoint_contents(&checkpoint.content_digest)
+            .expect("db error")
+            .expect("checkpoint contents not found");
+
+        // attempt to load full checkpoint contents in bulk
+        if let Some(full_contents) = self
+            .checkpoint_store
+            .get_full_checkpoint_contents_by_sequence_number(seq)
+            .expect("Failed to get checkpoint contents from store")
+            .tap_some(|_| debug!("loaded full checkpoint contents in bulk for sequence {seq}"))
+        {
+            let num_txns = full_contents.size();
+            let mut tx_digests = Vec::with_capacity(num_txns);
+            let mut transactions = Vec::with_capacity(num_txns);
+            let mut effects = Vec::with_capacity(num_txns);
+            let mut fx_digests = Vec::with_capacity(num_txns);
+
+            full_contents
+                .into_iter()
+                .zip(checkpoint_contents.iter())
+                .for_each(|(execution_data, digests)| {
+                    let tx_digest = digests.transaction;
+                    let fx_digest = digests.effects;
+                    debug_assert_eq!(tx_digest, *execution_data.transaction.digest());
+                    debug_assert_eq!(fx_digest, execution_data.effects.digest());
+
+                    tx_digests.push(tx_digest);
+                    transactions.push(VerifiedExecutableTransaction::new_from_checkpoint(
+                        VerifiedTransaction::new_unchecked(execution_data.transaction),
+                        epoch,
+                        seq,
+                    ));
+                    effects.push(execution_data.effects);
+                    fx_digests.push(fx_digest);
+                });
+
+            let executed_fx_digests = self
+                .transaction_cache_reader
+                .multi_get_executed_effects_digests(&tx_digests);
+
+            CheckpointExecutionState::new(
+                CheckpointExecutionData {
+                    checkpoint,
+                    checkpoint_contents,
+                    tx_digests,
+                    fx_digests,
+                    transactions,
+                    effects,
+                },
+                executed_fx_digests,
+            )
+        } else {
+            // load items one-by-one
+
+            let digests = checkpoint_contents.inner();
+
+            let (tx_digests, fx_digests): (Vec<_>, Vec<_>) =
+                digests.iter().map(|d| (d.transaction, d.effects)).unzip();
+            let transactions = self
+                .transaction_cache_reader
+                .multi_get_transaction_blocks(&tx_digests)
+                .into_iter()
+                .enumerate()
+                .map(|(i, tx)| {
+                    let tx = tx
+                        .unwrap_or_else(|| fatal!("transaction not found for {:?}", tx_digests[i]));
+                    let tx = Arc::try_unwrap(tx).unwrap_or_else(|tx| (*tx).clone());
+                    VerifiedExecutableTransaction::new_from_checkpoint(tx, epoch, seq)
+                })
+                .collect();
+            let effects = self
+                .transaction_cache_reader
+                .multi_get_effects(&fx_digests)
+                .into_iter()
+                .enumerate()
+                .map(|(i, effect)| {
+                    effect.unwrap_or_else(|| {
+                        fatal!("checkpoint effect not found for {:?}", digests[i])
+                    })
+                })
+                .collect();
+
+            let executed_fx_digests = self
+                .transaction_cache_reader
+                .multi_get_executed_effects_digests(&tx_digests);
+
+            CheckpointExecutionState::new(
+                CheckpointExecutionData {
+                    checkpoint,
+                    checkpoint_contents,
+                    tx_digests,
+                    fx_digests,
+                    transactions,
+                    effects,
+                },
+                executed_fx_digests,
+            )
         }
     }
 
+    // Execute all unexecuted transactions in the checkpoint
+    fn execute_checkpoint(&self, ckpt_state: &CheckpointExecutionState) -> Vec<TransactionDigest> {
+        // Find unexecuted transactions and their expected effects digests
+        let (unexecuted_tx_digests, unexecuted_txns, unexecuted_effects): (Vec<_>, Vec<_>, Vec<_>) =
+            itertools::multiunzip(
+                itertools::izip!(
+                    ckpt_state.data.transactions.iter(),
+                    ckpt_state.data.tx_digests.iter(),
+                    ckpt_state.data.fx_digests.iter(),
+                    ckpt_state.data.effects.iter(),
+                    ckpt_state.executed_fx_digests.iter()
+                )
+                .filter_map(
+                    |(txn, tx_digest, expected_fx_digest, effects, executed_fx_digest)| {
+                        if let Some(executed_fx_digest) = executed_fx_digest {
+                            assert_not_forked(
+                                &ckpt_state.data.checkpoint,
+                                tx_digest,
+                                expected_fx_digest,
+                                executed_fx_digest,
+                                &*self.transaction_cache_reader,
+                            );
+                            None
+                        } else if txn.transaction_data().is_end_of_epoch_tx() {
+                            None
+                        } else {
+                            Some((tx_digest, (txn.clone(), *expected_fx_digest), effects))
+                        }
+                    },
+                ),
+            );
+
+        for ((tx, _), effects) in itertools::izip!(unexecuted_txns.iter(), unexecuted_effects) {
+            if tx.contains_shared_object() {
+                self.epoch_store
+                    .acquire_shared_version_assignments_from_effects(
+                        tx,
+                        effects,
+                        &*self.object_cache_reader,
+                    )
+                    .expect("failed to acquire shared version assignments");
+            }
+        }
+
+        // Enqueue unexecuted transactions with their expected effects digests
+        self.tx_manager
+            .enqueue_with_expected_effects_digest(unexecuted_txns, &self.epoch_store);
+
+        unexecuted_tx_digests
+    }
+
+    // Execute the change epoch txn
+    async fn execute_change_epoch_tx(&self, ckpt_state: &CheckpointExecutionState) {
+        let change_epoch_tx = ckpt_state.data.transactions.last().unwrap();
+        let change_epoch_fx = ckpt_state.data.effects.last().unwrap();
+        assert_eq!(
+            change_epoch_tx.digest(),
+            change_epoch_fx.transaction_digest()
+        );
+        assert!(
+            change_epoch_tx.transaction_data().is_end_of_epoch_tx(),
+            "final txn must be an end of epoch txn"
+        );
+
+        // Ordinarily we would assert that the change epoch txn has not been executed yet.
+        // However, during crash recovery, it is possible that we already passed this point and
+        // the txn has been executed. You can uncomment this assert if you are debugging a problem
+        // related to reconfig. If you hit this assert and it is not because of crash-recovery,
+        // it may indicate a bug in the checkpoint executor.
+        //
+        //     if self
+        //         .transaction_cache_reader
+        //         .get_executed_effects(change_epoch_tx.digest())
+        //         .is_some()
+        //     {
+        //         fatal!(
+        //             "end of epoch txn must not have been executed: {:?}",
+        //             change_epoch_tx.digest()
+        //         );
+        //     }
+
+        self.epoch_store
+            .acquire_shared_version_assignments_from_effects(
+                change_epoch_tx,
+                change_epoch_fx,
+                self.object_cache_reader.as_ref(),
+            )
+            .expect("Acquiring shared version assignments for change_epoch tx cannot fail");
+
+        info!(
+            "scheduling change epoch txn with digest: {:?}, expected effects digest: {:?}",
+            change_epoch_tx.digest(),
+            change_epoch_fx.digest()
+        );
+        self.tx_manager.enqueue_with_expected_effects_digest(
+            vec![(change_epoch_tx.clone(), change_epoch_fx.digest())],
+            &self.epoch_store,
+        );
+
+        self.transaction_cache_reader
+            .notify_read_executed_effects_digests(&[*change_epoch_tx.digest()])
+            .await;
+    }
+
+    // Increment the highest executed checkpoint watermark and prune old full-checkpoint contents
     fn bump_highest_executed_checkpoint(&self, checkpoint: &VerifiedCheckpoint) {
         // Ensure that we are not skipping checkpoints at any point
         let seq = *checkpoint.sequence_number();
@@ -438,36 +643,33 @@ impl CheckpointExecutor {
 
     /// Post processing and plumbing after we executed a checkpoint. This function is guaranteed
     /// to be called in the order of checkpoint sequence number.
-    #[instrument(level = "info", skip_all, fields(seq = ?checkpoint.sequence_number()))]
-    async fn process_executed_checkpoint(
-        &self,
-        epoch_store: &AuthorityPerEpochStore,
-        checkpoint: &VerifiedCheckpoint,
-        checkpoint_acc: Option<Accumulator>,
-        checkpoint_data: Option<CheckpointData>,
-        all_tx_digests: &[TransactionDigest],
-        randomness_rounds: Vec<RandomnessRound>,
-    ) {
+    #[instrument(level = "debug", skip_all)]
+    async fn process_executed_checkpoint(&self, mut ckpt_state: CheckpointExecutionState) {
         // Commit all transaction effects to disk
         let cache_commit = self.state.get_cache_commit();
-        debug!("committing checkpoint transactions to disk");
+        let seq = ckpt_state.data.checkpoint.sequence_number;
+        debug!(?seq, "committing checkpoint transactions to disk");
         cache_commit.commit_transaction_outputs(
-            epoch_store.epoch(),
-            all_tx_digests,
-            epoch_store
+            self.epoch_store.epoch(),
+            &ckpt_state.data.tx_digests,
+            self.epoch_store
                 .protocol_config()
                 .use_object_per_epoch_marker_table_v2_as_option()
                 .unwrap_or(false),
         );
 
-        epoch_store
-            .handle_finalized_checkpoint(checkpoint.data(), all_tx_digests)
+        self.epoch_store
+            .handle_finalized_checkpoint(&ckpt_state.data.checkpoint, &ckpt_state.data.tx_digests)
             .expect("cannot fail");
 
         // Once the checkpoint is finalized, we know that any randomness contained in this checkpoint has
         // been successfully included in a checkpoint certified by quorum of validators.
         // (RandomnessManager/RandomnessReporter is only present on validators.)
-        if let Some(randomness_reporter) = epoch_store.randomness_reporter() {
+        if let Some(randomness_reporter) = self.epoch_store.randomness_reporter() {
+            let randomness_rounds = self.extract_randomness_rounds(
+                &ckpt_state.data.checkpoint,
+                &ckpt_state.data.checkpoint_contents,
+            );
             for round in randomness_rounds {
                 debug!(
                     ?round,
@@ -479,26 +681,38 @@ impl CheckpointExecutor {
             }
         }
 
-        if let Some(checkpoint_data) = checkpoint_data {
-            self.commit_index_updates_and_enqueue_to_subscription_service(checkpoint_data)
-                .await;
+        if let Some(checkpoint_data) = ckpt_state.full_data.take() {
+            self.commit_index_updates_and_enqueue_to_subscription_service(checkpoint_data);
         }
 
-        if !checkpoint.is_last_checkpoint_of_epoch() {
+        self.accumulator
+            .accumulate_running_root(&self.epoch_store, seq, ckpt_state.accumulator)
+            .await
+            .expect("Failed to accumulate running root");
+
+        if ckpt_state.data.checkpoint.is_last_checkpoint_of_epoch() {
+            self.checkpoint_store
+                .insert_epoch_last_checkpoint(self.epoch_store.epoch(), &ckpt_state.data.checkpoint)
+                .expect("Failed to insert epoch last checkpoint");
+
             self.accumulator
-                .accumulate_running_root(epoch_store, checkpoint.sequence_number, checkpoint_acc)
-                .await
-                .expect("Failed to accumulate running root");
-            self.bump_highest_executed_checkpoint(checkpoint);
+                .accumulate_epoch(self.epoch_store.clone(), seq)
+                .expect("Accumulating epoch cannot fail");
+
+            self.checkpoint_store
+                .prune_local_summaries()
+                .tap_err(|e| debug_fatal!("Failed to prune local summaries: {}", e))
+                .ok();
         }
+
+        fail_point!("crash");
+
+        self.bump_highest_executed_checkpoint(&ckpt_state.data.checkpoint);
     }
 
     /// If configured, commit the pending index updates for the provided checkpoint as well as
     /// enqueuing the checkpoint to the subscription service
-    async fn commit_index_updates_and_enqueue_to_subscription_service(
-        &self,
-        checkpoint: CheckpointData,
-    ) {
+    fn commit_index_updates_and_enqueue_to_subscription_service(&self, checkpoint: CheckpointData) {
         if let Some(rpc_index) = &self.state.rpc_index {
             rpc_index
                 .commit_update_for_checkpoint(checkpoint.checkpoint_summary.sequence_number)
@@ -506,933 +720,78 @@ impl CheckpointExecutor {
         }
 
         if let Some(sender) = &self.subscription_service_checkpoint_sender {
-            if let Err(e) = sender.send(checkpoint).await {
-                tracing::warn!("unable to send checkpoint to subscription service: {e}");
+            if let Err(e) = sender.blocking_send(checkpoint) {
+                warn!("unable to send checkpoint to subscription service: {e}");
             }
         }
     }
 
-    #[instrument(level = "debug", skip_all)]
-    fn schedule_synced_checkpoints(
-        &self,
-        pending: &mut CheckpointExecutionBuffer,
-        next_to_schedule: &mut CheckpointSequenceNumber,
-        epoch_store: Arc<AuthorityPerEpochStore>,
-        run_with_range: Option<RunWithRange>,
-    ) {
-        let Some(latest_synced_checkpoint) = self
-            .checkpoint_store
-            .get_highest_synced_checkpoint()
-            .expect("Failed to read highest synced checkpoint")
-        else {
-            debug!("No checkpoints to schedule, highest synced checkpoint is None",);
-            return;
-        };
-
-        while *next_to_schedule <= *latest_synced_checkpoint.sequence_number()
-            && pending.len() < self.config.checkpoint_execution_max_concurrency
-        {
-            let checkpoint = self
-                .checkpoint_store
-                .get_checkpoint_by_sequence_number(*next_to_schedule)
-                .unwrap()
-                .unwrap_or_else(|| {
-                    panic!(
-                        "Checkpoint sequence number {:?} does not exist in checkpoint store",
-                        *next_to_schedule
-                    )
-                });
-            if checkpoint.epoch() > epoch_store.epoch() {
-                return;
-            }
-            match run_with_range {
-                Some(RunWithRange::Checkpoint(seq)) if *next_to_schedule > seq => {
-                    debug!(
-                        "RunWithRange Checkpoint {} is set, not scheduling checkpoint {}",
-                        seq, *next_to_schedule
-                    );
-                    return;
-                }
-                _ => {
-                    self.schedule_checkpoint(checkpoint, pending, epoch_store.clone());
-                    *next_to_schedule += 1;
-                }
-            }
-        }
-    }
-
-    #[instrument(level = "error", skip_all, fields(seq = ?checkpoint.sequence_number(), epoch = ?epoch_store.epoch()))]
-    fn schedule_checkpoint(
-        &self,
-        checkpoint: VerifiedCheckpoint,
-        pending: &mut CheckpointExecutionBuffer,
-        epoch_store: Arc<AuthorityPerEpochStore>,
-    ) {
-        debug!("Scheduling checkpoint for execution");
-
-        // Mismatch between node epoch and checkpoint epoch after startup
-        // crash recovery is invalid
-        let checkpoint_epoch = checkpoint.epoch();
-        assert_eq!(
-            checkpoint_epoch,
-            epoch_store.epoch(),
-            "Epoch mismatch after startup recovery. checkpoint epoch: {:?}, node epoch: {:?}",
-            checkpoint_epoch,
-            epoch_store.epoch(),
-        );
-
-        let metrics = self.metrics.clone();
-        let local_execution_timeout_sec = self.config.local_execution_timeout_sec;
-        let data_ingestion_dir = self.config.data_ingestion_dir.clone();
-        let checkpoint_store = self.checkpoint_store.clone();
-        let object_cache_reader = self.object_cache_reader.clone();
-        let transaction_cache_reader = self.transaction_cache_reader.clone();
-        let tx_manager = self.tx_manager.clone();
-        let accumulator = self.accumulator.clone();
-        let state = self.state.clone();
-        let subscription_service_enabled = self.subscription_service_checkpoint_sender.is_some();
-
-        pending.push_back(spawn_monitored_task!(async move {
-            let epoch_store = epoch_store.clone();
-            let (tx_digests, checkpoint_acc, checkpoint_data, randomness_rounds) = loop {
-                match execute_checkpoint(
-                    checkpoint.clone(),
-                    &state,
-                    object_cache_reader.as_ref(),
-                    transaction_cache_reader.as_ref(),
-                    checkpoint_store.clone(),
-                    epoch_store.clone(),
-                    tx_manager.clone(),
-                    accumulator.clone(),
-                    local_execution_timeout_sec,
-                    &metrics,
-                    data_ingestion_dir.clone(),
-                    subscription_service_enabled,
-                )
-                .await
-                {
-                    Err(err) => {
-                        error!(
-                            "Error while executing checkpoint, will retry in 1s: {:?}",
-                            err
-                        );
-                        tokio::time::sleep(Duration::from_secs(1)).await;
-                        metrics.checkpoint_exec_errors.inc();
-                    }
-                    Ok((tx_digests, checkpoint_acc, checkpoint_data, randomness_rounds)) => {
-                        break (
-                            tx_digests,
-                            checkpoint_acc,
-                            checkpoint_data,
-                            randomness_rounds,
-                        )
-                    }
-                }
-            };
-            (
-                checkpoint,
-                checkpoint_acc,
-                checkpoint_data,
-                tx_digests,
-                randomness_rounds,
-            )
-        }));
-    }
-
-    #[instrument(level = "info", skip_all)]
-    async fn execute_change_epoch_tx(
-        &self,
-        execution_digests: ExecutionDigests,
-        change_epoch_tx_digest: TransactionDigest,
-        change_epoch_tx: VerifiedExecutableTransaction,
-        epoch_store: Arc<AuthorityPerEpochStore>,
-        checkpoint: VerifiedCheckpoint,
-    ) {
-        let change_epoch_fx = self
-            .transaction_cache_reader
-            .get_effects(&execution_digests.effects)
-            .expect("Change_epoch tx effects must exist");
-
-        if change_epoch_tx.contains_shared_object() {
-            epoch_store
-                .acquire_shared_version_assignments_from_effects(
-                    &change_epoch_tx,
-                    &change_epoch_fx,
-                    self.object_cache_reader.as_ref(),
-                )
-                .expect("Acquiring shared version assignments for change_epoch tx cannot fail");
-        }
-
-        self.tx_manager.enqueue_with_expected_effects_digest(
-            vec![(change_epoch_tx.clone(), execution_digests.effects)],
-            &epoch_store,
-        );
-        handle_execution_effects(
-            &self.state,
-            vec![execution_digests],
-            vec![change_epoch_tx_digest],
-            checkpoint.clone(),
-            self.checkpoint_store.clone(),
-            self.object_cache_reader.as_ref(),
-            self.transaction_cache_reader.as_ref(),
-            epoch_store.clone(),
-            self.tx_manager.clone(),
-            self.accumulator.clone(),
-            self.config.local_execution_timeout_sec,
-            self.config.data_ingestion_dir.clone(),
-            self.subscription_service_checkpoint_sender.is_some(),
-        )
-        .await;
-    }
-
-    /// Check whether `checkpoint` is the last checkpoint of the current epoch. If so,
-    /// perform special case logic (execute change_epoch tx, accumulate epoch,
-    /// finalize transactions), then return true.
-    pub async fn check_epoch_last_checkpoint(
-        &self,
-        epoch_store: Arc<AuthorityPerEpochStore>,
-        checkpoint: &Option<VerifiedCheckpoint>,
-    ) -> bool {
-        let cur_epoch = epoch_store.epoch();
-
-        if let Some(checkpoint) = checkpoint {
-            if checkpoint.epoch() == cur_epoch {
-                if let Some((change_epoch_execution_digests, change_epoch_tx)) =
-                    extract_end_of_epoch_tx(
-                        checkpoint,
-                        self.transaction_cache_reader.as_ref(),
-                        self.checkpoint_store.clone(),
-                        epoch_store.clone(),
-                    )
-                {
-                    let change_epoch_tx_digest = change_epoch_execution_digests.transaction;
-
-                    info!(
-                        ended_epoch = cur_epoch,
-                        last_checkpoint = checkpoint.sequence_number(),
-                        "Reached end of epoch, executing change_epoch transaction",
-                    );
-
-                    self.execute_change_epoch_tx(
-                        change_epoch_execution_digests,
-                        change_epoch_tx_digest,
-                        change_epoch_tx,
-                        epoch_store.clone(),
-                        checkpoint.clone(),
-                    )
-                    .await;
-
-                    let cache_commit = self.state.get_cache_commit();
-                    cache_commit.commit_transaction_outputs(
-                        cur_epoch,
-                        &[change_epoch_tx_digest],
-                        epoch_store
-                            .protocol_config()
-                            .use_object_per_epoch_marker_table_v2_as_option()
-                            .unwrap_or(false),
-                    );
-                    fail_point_async!("prune-and-compact");
-
-                    // For finalizing the checkpoint, we need to pass in all checkpoint
-                    // transaction effects, not just the change_epoch tx effects. However,
-                    // we have already notify awaited all tx effects separately (once
-                    // for change_epoch tx, and once for all other txes). Therefore this
-                    // should be a fast operation
-                    let all_tx_digests: Vec<_> = self
-                        .checkpoint_store
-                        .get_checkpoint_contents(&checkpoint.content_digest)
-                        .expect("read cannot fail")
-                        .expect("Checkpoint contents should exist")
-                        .iter()
-                        .map(|digests| digests.transaction)
-                        .collect();
-
-                    let effects = self
-                        .transaction_cache_reader
-                        .notify_read_executed_effects(&all_tx_digests)
-                        .await;
-
-                    let (_acc, checkpoint_data) = finalize_checkpoint(
-                        &self.state,
-                        self.object_cache_reader.as_ref(),
-                        self.transaction_cache_reader.as_ref(),
-                        self.checkpoint_store.clone(),
-                        &all_tx_digests,
-                        &epoch_store,
-                        checkpoint.clone(),
-                        self.accumulator.clone(),
-                        effects,
-                        self.config.data_ingestion_dir.clone(),
-                        self.subscription_service_checkpoint_sender.is_some(),
-                    )
-                    .await
-                    .expect("Finalizing checkpoint cannot fail");
-
-                    if let Some(checkpoint_data) = checkpoint_data {
-                        self.commit_index_updates_and_enqueue_to_subscription_service(
-                            checkpoint_data,
-                        )
-                        .await;
-                    }
-
-                    self.checkpoint_store
-                        .insert_epoch_last_checkpoint(cur_epoch, checkpoint)
-                        .expect("Failed to insert epoch last checkpoint");
-
-                    self.accumulator
-                        .accumulate_running_root(&epoch_store, checkpoint.sequence_number, None)
-                        .await
-                        .expect("Failed to accumulate running root");
-                    self.accumulator
-                        .accumulate_epoch(epoch_store.clone(), *checkpoint.sequence_number())
-                        .expect("Accumulating epoch cannot fail");
-
-                    self.bump_highest_executed_checkpoint(checkpoint);
-
-                    return true;
-                }
-            }
-        }
-        false
-    }
-}
-
-// Logs within the function are annotated with the checkpoint sequence number and epoch,
-// from schedule_checkpoint().
-#[allow(clippy::type_complexity)]
-#[instrument(level = "debug", skip_all, fields(seq = ?checkpoint.sequence_number(), epoch = ?epoch_store.epoch()))]
-async fn execute_checkpoint(
-    checkpoint: VerifiedCheckpoint,
-    state: &AuthorityState,
-    object_cache_reader: &dyn ObjectCacheRead,
-    transaction_cache_reader: &dyn TransactionCacheRead,
-    checkpoint_store: Arc<CheckpointStore>,
-    epoch_store: Arc<AuthorityPerEpochStore>,
-    transaction_manager: Arc<TransactionManager>,
-    accumulator: Arc<StateAccumulator>,
-    local_execution_timeout_sec: u64,
-    metrics: &Arc<CheckpointExecutorMetrics>,
-    data_ingestion_dir: Option<PathBuf>,
-    subscription_service_enabled: bool,
-) -> SuiResult<(
-    Vec<TransactionDigest>,
-    Option<Accumulator>,
-    Option<CheckpointData>,
-    Vec<RandomnessRound>,
-)> {
-    debug!("Preparing checkpoint for execution",);
-    let prepare_start = Instant::now();
-
-    // this function must guarantee that all transactions in the checkpoint are executed before it
-    // returns. This invariant is enforced in two phases:
-    // - First, we filter out any already executed transactions from the checkpoint in
-    //   get_unexecuted_transactions()
-    // - Second, we execute all remaining transactions.
-
-    let (execution_digests, all_tx_digests, executable_txns, randomness_rounds) =
-        get_unexecuted_transactions(
-            checkpoint.clone(),
-            transaction_cache_reader,
-            checkpoint_store.clone(),
-            epoch_store.clone(),
-        );
-
-    let tx_count = execution_digests.len();
-    debug!("Number of transactions in the checkpoint: {:?}", tx_count);
-    metrics
-        .checkpoint_transaction_count
-        .observe(tx_count as f64);
-
-    let (checkpoint_acc, checkpoint_data) = execute_transactions(
-        execution_digests,
-        all_tx_digests.clone(),
-        executable_txns,
-        state,
-        object_cache_reader,
-        transaction_cache_reader,
-        checkpoint_store.clone(),
-        epoch_store.clone(),
-        transaction_manager,
-        accumulator,
-        local_execution_timeout_sec,
-        checkpoint,
-        metrics,
-        prepare_start,
-        data_ingestion_dir,
-        subscription_service_enabled,
-    )
-    .await?;
-
-    Ok((
-        all_tx_digests,
-        checkpoint_acc,
-        checkpoint_data,
-        randomness_rounds,
-    ))
-}
-
-#[instrument(level = "error", skip_all, fields(seq = ?checkpoint.sequence_number(), epoch = ?epoch_store.epoch()))]
-async fn handle_execution_effects(
-    state: &AuthorityState,
-    execution_digests: Vec<ExecutionDigests>,
-    all_tx_digests: Vec<TransactionDigest>,
-    checkpoint: VerifiedCheckpoint,
-    checkpoint_store: Arc<CheckpointStore>,
-    object_cache_reader: &dyn ObjectCacheRead,
-    transaction_cache_reader: &dyn TransactionCacheRead,
-    epoch_store: Arc<AuthorityPerEpochStore>,
-    transaction_manager: Arc<TransactionManager>,
-    accumulator: Arc<StateAccumulator>,
-    local_execution_timeout_sec: u64,
-    data_ingestion_dir: Option<PathBuf>,
-    subscription_service_enabled: bool,
-) -> (Option<Accumulator>, Option<CheckpointData>) {
-    // Once synced_txns have been awaited, all txns should have effects committed.
-    let mut periods = 1;
-    let log_timeout_sec = Duration::from_secs(local_execution_timeout_sec);
-    // Whether the checkpoint is next to execute and blocking additional executions.
-    let mut blocking_execution = false;
-    loop {
-        let effects_future = transaction_cache_reader.notify_read_executed_effects(&all_tx_digests);
-
-        match timeout(log_timeout_sec, effects_future).await {
-            Err(_elapsed) => {
-                // Reading this value every timeout should be ok.
-                let highest_seq = checkpoint_store
-                    .get_highest_executed_checkpoint_seq_number()
-                    .unwrap()
-                    .unwrap_or_default();
-                if checkpoint.sequence_number <= highest_seq {
-                    error!(
-                        "Re-executing checkpoint {} after higher checkpoint {} has executed!",
-                        checkpoint.sequence_number, highest_seq
-                    );
-                    continue;
-                }
-                if checkpoint.sequence_number > highest_seq + 1 {
-                    trace!(
-                        "Checkpoint {} is still executing. Highest executed = {}",
-                        checkpoint.sequence_number,
-                        highest_seq
-                    );
-                    continue;
-                }
-                if !blocking_execution {
-                    trace!(
-                        "Checkpoint {} is next to execute.",
-                        checkpoint.sequence_number
-                    );
-                    blocking_execution = true;
-                    continue;
-                }
-
-                // Only log details when the checkpoint is next to execute, but has not finished
-                // execution within log_timeout_sec.
-                let missing_digests: Vec<TransactionDigest> = transaction_cache_reader
-                    .multi_get_executed_effects_digests(&all_tx_digests)
-                    .iter()
-                    .zip(all_tx_digests.clone())
-                    .filter_map(
-                        |(fx, digest)| {
-                            if fx.is_none() {
-                                Some(digest)
-                            } else {
-                                None
-                            }
-                        },
-                    )
-                    .collect();
-
-                if missing_digests.is_empty() {
-                    // All effects just become available.
-                    continue;
-                }
-
-                warn!(
-                    "Transaction effects for checkpoint tx digests {:?} not present within {:?}. ",
-                    missing_digests,
-                    log_timeout_sec * periods,
+    // Write checkpoint data to indexes and disk (if configured)
+    fn write_checkpoint_data(&self, checkpoint_data: &CheckpointData) {
+        if self.state.rpc_index.is_some() || self.config.data_ingestion_dir.is_some() {
+            // Index the checkpoint. this is done out of order and is not written and committed to the
+            // DB until later (committing must be done in-order)
+            if let Some(rpc_index) = &self.state.rpc_index {
+                let mut layout_resolver = self.epoch_store.executor().type_layout_resolver(
+                    Box::new(PackageStoreWithFallback::new(
+                        self.state.get_backing_package_store(),
+                        checkpoint_data,
+                    )),
                 );
 
-                // Print out more information for the 1st pending transaction, which should have
-                // all of its input available.
-                let pending_digest = missing_digests.first().unwrap();
-                if let Some(missing_input) = transaction_manager.get_missing_input(pending_digest) {
-                    warn!(
-                        "Transaction {pending_digest:?} has missing input objects {missing_input:?}",
-                    );
-                }
-                periods += 1;
+                rpc_index.index_checkpoint(checkpoint_data, layout_resolver.as_mut());
             }
-            Ok(effects) => {
-                for (tx_digest, expected_digest, actual_effects) in
-                    izip!(&all_tx_digests, &execution_digests, &effects)
-                {
-                    let expected_effects_digest = &expected_digest.effects;
-                    assert_not_forked(
-                        &checkpoint,
-                        tx_digest,
-                        expected_effects_digest,
-                        &actual_effects.digest(),
-                        transaction_cache_reader,
-                    );
-                }
 
-                // if end of epoch checkpoint, we must finalize the checkpoint after executing
-                // the change epoch tx, which is done after all other checkpoint execution
-                if checkpoint.end_of_epoch_data.is_none() {
-                    let (checkpoint_acc, checkpoint_data) = finalize_checkpoint(
-                        state,
-                        object_cache_reader,
-                        transaction_cache_reader,
-                        checkpoint_store.clone(),
-                        &all_tx_digests,
-                        &epoch_store,
-                        checkpoint.clone(),
-                        accumulator.clone(),
-                        effects,
-                        data_ingestion_dir,
-                        subscription_service_enabled,
-                    )
-                    .await
-                    .expect("Finalizing checkpoint cannot fail");
-                    return (Some(checkpoint_acc), checkpoint_data);
-                } else {
-                    return (None, None);
-                }
+            if let Some(path) = &self.config.data_ingestion_dir {
+                store_checkpoint_locally(path, checkpoint_data)
+                    .expect("failed to store checkpoint locally");
             }
         }
     }
-}
 
-fn assert_not_forked(
-    checkpoint: &VerifiedCheckpoint,
-    tx_digest: &TransactionDigest,
-    expected_digest: &TransactionEffectsDigest,
-    actual_effects_digest: &TransactionEffectsDigest,
-    cache_reader: &dyn TransactionCacheRead,
-) {
-    if *expected_digest != *actual_effects_digest {
-        let actual_effects = cache_reader
-            .get_executed_effects(tx_digest)
-            .expect("actual effects should exist");
-
-        // log observed effects (too big for panic message) and then panic.
-        error!(
-            ?checkpoint,
-            ?tx_digest,
-            ?expected_digest,
-            ?actual_effects,
-            "fork detected!"
-        );
-        panic!(
-            "When executing checkpoint {}, transaction {} \
-            is expected to have effects digest {}, but got {}!",
-            checkpoint.sequence_number(),
-            tx_digest,
-            expected_digest,
-            actual_effects_digest,
-        );
-    }
-}
-
-// Given a checkpoint, find the end of epoch transaction, if it exists
-fn extract_end_of_epoch_tx(
-    checkpoint: &VerifiedCheckpoint,
-    cache_reader: &dyn TransactionCacheRead,
-    checkpoint_store: Arc<CheckpointStore>,
-    epoch_store: Arc<AuthorityPerEpochStore>,
-) -> Option<(ExecutionDigests, VerifiedExecutableTransaction)> {
-    checkpoint.end_of_epoch_data.as_ref()?;
-
-    // Last checkpoint must have the end of epoch transaction as the last transaction.
-
-    let checkpoint_sequence = checkpoint.sequence_number();
-    let execution_digests = checkpoint_store
-        .get_checkpoint_contents(&checkpoint.content_digest)
-        .expect("Failed to get checkpoint contents from store")
-        .unwrap_or_else(|| {
-            panic!(
-                "Checkpoint contents for digest {:?} does not exist",
-                checkpoint.content_digest
-            )
-        })
-        .into_inner();
-
-    let digests = execution_digests
-        .last()
-        .expect("Final checkpoint must have at least one transaction");
-
-    let change_epoch_tx = cache_reader.get_transaction_block(&digests.transaction);
-
-    let change_epoch_tx = VerifiedExecutableTransaction::new_from_checkpoint(
-        (*change_epoch_tx.unwrap_or_else(||
-            panic!(
-                "state-sync should have ensured that transaction with digests {:?} exists for checkpoint: {checkpoint:?}",
-                digests
-            )
-        )).clone(),
-        epoch_store.epoch(),
-        *checkpoint_sequence,
-    );
-
-    assert!(change_epoch_tx
-        .data()
-        .intent_message()
-        .value
-        .is_end_of_epoch_tx());
-
-    Some((*digests, change_epoch_tx))
-}
-
-// Given a checkpoint, filter out any already executed transactions, then return the remaining
-// execution digests, transaction digests, transactions to be executed, and randomness rounds
-// (if any) included in the checkpoint.
-#[allow(clippy::type_complexity)]
-fn get_unexecuted_transactions(
-    checkpoint: VerifiedCheckpoint,
-    cache_reader: &dyn TransactionCacheRead,
-    checkpoint_store: Arc<CheckpointStore>,
-    epoch_store: Arc<AuthorityPerEpochStore>,
-) -> (
-    Vec<ExecutionDigests>,
-    Vec<TransactionDigest>,
-    Vec<(VerifiedExecutableTransaction, TransactionEffectsDigest)>,
-    Vec<RandomnessRound>,
-) {
-    let checkpoint_sequence = checkpoint.sequence_number();
-    let full_contents = checkpoint_store
-        .get_full_checkpoint_contents_by_sequence_number(*checkpoint_sequence)
-        .expect("Failed to get checkpoint contents from store")
-        .tap_some(|_| {
-            debug!("loaded full checkpoint contents in bulk for sequence {checkpoint_sequence}")
-        });
-
-    let mut execution_digests = checkpoint_store
-        .get_checkpoint_contents(&checkpoint.content_digest)
-        .expect("Failed to get checkpoint contents from store")
-        .unwrap_or_else(|| {
-            panic!(
-                "Checkpoint contents for digest {:?} does not exist",
-                checkpoint.content_digest
-            )
-        })
-        .into_inner();
-
-    let full_contents_txns = full_contents.map(|c| {
-        c.into_iter()
-            .zip(execution_digests.iter())
-            .map(|(txn, digests)| (digests.transaction, txn))
-            .collect::<HashMap<_, _>>()
-    });
-
-    // Remove the change epoch transaction so that we can special case its execution.
-    checkpoint.end_of_epoch_data.as_ref().tap_some(|_| {
-        let digests = execution_digests
-            .pop()
-            .expect("Final checkpoint must have at least one transaction");
-
-        let change_epoch_tx = cache_reader
-            .get_transaction_block(&digests.transaction)
-            .unwrap_or_else(||
-                panic!(
-                    "state-sync should have ensured that transaction with digests {digests:?} exists for checkpoint: {}",
-                    checkpoint.sequence_number()
-                )
+    // Extract randomness rounds from the checkpoint version-specific data (if available).
+    // Otherwise, extract randomness rounds from the first transaction in the checkpoint
+    fn extract_randomness_rounds(
+        &self,
+        checkpoint: &VerifiedCheckpoint,
+        checkpoint_contents: &CheckpointContents,
+    ) -> Vec<RandomnessRound> {
+        if let Some(version_specific_data) = checkpoint
+            .version_specific_data(self.epoch_store.protocol_config())
+            .expect("unable to get verison_specific_data")
+        {
+            // With version-specific data, randomness rounds are stored in checkpoint summary.
+            version_specific_data.into_v1().randomness_rounds
+        } else {
+            // Before version-specific data, checkpoint batching must be disabled. In this case,
+            // randomness state update tx must be first if it exists, because all other
+            // transactions in a checkpoint that includes a randomness state update are causally
+            // dependent on it.
+            assert_eq!(
+                0,
+                self.epoch_store
+                    .protocol_config()
+                    .min_checkpoint_interval_ms_as_option()
+                    .unwrap_or_default(),
             );
-        assert!(change_epoch_tx.data().intent_message().value.is_end_of_epoch_tx());
-    });
-
-    let randomness_rounds = if let Some(version_specific_data) = checkpoint
-        .version_specific_data(epoch_store.protocol_config())
-        .expect("unable to get verison_specific_data")
-    {
-        // With version-specific data, randomness rounds are stored in checkpoint summary.
-        version_specific_data.into_v1().randomness_rounds
-    } else {
-        // Before version-specific data, checkpoint batching must be disabled. In this case,
-        // randomness state update tx must be first if it exists, because all other
-        // transactions in a checkpoint that includes a randomness state update are causally
-        // dependent on it.
-        assert_eq!(
-            0,
-            epoch_store
-                .protocol_config()
-                .min_checkpoint_interval_ms_as_option()
-                .unwrap_or_default(),
-        );
-        if let Some(first_digest) = execution_digests.first() {
-            let maybe_randomness_tx = cache_reader.get_transaction_block(&first_digest.transaction)
-            .unwrap_or_else(||
-                panic!(
-                    "state-sync should have ensured that transaction with digests {first_digest:?} exists for checkpoint: {}",
-                    checkpoint.sequence_number()
-                )
-            );
-            if let TransactionKind::RandomnessStateUpdate(rsu) =
-                maybe_randomness_tx.data().transaction_data().kind()
-            {
-                vec![rsu.randomness_round]
+            if let Some(first_digest) = checkpoint_contents.inner().first() {
+                let maybe_randomness_tx = self.transaction_cache_reader.get_transaction_block(&first_digest.transaction)
+                .unwrap_or_else(||
+                    fatal!(
+                        "state-sync should have ensured that transaction with digests {first_digest:?} exists for checkpoint: {}",
+                        checkpoint.sequence_number()
+                    )
+                );
+                if let TransactionKind::RandomnessStateUpdate(rsu) =
+                    maybe_randomness_tx.data().transaction_data().kind()
+                {
+                    vec![rsu.randomness_round]
+                } else {
+                    Vec::new()
+                }
             } else {
                 Vec::new()
             }
-        } else {
-            Vec::new()
-        }
-    };
-
-    let all_tx_digests: Vec<TransactionDigest> =
-        execution_digests.iter().map(|tx| tx.transaction).collect();
-
-    let executed_effects_digests = cache_reader.multi_get_executed_effects_digests(&all_tx_digests);
-
-    let (unexecuted_txns, expected_effects_digests): (Vec<_>, Vec<_>) =
-        izip!(execution_digests.iter(), executed_effects_digests.iter())
-            .filter_map(|(digests, effects_digest)| match effects_digest {
-                None => Some((digests.transaction, digests.effects)),
-                Some(actual_effects_digest) => {
-                    let tx_digest = &digests.transaction;
-                    let effects_digest = &digests.effects;
-                    trace!(
-                        "Transaction with digest {:?} has already been executed",
-                        tx_digest
-                    );
-                    assert_not_forked(
-                        &checkpoint,
-                        tx_digest,
-                        effects_digest,
-                        actual_effects_digest,
-                        cache_reader,
-                    );
-                    None
-                }
-            })
-            .unzip();
-
-    // read remaining unexecuted transactions from store
-    let executable_txns: Vec<_> = if let Some(full_contents_txns) = full_contents_txns {
-        unexecuted_txns
-            .into_iter()
-            .zip(expected_effects_digests)
-            .map(|(tx_digest, expected_effects_digest)| {
-                let tx = &full_contents_txns.get(&tx_digest).unwrap().transaction;
-                (
-                    VerifiedExecutableTransaction::new_from_checkpoint(
-                        VerifiedTransaction::new_unchecked(tx.clone()),
-                        epoch_store.epoch(),
-                        *checkpoint_sequence,
-                    ),
-                    expected_effects_digest,
-                )
-            })
-            .collect()
-    } else {
-        cache_reader
-            .multi_get_transaction_blocks(&unexecuted_txns)
-            .into_iter()
-            .zip(expected_effects_digests)
-            .enumerate()
-            .map(|(i, (tx, expected_effects_digest))| {
-                let tx = tx.unwrap_or_else(||
-                    fatal!(
-                        "state-sync should have ensured that transaction with digest {:?} exists for checkpoint: {checkpoint:?}",
-                        unexecuted_txns[i]
-                    )
-                );
-                // change epoch tx is handled specially in check_epoch_last_checkpoint
-                assert!(!tx.data().intent_message().value.is_end_of_epoch_tx());
-                (
-                    VerifiedExecutableTransaction::new_from_checkpoint(
-                        Arc::try_unwrap(tx).unwrap_or_else(|tx| (*tx).clone()),
-                        epoch_store.epoch(),
-                        *checkpoint_sequence,
-                    ),
-                    expected_effects_digest
-                )
-            })
-            .collect()
-    };
-
-    (
-        execution_digests,
-        all_tx_digests,
-        executable_txns,
-        randomness_rounds,
-    )
-}
-
-// Logs within the function are annotated with the checkpoint sequence number and epoch,
-// from schedule_checkpoint().
-#[instrument(level = "debug", skip_all)]
-async fn execute_transactions(
-    execution_digests: Vec<ExecutionDigests>,
-    all_tx_digests: Vec<TransactionDigest>,
-    executable_txns: Vec<(VerifiedExecutableTransaction, TransactionEffectsDigest)>,
-    state: &AuthorityState,
-    object_cache_reader: &dyn ObjectCacheRead,
-    transaction_cache_reader: &dyn TransactionCacheRead,
-    checkpoint_store: Arc<CheckpointStore>,
-    epoch_store: Arc<AuthorityPerEpochStore>,
-    transaction_manager: Arc<TransactionManager>,
-    state_accumulator: Arc<StateAccumulator>,
-    local_execution_timeout_sec: u64,
-    checkpoint: VerifiedCheckpoint,
-    metrics: &Arc<CheckpointExecutorMetrics>,
-    prepare_start: Instant,
-    data_ingestion_dir: Option<PathBuf>,
-    subscription_service_enabled: bool,
-) -> SuiResult<(Option<Accumulator>, Option<CheckpointData>)> {
-    let effects_digests: HashMap<_, _> = execution_digests
-        .iter()
-        .map(|digest| (digest.transaction, digest.effects))
-        .collect();
-
-    let shared_effects_digests = executable_txns
-        .iter()
-        .filter(|(tx, _)| tx.contains_shared_object())
-        .map(|(tx, _)| {
-            *effects_digests
-                .get(tx.digest())
-                .expect("Transaction digest not found in effects_digests")
-        })
-        .collect::<Vec<_>>();
-
-    let digest_to_effects: HashMap<TransactionDigest, TransactionEffects> =
-        transaction_cache_reader
-            .multi_get_effects(&shared_effects_digests)
-            .into_iter()
-            .zip(shared_effects_digests)
-            .map(|(fx, fx_digest)| {
-                if fx.is_none() {
-                    panic!(
-                        "Transaction effects for effects digest {:?} do not exist in effects table",
-                        fx_digest
-                    );
-                }
-                let fx = fx.unwrap();
-                (*fx.transaction_digest(), fx)
-            })
-            .collect();
-
-    for (tx, _) in &executable_txns {
-        if tx.contains_shared_object() {
-            epoch_store.acquire_shared_version_assignments_from_effects(
-                tx,
-                digest_to_effects.get(tx.digest()).unwrap(),
-                object_cache_reader,
-            )?;
         }
     }
-
-    let prepare_elapsed = prepare_start.elapsed();
-    metrics
-        .checkpoint_prepare_latency
-        .observe(prepare_elapsed.as_secs_f64());
-    if checkpoint.sequence_number % CHECKPOINT_PROGRESS_LOG_COUNT_INTERVAL == 0 {
-        info!(
-            "Checkpoint preparation for execution took {:?}",
-            prepare_elapsed
-        );
-    }
-
-    let exec_start = Instant::now();
-    transaction_manager.enqueue_with_expected_effects_digest(executable_txns.clone(), &epoch_store);
-
-    let (checkpoint_acc, checkpoint_data) = handle_execution_effects(
-        state,
-        execution_digests,
-        all_tx_digests,
-        checkpoint.clone(),
-        checkpoint_store,
-        object_cache_reader,
-        transaction_cache_reader,
-        epoch_store,
-        transaction_manager,
-        state_accumulator,
-        local_execution_timeout_sec,
-        data_ingestion_dir,
-        subscription_service_enabled,
-    )
-    .await;
-
-    let exec_elapsed = exec_start.elapsed();
-    metrics
-        .checkpoint_exec_latency
-        .observe(exec_elapsed.as_secs_f64());
-    if checkpoint.sequence_number % CHECKPOINT_PROGRESS_LOG_COUNT_INTERVAL == 0 {
-        info!("Checkpoint execution took {:?}", exec_elapsed);
-    }
-
-    Ok((checkpoint_acc, checkpoint_data))
-}
-
-#[instrument(level = "info", skip_all, fields(seq = ?checkpoint.sequence_number(), epoch = ?epoch_store.epoch()))]
-async fn finalize_checkpoint(
-    state: &AuthorityState,
-    object_cache_reader: &dyn ObjectCacheRead,
-    transaction_cache_reader: &dyn TransactionCacheRead,
-    checkpoint_store: Arc<CheckpointStore>,
-    tx_digests: &[TransactionDigest],
-    epoch_store: &Arc<AuthorityPerEpochStore>,
-    checkpoint: VerifiedCheckpoint,
-    accumulator: Arc<StateAccumulator>,
-    effects: Vec<TransactionEffects>,
-    data_ingestion_dir: Option<PathBuf>,
-    subscription_service_enabled: bool,
-) -> SuiResult<(Accumulator, Option<CheckpointData>)> {
-    debug!("finalizing checkpoint");
-    epoch_store.insert_finalized_transactions(tx_digests, checkpoint.sequence_number)?;
-
-    if state.is_fullnode(epoch_store) {
-        state.congestion_tracker.process_checkpoint_effects(
-            transaction_cache_reader,
-            &checkpoint,
-            &effects,
-        );
-    }
-
-    // TODO remove once we no longer need to support this table for read RPC
-    state
-        .get_checkpoint_cache()
-        .deprecated_insert_finalized_transactions(
-            tx_digests,
-            epoch_store.epoch(),
-            checkpoint.sequence_number,
-        );
-
-    let checkpoint_acc =
-        accumulator.accumulate_checkpoint(&effects, checkpoint.sequence_number, epoch_store)?;
-
-    let checkpoint_data = if subscription_service_enabled
-        || state.rpc_index.is_some()
-        || data_ingestion_dir.is_some()
-    {
-        let checkpoint_data = load_checkpoint_data(
-            checkpoint,
-            object_cache_reader,
-            transaction_cache_reader,
-            checkpoint_store,
-            tx_digests,
-        )?;
-
-        // Index the checkpoint. this is done out of order and is not written and committed to the
-        // DB until later (committing must be done in-order)
-        if let Some(rpc_index) = &state.rpc_index {
-            let mut layout_resolver = epoch_store.executor().type_layout_resolver(Box::new(
-                PackageStoreWithFallback::new(state.get_backing_package_store(), &checkpoint_data),
-            ));
-
-            rpc_index.index_checkpoint(&checkpoint_data, layout_resolver.as_mut());
-        }
-
-        if let Some(path) = data_ingestion_dir {
-            store_checkpoint_locally(path, &checkpoint_data)?;
-        }
-
-        Some(checkpoint_data)
-    } else {
-        None
-    };
-
-    Ok((checkpoint_acc, checkpoint_data))
 }

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -200,7 +200,11 @@ impl CheckpointExecutor {
     #[instrument(level = "error", skip_all, fields(epoch = ?self.epoch_store.epoch()))]
     pub async fn run_epoch(self, run_with_range: Option<RunWithRange>) -> StopReason {
         let _metrics_guard = mysten_metrics::monitored_scope("CheckpointExecutor::run_epoch");
-        debug!(?run_with_range, "CheckpointExecutor::run_epoch");
+        info!(?run_with_range, "CheckpointExecutor::run_epoch");
+        debug!(
+            "Checkpoint executor running for epoch {:?}",
+            self.epoch_store.epoch(),
+        );
 
         // check if we want to run this epoch based on RunWithRange condition value
         // we want to be inclusive of the defined RunWithRangeEpoch::Epoch

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/utils.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/utils.rs
@@ -1,0 +1,199 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{sync::Arc, time::Instant};
+
+use crate::checkpoints::CheckpointStore;
+use crate::execution_cache::TransactionCacheRead;
+use futures::{future::Either, Stream};
+use mysten_common::fatal;
+use std::time::Duration;
+use sui_types::{
+    base_types::{TransactionDigest, TransactionEffectsDigest},
+    messages_checkpoint::{CheckpointSequenceNumber, VerifiedCheckpoint},
+};
+use tracing::{debug, error, info, instrument, warn};
+
+#[instrument(level = "debug", skip_all)]
+pub(super) fn stream_synced_checkpoints(
+    checkpoint_store: Arc<CheckpointStore>,
+    start_seq: CheckpointSequenceNumber,
+    stop_seq: Option<CheckpointSequenceNumber>,
+) -> impl Stream<Item = VerifiedCheckpoint> + 'static {
+    let scheduling_timeout_config = get_scheduling_timeout();
+    let panic_timeout = scheduling_timeout_config.panic_timeout;
+    let warning_timeout = scheduling_timeout_config.warning_timeout;
+
+    struct State {
+        current_seq: CheckpointSequenceNumber,
+        checkpoint_store: Arc<CheckpointStore>,
+        warning_timeout: Duration,
+        panic_timeout: Option<Duration>,
+        stop_seq: Option<CheckpointSequenceNumber>,
+    }
+
+    let state = State {
+        current_seq: start_seq,
+        checkpoint_store,
+        warning_timeout,
+        panic_timeout,
+        stop_seq,
+    };
+
+    futures::stream::unfold(Some(state), |state| async move {
+        match state {
+            None => None,
+            Some(state) if state.current_seq > state.stop_seq.unwrap_or(u64::MAX) => None,
+            Some(mut state) => {
+                let seq = state.current_seq;
+                let checkpoint = wait_for_checkpoint(
+                    &state.checkpoint_store,
+                    seq,
+                    state.warning_timeout,
+                    state.panic_timeout,
+                )
+                .await;
+                info!(
+                    "received synced checkpoint: {:?}",
+                    checkpoint.sequence_number
+                );
+                if checkpoint.end_of_epoch_data.is_some() {
+                    Some((checkpoint, None))
+                } else {
+                    state.current_seq = seq + 1;
+                    Some((checkpoint, Some(state)))
+                }
+            }
+        }
+    })
+}
+
+async fn wait_for_checkpoint(
+    checkpoint_store: &CheckpointStore,
+    seq: CheckpointSequenceNumber,
+    warning_timeout: Duration,
+    panic_timeout: Option<Duration>,
+) -> VerifiedCheckpoint {
+    debug!("waiting for checkpoint: {:?}", seq);
+    loop {
+        tokio::select! {
+            checkpoint = checkpoint_store.notify_read_synced_checkpoint(seq) => {
+                return checkpoint;
+            }
+
+            _ = tokio::time::sleep(warning_timeout) => {
+                warn!(
+                    "Received no new synced checkpoints for {warning_timeout:?}. Next checkpoint to be scheduled: {seq}",
+                );
+            }
+
+            _ = panic_timeout
+                        .map(|d| Either::Left(tokio::time::sleep(d)))
+                        .unwrap_or_else(|| Either::Right(futures::future::pending())) => {
+                fatal!("No new synced checkpoints received for {panic_timeout:?}");
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct CheckpointTimeoutConfig {
+    pub panic_timeout: Option<Duration>,
+    pub warning_timeout: Duration,
+}
+
+// We use a thread local so that the config can be overridden on a per-test basis. This means
+// that get_scheduling_timeout() can be called multiple times in a multithreaded context, but
+// the function is still very cheap to call so this is okay.
+thread_local! {
+    static SCHEDULING_TIMEOUT: once_cell::sync::OnceCell<CheckpointTimeoutConfig> =
+        const { once_cell::sync::OnceCell::new() };
+}
+
+#[cfg(msim)]
+pub fn init_checkpoint_timeout_config(config: CheckpointTimeoutConfig) {
+    SCHEDULING_TIMEOUT.with(|s| {
+        s.set(config).expect("SchedulingTimeoutConfig already set");
+    });
+}
+
+fn get_scheduling_timeout() -> CheckpointTimeoutConfig {
+    fn inner() -> CheckpointTimeoutConfig {
+        let panic_timeout: Option<Duration> = if cfg!(msim) {
+            Some(Duration::from_secs(45))
+        } else {
+            std::env::var("NEW_CHECKPOINT_PANIC_TIMEOUT_MS")
+                .ok()
+                .and_then(|s| s.parse::<u64>().ok())
+                .map(Duration::from_millis)
+        };
+
+        let warning_timeout: Duration = std::env::var("NEW_CHECKPOINT_WARNING_TIMEOUT_MS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .map(Duration::from_millis)
+            .unwrap_or(Duration::from_secs(5));
+
+        CheckpointTimeoutConfig {
+            panic_timeout,
+            warning_timeout,
+        }
+    }
+
+    SCHEDULING_TIMEOUT.with(|s| *s.get_or_init(inner))
+}
+
+pub(super) fn assert_not_forked(
+    checkpoint: &VerifiedCheckpoint,
+    tx_digest: &TransactionDigest,
+    expected_digest: &TransactionEffectsDigest,
+    actual_effects_digest: &TransactionEffectsDigest,
+    cache_reader: &dyn TransactionCacheRead,
+) {
+    if *expected_digest != *actual_effects_digest {
+        let actual_effects = cache_reader
+            .get_executed_effects(tx_digest)
+            .expect("actual effects should exist");
+
+        // log observed effects (too big for panic message) and then panic.
+        error!(
+            ?checkpoint,
+            ?tx_digest,
+            ?expected_digest,
+            ?actual_effects,
+            "fork detected!"
+        );
+        panic!(
+            "When executing checkpoint {}, transaction {} \
+            is expected to have effects digest {}, but got {}!",
+            checkpoint.sequence_number(),
+            tx_digest,
+            expected_digest,
+            actual_effects_digest,
+        );
+    }
+}
+
+#[derive(Default)]
+pub(super) struct TPSEstimator {
+    last_update: Option<Instant>,
+    transaction_count: u64,
+    tps: f64,
+}
+
+impl TPSEstimator {
+    pub fn update(&mut self, now: Instant, transaction_count: u64) -> f64 {
+        if let Some(last_update) = self.last_update {
+            if now > last_update {
+                let delta_t = now.duration_since(last_update);
+                let delta_c = transaction_count - self.transaction_count;
+                let tps = delta_c as f64 / delta_t.as_secs_f64();
+                self.tps = self.tps * 0.9 + tps * 0.1;
+            }
+        }
+
+        self.last_update = Some(now);
+        self.transaction_count = transaction_count;
+        self.tps
+    }
+}

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1664,9 +1664,16 @@ impl CheckpointBuilder {
                         sequence_number,
                         &self.epoch_store,
                     )?;
+
                     state_acc
-                        .accumulate_running_root(&self.epoch_store, sequence_number, Some(acc))
+                        .wait_for_previous_running_root(&self.epoch_store, sequence_number)
                         .await?;
+
+                    state_acc.accumulate_running_root(
+                        &self.epoch_store,
+                        sequence_number,
+                        Some(acc),
+                    )?;
                     state_acc
                         .digest_epoch(self.epoch_store.clone(), sequence_number)
                         .await?

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -902,7 +902,6 @@ impl CheckpointStore {
         state: &AuthorityState,
         epoch_store: &AuthorityPerEpochStore,
     ) {
-        info!("rexecuting locally computed checkpoints for crash recovery");
         let epoch = epoch_store.epoch();
         let highest_executed = self
             .get_highest_executed_checkpoint_seq_number()
@@ -913,6 +912,11 @@ impl CheckpointStore {
             info!("no locally built checkpoints to verify");
             return;
         };
+
+        info!(
+            "rexecuting locally computed checkpoints for crash recovery from {} to {}",
+            highest_executed, highest_built
+        );
 
         for seq in highest_executed + 1..=*highest_built.sequence_number() {
             info!(?seq, "Re-executing locally computed checkpoint");

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -778,16 +778,6 @@ impl TransactionManager {
         self.metrics.execution_driver_dispatch_queue.inc();
     }
 
-    /// Gets the missing input object keys for the given transaction.
-    pub(crate) fn get_missing_input(&self, digest: &TransactionDigest) -> Option<Vec<InputKey>> {
-        let reconfig_lock = self.inner.read();
-        let inner = reconfig_lock.read();
-        inner
-            .pending_certificates
-            .get(digest)
-            .map(|cert| cert.waiting_input_objects.clone().into_iter().collect())
-    }
-
     // Returns the number of transactions waiting on each object ID, as well as the age of the oldest transaction in the queue.
     pub(crate) fn objects_queue_len_and_age(
         &self,

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1814,6 +1814,8 @@ impl SuiNode {
                 &new_epoch_start_state,
             );
 
+            let mut validator_components_lock_guard = self.validator_components.lock().await;
+
             // The following code handles 4 different cases, depending on whether the node
             // was a validator in the previous epoch, and whether the node is a validator
             // in the new epoch.
@@ -1836,7 +1838,7 @@ impl SuiNode {
                 mut checkpoint_service_tasks,
                 checkpoint_metrics,
                 sui_tx_validator_metrics,
-            }) = self.validator_components.lock().await.take()
+            }) = validator_components_lock_guard.take()
             {
                 info!("Reconfiguring the validator.");
                 // Cancel the old checkpoint service tasks.
@@ -1938,7 +1940,7 @@ impl SuiNode {
                     None
                 }
             };
-            *self.validator_components.lock().await = new_validator_components;
+            *validator_components_lock_guard = new_validator_components;
 
             // Force releasing current epoch store DB handle, because the
             // Arc<AuthorityPerEpochStore> may linger.

--- a/crates/sui-single-node-benchmark/src/benchmark_context.rs
+++ b/crates/sui-single-node-benchmark/src/benchmark_context.rs
@@ -399,7 +399,7 @@ impl BenchmarkContext {
             .await;
         info!("Built {} checkpoints", checkpoints.len());
         let last_checkpoint_seq = *checkpoints.last().unwrap().0.sequence_number();
-        let (mut checkpoint_executor, checkpoint_sender) = validator.create_checkpoint_executor();
+        let checkpoint_executor = validator.create_checkpoint_executor();
         for (checkpoint, contents) in checkpoints {
             let state = validator.get_validator();
             state
@@ -417,15 +417,11 @@ impl BenchmarkContext {
                 .get_checkpoint_store()
                 .update_highest_synced_checkpoint(&checkpoint)
                 .unwrap();
-            checkpoint_sender.send(checkpoint).unwrap();
         }
         let start_time = std::time::Instant::now();
         info!("Starting checkpoint execution. You can now attach a profiler");
         checkpoint_executor
-            .run_epoch(
-                validator.get_epoch_store().clone(),
-                Some(RunWithRange::Checkpoint(last_checkpoint_seq)),
-            )
+            .run_epoch(Some(RunWithRange::Checkpoint(last_checkpoint_seq)))
             .await;
         let elapsed = start_time.elapsed().as_millis() as f64 / 1000f64;
         info!(

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -30,7 +30,6 @@ use sui_types::transaction::{
     CertifiedTransaction, Transaction, TransactionDataAPI, VerifiedCertificate,
     VerifiedTransaction, DEFAULT_VALIDATOR_GAS_PRICE,
 };
-use tokio::sync::broadcast;
 
 #[derive(Clone)]
 pub struct SingleValidator {
@@ -267,20 +266,16 @@ impl SingleValidator {
         checkpoints
     }
 
-    pub fn create_checkpoint_executor(
-        &self,
-    ) -> (CheckpointExecutor, broadcast::Sender<VerifiedCheckpoint>) {
+    pub fn create_checkpoint_executor(&self) -> CheckpointExecutor {
         let validator = self.get_validator();
-        let (ckpt_sender, ckpt_receiver) = broadcast::channel(1000000);
-        let checkpoint_executor = CheckpointExecutor::new_for_tests(
-            ckpt_receiver,
+        CheckpointExecutor::new_for_tests(
+            self.epoch_store.clone(),
             validator.get_checkpoint_store().clone(),
             validator.clone(),
             Arc::new(StateAccumulator::new_for_tests(
                 validator.get_accumulator_store().clone(),
             )),
-        );
-        (checkpoint_executor, ckpt_sender)
+        )
     }
 
     pub(crate) fn create_in_memory_store(&self) -> InMemoryObjectStore {

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -43,7 +43,7 @@ validator_configs:
       max-transactions-in-batch: 1000
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
-      checkpoint-execution-max-concurrency: 200
+      checkpoint-execution-max-concurrency: 40
       local-execution-timeout-sec: 30
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
@@ -205,7 +205,7 @@ validator_configs:
       max-transactions-in-batch: 1000
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
-      checkpoint-execution-max-concurrency: 200
+      checkpoint-execution-max-concurrency: 40
       local-execution-timeout-sec: 30
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
@@ -367,7 +367,7 @@ validator_configs:
       max-transactions-in-batch: 1000
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
-      checkpoint-execution-max-concurrency: 200
+      checkpoint-execution-max-concurrency: 40
       local-execution-timeout-sec: 30
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
@@ -529,7 +529,7 @@ validator_configs:
       max-transactions-in-batch: 1000
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
-      checkpoint-execution-max-concurrency: 200
+      checkpoint-execution-max-concurrency: 40
       local-execution-timeout-sec: 30
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
@@ -691,7 +691,7 @@ validator_configs:
       max-transactions-in-batch: 1000
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
-      checkpoint-execution-max-concurrency: 200
+      checkpoint-execution-max-concurrency: 40
       local-execution-timeout-sec: 30
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
@@ -853,7 +853,7 @@ validator_configs:
       max-transactions-in-batch: 1000
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
-      checkpoint-execution-max-concurrency: 200
+      checkpoint-execution-max-concurrency: 40
       local-execution-timeout-sec: 30
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false
@@ -1015,7 +1015,7 @@ validator_configs:
       max-transactions-in-batch: 1000
     end-of-epoch-broadcast-channel-capacity: 128
     checkpoint-executor-config:
-      checkpoint-execution-max-concurrency: 200
+      checkpoint-execution-max-concurrency: 40
       local-execution-timeout-sec: 30
     db-checkpoint-config:
       perform-db-checkpoints-at-epoch-end: false

--- a/crates/sui-tool/src/db_tool/mod.rs
+++ b/crates/sui-tool/src/db_tool/mod.rs
@@ -414,6 +414,7 @@ pub fn rewind_checkpoint_execution(
             checkpoint.epoch()
         );
     }
+
     let highest_executed_sequence_number = checkpoint_db
         .get_highest_executed_checkpoint_seq_number()?
         .unwrap_or_default();

--- a/crates/test-cluster/Cargo.toml
+++ b/crates/test-cluster/Cargo.toml
@@ -22,6 +22,7 @@ rand.workspace = true
 tempfile.workspace = true
 sui-config.workspace = true
 sui-core.workspace = true
+mysten-common.workspace = true
 sui-framework.workspace = true
 sui-swarm-config.workspace = true
 sui-indexer.workspace = true


### PR DESCRIPTION
Stacked on #21232, #21233 and #21235

This simplifies CheckpointExecutor massively, in preparation for optimizations which will be needed for throughput improvements

TODO

- [x] Antithesis tests - passed an 8 hour test
- [x] PTN tests - no performance or correctness problems observed
- [x] sui-single-node-benchmark tests - performance is comparable with old version after dialing concurrency down a bit
