### PR TITLE
[suiop][env] fix messaging, remove error

### DIFF
--- a/crates/suiop-cli/src/cli/env/mod.rs
+++ b/crates/suiop-cli/src/cli/env/mod.rs
@@ -4,6 +4,7 @@
 use crate::{command::CommandOptions, run_cmd};
 use anyhow::Result;
 use clap::Parser;
+use colored::Colorize;
 use inquire::Select;
 use query_shell::get_shell_name;
 
@@ -32,6 +33,8 @@ pub fn load_environment(args: &LoadEnvironmentArgs) -> Result<()> {
             .expect("Failed to select environment")
             .to_owned()
     });
+
+    println!("{}", "Starting a subshell with the environment set... exit the shell (usually ctrl-d) to exit the env".bright_green());
 
     // get the user's shell
     let shell = get_shell_name()?;

--- a/crates/suiop-cli/src/main.rs
+++ b/crates/suiop-cli/src/main.rs
@@ -13,7 +13,7 @@ use suioplib::{
     },
     DEBUG_MODE,
 };
-use tracing::{debug, info, warn};
+use tracing::info;
 use tracing_subscriber::{
     filter::{EnvFilter, LevelFilter},
     FmtSubscriber,

--- a/crates/suiop-cli/src/main.rs
+++ b/crates/suiop-cli/src/main.rs
@@ -63,24 +63,6 @@ async fn main() -> Result<()> {
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
-    // Load environment variables from ~/.suiop/env_vars
-    debug!("loading environment variables");
-    let home_dir = std::env::var("HOME").expect("HOME environment variable not set");
-    let env_file_path = std::path::Path::new(&home_dir)
-        .join(".suiop")
-        .join("env_vars");
-
-    if let Ok(env_contents) = std::fs::read_to_string(env_file_path) {
-        for line in env_contents.lines() {
-            if let Some((key, value)) = line.split_once('=') {
-                debug!("setting environment variable {}={}", key, value);
-                std::env::set_var(key.trim(), value.trim());
-            }
-        }
-    } else {
-        warn!("Warning: Could not read ~/.suiop/env_vars file. Environment variables not loaded.");
-    }
-
     if *DEBUG_MODE {
         info!("Debug mode enabled");
     }


### PR DESCRIPTION
## Description 

- remove old error checking for an env file
- add a new message to indicate that a subshell is being created

## Test plan 

```
suiop-cli [jkj/suiop-env-msg-fix] suiop env                    
> Select an environment: mysten/default/vultr-api
Starting a subshell with the environment set... exit the shell (usually ctrl-d) to exit the env
error This project's package.json defines "packageManager": "yarn@pnpm@9.1.1". However the current global version of Yarn is 1.22.22.                                                                                                                                                                                

Presence of the "packageManager" field indicates that the project is meant to be used with Corepack, a tool included by default with all official Node.js distributions starting from 16.9 and 14.19.
Corepack must currently be enabled by running corepack enable in your terminal. For more information, check out https://yarnpkg.com/corepack.
done initializing 🎉
suiop-cli [jkj/suiop-env-msg-fix] 
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
