### PR TITLE
Fix typos and improve text consistency across codebase

### DIFF
--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_enum_field_mutable_invalid.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_enum_field_mutable_invalid.mvir
@@ -13,7 +13,7 @@ module 0x1.M {
     label f:
         // Borrow mut ref
         &mut E.V { f0: x } = copy(in);
-        // fill y with a diffrent immut ref
+        // fill y with a different immut ref
         y = &other;
         jump end;
     label t:

--- a/external-crates/move/crates/move-cli/tools.md
+++ b/external-crates/move/crates/move-cli/tools.md
@@ -35,7 +35,7 @@ handled for the `move-bytecode-viewer` that's defined in the
 `move-bytecode-viewer` crate, and not the `move-cli` crate).
 
 Some of the crates mentioned above are also binaries at the moment, however
-they should all be able to be made libaries only, with the possible
+they should all be able to be made libraries only, with the possible
 exception of the `move-coverage` crate. The primary reason for this, is
 that this tool can collect and report test coverage statistics across
 multiple packages, and multiple runs over a package. This functionality is

--- a/external-crates/move/crates/move-ir-to-bytecode/src/context.rs
+++ b/external-crates/move/crates/move-ir-to-bytecode/src/context.rs
@@ -187,7 +187,7 @@ impl StoredCompiledDependency {
 }
 
 pub(crate) enum CompiledDependency<'a> {
-    /// Simple `CompiledDependecyView` where the borrowed `CompiledModule` is held elsewehere,
+    /// Simple `CompiledDependencyView` where the borrowed `CompiledModule` is held elsewhere,
     /// Commonly, it is borrowed from outside of the compilers API
     Borrowed(CompiledDependencyView<'a>),
     /// `Stored` holds the `CompiledModule` as well as the `CompiledDependencyView` into the module

--- a/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
@@ -181,7 +181,7 @@ pub enum DependencyMode {
 }
 
 /// Wrapper struct to display a package as an inline table in the lock file (matching the
-/// convention in the source manifest).  This is necessary becase the `toml` crate does not
+/// convention in the source manifest).  This is necessary because the `toml` crate does not
 /// currently support serializing types as inline tables.
 struct PackageTOML<'a>(&'a Package);
 struct PackageWithResolverTOML<'a>(&'a Package);

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_incorrect_nested/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_incorrect_nested/Move.toml
@@ -1,5 +1,5 @@
 # Dependency graph and an override (ov) - technically, override in the root is capable of resolving
-# a conflict in the sub-graph for A but becase we expect sub-graphs to be correct as standalone
+# a conflict in the sub-graph for A but because we expect sub-graphs to be correct as standalone
 # entities (and our algorithm proceeds by constructing sub-graphs independently), this will result
 # in a failure.
 #

--- a/external-crates/move/crates/move-vm-integration-tests/src/tests/instantiation_tests.rs
+++ b/external-crates/move/crates/move-vm-integration-tests/src/tests/instantiation_tests.rs
@@ -185,7 +185,7 @@ fn test_runner(
     // assert_eq!(err, StatusCode::OUT_OF_GAS, "Must finish OutOfGas");
     assert!(
         check_result(time, ref_time),
-        "Instantion test taking too long {}",
+        "Instantiation test taking too long {}",
         time
     );
 }


### PR DESCRIPTION
**This PR includes several minor text improvements:**
1. Fixed spelling of `different` in `borrow_enum_field_mutable_invalid.mvir`
2. Standardized `libraries` casing in `move-cli/tools.md`
3. Fixed spelling of `CompiledDependencyView` in `context.rs`
4. Corrected `because` spelling in multiple files
5. Fixed capitalization in `Instantiation test` message

These changes improve code readability and maintain consistent terminology throughout the codebase. All modifications are text-only and do not affect functionality.