### PR TITLE
[protocol] Shift native tx context up a protocol version

### DIFF
--- a/crates/sui-framework-snapshot/src/lib.rs
+++ b/crates/sui-framework-snapshot/src/lib.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::{fs, io::Read, path::PathBuf};
 use sui_framework::{SystemPackage, SystemPackageMetadata};
+use sui_protocol_config::ProtocolVersion;
 use sui_types::base_types::ObjectID;
 use sui_types::{
     BRIDGE_PACKAGE_ID, DEEPBOOK_PACKAGE_ID, MOVE_STDLIB_PACKAGE_ID, SUI_FRAMEWORK_PACKAGE_ID,
@@ -100,7 +101,7 @@ pub fn update_bytecode_snapshot_manifest(
 }
 
 pub fn load_bytecode_snapshot(protocol_version: u64) -> anyhow::Result<Vec<SystemPackage>> {
-    let snapshot_path = snapshot_path_for_version(protocol_version)?;
+    let snapshot_path = dbg!(snapshot_path_for_version(protocol_version))?;
     let mut snapshots: BTreeMap<ObjectID, SystemPackage> = fs::read_dir(&snapshot_path)?
         .flatten()
         .map(|entry| {
@@ -128,11 +129,6 @@ pub fn manifest_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("manifest.json")
 }
 
-/// Given a protocol version:
-/// * The path to the snapshot directory for that version is returned, if it exists.
-/// * If the version is greater than the latest snapshot version, then `Ok(None)` is returned.
-/// * If the version does not exist, but there are snapshots present with versions greater than
-///   `version`, then the smallest snapshot number greater than `version` is returned.
 fn snapshot_path_for_version(version: u64) -> anyhow::Result<PathBuf> {
     let snapshot_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("bytecode_snapshot");
     let mut snapshots = BTreeSet::new();
@@ -151,9 +147,13 @@ fn snapshot_path_for_version(version: u64) -> anyhow::Result<PathBuf> {
         }
     }
 
+    if version == ProtocolVersion::MAX.as_u64() && !snapshots.contains(&version) {
+        anyhow::bail!("No snapshot found for version {}", version)
+    }
+
     snapshots
-        .range(version..)
-        .next()
+        .range(..=version)
+        .next_back()
         .map(|v| snapshot_dir.join(v.to_string()))
         .ok_or_else(|| anyhow::anyhow!("No snapshot found for version {}", version))
 }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1294,7 +1294,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "77",
+              "maxSupportedProtocolVersion": "78",
               "protocolVersion": "6",
               "featureFlags": {
                 "accept_passkey_in_multisig": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -18,7 +18,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-const MAX_PROTOCOL_VERSION: u64 = 77;
+const MAX_PROTOCOL_VERSION: u64 = 78;
 
 // Record history of protocol version allocations here:
 //
@@ -224,7 +224,8 @@ const MAX_PROTOCOL_VERSION: u64 = 77;
 // Version 77: Enable uncompressed point group ops on mainnet.
 //             Enable consensus garbage collection for testnet
 //             Enable the new consensus commit rule for testnet.
-//             Make `TxContext` Move API native
+// Version 78: Make `TxContext` Move API native
+
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -3358,7 +3359,8 @@ impl ProtocolConfig {
                         cfg.consensus_gc_depth = Some(60);
                         cfg.feature_flags.consensus_linearize_subdag_v2 = true;
                     }
-
+                }
+                78 => {
                     cfg.feature_flags.move_native_context = true;
                     cfg.tx_context_fresh_id_cost_base = Some(52);
                     cfg.tx_context_sender_cost_base = Some(30);

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_77.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_77.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
-snapshot_kind: text
 ---
 version: 77
 feature_flags:
@@ -74,7 +73,6 @@ feature_flags:
   variant_nodes: true
   consensus_zstd_compression: true
   minimize_child_object_mutations: true
-  move_native_context: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -198,15 +196,6 @@ transfer_freeze_object_cost_base: 52
 transfer_share_object_cost_base: 52
 transfer_receive_object_cost_base: 52
 tx_context_derive_id_cost_base: 52
-tx_context_fresh_id_cost_base: 52
-tx_context_sender_cost_base: 30
-tx_context_epoch_cost_base: 30
-tx_context_epoch_timestamp_ms_cost_base: 30
-tx_context_sponsor_cost_base: 30
-tx_context_gas_price_cost_base: 30
-tx_context_gas_budget_cost_base: 30
-tx_context_ids_created_cost_base: 30
-tx_context_replace_cost_base: 30
 types_is_one_time_witness_cost_base: 52
 types_is_one_time_witness_type_tag_cost_per_byte: 2
 types_is_one_time_witness_type_cost_per_byte: 2

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_78.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_78.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 77
+version: 78
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true
@@ -39,15 +39,11 @@ feature_flags:
   verify_legacy_zklogin_address: true
   recompute_has_public_transfer_in_execution: true
   accept_zklogin_in_multisig: true
-  accept_passkey_in_multisig: true
   include_consensus_digest_in_prologue: true
   hardened_otw_check: true
   allow_receiving_object_id: true
-  enable_poseidon: true
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
-  enable_group_ops_native_function_msm: true
-  enable_nitro_attestation: true
   reject_mutable_random_on_entry_functions: true
   per_object_congestion_control_mode: TotalGasBudgetWithCap
   consensus_choice: Mysticeti
@@ -57,32 +53,27 @@ feature_flags:
   reshare_at_same_initial_version: true
   resolve_abort_locations_to_package_id: true
   mysticeti_use_committed_subdag_digest: true
-  enable_vdf: true
   record_consensus_determined_version_assignments_in_prologue: true
   fresh_vm_on_framework_upgrade: true
   prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
   mysticeti_num_leaders_per_round: 1
   soft_bundle: true
   enable_coin_deny_list_v2: true
-  passkey_auth: true
-  authority_capabilities_v2: true
   rethrow_serialization_type_layout_errors: true
   consensus_distributed_vote_scoring_strategy: true
   consensus_round_prober: true
   validate_identifier_inputs: true
-  mysticeti_fastpath: true
   relocate_event_module: true
   uncompressed_g1_group_elements: true
   disallow_new_modules_in_deps_only_packages: true
   consensus_smart_ancestor_selection: true
   consensus_round_prober_probe_accepted_rounds: true
   native_charging_v2: true
-  consensus_linearize_subdag_v2: true
   convert_type_argument_error: true
   variant_nodes: true
   consensus_zstd_compression: true
   minimize_child_object_mutations: true
-  record_additional_state_digest_in_prologue: true
+  move_native_context: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -206,6 +197,15 @@ transfer_freeze_object_cost_base: 52
 transfer_share_object_cost_base: 52
 transfer_receive_object_cost_base: 52
 tx_context_derive_id_cost_base: 52
+tx_context_fresh_id_cost_base: 52
+tx_context_sender_cost_base: 30
+tx_context_epoch_cost_base: 30
+tx_context_epoch_timestamp_ms_cost_base: 30
+tx_context_sponsor_cost_base: 30
+tx_context_gas_price_cost_base: 30
+tx_context_gas_budget_cost_base: 30
+tx_context_ids_created_cost_base: 30
+tx_context_replace_cost_base: 30
 types_is_one_time_witness_cost_base: 52
 types_is_one_time_witness_type_tag_cost_per_byte: 2
 types_is_one_time_witness_type_cost_per_byte: 2
@@ -262,7 +262,6 @@ hash_blake2b256_data_cost_per_block: 2
 hash_keccak256_cost_base: 10
 hash_keccak256_data_cost_per_byte: 2
 hash_keccak256_data_cost_per_block: 2
-poseidon_bn254_cost_base: 260
 poseidon_bn254_cost_per_block: 388
 group_ops_bls12381_decode_scalar_cost: 7
 group_ops_bls12381_decode_g1_cost: 2848
@@ -304,8 +303,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-vdf_verify_vdf_cost: 1500
-vdf_hash_to_input_cost: 100
 nitro_attestation_parse_base_cost: 2650
 nitro_attestation_parse_cost_per_byte: 50
 nitro_attestation_verify_base_cost: 2481600
@@ -362,9 +359,7 @@ max_soft_bundle_size: 5
 bridge_should_try_to_finalize_committee: true
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 37000000
 max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 7400000
-consensus_gc_depth: 60
 gas_budget_based_txn_cost_cap_factor: 400000
 gas_budget_based_txn_cost_absolute_cap_commit_count: 50
 sip_45_consensus_amplification_threshold: 5
 use_object_per_epoch_marker_table_v2: true
-consensus_commit_rate_estimation_window_size: 10

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_77.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_77.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
-snapshot_kind: text
 ---
 version: 77
 feature_flags:
@@ -77,7 +76,6 @@ feature_flags:
   variant_nodes: true
   consensus_zstd_compression: true
   minimize_child_object_mutations: true
-  move_native_context: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -201,15 +199,6 @@ transfer_freeze_object_cost_base: 52
 transfer_share_object_cost_base: 52
 transfer_receive_object_cost_base: 52
 tx_context_derive_id_cost_base: 52
-tx_context_fresh_id_cost_base: 52
-tx_context_sender_cost_base: 30
-tx_context_epoch_cost_base: 30
-tx_context_epoch_timestamp_ms_cost_base: 30
-tx_context_sponsor_cost_base: 30
-tx_context_gas_price_cost_base: 30
-tx_context_gas_budget_cost_base: 30
-tx_context_ids_created_cost_base: 30
-tx_context_replace_cost_base: 30
 types_is_one_time_witness_cost_base: 52
 types_is_one_time_witness_type_tag_cost_per_byte: 2
 types_is_one_time_witness_type_cost_per_byte: 2

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_78.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_78.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 77
+version: 78
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true
@@ -43,11 +43,8 @@ feature_flags:
   include_consensus_digest_in_prologue: true
   hardened_otw_check: true
   allow_receiving_object_id: true
-  enable_poseidon: true
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
-  enable_group_ops_native_function_msm: true
-  enable_nitro_attestation: true
   reject_mutable_random_on_entry_functions: true
   per_object_congestion_control_mode: TotalGasBudgetWithCap
   consensus_choice: Mysticeti
@@ -57,7 +54,6 @@ feature_flags:
   reshare_at_same_initial_version: true
   resolve_abort_locations_to_package_id: true
   mysticeti_use_committed_subdag_digest: true
-  enable_vdf: true
   record_consensus_determined_version_assignments_in_prologue: true
   fresh_vm_on_framework_upgrade: true
   prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
@@ -65,12 +61,10 @@ feature_flags:
   soft_bundle: true
   enable_coin_deny_list_v2: true
   passkey_auth: true
-  authority_capabilities_v2: true
   rethrow_serialization_type_layout_errors: true
   consensus_distributed_vote_scoring_strategy: true
   consensus_round_prober: true
   validate_identifier_inputs: true
-  mysticeti_fastpath: true
   relocate_event_module: true
   uncompressed_g1_group_elements: true
   disallow_new_modules_in_deps_only_packages: true
@@ -82,7 +76,7 @@ feature_flags:
   variant_nodes: true
   consensus_zstd_compression: true
   minimize_child_object_mutations: true
-  record_additional_state_digest_in_prologue: true
+  move_native_context: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -206,6 +200,15 @@ transfer_freeze_object_cost_base: 52
 transfer_share_object_cost_base: 52
 transfer_receive_object_cost_base: 52
 tx_context_derive_id_cost_base: 52
+tx_context_fresh_id_cost_base: 52
+tx_context_sender_cost_base: 30
+tx_context_epoch_cost_base: 30
+tx_context_epoch_timestamp_ms_cost_base: 30
+tx_context_sponsor_cost_base: 30
+tx_context_gas_price_cost_base: 30
+tx_context_gas_budget_cost_base: 30
+tx_context_ids_created_cost_base: 30
+tx_context_replace_cost_base: 30
 types_is_one_time_witness_cost_base: 52
 types_is_one_time_witness_type_tag_cost_per_byte: 2
 types_is_one_time_witness_type_cost_per_byte: 2
@@ -262,7 +265,6 @@ hash_blake2b256_data_cost_per_block: 2
 hash_keccak256_cost_base: 10
 hash_keccak256_data_cost_per_byte: 2
 hash_keccak256_data_cost_per_block: 2
-poseidon_bn254_cost_base: 260
 poseidon_bn254_cost_per_block: 388
 group_ops_bls12381_decode_scalar_cost: 7
 group_ops_bls12381_decode_g1_cost: 2848
@@ -304,8 +306,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-vdf_verify_vdf_cost: 1500
-vdf_hash_to_input_cost: 100
 nitro_attestation_parse_base_cost: 2650
 nitro_attestation_parse_cost_per_byte: 50
 nitro_attestation_verify_base_cost: 2481600
@@ -367,4 +367,3 @@ gas_budget_based_txn_cost_cap_factor: 400000
 gas_budget_based_txn_cost_absolute_cap_commit_count: 50
 sip_45_consensus_amplification_threshold: 5
 use_object_per_epoch_marker_table_v2: true
-consensus_commit_rate_estimation_window_size: 10

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_78.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_78.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 77
+version: 78
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true
@@ -83,6 +83,7 @@ feature_flags:
   consensus_zstd_compression: true
   minimize_child_object_mutations: true
   record_additional_state_digest_in_prologue: true
+  move_native_context: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -206,6 +207,15 @@ transfer_freeze_object_cost_base: 52
 transfer_share_object_cost_base: 52
 transfer_receive_object_cost_base: 52
 tx_context_derive_id_cost_base: 52
+tx_context_fresh_id_cost_base: 52
+tx_context_sender_cost_base: 30
+tx_context_epoch_cost_base: 30
+tx_context_epoch_timestamp_ms_cost_base: 30
+tx_context_sponsor_cost_base: 30
+tx_context_gas_price_cost_base: 30
+tx_context_gas_budget_cost_base: 30
+tx_context_ids_created_cost_base: 30
+tx_context_replace_cost_base: 30
 types_is_one_time_witness_cost_base: 52
 types_is_one_time_witness_type_tag_cost_per_byte: 2
 types_is_one_time_witness_type_cost_per_byte: 2

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -6,7 +6,7 @@ ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 77
+  protocol_version: 78
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
   stake_subsidy_start_epoch: 0

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -3,7 +3,7 @@ source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis.sui_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 77
+protocol_version: 78
 system_state_version: 1
 validators:
   total_stake: 20000000000000000
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0xb13d7c27d667d040188b62a9de8fc8d4abe7852feaea39bbfc512db842132e6a"
+            id: "0xd1931c1995763e24d76726ca091cf0e4a13898302b1300f5fb4891f0bc7927ac"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x6fd744e1cdbd7eb4d95baaa7a30fc558ee99d2aa3bc196c09fa315825f93af48"
+      operation_cap_id: "0x3ce3f4f0812d7a6cbbd85827d84eb6c81e2b55066fa1a7806cc8ce8f28f51726"
       gas_price: 1000
       staking_pool:
-        id: "0x43a999a289775a0dbad7855e12618a8a88173d64eae4cef51f353c7dcdcb02c7"
+        id: "0x862b7983caaafc0f697dec280f67ea32abee210911b63fb66ec69816715e1d07"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x6afbf4c8147474162e8fbd4c3f316478ae2ba17b0b02ce2cfdc95cd49cd3b744"
+          id: "0x801b41da3f6d451a3d3df79efe3f8d71b7c47ebbf8db6a53fdf63305078cdb6d"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0xd5aa19c6ee72705200d9f1e338f2d108f0507217397485199fb87a2f17041e4f"
+            id: "0x5abdf3470540ce2eaeee71da63057a0a8088a680846624d2593a1c8c6fae7a3d"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0xecc37e8882be75a28c90801ffdfc43604cb0d79c68d46ce4bcb9861387c8dc0e"
+          id: "0x4ef04d009e37d2bec245122e2e9a1272f6b8f5c52ddf477e00c8c3e0a39664cd"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x0b52c53aa43d160e71323d560f676bb782ed4456c95438f6b5d319ca50534018"
+      id: "0x69255f754e0b76f7d60cd6e02ee7c8e1d696f3194db54ac70466a11026574250"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xc7ab31a303b64146e4ed86a6fddb9a2072ac025b55db05843b26ce74a04c7587"
+    id: "0x1c72632cd4434e29aa5fa11ff46ab4f28337ac54f9577d7cce7330a38fb204cc"
     size: 1
   inactive_validators:
-    id: "0xf83d61a2d7efbfa46da5caaf3f921ae9fbfffa4ddc40c0145c662d8f20f460ba"
+    id: "0xaffb82b8f4da28171326b978df3fef3eb522f2837c76b77e6f4d12b479d8a277"
     size: 0
   validator_candidates:
-    id: "0x1474cfb2171b1c141490faa457b9fe0fa189df78dc1e8199f9c43fdf0b0860b8"
+    id: "0x829ff1a3aae8f2ecaaa06c7e79909acb449d68f9fea44d82fce56e2d80fe680a"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x4b45abbf74891f929e993fded385ab28aaa4c06f6a952b4b365aba58c4f947ce"
+      id: "0xcd37365d91696bf2688e7b01824ac0e6ccee4c48784596b52334f1cdbbe97019"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0xfe7ef5eca9d534478d031b4e093a42711d71a6963002d53b65973a703fd113e7"
+      id: "0x6ecce82f8574ac1c0677d1583ded9f9617c4f795f4574b6ac5b21342179356e6"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x7b21b1f1b6fd7e5683238c985727c6cad501ee223306ebb4995756bcf57767ff"
+      id: "0x7c00d740814097d8c7f1e0d7efa3c16758c3d6858313a64d62cb66e7c6c3297f"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,5 +332,5 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x9850960daa45548e435afd42319c340fdfbcc32d2cb434436bc6e0608a12f4c9"
+    id: "0xb09169db36b8c16b07ce58bc1c2a67aae767d51db3b43c1749dc48f8be6ebd90"
   size: 0


### PR DESCRIPTION
## Description 

Shift the protocol config variables for the native context from 77 -> 78 (77 was cherry-picked into the previous release). 

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [X] Protocol: Add a new protocol version to add support for native transaction contexts and `sponsor`. 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
