### PR TITLE
[rpc-alt] make flaky write test sim tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13838,8 +13838,11 @@ dependencies = [
  "sui-indexer-alt",
  "sui-indexer-alt-framework",
  "sui-indexer-alt-jsonrpc",
+ "sui-macros",
  "sui-move-build",
  "sui-pg-db",
+ "sui-protocol-config",
+ "sui-simulator",
  "sui-swarm-config",
  "sui-transactional-test-runner",
  "sui-types",
@@ -13848,6 +13851,7 @@ dependencies = [
  "test-cluster",
  "tokio",
  "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing",
  "url",
 ]
 

--- a/crates/sui-indexer-alt-e2e-tests/Cargo.toml
+++ b/crates/sui-indexer-alt-e2e-tests/Cargo.toml
@@ -32,6 +32,9 @@ sui-types.workspace = true
 
 [target.'cfg(msim)'.dependencies]
 msim.workspace = true
+sui-protocol-config.workspace = true
+sui-simulator.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 async-trait.workspace = true
@@ -43,7 +46,9 @@ telemetry-subscribers.workspace = true
 
 move-core-types.workspace = true
 
+sui-macros.workspace = true
 sui-move-build.workspace = true
 sui-swarm-config.workspace = true
 sui-transactional-test-runner.workspace = true
 test-cluster.workspace = true
+tracing.workspace = true

--- a/crates/sui-indexer-alt-jsonrpc/Cargo.toml
+++ b/crates/sui-indexer-alt-jsonrpc/Cargo.toml
@@ -10,6 +10,9 @@ edition = "2021"
 name = "sui-indexer-alt-jsonrpc"
 path = "src/main.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 async-graphql = { workspace = true, features = ["dataloader"] }

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -182,7 +182,9 @@ impl RpcService {
 
         // Set-up another helper task that will listen for Ctrl-C and trigger the cancellation
         // token.
+        #[cfg(not(msim))]
         let ctrl_c_cancel = cancel.clone();
+        #[cfg(not(msim))]
         let h_ctrl_c = tokio::spawn(async move {
             tokio::select! {
                 _ = ctrl_c_cancel.cancelled() => {}
@@ -195,7 +197,10 @@ impl RpcService {
         Ok(tokio::spawn(async move {
             handle.stopped().await;
             cancel.cancel();
+            #[cfg(not(msim))]
             let _ = join!(h_cancel, h_ctrl_c);
+            #[cfg(msim)]
+            let _ = h_cancel;
         }))
     }
 }


### PR DESCRIPTION
## Description 

Write tests are flaky when run as normal tests in CI, and I couldn't repro locally. Based on ci logging, the issue was with sui test cluster that introduced the flakiness. This PR makes them sim tests so they can at least fail deterministically.

## Test plan 

edited tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
