### PR TITLE
Add `submit_best_effort` to SubmitToConsensus

### DIFF
--- a/crates/sui-core/src/authority/execution_time_estimator.rs
+++ b/crates/sui-core/src/authority/execution_time_estimator.rs
@@ -348,10 +348,12 @@ impl ExecutionTimeObserver {
         let transaction = ConsensusTransaction::new_execution_time_observation(
             ExecutionTimeObservation::new(epoch_store.name, to_share),
         );
-        if let Err(e) = self
-            .consensus_adapter
-            .submit_to_consensus(&[transaction], &epoch_store)
-        {
+
+        if let Err(e) = self.consensus_adapter.submit_best_effort(
+            &transaction,
+            &epoch_store,
+            Duration::from_secs(5),
+        ) {
             if !matches!(e, SuiError::EpochEnded(_)) {
                 epoch_store
                     .metrics
@@ -361,6 +363,9 @@ impl ExecutionTimeObserver {
                 warn!("failed to submit execution time observation: {e:?}");
             }
         } else {
+            // Note: it is not actually guaranteed that the observation has been submitted at this point,
+            // but that is also not true with ConsensusAdapter::submit_to_consensus. The only way to know
+            // for sure is to observe that the message is processed by consensus handler.
             assert_reachable!("successfully shares execution time observations");
             epoch_store
                 .metrics

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -80,6 +80,7 @@ pub struct ConsensusAdapterMetrics {
     pub sequencing_in_flight_submissions: IntGauge,
     pub sequencing_estimated_latency: IntGauge,
     pub sequencing_resubmission_interval_ms: IntGauge,
+    pub sequencing_best_effort_timeout: IntCounterVec,
 }
 
 impl ConsensusAdapterMetrics {
@@ -188,6 +189,12 @@ impl ConsensusAdapterMetrics {
                     SEQUENCING_CERTIFICATE_POSITION_BUCKETS.to_vec(),
                     registry,
                 ).unwrap(),
+            sequencing_best_effort_timeout: register_int_counter_vec_with_registry!(
+                "sequencing_best_effort_timeout",
+                "The number of times the best effort submission has timed out.",
+                &["tx_type"],
+                registry,
+            ).unwrap(),
         }
     }
 
@@ -209,6 +216,13 @@ pub trait SubmitToConsensus: Sync + Send + 'static {
         &self,
         transactions: &[ConsensusTransaction],
         epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) -> SuiResult;
+
+    fn submit_best_effort(
+        &self,
+        transaction: &ConsensusTransaction,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+        timeout: Duration,
     ) -> SuiResult;
 }
 
@@ -249,7 +263,7 @@ pub struct ConsensusAdapter {
     /// A structure to register metrics
     metrics: ConsensusAdapterMetrics,
     /// Semaphore limiting parallel submissions to consensus
-    submit_semaphore: Semaphore,
+    submit_semaphore: Arc<Semaphore>,
     latency_observer: LatencyObserver,
     protocol_config: ProtocolConfig,
 }
@@ -300,7 +314,7 @@ impl ConsensusAdapter {
             connection_monitor_status,
             low_scoring_authorities,
             metrics,
-            submit_semaphore: Semaphore::new(max_pending_local_submissions),
+            submit_semaphore: Arc::new(Semaphore::new(max_pending_local_submissions)),
             latency_observer: LatencyObserver::new(),
             consensus_throughput_profiler: ArcSwapOption::empty(),
             protocol_config,
@@ -1286,6 +1300,56 @@ impl SubmitToConsensus for Arc<ConsensusAdapter> {
     ) -> SuiResult {
         self.submit_batch(transactions, None, epoch_store)
             .map(|_| ())
+    }
+
+    fn submit_best_effort(
+        &self,
+        transaction: &ConsensusTransaction,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+        // timeout is required, or the spawned task can run forever
+        timeout: Duration,
+    ) -> SuiResult {
+        let permit = match self.submit_semaphore.clone().try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => {
+                return Err(SuiError::TooManyTransactionsPendingConsensus);
+            }
+        };
+
+        let _in_flight_submission_guard =
+            GaugeGuard::acquire(&self.metrics.sequencing_in_flight_submissions);
+
+        let key = SequencedConsensusTransactionKey::External(transaction.key());
+        let tx_type = classify(transaction);
+
+        let async_stage = {
+            let transaction = transaction.clone();
+            let epoch_store = epoch_store.clone();
+            let this = self.clone();
+
+            async move {
+                let _permit = permit; // Hold permit for lifetime of task
+
+                // 3. timeout submission attempt inside task
+                let result = tokio::time::timeout(
+                    timeout,
+                    this.submit_inner(&[transaction], &epoch_store, &[key], tx_type, false),
+                )
+                .await;
+
+                if let Err(e) = result {
+                    warn!("Consensus submission timed out: {e:?}");
+                    this.metrics
+                        .sequencing_best_effort_timeout
+                        .with_label_values(&[tx_type])
+                        .inc();
+                }
+            }
+        };
+
+        let epoch_store = epoch_store.clone();
+        spawn_monitored_task!(epoch_store.within_alive_epoch(async_stage));
+        Ok(())
     }
 }
 

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -1330,7 +1330,6 @@ impl SubmitToConsensus for Arc<ConsensusAdapter> {
             async move {
                 let _permit = permit; // Hold permit for lifetime of task
 
-                // 3. timeout submission attempt inside task
                 let result = tokio::time::timeout(
                     timeout,
                     this.submit_inner(&[transaction], &epoch_store, &[key], tx_type, false),

--- a/crates/sui-core/src/mock_consensus.rs
+++ b/crates/sui-core/src/mock_consensus.rs
@@ -7,9 +7,7 @@ use crate::checkpoints::CheckpointServiceNoop;
 use crate::consensus_adapter::{BlockStatusReceiver, ConsensusClient, SubmitToConsensus};
 use crate::consensus_handler::SequencedConsensusTransaction;
 use consensus_core::BlockRef;
-use mysten_common::random::get_rng;
 use prometheus::Registry;
-use rand::Rng;
 use std::sync::{Arc, Weak};
 use std::time::Duration;
 use sui_types::error::{SuiError, SuiResult};
@@ -18,7 +16,7 @@ use sui_types::messages_consensus::{ConsensusTransaction, ConsensusTransactionKi
 use sui_types::transaction::{VerifiedCertificate, VerifiedTransaction};
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
-use tracing::{debug, warn};
+use tracing::debug;
 
 pub struct MockConsensusClient {
     tx_sender: mpsc::Sender<ConsensusTransaction>,


### PR DESCRIPTION
To be used for consensus submissions which do not require commit confirmation
