### PR TITLE
Enable ExecutionTimeEstimate mode for congestion control in testnet

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -215,7 +215,7 @@ jobs:
     timeout-minutes: 45
     runs-on: [ ubuntu-ghcloud ]
     env:
-      MSIM_WATCHDOG_TIMEOUT_MS: 60000
+      MSIM_WATCHDOG_TIMEOUT_MS: 300000
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # Pin v4.1.1
         with:

--- a/crates/sui-e2e-tests/tests/framework_upgrades/mock_sui_systems/base/sources/sui_system.move
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/mock_sui_systems/base/sources/sui_system.move
@@ -91,4 +91,9 @@ module sui_system::sui_system {
         assert!(sui_system_state_inner::system_state_version(inner) == version, 0);
         inner
     }
+
+    fun store_execution_time_estimates(wrapper: &mut SuiSystemState, estimates_bytes: vector<u8>) {
+        let self = load_system_state_mut(wrapper);
+        sui_system_state_inner::store_execution_time_estimates(self, estimates_bytes)
+    }
 }

--- a/crates/sui-e2e-tests/tests/framework_upgrades/mock_sui_systems/base/sources/sui_system_state_inner.move
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/mock_sui_systems/base/sources/sui_system_state_inner.move
@@ -17,6 +17,8 @@ module sui_system::sui_system_state_inner {
 
     const SYSTEM_STATE_VERSION_V1: u64 = 18446744073709551605;  // u64::MAX - 10
 
+    const EXTRA_FIELD_EXECUTION_TIME_ESTIMATES_KEY: u64 = 0;
+
     public struct SystemParameters has store {
         epoch_duration_ms: u64,
         extra_fields: Bag,
@@ -112,5 +114,12 @@ module sui_system::sui_system_state_inner {
             inactive_validators: table::new(ctx),
             extra_fields: bag::new(ctx),
         }
+    }
+
+    public(package) fun store_execution_time_estimates(self: &mut SuiSystemStateInner, estimates: vector<u8>) {
+        if (bag::contains(&self.extra_fields, EXTRA_FIELD_EXECUTION_TIME_ESTIMATES_KEY)) {
+            let _: vector<u8> = bag::remove(&mut self.extra_fields, EXTRA_FIELD_EXECUTION_TIME_ESTIMATES_KEY);
+        };
+        bag::add(&mut self.extra_fields, EXTRA_FIELD_EXECUTION_TIME_ESTIMATES_KEY, estimates);
     }
 }

--- a/crates/sui-e2e-tests/tests/framework_upgrades/mock_sui_systems/deep_upgrade/sources/sui_system.move
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/mock_sui_systems/deep_upgrade/sources/sui_system.move
@@ -96,4 +96,9 @@ module sui_system::sui_system {
         assert!(sui_system_state_inner::system_state_version(inner) == version, 0);
         inner
     }
+
+    fun store_execution_time_estimates(wrapper: &mut SuiSystemState, estimates_bytes: vector<u8>) {
+        let self = load_system_state_mut(wrapper);
+        sui_system_state_inner::store_execution_time_estimates(self, estimates_bytes)
+    }
 }

--- a/crates/sui-e2e-tests/tests/framework_upgrades/mock_sui_systems/deep_upgrade/sources/sui_system_state_inner.move
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/mock_sui_systems/deep_upgrade/sources/sui_system_state_inner.move
@@ -21,6 +21,8 @@ module sui_system::sui_system_state_inner {
     // Not using MAX - 9 since it's already used in the shallow upgrade test.
     const SYSTEM_STATE_VERSION_V2: u64 = 18446744073709551607;  // u64::MAX - 8
 
+    const EXTRA_FIELD_EXECUTION_TIME_ESTIMATES_KEY: u64 = 0;
+
     public struct SystemParameters has store {
         epoch_duration_ms: u64,
         extra_fields: Bag,
@@ -184,5 +186,12 @@ module sui_system::sui_system_state_inner {
             inactive_validators,
             extra_fields,
         }
+    }
+
+    public(package) fun store_execution_time_estimates(self: &mut SuiSystemStateInnerV2, estimates: vector<u8>) {
+        if (bag::contains(&self.extra_fields, EXTRA_FIELD_EXECUTION_TIME_ESTIMATES_KEY)) {
+            let _: vector<u8> = bag::remove(&mut self.extra_fields, EXTRA_FIELD_EXECUTION_TIME_ESTIMATES_KEY);
+        };
+        bag::add(&mut self.extra_fields, EXTRA_FIELD_EXECUTION_TIME_ESTIMATES_KEY, estimates);
     }
 }

--- a/crates/sui-e2e-tests/tests/framework_upgrades/mock_sui_systems/shallow_upgrade/sources/sui_system.move
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/mock_sui_systems/shallow_upgrade/sources/sui_system.move
@@ -96,4 +96,9 @@ module sui_system::sui_system {
         assert!(sui_system_state_inner::system_state_version(inner) == version, 0);
         inner
     }
+
+    fun store_execution_time_estimates(wrapper: &mut SuiSystemState, estimates_bytes: vector<u8>) {
+        let self = load_system_state_mut(wrapper);
+        sui_system_state_inner::store_execution_time_estimates(self, estimates_bytes)
+    }
 }

--- a/crates/sui-e2e-tests/tests/framework_upgrades/mock_sui_systems/shallow_upgrade/sources/sui_system_state_inner.move
+++ b/crates/sui-e2e-tests/tests/framework_upgrades/mock_sui_systems/shallow_upgrade/sources/sui_system_state_inner.move
@@ -15,6 +15,8 @@ module sui_system::sui_system_state_inner {
     const SYSTEM_STATE_VERSION_V1: u64 = 18446744073709551605;  // u64::MAX - 10
     const SYSTEM_STATE_VERSION_V2: u64 = 18446744073709551606;  // u64::MAX - 9
 
+    const EXTRA_FIELD_EXECUTION_TIME_ESTIMATES_KEY: u64 = 0;
+
     public struct SystemParameters has store {
         epoch_duration_ms: u64,
         extra_fields: Bag,
@@ -142,5 +144,12 @@ module sui_system::sui_system_state_inner {
             epoch_start_timestamp_ms,
             extra_fields,
         }
+    }
+    
+    public(package) fun store_execution_time_estimates(self: &mut SuiSystemStateInnerV2, estimates: vector<u8>) {
+        if (bag::contains(&self.extra_fields, EXTRA_FIELD_EXECUTION_TIME_ESTIMATES_KEY)) {
+            let _: vector<u8> = bag::remove(&mut self.extra_fields, EXTRA_FIELD_EXECUTION_TIME_ESTIMATES_KEY);
+        };
+        bag::add(&mut self.extra_fields, EXTRA_FIELD_EXECUTION_TIME_ESTIMATES_KEY, estimates);
     }
 }

--- a/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
@@ -3,7 +3,7 @@
 
 use futures::future::join_all;
 use rand::rngs::OsRng;
-use std::collections::{BTreeSet, HashSet};
+use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
 use sui_core::consensus_adapter::position_submit_certificate;
@@ -16,9 +16,7 @@ use sui_test_transaction_builder::{make_transfer_sui_transaction, TestTransactio
 use sui_types::base_types::SuiAddress;
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::error::SuiError;
-use sui_types::gas::GasCostSummary;
 use sui_types::governance::MIN_VALIDATOR_JOINING_STAKE_MIST;
-use sui_types::message_envelope::Message;
 use sui_types::sui_system_state::{
     get_validator_from_table, sui_system_state_summary::get_validator_by_pool_id,
     SuiSystemStateTrait,
@@ -26,49 +24,6 @@ use sui_types::sui_system_state::{
 use sui_types::transaction::{TransactionDataAPI, TransactionExpiration, VerifiedTransaction};
 use test_cluster::{TestCluster, TestClusterBuilder};
 use tokio::time::sleep;
-
-#[sim_test]
-async fn advance_epoch_tx_test() {
-    let test_cluster = TestClusterBuilder::new().build().await;
-    let states = test_cluster
-        .swarm
-        .validator_node_handles()
-        .into_iter()
-        .map(|handle| handle.with(|node| node.state()))
-        .collect::<Vec<_>>();
-    let tasks: Vec<_> = states
-        .iter()
-        .map(|state| async {
-            let (_system_state, effects) = state
-                .create_and_execute_advance_epoch_tx(
-                    &state.epoch_store_for_testing(),
-                    &GasCostSummary::new(0, 0, 0, 0),
-                    0, // checkpoint
-                    0, // epoch_start_timestamp_ms
-                    vec![],
-                    0, // last_checkpoint
-                )
-                .await
-                .unwrap();
-            // Check that the validator didn't commit the transaction yet.
-            assert!(state
-                .get_signed_effects_and_maybe_resign(
-                    effects.transaction_digest(),
-                    &state.epoch_store_for_testing()
-                )
-                .unwrap()
-                .is_none());
-            effects
-        })
-        .collect();
-    let results: HashSet<_> = join_all(tasks)
-        .await
-        .into_iter()
-        .map(|result| result.digest())
-        .collect();
-    // Check that all validators have the same result.
-    assert_eq!(results.len(), 1);
-}
 
 #[sim_test]
 async fn basic_reconfig_end_to_end_test() {
@@ -723,6 +678,7 @@ async fn do_test_reconfig_with_committee_change_stress() {
 #[cfg(msim)]
 #[sim_test]
 async fn test_epoch_flag_upgrade() {
+    use std::collections::HashSet;
     use std::sync::Mutex;
     use sui_core::authority::epoch_start_configuration::EpochFlag;
     use sui_core::authority::epoch_start_configuration::EpochStartConfigTrait;

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -225,6 +225,7 @@ const MAX_PROTOCOL_VERSION: u64 = 78;
 //             Enable consensus garbage collection for testnet
 //             Enable the new consensus commit rule for testnet.
 // Version 78: Make `TxContext` Move API native
+//             Enable execution time estimate mode for congestion control on testnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -3375,6 +3376,19 @@ impl ProtocolConfig {
                     cfg.tx_context_ids_created_cost_base = Some(30);
                     cfg.tx_context_replace_cost_base = Some(30);
                     cfg.gas_model_version = Some(10);
+
+                    if chain != Chain::Mainnet {
+                        // Enable execution time estimate mode for congestion control on testnet.
+                        cfg.feature_flags.per_object_congestion_control_mode =
+                            PerObjectCongestionControlMode::ExecutionTimeEstimate(
+                                ExecutionTimeEstimateParams {
+                                    target_utilization: 30,
+                                    allowed_txn_cost_overage_burst_limit_us: 100_000, // 100 ms
+                                    randomness_scalar: 20,
+                                    max_estimate_us: 1_500_000, // 1.5s
+                                },
+                            );
+                    }
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_78.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_78.snap
@@ -46,7 +46,12 @@ feature_flags:
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
   reject_mutable_random_on_entry_functions: true
-  per_object_congestion_control_mode: TotalGasBudgetWithCap
+  per_object_congestion_control_mode:
+    ExecutionTimeEstimate:
+      target_utilization: 30
+      allowed_txn_cost_overage_burst_limit_us: 100000
+      randomness_scalar: 20
+      max_estimate_us: 1500000
   consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_78.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_78.snap
@@ -49,7 +49,12 @@ feature_flags:
   enable_group_ops_native_function_msm: true
   enable_nitro_attestation: true
   reject_mutable_random_on_entry_functions: true
-  per_object_congestion_control_mode: TotalGasBudgetWithCap
+  per_object_congestion_control_mode:
+    ExecutionTimeEstimate:
+      target_utilization: 30
+      allowed_txn_cost_overage_burst_limit_us: 100000
+      randomness_scalar: 20
+      max_estimate_us: 1500000
   consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30


### PR DESCRIPTION
## Description 

This enables a new congestion control mode that uses a predictive model for PTB command transaction time collaboratively built through consensus by validators.

## Test plan 

Unit tests, performance backtesting with tool in separate repo, manual inspection.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [x] Protocol: Enables new ExecutionTimeEstimate mode for congestion control in testnet.
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
