### PR TITLE
chore: Remove extra comma in `write!` macro for style consistency

### DIFF
--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -423,7 +423,7 @@ impl From<BlockRef> for Slot {
 // TODO: re-evaluate formats for production debugging.
 impl fmt::Display for Slot {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}{}", self.authority, self.round,)
+        write!(f, "{}{}", self.authority, self.round)
     }
 }
 


### PR DESCRIPTION
## Description 

I’ve removed the extra comma after `self.round` in the `write!` macro call. While this doesn't affect the program's functionality (since Rust allows trailing commas), it's better to follow the standard style and avoid unnecessary punctuation. The change improves readability and aligns with best practices.