### PR TITLE
[move-abstract-interpreter] Make move-abstract-interpreter more general

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16480,6 +16480,7 @@ dependencies = [
  "move-abstract-stack",
  "move-binary-format",
  "move-bytecode-utils",
+ "move-bytecode-verifier",
  "move-bytecode-verifier-meter",
  "move-core-types",
  "move-vm-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16476,7 +16476,6 @@ dependencies = [
 name = "sui-verifier-latest"
 version = "0.1.0"
 dependencies = [
- "move-abstract-interpreter",
  "move-abstract-stack",
  "move-binary-format",
  "move-bytecode-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7696,10 +7696,6 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-dependencies = [
- "move-binary-format",
- "move-bytecode-verifier-meter",
-]
 
 [[package]]
 name = "move-abstract-interpreter-v2"
@@ -7750,6 +7746,7 @@ dependencies = [
  "anyhow",
  "enum-compat-util",
  "indexmap 2.8.0",
+ "move-abstract-interpreter",
  "move-core-types",
  "move-proc-macros",
  "ref-cast",
@@ -8002,6 +7999,7 @@ dependencies = [
  "move-abstract-interpreter",
  "move-binary-format",
  "move-bytecode-source-map",
+ "move-bytecode-verifier",
  "move-command-line-common",
  "move-compiler",
  "move-core-types",

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -1907,8 +1907,6 @@ name = "move-abstract-interpreter"
 version = "0.1.0"
 dependencies = [
  "itertools 0.10.5",
- "move-binary-format",
- "move-bytecode-verifier-meter",
 ]
 
 [[package]]
@@ -1963,6 +1961,7 @@ dependencies = [
  "enum-compat-util",
  "getrandom 0.2.15",
  "indexmap 2.8.0",
+ "move-abstract-interpreter",
  "move-core-types",
  "move-proc-macros",
  "proptest",
@@ -2236,6 +2235,7 @@ dependencies = [
  "move-abstract-interpreter",
  "move-binary-format",
  "move-bytecode-source-map",
+ "move-bytecode-verifier",
  "move-command-line-common",
  "move-compiler",
  "move-core-types",

--- a/external-crates/move/crates/bytecode-verifier-tests/src/unit_tests/control_flow_graph_tests.rs
+++ b/external-crates/move/crates/bytecode-verifier-tests/src/unit_tests/control_flow_graph_tests.rs
@@ -3,7 +3,7 @@
 
 use itertools::Itertools;
 
-use crate::control_flow_graph::{BlockId, ControlFlowGraph, VMControlFlowGraph};
+use move_bytecode_verifier_meter::absint::ControlFlowGraph;
 
 use move_binary_format::file_format::{
     Bytecode, EnumDefinitionIndex, JumpTableInner, VariantJumpTable, VariantJumpTableIndex,
@@ -13,7 +13,7 @@ use move_binary_format::file_format::{
 fn traversal_no_loops() {
     let cfg = {
         use Bytecode::*;
-        VMControlFlowGraph::new(
+        ControlFlowGraph::new(
             &[
                 /* L0 */ LdTrue,
                 /*    */ BrTrue(3),
@@ -33,7 +33,7 @@ fn traversal_no_loops() {
 fn traversal_no_loops_with_switch() {
     let cfg = {
         use Bytecode::*;
-        VMControlFlowGraph::new(
+        ControlFlowGraph::new(
             &[
                 /* L0 */ VariantSwitch(VariantJumpTableIndex::new(0)),
                 /*    */ Nop,
@@ -62,7 +62,7 @@ fn traversal_no_loops_with_switch() {
 fn traversal_loops() {
     let cfg = {
         use Bytecode::*;
-        VMControlFlowGraph::new(
+        ControlFlowGraph::new(
             &[
                 /* L0: Outer head     */ LdTrue,
                 /*     Outer break    */ BrTrue(6),
@@ -85,7 +85,7 @@ fn traversal_loops() {
 fn traversal_loops_with_switch() {
     let cfg = {
         use Bytecode::*;
-        VMControlFlowGraph::new(
+        ControlFlowGraph::new(
             &[
                 /* L0: Outer head     */ LdTrue,
                 /*     Outer break    */ BrTrue(4),
@@ -112,7 +112,7 @@ fn traversal_loops_with_switch() {
 fn traversal_non_loop_back_branch() {
     let cfg = {
         use Bytecode::*;
-        VMControlFlowGraph::new(
+        ControlFlowGraph::new(
             &[
                 /* L0 */ Branch(2),
                 /* L1 */ Ret,
@@ -131,7 +131,7 @@ fn traversal_non_loop_back_branch() {
 fn traversal_non_loop_back_branch_variant_switch() {
     let cfg = {
         use Bytecode::*;
-        VMControlFlowGraph::new(
+        ControlFlowGraph::new(
             &[
                 /* L0 */ VariantSwitch(VariantJumpTableIndex::new(0)),
                 /* L1 */ Ret,
@@ -176,7 +176,7 @@ fn out_of_order_blocks_variant_switch() {
         let mut start_block = vec![Bytecode::VariantSwitch(VariantJumpTableIndex::new(0))];
         start_block.extend(blocks.clone().into_iter().flat_map(|(_, block)| block));
 
-        let cfg = VMControlFlowGraph::new(
+        let cfg = ControlFlowGraph::new(
             &start_block,
             &[VariantJumpTable {
                 // Doesn't matter
@@ -204,7 +204,7 @@ fn out_of_order_blocks_variant_switch() {
 
         let jump_table = JumpTableInner::Full(perm.iter().map(|i| 1 + *i * block_len).collect());
 
-        let cfg = VMControlFlowGraph::new(
+        let cfg = ControlFlowGraph::new(
             &blocks,
             &[VariantJumpTable {
                 // Doesn't matter

--- a/external-crates/move/crates/move-abstract-interpreter/Cargo.toml
+++ b/external-crates/move/crates/move-abstract-interpreter/Cargo.toml
@@ -7,10 +7,6 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
-[dependencies]
-move-binary-format.workspace = true
-move-bytecode-verifier-meter.workspace = true
-
 [dev-dependencies]
 itertools.workspace = true
 

--- a/external-crates/move/crates/move-abstract-interpreter/src/absint.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/absint.rs
@@ -1,40 +1,8 @@
-// Copyright (c) The Diem Core Contributors
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::control_flow_graph::{BlockId, ControlFlowGraph, VMControlFlowGraph};
-use move_binary_format::{
-    CompiledModule,
-    errors::PartialVMResult,
-    file_format::{
-        AbilitySet, Bytecode, CodeOffset, CodeUnit, FunctionDefinitionIndex, FunctionHandle,
-        Signature,
-    },
-};
-use move_bytecode_verifier_meter::{Meter, Scope};
+use crate::control_flow_graph::ControlFlowGraph;
 use std::collections::BTreeMap;
-
-/// A `FunctionContext` holds all the information needed by the verifier for `FunctionDefinition`.`
-/// A control flow graph is built for a function when the `FunctionContext` is created.
-pub struct FunctionContext<'a> {
-    index: Option<FunctionDefinitionIndex>,
-    code: &'a CodeUnit,
-    parameters: &'a Signature,
-    return_: &'a Signature,
-    locals: &'a Signature,
-    type_parameters: &'a [AbilitySet],
-    cfg: VMControlFlowGraph,
-}
-
-/// Trait for finite-height abstract domains. Infinite height domains would require a more complex
-/// trait with widening and a partial order.
-pub trait AbstractDomain: Clone + Sized {
-    fn join(
-        &mut self,
-        other: &Self,
-        meter: &mut (impl Meter + ?Sized),
-    ) -> PartialVMResult<JoinResult>;
-}
 
 #[derive(Debug)]
 pub enum JoinResult {
@@ -42,187 +10,141 @@ pub enum JoinResult {
     Unchanged,
 }
 
-#[allow(dead_code)]
-#[derive(Clone)]
-pub struct BlockInvariant<State> {
-    /// Precondition of the block
-    pre: State,
+pub trait AbstractDomain: Clone + Sized {
+    type Error;
+    fn join(&mut self, other: &Self) -> Result<JoinResult, Self::Error>;
 }
 
-/// A map from block id's to the pre/post of each block after a fixed point is reached.
-#[allow(dead_code)]
-pub type InvariantMap<State> = BTreeMap<BlockId, BlockInvariant<State>>;
-
-/// Costs for metered verification
-const ANALYZE_FUNCTION_BASE_COST: u128 = 10;
-const EXECUTE_BLOCK_BASE_COST: u128 = 10;
-const PER_BACKEDGE_COST: u128 = 10;
-const PER_SUCCESSOR_COST: u128 = 10;
-
-/// Take a pre-state + instruction and mutate it to produce a post-state
-/// Auxiliary data can be stored in self.
-pub trait TransferFunctions {
-    type State: AbstractDomain;
+pub trait AbstractInterpreter {
     type Error;
+    type BlockId: Copy + Ord;
 
-    /// Execute local@instr found at index local@index in the current basic block from pre-state
-    /// local@pre.
-    /// Should return an AnalysisError if executing the instruction is unsuccessful, and () if
-    /// the effects of successfully executing local@instr have been reflected by mutatating
-    /// local@pre.
-    /// Auxilary data from the analysis that is not part of the abstract state can be collected by
-    /// mutating local@self.
-    /// The last instruction index in the current block is local@last_index. Knowing this
-    /// information allows clients to detect the end of a basic block and special-case appropriately
-    /// (e.g., normalizing the abstract state before a join).
-    fn execute(
+    type State: AbstractDomain<Error = Self::Error>;
+    type InstructionIndex: Copy + Ord;
+    type Instruction;
+
+    fn start(&mut self) -> Result<(), Self::Error>;
+    fn join(
         &mut self,
         pre: &mut Self::State,
-        instr: &Bytecode,
-        index: CodeOffset,
-        last_index: CodeOffset,
-        meter: &mut (impl Meter + ?Sized),
-    ) -> PartialVMResult<()>;
+        post: &Self::State,
+    ) -> Result<JoinResult, Self::Error>;
+    fn visit_block_execution(&mut self, block_id: Self::BlockId) -> Result<(), Self::Error>;
+    fn visit_successor(&mut self, block_id: Self::BlockId) -> Result<(), Self::Error>;
+    fn visit_back_edge(
+        &mut self,
+        from: Self::BlockId,
+        to: Self::BlockId,
+    ) -> Result<(), Self::Error>;
+
+    fn execute(
+        &mut self,
+        state: &mut Self::State,
+        bounds: (Self::InstructionIndex, Self::InstructionIndex),
+        offset: Self::InstructionIndex,
+        instr: &Self::Instruction,
+    ) -> Result<(), Self::Error>;
 }
 
-pub trait AbstractInterpreter: TransferFunctions {
-    /// Analyze procedure local@function_context starting from pre-state local@initial_state.
-    fn analyze_function(
-        &mut self,
-        initial_state: Self::State,
-        function_context: &FunctionContext,
-        meter: &mut (impl Meter + ?Sized),
-    ) -> PartialVMResult<()> {
-        meter.add(Scope::Function, ANALYZE_FUNCTION_BASE_COST)?;
-        let mut inv_map = InvariantMap::new();
-        let entry_block_id = function_context.cfg().entry_block_id();
-        let mut next_block = Some(entry_block_id);
-        inv_map.insert(entry_block_id, BlockInvariant { pre: initial_state });
+/// Analyze procedure local@function_context starting from pre-state local@initial_state.
+pub fn analyze_function<A, CFG, S, E>(
+    interpreter: &mut A,
+    cfg: &CFG,
+    initial_state: S,
+) -> Result<(), E>
+where
+    A: AbstractInterpreter<
+        Error = E,
+        State = S,
+        BlockId = CFG::BlockId,
+        InstructionIndex = CFG::InstructionIndex,
+        Instruction = CFG::Instruction,
+    >,
+    CFG: ControlFlowGraph,
+    S: AbstractDomain<Error = E>,
+{
+    interpreter.start()?;
+    // meter.add(Scope::Function, ANALYZE_FUNCTION_BASE_COST)?;
+    let mut inv_map = BTreeMap::new();
+    let entry_block_id = cfg.entry_block_id();
+    let mut next_block = Some(entry_block_id);
+    inv_map.insert(entry_block_id, initial_state);
 
-        while let Some(block_id) = next_block {
-            let block_invariant = match inv_map.get_mut(&block_id) {
-                Some(invariant) => invariant,
-                None => {
-                    // This can only happen when all predecessors have errors,
-                    // so skip the block and move on to the next one
-                    next_block = function_context.cfg().next_block(block_id);
-                    continue;
-                }
-            };
+    while let Some(block_id) = next_block {
+        let block_invariant = match inv_map.get_mut(&block_id) {
+            Some(invariant) => invariant,
+            None => {
+                // This can only happen when all predecessors have errors,
+                // so skip the block and move on to the next one
+                next_block = cfg.next_block(block_id);
+                continue;
+            }
+        };
 
-            let pre_state = &block_invariant.pre;
-            // Note: this will stop analysis after the first error occurs, to avoid the risk of
-            // subsequent crashes
-            let post_state = self.execute_block(block_id, pre_state, function_context, meter)?;
+        let pre_state = &block_invariant;
+        // Note: this will stop analysis after the first error occurs, to avoid the risk of
+        // subsequent crashes
+        let post_state = execute_block(interpreter, cfg, block_id, pre_state)?;
 
-            let mut next_block_candidate = function_context.cfg().next_block(block_id);
-            // propagate postcondition of this block to successor blocks
-            for successor_block_id in function_context.cfg().successors(block_id) {
-                meter.add(Scope::Function, PER_SUCCESSOR_COST)?;
-                match inv_map.get_mut(successor_block_id) {
-                    Some(next_block_invariant) => {
-                        let join_result = {
-                            let old_pre = &mut next_block_invariant.pre;
-                            old_pre.join(&post_state, meter)
-                        }?;
-                        match join_result {
-                            JoinResult::Unchanged => {
-                                // Pre is the same after join. Reanalyzing this block would produce
-                                // the same post
-                            }
-                            JoinResult::Changed => {
-                                // If the cur->successor is a back edge, jump back to the beginning
-                                // of the loop, instead of the normal next block
-                                if function_context
-                                    .cfg()
-                                    .is_back_edge(block_id, *successor_block_id)
-                                {
-                                    meter.add(Scope::Function, PER_BACKEDGE_COST)?;
-                                    next_block_candidate = Some(*successor_block_id);
-                                    break;
-                                }
+        let mut next_block_candidate = cfg.next_block(block_id);
+        // propagate postcondition of this block to successor blocks
+        for &successor_block_id in cfg.successors(block_id) {
+            interpreter.visit_successor(successor_block_id)?;
+            // meter.add(Scope::Function, PER_SUCCESSOR_COST)?;
+            match inv_map.get_mut(&successor_block_id) {
+                Some(next_block_invariant) => {
+                    let join_result = interpreter.join(next_block_invariant, &post_state)?;
+                    match join_result {
+                        JoinResult::Unchanged => {
+                            // Pre is the same after join. Reanalyzing this block would produce
+                            // the same post
+                        }
+                        JoinResult::Changed => {
+                            // If the cur->successor is a back edge, jump back to the beginning
+                            // of the loop, instead of the normal next block
+                            if cfg.is_back_edge(block_id, successor_block_id) {
+                                interpreter.visit_back_edge(block_id, successor_block_id)?;
+                                // meter.add(Scope::Function, PER_BACKEDGE_COST)?;
+                                next_block_candidate = Some(successor_block_id);
+                                break;
                             }
                         }
                     }
-                    None => {
-                        // Haven't visited the next block yet. Use the post of the current block as
-                        // its pre
-                        inv_map.insert(
-                            *successor_block_id,
-                            BlockInvariant {
-                                pre: post_state.clone(),
-                            },
-                        );
-                    }
+                }
+                None => {
+                    // Haven't visited the next block yet. Use the post of the current block as
+                    // its pre
+                    inv_map.insert(successor_block_id, post_state.clone());
                 }
             }
-            next_block = next_block_candidate;
         }
-        Ok(())
+        next_block = next_block_candidate;
     }
-
-    fn execute_block(
-        &mut self,
-        block_id: BlockId,
-        pre_state: &Self::State,
-        function_context: &FunctionContext,
-        meter: &mut (impl Meter + ?Sized),
-    ) -> PartialVMResult<Self::State> {
-        meter.add(Scope::Function, EXECUTE_BLOCK_BASE_COST)?;
-        let mut state_acc = pre_state.clone();
-        let block_end = function_context.cfg().block_end(block_id);
-        for offset in function_context.cfg().instr_indexes(block_id) {
-            let instr = &function_context.code().code[offset as usize];
-            self.execute(&mut state_acc, instr, offset, block_end, meter)?
-        }
-        Ok(state_acc)
-    }
+    Ok(())
 }
 
-impl<'a> FunctionContext<'a> {
-    // Creates a `FunctionContext` for a module function.
-    pub fn new(
-        module: &'a CompiledModule,
-        index: FunctionDefinitionIndex,
-        code: &'a CodeUnit,
-        function_handle: &'a FunctionHandle,
-    ) -> Self {
-        Self {
-            index: Some(index),
-            code,
-            parameters: module.signature_at(function_handle.parameters),
-            return_: module.signature_at(function_handle.return_),
-            locals: module.signature_at(code.locals),
-            type_parameters: &function_handle.type_parameters,
-            cfg: VMControlFlowGraph::new(&code.code, &code.jump_tables),
-        }
+pub fn execute_block<A, S, CFG, E>(
+    interpreter: &mut A,
+    cfg: &CFG,
+    block_id: CFG::BlockId,
+    pre_state: &S,
+) -> Result<S, E>
+where
+    A: AbstractInterpreter<
+        Error = E,
+        State = S,
+        BlockId = CFG::BlockId,
+        InstructionIndex = CFG::InstructionIndex,
+        Instruction = CFG::Instruction,
+    >,
+    CFG: ControlFlowGraph,
+    S: AbstractDomain<Error = E>,
+{
+    interpreter.visit_block_execution(block_id)?;
+    let mut state_acc = pre_state.clone();
+    let bounds = (cfg.block_start(block_id), cfg.block_end(block_id));
+    for (offset, instr) in cfg.instructions(block_id) {
+        interpreter.execute(&mut state_acc, bounds, offset, instr)?
     }
-
-    pub fn index(&self) -> Option<FunctionDefinitionIndex> {
-        self.index
-    }
-
-    pub fn code(&self) -> &'a CodeUnit {
-        self.code
-    }
-
-    pub fn parameters(&self) -> &'a Signature {
-        self.parameters
-    }
-
-    pub fn return_(&self) -> &'a Signature {
-        self.return_
-    }
-
-    pub fn locals(&self) -> &'a Signature {
-        self.locals
-    }
-
-    pub fn type_parameters(&self) -> &'a [AbilitySet] {
-        self.type_parameters
-    }
-
-    pub fn cfg(&self) -> &VMControlFlowGraph {
-        &self.cfg
-    }
+    Ok(state_acc)
 }

--- a/external-crates/move/crates/move-abstract-interpreter/src/absint.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/absint.rs
@@ -61,13 +61,12 @@ pub fn analyze_function<A, CFG>(
 where
     A: AbstractInterpreter,
     CFG: ControlFlowGraph<
-        BlockId = A::BlockId,
-        InstructionIndex = A::InstructionIndex,
-        Instruction = A::Instruction,
-    >,
+            BlockId = A::BlockId,
+            InstructionIndex = A::InstructionIndex,
+            Instruction = A::Instruction,
+        >,
 {
     interpreter.start()?;
-    // meter.add(Scope::Function, ANALYZE_FUNCTION_BASE_COST)?;
     let mut inv_map = BTreeMap::new();
     let entry_block_id = cfg.entry_block_id();
     let mut next_block = Some(entry_block_id);
@@ -93,7 +92,6 @@ where
         // propagate postcondition of this block to successor blocks
         for &successor_block_id in cfg.successors(block_id) {
             interpreter.visit_successor(successor_block_id)?;
-            // meter.add(Scope::Function, PER_SUCCESSOR_COST)?;
             match inv_map.get_mut(&successor_block_id) {
                 Some(next_block_invariant) => {
                     let join_result = interpreter.join(next_block_invariant, &post_state)?;
@@ -107,7 +105,6 @@ where
                             // of the loop, instead of the normal next block
                             if cfg.is_back_edge(block_id, successor_block_id) {
                                 interpreter.visit_back_edge(block_id, successor_block_id)?;
-                                // meter.add(Scope::Function, PER_BACKEDGE_COST)?;
                                 next_block_candidate = Some(successor_block_id);
                                 break;
                             }
@@ -136,10 +133,10 @@ fn execute_block<A, CFG>(
 where
     A: AbstractInterpreter,
     CFG: ControlFlowGraph<
-        BlockId = A::BlockId,
-        InstructionIndex = A::InstructionIndex,
-        Instruction = A::Instruction,
-    >,
+            BlockId = A::BlockId,
+            InstructionIndex = A::InstructionIndex,
+            Instruction = A::Instruction,
+        >,
 {
     interpreter.visit_block_execution(block_id)?;
     let mut state_acc = pre_state.clone();

--- a/external-crates/move/crates/move-abstract-interpreter/src/absint.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/absint.rs
@@ -12,7 +12,6 @@ pub enum JoinResult {
 
 pub trait AbstractDomain: Clone + Sized {
     type Error;
-    fn join(&mut self, other: &Self) -> Result<JoinResult, Self::Error>;
 }
 
 pub trait AbstractInterpreter {
@@ -37,6 +36,16 @@ pub trait AbstractInterpreter {
         to: Self::BlockId,
     ) -> Result<(), Self::Error>;
 
+    /// Execute local@instr found at index local@index in the current basic block from pre-state
+    /// local@pre.
+    /// Should return an Err if executing the instruction is unsuccessful, and () if
+    /// the effects of successfully executing local@instr have been reflected by mutating
+    /// local@pre.
+    /// Auxiliary data from the analysis that is not part of the abstract state can be collected by
+    /// mutating local@self.
+    /// The last instruction index in the current block is local@last_index. Knowing this
+    /// information allows clients to detect the end of a basic block and special-case appropriately
+    /// (e.g., normalizing the abstract state before a join).
     fn execute(
         &mut self,
         state: &mut Self::State,

--- a/external-crates/move/crates/move-abstract-interpreter/src/control_flow_graph.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/control_flow_graph.rs
@@ -54,18 +54,18 @@ pub trait ControlFlowGraph {
 /// Used for the VM control flow graph
 pub trait Instruction: Sized {
     type Index: Copy + Ord;
-    type VariantJumpTable;
+    type VariantJumpTables: ?Sized;
     const ENTRY_BLOCK_ID: Self::Index;
 
     /// Return the successors of a given instruction
     fn get_successors(
         pc: Self::Index,
         code: &[Self],
-        jump_tables: &[Self::VariantJumpTable],
+        jump_tables: &Self::VariantJumpTables,
     ) -> Vec<Self::Index>;
 
     /// Return the offsets of jump targets for a given instruction
-    fn offsets(&self, jump_tables: &[Self::VariantJumpTable]) -> Vec<Self::Index>;
+    fn offsets(&self, jump_tables: &Self::VariantJumpTables) -> Vec<Self::Index>;
 
     fn usize_as_index(i: usize) -> Self::Index;
     fn index_as_usize(i: Self::Index) -> usize;
@@ -104,7 +104,7 @@ impl<InstructionIndex: std::fmt::Display + std::fmt::Debug> BasicBlock<Instructi
 }
 
 impl<'a, I: Instruction> VMControlFlowGraph<'a, I> {
-    pub fn new(code: &'a [I], jump_tables: &[I::VariantJumpTable]) -> Self {
+    pub fn new(code: &'a [I], jump_tables: &I::VariantJumpTables) -> Self {
         use std::collections::{BTreeMap as Map, BTreeSet as Set};
 
         let code_len = code.len();
@@ -267,7 +267,7 @@ impl<'a, I: Instruction> VMControlFlowGraph<'a, I> {
     fn record_block_ids(
         pc: usize,
         code: &[I],
-        jump_tables: &[I::VariantJumpTable],
+        jump_tables: &I::VariantJumpTables,
         block_ids: &mut BTreeSet<I::Index>,
     ) {
         let bytecode = &code[pc];

--- a/external-crates/move/crates/move-abstract-interpreter/src/control_flow_graph.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/control_flow_graph.rs
@@ -3,8 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module defines the control-flow graph uses for bytecode verification.
-use move_binary_format::file_format::{Bytecode, CodeOffset, VariantJumpTable};
-use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, btree_map::Entry};
 
 /// A trait that specifies the basic requirements for a CFG
 pub trait ControlFlowGraph {

--- a/external-crates/move/crates/move-abstract-interpreter/src/control_flow_graph.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/control_flow_graph.rs
@@ -345,7 +345,7 @@ impl<I: Instruction> ControlFlowGraph for VMControlFlowGraph<'_, I> {
     ) -> impl IntoIterator<Item = (Self::BlockId, &I)> {
         let start = I::index_as_usize(self.block_start(block_id));
         let end = I::index_as_usize(self.block_end(block_id));
-        (start..=end).map(|pc| (I::usize_as_index(pc), &self.code[pc as usize]))
+        (start..=end).map(|pc| (I::usize_as_index(pc), &self.code[pc]))
     }
 
     fn blocks(&self) -> Vec<Self::BlockId> {

--- a/external-crates/move/crates/move-abstract-interpreter/src/control_flow_graph.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/control_flow_graph.rs
@@ -51,6 +51,7 @@ pub trait ControlFlowGraph {
     fn num_back_edges(&self) -> usize;
 }
 
+/// Used for the VM control flow graph
 pub trait Instruction: Sized {
     type Index: Copy + Ord;
     type VariantJumpTable;

--- a/external-crates/move/crates/move-abstract-interpreter/src/control_flow_graph.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/control_flow_graph.rs
@@ -78,6 +78,8 @@ struct BasicBlock<InstructionIndex> {
 }
 
 /// The control flow graph that we build from the bytecode.
+/// Assumes a list of bytecode isntructions that satisfy the invariants specified in the VM's
+/// file format.
 pub struct VMControlFlowGraph<'a, I: Instruction> {
     code: &'a [I],
     /// The basic blocks

--- a/external-crates/move/crates/move-abstract-interpreter/src/control_flow_graph.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/control_flow_graph.rs
@@ -345,7 +345,7 @@ impl<I: Instruction> ControlFlowGraph for VMControlFlowGraph<'_, I> {
     ) -> impl IntoIterator<Item = (Self::BlockId, &I)> {
         let start = I::index_as_usize(self.block_start(block_id));
         let end = I::index_as_usize(self.block_end(block_id));
-        (start..end).map(|pc| (I::usize_as_index(pc), &self.code[pc as usize]))
+        (start..=end).map(|pc| (I::usize_as_index(pc), &self.code[pc as usize]))
     }
 
     fn blocks(&self) -> Vec<Self::BlockId> {

--- a/external-crates/move/crates/move-abstract-interpreter/src/control_flow_graph.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/control_flow_graph.rs
@@ -4,69 +4,73 @@
 
 //! This module defines the control-flow graph uses for bytecode verification.
 use move_binary_format::file_format::{Bytecode, CodeOffset, VariantJumpTable};
-use std::collections::{BTreeMap, BTreeSet, btree_map::Entry};
-
-// BTree/Hash agnostic type wrappers
-type Map<K, V> = BTreeMap<K, V>;
-type Set<V> = BTreeSet<V>;
-
-pub type BlockId = CodeOffset;
+use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
 
 /// A trait that specifies the basic requirements for a CFG
 pub trait ControlFlowGraph {
+    type BlockId: Copy + Ord;
+    type InstructionIndex: Copy + Ord;
+    type Instruction;
+
     /// Start index of the block ID in the bytecode vector
-    fn block_start(&self, block_id: BlockId) -> CodeOffset;
+    fn block_start(&self, block_id: Self::BlockId) -> Self::InstructionIndex;
 
     /// End index of the block ID in the bytecode vector
-    fn block_end(&self, block_id: BlockId) -> CodeOffset;
+    fn block_end(&self, block_id: Self::BlockId) -> Self::InstructionIndex;
 
     /// Successors of the block ID in the bytecode vector
-    fn successors(&self, block_id: BlockId) -> &Vec<BlockId>;
+    fn successors(&self, block_id: Self::BlockId) -> &[Self::BlockId];
 
     /// Return the next block in traversal order
-    fn next_block(&self, block_id: BlockId) -> Option<BlockId>;
+    fn next_block(&self, block_id: Self::BlockId) -> Option<Self::BlockId>;
 
     /// Iterator over the indexes of instructions in this block
-    fn instr_indexes(&self, block_id: BlockId) -> Box<dyn Iterator<Item = CodeOffset>>;
+    fn instructions(
+        &self,
+        block_id: Self::BlockId,
+    ) -> impl IntoIterator<Item = (Self::InstructionIndex, &Self::Instruction)>;
 
     /// Return an iterator over the blocks of the CFG
-    fn blocks(&self) -> Vec<BlockId>;
+    fn blocks(&self) -> Vec<Self::BlockId>;
 
     /// Return the number of blocks (vertices) in the control flow graph
-    fn num_blocks(&self) -> u16;
+    fn num_blocks(&self) -> usize;
 
     /// Return the id of the entry block for this control-flow graph
     /// Note: even a CFG with no instructions has an (empty) entry block.
-    fn entry_block_id(&self) -> BlockId;
+    fn entry_block_id(&self) -> Self::BlockId;
 
     /// Checks if the block ID is a loop head
-    fn is_loop_head(&self, block_id: BlockId) -> bool;
+    fn is_loop_head(&self, block_id: Self::BlockId) -> bool;
 
     /// Checks if the edge from cur->next is a back edge
     /// returns false if the edge is not in the cfg
-    fn is_back_edge(&self, cur: BlockId, next: BlockId) -> bool;
+    fn is_back_edge(&self, cur: Self::BlockId, next: Self::BlockId) -> bool;
 
     /// Return the number of back edges in the cfg
     fn num_back_edges(&self) -> usize;
 }
 
+type VMBlockId = file_format::CodeOffset;
+
 struct BasicBlock {
-    exit: CodeOffset,
-    successors: Vec<BlockId>,
+    exit: file_format::CodeOffset,
+    successors: Vec<VMBlockId>,
 }
 
 /// The control flow graph that we build from the bytecode.
-pub struct VMControlFlowGraph {
+pub struct VMControlFlowGraph<'a> {
+    code: &'a [file_format::Bytecode],
     /// The basic blocks
-    blocks: Map<BlockId, BasicBlock>,
+    blocks: BTreeMap<VMBlockId, BasicBlock>,
     /// Basic block ordering for traversal
-    traversal_successors: Map<BlockId, BlockId>,
+    traversal_successors: BTreeMap<VMBlockId, VMBlockId>,
     /// Map of loop heads with all of their back edges
-    loop_heads: Map<BlockId, /* back edges */ Set<BlockId>>,
+    loop_heads: BTreeMap<VMBlockId, /* back edges */ BTreeSet<VMBlockId>>,
 }
 
 impl BasicBlock {
-    pub fn display(&self, entry: BlockId) {
+    pub fn display(&self, entry: VMBlockId) {
         println!("+=======================+");
         println!("| Enter:  {}            |", entry);
         println!("+-----------------------+");
@@ -77,14 +81,20 @@ impl BasicBlock {
     }
 }
 
-const ENTRY_BLOCK_ID: BlockId = 0;
+const ENTRY_BLOCK_ID: VMBlockId = 0;
 
-impl VMControlFlowGraph {
-    pub fn new(code: &[Bytecode], jump_tables: &[VariantJumpTable]) -> Self {
+impl<'a> VMControlFlowGraph<'a> {
+    pub fn new(
+        code: &'a [file_format::Bytecode],
+        jump_tables: &[file_format::VariantJumpTable],
+    ) -> Self {
+        use file_format::{Bytecode, CodeOffset};
+        use std::collections::{BTreeMap as Map, BTreeSet as Set};
+
         let code_len = code.len() as CodeOffset;
         // First go through and collect block ids, i.e., offsets that begin basic blocks.
         // Need to do this first in order to handle backwards edges.
-        let mut block_ids = Set::new();
+        let mut block_ids = BTreeSet::new();
         block_ids.insert(ENTRY_BLOCK_ID);
         for pc in 0..code.len() {
             VMControlFlowGraph::record_block_ids(
@@ -134,7 +144,7 @@ impl VMControlFlowGraph {
             Done,
         }
 
-        let mut exploration: Map<BlockId, Exploration> = Map::new();
+        let mut exploration: Map<VMBlockId, Exploration> = Map::new();
         let mut stack = vec![ENTRY_BLOCK_ID];
 
         // For every loop in the CFG that is reachable from the entry block, there is an entry in
@@ -154,7 +164,7 @@ impl VMControlFlowGraph {
         //   (including `L`) will be visited while `F` is `InProgress`.
         // - Therefore, we will process the `L -> F` edge while `F` is `InProgress`.
         // - Therefore, we will record a back edge to it.
-        let mut loop_heads: Map<BlockId, Set<BlockId>> = Map::new();
+        let mut loop_heads: Map<VMBlockId, Set<VMBlockId>> = Map::new();
 
         // Blocks appear in `post_order` after all the blocks in their (non-reflexive) sub-graph.
         let mut post_order = Vec::with_capacity(blocks.len());
@@ -222,6 +232,7 @@ impl VMControlFlowGraph {
             .collect();
 
         VMControlFlowGraph {
+            code,
             blocks,
             traversal_successors,
             loop_heads,
@@ -235,33 +246,37 @@ impl VMControlFlowGraph {
         println!("Traversal: {:#?}", self.traversal_successors);
     }
 
-    fn is_end_of_block(pc: CodeOffset, code: &[Bytecode], block_ids: &Set<BlockId>) -> bool {
-        pc + 1 == (code.len() as CodeOffset) || block_ids.contains(&(pc + 1))
+    fn is_end_of_block(
+        pc: file_format::CodeOffset,
+        code: &[file_format::Bytecode],
+        block_ids: &BTreeSet<VMBlockId>,
+    ) -> bool {
+        pc + 1 == (code.len() as file_format::CodeOffset) || block_ids.contains(&(pc + 1))
     }
 
     fn record_block_ids(
-        pc: CodeOffset,
-        code: &[Bytecode],
-        jump_tables: &[VariantJumpTable],
-        block_ids: &mut Set<BlockId>,
+        pc: file_format::CodeOffset,
+        code: &[file_format::Bytecode],
+        jump_tables: &[file_format::VariantJumpTable],
+        block_ids: &mut BTreeSet<VMBlockId>,
     ) {
         let bytecode = &code[pc as usize];
 
         block_ids.extend(bytecode.offsets(jump_tables));
 
-        if bytecode.is_branch() && pc + 1 < (code.len() as CodeOffset) {
+        if bytecode.is_branch() && pc + 1 < (code.len() as file_format::CodeOffset) {
             block_ids.insert(pc + 1);
         }
     }
 
     /// A utility function that implements BFS-reachability from block_id with
     /// respect to get_targets function
-    fn traverse_by(&self, block_id: BlockId) -> Vec<BlockId> {
+    fn traverse_by(&self, block_id: VMBlockId) -> Vec<VMBlockId> {
         let mut ret = Vec::new();
         // We use this index to keep track of our frontier.
         let mut index = 0;
         // Guard against cycles
-        let mut seen = Set::new();
+        let mut seen = BTreeSet::new();
 
         ret.push(block_id);
         seen.insert(&block_id);
@@ -281,12 +296,16 @@ impl VMControlFlowGraph {
         ret
     }
 
-    pub fn reachable_from(&self, block_id: BlockId) -> Vec<BlockId> {
+    pub fn reachable_from(&self, block_id: VMBlockId) -> Vec<VMBlockId> {
         self.traverse_by(block_id)
     }
 }
 
-impl ControlFlowGraph for VMControlFlowGraph {
+impl ControlFlowGraph for VMControlFlowGraph<'_> {
+    type BlockId = VMBlockId;
+    type InstructionIndex = file_format::CodeOffset;
+    type Instruction = file_format::Bytecode;
+
     // Note: in the following procedures, it's safe not to check bounds because:
     // - Every CFG (even one with no instructions) has a block at ENTRY_BLOCK_ID
     // - The only way to acquire new BlockId's is via block_successors()
@@ -294,44 +313,49 @@ impl ControlFlowGraph for VMControlFlowGraph {
     // Note: it is still possible to get a BlockId from one CFG and use it in another CFG where it
     // is not valid. The design does not attempt to prevent this abuse of the API.
 
-    fn block_start(&self, block_id: BlockId) -> CodeOffset {
+    fn block_start(&self, block_id: VMBlockId) -> file_format::CodeOffset {
         block_id
     }
 
-    fn block_end(&self, block_id: BlockId) -> CodeOffset {
+    fn block_end(&self, block_id: VMBlockId) -> file_format::CodeOffset {
         self.blocks[&block_id].exit
     }
 
-    fn successors(&self, block_id: BlockId) -> &Vec<BlockId> {
+    fn successors(&self, block_id: VMBlockId) -> &[VMBlockId] {
         &self.blocks[&block_id].successors
     }
 
-    fn next_block(&self, block_id: BlockId) -> Option<CodeOffset> {
+    fn next_block(&self, block_id: VMBlockId) -> Option<file_format::CodeOffset> {
         debug_assert!(self.blocks.contains_key(&block_id));
         self.traversal_successors.get(&block_id).copied()
     }
 
-    fn instr_indexes(&self, block_id: BlockId) -> Box<dyn Iterator<Item = CodeOffset>> {
-        Box::new(self.block_start(block_id)..=self.block_end(block_id))
+    fn instructions(
+        &self,
+        block_id: VMBlockId,
+    ) -> impl IntoIterator<Item = (VMBlockId, &file_format::Bytecode)> {
+        let start = self.block_start(block_id);
+        let end = self.block_end(block_id);
+        (start..end).map(|pc| (pc, &self.code[pc as usize]))
     }
 
-    fn blocks(&self) -> Vec<BlockId> {
+    fn blocks(&self) -> Vec<VMBlockId> {
         self.blocks.keys().cloned().collect()
     }
 
-    fn num_blocks(&self) -> u16 {
-        self.blocks.len() as u16
+    fn num_blocks(&self) -> usize {
+        self.blocks.len()
     }
 
-    fn entry_block_id(&self) -> BlockId {
+    fn entry_block_id(&self) -> VMBlockId {
         ENTRY_BLOCK_ID
     }
 
-    fn is_loop_head(&self, block_id: BlockId) -> bool {
+    fn is_loop_head(&self, block_id: VMBlockId) -> bool {
         self.loop_heads.contains_key(&block_id)
     }
 
-    fn is_back_edge(&self, cur: BlockId, next: BlockId) -> bool {
+    fn is_back_edge(&self, cur: VMBlockId, next: VMBlockId) -> bool {
         self.loop_heads
             .get(&next)
             .is_some_and(|back_edges| back_edges.contains(&cur))

--- a/external-crates/move/crates/move-abstract-interpreter/src/lib.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/lib.rs
@@ -3,6 +3,3 @@
 
 pub mod absint;
 pub mod control_flow_graph;
-
-#[cfg(test)]
-mod unit_tests;

--- a/external-crates/move/crates/move-abstract-interpreter/src/unit_tests/mod.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/unit_tests/mod.rs
@@ -1,4 +1,0 @@
-// Copyright (c) The Move Contributors
-// SPDX-License-Identifier: Apache-2.0
-
-mod control_flow_graph_tests;

--- a/external-crates/move/crates/move-binary-format/Cargo.toml
+++ b/external-crates/move/crates/move-binary-format/Cargo.toml
@@ -21,6 +21,7 @@ arbitrary = { workspace = true, optional = true, features = ["derive"] }
 enum-compat-util.workspace = true
 move-proc-macros.workspace = true
 indexmap.workspace = true
+move-abstract-interpreter.workspace = true
 
 # wasm support (requires js feature of getrandom)
 getrandom = { workspace = true, features = ["js"], optional = true }

--- a/external-crates/move/crates/move-binary-format/src/file_format.rs
+++ b/external-crates/move/crates/move-binary-format/src/file_format.rs
@@ -2281,6 +2281,37 @@ impl Bytecode {
     }
 }
 
+impl move_abstract_interpreter::control_flow_graph::Instruction for Bytecode {
+    type Index = CodeOffset;
+    type VariantJumpTable = VariantJumpTable;
+
+    const ENTRY_BLOCK_ID: CodeOffset = 0;
+
+    fn get_successors(
+        pc: Self::Index,
+        code: &[Self],
+        jump_tables: &[Self::VariantJumpTable],
+    ) -> Vec<Self::Index> {
+        Bytecode::get_successors(pc, code, jump_tables)
+    }
+
+    fn offsets(&self, jump_tables: &[Self::VariantJumpTable]) -> Vec<Self::Index> {
+        self.offsets(jump_tables)
+    }
+
+    fn usize_as_index(i: usize) -> Self::Index {
+        i as CodeOffset
+    }
+
+    fn index_as_usize(i: Self::Index) -> usize {
+        i as usize
+    }
+
+    fn is_branch(&self) -> bool {
+        self.is_branch()
+    }
+}
+
 /// A `CompiledModule` defines the structure of a module which is the unit of published code.
 ///
 /// A `CompiledModule` contains a definition of types (with their fields) and functions.

--- a/external-crates/move/crates/move-binary-format/src/file_format.rs
+++ b/external-crates/move/crates/move-binary-format/src/file_format.rs
@@ -2283,19 +2283,19 @@ impl Bytecode {
 
 impl move_abstract_interpreter::control_flow_graph::Instruction for Bytecode {
     type Index = CodeOffset;
-    type VariantJumpTable = VariantJumpTable;
+    type VariantJumpTables = [VariantJumpTable];
 
     const ENTRY_BLOCK_ID: CodeOffset = 0;
 
     fn get_successors(
         pc: Self::Index,
         code: &[Self],
-        jump_tables: &[Self::VariantJumpTable],
+        jump_tables: &Self::VariantJumpTables,
     ) -> Vec<Self::Index> {
         Bytecode::get_successors(pc, code, jump_tables)
     }
 
-    fn offsets(&self, jump_tables: &[Self::VariantJumpTable]) -> Vec<Self::Index> {
+    fn offsets(&self, jump_tables: &Self::VariantJumpTables) -> Vec<Self::Index> {
         self.offsets(jump_tables)
     }
 

--- a/external-crates/move/crates/move-bytecode-verifier/src/absint.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/absint.rs
@@ -144,13 +144,13 @@ const EXECUTE_BLOCK_BASE_COST: u128 = 10;
 const PER_BACKEDGE_COST: u128 = 10;
 const PER_SUCCESSOR_COST: u128 = 10;
 
-struct AbstractInterpreter<'meter, 'tf, M: Meter + ?Sized, TF: TransferFunctions> {
-    pub meter: &'meter mut M,
-    pub transfer_functions: &'tf mut TF,
+struct AbstractInterpreter<'a, M: Meter + ?Sized, TF: TransferFunctions> {
+    pub meter: &'a mut M,
+    pub transfer_functions: &'a mut TF,
 }
 
-impl<'meter, 'tf, M: Meter + ?Sized, TF: TransferFunctions> absint::AbstractInterpreter
-    for AbstractInterpreter<'meter, 'tf, M, TF>
+impl<M: Meter + ?Sized, TF: TransferFunctions> absint::AbstractInterpreter
+    for AbstractInterpreter<'_, M, TF>
 {
     type Error = PartialVMError;
     type BlockId = CodeOffset;

--- a/external-crates/move/crates/move-bytecode-verifier/src/absint.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/absint.rs
@@ -1,0 +1,198 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_abstract_interpreter::{
+    absint::{self},
+    control_flow_graph,
+};
+use move_binary_format::{
+    errors::{PartialVMError, PartialVMResult},
+    file_format::{
+        AbilitySet, Bytecode, CodeOffset, CodeUnit, FunctionDefinitionIndex, FunctionHandle,
+        Signature,
+    },
+    CompiledModule,
+};
+use move_bytecode_verifier_meter::{Meter, Scope};
+
+//**************************************************************************************************
+// New traits and public APIS
+//**************************************************************************************************
+
+pub use absint::JoinResult;
+
+pub trait AbstractDomain: Clone + Sized {
+    fn join(
+        &mut self,
+        other: &Self,
+        meter: &mut (impl Meter + ?Sized),
+    ) -> PartialVMResult<JoinResult>;
+}
+
+pub trait TransferFunctions {
+    type State: AbstractDomain;
+
+    /// Execute local@instr found at index local@index in the current basic block from pre-state
+    /// local@pre.
+    /// Should return an Err if executing the instruction is unsuccessful, and () if
+    /// the effects of successfully executing local@instr have been reflected by mutating
+    /// local@pre.
+    /// Auxiliary data from the analysis that is not part of the abstract state can be collected by
+    /// mutating local@self.
+    /// The last instruction index in the current block is local@last_index. Knowing this
+    /// information allows clients to detect the end of a basic block and special-case appropriately
+    /// (e.g., normalizing the abstract state before a join).
+    fn execute(
+        &mut self,
+        pre: &mut Self::State,
+        instr: &Bytecode,
+        index: CodeOffset,
+        bounds: (CodeOffset, CodeOffset),
+        meter: &mut (impl Meter + ?Sized),
+    ) -> PartialVMResult<()>;
+}
+
+pub fn analyze_function<TF: TransferFunctions, M: Meter + ?Sized>(
+    function_context: &FunctionContext,
+    meter: &mut M,
+    transfer_functions: &mut TF,
+    initial_state: TF::State,
+) -> Result<(), PartialVMError> {
+    let mut interpreter = AbstractInterpreter {
+        function_context,
+        meter,
+        transfer_functions,
+    };
+    absint::analyze_function(
+        &mut interpreter,
+        &function_context.cfg,
+        DomainWrapper(initial_state),
+    )
+}
+
+/// A `FunctionContext` holds all the information needed by the verifier for `FunctionDefinition`.`
+/// A control flow graph is built for a function when the `FunctionContext` is created.
+pub struct FunctionContext<'a> {
+    index: Option<FunctionDefinitionIndex>,
+    parameters: &'a Signature,
+    return_: &'a Signature,
+    locals: &'a Signature,
+    type_parameters: &'a [AbilitySet],
+    cfg: ControlFlowGraph<'a>,
+}
+
+impl<'a> FunctionContext<'a> {
+    // Creates a `FunctionContext` for a module function.
+    pub fn new(
+        module: &'a CompiledModule,
+        index: FunctionDefinitionIndex,
+        code: &'a CodeUnit,
+        function_handle: &'a FunctionHandle,
+    ) -> Self {
+        Self {
+            index: Some(index),
+            parameters: module.signature_at(function_handle.parameters),
+            return_: module.signature_at(function_handle.return_),
+            locals: module.signature_at(code.locals),
+            type_parameters: &function_handle.type_parameters,
+            cfg: ControlFlowGraph::new(&code.code, &code.jump_tables),
+        }
+    }
+
+    pub fn index(&self) -> Option<FunctionDefinitionIndex> {
+        self.index
+    }
+
+    pub fn parameters(&self) -> &'a Signature {
+        self.parameters
+    }
+
+    pub fn return_(&self) -> &'a Signature {
+        self.return_
+    }
+
+    pub fn locals(&self) -> &'a Signature {
+        self.locals
+    }
+
+    pub fn type_parameters(&self) -> &'a [AbilitySet] {
+        self.type_parameters
+    }
+
+    pub fn cfg(&self) -> &ControlFlowGraph {
+        &self.cfg
+    }
+}
+
+//**************************************************************************************************
+// Wrappers around shared absint and control flow graph implementations
+//**************************************************************************************************
+
+#[derive(Clone)]
+struct DomainWrapper<T: AbstractDomain>(T);
+impl<T: AbstractDomain> absint::AbstractDomain for DomainWrapper<T> {
+    type Error = PartialVMError;
+}
+
+pub type ControlFlowGraph<'a> = control_flow_graph::VMControlFlowGraph<'a, Bytecode>;
+
+/// Costs for metered verification
+const ANALYZE_FUNCTION_BASE_COST: u128 = 10;
+const EXECUTE_BLOCK_BASE_COST: u128 = 10;
+const PER_BACKEDGE_COST: u128 = 10;
+const PER_SUCCESSOR_COST: u128 = 10;
+
+struct AbstractInterpreter<'context, 'meter, 'tf, M: Meter + ?Sized, TF: TransferFunctions> {
+    pub function_context: &'context FunctionContext<'context>,
+    pub meter: &'meter mut M,
+    pub transfer_functions: &'tf mut TF,
+}
+
+impl<'context, 'meter, 'tf, M: Meter + ?Sized, TF: TransferFunctions> absint::AbstractInterpreter
+    for AbstractInterpreter<'context, 'meter, 'tf, M, TF>
+{
+    type Error = PartialVMError;
+    type BlockId = CodeOffset;
+    type State = DomainWrapper<<TF as TransferFunctions>::State>;
+    type InstructionIndex = CodeOffset;
+    type Instruction = Bytecode;
+
+    fn start(&mut self) -> Result<(), Self::Error> {
+        self.meter.add(Scope::Function, ANALYZE_FUNCTION_BASE_COST)
+    }
+
+    fn join(
+        &mut self,
+        pre: &mut Self::State,
+        post: &Self::State,
+    ) -> Result<absint::JoinResult, Self::Error> {
+        pre.0.join(&post.0, self.meter)
+    }
+
+    fn visit_block_execution(&mut self, _block_id: Self::BlockId) -> Result<(), Self::Error> {
+        self.meter.add(Scope::Function, EXECUTE_BLOCK_BASE_COST)
+    }
+
+    fn visit_successor(&mut self, _block_id: Self::BlockId) -> Result<(), Self::Error> {
+        self.meter.add(Scope::Function, PER_SUCCESSOR_COST)
+    }
+
+    fn visit_back_edge(
+        &mut self,
+        _from: Self::BlockId,
+        _to: Self::BlockId,
+    ) -> Result<(), Self::Error> {
+        self.meter.add(Scope::Function, PER_BACKEDGE_COST)
+    }
+
+    fn execute(
+        &mut self,
+        state: &mut Self::State,
+        bounds: (Self::InstructionIndex, Self::InstructionIndex),
+        offset: Self::InstructionIndex,
+        instr: &Self::Instruction,
+    ) -> Result<(), Self::Error> {
+        self.transfer_functions
+            .execute(&mut state.0, instr, offset, bounds, self.meter)
+    }
+}

--- a/external-crates/move/crates/move-bytecode-verifier/src/absint.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/absint.rs
@@ -17,7 +17,7 @@ use move_bytecode_verifier_meter::{Meter, Scope};
 //**************************************************************************************************
 
 pub use absint::JoinResult;
-pub type VMControlFlowGraph<'a> = control_flow_graph::VMControlFlowGraph<'a, Bytecode>;
+pub type VMControlFlowGraph = control_flow_graph::VMControlFlowGraph<Bytecode>;
 
 pub trait AbstractDomain: Clone + Sized {
     fn join(
@@ -60,7 +60,12 @@ pub fn analyze_function<TF: TransferFunctions, M: Meter + ?Sized>(
         meter,
         transfer_functions,
     };
-    absint::analyze_function(&mut interpreter, &function_context.cfg, initial_state)
+    absint::analyze_function(
+        &mut interpreter,
+        &function_context.cfg,
+        &function_context.code.code,
+        initial_state,
+    )
 }
 
 /// A `FunctionContext` holds all the information needed by the verifier for `FunctionDefinition`.`
@@ -72,7 +77,7 @@ pub struct FunctionContext<'a> {
     return_: &'a Signature,
     locals: &'a Signature,
     type_parameters: &'a [AbilitySet],
-    cfg: VMControlFlowGraph<'a>,
+    cfg: VMControlFlowGraph,
 }
 
 impl<'a> FunctionContext<'a> {

--- a/external-crates/move/crates/move-bytecode-verifier/src/absint.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/absint.rs
@@ -3,12 +3,12 @@
 
 use move_abstract_interpreter::{absint, control_flow_graph};
 use move_binary_format::{
+    CompiledModule,
     errors::{PartialVMError, PartialVMResult},
     file_format::{
         AbilitySet, Bytecode, CodeOffset, CodeUnit, FunctionDefinitionIndex, FunctionHandle,
         Signature,
     },
-    CompiledModule,
 };
 use move_bytecode_verifier_meter::{Meter, Scope};
 

--- a/external-crates/move/crates/move-bytecode-verifier/src/code_unit_verifier.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/code_unit_verifier.rs
@@ -6,10 +6,11 @@
 //! The overall verification is split between stack_usage_verifier.rs and
 //! abstract_interpreter.rs. CodeUnitVerifier simply orchestrates calls into these two files.
 use crate::{
-    ability_cache::AbilityCache, acquires_list_verifier::AcquiresVerifier, control_flow,
-    locals_safety, reference_safety, stack_usage_verifier::StackUsageVerifier, type_safety,
+    ability_cache::AbilityCache, absint::FunctionContext, acquires_list_verifier::AcquiresVerifier,
+    control_flow, locals_safety, reference_safety, stack_usage_verifier::StackUsageVerifier,
+    type_safety,
 };
-use move_abstract_interpreter::{absint::FunctionContext, control_flow_graph::ControlFlowGraph};
+use move_abstract_interpreter::control_flow_graph::ControlFlowGraph;
 use move_binary_format::{
     IndexKind,
     errors::{Location, PartialVMError, PartialVMResult, VMResult},

--- a/external-crates/move/crates/move-bytecode-verifier/src/control_flow.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/control_flow.rs
@@ -13,10 +13,10 @@
 //!
 //! For bytecode versions 5 and below, delegates to `control_flow_v5`.
 use crate::{
+    absint::FunctionContext,
     control_flow_v5,
     loop_summary::{LoopPartition, LoopSummary},
 };
-use move_abstract_interpreter::absint::FunctionContext;
 use move_binary_format::{
     CompiledModule,
     errors::{PartialVMError, PartialVMResult},

--- a/external-crates/move/crates/move-bytecode-verifier/src/lib.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/lib.rs
@@ -9,6 +9,7 @@
 // Bounds checks are implemented in the `vm` crate.
 pub mod ability_cache;
 pub mod ability_field_requirements;
+pub mod absint;
 pub mod check_duplication;
 pub mod code_unit_verifier;
 pub mod constants;

--- a/external-crates/move/crates/move-bytecode-verifier/src/locals_safety/abstract_state.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/locals_safety/abstract_state.rs
@@ -5,7 +5,7 @@
 //! This module defines the abstract state for the local safety analysis.
 
 use crate::ability_cache::AbilityCache;
-use move_abstract_interpreter::absint::{AbstractDomain, FunctionContext, JoinResult};
+use crate::absint::{AbstractDomain, FunctionContext, JoinResult};
 use move_binary_format::{
     CompiledModule,
     errors::{PartialVMError, PartialVMResult},

--- a/external-crates/move/crates/move-bytecode-verifier/src/locals_safety/mod.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/locals_safety/mod.rs
@@ -9,12 +9,12 @@
 mod abstract_state;
 
 use crate::ability_cache::AbilityCache;
+use crate::absint::{analyze_function, FunctionContext, TransferFunctions};
 use abstract_state::{AbstractState, LocalState, RET_COST, STEP_BASE_COST};
-use move_abstract_interpreter::absint::{AbstractInterpreter, FunctionContext, TransferFunctions};
 use move_binary_format::{
-    CompiledModule,
     errors::{PartialVMError, PartialVMResult},
     file_format::{Bytecode, CodeOffset},
+    CompiledModule,
 };
 use move_bytecode_verifier_meter::{Meter, Scope};
 use move_core_types::vm_status::StatusCode;
@@ -26,7 +26,12 @@ pub(crate) fn verify<'a>(
     meter: &mut (impl Meter + ?Sized),
 ) -> PartialVMResult<()> {
     let initial_state = AbstractState::new(module, function_context, ability_cache, meter)?;
-    LocalsSafetyAnalysis().analyze_function(initial_state, function_context, meter)
+    analyze_function(
+        function_context,
+        meter,
+        &mut LocalsSafetyAnalysis(),
+        initial_state,
+    )
 }
 
 fn execute_inner(
@@ -176,18 +181,15 @@ struct LocalsSafetyAnalysis();
 
 impl TransferFunctions for LocalsSafetyAnalysis {
     type State = AbstractState;
-    type Error = PartialVMError;
 
     fn execute(
         &mut self,
         state: &mut Self::State,
         bytecode: &Bytecode,
         index: CodeOffset,
-        _last_index: CodeOffset,
+        _bounds: (CodeOffset, CodeOffset),
         meter: &mut (impl Meter + ?Sized),
     ) -> PartialVMResult<()> {
         execute_inner(state, bytecode, index, meter)
     }
 }
-
-impl AbstractInterpreter for LocalsSafetyAnalysis {}

--- a/external-crates/move/crates/move-bytecode-verifier/src/locals_safety/mod.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/locals_safety/mod.rs
@@ -9,12 +9,12 @@
 mod abstract_state;
 
 use crate::ability_cache::AbilityCache;
-use crate::absint::{analyze_function, FunctionContext, TransferFunctions};
+use crate::absint::{FunctionContext, TransferFunctions, analyze_function};
 use abstract_state::{AbstractState, LocalState, RET_COST, STEP_BASE_COST};
 use move_binary_format::{
-    errors::{PartialVMError, PartialVMResult},
-    file_format::{Bytecode, CodeOffset},
     CompiledModule,
+    errors::PartialVMResult,
+    file_format::{Bytecode, CodeOffset},
 };
 use move_bytecode_verifier_meter::{Meter, Scope};
 use move_core_types::vm_status::StatusCode;

--- a/external-crates/move/crates/move-bytecode-verifier/src/loop_summary.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/loop_summary.rs
@@ -75,7 +75,7 @@ impl LoopSummary {
             },
         }
 
-        let num_blocks = cfg.num_blocks() as usize;
+        let num_blocks = cfg.num_blocks();
 
         // Fields in LoopSummary that are filled via a depth-first traversal of `cfg`.
         let mut blocks = vec![0; num_blocks];

--- a/external-crates/move/crates/move-bytecode-verifier/src/loop_summary.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/loop_summary.rs
@@ -1,9 +1,9 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_abstract_interpreter::control_flow_graph::{
-    BlockId, ControlFlowGraph, VMControlFlowGraph,
-};
+use crate::absint::VMControlFlowGraph;
+use move_abstract_interpreter::control_flow_graph::ControlFlowGraph;
+use move_binary_format::file_format::CodeOffset;
 use std::collections::{BTreeMap, BTreeSet, btree_map::Entry};
 
 type BlockId = CodeOffset;

--- a/external-crates/move/crates/move-bytecode-verifier/src/loop_summary.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/loop_summary.rs
@@ -6,6 +6,8 @@ use move_abstract_interpreter::control_flow_graph::{
 };
 use std::collections::{BTreeMap, BTreeSet, btree_map::Entry};
 
+type BlockId = CodeOffset;
+
 /// Dense index into nodes in the same `LoopSummary`
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NodeId(u16);

--- a/external-crates/move/crates/move-bytecode-verifier/src/reference_safety/abstract_state.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/reference_safety/abstract_state.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module defines the abstract state for the type and memory safety analysis.
-use move_abstract_interpreter::absint::{AbstractDomain, FunctionContext, JoinResult};
+use crate::absint::{AbstractDomain, FunctionContext, JoinResult};
 use move_binary_format::{
     errors::{PartialVMError, PartialVMResult},
     file_format::{

--- a/external-crates/move/crates/move-bytecode-verifier/src/reference_safety/mod.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/reference_safety/mod.rs
@@ -10,9 +10,9 @@
 
 mod abstract_state;
 
+use crate::absint::{analyze_function, FunctionContext, TransferFunctions};
 use crate::reference_safety::abstract_state::STEP_BASE_COST;
 use abstract_state::{AbstractState, AbstractValue};
-use move_abstract_interpreter::absint::{AbstractInterpreter, FunctionContext, TransferFunctions};
 use move_abstract_stack::AbstractStack;
 use move_binary_format::{
     CompiledModule,
@@ -72,7 +72,7 @@ pub(crate) fn verify<'a>(
     let initial_state = AbstractState::new(function_context);
 
     let mut verifier = ReferenceSafetyAnalysis::new(module, function_context, name_def_map);
-    verifier.analyze_function(initial_state, function_context, meter)
+    analyze_function(function_context, meter, &mut verifier, initial_state)
 }
 
 fn call(
@@ -559,14 +559,13 @@ fn execute_inner(
 
 impl TransferFunctions for ReferenceSafetyAnalysis<'_> {
     type State = AbstractState;
-    type Error = PartialVMError;
 
     fn execute(
         &mut self,
         state: &mut Self::State,
         bytecode: &Bytecode,
         index: CodeOffset,
-        last_index: CodeOffset,
+        (_first_index, last_index): (CodeOffset, CodeOffset),
         meter: &mut (impl Meter + ?Sized),
     ) -> PartialVMResult<()> {
         execute_inner(self, state, bytecode, index, meter)?;
@@ -577,5 +576,3 @@ impl TransferFunctions for ReferenceSafetyAnalysis<'_> {
         Ok(())
     }
 }
-
-impl AbstractInterpreter for ReferenceSafetyAnalysis<'_> {}

--- a/external-crates/move/crates/move-bytecode-verifier/src/reference_safety/mod.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/reference_safety/mod.rs
@@ -10,7 +10,7 @@
 
 mod abstract_state;
 
-use crate::absint::{analyze_function, FunctionContext, TransferFunctions};
+use crate::absint::{FunctionContext, TransferFunctions, analyze_function};
 use crate::reference_safety::abstract_state::STEP_BASE_COST;
 use abstract_state::{AbstractState, AbstractValue};
 use move_abstract_stack::AbstractStack;

--- a/external-crates/move/crates/move-bytecode-verifier/src/stack_usage_verifier.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/stack_usage_verifier.rs
@@ -14,7 +14,9 @@ use move_abstract_interpreter::control_flow_graph::ControlFlowGraph;
 use move_binary_format::{
     CompiledModule,
     errors::{PartialVMError, PartialVMResult},
-    file_format::{Bytecode, CodeUnit, FunctionDefinitionIndex, Signature, StructFieldInformation},
+    file_format::{
+        Bytecode, CodeOffset, CodeUnit, FunctionDefinitionIndex, Signature, StructFieldInformation,
+    },
 };
 use move_bytecode_verifier_meter::Meter;
 use move_core_types::vm_status::StatusCode;

--- a/external-crates/move/crates/move-bytecode-verifier/src/stack_usage_verifier.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/stack_usage_verifier.rs
@@ -9,10 +9,8 @@
 //! the stack height by the number of values returned by the function as indicated in its
 //! signature. Additionally, the stack height must not dip below that at the beginning of the
 //! block for any basic block.
-use move_abstract_interpreter::{
-    absint::FunctionContext,
-    control_flow_graph::{BlockId, ControlFlowGraph},
-};
+use crate::absint::{FunctionContext, VMControlFlowGraph};
+use move_abstract_interpreter::control_flow_graph::ControlFlowGraph;
 use move_binary_format::{
     CompiledModule,
     errors::{PartialVMError, PartialVMResult},
@@ -21,6 +19,8 @@ use move_binary_format::{
 use move_bytecode_verifier_meter::Meter;
 use move_core_types::vm_status::StatusCode;
 use move_vm_config::verifier::VerifierConfig;
+
+type BlockId = CodeOffset;
 
 pub(crate) struct StackUsageVerifier<'a> {
     module: &'a CompiledModule,
@@ -53,7 +53,7 @@ impl<'a> StackUsageVerifier<'a> {
         &self,
         config: &VerifierConfig,
         block_id: BlockId,
-        cfg: &dyn ControlFlowGraph,
+        cfg: &VMControlFlowGraph,
     ) -> PartialVMResult<()> {
         let code = &self.code.code;
         let mut stack_size_increment = 0;

--- a/external-crates/move/crates/move-bytecode-verifier/src/type_safety.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/type_safety.rs
@@ -7,7 +7,8 @@
 
 use std::{cmp::max, num::NonZeroU64};
 
-use move_abstract_interpreter::{absint::FunctionContext, control_flow_graph::ControlFlowGraph};
+use crate::absint::FunctionContext;
+use move_abstract_interpreter::control_flow_graph::ControlFlowGraph;
 use move_abstract_stack::AbstractStack;
 use move_binary_format::{
     CompiledModule,
@@ -155,12 +156,10 @@ pub(crate) fn verify<'env>(
 ) -> PartialVMResult<()> {
     let mut checker = TypeSafetyChecker::new(module, function_context, ability_cache);
     let verifier = &mut checker;
+    let jump_tables = &verifier.function_context.code().jump_tables;
 
     for block_id in function_context.cfg().blocks() {
-        for offset in function_context.cfg().instr_indexes(block_id) {
-            let code = &verifier.function_context.code();
-            let instr = &code.code[offset as usize];
-            let jump_tables = &code.jump_tables;
+        for (offset, instr) in function_context.cfg().instructions(block_id) {
             verify_instr(verifier, instr, jump_tables, offset, meter)?
         }
     }

--- a/external-crates/move/crates/move-bytecode-verifier/src/type_safety.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/type_safety.rs
@@ -159,7 +159,10 @@ pub(crate) fn verify<'env>(
     let jump_tables = &verifier.function_context.code().jump_tables;
 
     for block_id in function_context.cfg().blocks() {
-        for (offset, instr) in function_context.cfg().instructions(block_id) {
+        for (offset, instr) in function_context
+            .cfg()
+            .instructions(&function_context.code().code, block_id)
+        {
             verify_instr(verifier, instr, jump_tables, offset, meter)?
         }
     }

--- a/external-crates/move/crates/move-coverage/Cargo.toml
+++ b/external-crates/move/crates/move-coverage/Cargo.toml
@@ -25,6 +25,7 @@ move-ir-types.workspace = true
 move-binary-format.workspace = true
 move-bytecode-source-map.workspace = true
 move-abstract-interpreter.workspace = true
+move-bytecode-verifier.workspace = true
 indexmap.workspace = true
 
 lcov.workspace = true

--- a/external-crates/move/crates/move-coverage/src/lcov.rs
+++ b/external-crates/move/crates/move-coverage/src/lcov.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use lcov::record::Record as LRecord;
-use move_abstract_interpreter::control_flow_graph::{ControlFlowGraph, VMControlFlowGraph};
+use move_abstract_interpreter::control_flow_graph::ControlFlowGraph;
 use move_binary_format::file_format::FunctionDefinitionIndex;
+use move_bytecode_verifier::absint::VMControlFlowGraph;
 use move_compiler::{
     compiled_unit::CompiledUnit, shared::files::MappedFiles,
     unit_test::filter_test_members::UNIT_TEST_POISON_FUN_NAME,

--- a/external-crates/move/crates/move-coverage/src/summary.rs
+++ b/external-crates/move/crates/move-coverage/src/summary.rs
@@ -7,9 +7,7 @@
 use crate::coverage_map::{
     ExecCoverageMap, ExecCoverageMapWithModules, ModuleCoverageMap, TraceMap,
 };
-use move_abstract_interpreter::control_flow_graph::{
-    BlockId, ControlFlowGraph, VMControlFlowGraph,
-};
+use move_abstract_interpreter::control_flow_graph::{ControlFlowGraph, VMControlFlowGraph};
 use move_binary_format::{
     CompiledModule,
     file_format::{Bytecode, CodeOffset},
@@ -21,6 +19,8 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     io::{self, Write},
 };
+
+type BlockId = CodeOffset;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ModuleSummary {

--- a/external-crates/move/crates/move-ir-compiler/src/unit_tests/cfg_tests.rs
+++ b/external-crates/move/crates/move-ir-compiler/src/unit_tests/cfg_tests.rs
@@ -3,8 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::unit_tests::testutils::compile_module_string;
-use move_abstract_interpreter::control_flow_graph::{ControlFlowGraph, VMControlFlowGraph};
+use move_abstract_interpreter::control_flow_graph::ControlFlowGraph;
 use move_binary_format::file_format::{Bytecode, VariantJumpTable};
+use move_bytecode_verifier::absint::VMControlFlowGraph;
 
 #[test]
 fn cfg_compile_script_ret() {
@@ -275,7 +276,7 @@ fn cfg_compile_if_else_with_two_aborts() {
 #[test]
 fn cfg_compile_variant_switch_simple() {
     let text = "
-        module 0x42.m { 
+        module 0x42.m {
             enum X has drop { V1 { x: u64 }, V2 { } }
 
             entry foo(x: Self.X) {
@@ -289,7 +290,7 @@ fn cfg_compile_variant_switch_simple() {
                 return;
             label b1:
                 return;
-            } 
+            }
         }
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
@@ -302,7 +303,7 @@ fn cfg_compile_variant_switch_simple() {
 #[test]
 fn cfg_compile_variant_switch_simple_unconditional_jump() {
     let text = "
-        module 0x42.m { 
+        module 0x42.m {
             enum X has drop { V1 { x: u64 }, V2 { } }
 
             entry foo(x: Self.X) {
@@ -313,13 +314,13 @@ fn cfg_compile_variant_switch_simple_unconditional_jump() {
                     V2 : b1,
                 };
             // This block is unreachable because `variant_switch` is an unconditional jump.
-            label fallthrough: 
+            label fallthrough:
                 return;
             label b0:
                 return;
             label b1:
                 return;
-            } 
+            }
         }
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
@@ -332,7 +333,7 @@ fn cfg_compile_variant_switch_simple_unconditional_jump() {
 #[test]
 fn cfg_compile_variant_switch() {
     let text = "
-        module 0x42.m { 
+        module 0x42.m {
             enum X { V1 { x: u64 }, V2 { } }
 
             entry foo(x: Self.X) {
@@ -352,10 +353,10 @@ fn cfg_compile_variant_switch() {
                 jump b3;
             label b3:
                 return;
-            label b4: 
+            label b4:
                 X.V2 {} = move(x);
                 jump b3;
-            } 
+            }
         }
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
@@ -368,7 +369,7 @@ fn cfg_compile_variant_switch() {
 #[test]
 fn cfg_compile_variant_switch_with_two_aborts() {
     let text = "
-        module 0x42.m { 
+        module 0x42.m {
             enum X { V1 { x: u64 }, V2 { } }
 
             entry foo(x: Self.X) {
@@ -388,10 +389,10 @@ fn cfg_compile_variant_switch_with_two_aborts() {
                 jump b3;
             label b3:
                 return;
-            label b4: 
+            label b4:
                 X.V2 {} = move(x);
                 abort 0;
-            } 
+            }
         }
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
@@ -404,7 +405,7 @@ fn cfg_compile_variant_switch_with_two_aborts() {
 #[test]
 fn cfg_compile_variant_switch_with_return() {
     let text = "
-        module 0x42.m { 
+        module 0x42.m {
             enum X { V1 { x: u64 }, V2 { } }
 
             entry foo(x: Self.X) {
@@ -430,10 +431,10 @@ fn cfg_compile_variant_switch_with_return() {
                 jump b3;
             label b3:
                 return;
-            label b4: 
+            label b4:
                 X.V2 {} = move(x);
                 abort 0;
-            } 
+            }
         }
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);

--- a/sui-execution/latest/sui-verifier/Cargo.toml
+++ b/sui-execution/latest/sui-verifier/Cargo.toml
@@ -16,7 +16,6 @@ move-vm-config.workspace = true
 move-abstract-stack.workspace = true
 
 move-bytecode-verifier = { path = "../../../external-crates/move/crates/move-bytecode-verifier" }
-move-abstract-interpreter = { path = "../../../external-crates/move/crates/move-abstract-interpreter" }
 
 sui-types.workspace = true
 sui-protocol-config.workspace = true

--- a/sui-execution/latest/sui-verifier/Cargo.toml
+++ b/sui-execution/latest/sui-verifier/Cargo.toml
@@ -15,6 +15,7 @@ move-core-types.workspace = true
 move-vm-config.workspace = true
 move-abstract-stack.workspace = true
 
+move-bytecode-verifier = { path = "../../../external-crates/move/crates/move-bytecode-verifier" }
 move-abstract-interpreter = { path = "../../../external-crates/move/crates/move-abstract-interpreter" }
 
 sui-types.workspace = true

--- a/sui-execution/latest/sui-verifier/src/id_leak_verifier.rs
+++ b/sui-execution/latest/sui-verifier/src/id_leak_verifier.rs
@@ -12,9 +12,7 @@
 //! 2. Written into a mutable reference
 //! 3. Added to a vector
 //! 4. Passed to a function cal::;
-use move_abstract_interpreter::absint::{
-    AbstractDomain, AbstractInterpreter, FunctionContext, JoinResult, TransferFunctions,
-};
+use move_abstract_interpreter::absint::JoinResult;
 use move_abstract_stack::AbstractStack;
 use move_binary_format::{
     errors::PartialVMError,
@@ -22,6 +20,9 @@ use move_binary_format::{
         Bytecode, CodeOffset, CompiledModule, FunctionDefinitionIndex, FunctionHandle, LocalIndex,
         StructDefinition, StructFieldInformation,
     },
+};
+use move_bytecode_verifier::absint::{
+    analyze_function, AbstractDomain, FunctionContext, TransferFunctions,
 };
 use move_bytecode_verifier_meter::{Meter, Scope};
 use move_core_types::{
@@ -135,10 +136,10 @@ fn verify_id_leak(
             None => continue,
         };
         let handle = module.function_handle_at(func_def.function);
-        let func_view =
+        let function_context =
             FunctionContext::new(module, FunctionDefinitionIndex(index as u16), code, handle);
-        let initial_state = AbstractState::new(&func_view);
-        let mut verifier = IDLeakAnalysis::new(module, &func_view);
+        let initial_state = AbstractState::new(&function_context);
+        let mut verifier = IDLeakAnalysis::new(module, &function_context);
         let function_to_verify = verifier.cur_function();
         if FUNCTIONS_TO_SKIP
             .iter()
@@ -146,10 +147,9 @@ fn verify_id_leak(
         {
             continue;
         }
-        verifier
-            .analyze_function(initial_state, &func_view, meter)
-            .map_err(|err| {
-                // Handle verifificaiton timeout specially
+        analyze_function(&function_context, meter, &mut verifier, initial_state).map_err(
+            |err| {
+                // Handle verification timeout specially
                 if check_for_verifier_timeout(&err.major_status()) {
                     to_verification_timeout_error(err.to_string())
                 } else if let Some(message) = err.source().as_ref() {
@@ -163,7 +163,8 @@ fn verify_id_leak(
                 } else {
                     verification_failure(err.to_string())
                 }
-            })?;
+            },
+        )?;
     }
 
     Ok(())
@@ -272,7 +273,6 @@ impl<'a> IDLeakAnalysis<'a> {
 }
 
 impl TransferFunctions for IDLeakAnalysis<'_> {
-    type Error = ExecutionError;
     type State = AbstractState;
 
     fn execute(
@@ -280,7 +280,7 @@ impl TransferFunctions for IDLeakAnalysis<'_> {
         state: &mut Self::State,
         bytecode: &Bytecode,
         index: CodeOffset,
-        last_index: CodeOffset,
+        (_first_index, last_index): (u16, u16),
         meter: &mut (impl Meter + ?Sized),
     ) -> Result<(), PartialVMError> {
         execute_inner(self, state, bytecode, index, meter)?;
@@ -298,8 +298,6 @@ impl TransferFunctions for IDLeakAnalysis<'_> {
         Ok(())
     }
 }
-
-impl AbstractInterpreter for IDLeakAnalysis<'_> {}
 
 fn call(
     verifier: &mut IDLeakAnalysis,

--- a/sui-execution/latest/sui-verifier/src/id_leak_verifier.rs
+++ b/sui-execution/latest/sui-verifier/src/id_leak_verifier.rs
@@ -12,7 +12,6 @@
 //! 2. Written into a mutable reference
 //! 3. Added to a vector
 //! 4. Passed to a function cal::;
-use move_abstract_interpreter::absint::JoinResult;
 use move_abstract_stack::AbstractStack;
 use move_binary_format::{
     errors::PartialVMError,
@@ -22,7 +21,7 @@ use move_binary_format::{
     },
 };
 use move_bytecode_verifier::absint::{
-    analyze_function, AbstractDomain, FunctionContext, TransferFunctions,
+    analyze_function, AbstractDomain, FunctionContext, JoinResult, TransferFunctions,
 };
 use move_bytecode_verifier_meter::{Meter, Scope};
 use move_core_types::{


### PR DESCRIPTION
## Description 

- Makes the abstract interpreter more general and removes the dependency on the file format
- Added the necessary wrapper traits in the verifier 
- Stacked on #21573
- This will let us use the same infrastructure in the move-model-2 and move-compiler

## Test plan 

- Non functional

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
