### PR TITLE
[fastpath] propose blocks with transaction votes

### DIFF
--- a/consensus/core/src/block.rs
+++ b/consensus/core/src/block.rs
@@ -602,6 +602,10 @@ impl VerifiedBlock {
         self.digest
     }
 
+    pub(crate) fn signed_block(&self) -> &SignedBlock {
+        &self.block
+    }
+
     /// Returns the serialized block with signature.
     pub(crate) fn serialized(&self) -> &Bytes {
         &self.serialized

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -38,7 +38,9 @@ enum CoreThreadCommand {
     AddBlocks(Vec<VerifiedBlock>, oneshot::Sender<BTreeSet<BlockRef>>),
     /// Checks if block refs exist locally and sync missing ones.
     CheckBlockRefs(Vec<BlockRef>, oneshot::Sender<BTreeSet<BlockRef>>),
-    /// Add committed sub dag blocks for processing and acceptance.
+    /// Adds certified commits and their certification blocks for processing and acceptance.
+    /// Returns missing ancestors of certification voting blocks. Blocks included in certified commits
+    /// cannot have missing ancestors.
     AddCertifiedCommits(CertifiedCommits, oneshot::Sender<BTreeSet<BlockRef>>),
     /// Called when the min round has passed or the leader timeout occurred and a block should be produced.
     /// When the command is called with `force = true`, then the block will be created for `round` skipping

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -451,6 +451,7 @@ impl CoreThreadDispatcher for MockCoreThreadDispatcher {
 
 #[cfg(test)]
 mod test {
+    use mysten_metrics::monitored_mpsc;
     use parking_lot::RwLock;
 
     use super::*;
@@ -465,6 +466,7 @@ mod test {
         round_tracker::PeerRoundTracker,
         storage::mem_store::MemStore,
         transaction::{TransactionClient, TransactionConsumer},
+        transaction_certifier::TransactionCertifier,
         CommitConsumer,
     };
 
@@ -482,6 +484,10 @@ mod test {
         );
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
         let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
+        let (blocks_sender, _blocks_receiver) =
+            monitored_mpsc::unbounded_channel("consensus_block_output");
+        let transaction_certifier =
+            TransactionCertifier::new(context.clone(), dag_state.clone(), blocks_sender);
         let (signals, signal_receivers) = CoreSignals::new(context.clone());
         let _block_receiver = signal_receivers.block_broadcast_receiver();
         let (commit_consumer, _commit_receiver, _transaction_receiver) = CommitConsumer::new(0);
@@ -505,6 +511,7 @@ mod test {
             context.clone(),
             leader_schedule,
             transaction_consumer,
+            transaction_certifier,
             block_manager,
             true,
             commit_observer,


### PR DESCRIPTION
## Description 

- Recover transaction votes after restarts, by re-evaluating transactions that need to be rejected, on blocks that has not been linked by proposed blocks.
- Include reject transaction votes from blocks newly linked by proposed blocks.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
