### PR TITLE
cli(ptb): support serializing `sui::object::ID`

### DIFF
--- a/crates/sui/src/client_ptb/ast.rs
+++ b/crates/sui/src/client_ptb/ast.rs
@@ -10,6 +10,7 @@ use move_core_types::parsing::{
 use move_core_types::runtime_value::MoveValue;
 use sui_types::{
     base_types::{ObjectID, RESOLVED_ASCII_STR, RESOLVED_STD_OPTION, RESOLVED_UTF8_STR},
+    id::RESOLVED_SUI_ID,
     Identifier, TypeTag,
 };
 
@@ -201,6 +202,15 @@ impl Argument {
                 } =>
             {
                 MoveValue::Vector(s.bytes().map(MoveValue::U8).collect::<Vec<_>>())
+            }
+            (Argument::Address(a), TypeTag::Struct(stag))
+                if (
+                    &stag.address,
+                    stag.module.as_ident_str(),
+                    stag.name.as_ident_str(),
+                ) == RESOLVED_SUI_ID =>
+            {
+                MoveValue::Address(a.into_inner())
             }
             (Argument::Option(sp!(loc, o)), TypeTag::Vector(ty)) => {
                 if let Some(v) = o {


### PR DESCRIPTION
## Description
Support passing `sui::object::ID` values as pure transaction inputs for `sui client ptb`.

## Test plan
Call a move function that accepts an `ID` parameter using `sui client ptb` (the ID is accepted as an address literal).

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Adds support to `sui client ptb` to create transactions with `sui::object::ID` values as pure inputs. ID inputs are specified like addresses (hexadecimal numbers with a leading `@`) and their type is inferred from usage.
- [ ] Rust SDK:
