### PR TITLE
[move/adapter] Make native extensions API fallible

### DIFF
--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
@@ -129,7 +129,7 @@ mod checked {
             if let Err(err) =
                 execute_command::<Mode>(&mut context, &mut mode_results, command, trace_builder_opt)
             {
-                let object_runtime: &ObjectRuntime = context.object_runtime();
+                let object_runtime: &ObjectRuntime = context.object_runtime()?;
                 // We still need to record the loaded child objects for replay
                 let loaded_runtime_objects = object_runtime.loaded_runtime_objects();
                 // we do not save the wrapped objects since on error, they should not be modified
@@ -142,7 +142,7 @@ mod checked {
         }
 
         // Save loaded objects table in case we fail in post execution
-        let object_runtime: &ObjectRuntime = context.object_runtime();
+        let object_runtime: &ObjectRuntime = context.object_runtime()?;
         // We still need to record the loaded child objects for replay
         // Record the objects loaded at runtime (dynamic fields + received) for
         // storage rebate calculation.

--- a/sui-execution/latest/sui-move-natives/src/address.rs
+++ b/sui-execution/latest/sui-move-natives/src/address.rs
@@ -32,7 +32,7 @@ pub fn from_bytes(
 
     let address_from_bytes_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .address_from_bytes_cost_params
         .clone();
 
@@ -71,7 +71,7 @@ pub fn to_u256(
 
     let address_to_u256_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .address_to_u256_cost_params
         .clone();
 
@@ -110,7 +110,7 @@ pub fn from_u256(
 
     let address_from_u256_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .address_from_u256_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/config.rs
+++ b/sui-execution/latest/sui-move-natives/src/config.rs
@@ -42,7 +42,7 @@ pub fn read_setting_impl(
         config_read_setting_impl_cost_per_byte,
     } = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .config_read_setting_impl_cost_params
         .clone();
 
@@ -83,7 +83,7 @@ pub fn read_setting_impl(
             E_BCS_SERIALIZATION_FAILURE,
         ));
     };
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
 
     let read_value_opt = consistent_value_before_current_epoch(
         object_runtime,

--- a/sui-execution/latest/sui-move-natives/src/crypto/bls12381.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/bls12381.rs
@@ -49,7 +49,7 @@ pub fn bls12381_min_sig_verify(
     // Load the cost parameters from the protocol config
     let bls12381_bls12381_min_sig_verify_cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .bls12381_bls12381_min_sig_verify_cost_params
         .clone();
     // Charge the base cost for this oper
@@ -129,7 +129,7 @@ pub fn bls12381_min_pk_verify(
     // Load the cost parameters from the protocol config
     let bls12381_bls12381_min_pk_verify_cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .bls12381_bls12381_min_pk_verify_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_k1.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_k1.rs
@@ -80,7 +80,7 @@ pub fn ecrecover(
 
     // Load the cost parameters from the protocol config
     let (ecdsa_k1_ecrecover_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>();
+        let cost_table = &context.extensions().get::<NativesCostTable>()?;
         (
             cost_table.ecdsa_k1_ecrecover_cost_params.clone(),
             cost_table.crypto_invalid_arguments_cost,
@@ -161,7 +161,7 @@ pub fn decompress_pubkey(
     // Load the cost parameters from the protocol config
     let ecdsa_k1_decompress_pubkey_cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .ecdsa_k1_decompress_pubkey_cost_params
         .clone();
     // Charge the base cost for this oper
@@ -226,7 +226,7 @@ pub fn secp256k1_verify(
 
     // Load the cost parameters from the protocol config
     let (ecdsa_k1_secp256k1_verify_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>();
+        let cost_table = &context.extensions().get::<NativesCostTable>()?;
         (
             cost_table.ecdsa_k1_secp256k1_verify_cost_params.clone(),
             cost_table.crypto_invalid_arguments_cost,

--- a/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_r1.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_r1.rs
@@ -71,7 +71,7 @@ pub fn ecrecover(
 
     // Load the cost parameters from the protocol config
     let (ecdsa_r1_ecrecover_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>();
+        let cost_table = &context.extensions().get::<NativesCostTable>()?;
         (
             cost_table.ecdsa_r1_ecrecover_cost_params.clone(),
             cost_table.crypto_invalid_arguments_cost,
@@ -175,7 +175,7 @@ pub fn secp256r1_verify(
     debug_assert!(args.len() == 4);
     // Load the cost parameters from the protocol config
     let (ecdsa_r1_secp256_r1_verify_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>();
+        let cost_table = &context.extensions().get::<NativesCostTable>()?;
         (
             cost_table.ecdsa_r1_secp256_r1_verify_cost_params.clone(),
             cost_table.crypto_invalid_arguments_cost,

--- a/sui-execution/latest/sui-move-natives/src/crypto/ecvrf.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/ecvrf.rs
@@ -50,7 +50,7 @@ pub fn ecvrf_verify(
     // Load the cost parameters from the protocol config
     let ecvrf_ecvrf_verify_cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .ecvrf_ecvrf_verify_cost_params
         .clone();
     // Charge the base cost for this oper

--- a/sui-execution/latest/sui-move-natives/src/crypto/ed25519.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/ed25519.rs
@@ -48,7 +48,7 @@ pub fn ed25519_verify(
     // Load the cost parameters from the protocol config
     let ed25519_verify_cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .ed25519_verify_cost_params
         .clone();
     // Charge the base cost for this oper

--- a/sui-execution/latest/sui-move-natives/src/crypto/groth16.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/groth16.rs
@@ -47,7 +47,7 @@ pub fn prepare_verifying_key_internal(
 
     // Load the cost parameters from the protocol config
     let (groth16_prepare_verifying_key_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>();
+        let cost_table = &context.extensions().get::<NativesCostTable>()?;
         (
             cost_table.groth16_prepare_verifying_key_cost_params.clone(),
             cost_table.crypto_invalid_arguments_cost,
@@ -135,7 +135,7 @@ pub fn verify_groth16_proof_internal(
 
     // Load the cost parameters from the protocol config
     let (groth16_verify_groth16_proof_internal_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>();
+        let cost_table = &context.extensions().get::<NativesCostTable>()?;
         (
             cost_table
                 .groth16_verify_groth16_proof_internal_cost_params
@@ -187,7 +187,7 @@ pub fn verify_groth16_proof_internal(
             context.charge_gas(crypto_invalid_arguments_cost);
             let cost = if context
                 .extensions()
-                .get::<ObjectRuntime>()
+                .get::<ObjectRuntime>()?
                 .protocol_config
                 .native_charging_v2()
             {

--- a/sui-execution/latest/sui-move-natives/src/crypto/hash.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/hash.rs
@@ -78,7 +78,7 @@ pub fn keccak256(
     // Load the cost parameters from the protocol config
     let hash_keccak256_cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .hash_keccak256_cost_params
         .clone();
     // Charge the base cost for this oper
@@ -118,7 +118,7 @@ pub fn blake2b256(
     // Load the cost parameters from the protocol config
     let hash_blake2b256_cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .hash_blake2b256_cost_params
         .clone();
     // Charge the base cost for this oper

--- a/sui-execution/latest/sui-move-natives/src/crypto/hmac.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/hmac.rs
@@ -45,7 +45,7 @@ pub fn hmac_sha3_256(
     // Load the cost parameters from the protocol config
     let hmac_hmac_sha3_256_cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .hmac_hmac_sha3_256_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/nitro_attestation.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/nitro_attestation.rs
@@ -44,12 +44,12 @@ macro_rules! native_charge_gas_early_exit_option {
     }};
 }
 
-fn is_supported(context: &NativeContext) -> bool {
-    context
+fn is_supported(context: &NativeContext) -> PartialVMResult<bool> {
+    Ok(context
         .extensions()
-        .get::<ObjectRuntime>()
+        .get::<ObjectRuntime>()?
         .protocol_config
-        .enable_nitro_attestation()
+        .enable_nitro_attestation())
 }
 
 pub fn load_nitro_attestation_internal(
@@ -61,7 +61,7 @@ pub fn load_nitro_attestation_internal(
     debug_assert!(args.len() == 2);
 
     let cost = context.gas_used();
-    if !is_supported(context) {
+    if !is_supported(context)? {
         return Ok(NativeResult::err(cost, NOT_SUPPORTED_ERROR));
     }
 
@@ -71,7 +71,7 @@ pub fn load_nitro_attestation_internal(
 
     let cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .nitro_attestation_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/poseidon.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/poseidon.rs
@@ -21,12 +21,12 @@ use std::ops::Mul;
 pub const NON_CANONICAL_INPUT: u64 = 0;
 pub const NOT_SUPPORTED_ERROR: u64 = 1;
 
-fn is_supported(context: &NativeContext) -> bool {
-    context
+fn is_supported(context: &NativeContext) -> PartialVMResult<bool> {
+    Ok(context
         .extensions()
-        .get::<ObjectRuntime>()
+        .get::<ObjectRuntime>()?
         .protocol_config
-        .enable_poseidon()
+        .enable_poseidon())
 }
 
 #[derive(Clone)]
@@ -49,14 +49,14 @@ pub fn poseidon_bn254_internal(
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     let cost = context.gas_used();
-    if !is_supported(context) {
+    if !is_supported(context)? {
         return Ok(NativeResult::err(cost, NOT_SUPPORTED_ERROR));
     }
 
     // Load the cost parameters from the protocol config
     let cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .poseidon_bn254_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/vdf.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/vdf.rs
@@ -23,12 +23,12 @@ use std::collections::VecDeque;
 pub const INVALID_INPUT_ERROR: u64 = 0;
 pub const NOT_SUPPORTED_ERROR: u64 = 1;
 
-fn is_supported(context: &NativeContext) -> bool {
-    context
+fn is_supported(context: &NativeContext) -> PartialVMResult<bool> {
+    Ok(context
         .extensions()
-        .get::<ObjectRuntime>()
+        .get::<ObjectRuntime>()?
         .protocol_config
-        .enable_vdf()
+        .enable_vdf())
 }
 
 #[derive(Clone)]
@@ -54,14 +54,14 @@ pub fn vdf_verify_internal(
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     let cost = context.gas_used();
-    if !is_supported(context) {
+    if !is_supported(context)? {
         return Ok(NativeResult::err(cost, NOT_SUPPORTED_ERROR));
     }
 
     // Load the cost parameters from the protocol config
     let cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .vdf_cost_params
         .clone();
 
@@ -124,14 +124,14 @@ pub fn hash_to_input_internal(
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     let cost = context.gas_used();
-    if !is_supported(context) {
+    if !is_supported(context)? {
         return Ok(NativeResult::err(cost, NOT_SUPPORTED_ERROR));
     }
 
     // Load the cost parameters from the protocol config
     let cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .vdf_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/zklogin.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/zklogin.rs
@@ -47,7 +47,7 @@ pub fn check_zklogin_id_internal(
     // Load the cost parameters from the protocol config
     let check_zklogin_id_cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .check_zklogin_id_cost_params
         .clone();
 
@@ -149,7 +149,7 @@ pub fn check_zklogin_issuer_internal(
     // Load the cost parameters from the protocol config
     let check_zklogin_issuer_cost_params = &context
         .extensions()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .check_zklogin_issuer_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/dynamic_field.rs
+++ b/sui-execution/latest/sui-move-natives/src/dynamic_field.rs
@@ -50,7 +50,7 @@ macro_rules! get_or_fetch_object {
             }
         };
 
-        let object_runtime: &mut ObjectRuntime = $context.extensions_mut().get_mut();
+        let object_runtime: &mut ObjectRuntime = $context.extensions_mut().get_mut()?;
         object_runtime.get_or_fetch_child_object(
             $parent,
             $child_id,
@@ -89,7 +89,7 @@ pub fn hash_type_and_key(
 
     let dynamic_field_hash_type_and_key_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .dynamic_field_hash_type_and_key_cost_params
         .clone();
 
@@ -170,7 +170,7 @@ pub fn add_child_object(
 
     let dynamic_field_add_child_object_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .dynamic_field_add_child_object_cost_params
         .clone();
 
@@ -228,7 +228,7 @@ pub fn add_child_object(
             * struct_tag_size.into()
     );
 
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     object_runtime.add_child_object(
         parent,
         child_id,
@@ -266,7 +266,7 @@ pub fn borrow_child_object(
 
     let dynamic_field_borrow_child_object_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .dynamic_field_borrow_child_object_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -342,7 +342,7 @@ pub fn remove_child_object(
 
     let dynamic_field_remove_child_object_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .dynamic_field_remove_child_object_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -405,7 +405,7 @@ pub fn has_child_object(
 
     let dynamic_field_has_child_object_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .dynamic_field_has_child_object_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -415,7 +415,7 @@ pub fn has_child_object(
 
     let child_id = pop_arg!(args, AccountAddress).into();
     let parent = pop_arg!(args, AccountAddress).into();
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let has_child = object_runtime.child_object_exists(parent, child_id)?;
     Ok(NativeResult::ok(
         context.gas_used(),
@@ -447,7 +447,7 @@ pub fn has_child_object_with_ty(
 
     let dynamic_field_has_child_object_with_ty_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .dynamic_field_has_child_object_with_ty_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -485,7 +485,7 @@ pub fn has_child_object_with_ty(
             * u64::from(tag.abstract_size_for_gas_metering()).into()
     );
 
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let has_child = object_runtime.child_object_exists_and_has_type(
         parent,
         child_id,

--- a/sui-execution/latest/sui-move-natives/src/event.rs
+++ b/sui-execution/latest/sui-move-natives/src/event.rs
@@ -38,7 +38,7 @@ pub fn emit(
 
     let event_emit_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .event_emit_cost_params
         .clone();
 
@@ -74,7 +74,7 @@ pub fn emit(
             * u64::from(tag_size).into()
     );
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let max_event_emit_size = obj_runtime.protocol_config.max_event_emit_size();
     let ev_size = u64::from(tag_size + event_value_size);
     // Check if the event size is within the limit
@@ -112,7 +112,7 @@ pub fn emit(
         event_emit_cost_params.event_emit_output_cost_per_byte * ev_size.into()
     );
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
 
     obj_runtime.emit_event(ty, *tag, event_value)?;
     Ok(NativeResult::ok(context.gas_used(), smallvec![]))
@@ -126,7 +126,7 @@ pub fn num_events(
 ) -> PartialVMResult<NativeResult> {
     assert!(ty_args.is_empty());
     assert!(args.is_empty());
-    let object_runtime_ref: &ObjectRuntime = context.extensions().get();
+    let object_runtime_ref: &ObjectRuntime = context.extensions().get()?;
     let num_events = object_runtime_ref.state.events().len();
     Ok(NativeResult::ok(
         legacy_test_cost(),
@@ -143,7 +143,7 @@ pub fn get_events_by_type(
     assert_eq!(ty_args.len(), 1);
     let specified_ty = ty_args.pop().unwrap();
     assert!(args.is_empty());
-    let object_runtime_ref: &ObjectRuntime = context.extensions().get();
+    let object_runtime_ref: &ObjectRuntime = context.extensions().get()?;
     let matched_events = object_runtime_ref
         .state
         .events()

--- a/sui-execution/latest/sui-move-natives/src/object.rs
+++ b/sui-execution/latest/sui-move-natives/src/object.rs
@@ -33,7 +33,7 @@ pub fn borrow_uid(
 
     let borrow_uid_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .borrow_uid_cost_params
         .clone();
 
@@ -65,7 +65,7 @@ pub fn delete_impl(
 
     let delete_impl_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .delete_impl_cost_params
         .clone();
 
@@ -78,7 +78,7 @@ pub fn delete_impl(
     // unwrap safe because the interface of native function guarantees it.
     let uid_bytes = pop_arg!(args, AccountAddress);
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     obj_runtime.delete_id(uid_bytes.into())?;
     Ok(NativeResult::ok(context.gas_used(), smallvec![]))
 }
@@ -102,7 +102,7 @@ pub fn record_new_uid(
 
     let record_new_id_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .record_new_id_cost_params
         .clone();
 
@@ -115,7 +115,7 @@ pub fn record_new_uid(
     // unwrap safe because the interface of native function guarantees it.
     let uid_bytes = pop_arg!(args, AccountAddress);
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     obj_runtime.new_id(uid_bytes.into())?;
     Ok(NativeResult::ok(context.gas_used(), smallvec![]))
 }

--- a/sui-execution/latest/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/latest/sui-move-natives/src/test_scenario.rs
@@ -96,7 +96,7 @@ pub fn end_transaction(
 ) -> PartialVMResult<NativeResult> {
     assert!(ty_args.is_empty());
     assert!(args.is_empty());
-    let object_runtime_ref: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime_ref: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let taken_shared_or_imm: BTreeMap<_, _> = object_runtime_ref
         .test_inventories
         .taken
@@ -154,7 +154,7 @@ pub fn end_transaction(
             ));
         }
     };
-    let object_runtime_ref: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime_ref: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let all_active_child_objects_with_values = object_runtime_ref
         .all_active_child_objects()
         .filter(|child| child.copied_value.is_some())
@@ -244,7 +244,7 @@ pub fn end_transaction(
     }
 
     // For any unused allocated tickets, remove them from the store.
-    let store: &&InMemoryTestStore = context.extensions().get();
+    let store: &&InMemoryTestStore = context.extensions().get()?;
     for id in unreceived {
         if store
             .0
@@ -269,7 +269,7 @@ pub fn end_transaction(
     }
     // find all wrapped objects
     let mut all_wrapped = BTreeSet::new();
-    let object_runtime_ref: &ObjectRuntime = context.extensions().get();
+    let object_runtime_ref: &ObjectRuntime = context.extensions().get()?;
     find_all_wrapped_objects(
         context,
         &mut all_wrapped,
@@ -303,7 +303,7 @@ pub fn end_transaction(
     }
 
     // new input objects are remaining taken objects not written/deleted
-    let object_runtime_ref: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime_ref: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let mut config_settings = vec![];
     for child in object_runtime_ref.all_active_child_objects() {
         let s: StructTag = child.move_type.clone().into();
@@ -379,7 +379,7 @@ pub fn take_from_address_by_id(
     let account: SuiAddress = pop_arg!(args, AccountAddress).into();
     pop_arg!(args, StructRef);
     assert!(args.is_empty());
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let res = take_from_inventory(
         |x| {
@@ -411,7 +411,7 @@ pub fn ids_for_address(
     let specified_ty = get_specified_ty(ty_args);
     let account: SuiAddress = pop_arg!(args, AccountAddress).into();
     assert!(args.is_empty());
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let ids = inventories
         .address_inventories
@@ -432,7 +432,7 @@ pub fn most_recent_id_for_address(
     let specified_ty = get_specified_ty(ty_args);
     let account: SuiAddress = pop_arg!(args, AccountAddress).into();
     assert!(args.is_empty());
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let most_recent_id = match inventories.address_inventories.get(&account) {
         None => pack_option(None),
@@ -454,7 +454,7 @@ pub fn was_taken_from_address(
     let id = pop_id(&mut args)?;
     let account: SuiAddress = pop_arg!(args, AccountAddress).into();
     assert!(args.is_empty());
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let was_taken = inventories
         .taken
@@ -477,7 +477,7 @@ pub fn take_immutable_by_id(
     let id = pop_id(&mut args)?;
     pop_arg!(args, StructRef);
     assert!(args.is_empty());
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let res = take_from_inventory(
         |x| {
@@ -514,7 +514,7 @@ pub fn most_recent_immutable_id(
 ) -> PartialVMResult<NativeResult> {
     let specified_ty = get_specified_ty(ty_args);
     assert!(args.is_empty());
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let most_recent_id = most_recent_at_ty(
         &inventories.taken,
@@ -536,7 +536,7 @@ pub fn was_taken_immutable(
     assert!(ty_args.is_empty());
     let id = pop_id(&mut args)?;
     assert!(args.is_empty());
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let was_taken = inventories
         .taken
@@ -559,7 +559,7 @@ pub fn take_shared_by_id(
     let id = pop_id(&mut args)?;
     pop_arg!(args, StructRef);
     assert!(args.is_empty());
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let res = take_from_inventory(
         |x| {
@@ -589,7 +589,7 @@ pub fn most_recent_id_shared(
 ) -> PartialVMResult<NativeResult> {
     let specified_ty = get_specified_ty(ty_args);
     assert!(args.is_empty());
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let most_recent_id = most_recent_at_ty(
         &inventories.taken,
@@ -611,7 +611,7 @@ pub fn was_taken_shared(
     assert!(ty_args.is_empty());
     let id = pop_id(&mut args)?;
     assert!(args.is_empty());
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let was_taken = inventories
         .taken
@@ -639,7 +639,7 @@ pub fn allocate_receiving_ticket_for_object(
             E_UNABLE_TO_ALLOCATE_RECEIVING_TICKET,
         ));
     };
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let object_version = SequenceNumber::new();
     let inventories = &mut object_runtime.test_inventories;
     if inventories.allocated_tickets.contains_key(&id) {
@@ -700,7 +700,7 @@ pub fn allocate_receiving_ticket_for_object(
     );
 
     // NB: Must be a `&&` reference since the extension stores a static ref to the object storage.
-    let store: &&InMemoryTestStore = context.extensions().get();
+    let store: &&InMemoryTestStore = context.extensions().get()?;
     store.0.with_borrow_mut(|store| store.insert_object(object));
 
     Ok(NativeResult::ok(
@@ -716,7 +716,7 @@ pub fn deallocate_receiving_ticket_for_object(
 ) -> PartialVMResult<NativeResult> {
     let id = pop_id(&mut args)?;
 
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     // Deallocate the ticket -- we should never hit this scenario
     let Some((_, value)) = inventories.allocated_tickets.remove(&id) else {
@@ -731,7 +731,7 @@ pub fn deallocate_receiving_ticket_for_object(
     inventories.objects.insert(id, value);
 
     // Remove the object from storage. We should never hit this scenario either.
-    let store: &&InMemoryTestStore = context.extensions().get();
+    let store: &&InMemoryTestStore = context.extensions().get()?;
     if store
         .0
         .with_borrow_mut(|store| store.remove_object(id).is_none())

--- a/sui-execution/latest/sui-move-natives/src/transfer.rs
+++ b/sui-execution/latest/sui-move-natives/src/transfer.rs
@@ -48,7 +48,7 @@ pub fn receive_object_internal(
     debug_assert!(args.len() == 3);
     let transfer_receive_object_internal_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .transfer_receive_object_internal_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -74,7 +74,7 @@ pub fn receive_object_internal(
         ));
     };
 
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let child = match object_runtime.receive_object(
         parent,
         child_id,
@@ -123,7 +123,7 @@ pub fn transfer_internal(
 
     let transfer_transfer_internal_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .transfer_transfer_internal_cost_params
         .clone();
 
@@ -161,7 +161,7 @@ pub fn freeze_object(
 
     let transfer_freeze_object_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .transfer_freeze_object_cost_params
         .clone();
 
@@ -197,7 +197,7 @@ pub fn share_object(
 
     let transfer_share_object_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .transfer_share_object_cost_params
         .clone();
 
@@ -240,6 +240,6 @@ fn object_runtime_transfer(
         );
     }
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     obj_runtime.transfer(owner, ty, obj)
 }

--- a/sui-execution/latest/sui-move-natives/src/tx_context.rs
+++ b/sui-execution/latest/sui-move-natives/src/tx_context.rs
@@ -34,7 +34,7 @@ pub fn derive_id(
 
     let tx_context_derive_id_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .tx_context_derive_id_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -48,7 +48,7 @@ pub fn derive_id(
     // unwrap safe because all digests in Move are serialized from the Rust `TransactionDigest`
     let digest = TransactionDigest::try_from(tx_hash.as_slice()).unwrap();
     let address = AccountAddress::from(ObjectID::derive_id(digest, ids_created));
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     obj_runtime.new_id(address.into())?;
 
     Ok(NativeResult::ok(
@@ -74,7 +74,7 @@ pub fn fresh_id(
 
     let tx_context_fresh_id_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .tx_context_fresh_id_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -82,9 +82,9 @@ pub fn fresh_id(
         tx_context_fresh_id_cost_params.tx_context_fresh_id_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut();
+    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
     let fresh_id = transaction_context.fresh_id();
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     object_runtime.new_id(fresh_id)?;
 
     Ok(NativeResult::ok(
@@ -111,7 +111,7 @@ pub fn sender(
 
     let tx_context_sender_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .tx_context_sender_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -119,7 +119,7 @@ pub fn sender(
         tx_context_sender_cost_params.tx_context_sender_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut();
+    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
     let sender = transaction_context.sender();
 
     Ok(NativeResult::ok(
@@ -146,7 +146,7 @@ pub fn epoch(
 
     let tx_context_epoch_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .tx_context_epoch_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -154,7 +154,7 @@ pub fn epoch(
         tx_context_epoch_cost_params.tx_context_epoch_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut();
+    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
     let epoch = transaction_context.epoch();
 
     Ok(NativeResult::ok(
@@ -181,7 +181,7 @@ pub fn epoch_timestamp_ms(
 
     let tx_context_epoch_timestamp_ms_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .tx_context_epoch_timestamp_ms_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -189,7 +189,7 @@ pub fn epoch_timestamp_ms(
         tx_context_epoch_timestamp_ms_cost_params.tx_context_epoch_timestamp_ms_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut();
+    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
     let timestamp = transaction_context.epoch_timestamp_ms();
 
     Ok(NativeResult::ok(
@@ -216,7 +216,7 @@ pub fn sponsor(
 
     let tx_context_sponsor_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .tx_context_sponsor_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -224,7 +224,7 @@ pub fn sponsor(
         tx_context_sponsor_cost_params.tx_context_sponsor_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut();
+    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
     let sponsor = transaction_context
         .sponsor()
         .map(|addr| addr.into())
@@ -251,7 +251,7 @@ pub fn gas_price(
 
     let tx_context_gas_price_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .tx_context_gas_price_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -259,7 +259,7 @@ pub fn gas_price(
         tx_context_gas_price_cost_params.tx_context_gas_price_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut();
+    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
     let gas_price = transaction_context.gas_price();
 
     Ok(NativeResult::ok(
@@ -286,7 +286,7 @@ pub fn gas_budget(
 
     let tx_context_gas_budget_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .tx_context_gas_budget_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -294,7 +294,7 @@ pub fn gas_budget(
         tx_context_gas_budget_cost_params.tx_context_gas_budget_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut();
+    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
     let gas_budget = transaction_context.gas_budget();
 
     Ok(NativeResult::ok(
@@ -321,7 +321,7 @@ pub fn ids_created(
 
     let tx_context_ids_created_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .tx_context_ids_created_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -329,7 +329,7 @@ pub fn ids_created(
         tx_context_ids_created_cost_params.tx_context_ids_created_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut();
+    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
     let ids_created = transaction_context.ids_created();
 
     Ok(NativeResult::ok(
@@ -369,7 +369,7 @@ pub fn replace(
 
     let tx_context_replace_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .tx_context_replace_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -385,7 +385,7 @@ pub fn replace(
     let epoch: u64 = pop_arg!(args, u64);
     let tx_hash: Vec<u8> = pop_arg!(args, Vec<u8>);
     let sender: AccountAddress = pop_arg!(args, AccountAddress);
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut();
+    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
     transaction_context.replace(
         sender,
         tx_hash,
@@ -418,7 +418,7 @@ pub fn last_created_id(
 
     let tx_context_derive_id_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .tx_context_derive_id_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -426,7 +426,7 @@ pub fn last_created_id(
         tx_context_derive_id_cost_params.tx_context_derive_id_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut();
+    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
     let mut ids_created = transaction_context.ids_created();
     if ids_created == 0 {
         return Ok(NativeResult::err(context.gas_used(), E_NO_IDS_CREATED));
@@ -434,7 +434,7 @@ pub fn last_created_id(
     ids_created -= 1;
     let digest = transaction_context.digest();
     let address = AccountAddress::from(ObjectID::derive_id(digest, ids_created));
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut();
+    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     obj_runtime.new_id(address.into())?;
 
     Ok(NativeResult::ok(

--- a/sui-execution/latest/sui-move-natives/src/types.rs
+++ b/sui-execution/latest/sui-move-natives/src/types.rs
@@ -61,7 +61,7 @@ pub fn is_one_time_witness(
 
     let type_is_one_time_witness_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .type_is_one_time_witness_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/validator.rs
+++ b/sui-execution/latest/sui-move-natives/src/validator.rs
@@ -33,7 +33,7 @@ pub fn validate_metadata_bcs(
 
     let validator_validate_metadata_bcs_cost_params = context
         .extensions_mut()
-        .get::<NativesCostTable>()
+        .get::<NativesCostTable>()?
         .validator_validate_metadata_bcs_cost_params
         .clone();
 


### PR DESCRIPTION
## Description 

It always annoyed me that this API was infallible as it should really return invariant violations if the extension is not found.

The bottom commit is the  core of the change and the other two commits on top are just the updates on the adapter side based on those changes. 


## Test plan 

Make sure existing tests pass. 

