### PR TITLE
[formatter] bugs & fixes

### DIFF
--- a/external-crates/move/tooling/prettier-extension/package-lock.json
+++ b/external-crates/move/tooling/prettier-extension/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "prettier-move",
-	"version": "0.1.0",
+	"version": "0.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prettier-move",
-			"version": "0.1.0",
+			"version": "0.3.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@mysten/prettier-plugin-move": "^0.2.2",
+				"@mysten/prettier-plugin-move": "^0.3.0",
 				"cosmiconfig": "^9.0.0",
 				"prettier": "^3.3.2"
 			},
@@ -233,9 +233,9 @@
 			}
 		},
 		"node_modules/@mysten/prettier-plugin-move": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@mysten/prettier-plugin-move/-/prettier-plugin-move-0.2.2.tgz",
-			"integrity": "sha512-nWw55WTOUnQmfRdAIL49CUJ6W1Zq0N9Q7zVw1Cw6xj9ciBFL0y3pW9Aw7iIiTKi1ZKwgQjLUiwsq8TxkQvjMUg==",
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@mysten/prettier-plugin-move/-/prettier-plugin-move-0.3.0.tgz",
+			"integrity": "sha512-bzo+oSVFgc9jif427qqNQaZMa++Q9l93R3rP3cLPiPaMO5asO55YfyzkW2VhysKpfx3lmIVhtQnybdIOl36U0A==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"prettier": "^3.3.2",
@@ -2588,9 +2588,9 @@
 			}
 		},
 		"node_modules/tar-fs": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
+			"integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -2680,9 +2680,9 @@
 			"license": "MIT"
 		},
 		"node_modules/undici": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
-			"integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==",
+			"version": "6.21.2",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
+			"integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/external-crates/move/tooling/prettier-extension/package.json
+++ b/external-crates/move/tooling/prettier-extension/package.json
@@ -1,9 +1,9 @@
 {
 	"name": "prettier-move",
 	"publisher": "mysten",
-	"displayName": "Move Formatter Developer Preview",
+	"displayName": "Move Formatter",
 	"description": "Adds Move code formatting to VSCode using Prettier@v3",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"private": true,
 	"preview": true,
 	"icon": "img/move.png",
@@ -76,7 +76,7 @@
 		"lint:fix": "pnpm run eslint:fix && pnpm run prettier:fix"
 	},
 	"dependencies": {
-		"@mysten/prettier-plugin-move": "^0.2.2",
+		"@mysten/prettier-plugin-move": "^0.3.0",
 		"cosmiconfig": "^9.0.0",
 		"prettier": "^3.3.2"
 	},

--- a/external-crates/move/tooling/prettier-extension/src/extension.js
+++ b/external-crates/move/tooling/prettier-extension/src/extension.js
@@ -89,8 +89,8 @@ async function findMatchingConfig(documentUri) {
 		};
 	}
 
-	const root = workspaceFolder.uri.path;
-	let lookup = documentUri.path;
+	const root = workspaceFolder.uri.fsPath;
+	let lookup = documentUri.fsPath;
 	let search = {};
 
 	// go back in the directory until the root is found; or until we find the

--- a/external-crates/move/tooling/prettier-move/package-lock.json
+++ b/external-crates/move/tooling/prettier-move/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prettier-plugin-move",
-	"version": "0.0.55",
+	"version": "0.2.3-alpha.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prettier-plugin-move",
-			"version": "0.0.55",
+			"version": "0.2.3-alpha.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"prettier": "^3.3.3",

--- a/external-crates/move/tooling/prettier-move/package-lock.json
+++ b/external-crates/move/tooling/prettier-move/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prettier-plugin-move",
-	"version": "0.2.3-alpha.4",
+	"version": "0.2.3-alpha.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prettier-plugin-move",
-			"version": "0.2.3-alpha.4",
+			"version": "0.2.3-alpha.5",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"prettier": "^3.3.3",

--- a/external-crates/move/tooling/prettier-move/package-lock.json
+++ b/external-crates/move/tooling/prettier-move/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prettier-plugin-move",
-	"version": "0.2.3-alpha.3",
+	"version": "0.2.3-alpha.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prettier-plugin-move",
-			"version": "0.2.3-alpha.3",
+			"version": "0.2.3-alpha.4",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"prettier": "^3.3.3",

--- a/external-crates/move/tooling/prettier-move/package-lock.json
+++ b/external-crates/move/tooling/prettier-move/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "prettier-plugin-move",
-	"version": "0.2.3-alpha.0",
+	"version": "0.2.3-alpha.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "prettier-plugin-move",
-			"version": "0.2.3-alpha.0",
+			"version": "0.2.3-alpha.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"prettier": "^3.3.3",

--- a/external-crates/move/tooling/prettier-move/package.json
+++ b/external-crates/move/tooling/prettier-move/package.json
@@ -2,7 +2,7 @@
 	"name": "@mysten/prettier-plugin-move",
 	"author": "Mysten Labs <build@mystenlabs.com>",
 	"description": "Move Plugin for Prettier",
-	"version": "0.2.3-alpha.0",
+	"version": "0.2.3-alpha.3",
 	"license": "Apache-2.0",
 	"keywords": [
 		"prettier",

--- a/external-crates/move/tooling/prettier-move/package.json
+++ b/external-crates/move/tooling/prettier-move/package.json
@@ -2,7 +2,7 @@
 	"name": "@mysten/prettier-plugin-move",
 	"author": "Mysten Labs <build@mystenlabs.com>",
 	"description": "Move Plugin for Prettier",
-	"version": "0.2.3-alpha.4",
+	"version": "0.3.0",
 	"license": "Apache-2.0",
 	"keywords": [
 		"prettier",

--- a/external-crates/move/tooling/prettier-move/package.json
+++ b/external-crates/move/tooling/prettier-move/package.json
@@ -2,7 +2,7 @@
 	"name": "@mysten/prettier-plugin-move",
 	"author": "Mysten Labs <build@mystenlabs.com>",
 	"description": "Move Plugin for Prettier",
-	"version": "0.2.2",
+	"version": "0.2.3-alpha.0",
 	"license": "Apache-2.0",
 	"keywords": [
 		"prettier",

--- a/external-crates/move/tooling/prettier-move/package.json
+++ b/external-crates/move/tooling/prettier-move/package.json
@@ -2,7 +2,7 @@
 	"name": "@mysten/prettier-plugin-move",
 	"author": "Mysten Labs <build@mystenlabs.com>",
 	"description": "Move Plugin for Prettier",
-	"version": "0.2.3-alpha.3",
+	"version": "0.2.3-alpha.4",
 	"license": "Apache-2.0",
 	"keywords": [
 		"prettier",

--- a/external-crates/move/tooling/prettier-move/prettier.config.js
+++ b/external-crates/move/tooling/prettier-move/prettier.config.js
@@ -7,6 +7,6 @@ module.exports = {
 	singleQuote: true,
 	tabWidth: 4,
 	trailingComma: 'all',
-	useTabs: true,
+	useTabs: false,
 	overrides: [],
 };

--- a/external-crates/move/tooling/prettier-move/src/cst/annotation.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/annotation.ts
@@ -8,64 +8,64 @@ import { list } from '../utilities';
 const { group, join } = doc.builders;
 
 export enum Annotation {
-	Annotation = 'annotation',
-	AnnotationItem = 'annotation_item',
-	AnnotationList = 'annotation_list',
-	AnnotationExpr = 'annotation_expr',
+    Annotation = 'annotation',
+    AnnotationItem = 'annotation_item',
+    AnnotationList = 'annotation_list',
+    AnnotationExpr = 'annotation_expr',
 }
 
 export default function (path: AstPath<Node>): treeFn | null {
-	switch (path.node.type) {
-		case Annotation.Annotation:
-			return printAnnotation;
-		case Annotation.AnnotationItem:
-			return printAnnotationItem;
-		case Annotation.AnnotationList:
-			return printAnnotationList;
-		case Annotation.AnnotationExpr:
-			return printAnnotationExpr;
-	}
+    switch (path.node.type) {
+        case Annotation.Annotation:
+            return printAnnotation;
+        case Annotation.AnnotationItem:
+            return printAnnotationItem;
+        case Annotation.AnnotationList:
+            return printAnnotationList;
+        case Annotation.AnnotationExpr:
+            return printAnnotationExpr;
+    }
 
-	return null;
+    return null;
 }
 
 /**
  * Print `annotation` node.
  */
 export function printAnnotation(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	return group(['#', list({ path, print, options, open: '[', close: ']' })]);
+    return group(['#', list({ path, print, options, open: '[', close: ']' })]);
 }
 
 /**
  * Print `annotation_item` node.
  */
 export function printAnnotationItem(path: AstPath<Node>, _opt: MoveOptions, print: printFn): Doc {
-	return path.map(print, 'nonFormattingChildren');
+    return path.map(print, 'nonFormattingChildren');
 }
 
 export function printAnnotationList(
-	path: AstPath<Node>,
-	options: MoveOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    options: MoveOptions,
+    print: printFn,
 ): Doc {
-	return [
-		path.call(print, 'nonFormattingChildren', 0),
-		list({ path, print, options, open: '(', close: ')', skipChildren: 1 }),
-	];
+    return [
+        path.call(print, 'nonFormattingChildren', 0),
+        list({ path, print, options, open: '(', close: ')', skipChildren: 1 }),
+    ];
 }
 
 /**
  * Print `annotation_expr` node.
  */
 export function printAnnotationExpr(path: AstPath<Node>, _opt: MoveOptions, print: printFn): Doc {
-	// allow `::module::Expression` in annotations
-	return join(
-		' = ',
-		path.map((path) => {
-			if (path.node.type === 'module_access' && path.node.previousSibling?.type == '::') {
-				return ['::', path.call(print)];
-			}
-			return path.call(print);
-		}, 'nonFormattingChildren'),
-	);
+    // allow `::module::Expression` in annotations
+    return join(
+        ' = ',
+        path.map((path) => {
+            if (path.node.type === 'module_access' && path.node.previousSibling?.type == '::') {
+                return ['::', path.call(print)];
+            }
+            return path.call(print);
+        }, 'nonFormattingChildren'),
+    );
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/common.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/common.ts
@@ -11,200 +11,200 @@ const { group, join, line, indent, hardline } = doc.builders;
  * Creates a callback function to print common nodes.
  */
 export default function (path: AstPath<Node>): treeFn | null {
-	switch (path.node.type) {
-		case Common.PrimitiveType:
-			return printPrimitiveType;
-		case Common.ModuleAccess:
-			return printModuleAccess;
+    switch (path.node.type) {
+        case Common.PrimitiveType:
+            return printPrimitiveType;
+        case Common.ModuleAccess:
+            return printModuleAccess;
 
-		// identifiers
-		case Common.Identifier:
-		case Common.FieldIdentifier:
-		case Common.VariableIdentifier:
-			return printIdentifier;
+        // identifiers
+        case Common.Identifier:
+        case Common.FieldIdentifier:
+        case Common.VariableIdentifier:
+            return printIdentifier;
 
-		case Common.RefType:
-			return printRefType;
-		case Common.FunctionType:
-			return printFunctionType;
-		case Common.FunctionTypeParameters:
-			return printFunctionTypeParameters;
+        case Common.RefType:
+            return printRefType;
+        case Common.FunctionType:
+            return printFunctionType;
+        case Common.FunctionTypeParameters:
+            return printFunctionTypeParameters;
 
-		case Common.Ability:
-			return printAbility;
+        case Common.Ability:
+            return printAbility;
 
-		case Common.TupleType:
-			return printTupleType;
+        case Common.TupleType:
+            return printTupleType;
 
-		// === Bindings ===
+        // === Bindings ===
 
-		case Common.BindUnpack:
-			return printBindUnpack;
-		case Common.BindFields:
-			return printBindFields;
-		case Common.MutBindField:
-			return printMutBindField;
-		case Common.BindField:
-			return printBindField;
-		case Common.BindList:
-			return printBindList;
-		case Common.CommaBindList:
-			return printCommaBindList;
-		case Common.OrBindList:
-			return printOrBindList;
-		case Common.AtBind:
-			return printAtBind;
-		case Common.BindNamedFields:
-			return printBindNamedFields;
-		case Common.BindPositionalFields:
-			return printBindPositionalFields;
-		case Common.BindVar:
-			return printBindVar;
-		case Common.MutBindVar:
-			return printMutBindVar;
-		case Common.ImmRef:
-			return printImmRef;
-		case Common.MutRef:
-			return printMutRef;
+        case Common.BindUnpack:
+            return printBindUnpack;
+        case Common.BindFields:
+            return printBindFields;
+        case Common.MutBindField:
+            return printMutBindField;
+        case Common.BindField:
+            return printBindField;
+        case Common.BindList:
+            return printBindList;
+        case Common.CommaBindList:
+            return printCommaBindList;
+        case Common.OrBindList:
+            return printOrBindList;
+        case Common.AtBind:
+            return printAtBind;
+        case Common.BindNamedFields:
+            return printBindNamedFields;
+        case Common.BindPositionalFields:
+            return printBindPositionalFields;
+        case Common.BindVar:
+            return printBindVar;
+        case Common.MutBindVar:
+            return printMutBindVar;
+        case Common.ImmRef:
+            return printImmRef;
+        case Common.MutRef:
+            return printMutRef;
 
-		case Common.Label:
-			return printLabel;
-		case Common.Alias:
-			return printAlias;
-		case Common.BlockIdentifier:
-			return printBlockIdentifier;
-		case Common.UnaryOperator:
-			return printUnaryOperator;
-		case Common.FieldInitializeList:
-			return printFieldInitializeList;
-		case Common.ExpressionField:
-			return printExpressionField;
-		case Common.ArgList:
-			return printArgList;
-	}
+        case Common.Label:
+            return printLabel;
+        case Common.Alias:
+            return printAlias;
+        case Common.BlockIdentifier:
+            return printBlockIdentifier;
+        case Common.UnaryOperator:
+            return printUnaryOperator;
+        case Common.FieldInitializeList:
+            return printFieldInitializeList;
+        case Common.ExpressionField:
+            return printExpressionField;
+        case Common.ArgList:
+            return printArgList;
+    }
 
-	return null;
+    return null;
 }
 
 /**
  * Nodes which are used across multiple files, yet can't be categorized.
  */
 export enum Common {
-	PrimitiveType = 'primitive_type',
-	VariableIdentifier = 'variable_identifier',
-	ModuleAccess = 'module_access',
-	Identifier = 'identifier',
-	RefType = 'ref_type',
-	FunctionType = 'function_type',
-	FunctionTypeParameters = 'function_type_parameters',
-	FieldIdentifier = 'field_identifier',
-	BlockIdentifier = 'block_identifier',
+    PrimitiveType = 'primitive_type',
+    VariableIdentifier = 'variable_identifier',
+    ModuleAccess = 'module_access',
+    Identifier = 'identifier',
+    RefType = 'ref_type',
+    FunctionType = 'function_type',
+    FunctionTypeParameters = 'function_type_parameters',
+    FieldIdentifier = 'field_identifier',
+    BlockIdentifier = 'block_identifier',
 
-	Ability = 'ability',
-	TupleType = 'tuple_type',
+    Ability = 'ability',
+    TupleType = 'tuple_type',
 
-	// === Bindings ===
+    // === Bindings ===
 
-	BindUnpack = 'bind_unpack',
-	BindFields = 'bind_fields',
-	MutBindField = 'mut_bind_field',
-	BindField = 'bind_field',
-	BindList = 'bind_list',
-	BindNamedFields = 'bind_named_fields',
-	CommaBindList = 'comma_bind_list',
-	OrBindList = 'or_bind_list',
-	AtBind = 'at_bind',
-	BindPositionalFields = 'bind_positional_fields',
-	BindVar = 'bind_var',
-	MutBindVar = 'mut_bind_var',
-	ImmRef = 'imm_ref',
-	MutRef = 'mut_ref',
+    BindUnpack = 'bind_unpack',
+    BindFields = 'bind_fields',
+    MutBindField = 'mut_bind_field',
+    BindField = 'bind_field',
+    BindList = 'bind_list',
+    BindNamedFields = 'bind_named_fields',
+    CommaBindList = 'comma_bind_list',
+    OrBindList = 'or_bind_list',
+    AtBind = 'at_bind',
+    BindPositionalFields = 'bind_positional_fields',
+    BindVar = 'bind_var',
+    MutBindVar = 'mut_bind_var',
+    ImmRef = 'imm_ref',
+    MutRef = 'mut_ref',
 
-	Label = 'label',
-	Alias = 'alias',
-	UnaryOperator = 'unary_op',
-	FieldInitializeList = 'field_initialize_list',
-	ExpressionField = 'exp_field',
+    Label = 'label',
+    Alias = 'alias',
+    UnaryOperator = 'unary_op',
+    FieldInitializeList = 'field_initialize_list',
+    ExpressionField = 'exp_field',
 
-	// used in `call_expression` and `macro_call_expression`
-	ArgList = 'arg_list',
+    // used in `call_expression` and `macro_call_expression`
+    ArgList = 'arg_list',
 }
 
 /**
  * Print `primitive_type` node.
  */
 export function printPrimitiveType(path: AstPath<Node>, _opt: MoveOptions, _p: printFn): Doc {
-	return path.node.text;
+    return path.node.text;
 }
 
 /**
  * Print `module_access` node.
  */
 export function printModuleAccess(path: AstPath<Node>, _opt: MoveOptions, print: printFn): Doc {
-	return path.map(print, 'children');
+    return path.map(print, 'children');
 }
 
 /**
  * Print `ref_type` node.
  */
 export function printRefType(path: AstPath<Node>, _opt: MoveOptions, print: printFn): Doc {
-	return group([
-		path.call(print, 'nonFormattingChildren', 0), // ref_type
-		path.call(print, 'nonFormattingChildren', 1), // type
-	]);
+    return group([
+        path.call(print, 'nonFormattingChildren', 0), // ref_type
+        path.call(print, 'nonFormattingChildren', 1), // type
+    ]);
 }
 
 /**
  * Print `arg_list` node.
  */
 function printArgList(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	const nodes = path.node.nonFormattingChildren;
+    const nodes = path.node.nonFormattingChildren;
 
-	if (nodes.length === 1 && nodes[0]!.isBreakableExpression) {
-		const child = nodes[0]!;
-		const shouldBreak =
-			nodes[0]?.trailingComment?.type === 'line_comment' ||
-			nodes[0]?.leadingComment.some((e) => e.type === 'line_comment');
+    if (nodes.length === 1 && nodes[0]!.isBreakableExpression) {
+        const child = nodes[0]!;
+        const shouldBreak =
+            nodes[0]?.trailingComment?.type === 'line_comment' ||
+            nodes[0]?.leadingComment.some((e) => e.type === 'line_comment');
 
-		if (shouldBreak) {
-			return [
-				'(',
-				indent(hardline),
-				indent(path.call(print, 'nonFormattingChildren', 0)),
-				hardline,
-				')',
-			];
-		}
+        if (shouldBreak) {
+            return [
+                '(',
+                indent(hardline),
+                indent(path.call(print, 'nonFormattingChildren', 0)),
+                hardline,
+                ')',
+            ];
+        }
 
-		return ['(', path.call(print, 'nonFormattingChildren', 0), ')'];
-	}
+        return ['(', path.call(print, 'nonFormattingChildren', 0), ')'];
+    }
 
-	return group(list({ path, print, options, open: '(', close: ')' }), {
-		shouldBreak: shouldBreakFirstChild(path),
-	});
+    return group(list({ path, print, options, open: '(', close: ')' }), {
+        shouldBreak: shouldBreakFirstChild(path),
+    });
 }
 
 /**
  * Print `ability` node.
  */
 export function printAbility(path: AstPath<Node>, _opt: MoveOptions, _p: printFn): Doc {
-	return path.node.text;
+    return path.node.text;
 }
 
 /**
  * Print `tuple_type` node.
  */
 export function printTupleType(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	return group(
-		list({
-			path,
-			print,
-			options,
-			open: '(',
-			close: ')',
-			shouldBreak: false,
-		}),
-	);
+    return group(
+        list({
+            path,
+            print,
+            options,
+            open: '(',
+            close: ')',
+            shouldBreak: false,
+        }),
+    );
 }
 
 // === Bindings ===
@@ -221,7 +221,7 @@ export function printTupleType(path: AstPath<Node>, options: MoveOptions, print:
  * `let Struct { field1, field2 } = ...;`
  */
 function printBindUnpack(path: AstPath<Node>, _opt: MoveOptions, print: printFn): Doc {
-	return path.map(print, 'nonFormattingChildren');
+    return path.map(print, 'nonFormattingChildren');
 }
 
 /**
@@ -229,28 +229,28 @@ function printBindUnpack(path: AstPath<Node>, _opt: MoveOptions, print: printFn)
  * Choice node between `bind_named_fields` and `bind_positional_fields`.
  */
 function printBindFields(path: AstPath<Node>, _opt: MoveOptions, print: printFn): Doc {
-	return path.call(print, 'nonFormattingChildren', 0);
+    return path.call(print, 'nonFormattingChildren', 0);
 }
 
 /**
  * Print `bind_field` node.
  */
 function printBindField(path: AstPath<Node>, _opt: MoveOptions, print: printFn): Doc {
-	// special case for `..` operator
-	if (path.node.child(0)?.type == '..') {
-		return '..';
-	}
+    // special case for `..` operator
+    if (path.node.child(0)?.type == '..') {
+        return '..';
+    }
 
-	// if there's only one child, we can just print it
-	// if there're two, they will be joined
-	return join(': ', path.map(print, 'nonFormattingChildren'));
+    // if there's only one child, we can just print it
+    // if there're two, they will be joined
+    return join(': ', path.map(print, 'nonFormattingChildren'));
 }
 
 /**
  * Print `mut_bind_field` node.
  */
 function printMutBindField(path: AstPath<Node>, _opt: MoveOptions, print: printFn): Doc {
-	return ['mut ', path.call(print, 'nonFormattingChildren', 0)];
+    return ['mut ', path.call(print, 'nonFormattingChildren', 0)];
 }
 
 /**
@@ -261,125 +261,125 @@ function printMutBindField(path: AstPath<Node>, _opt: MoveOptions, print: printF
  * - another is a list, and we know it because the first member is `(`.
  */
 function printBindList(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	if (path.node.nonFormattingChildren.length == 1) {
-		return join(' ', path.map(print, 'nonFormattingChildren'));
-	}
+    if (path.node.nonFormattingChildren.length == 1) {
+        return join(' ', path.map(print, 'nonFormattingChildren'));
+    }
 
-	return group(list({ path, print, options, open: '(', close: ')' }));
+    return group(list({ path, print, options, open: '(', close: ')' }));
 }
 
 /**
  * Print `comma_bind_list` node.
  */
 function printCommaBindList(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	return group(list({ path, print, options, open: '(', close: ')' }));
+    return group(list({ path, print, options, open: '(', close: ')' }));
 }
 
 /**
  * Print `at_bind` node.
  */
 function printAtBind(path: AstPath<Node>, _opt: MoveOptions, print: printFn): Doc {
-	return join(' @ ', path.map(print, 'nonFormattingChildren'));
+    return join(' @ ', path.map(print, 'nonFormattingChildren'));
 }
 
 /**
  * Print `or_bind_list` node.
  */
 function printOrBindList(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	return group(join([' |', line], path.map(print, 'nonFormattingChildren')));
+    return group(join([' |', line], path.map(print, 'nonFormattingChildren')));
 }
 
 /**
  * Print `bind_named_fields` node.
  */
 function printBindNamedFields(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	return [
-		' ',
-		group(list({ path, print, options, open: '{', close: '}', addWhitespace: true }), {
-			shouldBreak: shouldBreakFirstChild(path),
-		}),
-	];
+    return [
+        ' ',
+        group(list({ path, print, options, open: '{', close: '}', addWhitespace: true }), {
+            shouldBreak: shouldBreakFirstChild(path),
+        }),
+    ];
 }
 
 /**
  * Print `bind_positional_fields` node.
  */
 function printBindPositionalFields(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	return group(list({ path, print, options, open: '(', close: ')' }), {
-		shouldBreak: shouldBreakFirstChild(path),
-	});
+    return group(list({ path, print, options, open: '(', close: ')' }), {
+        shouldBreak: shouldBreakFirstChild(path),
+    });
 }
 
 /**
  * Print `bind_var` node.
  */
 function printBindVar(path: AstPath<Node>, _opt: MoveOptions, print: printFn): Doc {
-	return path.call(print, 'nonFormattingChildren', 0);
+    return path.call(print, 'nonFormattingChildren', 0);
 }
 
 /**
  * Print `mut_bind_var` node.
  */
 function printMutBindVar(path: AstPath<Node>, _opt: MoveOptions, print: printFn): Doc {
-	return ['mut ', path.call(print, 'nonFormattingChildren', 0)];
+    return ['mut ', path.call(print, 'nonFormattingChildren', 0)];
 }
 
 /**
  * Print `imm_ref` node.
  */
 function printImmRef(path: AstPath<Node>, _opt: MoveOptions, print: printFn): Doc {
-	return '&';
+    return '&';
 }
 
 /**
  * Print `mut_ref` node.
  */
 function printMutRef(path: AstPath<Node>, _opt: MoveOptions, print: printFn): Doc {
-	return '&mut ';
+    return '&mut ';
 }
 
 /**
  * Print `alias` node. ...as `identifier`
  */
 export function printAlias(path: AstPath<Node>, _opt: MoveOptions, print: printFn): Doc {
-	return ['as ', path.call(print, 'nonFormattingChildren', 0)];
+    return ['as ', path.call(print, 'nonFormattingChildren', 0)];
 }
 
 /**
  * Print `block_identifier` node.
  */
 function printBlockIdentifier(path: AstPath<Node>, _opt: MoveOptions, print: printFn): Doc {
-	return path.call(print, 'nonFormattingChildren', 0);
+    return path.call(print, 'nonFormattingChildren', 0);
 }
 
 /**
  * Print `label` node.
  */
 function printLabel(path: AstPath<Node>, _opt: MoveOptions, _p: printFn): Doc {
-	if (path.node.nextSibling?.type == ':') {
-		return [path.node.text, ':'];
-	}
+    if (path.node.nextSibling?.type == ':') {
+        return [path.node.text, ':'];
+    }
 
-	return path.node.text;
+    return path.node.text;
 }
 
 /**
  * Print `unary_op` node.
  */
 function printUnaryOperator(path: AstPath<Node>, _opt: MoveOptions, _p: printFn): Doc {
-	return path.node.text;
+    return path.node.text;
 }
 
 /**
  * Print `field_initialize_list` node.
  */
 function printFieldInitializeList(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	return [
-		' ',
-		group(list({ path, print, options, open: '{', close: '}', addWhitespace: true }), {
-			shouldBreak: shouldBreakFirstChild(path),
-		}),
-	];
+    return [
+        ' ',
+        group(list({ path, print, options, open: '{', close: '}', addWhitespace: true }), {
+            shouldBreak: shouldBreakFirstChild(path),
+        }),
+    ];
 }
 
 /**
@@ -389,13 +389,13 @@ function printFieldInitializeList(path: AstPath<Node>, options: MoveOptions, pri
  * - `expression`
  */
 function printExpressionField(path: AstPath<Node>, _opt: MoveOptions, print: printFn): Doc {
-	const children = path.map(print, 'nonFormattingChildren');
+    const children = path.map(print, 'nonFormattingChildren');
 
-	if (children.length === 1) {
-		return children[0]!;
-	}
+    if (children.length === 1) {
+        return children[0]!;
+    }
 
-	return group([children[0]!, ': ', children[1]!]);
+    return group([children[0]!, ': ', children[1]!]);
 }
 
 /**
@@ -405,26 +405,26 @@ function printExpressionField(path: AstPath<Node>, _opt: MoveOptions, print: pri
  * - `return_type`
  */
 function printFunctionType(path: AstPath<Node>, _opt: MoveOptions, print: printFn): Doc {
-	const children = path.map(print, 'nonFormattingChildren');
+    const children = path.map(print, 'nonFormattingChildren');
 
-	if (children.length === 0) {
-		return '||';
-	}
+    if (children.length === 0) {
+        return '||';
+    }
 
-	if (children.length === 1) {
-		return children[0]!;
-	}
+    if (children.length === 1) {
+        return children[0]!;
+    }
 
-	return join(' -> ', children);
+    return join(' -> ', children);
 }
 
 /**
  * Print `function_type_parameters` node.
  */
 function printFunctionTypeParameters(
-	path: AstPath<Node>,
-	options: MoveOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    options: MoveOptions,
+    print: printFn,
 ): Doc {
-	return group(list({ path, print, options, open: '|', close: '|' }));
+    return group(list({ path, print, options, open: '|', close: '|' }));
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/constant.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/constant.ts
@@ -18,13 +18,13 @@ export const NODE_TYPE = 'constant';
  * - `constant_identifier`
  */
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printConstant;
-	} else if (path.node.type === 'constant_identifier') {
-		return printIdentifier;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printConstant;
+    } else if (path.node.type === 'constant_identifier') {
+        return printIdentifier;
+    }
 
-	return null;
+    return null;
 }
 
 /**
@@ -33,36 +33,36 @@ export default function (path: AstPath<Node>): treeFn | null {
  * See `module-members/constant.move` for tests.
  */
 function printConstant(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	const expression = path.node.nonFormattingChildren[2];
-	const trailing = lineSuffix(printTrailingComment(path));
-	path.node.disableTrailingComment();
+    const expression = path.node.nonFormattingChildren[2];
+    const trailing = lineSuffix(printTrailingComment(path));
+    path.node.disableTrailingComment();
 
-	const printCb = (path: AstPath<Node>) => printConstExpression(path, options, print);
-	const groupId = Symbol('type_group');
+    const printCb = (path: AstPath<Node>) => printConstExpression(path, options, print);
+    const groupId = Symbol('type_group');
 
-	if (path.node.nonFormattingChildren.length !== 3) {
-		throw new Error('`constant` expects 3 children');
-	}
+    if (path.node.nonFormattingChildren.length !== 3) {
+        throw new Error('`constant` expects 3 children');
+    }
 
-	const [identDoc, typeDoc, exprDoc] = path.map(printCb, 'nonFormattingChildren');
-	const parts = [] as Doc[];
+    const [identDoc, typeDoc, exprDoc] = path.map(printCb, 'nonFormattingChildren');
+    const parts = [] as Doc[];
 
-	// const <ident> : <type> = <expr>;
-	parts.push('const ', identDoc!);
-	parts.push(': ', group(typeDoc!, { id: groupId }), ' =');
+    // const <ident> : <type> = <expr>;
+    parts.push('const ', identDoc!);
+    parts.push(': ', group(typeDoc!, { id: groupId }), ' =');
 
-	if (expression?.isList) {
-		parts.push(
-			group([
-				ifBreak(indent(line), ' ', { groupId }),
-				ifBreak(indent(exprDoc!), exprDoc, { groupId }),
-			]),
-		);
-	} else {
-		parts.push(group([indent(line), indent(exprDoc!)]));
-	}
+    if (expression?.isList) {
+        parts.push(
+            group([
+                ifBreak(indent(line), ' ', { groupId }),
+                ifBreak(indent(exprDoc!), exprDoc, { groupId }),
+            ]),
+        );
+    } else {
+        parts.push(group([indent(line), indent(exprDoc!)]));
+    }
 
-	return parts.concat([';', trailing]);
+    return parts.concat([';', trailing]);
 }
 
 // Sub-router for expressions in the const declaration. Special cases are:
@@ -70,41 +70,41 @@ function printConstant(path: AstPath<Node>, options: MoveOptions, print: printFn
 // - for vectors with `num` and `bool` literals, we want to fill single line
 // - for blocks we want breakability
 function printConstExpression(path: AstPath<Node>, options: MoveOptions, print: printFn) {
-	if (path.node.type === VectorExpression.NODE_TYPE) {
-		return prettyNumVector(path, options, print);
-	}
+    if (path.node.type === VectorExpression.NODE_TYPE) {
+        return prettyNumVector(path, options, print);
+    }
 
-	if (path.node.type === 'block') {
-		return printBreakableBlock(path, options, print);
-	}
+    if (path.node.type === 'block') {
+        return printBreakableBlock(path, options, print);
+    }
 
-	return print(path);
+    return print(path);
 }
 
 // TODO: optionally move this to `VectorExpression`
 function prettyNumVector(path: AstPath<Node>, options: MoveOptions, print: printFn) {
-	let elType = path.node.nonFormattingChildren[0]?.type;
-	if (elType && ['num_literal', 'bool_literal'].includes(elType)) {
-		let allSameType = !path.node.nonFormattingChildren.some((e) => e.type !== elType);
-		let hasComments = path.node.namedChildren.some(
-			(e) => e.trailingComment || e.leadingComment.length > 0,
-		);
+    let elType = path.node.nonFormattingChildren[0]?.type;
+    if (elType && ['num_literal', 'bool_literal'].includes(elType)) {
+        let allSameType = !path.node.nonFormattingChildren.some((e) => e.type !== elType);
+        let hasComments = path.node.namedChildren.some(
+            (e) => e.trailingComment || e.leadingComment.length > 0,
+        );
 
-		if (allSameType && !hasComments) {
-			const literals = path.map(print, 'nonFormattingChildren');
+        if (allSameType && !hasComments) {
+            const literals = path.map(print, 'nonFormattingChildren');
 
-			if (literals.length == 0) {
-				return 'vector[]';
-			}
+            if (literals.length == 0) {
+                return 'vector[]';
+            }
 
-			const elements = join([',', line], literals);
-			return [
-				'vector[',
-				group([indent(softline), indent(fill(elements)), ifBreak(','), softline]),
-				']',
-			];
-		}
-	}
+            const elements = join([',', line], literals);
+            return [
+                'vector[',
+                group([indent(softline), indent(fill(elements)), ifBreak(','), softline]),
+                ']',
+            ];
+        }
+    }
 
-	return print(path);
+    return print(path);
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/enum_definition.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/enum_definition.ts
@@ -8,39 +8,39 @@ import { printIdentifier, printTrailingComment } from '../utilities';
 const { join, lineSuffix, indent, hardline, group, line, ifBreak } = doc.builders;
 
 export default function (path: AstPath<Node>): treeFn | null {
-	switch (path.node.type) {
-		case EnumDefinition.EnumDefinition:
-			return printEnumDefinition;
-		case EnumDefinition.EnumVariants:
-			return printEnumVariants;
-		case EnumDefinition.Variant:
-			return printVariant;
+    switch (path.node.type) {
+        case EnumDefinition.EnumDefinition:
+            return printEnumDefinition;
+        case EnumDefinition.EnumVariants:
+            return printEnumVariants;
+        case EnumDefinition.Variant:
+            return printVariant;
 
-		// identifiers
-		case EnumDefinition.EnumIdentifier:
-		case EnumDefinition.VariantIdentifier:
-			return printIdentifier;
-	}
+        // identifiers
+        case EnumDefinition.EnumIdentifier:
+        case EnumDefinition.VariantIdentifier:
+            return printIdentifier;
+    }
 
-	return null;
+    return null;
 }
 
 export enum EnumDefinition {
-	EnumDefinition = 'enum_definition',
-	EnumVariants = 'enum_variants',
-	Variant = 'variant',
+    EnumDefinition = 'enum_definition',
+    EnumVariants = 'enum_variants',
+    Variant = 'variant',
 
-	EnumIdentifier = 'enum_identifier',
-	VariantIdentifier = 'variant_identifier',
+    EnumIdentifier = 'enum_identifier',
+    VariantIdentifier = 'variant_identifier',
 }
 
 /**
  * Print `enum_definition` node.
  */
 export function printEnumDefinition(path: AstPath<Node>, _opt: MoveOptions, print: printFn): Doc {
-	const isPublic = path.node.child(0)?.type == 'public';
+    const isPublic = path.node.child(0)?.type == 'public';
 
-	return [isPublic ? 'public ' : '', 'enum ', path.map(print, 'nonFormattingChildren')];
+    return [isPublic ? 'public ' : '', 'enum ', path.map(print, 'nonFormattingChildren')];
 }
 
 /**
@@ -48,18 +48,18 @@ export function printEnumDefinition(path: AstPath<Node>, _opt: MoveOptions, prin
  * List of `variant` nodes.
  */
 export function printEnumVariants(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	if (path.node.nonFormattingChildren.length === 0) {
-		return ' {}';
-	}
+    if (path.node.nonFormattingChildren.length === 0) {
+        return ' {}';
+    }
 
-	return group([
-		' {',
-		indent(hardline),
-		indent(join([',', line], path.map(print, 'nonFormattingChildren'))),
-		ifBreak(','),
-		hardline,
-		'}',
-	]);
+    return group([
+        ' {',
+        indent(hardline),
+        indent(join([',', line], path.map(print, 'nonFormattingChildren'))),
+        ifBreak(','),
+        hardline,
+        '}',
+    ]);
 }
 
 /**
@@ -69,7 +69,7 @@ export function printEnumVariants(path: AstPath<Node>, options: MoveOptions, pri
  * - `datatype_fields` (optional)
  */
 export function printVariant(path: AstPath<Node>, _opt: MoveOptions, print: printFn): Doc {
-	const trailing = lineSuffix(printTrailingComment(path, false));
-	path.node.disableTrailingComment();
-	return [path.map(print, 'nonFormattingChildren'), trailing];
+    const trailing = lineSuffix(printTrailingComment(path, false));
+    path.node.disableTrailingComment();
+    return [path.map(print, 'nonFormattingChildren'), trailing];
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/abort_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/abort_expression.ts
@@ -10,26 +10,26 @@ const { group, indent, line } = doc.builders;
 export const NODE_TYPE = 'abort_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printAbortExpression;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printAbortExpression;
+    }
 
-	return null;
+    return null;
 }
 
 /**
  * Print `abort_expression` node.
  */
 function printAbortExpression(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	const expression = path.node.nonFormattingChildren[0];
-	const printed = path.call(print, 'nonFormattingChildren', 0);
+    const expression = path.node.nonFormattingChildren[0];
+    const printed = path.call(print, 'nonFormattingChildren', 0);
 
-	if (!expression) return 'abort';
+    if (!expression) return 'abort';
 
-	return group([
-		'abort',
-		expression?.isList || expression?.isControlFlow
-			? [' ', printed]
-			: [indent(line), indent(printed)],
-	]);
+    return group([
+        'abort',
+        expression?.isList || expression?.isControlFlow
+            ? [' ', printed]
+            : [indent(line), indent(printed)],
+    ]);
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/annotation_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/annotation_expression.ts
@@ -10,29 +10,29 @@ const { group, indent, softline } = doc.builders;
 export const NODE_TYPE = 'annotation_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printAnnotationExpression;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printAnnotationExpression;
+    }
 
-	return null;
+    return null;
 }
 
 /**
  * Print `annotation_expression` node.
  */
 function printAnnotationExpression(path: AstPath<Node>, _opt: MoveOptions, print: printFn): Doc {
-	const children = path.map(print, 'nonFormattingChildren');
-	if (children.length !== 2) {
-		throw new Error('`annotation_expression` node should have 2 children');
-	}
+    const children = path.map(print, 'nonFormattingChildren');
+    if (children.length !== 2) {
+        throw new Error('`annotation_expression` node should have 2 children');
+    }
 
-	return group([
-		'(',
-		indent(softline),
-		indent(children[0]!), // expression
-		': ',
-		children[1]!, // type
-		softline,
-		')',
-	]);
+    return group([
+        '(',
+        indent(softline),
+        indent(children[0]!), // expression
+        ': ',
+        children[1]!, // type
+        softline,
+        ')',
+    ]);
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/assign_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/assign_expression.ts
@@ -49,13 +49,23 @@ function printAssignExpression(path: AstPath<Node>, options: MoveOptions, print:
         ),
     );
 
-    // then print the rhs
-    result.push(
-        group([
-            shouldBreak ? '' : indent(line),
-            indent(path.call(print, 'nonFormattingChildren', 1)),
-        ]),
-    );
+    const rhs = path.node.nonFormattingChildren[1]!;
+    if ((rhs.isControlFlow || rhs.isList) && !shouldBreak) {
+        result.push(
+            group([
+                ' ',
+                path.call(print, 'nonFormattingChildren', 1),
+            ]),
+        );
+    } else {
+        // then print the rhs
+        result.push(
+            group([
+                shouldBreak ? '' : indent(line),
+                indent(path.call(print, 'nonFormattingChildren', 1)),
+            ]),
+        );
+    }
 
     return result;
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/assign_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/assign_expression.ts
@@ -11,40 +11,51 @@ const { group, indent, line } = doc.builders;
 export const NODE_TYPE = 'assign_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printAssignExpression;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printAssignExpression;
+    }
 
-	return null;
+    return null;
 }
 
 /**
  * Print `assign_expression` node.
  */
 function printAssignExpression(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	if (path.node.nonFormattingChildren.length !== 2) {
-		throw new Error('`assign_expression` must have 2 children');
-	}
+    if (path.node.nonFormattingChildren.length !== 2) {
+        throw new Error('`assign_expression` must have 2 children');
+    }
 
-	const result: Doc[] = [];
-	let shouldBreak = false;
+    const result: Doc[] = [];
+    let shouldBreak = false;
 
-	// together with the LHS we print trailing comment if there is one
-	result.push(path.call((lhs) => {
-		const hasComment = !!lhs.node.trailingComment;
+    // together with the LHS we print trailing comment if there is one
+    result.push(
+        path.call(
+            (lhs) => {
+                const hasComment = !!lhs.node.trailingComment;
 
-		if (lhs.node.trailingComment?.type == 'line_comment') {
-			shouldBreak = true;
-			const trailingLineComment = printTrailingComment(lhs, true);
-			lhs.node.disableTrailingComment();
-			return [print(lhs), ' =', indent(trailingLineComment)];
-		}
+                if (lhs.node.trailingComment?.type == 'line_comment') {
+                    shouldBreak = true;
+                    const trailingLineComment = printTrailingComment(lhs, true);
+                    lhs.node.disableTrailingComment();
+                    return [print(lhs), ' =', indent(trailingLineComment)];
+                }
 
-		return [print(lhs), hasComment ? '=' : ' ='];
-	}, 'nonFormattingChildren', 0));
+                return [print(lhs), hasComment ? '=' : ' ='];
+            },
+            'nonFormattingChildren',
+            0,
+        ),
+    );
 
-	// then print the rhs
-	result.push(group([shouldBreak ? '' : indent(line), indent(path.call(print, 'nonFormattingChildren', 1))]));
+    // then print the rhs
+    result.push(
+        group([
+            shouldBreak ? '' : indent(line),
+            indent(path.call(print, 'nonFormattingChildren', 1)),
+        ]),
+    );
 
-	return result;
+    return result;
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/assign_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/assign_expression.ts
@@ -35,16 +35,16 @@ function printAssignExpression(path: AstPath<Node>, options: MoveOptions, print:
 
 		if (lhs.node.trailingComment?.type == 'line_comment') {
 			shouldBreak = true;
-			const trailingLineComment = printTrailingComment(lhs, false);
+			const trailingLineComment = printTrailingComment(lhs, true);
 			lhs.node.disableTrailingComment();
-			return [print(lhs), ' =', trailingLineComment];
+			return [print(lhs), ' =', indent(trailingLineComment)];
 		}
 
 		return [print(lhs), hasComment ? '=' : ' ='];
 	}, 'nonFormattingChildren', 0));
 
 	// then print the rhs
-	result.push(group([indent(line), indent(path.call(print, 'nonFormattingChildren', 1))], { shouldBreak }));
+	result.push(group([shouldBreak ? '' : indent(line), indent(path.call(print, 'nonFormattingChildren', 1))]));
 
 	return result;
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/assign_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/assign_expression.ts
@@ -51,12 +51,7 @@ function printAssignExpression(path: AstPath<Node>, options: MoveOptions, print:
 
     const rhs = path.node.nonFormattingChildren[1]!;
     if ((rhs.isControlFlow || rhs.isList) && !shouldBreak) {
-        result.push(
-            group([
-                ' ',
-                path.call(print, 'nonFormattingChildren', 1),
-            ]),
-        );
+        result.push(group([' ', path.call(print, 'nonFormattingChildren', 1)]));
     } else {
         // then print the rhs
         result.push(

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/assign_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/assign_expression.ts
@@ -44,7 +44,7 @@ function printAssignExpression(path: AstPath<Node>, options: MoveOptions, print:
 	}, 'nonFormattingChildren', 0));
 
 	// then print the rhs
-	result.push(group([indent(line), path.call(print, 'nonFormattingChildren', 1)], { shouldBreak }));
+	result.push(group([indent(line), indent(path.call(print, 'nonFormattingChildren', 1))], { shouldBreak }));
 
 	return result;
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/binary_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/binary_expression.ts
@@ -11,17 +11,17 @@ export const NODE_TYPE = 'binary_expression';
 
 // TODO: re-enable binary expression once we figure out how to achieve it.
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return () => path.node.text;
-		// TODO: re-enable binary expression once we figure out how to achieve it.
-		// return printBinaryExpression;
-	} else if (path.node.type === 'binary_operator') {
-		// return printBinaryOperator;
-		// TODO: re-enable binary expression once we figure out how to achieve it.
-		return () => path.node.text;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return () => path.node.text;
+        // TODO: re-enable binary expression once we figure out how to achieve it.
+        // return printBinaryExpression;
+    } else if (path.node.type === 'binary_operator') {
+        // return printBinaryOperator;
+        // TODO: re-enable binary expression once we figure out how to achieve it.
+        return () => path.node.text;
+    }
 
-	return null;
+    return null;
 }
 
 /**
@@ -29,25 +29,25 @@ export default function (path: AstPath<Node>): treeFn | null {
  * (Currently disabled)
  */
 function printBinaryExpression(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	if (path.node.nonFormattingChildren.length != 3) {
-		throw new Error('`binary_expression` node should have 3 children');
-	}
+    if (path.node.nonFormattingChildren.length != 3) {
+        throw new Error('`binary_expression` node should have 3 children');
+    }
 
-	const [one, two, three] = path.map(print, 'nonFormattingChildren');
-	const rhs = path.node.nonFormattingChildren[2];
+    const [one, two, three] = path.map(print, 'nonFormattingChildren');
+    const rhs = path.node.nonFormattingChildren[2];
 
-	if (rhs?.type === 'block' || rhs?.type === 'expression_list') {
-		return [one!, ' ', two!, ' ', three!];
-	}
+    if (rhs?.type === 'block' || rhs?.type === 'expression_list') {
+        return [one!, ' ', two!, ' ', three!];
+    }
 
-	return [one!, ' ', two!, group([line, three!], { shouldBreak: false })];
+    return [one!, ' ', two!, group([line, three!], { shouldBreak: false })];
 }
 
 /**
  * Print `binary_operator` node.
  */
 export function printBinaryOperator(path: AstPath<Node>, _opt: MoveOptions, _p: printFn): Doc {
-	return path.node.text;
+    return path.node.text;
 }
 
 /**

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/block.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/block.ts
@@ -11,11 +11,11 @@ const { group, indent, join, conditionalGroup, hardlineWithoutBreakParent } = do
 const NODE_TYPE = 'block';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printBlock;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printBlock;
+    }
 
-	return null;
+    return null;
 }
 
 /**
@@ -23,50 +23,50 @@ export default function (path: AstPath<Node>): treeFn | null {
  * lambda expressions.
  */
 export function printNonBreakingBlock(
-	path: AstPath<Node>,
-	options: MoveOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    options: MoveOptions,
+    print: printFn,
 ): Doc {
-	const length = path.node.nonFormattingChildren.length;
+    const length = path.node.nonFormattingChildren.length;
 
-	if (length == 0) {
-		return '{}';
-	}
+    if (length == 0) {
+        return '{}';
+    }
 
-	return group([
-		'{',
-		indent(hardlineWithoutBreakParent),
-		indent(join(hardlineWithoutBreakParent, path.map(print, 'namedAndEmptyLineChildren'))),
-		hardlineWithoutBreakParent,
-		'}',
-	]);
+    return group([
+        '{',
+        indent(hardlineWithoutBreakParent),
+        indent(join(hardlineWithoutBreakParent, path.map(print, 'namedAndEmptyLineChildren'))),
+        hardlineWithoutBreakParent,
+        '}',
+    ]);
 }
 
 export function printBreakableBlock(
-	path: AstPath<Node>,
-	options: MoveOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    options: MoveOptions,
+    print: printFn,
 ): Doc {
-	const length = path.node.nonFormattingChildren.length;
+    const length = path.node.nonFormattingChildren.length;
 
-	if (length == 0) {
-		return '{}';
-	}
+    if (length == 0) {
+        return '{}';
+    }
 
-	return block({
-		options,
-		print,
-		path,
-		shouldBreak: shouldBreakFirstChild(path),
-	});
+    return block({
+        options,
+        print,
+        path,
+        shouldBreak: shouldBreakFirstChild(path),
+    });
 }
 
 /**
  * Print `block` node.
  */
 export function printBlock(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	return conditionalGroup([
-		printBreakableBlock(path, options, print),
-		printNonBreakingBlock(path, options, print),
-	]);
+    return conditionalGroup([
+        printBreakableBlock(path, options, print),
+        printNonBreakingBlock(path, options, print),
+    ]);
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/block_item.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/block_item.ts
@@ -11,19 +11,19 @@ const { group, lineSuffix } = doc.builders;
 const NODE_TYPE = 'block_item';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printBlockItem;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printBlockItem;
+    }
 
-	return null;
+    return null;
 }
 
 /**
  * Print `block_item` node.
  */
 function printBlockItem(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	const trailing = lineSuffix(printTrailingComment(path));
-	path.node.disableTrailingComment();
+    const trailing = lineSuffix(printTrailingComment(path));
+    path.node.disableTrailingComment();
 
-	return [group([path.call(print, 'nonFormattingChildren', 0), ';', trailing])];
+    return [group([path.call(print, 'nonFormattingChildren', 0), ';', trailing])];
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/borrow_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/borrow_expression.ts
@@ -10,19 +10,19 @@ const {} = doc.builders;
 export const NODE_TYPE = 'borrow_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printBorrowExpression;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printBorrowExpression;
+    }
 
-	return null;
+    return null;
 }
 
 /**
  * Print `borrow_expression` node.
  */
 function printBorrowExpression(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	return [
-		path.call(print, 'nonFormattingChildren', 0), // borrow type
-		path.call(print, 'nonFormattingChildren', 1), // expression
-	];
+    return [
+        path.call(print, 'nonFormattingChildren', 0), // borrow type
+        path.call(print, 'nonFormattingChildren', 1), // expression
+    ];
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/break_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/break_expression.ts
@@ -10,24 +10,24 @@ const { join } = doc.builders;
 export const NODE_TYPE = 'break_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printBreakExpression;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printBreakExpression;
+    }
 
-	return null;
+    return null;
 }
 
 /**
  * Print `break_expression` node.
  */
 export function printBreakExpression(
-	path: AstPath<Node>,
-	options: MoveOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    options: MoveOptions,
+    print: printFn,
 ): Doc {
-	if (path.node.nonFormattingChildren.length > 0) {
-		return join(' ', ['break', ...path.map(print, 'nonFormattingChildren')]);
-	}
+    if (path.node.nonFormattingChildren.length > 0) {
+        return join(' ', ['break', ...path.map(print, 'nonFormattingChildren')]);
+    }
 
-	return 'break';
+    return 'break';
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/call_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/call_expression.ts
@@ -9,11 +9,11 @@ import { AstPath, Doc, doc } from 'prettier';
 export const NODE_TYPE = 'call_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printCallExpression;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printCallExpression;
+    }
 
-	return null;
+    return null;
 }
 
 /**
@@ -24,5 +24,5 @@ export default function (path: AstPath<Node>): treeFn | null {
  * - `arg_list`
  */
 function printCallExpression(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	return path.map(print, 'nonFormattingChildren');
+    return path.map(print, 'nonFormattingChildren');
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/cast_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/cast_expression.ts
@@ -10,11 +10,11 @@ const { join } = doc.builders;
 export const NODE_TYPE = 'cast_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printCastExpression;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printCastExpression;
+    }
 
-	return null;
+    return null;
 }
 
 /**
@@ -24,12 +24,12 @@ export default function (path: AstPath<Node>): treeFn | null {
  * - `type`
  */
 function printCastExpression(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	const parens = path.node.child(0)?.text == '(';
-	const children = path.map(print, 'nonFormattingChildren');
+    const parens = path.node.child(0)?.text == '(';
+    const children = path.map(print, 'nonFormattingChildren');
 
-	if (parens) {
-		return ['(', join(' as ', children), ')'];
-	}
+    if (parens) {
+        return ['(', join(' as ', children), ')'];
+    }
 
-	return join(' as ', children);
+    return join(' as ', children);
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/continue_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/continue_expression.ts
@@ -10,20 +10,20 @@ const {} = doc.builders;
 export const NODE_TYPE = 'continue_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printContinueExpression;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printContinueExpression;
+    }
 
-	return null;
+    return null;
 }
 
 /**
  * Print `continue_expression` node.
  */
 function printContinueExpression(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	if (path.node.nonFormattingChildren.length === 1) {
-		return ['continue ', path.call(print, 'nonFormattingChildren', 0)];
-	}
+    if (path.node.nonFormattingChildren.length === 1) {
+        return ['continue ', path.call(print, 'nonFormattingChildren', 0)];
+    }
 
-	return 'continue';
+    return 'continue';
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/dereference_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/dereference_expression.ts
@@ -10,24 +10,24 @@ const {} = doc.builders;
 export const NODE_TYPE = 'dereference_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printDereferenceExpression;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printDereferenceExpression;
+    }
 
-	return null;
+    return null;
 }
 
 /**
  * Print `dereference_expression` node.
- * 
+ *
  * Inside:
  * - `*`
  * - `_expression`
  */
 function printDereferenceExpression(
-	path: AstPath<Node>,
-	options: MoveOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    options: MoveOptions,
+    print: printFn,
 ): Doc {
-	return ['*', path.call(print, 'nonFormattingChildren', 0)];
+    return ['*', path.call(print, 'nonFormattingChildren', 0)];
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/dot_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/dot_expression.ts
@@ -35,10 +35,11 @@ function printDotExpression(path: AstPath<Node>, options: MoveOptions, print: pr
 		path.node.nonFormattingChildren[0]!.type === NODE_TYPE ||
 		path.node.parent?.type === NODE_TYPE;
 
+	const isParentList = path.node.parent?.isList;
+
 	// if dot expression has a trailing comment and it breaks, we need to
 	// print it manually after the rhs
 	const trailing = lineSuffix(printTrailingComment(path));
-	path.node.disableTrailingComment();
 
 	const lhs = path.call(
 		(path) => printNode(path, options, print, false),
@@ -57,12 +58,14 @@ function printDotExpression(path: AstPath<Node>, options: MoveOptions, print: pr
 	if (!isChain) {
 		const right = path.node.nonFormattingChildren[1]!;
 		if (right.leadingComment.length > 0) {
+			path.node.disableTrailingComment();
 			return [lhs, indent(softline), indent(rhs), trailing];
 		}
 
 		return [lhs, rhs];
 	}
 
+	path.node.disableTrailingComment();
 	const parts = [lhs, ifBreak(indent(softline), ''), ifBreak(indent(rhs), rhs), trailing];
 
 	// group if parent is not `dot_expression`

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/dot_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/dot_expression.ts
@@ -11,11 +11,11 @@ const { group, indent, ifBreak, breakParent, lineSuffix, softline } = doc.builde
 export const NODE_TYPE = 'dot_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printDotExpression;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printDotExpression;
+    }
 
-	return null;
+    return null;
 }
 
 /**
@@ -25,65 +25,65 @@ export default function (path: AstPath<Node>): treeFn | null {
  * @see [This Issue](https://github.com/prettier/prettier/issues/15710#issuecomment-1836701758)
  */
 function printDotExpression(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	if (path.node.nonFormattingChildren.length < 2) {
-		throw new Error('`dot_expression` node should have at least 2 children');
-	}
+    if (path.node.nonFormattingChildren.length < 2) {
+        throw new Error('`dot_expression` node should have at least 2 children');
+    }
 
-	// chain is a `dot_expression` that is a child of another `dot_expression`
-	// or which has a `dot_expression` as a child
-	const isChain =
-		path.node.nonFormattingChildren[0]!.type === NODE_TYPE ||
-		path.node.parent?.type === NODE_TYPE;
+    // chain is a `dot_expression` that is a child of another `dot_expression`
+    // or which has a `dot_expression` as a child
+    const isChain =
+        path.node.nonFormattingChildren[0]!.type === NODE_TYPE ||
+        path.node.parent?.type === NODE_TYPE;
 
-	const isParentList = path.node.parent?.isList;
+    const isParentList = path.node.parent?.isList;
 
-	// if dot expression has a trailing comment and it breaks, we need to
-	// print it manually after the rhs
-	const trailing = lineSuffix(printTrailingComment(path));
+    // if dot expression has a trailing comment and it breaks, we need to
+    // print it manually after the rhs
+    const trailing = lineSuffix(printTrailingComment(path));
 
-	const lhs = path.call(
-		(path) => printNode(path, options, print, false),
-		'nonFormattingChildren',
-		0,
-	);
-	const rhs = path.call(
-		(path) => printNode(path, options, print, true),
-		'nonFormattingChildren',
-		1,
-	);
+    const lhs = path.call(
+        (path) => printNode(path, options, print, false),
+        'nonFormattingChildren',
+        0,
+    );
+    const rhs = path.call(
+        (path) => printNode(path, options, print, true),
+        'nonFormattingChildren',
+        1,
+    );
 
-	// if it's a single expression, we don't need to group it
-	// and optionally no need to break it; no need to special
-	// print it in this case
-	if (!isChain) {
-		const right = path.node.nonFormattingChildren[1]!;
-		if (right.leadingComment.length > 0) {
-			path.node.disableTrailingComment();
-			return [lhs, indent(softline), indent(rhs), trailing];
-		}
+    // if it's a single expression, we don't need to group it
+    // and optionally no need to break it; no need to special
+    // print it in this case
+    if (!isChain) {
+        const right = path.node.nonFormattingChildren[1]!;
+        if (right.leadingComment.length > 0) {
+            path.node.disableTrailingComment();
+            return [lhs, indent(softline), indent(rhs), trailing];
+        }
 
-		return [lhs, rhs];
-	}
+        return [lhs, rhs];
+    }
 
-	path.node.disableTrailingComment();
-	const parts = [lhs, ifBreak(indent(softline), ''), ifBreak(indent(rhs), rhs), trailing];
+    path.node.disableTrailingComment();
+    const parts = [lhs, ifBreak(indent(softline), ''), ifBreak(indent(rhs), rhs), trailing];
 
-	// group if parent is not `dot_expression`
-	if (isChain && path.node.parent?.type !== NODE_TYPE) {
-		return group(parts);
-	}
+    // group if parent is not `dot_expression`
+    if (isChain && path.node.parent?.type !== NODE_TYPE) {
+        return group(parts);
+    }
 
-	return parts;
+    return parts;
 }
 
 // In `dot_expression` we need to keep the `.` in the same line as the `rhs`,
 // so we need to prevent automatic printing of comments in the `print` call, and
 // perform it manually.
 function printNode(path: AstPath<Node>, options: MoveOptions, print: printFn, insertDot = false) {
-	const leading = printLeadingComment(path, options);
-	const shouldBreak =
-		path.node.leadingComment.length > 0 || path.node.trailingComment?.type === 'line_comment';
+    const leading = printLeadingComment(path, options);
+    const shouldBreak =
+        path.node.leadingComment.length > 0 || path.node.trailingComment?.type === 'line_comment';
 
-	path.node.disableLeadingComment();
-	return [leading, shouldBreak ? breakParent : '', insertDot ? '.' : '', print(path)];
+    path.node.disableLeadingComment();
+    return [leading, shouldBreak ? breakParent : '', insertDot ? '.' : '', print(path)];
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/expression_list.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/expression_list.ts
@@ -11,22 +11,18 @@ const { group } = doc.builders;
 export const NODE_TYPE = 'expression_list';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printExpressionList;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printExpressionList;
+    }
 
-	return null;
+    return null;
 }
 
 /**
  * Print `expression_list` node.
  */
-function printExpressionList(
-	path: AstPath<Node>,
-	options: MoveOptions,
-	print: printFn,
-): Doc {
-	return group(list({ path, print, options, open: '(', close: ')' }), {
-		shouldBreak: false,
-	});
+function printExpressionList(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
+    return group(list({ path, print, options, open: '(', close: ')' }), {
+        shouldBreak: false,
+    });
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/identified_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/identified_expression.ts
@@ -10,11 +10,11 @@ const {} = doc.builders;
 export const NODE_TYPE = 'identified_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printIdentifiedExpression;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printIdentifiedExpression;
+    }
 
-	return null;
+    return null;
 }
 
 /**
@@ -22,9 +22,9 @@ export default function (path: AstPath<Node>): treeFn | null {
  * Also known as `label` in the grammar or `labeled_expression`.
  */
 function printIdentifiedExpression(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	return [
-		path.call(print, 'nonFormattingChildren', 0), // identifier
-		' ',
-		path.call(print, 'nonFormattingChildren', 1), // expression
-	];
+    return [
+        path.call(print, 'nonFormattingChildren', 0), // identifier
+        ' ',
+        path.call(print, 'nonFormattingChildren', 1), // expression
+    ];
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/if_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/if_expression.ts
@@ -76,8 +76,8 @@ function printIfExpression(path: AstPath<Node>, options: MoveOptions, print: pri
 			trueBranch.leadingComment.some((e) => e.type == 'line_comment') ||
 			trueBranch.trailingComment?.type == 'line_comment';
 
-		result.push([' ', path.call(print, 'nonFormattingChildren', 1)]);
-		hasElse && result.push(shouldBreak ? [line, 'else'] : ' else');
+		result.push(group([' ', path.call(print, 'nonFormattingChildren', 1)], { shouldBreak: false }));
+		hasElse && result.push(group([line, 'else'], { shouldBreak }));
 	} else {
 		result.push(
 			group(
@@ -99,7 +99,6 @@ function printIfExpression(path: AstPath<Node>, options: MoveOptions, print: pri
 	// else block
 	if (hasElse) {
 		const elseNode = path.node.nonFormattingChildren[2]!;
-		const printed = path.call(print, 'nonFormattingChildren', 2);
 		const shouldBreak =
 			elseNode.leadingComment.some((e) => e.type == 'line_comment') ||
 			elseNode.trailingComment?.type == 'line_comment';
@@ -107,7 +106,7 @@ function printIfExpression(path: AstPath<Node>, options: MoveOptions, print: pri
 		// special casing chained `if_expression` with the expectation that the
 		// expression can handle breaking / nesting itself.
 		if (elseNode.isList || elseNode.type == 'if_expression') {
-			result.push([' ', printed]);
+			result.push([' ', path.call(print, 'nonFormattingChildren', 2)]);
 		} else {
 			result.push(
 				group(

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/if_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/if_expression.ts
@@ -63,6 +63,7 @@ function printIfExpression(path: AstPath<Node>, options: MoveOptions, print: pri
         throw new Error('Invalid if_expression node');
     }
 
+    const isChain = path.parent?.type == 'if_expression';
     const hasElse = path.node.children.some((e) => e.type == 'else');
     const condition = path.node.nonFormattingChildren[0]!;
     const trueBranch = path.node.nonFormattingChildren[1]!;
@@ -141,7 +142,7 @@ function printIfExpression(path: AstPath<Node>, options: MoveOptions, print: pri
     //
     // also, if the else block is another `if_expression` we follow the same
     // logic as above
-    if (isTrueList || elseNode.type == 'if_expression') {
+    if (isTrueList) {
         result.push(group([line, 'else'], { shouldBreak: trueHasComment }));
         result.push([' ', path.call(print, 'nonFormattingChildren', 2)]);
         return result;
@@ -150,8 +151,8 @@ function printIfExpression(path: AstPath<Node>, options: MoveOptions, print: pri
     const elseBranchPrinted = path.call(print, 'nonFormattingChildren', 2);
 
     // if true branch is not a list, and else is a list, we newline
-    if (elseNode.isList && !isTrueList) {
-        result.push([hardlineWithoutBreakParent, 'else ', elseBranchPrinted]);
+    if ((elseNode.isList && !isTrueList) || elseNode.type == 'if_expression' || isChain) {
+        result.push([hardlineWithoutBreakParent, 'else ', group(elseBranchPrinted)]);
         return result;
     }
 

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/if_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/if_expression.ts
@@ -5,17 +5,17 @@ import { Node } from '../..';
 import { MoveOptions, printFn, treeFn } from '../../printer';
 import { AstPath, Doc, doc } from 'prettier';
 const { group, softline, line, ifBreak, indent, indentIfBreak, hardlineWithoutBreakParent } =
-	doc.builders;
+    doc.builders;
 
 /** The type of the node implemented in this file */
 export const NODE_TYPE = 'if_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printIfExpression;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printIfExpression;
+    }
 
-	return null;
+    return null;
 }
 
 /**
@@ -50,72 +50,72 @@ export default function (path: AstPath<Node>): treeFn | null {
  * ```
  */
 function printIfExpression(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	const hasElse = path.node.children.some((e) => e.type == 'else');
-	const condition = path.node.nonFormattingChildren[0];
-	const trueBranch = path.node.nonFormattingChildren[1];
-	const groupId = Symbol('if_expression_true');
-	const result: Doc[] = [];
+    const hasElse = path.node.children.some((e) => e.type == 'else');
+    const condition = path.node.nonFormattingChildren[0];
+    const trueBranch = path.node.nonFormattingChildren[1];
+    const groupId = Symbol('if_expression_true');
+    const result: Doc[] = [];
 
-	// condition group
-	result.push(
-		group([
-			'if (',
-			condition?.isList
-				? [indent(softline), path.call(print, 'nonFormattingChildren', 0), softline]
-				: [
-						indent(softline),
-						indent(path.call(print, 'nonFormattingChildren', 0)),
-						softline,
-					],
-			')',
-		]),
-	);
+    // condition group
+    result.push(
+        group([
+            'if (',
+            condition?.isList
+                ? [indent(softline), path.call(print, 'nonFormattingChildren', 0), softline]
+                : [
+                      indent(softline),
+                      indent(path.call(print, 'nonFormattingChildren', 0)),
+                      softline,
+                  ],
+            ')',
+        ]),
+    );
 
-	// true branch group
-	if (trueBranch?.isList) {
-		const shouldBreak =
-			trueBranch.leadingComment.some((e) => e.type == 'line_comment') ||
-			trueBranch.trailingComment?.type == 'line_comment';
+    // true branch group
+    if (trueBranch?.isList) {
+        const shouldBreak =
+            trueBranch.leadingComment.some((e) => e.type == 'line_comment') ||
+            trueBranch.trailingComment?.type == 'line_comment';
 
-		result.push(
-			group([' ', path.call(print, 'nonFormattingChildren', 1)], { shouldBreak: false }),
-		);
-		hasElse && result.push(group([line, 'else'], { shouldBreak }));
-	} else {
-		result.push(
-			group([indent(line), indent(path.call(print, 'nonFormattingChildren', 1))], {
-				id: groupId,
-			}),
-		);
+        result.push(
+            group([' ', path.call(print, 'nonFormattingChildren', 1)], { shouldBreak: false }),
+        );
+        hasElse && result.push(group([line, 'else'], { shouldBreak }));
+    } else {
+        result.push(
+            group([indent(line), indent(path.call(print, 'nonFormattingChildren', 1))], {
+                id: groupId,
+            }),
+        );
 
-		// link group breaking to the true branch, add `else` either with a
-		// newline or without - depends on whether true branch is converted into
-		// a block
-		hasElse &&
-			result.push([
-				ifBreak([hardlineWithoutBreakParent, 'else'], [line, 'else'], { groupId }),
-			]);
-	}
+        // link group breaking to the true branch, add `else` either with a
+        // newline or without - depends on whether true branch is converted into
+        // a block
+        hasElse &&
+            result.push([
+                ifBreak([hardlineWithoutBreakParent, 'else'], [line, 'else'], { groupId }),
+            ]);
+    }
 
-	// else block
-	if (hasElse) {
-		const elseNode = path.node.nonFormattingChildren[2]!;
-		const shouldBreak =
-			elseNode.leadingComment.some((e) => e.type == 'line_comment') ||
-			elseNode.trailingComment?.type == 'line_comment';
+    // else block
+    if (hasElse) {
+        const elseNode = path.node.nonFormattingChildren[2]!;
+        const shouldBreak =
+            elseNode.leadingComment.some((e) => e.type == 'line_comment') ||
+            elseNode.trailingComment?.type == 'line_comment';
 
-		// special casing chained `if_expression` with the expectation that the
-		// expression can handle breaking / nesting itself.
-		if (elseNode.isList || elseNode.type == 'if_expression') {
-			result.push([' ', path.call(print, 'nonFormattingChildren', 2)]);
-		} else {
-			result.push(
-				group([indent(line), indent(path.call(print, 'nonFormattingChildren', 2))], {
-					shouldBreak,
-				}),
-			);
-		}
-	}
+        // special casing chained `if_expression` with the expectation that the
+        // expression can handle breaking / nesting itself.
+        if (elseNode.isList || elseNode.type == 'if_expression') {
+            result.push([' ', path.call(print, 'nonFormattingChildren', 2)]);
+        } else {
+            result.push(
+                group([indent(line), indent(path.call(print, 'nonFormattingChildren', 2))], {
+                    shouldBreak,
+                }),
+            );
+        }
+    }
 
-	return result;
+    return result;
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/if_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/if_expression.ts
@@ -4,7 +4,7 @@
 import { Node } from '../..';
 import { MoveOptions, printFn, treeFn } from '../../printer';
 import { AstPath, Doc, doc } from 'prettier';
-const { group, softline, line, ifBreak, indent, hardlineWithoutBreakParent } = doc.builders;
+const { group, softline, line, ifBreak, indent, indentIfBreak, hardlineWithoutBreakParent } = doc.builders;
 
 /** The type of the node implemented in this file */
 export const NODE_TYPE = 'if_expression';
@@ -82,9 +82,8 @@ function printIfExpression(path: AstPath<Node>, options: MoveOptions, print: pri
 		result.push(
 			group(
 				[
-					ifBreak([' {', indent(hardlineWithoutBreakParent)], ' '),
+					indent(line),
 					indent(path.call(print, 'nonFormattingChildren', 1)),
-					ifBreak([hardlineWithoutBreakParent, '}'], ''),
 				],
 				{ id: groupId },
 			),
@@ -93,7 +92,7 @@ function printIfExpression(path: AstPath<Node>, options: MoveOptions, print: pri
 		// link group breaking to the true branch, add `else` either with a
 		// newline or without - depends on whether true branch is converted into
 		// a block
-		hasElse && result.push([ifBreak([' else'], [line, 'else'], { groupId })]);
+		hasElse && result.push([ifBreak([hardlineWithoutBreakParent, 'else'], [line, 'else'], { groupId })]);
 	}
 
 	// else block

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/if_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/if_expression.ts
@@ -93,11 +93,11 @@ function printIfExpression(path: AstPath<Node>, options: MoveOptions, print: pri
 			]))
 		} else {
 			result.push(
+				isTrueBlock ? ' ' : line,
+				'else',
 				group([
-					isTrueBlock ? ' ' : line,
-					'else',
 					indent(line),
-					indent(printed),
+					indent(path.call(print, 'nonFormattingChildren', 2)),
 				], { shouldBreak }),
 			);
 		}

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/if_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/if_expression.ts
@@ -4,7 +4,7 @@
 import { Node } from '../..';
 import { MoveOptions, printFn, treeFn } from '../../printer';
 import { AstPath, Doc, doc } from 'prettier';
-const { group, softline, ifBreak, indentIfBreak, line, indent } = doc.builders;
+const { group, softline, line, ifBreak, indent, hardlineWithoutBreakParent } = doc.builders;
 
 /** The type of the node implemented in this file */
 export const NODE_TYPE = 'if_expression';
@@ -34,26 +34,29 @@ export default function (path: AstPath<Node>): treeFn | null {
  * }
  *
  * // multi line + single line
- * if (cond)
+ * if (cond) {
  * 	return long_expr;
+ * }
  *
  * // multi line + single line + long expr
  * if (
  * 	long_cond ||
  *  long_cond
- * )
+ * ) {
  * 	return long_expr &&
  * 		long_expr;
+ * }
  * ```
  */
 function printIfExpression(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	const groupId = Symbol('if_expression');
 	const hasElse = path.node.children.some((e) => e.type == 'else');
-
 	const condition = path.node.nonFormattingChildren[0];
 	const trueBranch = path.node.nonFormattingChildren[1];
-	const result: Doc[] = [
-		// condition group
+	const groupId = Symbol('if_expression_true');
+	const result: Doc[] = [];
+
+	// condition group
+	result.push(
 		group([
 			'if (',
 			condition?.isList
@@ -65,40 +68,56 @@ function printIfExpression(path: AstPath<Node>, options: MoveOptions, print: pri
 					],
 			')',
 		]),
-		// body group
-		group(
-			[
-				trueBranch?.isList
-					? [' ', path.call(print, 'nonFormattingChildren', 1)]
-					: [indent(line), path.call(print, 'nonFormattingChildren', 1)],
-			],
-			{ id: groupId },
-		),
-	];
+	);
+
+	// true branch group
+	if (trueBranch?.isList) {
+		const shouldBreak =
+			trueBranch.leadingComment.some((e) => e.type == 'line_comment') ||
+			trueBranch.trailingComment?.type == 'line_comment';
+
+		result.push([' ', path.call(print, 'nonFormattingChildren', 1)]);
+		hasElse && result.push(shouldBreak ? [line, 'else'] : ' else');
+	} else {
+		result.push(
+			group(
+				[
+					ifBreak([' {', indent(hardlineWithoutBreakParent)], ' '),
+					indent(path.call(print, 'nonFormattingChildren', 1)),
+					ifBreak([hardlineWithoutBreakParent, '}'], ''),
+				],
+				{ id: groupId },
+			),
+		);
+
+		// link group breaking to the true branch, add `else` either with a
+		// newline or without - depends on whether true branch is converted into
+		// a block
+		hasElse && result.push([ifBreak([' else'], [line, 'else'], { groupId })]);
+	}
 
 	// else block
 	if (hasElse) {
-		const isTrueBlock = trueBranch?.type === 'block';
 		const elseNode = path.node.nonFormattingChildren[2]!;
 		const printed = path.call(print, 'nonFormattingChildren', 2);
 		const shouldBreak =
 			elseNode.leadingComment.some((e) => e.type == 'line_comment') ||
 			elseNode.trailingComment?.type == 'line_comment';
 
-		if (elseNode.isList || elseNode.isControlFlow) {
-			result.push(group([
-				isTrueBlock ? ' ' : line,
-				'else ',
-				printed,
-			]))
+		// special casing chained `if_expression` with the expectation that the
+		// expression can handle breaking / nesting itself.
+		if (elseNode.isList || elseNode.type == 'if_expression') {
+			result.push([' ', printed]);
 		} else {
 			result.push(
-				isTrueBlock ? ' ' : line,
-				'else',
-				group([
-					indent(line),
-					indent(path.call(print, 'nonFormattingChildren', 2)),
-				], { shouldBreak }),
+				group(
+					[
+						ifBreak([' {', indent(hardlineWithoutBreakParent)], ' '),
+						indent(path.call(print, 'nonFormattingChildren', 2)),
+						ifBreak([hardlineWithoutBreakParent, '}'], ''),
+					],
+					{ shouldBreak },
+				),
 			);
 		}
 	}

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/if_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/if_expression.ts
@@ -4,7 +4,8 @@
 import { Node } from '../..';
 import { MoveOptions, printFn, treeFn } from '../../printer';
 import { AstPath, Doc, doc } from 'prettier';
-const { group, softline, line, ifBreak, indent, indentIfBreak, hardlineWithoutBreakParent } = doc.builders;
+const { group, softline, line, ifBreak, indent, indentIfBreak, hardlineWithoutBreakParent } =
+	doc.builders;
 
 /** The type of the node implemented in this file */
 export const NODE_TYPE = 'if_expression';
@@ -76,23 +77,24 @@ function printIfExpression(path: AstPath<Node>, options: MoveOptions, print: pri
 			trueBranch.leadingComment.some((e) => e.type == 'line_comment') ||
 			trueBranch.trailingComment?.type == 'line_comment';
 
-		result.push(group([' ', path.call(print, 'nonFormattingChildren', 1)], { shouldBreak: false }));
+		result.push(
+			group([' ', path.call(print, 'nonFormattingChildren', 1)], { shouldBreak: false }),
+		);
 		hasElse && result.push(group([line, 'else'], { shouldBreak }));
 	} else {
 		result.push(
-			group(
-				[
-					indent(line),
-					indent(path.call(print, 'nonFormattingChildren', 1)),
-				],
-				{ id: groupId },
-			),
+			group([indent(line), indent(path.call(print, 'nonFormattingChildren', 1))], {
+				id: groupId,
+			}),
 		);
 
 		// link group breaking to the true branch, add `else` either with a
 		// newline or without - depends on whether true branch is converted into
 		// a block
-		hasElse && result.push([ifBreak([hardlineWithoutBreakParent, 'else'], [line, 'else'], { groupId })]);
+		hasElse &&
+			result.push([
+				ifBreak([hardlineWithoutBreakParent, 'else'], [line, 'else'], { groupId }),
+			]);
 	}
 
 	// else block
@@ -108,14 +110,9 @@ function printIfExpression(path: AstPath<Node>, options: MoveOptions, print: pri
 			result.push([' ', path.call(print, 'nonFormattingChildren', 2)]);
 		} else {
 			result.push(
-				group(
-					[
-						ifBreak([' {', indent(hardlineWithoutBreakParent)], ' '),
-						indent(path.call(print, 'nonFormattingChildren', 2)),
-						ifBreak([hardlineWithoutBreakParent, '}'], ''),
-					],
-					{ shouldBreak },
-				),
+				group([indent(line), indent(path.call(print, 'nonFormattingChildren', 2))], {
+					shouldBreak,
+				}),
 			);
 		}
 	}

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/index.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/index.ts
@@ -44,42 +44,42 @@ import vector_expression from './vector_expression';
 import while_expression from './while_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	// route to separated functions
-	const result =
-		abort_expression(path) ||
-		annotation_expression(path) ||
-		assign_expression(path) ||
-		binary_expression(path) ||
-		block_item(path) ||
-		block(path) ||
-		borrow_expression(path) ||
-		break_expression(path) ||
-		call_expression(path) ||
-		cast_expression(path) ||
-		continue_expression(path) ||
-		dereference_expression(path) ||
-		dot_expression(path) ||
-		expression_list(path) ||
-		if_expression(path) ||
-		identified_expression(path) ||
-		index_expression(path) ||
-		lambda_expression(path) ||
-		let_statement(path) ||
-		loop_expression(path) ||
-		macro_call_expression(path) ||
-		match_expression(path) ||
-		move_or_copy_expression(path) ||
-		name_expression(path) ||
-		pack_expression(path) ||
-		return_expression(path) ||
-		unary_expression(path) ||
-		unit_expression(path) ||
-		vector_expression(path) ||
-		while_expression(path);
+    // route to separated functions
+    const result =
+        abort_expression(path) ||
+        annotation_expression(path) ||
+        assign_expression(path) ||
+        binary_expression(path) ||
+        block_item(path) ||
+        block(path) ||
+        borrow_expression(path) ||
+        break_expression(path) ||
+        call_expression(path) ||
+        cast_expression(path) ||
+        continue_expression(path) ||
+        dereference_expression(path) ||
+        dot_expression(path) ||
+        expression_list(path) ||
+        if_expression(path) ||
+        identified_expression(path) ||
+        index_expression(path) ||
+        lambda_expression(path) ||
+        let_statement(path) ||
+        loop_expression(path) ||
+        macro_call_expression(path) ||
+        match_expression(path) ||
+        move_or_copy_expression(path) ||
+        name_expression(path) ||
+        pack_expression(path) ||
+        return_expression(path) ||
+        unary_expression(path) ||
+        unit_expression(path) ||
+        vector_expression(path) ||
+        while_expression(path);
 
-	if (result !== null) {
-		return result;
-	}
+    if (result !== null) {
+        return result;
+    }
 
-	return null;
+    return null;
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/index_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/index_expression.ts
@@ -11,27 +11,27 @@ const { group } = doc.builders;
 const NODE_TYPE = 'index_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	switch (path.node.type) {
-		case NODE_TYPE:
-			return printIndexExpression;
-	}
+    switch (path.node.type) {
+        case NODE_TYPE:
+            return printIndexExpression;
+    }
 
-	return null;
+    return null;
 }
 
 /**
  * Print `index_expression` node.
  */
 export function printIndexExpression(
-	path: AstPath<Node>,
-	options: MoveOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    options: MoveOptions,
+    print: printFn,
 ): Doc {
-	return group(
-		[
-			path.call(print, 'nonFormattingChildren', 0), // lhs
-			list({ path, options, open: '[', close: ']', print, skipChildren: 1 }),
-		],
-		{ shouldBreak: false },
-	);
+    return group(
+        [
+            path.call(print, 'nonFormattingChildren', 0), // lhs
+            list({ path, options, open: '[', close: ']', print, skipChildren: 1 }),
+        ],
+        { shouldBreak: false },
+    );
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/lambda_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/lambda_expression.ts
@@ -12,16 +12,16 @@ const { group, join, conditionalGroup } = doc.builders;
 const NODE_TYPE = 'lambda_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	switch (path.node.type) {
-		case NODE_TYPE:
-			return printLambdaExpression;
-		case 'lambda_bindings':
-			return printLambdaBindings;
-		case 'lambda_binding':
-			return printLambdaBinding;
-	}
+    switch (path.node.type) {
+        case NODE_TYPE:
+            return printLambdaExpression;
+        case 'lambda_bindings':
+            return printLambdaBindings;
+        case 'lambda_binding':
+            return printLambdaBinding;
+    }
 
-	return null;
+    return null;
 }
 
 /**
@@ -31,37 +31,37 @@ export default function (path: AstPath<Node>): treeFn | null {
  * - `_bind`
  */
 function printLambdaExpression(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	const children = path.node.nonFormattingChildren;
+    const children = path.node.nonFormattingChildren;
 
-	// just bindings
-	if (children.length === 1) {
-		return path.call(print, 'nonFormattingChildren', 0);
-	}
+    // just bindings
+    if (children.length === 1) {
+        return path.call(print, 'nonFormattingChildren', 0);
+    }
 
-	// bindings, expression or bindings, return type
-	if (children.length === 2) {
-		return join(' ', path.map(print, 'nonFormattingChildren'));
-	}
+    // bindings, expression or bindings, return type
+    if (children.length === 2) {
+        return join(' ', path.map(print, 'nonFormattingChildren'));
+    }
 
-	// bindings, return type, expression
-	if (children.length === 3) {
-		return [
-			path.call(print, 'nonFormattingChildren', 0), // bindings
-			' -> ',
-			path.call(print, 'nonFormattingChildren', 1), // return type
-			' ',
-			path.call(print, 'nonFormattingChildren', 2), // expression
-		];
-	}
+    // bindings, return type, expression
+    if (children.length === 3) {
+        return [
+            path.call(print, 'nonFormattingChildren', 0), // bindings
+            ' -> ',
+            path.call(print, 'nonFormattingChildren', 1), // return type
+            ' ',
+            path.call(print, 'nonFormattingChildren', 2), // expression
+        ];
+    }
 
-	throw new Error('`lambda_expression` node should have 1, 2 or 3 children');
+    throw new Error('`lambda_expression` node should have 1, 2 or 3 children');
 }
 
 /**
  * Print `lambda_bindings` node, contains comma-separated list of `lambda_binding` nodes.
  */
 function printLambdaBindings(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	return group(list({ path, print, options, open: '|', close: '|' }));
+    return group(list({ path, print, options, open: '|', close: '|' }));
 }
 
 /**
@@ -70,15 +70,15 @@ function printLambdaBindings(path: AstPath<Node>, options: MoveOptions, print: p
  * of non-formatting children.
  */
 function printLambdaBinding(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	// simple bind, will be handled by its function
-	if (path.node.nonFormattingChildren.length === 1) {
-		return path.call(print, 'nonFormattingChildren', 0);
-	}
+    // simple bind, will be handled by its function
+    if (path.node.nonFormattingChildren.length === 1) {
+        return path.call(print, 'nonFormattingChildren', 0);
+    }
 
-	// with type annotation
-	if (path.node.nonFormattingChildren.length === 2) {
-		return join(': ', path.map(print, 'nonFormattingChildren'));
-	}
+    // with type annotation
+    if (path.node.nonFormattingChildren.length === 2) {
+        return join(': ', path.map(print, 'nonFormattingChildren'));
+    }
 
-	throw new Error('`lambda_binding` node should have 1 or 2 children');
+    throw new Error('`lambda_binding` node should have 1 or 2 children');
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/let_statement.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/let_statement.ts
@@ -10,54 +10,54 @@ const { group, indent, line, indentIfBreak } = doc.builders;
 const NODE_TYPE = 'let_statement';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printLetStatement;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printLetStatement;
+    }
 
-	return null;
+    return null;
 }
 
 /**
  * Print `let_statement` node.
  */
 function printLetStatement(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	const nodes = path.node.nonFormattingChildren;
+    const nodes = path.node.nonFormattingChildren;
 
-	if (nodes.length === 1) {
-		return group(['let', ' ', path.call(print, 'nonFormattingChildren', 0)]);
-	}
+    if (nodes.length === 1) {
+        return group(['let', ' ', path.call(print, 'nonFormattingChildren', 0)]);
+    }
 
-	const printed = path.map(print, 'nonFormattingChildren');
-	const rhsNode = path.node.nonFormattingChildren.slice(-1)[0]!;
+    const printed = path.map(print, 'nonFormattingChildren');
+    const rhsNode = path.node.nonFormattingChildren.slice(-1)[0]!;
 
-	if (nodes.length === 2 && nodes[1]!.isTypeParam) {
-		const [bind, type] = printed;
-		return group(['let ', bind!, ': ', type!]);
-	}
+    if (nodes.length === 2 && nodes[1]!.isTypeParam) {
+        const [bind, type] = printed;
+        return group(['let ', bind!, ': ', type!]);
+    }
 
-	if (nodes.length === 2) {
-		const [bind, expr] = printed;
-		const result =
-			rhsNode.isBreakableExpression || rhsNode.isFunctionCall || rhsNode.isControlFlow
-				? ['let ', bind!, ' = ', expr!]
-				: ['let ', bind!, ' =', printLetExpression(expr!, rhsNode)];
+    if (nodes.length === 2) {
+        const [bind, expr] = printed;
+        const result =
+            rhsNode.isBreakableExpression || rhsNode.isFunctionCall || rhsNode.isControlFlow
+                ? ['let ', bind!, ' = ', expr!]
+                : ['let ', bind!, ' =', printLetExpression(expr!, rhsNode)];
 
-		return group(result, { shouldBreak: false });
-	}
+        return group(result, { shouldBreak: false });
+    }
 
-	const [bind, type, expr] = printed;
-	const result =
-		rhsNode.isBreakableExpression || rhsNode.isFunctionCall
-			? ['let ', bind!, ': ', type!, ' = ', expr!]
-			: ['let ', bind!, ': ', type!, ' =', printLetExpression(expr!, rhsNode)];
+    const [bind, type, expr] = printed;
+    const result =
+        rhsNode.isBreakableExpression || rhsNode.isFunctionCall
+            ? ['let ', bind!, ': ', type!, ' = ', expr!]
+            : ['let ', bind!, ': ', type!, ' =', printLetExpression(expr!, rhsNode)];
 
-	return result;
+    return result;
 }
 
 function printLetExpression(expression: Doc, node: Node) {
-	const groupId = Symbol('let_expression');
-	return group([indentIfBreak(line, { groupId }), indentIfBreak(expression, { groupId })], {
-		shouldBreak: false,
-		id: groupId,
-	});
+    const groupId = Symbol('let_expression');
+    return group([indentIfBreak(line, { groupId }), indentIfBreak(expression, { groupId })], {
+        shouldBreak: false,
+        id: groupId,
+    });
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/let_statement.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/let_statement.ts
@@ -4,59 +4,60 @@
 import { Node } from '../..';
 import { MoveOptions, printFn, treeFn } from '../../printer';
 import { AstPath, Doc, doc } from 'prettier';
-const { group, indent, line } = doc.builders;
+const { group, indent, line, indentIfBreak } = doc.builders;
 
 /** The type of the node implemented in this file */
 const NODE_TYPE = 'let_statement';
 
 export default function (path: AstPath<Node>): treeFn | null {
-    if (path.node.type === NODE_TYPE) {
-        return printLetStatement;
-    }
+	if (path.node.type === NODE_TYPE) {
+		return printLetStatement;
+	}
 
-    return null;
+	return null;
 }
 
 /**
  * Print `let_statement` node.
  */
 function printLetStatement(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-    const nodes = path.node.nonFormattingChildren;
+	const nodes = path.node.nonFormattingChildren;
 
-    if (nodes.length === 1) {
-        return group(['let', ' ', path.call(print, 'nonFormattingChildren', 0)]);
-    }
+	if (nodes.length === 1) {
+		return group(['let', ' ', path.call(print, 'nonFormattingChildren', 0)]);
+	}
 
-    const printed = path.map(print, 'nonFormattingChildren');
-    const rhsNode = path.node.nonFormattingChildren.slice(-1)[0]!;
+	const printed = path.map(print, 'nonFormattingChildren');
+	const rhsNode = path.node.nonFormattingChildren.slice(-1)[0]!;
 
-    if (nodes.length === 2 && nodes[1]!.isTypeParam) {
-        const [bind, type] = printed;
-        return group(['let ', bind!, ': ', type!]);
-    }
+	if (nodes.length === 2 && nodes[1]!.isTypeParam) {
+		const [bind, type] = printed;
+		return group(['let ', bind!, ': ', type!]);
+	}
 
-    if (nodes.length === 2) {
-        const [bind, expr] = printed;
-        const result =
-            rhsNode.isBreakableExpression || rhsNode.isFunctionCall
-                ? ['let ', bind!, ' = ', expr!]
-                : ['let ', bind!, ' =', indent(group([line, expr!], { shouldBreak: false }))];
+	if (nodes.length === 2) {
+		const [bind, expr] = printed;
+		const result =
+			rhsNode.isBreakableExpression || rhsNode.isFunctionCall || rhsNode.isControlFlow
+				? ['let ', bind!, ' = ', expr!]
+				: ['let ', bind!, ' =', printLetExpression(expr!, rhsNode)];
 
-        return group(result, { shouldBreak: false });
-    }
+		return group(result, { shouldBreak: false });
+	}
 
-    const [bind, type, expr] = printed;
-    const result =
-        rhsNode.isBreakableExpression || rhsNode.isFunctionCall
-            ? ['let ', bind!, ': ', type!, ' = ', expr!]
-            : [
-                  'let ',
-                  bind!,
-                  ': ',
-                  type!,
-                  ' =',
-                  indent(group([line, expr!], { shouldBreak: false })),
-              ];
+	const [bind, type, expr] = printed;
+	const result =
+		rhsNode.isBreakableExpression || rhsNode.isFunctionCall
+			? ['let ', bind!, ': ', type!, ' = ', expr!]
+			: ['let ', bind!, ': ', type!, ' =', printLetExpression(expr!, rhsNode)];
 
-    return result;
+	return result;
+}
+
+function printLetExpression(expression: Doc, node: Node) {
+	const groupId = Symbol('let_expression');
+	return group([indentIfBreak(line, { groupId }), indentIfBreak(expression, { groupId })], {
+		shouldBreak: false,
+		id: groupId,
+	});
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/let_statement.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/let_statement.ts
@@ -10,53 +10,53 @@ const { group, indent, line } = doc.builders;
 const NODE_TYPE = 'let_statement';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printLetStatement;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printLetStatement;
+    }
 
-	return null;
+    return null;
 }
 
 /**
  * Print `let_statement` node.
  */
 function printLetStatement(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	const nodes = path.node.nonFormattingChildren;
+    const nodes = path.node.nonFormattingChildren;
 
-	if (nodes.length === 1) {
-		return group(['let', ' ', path.call(print, 'nonFormattingChildren', 0)]);
-	}
+    if (nodes.length === 1) {
+        return group(['let', ' ', path.call(print, 'nonFormattingChildren', 0)]);
+    }
 
-	const printed = path.map(print, 'nonFormattingChildren');
-	const rhsNode = path.node.nonFormattingChildren.slice(-1)[0]!;
+    const printed = path.map(print, 'nonFormattingChildren');
+    const rhsNode = path.node.nonFormattingChildren.slice(-1)[0]!;
 
-	if (nodes.length === 2 && nodes[1]!.isTypeParam) {
-		const [bind, type] = printed;
-		return group(['let ', bind!, ': ', type!]);
-	}
+    if (nodes.length === 2 && nodes[1]!.isTypeParam) {
+        const [bind, type] = printed;
+        return group(['let ', bind!, ': ', type!]);
+    }
 
-	if (nodes.length === 2) {
-		const [bind, expr] = printed;
-		const result =
-			rhsNode.isBreakableExpression || rhsNode.isFunctionCall
-				? ['let ', bind!, ' = ', expr!]
-				: ['let ', bind!, ' =', indent(group([line, expr!], { shouldBreak: false }))];
+    if (nodes.length === 2) {
+        const [bind, expr] = printed;
+        const result =
+            rhsNode.isBreakableExpression || rhsNode.isFunctionCall
+                ? ['let ', bind!, ' = ', expr!]
+                : ['let ', bind!, ' =', indent(group([line, expr!], { shouldBreak: false }))];
 
-		return group(result, { shouldBreak: false });
-	}
+        return group(result, { shouldBreak: false });
+    }
 
-	const [bind, type, expr] = printed;
-	const result =
-		rhsNode.isBreakableExpression || rhsNode.isFunctionCall
-			? ['let ', bind!, ': ', type!, ' = ', expr!]
-			: [
-					'let ',
-					bind!,
-					': ',
-					type!,
-					' =',
-					indent(group([line, expr!], { shouldBreak: false })),
-				];
+    const [bind, type, expr] = printed;
+    const result =
+        rhsNode.isBreakableExpression || rhsNode.isFunctionCall
+            ? ['let ', bind!, ': ', type!, ' = ', expr!]
+            : [
+                  'let ',
+                  bind!,
+                  ': ',
+                  type!,
+                  ' =',
+                  indent(group([line, expr!], { shouldBreak: false })),
+              ];
 
-	return result;
+    return result;
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/let_statement.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/let_statement.ts
@@ -4,6 +4,7 @@
 import { Node } from '../..';
 import { MoveOptions, printFn, treeFn } from '../../printer';
 import { AstPath, Doc, doc } from 'prettier';
+import { printTrailingComment } from '../../utilities';
 const { group, indent, line, indentIfBreak } = doc.builders;
 
 /** The type of the node implemented in this file */
@@ -27,7 +28,16 @@ function printLetStatement(path: AstPath<Node>, options: MoveOptions, print: pri
         return group(['let', ' ', path.call(print, 'nonFormattingChildren', 0)]);
     }
 
-    const printed = path.map(print, 'nonFormattingChildren');
+    function printWithTrailing(path: AstPath<Node>): Doc {
+        let trailingComment: Doc = '';
+        if (path.node.trailingComment?.type == 'line_comment') {
+            trailingComment = printTrailingComment(path, true);
+            path.node.disableTrailingComment();
+        }
+        return [print(path), trailingComment];
+    }
+
+    const printed = path.map(printWithTrailing, 'nonFormattingChildren');
     const rhsNode = path.node.nonFormattingChildren.slice(-1)[0]!;
 
     if (nodes.length === 2 && nodes[1]!.isTypeParam) {

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/loop_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/loop_expression.ts
@@ -10,11 +10,11 @@ const {} = doc.builders;
 export const NODE_TYPE = 'loop_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printLoopExpression;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printLoopExpression;
+    }
 
-	return null;
+    return null;
 }
 
 /**
@@ -25,5 +25,5 @@ export default function (path: AstPath<Node>): treeFn | null {
  * ```
  */
 function printLoopExpression(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	return [`loop `, path.call(print, 'nonFormattingChildren', 0)];
+    return [`loop `, path.call(print, 'nonFormattingChildren', 0)];
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/macro_call_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/macro_call_expression.ts
@@ -11,11 +11,11 @@ const { group, indentIfBreak, line, softline, ifBreak, join } = doc.builders;
 const NODE_TYPE = 'macro_call_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printMacroCallExpression;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printMacroCallExpression;
+    }
 
-	return null;
+    return null;
 }
 
 /**
@@ -26,17 +26,17 @@ export default function (path: AstPath<Node>): treeFn | null {
  * - `arg_list`
  */
 function printMacroCallExpression(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	return path.map((path) => {
-		if (path.node.type === 'macro_module_access') {
-			return printMacroModuleAccess(path, options, print);
-		}
+    return path.map((path) => {
+        if (path.node.type === 'macro_module_access') {
+            return printMacroModuleAccess(path, options, print);
+        }
 
-		if (path.node.type === 'arg_list') {
-			return printMacroArgsList(path, options, print);
-		}
+        if (path.node.type === 'arg_list') {
+            return printMacroArgsList(path, options, print);
+        }
 
-		return print(path);
-	}, 'nonFormattingChildren');
+        return print(path);
+    }, 'nonFormattingChildren');
 }
 
 /**
@@ -46,34 +46,34 @@ function printMacroCallExpression(path: AstPath<Node>, options: MoveOptions, pri
  * - `!`
  */
 function printMacroModuleAccess(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	return [path.call(print, 'nonFormattingChildren', 0), '!'];
+    return [path.call(print, 'nonFormattingChildren', 0), '!'];
 }
 
 /**
  * Special function to print macro arguments list instead of `arg_list`.
  */
 function printMacroArgsList(path: AstPath<Node>, options: MoveOptions, print: printFn) {
-	if (path.node.type !== 'arg_list') {
-		throw new Error('Expected `arg_list` node');
-	}
+    if (path.node.type !== 'arg_list') {
+        throw new Error('Expected `arg_list` node');
+    }
 
-	if (path.node.namedChildCount === 0) {
-		return '()';
-	}
+    if (path.node.namedChildCount === 0) {
+        return '()';
+    }
 
-	const groupId = Symbol('macro_args_list');
+    const groupId = Symbol('macro_args_list');
 
-	return group(
-		list({
-			path,
-			options,
-			print,
-			open: '(',
-			close: ')',
-			addWhitespace: false,
-			shouldBreak: false,
-			indentGroup: groupId,
-		}),
-		{ id: groupId },
-	);
+    return group(
+        list({
+            path,
+            options,
+            print,
+            open: '(',
+            close: ')',
+            addWhitespace: false,
+            shouldBreak: false,
+            indentGroup: groupId,
+        }),
+        { id: groupId },
+    );
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/match_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/match_expression.ts
@@ -6,8 +6,7 @@ import { MoveOptions, printFn, treeFn } from '../../printer';
 import { AstPath, Doc } from 'prettier';
 import { list } from '../../utilities';
 import { builders } from 'prettier/doc';
-import { printBreakableBlock, printNonBreakingBlock } from './block';
-const { join, indent, group, softline, line, dedent, conditionalGroup } = builders;
+const { join, indent, group, softline, line } = builders;
 
 /** The type of the node implemented in this file */
 export const NODE_TYPE = 'match_expression';
@@ -72,7 +71,6 @@ function printMatchExpression(path: AstPath<Node>, options: MoveOptions, print: 
  */
 function printMatchArm(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
 	const children = path.map(print, 'nonFormattingChildren');
-	const groupId = Symbol('match_arm');
 
 	if (children.length < 2) {
 		throw new Error('`match_arm` node should have at least 2 children');

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/match_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/match_expression.ts
@@ -12,15 +12,15 @@ const { join, indent, group, softline, line } = builders;
 export const NODE_TYPE = 'match_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printMatchExpression;
-	} else if (path.node.type === 'match_arm') {
-		return printMatchArm;
-	} else if (path.node.type === 'match_condition') {
-		return printMatchCondition;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printMatchExpression;
+    } else if (path.node.type === 'match_arm') {
+        return printMatchArm;
+    } else if (path.node.type === 'match_condition') {
+        return printMatchCondition;
+    }
 
-	return null;
+    return null;
 }
 
 /**
@@ -33,58 +33,58 @@ export default function (path: AstPath<Node>): treeFn | null {
  * - `_match_body`
  */
 function printMatchExpression(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	const condNode = path.node.nonFormattingChildren[0]!;
-	const parts: Doc[] = ['match '];
+    const condNode = path.node.nonFormattingChildren[0]!;
+    const parts: Doc[] = ['match '];
 
-	if (condNode.isBreakableExpression) {
-		parts.push('(', path.call(print, 'nonFormattingChildren', 0), ')');
-	} else {
-		parts.push(
-			group([
-				'(',
-				indent(softline),
-				indent(path.call(print, 'nonFormattingChildren', 0)),
-				softline,
-				')',
-			]),
-		);
-	}
+    if (condNode.isBreakableExpression) {
+        parts.push('(', path.call(print, 'nonFormattingChildren', 0), ')');
+    } else {
+        parts.push(
+            group([
+                '(',
+                indent(softline),
+                indent(path.call(print, 'nonFormattingChildren', 0)),
+                softline,
+                ')',
+            ]),
+        );
+    }
 
-	parts.push(
-		' ',
-		list({
-			path,
-			print,
-			options,
-			open: '{',
-			close: '}',
-			skipChildren: 1,
-			shouldBreak: true,
-		}),
-	);
+    parts.push(
+        ' ',
+        list({
+            path,
+            print,
+            options,
+            open: '{',
+            close: '}',
+            skipChildren: 1,
+            shouldBreak: true,
+        }),
+    );
 
-	return parts;
+    return parts;
 }
 
 /**
  * Print `match_arm` node.
  */
 function printMatchArm(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	const children = path.map(print, 'nonFormattingChildren');
+    const children = path.map(print, 'nonFormattingChildren');
 
-	if (children.length < 2) {
-		throw new Error('`match_arm` node should have at least 2 children');
-	}
+    if (children.length < 2) {
+        throw new Error('`match_arm` node should have at least 2 children');
+    }
 
-	if (children.length == 2) {
-		return group(join(' => ', children));
-	}
+    if (children.length == 2) {
+        return group(join(' => ', children));
+    }
 
-	if (children.length == 3) {
-		return [children[0]!, ' ', children[1]!, group([' =>', indent(line), children[2]!])];
-	}
+    if (children.length == 3) {
+        return [children[0]!, ' ', children[1]!, group([' =>', indent(line), children[2]!])];
+    }
 
-	throw new Error('`match_arm` node should have at most 3 children');
+    throw new Error('`match_arm` node should have at most 3 children');
 }
 
 /**
@@ -92,11 +92,11 @@ function printMatchArm(path: AstPath<Node>, options: MoveOptions, print: printFn
  * Example: `Enum if (x == 1) => 1,`, `if (...)` here is a `match_condition` node.
  */
 function printMatchCondition(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	const children = path.node.nonFormattingChildren;
+    const children = path.node.nonFormattingChildren;
 
-	if (children.length !== 1) {
-		throw new Error('`match_condition` expects 1 child');
-	}
+    if (children.length !== 1) {
+        throw new Error('`match_condition` expects 1 child');
+    }
 
-	return ['if (', path.call(print, 'nonFormattingChildren', 0), ')'];
+    return ['if (', path.call(print, 'nonFormattingChildren', 0), ')'];
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/move_or_copy_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/move_or_copy_expression.ts
@@ -10,20 +10,20 @@ const {} = doc.builders;
 export const NODE_TYPE = 'move_or_copy_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printMoveOrCopyExpression;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printMoveOrCopyExpression;
+    }
 
-	return null;
+    return null;
 }
 
 /**
  * Print `move_or_copy_expression` node.
  */
 function printMoveOrCopyExpression(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	const ref = path.node.child(0)!.text == 'move' ? ['move', ' '] : ['copy', ' '];
-	return [
-		...ref,
-		path.call(print, 'nonFormattingChildren', 0), // expression
-	];
+    const ref = path.node.child(0)!.text == 'move' ? ['move', ' '] : ['copy', ' '];
+    return [
+        ...ref,
+        path.call(print, 'nonFormattingChildren', 0), // expression
+    ];
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/name_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/name_expression.ts
@@ -10,11 +10,11 @@ const {} = doc.builders;
 export const NODE_TYPE = 'name_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printNameExpression;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printNameExpression;
+    }
 
-	return null;
+    return null;
 }
 
 /**
@@ -24,5 +24,5 @@ export default function (path: AstPath<Node>): treeFn | null {
  * - `type_arguments`
  */
 function printNameExpression(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	return path.map(print, 'nonFormattingChildren');
+    return path.map(print, 'nonFormattingChildren');
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/pack_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/pack_expression.ts
@@ -10,11 +10,11 @@ const {} = doc.builders;
 export const NODE_TYPE = 'pack_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printPackExpression;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printPackExpression;
+    }
 
-	return null;
+    return null;
 }
 
 /**
@@ -25,5 +25,5 @@ export default function (path: AstPath<Node>): treeFn | null {
  * - `field_initialize_list`
  */
 function printPackExpression(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	return path.map(print, 'nonFormattingChildren');
+    return path.map(print, 'nonFormattingChildren');
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/return_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/return_expression.ts
@@ -10,41 +10,41 @@ const { join, indent } = doc.builders;
 export const NODE_TYPE = 'return_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printReturnExpression;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printReturnExpression;
+    }
 
-	return null;
+    return null;
 }
 
 /**
  * Print `return_expression` node.
  */
 function printReturnExpression(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	const nodes = path.node.nonFormattingChildren;
+    const nodes = path.node.nonFormattingChildren;
 
-	if (nodes.length === 0) {
-		return 'return';
-	}
+    if (nodes.length === 0) {
+        return 'return';
+    }
 
-	// either label or expression
-	if (nodes.length === 1) {
-		const expression = nodes[0]!;
-		const printed = path.call(print, 'nonFormattingChildren', 0);
-		return ['return ', expression.isBreakableExpression ? printed : indent(printed)];
-	}
+    // either label or expression
+    if (nodes.length === 1) {
+        const expression = nodes[0]!;
+        const printed = path.call(print, 'nonFormattingChildren', 0);
+        return ['return ', expression.isBreakableExpression ? printed : indent(printed)];
+    }
 
-	// labeled expression
-	if (nodes.length === 2) {
-		const expression = nodes[1]!;
-		const printedLabel = path.call(print, 'nonFormattingChildren', 0);
-		const printedExpression = path.call(print, 'nonFormattingChildren', 1);
-		return join(' ', [
-			'return',
-			printedLabel,
-			expression.isBreakableExpression ? printedExpression : indent(printedExpression),
-		]);
-	}
+    // labeled expression
+    if (nodes.length === 2) {
+        const expression = nodes[1]!;
+        const printedLabel = path.call(print, 'nonFormattingChildren', 0);
+        const printedExpression = path.call(print, 'nonFormattingChildren', 1);
+        return join(' ', [
+            'return',
+            printedLabel,
+            expression.isBreakableExpression ? printedExpression : indent(printedExpression),
+        ]);
+    }
 
-	throw new Error('Invalid return expression');
+    throw new Error('Invalid return expression');
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/unary_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/unary_expression.ts
@@ -10,19 +10,19 @@ const {} = doc.builders;
 export const NODE_TYPE = 'unary_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printUnaryExpression;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printUnaryExpression;
+    }
 
-	return null;
+    return null;
 }
 
 /**
  * Print `unary_expression` node.
  */
 function printUnaryExpression(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	return [
-		path.call(print, 'nonFormattingChildren', 0),
-		path.call(print, 'nonFormattingChildren', 1),
-	];
+    return [
+        path.call(print, 'nonFormattingChildren', 0),
+        path.call(print, 'nonFormattingChildren', 1),
+    ];
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/unit_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/unit_expression.ts
@@ -10,9 +10,9 @@ const {} = doc.builders;
 export const NODE_TYPE = 'unit_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return () => '()'
-	}
+    if (path.node.type === NODE_TYPE) {
+        return () => '()';
+    }
 
-	return null;
+    return null;
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/vector_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/vector_expression.ts
@@ -12,75 +12,75 @@ const { group, lineSuffix } = doc.builders;
 export const NODE_TYPE = 'vector_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printVectorExpression;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printVectorExpression;
+    }
 
-	return null;
+    return null;
 }
 
 /**
  * Print `vector_expression` node.
  */
 function printVectorExpression(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	if (path.node.namedChildCount === 0) {
-		return 'vector[]';
-	}
+    if (path.node.namedChildCount === 0) {
+        return 'vector[]';
+    }
 
-	// Injected print callback for elements in the vector
-	const printCb = (path: AstPath<Node>) => printElement(path, options, print);
-	const trailing = path.node.trailingComment;
-	let trailingComment: Doc = '';
+    // Injected print callback for elements in the vector
+    const printCb = (path: AstPath<Node>) => printElement(path, options, print);
+    const trailing = path.node.trailingComment;
+    let trailingComment: Doc = '';
 
-	if (trailing?.type === 'line_comment') {
-		trailingComment = printTrailingComment(path, false);
-		path.node.disableTrailingComment();
-	}
+    if (trailing?.type === 'line_comment') {
+        trailingComment = printTrailingComment(path, false);
+        path.node.disableTrailingComment();
+    }
 
-	// Vector without type specified
-	// Eg: `vector[....]`
-	if (path.node.child(0)?.text == 'vector[') {
-		return group(
-			[
-				'vector',
-				list({ path, print: printCb, options, open: '[', close: ']' }) as Doc[],
-				lineSuffix(trailingComment),
-			],
-			{ shouldBreak: false },
-		);
-	}
+    // Vector without type specified
+    // Eg: `vector[....]`
+    if (path.node.child(0)?.text == 'vector[') {
+        return group(
+            [
+                'vector',
+                list({ path, print: printCb, options, open: '[', close: ']' }) as Doc[],
+                lineSuffix(trailingComment),
+            ],
+            { shouldBreak: false },
+        );
+    }
 
-	if (!path.node.nonFormattingChildren[0]?.isTypeParam) {
-		throw new Error(
-			`Expected a type parameter in the \`vector_expression\`, got \`${path.node.nonFormattingChildren[0]?.type}\``,
-		);
-	}
+    if (!path.node.nonFormattingChildren[0]?.isTypeParam) {
+        throw new Error(
+            `Expected a type parameter in the \`vector_expression\`, got \`${path.node.nonFormattingChildren[0]?.type}\``,
+        );
+    }
 
-	if (path.node.nonFormattingChildren.slice(1).some((child) => child.isTypeParam)) {
-		throw new Error('Expected only one type parameter in the `vector_expression`');
-	}
+    if (path.node.nonFormattingChildren.slice(1).some((child) => child.isTypeParam)) {
+        throw new Error('Expected only one type parameter in the `vector_expression`');
+    }
 
-	// Vector with type
-	// Eg: `vector<TYPE>[...]`
-	return [
-		'vector<',
-		// do not break the type in vector literal
-		// indent(softline),
-		group(path.call(print, 'nonFormattingChildren', 0), { shouldBreak: false }),
-		'>',
-		group(
-			list({
-				path,
-				print: printCb,
-				options,
-				open: '[',
-				close: ']',
-				skipChildren: 1,
-				shouldBreak: false,
-			}) as Doc[],
-		),
-		lineSuffix(trailingComment),
-	];
+    // Vector with type
+    // Eg: `vector<TYPE>[...]`
+    return [
+        'vector<',
+        // do not break the type in vector literal
+        // indent(softline),
+        group(path.call(print, 'nonFormattingChildren', 0), { shouldBreak: false }),
+        '>',
+        group(
+            list({
+                path,
+                print: printCb,
+                options,
+                open: '[',
+                close: ']',
+                skipChildren: 1,
+                shouldBreak: false,
+            }) as Doc[],
+        ),
+        lineSuffix(trailingComment),
+    ];
 }
 
 /**
@@ -89,9 +89,9 @@ function printVectorExpression(path: AstPath<Node>, options: MoveOptions, print:
  * - we want to use breakable blocks for `block` nodes;
  */
 function printElement(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	if (path.node.type === 'block') {
-		return printBreakableBlock(path, options, print);
-	}
+    if (path.node.type === 'block') {
+        return printBreakableBlock(path, options, print);
+    }
 
-	return print(path);
+    return print(path);
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/expression/while_expression.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/expression/while_expression.ts
@@ -10,11 +10,11 @@ const { indent, softline, group } = doc.builders;
 export const NODE_TYPE = 'while_expression';
 
 export default function (path: AstPath<Node>): treeFn | null {
-	if (path.node.type === NODE_TYPE) {
-		return printWhileExpression;
-	}
+    if (path.node.type === NODE_TYPE) {
+        return printWhileExpression;
+    }
 
-	return null;
+    return null;
 }
 
 /**
@@ -34,12 +34,12 @@ export default function (path: AstPath<Node>): treeFn | null {
  * ```
  */
 function printWhileExpression(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	const condition = path.node.nonFormattingChildren[0]!.isList
-		? [indent(softline), path.call(print, 'nonFormattingChildren', 0), softline]
-		: [indent(softline), indent(path.call(print, 'nonFormattingChildren', 0)), softline];
+    const condition = path.node.nonFormattingChildren[0]!.isList
+        ? [indent(softline), path.call(print, 'nonFormattingChildren', 0), softline]
+        : [indent(softline), indent(path.call(print, 'nonFormattingChildren', 0)), softline];
 
-	return [
-		['while (', group(condition), ') '],
-		path.call(print, 'nonFormattingChildren', 1), // body
-	];
+    return [
+        ['while (', group(condition), ') '],
+        path.call(print, 'nonFormattingChildren', 1), // body
+    ];
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/formatting.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/formatting.ts
@@ -12,41 +12,41 @@ import { AstPath, Doc } from 'prettier';
  * @returns
  */
 export default function (path: AstPath<Node>): treeFn | null {
-	switch (path.node.type) {
-		case Formatting.LineComment:
-			return printLineComment;
-		case Formatting.BlockComment:
-			return printBlockComment;
-		case Formatting.EmptyLine:
-			return printEmptyLine;
-		case Formatting.Newline:
-			return printNewline;
-		default:
-			return null;
-	}
+    switch (path.node.type) {
+        case Formatting.LineComment:
+            return printLineComment;
+        case Formatting.BlockComment:
+            return printBlockComment;
+        case Formatting.EmptyLine:
+            return printEmptyLine;
+        case Formatting.Newline:
+            return printNewline;
+        default:
+            return null;
+    }
 }
 
 export enum Formatting {
-	LineComment = 'line_comment',
-	BlockComment = 'block_comment',
-	/**
-	 * Token that doesn't exist in the grammar but we insert it in
-	 * the `Tree` representation of CST to represent an empty line.
-	 */
-	EmptyLine = 'empty_line',
-	/**
-	 * Special node to insert a newline before the next node.
-	 * We use it to make a call to hardline or not.
-	 */
-	Newline = 'newline',
+    LineComment = 'line_comment',
+    BlockComment = 'block_comment',
+    /**
+     * Token that doesn't exist in the grammar but we insert it in
+     * the `Tree` representation of CST to represent an empty line.
+     */
+    EmptyLine = 'empty_line',
+    /**
+     * Special node to insert a newline before the next node.
+     * We use it to make a call to hardline or not.
+     */
+    Newline = 'newline',
 }
 
 export function startsOnNewLine(path: AstPath<Node>): boolean {
-	return path.previous?.type == Formatting.EmptyLine;
+    return path.previous?.type == Formatting.EmptyLine;
 }
 
 export function shouldNewLine(path: AstPath<Node>): boolean {
-	return path.node.nextNamedSibling?.type == Formatting.Newline;
+    return path.node.nextNamedSibling?.type == Formatting.Newline;
 }
 
 /**
@@ -56,24 +56,24 @@ export function shouldNewLine(path: AstPath<Node>): boolean {
  * @returns
  */
 export function isFormatting(node: Node): boolean {
-	return [
-		Formatting.LineComment,
-		Formatting.BlockComment,
-		Formatting.EmptyLine,
-		Formatting.Newline,
-	].includes(node.type as Formatting);
+    return [
+        Formatting.LineComment,
+        Formatting.BlockComment,
+        Formatting.EmptyLine,
+        Formatting.Newline,
+    ].includes(node.type as Formatting);
 }
 
 export function isComment(node: Node | null): boolean {
-	return [Formatting.LineComment, Formatting.BlockComment].includes(node?.type as Formatting);
+    return [Formatting.LineComment, Formatting.BlockComment].includes(node?.type as Formatting);
 }
 
 export function isEmptyLine(node: Node | null): boolean {
-	return Formatting.EmptyLine == node?.type;
+    return Formatting.EmptyLine == node?.type;
 }
 
 export function isNewline(node: Node | null): boolean {
-	return Formatting.Newline == node?.type;
+    return Formatting.Newline == node?.type;
 }
 
 /**
@@ -81,20 +81,20 @@ export function isNewline(node: Node | null): boolean {
  * Comments are handled via the `addLeadingComments` function.
  */
 export function printLineComment(path: AstPath<Node>): Doc {
-	return path.node.text;
+    return path.node.text;
 }
 
 /**
  * Print `block_comment` node.
  */
 export function printBlockComment(path: AstPath<Node>): Doc {
-	return path.node.text;
+    return path.node.text;
 }
 
 export function printEmptyLine(path: AstPath<Node>): Doc {
-	return ''; // should not be printed directly, used in `join(hardline)` to act as an extra newline
+    return ''; // should not be printed directly, used in `join(hardline)` to act as an extra newline
 }
 
 export function printNewline(path: AstPath<Node>): Doc {
-	return ''; // should not be printed, ever
+    return ''; // should not be printed, ever
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/function_definition.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/function_definition.ts
@@ -9,37 +9,37 @@ import { list, printIdentifier } from '../utilities';
 const { join, group } = doc.builders;
 
 export default function (path: AstPath<Node>): treeFn | null {
-	switch (path.node.type) {
-		case FunctionDefinition.NativeFunctionDefinition:
-			return printNativeFunctionDefinition;
-		case FunctionDefinition.FunctionDefinition:
-			return printFunctionDefinition;
-		case FunctionDefinition.MacroFunctionDefinition:
-			return printMacroFunctionDefinition;
-		case FunctionDefinition.VisibilityModifier:
-			return printVisibilityModifier;
-		case FunctionDefinition.FunctionParameters:
-			return printFunctionParameters;
-		case FunctionDefinition.FunctionParameter:
-			return printFunctionParameter;
-		case FunctionDefinition.MutFunctionParameter:
-			return printMutFunctionParameter;
-		case FunctionDefinition.ReturnType:
-			return printReturnType;
-		case FunctionDefinition.TypeArguments:
-			return printTypeArguments;
-		case FunctionDefinition.TypeParameters:
-			return printTypeParameters;
-		case FunctionDefinition.TypeParameter:
-			return printTypeParameter;
+    switch (path.node.type) {
+        case FunctionDefinition.NativeFunctionDefinition:
+            return printNativeFunctionDefinition;
+        case FunctionDefinition.FunctionDefinition:
+            return printFunctionDefinition;
+        case FunctionDefinition.MacroFunctionDefinition:
+            return printMacroFunctionDefinition;
+        case FunctionDefinition.VisibilityModifier:
+            return printVisibilityModifier;
+        case FunctionDefinition.FunctionParameters:
+            return printFunctionParameters;
+        case FunctionDefinition.FunctionParameter:
+            return printFunctionParameter;
+        case FunctionDefinition.MutFunctionParameter:
+            return printMutFunctionParameter;
+        case FunctionDefinition.ReturnType:
+            return printReturnType;
+        case FunctionDefinition.TypeArguments:
+            return printTypeArguments;
+        case FunctionDefinition.TypeParameters:
+            return printTypeParameters;
+        case FunctionDefinition.TypeParameter:
+            return printTypeParameter;
 
-		// identifiers
-		case FunctionDefinition.FunctionIdentifier:
-		case FunctionDefinition.TypeParameterIdentifier:
-			return printIdentifier;
-	}
+        // identifiers
+        case FunctionDefinition.FunctionIdentifier:
+        case FunctionDefinition.TypeParameterIdentifier:
+            return printIdentifier;
+    }
 
-	return null;
+    return null;
 }
 
 /**
@@ -49,107 +49,107 @@ export default function (path: AstPath<Node>): treeFn | null {
  * ```
  */
 export enum FunctionDefinition {
-	FunctionDefinition = 'function_definition',
-	FunctionIdentifier = 'function_identifier',
-	NativeFunctionDefinition = 'native_function_definition',
-	MacroFunctionDefinition = 'macro_function_definition',
-	VisibilityModifier = 'visibility_modifier',
-	FunctionParameters = 'function_parameters',
-	FunctionParameter = 'function_parameter',
-	MutFunctionParameter = 'mut_function_parameter',
-	ReturnType = 'ret_type',
-	TypeArguments = 'type_arguments',
-	TypeParameters = 'type_parameters',
-	TypeParameter = 'type_parameter',
-	TypeParameterIdentifier = 'type_parameter_identifier',
+    FunctionDefinition = 'function_definition',
+    FunctionIdentifier = 'function_identifier',
+    NativeFunctionDefinition = 'native_function_definition',
+    MacroFunctionDefinition = 'macro_function_definition',
+    VisibilityModifier = 'visibility_modifier',
+    FunctionParameters = 'function_parameters',
+    FunctionParameter = 'function_parameter',
+    MutFunctionParameter = 'mut_function_parameter',
+    ReturnType = 'ret_type',
+    TypeArguments = 'type_arguments',
+    TypeParameters = 'type_parameters',
+    TypeParameter = 'type_parameter',
+    TypeParameterIdentifier = 'type_parameter_identifier',
 }
 
 export type Modifiers = {
-	native?: boolean;
-	public?: boolean;
-	entry?: boolean;
-	['public(friend)']?: boolean;
-	['public(package)']?: boolean;
+    native?: boolean;
+    public?: boolean;
+    entry?: boolean;
+    ['public(friend)']?: boolean;
+    ['public(package)']?: boolean;
 };
 
 /**
  * Print `function_definition` node.
  */
 export function printFunctionDefinition(
-	path: AstPath<Node>,
-	options: MoveOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    options: MoveOptions,
+    print: printFn,
 ): Doc {
-	const nodes = path.node.nonFormattingChildren;
-	const retIndex = nodes.findIndex((e) => e.type == FunctionDefinition.ReturnType);
-	const modifiers = getModifiers(path);
-	const printCb = (path: AstPath<Node>) =>
-		path.node.type === 'block' ? printBreakableBlock(path, options, print) : print(path);
+    const nodes = path.node.nonFormattingChildren;
+    const retIndex = nodes.findIndex((e) => e.type == FunctionDefinition.ReturnType);
+    const modifiers = getModifiers(path);
+    const printCb = (path: AstPath<Node>) =>
+        path.node.type === 'block' ? printBreakableBlock(path, options, print) : print(path);
 
-	const signature = [
-		printModifiers(modifiers),
-		'fun ',
-		path.map((path) => {
-			// We already added modifiers in the previous step
-			if (path.node.type == 'modifier') return '';
-			if (path.node.type == 'block') return '';
-			if (path.node.type == 'ret_type') return '';
-			if (path.node.isFormatting) return '';
+    const signature = [
+        printModifiers(modifiers),
+        'fun ',
+        path.map((path) => {
+            // We already added modifiers in the previous step
+            if (path.node.type == 'modifier') return '';
+            if (path.node.type == 'block') return '';
+            if (path.node.type == 'ret_type') return '';
+            if (path.node.isFormatting) return '';
 
-			return print(path);
-		}, 'nonFormattingChildren'),
-	];
+            return print(path);
+        }, 'nonFormattingChildren'),
+    ];
 
-	return [
-		group([signature, path.call(print, 'nonFormattingChildren', retIndex)]),
-		' ',
-		path.call(printCb, 'nonFormattingChildren', nodes.length - 1),
-	];
+    return [
+        group([signature, path.call(print, 'nonFormattingChildren', retIndex)]),
+        ' ',
+        path.call(printCb, 'nonFormattingChildren', nodes.length - 1),
+    ];
 }
 
 export function printNativeFunctionDefinition(
-	path: AstPath<Node>,
-	_opt: MoveOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    _opt: MoveOptions,
+    print: printFn,
 ): Doc {
-	const modifiers = getModifiers(path);
+    const modifiers = getModifiers(path);
 
-	return [
-		printModifiers(modifiers),
-		'fun ',
-		group(
-			path.map((path) => {
-				if (path.node.type == 'modifier') return '';
-				return print(path);
-			}, 'nonFormattingChildren'),
-		),
-		';',
-	];
+    return [
+        printModifiers(modifiers),
+        'fun ',
+        group(
+            path.map((path) => {
+                if (path.node.type == 'modifier') return '';
+                return print(path);
+            }, 'nonFormattingChildren'),
+        ),
+        ';',
+    ];
 }
 
 /**
  * Print `macro_function_definition` node.
  */
 export function printMacroFunctionDefinition(
-	path: AstPath<Node>,
-	_opt: MoveOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    _opt: MoveOptions,
+    print: printFn,
 ): Doc {
-	const modifiers = getModifiers(path);
+    const modifiers = getModifiers(path);
 
-	return [
-		printModifiers(modifiers),
-		'macro fun ',
-		group(
-			path.map((path) => {
-				if (path.node.type == 'modifier') return '';
-				if (path.node.type == 'block') return '';
-				return print(path);
-			}, 'nonFormattingChildren'),
-		),
-		' ',
-		path.call(print, 'nonFormattingChildren', path.node.nonFormattingChildren.length - 1),
-	];
+    return [
+        printModifiers(modifiers),
+        'macro fun ',
+        group(
+            path.map((path) => {
+                if (path.node.type == 'modifier') return '';
+                if (path.node.type == 'block') return '';
+                return print(path);
+            }, 'nonFormattingChildren'),
+        ),
+        ' ',
+        path.call(print, 'nonFormattingChildren', path.node.nonFormattingChildren.length - 1),
+    ];
 }
 
 /**
@@ -157,148 +157,144 @@ export function printMacroFunctionDefinition(
  * Always followed by a space.
  */
 export function printVisibilityModifier(
-	path: AstPath<Node>, //  | Node | null,
-	_opt: MoveOptions,
-	_print: printFn,
+    path: AstPath<Node>, //  | Node | null,
+    _opt: MoveOptions,
+    _print: printFn,
 ): Doc {
-	return [path.node.text, ' '];
+    return [path.node.text, ' '];
 }
 
 /**
  * Print `function_parameters` node.
  */
 export function printFunctionParameters(
-	path: AstPath<Node>,
-	options: MoveOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    options: MoveOptions,
+    print: printFn,
 ): Doc {
-	return list({
-		path,
-		print,
-		options,
-		open: '(',
-		close: ')',
-		shouldBreak: false,
-	});
+    return list({
+        path,
+        print,
+        options,
+        open: '(',
+        close: ')',
+        shouldBreak: false,
+    });
 }
 
 /**
  * Print `function_parameter` node.
  */
 export function printFunctionParameter(
-	path: AstPath<Node>,
-	_opt: MoveOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    _opt: MoveOptions,
+    print: printFn,
 ): Doc {
-	const isMut = path.node.child(0)?.type == 'mut';
-	const isDollar = path.node.children.find((c) => c.type == '$');
+    const isMut = path.node.child(0)?.type == 'mut';
+    const isDollar = path.node.children.find((c) => c.type == '$');
 
-	return group([
-		isMut ? 'mut ' : '',
-		isDollar ? '$' : '',
-		path.call(print, 'nonFormattingChildren', 0), // variable_identifier
-		': ',
-		path.call(print, 'nonFormattingChildren', 1), // type
-	]);
+    return group([
+        isMut ? 'mut ' : '',
+        isDollar ? '$' : '',
+        path.call(print, 'nonFormattingChildren', 0), // variable_identifier
+        ': ',
+        path.call(print, 'nonFormattingChildren', 1), // type
+    ]);
 }
 
 /**
  * Print `mut` function parameter.
  */
 export function printMutFunctionParameter(
-	path: AstPath<Node>,
-	_opt: MoveOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    _opt: MoveOptions,
+    print: printFn,
 ): Doc {
-	return ['mut ', path.call(print, 'nonFormattingChildren', 0)];
+    return ['mut ', path.call(print, 'nonFormattingChildren', 0)];
 }
 
 /**
  * Print `ret_type` node.
  */
 export function printReturnType(path: AstPath<Node>, _opt: MoveOptions, print: printFn): Doc {
-	return [': ', path.call(print, 'nonFormattingChildren', 0)];
+    return [': ', path.call(print, 'nonFormattingChildren', 0)];
 }
 
 /**
  * Print `type_arguments` node.
  */
-export function printTypeArguments(
-	path: AstPath<Node>,
-	options: MoveOptions,
-	print: printFn,
-): Doc {
-	return group(
-		list({
-			path,
-			print,
-			options,
-			open: '<',
-			close: '>',
-			shouldBreak: false,
-		}),
-	);
+export function printTypeArguments(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
+    return group(
+        list({
+            path,
+            print,
+            options,
+            open: '<',
+            close: '>',
+            shouldBreak: false,
+        }),
+    );
 }
 
 /**
  * Print `type_parameters` node.
  */
 export function printTypeParameters(
-	path: AstPath<Node>,
-	options: MoveOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    options: MoveOptions,
+    print: printFn,
 ): Doc {
-	return group(
-		list({
-			path,
-			print,
-			options,
-			open: '<',
-			close: '>',
-			shouldBreak: false,
-		}),
-	);
+    return group(
+        list({
+            path,
+            print,
+            options,
+            open: '<',
+            close: '>',
+            shouldBreak: false,
+        }),
+    );
 }
 
 /**
  * Print `type_parameter` node.
  */
 export function printTypeParameter(path: AstPath<Node>, _opt: MoveOptions, print: printFn): Doc {
-	const isDollar = path.node.child(0)?.type == '$';
-	const isPhantom = path.node.child(0)?.type == 'phantom';
-	const parameter = path.call(print, 'nonFormattingChildren', 0);
-	const abilities = path.map(print, 'nonFormattingChildren').slice(1);
+    const isDollar = path.node.child(0)?.type == '$';
+    const isPhantom = path.node.child(0)?.type == 'phantom';
+    const parameter = path.call(print, 'nonFormattingChildren', 0);
+    const abilities = path.map(print, 'nonFormattingChildren').slice(1);
 
-	return [
-		isDollar ? '$' : '',
-		isPhantom ? 'phantom ' : '',
-		parameter,
-		abilities.length > 0 ? ': ' : '',
-		join(' + ', abilities),
-	];
+    return [
+        isDollar ? '$' : '',
+        isPhantom ? 'phantom ' : '',
+        parameter,
+        abilities.length > 0 ? ': ' : '',
+        join(' + ', abilities),
+    ];
 }
 
 /**
  * Helper function to get modifiers.
  */
 function getModifiers(path: AstPath<Node>): Modifiers {
-	const nodes = path.node.nonFormattingChildren;
+    const nodes = path.node.nonFormattingChildren;
 
-	return nodes
-		.filter((e) => e.type == 'modifier')
-		.map((e) => e.text.replace(' ', '')) // removes the space in `public (package)`
-		.reduce((acc, e) => ({ ...acc, [e]: true }), {});
+    return nodes
+        .filter((e) => e.type == 'modifier')
+        .map((e) => e.text.replace(' ', '')) // removes the space in `public (package)`
+        .reduce((acc, e) => ({ ...acc, [e]: true }), {});
 }
 
 /**
  * Helper function to print modifiers.
  */
 function printModifiers(modifiers: Modifiers): Doc {
-	return [
-		modifiers.public ? 'public ' : '',
-		modifiers['public(package)'] ? 'public(package) ' : '',
-		modifiers['public(friend)'] ? 'public(friend) ' : '',
-		modifiers.entry ? 'entry ' : '',
-		modifiers.native ? 'native ' : '',
-	];
+    return [
+        modifiers.public ? 'public ' : '',
+        modifiers['public(package)'] ? 'public(package) ' : '',
+        modifiers['public(friend)'] ? 'public(friend) ' : '',
+        modifiers.entry ? 'entry ' : '',
+        modifiers.native ? 'native ' : '',
+    ];
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/literal.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/literal.ts
@@ -9,61 +9,61 @@ import { treeFn } from '../printer';
  * Node: `_literal_value` in the grammar.json.
  */
 export enum Literal {
-	AddressLiteral = 'address_literal',
-	BoolLiteral = 'bool_literal',
-	NumLiteral = 'num_literal',
-	HexStringLiteral = 'hex_string_literal',
-	ByteStringLiteral = 'byte_string_literal',
+    AddressLiteral = 'address_literal',
+    BoolLiteral = 'bool_literal',
+    NumLiteral = 'num_literal',
+    HexStringLiteral = 'hex_string_literal',
+    ByteStringLiteral = 'byte_string_literal',
 }
 
 export default function (path: AstPath<Node>): treeFn | null {
-	switch (path.node.type) {
-		case Literal.AddressLiteral:
-			return printAddressLiteral;
-		case Literal.BoolLiteral:
-			return printBoolLiteral;
-		case Literal.NumLiteral:
-			return printNumLiteral;
-		case Literal.HexStringLiteral:
-			return printHexStringLiteral;
-		case Literal.ByteStringLiteral:
-			return printByteStringLiteral;
-	}
+    switch (path.node.type) {
+        case Literal.AddressLiteral:
+            return printAddressLiteral;
+        case Literal.BoolLiteral:
+            return printBoolLiteral;
+        case Literal.NumLiteral:
+            return printNumLiteral;
+        case Literal.HexStringLiteral:
+            return printHexStringLiteral;
+        case Literal.ByteStringLiteral:
+            return printByteStringLiteral;
+    }
 
-	return null;
+    return null;
 }
 
 /**
  * Print `byte_string_literal` node.
  */
 export function printByteStringLiteral(path: AstPath<Node>): Doc {
-	return path.node.text;
+    return path.node.text;
 }
 
 /**
  * Print `bool_literal` node.
  */
 export function printBoolLiteral(path: AstPath<Node>): Doc {
-	return path.node.text;
+    return path.node.text;
 }
 
 /**
  * Print `num_literal` node.
  */
 export function printNumLiteral(path: AstPath<Node>): Doc {
-	return path.node.text;
+    return path.node.text;
 }
 
 /**
  * Print `address_literal` node.
  */
 export function printAddressLiteral(path: AstPath<Node>): Doc {
-	return path.node.text;
+    return path.node.text;
 }
 
 /**
  * Print `hex_literal` node.
  */
 export function printHexStringLiteral(path: AstPath<Node>): Doc {
-	return path.node.text;
+    return path.node.text;
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/module.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/module.ts
@@ -17,79 +17,79 @@ const { join, hardline, indent } = doc.builders;
  * Creates a callback function to print modules and module-related nodes.
  */
 export default function (path: AstPath<Node>): treeFn | null {
-	switch (path.node.type) {
-		case Module.ModuleDefinition:
-			return printModuleDefinition;
-		case Module.ModuleIdentity:
-			return printModuleIdentity;
-		case Module.ModuleIdentifier:
-			return printIdentifier;
-		case Module.ModuleBody:
-			return printModuleBody;
-		default:
-			return null;
-	}
+    switch (path.node.type) {
+        case Module.ModuleDefinition:
+            return printModuleDefinition;
+        case Module.ModuleIdentity:
+            return printModuleIdentity;
+        case Module.ModuleIdentifier:
+            return printIdentifier;
+        case Module.ModuleBody:
+            return printModuleBody;
+        default:
+            return null;
+    }
 }
 
 /**
  * Module - top-level definition in a Move source file.
  */
 export enum Module {
-	ModuleDefinition = 'module_definition',
-	BlockComment = 'block_comment',
-	ModuleIdentity = 'module_identity',
-	ModuleIdentifier = 'module_identifier',
-	ModuleBody = 'module_body',
+    ModuleDefinition = 'module_definition',
+    BlockComment = 'block_comment',
+    ModuleIdentity = 'module_identity',
+    ModuleIdentifier = 'module_identifier',
+    ModuleBody = 'module_body',
 }
 
 /**
  * Print `module_definition` node.
  */
 export function printModuleDefinition(
-	path: AstPath<Node>,
-	options: MoveOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    options: MoveOptions,
+    print: printFn,
 ): Doc {
-	let useLabel = false;
+    let useLabel = false;
 
-	// when option is present we must check that there's only one module per file
-	if (options.useModuleLabel) {
-		const modules = path.parent!.nonFormattingChildren.filter(
-			(node) => node.type === path.node.type,
-		);
+    // when option is present we must check that there's only one module per file
+    if (options.useModuleLabel) {
+        const modules = path.parent!.nonFormattingChildren.filter(
+            (node) => node.type === path.node.type,
+        );
 
-		useLabel = modules.length == 1;
-	}
+        useLabel = modules.length == 1;
+    }
 
-	const result = ['module ', path.call(print, 'nonFormattingChildren', 0)];
+    const result = ['module ', path.call(print, 'nonFormattingChildren', 0)];
 
-	// if we're using the label, we must add a semicolon and print the body in a
-	// new line
-	if (useLabel) {
-		return result.concat([
-			';',
-			hardline,
-			hardline,
-			path.call(print, 'nonFormattingChildren', 1),
-		]);
-	}
+    // if we're using the label, we must add a semicolon and print the body in a
+    // new line
+    if (useLabel) {
+        return result.concat([
+            ';',
+            hardline,
+            hardline,
+            path.call(print, 'nonFormattingChildren', 1),
+        ]);
+    }
 
-	// when not module mabel, module body is a block with curly braces and
-	// indentation
-	return result.concat([
-		' {',
-		indent(hardline),
-		indent(path.call(print, 'nonFormattingChildren', 1)),
-		hardline,
-		'}',
-	]);
+    // when not module mabel, module body is a block with curly braces and
+    // indentation
+    return result.concat([
+        ' {',
+        indent(hardline),
+        indent(path.call(print, 'nonFormattingChildren', 1)),
+        hardline,
+        '}',
+    ]);
 }
 
 /**
  * Print `module_identity` node.
  */
 function printModuleIdentity(path: AstPath<Node>, options: ParserOptions, print: printFn): Doc {
-	return join('::', path.map(print, 'nonFormattingChildren'));
+    return join('::', path.map(print, 'nonFormattingChildren'));
 }
 
 /**
@@ -97,12 +97,12 @@ function printModuleIdentity(path: AstPath<Node>, options: ParserOptions, print:
  * For example, a function definition followed by a struct definition.
  */
 const separatedMembers = [
-	FunctionDefinition.FunctionDefinition,
-	StructDefinition.StructDefinition,
-	Constant.NODE_TYPE,
-	UseDeclaration.UseDeclaration,
-	UseDeclaration.FriendDeclaration,
-	EnumDefinition.EnumDefinition,
+    FunctionDefinition.FunctionDefinition,
+    StructDefinition.StructDefinition,
+    Constant.NODE_TYPE,
+    UseDeclaration.UseDeclaration,
+    UseDeclaration.FriendDeclaration,
+    EnumDefinition.EnumDefinition,
 ] as string[];
 
 /**
@@ -113,52 +113,48 @@ const separatedMembers = [
  * Additionally, if `groupImports` is set to `package` or `module`, we should group imports and
  * print them at the top of the module.
  */
-function printModuleBody(
-	path: AstPath<Node>,
-	options: MoveOptions,
-	print: printFn,
-): Doc {
-	const nodes = path.node.namedAndEmptyLineChildren;
-	const importsDoc = [] as Doc[];
-	const imports = collectImports(path.node);
-	if (Object.keys(imports).length > 0) {
-		importsDoc.push(
-			...(printImports(imports, options.autoGroupImports as 'package' | 'module') as Doc[]),
-		);
-	}
+function printModuleBody(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
+    const nodes = path.node.namedAndEmptyLineChildren;
+    const importsDoc = [] as Doc[];
+    const imports = collectImports(path.node);
+    if (Object.keys(imports).length > 0) {
+        importsDoc.push(
+            ...(printImports(imports, options.autoGroupImports as 'package' | 'module') as Doc[]),
+        );
+    }
 
-	const bodyDoc = [] as Doc[];
+    const bodyDoc = [] as Doc[];
 
-	path.each((path, i) => {
-		const next = nodes[i + 1];
+    path.each((path, i) => {
+        const next = nodes[i + 1];
 
-		// empty lines should be removed if they are next to grouped imports
-		if (path.node.isEmptyLine && path.node.previousNamedSibling?.isGroupedImport) return;
-		if (path.node.isGroupedImport) return;
-		if (path.node.isEmptyLine && !path.node.previousNamedSibling) return;
+        // empty lines should be removed if they are next to grouped imports
+        if (path.node.isEmptyLine && path.node.previousNamedSibling?.isGroupedImport) return;
+        if (path.node.isGroupedImport) return;
+        if (path.node.isEmptyLine && !path.node.previousNamedSibling) return;
 
-		if (
-			separatedMembers.includes(path.node.type) &&
-			separatedMembers.includes(next?.type || '') &&
-			path.node.type !== next?.type
-		) {
-			return bodyDoc.push([path.call(print), hardline]);
-		}
+        if (
+            separatedMembers.includes(path.node.type) &&
+            separatedMembers.includes(next?.type || '') &&
+            path.node.type !== next?.type
+        ) {
+            return bodyDoc.push([path.call(print), hardline]);
+        }
 
-		// force add empty line after function definitions
-		if (
-			path.node.type === FunctionDefinition.FunctionDefinition &&
-			next?.type === FunctionDefinition.FunctionDefinition
-		) {
-			return bodyDoc.push([path.call(print), hardline]);
-		}
+        // force add empty line after function definitions
+        if (
+            path.node.type === FunctionDefinition.FunctionDefinition &&
+            next?.type === FunctionDefinition.FunctionDefinition
+        ) {
+            return bodyDoc.push([path.call(print), hardline]);
+        }
 
-		return bodyDoc.push(path.call(print));
-	}, 'namedAndEmptyLineChildren');
+        return bodyDoc.push(path.call(print));
+    }, 'namedAndEmptyLineChildren');
 
-	if (bodyDoc.length > 0 && importsDoc.length > 0) {
-		bodyDoc.unshift(''); // add empty line before first member
-	}
+    if (bodyDoc.length > 0 && importsDoc.length > 0) {
+        bodyDoc.unshift(''); // add empty line before first member
+    }
 
-	return join(hardline, importsDoc.concat(bodyDoc));
+    return join(hardline, importsDoc.concat(bodyDoc));
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/module.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/module.ts
@@ -117,7 +117,7 @@ function printModuleBody(path: AstPath<Node>, options: MoveOptions, print: print
     const nodes = path.node.namedAndEmptyLineChildren;
     const importsDoc = [] as Doc[];
     const imports = collectImports(path.node);
-    if (Object.keys(imports).length > 0) {
+    if (imports.size > 0) {
         importsDoc.push(
             ...(printImports(imports, options.autoGroupImports as 'package' | 'module') as Doc[]),
         );

--- a/external-crates/move/tooling/prettier-move/src/cst/source_file.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/source_file.ts
@@ -10,15 +10,15 @@ const { hardline, join } = doc.builders;
  * Print a source node.
  */
 export default function (path: AstPath<Node>): treeFn | null {
-	switch (path.node.type) {
-		case SourceFile.SourceFile:
-			return printSourceFile;
-	}
-	return null;
+    switch (path.node.type) {
+        case SourceFile.SourceFile:
+            return printSourceFile;
+    }
+    return null;
 }
 
 export enum SourceFile {
-	SourceFile = 'source_file',
+    SourceFile = 'source_file',
 }
 
 /**
@@ -34,5 +34,5 @@ export enum SourceFile {
  * ```
  */
 function printSourceFile(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	return [join(hardline, path.map(print, 'namedAndEmptyLineChildren')), hardline];
+    return [join(hardline, path.map(print, 'namedAndEmptyLineChildren')), hardline];
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/struct_definition.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/struct_definition.ts
@@ -5,93 +5,93 @@ import { Node } from '..';
 import { MoveOptions, printFn, treeFn } from '../printer';
 import { AstPath, Doc, ParserOptions, doc } from 'prettier';
 import {
-	emptyBlockOrList,
-	list,
-	printIdentifier,
-	printLeadingComment,
-	printTrailingComment,
-	shouldBreakFirstChild,
+    emptyBlockOrList,
+    list,
+    printIdentifier,
+    printLeadingComment,
+    printTrailingComment,
+    shouldBreakFirstChild,
 } from '../utilities';
 const { group, join } = doc.builders;
 
 export default function (path: AstPath<Node>): treeFn | null {
-	switch (path.node.type) {
-		case StructDefinition.StructDefinition:
-			return printStructDefinition;
-		case StructDefinition.NativeStructDefinition:
-			return printNativeStructDefinition;
-		case StructDefinition.AbilityDeclarations:
-			return printAbilityDeclarations;
-		case StructDefinition.PostfixAbilityDeclarations:
-			return printPostfixAbilityDeclarations;
-		case StructDefinition.DatatypeFields:
-			return printDatatypeFields;
-		case StructDefinition.NamedFields:
-			return printNamedFields;
-		case StructDefinition.PositionalFields:
-			return printPositionalFields;
-		case StructDefinition.FieldAnnotation:
-			return printFieldAnnotation;
-		case StructDefinition.ApplyType:
-			return printApplyType;
-		case StructDefinition.StructIdentifier:
-			return printIdentifier;
-	}
+    switch (path.node.type) {
+        case StructDefinition.StructDefinition:
+            return printStructDefinition;
+        case StructDefinition.NativeStructDefinition:
+            return printNativeStructDefinition;
+        case StructDefinition.AbilityDeclarations:
+            return printAbilityDeclarations;
+        case StructDefinition.PostfixAbilityDeclarations:
+            return printPostfixAbilityDeclarations;
+        case StructDefinition.DatatypeFields:
+            return printDatatypeFields;
+        case StructDefinition.NamedFields:
+            return printNamedFields;
+        case StructDefinition.PositionalFields:
+            return printPositionalFields;
+        case StructDefinition.FieldAnnotation:
+            return printFieldAnnotation;
+        case StructDefinition.ApplyType:
+            return printApplyType;
+        case StructDefinition.StructIdentifier:
+            return printIdentifier;
+    }
 
-	return null;
+    return null;
 }
 
 export enum StructDefinition {
-	/**
-	 * Module-level definition
-	 * ```
-	 * public struct identifier ...
-	 * ```
-	 */
-	StructDefinition = 'struct_definition',
-	/**
-	 * Module-level definition (features `native` keyword and has no fields)
-	 * ```
-	 * native struct identifier ... ;
-	 * ```
-	 */
-	NativeStructDefinition = 'native_struct_definition',
-	AbilityDeclarations = 'ability_decls',
-	/**
-	 * Postfix ability declarations must be printed after the fields
-	 * and be followed by a semicolon.
-	 * ```
-	 * struct ident {} has store;
-	 * struct Point(u8) has store, drop;
-	 * ```
-	 */
-	PostfixAbilityDeclarations = 'postfix_ability_decls',
-	DatatypeFields = 'datatype_fields',
-	NamedFields = 'named_fields',
-	PositionalFields = 'positional_fields',
-	FieldAnnotation = 'field_annotation',
-	ApplyType = 'apply_type',
-	StructIdentifier = 'struct_identifier',
+    /**
+     * Module-level definition
+     * ```
+     * public struct identifier ...
+     * ```
+     */
+    StructDefinition = 'struct_definition',
+    /**
+     * Module-level definition (features `native` keyword and has no fields)
+     * ```
+     * native struct identifier ... ;
+     * ```
+     */
+    NativeStructDefinition = 'native_struct_definition',
+    AbilityDeclarations = 'ability_decls',
+    /**
+     * Postfix ability declarations must be printed after the fields
+     * and be followed by a semicolon.
+     * ```
+     * struct ident {} has store;
+     * struct Point(u8) has store, drop;
+     * ```
+     */
+    PostfixAbilityDeclarations = 'postfix_ability_decls',
+    DatatypeFields = 'datatype_fields',
+    NamedFields = 'named_fields',
+    PositionalFields = 'positional_fields',
+    FieldAnnotation = 'field_annotation',
+    ApplyType = 'apply_type',
+    StructIdentifier = 'struct_identifier',
 }
 
 /**
  * Print `struct_definition` node.
  */
 export function printNativeStructDefinition(
-	path: AstPath<Node>,
-	options: ParserOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    options: ParserOptions,
+    print: printFn,
 ): Doc {
-	const isPublic = path.node.child(0)!.type === 'public' ? ['public', ' '] : [];
-	return group([
-		...isPublic, // insert `public` keyword if present
-		'native',
-		' ',
-		'struct',
-		' ',
-		path.map(print, 'nonFormattingChildren'),
-		';',
-	]);
+    const isPublic = path.node.child(0)!.type === 'public' ? ['public', ' '] : [];
+    return group([
+        ...isPublic, // insert `public` keyword if present
+        'native',
+        ' ',
+        'struct',
+        ' ',
+        path.map(print, 'nonFormattingChildren'),
+        ';',
+    ]);
 }
 
 /**
@@ -99,17 +99,17 @@ export function printNativeStructDefinition(
  * Insert a newline before the comment if the previous node is not a line comment.
  */
 export function printStructDefinition(
-	path: AstPath<Node>,
-	options: ParserOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    options: ParserOptions,
+    print: printFn,
 ): Doc {
-	const isPublic = path.node.child(0)!.type === 'public' ? ['public', ' '] : [];
-	return group([
-		...isPublic, // insert `public` keyword if present
-		'struct',
-		' ',
-		path.map(print, 'nonFormattingChildren'),
-	]);
+    const isPublic = path.node.child(0)!.type === 'public' ? ['public', ' '] : [];
+    return group([
+        ...isPublic, // insert `public` keyword if present
+        'struct',
+        ' ',
+        path.map(print, 'nonFormattingChildren'),
+    ]);
 }
 
 type Ability = { name: 'key' | 'store' | 'drop'; text: Doc };
@@ -118,38 +118,38 @@ type Ability = { name: 'key' | 'store' | 'drop'; text: Doc };
  * Print `ability_decls` node.
  */
 export function printAbilityDeclarations(
-	path: AstPath<Node>,
-	options: MoveOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    options: MoveOptions,
+    print: printFn,
 ): Doc {
-	const abilities = formatAndSortAbilities(path, options, print);
-	return [
-		' has ',
-		join(
-			', ',
-			abilities.map((ability) => ability.text),
-		),
-		path.next?.namedChildren[0]?.type === StructDefinition.PositionalFields ? ' ' : '',
-	];
+    const abilities = formatAndSortAbilities(path, options, print);
+    return [
+        ' has ',
+        join(
+            ', ',
+            abilities.map((ability) => ability.text),
+        ),
+        path.next?.namedChildren[0]?.type === StructDefinition.PositionalFields ? ' ' : '',
+    ];
 }
 
 /**
  * Print `postfix_ability_decls` node.
  */
 export function printPostfixAbilityDeclarations(
-	path: AstPath<Node>,
-	options: MoveOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    options: MoveOptions,
+    print: printFn,
 ): Doc {
-	const abilities = formatAndSortAbilities(path, options, print);
-	return group([
-		' has ',
-		join(
-			', ',
-			abilities.map((ability) => ability.text),
-		),
-		';',
-	]);
+    const abilities = formatAndSortAbilities(path, options, print);
+    return group([
+        ' has ',
+        join(
+            ', ',
+            abilities.map((ability) => ability.text),
+        ),
+        ';',
+    ]);
 }
 
 /**
@@ -157,11 +157,11 @@ export function printPostfixAbilityDeclarations(
  * Prints the underlying fields of a datatype.
  */
 export function printDatatypeFields(
-	path: AstPath<Node>,
-	options: ParserOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    options: ParserOptions,
+    print: printFn,
 ): Doc {
-	return path.map(print, 'nonFormattingChildren');
+    return path.map(print, 'nonFormattingChildren');
 }
 
 /**
@@ -169,18 +169,18 @@ export function printDatatypeFields(
  * Prints the underlying fields of a struct.
  */
 export function printNamedFields(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	const children = path.map(print, 'nonFormattingChildren');
+    const children = path.map(print, 'nonFormattingChildren');
 
-	if (children.length === 0) {
-		return [' ', emptyBlockOrList(path, '{', '}', doc.builders.line)];
-	}
+    if (children.length === 0) {
+        return [' ', emptyBlockOrList(path, '{', '}', doc.builders.line)];
+    }
 
-	return [
-		' ',
-		group(list({ path, print, options, open: '{', close: '}', addWhitespace: true }), {
-			shouldBreak: shouldBreakFirstChild(path),
-		}),
-	];
+    return [
+        ' ',
+        group(list({ path, print, options, open: '{', close: '}', addWhitespace: true }), {
+            shouldBreak: shouldBreakFirstChild(path),
+        }),
+    ];
 }
 
 /**
@@ -188,42 +188,42 @@ export function printNamedFields(path: AstPath<Node>, options: MoveOptions, prin
  * Prints the underlying fields of a struct.
  */
 export function printPositionalFields(
-	path: AstPath<Node>,
-	options: MoveOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    options: MoveOptions,
+    print: printFn,
 ): Doc {
-	const children = path.map(print, 'nonFormattingChildren');
+    const children = path.map(print, 'nonFormattingChildren');
 
-	if (children.length === 0) {
-		return emptyBlockOrList(path, '(', ')', doc.builders.line);
-	}
+    if (children.length === 0) {
+        return emptyBlockOrList(path, '(', ')', doc.builders.line);
+    }
 
-	return group(list({ path, print, options, open: '(', close: ')' }), {
-		shouldBreak: false,
-	});
+    return group(list({ path, print, options, open: '(', close: ')' }), {
+        shouldBreak: false,
+    });
 }
 
 /**
  * Print `field_annotation` node.
  */
 export function printFieldAnnotation(
-	path: AstPath<Node>,
-	options: ParserOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    options: ParserOptions,
+    print: printFn,
 ): Doc {
-	return group([
-		path.call(print, 'nonFormattingChildren', 0), // field_identifier
-		':',
-		' ',
-		path.call(print, 'nonFormattingChildren', 1), // type
-	]);
+    return group([
+        path.call(print, 'nonFormattingChildren', 0), // field_identifier
+        ':',
+        ' ',
+        path.call(print, 'nonFormattingChildren', 1), // type
+    ]);
 }
 
 /**
  * Print `apply_type` node.
  */
 export function printApplyType(path: AstPath<Node>, options: ParserOptions, print: printFn): Doc {
-	return path.map(print, 'nonFormattingChildren');
+    return path.map(print, 'nonFormattingChildren');
 }
 
 /**
@@ -237,31 +237,31 @@ export function printApplyType(path: AstPath<Node>, options: ParserOptions, prin
  * Key always goes first, the rest are sorted alphabetically.
  */
 function formatAndSortAbilities(
-	path: AstPath<Node>,
-	options: MoveOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    options: MoveOptions,
+    print: printFn,
 ): Ability[] {
-	const abilities: Ability[] = path.map(
-		(path) => ({
-			name: path.node.text as Ability['name'],
-			text: [
-				printLeadingComment(path, options),
-				path.node.text,
-				printTrailingComment(path, true),
-			] as Doc,
-		}),
-		'nonFormattingChildren',
-	);
+    const abilities: Ability[] = path.map(
+        (path) => ({
+            name: path.node.text as Ability['name'],
+            text: [
+                printLeadingComment(path, options),
+                path.node.text,
+                printTrailingComment(path, true),
+            ] as Doc,
+        }),
+        'nonFormattingChildren',
+    );
 
-	// alphabetical but `key` always goes first
-	const priority = {
-		key: 0,
-		copy: 1,
-		drop: 2,
-		store: 3,
-	};
+    // alphabetical but `key` always goes first
+    const priority = {
+        key: 0,
+        copy: 1,
+        drop: 2,
+        store: 3,
+    };
 
-	abilities.sort((a, b) => priority[a.name] - priority[b.name]);
+    abilities.sort((a, b) => priority[a.name] - priority[b.name]);
 
-	return abilities;
+    return abilities;
 }

--- a/external-crates/move/tooling/prettier-move/src/cst/use_declaration.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/use_declaration.ts
@@ -7,28 +7,28 @@ import { MoveOptions, printFn, treeFn } from '../printer';
 const { group, indent, line, softline, ifBreak, join } = doc.builders;
 
 export default function (path: AstPath<Node>): treeFn | null {
-	switch (path.node.type) {
-		case UseDeclaration.UseDeclaration:
-			return printUseDeclaration;
-		case UseDeclaration.UseModule:
-			return printUseModule;
-		case UseDeclaration.UseMember:
-			return printUseMember;
-		case UseDeclaration.UseModuleMember:
-			return printUseModuleMember;
-		case UseDeclaration.UseModuleMembers:
-			return printUseModuleMembers;
-		case UseDeclaration.UseFun:
-			return printUseFun;
-		case UseDeclaration.ModuleIdentity:
-			return printModuleIdentity;
-		case UseDeclaration.FriendDeclaration:
-			return printFriendDeclaration;
-		case UseDeclaration.FriendAccess:
-			return printFriendAccess;
-		default:
-			return null;
-	}
+    switch (path.node.type) {
+        case UseDeclaration.UseDeclaration:
+            return printUseDeclaration;
+        case UseDeclaration.UseModule:
+            return printUseModule;
+        case UseDeclaration.UseMember:
+            return printUseMember;
+        case UseDeclaration.UseModuleMember:
+            return printUseModuleMember;
+        case UseDeclaration.UseModuleMembers:
+            return printUseModuleMembers;
+        case UseDeclaration.UseFun:
+            return printUseFun;
+        case UseDeclaration.ModuleIdentity:
+            return printModuleIdentity;
+        case UseDeclaration.FriendDeclaration:
+            return printFriendDeclaration;
+        case UseDeclaration.FriendAccess:
+            return printFriendAccess;
+        default:
+            return null;
+    }
 }
 
 /**
@@ -48,85 +48,81 @@ export default function (path: AstPath<Node>): treeFn | null {
  * )
  */
 export enum UseDeclaration {
-	/**
-	 * Module-level definition
-	 * ```
-	 * `<public> use ...;
-	 * ```
-	 */
-	UseDeclaration = 'use_declaration',
-	FriendDeclaration = 'friend_declaration',
-	FriendAccess = 'friend_access',
-	UseFun = 'use_fun',
+    /**
+     * Module-level definition
+     * ```
+     * `<public> use ...;
+     * ```
+     */
+    UseDeclaration = 'use_declaration',
+    FriendDeclaration = 'friend_declaration',
+    FriendAccess = 'friend_access',
+    UseFun = 'use_fun',
 
-	// all of the nodes below are implemented in `import-grouping.ts`
-	// hence should never be printed directly.
+    // all of the nodes below are implemented in `import-grouping.ts`
+    // hence should never be printed directly.
 
-	UseModule = 'use_module',
-	UseMember = 'use_member',
-	UseModuleMember = 'use_module_member',
-	UseModuleMembers = 'use_module_members',
-	ModuleIdentity = 'module_identity',
+    UseModule = 'use_module',
+    UseMember = 'use_member',
+    UseModuleMember = 'use_module_member',
+    UseModuleMembers = 'use_module_members',
+    ModuleIdentity = 'module_identity',
 }
 
 /**
  * Print @see `UseDeclaration.UseDeclaration` node.
  */
 export function printUseDeclaration(
-	path: AstPath<Node>,
-	options: MoveOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    options: MoveOptions,
+    print: printFn,
 ): Doc {
-	const firstChild = path.node.child(0);
-	const isPublic = firstChild && firstChild.type === 'public' ? ['public', ' '] : [];
-	return [
-		...isPublic, // insert `public` keyword if present
-		'use ',
-		path.call(print, 'nonFormattingChildren', 0),
-		';',
-	];
+    const firstChild = path.node.child(0);
+    const isPublic = firstChild && firstChild.type === 'public' ? ['public', ' '] : [];
+    return [
+        ...isPublic, // insert `public` keyword if present
+        'use ',
+        path.call(print, 'nonFormattingChildren', 0),
+        ';',
+    ];
 }
 
 /**
  * Print `use_fun` node `module_access` as `module_access`.`function_identifier`
  */
 export function printUseFun(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	return group([
-		'fun ',
-		path.call(print, 'nonFormattingChildren', 0), // module_access
-		' as',
-		indent(line),
-		path.call(print, 'nonFormattingChildren', 1), // module_access
-		'.',
-		path.call(print, 'nonFormattingChildren', 2), // function_identifier
-	]);
+    return group([
+        'fun ',
+        path.call(print, 'nonFormattingChildren', 0), // module_access
+        ' as',
+        indent(line),
+        path.call(print, 'nonFormattingChildren', 1), // module_access
+        '.',
+        path.call(print, 'nonFormattingChildren', 2), // function_identifier
+    ]);
 }
 
 /**
  * Print `friend_declaration` node.
  */
 export function printFriendDeclaration(
-	path: AstPath<Node>,
-	options: MoveOptions,
-	print: printFn,
+    path: AstPath<Node>,
+    options: MoveOptions,
+    print: printFn,
 ): Doc {
-	return group([
-		'friend',
-		indent(line),
-		path.call(print, 'nonFormattingChildren', 0), // module_access
-		';',
-	]);
+    return group([
+        'friend',
+        indent(line),
+        path.call(print, 'nonFormattingChildren', 0), // module_access
+        ';',
+    ]);
 }
 
 /**
  * Print `friend_access` node.
  */
-export function printFriendAccess(
-	path: AstPath<Node>,
-	options: MoveOptions,
-	print: printFn,
-): Doc {
-	return path.map(print, 'nonFormattingChildren');
+export function printFriendAccess(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
+    return path.map(print, 'nonFormattingChildren');
 }
 
 /**
@@ -134,10 +130,10 @@ export function printFriendAccess(
  * Currently only used for `use` with annotations.
  */
 export function printUseModule(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	return path.map((e) => {
-		if (e.node.type == 'as') return ' as ';
-		return print(e);
-	}, 'children');
+    return path.map((e) => {
+        if (e.node.type == 'as') return ' as ';
+        return print(e);
+    }, 'children');
 }
 
 /**
@@ -145,30 +141,30 @@ export function printUseModule(path: AstPath<Node>, options: MoveOptions, print:
  * Currently only used for `use` with annotations.
  */
 export function printUseMember(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	const isGroup = path.node.children.findIndex((e) => e.type == '{');
+    const isGroup = path.node.children.findIndex((e) => e.type == '{');
 
-	// not found `::{...}`
-	if (isGroup == -1) {
-		return group(
-			path.map((e) => {
-				if (e.node.type == 'as') return ' as ';
-				if (e.node.type == ',') return [',', line];
-				return print(e);
-			}, 'children'),
-		);
-	}
+    // not found `::{...}`
+    if (isGroup == -1) {
+        return group(
+            path.map((e) => {
+                if (e.node.type == 'as') return ' as ';
+                if (e.node.type == ',') return [',', line];
+                return print(e);
+            }, 'children'),
+        );
+    }
 
-	const children = path.map(print, 'nonFormattingChildren');
+    const children = path.map(print, 'nonFormattingChildren');
 
-	return group([
-		children[0]!,
-		'::{',
-		indent(softline),
-		indent(join([',', line], children.slice(1))),
-		ifBreak(','), // trailing comma
-		softline,
-		'}',
-	]);
+    return group([
+        children[0]!,
+        '::{',
+        indent(softline),
+        indent(join([',', line], children.slice(1))),
+        ifBreak(','), // trailing comma
+        softline,
+        '}',
+    ]);
 }
 
 /**
@@ -179,31 +175,39 @@ export function printUseMember(path: AstPath<Node>, options: MoveOptions, print:
  * Wraps the member into a group `{}` if it's too long (if line breaks).
  * Currently only used for `use` with annotations.
  */
-export function printUseModuleMember(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	return group([
-		path.call(print, 'nonFormattingChildren', 0), // module_access
-		'::',
-		ifBreak(['{', indent(line)]), // wrap with `{` if the member is too long
-		indent(path.call(print, 'nonFormattingChildren', 1)), // module_access
-		ifBreak([line, '}']), // trailing comma
-	]);
+export function printUseModuleMember(
+    path: AstPath<Node>,
+    options: MoveOptions,
+    print: printFn,
+): Doc {
+    return group([
+        path.call(print, 'nonFormattingChildren', 0), // module_access
+        '::',
+        ifBreak(['{', indent(line)]), // wrap with `{` if the member is too long
+        indent(path.call(print, 'nonFormattingChildren', 1)), // module_access
+        ifBreak([line, '}']), // trailing comma
+    ]);
 }
 
 /**
  * Print `use_module_members` node. `module_identity::{member_name, member_name}`
  * Currently only used for `use` with annotations.
  */
-export function printUseModuleMembers(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	const children = path.map(print, 'nonFormattingChildren');
-	return group([
-		children[0]!,
-		'::{',
-		indent(softline),
-		indent(join([',', line], children.slice(1))),
-		ifBreak(','), // trailing comma
-		softline,
-		'}',
-	]);
+export function printUseModuleMembers(
+    path: AstPath<Node>,
+    options: MoveOptions,
+    print: printFn,
+): Doc {
+    const children = path.map(print, 'nonFormattingChildren');
+    return group([
+        children[0]!,
+        '::{',
+        indent(softline),
+        indent(join([',', line], children.slice(1))),
+        ifBreak(','), // trailing comma
+        softline,
+        '}',
+    ]);
 }
 
 /**
@@ -211,20 +215,24 @@ export function printUseModuleMembers(path: AstPath<Node>, options: MoveOptions,
  * Is present in the `use_module_member` and `use_module_members` nodes.
  * Currently only used for `use` with annotations.
  */
-export function printModuleIdentity(path: AstPath<Node>, options: MoveOptions, print: printFn): Doc {
-	return join('::', path.map(print, 'nonFormattingChildren'));
+export function printModuleIdentity(
+    path: AstPath<Node>,
+    options: MoveOptions,
+    print: printFn,
+): Doc {
+    return join('::', path.map(print, 'nonFormattingChildren'));
 }
 
 /**
  * Checks whether the given path is a `use` import.
  */
 export function isUseImport(node: Node): boolean {
-	const firstChild = node.nonFormattingChildren[0]!;
+    const firstChild = node.nonFormattingChildren[0]!;
 
-	return (
-		node.type === UseDeclaration.UseDeclaration &&
-		(firstChild.type === UseDeclaration.UseModule ||
-			firstChild.type === UseDeclaration.UseModuleMember ||
-			firstChild.type === UseDeclaration.UseModuleMembers)
-	);
+    return (
+        node.type === UseDeclaration.UseDeclaration &&
+        (firstChild.type === UseDeclaration.UseModule ||
+            firstChild.type === UseDeclaration.UseModuleMember ||
+            firstChild.type === UseDeclaration.UseModuleMembers)
+    );
 }

--- a/external-crates/move/tooling/prettier-move/src/imports-grouping.ts
+++ b/external-crates/move/tooling/prettier-move/src/imports-grouping.ts
@@ -18,14 +18,14 @@ const { join, softline, indent, line, group } = doc.builders;
  * A simple type to represent grouped imports.
  */
 export type GroupedImports = {
-	[package_: string]: {
-		[module_: string]: Member[];
-	};
+    [package_: string]: {
+        [module_: string]: Member[];
+    };
 };
 
 type Member = {
-	name: string | 'Self';
-	alias: string | undefined;
+    name: string | 'Self';
+    alias: string | undefined;
 };
 
 /**
@@ -38,103 +38,103 @@ type Member = {
  * printed before.
  */
 export function printImports(imports: GroupedImports, option: 'module' | 'package'): Doc {
-	const pkgs = Object.keys(imports).sort();
-	const result = [] as Doc[];
+    const pkgs = Object.keys(imports).sort();
+    const result = [] as Doc[];
 
-	for (const pkg of pkgs) {
-		const modules = imports[pkg];
+    for (const pkg of pkgs) {
+        const modules = imports[pkg];
 
-		// typescript wants this
-		if (modules == undefined) {
-			continue;
-		}
+        // typescript wants this
+        if (modules == undefined) {
+            continue;
+        }
 
-		const keys = Object.keys(modules).sort();
+        const keys = Object.keys(modules).sort();
 
-		// if grouped by module
-		if (option === 'module') {
-			for (const mod of keys) {
-				if (modules[mod] == undefined) continue;
-				result.push(['use ', pkg, '::', printModule(mod, modules[mod]), ';']);
-			}
-		} else {
-			// if grouped by package
-			const modulesDoc = [] as Doc[];
+        // if grouped by module
+        if (option === 'module') {
+            for (const mod of keys) {
+                if (modules[mod] == undefined) continue;
+                result.push(['use ', pkg, '::', printModule(mod, modules[mod]), ';']);
+            }
+        } else {
+            // if grouped by package
+            const modulesDoc = [] as Doc[];
 
-			for (const mod of keys) {
-				if (modules[mod] == undefined) continue;
-				modulesDoc.push(printModule(mod, modules[mod]));
-			}
+            for (const mod of keys) {
+                if (modules[mod] == undefined) continue;
+                modulesDoc.push(printModule(mod, modules[mod]));
+            }
 
-			modulesDoc.length === 1
-				? result.push(['use ', pkg, '::', modulesDoc[0]!, ';'])
-				: result.push([
-						'use ',
-						pkg,
-						'::',
-						group([
-							'{',
-							indent(softline),
-							indent(join([',', line], modulesDoc)),
-							softline,
-							'}',
-						]),
-						';',
-					]);
-		}
-	}
+            modulesDoc.length === 1
+                ? result.push(['use ', pkg, '::', modulesDoc[0]!, ';'])
+                : result.push([
+                      'use ',
+                      pkg,
+                      '::',
+                      group([
+                          '{',
+                          indent(softline),
+                          indent(join([',', line], modulesDoc)),
+                          softline,
+                          '}',
+                      ]),
+                      ';',
+                  ]);
+        }
+    }
 
-	return result;
+    return result;
 }
 
 function printModule(mod: string, members: Member[]): Doc {
-	const printedKeys: string[] = [];
+    const printedKeys: string[] = [];
 
-	// perform deduplication of imports
-	members = members.filter((m) => {
-		const key = [mod, m.name, m.alias || '-'].join('');
-		if (printedKeys.includes(key)) return false;
-		printedKeys.push(key);
-		return true;
-	});
+    // perform deduplication of imports
+    members = members.filter((m) => {
+        const key = [mod, m.name, m.alias || '-'].join('');
+        if (printedKeys.includes(key)) return false;
+        printedKeys.push(key);
+        return true;
+    });
 
-	if (members.length === 1) {
-		const member = members[0]!;
-		if (member.name === 'Self') {
-			const alias = member.alias ? ` as ${member.alias}` : '';
-			return `${mod}${alias}`;
-		}
+    if (members.length === 1) {
+        const member = members[0]!;
+        if (member.name === 'Self') {
+            const alias = member.alias ? ` as ${member.alias}` : '';
+            return `${mod}${alias}`;
+        }
 
-		return [mod, '::', printMember(member)];
-	}
+        return [mod, '::', printMember(member)];
+    }
 
-	const selfIdx = members.findIndex((m) => m.name === 'Self');
-	if (selfIdx !== -1) {
-		const self = members.splice(selfIdx, 1);
-		members = [...self, ...members];
-	}
+    const selfIdx = members.findIndex((m) => m.name === 'Self');
+    if (selfIdx !== -1) {
+        const self = members.splice(selfIdx, 1);
+        members = [...self, ...members];
+    }
 
-	return members.length === 0
-		? [mod]
-		: [
-				mod,
-				'::',
-				group([
-					'{',
-					indent(softline),
-					indent(join([',', line], members.map(printMember))),
-					softline,
-					'}',
-				]),
-			];
+    return members.length === 0
+        ? [mod]
+        : [
+              mod,
+              '::',
+              group([
+                  '{',
+                  indent(softline),
+                  indent(join([',', line], members.map(printMember))),
+                  softline,
+                  '}',
+              ]),
+          ];
 }
 
 /**
  * Print a single member of a module with an optional alias.
  */
 function printMember({ name, alias }: Member): Doc {
-	const a = alias ? ` as ${alias}` : '';
-	return `${name}${a}`;
+    const a = alias ? ` as ${alias}` : '';
+    return `${name}${a}`;
 }
 
 /**
@@ -150,145 +150,149 @@ function printMember({ name, alias }: Member): Doc {
  * @returns
  */
 export function collectImports(node: Node): GroupedImports {
-	const grouped: GroupedImports = {};
-	const imports = node.nonFormattingChildren
-		.filter((n) => n.isGroupedImport)
-		.map((n) => n.nonFormattingChildren[0]!);
+    const grouped: GroupedImports = {};
+    const imports = node.nonFormattingChildren
+        .filter((n) => n.isGroupedImport)
+        .map((n) => n.nonFormattingChildren[0]!);
 
-	for (let import_ of imports) {
-		switch (import_.type) {
-			// `module_access` <as `alias`>;
-			case UseDeclaration.UseModule: {
-				const moduleIdentity = import_.nonFormattingChildren[0]!;
-				const alias = import_.nonFormattingChildren[1];
-				const [pkg, mod] = parseModuleIdentity(moduleIdentity);
+    for (let import_ of imports) {
+        switch (import_.type) {
+            // `module_access` <as `alias`>;
+            case UseDeclaration.UseModule: {
+                const moduleIdentity = import_.nonFormattingChildren[0]!;
+                const alias = import_.nonFormattingChildren[1];
+                const [pkg, mod] = parseModuleIdentity(moduleIdentity);
 
-				// we use `Self` in the tree to represent the current module
-				const rec = { name: 'Self', alias: alias?.text };
+                // we use `Self` in the tree to represent the current module
+                const rec = { name: 'Self', alias: alias?.text };
 
-				// if there hasn't been a registered package yet, add it
-				if (!grouped[pkg]) grouped[pkg] = {};
-				if (!grouped[pkg][mod]) grouped[pkg][mod] = [];
+                // if there hasn't been a registered package yet, add it
+                if (!grouped[pkg]) grouped[pkg] = {};
+                if (!grouped[pkg][mod]) grouped[pkg][mod] = [];
 
-				grouped[pkg][mod].push(rec);
+                grouped[pkg][mod].push(rec);
 
-				break;
-			}
-			// `<module_identity>::<use_member>`
-			case UseDeclaration.UseModuleMember: {
-				const moduleIdentity = import_.nonFormattingChildren[0]!;
-				const [pkg, mod] = parseModuleIdentity(moduleIdentity);
-				const useMember = import_.nonFormattingChildren[1]!;
-				const [name, alias] = parseUseMember(useMember);
+                break;
+            }
+            // `<module_identity>::<use_member>`
+            case UseDeclaration.UseModuleMember: {
+                const moduleIdentity = import_.nonFormattingChildren[0]!;
+                const [pkg, mod] = parseModuleIdentity(moduleIdentity);
+                const useMember = import_.nonFormattingChildren[1]!;
+                const [name, alias] = parseUseMember(useMember);
 
-				if (!grouped[pkg]) grouped[pkg] = {};
-				if (!grouped[pkg][mod]) grouped[pkg][mod] = [];
+                if (!grouped[pkg]) grouped[pkg] = {};
+                if (!grouped[pkg][mod]) grouped[pkg][mod] = [];
 
-				grouped[pkg][mod].push({ name, alias });
+                grouped[pkg][mod].push({ name, alias });
 
-				break;
-			}
-			// The only tricky node in this scheme. `use_module_members` can be
-			// both for grouped by package and for grouped by module, so we have
-			// to detect which version it is and then dance off of that.
-			case UseDeclaration.UseModuleMembers: {
-				const children = import_.nonFormattingChildren;
-				const isGroupedByPackage = children[0]!.type === 'module_identifier';
+                break;
+            }
+            // The only tricky node in this scheme. `use_module_members` can be
+            // both for grouped by package and for grouped by module, so we have
+            // to detect which version it is and then dance off of that.
+            case UseDeclaration.UseModuleMembers: {
+                const children = import_.nonFormattingChildren;
+                const isGroupedByPackage = children[0]!.type === 'module_identifier';
 
-				if (!isGroupedByPackage && children[0]!.type !== UseDeclaration.ModuleIdentity) {
-					throw new Error('Expected `module_identity` or `module_identifier`');
-				}
+                if (!isGroupedByPackage && children[0]!.type !== UseDeclaration.ModuleIdentity) {
+                    throw new Error('Expected `module_identity` or `module_identifier`');
+                }
 
-				// simple scenario: the first node is `module_identity`
-				if (!isGroupedByPackage) {
-					const moduleIdentity = children[0]!;
-					const [pkg, mod] = parseModuleIdentity(moduleIdentity);
-					const members = children.slice(1).map((n) => parseUseMember(n));
+                // simple scenario: the first node is `module_identity`
+                if (!isGroupedByPackage) {
+                    const moduleIdentity = children[0]!;
+                    const [pkg, mod] = parseModuleIdentity(moduleIdentity);
+                    const members = children.slice(1).map((n) => parseUseMember(n));
 
-					if (!grouped[pkg]) grouped[pkg] = {};
-					if (!grouped[pkg][mod]) grouped[pkg][mod] = [];
+                    if (!grouped[pkg]) grouped[pkg] = {};
+                    if (!grouped[pkg][mod]) grouped[pkg][mod] = [];
 
-					grouped[pkg][mod].push(...members.map(([name, alias]) => ({ name, alias })));
+                    grouped[pkg][mod].push(...members.map(([name, alias]) => ({ name, alias })));
 
-					break;
-				}
+                    break;
+                }
 
-				// complex scenario: the first node is `module_identifier`
-				// `use_member` can be recursive in this scenario with 1 level of nesting
-				const pkg = children[0]!.text;
-				if (!grouped[pkg]) grouped[pkg] = {};
+                // complex scenario: the first node is `module_identifier`
+                // `use_member` can be recursive in this scenario with 1 level of nesting
+                const pkg = children[0]!.text;
+                if (!grouped[pkg]) grouped[pkg] = {};
 
-				children.slice(1).forEach((node) => {
-					if (!node) return;
+                children.slice(1).forEach((node) => {
+                    if (!node) return;
 
-					if (node.type !== UseDeclaration.UseMember)
-						throw new Error('Expected `use_member` node got `' + node.type + '`');
+                    if (node.type !== UseDeclaration.UseMember)
+                        throw new Error('Expected `use_member` node got `' + node.type + '`');
 
-					const [first, ...rest] = node.nonFormattingChildren;
-					if (!first || first.type !== 'identifier')
-						throw new Error('Expected `identifier` node in `use_module_members`');
+                    const [first, ...rest] = node.nonFormattingChildren;
+                    if (!first || first.type !== 'identifier')
+                        throw new Error('Expected `identifier` node in `use_module_members`');
 
-					const mod = first.text;
-					if (!grouped[pkg]![mod]) grouped[pkg]![mod] = [];
+                    const mod = first.text;
+                    if (!grouped[pkg]![mod]) grouped[pkg]![mod] = [];
 
-					// if there's only one member and it's the module.
-					if (!rest.length) {
-						grouped[pkg]![mod].push({ name: 'Self', alias: undefined });
-						return;
-					}
+                    // if there's only one member and it's the module.
+                    if (!rest.length) {
+                        grouped[pkg]![mod].push({ name: 'Self', alias: undefined });
+                        return;
+                    }
 
-					// ident + ident is an alias
-					if (rest.length == 1 && rest[0]?.type === 'identifier') {
-						if (rest[0].previousSibling?.type !== "as") {
-							grouped[pkg]![mod].push({ name: rest[0].text, alias: undefined });
-						} else {
-							grouped[pkg]![mod].push({ name: 'Self', alias: rest[0].text });
-						}
+                    // ident + ident is an alias
+                    if (rest.length == 1 && rest[0]?.type === 'identifier') {
+                        if (rest[0].previousSibling?.type !== 'as') {
+                            grouped[pkg]![mod].push({ name: rest[0].text, alias: undefined });
+                        } else {
+                            grouped[pkg]![mod].push({ name: 'Self', alias: rest[0].text });
+                        }
 
-						return;
-					}
+                        return;
+                    }
 
-					// special case, no use member, but already expanded pair of identifiers.
-					if (rest.length == 2 && rest[0]?.type === 'identifier' && rest[1]?.type === 'identifier') {
-						if (rest[1].previousSibling?.type !== "as") {
-							throw new Error('Expected `as` keyword after module name');
-						}
+                    // special case, no use member, but already expanded pair of identifiers.
+                    if (
+                        rest.length == 2 &&
+                        rest[0]?.type === 'identifier' &&
+                        rest[1]?.type === 'identifier'
+                    ) {
+                        if (rest[1].previousSibling?.type !== 'as') {
+                            throw new Error('Expected `as` keyword after module name');
+                        }
 
-						grouped[pkg]![mod].push({ name: rest[0].text, alias: rest[1].text });
-						return;
-					}
+                        grouped[pkg]![mod].push({ name: rest[0].text, alias: rest[1].text });
+                        return;
+                    }
 
-					// the rest are `use_member` nodes
-					const members = rest.map(parseUseMember);
-					grouped[pkg]![mod].push(...members.map(([name, alias]) => ({ name, alias })));
-				});
-			}
-		}
-	}
+                    // the rest are `use_member` nodes
+                    const members = rest.map(parseUseMember);
+                    grouped[pkg]![mod].push(...members.map(([name, alias]) => ({ name, alias })));
+                });
+            }
+        }
+    }
 
-	return grouped;
+    return grouped;
 }
 
 /**
  * Parse a `module_identity` node returning a tuple of package and module.
  */
 function parseModuleIdentity(node: Node): [string, string] {
-	if (node.type !== UseDeclaration.ModuleIdentity) {
-		throw new Error('Expected `module_identity` node');
-	}
+    if (node.type !== UseDeclaration.ModuleIdentity) {
+        throw new Error('Expected `module_identity` node');
+    }
 
-	const [pkg, mod] = node.nonFormattingChildren.map((n) => n.text);
-	return [pkg!, mod!];
+    const [pkg, mod] = node.nonFormattingChildren.map((n) => n.text);
+    return [pkg!, mod!];
 }
 
 /**
  * Parse a simple `use_member` node returning a tuple of member and alias.
  */
 function parseUseMember(node: Node): [string, string | undefined] {
-	if (node.type !== UseDeclaration.UseMember) {
-		throw new Error('Expected `use_member` node, got `' + node.type + '`');
-	}
+    if (node.type !== UseDeclaration.UseMember) {
+        throw new Error('Expected `use_member` node, got `' + node.type + '`');
+    }
 
-	const [member, alias] = node.nonFormattingChildren.map((n) => n.text);
-	return [member!, alias];
+    const [member, alias] = node.nonFormattingChildren.map((n) => n.text);
+    return [member!, alias];
 }

--- a/external-crates/move/tooling/prettier-move/src/imports-grouping.ts
+++ b/external-crates/move/tooling/prettier-move/src/imports-grouping.ts
@@ -179,8 +179,6 @@ export function collectImports(node: Node): GroupedImports {
                 const useMember = import_.nonFormattingChildren[1]!;
                 const [name, alias] = parseUseMember(useMember);
 
-                // if (!grouped[pkg]) grouped[pkg] = new Map();
-                // if (!grouped[pkg][mod]) grouped[pkg][mod] = [];
                 if (!grouped.has(pkg)) grouped.set(pkg, new Map());
                 const pkgMap = grouped.get(pkg)!;
                 if (!pkgMap.has(mod)) pkgMap.set(mod, []);
@@ -206,8 +204,6 @@ export function collectImports(node: Node): GroupedImports {
                     const [pkg, mod] = parseModuleIdentity(moduleIdentity);
                     const members = children.slice(1).map((n) => parseUseMember(n));
 
-                    // if (!grouped[pkg]) grouped[pkg] = {};
-                    // if (!grouped[pkg][mod]) grouped[pkg][mod] = [];
                     if (!grouped.has(pkg)) grouped.set(pkg, new Map());
                     const pkgMap = grouped.get(pkg)!;
                     if (!pkgMap.has(mod)) pkgMap.set(mod, []);
@@ -223,7 +219,6 @@ export function collectImports(node: Node): GroupedImports {
                 const pkg = children[0]!.text;
                 if (!grouped.has(pkg)) grouped.set(pkg, new Map());
                 const pkgMap = grouped.get(pkg)!;
-
 
                 children.slice(1).forEach((node) => {
                     if (!node) return;

--- a/external-crates/move/tooling/prettier-move/src/index.ts
+++ b/external-crates/move/tooling/prettier-move/src/index.ts
@@ -18,11 +18,11 @@ import Parser = require('web-tree-sitter');
 import { print } from './printer';
 import { Tree } from './tree';
 import {
-	Parser as PrettierParser,
-	Printer,
-	Plugin,
-	SupportOption,
-	SupportLanguage,
+    Parser as PrettierParser,
+    Printer,
+    Plugin,
+    SupportOption,
+    SupportLanguage,
 } from 'prettier';
 
 /**
@@ -31,89 +31,89 @@ import {
 export type Node = Tree;
 
 export const languages: SupportLanguage[] = [
-	{
-		name: 'move',
-		extensions: ['.move'],
-		parsers: ['move'],
-	},
+    {
+        name: 'move',
+        extensions: ['.move'],
+        parsers: ['move'],
+    },
 ];
 
 export const parsers: { [key: string]: PrettierParser } = {
-	move: {
-		parse: (text: string): Promise<Node> => {
-			return (async (): Promise<Node> => {
-				await Parser.init();
-				const parser = new Parser();
-				const Lang = await Parser.Language.load(
-					path.join(__dirname, '..', 'tree-sitter-move.wasm'),
-				);
-				parser.setLanguage(Lang);
-				return new Tree(parser.parse(text).rootNode);
-			})();
-		},
+    move: {
+        parse: (text: string): Promise<Node> => {
+            return (async (): Promise<Node> => {
+                await Parser.init();
+                const parser = new Parser();
+                const Lang = await Parser.Language.load(
+                    path.join(__dirname, '..', 'tree-sitter-move.wasm'),
+                );
+                parser.setLanguage(Lang);
+                return new Tree(parser.parse(text).rootNode);
+            })();
+        },
 
-		astFormat: 'move',
-		locStart: () => -1,
-		locEnd: () => -1,
-	},
+        astFormat: 'move',
+        locStart: () => -1,
+        locEnd: () => -1,
+    },
 };
 
 export const printers: { [key: string]: Printer } = {
-	'move': { print },
+    move: { print },
 };
 
 export const options: Record<string, SupportOption> = {
-	autoGroupImports: {
-		type: 'choice',
-		category: 'Global',
-		default: 'package',
-		description: "Group all use imports by 'package', 'module' or 'none'.",
-		choices: [
-			{
-				value: 'package',
-				description:
-					'Group imports by package, eg `use sui::{balance::Balance, coin::Coin}',
-			},
-			{
-				value: 'module',
-				description:
-					'Group imports by module eg\n`use sui::balance::Balance;\nuse sui::coin::Coin`',
-			},
-		],
-	},
-	wrapComments: {
-		type: 'boolean',
-		category: 'Global',
-		default: false,
-		description: 'Wrap comments to the next line if the line is too long.',
-	},
-	useModuleLabel: {
-		type: 'boolean',
-		category: 'Global',
-		default: true,
-		description:
-			'Enable module labels instead of module with braces. This option will be ignored if there is more than one module in the file.',
-	},
-	enableErrorDebug: {
-		type: 'boolean',
-		category: 'Global',
-		default: false,
-		description: 'Print ERROR nodes instead of throwing an error.',
-	},
+    autoGroupImports: {
+        type: 'choice',
+        category: 'Global',
+        default: 'package',
+        description: "Group all use imports by 'package', 'module' or 'none'.",
+        choices: [
+            {
+                value: 'package',
+                description:
+                    'Group imports by package, eg `use sui::{balance::Balance, coin::Coin}',
+            },
+            {
+                value: 'module',
+                description:
+                    'Group imports by module eg\n`use sui::balance::Balance;\nuse sui::coin::Coin`',
+            },
+        ],
+    },
+    wrapComments: {
+        type: 'boolean',
+        category: 'Global',
+        default: false,
+        description: 'Wrap comments to the next line if the line is too long.',
+    },
+    useModuleLabel: {
+        type: 'boolean',
+        category: 'Global',
+        default: true,
+        description:
+            'Enable module labels instead of module with braces. This option will be ignored if there is more than one module in the file.',
+    },
+    enableErrorDebug: {
+        type: 'boolean',
+        category: 'Global',
+        default: false,
+        description: 'Print ERROR nodes instead of throwing an error.',
+    },
 };
 
 export const defaultOptions = {
-	tabWidth: 4,
-	useTabs: false,
-	printWidth: 100,
-	useModuleLabel: false,
-	groupImports: 'module',
+    tabWidth: 4,
+    useTabs: false,
+    printWidth: 100,
+    useModuleLabel: false,
+    groupImports: 'module',
 };
 
 export default {
-	languages,
-	parsers,
-	printers,
-	options,
-	defaultOptions,
+    languages,
+    parsers,
+    printers,
+    options,
+    defaultOptions,
 } as Plugin;

--- a/external-crates/move/tooling/prettier-move/src/printer.ts
+++ b/external-crates/move/tooling/prettier-move/src/printer.ts
@@ -26,12 +26,12 @@ import EnumDefinition from './cst/enum_definition';
 import Annotation from './cst/annotation';
 
 export type MoveOptions = ParserOptions & {
-	wrapComments: boolean;
-	alwaysBreakConditionals: boolean;
-	alwaysBreakStructDefinition: boolean;
-	useModuleLabel: boolean;
-	enableErrorDebug: boolean;
-	autoGroupImports: 'package' | 'module';
+    wrapComments: boolean;
+    alwaysBreakConditionals: boolean;
+    alwaysBreakStructDefinition: boolean;
+    useModuleLabel: boolean;
+    enableErrorDebug: boolean;
+    autoGroupImports: 'package' | 'module';
 };
 
 export type printFn = (path: AstPath) => Doc;
@@ -41,53 +41,53 @@ export type treeFn = (path: AstPath<Node>, options: MoveOptions, print: printFn)
  * Print the AST node at the given path.
  */
 export function print(path: AstPath<Node>, options: MoveOptions, print: printFn) {
-	// check if the node has an error child, if so, we throw an error or return the error text
-	const checkErrorsCb = (path: AstPath<Node>) => {
-		if (path.node.children.some((n) => n.type === 'ERROR')) {
-			if (options.enableErrorDebug) {
-				return ((path, options, print) => ['/* ERROR: */', path.node.text]) as treeFn;
-			} else {
-				throw new Error('tree-sitter failure on \n```\n' + path.node.text + '\n```');
-			}
-		}
+    // check if the node has an error child, if so, we throw an error or return the error text
+    const checkErrorsCb = (path: AstPath<Node>) => {
+        if (path.node.children.some((n) => n.type === 'ERROR')) {
+            if (options.enableErrorDebug) {
+                return ((path, options, print) => ['/* ERROR: */', path.node.text]) as treeFn;
+            } else {
+                throw new Error('tree-sitter failure on \n```\n' + path.node.text + '\n```');
+            }
+        }
 
-		if (path.node.children.some((n) => n.type === 'MISSING')) {
-			if (options.enableErrorDebug) {
-				return ((path, options, print) => ['/* MISSING: */', path.node.text]) as treeFn;
-			} else {
-				throw new Error('tree-sitter failure on \n```\n' + path.node.text + '\n```');
-			}
-		}
+        if (path.node.children.some((n) => n.type === 'MISSING')) {
+            if (options.enableErrorDebug) {
+                return ((path, options, print) => ['/* MISSING: */', path.node.text]) as treeFn;
+            } else {
+                throw new Error('tree-sitter failure on \n```\n' + path.node.text + '\n```');
+            }
+        }
 
-		return null;
-	};
+        return null;
+    };
 
-	// for unimplemented / not yet implemented nodes, we just return the node type
-	const defautCb: treeFn = (path, options, print) => {
-		return path.node.type;
-	};
+    // for unimplemented / not yet implemented nodes, we just return the node type
+    const defautCb: treeFn = (path, options, print) => {
+        return path.node.type;
+    };
 
-	const fn =
-		checkErrorsCb(path) ||
-		SourceFile(path) ||
-		Annotation(path) ||
-		Formatting(path) ||
-		Common(path) ||
-		Module(path) ||
-		UseDeclaration(path) ||
-		Constant(path) ||
-		EnumDefinition(path) ||
-		StructDefinition(path) ||
-		FunctionDefinition(path) ||
-		Expression(path) ||
-		Literal(path) ||
-		defautCb;
+    const fn =
+        checkErrorsCb(path) ||
+        SourceFile(path) ||
+        Annotation(path) ||
+        Formatting(path) ||
+        Common(path) ||
+        Module(path) ||
+        UseDeclaration(path) ||
+        Constant(path) ||
+        EnumDefinition(path) ||
+        StructDefinition(path) ||
+        FunctionDefinition(path) ||
+        Expression(path) ||
+        Literal(path) ||
+        defautCb;
 
-	return [
-		printLeadingComment(path, options),
-		// if the node has a `skipFormattingNode` property, we just return
-		// the text without formatting it
-		path.node.skipFormattingNode ? path.node.text : fn(path, options, print),
-		printTrailingComment(path),
-	];
+    return [
+        printLeadingComment(path, options),
+        // if the node has a `skipFormattingNode` property, we just return
+        // the text without formatting it
+        path.node.skipFormattingNode ? path.node.text : fn(path, options, print),
+        printTrailingComment(path),
+    ];
 }

--- a/external-crates/move/tooling/prettier-move/src/tree.ts
+++ b/external-crates/move/tooling/prettier-move/src/tree.ts
@@ -94,7 +94,7 @@ export class Tree {
     }
 
     /**
-     * Special case for lists, where we want to print the trailing comma.
+     * Disable the trailing comment for the current node.
      */
     disableTrailingComment() {
         this.enableTrailingComment = false;

--- a/external-crates/move/tooling/prettier-move/src/tree.ts
+++ b/external-crates/move/tooling/prettier-move/src/tree.ts
@@ -6,434 +6,430 @@ import { isFormatting } from './cst/formatting';
 import { isUseImport } from './cst/use_declaration';
 
 export interface Comment {
-	type: 'line_comment' | 'block_comment';
-	text: string;
-	newline: boolean;
+    type: 'line_comment' | 'block_comment';
+    text: string;
+    newline: boolean;
 }
 
 export class Tree {
-	public type: string;
-	public text: string;
-	public isNamed: boolean;
-	public children: Tree[];
-	public leadingComment: Comment[];
-	public trailingComment: Comment | null;
-	public enableLeadingComment: boolean = true;
-	public enableTrailingComment: boolean = true;
+    public type: string;
+    public text: string;
+    public isNamed: boolean;
+    public children: Tree[];
+    public leadingComment: Comment[];
+    public trailingComment: Comment | null;
+    public enableLeadingComment: boolean = true;
+    public enableTrailingComment: boolean = true;
 
-	/**
-	 * A reference lock to the parent node. This is a function that returns the
-	 * parent node. This way we remove the duplicate reference to the parent node
-	 * and avoid circular references.
-	 */
-	private getParent: () => Tree | null;
+    /**
+     * A reference lock to the parent node. This is a function that returns the
+     * parent node. This way we remove the duplicate reference to the parent node
+     * and avoid circular references.
+     */
+    private getParent: () => Tree | null;
 
-	/**
-	 * Marks if the comment has been used. This is useful to avoid using the same
-	 * comment multiple times + filter out comments that are already used.
-	 */
-	private isUsedComment: boolean = false;
+    /**
+     * Marks if the comment has been used. This is useful to avoid using the same
+     * comment multiple times + filter out comments that are already used.
+     */
+    private isUsedComment: boolean = false;
 
-	/**
-	 * Construct the `Tree` node from the `Parser.SyntaxNode`, additionally, run
-	 * some passes to clean-up the tree and make the structure more manageable and
-	 * easier to work with.
-	 *
-	 * Passes:
-	 * - Sum-up pairs of newlines into a single empty line.
-	 * - Filter out sequential empty lines.
-	 * - Filter out leading and trailing empty lines.
-	 * - Assign trailing comments to the node.
-	 * - Assign leading comments to the node.
-	 * - Filter out all assigned comments.
-	 *
-	 * @param node
-	 * @param parent
-	 */
-	constructor(node: Parser.SyntaxNode, parent: Tree | null = null) {
-		this.type = node.type;
-		this.text = node.text;
-		this.isNamed = node.isNamed();
-		this.leadingComment = [];
-		this.trailingComment = null;
-		this.getParent = () => parent;
+    /**
+     * Construct the `Tree` node from the `Parser.SyntaxNode`, additionally, run
+     * some passes to clean-up the tree and make the structure more manageable and
+     * easier to work with.
+     *
+     * Passes:
+     * - Sum-up pairs of newlines into a single empty line.
+     * - Filter out sequential empty lines.
+     * - Filter out leading and trailing empty lines.
+     * - Assign trailing comments to the node.
+     * - Assign leading comments to the node.
+     * - Filter out all assigned comments.
+     *
+     * @param node
+     * @param parent
+     */
+    constructor(node: Parser.SyntaxNode, parent: Tree | null = null) {
+        this.type = node.type;
+        this.text = node.text;
+        this.isNamed = node.isNamed();
+        this.leadingComment = [];
+        this.trailingComment = null;
+        this.getParent = () => parent;
 
-		// === Clean-up passes ===
+        // === Clean-up passes ===
 
-		// turn every node into a `Tree` node.
-		this.children = node.children.map((child) => new Tree(child, this));
+        // turn every node into a `Tree` node.
+        this.children = node.children.map((child) => new Tree(child, this));
 
-		// sum-up pairs of newlines into a single empty line.
-		this.children = this.children.reduce((acc, node) => {
-			if (node.isNewline && node.nextSibling?.isNewline) node.type = 'empty_line';
-			if (node.isNewline && acc[acc.length - 1]?.isEmptyLine) return acc;
-			return [...acc, node];
-		}, [] as Tree[]);
+        // sum-up pairs of newlines into a single empty line.
+        this.children = this.children.reduce((acc, node) => {
+            if (node.isNewline && node.nextSibling?.isNewline) node.type = 'empty_line';
+            if (node.isNewline && acc[acc.length - 1]?.isEmptyLine) return acc;
+            return [...acc, node];
+        }, [] as Tree[]);
 
-		// filter out sequential empty lines.
-		this.children = this.children.filter((node) => {
-			return !node.isEmptyLine || !node.previousNamedSibling?.isEmptyLine;
-		});
+        // filter out sequential empty lines.
+        this.children = this.children.filter((node) => {
+            return !node.isEmptyLine || !node.previousNamedSibling?.isEmptyLine;
+        });
 
-		// filter out leading and trailing empty lines.
-		this.children = this.children.filter((node) => {
-			if (!node.isEmptyLine) return true; // we only filter out empty lines
-			if (!node.previousNamedSibling) return false; // remove leading empty lines
-			if (!node.nextNamedSibling) return false; // remove trailing empty lines
-			return true;
-		});
+        // filter out leading and trailing empty lines.
+        this.children = this.children.filter((node) => {
+            if (!node.isEmptyLine) return true; // we only filter out empty lines
+            if (!node.previousNamedSibling) return false; // remove leading empty lines
+            if (!node.nextNamedSibling) return false; // remove trailing empty lines
+            return true;
+        });
 
-		// assign trailing comments to the node. modifies the tree in place.
-		this.children.forEach((child) => child.assignTrailingComments());
+        // assign trailing comments to the node. modifies the tree in place.
+        this.children.forEach((child) => child.assignTrailingComments());
 
-		// assign leading comments to the node. modifies the tree in place.
-		this.children.forEach((child) => child.assignLeadingComments());
+        // assign leading comments to the node. modifies the tree in place.
+        this.children.forEach((child) => child.assignLeadingComments());
 
-		// filter out all leading comments.
-		this.children = this.children.filter((child) => !child.isUsedComment);
-	}
+        // filter out all leading comments.
+        this.children = this.children.filter((child) => !child.isUsedComment);
+    }
 
-	/**
-	 * Special case for lists, where we want to print the trailing comma.
-	 */
-	disableTrailingComment() {
-		this.enableTrailingComment = false;
-	}
+    /**
+     * Special case for lists, where we want to print the trailing comma.
+     */
+    disableTrailingComment() {
+        this.enableTrailingComment = false;
+    }
 
-	/**
-	 * Special case for lists, where we want to print the leading character (eg `dot_expression`).
-	 */
-	disableLeadingComment() {
-		this.enableLeadingComment = false;
-	}
+    /**
+     * Special case for lists, where we want to print the leading character (eg `dot_expression`).
+     */
+    disableLeadingComment() {
+        this.enableLeadingComment = false;
+    }
 
-	/**
-	 * Find the parent node of a specific type. Optionally, break on a specific type.
-	 */
-	findParentUntil(type: string, breakOn: string[]): Tree | null {
-		let parent = this.parent;
-		while (parent) {
-			if (parent.type === type) return parent;
-			if (breakOn.includes(parent.type)) return null;
-			parent = parent.parent;
-		}
+    /**
+     * Find the parent node of a specific type. Optionally, break on a specific type.
+     */
+    findParentUntil(type: string, breakOn: string[]): Tree | null {
+        let parent = this.parent;
+        while (parent) {
+            if (parent.type === type) return parent;
+            if (breakOn.includes(parent.type)) return null;
+            parent = parent.parent;
+        }
 
-		return null;
-	}
+        return null;
+    }
 
-	/**
-	 * Check if the previous sibling is an annotation node. Ignore formatting nodes.
-	 */
-	get hasAnnotation(): boolean {
-		let prev = this.previousNamedSibling;
-		while (prev) {
-			if (prev.type === 'annotation') return true;
-			if (!prev.isFormatting) return false;
-			prev = prev.previousNamedSibling;
-		}
-		return false;
-	}
+    /**
+     * Check if the previous sibling is an annotation node. Ignore formatting nodes.
+     */
+    get hasAnnotation(): boolean {
+        let prev = this.previousNamedSibling;
+        while (prev) {
+            if (prev.type === 'annotation') return true;
+            if (!prev.isFormatting) return false;
+            prev = prev.previousNamedSibling;
+        }
+        return false;
+    }
 
-	/**
-	 * A flag to skip formatting for a specific node. A manual instruction from
-	 * the user is `prettier-ignore`. When placed above (leading comment) a node,
-	 * it will skip formatting for that node.
-	 */
-	get skipFormattingNode(): boolean {
-		return (
-			!!this.leadingComment.find((comment) => comment.text.includes('prettier-ignore')) ||
-			false
-		);
-	}
+    /**
+     * A flag to skip formatting for a specific node. A manual instruction from
+     * the user is `prettier-ignore`. When placed above (leading comment) a node,
+     * it will skip formatting for that node.
+     */
+    get skipFormattingNode(): boolean {
+        return (
+            !!this.leadingComment.find((comment) => comment.text.includes('prettier-ignore')) ||
+            false
+        );
+    }
 
-	/**
-	 * Get the number of named children.
-	 */
-	get namedChildCount(): number {
-		return this.namedChildren.length;
-	}
+    /**
+     * Get the number of named children.
+     */
+    get namedChildCount(): number {
+        return this.namedChildren.length;
+    }
 
-	get isFunctionCall(): boolean {
-		return this.type === 'call_expression' || this.type === 'macro_call_expression';
-	}
+    get isFunctionCall(): boolean {
+        return this.type === 'call_expression' || this.type === 'macro_call_expression';
+    }
 
-	/**
-	 * Tells whether a `Node` knows how to break itself.
-	 * Nodes that match the following types are considered breakable:
-	 * - `dot_expression`
-	 * - `vector_expression`
-	 * - `expression_list`
-	 * - `if_expression` (?)
-	 * - `pack_expression`
-	 * - `match_expression`
-	 * - `block`
-	 */
-	get isBreakableExpression(): boolean {
-		return [
-			// TODO: consider revisiting `call_expression` and `macro_call_expression`
-			// 'call_expression',
-			// 'macro_call_expression',
-			'dot_expression',
-			'index_expression',
-			'vector_expression',
-			'expression_list',
-			'if_expression',
-			'pack_expression',
-			'match_expression',
-			'block',
-		].includes(this.type);
-	}
+    /**
+     * Tells whether a `Node` knows how to break itself.
+     * Nodes that match the following types are considered breakable:
+     * - `dot_expression`
+     * - `vector_expression`
+     * - `expression_list`
+     * - `if_expression` (?)
+     * - `pack_expression`
+     * - `match_expression`
+     * - `block`
+     */
+    get isBreakableExpression(): boolean {
+        return [
+            // TODO: consider revisiting `call_expression` and `macro_call_expression`
+            // 'call_expression',
+            // 'macro_call_expression',
+            'dot_expression',
+            'index_expression',
+            'vector_expression',
+            'expression_list',
+            'if_expression',
+            'pack_expression',
+            'match_expression',
+            'block',
+        ].includes(this.type);
+    }
 
-	/**
-	 * Whether a node is a list node, like `vector_expression`, `expression_list`, or `block`.
-	 * Lists are typical breakable nodes, where each element is separated by a newline.
-	 */
-	get isList(): boolean {
-		return ['vector_expression', 'expression_list', 'block'].includes(this.type);
-	}
+    /**
+     * Whether a node is a list node, like `vector_expression`, `expression_list`, or `block`.
+     * Lists are typical breakable nodes, where each element is separated by a newline.
+     */
+    get isList(): boolean {
+        return ['vector_expression', 'expression_list', 'block'].includes(this.type);
+    }
 
-	/**
-	 * Whether a node is a control flow node, like `if_expression`, `while_expression`,
-	 * `loop_expression`, `abort_expression`, or `return_expression`.
-	 */
-	get isControlFlow(): boolean {
-		return [
-			'if_expression',
-			'while_expression',
-			'loop_expression',
-			'abort_expression',
-			'return_expression',
-		].includes(this.type);
-	}
+    /**
+     * Whether a node is a control flow node, like `if_expression`, `while_expression`,
+     * `loop_expression`, `abort_expression`, or `return_expression`.
+     */
+    get isControlFlow(): boolean {
+        return [
+            'if_expression',
+            'while_expression',
+            'loop_expression',
+            'abort_expression',
+            'return_expression',
+        ].includes(this.type);
+    }
 
-	/**
-	 * Important part of the `imports-grouping` functionality. This flag is used to
-	 * determine whether a node is an `use_module`, `use_module_members` or
-	 * `use_module_member` node to skip their printing if they're printed as grouped.
-	 */
-	get isGroupedImport(): boolean {
-		return isUseImport(this) && !this.hasAnnotation;
-	}
+    /**
+     * Important part of the `imports-grouping` functionality. This flag is used to
+     * determine whether a node is an `use_module`, `use_module_members` or
+     * `use_module_member` node to skip their printing if they're printed as grouped.
+     */
+    get isGroupedImport(): boolean {
+        return isUseImport(this) && !this.hasAnnotation;
+    }
 
-	/**
-	 * Whether a node is a `Formatting` node, like `line_comment`, `block_comment`,
-	 * `empty_line`, or `next_line`.
-	 */
-	get isFormatting(): boolean {
-		return isFormatting(this);
-	}
+    /**
+     * Whether a node is a `Formatting` node, like `line_comment`, `block_comment`,
+     * `empty_line`, or `next_line`.
+     */
+    get isFormatting(): boolean {
+        return isFormatting(this);
+    }
 
-	child(index: number): Tree | null {
-		return this.children[index] || null;
-	}
+    child(index: number): Tree | null {
+        return this.children[index] || null;
+    }
 
-	get isEmptyLine(): boolean {
-		return this.type === 'empty_line';
-	}
+    get isEmptyLine(): boolean {
+        return this.type === 'empty_line';
+    }
 
-	get isNewline(): boolean {
-		return this.type === 'newline';
-	}
+    get isNewline(): boolean {
+        return this.type === 'newline';
+    }
 
-	get isComment(): boolean {
-		return this.type === 'line_comment' || this.type === 'block_comment';
-	}
+    get isComment(): boolean {
+        return this.type === 'line_comment' || this.type === 'block_comment';
+    }
 
-	get isTypeParam(): boolean {
-		return [
-			'apply_type',
-			'ref_type',
-			'tuple_type',
-			'function_type',
-			'primitive_type'
-		].includes(this.type);
-	}
+    get isTypeParam(): boolean {
+        return ['apply_type', 'ref_type', 'tuple_type', 'function_type', 'primitive_type'].includes(
+            this.type,
+        );
+    }
 
-	get previousSibling(): Tree | null {
-		const parent = this.getParent();
-		if (!parent) {
-			return null;
-		}
+    get previousSibling(): Tree | null {
+        const parent = this.getParent();
+        if (!parent) {
+            return null;
+        }
 
-		const index = parent.children.indexOf(this);
-		if (index === 0) {
-			return null;
-		}
+        const index = parent.children.indexOf(this);
+        if (index === 0) {
+            return null;
+        }
 
-		return parent.children[index - 1] || null;
-	}
+        return parent.children[index - 1] || null;
+    }
 
-	get previousNamedSibling(): Tree | null {
-		let node = this.previousSibling;
-		while (node && !node.isNamed) {
-			node = node.previousSibling;
-		}
-		return node;
-	}
+    get previousNamedSibling(): Tree | null {
+        let node = this.previousSibling;
+        while (node && !node.isNamed) {
+            node = node.previousSibling;
+        }
+        return node;
+    }
 
-	get startsOnNewLine(): boolean {
-		return this.previousSibling?.isNewline || false;
-	}
+    get startsOnNewLine(): boolean {
+        return this.previousSibling?.isNewline || false;
+    }
 
-	get nonFormattingChildren(): Tree[] {
-		return this.namedChildren.filter((child) => !child.isFormatting);
-	}
+    get nonFormattingChildren(): Tree[] {
+        return this.namedChildren.filter((child) => !child.isFormatting);
+    }
 
-	get namedChildren(): Tree[] {
-		return this.children.filter((child) => child.isNamed);
-	}
+    get namedChildren(): Tree[] {
+        return this.children.filter((child) => child.isNamed);
+    }
 
-	get firstNamedChild(): Tree | null {
-		return this.namedChildren[0] || null;
-	}
+    get firstNamedChild(): Tree | null {
+        return this.namedChildren[0] || null;
+    }
 
-	get namedAndEmptyLineChildren(): Tree[] {
-		return this.namedChildren.filter((child) => {
-			return (
-				child.isNamed &&
-				(child.isEmptyLine ||
-					(child.isComment && !child.isUsedComment) ||
-					!child.isFormatting)
-			);
-		});
-	}
+    get namedAndEmptyLineChildren(): Tree[] {
+        return this.namedChildren.filter((child) => {
+            return (
+                child.isNamed &&
+                (child.isEmptyLine ||
+                    (child.isComment && !child.isUsedComment) ||
+                    !child.isFormatting)
+            );
+        });
+    }
 
-	get nextSibling(): Tree | null {
-		const parent = this.getParent();
-		if (!parent) {
-			return null;
-		}
+    get nextSibling(): Tree | null {
+        const parent = this.getParent();
+        if (!parent) {
+            return null;
+        }
 
-		const index = parent.children.indexOf(this);
-		if (index === parent.children.length - 1) {
-			return null;
-		}
+        const index = parent.children.indexOf(this);
+        if (index === parent.children.length - 1) {
+            return null;
+        }
 
-		return parent.children[index + 1] || null;
-	}
+        return parent.children[index + 1] || null;
+    }
 
-	get nextNamedSibling(): Tree | null {
-		let node = this.nextSibling;
-		while (node && !node.isNamed) {
-			node = node.nextSibling;
-		}
-		return node;
-	}
+    get nextNamedSibling(): Tree | null {
+        let node = this.nextSibling;
+        while (node && !node.isNamed) {
+            node = node.nextSibling;
+        }
+        return node;
+    }
 
-	get parent() {
-		return this.getParent();
-	}
+    get parent() {
+        return this.getParent();
+    }
 
-	/**
-	 * Print the Node as a JSON object. Remove the fields that are not necessary
-	 * for printing. May be extended shall one need to debug deeper.
-	 */
-	toJSON(): any {
-		return {
-			type: this.type,
-			isNamed: this.isNamed,
-			children: this.children.map((child) => child.toJSON()),
-			leadingComment: this.leadingComment,
-			trailingComment: this.trailingComment,
-		};
-	}
+    /**
+     * Print the Node as a JSON object. Remove the fields that are not necessary
+     * for printing. May be extended shall one need to debug deeper.
+     */
+    toJSON(): any {
+        return {
+            type: this.type,
+            isNamed: this.isNamed,
+            children: this.children.map((child) => child.toJSON()),
+            leadingComment: this.leadingComment,
+            trailingComment: this.trailingComment,
+        };
+    }
 
-	/**
-	 * Checks the following node and assigns it as a trailing comment if it is a comment.
-	 * The comment is then marked as used and will not be used again.
-	 */
-	private assignTrailingComments(): Tree {
-		if (!this.isNamed) return this;
-		if (this.isFormatting) return this;
+    /**
+     * Checks the following node and assigns it as a trailing comment if it is a comment.
+     * The comment is then marked as used and will not be used again.
+     */
+    private assignTrailingComments(): Tree {
+        if (!this.isNamed) return this;
+        if (this.isFormatting) return this;
 
-		const nextNamed = this.nextNamedSibling;
+        const nextNamed = this.nextNamedSibling;
 
-		if (!nextNamed?.isComment) return this;
-		if (nextNamed.isUsedComment) return this;
+        if (!nextNamed?.isComment) return this;
+        if (nextNamed.isUsedComment) return this;
 
-		// if it's a block comment, we need to make sure there's nothing in
-		// between the current node and the comment, otherwise block comment is
-		// associated with the next node.
-		if (nextNamed.type == 'block_comment') {
-			// any non-named node between the current node and the comment
-			// breaks the association.
-			if (nextNamed.previousSibling != this && !!nextNamed.nextNamedSibling) return this;
-			const addSpace = !!nextNamed.nextNamedSibling ? ' ' : '';
+        // if it's a block comment, we need to make sure there's nothing in
+        // between the current node and the comment, otherwise block comment is
+        // associated with the next node.
+        if (nextNamed.type == 'block_comment') {
+            // any non-named node between the current node and the comment
+            // breaks the association.
+            if (nextNamed.previousSibling != this && !!nextNamed.nextNamedSibling) return this;
+            const addSpace = !!nextNamed.nextNamedSibling ? ' ' : '';
 
-			this.trailingComment = {
-				type: nextNamed.type as 'line_comment' | 'block_comment',
-				text: nextNamed.text + addSpace,
-				newline: false,
-			};
-			this.nextNamedSibling!.isUsedComment = true;
-		}
+            this.trailingComment = {
+                type: nextNamed.type as 'line_comment' | 'block_comment',
+                text: nextNamed.text + addSpace,
+                newline: false,
+            };
+            this.nextNamedSibling!.isUsedComment = true;
+        }
 
-		if (nextNamed.type == 'line_comment') {
-			this.trailingComment = {
-				type: nextNamed.type as 'line_comment' | 'block_comment',
-				text: nextNamed.text,
-				newline: false,
-			};
+        if (nextNamed.type == 'line_comment') {
+            this.trailingComment = {
+                type: nextNamed.type as 'line_comment' | 'block_comment',
+                text: nextNamed.text,
+                newline: false,
+            };
 
-			this.nextNamedSibling!.isUsedComment = true;
-		}
+            this.nextNamedSibling!.isUsedComment = true;
+        }
 
-		return this;
-	}
+        return this;
+    }
 
-	/**
-	 * Walks backwards through the siblings and searches for comments preceding
-	 * the current node. If a comment is found, it is assigned to the `leadingComment`
-	 * property of the node, and the comment is marked as used.
-	 *
-	 * Used comments are filtered out and not used again.
-	 *
-	 * Motivation for this is to avoid duplicate association of a comment both as
-	 * a trailing comment and a leading comment.
-	 */
-	private assignLeadingComments(): Tree {
-		let comments = [];
-		let prev = this.previousNamedSibling;
-		let newline = false;
+    /**
+     * Walks backwards through the siblings and searches for comments preceding
+     * the current node. If a comment is found, it is assigned to the `leadingComment`
+     * property of the node, and the comment is marked as used.
+     *
+     * Used comments are filtered out and not used again.
+     *
+     * Motivation for this is to avoid duplicate association of a comment both as
+     * a trailing comment and a leading comment.
+     */
+    private assignLeadingComments(): Tree {
+        let comments = [];
+        let prev = this.previousNamedSibling;
+        let newline = false;
 
-		if (!this.isNamed) return this;
-		if (this.isFormatting) return this;
+        if (!this.isNamed) return this;
+        if (this.isFormatting) return this;
 
-		while (prev?.isNewline) {
-			newline = true;
-			prev = prev.previousNamedSibling;
-		}
+        while (prev?.isNewline) {
+            newline = true;
+            prev = prev.previousNamedSibling;
+        }
 
-		if (prev?.type == 'block_comment') {
-			if (prev.isUsedComment) return this;
+        if (prev?.type == 'block_comment') {
+            if (prev.isUsedComment) return this;
 
-			comments.unshift({
-				type: prev.type as 'line_comment' | 'block_comment',
-				text: prev.text,
-				newline,
-			});
+            comments.unshift({
+                type: prev.type as 'line_comment' | 'block_comment',
+                text: prev.text,
+                newline,
+            });
 
-			prev.isUsedComment = true;
-			this.leadingComment = comments;
-			return this;
-		}
+            prev.isUsedComment = true;
+            this.leadingComment = comments;
+            return this;
+        }
 
-		while (prev?.isComment || (prev?.isNewline && !prev?.isUsedComment)) {
-			if (prev.isUsedComment) break;
-			if (prev.isComment) {
-				comments.unshift({
-					type: prev.type as 'line_comment' | 'block_comment',
-					text: prev.text,
-					newline: true,
-				});
-				prev.isUsedComment = true;
-			}
+        while (prev?.isComment || (prev?.isNewline && !prev?.isUsedComment)) {
+            if (prev.isUsedComment) break;
+            if (prev.isComment) {
+                comments.unshift({
+                    type: prev.type as 'line_comment' | 'block_comment',
+                    text: prev.text,
+                    newline: true,
+                });
+                prev.isUsedComment = true;
+            }
 
-			prev = prev.previousNamedSibling; // move to the previous comment
-		}
+            prev = prev.previousNamedSibling; // move to the previous comment
+        }
 
-		this.leadingComment = comments;
+        this.leadingComment = comments;
 
-		return this;
-	}
+        return this;
+    }
 }

--- a/external-crates/move/tooling/prettier-move/src/tree.ts
+++ b/external-crates/move/tooling/prettier-move/src/tree.ts
@@ -198,6 +198,7 @@ export class Tree {
      */
     get isControlFlow(): boolean {
         return [
+            'identified_expression',
             'if_expression',
             'while_expression',
             'loop_expression',

--- a/external-crates/move/tooling/prettier-move/src/tree.ts
+++ b/external-crates/move/tooling/prettier-move/src/tree.ts
@@ -348,27 +348,29 @@ export class Tree {
         if (!nextNamed?.isComment) return this;
         if (nextNamed.isUsedComment) return this;
 
+        const comment = nextNamed;
+
         // if it's a block comment, we need to make sure there's nothing in
         // between the current node and the comment, otherwise block comment is
         // associated with the next node.
-        if (nextNamed.type == 'block_comment') {
+        if (comment.type == 'block_comment') {
             // any non-named node between the current node and the comment
             // breaks the association.
-            if (nextNamed.previousSibling != this && !!nextNamed.nextNamedSibling) return this;
-            const addSpace = !!nextNamed.nextNamedSibling ? ' ' : '';
+            if (comment.previousSibling != this && !!comment.nextNamedSibling) return this;
+            const addSpace = !!comment.nextNamedSibling ? ' ' : '';
 
             this.trailingComment = {
-                type: nextNamed.type as 'line_comment' | 'block_comment',
-                text: nextNamed.text + addSpace,
+                type: comment.type as 'line_comment' | 'block_comment',
+                text: comment.text + addSpace,
                 newline: false,
             };
             this.nextNamedSibling!.isUsedComment = true;
         }
 
-        if (nextNamed.type == 'line_comment') {
+        if (comment.type == 'line_comment') {
             this.trailingComment = {
-                type: nextNamed.type as 'line_comment' | 'block_comment',
-                text: nextNamed.text,
+                type: comment.type as 'line_comment' | 'block_comment',
+                text: comment.text,
                 newline: false,
             };
 

--- a/external-crates/move/tooling/prettier-move/src/utilities.ts
+++ b/external-crates/move/tooling/prettier-move/src/utilities.ts
@@ -6,26 +6,26 @@ import { AstPath, Doc, ParserOptions, doc } from 'prettier';
 import { MoveOptions, printFn } from './printer';
 
 const {
-	indent,
-	join,
-	fill,
-	softline,
-	dedent,
-	hardline,
-	line,
-	lineSuffix,
-	group,
-	indentIfBreak,
-	hardlineWithoutBreakParent,
-	breakParent,
-	ifBreak,
+    indent,
+    join,
+    fill,
+    softline,
+    dedent,
+    hardline,
+    line,
+    lineSuffix,
+    group,
+    indentIfBreak,
+    hardlineWithoutBreakParent,
+    breakParent,
+    ifBreak,
 } = doc.builders;
 
 /**
  * Prints an `identifier` node.
  */
 export function printIdentifier(path: AstPath<Node>): Doc {
-	return path.node.text;
+    return path.node.text;
 }
 
 /**
@@ -51,7 +51,7 @@ export function printIdentifier(path: AstPath<Node>): Doc {
  * @returns
  */
 export function shouldBreakFirstChild(path: AstPath<Node>): boolean {
-	return path.node.nonFormattingChildren[0]?.startsOnNewLine || false;
+    return path.node.nonFormattingChildren[0]?.startsOnNewLine || false;
 }
 
 /**
@@ -63,42 +63,42 @@ export function shouldBreakFirstChild(path: AstPath<Node>): boolean {
  * @returns
  */
 export function printLeadingComment(path: AstPath<Node>, options: MoveOptions): Doc[] {
-	const comments = path.node.leadingComment;
-	if (!comments || !comments.length) return [];
-	if (!path.node.enableLeadingComment) return [];
+    const comments = path.node.leadingComment;
+    if (!comments || !comments.length) return [];
+    if (!path.node.enableLeadingComment) return [];
 
-	if (comments.length == 1 && comments[0]!.type == 'block_comment') {
-		return [comments[0]!.text, comments[0]!.newline ? hardlineWithoutBreakParent : ' '];
-	}
+    if (comments.length == 1 && comments[0]!.type == 'block_comment') {
+        return [comments[0]!.text, comments[0]!.newline ? hardlineWithoutBreakParent : ' '];
+    }
 
-	if (options.wrapComments == false) {
-		return [
-			join(
-				hardlineWithoutBreakParent,
-				comments.map((c) =>
-					c.type == 'line_comment' ? [c.text, /* used to be breakParent */ ''] : [c.text],
-				),
-			),
-			hardlineWithoutBreakParent,
-		];
-	}
+    if (options.wrapComments == false) {
+        return [
+            join(
+                hardlineWithoutBreakParent,
+                comments.map((c) =>
+                    c.type == 'line_comment' ? [c.text, /* used to be breakParent */ ''] : [c.text],
+                ),
+            ),
+            hardlineWithoutBreakParent,
+        ];
+    }
 
-	// we do not concatenate the comments into a single string, and treat each
-	// line separately.
-	return comments.map((comment) => {
-		if (comment.type == 'line_comment') {
-			const isDoc = comment.text.startsWith('///');
-			const parts = comment.text.slice(isDoc ? 4 : 3).split(' ');
+    // we do not concatenate the comments into a single string, and treat each
+    // line separately.
+    return comments.map((comment) => {
+        if (comment.type == 'line_comment') {
+            const isDoc = comment.text.startsWith('///');
+            const parts = comment.text.slice(isDoc ? 4 : 3).split(' ');
 
-			return [
-				isDoc ? '/// ' : '// ',
-				fill(join(ifBreak([softline, isDoc ? '/// ' : '// '], ' '), parts)),
-				hardlineWithoutBreakParent,
-			];
-		}
+            return [
+                isDoc ? '/// ' : '// ',
+                fill(join(ifBreak([softline, isDoc ? '/// ' : '// '], ' '), parts)),
+                hardlineWithoutBreakParent,
+            ];
+        }
 
-		return comment.text;
-	});
+        return comment.text;
+    });
 }
 
 /**
@@ -110,149 +110,149 @@ export function printLeadingComment(path: AstPath<Node>, options: MoveOptions): 
  * @returns
  */
 export function printTrailingComment(path: AstPath<Node>, shouldBreak: boolean = false): Doc {
-	// we do not allow comments on empty lines
-	if (path.node.isEmptyLine) return '';
-	if (!path.node.enableTrailingComment) return '';
-	const comment = path.node.trailingComment;
-	if (!comment) return '';
-	if (comment.type == 'line_comment' && shouldBreak) {
-		return [' ', comment.text, hardline];
-	}
+    // we do not allow comments on empty lines
+    if (path.node.isEmptyLine) return '';
+    if (!path.node.enableTrailingComment) return '';
+    const comment = path.node.trailingComment;
+    if (!comment) return '';
+    if (comment.type == 'line_comment' && shouldBreak) {
+        return [' ', comment.text, hardline];
+    }
 
-	return [' ', comment.text];
+    return [' ', comment.text];
 }
 
 export function emptyBlockOrList(
-	path: AstPath<Node>,
-	open: string,
-	close: string,
-	line: Doc = hardline,
+    path: AstPath<Node>,
+    open: string,
+    close: string,
+    line: Doc = hardline,
 ): Doc {
-	const length = path.node.nonFormattingChildren.length;
-	const comments = path.node.namedChildren.filter((e) => e.isComment);
+    const length = path.node.nonFormattingChildren.length;
+    const comments = path.node.namedChildren.filter((e) => e.isComment);
 
-	if (length != 0) {
-		throw new Error('The list is not empty');
-	}
+    if (length != 0) {
+        throw new Error('The list is not empty');
+    }
 
-	if (comments.length == 0) {
-		return [open, close];
-	}
+    if (comments.length == 0) {
+        return [open, close];
+    }
 
-	if (comments.length == 1 && comments[0]!.type == 'block_comment') {
-		return group([open, indent(line), indent(comments[0]!.text), line, close]);
-	}
+    if (comments.length == 1 && comments[0]!.type == 'block_comment') {
+        return group([open, indent(line), indent(comments[0]!.text), line, close]);
+    }
 
-	return group(
-		[
-			open,
-			indent(line),
-			indent(
-				join(
-					line,
-					comments.map((c) => c.text),
-				),
-			),
-			line,
-			close,
-		],
-		{ shouldBreak: true },
-	);
+    return group(
+        [
+            open,
+            indent(line),
+            indent(
+                join(
+                    line,
+                    comments.map((c) => c.text),
+                ),
+            ),
+            line,
+            close,
+        ],
+        { shouldBreak: true },
+    );
 }
 
 /**
  * TODO: use this type for the `block()` function.
  */
 export type BlockOptions = {
-	path: AstPath<Node>;
-	print: printFn;
-	options: ParserOptions;
-	breakDependency?: Symbol;
+    path: AstPath<Node>;
+    print: printFn;
+    options: ParserOptions;
+    breakDependency?: Symbol;
 
-	lastLine?: boolean;
-	lineEnding?: Doc;
-	skipChildren?: number;
-	shouldBreak?: boolean;
+    lastLine?: boolean;
+    lineEnding?: Doc;
+    skipChildren?: number;
+    shouldBreak?: boolean;
 };
 
 /**
  */
 export function block({ path, print, options, shouldBreak, skipChildren }: BlockOptions) {
-	const length = path.node.nonFormattingChildren.length;
+    const length = path.node.nonFormattingChildren.length;
 
-	if (length == 0) {
-		return emptyBlockOrList(path, '{', '}', hardline);
-	}
+    if (length == 0) {
+        return emptyBlockOrList(path, '{', '}', hardline);
+    }
 
-	return group(
-		[
-			'{',
-			options.bracketSpacing ? ifBreak('', ' ') : '',
-			indent(softline),
-			indent(join(line, path.map(print, 'namedAndEmptyLineChildren').slice(skipChildren))),
-			softline,
-			options.bracketSpacing ? ifBreak('', ' ') : '',
-			'}',
-		],
-		{ shouldBreak },
-	);
+    return group(
+        [
+            '{',
+            options.bracketSpacing ? ifBreak('', ' ') : '',
+            indent(softline),
+            indent(join(line, path.map(print, 'namedAndEmptyLineChildren').slice(skipChildren))),
+            softline,
+            options.bracketSpacing ? ifBreak('', ' ') : '',
+            '}',
+        ],
+        { shouldBreak },
+    );
 }
 
 export function nonBreakingBlock({
-	path,
-	print,
-	options,
-	shouldBreak, // always breaks
-	skipChildren,
+    path,
+    print,
+    options,
+    shouldBreak, // always breaks
+    skipChildren,
 }: BlockOptions) {
-	const length = path.node.nonFormattingChildren.length;
+    const length = path.node.nonFormattingChildren.length;
 
-	if (length == 0) {
-		return emptyBlockOrList(path, '{', '}', hardlineWithoutBreakParent);
-	}
+    if (length == 0) {
+        return emptyBlockOrList(path, '{', '}', hardlineWithoutBreakParent);
+    }
 
-	return group([
-		'{',
-		indent(hardlineWithoutBreakParent),
-		indent(
-			join(
-				hardlineWithoutBreakParent,
-				path.map(print, 'namedAndEmptyLineChildren').slice(skipChildren || 0),
-			),
-		),
-		hardlineWithoutBreakParent,
-		'}',
-	]);
+    return group([
+        '{',
+        indent(hardlineWithoutBreakParent),
+        indent(
+            join(
+                hardlineWithoutBreakParent,
+                path.map(print, 'namedAndEmptyLineChildren').slice(skipChildren || 0),
+            ),
+        ),
+        hardlineWithoutBreakParent,
+        '}',
+    ]);
 }
 
 export type ListOptions = {
-	path: AstPath<Node>;
-	print: printFn;
-	options: MoveOptions;
-	/** Opening bracket. */
-	open: string;
-	/** Closing bracket. */
-	close: string;
-	/**
-	 * The number of children to skip when printing the list.
-	 */
-	skipChildren?: number;
-	/**
-	 * Whether to add a whitespace after the open bracket and before the close bracket.
-	 * ```
-	 * { a, b, c } // addWhitespace = true
-	 * {a, b, c}   // addWhitespace = false
-	 * ```
-	 */
-	addWhitespace?: boolean;
-	/**
-	 * Whether to break the list.
-	 */
-	shouldBreak?: boolean;
-	/**
-	 * Group ID for `indentIfBreak` to break the list.
-	 */
-	indentGroup?: symbol | null;
+    path: AstPath<Node>;
+    print: printFn;
+    options: MoveOptions;
+    /** Opening bracket. */
+    open: string;
+    /** Closing bracket. */
+    close: string;
+    /**
+     * The number of children to skip when printing the list.
+     */
+    skipChildren?: number;
+    /**
+     * Whether to add a whitespace after the open bracket and before the close bracket.
+     * ```
+     * { a, b, c } // addWhitespace = true
+     * {a, b, c}   // addWhitespace = false
+     * ```
+     */
+    addWhitespace?: boolean;
+    /**
+     * Whether to break the list.
+     */
+    shouldBreak?: boolean;
+    /**
+     * Group ID for `indentIfBreak` to break the list.
+     */
+    indentGroup?: symbol | null;
 };
 
 /**
@@ -260,128 +260,128 @@ export type ListOptions = {
  * TODO: keep trailing comments after the last element of the list.
  */
 export function list({
-	path,
-	print,
-	options,
-	open,
-	close,
-	indentGroup = null,
-	addWhitespace = false,
-	skipChildren = 0,
-	shouldBreak = false,
+    path,
+    print,
+    options,
+    open,
+    close,
+    indentGroup = null,
+    addWhitespace = false,
+    skipChildren = 0,
+    shouldBreak = false,
 }: ListOptions) {
-	const length = path.node.nonFormattingChildren.length;
-	const indentCb: (el: Doc) => Doc = (el) =>
-		indentGroup ? indentIfBreak(el, { groupId: indentGroup }) : indent(el);
+    const length = path.node.nonFormattingChildren.length;
+    const indentCb: (el: Doc) => Doc = (el) =>
+        indentGroup ? indentIfBreak(el, { groupId: indentGroup }) : indent(el);
 
-	// if there's no children the list should print, we still look up for non-
-	// formatting nodes, namely comments, to print them.
-	if (length == skipChildren) {
-		const lastNode = path.node.nonFormattingChildren[length - 1]!;
-		const indexInNamedChildren = path.node.namedChildren.indexOf(lastNode);
-		const otherNamedChildren = path.node.namedChildren
-			.slice(indexInNamedChildren + 1)
-			.filter((e) => e.isComment);
+    // if there's no children the list should print, we still look up for non-
+    // formatting nodes, namely comments, to print them.
+    if (length == skipChildren) {
+        const lastNode = path.node.nonFormattingChildren[length - 1]!;
+        const indexInNamedChildren = path.node.namedChildren.indexOf(lastNode);
+        const otherNamedChildren = path.node.namedChildren
+            .slice(indexInNamedChildren + 1)
+            .filter((e) => e.isComment);
 
-		if (!otherNamedChildren.length) {
-			return [open, close];
-		}
+        if (!otherNamedChildren.length) {
+            return [open, close];
+        }
 
-		return [
-			open,
-			indentCb(softline),
-			indentCb(
-				join(
-					hardline,
-					otherNamedChildren.map((c) => c.text),
-				),
-			),
-			hardline,
-			dedent(close),
-		];
-	}
+        return [
+            open,
+            indentCb(softline),
+            indentCb(
+                join(
+                    hardline,
+                    otherNamedChildren.map((c) => c.text),
+                ),
+            ),
+            hardline,
+            dedent(close),
+        ];
+    }
 
-	const lastNode = path.node.nonFormattingChildren[length - 1]!;
-	const indexInNamedChildren = path.node.namedChildren.indexOf(lastNode);
+    const lastNode = path.node.nonFormattingChildren[length - 1]!;
+    const indexInNamedChildren = path.node.namedChildren.indexOf(lastNode);
 
-	// collect all trailing comments
-	// after `nonFormattingChildren` and before end
-	let trailingComments = [] as Doc[];
-	if (indexInNamedChildren != -1) {
-		path.each((path, idx) => {
-			if (idx + 1 > indexInNamedChildren && path.node.isComment) {
-				return trailingComments.push(path.node.text);
-			}
-			return;
-		}, 'namedChildren');
-	}
+    // collect all trailing comments
+    // after `nonFormattingChildren` and before end
+    let trailingComments = [] as Doc[];
+    if (indexInNamedChildren != -1) {
+        path.each((path, idx) => {
+            if (idx + 1 > indexInNamedChildren && path.node.isComment) {
+                return trailingComments.push(path.node.text);
+            }
+            return;
+        }, 'namedChildren');
+    }
 
-	return [
-		open,
-		indentCb(addWhitespace ? line : softline),
-		shouldBreak ? breakParent : '',
-		indentCb(
-			path
-				.map((path, i) => {
-					const leading = printLeadingComment(path, options);
-					const comment = printTrailingComment(path, false);
-					let shouldBreak = false;
+    return [
+        open,
+        indentCb(addWhitespace ? line : softline),
+        shouldBreak ? breakParent : '',
+        indentCb(
+            path
+                .map((path, i) => {
+                    const leading = printLeadingComment(path, options);
+                    const comment = printTrailingComment(path, false);
+                    let shouldBreak = false;
 
-					// if the node has a trailing comment, we should break
-					if (path.node.trailingComment?.type == 'line_comment') {
-						shouldBreak = true;
-					}
+                    // if the node has a trailing comment, we should break
+                    if (path.node.trailingComment?.type == 'line_comment') {
+                        shouldBreak = true;
+                    }
 
-					const leadComment = path.node.leadingComment;
+                    const leadComment = path.node.leadingComment;
 
-					if (leadComment.length > 0 && leadComment![0]!.type == 'line_comment') {
-						shouldBreak = true;
-					}
+                    if (leadComment.length > 0 && leadComment![0]!.type == 'line_comment') {
+                        shouldBreak = true;
+                    }
 
-					if (
-						leadComment.length > 0 &&
-						leadComment[0]!.type == 'block_comment' &&
-						leadComment[0]!.newline
-					) {
-						shouldBreak = true;
-					}
+                    if (
+                        leadComment.length > 0 &&
+                        leadComment[0]!.type == 'block_comment' &&
+                        leadComment[0]!.newline
+                    ) {
+                        shouldBreak = true;
+                    }
 
-					path.node.disableTrailingComment();
-					path.node.disableLeadingComment();
+                    path.node.disableTrailingComment();
+                    path.node.disableLeadingComment();
 
-					const breakExpr = shouldBreak ? breakParent : '';
-					const shouldDedent = trailingComments.length == 0;
-					const endingExpr = addWhitespace ? line : softline;
-					const isLastChild = i == length - 1;
+                    const breakExpr = shouldBreak ? breakParent : '';
+                    const shouldDedent = trailingComments.length == 0;
+                    const endingExpr = addWhitespace ? line : softline;
+                    const isLastChild = i == length - 1;
 
-					if (isLastChild) {
-						return [
-							leading,
-							breakExpr,
-							print(path),
-							ifBreak(','),
-							shouldBreak ? lineSuffix(comment) : comment,
-							shouldDedent ? dedent(endingExpr) : endingExpr,
-						];
-					}
+                    if (isLastChild) {
+                        return [
+                            leading,
+                            breakExpr,
+                            print(path),
+                            ifBreak(','),
+                            shouldBreak ? lineSuffix(comment) : comment,
+                            shouldDedent ? dedent(endingExpr) : endingExpr,
+                        ];
+                    }
 
-					// if we are not at the last child, add a comma
-					return [
-						leading,
-						breakExpr,
-						print(path),
-						',',
-						shouldBreak ? lineSuffix(comment) : comment,
-						line,
-					];
-				}, 'nonFormattingChildren')
-				.slice(skipChildren)
-				.concat(
-					trailingComments.length
-						? [join(hardline, trailingComments), dedent(hardline)]
-						: [],
-				),
-		),
-		dedent(close),
-	];
+                    // if we are not at the last child, add a comma
+                    return [
+                        leading,
+                        breakExpr,
+                        print(path),
+                        ',',
+                        shouldBreak ? lineSuffix(comment) : comment,
+                        line,
+                    ];
+                }, 'nonFormattingChildren')
+                .slice(skipChildren)
+                .concat(
+                    trailingComments.length
+                        ? [join(hardline, trailingComments), dedent(hardline)]
+                        : [],
+                ),
+        ),
+        dedent(close),
+    ];
 }

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/abort_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/abort_expression.exp.move
@@ -12,7 +12,7 @@ fun abort_expression() {
         10
     };
     abort 100 + 300;
-    abort if (condition) 100 else 200;
+    abort if (true) 100 else 200;
 
     abort if (condition) {
         100

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/abort_expression.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/abort_expression.move
@@ -12,7 +12,7 @@ fun abort_expression() {
         10
     };
     abort 100 + 300;
-    abort if (condition) 100 else 200;
+    abort if (true) 100 else 200;
 
     abort if (condition) {
         100

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
@@ -20,8 +20,7 @@ fun basic() {
     } else do_this();
 
     if (true) call_something()
-    else
-        call_something_else();
+    else call_something_else();
 
     if (false) {
         call_something_else();
@@ -138,8 +137,7 @@ fun if_expression() {
     // and newline + indent it
     if (expression)
         expression_that_is_too_long
-    else
-        another_long_expression;
+    else another_long_expression;
 
     // same exampla with block will
     // be broken into multiple lines

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
@@ -6,10 +6,17 @@ module test::if_expression;
 
 fun basic() {
     if (true) call_something();
-    if (false)
-        call_something_else_call_something_else_call_something_else();
+    if (false) {
+        call_some_long_func()
+    };
 
     if (cond) do_this() else {
+        do_that();
+        do_this();
+    };
+
+    if (cond) push_else_out()
+    else {
         do_that();
         do_this();
     };
@@ -36,18 +43,90 @@ fun basic() {
 }
 
 fun control_flow() {
-    if (true)
-        return call_something();
-    if (true)
-        return call_something_else_call_something_else_call_something_else();
+    if (true) break;
+    if (true) abort;
+    if (true) return call();
+    if (true) {
+        return call_something()
+    };
+
+    'a: if (true) { break 'a; }
+}
+
+fun dot_expression() {
+    if (true) a.dot().expression()
+    else b.dot().expression();
+
+    if (true) {
+        staking
+            .pools[pool]
+            .borrow_mut()
+            .unwrap()
+            .stake(amount)
+    } else {
+        staking
+            .pools[pool]
+            .borrow_mut()
+            .stake(0)
+    }
+}
+
+fun lists() {
+    if (true) (1, 2, 3) else (
+        4,
+        5,
+        6,
+    );
+
+    // list can break itself
+    if (true) (
+        longer,
+        list,
+        values,
+    ) else (short, list, third);
+
+    // trailing comment on the true
+    // branch forces else on a new
+    // line, other comments work
+    if (true) /* wow */ (
+        longer,
+        /* haha */ list,
+        values,
+    ) // beep
+    else (short, list, third); // boop
+
+    // both lists are broken, no
+    // braces added to any branch
+    if (true) (
+        longer,
+        list,
+        values,
+    ) // beep
+    else (
+        even,
+        longer,
+        list,
+        better,
+    ); // boop
+
+    // vector expression is another
+    // list that is supported
+    if (true) vector[1, 2, 3, 4];
+
+    // printed in 2 lines
+    if (true) vector[
+        1,
+        2,
+        3,
+        4,
+    ] else vector[];
 }
 
 fun folding() {
     if (true) call_something()
-    else if (false)
+    else if (false) {
         call_something_else()
-    else
-        call_something_otherwise();
+    } else last_call();
 
     if (true) {
         call_something()
@@ -62,8 +141,9 @@ fun folding() {
 
     if (
         very_very_long_if_condition
-    )
-        very_very_long_if_condition > very_very_long_if_condition;
+    ) {
+        very_very_long_if_condition > very_very_long_if_condition
+    };
 
     let a = if (true) {
         call_something_else();
@@ -75,10 +155,11 @@ fun folding() {
         very_very_long_if_condition > very_very_long_if_condition ||
         very_very_long_if_condition + very_very_long_if_condition > 100 &&
         very_very_long_if_condition
-    )
+    ) {
         very_very_long_if_condition > very_very_long_if_condition &&
         very_very_long_if_condition > very_very_long_if_condition &&
-        very_very_long_if_condition > very_very_long_if_condition;
+        very_very_long_if_condition > very_very_long_if_condition
+    };
     // should break list of expressions inside parens, with indent;
     if (
         very_very_long_if_condition > very_very_long_if_condition ||
@@ -92,17 +173,19 @@ fun folding() {
 
     if (
         very_very_long_if_condition > very_very_long_if_condition
-    )
-        return very_very > very_very_long_if_condition + 100;
+    ) {
+        return very_very > very_very_long_if_condition + 100
+    };
 
     if (
         very_very_long_if_condition > very_very_long_if_condition &&
         very_very_long_if_condition > very_very_long_if_condition &&
         very_very_long_if_condition > very_very_long_if_condition
-    )
+    ) {
         return very_very_long_if_condition > very_very_long_if_condition &&
             very_very_long_if_condition > very_very_long_if_condition ||
             very_very_long_if_condition > very_very_long_if_condition
+    }
 }
 
 fun if_expression() {
@@ -134,12 +217,15 @@ fun if_expression() {
     };
 
     // should break on expression
-    // and newline + indent it
-    if (expression)
+    // and add block to both
+    // branches that break
+    if (expression) {
         expression_that_is_too_long
-    else another_long_expression;
+    } else {
+        another_long_expression_too
+    };
 
-    // same exampla with block will
+    // same example with block will
     // be broken into multiple lines
     if (expression) {
         expression_that_is_too_long
@@ -161,7 +247,8 @@ fun if_comments() {
     if (
         /* expr */ expression // comment
     ) expression
-    else
+    else {
         // comment
-        expression;
+        expression
+    };
 }

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
@@ -113,13 +113,43 @@ fun lists() {
     // list that is supported
     if (true) vector[1, 2, 3, 4];
 
+    // printed in 1 line
+    if (true) vector[] else abort;
+
     // printed in 2 lines
+    if (true) vector[1, 2, 3, 4]
+    else abort;
+
+    // does not break on else
+    if (true) vector[1, 2, 3, 4]
+    else vector[1, 2, 3, 4];
+
+    // uses space if true breaks
     if (true) vector[
-        1,
-        2,
-        3,
-        4,
+        100,
+        200,
+        300,
+        400,
     ] else vector[];
+
+    // breaks on both braches
+    if (true) vector[
+        100,
+        200,
+        300,
+        400,
+    ] else vector[
+        100,
+        200,
+        300,
+        400,
+        500,
+    ];
+
+    // changes with trailing
+    // comments
+    if (true) vector[1, 2] // line
+    else abort;
 }
 
 fun folding() {

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
@@ -148,7 +148,12 @@ fun lists() {
 
     // changes with trailing
     // comments
-    if (true) vector[1, 2] // line
+    if (true) vector[1, 2] // trailing
+    else abort;
+
+    // if list breaks, trailing
+    // comment forces else newline
+    if (true) vector[1, 2, 3, 4, 5] // trailing
     else abort;
 }
 

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
@@ -1,98 +1,169 @@
 // options:
-// printWidth: 80
+// printWidth: 35
+// useModuleLabel: true
 
-module test::if_expression {
-    public fun basic() {
-        if (true) call_something();
-        if (false)
-            call_something_else_call_something_else_call_something_else();
+module test::if_expression;
 
-        if (cond) do_this() else {
-            do_that();
-            do_this();
-        };
+fun basic() {
+    if (true) call_something();
+    if (false)
+        call_something_else_call_something_else_call_something_else();
 
-        if (cond) {
-            do_this();
-            do_that();
-        } else do_this();
+    if (cond) do_this() else {
+        do_that();
+        do_this();
+    };
 
-        if (true) call_something()
-        else call_something_else();
+    if (cond) {
+        do_this();
+        do_that();
+    } else do_this();
 
-        if (false) {
-            call_something_else();
-        } else {
-            another_call();
-        };
+    if (true) call_something()
+    else
+        call_something_else();
 
-        if (very_long_binding) {
-            call_something();
-        } else {
-            call_something_else();
-        };
-    }
+    if (false) {
+        call_something_else();
+    } else {
+        another_call();
+    };
 
-    public fun control_flow() {
-        if (true) return call_something();
-        if (true)
-            return call_something_else_call_something_else_call_something_else();
-    }
+    if (very_long_binding) {
+        call_something();
+    } else {
+        call_something_else();
+    };
+}
 
-    public fun folding() {
-        if (true) call_something()
-        else if (false) call_something_else()
-        else call_something_otherwise();
+fun control_flow() {
+    if (true)
+        return call_something();
+    if (true)
+        return call_something_else_call_something_else_call_something_else();
+}
 
-        if (true) {
-            call_something()
-        } else if (false) {
-            call_something_else()
-        } else {
-            call_something_otherwise()
-        };
+fun folding() {
+    if (true) call_something()
+    else if (false)
+        call_something_else()
+    else
+        call_something_otherwise();
 
-        // should keep as is, no additions;
-        if (true) { let a = b; };
+    if (true) {
+        call_something()
+    } else if (false) {
+        call_something_else()
+    } else {
+        call_something_otherwise()
+    };
 
-        if (very_very_long_if_condition)
-            very_very_long_if_condition > very_very_long_if_condition;
+    // should keep as is, no additions;
+    if (true) { let a = b; };
 
-        let a = if (true) {
-            call_something_else();
-        } else {
-            call_something_else();
-        };
+    if (
+        very_very_long_if_condition
+    )
+        very_very_long_if_condition > very_very_long_if_condition;
 
-        if (
+    let a = if (true) {
+        call_something_else();
+    } else {
+        call_something_else();
+    };
+
+    if (
+        very_very_long_if_condition > very_very_long_if_condition ||
+        very_very_long_if_condition + very_very_long_if_condition > 100 &&
+        very_very_long_if_condition
+    )
+        very_very_long_if_condition > very_very_long_if_condition &&
+        very_very_long_if_condition > very_very_long_if_condition &&
+        very_very_long_if_condition > very_very_long_if_condition;
+    // should break list of expressions inside parens, with indent;
+    if (
+        very_very_long_if_condition > very_very_long_if_condition ||
+        very_very_long_if_condition + very_very_long_if_condition > 100 &&
+        very_very_long_if_condition
+    ) {
+        very_very_long_if_condition > very_very_long_if_condition &&
+        very_very_long_if_condition > very_very_long_if_condition &&
+        very_very_long_if_condition > very_very_long_if_condition;
+    };
+
+    if (
+        very_very_long_if_condition > very_very_long_if_condition
+    )
+        return very_very > very_very_long_if_condition + 100;
+
+    if (
+        very_very_long_if_condition > very_very_long_if_condition &&
+        very_very_long_if_condition > very_very_long_if_condition &&
+        very_very_long_if_condition > very_very_long_if_condition
+    )
+        return very_very_long_if_condition > very_very_long_if_condition &&
             very_very_long_if_condition > very_very_long_if_condition ||
-            very_very_long_if_condition + very_very_long_if_condition > 100 &&
-            very_very_long_if_condition
-        )
-            very_very_long_if_condition > very_very_long_if_condition &&
-            very_very_long_if_condition > very_very_long_if_condition &&
-            very_very_long_if_condition > very_very_long_if_condition;
-        // should break list of expressions inside parens, with indent;
-        if (
-            very_very_long_if_condition > very_very_long_if_condition ||
-            very_very_long_if_condition + very_very_long_if_condition > 100 &&
-            very_very_long_if_condition
-        ) {
-            very_very_long_if_condition > very_very_long_if_condition &&
-            very_very_long_if_condition > very_very_long_if_condition &&
-            very_very_long_if_condition > very_very_long_if_condition;
-        };
-
-        if (very_very_long_if_condition > very_very_long_if_condition)
-            return very_very > very_very_long_if_condition + 100;
-
-        if (
-            very_very_long_if_condition > very_very_long_if_condition &&
-            very_very_long_if_condition > very_very_long_if_condition &&
             very_very_long_if_condition > very_very_long_if_condition
-        )
-            return very_very_long_if_condition > very_very_long_if_condition &&
-                very_very_long_if_condition > very_very_long_if_condition ||
-                very_very_long_if_condition > very_very_long_if_condition
-    }
+}
+
+fun if_expression() {
+    // standard if-else
+    if (true) true else false;
+
+    // with block
+    if (true) { true } else {
+        false
+    };
+
+    // with multiline block
+    if (true) {
+        true
+    } else {
+        false
+    };
+
+    // mix block / no block
+    if ({ expression }) {
+        return expression
+    } else expression;
+
+    // reverse mix block / no block
+    // should break on else (newline)
+    if (expression) expression
+    else {
+        return expression
+    };
+
+    // should break on expression
+    // and newline + indent it
+    if (expression)
+        expression_that_is_too_long
+    else
+        another_long_expression;
+
+    // same exampla with block will
+    // be broken into multiple lines
+    if (expression) {
+        expression_that_is_too_long
+    } else {
+        another_long_expression
+    };
+
+    if ({
+        expression
+    }) {
+        return expression
+    } else expression;
+}
+
+fun if_comments() {
+    // comment associativity should be fixed
+    // in the tree-sitter implementation by
+    // adding names to `if`, `else` and `condition`
+    if (
+        /* expr */ expression // comment
+    ) expression
+    else
+        // comment
+        expression;
 }

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
@@ -281,6 +281,13 @@ fun if_comments() {
         expression; // comment
 }
 
+fun if_chaining() {
+    if (true) 1
+    else if (false) 2
+    else if (true) 3
+    else 4;
+}
+
 fun misc_tests() {
     if (condition) doesnt_break; // trailing
     if (condition) doesnt_break // trailing

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
@@ -300,5 +300,10 @@ fun misc_tests() {
     else if (b == 1 || b == 65) 13 // a or A
     else if (b == 1 || b == 69) 14 // e or E
     else if (b == 1 || b == 83) 15 // s or S
-    else abort 1
+    else abort 1;
+
+    let value = bcs.peel_u8();
+    if (value == 0) false
+    else if (value == 1) true
+    else abort ENotBool
 }

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
@@ -280,3 +280,18 @@ fun if_comments() {
     else // comment
         expression; // comment
 }
+
+fun misc_tests() {
+    if (condition) doesnt_break; // trailing
+    if (condition) doesnt_break // trailing
+    else doesnt_break; // another trailing
+
+    if (48 <= b && b < 58) b - 48 // 0 .. 9
+    else if (b == 1 || b == 80) 10 // p or P
+    else if (b == 1 || b == 79) 11 // o or O
+    else if (b == 1 || b == 84) 12 // t or T
+    else if (b == 1 || b == 65) 13 // a or A
+    else if (b == 1 || b == 69) 14 // e or E
+    else if (b == 1 || b == 83) 15 // s or S
+    else abort 1
+}

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
@@ -61,12 +61,11 @@ fun dot_expression() {
             .borrow_mut()
             .unwrap()
             .stake(amount)
-    else {
+    else
         staking
             .pools[pool]
             .borrow_mut()
             .stake(0)
-    }
 }
 
 fun lists() {
@@ -250,9 +249,8 @@ fun if_expression() {
     // branches that break
     if (expression)
         expression_that_is_too_long
-    else {
-        another_long_expression_too
-    };
+    else
+        another_long_expression_too;
 
     // same example with block will
     // be broken into multiple lines
@@ -276,8 +274,7 @@ fun if_comments() {
     if (
         /* expr */ expression // comment
     ) expression
-    else {
+    else
         // comment
-        expression
-    };
+        expression;
 }

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
@@ -260,9 +260,7 @@ fun if_expression() {
         another_long_expression
     };
 
-    if ({
-        expression
-    }) {
+    if ({ expression }) {
         return expression
     } else expression;
 }

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
@@ -6,9 +6,8 @@ module test::if_expression;
 
 fun basic() {
     if (true) call_something();
-    if (false) {
-        call_some_long_func()
-    };
+    if (false)
+        call_some_long_func();
 
     if (cond) do_this() else {
         do_that();
@@ -46,9 +45,8 @@ fun control_flow() {
     if (true) break;
     if (true) abort;
     if (true) return call();
-    if (true) {
-        return call_something()
-    };
+    if (true)
+        return call_something();
 
     'a: if (true) { break 'a; }
 }
@@ -57,13 +55,13 @@ fun dot_expression() {
     if (true) a.dot().expression()
     else b.dot().expression();
 
-    if (true) {
+    if (true)
         staking
             .pools[pool]
             .borrow_mut()
             .unwrap()
             .stake(amount)
-    } else {
+    else {
         staking
             .pools[pool]
             .borrow_mut()
@@ -159,9 +157,9 @@ fun lists() {
 
 fun folding() {
     if (true) call_something()
-    else if (false) {
+    else if (false)
         call_something_else()
-    } else last_call();
+    else last_call();
 
     if (true) {
         call_something()
@@ -176,9 +174,8 @@ fun folding() {
 
     if (
         very_very_long_if_condition
-    ) {
-        very_very_long_if_condition > very_very_long_if_condition
-    };
+    )
+        very_very_long_if_condition > very_very_long_if_condition;
 
     let a = if (true) {
         call_something_else();
@@ -190,11 +187,10 @@ fun folding() {
         very_very_long_if_condition > very_very_long_if_condition ||
         very_very_long_if_condition + very_very_long_if_condition > 100 &&
         very_very_long_if_condition
-    ) {
+    )
         very_very_long_if_condition > very_very_long_if_condition &&
         very_very_long_if_condition > very_very_long_if_condition &&
-        very_very_long_if_condition > very_very_long_if_condition
-    };
+        very_very_long_if_condition > very_very_long_if_condition;
     // should break list of expressions inside parens, with indent;
     if (
         very_very_long_if_condition > very_very_long_if_condition ||
@@ -208,19 +204,17 @@ fun folding() {
 
     if (
         very_very_long_if_condition > very_very_long_if_condition
-    ) {
-        return very_very > very_very_long_if_condition + 100
-    };
+    )
+        return very_very > very_very_long_if_condition + 100;
 
     if (
         very_very_long_if_condition > very_very_long_if_condition &&
         very_very_long_if_condition > very_very_long_if_condition &&
         very_very_long_if_condition > very_very_long_if_condition
-    ) {
+    )
         return very_very_long_if_condition > very_very_long_if_condition &&
             very_very_long_if_condition > very_very_long_if_condition ||
             very_very_long_if_condition > very_very_long_if_condition
-    }
 }
 
 fun if_expression() {
@@ -254,9 +248,9 @@ fun if_expression() {
     // should break on expression
     // and add block to both
     // branches that break
-    if (expression) {
+    if (expression)
         expression_that_is_too_long
-    } else {
+    else {
         another_long_expression_too
     };
 

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.exp.move
@@ -9,7 +9,8 @@ fun basic() {
     if (false)
         call_some_long_func();
 
-    if (cond) do_this() else {
+    if (cond) do_this()
+    else {
         do_that();
         do_this();
     };
@@ -272,7 +273,10 @@ fun if_comments() {
     if (
         /* expr */ expression // comment
     ) expression
-    else
-        // comment
+    else // comment
         expression;
+
+    if (cond) expression
+    else // comment
+        expression; // comment
 }

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.move
@@ -1,100 +1,156 @@
 // options:
-// printWidth: 80
+// printWidth: 35
+// useModuleLabel: true
 
-module test::if_expression {
-    public fun basic() {
-        if (true) call_something();
-        if (false) call_something_else_call_something_else_call_something_else();
+module test::if_expression;
 
-
-        if (cond) do_this()
-        else {
-            do_that();
-            do_this();
-        };
-
-        if (cond) {
-            do_this();
-            do_that();
-        } else do_this();
+fun basic() {
+    if (true) call_something();
+    if (false) call_something_else_call_something_else_call_something_else();
 
 
-        if (true) call_something()
-        else call_something_else();
+    if (cond) do_this()
+    else {
+        do_that();
+        do_this();
+    };
 
-        if (false) {
-            call_something_else();
-        } else {
-            another_call();
-        };
+    if (cond) {
+        do_this();
+        do_that();
+    } else do_this();
 
-        if (very_long_binding) {
-            call_something();
-        } else {
-            call_something_else();
-        };
-    }
 
-    public fun control_flow() {
-        if (true) return call_something();
-        if (true) return call_something_else_call_something_else_call_something_else();
-    }
+    if (true) call_something()
+    else call_something_else();
 
-    public fun folding() {
+    if (false) {
+        call_something_else();
+    } else {
+        another_call();
+    };
 
-        if (true) call_something()
-        else if (false) call_something_else()
-        else call_something_otherwise();
+    if (very_long_binding) {
+        call_something();
+    } else {
+        call_something_else();
+    };
+}
 
-        if (true) {
-            call_something()
-        } else if (false) {
-            call_something_else()
-        } else {
-            call_something_otherwise()
-        };
+fun control_flow() {
+    if (true) return call_something();
+    if (true) return call_something_else_call_something_else_call_something_else();
+}
 
-        // should keep as is, no additions;
-        if (true) { let a = b; };
+fun folding() {
 
-        if (very_very_long_if_condition)
-            very_very_long_if_condition > very_very_long_if_condition;
+    if (true) call_something()
+    else if (false) call_something_else()
+    else call_something_otherwise();
 
-        let a = if (true) {
-            call_something_else();
-        } else {
-            call_something_else();
-        };
+    if (true) {
+        call_something()
+    } else if (false) {
+        call_something_else()
+    } else {
+        call_something_otherwise()
+    };
 
-        if (
+    // should keep as is, no additions;
+    if (true) { let a = b; };
+
+    if (very_very_long_if_condition)
+        very_very_long_if_condition > very_very_long_if_condition;
+
+    let a = if (true) {
+        call_something_else();
+    } else {
+        call_something_else();
+    };
+
+    if (
+        very_very_long_if_condition > very_very_long_if_condition ||
+        very_very_long_if_condition + very_very_long_if_condition > 100 &&
+        very_very_long_if_condition
+    )
+        very_very_long_if_condition > very_very_long_if_condition &&
+        very_very_long_if_condition > very_very_long_if_condition &&
+        very_very_long_if_condition > very_very_long_if_condition;
+    // should break list of expressions inside parens, with indent;
+    if (
+        very_very_long_if_condition > very_very_long_if_condition ||
+        very_very_long_if_condition + very_very_long_if_condition > 100 &&
+        very_very_long_if_condition
+    ) {
+        very_very_long_if_condition > very_very_long_if_condition &&
+        very_very_long_if_condition > very_very_long_if_condition &&
+        very_very_long_if_condition > very_very_long_if_condition;
+    };
+
+    if (very_very_long_if_condition > very_very_long_if_condition)
+        return very_very > very_very_long_if_condition + 100;
+
+    if (
+        very_very_long_if_condition > very_very_long_if_condition &&
+        very_very_long_if_condition > very_very_long_if_condition &&
+        very_very_long_if_condition > very_very_long_if_condition
+    )
+        return very_very_long_if_condition > very_very_long_if_condition &&
             very_very_long_if_condition > very_very_long_if_condition ||
-            very_very_long_if_condition + very_very_long_if_condition > 100 &&
-            very_very_long_if_condition
-        )
-            very_very_long_if_condition > very_very_long_if_condition &&
-            very_very_long_if_condition > very_very_long_if_condition &&
-            very_very_long_if_condition > very_very_long_if_condition;
-        // should break list of expressions inside parens, with indent;
-        if (
-            very_very_long_if_condition > very_very_long_if_condition ||
-            very_very_long_if_condition + very_very_long_if_condition > 100 &&
-            very_very_long_if_condition
-        ) {
-            very_very_long_if_condition > very_very_long_if_condition &&
-            very_very_long_if_condition > very_very_long_if_condition &&
-            very_very_long_if_condition > very_very_long_if_condition;
-        };
-
-        if (very_very_long_if_condition > very_very_long_if_condition)
-            return very_very > very_very_long_if_condition + 100;
-
-        if (
-            very_very_long_if_condition > very_very_long_if_condition &&
-            very_very_long_if_condition > very_very_long_if_condition &&
             very_very_long_if_condition > very_very_long_if_condition
-        )
-            return very_very_long_if_condition > very_very_long_if_condition &&
-                very_very_long_if_condition > very_very_long_if_condition ||
-                very_very_long_if_condition > very_very_long_if_condition
-    }
+}
+
+fun if_expression() {
+    // standard if-else
+    if (true) true else false;
+
+    // with block
+    if (true) { true } else { false };
+
+    // with multiline block
+    if (true) {
+        true
+    } else {
+        false
+    };
+
+    // mix block / no block
+    if ({ expression }) {
+       return expression
+    } else expression;
+
+    // reverse mix block / no block
+    // should break on else (newline)
+    if (expression) expression
+    else {
+        return expression
+    };
+
+    // should break on expression
+    // and newline + indent it
+    if (expression)
+        expression_that_is_too_long
+    else
+        another_long_expression;
+
+    // same exampla with block will
+    // be broken into multiple lines
+    if (expression) { expression_that_is_too_long }
+    else { another_long_expression };
+
+    if ({
+        expression
+    }) {
+       return expression
+    } else expression;
+}
+
+fun if_comments() {
+    // comment associativity should be fixed
+    // in the tree-sitter implementation by
+    // adding names to `if`, `else` and `condition`
+    if (/* expr */ expression) // comment
+        expression
+    else // comment
+        expression;
 }

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.move
@@ -109,7 +109,12 @@ fun lists() {
 
     // changes with trailing
     // comments
-    if (true) vector[1, 2] // line
+    if (true) vector[1, 2] // trailing
+    else abort;
+
+    // if list breaks, trailing
+    // comment forces else newline
+    if (true) vector[1, 2, 3, 4, 5] // trailing
     else abort;
 }
 

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.move
@@ -54,15 +54,17 @@ fun dot_expression() {
     if (true) a.dot().expression()
     else b.dot().expression();
 
-    if (true) staking
-        .pools[pool]
-        .borrow_mut()
-        .unwrap()
-        .stake(amount)
-    else staking
-        .pools[pool]
-        .borrow_mut()
-        .stake(0)
+    if (true)
+        staking
+            .pools[pool]
+            .borrow_mut()
+            .unwrap()
+            .stake(amount)
+    else
+        staking
+            .pools[pool]
+            .borrow_mut()
+            .stake(0)
 }
 
 fun lists() {

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.move
@@ -234,6 +234,13 @@ fun if_comments() {
     else expression; // comment
 }
 
+fun if_chaining() {
+    if (true) 1
+    else if (false) 2
+    else if (true) 3
+    else 4;
+}
+
 fun misc_tests() {
     if (condition) doesnt_break; // trailing
     if (condition) doesnt_break // trailing

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.move
@@ -6,11 +6,15 @@ module test::if_expression;
 
 fun basic() {
     if (true) call_something();
-    if (false) call_something_else_call_something_else_call_something_else();
+    if (false) call_some_long_func();
 
 
-    if (cond) do_this()
-    else {
+    if (cond) do_this() else {
+        do_that();
+        do_this();
+    };
+
+    if (cond) push_else_out() else {
         do_that();
         do_this();
     };
@@ -38,15 +42,61 @@ fun basic() {
 }
 
 fun control_flow() {
+    if (true) break;
+    if (true) abort;
+    if (true) return call();
     if (true) return call_something();
-    if (true) return call_something_else_call_something_else_call_something_else();
+
+    'a: if (true) { break 'a; }
+}
+
+fun dot_expression() {
+    if (true) a.dot().expression()
+    else b.dot().expression();
+
+    if (true) staking
+        .pools[pool]
+        .borrow_mut()
+        .unwrap()
+        .stake(amount)
+    else staking
+        .pools[pool]
+        .borrow_mut()
+        .stake(0)
+}
+
+fun lists() {
+    if (true) (1, 2, 3)
+    else (4, 5, 6);
+
+    // list can break itself
+    if (true) (longer, list, values)
+    else (short, list, third);
+
+    // trailing comment on the true
+    // branch forces else on a new
+    // line, other comments work
+    if (true) /* wow */ (longer, /* haha */ list, values) // beep
+    else (short, list, third); // boop
+
+    // both lists are broken, no
+    // braces added to any branch
+    if (true) (longer, list, values) // beep
+    else (even, longer, list, better); // boop
+
+    // vector expression is another
+    // list that is supported
+    if (true) vector[1, 2, 3, 4];
+
+    // printed in 2 lines
+    if (true) vector[1, 2, 3, 4]
+    else vector[];
 }
 
 fun folding() {
-
     if (true) call_something()
     else if (false) call_something_else()
-    else call_something_otherwise();
+    else last_call();
 
     if (true) {
         call_something()
@@ -127,13 +177,13 @@ fun if_expression() {
     };
 
     // should break on expression
-    // and newline + indent it
+    // and add block to both
+    // branches that break
     if (expression)
         expression_that_is_too_long
-    else
-        another_long_expression;
+    else another_long_expression_too;
 
-    // same exampla with block will
+    // same example with block will
     // be broken into multiple lines
     if (expression) { expression_that_is_too_long }
     else { another_long_expression };

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.move
@@ -213,9 +213,7 @@ fun if_expression() {
     if (expression) { expression_that_is_too_long }
     else { another_long_expression };
 
-    if ({
-        expression
-    }) {
+    if ({ expression }) {
        return expression
     } else expression;
 }

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.move
@@ -233,3 +233,18 @@ fun if_comments() {
     // comment
     else expression; // comment
 }
+
+fun misc_tests() {
+    if (condition) doesnt_break; // trailing
+    if (condition) doesnt_break // trailing
+    else doesnt_break; // another trailing
+
+    if (48 <= b && b < 58) b - 48 // 0 .. 9
+    else if (b == 1 || b == 80) 10 // p or P
+    else if (b == 1 || b == 79) 11 // o or O
+    else if (b == 1 || b == 84) 12 // t or T
+    else if (b == 1 || b == 65) 13 // a or A
+    else if (b == 1 || b == 69) 14 // e or E
+    else if (b == 1 || b == 83) 15 // s or S
+    else abort 1
+}

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.move
@@ -253,5 +253,10 @@ fun misc_tests() {
     else if (b == 1 || b == 65) 13 // a or A
     else if (b == 1 || b == 69) 14 // e or E
     else if (b == 1 || b == 83) 15 // s or S
-    else abort 1
+    else abort 1;
+
+    let value = bcs.peel_u8();
+    if (value == 0) false
+    else if (value == 1) true
+    else abort ENotBool
 }

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.move
@@ -228,4 +228,8 @@ fun if_comments() {
         expression
     else // comment
         expression;
+
+    if (cond) expression
+    // comment
+    else expression; // comment
 }

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/if_expression.move
@@ -88,9 +88,29 @@ fun lists() {
     // list that is supported
     if (true) vector[1, 2, 3, 4];
 
+    // printed in 1 line
+    if (true) vector[] else abort;
+
     // printed in 2 lines
     if (true) vector[1, 2, 3, 4]
+    else abort;
+
+    // does not break on else
+    if (true) vector[1, 2, 3, 4]
+    else vector[1, 2, 3, 4];
+
+    // uses space if true breaks
+    if (true) vector[100, 200, 300, 400]
     else vector[];
+
+    // breaks on both braches
+    if (true) vector[100, 200, 300, 400]
+    else vector[100, 200, 300, 400, 500];
+
+    // changes with trailing
+    // comments
+    if (true) vector[1, 2] // line
+    else abort;
 }
 
 fun folding() {

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/loop_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/loop_expression.exp.move
@@ -1,13 +1,21 @@
-module test::loop_expression {
-    public fun test_loop() {
-        loop break;
+// options:
+// printWidth: 35
+// useModuleLabel: true
 
-        loop {
-            break;
-        };
+module test::loop_expression;
 
-        loop {
-            break;
-        };
-    }
+fun test_loop() {
+    loop break;
+
+    loop {
+        break;
+    };
+
+    loop {
+        break;
+    };
+
+    'a: loop {
+        break 'a;
+    };
 }

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/loop_expression.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/loop_expression.move
@@ -1,13 +1,20 @@
-module test::loop_expression {
-    public fun test_loop() {
-        loop break;
+// options:
+// printWidth: 35
+// useModuleLabel: true
 
-        loop {
-            break;
-        };
+module test::loop_expression;
+fun test_loop() {
+    loop break;
 
-        loop {
-            break;
-        };
-    }
+    loop {
+        break;
+    };
+
+    loop {
+        break;
+    };
+
+    'a: loop {
+        break 'a;
+    };
 }

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/return_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/return_expression.exp.move
@@ -1,49 +1,44 @@
-// option:
-// print_width: 80
+// options:
+// printWidth: 80
+// useModuleLabel: true
 
-module test::return_expression {
-    public fun folding() {
-        // this is a return expression
-        return very_very > very_very_long_if_condition + 100;
-        return very_very_long_if_condition > very_very_long_if_condition &&
-                very_very_long_if_condition > very_very_long_if_condition ||
-                very_very_long_if_condition > very_very_long_if_condition; // this is a trailing comment for return
-        return very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition;
-        return {
-            if (block_expression()) 1
-            else 2
-        };
+module test::return_expression;
 
-        // and top comment
-        return; // another trailing
+fun folding() {
+    // this is a return expression
+    return very_very > very_very_long_if_condition + 100;
+    return very_very_long_if_condition > very_very_long_if_condition &&
+            very_very_long_if_condition > very_very_long_if_condition ||
+            very_very_long_if_condition > very_very_long_if_condition; // this is a trailing comment for return
+    return very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition;
+    return {
+        if (block_expression()) 1 else 2
+    };
 
-        return { a + b };
+    // and top comment
+    return; // another trailing
 
-        return vector[
-            first_return_value,
-            second_return_value,
-            third_return_value,
-        ];
+    return { a + b };
 
-        if (cond) {
-            do_something_very_very_nasty_and_its_super_long_too_hahahahaa()
-        } else return;
+    return vector[first_return_value, second_return_value, third_return_value];
 
-        return ({ a + b }, first_return_value, second_return_value);
+    if (cond) {
+        do_something_very_very_nasty_and_its_super_long_too_hahahahaa()
+    } else return;
 
-        return if (some_value) {
-            some_value
-        } else {
-            some_other_value
-        };
+    return ({ a + b }, first_return_value, second_return_value);
 
-        return if (some_value) some_value
-        else some_other_value;
+    return if (some_value) {
+        some_value
+    } else {
+        some_other_value
+    };
 
-        return (
-            very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition,
-            very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition,
-            very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition,
-        );
-    }
+    return if (some_value) some_value else some_other_value;
+
+    return (
+        very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition,
+        very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition,
+        very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition,
+    );
 }

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/return_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/return_expression.exp.move
@@ -12,8 +12,7 @@ fun folding() {
             very_very_long_if_condition > very_very_long_if_condition; // this is a trailing comment for return
     return very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition;
     return {
-        if (block_expression()) 1
-        else 2
+        if (block_expression()) 1 else 2
     };
 
     // and top comment

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/return_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/return_expression.exp.move
@@ -12,7 +12,8 @@ fun folding() {
             very_very_long_if_condition > very_very_long_if_condition; // this is a trailing comment for return
     return very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition;
     return {
-        if (block_expression()) 1 else 2
+        if (block_expression()) 1
+        else 2
     };
 
     // and top comment

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/return_expression.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/return_expression.move
@@ -1,54 +1,55 @@
-// option:
-// print_width: 80
+// options:
+// printWidth: 80
+// useModuleLabel: true
 
-module test::return_expression {
-    public fun folding() {
-        // this is a return expression
-        return very_very > very_very_long_if_condition + 100;
-        return very_very_long_if_condition > very_very_long_if_condition &&
-                very_very_long_if_condition > very_very_long_if_condition ||
-                very_very_long_if_condition > very_very_long_if_condition; // this is a trailing comment for return
-        return very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition;
-        return {
-            if (block_expression()) 1
-            else 2
-        };
+module test::return_expression;
 
-        // and top comment
-        return; // another trailing
+fun folding() {
+    // this is a return expression
+    return very_very > very_very_long_if_condition + 100;
+    return very_very_long_if_condition > very_very_long_if_condition &&
+            very_very_long_if_condition > very_very_long_if_condition ||
+            very_very_long_if_condition > very_very_long_if_condition; // this is a trailing comment for return
+    return very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition;
+    return {
+        if (block_expression()) 1
+        else 2
+    };
 
-        return { a + b };
+    // and top comment
+    return; // another trailing
 
-        return vector[
-            first_return_value,
-            second_return_value,
-            third_return_value
-        ];
+    return { a + b };
 
-        if (cond) {
-            do_something_very_very_nasty_and_its_super_long_too_hahahahaa()
-        }
-        else return;
+    return vector[
+        first_return_value,
+        second_return_value,
+        third_return_value
+    ];
 
-        return (
-            { a + b },
-            first_return_value,
-            second_return_value,
-        );
-
-        return if (some_value) {
-            some_value
-        } else {
-            some_other_value
-        };
-
-        return if (some_value) some_value
-        else some_other_value;
-
-        return (
-            very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition,
-            very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition,
-            very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition
-        );
+    if (cond) {
+        do_something_very_very_nasty_and_its_super_long_too_hahahahaa()
     }
+    else return;
+
+    return (
+        { a + b },
+        first_return_value,
+        second_return_value,
+    );
+
+    return if (some_value) {
+        some_value
+    } else {
+        some_other_value
+    };
+
+    return if (some_value) some_value
+    else some_other_value;
+
+    return (
+        very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition,
+        very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition,
+        very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition_very_very_long_if_condition
+    );
 }

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/while_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/while_expression.exp.move
@@ -1,24 +1,24 @@
 // options:
-// printWidth: 60
-// tabWidth: 4
+// printWidth: 35
+// useModuleLabel: true
 
-module test::while_expression {
-    fun test_while() {
-        // hey yall
-        'a: {};
+module test::while_expression;
 
-        // comments
-        while (true) {
-            break;
-        };
-        // hahaha
-        'a: while (
-            very_very_long_condition ||
-            very_very_long_condition ||
-            very_very_long_condition ||
-            very_very_long_condition
-        ) {
-            break;
-        };
-    }
+fun test_while() {
+    // hey yall
+    /* leading */ 'a: {}; // trailing
+
+    // comments
+    while (true) {
+        break;
+    }; // trailing
+    // hahaha
+    'a: /* a */  while (/* b */
+        very_very_long_condition ||
+        very_very_long_condition ||
+        very_very_long_condition ||
+        very_very_long_condition) // trailing
+    {
+        break;
+    };
 }

--- a/external-crates/move/tooling/prettier-move/tests/control-flow/while_expression.move
+++ b/external-crates/move/tooling/prettier-move/tests/control-flow/while_expression.move
@@ -1,27 +1,25 @@
 // options:
-// printWidth: 60
-// tabWidth: 4
+// printWidth: 35
+// useModuleLabel: true
 
-module test::while_expression {
-    fun test_while() {
+module test::while_expression;
+fun test_while() {
 
-        // hey yall
-        'a: {
+    // hey yall
+    /* leading */ 'a: {}; // trailing
 
-        };
-
-        // comments
-        while (true) {
-            break;
-        };
-        // hahaha
-        'a: while (
-            very_very_long_condition ||
-            very_very_long_condition ||
-            very_very_long_condition ||
-            very_very_long_condition
-        ) {
-            break;
-        };
-    }
+    // comments
+    while (true) {
+        break;
+    }; // trailing
+    // hahaha
+    'a: /* a */ while /* b */ (
+        very_very_long_condition ||
+        very_very_long_condition ||
+        very_very_long_condition ||
+        very_very_long_condition
+    ) // trailing
+    {
+        break;
+    };
 }

--- a/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.exp.move
@@ -14,10 +14,11 @@ fun assign_expression() {
 
     // assignment with if + break
     a =
-        if (long_condition)
+        if (long_condition) {
             long_expression
-        else
-            another_long_expression;
+        } else {
+            another_long_expression
+        };
 
     a = if (true) { a } else { b };
 

--- a/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.exp.move
@@ -38,16 +38,10 @@ fun assign_comment() {
 
     a = /* hahaha */ b;
 
-    // TODO:
-    // unsolved case of missing
-    // indentation when two types
-    // of trailing comments are
-    // mixed in lhs
     a /* unsolved */ = // comment
         b /* b */; // trailing
 
     a = // comment
         if (true) expr
-        else
-            longer_expression;
+        else longer_expression;
 }

--- a/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.exp.move
@@ -14,9 +14,9 @@ fun assign_expression() {
 
     // assignment with if + break
     a =
-        if (long_condition) {
+        if (long_condition)
             long_expression
-        } else {
+        else {
             another_long_expression
         };
 

--- a/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.exp.move
@@ -1,0 +1,48 @@
+// options:
+// printWidth: 35
+// tabWidth: 4
+// useModuleLabel: true
+
+module prettier::assign_expression;
+
+fun assign_expression() {
+    // straightforward example
+    a = b;
+
+    // assignment with if_expression
+    a = if (true) { b } else { c };
+
+    // assignment with if + break
+    a =
+        if (long_condition)
+        long_expression
+    else
+        another_long_expression;
+
+    a = if (true) { a } else { b };
+
+    // assignment with if + block
+    a = if (true) {
+        long_true_expression
+    } else {
+        long_false_expression
+    };
+}
+
+fun assign_comment() {
+    a /* before */ = /* after */ b;
+
+    // leading
+    a = // comment
+        b /* b */; // trailing
+
+    a = /* hahaha */ b;
+
+    // TODO:
+    // unsolved case of missing
+    // indentation when two types
+    // of trailing comments are
+    // mixed in lhs
+    a /* unsolved */ = // comment
+    b /* b */; // trailing
+}

--- a/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.exp.move
@@ -13,20 +13,50 @@ fun assign_expression() {
     a = if (true) { b } else { c };
 
     // assignment with if + break
-    a =
-        if (long_condition)
-            long_expression
-        else
-            another_long_expression;
+    assign = if (long_condition)
+        long_expression
+    else another_long_expression;
 
-    a = if (true) { a } else { b };
+    assign = if (true) { a } else {
+        b
+    };
 
     // assignment with if + block
-    a = if (true) {
-            long_true_expression
-        } else {
-            long_false_expression
-        };
+    assign = if (true) {
+        long_true_expression
+    } else {
+        long_false_expression
+    };
+
+    // assignment + control flow
+    assign = 'ret: if (true) {
+        long_true_expression
+    } else {
+        long_false_expression
+    };
+
+    assign = 'loop: loop {
+        break 'loop a;
+    };
+
+    assign = 'ret: 10u8.do!(|x| {
+        return 'ret x;
+    });
+
+    // Block
+
+    assign = {
+        // comment
+        a = b;
+        a
+    };
+
+    assign = vector[100, 200];
+    assign = vector[
+        100000,
+        200000,
+        30000,
+    ];
 }
 
 fun assign_comment() {

--- a/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.exp.move
@@ -38,6 +38,8 @@ fun assign_comment() {
 
     a = /* hahaha */ b;
 
+    // two types of trailing comments
+    // are mixed in lhs
     a /* unsolved */ = // comment
         b /* b */; // trailing
 

--- a/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.exp.move
@@ -16,9 +16,8 @@ fun assign_expression() {
     a =
         if (long_condition)
             long_expression
-        else {
-            another_long_expression
-        };
+        else
+            another_long_expression;
 
     a = if (true) { a } else { b };
 

--- a/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.exp.move
@@ -15,18 +15,18 @@ fun assign_expression() {
     // assignment with if + break
     a =
         if (long_condition)
-        long_expression
-    else
-        another_long_expression;
+            long_expression
+        else
+            another_long_expression;
 
     a = if (true) { a } else { b };
 
     // assignment with if + block
     a = if (true) {
-        long_true_expression
-    } else {
-        long_false_expression
-    };
+            long_true_expression
+        } else {
+            long_false_expression
+        };
 }
 
 fun assign_comment() {
@@ -44,5 +44,10 @@ fun assign_comment() {
     // of trailing comments are
     // mixed in lhs
     a /* unsolved */ = // comment
-    b /* b */; // trailing
+        b /* b */; // trailing
+
+    a = // comment
+        if (true) expr
+        else
+            longer_expression;
 }

--- a/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.move
+++ b/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.move
@@ -45,4 +45,8 @@ fun assign_comment() {
     // mixed in lhs
     a /* unsolved */ = // comment
         b /* b */; // trailing
+
+    a = // comment
+        if (true) expr
+        else longer_expression;
 }

--- a/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.move
+++ b/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.move
@@ -38,11 +38,8 @@ fun assign_comment() {
 
     a = /* hahaha */ b;
 
-    // TODO:
-    // unsolved case of missing
-    // indentation when two types
-    // of trailing comments are
-    // mixed in lhs
+    // two types of trailing comments
+    // are mixed in lhs
     a /* unsolved */ = // comment
         b /* b */; // trailing
 

--- a/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.move
+++ b/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.move
@@ -1,0 +1,48 @@
+// options:
+// printWidth: 35
+// tabWidth: 4
+// useModuleLabel: true
+
+module prettier::assign_expression;
+
+fun assign_expression() {
+    // straightforward example
+    a = b;
+
+    // assignment with if_expression
+    a = if (true) { b } else { c };
+
+    // assignment with if + break
+    a = if (long_condition)
+        long_expression
+    else
+        another_long_expression;
+
+    a = if (true) { a }
+        else { b };
+
+    // assignment with if + block
+    a = if (true) {
+        long_true_expression
+    } else {
+        long_false_expression
+    };
+}
+
+fun assign_comment() {
+    a /* before */ = /* after */ b;
+
+    // leading
+    a = // comment
+        b /* b */; // trailing
+
+    a = /* hahaha */ b;
+
+    // TODO:
+    // unsolved case of missing
+    // indentation when two types
+    // of trailing comments are
+    // mixed in lhs
+    a /* unsolved */ = // comment
+        b /* b */; // trailing
+}

--- a/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.move
+++ b/external-crates/move/tooling/prettier-move/tests/expression/assign_expression.move
@@ -13,20 +13,46 @@ fun assign_expression() {
     a = if (true) { b } else { c };
 
     // assignment with if + break
-    a = if (long_condition)
+    assign = if (long_condition)
         long_expression
     else
         another_long_expression;
 
-    a = if (true) { a }
+    assign = if (true) { a }
         else { b };
 
     // assignment with if + block
-    a = if (true) {
+    assign = if (true) {
         long_true_expression
     } else {
         long_false_expression
     };
+
+    // assignment + control flow
+    assign = 'ret: if (true) {
+        long_true_expression
+    } else {
+        long_false_expression
+    };
+
+    assign = 'loop: loop {
+        break 'loop a;
+    };
+
+    assign = 'ret: 10u8.do!(|x| {
+        return 'ret x;
+    });
+
+    // Block
+
+    assign = {
+        // comment
+        a = b;
+        a
+    };
+
+    assign = vector[100, 200];
+    assign = vector[100000, 200000, 30000];
 }
 
 fun assign_comment() {

--- a/external-crates/move/tooling/prettier-move/tests/expression/call_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/expression/call_expression.exp.move
@@ -3,7 +3,7 @@
 // tabWidth: 4
 // useModuleLabel: true
 
-module prettier::index_expression;
+module prettier::call_expression;
 
 fun call_expression() {
     call(/* a */ 10, /* b */ 10);
@@ -13,6 +13,16 @@ fun call_expression() {
         /* c */ 10,
     );
     call(/* a */ 10 /* trailing */);
+    call(
+        // leading
+        10,
+    );
+    call(
+        10, // trailing
+    );
+    call(
+        /* a */ 10, // trailing line
+    );
 }
 
 fun misc() {

--- a/external-crates/move/tooling/prettier-move/tests/expression/call_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/expression/call_expression.exp.move
@@ -23,6 +23,12 @@ fun call_expression() {
     call(
         /* a */ 10, // trailing line
     );
+
+    call(if (cond) {
+        b"1"
+    } else {
+        b"0"
+    }.to_string());
 }
 
 fun misc() {

--- a/external-crates/move/tooling/prettier-move/tests/expression/call_expression.move
+++ b/external-crates/move/tooling/prettier-move/tests/expression/call_expression.move
@@ -3,13 +3,23 @@
 // tabWidth: 4
 // useModuleLabel: true
 
-module prettier::index_expression;
+module prettier::call_expression;
 
 fun call_expression() {
 
     call(/* a */ 10, /* b */ 10);
     call(/* a */ 10, /* b */ 10, /* c */ 10);
     call(/* a */ 10 /* trailing */);
+    call(
+        // leading
+        10,
+    );
+    call(
+        10, // trailing
+    );
+    call(
+        /* a */ 10, // trailing line
+    );
 }
 
 fun misc() {

--- a/external-crates/move/tooling/prettier-move/tests/expression/call_expression.move
+++ b/external-crates/move/tooling/prettier-move/tests/expression/call_expression.move
@@ -20,6 +20,13 @@ fun call_expression() {
     call(
         /* a */ 10, // trailing line
     );
+
+    call(if (cond) {
+        b"1"
+    } else {
+        b"0"
+    }.to_string());
+
 }
 
 fun misc() {

--- a/external-crates/move/tooling/prettier-move/tests/expression/dot_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/expression/dot_expression.exp.move
@@ -121,6 +121,17 @@ fun dot_comments() {
     expression
         // lead
         .div(50); // trailing
+
+    // dot comment preserves trailing comment in a list of a single element
+    call(
+        b"".to_string() // comment kept
+    );
+
+    // leading comment is preserved in a list of a single element
+    call(
+        // leading comment
+        b"".to_string()
+    )
 }
 
 fun dot_with_lambda_lists() {

--- a/external-crates/move/tooling/prettier-move/tests/expression/dot_expression.move
+++ b/external-crates/move/tooling/prettier-move/tests/expression/dot_expression.move
@@ -100,6 +100,17 @@ fun dot_comments() {
     expression
         // lead
         .div(50); // trailing
+
+    // dot comment preserves trailing comment in a list of a single element
+    call(
+        b"".to_string(), // comment kept
+    );
+
+    // leading comment is preserved in a list of a single element
+    call(
+        // leading comment
+        b"".to_string(),
+    )
 }
 
 

--- a/external-crates/move/tooling/prettier-move/tests/expression/macro_call_and_lambda.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/expression/macro_call_and_lambda.exp.move
@@ -150,13 +150,15 @@ fun f() {
     animation.do_ref!(|el| {
         contents =
             contents
-            .map!(|mut contents| {
-                contents.push_back(el.to_string());
-                contents
-            })
-            .or!(
-                vector[el.to_string()],
-            );
+                .map!(|mut contents| {
+                    contents.push_back(el.to_string());
+                    contents
+                })
+                .or!(
+                    vector[
+                        el.to_string(),
+                    ],
+                );
     });
 
     stack.other!(argument, |x| x.do!());

--- a/external-crates/move/tooling/prettier-move/tests/expression/macro_call_and_lambda.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/expression/macro_call_and_lambda.exp.move
@@ -150,15 +150,13 @@ fun f() {
     animation.do_ref!(|el| {
         contents =
             contents
-                .map!(|mut contents| {
-                    contents.push_back(el.to_string());
-                    contents
-                })
-                .or!(
-                    vector[
-                        el.to_string(),
-                    ],
-                );
+            .map!(|mut contents| {
+                contents.push_back(el.to_string());
+                contents
+            })
+            .or!(
+                vector[el.to_string()],
+            );
     });
 
     stack.other!(argument, |x| x.do!());

--- a/external-crates/move/tooling/prettier-move/tests/expression/vector_expression.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/expression/vector_expression.exp.move
@@ -3,7 +3,7 @@
 // tabWidth: 4
 // useModuleLabel: true
 
-module prettier::dot_expression;
+module prettier::vector_expression;
 
 fun vector_simple() {
     // should be printed as is
@@ -14,7 +14,7 @@ fun vector_simple() {
 
     // should be expanded to multiple lines
     vector[
-        alice,
+        alice, // comments should be preserved
         bob,
         carl,
         dave,

--- a/external-crates/move/tooling/prettier-move/tests/expression/vector_expression.move
+++ b/external-crates/move/tooling/prettier-move/tests/expression/vector_expression.move
@@ -3,7 +3,7 @@
 // tabWidth: 4
 // useModuleLabel: true
 
-module prettier::dot_expression;
+module prettier::vector_expression;
 
 fun vector_simple() {
     // should be printed as is
@@ -14,11 +14,11 @@ fun vector_simple() {
 
     // should be expanded to multiple lines
     vector[
-        alice,
+        alice, // comments should be preserved
         bob,
         carl,
         dave,
-        eve
+        eve,
     ];
 }
 
@@ -38,7 +38,7 @@ fun vector_lists() {
     // expanded, with each vector on a new line
     vector[
         vector[1, 2, 3, 4, 5],
-        vector[1, 2, 3, 4, 5]
+        vector[1, 2, 3, 4, 5],
     ];
 
     // any vector breaking in a list breaks the list
@@ -61,7 +61,7 @@ fun vector_lists() {
     vector[
         { alice + bob + carl },
         { 2 },
-        { 3 }
+        { 3 },
     ];
 
     // when block broken, it gets expanded and
@@ -77,7 +77,7 @@ fun vector_lists() {
     vector[
         (
             alice + bob + carl + dave + smith
-        )
+        ),
     ];
 
     // expression list in a vector should always break

--- a/external-crates/move/tooling/prettier-move/tests/functions/let_statement.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/functions/let_statement.exp.move
@@ -1,5 +1,6 @@
 // options:
-// printWidth: 60
+// printWidth: 35
+// useModuleLabel: true
 
 // Testing strategy for let statement:
 //
@@ -9,140 +10,203 @@
 // - test let with very long unbreakable expressions
 // - test let with long breakable expressions
 // - write every example how it should be formatted
-module prettier::let_statement {
-    fun basic() {
-        let _;
-        let mut c;
+module prettier::let_statement;
+
+fun basic() {
+    let _;
+    let mut c;
+    let a = 1;
+    let x: u64;
+    let (a, b) = (1, 2);
+    let c: vector<u8> = vector[
+        1,
+        2,
+        3,
+    ];
+    let (mut a, mut b) = (1, 2);
+    let (
+        mut something,
+        something_else,
+        mut another_thing,
+    ) = (1, 2, 3);
+}
+
+fun breakable_expressions() {
+    let something = vector[
+        very_long_element_of_the_vector,
+    ];
+
+    let (item1, item2) = (
+        // breaks here
+        very_long_expression,
+        very_long_expression,
+    );
+
+    let item = Struct {
+        that: vector[],
+        packs: 1000,
+        itself: false,
+    };
+
+    let item = chain
+        .that_does()
+        .truly_magically()
+        .breaks_itself();
+
+    let item = {
+        block;
+        will_be;
+        block
+    };
+
+    let item = macro_call!(
+        very_long_list_expression_1,
+        very_long_list_expression_2,
+    );
+}
+
+fun unbreakable_expressions() {
+    let something =
+        very_long_expression_that_does_not_break_itself;
+    let Kiosk {
+        id,
+        profits,
+        owner: _,
+        item_count,
+    } = self;
+}
+
+fun break_list() {
+    let block = {
         let a = 1;
-        let x: u64;
-        let (a, b) = (1, 2);
-        let c: vector<u8> = vector[1, 2, 3];
-        let (mut a, mut b) = (1, 2);
-        let (
-            mut something,
-            something_else,
-            mut another_thing,
-        ) = (1, 2, 3);
-    }
+        let b = 2;
+        let c = 3;
+        a + b + c
+    };
 
-    fun breakable_expressions() {
-        let something = vector[
-            very_long_element_of_the_vector,
-        ];
+    let v = vector[
+        vector[1, 2, 3],
+        vector[4, 5, 6],
+        vector[7, 8, 9],
+    ];
 
-        let (item1, item2) = (
-            // breaks here
-            very_long_expression,
-            very_long_expression,
-        );
+    let (a, mut b, c) = (
+        very_long_list_expression_1,
+        very_long_list_expression_2,
+        very_long_list_expression_3,
+    );
+}
 
-        let item = Struct {
-            that: vector[],
-            packs: 1000,
-            itself: false,
-        };
+fun break_long_value() {
+    let (a, b, c) = (
+        very_very_very_long_value,
+        very_very_very_long_value,
+        very_very_very_long_value,
+    );
 
-        let item = chain
-            .that_does()
-            .truly_magically()
-            .breaks_itself();
+    let z = first()
+        .final()
+        .second_arg();
 
-        let item = {
-            block;
-            will_be;
-            block
-        };
+    let (
+        very_long_binding,
+        very_long_binding1,
+        very_long_binding2,
+    ) = (1, 2, 3);
 
-        let item = macro_call!(
-            very_long_list_expression_1,
-            very_long_list_expression_2,
-        );
-    }
+    let (
+        very_long_binding,
+        mut very_long_binding1,
+        very_long_binding2,
+    ) = (
+        very_very_very_long_value,
+        very_very_very_long_value,
+        very_very_very_long_value,
+    );
 
-    fun unbreakable_expressions() {
-        let something =
-            very_long_expression_that_does_not_break_itself;
-        let Kiosk { id, profits, owner: _, item_count } =
-            self;
-    }
+    let a =
+        very_very_very_long_value_very_long_value_very_long_value;
 
-    fun break_list() {
-        let block = {
-            let a = 1;
-            let b = 2;
-            let c = 3;
-            a + b + c
-        };
+    let c: TypeName<
+        Which<Is<Very<Big>>>,
+    > =
+        very_very_very_long_value_very_long_value_very_long_value;
 
-        let v = vector[
-            vector[1, 2, 3],
-            vector[4, 5, 6],
-            vector[7, 8, 9],
-        ];
-
-        let (a, mut b, c) = (
-            very_long_list_expression_1,
-            very_long_list_expression_2,
-            very_long_list_expression_3,
-        );
-    }
-
-    fun break_long_value() {
-        let (a, b, c) = (
-            very_very_very_long_value,
-            very_very_very_long_value,
-            very_very_very_long_value,
-        );
-
-        let z = first().final().second_arg();
-
-        let (
-            very_long_binding,
-            very_long_binding1,
-            very_long_binding2,
-        ) = (1, 2, 3);
-
-        let (
-            very_long_binding,
-            mut very_long_binding1,
-            very_long_binding2,
-        ) = (
-            very_very_very_long_value,
-            very_very_very_long_value,
-            very_very_very_long_value,
-        );
-
-        let a =
-            very_very_very_long_value_very_long_value_very_long_value;
-
-        let c: TypeName<Which<Is<Very<Big>>>> =
-            very_very_very_long_value_very_long_value_very_long_value;
-
-        let to_remain_locked = (
-            self.final_unlock_ts_sec -
+    let to_remain_locked = (
+        self.final_unlock_ts_sec -
                 math::min(self.final_unlock_ts_sec, now),
-        );
+    );
 
-        let to_remain_locked =
-            (
+    let to_remain_locked =
+        (
             self.final_unlock_ts_sec - math::min(self.final_unlock_ts_sec, now)
         ) * self.unlock_per_second;
 
-        let locked_amount_round =
-            balance::value(&self.locked_balance) / self.unlock_per_second * self.unlock_per_second;
-    }
+    let locked_amount_round =
+        balance::value(&self.locked_balance) / self.unlock_per_second * self.unlock_per_second;
+}
 
-    fun misc() {
-        let a =
-            very_very_long_if_condition > very_very_long_if_condition &&
+fun misc() {
+    let a =
+        very_very_long_if_condition > very_very_long_if_condition &&
         very_very_long_if_condition > very_very_long_if_condition &&
         very_very_long_if_condition > very_very_long_if_condition;
-    }
+}
 
-    fun let_match() {
-        let mut stone = match (e.is_black()) {
-            true => shape::use_(b"#b".to_string()),
-            false => shape::use_(b"#w".to_string()),
-        };
-    }
+fun let_match() {
+    let mut stone = match (e.is_black()) {
+        true => shape::use_(b"#b".to_string()),
+        false => shape::use_(b"#w".to_string()),
+    };
+}
+
+fun let_control_flow() {
+    // let assign with if_expression
+    a = if (true) { b } else { c };
+
+    // let assign with if + break
+    assign = if (long_condition)
+        long_expression
+    else another_long_expression;
+
+    assign = if (true) { a } else {
+        b
+    };
+
+    // let assign with if + block
+    assign = if (true) {
+        long_true_expression
+    } else {
+        long_false_expression
+    };
+
+    // let assign + control flow
+    assign = 'ret: if (true) {
+        long_true_expression
+    } else {
+        long_false_expression
+    };
+
+    assign = 'loop: loop {
+        break 'loop a;
+    };
+
+    assign = 'ret: 10u8.do!(|x| {
+        return 'ret x;
+    });
+
+    // Block
+
+    assign = {
+        // comment
+        a = b;
+        a
+    };
+
+    assign = vector[100, 200];
+    assign = vector[
+        100000,
+        200000,
+        30000,
+    ];
 }

--- a/external-crates/move/tooling/prettier-move/tests/functions/let_statement.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/functions/let_statement.exp.move
@@ -46,7 +46,7 @@ fun breakable_expressions() {
         that: vector[],
         packs: 1000,
         itself: false,
-    };
+    }; // trailing comment
 
     let item = chain
         .that_does()
@@ -139,8 +139,8 @@ fun break_long_value() {
 
     let to_remain_locked =
         (
-        self.final_unlock_ts_sec - math::min(self.final_unlock_ts_sec, now)
-    ) * self.unlock_per_second;
+            self.final_unlock_ts_sec - math::min(self.final_unlock_ts_sec, now)
+        ) * self.unlock_per_second;
 
     let locked_amount_round =
         balance::value(&self.locked_balance) / self.unlock_per_second * self.unlock_per_second;
@@ -170,12 +170,6 @@ fun let_control_flow() {
     let assign = if (cond)
         long_expression
     else another_long_expression;
-
-    let assign = if (cond) {
-        long_expression
-    } else {
-        another_long_expression
-    };
 
     let assign = if (
         long_condition

--- a/external-crates/move/tooling/prettier-move/tests/functions/let_statement.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/functions/let_statement.exp.move
@@ -134,13 +134,13 @@ fun break_long_value() {
 
     let to_remain_locked = (
         self.final_unlock_ts_sec -
-                math::min(self.final_unlock_ts_sec, now),
+            math::min(self.final_unlock_ts_sec, now),
     );
 
     let to_remain_locked =
         (
-            self.final_unlock_ts_sec - math::min(self.final_unlock_ts_sec, now)
-        ) * self.unlock_per_second;
+        self.final_unlock_ts_sec - math::min(self.final_unlock_ts_sec, now)
+    ) * self.unlock_per_second;
 
     let locked_amount_round =
         balance::value(&self.locked_balance) / self.unlock_per_second * self.unlock_per_second;
@@ -149,8 +149,8 @@ fun break_long_value() {
 fun misc() {
     let a =
         very_very_long_if_condition > very_very_long_if_condition &&
-        very_very_long_if_condition > very_very_long_if_condition &&
-        very_very_long_if_condition > very_very_long_if_condition;
+    very_very_long_if_condition > very_very_long_if_condition &&
+    very_very_long_if_condition > very_very_long_if_condition;
 }
 
 fun let_match() {
@@ -162,49 +162,69 @@ fun let_match() {
 
 fun let_control_flow() {
     // let assign with if_expression
-    a = if (true) { b } else { c };
+    let a = if (a) { b } else {
+        c
+    };
 
     // let assign with if + break
-    assign = if (long_condition)
+    let assign = if (cond)
         long_expression
     else another_long_expression;
 
-    assign = if (true) { a } else {
+    let assign = if (cond) {
+        long_expression
+    } else {
+        another_long_expression
+    };
+
+    let assign = if (
+        long_condition
+    ) long_expression
+    else another_long_expression;
+
+    let assign = if (true) { a }
+    else {
         b
     };
 
     // let assign with if + block
-    assign = if (true) {
+    let assign = if (true) {
         long_true_expression
     } else {
         long_false_expression
     };
 
     // let assign + control flow
-    assign = 'ret: if (true) {
+    let assign = 'ret: if (true) {
         long_true_expression
     } else {
         long_false_expression
     };
 
-    assign = 'loop: loop {
+    let assign = 'loop: loop {
         break 'loop a;
     };
 
-    assign = 'ret: 10u8.do!(|x| {
+    let assign = 'ret: 1u8.do!(
+        |x| {
+            return 'ret x;
+        },
+    );
+
+    let a = 'ret: 1u8.do!(|x| {
         return 'ret x;
     });
 
     // Block
 
-    assign = {
+    let assign = {
         // comment
         a = b;
         a
     };
 
-    assign = vector[100, 200];
-    assign = vector[
+    let assign = vector[100, 200];
+    let assign = vector[
         100000,
         200000,
         30000,

--- a/external-crates/move/tooling/prettier-move/tests/functions/let_statement.move
+++ b/external-crates/move/tooling/prettier-move/tests/functions/let_statement.move
@@ -1,5 +1,6 @@
 // options:
-// printWidth: 60
+// printWidth: 35
+// useModuleLabel: true
 
 // Testing strategy for let statement:
 //
@@ -130,5 +131,56 @@ module prettier::let_statement {
             true => shape::use_(b"#b".to_string()),
             false => shape::use_(b"#w".to_string()),
         };
+    }
+
+    fun let_control_flow() {
+        // let assign with if_expression
+        a = if (true) { b } else { c };
+
+        // let assign with if + break
+        assign = if (long_condition)
+            long_expression
+        else another_long_expression;
+
+        assign = if (true) { a } else {
+            b
+        };
+
+        // let assign with if + block
+        assign = if (true) {
+            long_true_expression
+        } else {
+            long_false_expression
+        };
+
+        // let assign + control flow
+        assign = 'ret: if (true) {
+            long_true_expression
+        } else {
+            long_false_expression
+        };
+
+        assign = 'loop: loop {
+            break 'loop a;
+        };
+
+        assign = 'ret: 10u8.do!(|x| {
+            return 'ret x;
+        });
+
+        // Block
+
+        assign = {
+            // comment
+            a = b;
+            a
+        };
+
+        assign = vector[100, 200];
+        assign = vector[
+            100000,
+            200000,
+            30000,
+        ];
     }
 }

--- a/external-crates/move/tooling/prettier-move/tests/functions/let_statement.move
+++ b/external-crates/move/tooling/prettier-move/tests/functions/let_statement.move
@@ -41,7 +41,7 @@ fun breakable_expressions() {
         that: vector[],
         packs: 1000,
         itself: false
-    };
+    }; // trailing comment
 
     let item = chain
         .that_does()
@@ -114,8 +114,8 @@ fun break_long_value() {
         );
 
     let to_remain_locked = (
-        self.final_unlock_ts_sec - math::min(self.final_unlock_ts_sec, now)
-    ) * self.unlock_per_second;
+            self.final_unlock_ts_sec - math::min(self.final_unlock_ts_sec, now)
+        ) * self.unlock_per_second;
 
     let locked_amount_round =
         balance::value(&self.locked_balance) / self.unlock_per_second * self.unlock_per_second;

--- a/external-crates/move/tooling/prettier-move/tests/functions/let_statement.move
+++ b/external-crates/move/tooling/prettier-move/tests/functions/let_statement.move
@@ -10,177 +10,184 @@
 // - test let with very long unbreakable expressions
 // - test let with long breakable expressions
 // - write every example how it should be formatted
-module prettier::let_statement {
-    fun basic() {
-        let _;
-        let mut c;
+module prettier::let_statement;
+
+fun basic() {
+    let _;
+    let mut c;
+    let a = 1;
+    let x: u64;
+    let (a, b) = (1, 2);
+    let c: vector<u8> = vector[1, 2, 3];
+    let (mut a, mut b) = (1, 2);
+    let (
+        mut something,
+        something_else,
+        mut another_thing,
+    ) = (1, 2, 3);
+}
+
+fun breakable_expressions() {
+    let something = vector[
+        very_long_element_of_the_vector,
+    ];
+
+    let (item1, item2) = ( // breaks here
+        very_long_expression,
+        very_long_expression,
+    );
+
+    let item = Struct {
+        that: vector[],
+        packs: 1000,
+        itself: false
+    };
+
+    let item = chain
+        .that_does()
+        .truly_magically()
+        .breaks_itself();
+
+    let item = {
+        block;
+        will_be;
+        block
+    };
+
+    let item = macro_call!(
+        very_long_list_expression_1,
+        very_long_list_expression_2,
+    );
+}
+
+fun unbreakable_expressions() {
+    let something = very_long_expression_that_does_not_break_itself;
+    let Kiosk { id, profits, owner: _, item_count } = self;
+}
+
+fun break_list() {
+    let block = {
         let a = 1;
-        let x: u64;
-        let (a, b) = (1, 2);
-        let c: vector<u8> = vector[1, 2, 3];
-        let (mut a, mut b) = (1, 2);
-        let (
-            mut something,
-            something_else,
-            mut another_thing,
-        ) = (1, 2, 3);
-    }
+        let b = 2;
+        let c = 3;
+        a + b + c
+    };
 
-    fun breakable_expressions() {
-        let something = vector[
-            very_long_element_of_the_vector,
-        ];
+    let v = vector[
+        vector[1, 2, 3],
+        vector[4, 5, 6],
+        vector[7, 8, 9],
+    ];
 
-        let (item1, item2) = ( // breaks here
-            very_long_expression,
-            very_long_expression,
+    let (a, mut b, c) = (
+        very_long_list_expression_1,
+        very_long_list_expression_2,
+        very_long_list_expression_3
+    );
+}
+
+fun break_long_value() {
+    let (a, b, c) = (
+        very_very_very_long_value,
+        very_very_very_long_value,
+        very_very_very_long_value
+    );
+
+    let z = first().final().second_arg();
+
+    let (very_long_binding, very_long_binding1, very_long_binding2) = (1, 2, 3);
+
+    let (very_long_binding, mut very_long_binding1, very_long_binding2) = (
+        very_very_very_long_value,
+        very_very_very_long_value,
+        very_very_very_long_value
+    );
+
+    let a = very_very_very_long_value_very_long_value_very_long_value;
+
+    let c: TypeName<Which<Is<Very<Big>>>> = very_very_very_long_value_very_long_value_very_long_value;
+
+    let to_remain_locked =
+        (
+            self.final_unlock_ts_sec -
+            math::min(self.final_unlock_ts_sec, now),
         );
 
-        let item = Struct {
-            that: vector[],
-            packs: 1000,
-            itself: false
-        };
+    let to_remain_locked = (
+        self.final_unlock_ts_sec - math::min(self.final_unlock_ts_sec, now)
+    ) * self.unlock_per_second;
 
-        let item = chain
-            .that_does()
-            .truly_magically()
-            .breaks_itself();
+    let locked_amount_round =
+        balance::value(&self.locked_balance) / self.unlock_per_second * self.unlock_per_second;
+}
 
-        let item = {
-            block;
-            will_be;
-            block
-        };
+fun misc() {
+    let a = very_very_long_if_condition > very_very_long_if_condition &&
+    very_very_long_if_condition > very_very_long_if_condition &&
+    very_very_long_if_condition > very_very_long_if_condition;
+}
 
-        let item = macro_call!(
-            very_long_list_expression_1,
-            very_long_list_expression_2,
-        );
-    }
+fun let_match() {
+    let mut stone = match (e.is_black()) {
+        true => shape::use_(b"#b".to_string()),
+        false => shape::use_(b"#w".to_string()),
+    };
+}
 
-    fun unbreakable_expressions() {
-        let something = very_long_expression_that_does_not_break_itself;
-        let Kiosk { id, profits, owner: _, item_count } = self;
-    }
+fun let_control_flow() {
+    // let assign with if_expression
+    let a = if (a) { b } else { c };
 
-    fun break_list() {
-        let block = {
-            let a = 1;
-            let b = 2;
-            let c = 3;
-            a + b + c
-        };
+    // let assign with if + break
+    let assign = if (cond) long_expression
+    else another_long_expression;
 
-        let v = vector[
-            vector[1, 2, 3],
-            vector[4, 5, 6],
-            vector[7, 8, 9],
-        ];
+    let assign = if (long_condition)
+        long_expression
+    else another_long_expression;
 
-        let (a, mut b, c) = (
-            very_long_list_expression_1,
-            very_long_list_expression_2,
-            very_long_list_expression_3
-        );
-    }
+    let assign = if (true) { a } else {
+        b
+    };
 
-    fun break_long_value() {
-        let (a, b, c) = (
-            very_very_very_long_value,
-            very_very_very_long_value,
-            very_very_very_long_value
-        );
+    // let assign with if + block
+    let assign = if (true) {
+        long_true_expression
+    } else {
+        long_false_expression
+    };
 
-        let z = first().final().second_arg();
+    // let assign + control flow
+    let assign = 'ret: if (true) {
+        long_true_expression
+    } else {
+        long_false_expression
+    };
 
-        let (very_long_binding, very_long_binding1, very_long_binding2) = (1, 2, 3);
+    let assign = 'loop: loop {
+        break 'loop a;
+    };
 
-        let (very_long_binding, mut very_long_binding1, very_long_binding2) = (
-            very_very_very_long_value,
-            very_very_very_long_value,
-            very_very_very_long_value
-        );
+    let assign = 'ret: 1u8.do!(|x| {
+        return 'ret x;
+    });
 
-        let a = very_very_very_long_value_very_long_value_very_long_value;
+    let a = 'ret: 1u8.do!(|x| {
+        return 'ret x;
+    });
 
-        let c: TypeName<Which<Is<Very<Big>>>> = very_very_very_long_value_very_long_value_very_long_value;
+    // Block
 
-        let to_remain_locked =
-            (
-                self.final_unlock_ts_sec -
-                math::min(self.final_unlock_ts_sec, now),
-            );
+    let assign = {
+        // comment
+        a = b;
+        a
+    };
 
-        let to_remain_locked = (
-            self.final_unlock_ts_sec - math::min(self.final_unlock_ts_sec, now)
-        ) * self.unlock_per_second;
-
-        let locked_amount_round =
-            balance::value(&self.locked_balance) / self.unlock_per_second * self.unlock_per_second;
-    }
-
-    fun misc() {
-        let a = very_very_long_if_condition > very_very_long_if_condition &&
-        very_very_long_if_condition > very_very_long_if_condition &&
-        very_very_long_if_condition > very_very_long_if_condition;
-    }
-
-    fun let_match() {
-        let mut stone = match (e.is_black()) {
-            true => shape::use_(b"#b".to_string()),
-            false => shape::use_(b"#w".to_string()),
-        };
-    }
-
-    fun let_control_flow() {
-        // let assign with if_expression
-        a = if (true) { b } else { c };
-
-        // let assign with if + break
-        assign = if (long_condition)
-            long_expression
-        else another_long_expression;
-
-        assign = if (true) { a } else {
-            b
-        };
-
-        // let assign with if + block
-        assign = if (true) {
-            long_true_expression
-        } else {
-            long_false_expression
-        };
-
-        // let assign + control flow
-        assign = 'ret: if (true) {
-            long_true_expression
-        } else {
-            long_false_expression
-        };
-
-        assign = 'loop: loop {
-            break 'loop a;
-        };
-
-        assign = 'ret: 10u8.do!(|x| {
-            return 'ret x;
-        });
-
-        // Block
-
-        assign = {
-            // comment
-            a = b;
-            a
-        };
-
-        assign = vector[100, 200];
-        assign = vector[
-            100000,
-            200000,
-            30000,
-        ];
-    }
+    let assign = vector[100, 200];
+    let assign = vector[
+        100000,
+        200000,
+        30000,
+    ];
 }

--- a/external-crates/move/tooling/prettier-move/tests/misc/misc.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/misc/misc.exp.move
@@ -3,14 +3,7 @@
 // autoGroupImports: package
 // useModuleLabel: true
 
-/*
- * @title Timelock
- *
- * @notice Locks any object with the store ability for a specific amount of time.
- *
- * @dev We do not provide a function to read the data inside the {Timelock<T>} to prevent capabilities from being used.
- */
-module suitears::timelock;
+module prettier::misc;
 
 use std::{string::String, type_name::{Self, TypeName}};
 use sui::{
@@ -121,31 +114,10 @@ public fun propose<DaoWitness: drop>(
 
 public fun inline_fun(): u128 { 1000 }
 
-// === Public View Function ===
-
-/*
-     * @notice Returns the unlock time in milliseconds.
-     *
-     * @param self A {Timelock<T>}
-     * @return u64. The `self.unlock_time`.
-     */
 public fun unlock_time<T: store>(self: &Timelock<T>): u64 {
     self.unlock_time
 }
 
-// === Public Mutative Function ===
-
-/*
-     * @notice Locks the `data` for `unlock_time` milliseconds.
-     *
-     * @param data An object with the store ability.
-     * @param c The shared `sui::clock::Clock` object.
-     * @patam unlock_time The lock period in milliseconds.
-     * @return {Timelock<T>}.
-     *
-     * aborts-if
-     * - `unlock_time` is in the past.
-     */
 public fun lock<T: store>(
     data: T,
     c: &Clock,
@@ -158,16 +130,6 @@ public fun lock<T: store>(
     Timelock { id: object::new(ctx), data, unlock_time }
 }
 
-/*
-     * @notice Unlocks a {Timelock<T>} and returns the locked resource `T`.
-     *
-     * @param self A {Timelock<T>}
-     * @param c The shared `sui::clock::Clock` object.
-     * @return `T`. An object with the store ability.
-     *
-     * aborts-if
-     * - `unlock_time` has not passed.
-     */
 public fun unlock<T: store>(self: Timelock<T>, c: &Clock): T {
     let Timelock { id, data, unlock_time } = self;
 
@@ -229,4 +191,22 @@ fun content() {
         },
         shape::ellipse(30, 30, 10, 5),
     ]);
+}
+
+public fun withdraw<T>(
+    vault: &mut Vault<T>,
+    key: key::Key,
+    ctx: &mut TxContext,
+): coin::Coin<T> {
+    assert_valid_key_code(vault, &key);
+    key.delete();
+
+    let new_coin = coin::from_balance(
+        balance::split(
+            &mut vault.balance,
+            vault.withdrawal_amount,
+        ),
+        ctx,
+    );
+    new_coin
 }

--- a/external-crates/move/tooling/prettier-move/tests/misc/misc.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/misc/misc.exp.move
@@ -210,3 +210,20 @@ public fun withdraw<T>(
     );
     new_coin
 }
+
+fun staking() {
+    let unadjusted_staking_reward_amount = unadjusted_staking_reward_amounts[i];
+    let adjusted_staking_reward_amount // If the validator is one of the slashed ones, then subtract the adjustment.
+     = if (individual_staking_reward_adjustments.contains(&i)) {
+        let adjustment = individual_staking_reward_adjustments[&i];
+        unadjusted_staking_reward_amount - adjustment
+    } else {
+        // Otherwise the slashed rewards should be distributed among the unslashed
+        // validators so add the corresponding adjustment.
+        let adjustment =
+            total_staking_reward_adjustment as u128 * voting_power
+                            / (total_unslashed_validator_voting_power as u128);
+        unadjusted_staking_reward_amount + (adjustment as u64)
+    };
+    adjusted_staking_reward_amounts.push_back(adjusted_staking_reward_amount);
+}

--- a/external-crates/move/tooling/prettier-move/tests/misc/misc.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/misc/misc.exp.move
@@ -221,8 +221,7 @@ fun staking() {
         // Otherwise the slashed rewards should be distributed among the unslashed
         // validators so add the corresponding adjustment.
         let adjustment =
-            total_staking_reward_adjustment as u128 * voting_power
-                            / (total_unslashed_validator_voting_power as u128);
+            total_staking_reward_adjustment as u128 * voting_power / (total_unslashed_validator_voting_power as u128);
         unadjusted_staking_reward_amount + (adjustment as u64)
     };
     adjusted_staking_reward_amounts.push_back(adjusted_staking_reward_amount);

--- a/external-crates/move/tooling/prettier-move/tests/misc/misc.move
+++ b/external-crates/move/tooling/prettier-move/tests/misc/misc.move
@@ -202,8 +202,7 @@ fun staking() {
         // Otherwise the slashed rewards should be distributed among the unslashed
         // validators so add the corresponding adjustment.
         let adjustment =
-            total_staking_reward_adjustment as u128 * voting_power
-                            / (total_unslashed_validator_voting_power as u128);
+            total_staking_reward_adjustment as u128 * voting_power / (total_unslashed_validator_voting_power as u128);
         unadjusted_staking_reward_amount + (adjustment as u64)
     };
     adjusted_staking_reward_amounts.push_back(adjusted_staking_reward_amount);

--- a/external-crates/move/tooling/prettier-move/tests/misc/misc.move
+++ b/external-crates/move/tooling/prettier-move/tests/misc/misc.move
@@ -191,3 +191,20 @@ public fun withdraw<T>(
     );
     new_coin
 }
+
+fun staking() {
+    let unadjusted_staking_reward_amount = unadjusted_staking_reward_amounts[i];
+    let adjusted_staking_reward_amount = // If the validator is one of the slashed ones, then subtract the adjustment.
+    if (individual_staking_reward_adjustments.contains(&i)) {
+        let adjustment = individual_staking_reward_adjustments[&i];
+        unadjusted_staking_reward_amount - adjustment
+    } else {
+        // Otherwise the slashed rewards should be distributed among the unslashed
+        // validators so add the corresponding adjustment.
+        let adjustment =
+            total_staking_reward_adjustment as u128 * voting_power
+                            / (total_unslashed_validator_voting_power as u128);
+        unadjusted_staking_reward_amount + (adjustment as u64)
+    };
+    adjusted_staking_reward_amounts.push_back(adjusted_staking_reward_amount);
+}

--- a/external-crates/move/tooling/prettier-move/tests/misc/misc.move
+++ b/external-crates/move/tooling/prettier-move/tests/misc/misc.move
@@ -3,212 +3,191 @@
 // autoGroupImports: package
 // useModuleLabel: true
 
-/*
- * @title Timelock
- *
- * @notice Locks any object with the store ability for a specific amount of time.
- *
- * @dev We do not provide a function to read the data inside the {Timelock<T>} to prevent capabilities from being used.
- */
-module suitears::timelock {
+module prettier::misc;
 
-    use std::{string::String, type_name::{Self, TypeName}};
-    use sui::{
-        clock::Clock,
-        coin::Coin,
-        dynamic_field as df,
-        sui::SUI,
-        table::{Self, Table}
+use std::{string::String, type_name::{Self, TypeName}};
+use sui::{
+    clock::Clock,
+    coin::Coin,
+    dynamic_field as df,
+    sui::SUI,
+    table::{Self, Table}
+};
+
+fun calculate_pending_rewards<StakeCoin, RewardCoin>(
+    acc: &Account<StakeCoin, RewardCoin>,
+    an_acc: &mut Account<StakeCoin, RewardCoin>,
+    stake_factor: u64,
+    accrued_rewards_per_share: u256,
+): u64 {
+    ((((acc.amount as u256) * accrued_rewards_per_share / (stake_factor as u256)) - acc.reward_debt) as u64)
+}
+
+// sui-system/validator_set.move
+fun compute_reward_adjustments(
+    mut slashed_validator_indices: vector<u64>,
+    reward_slashing_rate: u64,
+    unadjusted_staking_reward_amounts: &vector<u64>,
+    unadjusted_storage_fund_reward_amounts: &vector<u64>,
+): (
+    u64, // sum of staking reward adjustments
+    VecMap<u64, u64>, // mapping of individual validator's staking reward adjustment from index -> amount
+    u64, // sum of storage fund reward adjustments
+    VecMap<u64, u64>, // mapping of individual validator's storage fund reward adjustment from index -> amount
+) {
+    let unadjusted_storage_fund_reward_amount = unadjusted_storage_fund_reward_amounts[i];
+    let adjusted_storage_fund_reward_amount =
+        // If the validator is one of the slashed ones, then subtract the adjustment.
+        if (individual_storage_fund_reward_adjustments.contains(&i)) {
+            let adjustment = individual_storage_fund_reward_adjustments[&i];
+            unadjusted_storage_fund_reward_amount - adjustment
+        } else {
+            // Otherwise the slashed rewards should be equally distributed among the unslashed validators.
+            let adjustment = total_storage_fund_reward_adjustment / num_unslashed_validators;
+            unadjusted_storage_fund_reward_amount + adjustment
+        };
+
+    adjusted_storage_fund_reward_amounts.push_back(adjusted_storage_fund_reward_amount);
+}
+
+// === Imports ===
+
+public fun lock<T: store>(data: T, c: &Clock, unlock_time: u64, ctx: &mut TxContext): Timelock<
+    T
+> {
+    // It makes no sense to lock in the past
+    assert!(unlock_time > c.timestamp_ms(), EInvalidTime);
+}
+
+public fun propose<DaoWitness: drop>(
+    dao: &mut Dao<DaoWitness>,
+    c: &Clock,
+    authorized_witness: Option<TypeName>,
+    capability_id: Option<ID>,
+    action_delay: u64,
+    quorum_votes: u64,
+    hash: String,
+    // hash proposal title/content
+    ctx: &mut TxContext
+): Proposal<DaoWitness> {
+
+
+    assert!(action_delay >= dao.min_action_delay, EActionDelayTooShort);
+    assert!(quorum_votes >= dao.min_quorum_votes, EMinQuorumVotesTooSmall);
+    assert!(hash.length() != 0, EEmptyHash);
+
+    let start_time = c.timestamp_ms() + dao.voting_delay;
+
+
+
+    let proposal = Proposal {
+        id: object::new(ctx),
+        proposer: ctx.sender(),
+        start_time,
+        end_time: start_time + dao.voting_period,
+        for_votes: 0,
+        against_votes: 0,
+        eta: 0,
+        action_delay,
+        quorum_votes,
+        voting_quorum_rate: dao.voting_quorum_rate,
+        hash,
+        authorized_witness,
+        capability_id,
+        coin_type: dao.coin_type
     };
 
-    fun calculate_pending_rewards<StakeCoin, RewardCoin>(
-        acc: &Account<StakeCoin, RewardCoin>,
-        an_acc: &mut Account<StakeCoin, RewardCoin>,
-        stake_factor: u64,
-        accrued_rewards_per_share: u256,
-    ): u64 {
-        ((((acc.amount as u256) * accrued_rewards_per_share / (stake_factor as u256)) - acc.reward_debt) as u64)
-    }
+    emit(
+        NewProposal<DaoWitness> {
+            proposal_id: object::id(&proposal),
+            proposer: proposal.proposer
+        }
+    );
 
-    // sui-system/validator_set.move
-    fun compute_reward_adjustments(
-        mut slashed_validator_indices: vector<u64>,
-        reward_slashing_rate: u64,
-        unadjusted_staking_reward_amounts: &vector<u64>,
-        unadjusted_storage_fund_reward_amounts: &vector<u64>,
-    ): (
-        u64, // sum of staking reward adjustments
-        VecMap<u64, u64>, // mapping of individual validator's staking reward adjustment from index -> amount
-        u64, // sum of storage fund reward adjustments
-        VecMap<u64, u64>, // mapping of individual validator's storage fund reward adjustment from index -> amount
-    ) {
-        let unadjusted_storage_fund_reward_amount = unadjusted_storage_fund_reward_amounts[i];
-        let adjusted_storage_fund_reward_amount =
-            // If the validator is one of the slashed ones, then subtract the adjustment.
-            if (individual_storage_fund_reward_adjustments.contains(&i)) {
-                let adjustment = individual_storage_fund_reward_adjustments[&i];
-                unadjusted_storage_fund_reward_amount - adjustment
-            } else {
-                // Otherwise the slashed rewards should be equally distributed among the unslashed validators.
-                let adjustment = total_storage_fund_reward_adjustment / num_unslashed_validators;
-                unadjusted_storage_fund_reward_amount + adjustment
-            };
+    proposal
+}
 
-        adjusted_storage_fund_reward_amounts.push_back(adjusted_storage_fund_reward_amount);
-    }
+public fun inline_fun(): u128 { 1000 }
 
-    // === Imports ===
+public fun unlock_time<T: store>(self: &Timelock<T>): u64 {
+    self.unlock_time
+}
 
-    public fun lock<T: store>(data: T, c: &Clock, unlock_time: u64, ctx: &mut TxContext): Timelock<
-        T
-    > {
-        // It makes no sense to lock in the past
-        assert!(unlock_time > c.timestamp_ms(), EInvalidTime);
-    }
+public fun lock<T: store>(
+    data: T, c: &Clock, unlock_time: u64, ctx: &mut TxContext): Timelock<
+    T
+> {
+    // It makes no sense to lock in the past
+    assert!(unlock_time > c.timestamp_ms(), EInvalidTime);
 
-    public fun propose<DaoWitness: drop>(
-        dao: &mut Dao<DaoWitness>,
-        c: &Clock,
-        authorized_witness: Option<TypeName>,
-        capability_id: Option<ID>,
-        action_delay: u64,
-        quorum_votes: u64,
-        hash: String,
-        // hash proposal title/content
-        ctx: &mut TxContext
-    ): Proposal<DaoWitness> {
+    Timelock {id: object::new(ctx), data, unlock_time}
+}
 
+public fun unlock<T: store>(self: Timelock<T>, c: &Clock): T {
+    let Timelock { id, data, unlock_time } = self;
 
-        assert!(action_delay >= dao.min_action_delay, EActionDelayTooShort);
-        assert!(quorum_votes >= dao.min_quorum_votes, EMinQuorumVotesTooSmall);
-        assert!(hash.length() != 0, EEmptyHash);
+    assert!(c.timestamp_ms() >= unlock_time, ETooEarly);
+    id.delete();
+    data
+}
 
-        let start_time = c.timestamp_ms() + dao.voting_delay;
+/// Print the container as an `SVG` element.
+public fun to_string(container: &Container): String {
+    let (name, attributes, elements) = match (container) {
+        // Desc is a special case, it's just a list of descriptions.
+        Container::Desc(tags) => {
+            return (*tags).fold!(b"".to_string(), |mut svg, tag| {
+                svg.append(tag.to_string());
+                svg
+            })
+        },
+        // Root is a special case, we append all elements directly.
+        Container::Root(shapes) => {
+            return (*shapes).fold!(b"".to_string(), |mut svg, shape| {
+                svg.append(shape.to_string());
+                svg
+            })
+        },
+        Container::Defs(shapes) =>
+        (b"defs", vec_map::empty(), shapes.map_ref!(|shape| shape.to_string())),
+        Container::A(_href, attrs) => (b"a", *attrs, vector[]),
+        Container::G(shapes, attrs) => (b"g", *attrs, shapes.map_ref!(|shape| shape.to_string())),
+        _ => abort ENotImplemented,
+    };
 
+    print::print(name.to_string(), attributes, option::some(elements))
+}
 
+fun content() {
+    expression
+        // disappearing_comment_1
+        .div(50) // trailing_comment_1
+        // disappearing_comment_2
+        .mul(50); // trailing_comment_2
 
-        let proposal = Proposal {
-            id: object::new(ctx),
-            proposer: ctx.sender(),
-            start_time,
-            end_time: start_time + dao.voting_period,
-            for_votes: 0,
-            against_votes: 0,
-            eta: 0,
-            action_delay,
-            quorum_votes,
-            voting_quorum_rate: dao.voting_quorum_rate,
-            hash,
-            authorized_witness,
-            capability_id,
-            coin_type: dao.coin_type
-        };
+    svg.add_root(vector[{
+            let mut shape = shape::text(str.to_string(), 100, 50);
+            shape
+        }, shape::circle(10, 10, 5), {
+            let mut rect = shape::rect(10, 10, 20, 20);
+            rect
+        }, shape::ellipse(30, 30, 10, 5)]);
+}
 
-        emit(
-            NewProposal<DaoWitness> {
-                proposal_id: object::id(&proposal),
-                proposer: proposal.proposer
-            }
-        );
+public fun withdraw<T>(
+    vault: &mut Vault<T>,
+    key: key::Key,
+    ctx: &mut TxContext
+): coin::Coin<T> {
+    assert_valid_key_code(vault, &key);
+    key.delete();
 
-        proposal
-    }
-
-    public fun inline_fun(): u128 { 1000 }
-
-    // === Public View Function ===
-
-    /*
-     * @notice Returns the unlock time in milliseconds.
-     *
-     * @param self A {Timelock<T>}
-     * @return u64. The `self.unlock_time`.
-     */
-    public fun unlock_time<T: store>(self: &Timelock<T>): u64 {
-        self.unlock_time
-    }
-
-    // === Public Mutative Function ===
-
-    /*
-     * @notice Locks the `data` for `unlock_time` milliseconds.
-     *
-     * @param data An object with the store ability.
-     * @param c The shared `sui::clock::Clock` object.
-     * @patam unlock_time The lock period in milliseconds.
-     * @return {Timelock<T>}.
-     *
-     * aborts-if
-     * - `unlock_time` is in the past.
-     */
-    public fun lock<T: store>(
-        data: T, c: &Clock, unlock_time: u64, ctx: &mut TxContext): Timelock<
-        T
-    > {
-        // It makes no sense to lock in the past
-        assert!(unlock_time > c.timestamp_ms(), EInvalidTime);
-
-        Timelock {id: object::new(ctx), data, unlock_time}
-    }
-
-    /*
-     * @notice Unlocks a {Timelock<T>} and returns the locked resource `T`.
-     *
-     * @param self A {Timelock<T>}
-     * @param c The shared `sui::clock::Clock` object.
-     * @return `T`. An object with the store ability.
-     *
-     * aborts-if
-     * - `unlock_time` has not passed.
-     */
-    public fun unlock<T: store>(self: Timelock<T>, c: &Clock): T {
-        let Timelock { id, data, unlock_time } = self;
-
-        assert!(c.timestamp_ms() >= unlock_time, ETooEarly);
-        id.delete();
-        data
-    }
-
-    /// Print the container as an `SVG` element.
-    public fun to_string(container: &Container): String {
-        let (name, attributes, elements) = match (container) {
-            // Desc is a special case, it's just a list of descriptions.
-            Container::Desc(tags) => {
-                return (*tags).fold!(b"".to_string(), |mut svg, tag| {
-                    svg.append(tag.to_string());
-                    svg
-                })
-            },
-            // Root is a special case, we append all elements directly.
-            Container::Root(shapes) => {
-                return (*shapes).fold!(b"".to_string(), |mut svg, shape| {
-                    svg.append(shape.to_string());
-                    svg
-                })
-            },
-            Container::Defs(shapes) =>
-            (b"defs", vec_map::empty(), shapes.map_ref!(|shape| shape.to_string())),
-            Container::A(_href, attrs) => (b"a", *attrs, vector[]),
-            Container::G(shapes, attrs) => (b"g", *attrs, shapes.map_ref!(|shape| shape.to_string())),
-            _ => abort ENotImplemented,
-        };
-
-        print::print(name.to_string(), attributes, option::some(elements))
-    }
-
-    fun content() {
-        expression
-            // disappearing_comment_1
-            .div(50) // trailing_comment_1
-            // disappearing_comment_2
-            .mul(50); // trailing_comment_2
-
-        svg.add_root(vector[{
-                let mut shape = shape::text(str.to_string(), 100, 50);
-                shape
-            }, shape::circle(10, 10, 5), {
-                let mut rect = shape::rect(10, 10, 20, 20);
-                rect
-            }, shape::ellipse(30, 30, 10, 5)]);
-    }
+    let new_coin = coin::from_balance(
+        balance::split(
+            &mut vault.balance,
+            vault.withdrawal_amount
+        ),
+        ctx
+    );
+    new_coin
 }

--- a/external-crates/move/tooling/prettier-move/tests/misc/other.exp.move
+++ b/external-crates/move/tooling/prettier-move/tests/misc/other.exp.move
@@ -46,7 +46,7 @@ module prettier::other {
         character.add(
             AppKey {},
             BattleApp {
-                stats,
+                stats, // this comment should not be wiped
                 wins: 0,
                 losses: 0,
                 current_battle: option::none(),

--- a/external-crates/move/tooling/prettier-move/tests/misc/other.move
+++ b/external-crates/move/tooling/prettier-move/tests/misc/other.move
@@ -46,7 +46,7 @@ module prettier::other {
         character.add(
             AppKey {},
             BattleApp {
-                stats, // this comment is wiped
+                stats, // this comment should not be wiped
                 wins: 0, losses: 0, current_battle: option::none() },
         );
 


### PR DESCRIPTION
## Description 

- `dot_expression` now supports trailing comment in a list
- a single element of an `arg_list` can have **trailing** line comment
- a single element of an `arg_list` can have **leading** line comment
- trailing comment no longer breaks `vector_expression`

`if_expression`:
- indentation fixed in certain places
- `if-else` chain is a special behavior

## Test plan 

Features tests for all the cases.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
