### PR TITLE
Allow Apache 2.0 with LLVM Exceptions

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -68,7 +68,7 @@ allow = [
     "Unicode-DFS-2016",
     "Unicode-3.0",
     "Zlib",
-    #"Apache-2.0 WITH LLVM-exception",
+    "Apache-2.0 WITH LLVM-exception",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the


### PR DESCRIPTION
## Description 

This PR adds Apache 2.0 with LLVM exceptions to the allow list. This enables PR #21329 to be merged!

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
