### PR TITLE
fix spelling issues in comments 

### DIFF
--- a/external-crates/move/crates/move-vm-integration-tests/src/tests/instantiation_tests.rs
+++ b/external-crates/move/crates/move-vm-integration-tests/src/tests/instantiation_tests.rs
@@ -160,7 +160,7 @@ fn test_instantiation_no_instantiation() {
 // Common runner for all tests.
 // Run a control test (load_pop) and an instantiation test which is then
 // compared against the control.
-// Ensure that tests complete with "out of gas" and withing a given time range.
+// Ensure that tests complete with "out of gas" and within a given time range.
 fn test_runner(
     gas_val: u64,
     test_name: &str,
@@ -185,7 +185,7 @@ fn test_runner(
     // assert_eq!(err, StatusCode::OUT_OF_GAS, "Must finish OutOfGas");
     assert!(
         check_result(time, ref_time),
-        "Instantion test taking too long {}",
+        "Instantiation test taking too long {}",
         time
     );
 }

--- a/external-crates/move/crates/move-vm-runtime/src/move_vm.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/move_vm.rs
@@ -53,7 +53,7 @@ impl MoveVM {
     ///     none of them will try to publish a module. In other words, if there is a module publishing
     ///     Session it must be the only Session existing.
     ///   - In general, a new Move VM needs to be created whenever the storage gets modified by an
-    ///     outer envrionment, or otherwise the states may be out of sync. There are a few exceptional
+    ///     outer environment, or otherwise the states may be out of sync. There are a few exceptional
     ///     cases where this may not be necessary, with the most notable one being the common module
     ///     publishing flow: you can keep using the same Move VM if you publish some modules in a Session
     ///     and apply the effects to the storage when the Session ends.

--- a/external-crates/move/crates/move-vm-runtime/src/tracing2/tracer.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/tracing2/tracer.rs
@@ -222,7 +222,7 @@ impl<'a> VMTracer<'a> {
         std::mem::take(&mut self.effects)
     }
 
-    /// Insert a local with a specifice runtime location into the current frame.
+    /// Insert a local with a specific runtime location into the current frame.
     fn insert_local(&mut self, local_index: usize, local: RootedType) -> Option<()> {
         *self
             .current_frame_mut()?

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/vm_arguments_tests.rs
@@ -627,7 +627,7 @@ fn call_missing_item() {
     let module = empty_module();
     let id = &module.self_id();
     let function_name = IdentStr::new("foo").unwrap();
-    // mising module
+    // missing module
     let move_vm = MoveVM::new(vec![]).unwrap();
     let mut remote_view = RemoteStore::new();
     let mut session = move_vm.new_session(&remote_view);

--- a/external-crates/move/crates/move-vm-test-utils/src/tiered_gas_schedule.rs
+++ b/external-crates/move/crates/move-vm-test-utils/src/tiered_gas_schedule.rs
@@ -647,7 +647,7 @@ impl<'b> GasMeter for GasStatus<'b> {
     ) -> PartialVMResult<()> {
         // We will perform `num_args` number of pops.
         let num_args = args.len() as u64;
-        // The amount of data on the stack stays contstant except we have some extra metadata for
+        // The amount of data on the stack stays constant except we have some extra metadata for
         // the vector to hold the length of the vector.
         self.charge(1, 1, num_args, VEC_SIZE.into(), 0)
     }

--- a/external-crates/move/crates/move-vm-types/src/natives/function.rs
+++ b/external-crates/move/crates/move-vm-types/src/natives/function.rs
@@ -49,7 +49,7 @@ impl NativeResult {
 
     /// Failed execution. The failure is a runtime failure in the function and not an invariant
     /// failure of the VM which would raise a `PartialVMError` error directly.
-    /// The only thing the funciton can specify is its abort code, as if it had invoked the `Abort`
+    /// The only thing the function can specify is its abort code, as if it had invoked the `Abort`
     /// bytecode instruction
     pub fn err(cost: InternalGas, abort_code: u64) -> Self {
         NativeResult {


### PR DESCRIPTION
## Description 
external-crates/move/crates/move-vm-integration-tests/src/tests/instantiation_tests.rs
withing - within
Instantion - Instantiation

external-crates/move/crates/move-vm-runtime/src/move_vm.rs
envrionment - environment

external-crates/move/crates/move-vm-runtime/src/tracing2/tracer.rs
specifice - specific

external-crates/move/crates/move-vm-runtime/src/unit_tests/vm_arguments_tests.rs
mising - missing

external-crates/move/crates/move-vm-test-utils/src/tiered_gas_schedule.rs
contstant - constant

external-crates/move/crates/move-vm-types/src/natives/function.rs
funciton - function