### PR TITLE
chore: Remove unmaintained `difference` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3774,12 +3774,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
-name = "difference"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-
-[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7714,7 +7708,6 @@ dependencies = [
  "clap",
  "codespan-reporting",
  "colored",
- "difference",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-bytecode-utils",
@@ -7738,6 +7731,7 @@ dependencies = [
  "move-vm-test-utils",
  "move-vm-types",
  "serde_yaml 0.8.26",
+ "similar",
  "tempfile",
  "toml_edit 0.14.4",
  "walkdir",
@@ -7749,7 +7743,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
- "difference",
+ "colored",
  "dirs-next",
  "hex",
  "insta",

--- a/deny.toml
+++ b/deny.toml
@@ -22,8 +22,6 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 # output a note when they are encountered.
 ignore = [
     # "RUSTSEC-0000-0000",
-    # difference 2.0.0 is unmaintained
-    "RUSTSEC-2020-0095",
     # rusoto is unmaintained, use aws crates
     "RUSTSEC-2022-0071",
     # `tui` is unmaintained; use `ratatui` instead

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -843,12 +843,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "difference"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-
-[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1884,7 +1878,6 @@ dependencies = [
  "codespan-reporting",
  "colored",
  "datatest-stable",
- "difference",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-bytecode-utils",
@@ -1908,6 +1901,7 @@ dependencies = [
  "move-vm-test-utils",
  "move-vm-types",
  "serde_yaml",
+ "similar",
  "tempfile",
  "toml_edit 0.14.4",
  "walkdir",
@@ -1919,7 +1913,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
- "difference",
+ "colored",
  "dirs-next",
  "hex",
  "insta",
@@ -2382,7 +2376,6 @@ dependencies = [
  "async-trait",
  "clap 4.5.28",
  "datatest-stable",
- "difference",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-cli",
@@ -2417,7 +2410,6 @@ dependencies = [
  "codespan-reporting",
  "colored",
  "datatest-stable",
- "difference",
  "itertools",
  "move-binary-format",
  "move-bytecode-utils",

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -47,7 +47,6 @@ crossterm = "0.25.0"
 curve25519-dalek = { version = "0.1.0", package = "curve25519-dalek-fiat", default-features = false, features = ["std", "u64_backend"] }
 datatest-stable = "0.1.1"
 derivative = "2.2.0"
-difference = "2.0.0"
 digest = "0.9.0"
 dir-diff = "0.3.2"
 dirs-next = "2.0.0"

--- a/external-crates/move/crates/move-cli/Cargo.toml
+++ b/external-crates/move/crates/move-cli/Cargo.toml
@@ -11,16 +11,15 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
-colored.workspace = true
-difference.workspace = true
-serde_yaml.workspace = true
-clap.workspace = true
-tempfile.workspace = true
-walkdir.workspace = true
-codespan-reporting.workspace = true
-toml_edit.workspace = true
-
 bcs.workspace = true
+clap.workspace = true
+codespan-reporting.workspace = true
+colored.workspace = true
+serde_yaml.workspace = true
+similar.workspace = true
+tempfile.workspace = true
+toml_edit.workspace = true
+walkdir.workspace = true
 
 move-bytecode-source-map.workspace = true
 move-bytecode-verifier.workspace = true

--- a/external-crates/move/crates/move-cli/src/sandbox/commands/test.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/commands/test.rs
@@ -428,31 +428,16 @@ fn add_update_baseline_fix(s: impl AsRef<str>) -> String {
 }
 
 fn format_diff(expected: impl AsRef<str>, actual: impl AsRef<str>) -> String {
-    use difference::*;
+    use colored::Colorize;
+    use similar::ChangeTag::*;
+    let diff = similar::TextDiff::from_lines(expected.as_ref(), actual.as_ref());
 
-    let changeset = Changeset::new(expected.as_ref(), actual.as_ref(), "\n");
-
-    let mut ret = String::new();
-
-    for seq in changeset.diffs {
-        match &seq {
-            Difference::Same(x) => {
-                ret.push_str(x);
-                ret.push('\n');
-            }
-            Difference::Add(x) => {
-                ret.push_str("\x1B[92m");
-                ret.push_str(x);
-                ret.push_str("\x1B[0m");
-                ret.push('\n');
-            }
-            Difference::Rem(x) => {
-                ret.push_str("\x1B[91m");
-                ret.push_str(x);
-                ret.push_str("\x1B[0m");
-                ret.push('\n');
-            }
-        }
-    }
-    ret
+    diff.iter_all_changes()
+        .map(|change| match change.tag() {
+            Delete => format!("{}{}", "-".bold(), change.value()).red(),
+            Insert => format!("{}{}", "+".bold(), change.value()).green(),
+            Equal => change.value().dimmed(),
+        })
+        .map(|s| s.to_string())
+        .collect()
 }

--- a/external-crates/move/crates/move-command-line-common/Cargo.toml
+++ b/external-crates/move/crates/move-command-line-common/Cargo.toml
@@ -11,16 +11,16 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
-difference.workspace = true
-walkdir.workspace = true
-sha2.workspace = true
+bcs.workspace = true
+colored.workspace = true
+dirs-next.workspace = true
 hex.workspace = true
+insta = { workspace = true, features = ["serde"] }
 once_cell.workspace = true
 serde.workspace = true
-dirs-next.workspace = true
+sha2.workspace = true
 vfs.workspace = true
-bcs.workspace = true
-insta = { workspace = true, features = ["serde"] }
+walkdir.workspace = true
 
 move-core-types.workspace = true
 move-binary-format.workspace = true

--- a/external-crates/move/crates/move-transactional-test-runner/Cargo.toml
+++ b/external-crates/move/crates/move-transactional-test-runner/Cargo.toml
@@ -38,7 +38,6 @@ move-vm-runtime.workspace = true
 
 [dev-dependencies]
 datatest-stable.workspace = true
-difference.workspace = true
 
 [[test]]
 name = "tests"

--- a/external-crates/move/crates/move-unit-test/Cargo.toml
+++ b/external-crates/move/crates/move-unit-test/Cargo.toml
@@ -40,7 +40,6 @@ rand.workspace = true
 
 [dev-dependencies]
 datatest-stable.workspace = true
-difference.workspace = true
 
 [[bin]]
 name = "move-unit-test"

--- a/external-crates/move/deny.toml
+++ b/external-crates/move/deny.toml
@@ -42,8 +42,6 @@ yanked = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-  # difference 2.0.0 is unmaintained
-    "RUSTSEC-2020-0095",
     # `tui` is unmaintained; use `ratatui` instead
     "RUSTSEC-2023-0049",
     # `yaml-rust` is unmaintained


### PR DESCRIPTION
## Description 

This PR removes the `difference` dependency and replaces it in one instance with `similar`, to resolve [`RUSTSEC-2020-0095`](https://rustsec.org/advisories/RUSTSEC-2020-0095).

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
