### PR TITLE
Fix typos and improve clarity 

### DIFF
--- a/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/src/acquires_list_verifier.rs
+++ b/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/src/acquires_list_verifier.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! This module implements a checker for verifying properties about the acquires list on function
+//! This module implements a checker to verify properties about the acquires list on function
 //! definitions. Function definitions must annotate the global resources (declared in that module)
 //! accesssed by `BorrowGlobal`, `MoveFrom`, and any transitive function calls
 //! The list of acquired resources (stored in `FunctionDefinition`'s `acquires_global_resources`

--- a/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/src/check_duplication.rs
+++ b/external-crates/move/move-execution/v0/crates/move-bytecode-verifier/src/check_duplication.rs
@@ -46,7 +46,7 @@ impl<'a> DuplicationChecker<'a> {
         let checker = Self { module };
         checker.check_field_handles()?;
         checker.check_field_instantiations()?;
-        checker.check_function_defintions()?;
+        checker.check_function_definitions()?;
         checker.check_struct_definitions()?;
         checker.check_struct_instantiations()
     }
@@ -243,7 +243,7 @@ impl<'a> DuplicationChecker<'a> {
         Ok(())
     }
 
-    fn check_function_defintions(&self) -> PartialVMResult<()> {
+    fn check_function_definitions(&self) -> PartialVMResult<()> {
         // FunctionDefinition - contained FunctionHandle defines uniqueness
         if let Some(idx) =
             Self::first_duplicate_element(self.module.function_defs().iter().map(|x| x.function))


### PR DESCRIPTION
In acquires_list_verifier.rs:

Changed "verifying" to "verify" for better readability.


In check_duplication.rs:

Fixed typo: "defintions" to "definitions."