### PR TITLE
rpc-alt: various clean ups

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -287,7 +287,7 @@ impl OffchainCluster {
         let indexer = indexer.run().await.context("Failed to start indexer")?;
 
         let jsonrpc = start_rpc(
-            database_url.clone(),
+            Some(database_url.clone()),
             DbArgs::default(),
             rpc_args,
             WriteArgs::default(),

--- a/crates/sui-indexer-alt-e2e-tests/tests/write_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/write_tests.rs
@@ -12,10 +12,7 @@ use sui_indexer_alt_jsonrpc::{
     start_rpc, RpcArgs,
 };
 use sui_macros::sim_test;
-use sui_pg_db::{
-    temp::{get_available_port, TempDb},
-    DbArgs,
-};
+use sui_pg_db::{temp::get_available_port, DbArgs};
 use sui_swarm_config::genesis_config::AccountConfig;
 use test_cluster::{TestCluster, TestClusterBuilder};
 use tokio::task::JoinHandle;
@@ -28,8 +25,6 @@ struct WriteTestCluster {
     rpc_handle: JoinHandle<()>,
     client: Client,
     cancel: CancellationToken,
-    #[allow(unused)]
-    db: TempDb,
 }
 
 impl WriteTestCluster {
@@ -53,8 +48,6 @@ impl WriteTestCluster {
 
         let cancel = CancellationToken::new();
 
-        let db = TempDb::new().expect("Failed to create temporary database");
-
         let rpc_listen_address =
             SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), get_available_port());
         let rpc_url = Url::parse(&format!("http://{}/", rpc_listen_address))
@@ -69,7 +62,7 @@ impl WriteTestCluster {
         };
 
         let rpc_handle = start_rpc(
-            db.database().url().clone(),
+            None,
             DbArgs::default(),
             rpc_args,
             WriteArgs {
@@ -89,7 +82,6 @@ impl WriteTestCluster {
             rpc_handle,
             client: Client::new(),
             cancel,
-            db,
         })
     }
 

--- a/crates/sui-indexer-alt-framework/src/ingestion/client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/client.rs
@@ -5,13 +5,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::ingestion::local_client::LocalIngestionClient;
-use crate::ingestion::remote_client::RemoteIngestionClient;
-use crate::ingestion::Error as IngestionError;
-use crate::ingestion::Result as IngestionResult;
-use crate::metrics::CheckpointLagMetricReporter;
-use crate::metrics::IndexerMetrics;
-use crate::types::full_checkpoint_content::CheckpointData;
 use backoff::backoff::Constant;
 use backoff::Error as BE;
 use backoff::ExponentialBackoff;
@@ -22,6 +15,14 @@ use tokio_util::bytes::Bytes;
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
 use url::Url;
+
+use crate::ingestion::local_client::LocalIngestionClient;
+use crate::ingestion::remote_client::RemoteIngestionClient;
+use crate::ingestion::Error as IngestionError;
+use crate::ingestion::Result as IngestionResult;
+use crate::metrics::CheckpointLagMetricReporter;
+use crate::metrics::IndexerMetrics;
+use crate::types::full_checkpoint_content::CheckpointData;
 
 /// Wait at most this long between retries for transient errors.
 const MAX_TRANSIENT_RETRY_INTERVAL: Duration = Duration::from_secs(60);

--- a/crates/sui-indexer-alt-framework/src/task.rs
+++ b/crates/sui-indexer-alt-framework/src/task.rs
@@ -1,18 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{future::Future, iter, panic, pin::pin};
+use std::{future::Future, panic, pin::pin};
 
-use futures::{
-    future::{self, Either},
-    stream::{Stream, StreamExt},
-};
-use tokio::{
-    signal,
-    sync::oneshot,
-    task::{JoinHandle, JoinSet},
-};
-use tokio_util::sync::CancellationToken;
+use futures::stream::{Stream, StreamExt};
+use tokio::task::JoinSet;
 
 /// Extension trait introducing `try_for_each_spawned` to all streams.
 pub trait TrySpawnStreamExt: Stream {
@@ -128,46 +120,6 @@ impl<S: Stream + Sized + 'static> TrySpawnStreamExt for S {
             Ok(())
         }
     }
-}
-
-/// Manages cleanly exiting the process, either because one of its constituent services has stopped
-/// or because an interrupt signal was sent to the process.
-///
-/// Returns the exit values from all services that exited successfully.
-pub async fn graceful_shutdown<T>(
-    services: impl IntoIterator<Item = JoinHandle<T>>,
-    cancel: CancellationToken,
-) -> Vec<T> {
-    // If the service is naturalling winding down, we don't need to wait for an interrupt signal.
-    // This channel is used to short-circuit the await in that case.
-    let (cancel_ctrl_c_tx, cancel_ctrl_c_rx) = oneshot::channel();
-
-    let interrupt = async {
-        tokio::select! {
-            _ = cancel_ctrl_c_rx => {}
-            _ = cancel.cancelled() => {}
-            _ = signal::ctrl_c() => cancel.cancel(),
-        }
-
-        None
-    };
-
-    let interrupt = pin!(interrupt);
-    let futures: Vec<_> = services
-        .into_iter()
-        .map(|s| Either::Left(Box::pin(async move { s.await.ok() })))
-        .chain(iter::once(Either::Right(interrupt)))
-        .collect();
-
-    // Wait for the first service to finish, or for an interrupt signal.
-    let (first, _, rest) = future::select_all(futures).await;
-    let _ = cancel_ctrl_c_tx.send(());
-
-    // Wait for the remaining services to finish.
-    let mut results = vec![];
-    results.extend(first);
-    results.extend(future::join_all(rest).await.into_iter().flatten());
-    results
 }
 
 #[cfg(test)]

--- a/crates/sui-indexer-alt-jsonrpc/src/context.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/context.rs
@@ -49,9 +49,11 @@ pub(crate) struct Context {
 }
 
 impl Context {
-    /// Set-up access to the database through all the interfaces available in the context.
+    /// Set-up access to the database through all the interfaces available in the context. If
+    /// `database_url` is `None`, the interfaces will be set-up but will fail to accept any
+    /// connections.
     pub(crate) async fn new(
-        database_url: Url,
+        database_url: Option<Url>,
         db_args: DbArgs,
         config: RpcConfig,
         metrics: Arc<RpcMetrics>,

--- a/crates/sui-indexer-alt-jsonrpc/src/context.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/context.rs
@@ -7,6 +7,7 @@ use async_graphql::dataloader::DataLoader;
 use prometheus::Registry;
 use sui_package_resolver::Resolver;
 use sui_pg_db::DbArgs;
+use tokio_util::sync::CancellationToken;
 use url::Url;
 
 use crate::{
@@ -55,8 +56,10 @@ impl Context {
         config: RpcConfig,
         metrics: Arc<RpcMetrics>,
         registry: &Registry,
+        cancel: CancellationToken,
     ) -> Result<Self, Error> {
-        let pg_reader = PgReader::new(database_url, db_args, metrics.clone(), registry).await?;
+        let pg_reader =
+            PgReader::new(database_url, db_args, metrics.clone(), registry, cancel).await?;
         let pg_loader = Arc::new(pg_reader.as_data_loader());
 
         let kv_loader = if let Some(config) = config.bigtable.clone() {

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -201,10 +201,14 @@ impl Default for RpcArgs {
 /// command-line). The service will continue to run until the cancellation token is triggered, and
 /// will signal cancellation on the token when it is shutting down.
 ///
+/// Access to reads is controlled by the `database_url` -- if it is `None`, reads will not work.
+/// Similarly, access to writes (executing and dry-running transactions) is controlled by
+/// `write_args.fullnode_rpc_url`, which can be omitted to disable writes from this RPC.
+///
 /// The service may spin up auxiliary services (such as the system package task) to support itself,
 /// and will clean these up on shutdown as well.
 pub async fn start_rpc(
-    database_url: Url,
+    database_url: Option<Url>,
     db_args: DbArgs,
     rpc_args: RpcArgs,
     write_args: WriteArgs,

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -216,7 +216,15 @@ pub async fn start_rpc(
     let mut rpc = RpcService::new(rpc_args, registry, cancel.child_token())
         .context("Failed to create RPC service")?;
 
-    let context = Context::new(database_url, db_args, rpc_config, rpc.metrics(), registry).await?;
+    let context = Context::new(
+        database_url,
+        db_args,
+        rpc_config,
+        rpc.metrics(),
+        registry,
+        cancel.child_token(),
+    )
+    .await?;
 
     let system_package_task = SystemPackageTask::new(
         context.clone(),

--- a/crates/sui-indexer-alt-jsonrpc/src/main.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/main.rs
@@ -65,7 +65,7 @@ async fn main() -> anyhow::Result<()> {
             });
 
             let h_rpc = start_rpc(
-                database_url,
+                Some(database_url),
                 db_args,
                 rpc_args,
                 write_args,

--- a/crates/sui-indexer-alt-jsonrpc/src/main.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/main.rs
@@ -10,8 +10,9 @@ use sui_indexer_alt_jsonrpc::{
     start_rpc,
 };
 use sui_indexer_alt_metrics::MetricsService;
-use tokio::fs;
+use tokio::{fs, signal};
 use tokio_util::sync::CancellationToken;
+use tracing::info;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -50,6 +51,19 @@ async fn main() -> anyhow::Result<()> {
 
             let metrics = MetricsService::new(metrics_args, registry, cancel.child_token());
 
+            let h_ctrl_c = tokio::spawn({
+                let cancel = cancel.clone();
+                async move {
+                    tokio::select! {
+                        _ = cancel.cancelled() => {}
+                        _ = signal::ctrl_c() => {
+                            info!("Received Ctrl-C, shutting down...");
+                            cancel.cancel();
+                        }
+                    }
+                }
+            });
+
             let h_rpc = start_rpc(
                 database_url,
                 db_args,
@@ -67,6 +81,7 @@ async fn main() -> anyhow::Result<()> {
             let _ = h_rpc.await;
             cancel.cancel();
             let _ = h_metrics.await;
+            let _ = h_ctrl_c.await;
         }
 
         Command::GenerateConfig => {

--- a/crates/sui-indexer-alt-jsonrpc/src/metrics/middleware.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/metrics/middleware.rs
@@ -125,7 +125,7 @@ where
         };
 
         let method = this.method.as_ref();
-        let elapsed_ms = metrics.timer.stop_and_record() / 1000.0;
+        let elapsed_ms = metrics.timer.stop_and_record() * 1000.0;
 
         if let Some(code) = resp.as_error_code() {
             metrics

--- a/crates/sui-indexer-alt/src/bootstrap.rs
+++ b/crates/sui-indexer-alt/src/bootstrap.rs
@@ -6,13 +6,10 @@ use std::time::Duration;
 use anyhow::{bail, Context, Result};
 use diesel::{OptionalExtension, QueryDsl, SelectableHelper};
 use diesel_async::RunQueryDsl;
-use sui_indexer_alt_framework::{
-    task::graceful_shutdown,
-    types::{
-        full_checkpoint_content::CheckpointData,
-        sui_system_state::{get_sui_system_state, SuiSystemStateTrait},
-        transaction::{TransactionDataAPI, TransactionKind},
-    },
+use sui_indexer_alt_framework::types::{
+    full_checkpoint_content::CheckpointData,
+    sui_system_state::{get_sui_system_state, SuiSystemStateTrait},
+    transaction::{TransactionDataAPI, TransactionKind},
 };
 use sui_indexer_alt_schema::{
     checkpoints::StoredGenesis,
@@ -36,6 +33,8 @@ pub async fn bootstrap(
     retry_interval: Duration,
     cancel: CancellationToken,
 ) -> Result<StoredGenesis> {
+    info!("Bootstrapping indexer with genesis information");
+
     let Ok(mut conn) = indexer.db().connect().await else {
         bail!("Bootstrap failed to get connection for DB");
     };
@@ -60,19 +59,11 @@ pub async fn bootstrap(
     //
     // - Get the Genesis system transaction from the genesis checkpoint.
     // - Get the system state object that was written out by the system transaction.
-    let ingestion_client = indexer.ingestion_client().clone();
-    let wait_cancel = cancel.clone();
-    let genesis = tokio::spawn(async move {
-        ingestion_client
-            .wait_for(0, retry_interval, &wait_cancel)
-            .await
-    });
-
-    let Some(genesis_checkpoint) = graceful_shutdown(vec![genesis], cancel).await.pop() else {
-        bail!("Bootstrap cancelled");
-    };
-
-    let genesis_checkpoint = genesis_checkpoint.context("Failed to fetch genesis checkpoint")?;
+    let genesis_checkpoint = indexer
+        .ingestion_client()
+        .wait_for(0, retry_interval, &cancel)
+        .await
+        .context("Failed to fetch genesis checkpoint")?;
 
     let CheckpointData {
         checkpoint_summary,


### PR DESCRIPTION
## Description 

A number of small clean-ups, refactorings and fixes:

 - Fix scaling of elapsed time in tracing output (we were off by a factor of 1M because we were dividing by 1000 instead of multiplying by 1000).
 - Remove interrupt (Ctrl-C) handling from library code and into the set-up of `main`, so that we can avoid having to turn it off for msim tests. Make database connection acquisition pay attention to interrupts, so we aren't left waiting for the service to wind down because it's waiting for a connection to a database that will never talk back.
 - Make access to the database optional, so that we can turn it off for write tests (which don't need a database, and where trying to create a database had shown some signs of flakiness recently).

## Test plan 

Various (see each commit's description).

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
