### PR TITLE
archival: fix the issue where checkpoints from different epochs are appearing in the same batch

### DIFF
--- a/crates/sui-data-ingestion-core/src/reducer.rs
+++ b/crates/sui-data-ingestion-core/src/reducer.rs
@@ -81,4 +81,8 @@ where
     async fn commit(&self, batch: Vec<R>) -> Result<()> {
         self.as_ref().commit(batch).await
     }
+
+    fn should_close_batch(&self, batch: &[R], next_item: Option<&R>) -> bool {
+        self.as_ref().should_close_batch(batch, next_item)
+    }
 }

--- a/crates/sui-data-ingestion/src/workers/archival.rs
+++ b/crates/sui-data-ingestion/src/workers/archival.rs
@@ -9,6 +9,7 @@ use bytes::Bytes;
 use object_store::path::Path;
 use object_store::ObjectStore;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::io::Cursor;
 use sui_archival::{
     create_file_metadata_from_bytes, finalize_manifest, read_manifest_from_bytes, FileType,
@@ -131,6 +132,12 @@ impl Reducer<CheckpointData> for ArchivalReducer {
         if batch.is_empty() {
             return Err(anyhow::anyhow!("commit batch can't be empty"));
         }
+        let affected_epochs: HashSet<_> =
+            batch.iter().map(|c| c.checkpoint_summary.epoch).collect();
+        assert!(
+            affected_epochs.len() == 1,
+            "archival batch contains multiple epochs"
+        );
         let mut summary_buffer = vec![];
         let mut buffer = vec![];
         let first_checkpoint = &batch[0];


### PR DESCRIPTION
## Description 

caused by rust upgrade.
(+ added extra assert)

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
