### PR TITLE
rpc-alt: apply limits to package resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14094,6 +14094,7 @@ dependencies = [
  "sui-open-rpc-macros",
  "sui-package-resolver",
  "sui-pg-db",
+ "sui-protocol-config",
  "sui-types",
  "telemetry-subscribers",
  "thiserror 1.0.69",

--- a/crates/sui-indexer-alt-e2e-tests/packages/type_limits/Move.toml
+++ b/crates/sui-indexer-alt-e2e-tests/packages/type_limits/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "type_limits"
+edition = "2024.beta"
+
+[dependencies]
+Sui = { local = "../../../sui-framework/packages/sui-framework" }
+
+[addresses]
+type_limits = "0x0"

--- a/crates/sui-indexer-alt-e2e-tests/packages/type_limits/sources/type_limits.move
+++ b/crates/sui-indexer-alt-e2e-tests/packages/type_limits/sources/type_limits.move
@@ -1,0 +1,43 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module type_limits::type_limits;
+
+public struct Deep0<T: store> has key, store { id: UID, inner: T }
+public struct Deep1<T: store> has key, store { id: UID, inner: T }
+public struct Deep2<T: store> has key, store { id: UID, inner: T }
+public struct Deep3<T: store> has key, store { id: UID, inner: T }
+
+public struct Wide<T: store, U: store, V: store, W: store> has key, store {
+  id: UID,
+  t: T,
+  u: U,
+  v: V,
+  w: W,
+}
+
+public fun deep0<T: store>(inner: T, ctx: &mut TxContext): Deep0<T> {
+  Deep0 { id: object::new(ctx), inner }
+}
+
+public fun deep1<T: store>(inner: T, ctx: &mut TxContext): Deep1<T> {
+  Deep1 { id: object::new(ctx), inner }
+}
+
+public fun deep2<T: store>(inner: T, ctx: &mut TxContext): Deep2<T> {
+  Deep2 { id: object::new(ctx), inner }
+}
+
+public fun deep3<T: store>(inner: T, ctx: &mut TxContext): Deep3<T> {
+  Deep3 { id: object::new(ctx), inner }
+}
+
+public fun wide<T: store, U: store, V: store, W: store>(
+  t: T,
+  u: U,
+  v: V,
+  w: W,
+  ctx: &mut TxContext,
+): Wide<T, U, V, W> {
+  Wide { id: object::new(ctx), t, u, v, w }
+}

--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -22,6 +22,7 @@ use sui_pg_db::{
 };
 use sui_types::{
     base_types::{ObjectRef, SuiAddress},
+    crypto::AccountKeyPair,
     effects::{TransactionEffects, TransactionEffectsAPI},
     error::ExecutionError,
     execution_status::ExecutionStatus,
@@ -139,6 +140,15 @@ impl FullCluster {
     /// Return the reference gas price for the current epoch
     pub fn reference_gas_price(&self) -> u64 {
         self.executor.reference_gas_price()
+    }
+
+    /// Create a new account and credit it with `amount` gas units from a faucet account. Returns
+    /// the account, its keypair, and a reference to the gas object it was funded with.
+    pub fn funded_account(
+        &mut self,
+        amount: u64,
+    ) -> anyhow::Result<(SuiAddress, AccountKeyPair, ObjectRef)> {
+        self.executor.funded_account(amount)
     }
 
     /// Request gas from the faucet, sent to `address`. Return the object reference of the gas

--- a/crates/sui-indexer-alt-e2e-tests/tests/type_limit_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/type_limit_tests.rs
@@ -1,0 +1,333 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+
+use anyhow::Context;
+use move_core_types::{ident_str, language_storage::StructTag};
+use reqwest::Client;
+use serde_json::{json, Value};
+use simulacrum::Simulacrum;
+use sui_indexer_alt::config::{IndexerConfig, PipelineLayer};
+use sui_indexer_alt_e2e_tests::{find_address_owned, find_immutable, FullCluster};
+use sui_indexer_alt_framework::IndexerArgs;
+use sui_indexer_alt_jsonrpc::{
+    config::{PackageResolverLayer, RpcConfig},
+    data::system_package_task::SystemPackageTaskArgs,
+};
+use sui_move_build::BuildConfig;
+use sui_types::{
+    base_types::ObjectID,
+    programmable_transaction_builder::ProgrammableTransactionBuilder,
+    transaction::{Transaction, TransactionData},
+    Identifier, TypeTag,
+};
+use tokio_util::sync::CancellationToken;
+
+/// 5 SUI gas budget
+const DEFAULT_GAS_BUDGET: u64 = 5_000_000_000;
+
+/// We get a successful response if everything is within limits.
+#[tokio::test]
+async fn test_within_limits() {
+    let mut c = TypeLimitCluster::new(PackageResolverLayer::default()).await;
+
+    let object_id = c.create_deep(3).await;
+    c.cluster.create_checkpoint().await;
+
+    let result = c.get_object(object_id).await.unwrap();
+    assert!(
+        result["result"]["data"]["content"].is_object(),
+        "Result: {result:#?}"
+    );
+
+    c.cluster.stopped().await;
+}
+
+/// If we set a limit on how deeply nested some type arguments can be, then trying to fetch an
+/// object whose type is that deeply nested is going to cause problems.
+#[tokio::test]
+async fn test_type_argument_depth() {
+    let mut c = TypeLimitCluster::new(PackageResolverLayer {
+        max_type_argument_depth: 3,
+        ..Default::default()
+    })
+    .await;
+
+    let object_id = c.create_deep(4).await;
+    c.cluster.create_checkpoint().await;
+
+    let result = c.get_object(object_id).await.unwrap();
+    let Some(err) = result["error"]["message"].as_str() else {
+        panic!("Expected an error, got: {result:#?}");
+    };
+
+    assert!(err.contains("Type parameter nesting exceeded"), "{err}");
+    c.cluster.stopped().await;
+}
+
+/// There is also a limit on how many type parameters a single type can have.
+#[tokio::test]
+async fn test_type_argument_width() {
+    let mut c = TypeLimitCluster::new(PackageResolverLayer {
+        max_type_argument_width: 3,
+        ..Default::default()
+    })
+    .await;
+
+    let object_id = c.create_wide().await;
+    c.cluster.create_checkpoint().await;
+
+    let result = c.get_object(object_id).await.unwrap();
+    let Some(err) = result["error"]["message"].as_str() else {
+        panic!("Expected an error, got: {result:#?}");
+    };
+
+    assert!(err.contains("Expected at most 3 type parameters"), "{err}");
+    c.cluster.stopped().await;
+}
+
+/// This limit controls the number of types that need to be loaded to resolve the layout of a type.
+#[tokio::test]
+async fn test_type_nodes() {
+    let mut c = TypeLimitCluster::new(PackageResolverLayer {
+        max_type_nodes: 3,
+        ..Default::default()
+    })
+    .await;
+
+    let object_id = c.create_deep(4).await;
+    c.cluster.create_checkpoint().await;
+
+    let result = c.get_object(object_id).await.unwrap();
+    let Some(err) = result["error"]["message"].as_str() else {
+        panic!("Expected an error, got: {result:#?}");
+    };
+
+    assert!(
+        err.contains("More than 3 struct definitions required to resolve type"),
+        "{err}"
+    );
+
+    c.cluster.stopped().await;
+}
+
+/// This limit controls the depth of the resulting value layout.
+#[tokio::test]
+async fn test_value_depth() {
+    let mut c = TypeLimitCluster::new(PackageResolverLayer {
+        max_move_value_depth: 3,
+        ..Default::default()
+    })
+    .await;
+
+    let object_id = c.create_deep(4).await;
+    c.cluster.create_checkpoint().await;
+
+    let result = c.get_object(object_id).await.unwrap();
+    let Some(err) = result["error"]["message"].as_str() else {
+        panic!("Expected an error, got: {result:#?}");
+    };
+
+    assert!(
+        err.contains("Type layout nesting exceeded limit of 3"),
+        "{err}"
+    );
+
+    c.cluster.stopped().await;
+}
+
+struct TypeLimitCluster {
+    cluster: FullCluster,
+    package_id: ObjectID,
+    client: Client,
+}
+
+impl TypeLimitCluster {
+    /// Sets up a full cluster and publishes a test package containing types that can exercise type
+    /// resolution limits.
+    async fn new(package_resolver: PackageResolverLayer) -> Self {
+        // (1) Set-up a cluster that indexes object data and sets the given limits up.
+        let mut cluster = FullCluster::new_with_configs(
+            Simulacrum::new(),
+            IndexerArgs::default(),
+            SystemPackageTaskArgs::default(),
+            IndexerConfig {
+                pipeline: PipelineLayer {
+                    cp_sequence_numbers: Some(Default::default()),
+                    kv_objects: Some(Default::default()),
+                    obj_info: Some(Default::default()),
+                    obj_versions: Some(Default::default()),
+                    sum_packages: Some(Default::default()),
+                    ..Default::default()
+                },
+                ..IndexerConfig::for_test()
+            },
+            RpcConfig {
+                package_resolver,
+                ..RpcConfig::example()
+            },
+            &prometheus::Registry::new(),
+            CancellationToken::new(),
+        )
+        .await
+        .expect("Failed to set-up cluster");
+
+        // (2) Compile the test package.
+        let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.extend(["packages", "type_limits"]);
+
+        let pkg = BuildConfig::new_for_testing()
+            .build(&path)
+            .expect("Failed to compile package");
+
+        // (3) Create an address and fund it to be able to run transactions
+        let (sender, kp, gas) = cluster
+            .funded_account(DEFAULT_GAS_BUDGET)
+            .expect("Failed to get account");
+
+        // (4) Publish the test package
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let with_unpublished_deps = false;
+        builder.publish_immutable(
+            pkg.get_package_bytes(with_unpublished_deps),
+            pkg.get_dependency_storage_package_ids(),
+        );
+
+        let data = TransactionData::new_programmable(
+            sender,
+            vec![gas],
+            builder.finish(),
+            DEFAULT_GAS_BUDGET,
+            cluster.reference_gas_price(),
+        );
+
+        let (fx, _) = cluster
+            .execute_transaction(Transaction::from_data_and_signer(data, vec![&kp]))
+            .expect("Publish failed");
+
+        let package_id = find_immutable(&fx).expect("Couldn't find package").0;
+
+        Self {
+            cluster,
+            package_id,
+            client: Client::new(),
+        }
+    }
+
+    /// Run a transaction on the cluster to create a nested instance of the `DeepX` types from the
+    /// test package. The number of nestings is determined by the `depth` parameter, and the exact
+    /// types used cycle through `Deep0`, `Deep1`, `Deep2`, and `Deep3` in a round-robin fashion to
+    /// cause more types to be loaded.
+    pub async fn create_deep(&mut self, depth: usize) -> ObjectID {
+        let (sender, kp, gas) = self
+            .cluster
+            .funded_account(DEFAULT_GAS_BUDGET)
+            .expect("Failed to get account");
+
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let mut arg = builder.pure(42u64).unwrap();
+        let mut typ = TypeTag::U64;
+
+        for d in 0..depth {
+            arg = builder.programmable_move_call(
+                self.package_id,
+                ident_str!("type_limits").to_owned(),
+                Identifier::new(format!("deep{}", d % 4)).unwrap(),
+                vec![typ.clone()],
+                vec![arg],
+            );
+
+            typ = TypeTag::Struct(Box::new(StructTag {
+                address: self.package_id.into(),
+                module: ident_str!("type_limits").to_owned(),
+                name: Identifier::new(format!("Deep{}", d % 4)).unwrap(),
+                type_params: vec![typ.clone()],
+            }));
+        }
+
+        builder.transfer_args(sender, vec![arg]);
+
+        let data = TransactionData::new_programmable(
+            sender,
+            vec![gas],
+            builder.finish(),
+            DEFAULT_GAS_BUDGET,
+            self.cluster.reference_gas_price(),
+        );
+
+        let (fx, _) = self
+            .cluster
+            .execute_transaction(Transaction::from_data_and_signer(data, vec![&kp]))
+            .expect("Transaction failed");
+
+        find_address_owned(&fx).unwrap().0
+    }
+
+    /// Run a transaction on the cluster to create an instance of the `Wide` type from the test
+    /// package. All of the `Wide` type's parameters are instantiated to `u64`.
+    pub async fn create_wide(&mut self) -> ObjectID {
+        let (sender, kp, gas) = self
+            .cluster
+            .funded_account(DEFAULT_GAS_BUDGET)
+            .expect("Failed to get account");
+
+        let mut builder = ProgrammableTransactionBuilder::new();
+        let inner = builder.pure(42u64).unwrap();
+
+        let arg = builder.programmable_move_call(
+            self.package_id,
+            ident_str!("type_limits").to_owned(),
+            ident_str!("wide").to_owned(),
+            vec![TypeTag::U64; 4],
+            vec![inner; 4],
+        );
+
+        builder.transfer_args(sender, vec![arg]);
+
+        let data = TransactionData::new_programmable(
+            sender,
+            vec![gas],
+            builder.finish(),
+            DEFAULT_GAS_BUDGET,
+            self.cluster.reference_gas_price(),
+        );
+
+        let (fx, _) = self
+            .cluster
+            .execute_transaction(Transaction::from_data_and_signer(data, vec![&kp]))
+            .expect("Transaction failed");
+
+        find_address_owned(&fx).unwrap().0
+    }
+
+    /// Try and fetch the contents of an object from the cluster's RPC.
+    async fn get_object(&self, id: ObjectID) -> anyhow::Result<Value> {
+        let query = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "sui_getObject",
+            "params": [
+                id.to_string(),
+                {
+                    "showContent": true,
+                },
+            ]
+        });
+
+        let response = self
+            .client
+            .post(self.cluster.rpc_url())
+            .json(&query)
+            .send()
+            .await
+            .context("Request to JSON-RPC server failed")?;
+
+        let body: Value = response
+            .json()
+            .await
+            .context("Failed to parse JSON-RPC response")?;
+
+        Ok(body)
+    }
+}

--- a/crates/sui-indexer-alt-jsonrpc/Cargo.toml
+++ b/crates/sui-indexer-alt-jsonrpc/Cargo.toml
@@ -51,6 +51,7 @@ sui-open-rpc.workspace = true
 sui-open-rpc-macros.workspace = true
 sui-package-resolver.workspace = true
 sui-pg-db.workspace = true
+sui-protocol-config.workspace = true
 sui-types.workspace = true
 
 [dev-dependencies]

--- a/crates/sui-indexer-alt-jsonrpc/src/api/dynamic_fields.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/dynamic_fields.rs
@@ -141,8 +141,8 @@ async fn dynamic_field_object_response(
     };
 
     let options = SuiObjectDataOptions::full_content();
-    use RpcError as E;
 
+    use RpcError as E;
     Ok(SuiObjectResponse::new_with_data(
         objects::response::object_data_with_options(ctx, object, &options)
             .await

--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
@@ -19,7 +19,7 @@ use tokio::join;
 use crate::{
     context::Context,
     data::{object_info::LatestObjectInfoKey, objects::load_latest},
-    error::{rpc_bail, RpcError},
+    error::{rpc_bail, InternalContext, RpcError},
 };
 
 /// Fetch the necessary data from the stores in `ctx` and transform it to build a response for a
@@ -124,11 +124,11 @@ pub(crate) async fn object_data_with_options(
 
     let content = content
         .transpose()
-        .context("Failed to deserialize object content")?;
+        .internal_context("Failed to deserialize object content")?;
 
     let bcs = bcs
         .transpose()
-        .context("Failed to deserialize object to BCS")?;
+        .internal_context("Failed to deserialize object to BCS")?;
 
     Ok(SuiObjectData {
         object_id: object.id(),

--- a/crates/sui-indexer-alt-jsonrpc/src/config.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/config.rs
@@ -4,6 +4,7 @@
 use std::mem;
 
 use sui_default_config::DefaultConfig;
+use sui_protocol_config::ProtocolConfig;
 use sui_types::base_types::{ObjectID, SuiAddress};
 use tracing::warn;
 
@@ -29,6 +30,9 @@ pub struct RpcConfig {
     /// Configuration for bigtable kv store, if it is used.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bigtable_config: Option<BigtableConfig>,
+
+    /// Configuring limits for the package resolver.
+    pub package_resolver: PackageResolverLayer,
 
     #[serde(flatten)]
     pub extra: toml::Table,
@@ -83,6 +87,18 @@ pub struct BigtableConfig {
     pub instance_id: String,
 }
 
+#[DefaultConfig]
+#[derive(Clone, Debug)]
+pub struct PackageResolverLayer {
+    pub max_type_argument_depth: usize,
+    pub max_type_argument_width: usize,
+    pub max_type_nodes: usize,
+    pub max_move_value_depth: usize,
+
+    #[serde(flatten)]
+    pub extra: toml::Table,
+}
+
 impl RpcConfig {
     /// Generate an example configuration, suitable for demonstrating the fields available to
     /// configure.
@@ -93,6 +109,7 @@ impl RpcConfig {
             name_service: NameServiceConfig::default().into(),
             coins: CoinsConfig::default().into(),
             bigtable_config: None,
+            package_resolver: PackageResolverLayer::default(),
             extra: Default::default(),
         }
     }
@@ -143,6 +160,36 @@ impl CoinsLayer {
         CoinsConfig {
             default_page_size: self.default_page_size.unwrap_or(base.default_page_size),
             max_page_size: self.max_page_size.unwrap_or(base.max_page_size),
+        }
+    }
+}
+
+impl PackageResolverLayer {
+    pub fn finish(self) -> sui_package_resolver::Limits {
+        check_extra("package-resolver", self.extra);
+        sui_package_resolver::Limits {
+            max_type_argument_depth: self.max_type_argument_depth,
+            max_type_argument_width: self.max_type_argument_width,
+            max_type_nodes: self.max_type_nodes,
+            max_move_value_depth: self.max_move_value_depth,
+        }
+    }
+}
+
+impl Default for PackageResolverLayer {
+    fn default() -> Self {
+        // SAFETY: Accessing the max supported config by the binary (and disregarding specific
+        // chain state) is a safe operation for the RPC because we are only using this to set
+        // default values which can be overridden by configuration.
+        let config = ProtocolConfig::get_for_max_version_UNSAFE();
+
+        Self {
+            max_type_argument_depth: config.max_type_argument_depth() as usize,
+            max_type_argument_width: config.max_generic_instantiation_length() as usize,
+            max_type_nodes: config.max_type_nodes() as usize,
+            max_move_value_depth: config.max_move_value_depth() as usize,
+
+            extra: Default::default(),
         }
     }
 }

--- a/crates/sui-indexer-alt-jsonrpc/src/context.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/context.rs
@@ -45,6 +45,7 @@ impl Context {
     pub(crate) async fn new(
         db_args: DbArgs,
         bigtable_config: Option<BigtableConfig>,
+        limits: sui_package_resolver::Limits,
         metrics: Arc<RpcMetrics>,
         registry: &Registry,
     ) -> Result<Self, Error> {
@@ -59,7 +60,7 @@ impl Context {
         };
 
         let store = PackageCache::new(DbPackageStore::new(pg_loader.clone()));
-        let package_resolver = Arc::new(Resolver::new(store));
+        let package_resolver = Arc::new(Resolver::new_with_limits(store, limits));
 
         Ok(Self {
             pg_reader,

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -220,6 +220,7 @@ pub async fn start_rpc(
         name_service,
         coins,
         bigtable_config,
+        package_resolver,
         extra: _,
     } = rpc_config.finish();
 
@@ -227,11 +228,19 @@ pub async fn start_rpc(
     let transactions_config = transactions.finish(TransactionsConfig::default());
     let name_service_config = name_service.finish(NameServiceConfig::default());
     let coins_config = coins.finish(CoinsConfig::default());
+    let package_resolver_limits = package_resolver.finish();
 
     let mut rpc = RpcService::new(rpc_args, registry, cancel.child_token())
         .context("Failed to create RPC service")?;
 
-    let context = Context::new(db_args, bigtable_config, rpc.metrics(), registry).await?;
+    let context = Context::new(
+        db_args,
+        bigtable_config,
+        package_resolver_limits,
+        rpc.metrics(),
+        registry,
+    )
+    .await?;
 
     let system_package_task = SystemPackageTask::new(
         context.clone(),


### PR DESCRIPTION
## Description 

When initialising the RPC service's package resolver, configure its limits (previously it did not impose any). The limits are set in the RPC's config file, and default to the limits in the latest protocol version the RPC binary is aware of.

This PR also includes a new helper to `Simulacrum` to create a fresh funded account (in a separate commit).

## Test plan 

New E2E test:

```
sui$ cargo nextest run -p sui-indexer-alt-e2e-tests --test type_limit_tests
```
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
