### PR TITLE
rpc-alt: better latest object version data-loader

### DIFF
--- a/crates/sui-indexer-alt-jsonrpc/src/data/object_versions.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/object_versions.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use async_graphql::dataloader::Loader;
-use diesel::{ExpressionMethods, QueryDsl};
-use sui_indexer_alt_schema::{objects::StoredObjVersion, schema::obj_versions};
+use diesel::sql_types::{Array, Bytea};
+use sui_indexer_alt_schema::objects::StoredObjVersionKey;
 use sui_types::base_types::ObjectID;
 
 use crate::data::error::Error;
@@ -22,32 +22,45 @@ pub(crate) struct LatestObjectVersionKey(pub ObjectID);
 
 #[async_trait::async_trait]
 impl Loader<LatestObjectVersionKey> for PgReader {
-    type Value = StoredObjVersion;
+    type Value = StoredObjVersionKey;
     type Error = Arc<Error>;
 
     async fn load(
         &self,
         keys: &[LatestObjectVersionKey],
-    ) -> Result<HashMap<LatestObjectVersionKey, StoredObjVersion>, Self::Error> {
-        use obj_versions::dsl as v;
-
+    ) -> Result<HashMap<LatestObjectVersionKey, StoredObjVersionKey>, Self::Error> {
         if keys.is_empty() {
             return Ok(HashMap::new());
         }
 
         let mut conn = self.connect().await.map_err(Arc::new)?;
 
-        let ids: BTreeSet<_> = keys.iter().map(|k| k.0.into_bytes()).collect();
-        let obj_versions: Vec<StoredObjVersion> = conn
-            .results(
-                v::obj_versions
-                    .filter(v::object_id.eq_any(ids))
-                    .distinct_on(v::object_id)
-                    .order((v::object_id, v::object_version.desc())),
-            )
-            .await
-            .map_err(Arc::new)?;
+        let ids: Vec<_> = keys.iter().map(|k| k.0.into_bytes()).collect();
+        let query = diesel::sql_query(
+            r#"
+                SELECT
+                    k.object_id,
+                    v.object_version
+                FROM (
+                    SELECT UNNEST($1) object_id
+                ) k
+                CROSS JOIN LATERAL (
+                    SELECT
+                        object_version
+                    FROM
+                        obj_versions
+                    WHERE
+                        obj_versions.object_id = k.object_id
+                    ORDER BY
+                        object_version DESC
+                    LIMIT
+                        1
+                ) v
+            "#,
+        )
+        .bind::<Array<Bytea>, _>(ids);
 
+        let obj_versions: Vec<StoredObjVersionKey> = conn.results(query).await.map_err(Arc::new)?;
         let id_to_stored: HashMap<_, _> = obj_versions
             .into_iter()
             .map(|stored| (stored.object_id.clone(), stored))

--- a/crates/sui-indexer-alt-jsonrpc/src/data/object_versions.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/object_versions.rs
@@ -1,10 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::{BTreeSet, HashMap},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
 use async_graphql::dataloader::Loader;
 use diesel::sql_types::{Array, Bytea};

--- a/crates/sui-indexer-alt-schema/src/objects.rs
+++ b/crates/sui-indexer-alt-schema/src/objects.rs
@@ -30,6 +30,14 @@ pub struct StoredObjVersion {
     pub cp_sequence_number: i64,
 }
 
+/// Only the key fields of a row in `obj_versions`.
+#[derive(Selectable, Debug, Clone, QueryableByName)]
+#[diesel(table_name = obj_versions, primary_key(object_id, object_version))]
+pub struct StoredObjVersionKey {
+    pub object_id: Vec<u8>,
+    pub object_version: i64,
+}
+
 #[derive(AsExpression, FromSqlRow, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[diesel(sql_type = SmallInt)]
 #[repr(i16)]


### PR DESCRIPTION
## Description

Two improvements to the object versions data loader:

- Only fetch the columns we care about (that are covered by the index), so the query can be performed as an index only scan.
- Switch to a JOIN using `UNNEST(ARRAY[...])` to supply the keys, as it is more efficient than `SELECT DISTINCT ON (...)`.

## Test plan

Existing tests:

```
sui$ cargo nextest run -p sui-indexer-alt-e2e-tests
```
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
