### PR TITLE
[refactor] allow passing the sui protocol config chain override for antithesis Dockerfile

### DIFF
--- a/docker/sui-antithesis/docker-compose-antithesis.yaml
+++ b/docker/sui-antithesis/docker-compose-antithesis.yaml
@@ -5,7 +5,7 @@ services:
     networks:
       sui-network:
         ipv4_address: 10.0.0.11
-    image: sui-node:${SUI_NODE_A_TAG}:${SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE}
+    image: sui-node:${SUI_NODE_A_TAG}
     container_name: validator1
     hostname: validator1
     environment:
@@ -33,7 +33,7 @@ services:
     networks:
       sui-network:
         ipv4_address: 10.0.0.12
-    image: sui-node:${SUI_NODE_A_TAG}:${SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE}
+    image: sui-node:${SUI_NODE_A_TAG}
     container_name: validator2
     hostname: validator2
     environment:
@@ -61,7 +61,7 @@ services:
     networks:
       sui-network:
         ipv4_address: 10.0.0.13
-    image: sui-node-alt:${SUI_NODE_B_TAG}:${SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE}
+    image: sui-node-alt:${SUI_NODE_B_TAG}
     container_name: validator3
     hostname: validator3
     environment:
@@ -89,7 +89,7 @@ services:
     networks:
       sui-network:
         ipv4_address: 10.0.0.14
-    image: sui-node-alt:${SUI_NODE_B_TAG}:${SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE}
+    image: sui-node-alt:${SUI_NODE_B_TAG}
     container_name: validator4
     hostname: validator4
     environment:
@@ -117,7 +117,7 @@ services:
     networks:
       sui-network:
         ipv4_address: 10.0.0.15
-    image: sui-node-alt:${SUI_NODE_B_TAG}:${SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE}
+    image: sui-node-alt:${SUI_NODE_B_TAG}
     hostname: fullnode1
     container_name: fullnode1
     environment:
@@ -146,7 +146,7 @@ services:
     networks:
       sui-network:
         ipv4_address: 10.0.0.16
-    image: stress:${SUI_NODE_B_TAG}:${SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE}
+    image: stress:${SUI_NODE_B_TAG}
     container_name: stress
     environment:
       - RUST_LOG=info


### PR DESCRIPTION
## Description 

Necessary changes to the Docker file to support [docker/sui-antithesis/docker-compose-antithesis.yaml](https://github.com/MystenLabs/sui-operations/pull/4979)

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
