### PR TITLE
[Consensus] Enable Garbage Collection & New commit rule for testnet on version 77

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -222,6 +222,8 @@ const MAX_PROTOCOL_VERSION: u64 = 77;
 //             Removes unnecessary child object mutations
 //             Enable passkey auth in multisig for testnet.
 // Version 77: Enable uncompressed point group ops on mainnet.
+//             Enable consensus garbage collection for testnet
+//             Enable the new consensus commit rule for testnet.
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -3309,6 +3311,11 @@ impl ProtocolConfig {
                 }
                 77 => {
                     cfg.feature_flags.uncompressed_g1_group_elements = true;
+
+                    if chain != Chain::Mainnet {
+                        cfg.consensus_gc_depth = Some(60);
+                        cfg.feature_flags.consensus_linearize_subdag_v2 = true;
+                    }
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_77.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_77.snap
@@ -72,6 +72,7 @@ feature_flags:
   consensus_smart_ancestor_selection: true
   consensus_round_prober_probe_accepted_rounds: true
   native_charging_v2: true
+  consensus_linearize_subdag_v2: true
   convert_type_argument_error: true
   variant_nodes: true
   consensus_zstd_compression: true
@@ -352,6 +353,7 @@ max_soft_bundle_size: 5
 bridge_should_try_to_finalize_committee: true
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 37000000
 max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 7400000
+consensus_gc_depth: 60
 gas_budget_based_txn_cost_cap_factor: 400000
 gas_budget_based_txn_cost_absolute_cap_commit_count: 50
 sip_45_consensus_amplification_threshold: 5


### PR DESCRIPTION
## Description 

Enabling the consensus garbage collection & the new lineariser commit logic for testnet on protocol version 77.

## Test plan 

CI/PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [x] Protocol: Enable consensus garbage collection and new commit rule for testnet.
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
