### PR TITLE
[move-analyzer] Updates to support implicit dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14471,6 +14471,8 @@ dependencies = [
  "bin-version",
  "clap",
  "move-analyzer",
+ "sui-move-build",
+ "sui-package-management",
 ]
 
 [[package]]

--- a/crates/sui-move-lsp/Cargo.toml
+++ b/crates/sui-move-lsp/Cargo.toml
@@ -11,4 +11,6 @@ clap = { version = "4.1.4", features = ["derive"] }
 
 bin-version.workspace = true
 move-analyzer.workspace = true
+sui-move-build.workspace = true
+sui-package-management.workspace = true
 

--- a/crates/sui-move-lsp/src/bin/move-analyzer.rs
+++ b/crates/sui-move-lsp/src/bin/move-analyzer.rs
@@ -3,6 +3,8 @@
 
 use clap::*;
 use move_analyzer::analyzer;
+use sui_move_build::implicit_deps;
+use sui_package_management::system_package_versions::latest_system_packages;
 
 // Define the `GIT_REVISION` and `VERSION` consts
 bin_version::bin_version!();
@@ -18,5 +20,5 @@ struct App {}
 
 fn main() {
     App::parse();
-    analyzer::run();
+    analyzer::run(implicit_deps(latest_system_packages()));
 }

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -48,9 +48,10 @@ use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
 use sui_move::manage_package::resolve_lock_file_path;
 use sui_move::{self, execute_move_command};
 use sui_move_build::{
-    check_invalid_dependencies, check_unpublished_dependencies, BuildConfig as SuiBuildConfig,
-    SuiPackageHooks,
+    check_invalid_dependencies, check_unpublished_dependencies, implicit_deps,
+    BuildConfig as SuiBuildConfig, SuiPackageHooks,
 };
+use sui_package_management::system_package_versions::latest_system_packages;
 use sui_sdk::sui_client_config::{SuiClientConfig, SuiEnv};
 use sui_sdk::wallet_context::WalletContext;
 use sui_swarm::memory::Swarm;
@@ -639,7 +640,7 @@ impl SuiCommand {
             }
             SuiCommand::FireDrill { fire_drill } => run_fire_drill(fire_drill).await,
             SuiCommand::Analyzer => {
-                analyzer::run();
+                analyzer::run(implicit_deps(latest_system_packages()));
                 Ok(())
             }
         }

--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
   "publisher": "mysten",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "preview": true,
   "repository": {
     "url": "https://github.com/MystenLabs/sui.git",

--- a/external-crates/move/crates/move-analyzer/src/bin/move-analyzer.rs
+++ b/external-crates/move/crates/move-analyzer/src/bin/move-analyzer.rs
@@ -3,6 +3,7 @@
 
 use clap::Parser;
 use move_analyzer::analyzer;
+use std::collections::BTreeMap;
 
 #[derive(Parser)]
 #[clap(author, version, about)]
@@ -13,5 +14,5 @@ fn main() {
     // For now, move-analyzer only responds to options built-in to clap,
     // such as `--help` or `--version`.
     Options::parse();
-    analyzer::run();
+    analyzer::run(BTreeMap::new());
 }

--- a/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
+++ b/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
@@ -357,6 +357,7 @@ fn initial_symbols(
         project_path.as_path(),
         None,
         LintLevel::None,
+        BTreeMap::new(),
     )?;
 
     if let Some(f) = files.first() {
@@ -367,6 +368,7 @@ fn initial_symbols(
             project_path.as_path(),
             Some(vec![mod_file]),
             LintLevel::None,
+            BTreeMap::new(),
         )?;
     }
 


### PR DESCRIPTION
## Description 

This PR gets `move-analyzer` to work with recently introduced implicit dependencies

## Test plan 

Tested manually that when no "standard" dependencies are specified, Move VSCode extension does not report missing deps
