### PR TITLE
[indexer-alt] immediate predecessor pruning query for consistent pipelines

### DIFF
--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
@@ -223,58 +223,21 @@ pub(super) fn pruner<H: Handler + Send + Sync + 'static>(
                 }));
             }
 
-            // (4) Wait for all tasks to finish.
-            // For each task, if it succeeds, remove the range from the pending_prune_ranges.
-            // Otherwise the range will remain in the map and will be retried in the next iteration.
+            // Track highest successful prune
+            let mut highest_pruned = db_watermark.pruner_hi;
+
+            // (4) Wait for all tasks to finish. For each task, if it succeeds, remove the range
+            // from the pending_prune_ranges. Otherwise the range will remain in the map and will be
+            // retried in the next iteration. Update the highest_pruned watermark if the task
+            // succeeds in metrics and in db, to minimize redundant pruner work if the pipeline is
+            // restarted.
             while let Some(r) = tasks.next().await {
                 let ((from, to_exclusive), result) = r.unwrap();
                 match result {
                     Ok(()) => {
                         pending_prune_ranges.remove(&from);
                         let pruner_hi = pending_prune_ranges.get_pruner_hi() as i64;
-                        if db_watermark.pruner_hi != pruner_hi {
-                            // (4) Update the pruner watermark
-                            let guard = metrics
-                                .watermark_pruner_write_latency
-                                .with_label_values(&[H::NAME])
-                                .start_timer();
-
-                            let Ok(mut conn) = db.connect().await else {
-                                warn!(
-                                    pipeline = H::NAME,
-                                    "Pruner failed to connect, while updating watermark"
-                                );
-                                continue;
-                            };
-
-                            db_watermark.pruner_hi = pruner_hi;
-                            match db_watermark.update(&mut conn).await {
-                                Err(e) => {
-                                    let elapsed = guard.stop_and_record();
-                                    error!(
-                                        pipeline = H::NAME,
-                                        elapsed_ms = elapsed * 1000.0,
-                                        "Failed to update pruner watermark: {e}"
-                                    )
-                                }
-
-                                Ok(true) => {
-                                    let elapsed = guard.stop_and_record();
-                                    logger.log::<H>(&db_watermark, elapsed);
-
-                                    metrics
-                                        .watermark_pruner_hi_in_db
-                                        .with_label_values(&[H::NAME])
-                                        .set(db_watermark.pruner_hi);
-                                }
-                                Ok(false) => {}
-                            }
-                        }
-
-                        metrics
-                            .watermark_pruner_hi
-                            .with_label_values(&[H::NAME])
-                            .set(db_watermark.pruner_hi);
+                        highest_pruned = highest_pruned.max(pruner_hi);
                     }
                     Err(e) => {
                         error!(
@@ -283,42 +246,48 @@ pub(super) fn pruner<H: Handler + Send + Sync + 'static>(
                         );
                     }
                 }
-            }
 
-            // (4) Update the pruner watermark
-            let guard = metrics
-                .watermark_pruner_write_latency
-                .with_label_values(&[H::NAME])
-                .start_timer();
-
-            let Ok(mut conn) = db.connect().await else {
-                warn!(
-                    pipeline = H::NAME,
-                    "Pruner failed to connect, while updating watermark"
-                );
-                continue;
-            };
-
-            match db_watermark.update(&mut conn).await {
-                Err(e) => {
-                    let elapsed = guard.stop_and_record();
-                    error!(
-                        pipeline = H::NAME,
-                        elapsed_ms = elapsed * 1000.0,
-                        "Failed to update pruner watermark: {e}"
-                    )
-                }
-
-                Ok(true) => {
-                    let elapsed = guard.stop_and_record();
-                    logger.log::<H>(&db_watermark, elapsed);
-
+                if highest_pruned > db_watermark.pruner_hi {
                     metrics
-                        .watermark_pruner_hi_in_db
+                        .watermark_pruner_hi
                         .with_label_values(&[H::NAME])
-                        .set(db_watermark.pruner_hi);
+                        .set(highest_pruned);
+
+                    let guard = metrics
+                        .watermark_pruner_write_latency
+                        .with_label_values(&[H::NAME])
+                        .start_timer();
+
+                    let Ok(mut conn) = db.connect().await else {
+                        warn!(
+                            pipeline = H::NAME,
+                            "Pruner failed to connect, while updating watermark"
+                        );
+                        continue;
+                    };
+
+                    db_watermark.pruner_hi = highest_pruned;
+                    match db_watermark.update(&mut conn).await {
+                        Err(e) => {
+                            let elapsed = guard.stop_and_record();
+                            error!(
+                                pipeline = H::NAME,
+                                elapsed_ms = elapsed * 1000.0,
+                                "Failed to update pruner watermark: {e}"
+                            )
+                        }
+                        Ok(true) => {
+                            let elapsed = guard.stop_and_record();
+                            logger.log::<H>(&db_watermark, elapsed);
+
+                            metrics
+                                .watermark_pruner_hi_in_db
+                                .with_label_values(&[H::NAME])
+                                .set(db_watermark.pruner_hi);
+                        }
+                        Ok(false) => {}
+                    }
                 }
-                Ok(false) => {}
             }
         }
 

--- a/crates/sui-indexer-alt/src/handlers/coin_balance_buckets.rs
+++ b/crates/sui-indexer-alt/src/handlers/coin_balance_buckets.rs
@@ -202,13 +202,24 @@ impl Handler for CoinBalanceBuckets {
             .join(",");
         let query = format!(
             "
-            WITH to_prune_data (object_id, cp_sequence_number_exclusive) AS (
+            WITH modifications(object_id, cp_sequence_number) AS (
                 VALUES {}
+            ),
+            predecessors AS (
+                SELECT m.object_id, m.cp_sequence_number as mod_cp,
+                       (SELECT cp_sequence_number
+                        FROM coin_balance_buckets cbo
+                        WHERE cbo.{:?} = m.object_id
+                          AND cbo.{:?} < m.cp_sequence_number
+                        ORDER BY cp_sequence_number DESC
+                        LIMIT 1) as predecessor_cp
+                FROM modifications m
             )
             DELETE FROM coin_balance_buckets
-            USING to_prune_data
-            WHERE coin_balance_buckets.{:?} = to_prune_data.object_id
-              AND coin_balance_buckets.{:?} < to_prune_data.cp_sequence_number_exclusive
+            WHERE (object_id, cp_sequence_number) IN
+                (SELECT object_id, predecessor_cp
+                 FROM predecessors
+                 WHERE predecessor_cp IS NOT NULL)
             ",
             values,
             dsl::object_id,

--- a/crates/sui-indexer-alt/src/handlers/obj_info.rs
+++ b/crates/sui-indexer-alt/src/handlers/obj_info.rs
@@ -116,7 +116,7 @@ impl Handler for ObjInfo {
 
         let to_prune = self
             .pruning_lookup_table
-            .get_prune_info_v2(from, to_exclusive)?;
+            .get_prune_info(from, to_exclusive)?;
 
         if to_prune.is_empty() {
             self.pruning_lookup_table.gc_prune_info(from, to_exclusive);


### PR DESCRIPTION
## Description 

The current delete query causes contention when pruning concurrency > 1. This is because the `with to_prune_data` query submits deletion requests such that we may potentially have overlapping deletes for the same obj upper-bounded at different checkpoints. The `RowExclusiveLock`s eventually escalate to exclusive locks.

One way to circumvent this is by having the first deletion of an object be `(obj, < cp)`, and subsequent deletions be bounded on both sides. But this requires additional orchestration. Alternatively, we can modify the deletion query so that each deletion entry searches for its immediate predecessor. This means a small change on `get_prune_info` to return a vector of `(obj, cp)` instead of a mapping deduplicating same-object entries. Each tuple represents the exclusive checkpoint that the query should bound each lookup by.

Furthermore, for deletions, we include two entries, so that when it's time to prune a delete entry, we remove its predecessor and itself. 
    Example:
    - Create at CP 0
    - Modify at CP 1, 2, 10
    - Delete at CP 15
 
    Returns pairs for:
    - (obj, 1)  will prune CP 0 because 0 < 1
    - (obj, 2)  will prune CP 1 because 1 < 2
    - (obj, 10) will prune CP 2 because 2 < 10
    - (obj, 15) will prune CP 10 because 10 < 15
    - (obj, 16) will prune CP 15 because 15 < 16

This works in tandem with the new deletion query on `obj_info` and `coin_balance_buckets`.

## Test plan 

Existing tests pass

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
