### PR TITLE
Restore separate budget for randomness tx in ExecutionTimeEstimate mode

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -484,7 +484,7 @@ mod test {
                     ExecutionTimeEstimateParams {
                         target_utilization: rng.gen_range(1..=100),
                         allowed_txn_cost_overage_burst_limit_us: rng.gen_range(0..500_000),
-                        max_txn_cost_overage_per_object_in_commit_us: 10_000_000_000,
+                        randomness_scalar: rng.gen_range(10..=50),
                         max_estimate_us: 1_500_000,
                     },
                 ),

--- a/crates/sui-core/src/authority/execution_time_estimator.rs
+++ b/crates/sui-core/src/authority/execution_time_estimator.rs
@@ -535,7 +535,7 @@ mod tests {
                     ExecutionTimeEstimateParams {
                         target_utilization: 100,
                         allowed_txn_cost_overage_burst_limit_us: 0,
-                        max_txn_cost_overage_per_object_in_commit_us: u64::MAX,
+                        randomness_scalar: 100,
                         max_estimate_us: u64::MAX,
                     },
                 ),
@@ -675,7 +675,7 @@ mod tests {
                     ExecutionTimeEstimateParams {
                         target_utilization: 100,
                         allowed_txn_cost_overage_burst_limit_us: 0,
-                        max_txn_cost_overage_per_object_in_commit_us: u64::MAX,
+                        randomness_scalar: 0,
                         max_estimate_us: u64::MAX,
                     },
                 ),
@@ -771,7 +771,7 @@ mod tests {
                     ExecutionTimeEstimateParams {
                         target_utilization: 100,
                         allowed_txn_cost_overage_burst_limit_us: 0,
-                        max_txn_cost_overage_per_object_in_commit_us: u64::MAX,
+                        randomness_scalar: 0,
                         max_estimate_us: u64::MAX,
                     },
                 ),
@@ -1012,7 +1012,7 @@ mod tests {
 
                 // Not used in this test.
                 allowed_txn_cost_overage_burst_limit_us: 0,
-                max_txn_cost_overage_per_object_in_commit_us: 0,
+                randomness_scalar: 0,
             },
             std::iter::empty(),
         );

--- a/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
+++ b/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
@@ -18,6 +18,7 @@ use tracing::trace;
 #[derive(PartialEq, Eq, Clone, Debug)]
 struct Params {
     mode: PerObjectCongestionControlMode,
+    for_randomness: bool,
     max_accumulated_txn_cost_per_object_in_commit: u64,
     gas_budget_based_txn_cost_cap_factor: Option<u64>,
     gas_budget_based_txn_cost_absolute_cap: Option<u64>,
@@ -33,10 +34,17 @@ impl Params {
             PerObjectCongestionControlMode::ExecutionTimeEstimate(params) => {
                 let estimated_commit_period = commit_info.estimated_commit_period();
                 let commit_period_micros = estimated_commit_period.as_micros() as u64;
-                commit_period_micros
+                let mut budget = commit_period_micros
                     .checked_mul(params.target_utilization)
                     .unwrap_or(u64::MAX)
-                    / 100
+                    / 100;
+                if self.for_randomness {
+                    budget = budget
+                        .checked_mul(params.randomness_scalar)
+                        .unwrap_or(u64::MAX)
+                        / 100;
+                }
+                budget
             }
             _ => self.max_accumulated_txn_cost_per_object_in_commit,
         }
@@ -47,7 +55,14 @@ impl Params {
     pub fn max_burst(&self) -> u64 {
         match self.mode {
             PerObjectCongestionControlMode::ExecutionTimeEstimate(params) => {
-                params.allowed_txn_cost_overage_burst_limit_us
+                let mut burst = params.allowed_txn_cost_overage_burst_limit_us;
+                if self.for_randomness {
+                    burst = burst
+                        .checked_mul(params.randomness_scalar)
+                        .unwrap_or(u64::MAX)
+                        / 100;
+                }
+                burst
             }
             _ => self.allowed_txn_cost_overage_burst_per_object_in_commit,
         }
@@ -58,9 +73,7 @@ impl Params {
     // unschedulable regardless of congestion.
     pub fn max_overage(&self) -> u64 {
         match self.mode {
-            PerObjectCongestionControlMode::ExecutionTimeEstimate(params) => {
-                params.max_txn_cost_overage_per_object_in_commit_us
-            }
+            PerObjectCongestionControlMode::ExecutionTimeEstimate(_) => u64::MAX,
             _ => self.max_txn_cost_overage_per_object_in_commit,
         }
     }
@@ -110,6 +123,7 @@ impl SharedObjectCongestionTracker {
     pub fn new(
         initial_object_debts: impl IntoIterator<Item = (ObjectID, u64)>,
         mode: PerObjectCongestionControlMode,
+        for_randomness: bool,
         max_accumulated_txn_cost_per_object_in_commit: Option<u64>,
         gas_budget_based_txn_cost_cap_factor: Option<u64>,
         gas_budget_based_txn_cost_absolute_cap_commit_count: Option<u64>,
@@ -148,6 +162,7 @@ impl SharedObjectCongestionTracker {
             object_execution_cost,
             params: Params {
                 mode,
+                for_randomness,
                 max_accumulated_txn_cost_per_object_in_commit,
                 gas_budget_based_txn_cost_cap_factor,
                 gas_budget_based_txn_cost_absolute_cap,
@@ -167,6 +182,7 @@ impl SharedObjectCongestionTracker {
         Ok(Self::new(
             initial_object_debts,
             protocol_config.per_object_congestion_control_mode(),
+            for_randomness,
             if for_randomness {
                 protocol_config
                     .max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit_as_option()
@@ -417,6 +433,7 @@ mod object_cost_tests {
         let shared_object_congestion_tracker = SharedObjectCongestionTracker::new(
             [(object_id_0, 5), (object_id_1, 10)],
             PerObjectCongestionControlMode::TotalGasBudget,
+            false,
             Some(0), // not part of this test
             None,
             None,
@@ -545,7 +562,7 @@ mod object_cost_tests {
             PerObjectCongestionControlMode::ExecutionTimeEstimate(ExecutionTimeEstimateParams {
                 target_utilization: 100,
                 allowed_txn_cost_overage_burst_limit_us: 0,
-                max_txn_cost_overage_per_object_in_commit_us: 0,
+                randomness_scalar: 0,
                 max_estimate_us: u64::MAX,
             }),
         )]
@@ -578,6 +595,7 @@ mod object_cost_tests {
                 SharedObjectCongestionTracker::new(
                     [(shared_obj_0, 10), (shared_obj_1, 1)],
                     mode,
+                    false,
                     Some(max_accumulated_txn_cost_per_object_in_commit),
                     None,
                     None,
@@ -593,6 +611,7 @@ mod object_cost_tests {
                 SharedObjectCongestionTracker::new(
                     [(shared_obj_0, 2), (shared_obj_1, 1)],
                     mode,
+                    false,
                     Some(max_accumulated_txn_cost_per_object_in_commit),
                     None,
                     None,
@@ -608,6 +627,7 @@ mod object_cost_tests {
                 SharedObjectCongestionTracker::new(
                     [(shared_obj_0, 10), (shared_obj_1, 1)],
                     mode,
+                    false,
                     Some(max_accumulated_txn_cost_per_object_in_commit),
                     Some(45), // Make the cap just less than the gas budget, there are 1 objects in tx.
                     None,
@@ -623,6 +643,7 @@ mod object_cost_tests {
                 SharedObjectCongestionTracker::new(
                     [(shared_obj_0, 750), (shared_obj_1, 0)],
                     mode,
+                    false,
                     Some(max_accumulated_txn_cost_per_object_in_commit),
                     None,
                     None,
@@ -737,8 +758,8 @@ mod object_cost_tests {
             PerObjectCongestionControlMode::ExecutionTimeEstimate(ExecutionTimeEstimateParams {
                 target_utilization: 0, // Make should_defer_due_to_object_congestion always defer transactions.
                 allowed_txn_cost_overage_burst_limit_us: 0,
-                max_txn_cost_overage_per_object_in_commit_us: 0,
                 max_estimate_us: u64::MAX,
+                randomness_scalar: 0,
             }),
         )]
         mode: PerObjectCongestionControlMode,
@@ -751,6 +772,7 @@ mod object_cost_tests {
         let shared_object_congestion_tracker = SharedObjectCongestionTracker::new(
             [],
             mode,
+            false,
             Some(0), // Make should_defer_due_to_object_congestion always defer transactions.
             Some(2),
             None,
@@ -864,7 +886,7 @@ mod object_cost_tests {
             PerObjectCongestionControlMode::ExecutionTimeEstimate(ExecutionTimeEstimateParams {
                 target_utilization: 16,
                 allowed_txn_cost_overage_burst_limit_us: 0,
-                max_txn_cost_overage_per_object_in_commit_us: 10_000_000,
+                randomness_scalar: 0,
                 max_estimate_us: u64::MAX,
             }),
         )]
@@ -900,6 +922,7 @@ mod object_cost_tests {
                 SharedObjectCongestionTracker::new(
                     [(shared_obj_0, 102), (shared_obj_1, 90)],
                     mode,
+                    false,
                     Some(max_accumulated_txn_cost_per_object_in_commit),
                     None,
                     None,
@@ -915,6 +938,7 @@ mod object_cost_tests {
                 SharedObjectCongestionTracker::new(
                     [(shared_obj_0, 3), (shared_obj_1, 2)],
                     mode,
+                    false,
                     Some(max_accumulated_txn_cost_per_object_in_commit),
                     None,
                     None,
@@ -930,6 +954,7 @@ mod object_cost_tests {
                 SharedObjectCongestionTracker::new(
                     [(shared_obj_0, 100), (shared_obj_1, 90)],
                     mode,
+                    false,
                     Some(max_accumulated_txn_cost_per_object_in_commit),
                     Some(45), // Make the cap just less than the gas budget, there are 1 objects in tx.
                     None,
@@ -945,6 +970,7 @@ mod object_cost_tests {
                 SharedObjectCongestionTracker::new(
                     [(shared_obj_0, 1_700_000), (shared_obj_1, 300_000)],
                     mode,
+                    false,
                     Some(max_accumulated_txn_cost_per_object_in_commit),
                     None,
                     None,
@@ -1030,7 +1056,7 @@ mod object_cost_tests {
             PerObjectCongestionControlMode::ExecutionTimeEstimate(ExecutionTimeEstimateParams {
                 target_utilization: 16,
                 allowed_txn_cost_overage_burst_limit_us: 1_500_000,
-                max_txn_cost_overage_per_object_in_commit_us: 10_000_000,
+                randomness_scalar: 0,
                 max_estimate_us: u64::MAX,
             }),
         )]
@@ -1077,6 +1103,7 @@ mod object_cost_tests {
                 SharedObjectCongestionTracker::new(
                     [(shared_obj_0, 301), (shared_obj_1, 199)],
                     mode,
+                    false,
                     Some(max_accumulated_txn_cost_per_object_in_commit),
                     None,
                     None,
@@ -1095,6 +1122,7 @@ mod object_cost_tests {
                 SharedObjectCongestionTracker::new(
                     [(shared_obj_0, 5), (shared_obj_1, 4)],
                     mode,
+                    false,
                     Some(max_accumulated_txn_cost_per_object_in_commit),
                     None,
                     None,
@@ -1113,6 +1141,7 @@ mod object_cost_tests {
                 SharedObjectCongestionTracker::new(
                     [(shared_obj_0, 301), (shared_obj_1, 250)],
                     mode,
+                    false,
                     Some(max_accumulated_txn_cost_per_object_in_commit),
                     Some(45), // Make the cap just less than the gas budget, there are 1 objects in tx.
                     None,
@@ -1131,6 +1160,7 @@ mod object_cost_tests {
                 SharedObjectCongestionTracker::new(
                     [(shared_obj_0, 4_000_000), (shared_obj_1, 2_000_000)],
                     mode,
+                    false,
                     Some(max_accumulated_txn_cost_per_object_in_commit),
                     None,
                     None,
@@ -1218,7 +1248,7 @@ mod object_cost_tests {
                 // all params ignored in this test
                 target_utilization: 0,
                 allowed_txn_cost_overage_burst_limit_us: 0,
-                max_txn_cost_overage_per_object_in_commit_us: 0,
+                randomness_scalar: 0,
                 max_estimate_us: u64::MAX,
             }),
         )]
@@ -1237,6 +1267,7 @@ mod object_cost_tests {
         let mut shared_object_congestion_tracker = SharedObjectCongestionTracker::new(
             [(object_id_0, 5), (object_id_1, 10)],
             mode,
+            false,
             Some(0), // not part of this test
             cap_factor,
             None,
@@ -1254,6 +1285,7 @@ mod object_cost_tests {
             SharedObjectCongestionTracker::new(
                 [(object_id_0, 5), (object_id_1, 10)],
                 mode,
+                false,
                 Some(0), // not part of this test
                 cap_factor,
                 None,
@@ -1279,6 +1311,7 @@ mod object_cost_tests {
             SharedObjectCongestionTracker::new(
                 [(object_id_0, expected_object_0_cost), (object_id_1, 10)],
                 mode,
+                false,
                 Some(0), // not part of this test
                 cap_factor,
                 None,
@@ -1318,6 +1351,7 @@ mod object_cost_tests {
                     (object_id_2, expected_object_cost)
                 ],
                 mode,
+                false,
                 Some(0), // not part of this test
                 cap_factor,
                 None,
@@ -1359,6 +1393,7 @@ mod object_cost_tests {
                     (object_id_2, expected_object_cost)
                 ],
                 mode,
+                false,
                 Some(0), // not part of this test
                 cap_factor,
                 None,
@@ -1382,7 +1417,7 @@ mod object_cost_tests {
                 target_utilization: 100,
                 // set a burst limit to verify that it does not affect debt calculation.
                 allowed_txn_cost_overage_burst_limit_us: 1_600 * 5,
-                max_txn_cost_overage_per_object_in_commit_us: 1_600 * 10,
+                randomness_scalar: 0,
                 max_estimate_us: u64::MAX,
             }),
         )]
@@ -1415,6 +1450,7 @@ mod object_cost_tests {
                 SharedObjectCongestionTracker::new(
                     [(shared_obj_0, 80), (shared_obj_1, 80)],
                     mode,
+                    false,
                     Some(max_accumulated_txn_cost_per_object_in_commit),
                     None,
                     None,
@@ -1428,6 +1464,7 @@ mod object_cost_tests {
                 SharedObjectCongestionTracker::new(
                     [(shared_obj_0, 80), (shared_obj_1, 80)],
                     mode,
+                    false,
                     Some(max_accumulated_txn_cost_per_object_in_commit),
                     Some(45),
                     None,
@@ -1441,6 +1478,7 @@ mod object_cost_tests {
                 SharedObjectCongestionTracker::new(
                     [(shared_obj_0, 2), (shared_obj_1, 2)],
                     mode,
+                    false,
                     Some(max_accumulated_txn_cost_per_object_in_commit),
                     None,
                     None,
@@ -1454,6 +1492,7 @@ mod object_cost_tests {
                 SharedObjectCongestionTracker::new(
                     [(shared_obj_0, 500), (shared_obj_1, 500)],
                     mode,
+                    false,
                     Some(max_accumulated_txn_cost_per_object_in_commit),
                     None,
                     None,
@@ -1503,6 +1542,7 @@ mod object_cost_tests {
         let shared_object_congestion_tracker = SharedObjectCongestionTracker::new(
             [(object_id_0, 5), (object_id_1, 10), (object_id_2, 100)],
             PerObjectCongestionControlMode::TotalGasBudget,
+            false,
             Some(100),
             None,
             None,
@@ -1529,6 +1569,7 @@ mod object_cost_tests {
         let mut shared_object_congestion_tracker = SharedObjectCongestionTracker::new(
             [(object_id_0, 5), (object_id_1, 10), (object_id_2, 100)],
             PerObjectCongestionControlMode::TotalGasBudgetWithCap,
+            false,
             Some(100),
             Some(1000),
             Some(2),

--- a/crates/sui-core/src/unit_tests/congestion_control_tests.rs
+++ b/crates/sui-core/src/unit_tests/congestion_control_tests.rs
@@ -295,6 +295,7 @@ async fn test_congestion_control_execution_cancellation() {
         Some(SharedObjectCongestionTracker::new(
             [(shared_object_1.0, 10)],
             PerObjectCongestionControlMode::TotalGasBudget,
+            false,
             Some(
                 test_setup
                     .protocol_config

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -674,16 +674,17 @@ impl ConsensusTransactionOrdering {
 
 #[derive(Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 pub struct ExecutionTimeEstimateParams {
-    // targeted per-object utilization as an integer percentage (1-100)
+    // Targeted per-object utilization as an integer percentage (1-100).
     pub target_utilization: u64,
     // Schedule up to this much extra work (in microseconds) per object,
-    // but don't allow the running debt to exceed this limit (unless we
-    // are scheduling a single very large transaction, in which case the
-    // absolute limit will be used).
+    // but don't allow more than a single transaction to exceed this
+    // burst limit.
     pub allowed_txn_cost_overage_burst_limit_us: u64,
-    // absolute limit of how much estimated work to schedule in a commit,
-    // even if it all comes from a single transaction
-    pub max_txn_cost_overage_per_object_in_commit_us: u64,
+
+    // For separate budget for randomness-using tx, the above limits are
+    // used with this integer-percentage scaling factor (1-100).
+    pub randomness_scalar: u64,
+
     // Absolute maximum allowed transaction duration estimate (in microseconds).
     pub max_estimate_us: u64,
 }


### PR DESCRIPTION
Also includes some minor cleanups, most notably removing the absolute
limit param for this mode since we always set it to u64::MAX.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
