### PR TITLE
[move-stdlib] remove deprecated poison function

### DIFF
--- a/crates/sui-framework/packages/move-stdlib/sources/unit_test.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/unit_test.move
@@ -5,9 +5,6 @@
 /// Module providing testing functionality. Only included for tests.
 module std::unit_test;
 
-/// DEPRECATED
-public native fun create_signers_for_testing(num_signers: u64): vector<signer>;
-
 /// This function is used to poison modules compiled in `test` mode.
 /// This will cause a linking failure if an attempt is made to publish a
 /// test module in a VM that isn't in unit test mode.

--- a/examples/vesting/Move.toml
+++ b/examples/vesting/Move.toml
@@ -3,7 +3,7 @@ name = "vesting"
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
+Sui = { local = "../../crates/sui-framework/packages/sui-framework"  }
 
 [addresses]
 vesting = "0x0"

--- a/examples/vesting/Move.toml
+++ b/examples/vesting/Move.toml
@@ -3,7 +3,7 @@ name = "vesting"
 edition = "2024.beta"
 
 [dependencies]
-Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }
 
 [addresses]
 vesting = "0x0"

--- a/external-crates/move/crates/move-stdlib-natives/src/lib.rs
+++ b/external-crates/move/crates/move-stdlib-natives/src/lib.rs
@@ -100,10 +100,6 @@ impl GasParameters {
             },
             #[cfg(feature = "testing")]
             unit_test: unit_test::GasParameters {
-                create_signers_for_testing: unit_test::CreateSignersForTestingGasParameters {
-                    base_cost: 0.into(),
-                    unit_cost: 0.into(),
-                },
                 poison: unit_test::PoisonGasParameters {
                     base_cost: 0.into(),
                 },
@@ -131,10 +127,6 @@ impl GasParameters {
             },
             #[cfg(feature = "testing")]
             unit_test: unit_test::GasParameters {
-                create_signers_for_testing: unit_test::CreateSignersForTestingGasParameters {
-                    base_cost: 0.into(),
-                    unit_cost: 0.into(),
-                },
                 poison: unit_test::PoisonGasParameters {
                     base_cost: 0.into(),
                 },

--- a/external-crates/move/crates/move-stdlib-natives/src/unit_test.rs
+++ b/external-crates/move/crates/move-stdlib-natives/src/unit_test.rs
@@ -4,68 +4,16 @@
 
 use crate::helpers::make_module_natives;
 use move_binary_format::errors::PartialVMResult;
-use move_core_types::{
-    account_address::AccountAddress,
-    gas_algebra::{InternalGas, InternalGasPerArg, NumArgs},
-};
+use move_core_types::gas_algebra::InternalGas;
 use move_vm_runtime::{
     native_charge_gas_early_exit,
     native_functions::{NativeContext, NativeFunction},
 };
 use move_vm_types::{
-    loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
+    loaded_data::runtime_types::Type, natives::function::NativeResult, values::Value,
 };
 use smallvec::smallvec;
 use std::{collections::VecDeque, sync::Arc};
-
-/***************************************************************************************************
- * native fun create_signers_for_testing
- *
- *   gas cost: base_cost + unit_cost * num_of_signers
- *
- **************************************************************************************************/
-fn to_le_bytes(i: u64) -> [u8; AccountAddress::LENGTH] {
-    let bytes = i.to_le_bytes();
-    let mut result = [0u8; AccountAddress::LENGTH];
-    result[..bytes.len()].clone_from_slice(bytes.as_ref());
-    result
-}
-
-#[derive(Debug, Clone)]
-pub struct CreateSignersForTestingGasParameters {
-    pub base_cost: InternalGas,
-    pub unit_cost: InternalGasPerArg,
-}
-
-fn native_create_signers_for_testing(
-    gas_params: &CreateSignersForTestingGasParameters,
-    context: &mut NativeContext,
-    ty_args: Vec<Type>,
-    mut args: VecDeque<Value>,
-) -> PartialVMResult<NativeResult> {
-    debug_assert!(ty_args.is_empty());
-    debug_assert!(args.len() == 1);
-
-    let num_signers = pop_arg!(args, u64);
-    let signers = Value::vector_for_testing_only(
-        (0..num_signers).map(|i| Value::signer(AccountAddress::new(to_le_bytes(i)))),
-    );
-
-    let cost = gas_params.base_cost + gas_params.unit_cost * NumArgs::new(num_signers);
-    native_charge_gas_early_exit!(context, cost);
-
-    Ok(NativeResult::ok(context.gas_used(), smallvec![signers]))
-}
-
-pub fn make_native_create_signers_for_testing(
-    gas_params: CreateSignersForTestingGasParameters,
-) -> NativeFunction {
-    Arc::new(
-        move |context, ty_args, args| -> PartialVMResult<NativeResult> {
-            native_create_signers_for_testing(&gas_params, context, ty_args, args)
-        },
-    )
-}
 
 #[derive(Debug, Clone)]
 pub struct PoisonGasParameters {
@@ -98,18 +46,11 @@ pub fn make_native_poison(gas_params: PoisonGasParameters) -> NativeFunction {
  **************************************************************************************************/
 #[derive(Debug, Clone)]
 pub struct GasParameters {
-    pub create_signers_for_testing: CreateSignersForTestingGasParameters,
     pub poison: PoisonGasParameters,
 }
 
 pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, NativeFunction)> {
-    let natives = [
-        (
-            "create_signers_for_testing",
-            make_native_create_signers_for_testing(gas_params.create_signers_for_testing),
-        ),
-        ("poison", make_native_poison(gas_params.poison)),
-    ];
+    let natives = [("poison", make_native_poison(gas_params.poison))];
 
     make_module_natives(natives)
 }

--- a/external-crates/move/crates/move-stdlib/sources/unit_test.move
+++ b/external-crates/move/crates/move-stdlib/sources/unit_test.move
@@ -5,9 +5,6 @@
 /// Module providing testing functionality. Only included for tests.
 module std::unit_test {
 
-    /// DEPRECATED
-    native public fun create_signers_for_testing(num_signers: u64): vector<signer>;
-
     /// This function is used to poison modules compiled in `test` mode.
     /// This will cause a linking failure if an attempt is made to publish a
     /// test module in a VM that isn't in unit test mode.

--- a/external-crates/move/crates/move-unit-test/tests/test_sources/use_unit_test_module.move
+++ b/external-crates/move/crates/move-unit-test/tests/test_sources/use_unit_test_module.move
@@ -2,11 +2,6 @@ module 0x6::M {
     use std::unit_test;
 
     #[test]
-    fun poison_call_OLD() {
-        unit_test::create_signers_for_testing(0);
-    }
-
-    #[test]
     fun poison_call() {
         unit_test::poison();
     }

--- a/external-crates/move/crates/move-unit-test/tests/test_sources/use_unit_test_module.snap
+++ b/external-crates/move/crates/move-unit-test/tests/test_sources/use_unit_test_module.snap
@@ -3,5 +3,4 @@ source: crates/move-unit-test/tests/move_unit_test_testsuite.rs
 ---
 Running Move unit tests
 [ PASS    ] 0x6::M::poison_call
-[ PASS    ] 0x6::M::poison_call_OLD
-Test result: OK. Total tests: 2; passed: 2; failed: 0
+Test result: OK. Total tests: 1; passed: 1; failed: 0


### PR DESCRIPTION
## Description 

- Remove create_signers_for_testing as it is no longer used

## Test plan 

- Updated IDE to 1.43 and verified there were no errors about missing functions 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
