### PR TITLE
refactor(rpc-alt): use context instead of ok_or_else

### DIFF
--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
@@ -23,7 +23,7 @@ use crate::{
         object_info::LatestObjectInfoKey,
         objects::{load_latest, VersionedObjectKey},
     },
-    error::{internal_error, rpc_bail, RpcError},
+    error::{rpc_bail, RpcError},
 };
 
 /// Fetch the necessary data from the stores in `ctx` and transform it to build a response for a
@@ -72,7 +72,7 @@ pub(super) async fn latest_object(
     let o = load_latest(ctx.loader(), object_id)
         .await
         .context("Failed to load latest object")?
-        .ok_or_else(|| internal_error!("Could not find latest content for live object"))?;
+        .context("Could not find latest content for live object")?;
 
     Ok(SuiObjectResponse::new_with_data(
         object(ctx, o, options).await?,

--- a/crates/sui-indexer-alt-jsonrpc/src/api/transactions/filter.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/transactions/filter.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{anyhow, Context as _};
+use anyhow::Context as _;
 use diesel::{
     dsl::sql,
     expression::{
@@ -191,7 +191,7 @@ async fn by_checkpoint(
         let ix = (tx - cp_lo) as usize;
         let digest = digests
             .get(ix)
-            .ok_or_else(|| anyhow!("Transaction out of bounds in checkpoint"))?
+            .context("Transaction out of bounds in checkpoint")?
             .transaction
             .inner()
             .to_vec();
@@ -404,7 +404,7 @@ async fn from_sequence_numbers(
     for seq in rows {
         let bytes = digests
             .get(&TxDigestKey(seq as u64))
-            .ok_or_else(|| anyhow!("Missing transaction digest for transaction {seq}"))?
+            .with_context(|| format!("Missing transaction digest for transaction {seq}"))?
             .tx_digest
             .as_slice();
 

--- a/crates/sui-indexer-alt-jsonrpc/src/api/transactions/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/transactions/response.rs
@@ -32,7 +32,7 @@ use crate::{
         objects::VersionedObjectKey, transactions::TransactionKey,
         tx_balance_changes::TxBalanceChangeKey,
     },
-    error::{internal_error, invalid_params, rpc_bail, RpcError},
+    error::{invalid_params, rpc_bail, RpcError},
 };
 
 use super::error::Error;
@@ -313,7 +313,7 @@ async fn object_changes(
                 owner: o.owner().clone(),
                 object_type: o
                     .struct_tag()
-                    .ok_or_else(|| internal_error!("No type for object {object_id}"))?,
+                    .with_context(|| format!("No type for object {object_id}"))?,
                 object_id,
                 version: o.version(),
                 digest: d,
@@ -325,7 +325,7 @@ async fn object_changes(
                     recipient: o.owner().clone(),
                     object_type: o
                         .struct_tag()
-                        .ok_or_else(|| internal_error!("No type for object {object_id}"))?,
+                        .with_context(|| format!("No type for object {object_id}"))?,
                     object_id,
                     version: o.version(),
                     digest: od,
@@ -337,7 +337,7 @@ async fn object_changes(
                 owner: o.owner().clone(),
                 object_type: o
                     .struct_tag()
-                    .ok_or_else(|| internal_error!("No type for object {object_id}"))?,
+                    .with_context(|| format!("No type for object {object_id}"))?,
                 object_id,
                 version: o.version(),
                 previous_version: i.version(),
@@ -348,7 +348,7 @@ async fn object_changes(
                 sender: tx_data.sender(),
                 object_type: i
                     .struct_tag()
-                    .ok_or_else(|| internal_error!("No type for object {object_id}"))?,
+                    .with_context(|| format!("No type for object {object_id}"))?,
                 object_id,
                 version: effects.lamport_version(),
             },
@@ -357,7 +357,7 @@ async fn object_changes(
                 sender: tx_data.sender(),
                 object_type: i
                     .struct_tag()
-                    .ok_or_else(|| internal_error!("No type for object {object_id}"))?,
+                    .with_context(|| format!("No type for object {object_id}"))?,
                 object_id,
                 version: effects.lamport_version(),
             },


### PR DESCRIPTION
## Description

It's possible (and cleaner) to use `anyhow`'s `Context` on an `Option<T>` to convert it into an `anyhow::Result`.

## Test plan

Existing tests:

```
sui$ cargo nextest run         \
  -p sui-indexer-alt-e2e-tests \
  -p sui-indexer-alt-jsonrpc
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
