### PR TITLE
[bridge] add lbtc vault monitoring

### DIFF
--- a/crates/sui-bridge-indexer/src/main.rs
+++ b/crates/sui-bridge-indexer/src/main.rs
@@ -154,6 +154,7 @@ async fn start_watchdog(
         weth_address,
         usdt_address,
         wbtc_address,
+        lbtc_address,
     ) = get_eth_contract_addresses(eth_bridge_proxy_address, &eth_provider).await?;
 
     let eth_vault_balance = EthereumVaultBalance::new(
@@ -186,6 +187,16 @@ async fn start_watchdog(
     .await
     .unwrap_or_else(|e| panic!("Failed to create wbtc vault balance: {}", e));
 
+    let lbtc_vault_balance = EthereumVaultBalance::new(
+        eth_provider.clone(),
+        vault_address,
+        lbtc_address,
+        VaultAsset::LBTC,
+        watchdog_metrics.lbtc_vault_balance.clone(),
+    )
+    .await
+    .unwrap_or_else(|e| panic!("Failed to create lbtc vault balance: {}", e));
+
     let eth_bridge_status = EthBridgeStatus::new(
         eth_provider,
         eth_bridge_proxy_address,
@@ -198,6 +209,7 @@ async fn start_watchdog(
         Box::new(eth_vault_balance),
         Box::new(usdt_vault_balance),
         Box::new(wbtc_vault_balance),
+        Box::new(lbtc_vault_balance),
         Box::new(eth_bridge_status),
         Box::new(sui_bridge_status),
     ];

--- a/crates/sui-bridge-watchdog/eth_vault_balance.rs
+++ b/crates/sui-bridge-watchdog/eth_vault_balance.rs
@@ -17,6 +17,7 @@ pub enum VaultAsset {
     WETH,
     USDT,
     WBTC,
+    LBTC,
 }
 
 pub struct EthereumVaultBalance {

--- a/crates/sui-bridge/src/config.rs
+++ b/crates/sui-bridge/src/config.rs
@@ -272,6 +272,7 @@ impl BridgeNodeConfig {
             _weth_address,
             _usdt_address,
             _wbtc_address,
+            _lbtc_address,
         ) = get_eth_contract_addresses(bridge_proxy_address, &provider).await?;
         let config = EthBridgeConfig::new(config_address, provider.clone());
 

--- a/crates/sui-bridge/src/node.rs
+++ b/crates/sui-bridge/src/node.rs
@@ -165,7 +165,8 @@ async fn start_watchdog(
         _config_address,
         weth_address,
         usdt_address,
-        _wbtc_address,
+        wbtc_address,
+        lbtc_address,
     ) = get_eth_contract_addresses(eth_bridge_proxy_address, &eth_provider)
         .await
         .unwrap_or_else(|e| panic!("get_eth_contract_addresses should not fail: {}", e));
@@ -193,12 +194,22 @@ async fn start_watchdog(
     let wbtc_vault_balance = EthereumVaultBalance::new(
         eth_provider.clone(),
         vault_address,
-        _wbtc_address,
+        wbtc_address,
         VaultAsset::WBTC,
         watchdog_metrics.wbtc_vault_balance.clone(),
     )
     .await
     .unwrap_or_else(|e| panic!("Failed to create wbtc vault balance: {}", e));
+
+    let lbtc_vault_balance = EthereumVaultBalance::new(
+        eth_provider.clone(),
+        vault_address,
+        lbtc_address,
+        VaultAsset::LBTC,
+        watchdog_metrics.lbtc_vault_balance.clone(),
+    )
+    .await
+    .unwrap_or_else(|e| panic!("Failed to create lbtc vault balance: {}", e));
 
     let eth_bridge_status = EthBridgeStatus::new(
         eth_provider,
@@ -215,6 +226,7 @@ async fn start_watchdog(
         Box::new(eth_vault_balance),
         Box::new(usdt_vault_balance),
         Box::new(wbtc_vault_balance),
+        Box::new(lbtc_vault_balance),
         Box::new(eth_bridge_status),
         Box::new(sui_bridge_status),
     ];

--- a/crates/sui-bridge/src/sui_bridge_watchdog/eth_vault_balance.rs
+++ b/crates/sui-bridge/src/sui_bridge_watchdog/eth_vault_balance.rs
@@ -17,6 +17,7 @@ pub enum VaultAsset {
     WETH,
     USDT,
     WBTC,
+    LBTC,
 }
 
 pub struct EthereumVaultBalance {

--- a/crates/sui-bridge/src/sui_bridge_watchdog/metrics.rs
+++ b/crates/sui-bridge/src/sui_bridge_watchdog/metrics.rs
@@ -11,6 +11,7 @@ pub struct WatchdogMetrics {
     pub eth_vault_balance: IntGauge,
     pub usdt_vault_balance: IntGauge,
     pub wbtc_vault_balance: IntGauge,
+    pub lbtc_vault_balance: IntGauge,
     pub total_supplies: IntGaugeVec,
     pub eth_bridge_paused: IntGauge,
     pub sui_bridge_paused: IntGauge,
@@ -34,6 +35,12 @@ impl WatchdogMetrics {
             wbtc_vault_balance: register_int_gauge_with_registry!(
                 "bridge_wbtc_vault_balance",
                 "Current balance of wbtc eth vault",
+                registry,
+            )
+            .unwrap(),
+            lbtc_vault_balance: register_int_gauge_with_registry!(
+                "bridge_lbtc_vault_balance",
+                "Current balance of lbtc eth vault",
                 registry,
             )
             .unwrap(),

--- a/crates/sui-bridge/src/utils.rs
+++ b/crates/sui-bridge/src/utils.rs
@@ -115,6 +115,7 @@ pub async fn get_eth_contract_addresses<P: ethers::providers::JsonRpcClient + 's
     EthAddress,
     EthAddress,
     EthAddress,
+    EthAddress,
 )> {
     let sui_bridge = EthSuiBridge::new(bridge_proxy_address, provider.clone());
     let committee_address: EthAddress = sui_bridge.committee().call().await?;
@@ -127,6 +128,7 @@ pub async fn get_eth_contract_addresses<P: ethers::providers::JsonRpcClient + 's
     let weth_address: EthAddress = vault.w_eth().call().await?;
     let usdt_address: EthAddress = bridge_config.token_address_of(4).call().await?;
     let wbtc_address: EthAddress = bridge_config.token_address_of(1).call().await?;
+    let lbtc_address: EthAddress = bridge_config.token_address_of(6).call().await?;
 
     Ok((
         committee_address,
@@ -136,6 +138,7 @@ pub async fn get_eth_contract_addresses<P: ethers::providers::JsonRpcClient + 's
         weth_address,
         usdt_address,
         wbtc_address,
+        lbtc_address,
     ))
 }
 


### PR DESCRIPTION
## Description 

A PR to enable LBTC monitoring. @williampsmith we'll want to add this to one of our nodes for the LBTC launch. Because LBTC (token ID 6) is not added to testnet, we'll need to either enable LBTC to testnet (no code change required) before landing this PR OR come up with an alternative (maybe only push metrics for a token ID if its actually enabled? right now address of token ID 6 on testnet will return 0x0 so may break node. anyways not going to land this until we decide (after offsite) 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
