### PR TITLE
Avoid a spurious assert in tests

### DIFF
--- a/crates/sui-core/src/execution_cache/cache_types.rs
+++ b/crates/sui-core/src/execution_cache/cache_types.rs
@@ -188,7 +188,7 @@ const KEY_GENERATION_SIZE: usize = 1024 * 16;
 
 impl<K, V> MonotonicCache<K, V>
 where
-    K: Hash + Eq + Send + Sync + Copy + 'static,
+    K: Hash + Eq + Send + Sync + Copy + std::fmt::Debug + 'static,
     V: IsNewer + Clone + Send + Sync + 'static,
 {
     pub fn new(cache_size: u64) -> Self {
@@ -304,7 +304,7 @@ where
 
             // Ticket expiry should make this assert impossible.
             if entry.is_newer_than(&value) {
-                debug_fatal!("entry is newer than value");
+                debug_fatal!("entry is newer than value {:?}", key);
             } else {
                 *entry = value;
             }


### PR DESCRIPTION
This avoids the following crash:

```
thread '<unnamed>' panicked at crates/sui-core/src/execution_cache/cache_types.rs:307:17:
entry is newer than value 0x86aacc42979583a6797f4bb0cab20d436a1f41e215b2c87cb6e99ffdda5ec7db
stack backtrace:
   0: rust_begin_unwind
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/std/src/panicking.rs:692:5
   1: core::panicking::panic_fmt
             at /rustc/4d91de4e48198da2e33413efdcd9cd2cc0c46688/library/core/src/panicking.rs:75:14
   2: sui_core::execution_cache::cache_types::MonotonicCache<K,V>::insert
             at /Users/marklogan/dev/sui-wb/crates/sui-core/src/execution_cache/cache_types.rs:307:17
   3: sui_core::execution_cache::writeback_cache::WritebackCache::cache_latest_object_by_id
             at /Users/marklogan/dev/sui-wb/crates/sui-core/src/execution_cache/writeback_cache.rs:1210:12
   4: sui_core::execution_cache::writeback_cache::WritebackCache::cache_object_not_found
             at /Users/marklogan/dev/sui-wb/crates/sui-core/src/execution_cache/writeback_cache.rs:1224:9
   5: <sui_core::execution_cache::writeback_cache::WritebackCache as sui_core::execution_cache::ObjectCacheRead>::find_object_lt_or_eq_version::{{closure}}
   ...
```

The fix is to not overwrite an existing latest cache entry in this scenario, since it must already be in the correct state at the point at which the crash was triggered before.
