### PR TITLE
fix: fix ignored task results in `futures::join!`

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -1214,6 +1214,8 @@ mod test {
             assert!(!results.unique_move_functions_called.is_empty());
         });
 
-        let _ = futures::join!(bench_task, surfer_task);
+        let (bench_result, surfer_result) = futures::join!(bench_task, surfer_task);
+            bench_result?;
+            surfer_result?;
     }
 }


### PR DESCRIPTION
## Description  
I fixed the issue where the results of `bench_task` and `surfer_task` were being ignored using `let _ =`. Now the results are properly captured and errors are handled. This ensures that any task failures are properly addressed.

## Test plan  
- Verify that both tasks (`bench_task` and `surfer_task`) execute correctly.
- Ensure no errors are silently ignored and they are properly handled with `?`.

---

## Release notes

- [ ] Protocol: No changes.
- [ ] Nodes (Validators and Full nodes): No changes.
- [ ] gRPC: No changes.
- [ ] JSON-RPC: No changes.
- [ ] GraphQL: No changes.
- [ ] CLI: No changes.
- [ ] Rust SDK: No changes.