### PR TITLE
Fixing Grammar and Typographical Errors in Documentation

### DIFF
--- a/docker/fullnode/README.md
+++ b/docker/fullnode/README.md
@@ -45,7 +45,7 @@ After the Full node starts you can test the JSON-RPC interfaces.
 
 Sui Explorer supports connecting to a local network. To view activity on your local Full node, open the URL: [https://explorer.sui.io/?network=local](https://explorer.sui.io/?network=local).
 
-You can also change the network that Sui Explorer connects to by select it in the Sui Explorer interface. 
+You can also change the network that Sui Explorer connects to by selecting it in the Sui Explorer interface. 
 
 ### Stop the Full node
 

--- a/docker/stress/readme.md
+++ b/docker/stress/readme.md
@@ -2,5 +2,5 @@
 
 This image is currently meant to be built locally, and run as a part of `docker/sui-network/docker-compose.yaml`
 
-eg:
+e.g.,
 `docker build -t stress:testing --build-arg SUI_TOOLS_IMAGE_TAG=mainnet-v1.19.1 .`

--- a/docker/stress/readme.md
+++ b/docker/stress/readme.md
@@ -2,5 +2,5 @@
 
 This image is currently meant to be built locally, and run as a part of `docker/sui-network/docker-compose.yaml`
 
-e.g.,
+for example,
 `docker build -t stress:testing --build-arg SUI_TOOLS_IMAGE_TAG=mainnet-v1.19.1 .`

--- a/docker/sui-antithesis/README.md
+++ b/docker/sui-antithesis/README.md
@@ -22,7 +22,7 @@ docker compose up
 
 
 **additional info**
-The version of `sui` which is used to generate the genesis outputs must be on the same protocol version as the fullnode/validators (eg: `mysten/sui-node:mainnet-v1.19.1`)
+The version of `sui` that generates  the genesis outputs must be on the same protocol version as the fullnode/validators (for example, `mysten/sui-node:mainnet-v1.19.1`)
 Here's an example of how to build a `sui` binary that creates a genesis which is compatible with the release: `v1.19.1`
 ```
 git checkout releases/sui-v1.19.0-release

--- a/docker/sui-antithesis/README.md
+++ b/docker/sui-antithesis/README.md
@@ -22,7 +22,7 @@ docker compose up
 
 
 **additional info**
-The version of `sui` which is used to generate the genesis outputs much be on the same protocol version as the fullnode/validators (eg: `mysten/sui-node:mainnet-v1.19.1`)
+The version of `sui` which is used to generate the genesis outputs must be on the same protocol version as the fullnode/validators (eg: `mysten/sui-node:mainnet-v1.19.1`)
 Here's an example of how to build a `sui` binary that creates a genesis which is compatible with the release: `v1.19.1`
 ```
 git checkout releases/sui-v1.19.0-release


### PR DESCRIPTION
docker/fullnode/README.md

Before: "by select it" → After: "by selecting it"
Fix: Corrected verb form for grammatical accuracy.
docker/stress/readme.md

Before: "eg:" → After: "e.g.,"
Fix: Proper abbreviation formatting.
docker/sui-antithesis/README.md

Before: "much be" → After: "must be"
Fix: Fixed typo and improved clarity.