### PR TITLE
[indexer-alt][db-agnostic framework][2/n]  pg-agnostic `DbConnection` and `Store`, update sequential pipelines accordingly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13888,6 +13888,7 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "reqwest 0.12.9",
+ "scoped-futures",
  "serde",
  "sui-field-count",
  "sui-indexer-alt-metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -480,6 +480,7 @@ rustversion = "1.0.9"
 rustyline = "9.1.2"
 rustyline-derive = "0.7.0"
 schemars = { version = "0.8.21", features = ["either"] }
+scoped-futures = "0.1.3"
 scopeguard = "1.1"
 serde = { version = "1.0.144", features = ["derive", "rc"] }
 serde-env = "0.2.0"

--- a/crates/sui-indexer-alt-framework/Cargo.toml
+++ b/crates/sui-indexer-alt-framework/Cargo.toml
@@ -20,6 +20,7 @@ diesel_migrations.workspace = true
 futures.workspace = true
 prometheus.workspace = true
 reqwest.workspace = true
+scoped-futures.workspace = true
 serde.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -439,7 +439,7 @@ impl Indexer {
         let mut conn = self.db.connect().await.context("Failed DB connection")?;
 
         let watermark = conn
-            .committer_watermark(&P::NAME)
+            .committer_watermark(P::NAME)
             .await
             .with_context(|| format!("Failed to get watermark for {}", P::NAME))?;
 
@@ -447,7 +447,7 @@ impl Indexer {
             // If the pruner of this pipeline requires processed values in order to prune,
             // we must start ingestion from just after the pruner watermark,
             // so that we can process all values needed by the pruner.
-            conn.pruner_watermark(&P::NAME, Default::default())
+            conn.pruner_watermark(P::NAME, Default::default())
                 .await
                 .with_context(|| format!("Failed to get pruner watermark for {}", P::NAME))?
                 .map(|w| w.pruner_hi as u64)

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -451,12 +451,12 @@ impl Indexer {
             conn.pruner_watermark(P::NAME, Default::default())
                 .await
                 .with_context(|| format!("Failed to get pruner watermark for {}", P::NAME))?
-                .map(|w| w.pruner_hi as u64)
+                .map(|w| w.pruner_hi)
                 .unwrap_or_default()
         } else {
             watermark
                 .as_ref()
-                .map(|w| w.checkpoint_hi_inclusive as u64 + 1)
+                .map(|w| w.checkpoint_hi_inclusive + 1)
                 .unwrap_or_default()
         };
 

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -18,8 +18,8 @@ use pipeline::{
     Processor,
 };
 use prometheus::Registry;
-use store::{CommitterWatermark, DbConnection};
-use sui_indexer_alt_metrics::db::DbConnectionStatsCollector;
+use store::{CommitterWatermark, Connection};
+use sui_indexer_alt_metrics::db::ConnectionStatsCollector;
 use sui_pg_db::{temp::TempDb, Db, DbArgs};
 use tempfile::tempdir;
 use tokio::task::JoinHandle;
@@ -160,7 +160,7 @@ impl Indexer {
         let metrics = IndexerMetrics::new(registry);
 
         // TODO (wlmyng): Defer additional, db-specific metrics as an input arg
-        registry.register(Box::new(DbConnectionStatsCollector::new(
+        registry.register(Box::new(ConnectionStatsCollector::new(
             Some("indexer_db"),
             db.clone(),
         )))?;

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -337,7 +337,7 @@ impl Indexer {
     ) -> Result<()> {
         if let (Some(watermark), Some(first_checkpoint)) = (watermark, self.first_checkpoint) {
             ensure!(
-                first_checkpoint as i64 <= watermark.checkpoint_hi_inclusive + 1,
+                first_checkpoint <= watermark.checkpoint_hi_inclusive + 1,
                 "For pipeline {}, first checkpoint override {} is too far ahead of watermark {}. \
                  This could create gaps in the data.",
                 P::NAME,

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -19,7 +19,7 @@ use pipeline::{
 };
 use prometheus::Registry;
 use store::{CommitterWatermark, Connection};
-use sui_indexer_alt_metrics::db::ConnectionStatsCollector;
+use sui_indexer_alt_metrics::db::DbConnectionStatsCollector;
 use sui_pg_db::{temp::TempDb, Db, DbArgs};
 use tempfile::tempdir;
 use tokio::task::JoinHandle;
@@ -159,8 +159,9 @@ impl Indexer {
 
         let metrics = IndexerMetrics::new(registry);
 
-        // TODO (wlmyng): Defer additional, db-specific metrics as an input arg
-        registry.register(Box::new(ConnectionStatsCollector::new(
+        // TODO (wlmyng): Users will be responsible for configuring their registry with db metrics,
+        // if desired
+        registry.register(Box::new(DbConnectionStatsCollector::new(
             Some("indexer_db"),
             db.clone(),
         )))?;

--- a/crates/sui-indexer-alt-framework/src/models/watermarks.rs
+++ b/crates/sui-indexer-alt-framework/src/models/watermarks.rs
@@ -91,17 +91,6 @@ impl PgCommitterWatermark<'static> {
 }
 
 impl<'p> PgCommitterWatermark<'p> {
-    #[cfg(test)]
-    pub(crate) fn new_for_testing(pipeline: &'p str, checkpoint_hi_inclusive: u64) -> Self {
-        PgCommitterWatermark {
-            pipeline: pipeline.into(),
-            epoch_hi_inclusive: 0,
-            checkpoint_hi_inclusive: checkpoint_hi_inclusive as i64,
-            tx_hi: 0,
-            timestamp_ms_hi_inclusive: 0,
-        }
-    }
-
     /// Upsert the high watermark as long as it raises the watermark stored in the database.
     /// Returns a boolean indicating whether the watermark was actually updated or not.
     ///
@@ -174,16 +163,6 @@ impl PgPrunerWatermark<'static> {
 }
 
 impl PgPrunerWatermark<'_> {
-    #[cfg(test)]
-    pub(crate) fn new_for_testing(pipeline: &'static str, pruner_hi: u64) -> Self {
-        PgPrunerWatermark {
-            pipeline: pipeline.into(),
-            wait_for: 0,
-            reader_lo: 0,
-            pruner_hi: pruner_hi as i64,
-        }
-    }
-
     /// Update the pruner high watermark (only) for an existing watermark row, as long as this
     /// raises the watermark.
     ///

--- a/crates/sui-indexer-alt-framework/src/models/watermarks.rs
+++ b/crates/sui-indexer-alt-framework/src/models/watermarks.rs
@@ -3,7 +3,7 @@
 
 use std::{borrow::Cow, time::Duration};
 
-use chrono::{naive::NaiveDateTime, DateTime, Utc};
+use chrono::naive::NaiveDateTime;
 use diesel::{prelude::*, sql_types::BigInt};
 use diesel_async::RunQueryDsl;
 
@@ -14,7 +14,7 @@ use crate::FieldCount;
 
 #[derive(Insertable, Selectable, Queryable, Debug, Clone, FieldCount)]
 #[diesel(table_name = watermarks)]
-pub(crate) struct StoredWatermark {
+pub struct StoredWatermark {
     pub pipeline: String,
     pub epoch_hi_inclusive: i64,
     pub checkpoint_hi_inclusive: i64,
@@ -28,7 +28,7 @@ pub(crate) struct StoredWatermark {
 /// Fields that the committer is responsible for setting.
 #[derive(AsChangeset, Selectable, Queryable, Debug, Clone, FieldCount)]
 #[diesel(table_name = watermarks)]
-pub(crate) struct CommitterWatermark<'p> {
+pub struct PgCommitterWatermark<'p> {
     pub pipeline: Cow<'p, str>,
     pub epoch_hi_inclusive: i64,
     pub checkpoint_hi_inclusive: i64,
@@ -38,14 +38,14 @@ pub(crate) struct CommitterWatermark<'p> {
 
 #[derive(AsChangeset, Selectable, Queryable, Debug, Clone, FieldCount)]
 #[diesel(table_name = watermarks)]
-pub(crate) struct ReaderWatermark<'p> {
+pub struct PgReaderWatermark<'p> {
     pub pipeline: Cow<'p, str>,
     pub reader_lo: i64,
 }
 
 #[derive(Queryable, Debug, Clone, FieldCount, PartialEq, Eq)]
 #[diesel(table_name = watermarks)]
-pub(crate) struct PrunerWatermark<'p> {
+pub struct PgPrunerWatermark<'p> {
     /// The pipeline in question
     pub pipeline: Cow<'p, str>,
 
@@ -75,14 +75,14 @@ impl StoredWatermark {
     }
 }
 
-impl CommitterWatermark<'static> {
+impl PgCommitterWatermark<'static> {
     /// Get the current high watermark for the pipeline.
     pub(crate) async fn get(
         conn: &mut Connection<'_>,
         pipeline: &'static str,
     ) -> QueryResult<Option<Self>> {
         watermarks::table
-            .select(CommitterWatermark::as_select())
+            .select(PgCommitterWatermark::as_select())
             .filter(watermarks::pipeline.eq(pipeline))
             .first(conn)
             .await
@@ -90,32 +90,16 @@ impl CommitterWatermark<'static> {
     }
 }
 
-impl<'p> CommitterWatermark<'p> {
-    /// A new watermark with the given pipeline name indicating zero progress.
-    pub(crate) fn initial(pipeline: Cow<'p, str>) -> Self {
-        CommitterWatermark {
-            pipeline,
-            epoch_hi_inclusive: 0,
-            checkpoint_hi_inclusive: 0,
-            tx_hi: 0,
-            timestamp_ms_hi_inclusive: 0,
-        }
-    }
-
+impl<'p> PgCommitterWatermark<'p> {
     #[cfg(test)]
     pub(crate) fn new_for_testing(pipeline: &'p str, checkpoint_hi_inclusive: u64) -> Self {
-        CommitterWatermark {
+        PgCommitterWatermark {
             pipeline: pipeline.into(),
             epoch_hi_inclusive: 0,
             checkpoint_hi_inclusive: checkpoint_hi_inclusive as i64,
             tx_hi: 0,
             timestamp_ms_hi_inclusive: 0,
         }
-    }
-
-    /// The consensus timestamp associated with this checkpoint.
-    pub(crate) fn timestamp(&self) -> DateTime<Utc> {
-        DateTime::from_timestamp_millis(self.timestamp_ms_hi_inclusive).unwrap_or_default()
     }
 
     /// Upsert the high watermark as long as it raises the watermark stored in the database.
@@ -136,14 +120,7 @@ impl<'p> CommitterWatermark<'p> {
     }
 }
 
-impl<'p> ReaderWatermark<'p> {
-    pub(crate) fn new(pipeline: impl Into<Cow<'p, str>>, reader_lo: u64) -> Self {
-        ReaderWatermark {
-            pipeline: pipeline.into(),
-            reader_lo: reader_lo as i64,
-        }
-    }
-
+impl<'p> PgReaderWatermark<'p> {
     /// Update the reader low watermark for an existing watermark row, as long as this raises the
     /// watermark, and updates the timestamp this update happened to the database's current time.
     ///
@@ -159,7 +136,7 @@ impl<'p> ReaderWatermark<'p> {
     }
 }
 
-impl PrunerWatermark<'static> {
+impl PgPrunerWatermark<'static> {
     /// Get the bounds for the region that the pruner still has to prune for the given `pipeline`,
     /// along with a duration to wait before acting on this information, based on the time at which
     /// the pruner last updated the bounds, and the configured `delay`.
@@ -196,36 +173,15 @@ impl PrunerWatermark<'static> {
     }
 }
 
-impl PrunerWatermark<'_> {
+impl PgPrunerWatermark<'_> {
     #[cfg(test)]
     pub(crate) fn new_for_testing(pipeline: &'static str, pruner_hi: u64) -> Self {
-        PrunerWatermark {
+        PgPrunerWatermark {
             pipeline: pipeline.into(),
             wait_for: 0,
             reader_lo: 0,
             pruner_hi: pruner_hi as i64,
         }
-    }
-
-    /// How long to wait before the pruner can act on this information, or `None`, if there is no
-    /// need to wait.
-    pub(crate) fn wait_for(&self) -> Option<Duration> {
-        (self.wait_for > 0).then(|| Duration::from_millis(self.wait_for as u64))
-    }
-
-    /// The next chunk of checkpoints that the pruner should work on, to advance the watermark.
-    /// If no more checkpoints to prune, returns `None`.
-    /// Otherwise, returns a tuple (from, to_exclusive) where `from` is inclusive and `to_exclusive` is exclusive.
-    /// Advance the watermark as well.
-    pub(crate) fn next_chunk(&mut self, size: u64) -> Option<(u64, u64)> {
-        if self.pruner_hi >= self.reader_lo {
-            return None;
-        }
-
-        let from = self.pruner_hi as u64;
-        let to_exclusive = (from + size).min(self.reader_lo as u64);
-        self.pruner_hi = to_exclusive as i64;
-        Some((from, to_exclusive))
     }
 
     /// Update the pruner high watermark (only) for an existing watermark row, as long as this
@@ -242,8 +198,8 @@ impl PrunerWatermark<'_> {
     }
 }
 
-impl<'p> From<CommitterWatermark<'p>> for StoredWatermark {
-    fn from(watermark: CommitterWatermark<'p>) -> Self {
+impl<'p> From<PgCommitterWatermark<'p>> for StoredWatermark {
+    fn from(watermark: PgCommitterWatermark<'p>) -> Self {
         StoredWatermark {
             pipeline: watermark.pipeline.into_owned(),
             epoch_hi_inclusive: watermark.epoch_hi_inclusive,

--- a/crates/sui-indexer-alt-framework/src/models/watermarks.rs
+++ b/crates/sui-indexer-alt-framework/src/models/watermarks.rs
@@ -1,15 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{borrow::Cow, time::Duration};
-
 use chrono::naive::NaiveDateTime;
-use diesel::{prelude::*, sql_types::BigInt};
+use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 
 use crate::db::Connection;
 use crate::schema::watermarks;
-use crate::sql;
 use crate::FieldCount;
 
 #[derive(Insertable, Selectable, Queryable, Debug, Clone, FieldCount)]
@@ -25,42 +22,6 @@ pub struct StoredWatermark {
     pub pruner_hi: i64,
 }
 
-/// Fields that the committer is responsible for setting.
-#[derive(AsChangeset, Selectable, Queryable, Debug, Clone, FieldCount)]
-#[diesel(table_name = watermarks)]
-pub struct PgCommitterWatermark<'p> {
-    pub pipeline: Cow<'p, str>,
-    pub epoch_hi_inclusive: i64,
-    pub checkpoint_hi_inclusive: i64,
-    pub tx_hi: i64,
-    pub timestamp_ms_hi_inclusive: i64,
-}
-
-#[derive(AsChangeset, Selectable, Queryable, Debug, Clone, FieldCount)]
-#[diesel(table_name = watermarks)]
-pub struct PgReaderWatermark<'p> {
-    pub pipeline: Cow<'p, str>,
-    pub reader_lo: i64,
-}
-
-#[derive(Queryable, Debug, Clone, FieldCount, PartialEq, Eq)]
-#[diesel(table_name = watermarks)]
-pub struct PgPrunerWatermark<'p> {
-    /// The pipeline in question
-    pub pipeline: Cow<'p, str>,
-
-    /// How long to wait from when this query ran on the database until this information can be
-    /// used to prune the database. This number could be negative, meaning no waiting is necessary.
-    pub wait_for: i64,
-
-    /// The pruner can delete up to this checkpoint, (exclusive).
-    pub reader_lo: i64,
-
-    /// The pruner has already deleted up to this checkpoint (exclusive), so can continue from this
-    /// point.
-    pub pruner_hi: i64,
-}
-
 impl StoredWatermark {
     pub(crate) async fn get(
         conn: &mut Connection<'_>,
@@ -72,122 +33,5 @@ impl StoredWatermark {
             .first(conn)
             .await
             .optional()
-    }
-}
-
-impl PgCommitterWatermark<'static> {
-    /// Get the current high watermark for the pipeline.
-    pub(crate) async fn get(
-        conn: &mut Connection<'_>,
-        pipeline: &'static str,
-    ) -> QueryResult<Option<Self>> {
-        watermarks::table
-            .select(PgCommitterWatermark::as_select())
-            .filter(watermarks::pipeline.eq(pipeline))
-            .first(conn)
-            .await
-            .optional()
-    }
-}
-
-impl<'p> PgCommitterWatermark<'p> {
-    /// Upsert the high watermark as long as it raises the watermark stored in the database.
-    /// Returns a boolean indicating whether the watermark was actually updated or not.
-    ///
-    /// TODO(amnn): Test this (depends on supporting migrations and tempdb).
-    pub(crate) async fn update(&self, conn: &mut Connection<'_>) -> QueryResult<bool> {
-        use diesel::query_dsl::methods::FilterDsl;
-        Ok(diesel::insert_into(watermarks::table)
-            .values(StoredWatermark::from(self.clone()))
-            .on_conflict(watermarks::pipeline)
-            .do_update()
-            .set(self)
-            .filter(watermarks::checkpoint_hi_inclusive.lt(self.checkpoint_hi_inclusive))
-            .execute(conn)
-            .await?
-            > 0)
-    }
-}
-
-impl<'p> PgReaderWatermark<'p> {
-    /// Update the reader low watermark for an existing watermark row, as long as this raises the
-    /// watermark, and updates the timestamp this update happened to the database's current time.
-    ///
-    /// Returns a boolean indicating whether the watermark was actually updated or not.
-    pub(crate) async fn update(&self, conn: &mut Connection<'_>) -> QueryResult<bool> {
-        Ok(diesel::update(watermarks::table)
-            .set((self, watermarks::pruner_timestamp.eq(diesel::dsl::now)))
-            .filter(watermarks::pipeline.eq(&self.pipeline))
-            .filter(watermarks::reader_lo.lt(self.reader_lo))
-            .execute(conn)
-            .await?
-            > 0)
-    }
-}
-
-impl PgPrunerWatermark<'static> {
-    /// Get the bounds for the region that the pruner still has to prune for the given `pipeline`,
-    /// along with a duration to wait before acting on this information, based on the time at which
-    /// the pruner last updated the bounds, and the configured `delay`.
-    ///
-    /// The pruner is allowed to prune the region between the returned `pruner_hi` (inclusive) and
-    /// `reader_lo` (exclusive) after `wait_for` milliseconds have passed since this response was
-    /// returned.
-    pub(crate) async fn get(
-        conn: &mut Connection<'_>,
-        pipeline: &'static str,
-        delay: Duration,
-    ) -> QueryResult<Option<Self>> {
-        //     |---------- + delay ---------------------|
-        //                             |--- wait_for ---|
-        //     |-----------------------|----------------|
-        //     ^                       ^
-        //     pruner_timestamp        NOW()
-        let wait_for = sql!(as BigInt,
-            "CAST({BigInt} + 1000 * EXTRACT(EPOCH FROM pruner_timestamp - NOW()) AS BIGINT)",
-            delay.as_millis() as i64,
-        );
-
-        watermarks::table
-            .select((
-                watermarks::pipeline,
-                wait_for,
-                watermarks::reader_lo,
-                watermarks::pruner_hi,
-            ))
-            .filter(watermarks::pipeline.eq(pipeline))
-            .first(conn)
-            .await
-            .optional()
-    }
-}
-
-impl PgPrunerWatermark<'_> {
-    /// Update the pruner high watermark (only) for an existing watermark row, as long as this
-    /// raises the watermark.
-    ///
-    /// Returns a boolean indicating whether the watermark was actually updated or not.
-    pub(crate) async fn update(&self, conn: &mut Connection<'_>) -> QueryResult<bool> {
-        Ok(diesel::update(watermarks::table)
-            .set(watermarks::pruner_hi.eq(self.pruner_hi))
-            .filter(watermarks::pipeline.eq(&self.pipeline))
-            .execute(conn)
-            .await?
-            > 0)
-    }
-}
-
-impl<'p> From<PgCommitterWatermark<'p>> for StoredWatermark {
-    fn from(watermark: PgCommitterWatermark<'p>) -> Self {
-        StoredWatermark {
-            pipeline: watermark.pipeline.into_owned(),
-            epoch_hi_inclusive: watermark.epoch_hi_inclusive,
-            checkpoint_hi_inclusive: watermark.checkpoint_hi_inclusive,
-            tx_hi: watermark.tx_hi,
-            timestamp_ms_hi_inclusive: watermark.timestamp_ms_hi_inclusive,
-            reader_lo: 0,
-            pruner_timestamp: NaiveDateTime::UNIX_EPOCH,
-            pruner_hi: 0,
-        }
     }
 }

--- a/crates/sui-indexer-alt-framework/src/pg_store.rs
+++ b/crates/sui-indexer-alt-framework/src/pg_store.rs
@@ -1,0 +1,176 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::AsyncConnection;
+use scoped_futures::ScopedBoxFuture;
+
+use crate::db::{Connection as PgConnection, Db as PgDb};
+use crate::models::watermarks::{
+    PgCommitterWatermark, PgPrunerWatermark, PgReaderWatermark, StoredWatermark,
+};
+use crate::store::{
+    CommitterWatermark, DbConnection, HandlerBatch, PrunerWatermark, ReaderWatermark,
+    SequentialHandler, Store, TransactionalStore,
+};
+
+#[async_trait]
+impl<'c> DbConnection for PgConnection<'c> {
+    async fn committer_watermark(
+        &mut self,
+        pipeline: &'static str,
+    ) -> anyhow::Result<Option<CommitterWatermark>> {
+        let watermark = PgCommitterWatermark::get(self, pipeline)
+            .await
+            .map_err(anyhow::Error::from)?;
+
+        if let Some(watermark) = watermark {
+            Ok(Some(CommitterWatermark {
+                epoch_hi_inclusive: watermark.epoch_hi_inclusive,
+                checkpoint_hi_inclusive: watermark.checkpoint_hi_inclusive,
+                tx_hi: watermark.tx_hi,
+                timestamp_ms_hi_inclusive: watermark.timestamp_ms_hi_inclusive,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn reader_watermark(
+        &mut self,
+        pipeline: &'static str,
+    ) -> anyhow::Result<Option<ReaderWatermark>> {
+        let watermark = StoredWatermark::get(self, pipeline)
+            .await
+            .map_err(anyhow::Error::from)?;
+
+        if let Some(watermark) = watermark {
+            Ok(Some(ReaderWatermark {
+                checkpoint_hi_inclusive: watermark.checkpoint_hi_inclusive,
+                reader_lo: watermark.reader_lo,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn set_committer_watermark(
+        &mut self,
+        pipeline: &'static str,
+        watermark: CommitterWatermark,
+    ) -> anyhow::Result<bool> {
+        let watermark = PgCommitterWatermark {
+            pipeline: pipeline.into(),
+            epoch_hi_inclusive: watermark.epoch_hi_inclusive,
+            checkpoint_hi_inclusive: watermark.checkpoint_hi_inclusive,
+            tx_hi: watermark.tx_hi,
+            timestamp_ms_hi_inclusive: watermark.timestamp_ms_hi_inclusive,
+        };
+        watermark.update(self).await.map_err(Into::into)
+    }
+
+    async fn set_reader_watermark(
+        &mut self,
+        pipeline: &'static str,
+        reader_lo: i64,
+    ) -> anyhow::Result<bool> {
+        let watermark = PgReaderWatermark {
+            pipeline: pipeline.into(),
+            reader_lo,
+        };
+        watermark.update(self).await.map_err(Into::into)
+    }
+
+    async fn pruner_watermark(
+        &mut self,
+        pipeline: &'static str,
+        delay: Duration,
+    ) -> anyhow::Result<Option<PrunerWatermark>> {
+        let watermark = PgPrunerWatermark::get(self, pipeline, delay)
+            .await
+            .map_err(anyhow::Error::from)?;
+
+        if let Some(watermark) = watermark {
+            Ok(Some(PrunerWatermark {
+                pruner_hi: watermark.pruner_hi,
+                reader_lo: watermark.reader_lo,
+                wait_for: watermark.wait_for,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn set_pruner_watermark(
+        &mut self,
+        pipeline: &'static str,
+        pruner_hi: i64,
+    ) -> anyhow::Result<bool> {
+        let watermark = PgPrunerWatermark {
+            pipeline: pipeline.into(),
+            pruner_hi,
+            // These values are ignored by the update method
+            reader_lo: 0,
+            wait_for: 0,
+        };
+        watermark.update(self).await.map_err(Into::into)
+    }
+}
+
+#[async_trait]
+impl Store for PgDb {
+    type Connection<'c> = PgConnection<'c>;
+
+    async fn connect<'c>(&'c self) -> anyhow::Result<Self::Connection<'c>> {
+        let conn = self.connect().await?;
+        Ok(conn)
+    }
+}
+
+#[async_trait]
+impl TransactionalStore for PgDb {
+    async fn transactional_commit_with_watermark<'a, H>(
+        &'a self,
+        pipeline: &'static str,
+        watermark: &'a CommitterWatermark,
+        batch: &'a HandlerBatch<H>,
+    ) -> anyhow::Result<usize>
+    where
+        H: SequentialHandler<Store = Self> + Send + Sync + 'a,
+    {
+        let mut conn = self.connect().await?;
+
+        let result = AsyncConnection::transaction(&mut conn, |conn| {
+            async {
+                let watermark = PgCommitterWatermark {
+                    pipeline: pipeline.into(),
+                    epoch_hi_inclusive: watermark.epoch_hi_inclusive,
+                    checkpoint_hi_inclusive: watermark.checkpoint_hi_inclusive,
+                    tx_hi: watermark.tx_hi,
+                    timestamp_ms_hi_inclusive: watermark.timestamp_ms_hi_inclusive,
+                };
+                watermark.update(conn).await.map_err(anyhow::Error::from)?;
+                H::commit(batch, conn).await
+            }
+            .scope_boxed()
+        })
+        .await?;
+
+        Ok(result)
+    }
+
+    async fn transaction<'a, R, F>(&self, f: F) -> anyhow::Result<R>
+    where
+        R: Send + 'a,
+        F: Send + 'a,
+        F: for<'r> FnOnce(
+            &'r mut Self::Connection<'_>,
+        ) -> ScopedBoxFuture<'a, 'r, anyhow::Result<R>>,
+    {
+        let mut conn = self.connect().await?;
+        AsyncConnection::transaction(&mut conn, |conn| f(conn)).await
+    }
+}

--- a/crates/sui-indexer-alt-framework/src/pg_store.rs
+++ b/crates/sui-indexer-alt-framework/src/pg_store.rs
@@ -17,11 +17,11 @@ use crate::db::{Connection as PgConnection, Db as PgDb};
 use crate::models::watermarks::StoredWatermark;
 use crate::schema::watermarks;
 use crate::store::{
-    CommitterWatermark, DbConnection, PrunerWatermark, ReaderWatermark, Store, TransactionalStore,
+    CommitterWatermark, Connection, PrunerWatermark, ReaderWatermark, Store, TransactionalStore,
 };
 
 #[async_trait]
-impl DbConnection for PgConnection<'_> {
+impl Connection for PgConnection<'_> {
     async fn committer_watermark(
         &mut self,
         pipeline: &'static str,

--- a/crates/sui-indexer-alt-framework/src/pg_store.rs
+++ b/crates/sui-indexer-alt-framework/src/pg_store.rs
@@ -26,9 +26,7 @@ impl Connection for PgConnection<'_> {
         &mut self,
         pipeline: &'static str,
     ) -> anyhow::Result<Option<CommitterWatermark>> {
-        let watermark = StoredWatermark::get(self, pipeline)
-            .await
-            .map_err(anyhow::Error::from)?;
+        let watermark = StoredWatermark::get(self, pipeline).await?;
 
         if let Some(watermark) = watermark {
             Ok(Some(CommitterWatermark {
@@ -139,7 +137,7 @@ impl Connection for PgConnection<'_> {
 
         if let Some(watermark) = watermark {
             Ok(Some(PrunerWatermark {
-                wait_for: watermark.0,
+                wait_for_ms: watermark.0,
                 pruner_hi: watermark.1,
                 reader_lo: watermark.2,
             }))

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/commit_watermark.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/commit_watermark.rs
@@ -19,7 +19,7 @@ use crate::{
     db::Db,
     metrics::{CheckpointLagMetricReporter, IndexerMetrics},
     pipeline::{logging::WatermarkLogger, CommitterConfig, WatermarkPart, WARN_PENDING_WATERMARKS},
-    store::{CommitterWatermark, DbConnection},
+    store::{CommitterWatermark, Connection},
 };
 
 use super::Handler;

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/commit_watermark.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/commit_watermark.rs
@@ -158,22 +158,22 @@ pub(super) fn commit_watermark<H: Handler + 'static>(
                     metrics
                         .watermark_epoch
                         .with_label_values(&[H::NAME])
-                        .set(watermark.epoch_hi_inclusive);
+                        .set(watermark.epoch_hi_inclusive as i64);
 
                     metrics
                         .watermark_checkpoint
                         .with_label_values(&[H::NAME])
-                        .set(watermark.checkpoint_hi_inclusive);
+                        .set(watermark.checkpoint_hi_inclusive as i64);
 
                     metrics
                         .watermark_transaction
                         .with_label_values(&[H::NAME])
-                        .set(watermark.tx_hi);
+                        .set(watermark.tx_hi as i64);
 
                     metrics
                         .watermark_timestamp_ms
                         .with_label_values(&[H::NAME])
-                        .set(watermark.timestamp_ms_hi_inclusive);
+                        .set(watermark.timestamp_ms_hi_inclusive as i64);
 
                     debug!(
                         pipeline = H::NAME,
@@ -221,17 +221,17 @@ pub(super) fn commit_watermark<H: Handler + 'static>(
                                 metrics
                                     .watermark_epoch_in_db
                                     .with_label_values(&[H::NAME])
-                                    .set(watermark.epoch_hi_inclusive);
+                                    .set(watermark.epoch_hi_inclusive as i64);
 
                                 metrics
                                     .watermark_transaction_in_db
                                     .with_label_values(&[H::NAME])
-                                    .set(watermark.tx_hi);
+                                    .set(watermark.tx_hi as i64);
 
                                 metrics
                                     .watermark_timestamp_in_db_ms
                                     .with_label_values(&[H::NAME])
-                                    .set(watermark.timestamp_ms_hi_inclusive);
+                                    .set(watermark.timestamp_ms_hi_inclusive as i64);
                             }
                             Ok(false) => {}
                         }

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/commit_watermark.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/commit_watermark.rs
@@ -7,7 +7,6 @@ use std::{
     sync::Arc,
 };
 
-use sui_pg_db::Db;
 use tokio::{
     sync::mpsc,
     task::JoinHandle,
@@ -17,6 +16,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
 use crate::{
+    db::Db,
     metrics::{CheckpointLagMetricReporter, IndexerMetrics},
     pipeline::{logging::WatermarkLogger, CommitterConfig, WatermarkPart, WARN_PENDING_WATERMARKS},
     store::{CommitterWatermark, DbConnection},

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/commit_watermark.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/commit_watermark.rs
@@ -214,8 +214,8 @@ pub(super) fn commit_watermark<H: Handler + 'static>(
                                 logger.log::<H>(&watermark, elapsed);
 
                                 checkpoint_lag_reporter.report_lag(
-                                    watermark.checkpoint_hi_inclusive as u64,
-                                    watermark.timestamp_ms_hi_inclusive as u64,
+                                    watermark.checkpoint_hi_inclusive,
+                                    watermark.timestamp_ms_hi_inclusive
                                 );
 
                                 metrics

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
@@ -268,13 +268,7 @@ pub(crate) fn pipeline<H: Handler + Send + Sync + 'static>(
         pruner_cancel.clone(),
     );
 
-    let pruner = pruner(
-        handler,
-        pruner_config,
-        db.clone(),
-        metrics,
-        pruner_cancel.clone(),
-    );
+    let pruner = pruner(handler, pruner_config, db, metrics, pruner_cancel.clone());
 
     tokio::spawn(async move {
         let (_, _, _, _) = futures::join!(processor, collector, committer, commit_watermark);

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
@@ -17,7 +17,7 @@ use crate::{
     db::Db,
     metrics::IndexerMetrics,
     pipeline::logging::{LoggerWatermark, WatermarkLogger},
-    store::DbConnection,
+    store::Connection,
 };
 
 use super::{Handler, PrunerConfig};

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
@@ -171,7 +171,7 @@ pub(super) fn pruner<H: Handler + Send + Sync + 'static>(
             };
 
             // (2) Wait until this information can be acted upon.
-            if let Some(wait_for) = watermark.wait_for() {
+            if let Some(wait_for) = watermark.wait_for_ms() {
                 debug!(pipeline = H::NAME, ?wait_for, "Waiting to prune");
                 tokio::select! {
                     _ = tokio::time::sleep(wait_for) => {}

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
@@ -5,7 +5,6 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
-use sui_pg_db::Db;
 use tokio::{
     sync::Semaphore,
     task::JoinHandle,
@@ -15,6 +14,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
 use crate::{
+    db::Db,
     metrics::IndexerMetrics,
     pipeline::logging::{LoggerWatermark, WatermarkLogger},
     store::DbConnection,
@@ -132,7 +132,7 @@ pub(super) fn pruner<H: Handler + Send + Sync + 'static>(
 
         loop {
             // (1) Get the latest pruning bounds from the database.
-            let watermark = tokio::select! {
+            let mut watermark = tokio::select! {
                 _ = cancel.cancelled() => {
                     info!(pipeline = H::NAME, "Shutdown received");
                     break;

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
@@ -237,7 +237,7 @@ pub(super) fn pruner<H: Handler + Send + Sync + 'static>(
                 match result {
                     Ok(()) => {
                         pending_prune_ranges.remove(&from);
-                        let pruner_hi = pending_prune_ranges.get_pruner_hi() as i64;
+                        let pruner_hi = pending_prune_ranges.get_pruner_hi();
                         highest_pruned = highest_pruned.max(pruner_hi);
                     }
                     Err(e) => {
@@ -252,7 +252,7 @@ pub(super) fn pruner<H: Handler + Send + Sync + 'static>(
                     metrics
                         .watermark_pruner_hi
                         .with_label_values(&[H::NAME])
-                        .set(highest_pruned);
+                        .set(highest_pruned as i64);
 
                     let guard = metrics
                         .watermark_pruner_write_latency
@@ -287,7 +287,7 @@ pub(super) fn pruner<H: Handler + Send + Sync + 'static>(
                             metrics
                                 .watermark_pruner_hi_in_db
                                 .with_label_values(&[H::NAME])
-                                .set(highest_watermarked);
+                                .set(highest_watermarked as i64);
                         }
                         Ok(false) => {}
                     }

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
@@ -85,7 +85,7 @@ pub(super) fn reader_watermark<H: Handler + 'static>(
                         .with_label_values(&[H::NAME])
                         .set(new_reader_lo as i64);
 
-                    let Ok(updated) = conn.set_reader_watermark(H::NAME, new_reader_lo as i64).await else {
+                    let Ok(updated) = conn.set_reader_watermark(H::NAME, new_reader_lo).await else {
                         warn!(pipeline = H::NAME, "Failed to update reader watermark");
                         continue;
                     };

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
@@ -8,7 +8,7 @@ use tokio::{task::JoinHandle, time::interval};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
-use crate::{metrics::IndexerMetrics, store::DbConnection};
+use crate::{metrics::IndexerMetrics, store::Connection};
 
 use super::{Handler, PrunerConfig};
 

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
@@ -3,15 +3,12 @@
 
 use std::sync::Arc;
 
+use sui_pg_db::Db;
 use tokio::{task::JoinHandle, time::interval};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
-use crate::{
-    db::Db,
-    metrics::IndexerMetrics,
-    models::watermarks::{ReaderWatermark, StoredWatermark},
-};
+use crate::{metrics::IndexerMetrics, store::DbConnection};
 
 use super::{Handler, PrunerConfig};
 
@@ -28,7 +25,9 @@ use super::{Handler, PrunerConfig};
 /// when the provided cancellation token is triggered.
 pub(super) fn reader_watermark<H: Handler + 'static>(
     config: Option<PrunerConfig>,
-    db: Db,
+    // TODO (wlmyng): this will eventually be H::Store once we add the associated type to
+    // concurrent::Handler
+    store: Db,
     metrics: Arc<IndexerMetrics>,
     cancel: CancellationToken,
 ) -> JoinHandle<()> {
@@ -48,12 +47,12 @@ pub(super) fn reader_watermark<H: Handler + 'static>(
                 }
 
                 _ = poll.tick() => {
-                    let Ok(mut conn) = db.connect().await else {
+                    let Ok(mut conn) = store.connect().await else {
                         warn!(pipeline = H::NAME, "Reader watermark task failed to get connection for DB");
                         continue;
                     };
 
-                    let current = match StoredWatermark::get(&mut conn, H::NAME).await {
+                    let current = match conn.reader_watermark(H::NAME).await {
                         Ok(Some(current)) => current,
 
                         Ok(None) => {
@@ -86,10 +85,11 @@ pub(super) fn reader_watermark<H: Handler + 'static>(
                         .with_label_values(&[H::NAME])
                         .set(new_reader_lo as i64);
 
-                    let Ok(updated) = ReaderWatermark::new(H::NAME, new_reader_lo).update(&mut conn).await else {
+                    let Ok(updated) = conn.set_reader_watermark(H::NAME, new_reader_lo as i64).await else {
                         warn!(pipeline = H::NAME, "Failed to update reader watermark");
                         continue;
                     };
+
 
                     if updated {
                         info!(pipeline = H::NAME, new_reader_lo, "Watermark");

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
@@ -90,7 +90,6 @@ pub(super) fn reader_watermark<H: Handler + 'static>(
                         continue;
                     };
 
-
                     if updated {
                         info!(pipeline = H::NAME, new_reader_lo, "Watermark");
 

--- a/crates/sui-indexer-alt-framework/src/pipeline/logging.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/logging.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 use tracing::{debug, info};
 
-use crate::models::watermarks::{CommitterWatermark, PrunerWatermark};
+use crate::store::CommitterWatermark;
 
 use super::Processor;
 
@@ -85,7 +85,7 @@ impl WatermarkLogger {
     }
 }
 
-impl From<&CommitterWatermark<'_>> for LoggerWatermark {
+impl From<&CommitterWatermark> for LoggerWatermark {
     fn from(watermark: &CommitterWatermark) -> Self {
         Self {
             checkpoint: watermark.checkpoint_hi_inclusive,
@@ -94,10 +94,10 @@ impl From<&CommitterWatermark<'_>> for LoggerWatermark {
     }
 }
 
-impl From<&PrunerWatermark<'_>> for LoggerWatermark {
-    fn from(watermark: &PrunerWatermark) -> Self {
+impl LoggerWatermark {
+    pub fn checkpoint(checkpoint: i64) -> Self {
         Self {
-            checkpoint: watermark.pruner_hi,
+            checkpoint,
             transaction: None,
         }
     }

--- a/crates/sui-indexer-alt-framework/src/pipeline/logging.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/logging.rs
@@ -88,16 +88,16 @@ impl WatermarkLogger {
 impl From<&CommitterWatermark> for LoggerWatermark {
     fn from(watermark: &CommitterWatermark) -> Self {
         Self {
-            checkpoint: watermark.checkpoint_hi_inclusive,
-            transaction: Some(watermark.tx_hi),
+            checkpoint: watermark.checkpoint_hi_inclusive as i64,
+            transaction: Some(watermark.tx_hi as i64),
         }
     }
 }
 
 impl LoggerWatermark {
-    pub fn checkpoint(checkpoint: i64) -> Self {
+    pub fn checkpoint(checkpoint: u64) -> Self {
         Self {
-            checkpoint,
+            checkpoint: checkpoint as i64,
             transaction: None,
         }
     }

--- a/crates/sui-indexer-alt-framework/src/pipeline/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/mod.rs
@@ -105,17 +105,17 @@ impl<P: Processor> IndexedCheckpoint<P> {
 
     /// The checkpoint sequence number that this data is from
     fn checkpoint(&self) -> u64 {
-        self.watermark.checkpoint_hi_inclusive as u64
+        self.watermark.checkpoint_hi_inclusive
     }
 }
 
 impl WatermarkPart {
     fn checkpoint(&self) -> u64 {
-        self.watermark.checkpoint_hi_inclusive as u64
+        self.watermark.checkpoint_hi_inclusive
     }
 
     fn timestamp_ms(&self) -> u64 {
-        self.watermark.timestamp_ms_hi_inclusive as u64
+        self.watermark.timestamp_ms_hi_inclusive
     }
 
     /// Check if all the rows from this watermark are represented in this part.

--- a/crates/sui-indexer-alt-framework/src/pipeline/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/mod.rs
@@ -138,7 +138,7 @@ impl WatermarkPart {
 
         self.batch_rows -= rows;
         WatermarkPart {
-            watermark: self.watermark.clone(),
+            watermark: self.watermark,
             batch_rows: rows,
             total_rows: self.total_rows,
         }

--- a/crates/sui-indexer-alt-framework/src/pipeline/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/mod.rs
@@ -89,10 +89,10 @@ impl<P: Processor> IndexedCheckpoint<P> {
     ) -> Self {
         Self {
             watermark: CommitterWatermark {
-                epoch_hi_inclusive: epoch as i64,
-                checkpoint_hi_inclusive: cp_sequence_number as i64,
-                tx_hi: tx_hi as i64,
-                timestamp_ms_hi_inclusive: timestamp_ms as i64,
+                epoch_hi_inclusive: epoch,
+                checkpoint_hi_inclusive: cp_sequence_number,
+                tx_hi,
+                timestamp_ms_hi_inclusive: timestamp_ms,
             },
             values,
         }

--- a/crates/sui-indexer-alt-framework/src/pipeline/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/mod.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 pub use processor::Processor;
 use serde::{Deserialize, Serialize};
 
-use crate::models::watermarks::CommitterWatermark;
+use crate::store::CommitterWatermark;
 
 pub mod concurrent;
 mod logging;
@@ -44,14 +44,14 @@ struct IndexedCheckpoint<P: Processor> {
     /// Values to be inserted into the database from this checkpoint
     values: Vec<P::Value>,
     /// The watermark associated with this checkpoint
-    watermark: CommitterWatermark<'static>,
+    watermark: CommitterWatermark,
 }
 
 /// A representation of the proportion of a watermark.
 #[derive(Debug)]
 struct WatermarkPart {
     /// The watermark itself
-    watermark: CommitterWatermark<'static>,
+    watermark: CommitterWatermark,
     /// The number of rows from this watermark that are in this part
     batch_rows: usize,
     /// The total number of rows from this watermark
@@ -89,7 +89,6 @@ impl<P: Processor> IndexedCheckpoint<P> {
     ) -> Self {
         Self {
             watermark: CommitterWatermark {
-                pipeline: P::NAME.into(),
                 epoch_hi_inclusive: epoch as i64,
                 checkpoint_hi_inclusive: cp_sequence_number as i64,
                 tx_hi: tx_hi as i64,

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
@@ -198,22 +198,22 @@ where
                     metrics
                         .watermark_epoch
                         .with_label_values(&[H::NAME])
-                        .set(watermark.epoch_hi_inclusive);
+                        .set(watermark.epoch_hi_inclusive as i64);
 
                     metrics
                         .watermark_checkpoint
                         .with_label_values(&[H::NAME])
-                        .set(watermark.checkpoint_hi_inclusive);
+                        .set(watermark.checkpoint_hi_inclusive as i64);
 
                     metrics
                         .watermark_transaction
                         .with_label_values(&[H::NAME])
-                        .set(watermark.tx_hi);
+                        .set(watermark.tx_hi as i64);
 
                     metrics
                         .watermark_timestamp_ms
                         .with_label_values(&[H::NAME])
-                        .set(watermark.timestamp_ms_hi_inclusive);
+                        .set(watermark.timestamp_ms_hi_inclusive as i64);
 
                     let guard = metrics
                         .committer_commit_latency
@@ -287,22 +287,22 @@ where
                     metrics
                         .watermark_epoch_in_db
                         .with_label_values(&[H::NAME])
-                        .set(watermark.epoch_hi_inclusive);
+                        .set(watermark.epoch_hi_inclusive as i64);
 
                     metrics
                         .watermark_checkpoint_in_db
                         .with_label_values(&[H::NAME])
-                        .set(watermark.checkpoint_hi_inclusive);
+                        .set(watermark.checkpoint_hi_inclusive as i64);
 
                     metrics
                         .watermark_transaction_in_db
                         .with_label_values(&[H::NAME])
-                        .set(watermark.tx_hi);
+                        .set(watermark.tx_hi as i64);
 
                     metrics
                         .watermark_timestamp_in_db_ms
                         .with_label_values(&[H::NAME])
-                        .set(watermark.timestamp_ms_hi_inclusive);
+                        .set(watermark.timestamp_ms_hi_inclusive as i64);
 
                     // Ignore the result -- the ingestion service will close this channel
                     // once it is done, but there may still be checkpoints buffered that need

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
@@ -15,7 +15,7 @@ use tracing::{debug, info, warn};
 use crate::{
     metrics::IndexerMetrics,
     pipeline::{logging::WatermarkLogger, IndexedCheckpoint, WARN_PENDING_WATERMARKS},
-    store::{CommitterWatermark, DbConnection, TransactionalStore},
+    store::{CommitterWatermark, Connection, TransactionalStore},
 };
 
 use super::{Handler, SequentialConfig};

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
@@ -75,7 +75,7 @@ where
         // and whether that batch needs to be written out. By extension it also knows the next
         // checkpoint to expect and add to the batch.
         let (mut watermark, mut next_checkpoint) = if let Some(watermark) = watermark {
-            let next = watermark.checkpoint_hi_inclusive as u64 + 1;
+            let next = watermark.checkpoint_hi_inclusive + 1;
             (watermark, next)
         } else {
             (CommitterWatermark::default(), 0)
@@ -307,7 +307,7 @@ where
                     // Ignore the result -- the ingestion service will close this channel
                     // once it is done, but there may still be checkpoints buffered that need
                     // processing.
-                    let _ = tx.send((H::NAME, watermark.checkpoint_hi_inclusive as u64));
+                    let _ = tx.send((H::NAME, watermark.checkpoint_hi_inclusive));
 
                     let _ = std::mem::take(&mut batch);
                     pending_rows -= batch_rows;

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
@@ -49,7 +49,6 @@ pub(super) fn committer<H>(
 ) -> JoinHandle<()>
 where
     H: Handler + Send + Sync + 'static,
-    // Ensure that the store is transactional
     H::Store: TransactionalStore + 'static,
 {
     tokio::spawn(async move {

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/mod.rs
@@ -10,9 +10,8 @@ use tokio_util::sync::CancellationToken;
 use super::{processor::processor, CommitterConfig, Processor, PIPELINE_BUFFER};
 
 use crate::{
-    db::{self, Db},
     metrics::IndexerMetrics,
-    models::watermarks::CommitterWatermark,
+    store::{CommitterWatermark, Store, TransactionalStore},
     types::full_checkpoint_content::CheckpointData,
 };
 
@@ -39,6 +38,8 @@ mod committer;
 /// checkpoints that can be received before the next checkpoint.
 #[async_trait::async_trait]
 pub trait Handler: Processor {
+    type Store: TransactionalStore;
+
     /// If at least this many rows are pending, the committer will commit them eagerly.
     const MIN_EAGER_ROWS: usize = 50;
 
@@ -58,7 +59,10 @@ pub trait Handler: Processor {
 
     /// Take a batch of values and commit them to the database, returning the number of rows
     /// affected.
-    async fn commit(batch: &Self::Batch, conn: &mut db::Connection<'_>) -> anyhow::Result<usize>;
+    async fn commit<'a>(
+        batch: &Self::Batch,
+        conn: &mut <Self::Store as Store>::Connection<'a>,
+    ) -> anyhow::Result<usize>;
 }
 
 /// Configuration for a sequential pipeline
@@ -98,9 +102,9 @@ pub struct SequentialConfig {
 /// channels close, or any of its independent tasks fail.
 pub(crate) fn pipeline<H: Handler + Send + Sync + 'static>(
     handler: H,
-    initial_watermark: Option<CommitterWatermark<'static>>,
+    initial_watermark: Option<CommitterWatermark>,
     config: SequentialConfig,
-    db: Db,
+    db: H::Store,
     checkpoint_rx: mpsc::Receiver<Arc<CheckpointData>>,
     watermark_tx: mpsc::UnboundedSender<(&'static str, u64)>,
     metrics: Arc<IndexerMetrics>,
@@ -121,7 +125,7 @@ pub(crate) fn pipeline<H: Handler + Send + Sync + 'static>(
         initial_watermark,
         committer_rx,
         watermark_tx,
-        db.clone(),
+        db,
         metrics.clone(),
         cancel.clone(),
     );

--- a/crates/sui-indexer-alt-framework/src/store.rs
+++ b/crates/sui-indexer-alt-framework/src/store.rs
@@ -157,7 +157,7 @@ impl CommitterWatermark {
 
 impl PrunerWatermark {
     pub(crate) fn wait_for_ms(&self) -> Option<Duration> {
-        (self.wait_for_ms > 0).then(|| Duration::from_millis(self.wait_for_ms as u64))
+        (self.wait_for_ms > 0).then(|| Duration::from_millis(self.wait_for_ms))
     }
 
     /// The next chunk of checkpoints that the pruner should work on, to advance the watermark. If

--- a/crates/sui-indexer-alt-framework/src/store.rs
+++ b/crates/sui-indexer-alt-framework/src/store.rs
@@ -113,6 +113,7 @@ pub struct CommitterWatermark {
     pub timestamp_ms_hi_inclusive: i64,
 }
 
+/// Represents the inclusive lower bound of available data in the Store for some pipeline.
 #[derive(Default, Debug, Clone, Copy)]
 pub struct ReaderWatermark {
     /// Within the framework, this value is used to determine the new `reader_lo`.

--- a/crates/sui-indexer-alt-framework/src/store.rs
+++ b/crates/sui-indexer-alt-framework/src/store.rs
@@ -1,0 +1,152 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub use crate::pipeline::sequential::Handler as SequentialHandler;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use scoped_futures::ScopedBoxFuture;
+use std::time::Duration;
+
+pub use scoped_futures;
+
+/// Represents a database connection that can manage watermarks for pipeline operations in the
+/// framework.
+///
+/// This trait provides methods for the necessary reads and updates for the committer, reader, and
+/// pruner components of a data pipeline, allowing for tracking progress and coordination between
+/// different pipeline stages.
+#[async_trait]
+pub trait DbConnection: Send + Sync {
+    /// Given a pipeline, return the committer watermark from the database.
+    async fn committer_watermark(
+        &mut self,
+        pipeline: &'static str,
+    ) -> anyhow::Result<Option<CommitterWatermark>>;
+
+    /// Update the committer watermark, returns true if the watermark was actually updated.
+    async fn set_committer_watermark(
+        &mut self,
+        pipeline: &'static str,
+        watermark: CommitterWatermark,
+    ) -> anyhow::Result<bool>;
+
+    /// Given a pipeline, return the `checkpoint_hi_inclusive` and `reader_lo` from the database.
+    /// Checkpoint hi used to determine new reader lo and reader lo used to check whether to
+    /// actually make
+    async fn reader_watermark(
+        &mut self,
+        pipeline: &'static str,
+    ) -> anyhow::Result<Option<ReaderWatermark>>;
+
+    /// Update the reader watermark, returns true if the watermark was actually updated
+    async fn set_reader_watermark(
+        &mut self,
+        pipeline: &'static str,
+        reader_lo: i64,
+    ) -> anyhow::Result<bool>;
+
+    /// Get the pruner watermark with wait_for calculated
+    ///
+    /// # Implementation Requirements
+    /// This method MUST:
+    /// 1. Calculate wait_for as: delay + (pruner_timestamp - current_database_time)
+    /// 2. Return (pruner_hi, reader_lo, wait_for)
+    async fn pruner_watermark(
+        &mut self,
+        pipeline: &'static str,
+        delay: Duration,
+    ) -> anyhow::Result<Option<PrunerWatermark>>; // (pruner_hi, reader_lo, wait_for_ms)
+
+    /// Update the pruner watermark, returns true if the watermark was actually updated
+    async fn set_pruner_watermark(
+        &mut self,
+        pipeline: &'static str,
+        pruner_hi: i64,
+    ) -> anyhow::Result<bool>;
+}
+
+/// A storage-agnostic interface for managing pipeline watermarks.
+///
+/// This trait abstracts away the underlying storage implementation, providing
+/// a consistent way to connect to the database regardless of the specific
+/// storage technology being used.
+#[async_trait]
+pub trait Store: Send + Sync + 'static + Clone {
+    type Connection<'c>: DbConnection
+    where
+        Self: 'c;
+
+    async fn connect<'c>(&'c self) -> Result<Self::Connection<'c>, anyhow::Error>;
+}
+
+pub type HandlerBatch<H> = <H as SequentialHandler>::Batch;
+
+/// Extends the Store trait with transactional capabilities.
+///
+/// This trait provides methods to execute operations within a database transaction,
+/// ensuring atomicity when committing handler batches and updating watermarks.
+/// It allows for safely combining multiple database operations that must succeed
+/// or fail together.
+#[async_trait]
+pub trait TransactionalStore: Store {
+    /// Execute a handler's commit function and update the watermark within a transaction
+    async fn transactional_commit_with_watermark<'a, H>(
+        &'a self,
+        pipeline: &'static str,
+        watermark: &'a CommitterWatermark,
+        batch: &'a HandlerBatch<H>,
+    ) -> anyhow::Result<usize>
+    where
+        H: SequentialHandler<Store = Self> + Send + Sync + 'a;
+
+    async fn transaction<'a, R, F>(&self, f: F) -> anyhow::Result<R>
+    where
+        R: Send + 'a,
+        F: Send + 'a,
+        F: for<'r> FnOnce(
+            &'r mut Self::Connection<'_>,
+        ) -> ScopedBoxFuture<'a, 'r, anyhow::Result<R>>;
+}
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct CommitterWatermark {
+    pub epoch_hi_inclusive: i64,
+    pub checkpoint_hi_inclusive: i64,
+    pub tx_hi: i64,
+    pub timestamp_ms_hi_inclusive: i64,
+}
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct ReaderWatermark {
+    pub checkpoint_hi_inclusive: i64,
+    pub reader_lo: i64,
+}
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct PrunerWatermark {
+    pub pruner_hi: i64,
+    pub reader_lo: i64,
+    pub wait_for: i64,
+}
+
+impl CommitterWatermark {
+    pub(crate) fn timestamp(&self) -> DateTime<Utc> {
+        DateTime::from_timestamp_millis(self.timestamp_ms_hi_inclusive).unwrap_or_default()
+    }
+}
+
+impl PrunerWatermark {
+    pub(crate) fn wait_for(&self) -> Option<Duration> {
+        (self.wait_for > 0).then(|| Duration::from_millis(self.wait_for as u64))
+    }
+
+    pub(crate) fn next_chunk(&self, size: u64) -> Option<(u64, u64)> {
+        if self.pruner_hi >= self.reader_lo {
+            return None;
+        }
+
+        let from = self.pruner_hi as u64;
+        let to_exclusive = (from + size).min(self.reader_lo as u64);
+        Some((from, to_exclusive))
+    }
+}

--- a/crates/sui-indexer-alt/src/handlers/sum_packages.rs
+++ b/crates/sui-indexer-alt/src/handlers/sum_packages.rs
@@ -8,8 +8,9 @@ use diesel::{upsert::excluded, ExpressionMethods};
 use diesel_async::RunQueryDsl;
 use futures::future::try_join_all;
 use sui_indexer_alt_framework::{
-    db,
+    db::Db,
     pipeline::{sequential::Handler, Processor},
+    store::Store,
     types::full_checkpoint_content::CheckpointData,
     FieldCount,
 };
@@ -56,6 +57,7 @@ impl Processor for SumPackages {
 
 #[async_trait::async_trait]
 impl Handler for SumPackages {
+    type Store = Db;
     type Batch = BTreeMap<Vec<u8>, StoredPackage>;
 
     fn batch(batch: &mut Self::Batch, values: Vec<Self::Value>) {
@@ -64,7 +66,10 @@ impl Handler for SumPackages {
         }
     }
 
-    async fn commit(batch: &Self::Batch, conn: &mut db::Connection<'_>) -> Result<usize> {
+    async fn commit<'a>(
+        batch: &Self::Batch,
+        conn: &mut <Self::Store as Store>::Connection<'a>,
+    ) -> Result<usize> {
         let values: Vec<_> = batch.values().cloned().collect();
         let updates = values.chunks(MAX_INSERT_CHUNK_ROWS).map(|chunk| {
             diesel::insert_into(sum_packages::table)


### PR DESCRIPTION
## Description 

- Introduce the `DbConnection` and `Store` traits. `DbConnection` has methods for handling `watermarks`, while `Store` exposes a `DbConnection`. The `TransactionalStore` additionally has a `transaction` method for sequential pipelines.
- Demonstrate implementation with `pg_store`, in the framework for now due to all the tests within the crate.
- Sequential pipelines has been updated to demonstrate. the `sequential::Handler` now has an associated type, `Store: TransactionalStore`, which allows us to eventually make `Indexer` generic over `Store`, and the handlers aware of the `Store` type
- Most of the structs and implementations within `framework/model/watermark.rs`  has been inlined to the `DbConnection` methods. This will make it easier to lift `pg_store` out of the framework later, and also reduce the number of types we need to juggle. Framework tests have also been updated to use `DbConnection` methods, so there's less of a dependency on `sui-pg-db` already

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
