### PR TITLE
Base committer equivocating test case

### DIFF
--- a/consensus/core/src/tests/base_committer_declarative_tests.rs
+++ b/consensus/core/src/tests/base_committer_declarative_tests.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use crate::{
     base_committer::base_committer_builder::BaseCommitterBuilder, block::BlockAPI,
     commit::LeaderStatus, context::Context, dag_state::DagState, storage::mem_store::MemStore,
-    test_dag_parser::parse_dag,
+    test_dag_parser::parse_dag, TestBlock, VerifiedBlock,
 };
 
 #[tokio::test]
@@ -363,5 +363,104 @@ async fn indirect_skip() {
         assert_eq!(skipped_slot, leader_wave_2)
     } else {
         panic!("Expected a skipped leader")
+    };
+}
+
+/// Here we setup a situation where theres is an undecided leader (D)
+/// but later we encounter B which votes for D to make it committed directly
+#[tokio::test]
+async fn test_equivocating_direct_commit() {
+    telemetry_subscribers::init_for_testing();
+    let context = Arc::new(Context::new_for_test(4).0);
+    let dag_state = Arc::new(RwLock::new(DagState::new(
+        context.clone(),
+        Arc::new(MemStore::new()),
+    )));
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    let dag_str = "DAG {
+        Round 0 : { 4 },
+        Round 1 : { * },
+        Round 2 : { * },
+        Round 3 : { * }
+        Round 4 : { 
+            A -> [],
+            B -> [],
+            C -> [*],
+            D -> [*],
+        },
+        Round 5 : { * },
+    }";
+
+    let (_, dag_builder) = parse_dag(dag_str).expect("a DAG should be valid");
+    dag_builder.persist_all_blocks(dag_state.clone());
+
+    let leader_round_wave_1 = committer.leader_round(1);
+    tracing::info!("Leader round wave 1: {leader_round_wave_1}");
+    let leader_wave_1 = committer
+        .elect_leader(leader_round_wave_1)
+        .expect("there should be a leader for wave 2");
+    let leader_index_wave_1 = leader_wave_1.authority;
+    tracing::info!("Leader index wave 1: {leader_index_wave_1}");
+
+    let leader_status_wave_1 = committer.try_direct_decide(leader_wave_1);
+    if let LeaderStatus::Undecided(undecided) = leader_status_wave_1.clone() {
+        tracing::info!("Direct undecided leader at wave 1: {undecided}");
+    } else {
+        panic!(
+            "Expected LeaderStatus::Undecided for a leader in wave 1, applying a direct decicion rule, got {leader_status_wave_1}"
+        );
+    };
+
+    // Authority B is equivoking
+    let block_refs_round_3: Vec<_> = dag_builder
+        .blocks(3u32..=3)
+        .iter()
+        .map(|b| b.reference())
+        .collect();
+
+    // Authority B index is 1
+    let b4_votes_all = VerifiedBlock::new_for_test(
+        TestBlock::new(4, 1)
+            .set_ancestors(block_refs_round_3)
+            .set_timestamp_ms(4 * 1000 + 1 as u64)
+            .build(),
+    );
+
+    let round_4_refs: Vec<_> = dag_builder
+        .blocks(4u32..=4)
+        .iter()
+        .map(|b| {
+            if b.author().value() == 1 {
+                b4_votes_all.reference()
+            } else {
+                b.reference()
+            }
+        })
+        .collect();
+
+    dag_state.write().accept_block(b4_votes_all);
+
+    for block in dag_builder.blocks(5u32..=5).iter() {
+        let autor_index = block.author().value();
+        // skip own_index
+        if autor_index == 0 {
+            continue;
+        }
+        let block = VerifiedBlock::new_for_test(
+            TestBlock::new(5, autor_index as u32)
+                .set_ancestors(round_4_refs.clone())
+                .set_timestamp_ms(5 * 1000 + autor_index as u64)
+                .build(),
+        );
+        dag_state.write().accept_block(block);
+    }
+
+    if let LeaderStatus::Commit(committed) = leader_status_wave_1.clone() {
+        tracing::info!("Direct committed leader at wave 1: {committed}");
+    } else {
+        panic!(
+            "Expected LeaderStatus::Commit for a leader in wave 1, applying a direct decicion rule, got {leader_status_wave_1}"
+        );
     };
 }

--- a/consensus/core/src/tests/base_committer_declarative_tests.rs
+++ b/consensus/core/src/tests/base_committer_declarative_tests.rs
@@ -367,7 +367,7 @@ async fn indirect_skip() {
 }
 
 /// Here we setup a situation where theres is an undecided leader (D)
-/// but later we encounter B which votes for D to make it committed directly
+/// but later we encounter B' which votes for D to make it committed directly
 #[tokio::test]
 async fn test_equivocating_direct_commit() {
     telemetry_subscribers::init_for_testing();
@@ -462,6 +462,99 @@ async fn test_equivocating_direct_commit() {
     } else {
         panic!(
             "Expected LeaderStatus::Commit for a leader in wave 1, applying a direct decicion rule, got {leader_status_wave_1}"
+        );
+    };
+}
+
+/// Here we setup a situation where theres is an undecided leader (D)
+/// but later we encounter C' which doesn't vote for D to make it skipped directly
+#[tokio::test]
+async fn test_equivocating_direct_skip() {
+    telemetry_subscribers::init_for_testing();
+    let context = Arc::new(Context::new_for_test(4).0);
+    let dag_state = Arc::new(RwLock::new(DagState::new(
+        context.clone(),
+        Arc::new(MemStore::new()),
+    )));
+    let committer = BaseCommitterBuilder::new(context.clone(), dag_state.clone()).build();
+
+    let dag_str = "DAG {
+        Round 0 : { 4 },
+        Round 1 : { * },
+        Round 2 : { * },
+        Round 3 : { * }
+        Round 4 : { 
+            A -> [],
+            B -> [],
+            C -> [*],
+            D -> [*],
+        },
+        Round 5 : { * },
+    }";
+
+    let (_, dag_builder) = parse_dag(dag_str).expect("a DAG should be valid");
+    dag_builder.persist_all_blocks(dag_state.clone());
+
+    let leader_round_wave_1 = committer.leader_round(1);
+    tracing::info!("Leader round wave 1: {leader_round_wave_1}");
+    let leader_wave_1 = committer
+        .elect_leader(leader_round_wave_1)
+        .expect("there should be a leader for wave 1");
+    let leader_index_wave_1 = leader_wave_1.authority;
+    tracing::info!("Leader index wave 1: {leader_index_wave_1}");
+
+    let leader_status_wave_1 = committer.try_direct_decide(leader_wave_1);
+    if let LeaderStatus::Undecided(undecided) = leader_status_wave_1.clone() {
+        tracing::info!("Direct undecided leader at wave 1: {undecided}");
+    } else {
+        panic!(
+            "Expected LeaderStatus::Undecided for a leader in wave 1, applying a direct decicion rule, got {leader_status_wave_1}"
+        );
+    };
+
+    // Authority C index is 2
+    let c4_votes_none = VerifiedBlock::new_for_test(
+        TestBlock::new(4, 2)
+            .set_ancestors(vec![])
+            .set_timestamp_ms(4 * 1000 + 2 as u64)
+            .build(),
+    );
+
+    let round_4_refs: Vec<_> = dag_builder
+        .blocks(4u32..=4)
+        .iter()
+        .map(|b| {
+            if b.author().value() == 1 {
+                c4_votes_none.reference()
+            } else {
+                b.reference()
+            }
+        })
+        .collect();
+
+    dag_state.write().accept_block(c4_votes_none);
+
+    for block in dag_builder.blocks(5u32..=5).iter() {
+        let author_index = block.author().value();
+        // skip own_index
+        if author_index == 0 {
+            continue;
+        }
+        let block = VerifiedBlock::new_for_test(
+            TestBlock::new(5, author_index as u32)
+                .set_ancestors(round_4_refs.clone())
+                .set_timestamp_ms(5 * 1000 + author_index as u64)
+                .build(),
+        );
+        dag_state.write().accept_block(block);
+    }
+
+    let leader_status_wave_1 = committer.try_direct_decide(leader_wave_1);
+    if let LeaderStatus::Skip(skipped) = leader_status_wave_1.clone() {
+        tracing::info!("Direct skipped leader at wave 1: {skipped}");
+    } else {
+        panic!(
+            "Expected LeaderStatus::Skip for a leader in wave 1, applying a direct decicion rule, got {leader_status_wave_1}"
         );
     };
 }

--- a/consensus/core/src/tests/base_committer_declarative_tests.rs
+++ b/consensus/core/src/tests/base_committer_declarative_tests.rs
@@ -399,7 +399,7 @@ async fn test_equivocating_direct_commit() {
     tracing::info!("Leader round wave 1: {leader_round_wave_1}");
     let leader_wave_1 = committer
         .elect_leader(leader_round_wave_1)
-        .expect("there should be a leader for wave 2");
+        .expect("there should be a leader for wave 1");
     let leader_index_wave_1 = leader_wave_1.authority;
     tracing::info!("Leader index wave 1: {leader_index_wave_1}");
 
@@ -412,7 +412,7 @@ async fn test_equivocating_direct_commit() {
         );
     };
 
-    // Authority B is equivoking
+    // Authority B is equivocating
     let block_refs_round_3: Vec<_> = dag_builder
         .blocks(3u32..=3)
         .iter()
@@ -442,20 +442,21 @@ async fn test_equivocating_direct_commit() {
     dag_state.write().accept_block(b4_votes_all);
 
     for block in dag_builder.blocks(5u32..=5).iter() {
-        let autor_index = block.author().value();
+        let author_index = block.author().value();
         // skip own_index
-        if autor_index == 0 {
+        if author_index == 0 {
             continue;
         }
         let block = VerifiedBlock::new_for_test(
-            TestBlock::new(5, autor_index as u32)
+            TestBlock::new(5, author_index as u32)
                 .set_ancestors(round_4_refs.clone())
-                .set_timestamp_ms(5 * 1000 + autor_index as u64)
+                .set_timestamp_ms(5 * 1000 + author_index as u64)
                 .build(),
         );
         dag_state.write().accept_block(block);
     }
 
+    let leader_status_wave_1 = committer.try_direct_decide(leader_wave_1);
     if let LeaderStatus::Commit(committed) = leader_status_wave_1.clone() {
         tracing::info!("Direct committed leader at wave 1: {committed}");
     } else {

--- a/consensus/core/src/tests/base_committer_declarative_tests.rs
+++ b/consensus/core/src/tests/base_committer_declarative_tests.rs
@@ -423,7 +423,7 @@ async fn test_equivocating_direct_commit() {
     let b4_votes_all = VerifiedBlock::new_for_test(
         TestBlock::new(4, 1)
             .set_ancestors(block_refs_round_3)
-            .set_timestamp_ms(4 * 1000 + 1 as u64)
+            .set_timestamp_ms(4 * 1000 + 1_u64)
             .build(),
     );
 
@@ -516,7 +516,7 @@ async fn test_equivocating_direct_skip() {
     let c4_votes_none = VerifiedBlock::new_for_test(
         TestBlock::new(4, 2)
             .set_ancestors(vec![])
-            .set_timestamp_ms(4 * 1000 + 2 as u64)
+            .set_timestamp_ms(4 * 1000 + 2_u64)
             .build(),
     );
 


### PR DESCRIPTION
## Description 
Here we setup a situation where theres is an undecided leader (D), but later we encounter B which votes for D to make it committed directly.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
