### PR TITLE
Remove `bmwill/rust-cache` from rust builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,11 +106,7 @@ jobs:
         run: |
           mkdir -p ${{ env.TMP_BUILD_DIR }}
           aws s3 cp s3://sui-releases/releases/sui-${{ env.sui_tag }}-${os_type}.tgz ./tmp/sui-${{ env.sui_tag }}-${os_type}.tgz
-          tar -xf ./tmp/sui-${{ env.sui_tag }}-${os_type}.tgz -C ${{ env.TMP_BUILD_DIR }}
-
-      - name: Setup caching
-        if: ${{ env.s3_archive_exist == '' }}
-        uses: bmwill/rust-cache@v1 # Fork of 'Swatinem/rust-cache' which allows caching additional paths          
+          tar -xf ./tmp/sui-${{ env.sui_tag }}-${os_type}.tgz -C ${{ env.TMP_BUILD_DIR }}     
 
       - name: Install nexttest (Windows)
         if: ${{ matrix.os == 'windows-ghcloud' && env.s3_archive_exist == '' }}


### PR DESCRIPTION
## Description
Remove `bmwill/rust-cache` from rust builds. I meant to do this earlier and forgot. 
See https://mysten-labs.slack.com/archives/C02L5JL88JV/p1740681175394449 for contexgt.

## Test Plan
👀 
