### PR TITLE
only use Display impl for json rpc errors

### DIFF
--- a/crates/sui-json-rpc/src/logger.rs
+++ b/crates/sui-json-rpc/src/logger.rs
@@ -19,7 +19,7 @@ macro_rules! with_tracing {
 
                 let rpc_error: ErrorObjectOwned = e.into();
 
-                error!(error=?anyhow_error);
+                error!(error=%anyhow_error);
                 rpc_error
             });
 

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -733,7 +733,7 @@ impl ReadApiServer for ReadApi {
             let transaction_kv_store = self.transaction_kv_store.clone();
             let transaction = spawn_monitored_task!(async move {
                 let ret = transaction_kv_store.get_tx(digest).await.map_err(|err| {
-                    debug!(tx_digest=?digest, "Failed to get transaction: {:?}", err);
+                    debug!(tx_digest=?digest, "Failed to get transaction: {}", err);
                     Error::from(err)
                 });
                 add_server_timing("tx_kv_lookup");


### PR DESCRIPTION
The prior code generates enormous volumes of backtraces due to not-actually-erroneous states such as "transaction not found"
