### PR TITLE
chore: Add cargo deny check for external crates

### DIFF
--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -128,4 +128,4 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # Pin v4.1.1
       - uses: taiki-e/install-action@cargo-deny
-      - run: cargo deny check
+      - run: cargo deny --manifest-path external-crates/move/Cargo.toml check --hide-inclusion-graph

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -371,7 +371,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
       - uses: taiki-e/install-action@cargo-deny
-      - run: cargo deny check bans licenses sources
+      - run: cargo deny check bans licenses sources --hide-inclusion-graph
 
   cargo-deny-advisories:
     name: cargo-deny (advisories)
@@ -383,7 +383,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
       - uses: taiki-e/install-action@cargo-deny
-      - run: cargo deny check advisories
+      - run: cargo deny check advisories --hide-inclusion-graph
 
   sui-excution-cut:
     name: cutting a new execution layer

--- a/external-crates/move/deny.toml
+++ b/external-crates/move/deny.toml
@@ -8,43 +8,59 @@
 
 # The values provided in this template are the default values that will be used
 # when any section or field is not specified in your own configuration
+[graph]
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+# This means, if a particular package is only ever used as a target specific
+# dependency, such as, for example, the `nix` crate only being used via the
+# `target_family = "unix"` configuration, that only having windows targets in
+# this list would mean the nix crate, as well as any of its exclusive
+# dependencies not shared by any other crates, would be ignored, as the target
+# list here is effectively saying which targets you are building for.
+targets = [
+
+
+  # The triple can be any string, but only the target triples built in to
+  # rustc (as of 1.40) can be checked against actual config expressions
+  # { triple = "x86_64-unknown-linux-musl" },
+  # You can also specify which target_features you promise are enabled for a
+  # particular target. target_features are currently not validated against
+  # the actual valid features supported by the target architecture.
+  # { triple = "wasm32-unknown-unknown", features = ["atomics"] },
+]
 
 # This section is considered when running `cargo deny check advisories`
 # More documentation for the advisories section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
-version = 2
 # The path where the advisory database is cloned/fetched into
 db-path = "~/.cargo/advisory-db"
 # The url(s) of the advisory databases to use
 db-urls = ["https://github.com/rustsec/advisory-db"]
+# The lint level for crates that have been yanked from their source registry
+yanked = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    # "RUSTSEC-0000-0000",
-    # difference 2.0.0 is unmaintained
+  # difference 2.0.0 is unmaintained
     "RUSTSEC-2020-0095",
-    # rusoto is unmaintained, use aws crates
-    "RUSTSEC-2022-0071",
     # `tui` is unmaintained; use `ratatui` instead
     "RUSTSEC-2023-0049",
-    # we don't do RSA signing on Sui (only verifying for zklogin)
-    "RUSTSEC-2023-0071",
-    # A few dependencies use unpatched rustls.
-    "RUSTSEC-2024-0336",
-    # allow yaml-rust being unmaintained
+    # `yaml-rust` is unmaintained
     "RUSTSEC-2024-0320",
-    # allow unmaintained proc-macro-error used in transitive dependencies
+    # `proc-macro-error` is unmaintained, needed by `tabled`
     "RUSTSEC-2024-0370",
+    # `serde_cbor` is unmaintained
+    "RUSTSEC-2021-0127",
+    # `atty` is unmaintained
+    "RUSTSEC-2024-0375",
+    # Potential unaligned read in `atty`
+    "RUSTSEC-2021-0145",
 
-    # Temporarily allow until arrow family of crates updates `lexical-core` to 1.0
-    "RUSTSEC-2023-0086",
     # allow unmaintained instant crate used in transitive dependencies (backoff, cached, fastrand, parking_lot_*)
     "RUSTSEC-2024-0384",
     # allow unmaintained derivative crate used in transitive dependencies (ark-*)
     "RUSTSEC-2024-0388",
-    # allow outdated 'idna' until passkey-client crate is able to update
-    "RUSTSEC-2024-0421",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories
@@ -54,31 +70,28 @@ ignore = [
 # * Medium - CVSS Score 4.0 - 6.9
 # * High - CVSS Score 7.0 - 8.9
 # * Critical - CVSS Score 9.0 - 10.0
-#severity-threshold =
+# severity-threshold =
 
 # This section is considered when running `cargo deny check licenses`
 # More documentation for the licenses section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
-version = 2
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
-    "MIT",
-    "BSD-2-Clause",
-    "BSD-3-Clause",
-    "Apache-2.0",
-    "MPL-2.0",
-    "ISC",
-    "CC0-1.0",
-    "0BSD",
-    "LicenseRef-ring",
-    "Unlicense",
-    "BSL-1.0",
-    "Unicode-DFS-2016",
-    "Unicode-3.0",
-    #"Apache-2.0 WITH LLVM-exception",
+  "MIT",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "Apache-2.0",
+  "MPL-2.0",
+  "CC0-1.0",
+  "0BSD",
+  "Unlicense",
+  "BSL-1.0",
+  "Unicode-3.0",
+  "Zlib",
+  "NCSA"
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
@@ -88,42 +101,32 @@ confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
-    # Each entry is the crate and version constraint, and its specific allow
-    # list
-    #{ allow = ["Zlib"], name = "adler32", version = "*" },
+
+
+  # Each entry is the crate and version constraint, and its specific allow
+  # list
+  # { allow = ["Zlib"], name = "adler32", version = "*" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,
 # adding a clarification entry for it allows you to manually specify the
 # licensing information
-#[[licenses.clarify]]
+# [[licenses.clarify]]
 # The name of the crate the clarification applies to
-#name = "ring"
+# name = "ring"
 # The optional version constraint for the crate
-#version = "*"
+# version = "*"
 # The SPDX expression for the license requirements of the crate
-#expression = "MIT AND ISC AND OpenSSL"
+# expression = "MIT AND ISC AND OpenSSL"
 # One or more files in the crate's source used as the "source of truth" for
 # the license expression. If the contents match, the clarification will be used
 # when running the license check, otherwise the clarification will be ignored
 # and the crate will be checked normally, which may produce warnings or errors
 # depending on the rest of your configuration
-#license-files = [
-    # Each entry is a crate relative path, and the (opaque) hash of its contents
-    #{ path = "LICENSE", hash = 0xbd0eed23 }
-#]
-[[licenses.clarify]]
-name = "ring"
-expression = "LicenseRef-ring"
-license-files = [
-    { path = "LICENSE", hash = 0xbd0eed23 }
-]
-[[licenses.clarify]]
-name = "target-lexicon"
-version = "*"
-expression = "Apache-2.0"
-license-files = [
-]
+# license-files = [
+# Each entry is a crate relative path, and the (opaque) hash of its contents
+# { path = "LICENSE", hash = 0xbd0eed23 }
+# ]
 
 [licenses.private]
 # If true, ignores workspace crates that aren't published, or are only
@@ -133,7 +136,9 @@ ignore = false
 # is only published to private registries, and ignore is true, the crate will
 # not have its license(s) checked
 registries = [
-    #"https://sekretz.com/registry
+
+
+  # "https://sekretz.com/registry
 ]
 
 # This section is considered when running `cargo deny check bans`.
@@ -141,7 +146,7 @@ registries = [
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
 [bans]
 # Lint level for when multiple versions of the same crate are detected
-multiple-versions = "allow"
+multiple-versions = "warn"
 # Lint level for when a crate version requirement is `*`
 wildcards = "allow"
 # The graph highlighting used when creating dotgraphs for crates
@@ -152,28 +157,41 @@ wildcards = "allow"
 highlight = "all"
 # List of crates that are allowed. Use with care!
 allow = [
-    #{ name = "ansi_term", version = "=0.11.0" },
+
+
+  # { name = "ansi_term", version = "=0.11.0" },
 ]
 # List of crates to deny
 deny = [
-    # Each entry the name of a crate and a version range. If version is
-    # not specified, all versions will be matched.
-    #{ name = "ansi_term", version = "=0.11.0" },
-    #
-    # Wrapper crates can optionally be specified to allow the crate when it
-    # is a direct dependency of the otherwise banned crate
-    #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
+
+
+  # Each entry the name of a crate and a version range. If version is
+  # not specified, all versions will be matched.
+  # { name = "ansi_term", version = "=0.11.0" },
+  #
+  # Wrapper crates can optionally be specified to allow the crate when it
+  # is a direct dependency of the otherwise banned crate
+  # { name = "ansi_term", version = "=0.11.0", wrappers = [] },
 ]
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    #{ name = "ansi_term", version = "=0.11.0" },
+  "hermit-abi",
+  # { name = "ansi_term", version = "=0.11.0" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite
 skip-tree = [
-    #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
+  "codespan",
+  "colored",
+  "itertools",
+  "lsp-types",
+  "ouroboros",
+  "tracing-subscriber",
+  "serde_yaml",
+  "getrandom",
+  # { name = "ansi_term", version = "=0.11.0", depth = 20 },
 ]
 
 # This section is considered when running `cargo deny check sources`.
@@ -190,15 +208,6 @@ unknown-git = "warn"
 # if not specified. If it is specified but empty, no registries are allowed.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
-allow-git = [
-    "https://github.com/asonnino/prometheus-parser",
-    "https://github.com/zhiburt/tabled",
-]
+allow-git = []
 
 [sources.allow-org]
-github = [
-    "mystenmark",
-    "bmwill",
-    "mystenlabs",
-    "nextest-rs",
-]


### PR DESCRIPTION
## Description 

Currently the external crates cargo deny job runs at the top level and thus does not check the external crates manifest/lock file. This PR adds an additional `deny.toml` specific to the external crates and updates the CI job so that it uses the correct manifest. Also adds the `--hide-inclusion-graph` flag as this helps to reduce the spam in the CI logs.

NOTE: If only the top level `deny.toml` is used for both, then warnings are emitted for ignored RUSTSEC, licenses, etc. that do not apply to the manifest which cannot be silenced.

Currently, running with the top-level `deny.toml` on the external crates reports several issues:

```sh
sui git:(main) cargo deny --manifest-path=external-crates/move/Cargo.toml check --hide-inclusion-graph 
warning[unmatched-source]: allowed source was not encountered
    ┌─ deny.toml:207:6
    │
207 │     "https://github.com/asonnino/prometheus-parser",
    │      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ no crate source matched these criteria

warning[unmatched-source]: allowed source was not encountered
    ┌─ deny.toml:208:6
    │
208 │     "https://github.com/zhiburt/tabled",
    │      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ no crate source matched these criteria

warning[unmatched-organization]: allowed 'github.com' organization  was not encountered
    ┌─ deny.toml:213:6
    │
213 │     "mystenmark",
    │      ━━━━━━━━━━ no crate source fell under this organization

warning[unmatched-organization]: allowed 'github.com' organization  was not encountered
    ┌─ deny.toml:214:6
    │
214 │     "bmwill",
    │      ━━━━━━ no crate source fell under this organization

warning[unmatched-organization]: allowed 'github.com' organization  was not encountered
    ┌─ deny.toml:215:6
    │
215 │     "mystenlabs",
    │      ━━━━━━━━━━ no crate source fell under this organization

warning[unmatched-organization]: allowed 'github.com' organization  was not encountered
    ┌─ deny.toml:216:6
    │
216 │     "nextest-rs",
    │      ━━━━━━━━━━ no crate source fell under this organization

error[rejected]: failed to satisfy license requirements
  ┌─ registry+https://github.com/rust-lang/crates.io-index#libfuzzer-sys@0.4.9:4:36
  │
4 │ license = "(MIT OR Apache-2.0) AND NCSA"
  │            ────────────────────────━━━━
  │            │                       │
  │            │                       rejected: license is not explicitly allowed
  │            license expression retrieved via Cargo.toml `license`
  │
  ├ NCSA - University of Illinois/NCSA Open Source License:
  ├   - OSI approved
  ├   - FSF Free/Libre

warning[license-not-encountered]: license was not encountered
   ┌─ deny.toml:73:6
   │
73 │     "ISC",
   │      ━━━ unmatched license allowance

warning[license-not-encountered]: license was not encountered
   ┌─ deny.toml:79:6
   │
79 │     "Unicode-DFS-2016",
   │      ━━━━━━━━━━━━━━━━ unmatched license allowance

warning[license-not-encountered]: license was not encountered
   ┌─ deny.toml:76:6
   │
76 │     "LicenseRef-ring",
   │      ━━━━━━━━━━━━━━━ unmatched license allowance

error[unsound]: Potential unaligned read
   ┌─ /Users/chloe/Repositories/sui/external-crates/move/Cargo.lock:14:1
   │
14 │ atty 0.2.14 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unsound advisory detected
   │
   ├ ID: RUSTSEC-2021-0145
   ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2021-0145
   ├ On windows, `atty` dereferences a potentially unaligned pointer.
     
     In practice however, the pointer won't be unaligned unless a custom global allocator is used.
     
     In particular, the `System` allocator on windows uses `HeapAlloc`, which guarantees a large enough alignment.
     
     # atty is Unmaintained
     
     A Pull Request with a fix has been provided over a year ago but the maintainer seems to be unreachable.
     
     Last release of `atty` was almost 3 years ago.
     
     ## Possible Alternative(s)
     
     The below list has not been vetted in any way and may or may not contain alternatives;
     
      - [std::io::IsTerminal](https://doc.rust-lang.org/stable/std/io/trait.IsTerminal.html) - Stable since Rust 1.70.0
      - [is-terminal](https://crates.io/crates/is-terminal) - Standalone crate supporting Rust older than 1.70.0
   ├ Announcement: https://github.com/softprops/atty/issues/50
   ├ Solution: No safe upgrade is available!

error[unmaintained]: `atty` is unmaintained
   ┌─ /Users/chloe/Repositories/sui/external-crates/move/Cargo.lock:14:1
   │
14 │ atty 0.2.14 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
   │
   ├ ID: RUSTSEC-2024-0375
   ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0375
   ├ The maintainer of `atty` has [published](https://github.com/softprops/atty/commit/5bfdbe9e48c6ca6a4909e8d5b04f5e843a257e93) an official notice that the crate is no longer
     under development, and that users should instead rely on the functionality in the standard library's [`IsTerminal`](https://doc.rust-lang.org/std/io/trait.IsTerminal.html) trait.
     
     ## Alternative(s)
     
     - [std::io::IsTerminal](https://doc.rust-lang.org/stable/std/io/trait.IsTerminal.html) - Stable since Rust 1.70.0 and the recommended replacement per the `atty` maintainer.
     - [is-terminal](https://crates.io/crates/is-terminal) - Standalone crate supporting Rust older than 1.70.0
   ├ Announcement: https://github.com/softprops/atty/issues/57
   ├ Solution: No safe upgrade is available!

error[unmaintained]: serde_cbor is unmaintained
    ┌─ /Users/chloe/Repositories/sui/external-crates/move/Cargo.lock:305:1
    │
305 │ serde_cbor 0.11.2 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
    │
    ├ ID: RUSTSEC-2021-0127
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2021-0127
    ├ The `serde_cbor` crate is unmaintained. The author has archived the github repository.
      
      Alternatives proposed by the author:
      
       * [`ciborium`](https://crates.io/crates/ciborium)
       * [`minicbor`](https://crates.io/crates/minicbor)
    ├ Announcement: https://github.com/pyfisch/cbor
    ├ Solution: No safe upgrade is available!

warning[advisory-not-detected]: advisory was not encountered
   ┌─ deny.toml:28:6
   │
28 │     "RUSTSEC-2022-0071",
   │      ━━━━━━━━━━━━━━━━━ no crate matched advisory criteria

warning[advisory-not-detected]: advisory was not encountered
   ┌─ deny.toml:32:6
   │
32 │     "RUSTSEC-2023-0071",
   │      ━━━━━━━━━━━━━━━━━ no crate matched advisory criteria

warning[advisory-not-detected]: advisory was not encountered
   ┌─ deny.toml:41:6
   │
41 │     "RUSTSEC-2023-0086",
   │      ━━━━━━━━━━━━━━━━━ no crate matched advisory criteria

warning[advisory-not-detected]: advisory was not encountered
   ┌─ deny.toml:34:6
   │
34 │     "RUSTSEC-2024-0336",
   │      ━━━━━━━━━━━━━━━━━ no crate matched advisory criteria

warning[advisory-not-detected]: advisory was not encountered
   ┌─ deny.toml:47:6
   │
47 │     "RUSTSEC-2024-0421",
   │      ━━━━━━━━━━━━━━━━━ no crate matched advisory criteria

advisories FAILED, bans ok, licenses FAILED, sources ok
```

After this change:

```sh
sui git:(split-external-deny) cargo deny --manifest-path=external-crates/move/Cargo.toml check --hide-inclusion-graph 
warning[duplicate]: found 2 duplicate entries for crate 'clap'
   ┌─ /Users/chloe/Repositories/sui/external-crates/move/Cargo.lock:44:1
   │  
44 │ ╭ clap 2.34.0 registry+https://github.com/rust-lang/crates.io-index
45 │ │ clap 3.2.25 registry+https://github.com/rust-lang/crates.io-index
46 │ │ clap 4.5.28 registry+https://github.com/rust-lang/crates.io-index
   │ ╰─────────────────────────────────────────────────────────────────┘ lock entries

warning[duplicate]: found 2 duplicate entries for crate 'mio'
    ┌─ /Users/chloe/Repositories/sui/external-crates/move/Cargo.lock:168:1
    │  
168 │ ╭ mio 0.8.11 registry+https://github.com/rust-lang/crates.io-index
169 │ │ mio 1.0.3 registry+https://github.com/rust-lang/crates.io-index
    │ ╰───────────────────────────────────────────────────────────────┘ lock entries

warning[duplicate]: found 2 duplicate entries for crate 'parking_lot'
    ┌─ /Users/chloe/Repositories/sui/external-crates/move/Cargo.lock:243:1
    │  
243 │ ╭ parking_lot 0.11.2 registry+https://github.com/rust-lang/crates.io-index
244 │ │ parking_lot 0.12.3 registry+https://github.com/rust-lang/crates.io-index
    │ ╰────────────────────────────────────────────────────────────────────────┘ lock entries

warning[duplicate]: found 2 duplicate entries for crate 'parking_lot_core'
    ┌─ /Users/chloe/Repositories/sui/external-crates/move/Cargo.lock:245:1
    │  
245 │ ╭ parking_lot_core 0.8.6 registry+https://github.com/rust-lang/crates.io-index
246 │ │ parking_lot_core 0.9.10 registry+https://github.com/rust-lang/crates.io-index
    │ ╰─────────────────────────────────────────────────────────────────────────────┘ lock entries

warning[duplicate]: found 2 duplicate entries for crate 'rand'
    ┌─ /Users/chloe/Repositories/sui/external-crates/move/Cargo.lock:273:1
    │  
273 │ ╭ rand 0.7.3 registry+https://github.com/rust-lang/crates.io-index
274 │ │ rand 0.8.5 registry+https://github.com/rust-lang/crates.io-index
    │ ╰────────────────────────────────────────────────────────────────┘ lock entries

warning[duplicate]: found 2 duplicate entries for crate 'rand_chacha'
    ┌─ /Users/chloe/Repositories/sui/external-crates/move/Cargo.lock:275:1
    │  
275 │ ╭ rand_chacha 0.2.2 registry+https://github.com/rust-lang/crates.io-index
276 │ │ rand_chacha 0.3.1 registry+https://github.com/rust-lang/crates.io-index
    │ ╰───────────────────────────────────────────────────────────────────────┘ lock entries

warning[duplicate]: found 2 duplicate entries for crate 'rand_core'
    ┌─ /Users/chloe/Repositories/sui/external-crates/move/Cargo.lock:277:1
    │  
277 │ ╭ rand_core 0.5.1 registry+https://github.com/rust-lang/crates.io-index
278 │ │ rand_core 0.6.4 registry+https://github.com/rust-lang/crates.io-index
    │ ╰─────────────────────────────────────────────────────────────────────┘ lock entries

warning[duplicate]: found 2 duplicate entries for crate 'redox_syscall'
    ┌─ /Users/chloe/Repositories/sui/external-crates/move/Cargo.lock:284:1
    │  
284 │ ╭ redox_syscall 0.2.16 registry+https://github.com/rust-lang/crates.io-index
285 │ │ redox_syscall 0.5.8 registry+https://github.com/rust-lang/crates.io-index
    │ ╰─────────────────────────────────────────────────────────────────────────┘ lock entries

warning[duplicate]: found 2 duplicate entries for crate 'toml_edit'
    ┌─ /Users/chloe/Repositories/sui/external-crates/move/Cargo.lock:352:1
    │  
352 │ ╭ toml_edit 0.14.4 registry+https://github.com/rust-lang/crates.io-index
353 │ │ toml_edit 0.19.15 registry+https://github.com/rust-lang/crates.io-index
    │ ╰───────────────────────────────────────────────────────────────────────┘ lock entries

warning[duplicate]: found 2 duplicate entries for crate 'windows-sys'
    ┌─ /Users/chloe/Repositories/sui/external-crates/move/Cargo.lock:394:1
    │  
394 │ ╭ windows-sys 0.48.0 registry+https://github.com/rust-lang/crates.io-index
395 │ │ windows-sys 0.52.0 registry+https://github.com/rust-lang/crates.io-index
    │ ╰────────────────────────────────────────────────────────────────────────┘ lock entries

advisories ok, bans ok, licenses ok, sources ok
```

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
