### PR TITLE
rpc-alt: resolveNameServiceNames

### DIFF
--- a/crates/sui-indexer-alt-jsonrpc/src/api/name_service/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/name_service/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use sui_json_rpc_types::Page as PageResponse;
 use sui_open_rpc::Module;
 use sui_open_rpc_macros::open_rpc;
 use sui_types::base_types::SuiAddress;
@@ -25,6 +26,20 @@ trait NameServiceApi {
         /// The name to resolve
         name: String,
     ) -> RpcResult<Option<SuiAddress>>;
+
+    /// Find the SuiNS name that points to this address.
+    ///
+    /// Although this method's response is paginated, it will only ever return at most one name.
+    #[method(name = "resolveNameServiceNames")]
+    async fn resolve_name_service_names(
+        &self,
+        /// The address to resolve
+        address: SuiAddress,
+        /// Unused pagination cursor
+        cursor: Option<String>,
+        /// Unused pagination limit
+        limit: Option<usize>,
+    ) -> RpcResult<PageResponse<String, String>>;
 }
 
 pub(crate) struct NameService(pub Context);
@@ -36,6 +51,25 @@ impl NameServiceApiServer for NameService {
         Ok(response::resolved_address(ctx, &name)
             .await
             .with_internal_context(|| format!("Resolving SuiNS name {name:?}"))?)
+    }
+
+    async fn resolve_name_service_names(
+        &self,
+        address: SuiAddress,
+        _cursor: Option<String>,
+        _limit: Option<usize>,
+    ) -> RpcResult<PageResponse<String, String>> {
+        let Self(ctx) = self;
+
+        let mut page = PageResponse::empty();
+        if let Some(name) = response::resolved_name(ctx, address)
+            .await
+            .with_internal_context(|| format!("Resolving address {address}"))?
+        {
+            page.data.push(name);
+        }
+
+        Ok(page)
     }
 }
 

--- a/crates/sui-indexer-alt-jsonrpc/src/api/name_service/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/name_service/response.rs
@@ -6,13 +6,13 @@ use diesel::{ExpressionMethods, QueryDsl};
 use futures::future::OptionFuture;
 use sui_indexer_alt_schema::schema::watermarks;
 use sui_name_service::{Domain, NameRecord, NameServiceError};
-use sui_types::base_types::SuiAddress;
+use sui_types::{base_types::SuiAddress, dynamic_field::Field};
 use tokio::join;
 
 use crate::{
     context::Context,
     data::objects::load_live,
-    error::{invalid_params, RpcError},
+    error::{invalid_params, InternalContext, RpcError},
 };
 
 use super::Error;
@@ -88,6 +88,42 @@ pub(super) async fn resolved_address(
         Err(invalid_params(E::NameService(
             NameServiceError::NameExpired,
         )))
+    }
+}
+
+/// Attempt to to translate the given `address` to its SuiNS name, as long as the reverse mapping
+/// exists, and the forward mapping points to the address.
+pub(super) async fn resolved_name(
+    ctx: &Context,
+    address: SuiAddress,
+) -> Result<Option<String>, RpcError<Error>> {
+    let config = &ctx.config().name_service;
+
+    let reverse_record_id = config.reverse_record_field_id(address.as_ref());
+    let Some(reverse_record_object) = load_live(ctx, reverse_record_id)
+        .await
+        .context("Failed to fetch reverse record")?
+    else {
+        return Ok(None);
+    };
+
+    let reverse_record: Field<SuiAddress, Domain> = bcs::from_bytes(
+        reverse_record_object
+            .data
+            .try_as_move()
+            .context("Reverse record not a Move object")?
+            .contents(),
+    )
+    .context("Failed to deserialize reverse record")?;
+
+    // Before returning the domain, check that it is still valid and points to this address.
+    // If forward resolution fails with a user error, it means the reverse record is no longer
+    // valid. Internal errors are unexpected and should be propagated.
+    let domain = reverse_record.value.to_string();
+    match resolved_address(ctx, &domain).await {
+        Ok(Some(actual_address)) if actual_address == address => Ok(Some(domain)),
+        Ok(_) | Err(RpcError::InvalidParams(_)) => Ok(None),
+        Err(e) => Err(e).internal_context("Failed to resolve address"),
     }
 }
 


### PR DESCRIPTION
## Description

Implement reverse resolution for SuiNS.

## Test plan

Add new assertions to existing name service tests:

```
sui$ cargo nextest run -p sui-indexer-alt-e2e-tests \
  --test name_service_tests
```

## Stack

- #21471 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
