### PR TITLE
changed references to my_module to example

### DIFF
--- a/docs/content/guides/developer/first-app/build-test.mdx
+++ b/docs/content/guides/developer/first-app/build-test.mdx
@@ -75,7 +75,7 @@ error[E06001]: unused value without 'drop'
 54 │ │             magic: 42,
 55 │ │             strength: 7,
 56 │ │         };
-   │ ╰─────────' The type 'my_first_package::my_module::Sword' does not have the ability 'drop'
+   │ ╰─────────' The type 'my_first_package::example::Sword' does not have the ability 'drop'
    · │
 59 │           assert!(sword.magic() == 42 && sword.strength() == 7, 1);
    │                                                                   ^ Invalid return
@@ -98,7 +98,7 @@ BUILDING MoveStdlib
 BUILDING Sui
 BUILDING my_first_package
 Running Move unit tests
-[ PASS    ] 0x0::my_module::test_sword_create
+[ PASS    ] 0x0::example::test_sword_create
 Test result: OK. Total tests: 1; passed: 1; failed: 0
 ```
 
@@ -163,8 +163,8 @@ BUILDING Sui
 BUILDING MoveStdlib
 BUILDING my_first_package
 Running Move unit tests
-[ PASS    ] 0x0::my_module::test_sword_create
-[ PASS    ] 0x0::my_module::test_sword_transactions
+[ PASS    ] 0x0::example::test_sword_create
+[ PASS    ] 0x0::example::test_sword_transactions
 Test result: OK. Total tests: 2; passed: 2; failed: 0
 ```
 

--- a/docs/content/guides/developer/first-app/write-package.mdx
+++ b/docs/content/guides/developer/first-app/write-package.mdx
@@ -23,13 +23,13 @@ The manifest file contents include available sections of the manifest and commen
 
 ### Defining the package
 
-You have a package now but it doesn't do anything. To make your package useful, you must add logic contained in `.move` source files that define _modules_. Use a text editor or the command line to create your first package source file named `my_module.move` in the `sources` directory of the package:
+You have a package now but it doesn't do anything. To make your package useful, you must add logic contained in `.move` source files that define _modules_. Use a text editor or the command line to create your first package source file named `example.move` in the `sources` directory of the package:
 
 ```sh
-$ touch my_first_package/sources/my_module.move
+$ touch my_first_package/sources/example.move
 ```
 
-Populate the `my_module.move` file with the following code:
+Populate the `example.move` file with the following code:
 
 {@inject: examples/move/first_package/sources/example.move#first noTests}
 


### PR DESCRIPTION
## Description 

There's a confusing bit of documentation to follow on the pages "Write a move package" and "Build and Test packages".

On the instructions to "Write a move package", it states to create a file called my_module.move. However, in the source code it is referenced as example.move.

<img width="1038" alt="image" src="https://github.com/user-attachments/assets/bbb4525c-e6f4-40ec-bb8f-38047c5a74bc" />

This can confuse the reader of the document as later on in the "Build and Test packages" section, that same file is referenced as example.move

<img width="1038" alt="image" src="https://github.com/user-attachments/assets/abe801a7-47c5-44f9-bf42-653ac225bf98" />

I have renamed the my_module references to example for a consistent user experience.
## Test plan 

I changed the my_module.move markdown to example.move.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
