### PR TITLE
rpc-alt: loosen pure input layouts calculation

### DIFF
--- a/crates/sui-indexer-alt-jsonrpc/src/api/dynamic_fields.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/dynamic_fields.rs
@@ -110,7 +110,6 @@ async fn dynamic_field_object_response(
                 | PRE::Deserialize(_)
                 | PRE::EmptyPackage(_)
                 | PRE::FunctionNotFound(_, _, _)
-                | PRE::InputTypeConflict(_, _, _)
                 | PRE::LinkageNotFound(_)
                 | PRE::NoTypeOrigin(_, _, _)
                 | PRE::NotAnIdentifier(_)

--- a/crates/sui-indexer-alt-jsonrpc/src/api/move_utils/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/move_utils/response.rs
@@ -60,7 +60,6 @@ pub(super) async fn function(
                 | PRE::DatatypeNotFound(_, _, _)
                 | PRE::Deserialize(_)
                 | PRE::EmptyPackage(_)
-                | PRE::InputTypeConflict(_, _, _)
                 | PRE::LinkageNotFound(_)
                 | PRE::NoTypeOrigin(_, _, _)
                 | PRE::NotAnIdentifier(_)

--- a/crates/sui-package-resolver/src/error.rs
+++ b/crates/sui-package-resolver/src/error.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use move_binary_format::errors::VMError;
 use move_core_types::account_address::AccountAddress;
-use sui_types::TypeTag;
 use thiserror::Error;
 
 #[derive(Error, Debug, Clone)]
@@ -30,13 +29,6 @@ pub enum Error {
         .0.to_canonical_display(/* with_prefix */ true),
     )]
     FunctionNotFound(AccountAddress, String, String),
-
-    #[error(
-        "Conflicting types for input {0}: {} and {}",
-        .1.to_canonical_display(/* with_prefix */ true),
-        .2.to_canonical_display(/* with_prefix */ true),
-    )]
-    InputTypeConflict(u16, TypeTag, TypeTag),
 
     #[error(
         "Linkage not found for package: {}",

--- a/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__pure_input_layouts_conflicting.snap
+++ b/crates/sui-package-resolver/src/snapshots/sui_package_resolver__tests__pure_input_layouts_conflicting.snap
@@ -1,0 +1,19 @@
+---
+source: crates/sui-package-resolver/src/lib.rs
+expression: output
+---
+???
+u64
+???
+???
+???
+struct 0x1::option::Option<0x1::string::String> {
+    vec: vector<struct 0x1::string::String {
+        bytes: vector<u8>,
+    }>,
+}
+vector<struct 0x1::option::Option<0x1::ascii::String> {
+    vec: vector<struct 0x1::ascii::String {
+        bytes: vector<u8>,
+    }>,
+}>


### PR DESCRIPTION
## Description

If it appears based on context that a pure input is being used as multiple types, produce no layout for that input, rather than erroring out pure input layout calculation.

## Test plan

Updated tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
