### PR TITLE
rpc-alt: fix indices

### DIFF
--- a/crates/sui-indexer-alt-schema/migrations/2025-02-17-182226_tx_digests_tx_digest/down.sql
+++ b/crates/sui-indexer-alt-schema/migrations/2025-02-17-182226_tx_digests_tx_digest/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS tx_digests_tx_digest;

--- a/crates/sui-indexer-alt-schema/migrations/2025-02-17-182226_tx_digests_tx_digest/up.sql
+++ b/crates/sui-indexer-alt-schema/migrations/2025-02-17-182226_tx_digests_tx_digest/up.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS tx_digests_tx_sequence_number;
+
+CREATE INDEX IF NOT EXISTS tx_digests_tx_digest
+ON tx_digests (tx_digest);

--- a/crates/sui-indexer-alt-schema/migrations/2025-02-17-183604_obj_info_object_id_desc/down.sql
+++ b/crates/sui-indexer-alt-schema/migrations/2025-02-17-183604_obj_info_object_id_desc/down.sql
@@ -1,0 +1,36 @@
+DROP INDEX IF EXISTS obj_info_owner_object_id_desc;
+DROP INDEX IF EXISTS obj_info_pkg_object_id_desc;
+DROP INDEX IF EXISTS obj_info_mod_object_id_desc;
+DROP INDEX IF EXISTS obj_info_name_object_id_desc;
+DROP INDEX IF EXISTS obj_info_inst_object_id_desc;
+DROP INDEX IF EXISTS obj_info_owner_pkg_object_id_desc;
+DROP INDEX IF EXISTS obj_info_owner_mod_object_id_desc;
+DROP INDEX IF EXISTS obj_info_owner_name_object_id_desc;
+DROP INDEX IF EXISTS obj_info_owner_inst_object_id_desc;
+
+CREATE INDEX IF NOT EXISTS obj_info_owner
+ON obj_info (owner_kind, owner_id, cp_sequence_number DESC, object_id);
+
+CREATE INDEX IF NOT EXISTS obj_info_pkg
+ON obj_info (package, cp_sequence_number DESC, object_id);
+
+CREATE INDEX IF NOT EXISTS obj_info_mod
+ON obj_info (package, module, cp_sequence_number DESC, object_id);
+
+CREATE INDEX IF NOT EXISTS obj_info_name
+ON obj_info (package, module, name, cp_sequence_number DESC, object_id);
+
+CREATE INDEX IF NOT EXISTS obj_info_inst
+ON obj_info (package, module, name, instantiation, cp_sequence_number DESC, object_id);
+
+CREATE INDEX IF NOT EXISTS obj_info_owner_pkg
+ON obj_info (owner_kind, owner_id, package, cp_sequence_number DESC, object_id);
+
+CREATE INDEX IF NOT EXISTS obj_info_owner_mod
+ON obj_info (owner_kind, owner_id, package, module, cp_sequence_number DESC, object_id);
+
+CREATE INDEX IF NOT EXISTS obj_info_owner_name
+ON obj_info (owner_kind, owner_id, package, module, name, cp_sequence_number DESC, object_id);
+
+CREATE INDEX IF NOT EXISTS obj_info_owner_inst
+ON obj_info (owner_kind, owner_id, package, module, name, instantiation, cp_sequence_number DESC, object_id);

--- a/crates/sui-indexer-alt-schema/migrations/2025-02-17-183604_obj_info_object_id_desc/up.sql
+++ b/crates/sui-indexer-alt-schema/migrations/2025-02-17-183604_obj_info_object_id_desc/up.sql
@@ -1,0 +1,36 @@
+DROP INDEX IF EXISTS obj_info_owner;
+DROP INDEX IF EXISTS obj_info_pkg;
+DROP INDEX IF EXISTS obj_info_mod;
+DROP INDEX IF EXISTS obj_info_name;
+DROP INDEX IF EXISTS obj_info_inst;
+DROP INDEX IF EXISTS obj_info_owner_pkg;
+DROP INDEX IF EXISTS obj_info_owner_mod;
+DROP INDEX IF EXISTS obj_info_owner_name;
+DROP INDEX IF EXISTS obj_info_owner_inst;
+
+CREATE INDEX IF NOT EXISTS obj_info_owner_object_id_desc
+ON obj_info (owner_kind, owner_id, cp_sequence_number DESC, object_id DESC);
+
+CREATE INDEX IF NOT EXISTS obj_info_pkg_object_id_desc
+ON obj_info (package, cp_sequence_number DESC, object_id DESC);
+
+CREATE INDEX IF NOT EXISTS obj_info_mod_object_id_desc
+ON obj_info (package, module, cp_sequence_number DESC, object_id DESC);
+
+CREATE INDEX IF NOT EXISTS obj_info_name_object_id_desc
+ON obj_info (package, module, name, cp_sequence_number DESC, object_id DESC);
+
+CREATE INDEX IF NOT EXISTS obj_info_inst_object_id_desc
+ON obj_info (package, module, name, instantiation, cp_sequence_number DESC, object_id DESC);
+
+CREATE INDEX IF NOT EXISTS obj_info_owner_pkg_object_id_desc
+ON obj_info (owner_kind, owner_id, package, cp_sequence_number DESC, object_id DESC);
+
+CREATE INDEX IF NOT EXISTS obj_info_owner_mod_object_id_desc
+ON obj_info (owner_kind, owner_id, package, module, cp_sequence_number DESC, object_id DESC);
+
+CREATE INDEX IF NOT EXISTS obj_info_owner_name_object_id_desc
+ON obj_info (owner_kind, owner_id, package, module, name, cp_sequence_number DESC, object_id DESC);
+
+CREATE INDEX IF NOT EXISTS obj_info_owner_inst_object_id_desc
+ON obj_info (owner_kind, owner_id, package, module, name, instantiation, cp_sequence_number DESC, object_id DESC);


### PR DESCRIPTION
## Description 

Two changes to the indexer-alt schema to support efficient querying in rpc-alt:

- I mistakenly added an index on `tx_digests` for `tx_sequence_number` but one already exists (it is the primary key). I meant to add an index on `tx_digest` to support fetching a transaction's balance changes.
- `cp_sequence_number` and `object_id` should be ordered the same in `obj_info` indices to make efficient use of indices while bounding results because of cursors.

These migrations may need to be run proactively on our production instances (if we have any) before landing to prevent stalling deployments.

## Test plan 

Run the following locally:

```
sui-indexer-alt-schema$ ./generate_schema.sh
sui-indexer-alt-schema$ cargo run -p sui-indexer-alt -- reset-database
```

Also run the indexer locally and confirm that queries generated by the
RPC service make better use of the indices.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
