### PR TITLE
[rpc-alt] bring transaction response to parity with fullnode rpc

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/get_transaction_block.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/get_transaction_block.move
@@ -137,3 +137,19 @@ module test::counter {
     "@{digest_3}"
   ]
 }
+
+//# programmable --sender A --inputs 42 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# advance-clock --duration-ns 1000000
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "sui_getTransactionBlock",
+  "params": [
+    "@{digest_13}"
+  ]
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/get_transaction_block.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/get_transaction_block.move
@@ -129,3 +129,11 @@ module test::counter {
     }
   ]
 }
+
+//# run-jsonrpc
+{
+  "method": "sui_getTransactionBlock",
+  "params": [
+    "@{digest_3}"
+  ]
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/get_transaction_block.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/get_transaction_block.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 12 tasks
+processed 13 tasks
 
 init:
 A: object(0,0), B: object(0,1)
@@ -955,5 +955,15 @@ Response: {
         "amount": "-1997922"
       }
     ]
+  }
+}
+
+task 12, lines 133-139:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 7,
+  "result": {
+    "digest": "DQQTRmCg1KDocZb1JwChJa8nQjAG9UaY2Jy1GnFKamDQ"
   }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/get_transaction_block.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/get_transaction_block.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 13 tasks
+processed 17 tasks
 
 init:
 A: object(0,0), B: object(0,1)
@@ -43,7 +43,9 @@ Response: {
   "jsonrpc": "2.0",
   "id": 0,
   "result": {
-    "digest": "5p9wHYHPWxr5qSCDifjzxQLxv8Berk2tik2jtyfoQmQL"
+    "digest": "5p9wHYHPWxr5qSCDifjzxQLxv8Berk2tik2jtyfoQmQL",
+    "timestampMs": "0",
+    "checkpoint": "1"
   }
 }
 
@@ -66,6 +68,8 @@ Response: {
   "result": {
     "digest": "5p9wHYHPWxr5qSCDifjzxQLxv8Berk2tik2jtyfoQmQL",
     "rawTransaction": "AAADAQFBd+JUVDhx5XeiGSNJI5s4UQEfXa07GCfaFCUk98lC1wIAAAAAAAAAAQAIKgAAAAAAAAAAIPzMmkIbuxPBpmoaqY8K11Ap7elIV3ecaRW0T5QGi5IeBgBiHbdDLb65YtqclRm+ClCfrP6oKqHdC41gITwzJcAVqAdjb3VudGVyA2luYwABAQAAAGIdt0Mtvrli2pyVGb4KUJ+s/qgqod0LjWAhPDMlwBWoB2NvdW50ZXIGaW5jX2J5AAIBAAABAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIEY29pbgV2YWx1ZQEHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIDc3VpA1NVSQABAABiHbdDLb65YtqclRm+ClCfrP6oKqHdC41gITwzJcAVqAdjb3VudGVyBmluY19ieQACAQAAAgIAAGIdt0Mtvrli2pyVGb4KUJ+s/qgqod0LjWAhPDMlwBWoB2NvdW50ZXIEdGFrZQACAQAAAQEAAQECBAABAgD8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHgEoNNhdv+/c1m8EgRIxuoGIk3k+g6iV1TQC/ZnhMuNlYgEAAAAAAAAAIAxTyQqgv33v1e2KKeTKCujrlS8ekEWqYA2s3/WsyFOJ/MyaQhu7E8GmahqpjwrXUCnt6UhXd5xpFbRPlAaLkh7oAwAAAAAAAADyBSoBAAAAAA==",
+    "timestampMs": "0",
+    "checkpoint": "1",
     "rawEffects": [
       1,
       0,
@@ -881,7 +885,9 @@ Response: {
         "4hN1oBeozq3Hno8q9JfKkrTUQHs21Q2j7UWHk1bxSk5B",
         "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr"
       ]
-    }
+    },
+    "timestampMs": "0",
+    "checkpoint": "1"
   }
 }
 
@@ -909,7 +915,9 @@ Response: {
         "bcs": "JICMsK9LOQklt3bXsnmvMf5XLPQuSXhekvIVcAMcljI=",
         "timestampMs": "0"
       }
-    ]
+    ],
+    "timestampMs": "0",
+    "checkpoint": "1"
   }
 }
 
@@ -928,7 +936,9 @@ Response: {
         "coinType": "0x2::sui::SUI",
         "amount": "-3331604"
       }
-    ]
+    ],
+    "timestampMs": "0",
+    "checkpoint": "1"
   }
 }
 
@@ -954,7 +964,9 @@ Response: {
         "coinType": "0x2::sui::SUI",
         "amount": "-1997922"
       }
-    ]
+    ],
+    "timestampMs": "0",
+    "checkpoint": "1"
   }
 }
 
@@ -964,6 +976,32 @@ Response: {
   "jsonrpc": "2.0",
   "id": 7,
   "result": {
-    "digest": "DQQTRmCg1KDocZb1JwChJa8nQjAG9UaY2Jy1GnFKamDQ"
+    "digest": "DQQTRmCg1KDocZb1JwChJa8nQjAG9UaY2Jy1GnFKamDQ",
+    "timestampMs": "0",
+    "checkpoint": "1"
+  }
+}
+
+task 13, lines 141-143:
+//# programmable --sender A --inputs 42 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(13,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 15, line 147:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 16, lines 149-155:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 8,
+  "result": {
+    "digest": "EqetytyfLz9ZHibuFprKdEPLxqPAA3TsHrmLzsvqBXWF",
+    "timestampMs": "1",
+    "checkpoint": "2"
   }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/object_changes/create_delete.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/object_changes/create_delete.snap
@@ -62,7 +62,9 @@ Response: {
         "version": "2",
         "digest": "8dXr7d9fBENNdxBX1G3jzb6s8V5QKDWewqUiM4hUNPYq"
       }
-    ]
+    ],
+    "timestampMs": "0",
+    "checkpoint": "1"
   }
 }
 
@@ -93,6 +95,8 @@ Response: {
         "objectId": "0xc7162cc23503adb20cb79297ed7ce9079f7430cdd57fe901c3c4d8becc36db8d",
         "version": "3"
       }
-    ]
+    ],
+    "timestampMs": "0",
+    "checkpoint": "1"
   }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/object_changes/create_wrap_unwrap_delete.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/object_changes/create_wrap_unwrap_delete.snap
@@ -70,7 +70,9 @@ Response: {
         "previousVersion": "2",
         "digest": "9M8HLgH8K16BkshyD9aJFPoQ6iHxcNrqyEJNtiz5SZop"
       }
-    ]
+    ],
+    "timestampMs": "0",
+    "checkpoint": "1"
   }
 }
 
@@ -106,6 +108,8 @@ Response: {
         "previousVersion": "3",
         "digest": "B5DRwEEFLfGp3KbXbJBv6jG4UzzmHdJW8iXi1Hqo3iSt"
       }
-    ]
+    ],
+    "timestampMs": "0",
+    "checkpoint": "1"
   }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/object_changes/publish_upgrade.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/object_changes/publish_upgrade.snap
@@ -62,7 +62,9 @@ Response: {
         "previousVersion": "1",
         "digest": "BRwz4gsomJX3ka2jqYBp7Ud2XSmL4We8weumCPsMSYSm"
       }
-    ]
+    ],
+    "timestampMs": "0",
+    "checkpoint": "1"
   }
 }
 
@@ -108,6 +110,8 @@ Response: {
           "N"
         ]
       }
-    ]
+    ],
+    "timestampMs": "0",
+    "checkpoint": "1"
   }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/object_changes/transfer.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/object_changes/transfer.snap
@@ -61,6 +61,8 @@ Response: {
         "previousVersion": "2",
         "digest": "GNoT9p5mUDUpCiAs4enq3HKjFZE8DjnKfC5xZyFZwgdR"
       }
-    ]
+    ],
+    "timestampMs": "0",
+    "checkpoint": "1"
   }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/object_changes/unwrap.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/object_changes/unwrap.snap
@@ -64,6 +64,8 @@ Response: {
         "previousVersion": "2",
         "digest": "Htp48aPEeYX141zEKbAQW9bB2jyUsL2MKVDDT9B3PXcw"
       }
-    ]
+    ],
+    "timestampMs": "0",
+    "checkpoint": "1"
   }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/object_changes/wrap.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/object_changes/wrap.snap
@@ -71,6 +71,8 @@ Response: {
         "objectId": "0xea80aa0712647964efcf2b71dfab5b996245ab7302c1d010179a08fb9ca4d078",
         "version": "3"
       }
-    ]
+    ],
+    "timestampMs": "0",
+    "checkpoint": "1"
   }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/query/all.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/query/all.snap
@@ -58,22 +58,34 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "3FJ4fSrf7toVCANccxAbeJ5A1iSzwKLghCYcaz9atbCD"
+        "digest": "3FJ4fSrf7toVCANccxAbeJ5A1iSzwKLghCYcaz9atbCD",
+        "timestampMs": "0",
+        "checkpoint": "0"
       },
       {
-        "digest": "Fx83wfghpUeiBQJ2C1Vt9WwY5rkGUWWgoXSCGfomqqnv"
+        "digest": "Fx83wfghpUeiBQJ2C1Vt9WwY5rkGUWWgoXSCGfomqqnv",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "4tTfhF9TpbEbJ1efxQbc6A4DWVbBzUYwNhXgt7zsmJsc"
+        "digest": "4tTfhF9TpbEbJ1efxQbc6A4DWVbBzUYwNhXgt7zsmJsc",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "BULsDepy775taHDviboyivQdnoWkB5QMDYiM1kGcfbQ9"
+        "digest": "BULsDepy775taHDviboyivQdnoWkB5QMDYiM1kGcfbQ9",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "3H9FD5LGcHgFSQBfiziYa5f31b86iuQe9Cn5DVMenMAG"
+        "digest": "3H9FD5LGcHgFSQBfiziYa5f31b86iuQe9Cn5DVMenMAG",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "8p2kdvQUf3TKihDPyC62ggc79intjzNW7TnfaA7an9At"
+        "digest": "8p2kdvQUf3TKihDPyC62ggc79intjzNW7TnfaA7an9At",
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "NQ==",
@@ -89,13 +101,19 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "3FJ4fSrf7toVCANccxAbeJ5A1iSzwKLghCYcaz9atbCD"
+        "digest": "3FJ4fSrf7toVCANccxAbeJ5A1iSzwKLghCYcaz9atbCD",
+        "timestampMs": "0",
+        "checkpoint": "0"
       },
       {
-        "digest": "Fx83wfghpUeiBQJ2C1Vt9WwY5rkGUWWgoXSCGfomqqnv"
+        "digest": "Fx83wfghpUeiBQJ2C1Vt9WwY5rkGUWWgoXSCGfomqqnv",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "4tTfhF9TpbEbJ1efxQbc6A4DWVbBzUYwNhXgt7zsmJsc"
+        "digest": "4tTfhF9TpbEbJ1efxQbc6A4DWVbBzUYwNhXgt7zsmJsc",
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "Mg==",
@@ -111,13 +129,19 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "BULsDepy775taHDviboyivQdnoWkB5QMDYiM1kGcfbQ9"
+        "digest": "BULsDepy775taHDviboyivQdnoWkB5QMDYiM1kGcfbQ9",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "3H9FD5LGcHgFSQBfiziYa5f31b86iuQe9Cn5DVMenMAG"
+        "digest": "3H9FD5LGcHgFSQBfiziYa5f31b86iuQe9Cn5DVMenMAG",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "8p2kdvQUf3TKihDPyC62ggc79intjzNW7TnfaA7an9At"
+        "digest": "8p2kdvQUf3TKihDPyC62ggc79intjzNW7TnfaA7an9At",
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "NQ==",
@@ -133,22 +157,34 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "8p2kdvQUf3TKihDPyC62ggc79intjzNW7TnfaA7an9At"
+        "digest": "8p2kdvQUf3TKihDPyC62ggc79intjzNW7TnfaA7an9At",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "3H9FD5LGcHgFSQBfiziYa5f31b86iuQe9Cn5DVMenMAG"
+        "digest": "3H9FD5LGcHgFSQBfiziYa5f31b86iuQe9Cn5DVMenMAG",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "BULsDepy775taHDviboyivQdnoWkB5QMDYiM1kGcfbQ9"
+        "digest": "BULsDepy775taHDviboyivQdnoWkB5QMDYiM1kGcfbQ9",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "4tTfhF9TpbEbJ1efxQbc6A4DWVbBzUYwNhXgt7zsmJsc"
+        "digest": "4tTfhF9TpbEbJ1efxQbc6A4DWVbBzUYwNhXgt7zsmJsc",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "Fx83wfghpUeiBQJ2C1Vt9WwY5rkGUWWgoXSCGfomqqnv"
+        "digest": "Fx83wfghpUeiBQJ2C1Vt9WwY5rkGUWWgoXSCGfomqqnv",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "3FJ4fSrf7toVCANccxAbeJ5A1iSzwKLghCYcaz9atbCD"
+        "digest": "3FJ4fSrf7toVCANccxAbeJ5A1iSzwKLghCYcaz9atbCD",
+        "timestampMs": "0",
+        "checkpoint": "0"
       }
     ],
     "nextCursor": "MA==",
@@ -164,10 +200,14 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "4tTfhF9TpbEbJ1efxQbc6A4DWVbBzUYwNhXgt7zsmJsc"
+        "digest": "4tTfhF9TpbEbJ1efxQbc6A4DWVbBzUYwNhXgt7zsmJsc",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "Fx83wfghpUeiBQJ2C1Vt9WwY5rkGUWWgoXSCGfomqqnv"
+        "digest": "Fx83wfghpUeiBQJ2C1Vt9WwY5rkGUWWgoXSCGfomqqnv",
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "MQ==",
@@ -265,7 +305,9 @@ Response: {
           "txSignatures": [
             "APiQZonSLcnMfxma2YMk7AvdgkWSew2B3HWH98dbyf5Z67cR5ojet/acq516WO9rbD/hEJJMd51bgmjm3MOyTgN/UUY663bYjcm3XmNyULIgxJz1t5Z9vxfB+fp8WUoJKA=="
           ]
-        }
+        },
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
         "digest": "BULsDepy775taHDviboyivQdnoWkB5QMDYiM1kGcfbQ9",
@@ -328,7 +370,9 @@ Response: {
           "txSignatures": [
             "AEgcwTWMXQYfQwFRXqb3R26Z7LMv7ODaZHJ8zJd2LT88eg+2Y98zJwUUDxxmMj3tAadcwBgLTdcRFe6lzcO2jgl/UUY663bYjcm3XmNyULIgxJz1t5Z9vxfB+fp8WUoJKA=="
           ]
-        }
+        },
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "Mw==",

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/query/by_address.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/query/by_address.snap
@@ -59,22 +59,34 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "8qp8ApXWxQd51P9Gpm3TUVJ34AZDez92XCbYEiP3APnG"
+        "digest": "8qp8ApXWxQd51P9Gpm3TUVJ34AZDez92XCbYEiP3APnG",
+        "timestampMs": "0",
+        "checkpoint": "0"
       },
       {
-        "digest": "4ruQaWZMoHKvnjehy4z1x4414aFDR4bq2FZvvdu9r632"
+        "digest": "4ruQaWZMoHKvnjehy4z1x4414aFDR4bq2FZvvdu9r632",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "BuLMtUTq3SkN2kthNpyahw1Uk4fMfyzZoWYxbibG7hMz"
+        "digest": "BuLMtUTq3SkN2kthNpyahw1Uk4fMfyzZoWYxbibG7hMz",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "EwxPaLPt5JequknCPY6czc6Pv2UBNibCcYaZeRnGgEyC"
+        "digest": "EwxPaLPt5JequknCPY6czc6Pv2UBNibCcYaZeRnGgEyC",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "CRzUqkJKvbfpKMwjkaBShpspHz155ghjb4mXbBdCeuFn"
+        "digest": "CRzUqkJKvbfpKMwjkaBShpspHz155ghjb4mXbBdCeuFn",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "8LKQRN6iSH3rQKkAWGjR82qxpLrG1Pj572BBLECC2p91"
+        "digest": "8LKQRN6iSH3rQKkAWGjR82qxpLrG1Pj572BBLECC2p91",
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "NQ==",
@@ -90,22 +102,34 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "8qp8ApXWxQd51P9Gpm3TUVJ34AZDez92XCbYEiP3APnG"
+        "digest": "8qp8ApXWxQd51P9Gpm3TUVJ34AZDez92XCbYEiP3APnG",
+        "timestampMs": "0",
+        "checkpoint": "0"
       },
       {
-        "digest": "4ruQaWZMoHKvnjehy4z1x4414aFDR4bq2FZvvdu9r632"
+        "digest": "4ruQaWZMoHKvnjehy4z1x4414aFDR4bq2FZvvdu9r632",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "BuLMtUTq3SkN2kthNpyahw1Uk4fMfyzZoWYxbibG7hMz"
+        "digest": "BuLMtUTq3SkN2kthNpyahw1Uk4fMfyzZoWYxbibG7hMz",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "EwxPaLPt5JequknCPY6czc6Pv2UBNibCcYaZeRnGgEyC"
+        "digest": "EwxPaLPt5JequknCPY6czc6Pv2UBNibCcYaZeRnGgEyC",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "CRzUqkJKvbfpKMwjkaBShpspHz155ghjb4mXbBdCeuFn"
+        "digest": "CRzUqkJKvbfpKMwjkaBShpspHz155ghjb4mXbBdCeuFn",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "8LKQRN6iSH3rQKkAWGjR82qxpLrG1Pj572BBLECC2p91"
+        "digest": "8LKQRN6iSH3rQKkAWGjR82qxpLrG1Pj572BBLECC2p91",
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "NQ==",
@@ -121,22 +145,34 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "8qp8ApXWxQd51P9Gpm3TUVJ34AZDez92XCbYEiP3APnG"
+        "digest": "8qp8ApXWxQd51P9Gpm3TUVJ34AZDez92XCbYEiP3APnG",
+        "timestampMs": "0",
+        "checkpoint": "0"
       },
       {
-        "digest": "4ruQaWZMoHKvnjehy4z1x4414aFDR4bq2FZvvdu9r632"
+        "digest": "4ruQaWZMoHKvnjehy4z1x4414aFDR4bq2FZvvdu9r632",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "BuLMtUTq3SkN2kthNpyahw1Uk4fMfyzZoWYxbibG7hMz"
+        "digest": "BuLMtUTq3SkN2kthNpyahw1Uk4fMfyzZoWYxbibG7hMz",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "EwxPaLPt5JequknCPY6czc6Pv2UBNibCcYaZeRnGgEyC"
+        "digest": "EwxPaLPt5JequknCPY6czc6Pv2UBNibCcYaZeRnGgEyC",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "CRzUqkJKvbfpKMwjkaBShpspHz155ghjb4mXbBdCeuFn"
+        "digest": "CRzUqkJKvbfpKMwjkaBShpspHz155ghjb4mXbBdCeuFn",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "8LKQRN6iSH3rQKkAWGjR82qxpLrG1Pj572BBLECC2p91"
+        "digest": "8LKQRN6iSH3rQKkAWGjR82qxpLrG1Pj572BBLECC2p91",
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "NQ==",
@@ -152,16 +188,24 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "8qp8ApXWxQd51P9Gpm3TUVJ34AZDez92XCbYEiP3APnG"
+        "digest": "8qp8ApXWxQd51P9Gpm3TUVJ34AZDez92XCbYEiP3APnG",
+        "timestampMs": "0",
+        "checkpoint": "0"
       },
       {
-        "digest": "BuLMtUTq3SkN2kthNpyahw1Uk4fMfyzZoWYxbibG7hMz"
+        "digest": "BuLMtUTq3SkN2kthNpyahw1Uk4fMfyzZoWYxbibG7hMz",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "CRzUqkJKvbfpKMwjkaBShpspHz155ghjb4mXbBdCeuFn"
+        "digest": "CRzUqkJKvbfpKMwjkaBShpspHz155ghjb4mXbBdCeuFn",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "8LKQRN6iSH3rQKkAWGjR82qxpLrG1Pj572BBLECC2p91"
+        "digest": "8LKQRN6iSH3rQKkAWGjR82qxpLrG1Pj572BBLECC2p91",
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "NQ==",
@@ -177,16 +221,24 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "8qp8ApXWxQd51P9Gpm3TUVJ34AZDez92XCbYEiP3APnG"
+        "digest": "8qp8ApXWxQd51P9Gpm3TUVJ34AZDez92XCbYEiP3APnG",
+        "timestampMs": "0",
+        "checkpoint": "0"
       },
       {
-        "digest": "BuLMtUTq3SkN2kthNpyahw1Uk4fMfyzZoWYxbibG7hMz"
+        "digest": "BuLMtUTq3SkN2kthNpyahw1Uk4fMfyzZoWYxbibG7hMz",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "CRzUqkJKvbfpKMwjkaBShpspHz155ghjb4mXbBdCeuFn"
+        "digest": "CRzUqkJKvbfpKMwjkaBShpspHz155ghjb4mXbBdCeuFn",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "8LKQRN6iSH3rQKkAWGjR82qxpLrG1Pj572BBLECC2p91"
+        "digest": "8LKQRN6iSH3rQKkAWGjR82qxpLrG1Pj572BBLECC2p91",
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "NQ==",
@@ -202,13 +254,19 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "8qp8ApXWxQd51P9Gpm3TUVJ34AZDez92XCbYEiP3APnG"
+        "digest": "8qp8ApXWxQd51P9Gpm3TUVJ34AZDez92XCbYEiP3APnG",
+        "timestampMs": "0",
+        "checkpoint": "0"
       },
       {
-        "digest": "EwxPaLPt5JequknCPY6czc6Pv2UBNibCcYaZeRnGgEyC"
+        "digest": "EwxPaLPt5JequknCPY6czc6Pv2UBNibCcYaZeRnGgEyC",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "CRzUqkJKvbfpKMwjkaBShpspHz155ghjb4mXbBdCeuFn"
+        "digest": "CRzUqkJKvbfpKMwjkaBShpspHz155ghjb4mXbBdCeuFn",
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "NA==",
@@ -224,13 +282,19 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "8qp8ApXWxQd51P9Gpm3TUVJ34AZDez92XCbYEiP3APnG"
+        "digest": "8qp8ApXWxQd51P9Gpm3TUVJ34AZDez92XCbYEiP3APnG",
+        "timestampMs": "0",
+        "checkpoint": "0"
       },
       {
-        "digest": "EwxPaLPt5JequknCPY6czc6Pv2UBNibCcYaZeRnGgEyC"
+        "digest": "EwxPaLPt5JequknCPY6czc6Pv2UBNibCcYaZeRnGgEyC",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "CRzUqkJKvbfpKMwjkaBShpspHz155ghjb4mXbBdCeuFn"
+        "digest": "CRzUqkJKvbfpKMwjkaBShpspHz155ghjb4mXbBdCeuFn",
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "NA==",
@@ -246,16 +310,24 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "4ruQaWZMoHKvnjehy4z1x4414aFDR4bq2FZvvdu9r632"
+        "digest": "4ruQaWZMoHKvnjehy4z1x4414aFDR4bq2FZvvdu9r632",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "BuLMtUTq3SkN2kthNpyahw1Uk4fMfyzZoWYxbibG7hMz"
+        "digest": "BuLMtUTq3SkN2kthNpyahw1Uk4fMfyzZoWYxbibG7hMz",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "EwxPaLPt5JequknCPY6czc6Pv2UBNibCcYaZeRnGgEyC"
+        "digest": "EwxPaLPt5JequknCPY6czc6Pv2UBNibCcYaZeRnGgEyC",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "CRzUqkJKvbfpKMwjkaBShpspHz155ghjb4mXbBdCeuFn"
+        "digest": "CRzUqkJKvbfpKMwjkaBShpspHz155ghjb4mXbBdCeuFn",
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "NA==",
@@ -271,7 +343,9 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "8LKQRN6iSH3rQKkAWGjR82qxpLrG1Pj572BBLECC2p91"
+        "digest": "8LKQRN6iSH3rQKkAWGjR82qxpLrG1Pj572BBLECC2p91",
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "NQ==",
@@ -299,10 +373,14 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "BuLMtUTq3SkN2kthNpyahw1Uk4fMfyzZoWYxbibG7hMz"
+        "digest": "BuLMtUTq3SkN2kthNpyahw1Uk4fMfyzZoWYxbibG7hMz",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "CRzUqkJKvbfpKMwjkaBShpspHz155ghjb4mXbBdCeuFn"
+        "digest": "CRzUqkJKvbfpKMwjkaBShpspHz155ghjb4mXbBdCeuFn",
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "NA==",

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/query/by_call.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/query/by_call.snap
@@ -132,7 +132,9 @@ Response: {
             "bcs": "AA==",
             "timestampMs": "0"
           }
-        ]
+        ],
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
         "digest": "qWrgRMDfbXXZ4xd5iHyBP6rkiVTi62MC4p4yNibGN3P",
@@ -153,7 +155,9 @@ Response: {
             "bcs": "AA==",
             "timestampMs": "0"
           }
-        ]
+        ],
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
         "digest": "2nKQ3MtBGCX6QoJwRTL5WB5vPybJi7Qj3H3Jkc6pugji",
@@ -174,7 +178,9 @@ Response: {
             "bcs": "AA==",
             "timestampMs": "0"
           }
-        ]
+        ],
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
         "digest": "6LNtqJmb5p8XRcDrJgabzMxhYtvm5c2e2E2DRodXMzXo",
@@ -195,7 +201,9 @@ Response: {
             "bcs": "AA==",
             "timestampMs": "0"
           }
-        ]
+        ],
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
         "digest": "4kLbqeuvmcLFJop6Q8GfsYhpzttevpz59GfRHztYwnxV",
@@ -216,7 +224,9 @@ Response: {
             "bcs": "AA==",
             "timestampMs": "0"
           }
-        ]
+        ],
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
         "digest": "G4mwJCdgFp3EdqBzu1T7vwhYM2kHGN9KUZfU8ouNFkdG",
@@ -237,7 +247,9 @@ Response: {
             "bcs": "AA==",
             "timestampMs": "0"
           }
-        ]
+        ],
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
         "digest": "41AWYX1pEDqX5wkEJAY14R3vryPAxufEJMCw5J2bWbih",
@@ -258,7 +270,9 @@ Response: {
             "bcs": "AA==",
             "timestampMs": "0"
           }
-        ]
+        ],
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
         "digest": "BWhH8VXVSD8rnGCXcLLBvtX375Lijzz9imJ9H5PQd955",
@@ -279,7 +293,9 @@ Response: {
             "bcs": "AA==",
             "timestampMs": "0"
           }
-        ]
+        ],
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
         "digest": "3hNt4BeLzvSdwSZypvynfP7uERdxeuea64qkqTJ1BiBs",
@@ -300,7 +316,9 @@ Response: {
             "bcs": "AA==",
             "timestampMs": "0"
           }
-        ]
+        ],
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "MTM=",
@@ -334,7 +352,9 @@ Response: {
             "bcs": "AA==",
             "timestampMs": "0"
           }
-        ]
+        ],
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
         "digest": "2nKQ3MtBGCX6QoJwRTL5WB5vPybJi7Qj3H3Jkc6pugji",
@@ -355,7 +375,9 @@ Response: {
             "bcs": "AA==",
             "timestampMs": "0"
           }
-        ]
+        ],
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
         "digest": "4kLbqeuvmcLFJop6Q8GfsYhpzttevpz59GfRHztYwnxV",
@@ -376,7 +398,9 @@ Response: {
             "bcs": "AA==",
             "timestampMs": "0"
           }
-        ]
+        ],
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
         "digest": "G4mwJCdgFp3EdqBzu1T7vwhYM2kHGN9KUZfU8ouNFkdG",
@@ -397,7 +421,9 @@ Response: {
             "bcs": "AA==",
             "timestampMs": "0"
           }
-        ]
+        ],
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
         "digest": "BWhH8VXVSD8rnGCXcLLBvtX375Lijzz9imJ9H5PQd955",
@@ -418,7 +444,9 @@ Response: {
             "bcs": "AA==",
             "timestampMs": "0"
           }
-        ]
+        ],
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
         "digest": "3hNt4BeLzvSdwSZypvynfP7uERdxeuea64qkqTJ1BiBs",
@@ -439,7 +467,9 @@ Response: {
             "bcs": "AA==",
             "timestampMs": "0"
           }
-        ]
+        ],
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "MTM=",
@@ -473,7 +503,9 @@ Response: {
             "bcs": "AA==",
             "timestampMs": "0"
           }
-        ]
+        ],
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
         "digest": "A4k5qryEEuEGCdtcXDMUVe9STVw7vQeXVhjH31rw21E7",
@@ -494,7 +526,9 @@ Response: {
             "bcs": "AA==",
             "timestampMs": "0"
           }
-        ]
+        ],
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
         "digest": "9dNCpuyieuA7zRYNAPqunTRfNemy7r4WYg6h8vW3FPQz",
@@ -515,7 +549,9 @@ Response: {
             "bcs": "AA==",
             "timestampMs": "0"
           }
-        ]
+        ],
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "MTQ=",

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/query/by_checkpoint.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/query/by_checkpoint.snap
@@ -182,7 +182,9 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "ARwAbZ2EETkMxUDTEwx2BoL95cbqnLVmiRDVH53h6UHa"
+        "digest": "ARwAbZ2EETkMxUDTEwx2BoL95cbqnLVmiRDVH53h6UHa",
+        "timestampMs": "0",
+        "checkpoint": "2"
       }
     ],
     "nextCursor": "MQ==",
@@ -198,16 +200,24 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "63rb3kkmYLsb5THn4GV3VHp5sDZ5GffaY3TWo3jaFC78"
+        "digest": "63rb3kkmYLsb5THn4GV3VHp5sDZ5GffaY3TWo3jaFC78",
+        "timestampMs": "0",
+        "checkpoint": "3"
       },
       {
-        "digest": "4JBFZsv4ZykFeBPHbJsfdEmHjNTnsgNJL555ZiTGSbZA"
+        "digest": "4JBFZsv4ZykFeBPHbJsfdEmHjNTnsgNJL555ZiTGSbZA",
+        "timestampMs": "0",
+        "checkpoint": "3"
       },
       {
-        "digest": "FWb7SBiW1434mcyZwiMgP49uKPXDqrFJ78e62KeVdG7x"
+        "digest": "FWb7SBiW1434mcyZwiMgP49uKPXDqrFJ78e62KeVdG7x",
+        "timestampMs": "0",
+        "checkpoint": "3"
       },
       {
-        "digest": "AtFjxXNoMNmELt3bspkiXsE2SR7GA7wHHFJSLyiumUYQ"
+        "digest": "AtFjxXNoMNmELt3bspkiXsE2SR7GA7wHHFJSLyiumUYQ",
+        "timestampMs": "0",
+        "checkpoint": "3"
       }
     ],
     "nextCursor": "NQ==",
@@ -235,7 +245,9 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "ARwAbZ2EETkMxUDTEwx2BoL95cbqnLVmiRDVH53h6UHa"
+        "digest": "ARwAbZ2EETkMxUDTEwx2BoL95cbqnLVmiRDVH53h6UHa",
+        "timestampMs": "0",
+        "checkpoint": "2"
       }
     ],
     "nextCursor": "MQ==",
@@ -251,16 +263,24 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "AtFjxXNoMNmELt3bspkiXsE2SR7GA7wHHFJSLyiumUYQ"
+        "digest": "AtFjxXNoMNmELt3bspkiXsE2SR7GA7wHHFJSLyiumUYQ",
+        "timestampMs": "0",
+        "checkpoint": "3"
       },
       {
-        "digest": "FWb7SBiW1434mcyZwiMgP49uKPXDqrFJ78e62KeVdG7x"
+        "digest": "FWb7SBiW1434mcyZwiMgP49uKPXDqrFJ78e62KeVdG7x",
+        "timestampMs": "0",
+        "checkpoint": "3"
       },
       {
-        "digest": "4JBFZsv4ZykFeBPHbJsfdEmHjNTnsgNJL555ZiTGSbZA"
+        "digest": "4JBFZsv4ZykFeBPHbJsfdEmHjNTnsgNJL555ZiTGSbZA",
+        "timestampMs": "0",
+        "checkpoint": "3"
       },
       {
-        "digest": "63rb3kkmYLsb5THn4GV3VHp5sDZ5GffaY3TWo3jaFC78"
+        "digest": "63rb3kkmYLsb5THn4GV3VHp5sDZ5GffaY3TWo3jaFC78",
+        "timestampMs": "0",
+        "checkpoint": "3"
       }
     ],
     "nextCursor": "Mg==",
@@ -288,7 +308,9 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "ARwAbZ2EETkMxUDTEwx2BoL95cbqnLVmiRDVH53h6UHa"
+        "digest": "ARwAbZ2EETkMxUDTEwx2BoL95cbqnLVmiRDVH53h6UHa",
+        "timestampMs": "0",
+        "checkpoint": "2"
       }
     ],
     "nextCursor": "MQ==",
@@ -304,10 +326,14 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "63rb3kkmYLsb5THn4GV3VHp5sDZ5GffaY3TWo3jaFC78"
+        "digest": "63rb3kkmYLsb5THn4GV3VHp5sDZ5GffaY3TWo3jaFC78",
+        "timestampMs": "0",
+        "checkpoint": "3"
       },
       {
-        "digest": "4JBFZsv4ZykFeBPHbJsfdEmHjNTnsgNJL555ZiTGSbZA"
+        "digest": "4JBFZsv4ZykFeBPHbJsfdEmHjNTnsgNJL555ZiTGSbZA",
+        "timestampMs": "0",
+        "checkpoint": "3"
       }
     ],
     "nextCursor": "Mw==",
@@ -335,7 +361,9 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "ARwAbZ2EETkMxUDTEwx2BoL95cbqnLVmiRDVH53h6UHa"
+        "digest": "ARwAbZ2EETkMxUDTEwx2BoL95cbqnLVmiRDVH53h6UHa",
+        "timestampMs": "0",
+        "checkpoint": "2"
       }
     ],
     "nextCursor": "MQ==",
@@ -351,10 +379,14 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "AtFjxXNoMNmELt3bspkiXsE2SR7GA7wHHFJSLyiumUYQ"
+        "digest": "AtFjxXNoMNmELt3bspkiXsE2SR7GA7wHHFJSLyiumUYQ",
+        "timestampMs": "0",
+        "checkpoint": "3"
       },
       {
-        "digest": "FWb7SBiW1434mcyZwiMgP49uKPXDqrFJ78e62KeVdG7x"
+        "digest": "FWb7SBiW1434mcyZwiMgP49uKPXDqrFJ78e62KeVdG7x",
+        "timestampMs": "0",
+        "checkpoint": "3"
       }
     ],
     "nextCursor": "NA==",
@@ -370,10 +402,14 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "FWb7SBiW1434mcyZwiMgP49uKPXDqrFJ78e62KeVdG7x"
+        "digest": "FWb7SBiW1434mcyZwiMgP49uKPXDqrFJ78e62KeVdG7x",
+        "timestampMs": "0",
+        "checkpoint": "3"
       },
       {
-        "digest": "AtFjxXNoMNmELt3bspkiXsE2SR7GA7wHHFJSLyiumUYQ"
+        "digest": "AtFjxXNoMNmELt3bspkiXsE2SR7GA7wHHFJSLyiumUYQ",
+        "timestampMs": "0",
+        "checkpoint": "3"
       }
     ],
     "nextCursor": "NQ==",
@@ -389,7 +425,9 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "63rb3kkmYLsb5THn4GV3VHp5sDZ5GffaY3TWo3jaFC78"
+        "digest": "63rb3kkmYLsb5THn4GV3VHp5sDZ5GffaY3TWo3jaFC78",
+        "timestampMs": "0",
+        "checkpoint": "3"
       }
     ],
     "nextCursor": "Mg==",
@@ -405,10 +443,14 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "63rb3kkmYLsb5THn4GV3VHp5sDZ5GffaY3TWo3jaFC78"
+        "digest": "63rb3kkmYLsb5THn4GV3VHp5sDZ5GffaY3TWo3jaFC78",
+        "timestampMs": "0",
+        "checkpoint": "3"
       },
       {
-        "digest": "4JBFZsv4ZykFeBPHbJsfdEmHjNTnsgNJL555ZiTGSbZA"
+        "digest": "4JBFZsv4ZykFeBPHbJsfdEmHjNTnsgNJL555ZiTGSbZA",
+        "timestampMs": "0",
+        "checkpoint": "3"
       }
     ],
     "nextCursor": "Mw==",
@@ -448,10 +490,14 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "AtFjxXNoMNmELt3bspkiXsE2SR7GA7wHHFJSLyiumUYQ"
+        "digest": "AtFjxXNoMNmELt3bspkiXsE2SR7GA7wHHFJSLyiumUYQ",
+        "timestampMs": "0",
+        "checkpoint": "3"
       },
       {
-        "digest": "FWb7SBiW1434mcyZwiMgP49uKPXDqrFJ78e62KeVdG7x"
+        "digest": "FWb7SBiW1434mcyZwiMgP49uKPXDqrFJ78e62KeVdG7x",
+        "timestampMs": "0",
+        "checkpoint": "3"
       }
     ],
     "nextCursor": "NA==",

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/query/by_object.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/transactions/query/by_object.snap
@@ -48,19 +48,29 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "3FJ4fSrf7toVCANccxAbeJ5A1iSzwKLghCYcaz9atbCD"
+        "digest": "3FJ4fSrf7toVCANccxAbeJ5A1iSzwKLghCYcaz9atbCD",
+        "timestampMs": "0",
+        "checkpoint": "0"
       },
       {
-        "digest": "ARwAbZ2EETkMxUDTEwx2BoL95cbqnLVmiRDVH53h6UHa"
+        "digest": "ARwAbZ2EETkMxUDTEwx2BoL95cbqnLVmiRDVH53h6UHa",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "Cs81ueNvP7Y63qibhhJXvEKhqXqVXsWRRuZKvxDJgd37"
+        "digest": "Cs81ueNvP7Y63qibhhJXvEKhqXqVXsWRRuZKvxDJgd37",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "21AuR8T8joUdTFAM8rBUqMiqQG57CEvW9PBTWoUxZCEW"
+        "digest": "21AuR8T8joUdTFAM8rBUqMiqQG57CEvW9PBTWoUxZCEW",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "FNmBXaFzxKExTXCparbWdGXfFrj6cchG9Rx1uEeGw4vP"
+        "digest": "FNmBXaFzxKExTXCparbWdGXfFrj6cchG9Rx1uEeGw4vP",
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "NA==",
@@ -76,13 +86,19 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "ARwAbZ2EETkMxUDTEwx2BoL95cbqnLVmiRDVH53h6UHa"
+        "digest": "ARwAbZ2EETkMxUDTEwx2BoL95cbqnLVmiRDVH53h6UHa",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "Cs81ueNvP7Y63qibhhJXvEKhqXqVXsWRRuZKvxDJgd37"
+        "digest": "Cs81ueNvP7Y63qibhhJXvEKhqXqVXsWRRuZKvxDJgd37",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "FNmBXaFzxKExTXCparbWdGXfFrj6cchG9Rx1uEeGw4vP"
+        "digest": "FNmBXaFzxKExTXCparbWdGXfFrj6cchG9Rx1uEeGw4vP",
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "NA==",
@@ -98,10 +114,14 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "Cs81ueNvP7Y63qibhhJXvEKhqXqVXsWRRuZKvxDJgd37"
+        "digest": "Cs81ueNvP7Y63qibhhJXvEKhqXqVXsWRRuZKvxDJgd37",
+        "timestampMs": "0",
+        "checkpoint": "1"
       },
       {
-        "digest": "21AuR8T8joUdTFAM8rBUqMiqQG57CEvW9PBTWoUxZCEW"
+        "digest": "21AuR8T8joUdTFAM8rBUqMiqQG57CEvW9PBTWoUxZCEW",
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "Mw==",
@@ -117,7 +137,9 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "Cs81ueNvP7Y63qibhhJXvEKhqXqVXsWRRuZKvxDJgd37"
+        "digest": "Cs81ueNvP7Y63qibhhJXvEKhqXqVXsWRRuZKvxDJgd37",
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "Mg==",
@@ -133,7 +155,9 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "21AuR8T8joUdTFAM8rBUqMiqQG57CEvW9PBTWoUxZCEW"
+        "digest": "21AuR8T8joUdTFAM8rBUqMiqQG57CEvW9PBTWoUxZCEW",
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "Mw==",
@@ -149,7 +173,9 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "FNmBXaFzxKExTXCparbWdGXfFrj6cchG9Rx1uEeGw4vP"
+        "digest": "FNmBXaFzxKExTXCparbWdGXfFrj6cchG9Rx1uEeGw4vP",
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "NA==",
@@ -165,7 +191,9 @@ Response: {
   "result": {
     "data": [
       {
-        "digest": "Cs81ueNvP7Y63qibhhJXvEKhqXqVXsWRRuZKvxDJgd37"
+        "digest": "Cs81ueNvP7Y63qibhhJXvEKhqXqVXsWRRuZKvxDJgd37",
+        "timestampMs": "0",
+        "checkpoint": "1"
       }
     ],
     "nextCursor": "Mg==",

--- a/crates/sui-indexer-alt-jsonrpc/src/api/transactions/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/transactions/mod.rs
@@ -31,7 +31,7 @@ trait TransactionsApi {
         /// The digest of the queried transaction.
         digest: TransactionDigest,
         /// Options controlling the output format.
-        options: SuiTransactionBlockResponseOptions,
+        options: Option<SuiTransactionBlockResponseOptions>,
     ) -> RpcResult<SuiTransactionBlockResponse>;
 }
 
@@ -72,12 +72,14 @@ impl TransactionsApiServer for Transactions {
     async fn get_transaction_block(
         &self,
         digest: TransactionDigest,
-        options: SuiTransactionBlockResponseOptions,
+        options: Option<SuiTransactionBlockResponseOptions>,
     ) -> RpcResult<SuiTransactionBlockResponse> {
         let Self(ctx) = self;
-        Ok(response::transaction(ctx, digest, &options)
-            .await
-            .with_internal_context(|| format!("Failed to get transaction {digest}"))?)
+        Ok(
+            response::transaction(ctx, digest, &options.unwrap_or_default())
+                .await
+                .with_internal_context(|| format!("Failed to get transaction {digest}"))?,
+        )
     }
 }
 

--- a/crates/sui-indexer-alt-jsonrpc/src/api/transactions/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/transactions/response.rs
@@ -69,6 +69,9 @@ pub(super) async fn transaction(
 
     let mut response = SuiTransactionBlockResponse::new(digest);
 
+    response.timestamp_ms = Some(tx.timestamp_ms());
+    response.checkpoint = Some(tx.cp_sequence_number());
+
     if options.show_input {
         response.transaction = Some(input(ctx, &tx).await?);
     }

--- a/crates/sui-indexer-alt-jsonrpc/src/data/kv_loader.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/kv_loader.rs
@@ -233,4 +233,11 @@ impl TransactionContents {
             Self::Bigtable(kv) => kv.timestamp,
         }
     }
+
+    pub(crate) fn cp_sequence_number(&self) -> u64 {
+        match self {
+            Self::Pg(stored) => stored.cp_sequence_number as u64,
+            Self::Bigtable(kv) => kv.checkpoint_number,
+        }
+    }
 }


### PR DESCRIPTION
## Description 

There are some discrepancies between our transaction API and fullnode rpc's so this PR aims to close that gap.
Most of the changes are test snapshot changes due to the addition of checkpoint sequence number and timestamp.

## Test plan 

Added a test and modified some tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
