### PR TITLE
[json-rpc] Update variants to be returned in declaration order

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_move.rs
+++ b/crates/sui-json-rpc-types/src/sui_move.rs
@@ -77,7 +77,8 @@ pub struct SuiMoveNormalizedStruct {
 pub struct SuiMoveNormalizedEnum {
     pub abilities: SuiMoveAbilitySet,
     pub type_parameters: Vec<SuiMoveStructTypeParameter>,
-    pub variants: BTreeMap<String, Vec<SuiMoveNormalizedField>>,
+    // NB: Don't use a `BTreeMap` here as we want to keep the declaration order of the variants
+    pub variants: Vec<(String, Vec<SuiMoveNormalizedField>)>,
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
@@ -246,7 +247,7 @@ impl From<NormalizedEnum> for SuiMoveNormalizedEnum {
                             .collect::<Vec<SuiMoveNormalizedField>>(),
                     )
                 })
-                .collect::<BTreeMap<String, Vec<SuiMoveNormalizedField>>>(),
+                .collect::<Vec<(String, Vec<SuiMoveNormalizedField>)>>(),
         }
     }
 }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -8988,12 +8988,22 @@
             }
           },
           "variants": {
-            "type": "object",
-            "additionalProperties": {
+            "type": "array",
+            "items": {
               "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/SuiMoveNormalizedField"
-              }
+              "items": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SuiMoveNormalizedField"
+                  }
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
             }
           }
         }


### PR DESCRIPTION
We were collecting these into a `BTreeMap` when building up the json response which was leading to the variants in an enum type to be returned in lexicographic order instead of declaration order.

This updates this to collect into a vector of tuples instead so that declaration order of the variants is preserved in the json output. This closes the issue in #20914.

## Test plan 

Ran this on the repro in #20914 and confirmed that the enum variants are returned in order. 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [X] JSON-RPC: Ordering of enum variants in Move enum types are now returned in declaration order as opposed to lexicographic order.  
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
