### PR TITLE
fix: typos in documentation files

### DIFF
--- a/external-crates/move/crates/move-cli/README.md
+++ b/external-crates/move/crates/move-cli/README.md
@@ -471,7 +471,7 @@ Module 00000000000000000000000000000002::Test
 ```
 
 The output indicates that not only the test is passed, but also that 100%
-instruction coverage is observed in the `publish` funciton. This is expected
+instruction coverage is observed in the `publish` function. This is expected
 as the whole purpose of our `test_script.move` is to run the `publish` function.
 At the same time, the other two functions, `unpublish` and `write`, are never
 executed, making the average coverage 27.78% for the whole `Test` module.

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/dependencies/dependency_order.move
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/dependencies/dependency_order.move
@@ -7,7 +7,7 @@ module 0x42::C {
 }
 
 //# publish
-// names used to try to force an ordering of depedencies
+// names used to try to force an ordering of dependencies
 module 0x43::B {
     public fun foo(): 0x42::C::T {
         0x42::C::foo()

--- a/external-crates/move/crates/move-compiler/tests/sui_mode/struct_with_key/key_struct_first_field_not_id.move
+++ b/external-crates/move/crates/move-compiler/tests/sui_mode/struct_with_key/key_struct_first_field_not_id.move
@@ -1,4 +1,4 @@
-// invalid, first field of an ojbect must be sui::object::UID
+// invalid, first field of an object must be sui::object::UID
 module a::m {
     struct S has key {
         flag: bool

--- a/external-crates/move/crates/move-ir-to-bytecode/src/compiler.rs
+++ b/external-crates/move/crates/move-ir-to-bytecode/src/compiler.rs
@@ -404,7 +404,7 @@ pub fn compile_module<'a>(
 
     for ir_constant in module.constants {
         // If the constant is an error constant in the source, then add the error constant's name
-        // look up the constant's name, as a constant valeu -- this may be present already,
+        // look up the constant's name, as a constant value -- this may be present already,
         // e.g., in the case of something like `const Foo: vector<u8> = b"Foo"` in which case the
         // new index will not be added and the previous index will be used.
         if ir_constant.is_error_constant {

--- a/external-crates/move/crates/move-package/tests/test_additional_addresses.rs
+++ b/external-crates/move/crates/move-package/tests/test_additional_addresses.rs
@@ -12,7 +12,7 @@ use std::{collections::BTreeMap, path::PathBuf};
 use tempfile::tempdir;
 
 #[test]
-fn test_additonal_addresses() {
+fn test_additional_addresses() {
     let path: PathBuf = [
         "tests",
         "test_sources",
@@ -74,7 +74,7 @@ fn test_additonal_addresses() {
 }
 
 #[test]
-fn test_additonal_addresses_already_assigned_same_value() {
+fn test_additional_addresses_already_assigned_same_value() {
     let path: PathBuf = ["tests", "test_sources", "basic_no_deps_address_assigned"]
         .into_iter()
         .collect();
@@ -120,7 +120,7 @@ fn test_additonal_addresses_already_assigned_same_value() {
 }
 
 #[test]
-fn test_additonal_addresses_already_assigned_different_value() {
+fn test_additional_addresses_already_assigned_different_value() {
     let path: PathBuf = ["tests", "test_sources", "basic_no_deps_address_assigned"]
         .into_iter()
         .collect();

--- a/external-crates/move/crates/move-vm-integration-tests/src/tests/exec_func_effects_tests.rs
+++ b/external-crates/move/crates/move-vm-integration-tests/src/tests/exec_func_effects_tests.rs
@@ -52,7 +52,7 @@ fn fail_arg_deserialize() {
     }
 }
 
-// check happy path for writing to mut ref args - may be unecessary / covered by other tests
+// check happy path for writing to mut ref args - may be unnecessary / covered by other tests
 #[test]
 fn mutref_output_success() {
     let mod_code = setup_module();


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `funciton` to `function`
Corrected `depedencies` to `dependencies`
Corrected `ojbect` to `object`
Corrected `valeu` to `value`
Corrected `additonal` to `additional`
Corrected `unecessary` to `unnecessary`

Please review the changes and let me know if any additional changes are needed.