### PR TITLE
change MockConsensusClient to return error on overflow instead of panic

### DIFF
--- a/crates/sui-core/src/mock_consensus.rs
+++ b/crates/sui-core/src/mock_consensus.rs
@@ -9,7 +9,7 @@ use crate::consensus_handler::SequencedConsensusTransaction;
 use consensus_core::BlockRef;
 use prometheus::Registry;
 use std::sync::{Arc, Weak};
-use sui_types::error::SuiResult;
+use sui_types::error::{SuiError, SuiResult};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::messages_consensus::{ConsensusTransaction, ConsensusTransactionKind};
 use sui_types::transaction::{VerifiedCertificate, VerifiedTransaction};
@@ -104,7 +104,7 @@ impl MockConsensusClient {
         let transaction = &transactions[0];
         self.tx_sender
             .try_send(transaction.clone())
-            .expect("MockConsensusClient channel should not overflow");
+            .map_err(|_| SuiError::from("MockConsensusClient channel overflowed"))?;
         Ok(with_block_status(consensus_core::BlockStatus::Sequenced(
             BlockRef::MIN,
         )))


### PR DESCRIPTION
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
