### PR TITLE
chore: fix incorrect import path for TapFallible in crate tap

### DIFF
--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -5,7 +5,7 @@ use std::{collections::BTreeMap, sync::Arc};
 use mysten_common::debug_fatal;
 use mysten_metrics::monitored_mpsc::{channel, Receiver, Sender};
 use parking_lot::Mutex;
-use tap::tap::TapFallible;
+use tap::TapFallible;
 use thiserror::Error;
 use tokio::sync::oneshot;
 use tracing::{error, warn};


### PR DESCRIPTION
## **Description**  

I noticed that the import path for `TapFallible` was incorrect. In crate **tap** (version 1.0 and above), the correct path is `tap::TapFallible`, not `tap::tap::TapFallible`. This is confirmed by both the official documentation and the source code.  

This change ensures that the import is valid and aligns with the expected usage.  

## **Test plan**  

- Verified the correct import path in the crate **tap** documentation and source code.  
- Ensured that the code compiles successfully with the corrected import.  

---  

## **Release notes**  

- [ ] Protocol:  
- [ ] Nodes (Validators and Full nodes):  
- [ ] gRPC:  
- [ ] JSON-RPC:  
- [ ] GraphQL:  
- [ ] CLI:  
- [ ] Rust SDK: Fixed incorrect import path for `TapFallible`.