### PR TITLE
store: introduce events_2 table to store events keyed by transaction digest

### DIFF
--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -566,7 +566,7 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
 
     fn get_events(
         &self,
-        event_digest: &sui_types::digests::TransactionEventsDigest,
+        event_digest: &sui_types::digests::TransactionDigest,
     ) -> Option<sui_types::effects::TransactionEvents> {
         self.store().get_transaction_events(event_digest)
     }

--- a/crates/simulacrum/src/store/in_mem_store.rs
+++ b/crates/simulacrum/src/store/in_mem_store.rs
@@ -11,7 +11,7 @@ use sui_types::{
     base_types::{AuthorityName, ObjectID, SequenceNumber, SuiAddress},
     committee::{Committee, EpochId},
     crypto::{AccountKeyPair, AuthorityKeyPair},
-    digests::{ObjectDigest, TransactionDigest, TransactionEventsDigest},
+    digests::{ObjectDigest, TransactionDigest},
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     error::SuiError,
     messages_checkpoint::{
@@ -35,9 +35,7 @@ pub struct InMemoryStore {
     // Transaction data
     transactions: HashMap<TransactionDigest, VerifiedTransaction>,
     effects: HashMap<TransactionDigest, TransactionEffects>,
-    events: HashMap<TransactionEventsDigest, TransactionEvents>,
-    // Map from transaction digest to events digest for easy lookup
-    events_tx_digest_index: HashMap<TransactionDigest, TransactionEventsDigest>,
+    events: HashMap<TransactionDigest, TransactionEvents>,
 
     // Committee data
     epoch_to_committee: Vec<Committee>,
@@ -97,10 +95,7 @@ impl InMemoryStore {
         self.effects.get(digest)
     }
 
-    pub fn get_transaction_events(
-        &self,
-        digest: &TransactionEventsDigest,
-    ) -> Option<&TransactionEvents> {
+    pub fn get_transaction_events(&self, digest: &TransactionDigest) -> Option<&TransactionEvents> {
         self.events.get(digest)
     }
 
@@ -198,9 +193,7 @@ impl InMemoryStore {
     }
 
     pub fn insert_events(&mut self, tx_digest: &TransactionDigest, events: TransactionEvents) {
-        self.events_tx_digest_index
-            .insert(*tx_digest, events.digest());
-        self.events.insert(events.digest(), events);
+        self.events.insert(*tx_digest, events);
     }
 
     pub fn update_objects(
@@ -408,21 +401,8 @@ impl SimulatorStore for InMemoryStore {
         self.get_transaction_effects(digest).cloned()
     }
 
-    fn get_transaction_events(
-        &self,
-        digest: &TransactionEventsDigest,
-    ) -> Option<TransactionEvents> {
+    fn get_transaction_events(&self, digest: &TransactionDigest) -> Option<TransactionEvents> {
         self.get_transaction_events(digest).cloned()
-    }
-
-    fn get_transaction_events_by_tx_digest(
-        &self,
-        tx_digest: &TransactionDigest,
-    ) -> Option<TransactionEvents> {
-        self.events_tx_digest_index
-            .get(tx_digest)
-            .and_then(|x| self.events.get(x))
-            .cloned()
     }
 
     fn get_object(&self, id: &ObjectID) -> Option<Object> {

--- a/crates/simulacrum/src/store/mod.rs
+++ b/crates/simulacrum/src/store/mod.rs
@@ -12,7 +12,7 @@ use sui_types::transaction::ReceivingObjects;
 use sui_types::{
     base_types::{ObjectID, SequenceNumber, SuiAddress},
     committee::{Committee, EpochId},
-    digests::{ObjectDigest, TransactionDigest, TransactionEventsDigest},
+    digests::{ObjectDigest, TransactionDigest},
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     error::SuiResult,
     messages_checkpoint::{
@@ -74,13 +74,7 @@ pub trait SimulatorStore:
 
     fn get_transaction_effects(&self, digest: &TransactionDigest) -> Option<TransactionEffects>;
 
-    fn get_transaction_events(&self, digest: &TransactionEventsDigest)
-        -> Option<TransactionEvents>;
-
-    fn get_transaction_events_by_tx_digest(
-        &self,
-        tx_digest: &TransactionDigest,
-    ) -> Option<TransactionEvents>;
+    fn get_transaction_events(&self, digest: &TransactionDigest) -> Option<TransactionEvents>;
 
     fn get_object(&self, id: &ObjectID) -> Option<Object>;
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -216,6 +216,7 @@ pub mod authority_test_utils;
 pub mod authority_per_epoch_store;
 pub mod authority_per_epoch_store_pruner;
 
+mod authority_store_migrations;
 pub mod authority_store_pruner;
 pub mod authority_store_tables;
 pub mod authority_store_types;
@@ -2963,6 +2964,7 @@ impl AuthorityState {
             rx_ready_certificates,
             rx_execution_shutdown,
         ));
+        spawn_monitored_task!(authority_store_migrations::migrate_events(store));
 
         // TODO: This doesn't belong to the constructor of AuthorityState.
         state

--- a/crates/sui-core/src/authority/authority_store_migrations.rs
+++ b/crates/sui-core/src/authority/authority_store_migrations.rs
@@ -1,0 +1,88 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::authority::AuthorityStore;
+use std::sync::Arc;
+use sui_types::effects::TransactionEffectsAPI;
+use typed_store::traits::Map;
+
+// Temporary migration task that can be removed in a release or two once we've removed the old
+// events table and are sure we don't need to revert to using the old events table
+pub async fn migrate_events(store: Arc<AuthorityStore>) {
+    tracing::info!("Starting events table migration");
+
+    let result = tokio::task::spawn_blocking(move || {
+        let span = tracing::info_span!(
+            "migrate_events",
+            transaction = tracing::field::Empty,
+            effects = tracing::field::Empty,
+        );
+        let _entered = span.enter();
+
+        let mut batch = store.perpetual_tables.events_2.batch();
+
+        for entry in store.perpetual_tables.executed_effects.safe_iter() {
+            let (txn_digest, effects_digest) = entry?;
+            span.record("transaction", tracing::field::debug(&txn_digest));
+            span.record("effects", tracing::field::debug(&effects_digest));
+
+            // If there's already an entry for this transaction in the new table we can skip it
+            if store.perpetual_tables.events_2.contains_key(&txn_digest)? {
+                continue;
+            }
+
+            let effects = if let Some(effects) = store.get_effects(&effects_digest)? {
+                effects
+            } else {
+                // Skip this one if we can't find the effects
+                continue;
+            };
+
+            let events_digest = if let Some(events_digest) = effects.events_digest() {
+                events_digest
+            } else {
+                // There are no events so we can continue to the next entry
+                continue;
+            };
+
+            let events = if let Some(events) = store.get_events_by_events_digest(events_digest)? {
+                // Check that the events we're loading do match the expected events digest for this
+                // transaction
+                let fetched_events_digest = events.digest();
+                if &fetched_events_digest != events_digest {
+                    tracing::warn!(
+                        expected_events_digest =? events_digest,
+                        fetched_events_digest =? fetched_events_digest,
+                        "fetched events don't matched expected digest; skipping",
+                    );
+                    continue;
+                }
+                events
+            } else {
+                // Skip this one if we can't find the events. This means they were liked already
+                // pruned
+                continue;
+            };
+
+            batch.insert_batch(&store.perpetual_tables.events_2, [(&txn_digest, &events)])?;
+
+            // If the batch size grows to greater that 128MB then write out to the DB so that the
+            // data we need to hold in memory doesn't grown unbounded.
+            if batch.size_in_bytes() >= 1 << 27 {
+                std::mem::replace(&mut batch, store.perpetual_tables.events_2.batch()).write()?;
+            }
+        }
+
+        batch.write()?;
+
+        Ok::<_, anyhow::Error>(())
+    })
+    .await
+    .unwrap();
+
+    if let Err(e) = result {
+        tracing::warn!("Error encountered while Finished events table migration: {e}");
+    }
+
+    tracing::info!("Finished events table migration");
+}

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -258,6 +258,8 @@ impl AuthorityStorePruner {
             effect_digests.push(effects_digest);
 
             if let Some(event_digest) = effects.events_digest() {
+                perpetual_batch
+                    .delete_batch(&perpetual_db.events_2, [effects.transaction_digest()])?;
                 if let Some(next_digest) = event_digest.next_lexicographical() {
                     perpetual_batch.schedule_delete_range(
                         &perpetual_db.events,

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use sui_types::accumulator::Accumulator;
 use sui_types::base_types::SequenceNumber;
 use sui_types::digests::TransactionEventsDigest;
-use sui_types::effects::TransactionEffects;
+use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::storage::{FullObjectKey, MarkerValue};
 use tracing::error;
 use typed_store::metrics::SamplingInterval;
@@ -99,6 +99,9 @@ pub struct AuthorityPerpetualTables {
     // TODO: Figure out what to do with this table in the long run.
     // Also we need a pruning policy for this table. We can prune this table along with tx/effects.
     pub(crate) events: DBMap<(TransactionEventsDigest, usize), Event>,
+
+    // Events keyed by the digest of the transaction that produced them.
+    pub(crate) events_2: DBMap<TransactionDigest, TransactionEvents>,
 
     /// DEPRECATED in favor of the table of the same name in authority_per_epoch_store.
     /// Please do not add new accessors/callsites.
@@ -454,6 +457,7 @@ impl AuthorityPerpetualTables {
         self.objects.unsafe_clear()?;
         self.live_owned_object_markers.unsafe_clear()?;
         self.executed_effects.unsafe_clear()?;
+        self.events_2.unsafe_clear()?;
         self.events.unsafe_clear()?;
         self.executed_transactions_to_checkpoint.unsafe_clear()?;
         self.root_state_hash_by_epoch.unsafe_clear()?;

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -658,8 +658,11 @@ impl ValidatorService {
                 .get_signed_effects_and_maybe_resign(&tx_digest, epoch_store)?
             {
                 let events = if include_events {
-                    if let Some(digest) = signed_effects.events_digest() {
-                        Some(self.state.get_transaction_events(digest)?)
+                    if signed_effects.events_digest().is_some() {
+                        Some(
+                            self.state
+                                .get_transaction_events(signed_effects.transaction_digest())?,
+                        )
                     } else {
                         None
                     }
@@ -831,8 +834,8 @@ impl ValidatorService {
                     _ => panic!("`handle_submit_to_consensus` received transaction that is not a CertifiedTransaction or UserTransaction"),
                 };
                 let events = if include_events {
-                    if let Some(digest) = effects.events_digest() {
-                        Some(self.state.get_transaction_events(digest)?)
+                    if effects.events_digest().is_some() {
+                        Some(self.state.get_transaction_events(effects.transaction_digest())?)
                     } else {
                         None
                     }

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/data_ingestion_handler.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/data_ingestion_handler.rs
@@ -17,29 +17,32 @@ pub(crate) fn load_checkpoint_data(
     object_cache_reader: &dyn ObjectCacheRead,
     transaction_cache_reader: &dyn TransactionCacheRead,
 ) -> SuiResult<CheckpointData> {
-    let event_digests = ckpt_tx_data
+    let event_tx_digests = ckpt_tx_data
         .effects
         .iter()
-        .flat_map(|fx| fx.events_digest().copied())
+        .flat_map(|fx| fx.events_digest().map(|_| fx.transaction_digest()).copied())
         .collect::<Vec<_>>();
 
     let events = transaction_cache_reader
-        .multi_get_events(&event_digests)
+        .multi_get_events(&event_tx_digests)
         .into_iter()
-        .zip(&event_digests)
-        .map(|(event, digest)| event.ok_or(SuiError::TransactionEventsNotFound { digest: *digest }))
-        .collect::<SuiResult<Vec<_>>>()?;
+        .zip(event_tx_digests)
+        .map(|(maybe_event, tx_digest)| {
+            maybe_event
+                .ok_or(SuiError::TransactionEventsNotFound { digest: tx_digest })
+                .map(|event| (tx_digest, event))
+        })
+        .collect::<SuiResult<HashMap<_, _>>>()?;
 
-    let events: HashMap<_, _> = event_digests.into_iter().zip(events).collect();
     let mut full_transactions = Vec::with_capacity(ckpt_tx_data.transactions.len());
     for (tx, fx) in ckpt_tx_data
         .transactions
         .iter()
         .zip(ckpt_tx_data.effects.iter())
     {
-        let events = fx.events_digest().map(|event_digest| {
+        let events = fx.events_digest().map(|_event_digest| {
             events
-                .get(event_digest)
+                .get(fx.transaction_digest())
                 .cloned()
                 .expect("event was already checked to be present")
         });

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -2771,7 +2771,6 @@ mod tests {
     use sui_protocol_config::{Chain, ProtocolConfig};
     use sui_types::base_types::{ObjectID, SequenceNumber, TransactionEffectsDigest};
     use sui_types::crypto::Signature;
-    use sui_types::digests::TransactionEventsDigest;
     use sui_types::effects::{TransactionEffects, TransactionEvents};
     use sui_types::messages_checkpoint::SignedCheckpointSummary;
     use sui_types::move_package::MovePackage;
@@ -3068,10 +3067,7 @@ mod tests {
             unimplemented!()
         }
 
-        fn multi_get_events(
-            &self,
-            _: &[TransactionEventsDigest],
-        ) -> Vec<Option<TransactionEvents>> {
+        fn multi_get_events(&self, _: &[TransactionDigest]) -> Vec<Option<TransactionEvents>> {
             unimplemented!()
         }
     }

--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use sui_config::ExecutionCacheConfig;
 use sui_protocol_config::ProtocolVersion;
 use sui_types::base_types::{FullObjectID, VerifiedExecutionData};
-use sui_types::digests::{TransactionDigest, TransactionEffectsDigest, TransactionEventsDigest};
+use sui_types::digests::{TransactionDigest, TransactionEffectsDigest};
 use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::error::{SuiError, SuiResult, UserInputError};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
@@ -499,12 +499,9 @@ pub trait TransactionCacheRead: Send + Sync {
             .expect("multi-get must return correct number of items")
     }
 
-    fn multi_get_events(
-        &self,
-        event_digests: &[TransactionEventsDigest],
-    ) -> Vec<Option<TransactionEvents>>;
+    fn multi_get_events(&self, digests: &[TransactionDigest]) -> Vec<Option<TransactionEvents>>;
 
-    fn get_events(&self, digest: &TransactionEventsDigest) -> Option<TransactionEvents> {
+    fn get_events(&self, digest: &TransactionDigest) -> Option<TransactionEvents> {
         self.multi_get_events(&[*digest])
             .pop()
             .expect("multi-get must return correct number of items")

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -17,7 +17,6 @@ use sui_types::base_types::SuiAddress;
 use sui_types::base_types::TransactionDigest;
 use sui_types::committee::Committee;
 use sui_types::committee::EpochId;
-use sui_types::digests::TransactionEventsDigest;
 use sui_types::effects::{TransactionEffects, TransactionEvents};
 use sui_types::messages_checkpoint::CheckpointContentsDigest;
 use sui_types::messages_checkpoint::CheckpointDigest;
@@ -206,7 +205,7 @@ impl ReadStore for RocksDbStore {
             .get_executed_effects(digest)
     }
 
-    fn get_events(&self, digest: &TransactionEventsDigest) -> Option<TransactionEvents> {
+    fn get_events(&self, digest: &TransactionDigest) -> Option<TransactionEvents> {
         self.cache_traits
             .transaction_cache_reader
             .get_events(digest)
@@ -426,7 +425,7 @@ impl ReadStore for RestReadStore {
         self.rocks.get_transaction_effects(digest)
     }
 
-    fn get_events(&self, digest: &TransactionEventsDigest) -> Option<TransactionEvents> {
+    fn get_events(&self, digest: &TransactionDigest) -> Option<TransactionEvents> {
         self.rocks.get_events(digest)
     }
 

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -226,8 +226,8 @@ impl LocalAuthorityClient {
         .into_inner();
 
         let events = if request.include_events {
-            if let Some(digest) = signed_effects.events_digest() {
-                Some(state.get_transaction_events(digest)?)
+            if signed_effects.events_digest().is_some() {
+                Some(state.get_transaction_events(signed_effects.transaction_digest())?)
             } else {
                 None
             }

--- a/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
+++ b/crates/sui-core/src/unit_tests/move_package_upgrade_tests.rs
@@ -1238,10 +1238,10 @@ async fn test_upgraded_types_in_one_txn() {
     let e1_type = StructTag::from_str(&format!("{package_v2}::base::BModEvent")).unwrap();
     let e2_type = StructTag::from_str(&format!("{package_v3}::base::CModEvent")).unwrap();
 
-    let event_digest = effects.events_digest().unwrap();
+    let _event_digest = effects.events_digest().unwrap();
     let mut events = runner
         .authority_state
-        .get_transaction_events(event_digest)
+        .get_transaction_events(effects.transaction_digest())
         .unwrap()
         .data;
     events.sort_by(|a, b| a.type_.name.as_str().cmp(b.type_.name.as_str()));

--- a/crates/sui-core/src/validator_tx_finalizer.rs
+++ b/crates/sui-core/src/validator_tx_finalizer.rs
@@ -355,9 +355,11 @@ mod tests {
                     &epoch_store,
                 )
                 .await?;
-            let events = match effects.events_digest() {
-                None => TransactionEvents::default(),
-                Some(digest) => self.authority.get_transaction_events(digest)?,
+            let events = if effects.events_digest().is_some() {
+                self.authority
+                    .get_transaction_events(effects.transaction_digest())?
+            } else {
+                TransactionEvents::default()
             };
             let signed_effects = self
                 .authority

--- a/crates/sui-rpc-api/src/reader.rs
+++ b/crates/sui-rpc-api/src/reader.rs
@@ -86,9 +86,9 @@ impl StateReader {
             .inner()
             .get_transaction_effects(&transaction_digest)
             .ok_or(TransactionNotFoundError(digest))?;
-        let events = if let Some(event_digest) = effects.events_digest() {
+        let events = if effects.events_digest().is_some() {
             self.inner()
-                .get_events(event_digest)
+                .get_events(effects.transaction_digest())
                 .ok_or(TransactionNotFoundError(digest))?
                 .pipe(Some)
         } else {

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -30,7 +30,6 @@ use sui_types::base_types::SuiAddress;
 use sui_types::base_types::VersionNumber;
 use sui_types::committee::EpochId;
 use sui_types::digests::TransactionDigest;
-use sui_types::digests::TransactionEventsDigest;
 use sui_types::effects::TransactionEffects;
 use sui_types::effects::TransactionEvents;
 use sui_types::error::ExecutionError;
@@ -363,10 +362,10 @@ impl ReadStore for ValidatorWithFullnode {
             .get_executed_effects(tx_digest)
     }
 
-    fn get_events(&self, event_digest: &TransactionEventsDigest) -> Option<TransactionEvents> {
+    fn get_events(&self, digest: &TransactionDigest) -> Option<TransactionEvents> {
         self.validator
             .get_transaction_cache_reader()
-            .get_events(event_digest)
+            .get_events(digest)
     }
 
     fn get_full_checkpoint_contents_by_sequence_number(
@@ -441,7 +440,7 @@ impl TransactionalAdapter for Simulacrum<StdRng, PersistedStore> {
     ) -> SuiResult<Vec<Event>> {
         Ok(self
             .store()
-            .get_transaction_events_by_tx_digest(tx_digest)
+            .get_transaction_events(tx_digest)
             .map(|x| x.data)
             .unwrap_or_default())
     }

--- a/crates/sui-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/sui-transactional-test-runner/src/simulator_persisted_store.rs
@@ -17,7 +17,7 @@ use sui_types::{
     base_types::{ObjectID, SequenceNumber, SuiAddress, VersionNumber},
     committee::{Committee, EpochId},
     crypto::AccountKeyPair,
-    digests::{ObjectDigest, TransactionDigest, TransactionEventsDigest},
+    digests::{ObjectDigest, TransactionDigest},
     effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents},
     error::{SuiError, UserInputError},
     messages_checkpoint::{
@@ -63,8 +63,7 @@ pub struct PersistedStoreInner {
     // Transaction data
     transactions: DBMap<TransactionDigest, sui_types::transaction::TrustedTransaction>,
     effects: DBMap<TransactionDigest, TransactionEffects>,
-    events: DBMap<TransactionEventsDigest, TransactionEvents>,
-    events_tx_digest_index: DBMap<TransactionDigest, TransactionEventsDigest>,
+    events: DBMap<TransactionDigest, TransactionEvents>,
 
     // Committee data
     epoch_to_committee: DBMap<(), Vec<Committee>>,
@@ -230,30 +229,11 @@ impl SimulatorStore for PersistedStore {
             .expect("Fatal: DB read failed")
     }
 
-    fn get_transaction_events(
-        &self,
-        digest: &TransactionEventsDigest,
-    ) -> Option<TransactionEvents> {
+    fn get_transaction_events(&self, digest: &TransactionDigest) -> Option<TransactionEvents> {
         self.read_write
             .events
             .get(digest)
             .expect("Fatal: DB read failed")
-    }
-
-    fn get_transaction_events_by_tx_digest(
-        &self,
-        tx_digest: &TransactionDigest,
-    ) -> Option<TransactionEvents> {
-        self.read_write
-            .events_tx_digest_index
-            .get(tx_digest)
-            .expect("Fatal: DB read failed")
-            .and_then(|x| {
-                self.read_write
-                    .events
-                    .get(&x)
-                    .expect("Fatal: DB read failed")
-            })
     }
 
     fn get_object(&self, id: &ObjectID) -> Option<Object> {
@@ -368,12 +348,8 @@ impl SimulatorStore for PersistedStore {
 
     fn insert_events(&mut self, tx_digest: &TransactionDigest, events: TransactionEvents) {
         self.read_write
-            .events_tx_digest_index
-            .insert(tx_digest, &events.digest())
-            .expect("Fatal: DB write failed");
-        self.read_write
             .events
-            .insert(&events.digest(), &events)
+            .insert(tx_digest, &events)
             .expect("Fatal: DB write failed");
     }
 
@@ -636,7 +612,7 @@ impl ReadStore for PersistedStoreInnerReadOnlyWrapper {
             .expect("Fatal: DB read failed")
     }
 
-    fn get_events(&self, event_digest: &TransactionEventsDigest) -> Option<TransactionEvents> {
+    fn get_events(&self, event_digest: &TransactionDigest) -> Option<TransactionEvents> {
         self.sync();
         self.inner
             .events

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -66,7 +66,7 @@ use sui_swarm_config::genesis_config::AccountConfig;
 use sui_types::base_types::{SequenceNumber, VersionNumber};
 use sui_types::committee::EpochId;
 use sui_types::crypto::{get_authority_key_pair, RandomnessRound};
-use sui_types::digests::{ConsensusCommitDigest, TransactionDigest, TransactionEventsDigest};
+use sui_types::digests::{ConsensusCommitDigest, TransactionDigest};
 use sui_types::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
 use sui_types::messages_checkpoint::{
     CheckpointContents, CheckpointContentsDigest, CheckpointSequenceNumber, VerifiedCheckpoint,
@@ -2584,8 +2584,8 @@ impl ReadStore for SuiTestAdapter {
         self.executor.get_transaction_effects(tx_digest)
     }
 
-    fn get_events(&self, event_digest: &TransactionEventsDigest) -> Option<TransactionEvents> {
-        self.executor.get_events(event_digest)
+    fn get_events(&self, digest: &TransactionDigest) -> Option<TransactionEvents> {
+        self.executor.get_events(digest)
     }
 
     fn get_full_checkpoint_contents_by_sequence_number(

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -37,7 +37,6 @@ macro_rules! fp_ensure {
         }
     };
 }
-use crate::digests::TransactionEventsDigest;
 use crate::execution_status::{CommandIndex, ExecutionFailureStatus};
 pub(crate) use fp_ensure;
 
@@ -497,7 +496,7 @@ pub enum SuiError {
     #[error("{TRANSACTIONS_NOT_FOUND_MSG_PREFIX} [{:?}].", digests)]
     TransactionsNotFound { digests: Vec<TransactionDigest> },
     #[error("Could not find the referenced transaction events [{digest:?}].")]
-    TransactionEventsNotFound { digest: TransactionEventsDigest },
+    TransactionEventsNotFound { digest: TransactionDigest },
     #[error(
         "Attempt to move to `Executed` state an transaction that has already been executed: {:?}.",
         digest

--- a/crates/sui-types/src/storage/shared_in_memory_store.rs
+++ b/crates/sui-types/src/storage/shared_in_memory_store.rs
@@ -5,7 +5,7 @@ use super::error::Result;
 use super::ObjectStore;
 use crate::base_types::{EpochId, TransactionDigest};
 use crate::committee::Committee;
-use crate::digests::{CheckpointContentsDigest, CheckpointDigest, TransactionEventsDigest};
+use crate::digests::{CheckpointContentsDigest, CheckpointDigest};
 use crate::effects::{TransactionEffects, TransactionEvents};
 use crate::messages_checkpoint::{
     CheckpointContents, CheckpointSequenceNumber, FullCheckpointContents, VerifiedCheckpoint,
@@ -111,7 +111,7 @@ impl ReadStore for SharedInMemoryStore {
         self.inner().get_transaction_effects(digest).cloned()
     }
 
-    fn get_events(&self, digest: &TransactionEventsDigest) -> Option<TransactionEvents> {
+    fn get_events(&self, digest: &TransactionDigest) -> Option<TransactionEvents> {
         self.inner().get_transaction_events(digest).cloned()
     }
 
@@ -202,7 +202,7 @@ pub struct InMemoryStore {
     checkpoint_contents: HashMap<CheckpointContentsDigest, CheckpointContents>,
     transactions: HashMap<TransactionDigest, VerifiedTransaction>,
     effects: HashMap<TransactionDigest, TransactionEffects>,
-    events: HashMap<TransactionEventsDigest, TransactionEvents>,
+    events: HashMap<TransactionDigest, TransactionEvents>,
 
     epoch_to_committee: Vec<Committee>,
 
@@ -419,10 +419,7 @@ impl InMemoryStore {
         self.effects.get(digest)
     }
 
-    pub fn get_transaction_events(
-        &self,
-        digest: &TransactionEventsDigest,
-    ) -> Option<&TransactionEvents> {
+    pub fn get_transaction_events(&self, digest: &TransactionDigest) -> Option<&TransactionEvents> {
         self.events.get(digest)
     }
 }
@@ -512,7 +509,7 @@ impl ReadStore for SingleCheckpointSharedInMemoryStore {
         self.0.get_transaction_effects(digest)
     }
 
-    fn get_events(&self, digest: &TransactionEventsDigest) -> Option<TransactionEvents> {
+    fn get_events(&self, digest: &TransactionDigest) -> Option<TransactionEvents> {
         self.0.get_events(digest)
     }
 


### PR DESCRIPTION
## Description 

    store: introduce events_2 table to store events keyed by transaction digest

    In Sui TransactionEvents are not unique and multiple transactions can
    produce the exact same set of TransactionEvents. Today these events are
    stored in a table keyed by TransactionEventsDigest which can lead to an
    unfortunate scenario when pruning is enabled. If we have two
    transactions `A` and `B`, both of which produced events `E`, when the
    pruner goes to prune transaction `A` it will also remove events `E` from
    the database. This will lead to a situation where the node will be
    unable to find locally the events produced by transaction `B`.

    In order to fix this bug this patch introduces a new `events_2` table to
    store events keyed by the transaction digest of the transaction that
    produced them. It also updates the interface used to read events from
    the db to require a `TransactionDigest` instead of a
    `TransactionEventsDigest`. Internally the `events_2` table is first checked
    but then there is fallback logic to lookup the events from the `events`
    table. This fallback logic can eventually be removed once we've
    completed a db migration and deprecate the `events` table.


## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
