### PR TITLE
[move][tracing] Allow references to flow in and out of entrypoints

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/interpreter.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/interpreter.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    close_frame, close_initial_frame, close_instruction,
+    close_frame, close_initial_native_frame, close_instruction,
     loader::{Function, Loader, Resolver},
     native_functions::NativeContext,
     open_frame, open_initial_frame, open_instruction, trace,
@@ -148,7 +148,7 @@ impl Interpreter {
                         .finish(Location::Module(function.module_id().clone()))
                 });
 
-            close_initial_frame!(tracer, &function, &return_values, gas_meter);
+            close_initial_native_frame!(tracer, &function, &return_values, gas_meter);
 
             Ok(return_values?.into_iter().collect())
         } else {

--- a/external-crates/move/crates/move-vm-runtime/src/tracing2/mod.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/tracing2/mod.rs
@@ -26,11 +26,11 @@ macro_rules! open_initial_frame {
 }
 
 #[macro_export]
-macro_rules! close_initial_frame {
+macro_rules! close_initial_native_frame {
     ($tracer: expr, $function: expr, $return_values: expr, $gas_meter: expr) => {
         if $crate::tracing2::TRACING_ENABLED {
             $tracer.as_mut().map(|tracer| {
-                tracer.close_initial_frame($return_values, $gas_meter.remaining_gas().into())
+                tracer.close_initial_native_frame($return_values, $gas_meter.remaining_gas().into())
             });
             move_vm_profiler::profile_close_frame!($gas_meter, $function.pretty_string());
         }

--- a/external-crates/move/crates/move-vm-runtime/src/tracing2/tracer.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/tracing2/tracer.rs
@@ -495,6 +495,7 @@ impl VMTracer<'_> {
         let function_type_info = FunctionTypeInfo::new(function, loader, ty_args, link_context)?;
 
         assert!(function_type_info.local_types.len() == function.local_count());
+        let start_trace_index = self.trace.current_trace_offset();
 
         let call_args: Vec<_> = args
             .iter()
@@ -502,8 +503,30 @@ impl VMTracer<'_> {
             .map(|(value, tag_with_layout_info_opt)| {
                 let (layout, ref_type) = tag_with_layout_info_opt.layout;
                 let move_value = value.as_annotated_move_value_for_tracing_only(&layout?)?;
-                assert!(ref_type.is_none());
-                Some(TraceValue::RuntimeValue { value: move_value })
+                match ref_type {
+                    Some(ref_type) => {
+                        let id = self.trace.current_trace_offset();
+                        let location = RuntimeLocation::Global(id);
+                        self.trace.effect(EF::DataLoad(DataLoad {
+                            ref_type: ref_type.clone(),
+                            location: location.as_trace_location(),
+                            snapshot: move_value.clone(),
+                        }));
+                        let trace_value = match &ref_type {
+                            RefType::Imm => TraceValue::ImmRef {
+                                location: location.as_trace_location(),
+                                snapshot: Box::new(move_value),
+                            },
+                            RefType::Mut => TraceValue::MutRef {
+                                location: location.as_trace_location(),
+                                snapshot: Box::new(move_value),
+                            },
+                        };
+                        self.loaded_data.insert(id, trace_value.clone());
+                        Some(trace_value)
+                    }
+                    None => Some(TraceValue::RuntimeValue { value: move_value }),
+                }
             })
             .collect::<Option<_>>()?;
 
@@ -511,14 +534,23 @@ impl VMTracer<'_> {
             .local_types
             .iter()
             .cloned()
-            .map(|tag_with_layout_info_opt| {
+            .enumerate()
+            .map(|(i, tag_with_layout_info_opt)| {
                 let (layout, ref_type) = tag_with_layout_info_opt.layout;
                 LocalType {
                     layout,
                     ref_type: ref_type
-                        .map(|r_type| match r_type {
-                            RefType::Imm => ReferenceType::Empty { ref_type: r_type },
-                            RefType::Mut => ReferenceType::Empty { ref_type: r_type },
+                        .map(|r_type| {
+                            let possible_location = start_trace_index + i;
+                            if self.loaded_data.contains_key(&possible_location) {
+                                let location = RuntimeLocation::Global(possible_location);
+                                ReferenceType::Filled {
+                                    ref_type: r_type,
+                                    location,
+                                }
+                            } else {
+                                ReferenceType::Empty { ref_type: r_type }
+                            }
                         })
                         .unwrap_or(ReferenceType::Value),
                 }
@@ -559,7 +591,11 @@ impl VMTracer<'_> {
         Some(())
     }
 
-    fn close_initial_frame_(&mut self, return_values: &[Value], remaining_gas: u64) -> Option<()> {
+    fn close_initial_native_frame_(
+        &mut self,
+        return_values: &[Value],
+        remaining_gas: u64,
+    ) -> Option<()> {
         let current_frame_return_tys = self.current_frame()?.return_types.clone();
         let return_values: Vec<_> = return_values
             .iter()
@@ -567,8 +603,30 @@ impl VMTracer<'_> {
             .map(|(value, tag_with_layout_info_opt)| {
                 let (layout, ref_type) = tag_with_layout_info_opt.layout;
                 let move_value = value.as_annotated_move_value_for_tracing_only(&layout?)?;
-                assert!(ref_type.is_none());
-                Some(TraceValue::RuntimeValue { value: move_value })
+                match ref_type {
+                    Some(ref_type) => {
+                        let id = self.trace.current_trace_offset();
+                        let location = RuntimeLocation::Global(id);
+                        self.trace.effect(EF::DataLoad(DataLoad {
+                            ref_type: ref_type.clone(),
+                            location: location.as_trace_location(),
+                            snapshot: move_value.clone(),
+                        }));
+                        let trace_value = match &ref_type {
+                            RefType::Imm => TraceValue::ImmRef {
+                                location: location.as_trace_location(),
+                                snapshot: Box::new(move_value),
+                            },
+                            RefType::Mut => TraceValue::MutRef {
+                                location: location.as_trace_location(),
+                                snapshot: Box::new(move_value),
+                            },
+                        };
+                        self.loaded_data.insert(id, trace_value.clone());
+                        Some(trace_value)
+                    }
+                    None => Some(TraceValue::RuntimeValue { value: move_value }),
+                }
             })
             .collect::<Option<_>>()?;
         self.trace.close_frame(
@@ -1554,7 +1612,7 @@ impl<'a> VMTracer<'a> {
         self.emit_trace_error_if_err(opt.is_none());
     }
 
-    pub(crate) fn close_initial_frame(
+    pub(crate) fn close_initial_native_frame(
         &mut self,
         return_values: &VMResult<SmallVec<[Value; 1]>>,
         remaining_gas: u64,
@@ -1567,7 +1625,7 @@ impl<'a> VMTracer<'a> {
                 return;
             }
         };
-        let opt = self.close_initial_frame_(return_values, remaining_gas);
+        let opt = self.close_initial_native_frame_(return_values, remaining_gas);
         self.emit_trace_error_if_err(opt.is_none());
     }
 


### PR DESCRIPTION
## Description 

Fixes a bug that @awelc found when implementing the tracer for PTBs. In particular tracing never allowed/accounted for external references being able to flow into- and out-of entrypoints (and native entrypoints). This fixes this problem by issuing global data loads in the trace + recording the proper value fills in locals in the frame for external references.

This also renames the function/macro `close_initial_frame` to `close_initial_native_frame` as this function is only called in the case where the entrypoint is a native function. Otherwise the normal `close_frame` is called. 

## Test plan 

Ran it against the repro that @awelc had and verified it worked and made sure existing tests passed. 

