### PR TITLE
[rpc-alt] fix fullnode rpc url arg

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -14,7 +14,8 @@ use simulacrum::Simulacrum;
 use sui_indexer_alt::{config::IndexerConfig, setup_indexer};
 use sui_indexer_alt_framework::{ingestion::ClientArgs, schema::watermarks, IndexerArgs};
 use sui_indexer_alt_jsonrpc::{
-    config::RpcConfig, data::system_package_task::SystemPackageTaskArgs, start_rpc, RpcArgs,
+    api::write::WriteArgs, config::RpcConfig, data::system_package_task::SystemPackageTaskArgs,
+    start_rpc, RpcArgs,
 };
 use sui_pg_db::{
     temp::{get_available_port, TempDb},
@@ -286,7 +287,7 @@ impl OffchainCluster {
             database_url.clone(),
             DbArgs::default(),
             rpc_args,
-            None,
+            WriteArgs::default(),
             system_package_task_args,
             rpc_config,
             registry,

--- a/crates/sui-indexer-alt-e2e-tests/tests/write_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/write_tests.rs
@@ -71,7 +71,9 @@ impl WriteTestCluster {
             db.database().url().clone(),
             DbArgs::default(),
             rpc_args,
-            Some(WriteArgs { fullnode_rpc_url }),
+            WriteArgs {
+                fullnode_rpc_url: Some(fullnode_rpc_url),
+            },
             SystemPackageTaskArgs::default(),
             RpcConfig::default(),
             &registry,

--- a/crates/sui-indexer-alt-jsonrpc/src/api/write.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/write.rs
@@ -52,10 +52,11 @@ pub trait WriteApi {
     ) -> RpcResult<DryRunTransactionBlockResponse>;
 }
 
-#[derive(clap::Args, Debug, Clone)]
+#[derive(clap::Args, Debug, Clone, Default)]
 pub struct WriteArgs {
     /// The URL of the fullnode RPC we connect to for executing transactions.
-    pub fullnode_rpc_url: url::Url,
+    #[arg(long)]
+    pub fullnode_rpc_url: Option<url::Url>,
 }
 
 pub(crate) struct Write(pub HttpClient);
@@ -67,7 +68,7 @@ pub enum Error {
 }
 
 impl Write {
-    pub fn new(args: WriteArgs, config: WriteConfig) -> anyhow::Result<Self> {
+    pub fn new(fullnode_rpc_url: url::Url, config: WriteConfig) -> anyhow::Result<Self> {
         let mut headers = HeaderMap::new();
         headers.insert(
             CLIENT_SDK_TYPE_HEADER,
@@ -78,7 +79,7 @@ impl Write {
             HttpClientBuilder::default()
                 .max_request_size(config.max_request_size)
                 .set_headers(headers.clone())
-                .build(&args.fullnode_rpc_url)
+                .build(&fullnode_rpc_url)
                 .context("Failed to initialize fullnode RPC client")?,
         ))
     }

--- a/crates/sui-indexer-alt-jsonrpc/src/args.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/args.rs
@@ -40,7 +40,7 @@ pub enum Command {
         metrics_args: MetricsArgs,
 
         #[command(flatten)]
-        write_args: Option<WriteArgs>,
+        write_args: WriteArgs,
 
         /// Path to the RPC's configuration TOML file. If one is not provided, the default values for
         /// the configuration will be set.

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -219,7 +219,7 @@ pub async fn start_rpc(
     database_url: Url,
     db_args: DbArgs,
     rpc_args: RpcArgs,
-    write_args: Option<WriteArgs>,
+    write_args: WriteArgs,
     system_package_task_args: SystemPackageTaskArgs,
     rpc_config: RpcConfig,
     registry: &Registry,
@@ -248,8 +248,11 @@ pub async fn start_rpc(
     rpc.add_module(Transactions(context.clone()))?;
 
     // Add the write module if a fullnode rpc url is provided.
-    if let Some(write_args) = write_args {
-        rpc.add_module(Write::new(write_args, context.config().write.clone())?)?;
+    if let Some(fullnode_rpc_url) = write_args.fullnode_rpc_url {
+        rpc.add_module(Write::new(
+            fullnode_rpc_url,
+            context.config().write.clone(),
+        )?)?;
     }
 
     let h_rpc = rpc.run().await.context("Failed to start RPC service")?;


### PR DESCRIPTION
## Description 

I realized the way we handled the write arg (fullnode rpc url) was incorrect. We wanted it to be an optional arg but it's not actually optional due to the `#[command(flatten)]` attribute and causes this error when a fullnode url is not provided:
```
error: the following required arguments were not provided:
  <FULLNODE_RPC_URL>

Usage: sui-indexer-alt-jsonrpc rpc --database-url <DATABASE_URL> --config <CONFIG> <FULLNODE_RPC_URL>
```

## Test plan 

edited tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
