### PR TITLE
[deny] Add `ring` rustsec to ignore

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -30,7 +30,6 @@ ignore = [
     "RUSTSEC-2024-0320",
     # allow unmaintained proc-macro-error used in transitive dependencies
     "RUSTSEC-2024-0370",
-
     # Temporarily allow until arrow family of crates updates `lexical-core` to 1.0
     "RUSTSEC-2023-0086",
     # allow unmaintained instant crate used in transitive dependencies (backoff, cached, fastrand, parking_lot_*)
@@ -39,6 +38,8 @@ ignore = [
     "RUSTSEC-2024-0388",
     # allow outdated 'idna' until passkey-client crate is able to update
     "RUSTSEC-2024-0421",
+    # allow unmaintained ring
+    "RUSTSEC-2025-0007"
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
## Description 

Latest PRs started to fail on the cargo deny job: https://github.com/MystenLabs/sui/actions/runs/13467427723/job/37635981270?pr=21302

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
