### PR TITLE
fix(sui-move): `sui move new` command fails with `os error 2` if using `<NAME>` with uppercase letter(s)

### DIFF
--- a/crates/sui-move/src/new.rs
+++ b/crates/sui-move/src/new.rs
@@ -21,10 +21,11 @@ pub struct New {
 impl New {
     pub fn execute(self, path: Option<&Path>) -> anyhow::Result<()> {
         let name = &self.new.name.to_lowercase();
+        let provided_name = &self.new.name.to_string();
 
         self.new
             .execute(path, [(SUI_PKG_NAME, SUI_PKG_PATH)], [(name, "0x0")], "")?;
-        let p = path.unwrap_or_else(|| Path::new(&name));
+        let p = path.unwrap_or_else(|| Path::new(&provided_name));
         let mut w = std::fs::File::create(
             p.join(SourcePackageLayout::Sources.path())
                 .join(format!("{name}.move")),

--- a/crates/sui/tests/shell_tests/new_tests/new_uppercase_name.sh
+++ b/crates/sui/tests/shell_tests/new_tests/new_uppercase_name.sh
@@ -1,0 +1,11 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# test that `sui move new` works as expected with `<NAME>` containing uppercase letter(s)
+sui move new _Example_A
+echo ==== files in project ====
+ls -A _Example_A
+echo ==== files in sources ====
+ls -A _Example_A/sources
+echo ==== files in tests =====
+ls -A _Example_A/tests

--- a/crates/sui/tests/snapshots/shell_tests__new_tests__new_uppercase_name.sh.snap
+++ b/crates/sui/tests/snapshots/shell_tests__new_tests__new_uppercase_name.sh.snap
@@ -1,0 +1,32 @@
+---
+source: crates/sui/tests/shell_tests.rs
+description: tests/shell_tests/new_tests/new_uppercase_name.sh
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# test that `sui move new` works as expected with `<NAME>` containing uppercase letter(s)
+sui move new _Example_A
+echo ==== files in project ====
+ls -A _Example_A
+echo ==== files in sources ====
+ls -A _Example_A/sources
+echo ==== files in tests =====
+ls -A _Example_A/tests
+
+----- results -----
+success: true
+exit_code: 0
+----- stdout -----
+==== files in project ====
+.gitignore
+Move.toml
+sources
+tests
+==== files in sources ====
+_example_a.move
+==== files in tests =====
+_example_a_tests.move
+
+----- stderr -----

--- a/external-crates/move/crates/move-cli/src/base/new.rs
+++ b/external-crates/move/crates/move-cli/src/base/new.rs
@@ -41,8 +41,8 @@ impl New {
 
         ensure!(
             Identifier::is_valid(&self.name),
-            "Invalid package name. Package name must start with a lowercase letter \
-                     and consist only of lowercase letters, numbers, and underscores."
+            "Invalid package name. Package name must start with a letter or underscore \
+                     and consist only of letters, numbers, and underscores."
         );
 
         let path = path.unwrap_or_else(|| Path::new(&self.name));


### PR DESCRIPTION
Creating a new Move package with the `sui move new` command using only the required argument `<NAME>` fails with `No such file or directory (os error 2)` if `<NAME>` contains uppercase letter(s).

Porting over [iotaledger/iota/issues/4895](https://github.com/iotaledger/iota/issues/4895).

## Description 

_Describe the changes or additions included in this PR._

- Use the provided `<NAME>` instead of its lowercase variant to obtain the correct and existing path for writing.
- Update `<NAME>` validation error message: since `<NAME>` is validated as an `Identifier`, a valid `<NAME>` can also start with an uppercase letter or underscore.

## Test plan 

_How did you test the new or updated feature?_

The issue can be tested before and after the proposed changes as follows:

```console
cargo build -p sui
./target/debug/sui move new Xxx
```

> [!NOTE]
> The issue seems to be reproducible only on Linux.
> On MacOS, the bug might not be reproducible due to MacOS default case-insensitivity.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
