### PR TITLE
[move] Add static explicit marker for Move native extensions

### DIFF
--- a/external-crates/move/crates/move-unit-test/src/extensions.rs
+++ b/external-crates/move/crates/move-unit-test/src/extensions.rs
@@ -44,7 +44,7 @@ pub(crate) fn new_extensions<'a>() -> NativeContextExtensions<'a> {
 mod tests {
     use crate::extensions::{new_extensions, set_extension_hook};
     use better_any::{Tid, TidAble};
-    use move_vm_runtime::native_extensions::NativeContextExtensions;
+    use move_vm_runtime::native_extensions::{NativeContextExtensions, NativeExtensionMarker};
 
     /// A test that extension hooks work as expected.
     #[test]
@@ -56,6 +56,7 @@ mod tests {
 
     #[derive(Tid)]
     struct TestExtension();
+    impl NativeExtensionMarker<'_> for TestExtension {}
 
     fn my_hook(ext: &mut NativeContextExtensions) {
         ext.add(TestExtension())

--- a/sui-execution/latest/sui-move-natives/src/lib.rs
+++ b/sui-execution/latest/sui-move-natives/src/lib.rs
@@ -58,7 +58,10 @@ use move_core_types::{
     vm_status::StatusCode,
 };
 use move_stdlib_natives::{self as MSN, GasParameters};
-use move_vm_runtime::native_functions::{NativeContext, NativeFunction, NativeFunctionTable};
+use move_vm_runtime::{
+    native_extensions::NativeExtensionMarker,
+    native_functions::{NativeContext, NativeFunction, NativeFunctionTable},
+};
 use move_vm_types::{
     loaded_data::runtime_types::Type,
     natives::function::NativeResult,
@@ -189,6 +192,8 @@ pub struct NativesCostTable {
     // nitro attestation
     pub nitro_attestation_cost_params: NitroAttestationCostParams,
 }
+
+impl NativeExtensionMarker<'_> for NativesCostTable {}
 
 impl NativesCostTable {
     pub fn from_protocol_config(protocol_config: &ProtocolConfig) -> NativesCostTable {

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
@@ -21,6 +21,7 @@ use move_core_types::{
     runtime_value as R,
     vm_status::StatusCode,
 };
+use move_vm_runtime::native_extensions::NativeExtensionMarker;
 use move_vm_types::{
     loaded_data::runtime_types::Type,
     values::{GlobalValue, Value},
@@ -112,6 +113,8 @@ pub struct ObjectRuntime<'a> {
     pub(crate) protocol_config: &'a ProtocolConfig,
     pub(crate) metrics: Arc<LimitsMetrics>,
 }
+
+impl<'a> NativeExtensionMarker<'a> for ObjectRuntime<'a> {}
 
 pub enum TransferResult {
     New,

--- a/sui-execution/latest/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/latest/sui-move-natives/src/test_scenario.rs
@@ -15,7 +15,7 @@ use move_core_types::{
     language_storage::StructTag,
     vm_status::StatusCode,
 };
-use move_vm_runtime::native_functions::NativeContext;
+use move_vm_runtime::{native_extensions::NativeExtensionMarker, native_functions::NativeContext};
 use move_vm_types::{
     loaded_data::runtime_types::Type,
     natives::function::NativeResult,
@@ -56,6 +56,7 @@ type Set<K> = IndexSet<K>;
 /// writing) while hiding mutability.
 #[derive(Tid)]
 pub struct InMemoryTestStore(pub &'static LocalKey<RefCell<InMemoryStorage>>);
+impl<'a> NativeExtensionMarker<'a> for &'a InMemoryTestStore {}
 
 impl ChildObjectResolver for InMemoryTestStore {
     fn read_child_object(

--- a/sui-execution/latest/sui-move-natives/src/transaction_context.rs
+++ b/sui-execution/latest/sui-move-natives/src/transaction_context.rs
@@ -4,6 +4,7 @@
 use better_any::{Tid, TidAble};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{account_address::AccountAddress, vm_status::StatusCode};
+use move_vm_runtime::native_extensions::NativeExtensionMarker;
 use std::{cell::RefCell, rc::Rc};
 use sui_types::{
     base_types::{ObjectID, SuiAddress, TxContext},
@@ -19,6 +20,8 @@ pub struct TransactionContext {
     pub(crate) tx_context: Rc<RefCell<TxContext>>,
     test_only: bool,
 }
+
+impl NativeExtensionMarker<'_> for TransactionContext {}
 
 impl TransactionContext {
     pub fn new(tx_context: Rc<RefCell<TxContext>>) -> Self {


### PR DESCRIPTION
## Description 

Replaces the usage of `TidAble<'a>` for `NativeExtensionMarker<'a>` in the interface for native extensions. This makes trying to query for a type in the native context extensions without registering the _exact_ type a static error. This explicitly does not have blanket implementations for wrappers of an underlying type that implements the trait unlike [`TidAble`](https://docs.rs/better_any/latest/better_any/trait.TidAble.html). This means you must register the exact type that you will be adding to the extensions with the `NativeExtensionMarker` trait.

## Test plan 

Make sure existing tests pass.

