### PR TITLE
[cli] improve publishing of empty modules error

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1085,6 +1085,13 @@ impl SuiClientCommands {
                     compiled_package.get_package_bytes(with_unpublished_dependencies);
                 let dep_ids = compiled_package.get_published_dependencies_ids();
 
+                if compiled_modules.len() == 0 {
+                    return Err(SuiError::ModulePublishFailure {
+                        error: "No modules found in the package".to_string(),
+                    }
+                    .into());
+                }
+
                 let tx_kind = client
                     .transaction_builder()
                     .publish_tx_kind(sender, compiled_modules, dep_ids)


### PR DESCRIPTION
## Description 

Return error before publishing an empty set of modules.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
