### PR TITLE
feat(analytics-indexer): Filter nested object types in handler

### DIFF
--- a/crates/sui-analytics-indexer/src/package_store.rs
+++ b/crates/sui-analytics-indexer/src/package_store.rs
@@ -3,6 +3,7 @@
 
 use async_trait::async_trait;
 use move_core_types::account_address::AccountAddress;
+#[cfg(not(test))]
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
@@ -11,8 +12,11 @@ use sui_package_resolver::{
 };
 use sui_rpc_api::Client;
 use sui_types::base_types::ObjectID;
-use sui_types::object::{Data, Object};
+#[cfg(not(test))]
+use sui_types::object::Data;
+use sui_types::object::Object;
 use thiserror::Error;
+#[cfg(not(test))]
 use tokio::sync::RwLock;
 use typed_store::rocks::{DBMap, MetricConf};
 use typed_store::traits::TableSummary;
@@ -71,6 +75,7 @@ impl PackageStoreTables {
 pub struct LocalDBPackageStore {
     package_store_tables: Arc<PackageStoreTables>,
     fallback_client: Client,
+    #[cfg(not(test))]
     original_id_cache: Arc<RwLock<HashMap<AccountAddress, ObjectID>>>,
 }
 
@@ -79,6 +84,7 @@ impl LocalDBPackageStore {
         Self {
             package_store_tables: PackageStoreTables::new(path),
             fallback_client: Client::new(rest_url).unwrap(),
+            #[cfg(not(test))]
             original_id_cache: Arc::new(RwLock::new(HashMap::new())),
         }
     }
@@ -112,6 +118,7 @@ impl LocalDBPackageStore {
     }
 
     /// Gets the original package id for the given package id.
+    #[cfg(not(test))]
     pub async fn get_original_package_id(&self, id: AccountAddress) -> Result<ObjectID> {
         if let Some(&original_id) = self.original_id_cache.read().await.get(&id) {
             return Ok(original_id);
@@ -127,6 +134,11 @@ impl LocalDBPackageStore {
         self.original_id_cache.write().await.insert(id, original_id);
 
         Ok(original_id)
+    }
+
+    #[cfg(test)]
+    pub async fn get_original_package_id(&self, id: AccountAddress) -> Result<ObjectID> {
+        Ok(id.into())
     }
 }
 


### PR DESCRIPTION
## Description 

Enhanced the package filtering logic in `ObjectHandler` to check the entire type hierarchy of objects, including nested type parameters. Previously, the filter only checked the top-level package address, which meant objects with matching package addresses in their type parameters were not being captured. This impacted our ability to read dynamic fields in walrus objects for instance.  For example - `0x2::dynamic_field::Field<u64, 0x795ddbc26b8cfff2551f45e198b87fc19473f2df50f995376b924ac80e56f88b::staking_inner::StakingInnerV1>` is not getting filtered through but contains important info that data science needs.

## Test plan 

Added some unit tests
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
