### PR TITLE
Refactors to `BuildConfig`

### DIFF
--- a/crates/sui-json-rpc-tests/tests/balance_changes_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/balance_changes_tests.rs
@@ -20,7 +20,7 @@ async fn test_dry_run_publish_with_mocked_coin() -> Result<(), anyhow::Error> {
     move_package::package_hooks::register_package_hooks(Box::new(SuiPackageHooks));
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.extend(["tests", "data", "dummy_modules_publish"]);
-    let compiled_package = BuildConfig::default().build(&path)?;
+    let compiled_package = BuildConfig::new_for_testing().build(&path)?;
     let compiled_modules_bytes = compiled_package
         .get_package_base64(false)
         .into_iter()

--- a/crates/sui-json-rpc-tests/tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/rpc_server_tests.rs
@@ -571,7 +571,7 @@ async fn test_get_total_supply() -> Result<(), anyhow::Error> {
     // Publish test coin package
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.extend(["tests", "data", "dummy_modules_publish"]);
-    let compiled_package = BuildConfig::default().build(&path)?;
+    let compiled_package = BuildConfig::new_for_testing().build(&path)?;
     let compiled_modules_bytes =
         compiled_package.get_package_base64(/* with_unpublished_deps */ false);
     let dependencies = compiled_package.get_dependency_storage_package_ids();

--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -35,7 +35,7 @@ use move_package::{
     package_hooks::{PackageHooks, PackageIdentifier},
     resolution::{dependency_graph::DependencyGraph, resolution_graph::ResolvedGraph},
     source_package::parsed_manifest::{Dependencies, PackageName},
-    BuildConfig as MoveBuildConfig,
+    BuildConfig as MoveBuildConfig, LintFlag,
 };
 use move_package::{
     source_package::parsed_manifest::OnChainInfo, source_package::parsed_manifest::SourceManifest,
@@ -110,17 +110,26 @@ pub struct BuildConfig {
 impl BuildConfig {
     pub fn new_for_testing() -> Self {
         move_package::package_hooks::register_package_hooks(Box::new(SuiPackageHooks));
-        let mut build_config: Self = Default::default();
+
+        // Note: in the future, consider changing this to dependencies on the local system
+        // packages:
+        let implicit_dependencies = Dependencies::new();
         let install_dir = tempfile::tempdir().unwrap().into_path();
-        let lock_file = install_dir.join("Move.lock");
-        build_config.config.install_dir = Some(install_dir);
-        build_config.config.lock_file = Some(lock_file);
-        build_config
-            .config
-            .lint_flag
-            .set(move_compiler::linters::LintLevel::None);
-        build_config.config.silence_warnings = true;
-        build_config
+        let config = MoveBuildConfig {
+            default_flavor: Some(move_compiler::editions::Flavor::Sui),
+            implicit_dependencies,
+            lock_file: Some(install_dir.join("Move.lock")),
+            install_dir: Some(install_dir),
+            lint_flag: LintFlag::LEVEL_NONE,
+            silence_warnings: true,
+            ..MoveBuildConfig::default()
+        };
+        BuildConfig {
+            config,
+            run_bytecode_verifier: true,
+            print_diags_to_stderr: false,
+            chain_id: None,
+        }
     }
 
     pub fn new_for_testing_replace_addresses<I, S>(dep_original_addresses: I) -> Self
@@ -697,22 +706,6 @@ impl CompiledPackage {
             .retain(|pkg_name, _| pkgs_to_keep.contains(pkg_name));
 
         Ok(())
-    }
-}
-
-impl Default for BuildConfig {
-    fn default() -> Self {
-        let config = MoveBuildConfig {
-            default_flavor: Some(move_compiler::editions::Flavor::Sui),
-            implicit_dependencies: Dependencies::new(),
-            ..MoveBuildConfig::default()
-        };
-        BuildConfig {
-            config,
-            run_bytecode_verifier: true,
-            print_diags_to_stderr: false,
-            chain_id: None,
-        }
     }
 }
 

--- a/crates/sui-move-build/src/lib.rs
+++ b/crates/sui-move-build/src/lib.rs
@@ -263,6 +263,37 @@ pub fn build_from_resolution_graph(
 
     // collect bytecode dependencies as these are not returned as part of core
     // `CompiledPackage`
+    let bytecode_deps = collect_bytecode_deps(&resolution_graph)?;
+
+    // compile!
+    let result = if print_diags_to_stderr {
+        BuildConfig::compile_package(&resolution_graph, &mut std::io::stderr())
+    } else {
+        BuildConfig::compile_package(&resolution_graph, &mut std::io::sink())
+    };
+
+    let (package, fn_info) = result.map_err(|error| SuiError::ModuleBuildFailure {
+        // Use [Debug] formatting to capture [anyhow] error context
+        error: format!("{:?}", error),
+    })?;
+
+    if run_bytecode_verifier {
+        verify_bytecode(&package, &fn_info)?;
+    }
+
+    Ok(CompiledPackage {
+        package,
+        published_at,
+        dependency_ids,
+        bytecode_deps,
+        dependency_graph: resolution_graph.graph,
+    })
+}
+
+/// Returns the deps from `resolution_graph` that have no source code
+fn collect_bytecode_deps(
+    resolution_graph: &ResolvedGraph,
+) -> SuiResult<Vec<(Symbol, CompiledModule)>> {
     let mut bytecode_deps = vec![];
     for (name, pkg) in resolution_graph.package_table.iter() {
         if !pkg
@@ -293,46 +324,26 @@ pub fn build_from_resolution_graph(
             bytecode_deps.push((*name, module));
         }
     }
+    Ok(bytecode_deps)
+}
 
-    let result = if print_diags_to_stderr {
-        BuildConfig::compile_package(&resolution_graph, &mut std::io::stderr())
-    } else {
-        BuildConfig::compile_package(&resolution_graph, &mut std::io::sink())
-    };
-    // write build failure diagnostics to stderr, convert `error` to `String` using `Debug`
-    // format to include anyhow's error context chain.
-    let (package, fn_info) = match result {
-        Err(error) => {
-            return Err(SuiError::ModuleBuildFailure {
-                error: format!("{:?}", error),
-            })
-        }
-        Ok((package, fn_info)) => (package, fn_info),
-    };
+/// Check that the compiled modules in `package` are valid
+fn verify_bytecode(package: &MoveCompiledPackage, fn_info: &FnInfoMap) -> SuiResult<()> {
+    let compiled_modules = package.root_modules_map();
+    let verifier_config = ProtocolConfig::get_for_version(ProtocolVersion::MAX, Chain::Unknown)
+        .verifier_config(/* signing_limits */ None);
 
-    if run_bytecode_verifier {
-        let verifier_config = ProtocolConfig::get_for_version(ProtocolVersion::MAX, Chain::Unknown)
-            .verifier_config(/* signing_limits */ None);
-
-        let compiled_modules = package.root_modules_map();
-        for m in compiled_modules.iter_modules() {
-            move_bytecode_verifier::verify_module_unmetered(m).map_err(|err| {
-                SuiError::ModuleVerificationFailure {
-                    error: err.to_string(),
-                }
-            })?;
-            sui_bytecode_verifier::sui_verify_module_unmetered(m, &fn_info, &verifier_config)?;
-        }
-        // TODO(https://github.com/MystenLabs/sui/issues/69): Run Move linker
+    for m in compiled_modules.iter_modules() {
+        move_bytecode_verifier::verify_module_unmetered(m).map_err(|err| {
+            SuiError::ModuleVerificationFailure {
+                error: err.to_string(),
+            }
+        })?;
+        sui_bytecode_verifier::sui_verify_module_unmetered(m, fn_info, &verifier_config)?;
     }
+    // TODO(https://github.com/MystenLabs/sui/issues/69): Run Move linker
 
-    Ok(CompiledPackage {
-        package,
-        published_at,
-        dependency_ids,
-        bytecode_deps,
-        dependency_graph: resolution_graph.graph,
-    })
+    Ok(())
 }
 
 impl CompiledPackage {

--- a/crates/sui-proc-macros/src/lib.rs
+++ b/crates/sui-proc-macros/src/lib.rs
@@ -58,7 +58,7 @@ pub fn init_static_initializers(_args: TokenStream, item: TokenStream) -> TokenS
 
                     register_package_hooks(Box::new(SuiPackageHooks {}));
                     let mut path = PathBuf::from(env!("SIMTEST_STATIC_INIT_MOVE"));
-                    let mut build_config = BuildConfig::default();
+                    let mut build_config = BuildConfig::new_for_testing();
 
                     build_config.config.install_dir = Some(TempDir::new().unwrap().into_path());
                     let _all_module_bytes = build_config

--- a/crates/sui-rosetta/tests/custom_coins/test_coin_utils.rs
+++ b/crates/sui-rosetta/tests/custom_coins/test_coin_utils.rs
@@ -13,7 +13,7 @@ use sui_json_rpc_types::{
     SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
 };
 use sui_keys::keystore::{AccountKeystore, Keystore};
-use sui_move_build::BuildConfig as MoveBuildConfig;
+use sui_move_build::BuildConfig;
 
 use sui_sdk::SuiClient;
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
@@ -135,7 +135,7 @@ pub async fn init_package(
 ) -> Result<InitRet> {
     let path_buf = base::reroot_path(Some(path))?;
 
-    let move_build_config = MoveBuildConfig::default();
+    let move_build_config = BuildConfig::new_for_testing();
     let compiled_modules = move_build_config.build(path_buf.as_path())?;
     let modules_bytes = compiled_modules.get_package_bytes(false);
 

--- a/crates/sui-source-validation/src/tests.rs
+++ b/crates/sui-source-validation/src/tests.rs
@@ -685,7 +685,7 @@ async fn successful_verification_with_bytecode_dep() -> anyhow::Result<()> {
         let pkg_path = copy_published_package(&tempdir, "b", b_ref.0.into()).await?;
 
         move_package::package_hooks::register_package_hooks(Box::new(SuiPackageHooks));
-        BuildConfig::default().build(&pkg_path).unwrap();
+        BuildConfig::new_for_testing().build(&pkg_path).unwrap();
 
         fs::remove_dir_all(pkg_path.join("sources"))?;
     };

--- a/crates/sui-source-validation/src/tests.rs
+++ b/crates/sui-source-validation/src/tests.rs
@@ -668,6 +668,7 @@ async fn successful_versioned_dependency_verification() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+#[ignore] // TODO: DVX-786
 async fn successful_verification_with_bytecode_dep() -> anyhow::Result<()> {
     let mut cluster = TestClusterBuilder::new().build().await;
     let context = &mut cluster.wallet;

--- a/crates/sui/src/client_ptb/builder.rs
+++ b/crates/sui/src/client_ptb/builder.rs
@@ -23,7 +23,7 @@ use move_core_types::parsing::{
 use move_core_types::{
     account_address::AccountAddress, annotated_value::MoveTypeLayout, ident_str,
 };
-use move_package::BuildConfig;
+use move_package::BuildConfig as MoveBuildConfig;
 use std::{collections::BTreeMap, path::Path};
 use sui_json::{is_receiving_argument, primitive_type};
 use sui_json_rpc_types::{SuiObjectData, SuiObjectDataOptions, SuiRawData};
@@ -932,7 +932,7 @@ impl<'a> PTBBuilder<'a> {
             }
             ParsedPTBCommand::Publish(sp!(pkg_loc, package_path)) => {
                 let chain_id = self.reader.get_chain_identifier().await.ok();
-                let build_config = BuildConfig::default();
+                let build_config = MoveBuildConfig::default();
                 let package_path = Path::new(&package_path);
                 let build_config = resolve_lock_file_path(build_config.clone(), Some(package_path))
                     .map_err(|e| err!(pkg_loc, "{e}"))?;
@@ -1000,7 +1000,7 @@ impl<'a> PTBBuilder<'a> {
                     .await?;
 
                 let chain_id = self.reader.get_chain_identifier().await.ok();
-                let build_config = BuildConfig::default();
+                let build_config = MoveBuildConfig::default();
                 let package_path = Path::new(&package_path);
                 let build_config = resolve_lock_file_path(build_config.clone(), Some(package_path))
                     .map_err(|e| err!(path_loc, "{e}"))?;

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -4256,7 +4256,7 @@ async fn test_tree_shaking_package_with_bytecode_deps() -> Result<(), anyhow::Er
     }
     move_package::package_hooks::register_package_hooks(Box::new(SuiPackageHooks));
     // now build the package which will create the build folder and a new Move.lock file
-    BuildConfig::default().build(&package_path).unwrap();
+    BuildConfig::new_for_testing().build(&package_path).unwrap();
     fs::remove_dir_all(package_path.join("sources"))?;
 
     let (package_f_id, _) = test

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -4234,6 +4234,7 @@ async fn test_tree_shaking_package_with_unpublished_deps() -> Result<(), anyhow:
 }
 
 #[sim_test]
+#[ignore] // TODO: DVX-786
 async fn test_tree_shaking_package_with_bytecode_deps() -> Result<(), anyhow::Error> {
     let mut test = TreeShakingTest::new().await?;
     let with_unpublished_dependencies = false;


### PR DESCRIPTION
## Description 

This removes `sui_move_build::BuildConfig::default` and makes other small changes

## PR stack

#21204 Add implicit Sui dependencies
#21384 Refactors to BuildConfig
#21383 Add support for implicits to move package management

This also depends on @stefan-mysten 's ongoing tree-shaking work in #21356 

## Test plan 

Since no behavior should change, existing tests are sufficient

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
