### PR TITLE
feat: extend FieldCount trait for enum type

### DIFF
--- a/crates/sui-field-count-derive/src/lib.rs
+++ b/crates/sui-field-count-derive/src/lib.rs
@@ -11,10 +11,10 @@ pub fn field_count_derive(input: TokenStream) -> TokenStream {
     let generics = input.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
-    let fields_count = if let syn::Data::Struct(data_struct) = input.data {
-        data_struct.fields.len()
-    } else {
-        panic!("FieldCount can only be derived for structs");
+    let fields_count = match input.data {
+        syn::Data::Struct(data_struct) => data_struct.fields.len(),
+        syn::Data::Enum(data_enum) => data_enum.variants.len(),
+        syn::Data::Union(_) => panic!("FieldCount cannot be derived for unions"),
     };
 
     let expanded = quote! {
@@ -22,6 +22,5 @@ pub fn field_count_derive(input: TokenStream) -> TokenStream {
             const FIELD_COUNT: usize = #fields_count;
         }
     };
-
     TokenStream::from(expanded)
 }


### PR DESCRIPTION
make the FieldCount trait support Enum type as well to extend the further logic when implementing handler in alt-indexer-framework

for example, we might want to handle multiple related data in single processor instead of handling them in individual processors which might be down to efficiency

```
#[derive(Clone, Debug)]
pub enum DeepBookData {
    Flashloan(Flashloan),
    OrderUpdate(OrderUpdate),
    OrderFill(OrderFill),
    PoolPrice(PoolPrice),
    Balances(Balances),
    Proposals(Proposals),
    Rebates(Rebates),
    Stakes(Stakes),
    TradeParamsUpdate(TradeParamsUpdate),
    Votes(Votes),
    Error(SuiTxnError),
}

impl Processor for DeepBookEventsBuckets {
    const NAME: &'static str = "deepbook_buckets";

    type Value = DeepBookData;

    fn process(&self, checkpoint: &Arc<CheckpointData>) -> Result<Vec<Self::Value>> {

    ...
}
```