### PR TITLE
[Cherrypick] Add `submit_best_effort` to SubmitToConsensus (#21561)

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -783,7 +783,7 @@ impl ConsensusConfig {
     }
 
     pub fn max_pending_transactions(&self) -> usize {
-        self.max_pending_transactions.unwrap_or(20_000)
+        self.max_pending_transactions.unwrap_or(40_000)
     }
 
     pub fn submit_delay_step_override(&self) -> Option<Duration> {

--- a/crates/sui-core/src/authority/execution_time_estimator.rs
+++ b/crates/sui-core/src/authority/execution_time_estimator.rs
@@ -349,10 +349,12 @@ impl ExecutionTimeObserver {
         let transaction = ConsensusTransaction::new_execution_time_observation(
             ExecutionTimeObservation::new(epoch_store.name, to_share),
         );
-        if let Err(e) = self
-            .consensus_adapter
-            .submit_to_consensus(&[transaction], &epoch_store)
-        {
+
+        if let Err(e) = self.consensus_adapter.submit_best_effort(
+            &transaction,
+            &epoch_store,
+            Duration::from_secs(5),
+        ) {
             if !matches!(e, SuiError::EpochEnded(_)) {
                 epoch_store
                     .metrics

--- a/crates/sui-core/src/mock_consensus.rs
+++ b/crates/sui-core/src/mock_consensus.rs
@@ -9,6 +9,7 @@ use crate::consensus_handler::SequencedConsensusTransaction;
 use consensus_core::BlockRef;
 use prometheus::Registry;
 use std::sync::{Arc, Weak};
+use std::time::Duration;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::messages_consensus::{ConsensusTransaction, ConsensusTransactionKind};
@@ -118,6 +119,15 @@ impl SubmitToConsensus for MockConsensusClient {
         _epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
         self.submit_impl(transactions).map(|_response| ())
+    }
+
+    fn submit_best_effort(
+        &self,
+        transaction: &ConsensusTransaction,
+        _epoch_store: &Arc<AuthorityPerEpochStore>,
+        _timeout: Duration,
+    ) -> SuiResult {
+        self.submit_impl(&[transaction.clone()]).map(|_response| ())
     }
 }
 


### PR DESCRIPTION
To be used for consensus submissions which do not require commit
confirmation

## Description 

Fix for issue which can cause all consensus submission permits to be consumed

## Test plan 

- Load test in PTN
- Antithesis tests (ongoing)

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [x] Nodes (Validators and Full nodes): Upgrade to new version required for validators. Fullnodes unaffected
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
