### PR TITLE
rpc benchmark: custom log path, debug info etc.

### DIFF
--- a/crates/sui-rpc-benchmark/src/config.rs
+++ b/crates/sui-rpc-benchmark/src/config.rs
@@ -24,7 +24,7 @@ impl Default for BenchmarkConfig {
     fn default() -> Self {
         Self {
             concurrency: 50,
-            duration: Some(Duration::from_secs(30)),
+            duration: None,
             json_rpc_file_path: None,
             json_rpc_methods_to_skip: HashSet::new(),
         }

--- a/crates/sui-rpc-benchmark/src/json_rpc/runner.rs
+++ b/crates/sui-rpc-benchmark/src/json_rpc/runner.rs
@@ -194,8 +194,8 @@ pub async fn run_queries(
     let requests: Vec<_> = requests
         .iter()
         .filter(|r| !methods_to_skip.contains(&r.method))
-        // TODO: remove this hack when the SDK has removed all MatchAny related implementation.
-        // Skip suix_getOwnedObjects requests with MatchAny filter b/c it's not supported.
+        // TODO: remove this hack when the SDK has removed all MatchAny & MatchAll related implementation.
+        // Skip suix_getOwnedObjects requests with MatchAny & MatchAll filters b/c it's not supported.
         .filter(|r| {
             !(r.method == "suix_getOwnedObjects"
                 && r.body_json
@@ -203,8 +203,9 @@ pub async fn run_queries(
                     .and_then(|p| p.as_array())
                     .and_then(|p| p.get(1))
                     .and_then(|p| p.get("filter"))
-                    .and_then(|f| f.get("MatchAny"))
-                    .is_some())
+                    .and_then(|f| f.as_object())
+                    .map(|f| f.contains_key("MatchAny") || f.contains_key("MatchAll"))
+                    .unwrap_or(false))
         })
         .cloned()
         .collect();


### PR DESCRIPTION
## Description 

main changes are:
- custom grafana log dest. path via cli
- change default execution behavior to be: run until the end instead of default duration of 30s
- add debug info for json rpc runner

## Test plan 

local run of benchmark like
RUST_LOG=sui_rpc_benchmark=debug cargo run --bin sui-rpc-benchmark -- jsonrpc --endpoint https://rpc-fpa.sui-mainnet.mystenlabs.com/json-rpc --requests-file /Users/gegao/Desktop/10k/sampled_read_requests.jsonl

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
