### PR TITLE
[Consensus] do not enable GC for testnet with version 76

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -3305,10 +3305,6 @@ impl ProtocolConfig {
                     cfg.feature_flags.minimize_child_object_mutations = true;
 
                     if chain != Chain::Mainnet {
-                        cfg.consensus_gc_depth = Some(60);
-                        cfg.feature_flags.consensus_linearize_subdag_v2 = true;
-                    }
-                    if chain != Chain::Mainnet {
                         cfg.feature_flags.accept_passkey_in_multisig = true;
                     }
                 }

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -220,8 +220,6 @@ const MAX_PROTOCOL_VERSION: u64 = 76;
 // Version 75: Enable passkey auth in testnet.
 // Version 76: Deprecate Deepbook V2 order placement and deposit.
 //             Removes unnecessary child object mutations
-//             Enable consensus garbage collection for testnet
-//             Enable the new consensus commit rule for testnet.
 //             Enable passkey auth in multisig for testnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_76.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_76.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
-snapshot_kind: text
 ---
 version: 76
 feature_flags:
@@ -72,7 +71,6 @@ feature_flags:
   consensus_smart_ancestor_selection: true
   consensus_round_prober_probe_accepted_rounds: true
   native_charging_v2: true
-  consensus_linearize_subdag_v2: true
   convert_type_argument_error: true
   variant_nodes: true
   consensus_zstd_compression: true
@@ -353,7 +351,6 @@ max_soft_bundle_size: 5
 bridge_should_try_to_finalize_committee: true
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 37000000
 max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 7400000
-consensus_gc_depth: 60
 gas_budget_based_txn_cost_cap_factor: 400000
 gas_budget_based_txn_cost_absolute_cap_commit_count: 50
 sip_45_consensus_amplification_threshold: 5


### PR DESCRIPTION
## Description 

Will enable on the second testnet 1.44 release behind a new protocol version (77).

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
