### PR TITLE
rpc-alt: fix repeated object internal error

### DIFF
--- a/crates/sui-indexer-alt-jsonrpc/src/api/dynamic_fields.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/dynamic_fields.rs
@@ -141,8 +141,8 @@ async fn dynamic_field_object_response(
     };
 
     let options = SuiObjectDataOptions::full_content();
-    use RpcError as E;
 
+    use RpcError as E;
     Ok(SuiObjectResponse::new_with_data(
         objects::response::object(ctx, object, &options)
             .await

--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/response.rs
@@ -23,7 +23,7 @@ use crate::{
         object_info::LatestObjectInfoKey,
         objects::{load_latest, VersionedObjectKey},
     },
-    error::{internal_error, rpc_bail, RpcError},
+    error::{internal_error, rpc_bail, InternalContext, RpcError},
 };
 
 /// Fetch the necessary data from the stores in `ctx` and transform it to build a response for a
@@ -138,11 +138,11 @@ pub(crate) async fn object(
 
     let content = content
         .transpose()
-        .context("Failed to deserialize object content")?;
+        .internal_context("Failed to deserialize object content")?;
 
     let bcs = bcs
         .transpose()
-        .context("Failed to deserialize object to BCS")?;
+        .internal_context("Failed to deserialize object to BCS")?;
 
     Ok(SuiObjectData {
         object_id: object.id(),


### PR DESCRIPTION
## Description
Fix an issue where the error context was improperly set on an internal error using `context` instead of `internal_context`. This unnecessarily wraps an existing `RpcError` in an `anyhow::Error` and back into an `RpcError` creating a confusing message (IDs are truncated for the commit message):

```
Internal Error:
Failed to get object 0x578...218 at latest version:
Failed to deserialize object content:
Internal Error:
Failed to resolve type layout for 0x000...002::coin::Coin<0x361...586::aifrens::AIFRENS>:
Expected at most 0 type parameters, got 1:
Failed to resolve type layout for 0x000...002::coin::Coin<0x361...586::aifrens::AIFRENS>:
Expected at most 0 type parameters, got 1
```

## Test plan

After the change, the above error now looks like:

```
Internal Error:
Failed to get object 0x578...218 at latest version:
Failed to deserialize object content:
Failed to resolve type layout for 0x000...002::coin::Coin<0x361...586::aifrens::AIFRENS>:
Expected at most 0 type parameters, got 1
```

## Stack

- #21258 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
