### PR TITLE
rpc-alt: fix transactions next cursor behavior

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/query/by_checkpoint.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/query/by_checkpoint.snap
@@ -423,7 +423,7 @@ Response: {
   "id": 19,
   "result": {
     "data": [],
-    "nextCursor": null,
+    "nextCursor": "Ng==",
     "hasNextPage": false
   }
 }
@@ -435,7 +435,7 @@ Response: {
   "id": 20,
   "result": {
     "data": [],
-    "nextCursor": null,
+    "nextCursor": "MA==",
     "hasNextPage": false
   }
 }

--- a/crates/sui-indexer-alt-jsonrpc/src/api/transactions/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/transactions/mod.rs
@@ -107,8 +107,15 @@ impl QueryTransactionsApiServer for QueryTransactions {
             data: digests,
             next_cursor,
             has_next_page,
-        } = filter::transactions(ctx, config, &query.filter, cursor, limit, descending_order)
-            .await?;
+        } = filter::transactions(
+            ctx,
+            config,
+            &query.filter,
+            cursor.clone(),
+            limit,
+            descending_order,
+        )
+        .await?;
 
         let options = query.options.unwrap_or_default();
 
@@ -131,7 +138,7 @@ impl QueryTransactionsApiServer for QueryTransactions {
 
         Ok(Page {
             data,
-            next_cursor,
+            next_cursor: next_cursor.or(cursor),
             has_next_page,
         })
     }


### PR DESCRIPTION
## Description

If the transaction query returns an empty result and a cursor was supplied, then return that cursor back in the response, so that the client can poll for new results by repeatedly requesting new pages.

This matches the revised behaviour for pagination in `sui-indexer`'s `reader`. Note that in `rpc-alt`, this behaviour is currently only applicable to paginating transactions -- object and coin pagination flow backwards through time, so if you reach an empty result, there is no point retrying it.

## Test plan

```
sui$ cargo nextest run -p sui-indexer-alt-e2e-tests
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
