### PR TITLE
fix(sui-json-rpc-types): fix `Display` of `SuiTransactionBlockResponse` with empty balance changes

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -323,17 +323,28 @@ impl Display for SuiTransactionBlockResponse {
         }
 
         if let Some(balance_changes) = &self.balance_changes {
-            let mut builder = TableBuilder::default();
-            for balance in balance_changes {
-                builder.push_record(vec![format!("{}", balance)]);
+            // Only build a table if the vector of balance changes is non-empty.
+            // Empty balance changes occur, for example, for system transactions
+            // like `ConsensusCommitPrologueV3`
+            if !balance_changes.is_empty() {
+                let mut builder = TableBuilder::default();
+
+                for balance in balance_changes {
+                    builder.push_record(vec![format!("{}", balance)]);
+                }
+
+                let mut table = builder.build();
+                table.with(TablePanel::header("Balance Changes"));
+                table.with(TableStyle::rounded().horizontals([HorizontalLine::new(
+                    1,
+                    TableStyle::modern().get_horizontal(),
+                )]));
+                writeln!(writer, "{}", table)?;
+            } else {
+                writeln!(writer, "╭────────────────────╮")?;
+                writeln!(writer, "│ No balance changes │")?;
+                writeln!(writer, "╰────────────────────╯")?;
             }
-            let mut table = builder.build();
-            table.with(TablePanel::header("Balance Changes"));
-            table.with(TableStyle::rounded().horizontals([HorizontalLine::new(
-                1,
-                TableStyle::modern().get_horizontal(),
-            )]));
-            writeln!(writer, "{}", table)?;
         }
         Ok(())
     }


### PR DESCRIPTION
Formatting an instance of `SuiTransactionBlockResponse` using an empty format `{}` panics if the instance contains an empty vector of balance changes, which occurs for system transactions like `ConsensusCommitPrologueV3`.

Porting over https://github.com/iotaledger/iota/issues/5366

## Description 

_Describe the changes or additions included in this PR._

In the `Display` implementation for `SuiTransactionBlockResponse`, add a check for a vector of balance changes being non-empty -- only then a build a table and safely operate on it. A similar check is done in the `Display` implementation for `SuiTransactionBlockEvents`.

## Test plan 

_How did you test the new or updated feature?_

Added `test_display_transaction_block_with_empty_balance_changes` test:

```console
cargo test -p sui-json-rpc-tests test_display_transaction_block_with_empty_balance_changes -- --exact
```

Running this test on the `main` branch without proposed changes panics:

```
---- test_display_transaction_block_with_empty_balance_changes stdout ----
thread 'test_display_transaction_block_with_empty_balance_changes' panicked at /home/rom/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tabled-0.12.2/src/grid/records/records_mut.rs:25:18:
index out of bounds: the len is 0 but the index is 0
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: