### PR TITLE
Increase dashmap shards and use segmented Moka cache to reduce lock contention

### DIFF
--- a/crates/sui-core/src/execution_cache/cache_types.rs
+++ b/crates/sui-core/src/execution_cache/cache_types.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::{cmp::Ordering, hash::DefaultHasher};
 
-use moka::sync::Cache as MokaCache;
+use moka::sync::SegmentedCache as MokaCache;
 use mysten_common::debug_fatal;
 use parking_lot::Mutex;
 use sui_types::base_types::SequenceNumber;
@@ -193,7 +193,7 @@ where
 {
     pub fn new(cache_size: u64) -> Self {
         Self {
-            cache: MokaCache::builder().max_capacity(cache_size).build(),
+            cache: MokaCache::builder(8).max_capacity(cache_size).build(),
             key_generation: (0..KEY_GENERATION_SIZE)
                 .map(|_| AtomicU64::new(0))
                 .collect(),


### PR DESCRIPTION
Since these structures are created once at startup, this should have very little downside
