### PR TITLE
Better test coverage for consensus adapter max_in_flight behavior

### DIFF
--- a/crates/mysten-common/src/random_util.rs
+++ b/crates/mysten-common/src/random_util.rs
@@ -45,3 +45,15 @@ pub type TempDir = tempfile::TempDir;
 pub fn tempdir() -> std::io::Result<TempDir> {
     nondeterministic!(tempfile::tempdir())
 }
+
+pub fn randomize_limit_in_tests<T>(min: T, limit: T) -> T
+where
+    T: Copy + PartialOrd + rand::distributions::uniform::SampleUniform + TryFrom<usize>,
+{
+    if !in_test_configuration() {
+        return limit;
+    }
+
+    let mut rng = get_rng();
+    rng.gen_range(min..=limit)
+}


### PR DESCRIPTION
Attempt to find bugs in which pending consensus transactions are never marked as processed.
