### PR TITLE
[Cherry Pick] Delay delete of deferred transactions until end of commit handler (#21376)

### DIFF
--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -103,6 +103,10 @@ impl ConsensusCommitOutput {
         }
     }
 
+    pub fn get_deleted_deferred_txn_keys(&self) -> impl Iterator<Item = DeferralKey> + use<'_> {
+        self.deleted_deferred_txns.iter().cloned()
+    }
+
     fn get_randomness_last_round_timestamp(&self) -> Option<TimestampMs> {
         self.next_randomness_round.as_ref().map(|(_, ts)| *ts)
     }


### PR DESCRIPTION
This fixes a bug in how we handle the end of epoch pre- and post- data
quarantining.

In the old code, we check if there were any deferred txns loaded in the
current commit with this code:
https://github.com/MystenLabs/sui/blob/2f52a7283e5f805b728ce1570cb66d27f0a95648/crates/sui-core/src/authority/authority_per_epoch_store.rs#L2150

Because this looks at the table, it does not reflect that the fact that
we may have already scheduled deletes from the table.

In the new code, we look at the in-memory map
https://github.com/MystenLabs/sui/blob/67fea6a41b90e6b49d9829766a29b4f74cfa4900/crates/sui-core/src/authority/authority_per_epoch_store.rs#L2038
- keys are removed from this map immediately upon loading them at
https://github.com/MystenLabs/sui/blob/67fea6a41b90e6b49d9829766a29b4f74cfa4900/crates/sui-core/src/authority/authority_per_epoch_store.rs#L1884

This in turn can cause us to improperly skip drop randomness
transactions at the end of the epoch here:
https://github.com/MystenLabs/sui/blob/67fea6a41b90e6b49d9829766a29b4f74cfa4900/crates/sui-core/src/authority/authority_per_epoch_store.rs#L3594

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
