### PR TITLE
[consensus] reduce leader timeout to 200ms

### DIFF
--- a/consensus/config/src/parameters.rs
+++ b/consensus/config/src/parameters.rs
@@ -94,7 +94,7 @@ pub struct Parameters {
 
 impl Parameters {
     pub(crate) fn default_leader_timeout() -> Duration {
-        Duration::from_millis(250)
+        Duration::from_millis(200)
     }
 
     pub(crate) fn default_min_round_delay() -> Duration {

--- a/consensus/config/tests/snapshots/parameters_test__parameters.snap
+++ b/consensus/config/tests/snapshots/parameters_test__parameters.snap
@@ -4,7 +4,7 @@ expression: parameters
 ---
 leader_timeout:
   secs: 0
-  nanos: 250000000
+  nanos: 200000000
 min_round_delay:
   secs: 0
   nanos: 50000000


### PR DESCRIPTION
## Description 

With round interval of 70-80ms, using 250ms for leader timeout seems a bit excessive.

## Test plan 

PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
