### PR TITLE
refactor(rpc-alt): pass configs via Context

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/name_service_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/name_service_tests.rs
@@ -393,7 +393,7 @@ impl SuiNSCluster {
         };
 
         let rpc_config = RpcConfig {
-            name_service: config.clone().into(),
+            name_service: config.clone(),
             ..Default::default()
         };
 

--- a/crates/sui-indexer-alt-e2e-tests/tests/transaction_pruning_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/transaction_pruning_tests.rs
@@ -219,7 +219,7 @@ async fn cluster_with_pipelines(pipeline: PipelineLayer) -> FullCluster {
             pipeline,
             ..IndexerConfig::for_test()
         },
-        RpcConfig::example(),
+        RpcConfig::default(),
         &prometheus::Registry::new(),
         CancellationToken::new(),
     )

--- a/crates/sui-indexer-alt-e2e-tests/tests/transactional_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/transactional_tests.rs
@@ -123,7 +123,7 @@ async fn cluster(config: &OffChainConfig) -> Arc<OffchainCluster> {
         ..Default::default()
     });
 
-    let rpc_config = RpcConfig::example();
+    let rpc_config = RpcConfig::default();
 
     Arc::new(
         OffchainCluster::new(

--- a/crates/sui-indexer-alt-e2e-tests/tests/type_limit_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/type_limit_tests.rs
@@ -164,8 +164,8 @@ impl TypeLimitCluster {
                 ..IndexerConfig::for_test()
             },
             RpcConfig {
-                package_resolver,
-                ..RpcConfig::example()
+                package_resolver: package_resolver.finish(),
+                ..RpcConfig::default()
             },
             &prometheus::Registry::new(),
             CancellationToken::new(),

--- a/crates/sui-indexer-alt-jsonrpc/src/api/move_utils/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/move_utils/response.rs
@@ -11,8 +11,8 @@ use sui_package_resolver::{FunctionDef, OpenSignature, OpenSignatureBody, Refere
 use sui_types::{base_types::ObjectID, Identifier};
 
 use crate::{
+    context::Context,
     error::{invalid_params, RpcError},
-    Context,
 };
 
 use super::error::Error;

--- a/crates/sui-indexer-alt-jsonrpc/src/api/name_service/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/name_service/mod.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use sui_name_service::NameServiceConfig;
 use sui_open_rpc::Module;
 use sui_open_rpc_macros::open_rpc;
 use sui_types::base_types::SuiAddress;
@@ -28,13 +27,13 @@ trait NameServiceApi {
     ) -> RpcResult<Option<SuiAddress>>;
 }
 
-pub(crate) struct NameService(pub Context, pub NameServiceConfig);
+pub(crate) struct NameService(pub Context);
 
 #[async_trait::async_trait]
 impl NameServiceApiServer for NameService {
     async fn resolve_name_service_address(&self, name: String) -> RpcResult<Option<SuiAddress>> {
-        let Self(ctx, config) = self;
-        Ok(response::resolved_address(ctx, config, &name)
+        let Self(ctx) = self;
+        Ok(response::resolved_address(ctx, &name)
             .await
             .with_internal_context(|| format!("Resolving SuiNS name {name:?}"))?)
     }

--- a/crates/sui-indexer-alt-jsonrpc/src/api/name_service/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/name_service/response.rs
@@ -5,14 +5,14 @@ use anyhow::Context as _;
 use diesel::{ExpressionMethods, QueryDsl};
 use futures::future::OptionFuture;
 use sui_indexer_alt_schema::schema::watermarks;
-use sui_name_service::{Domain, NameRecord, NameServiceConfig, NameServiceError};
+use sui_name_service::{Domain, NameRecord, NameServiceError};
 use sui_types::base_types::SuiAddress;
 use tokio::join;
 
 use crate::{
+    context::Context,
     data::objects::load_live,
     error::{invalid_params, RpcError},
-    Context,
 };
 
 use super::Error;
@@ -21,7 +21,6 @@ use super::Error;
 /// and it hasn't expired.
 pub(super) async fn resolved_address(
     ctx: &Context,
-    config: &NameServiceConfig,
     name: &str,
 ) -> Result<Option<SuiAddress>, RpcError<Error>> {
     use Error as E;
@@ -30,6 +29,7 @@ pub(super) async fn resolved_address(
         .parse()
         .map_err(|e| invalid_params(E::NameService(e)))?;
 
+    let config = &ctx.config().name_service;
     let domain_record_id = config.record_field_id(&domain);
     let parent_record_id = config.record_field_id(&domain.parent());
 

--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/filter.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/filter.rs
@@ -17,12 +17,12 @@ use sui_types::{
 };
 
 use crate::{
+    context::Context,
     error::RpcError,
     paginate::{BcsCursor, Cursor as _, Page},
-    Context,
 };
 
-use super::{error::Error, ObjectsConfig};
+use super::error::Error;
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Default)]
 #[serde(rename_all = "camelCase", rename = "ObjectResponseQuery", default)]
@@ -104,7 +104,6 @@ impl SuiObjectDataFilter {
 /// any results).
 pub(super) async fn owned_objects(
     ctx: &Context,
-    config: &ObjectsConfig,
     owner: SuiAddress,
     filter: &Option<SuiObjectDataFilter>,
     cursor: Option<String>,
@@ -126,6 +125,7 @@ pub(super) async fn owned_objects(
         };
     }
 
+    let config = &ctx.config().objects;
     let page: Page<Cursor> = Page::from_params(
         config.default_page_size,
         config.max_page_size,

--- a/crates/sui-indexer-alt-jsonrpc/src/api/transactions/filter.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/transactions/filter.rs
@@ -28,12 +28,13 @@ use sui_types::{
 };
 
 use crate::{
+    context::Context,
     data::tx_digests::TxDigestKey,
     error::{invalid_params, RpcError},
     paginate::{Cursor as _, JsonCursor, Page},
 };
 
-use super::{error::Error, Context, TransactionsConfig};
+use super::error::Error;
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Default)]
 #[serde(
@@ -81,12 +82,12 @@ type Digests = PageResponse<TransactionDigest, String>;
 /// results).
 pub(super) async fn transactions(
     ctx: &Context,
-    config: &TransactionsConfig,
     filter: &Option<TransactionFilter>,
     cursor: Option<String>,
     limit: Option<usize>,
     descending_order: Option<bool>,
 ) -> Result<Digests, RpcError<Error>> {
+    let config = &ctx.config().transactions;
     let page: Page<Cursor> = Page::from_params(
         config.default_page_size,
         config.max_page_size,

--- a/crates/sui-indexer-alt-jsonrpc/src/config.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/config.rs
@@ -29,7 +29,7 @@ pub struct RpcConfig {
 
     /// Configuration for bigtable kv store, if it is used.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bigtable_config: Option<BigtableConfig>,
+    pub bigtable: Option<BigtableConfig>,
 
     /// Configuring limits for the package resolver.
     pub package_resolver: PackageResolverLayer,
@@ -108,7 +108,7 @@ impl RpcConfig {
             transactions: TransactionsConfig::default().into(),
             name_service: NameServiceConfig::default().into(),
             coins: CoinsConfig::default().into(),
-            bigtable_config: None,
+            bigtable: None,
             package_resolver: PackageResolverLayer::default(),
             extra: Default::default(),
         }

--- a/crates/sui-indexer-alt-jsonrpc/src/config.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/config.rs
@@ -8,13 +8,32 @@ use sui_protocol_config::ProtocolConfig;
 use sui_types::base_types::{ObjectID, SuiAddress};
 use tracing::warn;
 
-use crate::api::{coin::CoinsConfig, objects::ObjectsConfig, transactions::TransactionsConfig};
-
 pub use sui_name_service::NameServiceConfig;
+
+#[derive(Debug)]
+pub struct RpcConfig {
+    /// Configuration for object-related RPC methods.
+    pub objects: ObjectsConfig,
+
+    /// Configuration for transaction-related RPC methods.
+    pub transactions: TransactionsConfig,
+
+    /// Configuration for SuiNS related RPC methods.
+    pub name_service: NameServiceConfig,
+
+    /// Configuration for coin-related RPC methods.
+    pub coins: CoinsConfig,
+
+    /// Configuration for bigtable kv store, if it is used.
+    pub bigtable: Option<BigtableConfig>,
+
+    /// Configuring limits for the package resolver.
+    pub package_resolver: sui_package_resolver::Limits,
+}
 
 #[DefaultConfig]
 #[derive(Clone, Default, Debug)]
-pub struct RpcConfig {
+pub struct RpcLayer {
     /// Configuration for object-related RPC methods.
     pub objects: ObjectsLayer,
 
@@ -38,6 +57,19 @@ pub struct RpcConfig {
     pub extra: toml::Table,
 }
 
+#[derive(Debug, Clone)]
+pub struct ObjectsConfig {
+    /// The maximum number of keys that can be queried in a single multi-get request.
+    pub max_multi_get_objects: usize,
+
+    /// The default page size limit when querying objects, if none is provided.
+    pub default_page_size: usize,
+
+    /// The largest acceptable page size when querying transactions. Requesting a page larger than
+    /// this is a user error.
+    pub max_page_size: usize,
+}
+
 #[DefaultConfig]
 #[derive(Clone, Default, Debug)]
 pub struct ObjectsLayer {
@@ -47,6 +79,16 @@ pub struct ObjectsLayer {
 
     #[serde(flatten)]
     pub extra: toml::Table,
+}
+
+#[derive(Debug, Clone)]
+pub struct TransactionsConfig {
+    /// The default page size limit when querying transactions, if none is provided.
+    pub default_page_size: usize,
+
+    /// The largest acceptable page size when querying transactions. Requesting a page larger than
+    /// this is a user error.
+    pub max_page_size: usize,
 }
 
 #[DefaultConfig]
@@ -68,6 +110,16 @@ pub struct NameServiceLayer {
 
     #[serde(flatten)]
     pub extra: toml::Table,
+}
+
+#[derive(Debug, Clone)]
+pub struct CoinsConfig {
+    /// The default page size limit when querying coins, if none is provided.
+    pub default_page_size: usize,
+
+    /// The largest acceptable page size when querying coins. Requesting a page larger than
+    /// this is a user error.
+    pub max_page_size: usize,
 }
 
 #[DefaultConfig]
@@ -99,7 +151,7 @@ pub struct PackageResolverLayer {
     pub extra: toml::Table,
 }
 
-impl RpcConfig {
+impl RpcLayer {
     /// Generate an example configuration, suitable for demonstrating the fields available to
     /// configure.
     pub fn example() -> Self {
@@ -116,7 +168,14 @@ impl RpcConfig {
 
     pub fn finish(mut self) -> RpcConfig {
         check_extra("top-level", mem::take(&mut self.extra));
-        self
+        RpcConfig {
+            objects: self.objects.finish(ObjectsConfig::default()),
+            transactions: self.transactions.finish(TransactionsConfig::default()),
+            name_service: self.name_service.finish(NameServiceConfig::default()),
+            coins: self.coins.finish(CoinsConfig::default()),
+            bigtable: self.bigtable,
+            package_resolver: self.package_resolver.finish(),
+        }
     }
 }
 
@@ -172,6 +231,47 @@ impl PackageResolverLayer {
             max_type_argument_width: self.max_type_argument_width,
             max_type_nodes: self.max_type_nodes,
             max_move_value_depth: self.max_move_value_depth,
+        }
+    }
+}
+
+impl Default for RpcConfig {
+    fn default() -> Self {
+        Self {
+            objects: ObjectsConfig::default(),
+            transactions: TransactionsConfig::default(),
+            name_service: NameServiceConfig::default(),
+            coins: CoinsConfig::default(),
+            bigtable: None,
+            package_resolver: PackageResolverLayer::default().finish(),
+        }
+    }
+}
+
+impl Default for ObjectsConfig {
+    fn default() -> Self {
+        Self {
+            max_multi_get_objects: 50,
+            default_page_size: 50,
+            max_page_size: 100,
+        }
+    }
+}
+
+impl Default for TransactionsConfig {
+    fn default() -> Self {
+        Self {
+            default_page_size: 50,
+            max_page_size: 100,
+        }
+    }
+}
+
+impl Default for CoinsConfig {
+    fn default() -> Self {
+        Self {
+            default_page_size: 50,
+            max_page_size: 100,
         }
     }
 }

--- a/crates/sui-indexer-alt-jsonrpc/src/data/bigtable_reader.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/bigtable_reader.rs
@@ -1,9 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::data::error::Error;
 use async_graphql::dataloader::DataLoader;
 use sui_kvstore::BigTableClient;
+
+use crate::data::error::Error;
 
 /// A reader backed by Bigtable kv store.
 /// In order to use this reader, the environment variable `GOOGLE_APPLICATION_CREDENTIALS`

--- a/crates/sui-indexer-alt-jsonrpc/src/data/checkpoints.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/checkpoints.rs
@@ -15,8 +15,7 @@ use sui_types::{
     messages_checkpoint::{CheckpointContents, CheckpointSequenceNumber, CheckpointSummary},
 };
 
-use super::error::Error;
-use super::{bigtable_reader::BigtableReader, pg_reader::PgReader};
+use super::{bigtable_reader::BigtableReader, error::Error, pg_reader::PgReader};
 
 /// Key for fetching a checkpoint's content by its sequence number.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/sui-indexer-alt-jsonrpc/src/data/kv_loader.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/kv_loader.rs
@@ -1,11 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::error::Error;
-use super::objects::VersionedObjectKey;
-use super::pg_reader::PgReader;
-use super::transactions::TransactionKey;
-use super::{bigtable_reader::BigtableReader, checkpoints::CheckpointKey};
 use async_graphql::dataloader::DataLoader;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -21,6 +16,11 @@ use sui_types::{
     event::Event,
     messages_checkpoint::{CheckpointContents, CheckpointSummary},
     object::Object,
+};
+
+use super::{
+    bigtable_reader::BigtableReader, checkpoints::CheckpointKey, error::Error,
+    objects::VersionedObjectKey, pg_reader::PgReader, transactions::TransactionKey,
 };
 
 /// A loader for point lookups in kv stores backed by either Bigtable or Postgres.

--- a/crates/sui-indexer-alt-jsonrpc/src/data/object_info.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/object_info.rs
@@ -11,8 +11,9 @@ use diesel::{ExpressionMethods, QueryDsl};
 use sui_indexer_alt_schema::{objects::StoredObjInfo, schema::obj_info};
 use sui_types::base_types::ObjectID;
 
-use super::pg_reader::PgReader;
 use crate::data::error::Error;
+
+use super::pg_reader::PgReader;
 
 /// Key for fetching the latest object info record for an object. This record corresponds to the
 /// last time the object's ownership information changed.

--- a/crates/sui-indexer-alt-jsonrpc/src/data/object_versions.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/object_versions.rs
@@ -11,8 +11,9 @@ use diesel::{ExpressionMethods, QueryDsl};
 use sui_indexer_alt_schema::{objects::StoredObjVersion, schema::obj_versions};
 use sui_types::base_types::ObjectID;
 
-use super::pg_reader::PgReader;
 use crate::data::error::Error;
+
+use super::pg_reader::PgReader;
 
 /// Key for fetching the latest version of an object, not accounting for deletions or wraps. If the
 /// object has been deleted or wrapped, the version before the delete/wrap is returned.

--- a/crates/sui-indexer-alt-jsonrpc/src/data/objects.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/objects.rs
@@ -8,14 +8,15 @@ use async_graphql::dataloader::Loader;
 use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl};
 use serde::de::DeserializeOwned;
 use sui_indexer_alt_schema::{objects::StoredObject, schema::kv_objects};
+use sui_kvstore::KeyValueStoreReader;
+use sui_types::{base_types::ObjectID, object::Object, storage::ObjectKey};
+
+use crate::context::Context;
 
 use super::{
     bigtable_reader::BigtableReader, error::Error, object_info::LatestObjectInfoKey,
     object_versions::LatestObjectVersionKey, pg_reader::PgReader,
 };
-use crate::Context;
-use sui_kvstore::KeyValueStoreReader;
-use sui_types::{base_types::ObjectID, object::Object, storage::ObjectKey};
 
 /// Key for fetching the contents a particular version of an object.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/sui-indexer-alt-jsonrpc/src/data/pg_reader.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/pg_reader.rs
@@ -16,8 +16,8 @@ use sui_indexer_alt_metrics::db::DbConnectionStatsCollector;
 use sui_pg_db as db;
 use tracing::debug;
 
-use crate::data::error::Error;
-use crate::metrics::RpcMetrics;
+use crate::{data::error::Error, metrics::RpcMetrics};
+
 /// This wrapper type exists to perform error conversion between the data fetching layer and the
 /// RPC layer, metrics collection, and debug logging of database queries.
 #[derive(Clone)]

--- a/crates/sui-indexer-alt-jsonrpc/src/data/transactions.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/transactions.rs
@@ -12,8 +12,9 @@ use sui_indexer_alt_schema::{schema::kv_transactions, transactions::StoredTransa
 use sui_kvstore::{KeyValueStoreReader, TransactionData as KVTransactionData};
 use sui_types::digests::TransactionDigest;
 
-use super::{bigtable_reader::BigtableReader, pg_reader::PgReader};
 use crate::data::error::Error;
+
+use super::{bigtable_reader::BigtableReader, pg_reader::PgReader};
 
 /// Key for fetching transaction contents (TransactionData, Effects, and Events) by digest.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/sui-indexer-alt-jsonrpc/src/data/tx_balance_changes.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/tx_balance_changes.rs
@@ -14,8 +14,9 @@ use sui_indexer_alt_schema::{
 };
 use sui_types::digests::TransactionDigest;
 
-use super::pg_reader::PgReader;
 use crate::data::error::Error;
+
+use super::pg_reader::PgReader;
 
 /// Key for fetching a transaction's balance changes by digest.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/sui-indexer-alt-jsonrpc/src/data/tx_digests.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/tx_digests.rs
@@ -10,8 +10,7 @@ use async_graphql::dataloader::Loader;
 use diesel::{ExpressionMethods, QueryDsl};
 use sui_indexer_alt_schema::{schema::tx_digests, transactions::StoredTxDigest};
 
-use super::error::Error;
-use super::pg_reader::PgReader;
+use super::{error::Error, pg_reader::PgReader};
 
 /// Key for fetching a transaction's digest by its sequence number.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -219,7 +219,7 @@ pub async fn start_rpc(
         transactions,
         name_service,
         coins,
-        bigtable_config,
+        bigtable,
         package_resolver,
         extra: _,
     } = rpc_config.finish();
@@ -235,7 +235,7 @@ pub async fn start_rpc(
 
     let context = Context::new(
         db_args,
-        bigtable_config,
+        bigtable,
         package_resolver_limits,
         rpc.metrics(),
         registry,

--- a/crates/sui-indexer-alt-jsonrpc/src/main.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/main.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 use prometheus::Registry;
 use sui_indexer_alt_jsonrpc::{
     args::{Args, Command},
-    config::RpcConfig,
+    config::RpcLayer,
     start_rpc,
 };
 use sui_indexer_alt_metrics::MetricsService;
@@ -36,8 +36,9 @@ async fn main() -> anyhow::Result<()> {
 
                 toml::from_str(&contents).context("Failed to parse configuration TOML file")?
             } else {
-                RpcConfig::default()
-            };
+                RpcLayer::default()
+            }
+            .finish();
 
             let cancel = CancellationToken::new();
 
@@ -64,7 +65,7 @@ async fn main() -> anyhow::Result<()> {
         }
 
         Command::GenerateConfig => {
-            let config = RpcConfig::example();
+            let config = RpcLayer::example();
             let config_toml = toml::to_string_pretty(&config)
                 .context("Failed to serialize default configuration to TOML.")?;
 

--- a/crates/sui-package-resolver/src/lib.rs
+++ b/crates/sui-package-resolver/src/lib.rs
@@ -55,7 +55,7 @@ pub struct Resolver<S> {
 
 /// Optional configuration that imposes limits on the work that the resolver can do for each
 /// request.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Limits {
     /// Maximum recursion depth through type parameters.
     pub max_type_argument_depth: usize,


### PR DESCRIPTION
## Description 

A couple of refactorings, mostly to do with configs:

- The main change is that instead of breaking apart the config and giving it to each module that needed it, it is now stored in the `Context` where all modules can access it. The motivation for this came from working on `showDisplay` which is relevant to a multiple modules but is quite deeply nested, so threading the config into the right place became quite tedious/noisy.
- As part of this change, I split apart the old `RpcConfig` into an `RpcLayer` and `RpcConfig` -- this was so that the `Context` could hold on to one value (of `RpcConfig`) rather than having to pass each module's config to it individually (and access them individually through their own modifiers).
- This PR also cleans up various imports across the `rpc-alt` codebase, to follow a standard order and style (not a big deal, but seeing as I noticed, I thought I would clean it up): imports are grouped by their top-level identifier, and we order imports as follows (with a blank line between each group): `std::`, dependency imports, `crate::`, `super::`, `self::`.

## Test plan 
CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
