### PR TITLE
[sui-proxy] remove std::env::set_var

### DIFF
--- a/crates/sui-proxy/src/admin.rs
+++ b/crates/sui-proxy/src/admin.rs
@@ -97,6 +97,7 @@ pub fn app(
     client: ReqwestClient,
     relay: HistogramRelay,
     allower: Option<SuiNodeProvider>,
+    timeout_secs: Option<u64>,
 ) -> Router {
     // build our application with a route and our sender mpsc
     let mut router = Router::new()
@@ -116,10 +117,9 @@ pub fn app(
         // Enforce on all routes.
         // If the request does not complete within the specified timeout it will be aborted
         // and a 408 Request Timeout response will be sent.
-        .layer(TimeoutLayer::new(Duration::from_secs(var!(
-            "NODE_CLIENT_TIMEOUT",
-            20
-        ))))
+        .layer(TimeoutLayer::new(Duration::from_secs(
+            timeout_secs.unwrap_or(20),
+        )))
         .layer(Extension(relay))
         .layer(Extension(labels))
         .layer(Extension(client))

--- a/crates/sui-proxy/src/lib.rs
+++ b/crates/sui-proxy/src/lib.rs
@@ -135,6 +135,7 @@ mod tests {
             client,
             HistogramRelay::new(),
             Some(allower.clone()),
+            None,
         );
 
         let listener = std::net::TcpListener::bind("localhost:0").unwrap();
@@ -237,10 +238,7 @@ mod tests {
             "dummy user agent",
         );
 
-        // this will affect other tests if they are run in parallel, but we only have two tests, so it shouldn't be an issue (yet)
-        // even still, the other tests complete very fast so those tests would also need to slow down by orders and orders to be
-        // bothered by this env var
-        std::env::set_var("NODE_CLIENT_TIMEOUT", "5");
+        let timeout_secs = Some(2u64);
 
         let app = admin::app(
             Labels {
@@ -250,6 +248,7 @@ mod tests {
             client,
             HistogramRelay::new(),
             Some(allower.clone()),
+            timeout_secs,
         );
 
         let listener = std::net::TcpListener::bind("localhost:0").unwrap();
@@ -307,7 +306,5 @@ mod tests {
             .expect("expected a successful post with a self-signed certificate");
         let status = res.status();
         assert_eq!(status, StatusCode::REQUEST_TIMEOUT);
-        // Clean up the environment variable
-        std::env::remove_var("NODE_CLIENT_TIMEOUT");
     }
 }

--- a/crates/sui-proxy/src/main.rs
+++ b/crates/sui-proxy/src/main.rs
@@ -84,6 +84,12 @@ async fn main() -> Result<()> {
             "unavailable",
         ))
         .unwrap();
+
+    let timeout_secs = match env::var("NODE_CLIENT_TIMEOUT") {
+        Ok(val) => val.parse::<u64>().ok(),
+        Err(_) => None,
+    };
+
     let app = app(
         Labels {
             network: config.network,
@@ -93,6 +99,7 @@ async fn main() -> Result<()> {
         client,
         histogram_relay,
         allower,
+        timeout_secs,
     );
 
     server(listener, app, Some(acceptor)).await.unwrap();


### PR DESCRIPTION
## Description 

remove `std::env::set_var` from tests and allow timeout to be set without relying on an env var

for: https://github.com/MystenLabs/sui/pull/21488
## Test plan 

local tests


