### PR TITLE
chore: fixed formatting issue in log output for better syntax

### DIFF
--- a/consensus/simtests/src/node.rs
+++ b/consensus/simtests/src/node.rs
@@ -54,7 +54,7 @@ impl AuthorityNode {
 
     /// Start this Node
     pub async fn start(&self) -> Result<()> {
-        info!(index =% self.config.authority_index, "starting in-memory node");
+        info!(index = %self.config.authority_index, "starting in-memory node");
         let config = self.config.clone();
         *self.inner.lock() = Some(AuthorityNodeInner::spawn(config).await);
         Ok(())


### PR DESCRIPTION
## Description 

I fixed an issue with the log formatting where there was no space after the equals sign, and a `%` symbol appeared right before the variable value without a space. This fix ensures proper syntax for clearer and more readable logs.

---

## Test plan
1. Run the application and check the log outputs.  
2. Verify that there is a space after the equals sign and no `%` symbol directly before the variable value.  
3. Ensure that the logs are syntactically correct and readable.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
