### PR TITLE
[faucet] Try to find an address with sufficient gas coins

### DIFF
--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -1112,7 +1112,7 @@ async fn find_gas_coins_and_address(
 
     for address in std::iter::once(active_address).chain(wallet.get_addresses().into_iter()) {
         let coins: Vec<_> = wallet
-            .gas_objects(active_address)
+            .gas_objects(address)
             .await
             .map_err(|e| FaucetError::Wallet(e.to_string()))?
             .iter()
@@ -1124,6 +1124,7 @@ async fn find_gas_coins_and_address(
                 }
             })
             .collect();
+
 
         if !coins.is_empty() {
             return Ok((coins, address));

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -1125,7 +1125,6 @@ async fn find_gas_coins_and_address(
             })
             .collect();
 
-
         if !coins.is_empty() {
             return Ok((coins, address));
         }

--- a/crates/sui-faucet/src/faucet/simple_faucet.rs
+++ b/crates/sui-faucet/src/faucet/simple_faucet.rs
@@ -103,7 +103,7 @@ impl SimpleFaucet {
         config: FaucetConfig,
     ) -> Result<Arc<Self>, FaucetError> {
         let (coins, active_address) = find_gas_coins_and_address(&mut wallet, &config).await?;
-        info!("SimpleFaucet::new with active address: {active_address}");
+        info!("Starting faucet with address: {:?}", active_address);
 
         let metrics = FaucetMetrics::new(prometheus_registry);
         // set initial balance when faucet starts
@@ -1100,71 +1100,39 @@ pub async fn batch_transfer_gases(
 }
 
 /// Finds gas coins with sufficient balance and returns the address to use as the active address
-/// for the wallet. If the initial active address in the wallet does not have enough gas coins,
+/// for the faucet. If the initial active address in the wallet does not have enough gas coins,
 /// it will iterate through the addresses to find one with sufficient gas coins.
 async fn find_gas_coins_and_address(
     wallet: &mut WalletContext,
     config: &FaucetConfig,
 ) -> Result<(Vec<GasCoin>, SuiAddress), FaucetError> {
-    let mut active_address = wallet
+    let active_address = wallet
         .active_address()
         .map_err(|e| FaucetError::Wallet(e.to_string()))?;
 
-    let mut coins = wallet
-        .gas_objects(active_address)
-        .await
-        .map_err(|e| FaucetError::Wallet(e.to_string()))?
-        .iter()
-        // Ok to unwrap() since `get_gas_objects` guarantees gas
-        .map(|q| GasCoin::try_from(&q.1).unwrap())
-        .filter(|coin| coin.0.balance.value() >= (config.amount * config.num_coins as u64))
-        .collect::<Vec<GasCoin>>();
+    for address in std::iter::once(active_address).chain(wallet.get_addresses().into_iter()) {
+        let coins: Vec<_> = wallet
+            .gas_objects(active_address)
+            .await
+            .map_err(|e| FaucetError::Wallet(e.to_string()))?
+            .iter()
+            .filter_map(|(balance, obj)| {
+                if *balance >= config.amount * config.num_coins as u64 {
+                    GasCoin::try_from(obj).ok()
+                } else {
+                    None
+                }
+            })
+            .collect();
 
-    if coins.is_empty() && wallet.get_addresses().len() == 1 {
-        return Err(FaucetError::Wallet(
-            "No gas coins found with sufficient balance".to_string(),
-        ));
-    }
-
-    if coins.is_empty() {
-        let addresses = wallet.get_addresses();
-
-        let mut address = None;
-        let mut last_balance = 0;
-        // find the address with at least five gas coins and sufficient SUI
-        // this is particularly useful for local network that is started from genesis and the
-        // active address is a different one than one of the whale accounts created during genesis
-        // or if it does not have any SUI
-        for addr in addresses {
-            let gas_coins = wallet
-                .gas_objects(addr)
-                .await
-                .map_err(|e| FaucetError::Wallet(e.to_string()))?
-                .iter()
-                // Ok to unwrap() since `gas_objects` guarantees gas
-                .map(|q| GasCoin::try_from(&q.1).unwrap())
-                .filter(|coin| coin.0.balance.value() >= (config.amount * config.num_coins as u64))
-                .collect::<Vec<GasCoin>>();
-            let balance = gas_coins
-                .iter()
-                .map(|coin| coin.0.balance.value())
-                .sum::<u64>();
-
-            if gas_coins.len() >= 5 && balance > last_balance {
-                address = Some(addr);
-                coins = gas_coins;
-                last_balance = balance;
-            }
+        if !coins.is_empty() {
+            return Ok((coins, address));
         }
-
-        active_address = address.ok_or_else(|| {
-            FaucetError::Wallet("No address found with sufficient coins".to_string())
-        })?;
     }
 
-    info!("Starting faucet with address: {:?}", active_address);
-
-    Ok((coins, active_address))
+    Err(FaucetError::Wallet(
+        "No address found with sufficient coins".to_string(),
+    ))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description 

This PR fixes the issue of the localnet failing to start in this specific scenario:
- local network started from genesis: `sui start --with-faucet`
- new address was created and requested gas, and switched to being the active address.
- stop the network
- start the network again with `sui start --with-faucet`.

What happens is that the `active-address` does not have the objects yet, depending on how the indexing of the DB goes, so the faucet cannot start without gas coins.

Should close issue #21255.

## Test plan 

Re-run the tests + run `sui start` with different flags.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
