### PR TITLE
fix: fix incorrect handling of the `--no-build` flag in argparse

### DIFF
--- a/scripts/simtest/seed-search.py
+++ b/scripts/simtest/seed-search.py
@@ -20,7 +20,7 @@ parser.add_argument(
     default=int(subprocess.check_output(["date", "+%s"]).decode("utf-8").strip()) * 1000
 )
 parser.add_argument('--concurrency', type=int, help='Number of concurrent tests to run', default=os.cpu_count())
-parser.add_argument('--no-build', type=bool, help='Skip building the test binary', default=False)
+parser.add_argument('--no-build', action='store_true', help='Skip building the test binary')
 args = parser.parse_args()
 
 def run_command(command, env_vars):


### PR DESCRIPTION
## Description
I’ve updated the `--no-build` argument handling in argparse to use `action='store_true'` instead of `type=bool`. The previous approach caused unexpected behavior when parsing `'True'` or `'False'` as booleans, leading to incorrect results.

Now, the flag works as expected—if `--no-build` is provided, it sets the value to `True`; if not, it remains `False`. This ensures proper behavior when handling this argument.

---

## Test plan
1. Run the script without the `--no-build` flag and verify that the value is `False`.
2. Run the script with the `--no-build` flag and ensure that the value is `True`.
3. Check edge cases for other boolean arguments and ensure the behavior is consistent.

---

## Release notes
- Fixed incorrect handling of the `--no-build` flag in argparse by switching to `action='store_true'`, ensuring proper boolean behavior.
- Updated the CLI to correctly interpret the flag as a boolean.

- [ ] Protocol: No changes
- [ ] Nodes (Validators and Full nodes): No changes
- [ ] gRPC: No changes
- [ ] JSON-RPC: No changes
- [ ] GraphQL: No changes
- [ ] CLI: Fixed argument parsing for `--no-build` flag.
- [ ] Rust SDK: No changes
