### PR TITLE
[move-ide] Added an option to force bundled move-analyzer

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/CONTRIBUTING.md
+++ b/external-crates/move/crates/move-analyzer/editors/code/CONTRIBUTING.md
@@ -60,7 +60,7 @@ To be added to the group of maintainers allowed to release new versions of the m
 2. Sign in with your Microsoft account's email address. If using a corporate email address, you'll go through an authentication flow specific to your organization (two-factor authentication, for example).
 3. Once you've signed in, contact someone who is already in the existing group of maintainers, and ask them to [please add you to this list of members](https://marketplace.visualstudio.com/manage/publishers/move). If you do not know anyone in this group personally, run `git log -- language/move-analyzer/editors/code` and send an email to one or more of the people who have committed to this directory.
 
-Once you've been added, confirm that you are able to access [the `move` publisher page](https://marketplace.visualstudio.com/manage/publishers/move). If you can see yourself listed in the "Members" tab, then you have successfully been added to the publisher team.
+Once you've been added, confirm that you are able to access [the `mysten` publisher page](https://marketplace.visualstudio.com/manage/publishers/mysten). If you can see yourself listed in the "Members" tab, then you have successfully been added to the publisher team.
 
 ### 2: Publish a new version
 
@@ -74,11 +74,11 @@ To publish a new version of the extension, you'll need to:
 
 Follow the instructions in [the Visual Studio Code documentation on creating a personal access token](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token). To summarize:
 
-1. From the [`move` publisher page](https://marketplace.visualstudio.com/manage/publishers/mysten), click on your username in the upper-right of the page. This will load [your Azure DevOps page](https://aex.dev.azure.com/me).
+1. From the [`mysten` publisher page](https://marketplace.visualstudio.com/manage/publishers/mysten), click on your username in the upper-right of the page. This will load [your Azure DevOps page](https://aex.dev.azure.com/me).
 2. On that page, click on the `dev.azure.com/<name>` link below "Azure DevOps Organizations." If you have more than one organization listed there, choose the one you feel is best. This will load the `https://dev.azure.com/<name>` organization page.
 3. On that page, click on the "User Settings" icon in the upper-right, and select "Personal access tokens" from the drop-down menu. This will load the "Personal Access Tokens" page.
 4. On that page, click "New Token." Name it whatever you like but make sure to select an expiration of 30 days, select "All accessible organizations" under the "Organization" drop-down menu, and click the "Custom defined" button under "Scopes" followed by setting (only) "Marketplace" scope on the list of custom scopes to "Manage". Click "Create," and copy the token that is presented on the following page to your clipboard.
-5. Using your command line, enter the directory containing this `CONTRIBUTING.md` file, make sure you've installed the project's dependencies using `npm install`, and then run `npx vsce login move`. You will be prompted to enter the token you just copied in the previous step. Do so, and you'll have successfully authenticated on the command line.
+5. Using your command line, enter the directory containing this `CONTRIBUTING.md` file, make sure you've installed the project's dependencies using `npm install`, and then run `npx vsce login mysten`. You will be prompted to enter the token you just copied in the previous step. Do so, and you'll have successfully authenticated on the command line.
 
 #### 2.2: Update the version number of the extension
 

--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -57,6 +57,11 @@
       "type": "object",
       "title": "Move",
       "properties": {
+        "move.force-bundled": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Prefer bundled version of move-analyzer binary over the one from on-path sui binary"
+        },
         "move.inlay-hints.type": {
           "type": "boolean",
           "default": true,

--- a/external-crates/move/crates/move-analyzer/editors/code/src/configuration.ts
+++ b/external-crates/move/crates/move-analyzer/editors/code/src/configuration.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 
 export const MOVE_CONF_NAME = 'move';
 export const LINT_OPT = 'lint';
+export const FORCE_BUNDLED = 'force-bundled';
 export const TYPE_HINTS_OPT = 'inlay-hints.type';
 export const PARAM_HINTS_OPT = 'inlay-hints.param';
 export const SUI_PATH_OPT = 'sui.path';
@@ -72,6 +73,10 @@ export class Configuration {
 
     get lint(): string {
         return this.configuration.get(LINT_OPT) ?? 'default';
+    }
+
+    get forceBundled(): boolean {
+        return this.configuration.get(FORCE_BUNDLED) ?? false;
     }
 
     get inlayHintsForType(): boolean {


### PR DESCRIPTION
## Description 

I recently encountered a user problem when their VSCode was picking up their on-path `sui` binary to get `move-analyzer` functionality out of it but it did not work. What did work was to keep using the bundled `move-analyzer` but there wasn't a convenient option to force it. This PR adds this kind of option to the extension's config.

Generally, we want people to use `move-analyzer` from `sui` binary if available so that they have consistent compiler behavior (mostly with respect to diagnostics), That's why the new option defaults to `false`.

Another use for this option is if someone is savvy enough to have a custom `sui` binary on their path but it's a debug version - we definitely don't want `move-analyzer` running in debug mode

## Test plan 

Tested manually that flipping the flag back and forth results in expected behavior
