### PR TITLE
Expose `GasData` through executor

### DIFF
--- a/crates/simulacrum/src/epoch_state.rs
+++ b/crates/simulacrum/src/epoch_state.rs
@@ -134,7 +134,7 @@ impl EpochState {
         )?;
 
         let transaction_data = transaction.data().transaction_data();
-        let (kind, signer, gas) = transaction_data.execution_parts();
+        let (kind, signer, gas_data) = transaction_data.execution_parts();
         let (inner_temp_store, gas_status, effects, _timings, result) =
             self.executor.execute_transaction_to_effects(
                 store.backing_store(),
@@ -145,7 +145,7 @@ impl EpochState {
                 &self.epoch_start_state.epoch(),
                 self.epoch_start_state.epoch_start_timestamp_ms(),
                 checked_input_objects,
-                gas,
+                gas_data,
                 gas_status,
                 kind,
                 signer,

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -1690,8 +1690,14 @@ async fn test_publish_dependent_module_ok() {
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);
 
-    let dependent_module_id =
-        TxContext::new(&sender, transaction.digest(), &EpochData::new_test()).fresh_id();
+    let dependent_module_id = TxContext::new(
+        &sender,
+        transaction.digest(),
+        &EpochData::new_test(),
+        rgp,
+        None,
+    )
+    .fresh_id();
 
     // Object does not exist
     assert!(authority.get_object(&dependent_module_id).await.is_none());
@@ -1739,8 +1745,14 @@ async fn test_publish_module_no_dependencies_ok() {
         rgp,
     );
     let transaction = to_sender_signed_transaction(data, &sender_key);
-    let _module_object_id =
-        TxContext::new(&sender, transaction.digest(), &EpochData::new_test()).fresh_id();
+    let _module_object_id = TxContext::new(
+        &sender,
+        transaction.digest(),
+        &EpochData::new_test(),
+        rgp,
+        None,
+    )
+    .fresh_id();
     let signed_effects = send_and_confirm_transaction(&authority, transaction)
         .await
         .unwrap()

--- a/crates/sui-genesis-builder/src/lib.rs
+++ b/crates/sui-genesis-builder/src/lib.rs
@@ -914,7 +914,8 @@ fn create_genesis_transaction(
         let expensive_checks = false;
         let certificate_deny_set = HashSet::new();
         let transaction_data = &genesis_transaction.data().intent_message().value;
-        let (kind, signer, _) = transaction_data.execution_parts();
+        let (kind, signer, mut gas_data) = transaction_data.execution_parts();
+        gas_data.payment = vec![];
         let input_objects = CheckedInputObjects::new_for_genesis(vec![]);
         let (inner_temp_store, _, effects, _timings, _execution_error) = executor
             .execute_transaction_to_effects(
@@ -926,7 +927,7 @@ fn create_genesis_transaction(
                 &epoch_data.epoch_id(),
                 epoch_data.epoch_start_timestamp(),
                 input_objects,
-                vec![],
+                gas_data,
                 SuiGasStatus::new_unmetered(),
                 kind,
                 signer,

--- a/crates/sui-replay/src/types.rs
+++ b/crates/sui-replay/src/types.rs
@@ -44,6 +44,8 @@ pub struct OnChainTransactionInfo {
     pub modified_at_versions: Vec<(ObjectID, SequenceNumber)>,
     pub shared_object_refs: Vec<ObjectRef>,
     pub gas: Vec<(ObjectID, SequenceNumber, ObjectDigest)>,
+    #[serde(default)]
+    pub gas_owner: Option<SuiAddress>,
     pub gas_budget: u64,
     pub gas_price: u64,
     pub executed_epoch: u64,

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -205,7 +205,7 @@ impl SingleValidator {
             self.epoch_store.reference_gas_price(),
         )
         .unwrap();
-        let (kind, signer, gas) = executable.transaction_data().execution_parts();
+        let (kind, signer, gas_data) = executable.transaction_data().execution_parts();
         let (inner_temp_store, _, effects, _timings, _) =
             self.epoch_store.executor().execute_transaction_to_effects(
                 &store,
@@ -216,7 +216,7 @@ impl SingleValidator {
                 &self.epoch_store.epoch(),
                 0,
                 input_objects,
-                gas,
+                gas_data,
                 gas_status,
                 kind,
                 signer,

--- a/crates/sui-swarm-config/src/network_config_builder.rs
+++ b/crates/sui-swarm-config/src/network_config_builder.rs
@@ -599,7 +599,8 @@ mod test {
         let certificate_deny_set = HashSet::new();
         let epoch = EpochData::new_test();
         let transaction_data = &genesis_transaction.data().intent_message().value;
-        let (kind, signer, _) = transaction_data.execution_parts();
+        let (kind, signer, mut gas_data) = transaction_data.execution_parts();
+        gas_data.payment = vec![];
         let input_objects = CheckedInputObjects::new_for_genesis(vec![]);
 
         let (_inner_temp_store, _, effects, _timings, _execution_error) = executor
@@ -612,7 +613,7 @@ mod test {
                 &epoch.epoch_id(),
                 epoch.epoch_start_timestamp(),
                 input_objects,
-                vec![],
+                gas_data,
                 SuiGasStatus::new_unmetered(),
                 kind,
                 signer,

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -1017,6 +1017,10 @@ pub struct TxContext {
     epoch_timestamp_ms: CheckpointTimestamp,
     /// Number of `ObjectID`'s generated during execution of the current transaction
     ids_created: u64,
+    // gas price passed to transaction as input
+    gas_price: u64,
+    // address of the sponsor if any
+    sponsor: Option<AccountAddress>,
 }
 
 #[derive(PartialEq, Eq, Clone, Copy)]
@@ -1030,12 +1034,20 @@ pub enum TxContextKind {
 }
 
 impl TxContext {
-    pub fn new(sender: &SuiAddress, digest: &TransactionDigest, epoch_data: &EpochData) -> Self {
+    pub fn new(
+        sender: &SuiAddress,
+        digest: &TransactionDigest,
+        epoch_data: &EpochData,
+        gas_price: u64,
+        sponsor: Option<SuiAddress>,
+    ) -> Self {
         Self::new_from_components(
             sender,
             digest,
             &epoch_data.epoch_id(),
             epoch_data.epoch_start_timestamp(),
+            gas_price,
+            sponsor,
         )
     }
 
@@ -1044,6 +1056,8 @@ impl TxContext {
         digest: &TransactionDigest,
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
+        gas_price: u64,
+        sponsor: Option<SuiAddress>,
     ) -> Self {
         Self {
             sender: AccountAddress::new(sender.0),
@@ -1051,6 +1065,8 @@ impl TxContext {
             epoch: *epoch_id,
             epoch_timestamp_ms,
             ids_created: 0,
+            gas_price,
+            sponsor: sponsor.map(|s| s.into()),
         }
     }
 
@@ -1125,20 +1141,6 @@ impl TxContext {
         }
         self.ids_created = other.ids_created;
         Ok(())
-    }
-
-    // Generate a random TxContext for testing.
-    pub fn random_for_testing_only() -> Self {
-        Self::new(
-            &SuiAddress::random_for_testing_only(),
-            &TransactionDigest::random(),
-            &EpochData::new_test(),
-        )
-    }
-
-    /// Generate a TxContext for testing with a specific sender.
-    pub fn with_sender_for_testing_only(sender: &SuiAddress) -> Self {
-        Self::new(sender, &TransactionDigest::random(), &EpochData::new_test())
     }
 }
 

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -32,6 +32,7 @@ pub mod checked {
         fn bucketize_computation(&mut self) -> Result<(), ExecutionError>;
         fn summary(&self) -> GasCostSummary;
         fn gas_budget(&self) -> u64;
+        fn gas_price(&self) -> u64;
         fn storage_gas_units(&self) -> u64;
         fn storage_rebate(&self) -> u64;
         fn unmetered_storage_rebate(&self) -> u64;
@@ -105,6 +106,12 @@ pub mod checked {
         ) -> UserInputResult {
             match self {
                 Self::V2(status) => status.check_gas_balance(gas_objs, gas_budget),
+            }
+        }
+
+        pub fn gas_price(&self) -> u64 {
+            match self {
+                Self::V2(status) => status.gas_price(),
             }
         }
     }

--- a/crates/sui-types/src/gas_model/gas_v2.rs
+++ b/crates/sui-types/src/gas_model/gas_v2.rs
@@ -408,6 +408,10 @@ mod checked {
             self.gas_budget
         }
 
+        fn gas_price(&self) -> u64 {
+            self.gas_price
+        }
+
         fn storage_gas_units(&self) -> u64 {
             self.per_object_storage
                 .iter()

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -1983,12 +1983,8 @@ impl TransactionData {
         }
     }
 
-    pub fn execution_parts(&self) -> (TransactionKind, SuiAddress, Vec<ObjectRef>) {
-        (
-            self.kind().clone(),
-            self.sender(),
-            self.gas_data().payment.clone(),
-        )
+    pub fn execution_parts(&self) -> (TransactionKind, SuiAddress, GasData) {
+        (self.kind().clone(), self.sender(), self.gas_data().clone())
     }
 
     pub fn uses_randomness(&self) -> bool {

--- a/sui-execution/src/executor.rs
+++ b/sui-execution/src/executor.rs
@@ -6,8 +6,9 @@ use std::{collections::HashSet, sync::Arc};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::execution::ExecutionTiming;
 use sui_types::storage::BackingStore;
+use sui_types::transaction::GasData;
 use sui_types::{
-    base_types::{ObjectRef, SuiAddress},
+    base_types::SuiAddress,
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
@@ -36,7 +37,7 @@ pub trait Executor {
         // Transaction Inputs
         input_objects: CheckedInputObjects,
         // Gas related
-        gas_coins: Vec<ObjectRef>,
+        gas: GasData,
         gas_status: SuiGasStatus,
         // Transaction
         transaction_kind: TransactionKind,
@@ -65,7 +66,7 @@ pub trait Executor {
         // Transaction Inputs
         input_objects: CheckedInputObjects,
         // Gas related
-        gas_coins: Vec<ObjectRef>,
+        gas: GasData,
         gas_status: SuiGasStatus,
         // Transaction
         transaction_kind: TransactionKind,

--- a/sui-execution/src/latest.rs
+++ b/sui-execution/src/latest.rs
@@ -1,16 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::PathBuf;
-use std::{collections::HashSet, sync::Arc};
-
 use move_binary_format::CompiledModule;
 use move_trace_format::format::MoveTraceBuilder;
 use move_vm_config::verifier::{MeterConfig, VerifierConfig};
+use std::{collections::HashSet, path::PathBuf, sync::Arc};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::execution::ExecutionTiming;
+use sui_types::transaction::GasData;
 use sui_types::{
-    base_types::{ObjectRef, SuiAddress, TxContext},
+    base_types::{SuiAddress, TxContext},
     committee::EpochId,
     digests::TransactionDigest,
     effects::TransactionEffects,
@@ -76,7 +75,7 @@ impl executor::Executor for Executor {
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
         input_objects: CheckedInputObjects,
-        gas_coins: Vec<ObjectRef>,
+        gas: GasData,
         gas_status: SuiGasStatus,
         transaction_kind: TransactionKind,
         transaction_signer: SuiAddress,
@@ -92,7 +91,7 @@ impl executor::Executor for Executor {
         execute_transaction_to_effects::<execution_mode::Normal>(
             store,
             input_objects,
-            gas_coins,
+            gas,
             gas_status,
             transaction_kind,
             transaction_signer,
@@ -118,7 +117,7 @@ impl executor::Executor for Executor {
         epoch_id: &EpochId,
         epoch_timestamp_ms: u64,
         input_objects: CheckedInputObjects,
-        gas_coins: Vec<ObjectRef>,
+        gas: GasData,
         gas_status: SuiGasStatus,
         transaction_kind: TransactionKind,
         transaction_signer: SuiAddress,
@@ -134,7 +133,7 @@ impl executor::Executor for Executor {
             execute_transaction_to_effects::<execution_mode::DevInspect<true>>(
                 store,
                 input_objects,
-                gas_coins,
+                gas,
                 gas_status,
                 transaction_kind,
                 transaction_signer,
@@ -152,7 +151,7 @@ impl executor::Executor for Executor {
             execute_transaction_to_effects::<execution_mode::DevInspect<false>>(
                 store,
                 input_objects,
-                gas_coins,
+                gas,
                 gas_status,
                 transaction_kind,
                 transaction_signer,
@@ -186,6 +185,9 @@ impl executor::Executor for Executor {
             transaction_digest,
             &epoch_id,
             epoch_timestamp_ms,
+            // genesis transaction: RGP: 1, sponsor: None
+            1,
+            None,
         );
         execute_genesis_state_update(
             store,

--- a/sui-execution/v0/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v0/sui-adapter/src/execution_engine.rs
@@ -87,6 +87,9 @@ mod checked {
             &transaction_digest,
             epoch_id,
             epoch_timestamp_ms,
+            // Those values are unused in execution versions before 3 (or latest)
+            1,
+            None,
         );
 
         let is_epoch_change = matches!(transaction_kind, TransactionKind::ChangeEpoch(_));

--- a/sui-execution/v1/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v1/sui-adapter/src/execution_engine.rs
@@ -103,6 +103,9 @@ mod checked {
             &transaction_digest,
             epoch_id,
             epoch_timestamp_ms,
+            // Those values are unused in execution versions before 3 (or latest)
+            1,
+            None,
         );
 
         let is_epoch_change = transaction_kind.is_end_of_epoch_tx();

--- a/sui-execution/v2/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v2/sui-adapter/src/execution_engine.rs
@@ -114,6 +114,9 @@ mod checked {
             &transaction_digest,
             epoch_id,
             epoch_timestamp_ms,
+            // Those values are unused in execution versions before 3 (or latest)
+            1,
+            None,
         );
 
         let is_epoch_change = transaction_kind.is_end_of_epoch_tx();


### PR DESCRIPTION
## Description 
Changed executor API to take `GasData` instead of gas payments only (`Vec<ObjectRef>`). That allows us to expose more info about gas and sponsor to the `TxContext` in execution.
I wondered whether the info about sponsor and more (e.g. gas price and budget) should be computed on the client of the executor (e.g. in `authority.rs` and I had the code initially that way) but it makes for a more intrusive change. 
Passing the `GasData` allows the executor to compute everything is needed for execution with a more stable API. Thoughts welcome.

This PR should change nothing in the current implementation and though `sponsor` and `gas_price` are exposed to the `TxContext` (the Rust side) they are unused at the moment (in this PR, later PRs will use that).

`authority::dev_inspect_transaction_block` has changed a bit to make it more readable for me. I believe it is correct but please @emmazzz @amnn @jordanjennings-mysten take a look, I may have missed something.

The replay data structure is changed to add the sponsor, however we are not changing the serialization at the moment and old serialized blobs should still work (thanks @tzakian for the suggestion).


## Test plan 

Existing tests as this changes nothing

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
