### PR TITLE
[15/n][vm-rewrite] Rebase + all typetags are defining ID based now

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/entry_points/missing_type.exp
+++ b/crates/sui-adapter-transactional-tests/tests/entry_points/missing_type.exp
@@ -12,12 +12,12 @@ gas summary: computation_cost: 1000000, storage_cost: 3876000,  storage_rebate: 
 task 2, line 17:
 //# run test::m::foo --type-args test::x::x
 Error: Transaction Effects Status: Error for type argument at index 0: A type was not found in the module specified.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: TypeArgumentError { argument_idx: 0, kind: TypeNotFound }, source: None, command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: TypeArgumentError { argument_idx: 0, kind: TypeNotFound }, source: Some("Unable to resolve type input: test::x::x"), command: Some(0) } }
 
 task 3, line 19:
 //# run test::m::foo --type-args test::m::SUI
 Error: Transaction Effects Status: Error for type argument at index 0: A type was not found in the module specified.
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: TypeArgumentError { argument_idx: 0, kind: TypeNotFound }, source: None, command: Some(0) } }
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: TypeArgumentError { argument_idx: 0, kind: TypeNotFound }, source: Some("Unable to resolve type input: test::m::SUI"), command: Some(0) } }
 
 task 4, line 21:
 //# run test::m::foo --type-args test::m::S

--- a/external-crates/move/crates/move-vm-runtime/src/execution/mod.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/mod.rs
@@ -7,3 +7,4 @@ pub mod tracing;
 pub mod values;
 pub mod vm;
 pub use crate::jit::execution::ast::Type;
+pub use crate::jit::execution::ast::TypeSubst;

--- a/external-crates/move/crates/move-vm-runtime/src/execution/values/values_impl.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/values/values_impl.rs
@@ -644,9 +644,6 @@ impl Container {
 
 impl Reference {
     pub fn equals(&self, other: &Reference) -> PartialVMResult<bool> {
-        if let Reference::Global(other) = other {
-            return self.equals(&Reference::Container(other.value.ptr_clone()));
-        }
         // TODO: auto-gen this?
         match_reference_impls!(self; other;
             container ref_1, ref_2 => {

--- a/external-crates/move/crates/move-vm-runtime/src/execution/vm.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/vm.rs
@@ -239,6 +239,8 @@ impl<'extensions> MoveVM<'extensions> {
             .map_err(|e| e.finish(Location::Undefined))
     }
 
+    /// Return a `TypeTag` for the provided `Type` using the VM's virtual tables. The returned
+    /// `TypeTag` will use defining type IDs.
     pub fn type_tag_for_type_defining_ids(&self, ty: &Type) -> VMResult<TypeTag> {
         self.virtual_tables
             .type_to_type_tag(ty)
@@ -249,6 +251,8 @@ impl<'extensions> MoveVM<'extensions> {
     /// NB: the `TypeTag` is coming from outside and therefore _may_ not represent a valid type
     /// (e.g., an undefined type). Therefore any errors in resolution should be treated as runtime
     /// errors and not anything else.
+    /// Additionally, the type tag _must_ use defining type IDs. Original/runtime IDs (or package
+    /// IDs) are not correct here.
     pub fn load_type(&self, tag: &TypeTag) -> VMResult<Type> {
         self.virtual_tables
             .load_type(tag)
@@ -259,6 +263,8 @@ impl<'extensions> MoveVM<'extensions> {
     /// NB: the `TypeTag` is coming from outside and therefore _may_ not represent a valid type
     /// (e.g., an undefined type). Therefore any errors in resolution should be treated as runtime
     /// errors and not anything else.
+    /// Additionally, the type tag _must_ use defining type IDs. Original/runtime IDs (or package
+    /// IDs) are not correct here.
     pub fn runtime_type_layout(&self, ty: &TypeTag) -> VMResult<runtime_value::MoveTypeLayout> {
         self.virtual_tables
             .get_type_layout(ty)
@@ -269,6 +275,8 @@ impl<'extensions> MoveVM<'extensions> {
     /// NB: the `TypeTag` is coming from outside and therefore _may_ not represent a valid type
     /// (e.g., an undefined type). Therefore any errors in resolution should be treated as runtime
     /// errors and not anything else.
+    /// Additionally, the type tag _must_ use defining type IDs. Original/runtime IDs (or package
+    /// IDs) are not correct here.
     pub fn annotated_type_layout(&self, ty: &TypeTag) -> VMResult<annotated_value::MoveTypeLayout> {
         self.virtual_tables
             .get_fully_annotated_type_layout(ty)

--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
@@ -424,12 +424,11 @@ fn datatypes(
         Ok(ModuleId::new(*defining_address, module_id))
     }
 
-    let runtime_id = context.runtime_id;
-
-    let structs: ArenaVec<StructDef> = structs(context, &runtime_id, module)?;
-    let enums: ArenaVec<EnumDef> = enums(context, &runtime_id, module)?;
-
     let runtime_id = module.self_id();
+    let runtime_address = *runtime_id.address();
+    let structs: ArenaVec<StructDef> = structs(context, &runtime_address, module)?;
+    let enums: ArenaVec<EnumDef> = enums(context, &runtime_address, module)?;
+
     let interner = string_interner();
 
     let struct_descriptors = structs

--- a/external-crates/move/crates/move-vm-runtime/src/natives/functions.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/natives/functions.rs
@@ -264,7 +264,6 @@ impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
         self.vtables.type_to_runtime_type_tag(ty)
     }
 
-    // XXX(vm-rewrite): Need to properly handle defining IDs here.
     pub fn type_tag_to_type_layout(
         &self,
         ty: &TypeTag,
@@ -278,7 +277,6 @@ impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
         }
     }
 
-    // XXX(vm-rewrite): Need to properly handle defining IDs here.
     pub fn type_tag_to_annotated_type_layout(
         &self,
         ty: &TypeTag,

--- a/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
@@ -67,17 +67,7 @@ impl<'state, 'vm> LayoutResolver for TypeLayoutResolver<'state, 'vm> {
         };
 
         let type_tag = TypeTag::Struct(Box::new(struct_tag.clone()));
-        let Ok(runtime_tag) = self
-            .linkage_resolver
-            .resolver()
-            .runtime_type_tag(&type_tag, &data_store)
-        else {
-            return Err(SuiError::FailObjectLayout {
-                st: format!("{}", struct_tag),
-            });
-        };
-
-        match vm.annotated_type_layout(&runtime_tag) {
+        match vm.annotated_type_layout(&type_tag) {
             Ok(A::MoveTypeLayout::Struct(s)) => Ok(A::MoveDatatypeLayout::Struct(s)),
             Ok(A::MoveTypeLayout::Enum(e)) => Ok(A::MoveDatatypeLayout::Enum(e)),
             _ => Err(SuiError::FailObjectLayout {


### PR DESCRIPTION
## Description 

Some minor changes on to the arena-rewrite for the VM, but this is mainly to make typetags always defining-id based (except on one area where we use original IDs for a native function that specifically needs original IDs).   

## Test plan 

CI

