### PR TITLE
[Consensus] rework commit & block timestamps

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -58,6 +58,7 @@ impl ConsensusAuthority {
         protocol_config: ProtocolConfig,
         protocol_keypair: ProtocolKeyPair,
         network_keypair: NetworkKeyPair,
+        clock: Arc<Clock>,
         transaction_verifier: Arc<dyn TransactionVerifier>,
         commit_consumer: CommitConsumer,
         registry: Registry,
@@ -66,7 +67,6 @@ impl ConsensusAuthority {
         // make decisions on whether amnesia recovery should run or not. When `boot_counter` is 0, then `ConsensusAuthority`
         // will initiate the process of amnesia recovery if that's enabled in the parameters.
         boot_counter: u64,
-        clock: Arc<Clock>,
     ) -> Self {
         match network_type {
             ConsensusNetwork::Anemo => {
@@ -77,11 +77,11 @@ impl ConsensusAuthority {
                     protocol_config,
                     protocol_keypair,
                     network_keypair,
+                    clock,
                     transaction_verifier,
                     commit_consumer,
                     registry,
                     boot_counter,
-                    clock,
                 )
                 .await;
                 Self::WithAnemo(authority)
@@ -94,11 +94,11 @@ impl ConsensusAuthority {
                     protocol_config,
                     protocol_keypair,
                     network_keypair,
+                    clock,
                     transaction_verifier,
                     commit_consumer,
                     registry,
                     boot_counter,
-                    clock,
                 )
                 .await;
                 Self::WithTonic(authority)
@@ -180,11 +180,11 @@ where
         // kept in Core.
         protocol_keypair: ProtocolKeyPair,
         network_keypair: NetworkKeyPair,
+        clock: Arc<Clock>,
         transaction_verifier: Arc<dyn TransactionVerifier>,
         commit_consumer: CommitConsumer,
         registry: Registry,
         boot_counter: u64,
-        clock: Arc<Clock>,
     ) -> Self {
         assert!(
             committee.is_valid_index(own_index),
@@ -504,11 +504,11 @@ mod tests {
             ProtocolConfig::get_for_max_version_UNSAFE(),
             protocol_keypair,
             network_keypair,
+            Arc::new(Clock::default()),
             Arc::new(txn_verifier),
             commit_consumer,
             registry,
             0,
-            Arc::new(Clock::default()),
         )
         .await;
 
@@ -900,11 +900,11 @@ mod tests {
             protocol_config,
             protocol_keypair,
             network_keypair,
+            Arc::new(Clock::default()),
             Arc::new(txn_verifier),
             commit_consumer,
             registry,
             boot_counter,
-            Arc::new(Clock::default()),
         )
         .await;
 

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -531,7 +531,7 @@ mod tests {
 
         if gc_depth == 0 {
             protocol_config.set_consensus_linearize_subdag_v2_for_testing(false);
-            protocol_config.set_consensus_median_based_timestamp(false);
+            protocol_config.set_consensus_median_based_commit_timestamp_for_testing(false);
         }
 
         let temp_dirs = (0..NUM_OF_AUTHORITIES)
@@ -746,7 +746,7 @@ mod tests {
 
         if gc_depth == 0 {
             protocol_config.set_consensus_linearize_subdag_v2_for_testing(false);
-            protocol_config.set_consensus_median_based_timestamp(false);
+            protocol_config.set_consensus_median_based_commit_timestamp_for_testing(false);
         }
 
         for (index, _authority_info) in committee.authorities() {

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -66,6 +66,7 @@ impl ConsensusAuthority {
         // make decisions on whether amnesia recovery should run or not. When `boot_counter` is 0, then `ConsensusAuthority`
         // will initiate the process of amnesia recovery if that's enabled in the parameters.
         boot_counter: u64,
+        clock: Arc<Clock>,
     ) -> Self {
         match network_type {
             ConsensusNetwork::Anemo => {
@@ -80,6 +81,7 @@ impl ConsensusAuthority {
                     commit_consumer,
                     registry,
                     boot_counter,
+                    clock,
                 )
                 .await;
                 Self::WithAnemo(authority)
@@ -96,6 +98,7 @@ impl ConsensusAuthority {
                     commit_consumer,
                     registry,
                     boot_counter,
+                    clock,
                 )
                 .await;
                 Self::WithTonic(authority)
@@ -181,6 +184,7 @@ where
         commit_consumer: CommitConsumer,
         registry: Registry,
         boot_counter: u64,
+        clock: Arc<Clock>,
     ) -> Self {
         assert!(
             committee.is_valid_index(own_index),
@@ -207,7 +211,7 @@ where
             parameters,
             protocol_config,
             initialise_metrics(registry),
-            Arc::new(Clock::new()),
+            clock,
         ));
         let start_time = Instant::now();
 
@@ -504,6 +508,7 @@ mod tests {
             commit_consumer,
             registry,
             0,
+            Arc::new(Clock::default()),
         )
         .await;
 
@@ -899,6 +904,7 @@ mod tests {
             commit_consumer,
             registry,
             boot_counter,
+            Arc::new(Clock::default()),
         )
         .await;
 

--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -531,6 +531,7 @@ mod tests {
 
         if gc_depth == 0 {
             protocol_config.set_consensus_linearize_subdag_v2_for_testing(false);
+            protocol_config.set_consensus_median_based_timestamp(false);
         }
 
         let temp_dirs = (0..NUM_OF_AUTHORITIES)
@@ -745,6 +746,7 @@ mod tests {
 
         if gc_depth == 0 {
             protocol_config.set_consensus_linearize_subdag_v2_for_testing(false);
+            protocol_config.set_consensus_median_based_timestamp(false);
         }
 
         for (index, _authority_info) in committee.authorities() {

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -884,8 +884,8 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
     #[rstest]
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_handle_send_block(#[values(false, true)] median_based_timestamp: bool) {
         let (mut context, _keys) = Context::new_for_test(4);
         context

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -162,7 +162,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 self.context
                     .metrics
                     .node_metrics
-                    .block_timestamp_drift_wait_ms
+                    .block_timestamp_drift_ms
                     .with_label_values(&[peer_hostname, "handle_send_block"])
                     .inc_by(forward_time_drift.as_millis() as u64);
                 debug!(
@@ -178,7 +178,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             self.context
                 .metrics
                 .node_metrics
-                .block_timestamp_drift_wait_ms
+                .block_timestamp_drift_ms
                 .with_label_values(&[peer_hostname, "handle_send_block"])
                 .inc_by(forward_time_drift.as_millis() as u64);
         }

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -124,49 +124,63 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
         let block_ref = verified_block.reference();
         debug!("Received block {} via send block.", block_ref);
 
-        // Reject block with timestamp too far in the future.
         let now = self.context.clock.timestamp_utc_ms();
         let forward_time_drift =
             Duration::from_millis(verified_block.timestamp_ms().saturating_sub(now));
-        if forward_time_drift > self.context.parameters.max_forward_time_drift {
-            self.context
-                .metrics
-                .node_metrics
-                .rejected_future_blocks
-                .with_label_values(&[peer_hostname])
-                .inc();
-            debug!(
-                "Block {:?} timestamp ({} > {}) is too far in the future, rejected.",
-                block_ref,
-                verified_block.timestamp_ms(),
-                now,
-            );
-            return Err(ConsensusError::BlockRejected {
-                block_ref,
-                reason: format!(
-                    "Block timestamp is too far in the future: {} > {}",
-                    verified_block.timestamp_ms(),
-                    now
-                ),
-            });
-        }
 
-        // Wait until the block's timestamp is current.
-        if forward_time_drift > Duration::ZERO {
+        if !self
+            .context
+            .protocol_config
+            .consensus_median_based_commit_timestamp()
+        {
+            // Reject block with timestamp too far in the future.
+            if forward_time_drift > self.context.parameters.max_forward_time_drift {
+                self.context
+                    .metrics
+                    .node_metrics
+                    .rejected_future_blocks
+                    .with_label_values(&[peer_hostname])
+                    .inc();
+                debug!(
+                    "Block {:?} timestamp ({} > {}) is too far in the future, rejected.",
+                    block_ref,
+                    verified_block.timestamp_ms(),
+                    now,
+                );
+                return Err(ConsensusError::BlockRejected {
+                    block_ref,
+                    reason: format!(
+                        "Block timestamp is too far in the future: {} > {}",
+                        verified_block.timestamp_ms(),
+                        now
+                    ),
+                });
+            }
+
+            // Wait until the block's timestamp is current.
+            if forward_time_drift > Duration::ZERO {
+                self.context
+                    .metrics
+                    .node_metrics
+                    .block_timestamp_drift_wait_ms
+                    .with_label_values(&[peer_hostname, "handle_send_block"])
+                    .inc_by(forward_time_drift.as_millis() as u64);
+                debug!(
+                    "Block {:?} timestamp ({} > {}) is in the future, waiting for {}ms",
+                    block_ref,
+                    verified_block.timestamp_ms(),
+                    now,
+                    forward_time_drift.as_millis(),
+                );
+                sleep(forward_time_drift).await;
+            }
+        } else {
             self.context
                 .metrics
                 .node_metrics
                 .block_timestamp_drift_wait_ms
                 .with_label_values(&[peer_hostname, "handle_send_block"])
                 .inc_by(forward_time_drift.as_millis() as u64);
-            debug!(
-                "Block {:?} timestamp ({} > {}) is in the future, waiting for {}ms",
-                block_ref,
-                verified_block.timestamp_ms(),
-                now,
-                forward_time_drift.as_millis(),
-            );
-            sleep(forward_time_drift).await;
         }
 
         // Observe the block for the commit votes. When local commit is lagging too much,
@@ -730,6 +744,7 @@ mod tests {
     use consensus_config::AuthorityIndex;
     use mysten_metrics::monitored_mpsc;
     use parking_lot::{Mutex, RwLock};
+    use rstest::rstest;
     use std::collections::BTreeSet;
     use std::sync::Arc;
     use std::time::Duration;
@@ -870,8 +885,12 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn test_handle_send_block() {
-        let (context, _keys) = Context::new_for_test(4);
+    #[rstest]
+    async fn test_handle_send_block(#[values(false, true)] median_based_timestamp: bool) {
+        let (mut context, _keys) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_median_based_commit_timestamp_for_testing(median_based_timestamp);
         let context = Arc::new(context);
         let block_verifier = Arc::new(crate::block_verifier::NoopBlockVerifier {});
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
@@ -929,9 +948,12 @@ mod tests {
         });
 
         sleep(max_drift / 2).await;
-        assert!(core_dispatcher.get_blocks().is_empty());
 
-        sleep(max_drift).await;
+        if !median_based_timestamp {
+            assert!(core_dispatcher.get_blocks().is_empty());
+            sleep(max_drift).await;
+        }
+
         let blocks = core_dispatcher.get_blocks();
         assert_eq!(blocks.len(), 1);
         assert_eq!(blocks[0], input_block);

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -1269,7 +1269,10 @@ mod tests {
 
     #[tokio::test]
     async fn reject_blocks_failing_verifications() {
-        let (context, _key_pairs) = Context::new_for_test(4);
+        let (mut context, _key_pairs) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_median_based_timestamp(false);
         let context = Arc::new(context);
 
         // create a DAG of rounds 1 ~ 5.

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -362,11 +362,6 @@ impl BlockManager {
                     }
                 }
 
-                debug!(
-                    "Checking for ancestors {:?} for block: {:?} and gc_round {:?}",
-                    ancestor_blocks, b, gc_round
-                );
-
                 if let Err(e) =
                     self.block_verifier
                         .check_ancestors(&b, &ancestor_blocks, gc_enabled, gc_round)

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -287,7 +287,7 @@ impl BlockManager {
         let blocks_to_accept = if self
             .context
             .protocol_config
-            .consensus_median_based_timestamp()
+            .consensus_median_based_commit_timestamp()
         {
             unsuspended_blocks.into_iter().collect::<Vec<_>>()
         } else {
@@ -1272,7 +1272,7 @@ mod tests {
         let (mut context, _key_pairs) = Context::new_for_test(4);
         context
             .protocol_config
-            .set_consensus_median_based_timestamp(false);
+            .set_consensus_median_based_commit_timestamp_for_testing(false);
         let context = Arc::new(context);
 
         // create a DAG of rounds 1 ~ 5.
@@ -1425,7 +1425,7 @@ mod tests {
         let (mut context, _key_pairs) = Context::new_for_test(4);
         context
             .protocol_config
-            .set_consensus_median_based_timestamp(median_based_timestamp);
+            .set_consensus_median_based_commit_timestamp_for_testing(median_based_timestamp);
 
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -1433,7 +1433,7 @@ mod tests {
 
         let mut block_manager = BlockManager::new(
             context.clone(),
-            dag_state,
+            dag_state.clone(),
             Arc::new(SignedBlockVerifier::new(
                 context.clone(),
                 Arc::new(NoopTransactionVerifier {}),

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -229,7 +229,7 @@ mod tests {
         let (mut context, _keys) = Context::new_for_test(num_authorities);
         context
             .protocol_config
-            .set_consensus_median_based_timestamp(consensus_median_timestamp);
+            .set_consensus_median_based_commit_timestamp_for_testing(consensus_median_timestamp);
 
         let context = Arc::new(context);
 

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -217,8 +217,9 @@ mod tests {
 
     use super::*;
     use crate::{
-        block::BlockRef, context::Context, dag_state::DagState, linearizer::median,
-        storage::mem_store::MemStore, test_dag_builder::DagBuilder,
+        block::BlockRef, context::Context, dag_state::DagState,
+        linearizer::median_timestamp_by_stake, storage::mem_store::MemStore,
+        test_dag_builder::DagBuilder,
     };
 
     #[rstest]
@@ -284,18 +285,12 @@ mod tests {
                     .filter(|block_ref| block_ref.round == leaders[idx].round() - 1)
                     .cloned()
                     .collect::<Vec<_>>();
-                let ancestor_timestamps = dag_state
+                let blocks = dag_state
                     .read()
                     .get_blocks(&block_refs)
                     .into_iter()
-                    .map(|block_opt| {
-                        block_opt
-                            .expect("We should have all blocks in dag state.")
-                            .timestamp_ms()
-                    })
-                    .collect::<Vec<_>>();
-
-                median(ancestor_timestamps)
+                    .map(|block_opt| block_opt.expect("We should have all blocks in dag state."));
+                median_timestamp_by_stake(&context, blocks).unwrap()
             } else {
                 leaders[idx].timestamp_ms()
             };

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -286,7 +286,7 @@ mod tests {
                     .collect::<Vec<_>>();
 
                 if ancestor_timestamps.is_empty() {
-                    leaders[idx].timestamp_ms()
+                    0
                 } else {
                     median(ancestor_timestamps).unwrap()
                 }

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -632,27 +632,28 @@ impl<C: NetworkClient> CommitSyncer<C> {
             }
         }
 
-        // We want to run the following checks only if the median based commit timestamp is not enabled.
-        if !inner
-            .context
-            .protocol_config
-            .consensus_median_based_commit_timestamp()
-        {
-            // 8. Make sure fetched block (and votes) timestamps are lower than current time.
-            for block in fetched_blocks.values().chain(vote_blocks.iter()) {
-                let now_ms = inner.context.clock.timestamp_utc_ms();
-                let forward_drift = block.timestamp_ms().saturating_sub(now_ms);
-                if forward_drift == 0 {
-                    continue;
-                };
-                let peer_hostname = &inner.context.committee.authority(target_authority).hostname;
-                inner
-                    .context
-                    .metrics
-                    .node_metrics
-                    .block_timestamp_drift_wait_ms
-                    .with_label_values(&[peer_hostname, "commit_syncer"])
-                    .inc_by(forward_drift);
+        // 8. Make sure fetched block (and votes) timestamps are lower than current time.
+        for block in fetched_blocks.values().chain(vote_blocks.iter()) {
+            let now_ms = inner.context.clock.timestamp_utc_ms();
+            let forward_drift = block.timestamp_ms().saturating_sub(now_ms);
+            if forward_drift == 0 {
+                continue;
+            };
+            let peer_hostname = &inner.context.committee.authority(target_authority).hostname;
+            inner
+                .context
+                .metrics
+                .node_metrics
+                .block_timestamp_drift_wait_ms
+                .with_label_values(&[peer_hostname, "commit_syncer"])
+                .inc_by(forward_drift);
+
+            // We want to run the following checks only if the median based commit timestamp is not enabled.
+            if !inner
+                .context
+                .protocol_config
+                .consensus_median_based_commit_timestamp()
+            {
                 let forward_drift = Duration::from_millis(forward_drift);
                 if forward_drift >= inner.context.parameters.max_forward_time_drift {
                     warn!(
@@ -693,32 +694,6 @@ impl<C: NetworkClient> CommitSyncer<C> {
                     inner
                         .transaction_certifier
                         .add_voted_blocks(vec![(block.clone(), vec![])]);
-                }
-            }
-        }
-
-        // 10. Make sure the last commit's timestamp is not too far in the future compared to now, when the median based timestamp is enabled.
-        // Since the commit's timestamp is calculated based on the median of the leader's blocks timestamps, we do have a guaratnee that for the last
-        // synced quorum we do have at least 50% of that whose timestamps are lower than the current local time.
-        if inner
-            .context
-            .protocol_config
-            .consensus_median_based_commit_timestamp()
-        {
-            if let Some(commit) = commits.last() {
-                let now_ms = inner.context.clock.timestamp_utc_ms();
-                let commit_ms = commit.timestamp_ms();
-                let forward_drift = commit_ms.saturating_sub(now_ms);
-                let forward_drift = Duration::from_millis(forward_drift);
-
-                if forward_drift >= inner.context.parameters.max_forward_time_drift {
-                    warn!(
-                        "Local clock is behind compared to last sync commit: local ts {}, commit ts {} for commit {}",
-                        now_ms,
-                        commit_ms,
-                        commit.index()
-                    );
-                    sleep(forward_drift).await;
                 }
             }
         }

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -644,7 +644,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
                 .context
                 .metrics
                 .node_metrics
-                .block_timestamp_drift_wait_ms
+                .block_timestamp_drift_ms
                 .with_label_values(&[peer_hostname, "commit_syncer"])
                 .inc_by(forward_drift);
 

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -632,30 +632,37 @@ impl<C: NetworkClient> CommitSyncer<C> {
             }
         }
 
-        // 8. Make sure fetched block (and votes) timestamps are lower than current time.
-        for block in fetched_blocks.values().chain(vote_blocks.iter()) {
-            let now_ms = inner.context.clock.timestamp_utc_ms();
-            let forward_drift = block.timestamp_ms().saturating_sub(now_ms);
-            if forward_drift == 0 {
-                continue;
-            };
-            let peer_hostname = &inner.context.committee.authority(target_authority).hostname;
-            inner
-                .context
-                .metrics
-                .node_metrics
-                .block_timestamp_drift_wait_ms
-                .with_label_values(&[peer_hostname, "commit_syncer"])
-                .inc_by(forward_drift);
-            let forward_drift = Duration::from_millis(forward_drift);
-            if forward_drift >= inner.context.parameters.max_forward_time_drift {
-                warn!(
-                    "Local clock is behind a quorum of peers: local ts {}, committed block ts {}",
-                    now_ms,
-                    block.timestamp_ms()
-                );
+        // We want to run the following checks only if the median based commit timestamp is not enabled.
+        if !inner
+            .context
+            .protocol_config
+            .consensus_median_based_timestamp()
+        {
+            // 8. Make sure fetched block (and votes) timestamps are lower than current time.
+            for block in fetched_blocks.values().chain(vote_blocks.iter()) {
+                let now_ms = inner.context.clock.timestamp_utc_ms();
+                let forward_drift = block.timestamp_ms().saturating_sub(now_ms);
+                if forward_drift == 0 {
+                    continue;
+                };
+                let peer_hostname = &inner.context.committee.authority(target_authority).hostname;
+                inner
+                    .context
+                    .metrics
+                    .node_metrics
+                    .block_timestamp_drift_wait_ms
+                    .with_label_values(&[peer_hostname, "commit_syncer"])
+                    .inc_by(forward_drift);
+                let forward_drift = Duration::from_millis(forward_drift);
+                if forward_drift >= inner.context.parameters.max_forward_time_drift {
+                    warn!(
+                        "Local clock is behind a quorum of peers: local ts {}, committed block ts {}",
+                        now_ms,
+                        block.timestamp_ms()
+                    );
+                }
+                sleep(forward_drift).await;
             }
-            sleep(forward_drift).await;
         }
 
         // 9. Now create certified commits by assigning the blocks to each commit.
@@ -686,6 +693,30 @@ impl<C: NetworkClient> CommitSyncer<C> {
                     inner
                         .transaction_certifier
                         .add_voted_blocks(vec![(block.clone(), vec![])]);
+                }
+            }
+        }
+
+        // 10. Make sure the last timestamp commit is not too far in the future compared to now, when the median based timestamp is enabled.
+        if inner
+            .context
+            .protocol_config
+            .consensus_median_based_timestamp()
+        {
+            if let Some(commit) = commits.last() {
+                let now_ms = inner.context.clock.timestamp_utc_ms();
+                let commit_ms = commit.timestamp_ms();
+                let forward_drift = commit_ms.saturating_sub(now_ms);
+                let forward_drift = Duration::from_millis(forward_drift);
+
+                if forward_drift >= inner.context.parameters.max_forward_time_drift {
+                    warn!(
+                        "Local clock is behind compared to last sync commit: local ts {}, commit ts {} for commit {}",
+                        now_ms,
+                        commit_ms,
+                        commit.index()
+                    );
+                    sleep(forward_drift).await;
                 }
             }
         }

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -697,7 +697,9 @@ impl<C: NetworkClient> CommitSyncer<C> {
             }
         }
 
-        // 10. Make sure the last timestamp commit is not too far in the future compared to now, when the median based timestamp is enabled.
+        // 10. Make sure the last commit's timestamp is not too far in the future compared to now, when the median based timestamp is enabled.
+        // Since the commit's timestamp is calculated based on the median of the leader's blocks timestamps, we do have a guaratnee that for the last
+        // synced quorum we do have at least 50% of that whose timestamps are lower than the current local time.
         if inner
             .context
             .protocol_config

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -636,7 +636,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
         if !inner
             .context
             .protocol_config
-            .consensus_median_based_timestamp()
+            .consensus_median_based_commit_timestamp()
         {
             // 8. Make sure fetched block (and votes) timestamps are lower than current time.
             for block in fetched_blocks.values().chain(vote_blocks.iter()) {
@@ -703,7 +703,7 @@ impl<C: NetworkClient> CommitSyncer<C> {
         if inner
             .context
             .protocol_config
-            .consensus_median_based_timestamp()
+            .consensus_median_based_commit_timestamp()
         {
             if let Some(commit) = commits.last() {
                 let now_ms = inner.context.clock.timestamp_utc_ms();

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -54,7 +54,6 @@ impl Context {
 
     /// Create a test context with a committee of given size and even stake
     #[cfg(test)]
-    #[allow(unused)]
     pub(crate) fn new_for_test(
         committee_size: usize,
     ) -> (Self, Vec<(NetworkKeyPair, ProtocolKeyPair)>) {

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -101,13 +101,6 @@ impl Context {
         self.protocol_config = protocol_config;
         self
     }
-
-    #[cfg(test)]
-    #[allow(unused)]
-    pub(crate) fn with_clock(mut self, clock: Clock) -> Self {
-        self.clock = Arc::new(clock);
-        self
-    }
 }
 
 /// A clock that allows to derive the current UNIX system timestamp while guaranteeing that timestamp
@@ -133,7 +126,6 @@ impl Default for Clock {
 }
 
 impl Clock {
-    #[allow(unused)]
     pub fn new_for_test(clock_drift: BlockTimestampMs) -> Self {
         Self {
             initial_instant: Instant::now(),

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -137,6 +137,13 @@ impl Clock {
     // Calculated with Tokio Instant to ensure monotonicity,
     // and to allow testing with tokio clock.
     pub(crate) fn timestamp_utc_ms(&self) -> BlockTimestampMs {
+        if cfg!(not(any(msim, test))) {
+            assert_eq!(
+                self.clock_drift, 0,
+                "Clock drift should not be set in non testing environments."
+            );
+        }
+
         let now: Instant = Instant::now();
         let monotonic_system_time = self
             .initial_system_time

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -204,11 +204,18 @@ impl Core {
             .dag_state
             .read()
             .get_last_cached_block_per_authority(Round::MAX);
+
         let max_ancestor_timestamp = ancestor_blocks
             .iter()
             .fold(0, |ts, (b, _)| ts.max(b.timestamp_ms()));
         let wait_ms = max_ancestor_timestamp.saturating_sub(self.context.clock.timestamp_utc_ms());
-        if wait_ms > 0 {
+        if self
+            .context
+            .protocol_config
+            .consensus_median_based_timestamp()
+        {
+            info!("Median based timestamp is enabled. Will not wait for {} ms while recovering ancestors from storage", wait_ms);
+        } else if wait_ms > 0 {
             warn!(
                 "Waiting for {} ms while recovering ancestors from storage",
                 wait_ms
@@ -597,15 +604,19 @@ impl Core {
                 .observe(clock_round.saturating_sub(ancestor.round()).into());
         }
 
-        // Ensure ancestor timestamps are not more advanced than the current time.
-        // Also catch the issue if system's clock go backwards.
         let now = self.context.clock.timestamp_utc_ms();
         ancestors.iter().for_each(|block| {
-            assert!(
-                block.timestamp_ms() <= now,
-                "Violation: ancestor block {:?} has timestamp {}, greater than current timestamp {now}. Proposing for round {}.",
-                block, block.timestamp_ms(), clock_round
-            );
+            if self.context.protocol_config.consensus_median_based_timestamp() {
+                debug!("Ancestor block {:?} has timestamp {}, greater than current timestamp {now}. Proposing for round {}.", block, block.timestamp_ms(), clock_round);
+            } else {
+                // Ensure ancestor timestamps are not more advanced than the current time.
+                // Also catch the issue if system's clock go backwards.
+                assert!(
+                    block.timestamp_ms() <= now,
+                    "Violation: ancestor block {:?} has timestamp {}, greater than current timestamp {now}. Proposing for round {}.",
+                    block, block.timestamp_ms(), clock_round
+                );
+            }
         });
 
         // Consume the next transactions to be included. Do not drop the guards yet as this would acknowledge

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -212,7 +212,7 @@ impl Core {
         if self
             .context
             .protocol_config
-            .consensus_median_based_timestamp()
+            .consensus_median_based_commit_timestamp()
         {
             info!("Median based timestamp is enabled. Will not wait for {} ms while recovering ancestors from storage", wait_ms);
         } else if wait_ms > 0 {
@@ -606,7 +606,7 @@ impl Core {
 
         let now = self.context.clock.timestamp_utc_ms();
         ancestors.iter().for_each(|block| {
-            if self.context.protocol_config.consensus_median_based_timestamp() {
+            if self.context.protocol_config.consensus_median_based_commit_timestamp() {
                 if block.timestamp_ms() > now {
                     debug!("Ancestor block {:?} has timestamp {}, greater than current timestamp {now}. Proposing for round {}.", block, block.timestamp_ms(), clock_round);
                     let authority = &self.context.committee.authority(block.author()).hostname;

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -608,7 +608,7 @@ impl Core {
         ancestors.iter().for_each(|block| {
             if self.context.protocol_config.consensus_median_based_commit_timestamp() {
                 if block.timestamp_ms() > now {
-                    debug!("Ancestor block {:?} has timestamp {}, greater than current timestamp {now}. Proposing for round {}.", block, block.timestamp_ms(), clock_round);
+                    trace!("Ancestor block {:?} has timestamp {}, greater than current timestamp {now}. Proposing for round {}.", block, block.timestamp_ms(), clock_round);
                     let authority = &self.context.committee.authority(block.author()).hostname;
                     self.context
                         .metrics

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -611,11 +611,11 @@ impl Core {
                     debug!("Ancestor block {:?} has timestamp {}, greater than current timestamp {now}. Proposing for round {}.", block, block.timestamp_ms(), clock_round);
                     let authority = &self.context.committee.authority(block.author()).hostname;
                     self.context
-                    .metrics
-                    .node_metrics
-                    .proposed_block_ancestors_timestamp_drift_ms
-                    .with_label_values(&[authority])
-                    .inc_by(block.timestamp_ms().saturating_sub(now));
+                        .metrics
+                        .node_metrics
+                        .proposed_block_ancestors_timestamp_drift_ms
+                        .with_label_values(&[authority])
+                        .inc_by(block.timestamp_ms().saturating_sub(now));
                 }
             } else {
                 // Ensure ancestor timestamps are not more advanced than the current time.

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -790,7 +790,7 @@ impl DagState {
                 .saturating_sub(last_commit.timestamp_ms())
         } else {
             assert_eq!(commit.index(), 1);
-            commit.timestamp_ms()
+            0
         };
 
         self.context

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -771,7 +771,7 @@ impl DagState {
     // Buffers a new commit in memory and updates last committed rounds.
     // REQUIRED: must not skip over any commit index.
     pub(crate) fn add_commit(&mut self, commit: TrustedCommit) {
-        if let Some(last_commit) = &self.last_commit {
+        let time_diff = if let Some(last_commit) = &self.last_commit {
             if commit.index() <= last_commit.index() {
                 error!(
                     "New commit index {} <= last commit index {}!",
@@ -785,9 +785,19 @@ impl DagState {
             if commit.timestamp_ms() < last_commit.timestamp_ms() {
                 panic!("Commit timestamps do not monotonically increment, prev commit {:?}, new commit {:?}", last_commit, commit);
             }
+            commit
+                .timestamp_ms()
+                .saturating_sub(last_commit.timestamp_ms())
         } else {
             assert_eq!(commit.index(), 1);
-        }
+            commit.timestamp_ms()
+        };
+
+        self.context
+            .metrics
+            .node_metrics
+            .last_commit_time_diff
+            .observe(time_diff as f64);
 
         let commit_round_advanced = if let Some(previous_commit) = &self.last_commit {
             previous_commit.round() < commit.round()

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -13,7 +13,7 @@ use std::{
 use consensus_config::AuthorityIndex;
 use itertools::Itertools as _;
 use tokio::time::Instant;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, trace};
 
 use crate::{
     block::{
@@ -292,11 +292,31 @@ impl DagState {
 
         let now = self.context.clock.timestamp_utc_ms();
         if block.timestamp_ms() > now {
-            panic!(
-                "Block {:?} cannot be accepted! Block timestamp {} is greater than local timestamp {}.",
-                block, block.timestamp_ms(), now,
-            );
+            if self
+                .context
+                .protocol_config
+                .consensus_median_based_commit_timestamp()
+            {
+                trace!(
+                    "Block {:?} with timestamp {} is greater than local timestamp {}.",
+                    block,
+                    block.timestamp_ms(),
+                    now,
+                );
+            } else {
+                panic!(
+                    "Block {:?} cannot be accepted! Block timestamp {} is greater than local timestamp {}.",
+                    block, block.timestamp_ms(), now,
+                );
+            }
         }
+        let hostname = &self.context.committee.authority(block_ref.author).hostname;
+        self.context
+            .metrics
+            .node_metrics
+            .accepted_block_time_drift_ms
+            .with_label_values(&[hostname])
+            .inc_by(block.timestamp_ms().saturating_sub(now));
 
         // TODO: Move this check to core
         // Ensure we don't write multiple blocks per slot for our own index
@@ -2381,5 +2401,55 @@ mod test {
                 }
             }
         }
+    }
+
+    #[tokio::test]
+    #[should_panic]
+    async fn test_accept_block_panics_when_timestamp_is_ahead() {
+        // GIVEN
+        let (mut context, _) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_median_based_commit_timestamp_for_testing(false);
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let mut dag_state = DagState::new(context.clone(), store.clone());
+
+        // Set a timestamp for the block that is ahead of the current time
+        let block_timestamp = context.clock.timestamp_utc_ms() + 5_000;
+
+        let block = VerifiedBlock::new_for_test(
+            TestBlock::new(10, 0)
+                .set_timestamp_ms(block_timestamp)
+                .build(),
+        );
+
+        // Try to accept the block - it will panic as accepted block timestamp is ahead of the current time
+        dag_state.accept_block(block);
+    }
+
+    #[tokio::test]
+    async fn test_accept_block_not_panics_when_timestamp_is_ahead_and_median_timestamp() {
+        // GIVEN
+        let (mut context, _) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_median_based_commit_timestamp_for_testing(true);
+
+        let context = Arc::new(context);
+        let store = Arc::new(MemStore::new());
+        let mut dag_state = DagState::new(context.clone(), store.clone());
+
+        // Set a timestamp for the block that is ahead of the current time
+        let block_timestamp = context.clock.timestamp_utc_ms() + 5_000;
+
+        let block = VerifiedBlock::new_for_test(
+            TestBlock::new(10, 0)
+                .set_timestamp_ms(block_timestamp)
+                .build(),
+        );
+
+        // Try to accept the block - it should not panic
+        dag_state.accept_block(block);
     }
 }

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -61,9 +61,10 @@ pub use block::{
     BlockAPI, BlockRef, CertifiedBlock, CertifiedBlocksOutput, Round, TransactionIndex,
 };
 /// Exported API for testing.
-pub use block::{TestBlock, Transaction, VerifiedBlock};
+pub use block::{BlockTimestampMs, TestBlock, Transaction, VerifiedBlock};
 pub use commit::{CommitDigest, CommitIndex, CommitRef, CommittedSubDag};
 pub use commit_consumer::{CommitConsumer, CommitConsumerMonitor};
+pub use context::Clock;
 pub use network::{
     connection_monitor::{AnemoConnectionMonitor, ConnectionMonitorHandle, ConnectionStatus},
     metrics::{MetricsMakeCallbackHandler, NetworkRouteMetrics, QuinnConnectionMetrics},

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -111,8 +111,12 @@ impl Linearizer {
 
         drop(dag_state);
 
-        let timestamp_ms =
-            self.calculate_commit_timestamp(&leader_block, last_commit_timestamp_ms, &to_commit);
+        let timestamp_ms = Self::calculate_commit_timestamp(
+            &self.context,
+            &leader_block,
+            last_commit_timestamp_ms,
+            &to_commit,
+        );
 
         // Create the Commit.
         let commit = Commit::new(
@@ -146,17 +150,13 @@ impl Linearizer {
     /// Calculates the commit's timestamp. If the median based timestamp calculation is enabled, then the timestamp will be calculated as the median of
     /// leader's committed strong ancestors (leader.round - 1). Otherwise, the leader's timestamp will be used. To ensure that commit timestamp monotonicity is
     /// respected it is compared against the `last_commit_timestamp_ms` and the maximum of the two is returned.
-    fn calculate_commit_timestamp(
-        &mut self,
+    pub(crate) fn calculate_commit_timestamp(
+        context: &Context,
         leader_block: &VerifiedBlock,
         last_commit_timestamp_ms: BlockTimestampMs,
         to_commit: &[VerifiedBlock],
     ) -> BlockTimestampMs {
-        let timestamp_ms = if self
-            .context
-            .protocol_config
-            .consensus_median_based_timestamp()
-        {
+        let timestamp_ms = if context.protocol_config.consensus_median_based_timestamp() {
             let leader_ancestors = leader_block
                 .ancestors()
                 .iter()

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -156,11 +156,12 @@ impl Linearizer {
         let timestamp_ms =
             if context.protocol_config.consensus_median_based_timestamp() && to_commit.len() > 1 {
                 // We are calculating the median based timestamp only when the flag is enabled and there are more than one blocks to commit.
-                // The only case to have one block to commit that would be the case where we have only one authority in commitee and the leader is the only one
-                // which gets committed.
+                // The only case to have one block to commit would be when we have only one authority in commitee and the only block that gets committed
+                // is the leader's.
 
                 // Attention should be paid that we are calculating the timestamp only using the leader's committed strong ancestors which should be all the blocks
-                // or round leader.round - 1.
+                // or round leader.round - 1. Not necessary to search and recheck here the leader's ancestors as by the protocol rules it's impossible to commit any block
+                // of round leader.round - 1 unless it is a leader's strong ancestor.
                 let timestamps = to_commit
                     .iter()
                     .filter_map(|block| {

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -967,8 +967,8 @@ mod tests {
     #[rstest]
     #[case(false, 5_000, 5_000, 6_000)]
     #[case(true, 2_500, 3_000, 6_000)]
-    #[test]
-    fn test_calculate_commit_timestamp(
+    #[tokio::test]
+    async fn test_calculate_commit_timestamp(
         #[case] consensus_median_timestamp: bool,
         #[case] timestamp_1: u64,
         #[case] timestamp_2: u64,

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -1166,8 +1166,8 @@ mod tests {
         assert_eq!(median_timestamps_by_stake_inner(timestamps, 14), 5_000);
     }
 
-    #[test]
-    fn test_median_timestamps_by_stake_errors() {
+    #[tokio::test]
+    async fn test_median_timestamps_by_stake_errors() {
         let num_authorities = 4;
         let (mut context, _keys) = Context::new_for_test(num_authorities);
         context

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -153,7 +153,10 @@ impl Linearizer {
         last_commit_timestamp_ms: BlockTimestampMs,
         to_commit: &[VerifiedBlock],
     ) -> BlockTimestampMs {
-        let timestamp_ms = if context.protocol_config.consensus_median_based_timestamp() {
+        let timestamp_ms = if context
+            .protocol_config
+            .consensus_median_based_commit_timestamp()
+        {
             // Attention should be paid that we are calculating the timestamp only using the leader's committed strong ancestors which should be all the blocks
             // or round leader.round - 1. Not necessary to search and recheck here the leader's ancestors as by the protocol rules it's impossible to commit any block
             // of round leader.round - 1 unless it is a leader's strong ancestor.
@@ -421,7 +424,7 @@ mod tests {
         let (mut context, _keys) = Context::new_for_test(num_authorities);
         context
             .protocol_config
-            .set_consensus_median_based_timestamp(consensus_median_timestamp);
+            .set_consensus_median_based_commit_timestamp_for_testing(consensus_median_timestamp);
 
         let context = Arc::new(context);
 
@@ -562,7 +565,7 @@ mod tests {
         let (mut context, _) = Context::new_for_test(num_authorities);
         context
             .protocol_config
-            .set_consensus_median_based_timestamp(consensus_median_timestamp);
+            .set_consensus_median_based_commit_timestamp_for_testing(consensus_median_timestamp);
 
         let context = Arc::new(context);
 
@@ -704,7 +707,7 @@ mod tests {
             .set_consensus_gc_depth_for_testing(gc_depth);
         context
             .protocol_config
-            .set_consensus_median_based_timestamp(consensus_median_timestamp);
+            .set_consensus_median_based_commit_timestamp_for_testing(consensus_median_timestamp);
 
         if gc_depth == 0 {
             context
@@ -843,7 +846,7 @@ mod tests {
             .set_consensus_gc_depth_for_testing(gc_depth);
         context
             .protocol_config
-            .set_consensus_median_based_timestamp(consensus_median_timestamp);
+            .set_consensus_median_based_commit_timestamp_for_testing(consensus_median_timestamp);
         context
             .protocol_config
             .set_consensus_linearize_subdag_v2_for_testing(true);
@@ -968,7 +971,7 @@ mod tests {
 
         context
             .protocol_config
-            .set_consensus_median_based_timestamp(consensus_median_timestamp);
+            .set_consensus_median_based_commit_timestamp_for_testing(consensus_median_timestamp);
 
         let context = Arc::new(context);
 

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -120,6 +120,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) core_skipped_proposals: IntCounterVec,
     pub(crate) highest_accepted_authority_round: IntGaugeVec,
     pub(crate) highest_accepted_round: IntGauge,
+    pub(crate) accepted_block_time_drift_ms: IntCounterVec,
     pub(crate) accepted_blocks: IntCounterVec,
     pub(crate) dag_state_recent_blocks: IntGauge,
     pub(crate) dag_state_recent_refs: IntGauge,
@@ -338,6 +339,12 @@ impl NodeMetrics {
             highest_accepted_round: register_int_gauge_with_registry!(
                 "highest_accepted_round",
                 "The highest round where a block has been accepted. Resets on restart.",
+                registry,
+            ).unwrap(),
+            accepted_block_time_drift_ms: register_int_counter_vec_with_registry!(
+                "accepted_block_time_drift_ms",
+                "The time drift in ms of an accepted block compared to local time",
+                &["authority"],
                 registry,
             ).unwrap(),
             accepted_blocks: register_int_counter_vec_with_registry!(

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -103,6 +103,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) proposed_block_transactions: Histogram,
     pub(crate) proposed_block_ancestors: Histogram,
     pub(crate) proposed_block_ancestors_depth: HistogramVec,
+    pub(crate) proposed_block_ancestors_timestamp_drift_ms: IntCounterVec,
     pub(crate) highest_verified_authority_round: IntGaugeVec,
     pub(crate) lowest_verified_authority_round: IntGaugeVec,
     pub(crate) block_proposal_interval: Histogram,
@@ -231,6 +232,12 @@ impl NodeMetrics {
                 "proposed_block_ancestors",
                 "Number of ancestors in proposed blocks",
                 exponential_buckets(1.0, 1.4, 20).unwrap(),
+                registry,
+            ).unwrap(),
+            proposed_block_ancestors_timestamp_drift_ms: register_int_counter_vec_with_registry!(
+                "proposed_block_ancestors_timestamp_drift_ms",
+                "The drift in ms of ancestors' timestamps included in newly proposed blocks",
+                &["authority"],
                 registry,
             ).unwrap(),
             proposed_block_ancestors_depth: register_histogram_vec_with_registry!(

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -109,7 +109,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) block_proposal_interval: Histogram,
     pub(crate) block_proposal_leader_wait_ms: IntCounterVec,
     pub(crate) block_proposal_leader_wait_count: IntCounterVec,
-    pub(crate) block_timestamp_drift_wait_ms: IntCounterVec,
+    pub(crate) block_timestamp_drift_ms: IntCounterVec,
     pub(crate) blocks_per_commit_count: Histogram,
     pub(crate) blocks_pruned_on_commit: IntCounterVec,
     pub(crate) broadcaster_rtt_estimate_ms: IntGaugeVec,
@@ -279,9 +279,9 @@ impl NodeMetrics {
                 &["authority"],
                 registry,
             ).unwrap(),
-            block_timestamp_drift_wait_ms: register_int_counter_vec_with_registry!(
-                "block_timestamp_drift_wait_ms",
-                "Total time in ms spent waiting, when a received block has timestamp in future.",
+            block_timestamp_drift_ms: register_int_counter_vec_with_registry!(
+                "block_timestamp_drift_ms",
+                "The clock drift time between a received block and the current node's time.",
                 &["authority", "source"],
                 registry,
             ).unwrap(),

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -144,6 +144,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) last_committed_authority_round: IntGaugeVec,
     pub(crate) last_committed_leader_round: IntGauge,
     pub(crate) last_commit_index: IntGauge,
+    pub(crate) last_commit_time_diff: Histogram,
     pub(crate) last_known_own_block_round: IntGauge,
     pub(crate) sync_last_known_own_block_retries: IntCounter,
     pub(crate) commit_round_advancement_interval: Histogram,
@@ -488,6 +489,12 @@ impl NodeMetrics {
             last_commit_index: register_int_gauge_with_registry!(
                 "last_commit_index",
                 "Index of the last commit.",
+                registry,
+            ).unwrap(),
+            last_commit_time_diff: register_histogram_with_registry!(
+                "last_commit_time_diff",
+                "The time diff between the last commit and previous one.",
+                LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             ).unwrap(),
             commit_round_advancement_interval: register_histogram_with_registry!(

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -664,13 +664,17 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             // TODO: improve efficiency, maybe suspend and continue processing the block asynchronously.
             let now = context.clock.timestamp_utc_ms();
             if now < verified_block.timestamp_ms() {
-                warn!(
-                    "Synced block {} timestamp {} is in the future (now={}). Ignoring.",
-                    verified_block.reference(),
-                    verified_block.timestamp_ms(),
-                    now
-                );
-                continue;
+                if context.protocol_config.consensus_median_based_timestamp() {
+                    debug!("Synced block {} timestamp {} is in the future (now={}). Will not ignore as median based timestamp is enabled.", verified_block.reference(), verified_block.timestamp_ms(), now);
+                } else {
+                    warn!(
+                        "Synced block {} timestamp {} is in the future (now={}). Ignoring.",
+                        verified_block.reference(),
+                        verified_block.timestamp_ms(),
+                        now
+                    );
+                    continue;
+                }
             }
 
             verified_blocks.push(verified_block.clone());

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -672,7 +672,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 context
                     .metrics
                     .node_metrics
-                    .block_timestamp_drift_wait_ms
+                    .block_timestamp_drift_ms
                     .with_label_values(&[peer_hostname, "synchronizer"])
                     .inc_by(drift);
 

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -664,7 +664,10 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             // TODO: improve efficiency, maybe suspend and continue processing the block asynchronously.
             let now = context.clock.timestamp_utc_ms();
             if now < verified_block.timestamp_ms() {
-                if context.protocol_config.consensus_median_based_timestamp() {
+                if context
+                    .protocol_config
+                    .consensus_median_based_commit_timestamp()
+                {
                     debug!("Synced block {} timestamp {} is in the future (now={}). Will not ignore as median based timestamp is enabled.", verified_block.reference(), verified_block.timestamp_ms(), now);
                 } else {
                     warn!(

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -663,12 +663,24 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             // Dropping is ok because the block will be refetched.
             // TODO: improve efficiency, maybe suspend and continue processing the block asynchronously.
             let now = context.clock.timestamp_utc_ms();
-            if now < verified_block.timestamp_ms() {
+            let drift = verified_block.timestamp_ms().saturating_sub(now) as u64;
+            if drift > 0 {
+                let peer_hostname = &context
+                    .committee
+                    .authority(verified_block.author())
+                    .hostname;
+                context
+                    .metrics
+                    .node_metrics
+                    .block_timestamp_drift_wait_ms
+                    .with_label_values(&[peer_hostname, "synchronizer"])
+                    .inc_by(drift);
+
                 if context
                     .protocol_config
                     .consensus_median_based_commit_timestamp()
                 {
-                    debug!("Synced block {} timestamp {} is in the future (now={}). Will not ignore as median based timestamp is enabled.", verified_block.reference(), verified_block.timestamp_ms(), now);
+                    trace!("Synced block {} timestamp {} is in the future (now={}). Will not ignore as median based timestamp is enabled.", verified_block.reference(), verified_block.timestamp_ms(), now);
                 } else {
                     warn!(
                         "Synced block {} timestamp {} is in the future (now={}). Ignoring.",

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -228,9 +228,9 @@ impl DagBuilder {
 
             last_timestamp_ms = Linearizer::calculate_commit_timestamp(
                 &self.context.clone(),
+                &mut storage,
                 &leader_block,
                 last_timestamp_ms,
-                &to_commit,
             );
 
             // Update the last committed rounds

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -592,8 +592,9 @@ impl<'a> LayerBuilder<'a> {
     pub fn with_timestamps(mut self, timestamps: Vec<BlockTimestampMs>) -> Self {
         // authorities must be specified for this to apply
         assert!(self.specified_authorities.is_some());
-        assert!(
-            self.specified_authorities.as_ref().unwrap().len() == timestamps.len(),
+        assert_eq!(
+            self.specified_authorities.as_ref().unwrap().len(),
+            timestamps.len(),
             "Timestamps should be provided for each specified authority"
         );
         self.timestamps = timestamps;

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -218,13 +218,19 @@ impl DagBuilder {
                 .saturating_sub(self.context.protocol_config.gc_depth());
 
             let leader_block_ref = leader_block.reference();
-            last_timestamp_ms = leader_block.timestamp_ms().max(last_timestamp_ms);
 
             let (to_commit, rejected_transactions) = Linearizer::linearize_sub_dag(
                 &self.context.clone(),
-                leader_block,
+                leader_block.clone(),
                 self.last_committed_rounds.clone(),
                 &mut storage,
+            );
+
+            last_timestamp_ms = Linearizer::calculate_commit_timestamp(
+                &self.context.clone(),
+                &leader_block,
+                last_timestamp_ms,
+                &to_commit,
             );
 
             // Update the last committed rounds
@@ -457,6 +463,9 @@ pub struct LayerBuilder<'a> {
     // Ancestors to link to the current layer
     ancestors: Vec<BlockRef>,
 
+    // The block timestamps for the layer for each specified authority. This will work as base timestamp and the round will be added to make sure that timestamps do offset.
+    timestamps: Vec<BlockTimestampMs>,
+
     // Accumulated blocks to write to dag state
     blocks: Vec<VerifiedBlock>,
 }
@@ -486,6 +495,7 @@ impl<'a> LayerBuilder<'a> {
             random_weak_links: false,
             random_weak_links_random_seed: None,
             ancestors,
+            timestamps: vec![],
             blocks: vec![],
         }
     }
@@ -576,6 +586,17 @@ impl<'a> LayerBuilder<'a> {
         // authorities must be specified for this to apply
         assert!(self.specified_authorities.is_some());
         self.skip_block = true;
+        self
+    }
+
+    pub fn with_timestamps(mut self, timestamps: Vec<BlockTimestampMs>) -> Self {
+        // authorities must be specified for this to apply
+        assert!(self.specified_authorities.is_some());
+        assert!(
+            self.specified_authorities.as_ref().unwrap().len() == timestamps.len(),
+            "Timestamps should be provided for each specified authority"
+        );
+        self.timestamps = timestamps;
         self
     }
 
@@ -759,13 +780,12 @@ impl<'a> LayerBuilder<'a> {
                 .collect::<Vec<_>>();
             let num_blocks = self.num_blocks_to_create(authority);
             for num_block in 0..num_blocks {
-                let author = authority.value() as u32;
-                let base_ts = round as BlockTimestampMs * 1000;
+                let timestamp = self.block_timestamp(authority, round, num_block);
                 let block = VerifiedBlock::new_for_test(
-                    TestBlock::new(round, author)
+                    TestBlock::new(round, authority.value() as u32)
                         .set_transactions(transactions.clone())
                         .set_ancestors(ancestors.clone())
-                        .set_timestamp_ms(base_ts + (author + round + num_block) as u64)
+                        .set_timestamp_ms(timestamp)
                         .build(),
                 );
                 references.push(block.reference());
@@ -791,6 +811,24 @@ impl<'a> LayerBuilder<'a> {
         } else {
             1
         }
+    }
+
+    fn block_timestamp(
+        &self,
+        authority: AuthorityIndex,
+        round: Round,
+        num_block: u32,
+    ) -> BlockTimestampMs {
+        if self.specified_authorities.is_some() && !self.timestamps.is_empty() {
+            let specified_authorities = self.specified_authorities.as_ref().unwrap();
+
+            if let Some(position) = specified_authorities.iter().position(|&x| x == authority) {
+                return self.timestamps[position] + (round + num_block) as u64;
+            }
+        }
+        let author = authority.value() as u32;
+        let base_ts = round as BlockTimestampMs * 1000;
+        base_ts + (author + round + num_block) as u64
     }
 
     fn should_skip_block(&self, round: Round, authority: AuthorityIndex) -> bool {

--- a/consensus/simtests/src/node.rs
+++ b/consensus/simtests/src/node.rs
@@ -282,11 +282,11 @@ pub(crate) async fn make_authority(
         protocol_config,
         protocol_keypair,
         network_keypair,
+        Arc::new(Clock::new_for_test(clock_drift)),
         Arc::new(txn_verifier),
         commit_consumer,
         registry,
         boot_counter,
-        Arc::new(Clock::new_for_test(clock_drift)),
     )
     .await;
 

--- a/consensus/simtests/src/node.rs
+++ b/consensus/simtests/src/node.rs
@@ -19,7 +19,8 @@ use tempfile::TempDir;
 use consensus_core::network::tonic_network::to_socket_addr;
 use consensus_core::transaction::NoopTransactionVerifier;
 use consensus_core::{
-    CommitConsumer, CommitConsumerMonitor, CommittedSubDag, ConsensusAuthority, TransactionClient,
+    BlockTimestampMs, Clock, CommitConsumer, CommitConsumerMonitor, CommittedSubDag,
+    ConsensusAuthority, TransactionClient,
 };
 
 #[derive(Clone)]
@@ -31,6 +32,7 @@ pub(crate) struct Config {
     pub keypairs: Vec<(NetworkKeyPair, ProtocolKeyPair)>,
     pub network_type: ConsensusNetwork,
     pub boot_counter: u64,
+    pub clock_drift: BlockTimestampMs,
     pub protocol_config: ProtocolConfig,
 }
 
@@ -250,6 +252,7 @@ pub(crate) async fn make_authority(
         network_type,
         boot_counter,
         protocol_config,
+        clock_drift,
     } = config;
 
     let registry = Registry::new();
@@ -283,6 +286,7 @@ pub(crate) async fn make_authority(
         commit_consumer,
         registry,
         boot_counter,
+        Arc::new(Clock::new_for_test(clock_drift)),
     )
     .await;
 

--- a/consensus/simtests/src/tests/simtests.rs
+++ b/consensus/simtests/src/tests/simtests.rs
@@ -41,72 +41,86 @@ mod test {
     #[sim_test(config = "test_config()")]
     async fn test_committee_start_simple() {
         telemetry_subscribers::init_for_testing();
-        let db_registry = Registry::new();
-        DBMetrics::init(&db_registry);
+        for median_based_timestamp in vec![true, false] {
+            tracing::info!("Running with median_based_timestamp = {median_based_timestamp}");
+            let db_registry = Registry::new();
+            DBMetrics::init(&db_registry);
 
-        const NUM_OF_AUTHORITIES: usize = 10;
-        let (committee, keypairs) = local_committee_and_keys(0, [1; NUM_OF_AUTHORITIES].to_vec());
-        let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-        protocol_config.set_consensus_gc_depth_for_testing(3);
+            const NUM_OF_AUTHORITIES: usize = 10;
+            let (committee, keypairs) =
+                local_committee_and_keys(0, [1; NUM_OF_AUTHORITIES].to_vec());
+            let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
+            protocol_config.set_consensus_gc_depth_for_testing(3);
+            protocol_config
+                .set_consensus_median_based_commit_timestamp_for_testing(median_based_timestamp);
 
-        let mut authorities = Vec::with_capacity(committee.size());
-        let mut transaction_clients = Vec::with_capacity(committee.size());
-        let mut boot_counters = [0; NUM_OF_AUTHORITIES];
+            let mut authorities = Vec::with_capacity(committee.size());
+            let mut transaction_clients = Vec::with_capacity(committee.size());
+            let mut boot_counters = [0; NUM_OF_AUTHORITIES];
+            let mut clock_drifts = [0; NUM_OF_AUTHORITIES];
+            clock_drifts[0] = 50;
+            clock_drifts[1] = 100;
+            clock_drifts[2] = 120;
 
-        for (index, _authority_info) in committee.authorities() {
-            let config = Config {
-                authority_index: index,
-                db_dir: Arc::new(TempDir::new().unwrap()),
-                committee: committee.clone(),
-                keypairs: keypairs.clone(),
-                network_type: sui_protocol_config::ConsensusNetwork::Tonic,
-                boot_counter: boot_counters[index],
-                protocol_config: protocol_config.clone(),
-            };
-            let node = AuthorityNode::new(config);
+            for (authority_index, _authority_info) in committee.authorities() {
+                // Introduce a non-trivial clock drift for the first node (it's time will be ahead of the others). This will provide extra reassurance
+                // around the block timestamp checks.
+                let config = Config {
+                    authority_index,
+                    db_dir: Arc::new(TempDir::new().unwrap()),
+                    committee: committee.clone(),
+                    keypairs: keypairs.clone(),
+                    network_type: sui_protocol_config::ConsensusNetwork::Tonic,
+                    boot_counter: boot_counters[authority_index],
+                    protocol_config: protocol_config.clone(),
+                    clock_drift: clock_drifts[authority_index.value() as usize],
+                };
+                let node = AuthorityNode::new(config);
 
-            if index != AuthorityIndex::new_for_test(NUM_OF_AUTHORITIES as u32 - 1) {
-                node.start().await.unwrap();
-                node.spawn_committed_subdag_consumer().unwrap();
+                if authority_index != AuthorityIndex::new_for_test(NUM_OF_AUTHORITIES as u32 - 1) {
+                    node.start().await.unwrap();
+                    node.spawn_committed_subdag_consumer().unwrap();
 
-                let client = node.transaction_client();
-                transaction_clients.push(client);
+                    let client = node.transaction_client();
+                    transaction_clients.push(client);
+                }
+
+                boot_counters[authority_index] += 1;
+                authorities.push(node);
             }
 
-            boot_counters[index] += 1;
-            authorities.push(node);
+            let transaction_clients_clone = transaction_clients.clone();
+            let _handle = tokio::spawn(async move {
+                const NUM_TRANSACTIONS: u16 = 1000;
+
+                for i in 0..NUM_TRANSACTIONS {
+                    let txn = vec![i as u8; 16];
+                    transaction_clients_clone[i as usize % transaction_clients_clone.len()]
+                        .submit(vec![txn])
+                        .await
+                        .unwrap();
+                }
+            });
+
+            // wait for authorities
+            sleep(Duration::from_secs(60)).await;
+
+            // Now start the fourth authority and let it start
+            authorities[NUM_OF_AUTHORITIES - 1].start().await.unwrap();
+            authorities[NUM_OF_AUTHORITIES - 1]
+                .spawn_committed_subdag_consumer()
+                .unwrap();
+
+            // Wait for it to catch up
+            sleep(Duration::from_secs(230)).await;
+            let commit_consumer_monitor =
+                authorities[NUM_OF_AUTHORITIES - 1].commit_consumer_monitor();
+            let highest_committed_index = commit_consumer_monitor.highest_handled_commit();
+            assert!(
+                highest_committed_index >= 80,
+                "Highest handled commit {highest_committed_index} < 80"
+            );
         }
-
-        let transaction_clients_clone = transaction_clients.clone();
-        let _handle = tokio::spawn(async move {
-            const NUM_TRANSACTIONS: u16 = 1000;
-
-            for i in 0..NUM_TRANSACTIONS {
-                let txn = vec![i as u8; 16];
-                transaction_clients_clone[i as usize % transaction_clients_clone.len()]
-                    .submit(vec![txn])
-                    .await
-                    .unwrap();
-            }
-        });
-
-        // wait for authorities
-        sleep(Duration::from_secs(60)).await;
-
-        // Now start the fourth authority and let it start
-        authorities[NUM_OF_AUTHORITIES - 1].start().await.unwrap();
-        authorities[NUM_OF_AUTHORITIES - 1]
-            .spawn_committed_subdag_consumer()
-            .unwrap();
-
-        // Wait for it to catch up
-        sleep(Duration::from_secs(230)).await;
-        let commit_consumer_monitor = authorities[NUM_OF_AUTHORITIES - 1].commit_consumer_monitor();
-        let highest_committed_index = commit_consumer_monitor.highest_handled_commit();
-        assert!(
-            highest_committed_index >= 80,
-            "Highest handled commit {highest_committed_index} < 80"
-        );
     }
 
     /// Creates a committee for local testing, and the corresponding key pairs for the authorities.

--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -5,7 +5,9 @@ use std::{path::PathBuf, sync::Arc};
 use arc_swap::ArcSwapOption;
 use async_trait::async_trait;
 use consensus_config::{Committee, NetworkKeyPair, Parameters, ProtocolKeyPair};
-use consensus_core::{CommitConsumer, CommitConsumerMonitor, CommitIndex, ConsensusAuthority};
+use consensus_core::{
+    Clock, CommitConsumer, CommitConsumerMonitor, CommitIndex, ConsensusAuthority,
+};
 use fastcrypto::ed25519;
 use mysten_metrics::{RegistryID, RegistryService};
 use prometheus::Registry;
@@ -189,6 +191,7 @@ impl ConsensusManagerTrait for MysticetiManager {
             commit_consumer,
             registry.clone(),
             *boot_counter,
+            Arc::new(Clock::default()),
         )
         .await;
         let client = authority.transaction_client();

--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -187,11 +187,11 @@ impl ConsensusManagerTrait for MysticetiManager {
             protocol_config.clone(),
             self.protocol_keypair.clone(),
             self.network_keypair.clone(),
+            Arc::new(Clock::default()),
             Arc::new(tx_validator.clone()),
             commit_consumer,
             registry.clone(),
             *boot_counter,
-            Arc::new(Clock::default()),
         )
         .await;
         let client = authority.transaction_client();

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1308,6 +1308,7 @@
                 "commit_root_state_digest": false,
                 "consensus_distributed_vote_scoring_strategy": false,
                 "consensus_linearize_subdag_v2": false,
+                "consensus_median_based_timestamp": false,
                 "consensus_order_end_of_epoch_last": true,
                 "consensus_round_prober": false,
                 "consensus_round_prober_probe_accepted_rounds": false,

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1308,7 +1308,7 @@
                 "commit_root_state_digest": false,
                 "consensus_distributed_vote_scoring_strategy": false,
                 "consensus_linearize_subdag_v2": false,
-                "consensus_median_based_timestamp": false,
+                "consensus_median_based_commit_timestamp": false,
                 "consensus_order_end_of_epoch_last": true,
                 "consensus_round_prober": false,
                 "consensus_round_prober_probe_accepted_rounds": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -647,6 +647,11 @@ struct FeatureFlags {
     // If true, enable `TxContext` Move API to go native.
     #[serde(skip_serializing_if = "is_false")]
     move_native_context: bool,
+
+    // If true, then it (1) will not enforce monotonicity checks for a block's ancestors and (2) calculates the commit's timestamp based on the 
+    // median timestamp of the leader's ancestors.
+    #[serde(skip_serializing_if = "is_false")]
+    consensus_median_based_timestamp: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -1846,6 +1851,15 @@ impl ProtocolConfig {
         assert!(
             !res || self.gc_depth() > 0,
             "The consensus linearize sub dag V2 requires GC to be enabled"
+        );
+        res
+    }
+
+    pub fn consensus_median_based_timestamp(&self) -> bool {
+        let res = self.feature_flags.consensus_median_based_timestamp;
+        assert!(
+            !res || self.gc_depth() > 0,
+            "The consensus median based timestamp requires GC to be enabled"
         );
         res
     }
@@ -3573,8 +3587,13 @@ impl ProtocolConfig {
         self.feature_flags.mysticeti_fastpath = val;
     }
 
+
     pub fn set_accept_passkey_in_multisig_for_testing(&mut self, val: bool) {
         self.feature_flags.accept_passkey_in_multisig = val;
+    }
+
+    pub fn set_consensus_median_based_timestamp(&mut self, val: bool) {
+        self.feature_flags.consensus_median_based_timestamp = val;
     }
 }
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -3590,7 +3590,7 @@ impl ProtocolConfig {
     pub fn set_accept_passkey_in_multisig_for_testing(&mut self, val: bool) {
         self.feature_flags.accept_passkey_in_multisig = val;
     }
-    
+
     pub fn set_consensus_median_based_commit_timestamp_for_testing(&mut self, val: bool) {
         self.feature_flags.consensus_median_based_commit_timestamp = val;
     }

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -648,7 +648,7 @@ struct FeatureFlags {
     #[serde(skip_serializing_if = "is_false")]
     move_native_context: bool,
 
-    // If true, then it (1) will not enforce monotonicity checks for a block's ancestors and (2) calculates the commit's timestamp based on the 
+    // If true, then it (1) will not enforce monotonicity checks for a block's ancestors and (2) calculates the commit's timestamp based on the
     // median timestamp of the leader's ancestors.
     #[serde(skip_serializing_if = "is_false")]
     consensus_median_based_commit_timestamp: bool,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -651,7 +651,7 @@ struct FeatureFlags {
     // If true, then it (1) will not enforce monotonicity checks for a block's ancestors and (2) calculates the commit's timestamp based on the 
     // median timestamp of the leader's ancestors.
     #[serde(skip_serializing_if = "is_false")]
-    consensus_median_based_timestamp: bool,
+    consensus_median_based_commit_timestamp: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -1855,11 +1855,11 @@ impl ProtocolConfig {
         res
     }
 
-    pub fn consensus_median_based_timestamp(&self) -> bool {
-        let res = self.feature_flags.consensus_median_based_timestamp;
+    pub fn consensus_median_based_commit_timestamp(&self) -> bool {
+        let res = self.feature_flags.consensus_median_based_commit_timestamp;
         assert!(
             !res || self.gc_depth() > 0,
-            "The consensus median based timestamp requires GC to be enabled"
+            "The consensus median based commit timestamp requires GC to be enabled"
         );
         res
     }
@@ -3587,13 +3587,12 @@ impl ProtocolConfig {
         self.feature_flags.mysticeti_fastpath = val;
     }
 
-
     pub fn set_accept_passkey_in_multisig_for_testing(&mut self, val: bool) {
         self.feature_flags.accept_passkey_in_multisig = val;
     }
-
-    pub fn set_consensus_median_based_timestamp(&mut self, val: bool) {
-        self.feature_flags.consensus_median_based_timestamp = val;
+    
+    pub fn set_consensus_median_based_commit_timestamp_for_testing(&mut self, val: bool) {
+        self.feature_flags.consensus_median_based_commit_timestamp = val;
     }
 }
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1856,7 +1856,11 @@ impl ProtocolConfig {
     }
 
     pub fn consensus_median_based_commit_timestamp(&self) -> bool {
-        let res = self.feature_flags.consensus_median_based_commit_timestamp;
+        let res = if cfg!(msim) {
+            true
+        } else {
+            self.feature_flags.consensus_median_based_commit_timestamp
+        };
         assert!(
             !res || self.gc_depth() > 0,
             "The consensus median based commit timestamp requires GC to be enabled"


### PR DESCRIPTION
## Description 

This PR is doing the following:
1. Is dropping the timestamp monotonicity block ancestor checks. We'll no longer check whether a block's ancestors timestamps are strictly lower than the block in question.
2. Calculating the commit's timestamp by using the leader's strong ancestors timestamps median. The calculation is stake based.

As it has been discussed, this will make the protocol more robust when it comes to block validity verification and repercussions of it. It is also simplifying the block acceptance path.

## Test plan 

CI/PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
