### PR TITLE
rpc-alt: Macro for building diesel `SqlLiteral`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14046,6 +14046,7 @@ dependencies = [
  "sui-field-count",
  "sui-indexer-alt-metrics",
  "sui-pg-db",
+ "sui-sql-macro",
  "sui-storage",
  "sui-types",
  "telemetry-subscribers",
@@ -14095,6 +14096,7 @@ dependencies = [
  "sui-package-resolver",
  "sui-pg-db",
  "sui-protocol-config",
+ "sui-sql-macro",
  "sui-types",
  "telemetry-subscribers",
  "thiserror 1.0.69",
@@ -15471,6 +15473,15 @@ dependencies = [
  "tower-http 0.5.2",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "sui-sql-macro"
+version = "1.44.0"
+dependencies = [
+ "quote 1.0.37",
+ "syn 1.0.107",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,6 +165,7 @@ members = [
     "crates/sui-snapshot",
     "crates/sui-source-validation",
     "crates/sui-source-validation-service",
+    "crates/sui-sql-macro",
     "crates/sui-storage",
     "crates/sui-surfer",
     "crates/sui-swarm",
@@ -692,6 +693,7 @@ sui-simulator = { path = "crates/sui-simulator" }
 sui-snapshot = { path = "crates/sui-snapshot" }
 sui-source-validation = { path = "crates/sui-source-validation" }
 sui-source-validation-service = { path = "crates/sui-source-validation-service" }
+sui-sql-macro = { path = "crates/sui-sql-macro" }
 sui-storage = { path = "crates/sui-storage" }
 sui-surfer = { path = "crates/sui-surfer" }
 sui-swarm = { path = "crates/sui-swarm" }

--- a/crates/sui-indexer-alt-framework/Cargo.toml
+++ b/crates/sui-indexer-alt-framework/Cargo.toml
@@ -32,6 +32,7 @@ url.workspace = true
 sui-field-count.workspace = true
 sui-indexer-alt-metrics.workspace = true
 sui-pg-db.workspace = true
+sui-sql-macro.workspace = true
 sui-storage.workspace = true
 sui-types.workspace = true
 

--- a/crates/sui-indexer-alt-framework/src/models/watermarks.rs
+++ b/crates/sui-indexer-alt-framework/src/models/watermarks.rs
@@ -4,10 +4,11 @@
 use std::{borrow::Cow, time::Duration};
 
 use chrono::{naive::NaiveDateTime, DateTime, Utc};
-use diesel::{dsl::sql, prelude::*, sql_types};
+use diesel::{prelude::*, sql_types::BigInt};
 use diesel_async::RunQueryDsl;
 use sui_field_count::FieldCount;
 use sui_pg_db::Connection;
+use sui_sql_macro::sql;
 
 use crate::schema::watermarks;
 
@@ -176,10 +177,10 @@ impl PrunerWatermark<'static> {
         //     |-----------------------|----------------|
         //     ^                       ^
         //     pruner_timestamp        NOW()
-        let wait_for = sql::<sql_types::BigInt>(&format!(
-            "CAST({} + 1000 * EXTRACT(EPOCH FROM pruner_timestamp - NOW()) AS BIGINT)",
-            delay.as_millis(),
-        ));
+        let wait_for = sql!(as BigInt,
+            "CAST({BigInt} + 1000 * EXTRACT(EPOCH FROM pruner_timestamp - NOW()) AS BIGINT)",
+            delay.as_millis() as i64,
+        );
 
         watermarks::table
             .select((

--- a/crates/sui-indexer-alt-jsonrpc/Cargo.toml
+++ b/crates/sui-indexer-alt-jsonrpc/Cargo.toml
@@ -52,6 +52,7 @@ sui-open-rpc-macros.workspace = true
 sui-package-resolver.workspace = true
 sui-pg-db.workspace = true
 sui-protocol-config.workspace = true
+sui-sql-macro.workspace = true
 sui-types.workspace = true
 
 [dev-dependencies]

--- a/crates/sui-sql-macro/Cargo.toml
+++ b/crates/sui-sql-macro/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "sui-sql-macro"
+version.workspace = true
+authors = ["Mysten Labs <build@mystenlabs.com"]
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote.workspace = true
+syn.workspace = true
+thiserror.workspace = true

--- a/crates/sui-sql-macro/src/lexer.rs
+++ b/crates/sui-sql-macro/src/lexer.rs
@@ -1,0 +1,150 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt;
+
+/// Lexer for SQL format strings. Format string can contain regular text, or binders surrounded by
+/// curly braces. Curly braces are escaped by doubling them up.
+pub(crate) struct Lexer<'s> {
+    src: &'s str,
+    off: usize,
+}
+
+/// A lexeme is a token along with its offset in the source string, and the slice of source string
+/// that it originated from.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct Lexeme<'s>(pub Token, pub usize, pub &'s str);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Token {
+    /// '{'
+    LCurl,
+    /// '}'
+    RCurl,
+    /// Any other text
+    Text,
+}
+
+impl<'s> Lexer<'s> {
+    pub(crate) fn new(src: &'s str) -> Self {
+        Self { src, off: 0 }
+    }
+}
+
+impl<'s> Iterator for Lexer<'s> {
+    type Item = Lexeme<'s>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let off = self.off;
+        let bytes = self.src.as_bytes();
+        let fst = bytes.first()?;
+
+        Some(match fst {
+            b'{' => {
+                let span = &self.src[..1];
+                self.src = &self.src[1..];
+                self.off += 1;
+                Lexeme(Token::LCurl, off, span)
+            }
+
+            b'}' => {
+                let span = &self.src[..1];
+                self.src = &self.src[1..];
+                self.off += 1;
+                Lexeme(Token::RCurl, off, span)
+            }
+
+            _ => {
+                let end = self.src.find(['{', '}']).unwrap_or(self.src.len());
+                let span = &self.src[..end];
+                self.src = &self.src[end..];
+                self.off += end;
+                Lexeme(Token::Text, off, span)
+            }
+        })
+    }
+}
+
+impl fmt::Display for Token {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Token as T;
+        match self {
+            T::LCurl => write!(f, "'{{'"),
+            T::RCurl => write!(f, "'}}'"),
+            T::Text => write!(f, "text"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use Lexeme as L;
+    use Token as T;
+
+    /// Lexing source material that only contains text and no curly braces.
+    #[test]
+    fn test_all_text() {
+        let lexer = Lexer::new("foo bar");
+        let lexemes: Vec<_> = lexer.collect();
+        assert_eq!(lexemes, vec![L(T::Text, 0, "foo bar")]);
+    }
+
+    /// When the lexer encounters curly braces in the source material it breaks up the text with
+    /// curly brace tokens.
+    #[test]
+    fn test_curlies() {
+        let lexer = Lexer::new("foo {bar} baz");
+        let lexemes: Vec<_> = lexer.collect();
+        assert_eq!(
+            lexemes,
+            vec![
+                L(T::Text, 0, "foo "),
+                L(T::LCurl, 4, "{"),
+                L(T::Text, 5, "bar"),
+                L(T::RCurl, 8, "}"),
+                L(T::Text, 9, " baz"),
+            ],
+        );
+    }
+
+    /// Repeated curly braces next to each other are used to escape those braces.
+    #[test]
+    fn test_escape_curlies() {
+        let lexer = Lexer::new("foo {{bar}} baz");
+        let lexemes: Vec<_> = lexer.collect();
+        assert_eq!(
+            lexemes,
+            vec![
+                L(T::Text, 0, "foo "),
+                L(T::LCurl, 4, "{"),
+                L(T::LCurl, 5, "{"),
+                L(T::Text, 6, "bar"),
+                L(T::RCurl, 9, "}"),
+                L(T::RCurl, 10, "}"),
+                L(T::Text, 11, " baz"),
+            ],
+        );
+    }
+
+    /// Each curly brace is given its own token so that the parser can parse this as an escaped
+    /// opening curly followed by an empty binder, followed by a literal closing curly. If the
+    /// lexer was responsible for detecting escaped curlies, it would eagerly detect the escaped
+    /// closing curly and then the closing curly for the binder.
+    #[test]
+    fn test_combination_curlies() {
+        let lexer = Lexer::new("{{{}}}");
+        let lexemes: Vec<_> = lexer.collect();
+        assert_eq!(
+            lexemes,
+            vec![
+                L(T::LCurl, 0, "{"),
+                L(T::LCurl, 1, "{"),
+                L(T::LCurl, 2, "{"),
+                L(T::RCurl, 3, "}"),
+                L(T::RCurl, 4, "}"),
+                L(T::RCurl, 5, "}"),
+            ],
+        );
+    }
+}

--- a/crates/sui-sql-macro/src/lib.rs
+++ b/crates/sui-sql-macro/src/lib.rs
@@ -1,0 +1,109 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_macro_input,
+    punctuated::Punctuated,
+    Error, Expr, LitStr, Result, Token, Type,
+};
+
+use crate::{
+    lexer::Lexer,
+    parser::{Format, Parser},
+};
+
+mod lexer;
+mod parser;
+
+/// Rust syntax for `sql!(as T, "format", binds,*)`
+struct SqlInput {
+    return_: Type,
+    format_: LitStr,
+    binds: Punctuated<Expr, Token![,]>,
+}
+
+impl Parse for SqlInput {
+    fn parse(input: ParseStream) -> Result<Self> {
+        input.parse::<Token![as]>()?;
+        let return_ = input.parse()?;
+        input.parse::<Token![,]>()?;
+        let format_ = input.parse()?;
+
+        if input.is_empty() {
+            return Ok(Self {
+                return_,
+                format_,
+                binds: Punctuated::new(),
+            });
+        }
+
+        input.parse::<Token![,]>()?;
+        let binds = Punctuated::parse_terminated(input)?;
+
+        Ok(Self {
+            return_,
+            format_,
+            binds,
+        })
+    }
+}
+
+/// The `sql!` macro is used to construct a `diesel::SqlLiteral<T>` using a format string to
+/// describe the SQL snippet with the following syntax:
+///
+/// ```rust,ignore
+/// sql!(as T, "format", binds,*)
+/// ```
+///
+/// `T` is the `SqlType` that the literal will be interpreted as, as a Rust expression. The format
+/// string introduces binders with curly braces, surrounding the `SqlType` of the bound value. This
+/// type is given as a string which must correspond to a type in the `diesel::sql_types` module.
+/// Bound values following in the order matching their binders in the string:
+///
+/// ```rust,ignore
+/// sql!(as Bool, "{BigInt} <= foo AND foo < {BigInt}", 5, 10)
+/// ```
+///
+/// The above macro invocation will generate the following code:
+///
+/// ```rust,ignore
+/// sql::<Bool>("")
+///    .bind::<BigInt, _>(5)
+///    .sql(" <= foo AND foo < ")
+///    .bind::<BigInt, _>(10)
+///    .sql("")
+/// ```
+#[proc_macro]
+pub fn sql(input: TokenStream) -> TokenStream {
+    let SqlInput {
+        return_,
+        format_,
+        binds,
+        ..
+    } = parse_macro_input!(input as SqlInput);
+
+    let format_str = format_.value();
+    let lexemes: Vec<_> = Lexer::new(&format_str).collect();
+    let Format { head, tail } = match Parser::new(&lexemes).format() {
+        Ok(format) => format,
+        Err(err) => {
+            return Error::new(format_.span(), err).into_compile_error().into();
+        }
+    };
+
+    let mut tokens = quote! {
+        ::diesel::dsl::sql::<#return_>(#head)
+    };
+
+    for (expr, (ty, suffix)) in binds.iter().zip(tail.into_iter()) {
+        tokens.extend(quote! {
+            .bind::<::diesel::sql_types::#ty, _>(#expr)
+            .sql(#suffix)
+        });
+    }
+
+    tokens.into()
+}

--- a/crates/sui-sql-macro/src/parser.rs
+++ b/crates/sui-sql-macro/src/parser.rs
@@ -1,0 +1,306 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::borrow::Cow;
+
+use crate::lexer::{Lexeme, Token};
+
+/// Recursive descent parser for format strings. This struct is intended to be lightweight to
+/// support efficient backtracking. Backtracking is implemented by operating on a copy of the
+/// parser's state, and only updating the original when the copy has reached a known good position.
+#[derive(Copy, Clone)]
+pub(crate) struct Parser<'l, 's> {
+    lexemes: &'l [Lexeme<'s>],
+}
+
+/// Structured representation of a format string, starting with a text prefix (the head), followed
+/// by interleaved binders followed by text suffixes (the tail).
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct Format<'s> {
+    pub head: Cow<'s, str>,
+    pub tail: Vec<(syn::Type, Cow<'s, str>)>,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum Error {
+    #[error("Unexpected {actual} at offset {offset}, expected {expect}")]
+    Unexpected {
+        offset: usize,
+        actual: Token,
+        expect: Token,
+    },
+
+    #[error("Unexpected end of format string, expected: {expect:?}")]
+    UnexpectedEos { expect: Token },
+
+    #[error("Error parsing type for binder at offset {offset}: {source}")]
+    TypeParse { offset: usize, source: syn::Error },
+}
+
+/// Recursive descent parser recognizing the following grammar:
+///
+///   format        ::= text? (bind text?)*
+///   text          ::= part +
+///   part          ::= lcurly_escape | rcurly_escape | TEXT
+///   bind          ::= '{' TEXT '}'
+///   lcurly_escape ::= '{' '{'
+///   rcurly_escape ::= '}' '}'
+///
+/// The parser reads tokens from the front, consuming them when it is able to successfully parse a
+/// non-terminal. When parsing fails, the parser may be left in an indeterminate state.
+/// Backtracking requires explicitly copying the parser state.
+impl<'l, 's> Parser<'l, 's> {
+    /// Constructs a new parser instance that will consume the given `lexemes`.
+    pub(crate) fn new(lexemes: &'l [Lexeme<'s>]) -> Self {
+        Self { lexemes }
+    }
+
+    /// Entrypoint to the parser. Consumes the entire remaining output (and therefore also the
+    /// parser).
+    pub(crate) fn format(mut self) -> Result<Format<'s>, Error> {
+        let head = self.text_opt();
+
+        let mut tail = vec![];
+        while let Some(bind) = self.bind()? {
+            let suffix = self.text_opt();
+            tail.push((bind, suffix));
+        }
+
+        Ok(Format { head, tail })
+    }
+
+    /// Parse a strand of text. The parser is left in its initial state and an empty string is
+    /// returned if there was no text to parse.
+    fn text_opt(&mut self) -> Cow<'s, str> {
+        let mut copy = *self;
+        copy.text().map_or(Cow::Borrowed(""), |t| {
+            *self = copy;
+            t
+        })
+    }
+
+    /// Parse a strand of text by gathering together as many `part`s as possible. Errors if there
+    /// is not at least one `part` to consume.
+    fn text(&mut self) -> Result<Cow<'s, str>, Error> {
+        let mut text = self.part()?;
+
+        let mut copy = *self;
+        while let Ok(part) = copy.part() {
+            text += part;
+            *self = copy;
+        }
+
+        Ok(text)
+    }
+
+    /// Parses any of the three possible `part`s of a text strand: a string of text, or an escaped
+    /// curly brace. Errors if the token stream starts with a binder.
+    fn part(&mut self) -> Result<Cow<'s, str>, Error> {
+        let mut copy = *self;
+        if let Ok(s) = copy.lcurly_escape() {
+            *self = copy;
+            return Ok(s);
+        }
+
+        let mut copy = *self;
+        if let Ok(s) = copy.rcurly_escape() {
+            *self = copy;
+            return Ok(s);
+        }
+
+        let Lexeme(_, _, text) = self.eat(Token::Text)?;
+        Ok(Cow::Borrowed(text))
+    }
+
+    /// Parses as an escaped left curly brace (two curly brace tokens).
+    fn lcurly_escape(&mut self) -> Result<Cow<'s, str>, Error> {
+        use Token as T;
+        self.eat(T::LCurl)?;
+        self.eat(T::LCurl)?;
+        Ok(Cow::Borrowed("{"))
+    }
+
+    /// Parses as an escaped right curly brace (two curly brace tokens).
+    fn rcurly_escape(&mut self) -> Result<Cow<'s, str>, Error> {
+        use Token as T;
+        self.eat(T::RCurl)?;
+        self.eat(T::RCurl)?;
+        Ok(Cow::Borrowed("}"))
+    }
+
+    /// Parses a binding (a text token surrounded by curly braces).
+    fn bind(&mut self) -> Result<Option<syn::Type>, Error> {
+        if self.lexemes.is_empty() {
+            return Ok(None);
+        }
+
+        self.eat(Token::LCurl)?;
+        let Lexeme(_, offset, bind) = self.eat(Token::Text)?;
+        self.eat(Token::RCurl)?;
+
+        let bind = syn::parse_str(bind).map_err(|source| Error::TypeParse { offset, source })?;
+        Ok(Some(bind))
+    }
+
+    /// Consume the next token (returning it) as long as it matches `expect`.
+    fn eat(&mut self, expect: Token) -> Result<Lexeme<'s>, Error> {
+        let &lexeme = self
+            .lexemes
+            .first()
+            .ok_or(Error::UnexpectedEos { expect })?;
+
+        if lexeme.0 == expect {
+            self.lexemes = &self.lexemes[1..];
+            Ok(lexeme)
+        } else {
+            Err(Error::Unexpected {
+                offset: lexeme.1,
+                actual: lexeme.0,
+                expect,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Lexer;
+
+    use super::*;
+
+    /// Test helper for lexing and parsing a format string.
+    fn parse(s: &str) -> Result<Format, Error> {
+        let lexemes: Vec<_> = Lexer::new(s).collect();
+        Parser::new(&lexemes).format()
+    }
+
+    /// Parse a Rust type from a string, to compare against in tests.
+    fn type_(s: &str) -> syn::Type {
+        syn::parse_str(s).unwrap()
+    }
+
+    #[test]
+    fn test_no_binds() {
+        // A simple format string with no binders will gather everything into the head.
+        assert_eq!(
+            parse("foo").unwrap(),
+            Format {
+                head: "foo".into(),
+                tail: vec![]
+            }
+        );
+    }
+
+    #[test]
+    fn test_single_bind() {
+        // A binder is parsed without its surrounding binders as a type, and splits the format
+        // string in two.
+        assert_eq!(
+            parse("foo = {Text} AND bar = 42").unwrap(),
+            Format {
+                head: "foo = ".into(),
+                tail: vec![(type_("Text"), " AND bar = 42".into())]
+            },
+        );
+    }
+
+    #[test]
+    fn test_multiple_binds() {
+        // When there are multiple binders the parser needs to detect the gap between binders.
+        assert_eq!(
+            parse("foo = {Text} AND (bar < {BigInt} OR bar > 5)").unwrap(),
+            Format {
+                head: "foo = ".into(),
+                tail: vec![
+                    (type_("Text"), " AND (bar < ".into()),
+                    (type_("BigInt"), " OR bar > 5)".into()),
+                ],
+            },
+        );
+    }
+
+    #[test]
+    fn test_ends_with_a_bind() {
+        // If the format string ends with a binder, the parser still needs to find an empty suffix
+        // binder.
+        assert_eq!(
+            parse("bar BETWEEN {BigInt} AND {BigInt}").unwrap(),
+            Format {
+                head: "bar BETWEEN ".into(),
+                tail: vec![
+                    (type_("BigInt"), " AND ".into()),
+                    (type_("BigInt"), "".into()),
+                ],
+            },
+        );
+    }
+
+    #[test]
+    fn test_escaped_curlies() {
+        // Escaped curlies are de-duplicated in the parsed output, but the parser does not break up
+        // strands of format string on them.
+        assert_eq!(
+            parse("foo LIKE '{{bar%'").unwrap(),
+            Format {
+                head: "foo LIKE '{bar%'".into(),
+                tail: vec![],
+            },
+        );
+    }
+
+    #[test]
+    fn test_curly_nest() {
+        // This input can be tricky to parse if the lexer treats escaped curlies as a single token.
+        assert_eq!(
+            parse("{{{Bool}}}").unwrap(),
+            Format {
+                head: "{".into(),
+                tail: vec![(type_("Bool"), "}".into())],
+            },
+        );
+    }
+
+    #[test]
+    fn test_bind_unexpected_token() {
+        // Error if the binder is not properly closed.
+        assert!(matches!(
+            parse("{Bool{").unwrap_err(),
+            Error::Unexpected {
+                offset: 5,
+                actual: Token::LCurl,
+                expect: Token::RCurl
+            },
+        ));
+    }
+
+    #[test]
+    fn test_bind_no_type() {
+        // Error if the binder does not contain a type.
+        assert!(matches!(
+            parse("foo = {").unwrap_err(),
+            Error::UnexpectedEos {
+                expect: Token::Text,
+            },
+        ));
+    }
+
+    #[test]
+    fn test_bind_no_rcurly() {
+        // Error if the binder ends before it is closed.
+        assert!(matches!(
+            parse("foo = {Text").unwrap_err(),
+            Error::UnexpectedEos {
+                expect: Token::RCurl,
+            },
+        ));
+    }
+
+    #[test]
+    fn test_bind_bad_type() {
+        // Failure to parse the binder as a Rust type is also an error for this parser.
+        assert!(matches!(
+            parse("foo = {not a type}").unwrap_err(),
+            Error::TypeParse { offset: 7, .. },
+        ));
+    }
+}


### PR DESCRIPTION
## Description

Introduce a macro that allows for building a `SqlLiteral` using a format-string-like syntax.

`SqlLiteral` should allow us to keep using `diesel` and not have to worry about how to handle scenarios where we need to introduce snippets of raw SQL -- it makes it possible to do so while still taking advantage of strong typing on the boundary and diesel's support for escaping values.

However, it has poor ergonomics, requiring lots of boilerplate (chains of function calls and type annotations) which break up and hide the query being built. The newly introduced macro allows for building the same structure using a format string. See diff for docs and examples of usage.

Some features that were not included in the initial implementation, but could be added later include:

- inlining binds (similar to inlining interpolated values in format strings:
  - `sql!("foo = {bar:BigInt}")` instead of
  - `sql!("foo = {BigInt}", bar)`
- named binds (again, similar to the same feature in `format!` strings):
  - `sql!("foo = {bar:BigInt}", bar = 1 + 2)`.
- support for normal format strings, which in particular would allow us to interpolate column and table names into sql snippets.

## Test plan

The macro comes with extensive unit tests, and the usages are covered by existing tests:

```
cargo nextest run            \
  -p sui-sql-macro           \
  -p sui-indexer-alt         \
  -p sui-indexer-alt-jsonrpc \
  -p sui-indexer-alt-e2e-tests
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
