### PR TITLE
deleted duplicate tuples.md

### DIFF
--- a/external-crates/move/documentation/book/src/primitive-types/tuples.md
+++ b/external-crates/move/documentation/book/src/primitive-types/tuples.md
@@ -8,7 +8,6 @@ limited:
 
 - They can only appear in expressions (usually in the return position for a function).
 - They cannot be bound to local variables.
-- They cannot be bound to local variables.
 - They cannot be stored in structs.
 - Tuple types cannot be used to instantiate generics.
 


### PR DESCRIPTION
## Description 
external-crates/move/documentation/book/src/primitive-types/tuples.md
- They cannot be bound to local variables.
