### PR TITLE
[move][move-vm][rewrite][cleanup 4/n] Replace AST Identifiers with IdentifierKey

### DIFF
--- a/external-crates/move/crates/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -368,7 +368,7 @@ impl OnDiskStateView {
             };
 
             // Process each module and add its dependencies to the to_process list
-            for (_, module) in &pkg.modules {
+            for module in pkg.modules.values() {
                 let module = CompiledModule::deserialize_with_defaults(module).unwrap();
                 let deps = module
                     .immediate_dependencies()

--- a/external-crates/move/crates/move-transactional-test-runner/src/tasks.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/tasks.rs
@@ -297,7 +297,7 @@ impl<ExtraValueArgs: ParsableValue> PublishRunCommand<ExtraValueArgs> {
             .map(|call| {
                 let name = parse_qualified_module_access(&call[0])?;
                 let args: Vec<ParsedValue<ExtraValueArgs>> = call[1..]
-                    .into_iter()
+                    .iter()
                     .map(|arg| {
                         ParsedValue::<ExtraValueArgs>::parse(arg)
                             .map_err(|e| anyhow!("Failed to parse argument: {}", e))

--- a/external-crates/move/crates/move-vm-runtime/src/cache/arena.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/cache/arena.rs
@@ -69,10 +69,12 @@ impl Arena {
     }
 
     /// SAFETY:
+    /// 0. This must never be called on strings (or any other type that contains internal
+    ///    allocations or pointers), as they have heap-allocated byte arrays that will be leaked
+    ///    when the arena is released. This box is allocated in the arena, and thus even if it is
+    ///    dropped, any internal memory will not be reclaimed.
     /// 1. It is the caller's responsibility to ensure that `self` is not shared across threads
     ///    during this call.
-    /// 2. This box is allocated in the arena, and thus even it is dropped its memory will not be
-    ///    reclaimed until the arena is discarded.
     pub fn alloc_box<T>(&self, item: T) -> PartialVMResult<ArenaBox<T>> {
         if let Ok(slice) = self.0.try_alloc(item) {
             Ok(ArenaBox(unsafe {

--- a/external-crates/move/crates/move-vm-runtime/src/cache/identifier_interner.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/cache/identifier_interner.rs
@@ -9,6 +9,70 @@ use move_core_types::{
 
 use lasso::{Spur, ThreadedRodeo};
 
+use once_cell::sync::Lazy;
+use std::sync::Arc;
+
+// -------------------------------------------------------------------------------------------------
+// Global Interner
+// -------------------------------------------------------------------------------------------------
+
+/// IDENTIFIER INTERNER
+/// The Ientifier Interner is global across Move Runtimes and defined here. This is for two reasons:
+/// 1. The interner is _always_ a win compared to non-interned identifiers, which hold their
+///    strings in boxes. This is always a strict memory win, in all cases. The overall size of the
+///    interner plus its definitions is always going to be smaller than holding those individual
+///    identifiers.
+/// 2. Different runs will benefit from intern reuse: even if the runtime is discarded, interning
+///    is a near-constant cost when spinning up a new runtime. Moreover, the interner can be set to
+///    have a maximum memory it will refuse to exceed.
+///    TODO: Set up this; `lasso` supports it but we need to expose that interface.
+/// 3. If absolutely necessary, the execution layer _can_ dump the interner.
+static STRING_INTERNER: Lazy<Arc<IdentifierInterner>> =
+    Lazy::new(|| Arc::new(IdentifierInterner::new()));
+
+/// Function to access the global StringInterner
+fn global_interner() -> Arc<IdentifierInterner> {
+    Arc::clone(&STRING_INTERNER)
+}
+
+/// Get the interned identifier value. This may raise an invariant error if `try_get_or_intern`
+/// fails, but that's likely a serious OOM issue.
+pub fn intern_identifier(ident: &Identifier) -> PartialVMResult<IdentifierKey> {
+    let interner = global_interner();
+    interner.get_or_intern_str_internal(ident.borrow_str())
+}
+
+/// Get the interned identifier string value. This may raise an invariant error if
+/// `get_or_intern` fails, but that's likely a serious OOM issue.
+pub fn intern_ident_str(ident_str: &IdentStr) -> PartialVMResult<IdentifierKey> {
+    let interner = global_interner();
+    interner.get_or_intern_str_internal(ident_str.borrow_str())
+}
+
+/// Get the interned identifier value, using `key_type` in the error case. This may raise an invariant error if `try_get_or_intern`
+/// fails, but that's likely a serious OOM issue.
+pub fn intern_identifier_with_msg(
+    ident: &Identifier,
+    key_type: &str,
+) -> PartialVMResult<IdentifierKey> {
+    let interner = global_interner();
+    interner
+        .get_or_intern_str_internal(ident.borrow_str())
+        .map_err(|err| err.with_message(format!("While attempting to intern {key_type}")))
+}
+
+/// Resolve an identifier in the interner or produce an invariant violation. This is for use
+/// when the key _must_ be there, as it produces an error when it is not found. The `key_type`
+/// is used to make a more-informative error message.
+pub fn resolve_interned(key: &IdentifierKey, key_type: &str) -> PartialVMResult<Identifier> {
+    let interner = global_interner();
+    interner.resolve_ident(key, key_type)
+}
+
+// -------------------------------------------------------------------------------------------------
+// Types
+// -------------------------------------------------------------------------------------------------
+
 /// A wrapper around a lasso ThreadedRoade with some niceties to make it easier to use in the VM.
 #[derive(Debug)]
 pub struct IdentifierInterner(ThreadedRodeo);
@@ -17,7 +81,22 @@ pub struct IdentifierInterner(ThreadedRodeo);
 /// FIXME: Set to 1 billion, but should be experimentally determined based on actual run data.
 const IDENTIFIER_SLOTS: usize = 1_000_000_000;
 
-pub type IdentifierKey = Spur;
+// Note: these are not hashable or orderable -- their ordering is unstable, so they should not be
+// used as keys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct IdentifierKey(Spur);
+
+// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
+// Impls
+// -------------------------------------------------------------------------------------------------
+
+impl Default for IdentifierInterner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl IdentifierInterner {
     pub fn new() -> Self {
@@ -25,18 +104,11 @@ impl IdentifierInterner {
         Self(rodeo)
     }
 
-    /// Resolve an identifier in the interner or produce an invariant violation. This is for use
-    /// when the key _must_ be there, as it produces an error when it is not found. The `key_type`
-    /// is used to make a more-informative error message.
-    /// [SAFETY] The unsafe code is creating an identifier without checking its vailidity, but it
-    /// was added as a valid identifier to the interner in the first place.
+    // [SAFETY] The unsafe code is creating an identifier without checking its vailidity, but it
+    // was added as a valid identifier to the interner in the first place.
     #[allow(unsafe_code)]
-    pub fn resolve_ident(
-        &self,
-        key: &IdentifierKey,
-        key_type: &str,
-    ) -> PartialVMResult<Identifier> {
-        if let Some(result) = self.0.try_resolve(key) {
+    fn resolve_ident(&self, key: &IdentifierKey, key_type: &str) -> PartialVMResult<Identifier> {
+        if let Some(result) = self.0.try_resolve(&key.0) {
             unsafe { Ok(Identifier::new_unchecked(result)) }
         } else {
             Err(
@@ -46,23 +118,17 @@ impl IdentifierInterner {
         }
     }
 
-    /// Get the interned identifier value. This may raise an invariant error if `try_get_or_intern`
-    /// fails, but that's likely a serious OOM issue.
     pub fn get_or_intern_identifier(&self, ident: &Identifier) -> PartialVMResult<IdentifierKey> {
         self.get_or_intern_str_internal(ident.borrow_str())
     }
 
-    /// Get the interned identifier string value. This may raise an invariant error if
-    /// `get_or_intern` fails, but that's likely a serious OOM issue.
     pub fn get_or_intern_ident_str(&self, ident_str: &IdentStr) -> PartialVMResult<IdentifierKey> {
         self.get_or_intern_str_internal(ident_str.borrow_str())
     }
 
-    /// Get the interned string value. This may raise an invariant error if `get_or_intern` fails,
-    /// but that's likely a serious OOM issue.
     fn get_or_intern_str_internal(&self, string: &str) -> PartialVMResult<IdentifierKey> {
         match self.0.try_get_or_intern(string) {
-            Ok(result) => Ok(result),
+            Ok(result) => Ok(IdentifierKey(result)),
             Err(err) => Err(PartialVMError::new(StatusCode::INTERNER_LIMIT_REACHED)
                 .with_message(format!("Failed to intern {string} ident; error: {err:?}."))),
         }

--- a/external-crates/move/crates/move-vm-runtime/src/dev_utils/in_memory_test_adapter.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/dev_utils/in_memory_test_adapter.rs
@@ -93,7 +93,7 @@ impl InMemoryTestAdapter {
             };
 
             // Process each module and add its dependencies to the to_process list
-            for (_, module) in &pkg.modules {
+            for module in pkg.modules.values() {
                 let module = CompiledModule::deserialize_with_defaults(module).unwrap();
                 let deps = module
                     .immediate_dependencies()

--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/eval.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/eval.rs
@@ -132,7 +132,7 @@ fn step(
     assert!(
         pc <= instructions.len(),
         "PC beyond instruction count for {}",
-        fun_ref.name
+        fun_ref.name()
     );
     let instruction = &instructions[pc];
 
@@ -882,8 +882,8 @@ fn call_function(
         // Charge for a non-generic call
         gas_meter
             .charge_call(
-                module_id,
-                function.name(),
+                &module_id,
+                &function.name_str(),
                 last_n_operands,
                 (function.local_count() as u64).into(),
             )
@@ -892,8 +892,8 @@ fn call_function(
         // Charge for a generic call
         gas_meter
             .charge_call_generic(
-                module_id,
-                function.name(),
+                &module_id,
+                &function.name_str(),
                 ty_args.iter().map(|ty| ResolvableType {
                     ty,
                     vtables: run_context.vtables,

--- a/external-crates/move/crates/move-vm-runtime/src/execution/values/values_impl.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/values/values_impl.rs
@@ -2198,7 +2198,7 @@ impl GlobalValueImpl {
             Self::Cached {
                 fingerprint,
                 container,
-            } => !fingerprint.same_value(&container),
+            } => !fingerprint.same_value(container),
         }
     }
 }

--- a/external-crates/move/crates/move-vm-runtime/src/lib.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/lib.rs
@@ -33,26 +33,3 @@ mod unit_tests;
 // Only include debugging functionality in debug or tracing builds
 // #[cfg(any(debug_assertions, feature = "tracing"))]
 // mod debug;
-
-use cache::identifier_interner::IdentifierInterner;
-use once_cell::sync::Lazy;
-use std::sync::Arc;
-
-/// IDENTIFIER INTERNER
-/// The Ientifier Interner is global across Move Runtimes and defined here. This is for two reasons:
-/// 1. The interner is _always_ a win compared to non-interned identifiers, which hold their
-///    strings in boxes. This is always a strict memory win, in all cases. The overall size of the
-///    interner plus its definitions is always going to be smaller than holding those individual
-///    identifiers.
-/// 2. Different runs will benefit from intern reuse: even if the runtime is discarded, interning
-///    is a near-constant cost when spinning up a new runtime. Moreover, the interner can be set to
-///    have a maximum memory it will refuse to exceed.
-///    TODO: Set up this; `lasso` supports it but we need to expose that interface.
-/// 3. If absolutely necessary, the execution layer _can_ dump the interner.
-static STRING_INTERNER: Lazy<Arc<IdentifierInterner>> =
-    Lazy::new(|| Arc::new(IdentifierInterner::new()));
-
-/// Function to access the global StringInterner
-fn string_interner() -> Arc<IdentifierInterner> {
-    Arc::clone(&STRING_INTERNER)
-}

--- a/external-crates/move/crates/move-vm-runtime/src/shared/mod.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/shared/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
+use std::{collections::HashMap, hash::Hash};
 
 pub mod binary_cache;
 pub mod constants;
@@ -27,10 +27,10 @@ macro_rules! try_block {
 // key to retrieve the entry and support the error case.
 #[allow(clippy::map_entry)]
 /// Either returns a BTreeMap of unique keys, or a repeated key if the input keys are not unique.
-pub fn unique_map<Key: Ord, Value>(
+pub fn unique_map<Key: Hash + Eq, Value>(
     values: impl IntoIterator<Item = (Key, Value)>,
-) -> Result<BTreeMap<Key, Value>, Key> {
-    let mut map = BTreeMap::new();
+) -> Result<HashMap<Key, Value>, Key> {
+    let mut map = HashMap::new();
     for (k, v) in values {
         if map.contains_key(&k) {
             return Err(k);

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/loader_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/loader_tests.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::redundant_clone)]
 
 use crate::{
+    cache::identifier_interner::intern_ident_str,
     dev_utils::{
         compilation_utils::{compile_packages_in_file, expect_modules},
         in_memory_test_adapter::InMemoryTestAdapter,
@@ -22,7 +23,6 @@ use crate::{
         serialization::SerializedReturnValues,
         types::{PackageStorageId, RuntimePackageId},
     },
-    string_interner,
 };
 use move_binary_format::{
     errors::VMResult,
@@ -211,12 +211,8 @@ impl Adapter {
             .calculate_depth_of_type(&VirtualTableKey {
                 package_key: *module_id.address(),
                 inner_pkg_key: IntraPackageKey {
-                    module_name: string_interner()
-                        .get_or_intern_ident_str(module_id.name())
-                        .unwrap(),
-                    member_name: string_interner()
-                        .get_or_intern_ident_str(struct_name)
-                        .unwrap(),
+                    module_name: intern_ident_str(module_id.name()).unwrap(),
+                    member_name: intern_ident_str(struct_name).unwrap(),
                 },
             })
             .expect("computing depth of datatype should succeed")

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/package_cache_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/package_cache_tests.rs
@@ -158,10 +158,6 @@ fn load_package_external_package_calls_no_types() {
     assert_eq!(l_pkg.runtime.loaded_modules.len(), 1);
     assert_eq!(l_pkg.runtime.storage_id, package2_address);
     assert_eq!(l_pkg.runtime.vtable.functions.len(), 1);
-
-    for fptr in l_pkg.runtime.vtable.functions.values() {
-        println!("{:#?}", fptr.to_ref().code());
-    }
 }
 
 #[test]


### PR DESCRIPTION
## Description 

This replaces `Identifier`s in the execution AST with `IdentifierKey`, because identifiers (and the strings they hold) led to memory leaks -- the string bytes were heap-allocated, so leaked when the Identifiers were dropped.

This also refactors the interner to be more self-contained.

## Test plan 

Tests all pass, plus this command reported no leaks:

```
RUSTFLAGS="-Zsanitizer=address" cargo +nightly test -j 1 -Zbuild-std --target x86_64-unknown-linux-gnu
```

This now reports no leaks.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
