### PR TITLE
[docs] CircomReduction required for ark-circom

### DIFF
--- a/docs/content/guides/developer/cryptography/groth16.mdx
+++ b/docs/content/guides/developer/cryptography/groth16.mdx
@@ -48,6 +48,7 @@ To generate a proof verifiable in Sui, you need to generate a witness. This exam
 use ark_bn254::Bn254;
 use ark_circom::CircomBuilder;
 use ark_circom::CircomConfig;
+use ark_circom::CircomReduction;
 use ark_groth16::{Groth16, prepare_verifying_key};
 use ark_serialize::CanonicalSerialize;
 use ark_snark::SNARK;
@@ -74,7 +75,7 @@ fn main() {
     let public_inputs = circuit.get_public_inputs().unwrap();
 
     // Create proof
-    let proof = Groth16::<Bn254>::prove(&pk, circuit, &mut rng).unwrap();
+    let proof = Groth16::<Bn254, CircomReduction>::prove(&pk, circuit, &mut rng).unwrap();
 
     // Verify proof
     let pvk = prepare_verifying_key(&pk.vk);


### PR DESCRIPTION
## Description 

When the version of the Rust dependency ark-works is upgraded to 0.5, CircomReduction needs to be added to ensure verification.


## Test plan 


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
