### PR TITLE
[consensus] Change leader (exclusion) stake threshold percent from 20 -> 30

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -227,6 +227,7 @@ const MAX_PROTOCOL_VERSION: u64 = 79;
 // Version 78: Make `TxContext` Move API native
 //             Enable execution time estimate mode for congestion control on testnet.
 // Version 79: Enable median based commit timestamp in consensus on testnet.
+//             Increase threshold for bad nodes that won't be considered leaders in consensus in testnet
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -3412,6 +3413,10 @@ impl ProtocolConfig {
                 79 => {
                     if chain != Chain::Mainnet {
                         cfg.feature_flags.consensus_median_based_commit_timestamp = true;
+
+                        // Increase threshold for bad nodes that won't be considered
+                        // leaders in consensus in testnet
+                        cfg.consensus_bad_nodes_stake_threshold = Some(30);
                     }
                 }
                 // Use this template when making changes:

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_79.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_79.snap
@@ -347,7 +347,7 @@ vector_swap_base_cost: 52
 debug_print_base_cost: 52
 debug_print_stack_trace_base_cost: 52
 execution_version: 3
-consensus_bad_nodes_stake_threshold: 20
+consensus_bad_nodes_stake_threshold: 30
 max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_79.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_79.snap
@@ -356,7 +356,7 @@ vector_swap_base_cost: 52
 debug_print_base_cost: 52
 debug_print_stack_trace_base_cost: 52
 execution_version: 3
-consensus_bad_nodes_stake_threshold: 20
+consensus_bad_nodes_stake_threshold: 30
 max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800


### PR DESCRIPTION
## Test plan 

Pending PTN test

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [X] Protocol: v79  Increase threshold for bad nodes that won't be considered leaders in consensus in testnet
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
