### PR TITLE
rpc-alt: track deletes/wraps for dynamic (object)? fields

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/dynamic_fields/deleted.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/dynamic_fields/deleted.move
@@ -1,0 +1,79 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --simulator
+
+// 1. Look for a dynamic field that doesn't exist yet (should return nothing).
+// 2. Add the dynamic field and then look for it again (should return the dynamic field).
+// 3. Delete the dynamic field and look for it once again (should not return anything).
+// 4, 5, 6. The same again, but for dynamic object fields.
+
+//# programmable --sender A --inputs @A
+//> 0: sui::bag::new();
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "suix_getDynamicFieldObject",
+  "params": ["@{obj_1_0}", { "type": "u64", "value": "42" }]
+}
+
+//# programmable --sender A --inputs object(1,0) 42
+//> 0: sui::bag::add<u64, u64>(Input(0), Input(1), Input(1))
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "suix_getDynamicFieldObject",
+  "params": ["@{obj_1_0}", { "type": "u64", "value": "42" }]
+}
+
+//# programmable --sender A --inputs object(1,0) 42
+//> 0: sui::bag::remove<u64, u64>(Input(0), Input(1))
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "suix_getDynamicFieldObject",
+  "params": ["@{obj_1_0}", { "type": "u64", "value": "42" }]
+}
+
+//# programmable --sender A --inputs @A
+//> 0: sui::object_bag::new();
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "suix_getDynamicFieldObject",
+  "params": ["@{obj_10_0}", { "type": "u64", "value": "43" }]
+}
+
+//# programmable --sender A --inputs object(10,0) 43
+//> 0: SplitCoins(Gas, [Input(1)]);
+//> 1: sui::object_bag::add<u64, sui::coin::Coin<sui::sui::SUI>>(Input(0), Input(1), Result(0))
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "suix_getDynamicFieldObject",
+  "params": ["@{obj_10_0}", { "type": "u64", "value": "43" }]
+}
+
+//# programmable --sender A --inputs object(10,0) 43
+//> 0: sui::object_bag::remove<u64, sui::coin::Coin<sui::sui::SUI>>(Input(0), Input(1));
+//> 1: MergeCoins(Gas, [Result(0)])
+
+//# create-checkpoint
+
+//# run-jsonrpc
+{
+  "method": "suix_getDynamicFieldObject",
+  "params": ["@{obj_10_0}", { "type": "u64", "value": "43" }]
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/dynamic_fields/deleted.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/dynamic_fields/deleted.snap
@@ -1,0 +1,192 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 19 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 11-13:
+//# programmable --sender A --inputs @A
+//> 0: sui::bag::new();
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2287600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 15:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 17-21:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": {
+    "error": {
+      "code": "dynamicFieldNotFound",
+      "parent_object_id": "0xdd806f262555a167b932495c24765daccc1ba6ebee5e8a696155818e6b5e93ad"
+    }
+  }
+}
+
+task 4, lines 23-24:
+//# programmable --sender A --inputs object(1,0) 42
+//> 0: sui::bag::add<u64, u64>(Input(0), Input(1), Input(1))
+created: object(4,0)
+mutated: object(0,0), object(1,0)
+gas summary: computation_cost: 1000000, storage_cost: 3754400,  storage_rebate: 2264724, non_refundable_storage_fee: 22876
+
+task 5, line 26:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 6, lines 28-32:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "data": {
+      "objectId": "0xd75efa771017d6658b663e6a9e6636f1667a9c599b3a21e7c6c8cd82e12d13c7",
+      "version": "3",
+      "digest": "624wRp2tvzaqSZdxGqSbns87FAuATEGA6KGdvg2ncvgv",
+      "type": "0x2::dynamic_field::Field<u64, u64>",
+      "owner": {
+        "ObjectOwner": "0xdd806f262555a167b932495c24765daccc1ba6ebee5e8a696155818e6b5e93ad"
+      },
+      "previousTransaction": "ERcxEuSHy68ZKVaJNTMqcTgC5fwXrrFvvz6Gyg4x4YkB",
+      "storageRebate": "1466800",
+      "content": {
+        "dataType": "moveObject",
+        "type": "0x2::dynamic_field::Field<u64, u64>",
+        "hasPublicTransfer": false,
+        "fields": {
+          "id": {
+            "id": "0xd75efa771017d6658b663e6a9e6636f1667a9c599b3a21e7c6c8cd82e12d13c7"
+          },
+          "name": "42",
+          "value": "42"
+        }
+      }
+    }
+  }
+}
+
+task 7, lines 34-35:
+//# programmable --sender A --inputs object(1,0) 42
+//> 0: sui::bag::remove<u64, u64>(Input(0), Input(1))
+mutated: object(0,0), object(1,0)
+deleted: object(4,0)
+gas summary: computation_cost: 1000000, storage_cost: 2287600,  storage_rebate: 3716856, non_refundable_storage_fee: 37544
+
+task 8, line 37:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 9, lines 39-43:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "error": {
+      "code": "dynamicFieldNotFound",
+      "parent_object_id": "0xdd806f262555a167b932495c24765daccc1ba6ebee5e8a696155818e6b5e93ad"
+    }
+  }
+}
+
+task 10, lines 45-47:
+//# programmable --sender A --inputs @A
+//> 0: sui::object_bag::new();
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(10,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2386400,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 11, line 49:
+//# create-checkpoint
+Checkpoint created: 4
+
+task 12, lines 51-55:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "error": {
+      "code": "dynamicFieldNotFound",
+      "parent_object_id": "0x5b6646bd3bd05c8879a35680bebf1e98b500577ebb5df1264e05982cd3c1cfe1"
+    }
+  }
+}
+
+task 13, lines 57-59:
+//# programmable --sender A --inputs object(10,0) 43
+//> 0: SplitCoins(Gas, [Input(1)]);
+//> 1: sui::object_bag::add<u64, sui::coin::Coin<sui::sui::SUI>>(Input(0), Input(1), Result(0))
+created: object(13,0), object(13,1)
+mutated: object(0,0), object(10,0)
+gas summary: computation_cost: 1000000, storage_cost: 5829200,  storage_rebate: 2362536, non_refundable_storage_fee: 23864
+
+task 14, line 61:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 15, lines 63-67:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 4,
+  "result": {
+    "data": {
+      "objectId": "0x3ea375e25bbb343aff51cc660831991fa8439ba13b7f8f3c66f03d753e4781f7",
+      "version": "6",
+      "digest": "9umLoT7xLRAdnVEepn7UEfnu749rHtdg1M5sfAVUG4gZ",
+      "type": "0x2::coin::Coin<0x2::sui::SUI>",
+      "owner": {
+        "ObjectOwner": "0xc80cc03828dd161e38345cc2d379e8ed93fb0c01833ab546735549e61a71efed"
+      },
+      "previousTransaction": "3U83Emhm1vzUDaR62FyDvq8WwS6G7pbRhtwGhySAvnMe",
+      "storageRebate": "988000",
+      "content": {
+        "dataType": "moveObject",
+        "type": "0x2::coin::Coin<0x2::sui::SUI>",
+        "hasPublicTransfer": true,
+        "fields": {
+          "balance": "43",
+          "id": {
+            "id": "0x3ea375e25bbb343aff51cc660831991fa8439ba13b7f8f3c66f03d753e4781f7"
+          }
+        }
+      }
+    }
+  }
+}
+
+task 16, lines 69-71:
+//# programmable --sender A --inputs object(10,0) 43
+//> 0: sui::object_bag::remove<u64, sui::coin::Coin<sui::sui::SUI>>(Input(0), Input(1));
+//> 1: MergeCoins(Gas, [Result(0)])
+mutated: object(0,0), object(10,0)
+deleted: object(13,0), object(13,1)
+gas summary: computation_cost: 1000000, storage_cost: 2386400,  storage_rebate: 5770908, non_refundable_storage_fee: 58292
+
+task 17, line 73:
+//# create-checkpoint
+Checkpoint created: 6
+
+task 18, lines 75-79:
+//# run-jsonrpc
+Response: {
+  "jsonrpc": "2.0",
+  "id": 5,
+  "result": {
+    "error": {
+      "code": "dynamicFieldNotFound",
+      "parent_object_id": "0x5b6646bd3bd05c8879a35680bebf1e98b500577ebb5df1264e05982cd3c1cfe1"
+    }
+  }
+}

--- a/crates/sui-indexer-alt-jsonrpc/src/api/dynamic_fields.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/dynamic_fields.rs
@@ -18,7 +18,7 @@ use tokio::try_join;
 
 use crate::{
     context::Context,
-    data::objects::load_latest,
+    data::objects::load_live,
     error::{invalid_params, rpc_bail, RpcError},
 };
 
@@ -164,7 +164,7 @@ async fn load_df(
     let id = derive_dynamic_field_id(parent_id, type_, value)
         .context("Failed to derive dynamic field ID")?;
 
-    Ok(load_latest(ctx, id)
+    Ok(load_live(ctx, id)
         .await
         .context("Failed to load dynamic field")?)
 }
@@ -184,7 +184,7 @@ async fn load_dof(
     let id = derive_dynamic_field_id(parent_id, &wrapper, name)
         .context("Failed to derive dynamic object field ID")?;
 
-    let Some(object) = load_latest(ctx, id)
+    let Some(object) = load_live(ctx, id)
         .await
         .context("Failed to load dynamic object field")?
     else {
@@ -199,7 +199,7 @@ async fn load_dof(
     let value = ObjectID::from_bytes(&move_object.contents()[ObjectID::LENGTH + name.len()..])
         .context("Failed to extract object ID from dynamic object field")?;
 
-    Ok(load_latest(ctx, value)
+    Ok(load_live(ctx, value)
         .await
         .context("Failed to load dynamic field object")?)
 }


### PR DESCRIPTION
## Description

If a dynamic field has been deleted or wrapped, we should indicate that it has not been found (rather than fetching the last live version).

## Test plan

```
sui$ cargo nextest run -p sui-indexer-alt-e2e-tests \
  -- dynamic_fields/deleted
```

## Stack

- #21471 
- #21482 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
