### PR TITLE
[indexer-alt]: Changes visibility of IngestionService and Indexer metrics

### DIFF
--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -68,7 +68,7 @@ pub struct IngestionConfig {
     pub retry_interval_ms: u64,
 }
 
-pub(crate) struct IngestionService {
+pub struct IngestionService {
     config: IngestionConfig,
     client: IngestionClient,
     ingest_hi_tx: mpsc::UnboundedSender<(&'static str, u64)>,
@@ -86,7 +86,7 @@ impl IngestionConfig {
 impl IngestionService {
     /// TODO: If we want to expose this as part of the framework, so people can run just an
     /// ingestion service, we will need to split `IngestionMetrics` out from `IndexerMetrics`.
-    pub(crate) fn new(
+    pub fn new(
         args: ClientArgs,
         config: IngestionConfig,
         metrics: Arc<IndexerMetrics>,
@@ -134,7 +134,7 @@ impl IngestionService {
     /// run ahead of the watermark by more than the config's buffer_size.
     ///
     /// Returns the channel to receive checkpoints from and the channel to accept watermarks from.
-    pub(crate) fn subscribe(
+    pub fn subscribe(
         &mut self,
     ) -> (
         mpsc::Receiver<Arc<CheckpointData>>,
@@ -159,7 +159,7 @@ impl IngestionService {
     /// If ingestion reaches the leading edge of the network, it will encounter checkpoints that do
     /// not exist yet. These will be retried repeatedly on a fixed `retry_interval` until they
     /// become available.
-    pub(crate) async fn run<I>(self, checkpoints: I) -> Result<(JoinHandle<()>, JoinHandle<()>)>
+    pub async fn run<I>(self, checkpoints: I) -> Result<(JoinHandle<()>, JoinHandle<()>)>
     where
         I: IntoIterator<Item = u64> + Send + Sync + 'static,
         I::IntoIter: Send + Sync + 'static,

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -37,7 +37,7 @@ pub use sui_types as types;
 pub mod cluster;
 pub mod handlers;
 pub mod ingestion;
-pub(crate) mod metrics;
+pub mod metrics;
 pub mod models;
 pub mod pipeline;
 pub mod schema;

--- a/crates/sui-indexer-alt-framework/src/metrics.rs
+++ b/crates/sui-indexer-alt-framework/src/metrics.rs
@@ -145,7 +145,7 @@ pub(crate) struct CheckpointLagMetricReporter {
 }
 
 impl IndexerMetrics {
-    pub(crate) fn new(registry: &Registry) -> Arc<Self> {
+    pub fn new(registry: &Registry) -> Arc<Self> {
         Arc::new(Self {
             total_ingested_checkpoints: register_int_counter_with_registry!(
                 "indexer_total_ingested_checkpoints",


### PR DESCRIPTION
## Description 

Changes visibility of IngestionService and Indexer metrics to public.
This is useful for cases where the IngestionService is needed in a standalone mode and out of the context of the Indexer. 
For example, when a custom range of checkpoints need to be parsed.

```
let mut ingestion_service = IngestionService::new(
        client_args,
        IngestionConfig::default(),
        metrics,
        cancel.clone(),
    )?;
    let (mut rx, _) = ingestion_service.subscribe();

    // Fetch malicious transactions and start ingestion
    let checkpoint_ids = pipeline.fetch_malicious_trxs().await?;
    println!("Found {} checkpoint IDs to process", checkpoint_ids.len());

    let (_, _) = ingestion_service
        .run(checkpoint_ids)
        .await
        .context("Failed to start ingestion service")?;
```

## Test plan 

Existing tests pass

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
