### PR TITLE
jsonrpc: fix incorrect indexing of coin objects with tto

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -9,7 +9,7 @@ use crate::execution_cache::TransactionCacheRead;
 use crate::jsonrpc_index::CoinIndexKey2;
 use crate::rpc_index::RpcIndexStore;
 use crate::transaction_outputs::TransactionOutputs;
-use crate::verify_indexes::verify_indexes;
+use crate::verify_indexes::{fix_indexes, verify_indexes};
 use anyhow::anyhow;
 use arc_swap::{ArcSwap, Guard};
 use async_trait::async_trait;
@@ -2952,6 +2952,8 @@ impl AuthorityState {
             congestion_tracker: Arc::new(CongestionTracker::new()),
         });
 
+        let state_clone = Arc::downgrade(&state);
+        spawn_monitored_task!(fix_indexes(state_clone));
         // Start a task to execute ready certificates.
         let authority_state = Arc::downgrade(&state);
         spawn_monitored_task!(execution_process(

--- a/crates/sui-core/src/jsonrpc_index.rs
+++ b/crates/sui-core/src/jsonrpc_index.rs
@@ -192,7 +192,7 @@ impl IndexStoreMetrics {
 pub struct IndexStoreCaches {
     per_coin_type_balance: ShardedLruCache<(SuiAddress, TypeTag), SuiResult<TotalBalance>>,
     all_balances: ShardedLruCache<SuiAddress, SuiResult<Arc<HashMap<TypeTag, TotalBalance>>>>,
-    locks: MutexTable<SuiAddress>,
+    pub locks: MutexTable<SuiAddress>,
 }
 
 #[derive(Default)]
@@ -322,7 +322,7 @@ impl IndexStoreTables {
 pub struct IndexStore {
     next_sequence_number: AtomicU64,
     tables: IndexStoreTables,
-    caches: IndexStoreCaches,
+    pub caches: IndexStoreCaches,
     metrics: Arc<IndexStoreMetrics>,
     max_type_length: u64,
     remove_deprecated_tables: bool,

--- a/crates/sui-core/src/verify_indexes.rs
+++ b/crates/sui-core/src/verify_indexes.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Weak;
 use std::{collections::BTreeMap, sync::Arc};
 
 use crate::jsonrpc_index::{CoinIndexKey2, CoinInfo, IndexStore};
@@ -9,6 +10,7 @@ use sui_types::{base_types::ObjectInfo, object::Owner};
 use tracing::info;
 use typed_store::traits::Map;
 
+use crate::authority::AuthorityState;
 use crate::{authority::authority_store_tables::LiveObject, state_accumulator::AccumulatorStore};
 
 /// This is a very expensive function that verifies some of the secondary indexes. This is done by
@@ -88,5 +90,63 @@ pub fn verify_indexes(store: &dyn AccumulatorStore, indexes: Arc<IndexStore>) ->
 
     info!("Finished running index verification checks");
 
+    Ok(())
+}
+
+// temporary code to repair the coin index. This should be removed in the next release
+pub async fn fix_indexes(authority_state: Weak<AuthorityState>) -> Result<()> {
+    let is_violation = |coin_index_key: &CoinIndexKey2, state: &Arc<AuthorityState>| -> bool {
+        if let Some(object) = state
+            .get_object_store()
+            .get_object(&coin_index_key.object_id)
+        {
+            if matches!(object.owner, Owner::AddressOwner(real_owner_id) | Owner::ObjectOwner(real_owner_id) if coin_index_key.owner == real_owner_id)
+            {
+                return false;
+            }
+        }
+        true
+    };
+
+    tracing::info!("Starting fixing coin index");
+    // populate candidate list without locking. Some entries are benign
+    let authority_state_clone = authority_state.clone();
+    let candidates = tokio::task::spawn_blocking(move || {
+        if let Some(authority) = authority_state_clone.upgrade() {
+            let mut batch = vec![];
+            if let Some(indexes) = &authority.indexes {
+                for entry in indexes.tables().coin_index().safe_iter() {
+                    let (coin_index_key, _) = entry?;
+                    if is_violation(&coin_index_key, &authority) {
+                        batch.push(coin_index_key);
+                    }
+                }
+            }
+            return Ok::<Vec<_>, anyhow::Error>(batch);
+        }
+        Ok(vec![])
+    })
+    .await??;
+
+    if let Some(authority) = authority_state.upgrade() {
+        if let Some(indexes) = &authority.indexes {
+            for chunk in candidates.chunks(100) {
+                let _locks = indexes
+                    .caches
+                    .locks
+                    .acquire_locks(chunk.iter().map(|key| key.owner));
+                let mut batch = vec![];
+                for key in chunk {
+                    if is_violation(key, &authority) {
+                        batch.push(key);
+                    }
+                }
+                let mut wb = indexes.tables().coin_index().batch();
+                wb.delete_batch(indexes.tables().coin_index(), batch)?;
+                wb.write()?;
+            }
+        }
+    }
+    tracing::info!("Finished fix for the coin index");
     Ok(())
 }

--- a/crates/sui-json-rpc-tests/tests/data/tto/Move.toml
+++ b/crates/sui-json-rpc-tests/tests/data/tto/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "tto"
+version = "0.0.1"
+edition = "2024.beta"
+
+[dependencies]
+Sui = { local = "../../../../sui-framework/packages/sui-framework" }
+
+[addresses]
+tto =  "0x0"

--- a/crates/sui-json-rpc-tests/tests/data/tto/sources/tto.move
+++ b/crates/sui-json-rpc-tests/tests/data/tto/sources/tto.move
@@ -1,0 +1,27 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module tto::M1 {
+    use sui::coin::Coin;
+    use sui::sui::SUI;
+    use sui::object::{Self, UID};
+    use sui::tx_context::{Self, TxContext};
+    use sui::transfer::{Self, Receiving};
+
+    public struct A has key, store {
+        id: UID,
+    }
+
+    public fun start(coin: Coin<SUI>, ctx: &mut TxContext) {
+        let a = A { id: object::new(ctx) };
+        let a_address = object::id_address(&a);
+
+        transfer::public_transfer(a, tx_context::sender(ctx));
+        transfer::public_transfer(coin, a_address);
+    }
+
+    public entry fun receive(parent: &mut A, x: Receiving<Coin<SUI>>) {
+        let coin = transfer::public_receive(&mut parent.id, x);
+        transfer::public_transfer(coin, @tto);
+    }
+}

--- a/crates/sui-json-rpc-tests/tests/tto.rs
+++ b/crates/sui-json-rpc-tests/tests/tto.rs
@@ -17,7 +17,6 @@ use sui_types::transaction::{CallArg, ObjectArg, TransactionData, TransactionKin
 use sui_types::Identifier;
 use test_cluster::TestClusterBuilder;
 
-#[should_panic] // Test should panic since tracking of balance for TTO is broken
 #[tokio::test]
 async fn test_indexing_with_tto() {
     let cluster = TestClusterBuilder::new().build().await;

--- a/crates/sui-json-rpc-tests/tests/tto.rs
+++ b/crates/sui-json-rpc-tests/tests/tto.rs
@@ -1,0 +1,302 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+use sui_json_rpc_api::{
+    CoinReadApiClient, IndexerApiClient, TransactionBuilderClient, WriteApiClient,
+};
+use sui_json_rpc_types::{
+    ObjectChange, SuiObjectDataOptions, SuiObjectResponseQuery, SuiTransactionBlockResponseOptions,
+    TransactionBlockBytes,
+};
+use sui_move_build::BuildConfig;
+use sui_types::base_types::SuiAddress;
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+use sui_types::quorum_driver_types::ExecuteTransactionRequestType;
+use sui_types::transaction::{CallArg, ObjectArg, TransactionData, TransactionKind};
+use sui_types::Identifier;
+use test_cluster::TestClusterBuilder;
+
+#[should_panic] // Test should panic since tracking of balance for TTO is broken
+#[tokio::test]
+async fn test_indexing_with_tto() {
+    let cluster = TestClusterBuilder::new().build().await;
+
+    let http_client = cluster.rpc_client();
+    let address = cluster.get_address_0();
+
+    let objects = http_client
+        .get_owned_objects(
+            address,
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
+            None,
+            None,
+        )
+        .await
+        .unwrap()
+        .data;
+
+    let gas = objects[0].object().unwrap();
+    let coin = objects[1].object().unwrap();
+
+    //
+    // Publish the TTO package
+    //
+
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.extend(["tests", "data", "tto"]);
+    let compiled_package = BuildConfig::new_for_testing().build(&path).unwrap();
+    let compiled_modules_bytes =
+        compiled_package.get_package_base64(/* with_unpublished_deps */ false);
+    let dependencies = compiled_package.get_dependency_storage_package_ids();
+
+    let transaction_bytes: TransactionBlockBytes = http_client
+        .publish(
+            address,
+            compiled_modules_bytes,
+            dependencies,
+            Some(gas.object_id),
+            100_000_000.into(),
+        )
+        .await
+        .unwrap();
+
+    let tx = cluster
+        .wallet
+        .sign_transaction(&transaction_bytes.to_data().unwrap());
+    let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
+
+    let tx_response = http_client
+        .execute_transaction_block(
+            tx_bytes,
+            signatures,
+            Some(
+                SuiTransactionBlockResponseOptions::new()
+                    .with_object_changes()
+                    .with_events(),
+            ),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await
+        .unwrap();
+
+    //
+    // Run the `start` function to initialize the setup and TTO a coin
+    //
+
+    let object_changes = tx_response.object_changes.unwrap();
+    let package_id = object_changes
+        .iter()
+        .find_map(|e| {
+            if let ObjectChange::Published { package_id, .. } = e {
+                Some(package_id)
+            } else {
+                None
+            }
+        })
+        .unwrap();
+    let gas = object_changes
+        .iter()
+        .find_map(|c| {
+            if let ObjectChange::Mutated {
+                object_id,
+                version,
+                digest,
+                ..
+            } = c
+            {
+                if object_id == &gas.object_id {
+                    Some((*object_id, *version, *digest))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+        .unwrap();
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder
+        .move_call(
+            package_id.to_owned(),
+            Identifier::new("M1").unwrap(),
+            Identifier::new("start").unwrap(),
+            vec![],
+            vec![CallArg::Object(ObjectArg::ImmOrOwnedObject(
+                coin.object_ref(),
+            ))],
+        )
+        .unwrap();
+    let ptb = builder.finish();
+
+    let gas_data = sui_types::transaction::GasData {
+        payment: vec![gas],
+        owner: address,
+        price: 1000,
+        budget: 100_000_000,
+    };
+
+    let kind = TransactionKind::ProgrammableTransaction(ptb);
+    let tx_data = TransactionData::new_with_gas_data(kind, address, gas_data);
+
+    let tx = cluster.wallet.sign_transaction(&tx_data);
+    let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
+
+    let tx_response = http_client
+        .execute_transaction_block(
+            tx_bytes,
+            signatures,
+            Some(
+                SuiTransactionBlockResponseOptions::new()
+                    .with_effects()
+                    .with_object_changes(),
+            ),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await
+        .unwrap();
+
+    let object_changes = tx_response.object_changes.unwrap();
+
+    let parent = object_changes
+        .iter()
+        .find_map(|e| {
+            if let ObjectChange::Created {
+                object_id,
+                version,
+                digest,
+                ..
+            } = e
+            {
+                Some((*object_id, *version, *digest))
+            } else {
+                None
+            }
+        })
+        .unwrap();
+
+    let gas = object_changes
+        .iter()
+        .find_map(|c| {
+            if let ObjectChange::Mutated {
+                object_id,
+                version,
+                digest,
+                ..
+            } = c
+            {
+                if object_id == &gas.0 {
+                    Some((*object_id, *version, *digest))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+        .unwrap();
+
+    let coin = object_changes
+        .iter()
+        .find_map(|c| {
+            if let ObjectChange::Mutated {
+                object_id,
+                version,
+                digest,
+                ..
+            } = c
+            {
+                if object_id == &coin.object_id {
+                    Some((*object_id, *version, *digest))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+        .unwrap();
+
+    let parent_start_balance = http_client
+        .get_balance(parent.0.into(), None)
+        .await
+        .unwrap()
+        .total_balance;
+    assert_eq!(
+        http_client
+            .get_balance(SuiAddress::ZERO, None)
+            .await
+            .unwrap()
+            .total_balance,
+        0
+    );
+
+    //
+    // Run the `receive` function to receive the coin from TTO and send it to 0x0
+    //
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder
+        .move_call(
+            package_id.to_owned(),
+            Identifier::new("M1").unwrap(),
+            Identifier::new("receive").unwrap(),
+            vec![],
+            vec![
+                CallArg::Object(ObjectArg::ImmOrOwnedObject(parent)),
+                CallArg::Object(ObjectArg::Receiving(coin)),
+            ],
+        )
+        .unwrap();
+    let ptb = builder.finish();
+
+    let gas_data = sui_types::transaction::GasData {
+        payment: vec![gas],
+        owner: address,
+        price: 1000,
+        budget: 100_000_000,
+    };
+
+    let kind = TransactionKind::ProgrammableTransaction(ptb);
+    let tx_data = TransactionData::new_with_gas_data(kind, address, gas_data);
+
+    let tx = cluster.wallet.sign_transaction(&tx_data);
+    let (tx_bytes, signatures) = tx.to_tx_bytes_and_signatures();
+
+    let _tx_response = http_client
+        .execute_transaction_block(
+            tx_bytes,
+            signatures,
+            Some(
+                SuiTransactionBlockResponseOptions::new()
+                    .with_effects()
+                    .with_object_changes(),
+            ),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        http_client
+            .get_balance(parent.0.into(), None)
+            .await
+            .unwrap()
+            .total_balance,
+        0
+    );
+    assert_eq!(
+        http_client
+            .get_balance(SuiAddress::ZERO, None)
+            .await
+            .unwrap()
+            .total_balance,
+        parent_start_balance
+    );
+}


### PR DESCRIPTION
## Description 

Fix incorrect indexing of coin objects with tto as well as introduce a temporary background task to repair the indexes.

Closes: #21230
Closes: #21229

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
