### PR TITLE
fix!: Remove double indirection in `MoveFieldLayout`

### DIFF
--- a/crates/sui-core/src/unit_tests/subscription_handler_tests.rs
+++ b/crates/sui-core/src/unit_tests/subscription_handler_tests.rs
@@ -85,7 +85,7 @@ impl TestEvent {
     fn layout() -> MoveStructLayout {
         MoveStructLayout {
             type_: Self::type_(),
-            fields: Box::new(vec![
+            fields: vec![
                 MoveFieldLayout::new(ident_str!("creator").to_owned(), MoveTypeLayout::Address),
                 MoveFieldLayout::new(
                     ident_str!("name").to_owned(),
@@ -101,7 +101,7 @@ impl TestEvent {
                         GasCoin::layout(),
                     )))),
                 ),
-            ]),
+            ],
         }
     }
 }
@@ -133,10 +133,10 @@ impl UTF8String {
     fn layout() -> MoveStructLayout {
         MoveStructLayout {
             type_: Self::type_(),
-            fields: Box::new(vec![MoveFieldLayout::new(
+            fields: vec![MoveFieldLayout::new(
                 ident_str!("bytes").to_owned(),
                 MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),
-            )]),
+            )],
         }
     }
 }

--- a/crates/sui-graphql-rpc/src/types/move_value.rs
+++ b/crates/sui-graphql-rpc/src/types/move_value.rs
@@ -488,10 +488,10 @@ mod tests {
         ($type:literal { $($name:literal : $layout:expr),* $(,)?}) => {
             A::MoveTypeLayout::Struct(Box::new(S {
                 type_: StructTag::from_str($type).expect("Failed to parse struct"),
-                fields: Box::new(vec![$(MoveFieldLayout {
+                fields: vec![$(MoveFieldLayout {
                     name: ident_str!($name).to_owned(),
                     layout: $layout,
-                }),*])
+                }),*]
             }))
         }
     }

--- a/crates/sui-json/src/tests.rs
+++ b/crates/sui-json/src/tests.rs
@@ -625,10 +625,10 @@ fn test_sui_call_arg_string_type() {
             name: STD_ASCII_STRUCT_NAME.into(),
             type_params: vec![],
         },
-        fields: Box::new(vec![MoveFieldLayout {
+        fields: vec![MoveFieldLayout {
             name: ident_str!("bytes").into(),
             layout: MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),
-        }]),
+        }],
     })));
     let v = SuiJsonValue::from_bcs_bytes(string_layout.as_ref(), &arg1).unwrap();
 
@@ -646,10 +646,10 @@ fn test_sui_call_arg_option_type() {
             name: STD_ASCII_STRUCT_NAME.into(),
             type_params: vec![],
         },
-        fields: Box::new(vec![MoveFieldLayout {
+        fields: vec![MoveFieldLayout {
             name: ident_str!("bytes").into(),
             layout: MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),
-        }]),
+        }],
     }));
 
     let option_layout = MoveTypeLayout::Struct(Box::new(MoveStructLayout {
@@ -659,10 +659,10 @@ fn test_sui_call_arg_option_type() {
             name: STD_OPTION_STRUCT_NAME.into(),
             type_params: vec![],
         },
-        fields: Box::new(vec![MoveFieldLayout {
+        fields: vec![MoveFieldLayout {
             name: ident_str!("vec").into(),
             layout: MoveTypeLayout::Vector(Box::new(string_layout.clone())),
-        }]),
+        }],
     }));
 
     let v = SuiJsonValue::from_bcs_bytes(Some(option_layout).as_ref(), &arg1).unwrap();
@@ -709,10 +709,10 @@ fn test_convert_string_vec() {
             name: STD_ASCII_STRUCT_NAME.into(),
             type_params: vec![],
         },
-        fields: Box::new(vec![MoveFieldLayout {
+        fields: vec![MoveFieldLayout {
             name: ident_str!("bytes").into(),
             layout: MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),
-        }]),
+        }],
     }));
 
     let layout = MoveTypeLayout::Vector(Box::new(string_layout));
@@ -744,10 +744,10 @@ fn test_string_vec_df_name_child_id_eq() {
             name: STD_ASCII_STRUCT_NAME.into(),
             type_params: vec![],
         },
-        fields: Box::new(vec![MoveFieldLayout {
+        fields: vec![MoveFieldLayout {
             name: ident_str!("bytes").into(),
             layout: MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),
-        }]),
+        }],
     }));
 
     let layout = MoveTypeLayout::Struct(Box::new(MoveStructLayout {
@@ -757,10 +757,10 @@ fn test_string_vec_df_name_child_id_eq() {
             name: STD_ASCII_STRUCT_NAME.into(),
             type_params: vec![],
         },
-        fields: Box::new(vec![MoveFieldLayout::new(
+        fields: vec![MoveFieldLayout::new(
             Identifier::from_str("labels").unwrap(),
             MoveTypeLayout::Vector(Box::new(string_layout)),
-        )]),
+        )],
     }));
 
     let sui_json = SuiJsonValue::new(name).unwrap();

--- a/crates/sui-mvr-graphql-rpc/src/types/move_value.rs
+++ b/crates/sui-mvr-graphql-rpc/src/types/move_value.rs
@@ -488,10 +488,10 @@ mod tests {
         ($type:literal { $($name:literal : $layout:expr),* $(,)?}) => {
             A::MoveTypeLayout::Struct(Box::new(S {
                 type_: StructTag::from_str($type).expect("Failed to parse struct"),
-                fields: Box::new(vec![$(MoveFieldLayout {
+                fields: vec![$(MoveFieldLayout {
                     name: ident_str!($name).to_owned(),
                     layout: $layout,
-                }),*])
+                }),*]
             }))
         }
     }

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -1207,7 +1207,7 @@ impl RpcExampleProvider {
                     },
                     MoveStructLayout {
                         type_: struct_tag,
-                        fields: Box::new(Vec::new()),
+                        fields: Vec::new(),
                     },
                 )
                 .unwrap(),

--- a/crates/sui-package-resolver/src/lib.rs
+++ b/crates/sui-package-resolver/src/lib.rs
@@ -1516,7 +1516,7 @@ impl<'l> ResolutionContext<'l> {
                 (
                     MoveTypeLayout::Struct(Box::new(MoveStructLayout {
                         type_,
-                        fields: Box::new(resolved_fields),
+                        fields: resolved_fields,
                     })),
                     field_depth + 1,
                 )

--- a/crates/sui-types/src/balance.rs
+++ b/crates/sui-types/src/balance.rs
@@ -78,10 +78,10 @@ impl Balance {
     pub fn layout(type_param: TypeTag) -> MoveStructLayout {
         MoveStructLayout {
             type_: Self::type_(type_param),
-            fields: Box::new(vec![MoveFieldLayout::new(
+            fields: vec![MoveFieldLayout::new(
                 ident_str!("value").to_owned(),
                 MoveTypeLayout::U64,
-            )]),
+            )],
         }
     }
 }

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -938,10 +938,10 @@ pub fn move_ascii_str_layout() -> A::MoveStructLayout {
             name: STD_ASCII_STRUCT_NAME.to_owned(),
             type_params: vec![],
         },
-        fields: Box::new(vec![A::MoveFieldLayout::new(
+        fields: vec![A::MoveFieldLayout::new(
             ident_str!("bytes").into(),
             A::MoveTypeLayout::Vector(Box::new(A::MoveTypeLayout::U8)),
-        )]),
+        )],
     }
 }
 
@@ -953,10 +953,10 @@ pub fn move_utf8_str_layout() -> A::MoveStructLayout {
             name: STD_UTF8_STRUCT_NAME.to_owned(),
             type_params: vec![],
         },
-        fields: Box::new(vec![A::MoveFieldLayout::new(
+        fields: vec![A::MoveFieldLayout::new(
             ident_str!("bytes").into(),
             A::MoveTypeLayout::Vector(Box::new(A::MoveTypeLayout::U8)),
-        )]),
+        )],
     }
 }
 

--- a/crates/sui-types/src/coin.rs
+++ b/crates/sui-types/src/coin.rs
@@ -95,7 +95,7 @@ impl Coin {
     pub fn layout(type_param: TypeTag) -> MoveStructLayout {
         MoveStructLayout {
             type_: Self::type_(type_param.clone()),
-            fields: Box::new(vec![
+            fields: vec![
                 MoveFieldLayout::new(
                     ident_str!("id").to_owned(),
                     MoveTypeLayout::Struct(Box::new(UID::layout())),
@@ -104,7 +104,7 @@ impl Coin {
                     ident_str!("balance").to_owned(),
                     MoveTypeLayout::Struct(Box::new(Balance::layout(type_param))),
                 ),
-            ]),
+            ],
         }
     }
 

--- a/crates/sui-types/src/id.rs
+++ b/crates/sui-types/src/id.rs
@@ -61,10 +61,10 @@ impl UID {
     pub fn layout() -> MoveStructLayout {
         MoveStructLayout {
             type_: Self::type_(),
-            fields: Box::new(vec![MoveFieldLayout::new(
+            fields: vec![MoveFieldLayout::new(
                 ident_str!("id").to_owned(),
                 MoveTypeLayout::Struct(Box::new(ID::layout())),
-            )]),
+            )],
         }
     }
 }
@@ -86,10 +86,10 @@ impl ID {
     pub fn layout() -> MoveStructLayout {
         MoveStructLayout {
             type_: Self::type_(),
-            fields: Box::new(vec![MoveFieldLayout::new(
+            fields: vec![MoveFieldLayout::new(
                 ident_str!("bytes").to_owned(),
                 MoveTypeLayout::Address,
-            )]),
+            )],
         }
     }
 }

--- a/crates/sui-types/src/object/balance_traversal.rs
+++ b/crates/sui-types/src/object/balance_traversal.rs
@@ -289,10 +289,7 @@ mod tests {
             .map(|(name, layout)| A::MoveFieldLayout::new(Identifier::new(name).unwrap(), layout))
             .collect();
 
-        A::MoveTypeLayout::Struct(Box::new(A::MoveStructLayout {
-            type_,
-            fields: Box::new(fields),
-        }))
+        A::MoveTypeLayout::Struct(Box::new(A::MoveStructLayout { type_, fields }))
     }
 
     /// BCS encode Move value.

--- a/crates/sui-types/src/object/bounded_visitor.rs
+++ b/crates/sui-types/src/object/bounded_visitor.rs
@@ -512,10 +512,7 @@ pub(crate) mod tests {
             .map(|(name, layout)| A::MoveFieldLayout::new(ident_(name), layout))
             .collect();
 
-        A::MoveTypeLayout::Struct(Box::new(A::MoveStructLayout {
-            type_,
-            fields: Box::new(fields),
-        }))
+        A::MoveTypeLayout::Struct(Box::new(A::MoveStructLayout { type_, fields }))
     }
 
     /// Create a variant value for test purposes.

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -2368,18 +2368,10 @@ dependencies = [
 name = "move-trace-format"
 version = "0.0.1"
 dependencies = [
- "anyhow",
- "enum-compat-util",
- "getrandom 0.2.15",
  "move-binary-format",
  "move-core-types",
- "move-proc-macros",
- "proptest",
- "proptest-derive",
- "ref-cast",
  "serde",
  "serde_json",
- "variant_count",
 ]
 
 [[package]]

--- a/external-crates/move/crates/move-bytecode-utils/src/layout.rs
+++ b/external-crates/move/crates/move-bytecode-utils/src/layout.rs
@@ -591,10 +591,7 @@ impl DatatypeLayoutBuilder {
                     .zip(layouts)
                     .map(|(name, layout)| A::MoveFieldLayout::new(name, layout))
                     .collect();
-                Ok(A::MoveStructLayout {
-                    type_,
-                    fields: Box::new(fields),
-                })
+                Ok(A::MoveStructLayout { type_, fields })
             }
         }
     }

--- a/external-crates/move/crates/move-core-types/src/annotated_value.rs
+++ b/external-crates/move/crates/move-core-types/src/annotated_value.rs
@@ -88,7 +88,7 @@ impl MoveFieldLayout {
 pub struct MoveStructLayout {
     /// An decorated representation with both types and human-readable field names
     pub type_: StructTag,
-    pub fields: Box<Vec<MoveFieldLayout>>,
+    pub fields: Vec<MoveFieldLayout>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -341,10 +341,7 @@ impl MoveVariant {
 
 impl MoveStructLayout {
     pub fn new(type_: StructTag, fields: Vec<MoveFieldLayout>) -> Self {
-        Self {
-            type_,
-            fields: Box::new(fields),
-        }
+        Self { type_, fields }
     }
 
     pub fn into_fields(self) -> Vec<MoveTypeLayout> {

--- a/external-crates/move/crates/move-core-types/src/unit_tests/value_test.rs
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/value_test.rs
@@ -43,14 +43,12 @@ fn struct_deserialization() {
 
     let struct_type_layout = A::MoveStructLayout {
         type_: struct_type.clone(),
-        fields: Box::new(
-            vec![
-                A::MoveFieldLayout::new(ident_str!("f").to_owned(), A::MoveTypeLayout::U64),
-                A::MoveFieldLayout::new(ident_str!("g").to_owned(), A::MoveTypeLayout::Bool),
-            ]
-            .into_iter()
-            .collect(),
-        ),
+        fields: vec![
+            A::MoveFieldLayout::new(ident_str!("f").to_owned(), A::MoveTypeLayout::U64),
+            A::MoveFieldLayout::new(ident_str!("g").to_owned(), A::MoveTypeLayout::Bool),
+        ]
+        .into_iter()
+        .collect(),
     };
 
     let deser_typed_value = A::MoveValue::simple_deserialize(

--- a/external-crates/move/crates/move-core-types/src/unit_tests/visitor_test.rs
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/visitor_test.rs
@@ -1073,10 +1073,7 @@ pub(crate) fn struct_layout_(rep: &str, fields: Vec<(&str, MoveTypeLayout)>) -> 
         .map(|(name, layout)| MoveFieldLayout::new(Identifier::new(name).unwrap(), layout))
         .collect();
 
-    MoveTypeLayout::Struct(Box::new(MoveStructLayout {
-        type_,
-        fields: Box::new(fields),
-    }))
+    MoveTypeLayout::Struct(Box::new(MoveStructLayout { type_, fields }))
 }
 
 /// Create a variant value for test purposes.


### PR DESCRIPTION
## Description 

The `MoveFieldLayout` struct `fields` was wrapped in a box as part of https://github.com/MystenLabs/sui/pull/19310, which states in its reasoning:

> Boxes fields in the MoveTypeLayout to make the enum size smaller for type layouts.

However, this field being boxed does not affect the enums which this was referring to as it is also boxed in the variants. This means that the variant size of those enums is always the size of a pointer. Thus, this additional box around the vec serves only to create an additional indirection.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
