### PR TITLE
Test infra improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "antithesis_sdk"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201eba73b76341631014baf9c0018e703af204a1e0f15d7664d8a0947f6be74d"
+dependencies = [
+ "libc",
+ "libloading 0.8.6",
+ "linkme",
+ "once_cell",
+ "rand 0.8.5",
+ "rustc_version_runtime",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2482,7 +2498,7 @@ checksum = "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
 dependencies = [
  "glob",
  "libc",
- "libloading",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -6938,6 +6954,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7005,6 +7031,26 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linkme"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22d227772b5999ddc0690e733f734f95ca05387e329c4084fe65678c51198ffe"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71a98813fa0073a317ed6a8055dcd4722a49d9b862af828ee68449adb799b6be"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -8313,12 +8359,16 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 name = "mysten-common"
 version = "0.1.0"
 dependencies = [
+ "antithesis_sdk",
  "anyhow",
+ "either",
  "fastcrypto",
  "futures",
  "mysten-metrics",
+ "once_cell",
  "parking_lot 0.12.3",
  "prometheus",
+ "rand 0.8.5",
  "reqwest 0.12.9",
  "snap",
  "sui-tls",
@@ -11115,6 +11165,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version_runtime"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+dependencies = [
+ "rustc_version",
+ "semver 1.0.23",
+]
+
+[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13090,6 +13150,7 @@ name = "sui-core"
 version = "0.1.0"
 dependencies = [
  "anemo",
+ "antithesis_sdk",
  "anyhow",
  "arc-swap",
  "async-stream",
@@ -14644,6 +14705,7 @@ version = "1.46.0"
 dependencies = [
  "anemo",
  "anemo-tower",
+ "antithesis_sdk",
  "anyhow",
  "arc-swap",
  "axum 0.7.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,6 +264,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]
+antithesis_sdk = "0.2.5"
 anyhow = "1.0.71"
 arrow = "54"
 arrow-array = "54"

--- a/crates/mysten-common/Cargo.toml
+++ b/crates/mysten-common/Cargo.toml
@@ -6,8 +6,15 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
+rand.workspace = true
+antithesis_sdk.workspace = true
+either.workspace = true
 snap.workspace = true
+once_cell.workspace = true
 tokio.workspace = true
 futures.workspace = true
 parking_lot.workspace = true

--- a/crates/mysten-common/src/lib.rs
+++ b/crates/mysten-common/src/lib.rs
@@ -1,6 +1,23 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use once_cell::sync::Lazy;
+use tracing::warn;
+
 pub mod logging;
 pub mod metrics;
+pub mod random;
 pub mod sync;
+pub mod util;
+
+#[inline(always)]
+pub fn in_antithesis() -> bool {
+    static IN_ANTITHESIS: Lazy<bool> = Lazy::new(|| {
+        let in_antithesis = std::env::var("ANTITHESIS_OUTPUT_DIR").is_ok();
+        if in_antithesis {
+            warn!("Detected that we are running in antithesis");
+        }
+        in_antithesis
+    });
+    *IN_ANTITHESIS
+}

--- a/crates/mysten-common/src/lib.rs
+++ b/crates/mysten-common/src/lib.rs
@@ -21,3 +21,8 @@ pub fn in_antithesis() -> bool {
     });
     *IN_ANTITHESIS
 }
+
+#[inline(always)]
+pub fn in_test_configuration() -> bool {
+    in_antithesis() || cfg!(msim) || cfg!(debug_assertions)
+}

--- a/crates/mysten-common/src/logging.rs
+++ b/crates/mysten-common/src/logging.rs
@@ -12,7 +12,7 @@ macro_rules! fatal {
     }};
 }
 
-pub use antithesis_sdk::assert_reachable;
+pub use antithesis_sdk::assert_reachable as assert_reachable_antithesis;
 
 #[inline(always)]
 pub fn crash_on_debug() -> bool {
@@ -44,9 +44,12 @@ macro_rules! assert_reachable {
     () => {
         $crate::logging::assert_reachable!("");
     };
-    ($message:literal) => {
-        $crate::logging::assert_reachable!($message);
-    };
+    ($message:literal) => {{
+        // calling in to antithesis sdk breaks determinisim in simtests (on linux only)
+        if !cfg!(msim) {
+            $crate::logging::assert_reachable_antithesis!($message);
+        }
+    }};
 }
 
 mod tests {

--- a/crates/mysten-common/src/logging.rs
+++ b/crates/mysten-common/src/logging.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::in_test_configuration;
 use once_cell::sync::Lazy;
 
 #[macro_export]
@@ -16,10 +17,7 @@ pub use antithesis_sdk::assert_reachable;
 #[inline(always)]
 pub fn crash_on_debug() -> bool {
     static CRASH_ON_DEBUG: Lazy<bool> = Lazy::new(|| {
-        cfg!(msim)
-            || cfg!(debug_assertions)
-            || std::env::var("ANTITHESIS_OUTPUT_DIR").is_ok()
-            || std::env::var("SUI_ENABLE_DEBUG_ASSERTIONS").is_ok()
+        in_test_configuration() || std::env::var("SUI_ENABLE_DEBUG_ASSERTIONS").is_ok()
     });
 
     *CRASH_ON_DEBUG

--- a/crates/mysten-common/src/random.rs
+++ b/crates/mysten-common/src/random.rs
@@ -1,0 +1,57 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::in_antithesis;
+
+/// Get a random number generator.
+///
+/// If we are running in antithesis mode, use the antithesis RNG.
+/// Otherwise, use the rand::thread_rng().
+#[inline(always)]
+pub fn get_rng() -> impl rand::Rng {
+    if in_antithesis() {
+        Either::Right(antithesis_sdk::random::AntithesisRng)
+    } else {
+        Either::Left(rand::thread_rng())
+    }
+}
+
+// Need our own Either implementation so we can impl rand::RngCore for it.
+pub enum Either<L, R> {
+    Left(L),
+    Right(R),
+}
+
+impl<L, R> rand::RngCore for Either<L, R>
+where
+    L: rand::RngCore,
+    R: rand::RngCore,
+{
+    fn next_u32(&mut self) -> u32 {
+        match self {
+            Either::Left(l) => l.next_u32(),
+            Either::Right(r) => r.next_u32(),
+        }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        match self {
+            Either::Left(l) => l.next_u64(),
+            Either::Right(r) => r.next_u64(),
+        }
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        match self {
+            Either::Left(l) => l.fill_bytes(dest),
+            Either::Right(r) => r.fill_bytes(dest),
+        }
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        match self {
+            Either::Left(l) => l.try_fill_bytes(dest),
+            Either::Right(r) => r.try_fill_bytes(dest),
+        }
+    }
+}

--- a/crates/mysten-common/src/util.rs
+++ b/crates/mysten-common/src/util.rs
@@ -1,16 +1,16 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::in_antithesis;
+use crate::in_test_configuration;
 use crate::random::get_rng;
 use rand::seq::SliceRandom;
 use rand::Rng;
 
-pub fn randomize_cache_capacity<T>(size: T) -> T
+pub fn randomize_cache_capacity_in_tests<T>(size: T) -> T
 where
     T: Copy + PartialOrd + rand::distributions::uniform::SampleUniform + TryFrom<usize>,
 {
-    if !in_antithesis() && !cfg!(msim) {
+    if !in_test_configuration() {
         return size;
     }
 

--- a/crates/mysten-common/src/util.rs
+++ b/crates/mysten-common/src/util.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::in_antithesis;
+use crate::random::get_rng;
+use rand::seq::SliceRandom;
+use rand::Rng;
+
+pub fn randomize_cache_capacity<T>(size: T) -> T
+where
+    T: Copy + PartialOrd + rand::distributions::uniform::SampleUniform + TryFrom<usize>,
+{
+    if !in_antithesis() && !cfg!(msim) {
+        return size;
+    }
+
+    let mut rng = get_rng();
+
+    // Three choices for cache size
+    //
+    // 2: constant evictions
+    // size: presumably chosen to minimize evictions
+    // random: thrown in case there are weird behaviors at specific but arbitrary eviction/miss rates.
+    //
+    // We don't simply use a uniform random choice because the most interesting cases are probably
+    // a) the value that will be used in production and b) a very tiny value so we want those two
+    // cases to get picked more often.
+
+    // using unwrap() invokes all sorts of requirements on Debug impls.
+    let Ok(two) = T::try_from(2) else {
+        panic!("Failed to convert 2 to T");
+    };
+
+    let random_size = rng.gen_range(two..size);
+    let choices = [two, size, random_size];
+    *choices.choose(&mut rng).unwrap()
+}

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 workspace = true
 
 [dependencies]
+antithesis_sdk.workspace = true
 anyhow = { workspace = true, features = ["backtrace"] }
 arc-swap.workspace = true
 async-trait.workspace = true

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -19,6 +19,7 @@ use futures::future::{join_all, select, Either};
 use futures::FutureExt;
 use itertools::{izip, Itertools};
 use move_bytecode_utils::module_cache::SyncModuleCache;
+use mysten_common::assert_reachable;
 use mysten_common::sync::notify_once::NotifyOnce;
 use mysten_common::sync::notify_read::NotifyRead;
 use mysten_common::{debug_fatal, fatal};
@@ -3248,6 +3249,7 @@ impl AuthorityPerEpochStore {
             match cancelled_txns.get(txn.digest()) {
                 Some(CancelConsensusCertificateReason::CongestionOnObjects(_))
                 | Some(CancelConsensusCertificateReason::DkgFailed) => {
+                    assert_reachable!("cancelled transactions");
                     let assigned_versions = SharedObjVerManager::assign_versions_for_certificate(
                         txn,
                         &mut shared_input_next_version,

--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -14,8 +14,8 @@ use fastcrypto_zkp::bn254::zk_login::{JwkId, JWK};
 use moka::policy::EvictionPolicy;
 use moka::sync::SegmentedCache as MokaCache;
 use mysten_common::fatal;
+use mysten_common::util::randomize_cache_capacity;
 use parking_lot::Mutex;
-use rand::seq::SliceRandom;
 use std::collections::{hash_map, BTreeMap, BTreeSet, HashMap, VecDeque};
 use sui_types::authenticator_state::ActiveJwk;
 use sui_types::base_types::{AuthorityName, SequenceNumber};
@@ -396,13 +396,7 @@ impl ConsensusOutputCache {
             "This version of sui-node can only run after data quarantining has been enabled. Please run version 1.45.0 or later to the end of the current epoch and retry"
         );
 
-        let executed_in_epoch_cache_capacity = if cfg!(msim) {
-            // Ensure that we test under conditions of constant, frequent,
-            // and rare cache evictions.
-            *[2, 100, 50000].choose(&mut rand::thread_rng()).unwrap()
-        } else {
-            50_000
-        };
+        let executed_in_epoch_cache_capacity = 50_000;
 
         Self {
             shared_version_assignments: Default::default(),
@@ -411,7 +405,7 @@ impl ConsensusOutputCache {
             executed_in_epoch: RwLock::new(DashMap::with_shard_amount(2048)),
             executed_in_epoch_cache: MokaCache::builder(8)
                 // most queries should be for recent transactions
-                .max_capacity(executed_in_epoch_cache_capacity)
+                .max_capacity(randomize_cache_capacity(executed_in_epoch_cache_capacity))
                 .eviction_policy(EvictionPolicy::lru())
                 .build(),
             metrics,

--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -14,7 +14,7 @@ use fastcrypto_zkp::bn254::zk_login::{JwkId, JWK};
 use moka::policy::EvictionPolicy;
 use moka::sync::SegmentedCache as MokaCache;
 use mysten_common::fatal;
-use mysten_common::util::randomize_cache_capacity;
+use mysten_common::util::randomize_cache_capacity_in_tests;
 use parking_lot::Mutex;
 use std::collections::{hash_map, BTreeMap, BTreeSet, HashMap, VecDeque};
 use sui_types::authenticator_state::ActiveJwk;
@@ -405,7 +405,9 @@ impl ConsensusOutputCache {
             executed_in_epoch: RwLock::new(DashMap::with_shard_amount(2048)),
             executed_in_epoch_cache: MokaCache::builder(8)
                 // most queries should be for recent transactions
-                .max_capacity(randomize_cache_capacity(executed_in_epoch_cache_capacity))
+                .max_capacity(randomize_cache_capacity_in_tests(
+                    executed_in_epoch_cache_capacity,
+                ))
                 .eviction_policy(EvictionPolicy::lru())
                 .build(),
             metrics,

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -13,7 +13,7 @@ use arc_swap::ArcSwap;
 use consensus_config::Committee as ConsensusCommittee;
 use consensus_core::{CertifiedBlocksOutput, CommitConsumerMonitor, CommitIndex};
 use lru::LruCache;
-use mysten_common::debug_fatal;
+use mysten_common::{debug_fatal, util::randomize_cache_capacity};
 use mysten_metrics::{
     monitored_future,
     monitored_mpsc::{self, UnboundedReceiver},
@@ -527,7 +527,9 @@ impl<C> ConsensusHandler<C> {
             low_scoring_authorities,
             committee,
             metrics,
-            processed_cache: LruCache::new(NonZeroUsize::new(PROCESSED_CACHE_CAP).unwrap()),
+            processed_cache: LruCache::new(
+                NonZeroUsize::new(randomize_cache_capacity(PROCESSED_CACHE_CAP)).unwrap(),
+            ),
             transaction_manager_sender,
             throughput_calculator,
             additional_consensus_state: AdditionalConsensusState::new(

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -13,7 +13,7 @@ use arc_swap::ArcSwap;
 use consensus_config::Committee as ConsensusCommittee;
 use consensus_core::{CertifiedBlocksOutput, CommitConsumerMonitor, CommitIndex};
 use lru::LruCache;
-use mysten_common::{debug_fatal, util::randomize_cache_capacity};
+use mysten_common::{debug_fatal, util::randomize_cache_capacity_in_tests};
 use mysten_metrics::{
     monitored_future,
     monitored_mpsc::{self, UnboundedReceiver},
@@ -528,7 +528,7 @@ impl<C> ConsensusHandler<C> {
             committee,
             metrics,
             processed_cache: LruCache::new(
-                NonZeroUsize::new(randomize_cache_capacity(PROCESSED_CACHE_CAP)).unwrap(),
+                NonZeroUsize::new(randomize_cache_capacity_in_tests(PROCESSED_CACHE_CAP)).unwrap(),
             ),
             transaction_manager_sender,
             throughput_calculator,

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -54,7 +54,7 @@ use dashmap::DashMap;
 use futures::{future::BoxFuture, FutureExt};
 use moka::sync::SegmentedCache as MokaCache;
 use mysten_common::sync::notify_read::NotifyRead;
-use mysten_common::util::randomize_cache_capacity;
+use mysten_common::util::randomize_cache_capacity_in_tests;
 use parking_lot::Mutex;
 use prometheus::Registry;
 use std::collections::{BTreeMap, BTreeSet};
@@ -334,31 +334,38 @@ struct CachedCommittedData {
 impl CachedCommittedData {
     fn new(config: &ExecutionCacheConfig) -> Self {
         let object_cache = MokaCache::builder(8)
-            .max_capacity(randomize_cache_capacity(config.object_cache_size()))
+            .max_capacity(randomize_cache_capacity_in_tests(
+                config.object_cache_size(),
+            ))
             .build();
         let marker_cache = MokaCache::builder(8)
-            .max_capacity(randomize_cache_capacity(config.marker_cache_size()))
+            .max_capacity(randomize_cache_capacity_in_tests(
+                config.marker_cache_size(),
+            ))
             .build();
 
-        let transactions =
-            MonotonicCache::new(randomize_cache_capacity(config.transaction_cache_size()));
-        let transaction_effects =
-            MonotonicCache::new(randomize_cache_capacity(config.effect_cache_size()));
-        let transaction_events =
-            MonotonicCache::new(randomize_cache_capacity(config.events_cache_size()));
-        let executed_effects_digests = MonotonicCache::new(randomize_cache_capacity(
+        let transactions = MonotonicCache::new(randomize_cache_capacity_in_tests(
+            config.transaction_cache_size(),
+        ));
+        let transaction_effects = MonotonicCache::new(randomize_cache_capacity_in_tests(
+            config.effect_cache_size(),
+        ));
+        let transaction_events = MonotonicCache::new(randomize_cache_capacity_in_tests(
+            config.events_cache_size(),
+        ));
+        let executed_effects_digests = MonotonicCache::new(randomize_cache_capacity_in_tests(
             config.executed_effect_cache_size(),
         ));
 
         let transaction_objects = MokaCache::builder(8)
-            .max_capacity(randomize_cache_capacity(
+            .max_capacity(randomize_cache_capacity_in_tests(
                 config.transaction_objects_cache_size(),
             ))
             .build();
 
         Self {
             object_cache,
-            object_by_id_cache: MonotonicCache::new(randomize_cache_capacity(
+            object_by_id_cache: MonotonicCache::new(randomize_cache_capacity_in_tests(
                 config.object_by_id_cache_size(),
             )),
             marker_cache,
@@ -471,7 +478,9 @@ impl WritebackCache {
         backpressure_manager: Arc<BackpressureManager>,
     ) -> Self {
         let packages = MokaCache::builder(8)
-            .max_capacity(randomize_cache_capacity(config.package_cache_size()))
+            .max_capacity(randomize_cache_capacity_in_tests(
+                config.package_cache_size(),
+            ))
             .build();
         Self {
             dirty: UncommittedData::new(),

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use lru::LruCache;
-use mysten_common::{fatal, util::randomize_cache_capacity};
+use mysten_common::{fatal, util::randomize_cache_capacity_in_tests};
 use mysten_metrics::monitored_scope;
 use parking_lot::RwLock;
 use sui_types::{
@@ -187,7 +187,7 @@ struct AvailableObjectsCache {
 
 impl AvailableObjectsCache {
     fn new(metrics: Arc<AuthorityMetrics>) -> Self {
-        Self::new_with_size(metrics, randomize_cache_capacity(100000))
+        Self::new_with_size(metrics, randomize_cache_capacity_in_tests(100000))
     }
 
     fn new_with_size(metrics: Arc<AuthorityMetrics>, size: usize) -> Self {

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -197,11 +197,6 @@ impl AvailableObjectsCache {
         }
     }
 
-    #[cfg(test)]
-    fn new_with_size_for_unittest(metrics: Arc<AuthorityMetrics>, size: usize) -> Self {
-        Self::new_with_size(metrics, size)
-    }
-
     fn enable_unbounded_cache(&mut self) {
         self.unbounded_cache_enabled += 1;
     }
@@ -1021,7 +1016,7 @@ mod test {
     #[cfg_attr(msim, ignore)]
     fn test_available_objects_cache() {
         let metrics = Arc::new(AuthorityMetrics::new(&Registry::default()));
-        let mut cache = AvailableObjectsCache::new_with_size_for_unittest(metrics, 5);
+        let mut cache = AvailableObjectsCache::new_with_size(metrics, 5);
 
         // insert 10 unique unversioned objects
         for i in 0..10 {

--- a/crates/sui-macros/src/lib.rs
+++ b/crates/sui-macros/src/lib.rs
@@ -316,6 +316,13 @@ macro_rules! replay_log {
     };
 }
 
+pub static ANTITHESIS_ASSERTIONS_ENABLED: once_cell::sync::Lazy<bool> =
+    once_cell::sync::Lazy::new(|| {
+        std::env::var("ANTITHESIS_ASSERTIONS_ENABLED")
+            .map(|s| s == "1")
+            .unwrap_or(false)
+    });
+
 // These tests need to be run in release mode, since debug mode does overflow checks by default!
 #[cfg(test)]
 mod test {

--- a/crates/sui-node/Cargo.toml
+++ b/crates/sui-node/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 [dependencies]
 anemo.workspace = true
 anemo-tower.workspace = true
+antithesis_sdk.workspace = true
 arc-swap.workspace = true
 axum.workspace = true
 anyhow.workspace = true

--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -43,6 +43,8 @@ struct Args {
 }
 
 fn main() {
+    antithesis_sdk::antithesis_init();
+
     move_vm_profiler::ensure_move_vm_profiler_disabled();
 
     // Ensure that a validator never calls get_for_min_version/get_for_max_version_UNSAFE.


### PR DESCRIPTION
- Integrate Antithesis SDK
- Add reachability assertions
- Use antithesis RNG when available.
- `debug_fatal!` panics on antithesis
- randomize cache capacities to exercise cache miss/eviction paths
