### PR TITLE
Refactor Analytics Indexer

### DIFF
--- a/crates/sui-analytics-indexer/src/analytics_processor.rs
+++ b/crates/sui-analytics-indexer/src/analytics_processor.rs
@@ -25,8 +25,7 @@ use crate::analytics_metrics::AnalyticsMetrics;
 use crate::handlers::AnalyticsHandler;
 use crate::writers::AnalyticsWriter;
 use crate::{
-    join_paths, AnalyticsIndexerConfig, FileMetadata, MaxCheckpointReader, ParquetSchema,
-    TaskConfig, EPOCH_DIR_PREFIX,
+    join_paths, FileMetadata, MaxCheckpointReader, ParquetSchema, TaskContext, EPOCH_DIR_PREFIX,
 };
 
 struct State<S: Serialize + ParquetSchema> {
@@ -40,8 +39,7 @@ struct State<S: Serialize + ParquetSchema> {
 pub struct AnalyticsProcessor<S: Serialize + ParquetSchema> {
     handler: Box<dyn AnalyticsHandler<S>>,
     state: Mutex<State<S>>,
-    metrics: AnalyticsMetrics,
-    task_config: Arc<TaskConfig>,
+    task_context: TaskContext,
     sender: mpsc::Sender<FileMetadata>,
     #[allow(dead_code)]
     kill_sender: oneshot::Sender<()>,
@@ -75,16 +73,19 @@ impl<S: Serialize + ParquetSchema + 'static> Worker for AnalyticsProcessor<S> {
 
         let num_checkpoints_processed =
             state.current_checkpoint_range.end - state.current_checkpoint_range.start;
-        let cut_new_files = (num_checkpoints_processed >= self.task_config.checkpoint_interval)
-            || (state.last_commit_instant.elapsed().as_secs() > self.task_config.time_interval_s)
+        let cut_new_files = (num_checkpoints_processed
+            >= self.task_context.config.checkpoint_interval)
+            || (state.last_commit_instant.elapsed().as_secs()
+                > self.task_context.config.time_interval_s)
             || (state.num_checkpoint_iterations % CHECK_FILE_SIZE_ITERATION_CYCLE == 0
                 && state.writer.file_size()?.unwrap_or(0)
-                    > self.task_config.max_file_size_mb * 1024 * 1024);
+                    > self.task_context.config.max_file_size_mb * 1024 * 1024);
         if cut_new_files {
             self.cut(&mut state).await?;
             self.reset(&mut state)?;
         }
-        self.metrics
+        self.task_context
+            .metrics
             .total_received
             .with_label_values(&[self.name()])
             .inc();
@@ -107,27 +108,25 @@ impl<S: Serialize + ParquetSchema + 'static> AnalyticsProcessor<S> {
         writer: Box<dyn AnalyticsWriter<S>>,
         max_checkpoint_reader: Box<dyn MaxCheckpointReader>,
         next_checkpoint_seq_num: CheckpointSequenceNumber,
-        metrics: AnalyticsMetrics,
-        config: Arc<AnalyticsIndexerConfig>,
-        task_config: Arc<TaskConfig>,
+        task_context: TaskContext,
     ) -> Result<Self> {
         let local_store_config = ObjectStoreConfig {
-            directory: Some(task_config.checkpoint_dir()?.to_path_buf()),
+            directory: Some(task_context.checkpoint_dir_path().to_path_buf()),
             object_store: Some(ObjectStoreType::File),
             ..Default::default()
         };
         let local_object_store = local_store_config.make()?;
-        let remote_object_store = config.remote_store_config.make()?;
+        let remote_object_store = task_context.job_config.remote_store_config.make()?;
         let (kill_sender, kill_receiver) = oneshot::channel::<()>();
         let (sender, receiver) = mpsc::channel::<FileMetadata>(100);
         let name: String = handler.name().parse()?;
-        let checkpoint_dir = task_config.checkpoint_dir()?;
-        let cloned_metrics = metrics.clone();
+        let checkpoint_dir = task_context.checkpoint_dir_path();
+        let cloned_metrics = task_context.metrics.clone();
         tokio::task::spawn(Self::start_syncing_with_remote(
             remote_object_store,
             local_object_store.clone(),
             checkpoint_dir.to_path_buf(),
-            task_config.remote_store_path_prefix()?,
+            task_context.config.remote_store_path_prefix()?,
             receiver,
             kill_receiver,
             cloned_metrics,
@@ -136,7 +135,7 @@ impl<S: Serialize + ParquetSchema + 'static> AnalyticsProcessor<S> {
         let (max_checkpoint_sender, max_checkpoint_receiver) = oneshot::channel::<()>();
         tokio::task::spawn(Self::setup_max_checkpoint_metrics_updates(
             max_checkpoint_reader,
-            metrics.clone(),
+            task_context.metrics.clone(),
             max_checkpoint_receiver,
             name,
         ));
@@ -153,8 +152,7 @@ impl<S: Serialize + ParquetSchema + 'static> AnalyticsProcessor<S> {
             kill_sender,
             sender,
             max_checkpoint_sender,
-            metrics,
-            task_config,
+            task_context,
         })
     }
 
@@ -167,8 +165,8 @@ impl<S: Serialize + ParquetSchema + 'static> AnalyticsProcessor<S> {
             && state.writer.flush(state.current_checkpoint_range.end)?
         {
             let file_metadata = FileMetadata::new(
-                self.task_config.file_type,
-                self.task_config.file_format,
+                self.task_context.config.file_type,
+                self.task_context.config.file_format,
                 state.current_epoch,
                 state.current_checkpoint_range.clone(),
             );
@@ -184,8 +182,8 @@ impl<S: Serialize + ParquetSchema + 'static> AnalyticsProcessor<S> {
 
     fn epoch_dir(&self, state: &State<S>) -> Result<PathBuf> {
         let path = path_to_filesystem(
-            self.task_config.checkpoint_dir()?.to_path_buf(),
-            &self.task_config.file_type.dir_prefix(),
+            self.task_context.checkpoint_dir_path().to_path_buf(),
+            &self.task_context.config.file_type.dir_prefix(),
         )?
         .join(format!("{}{}", EPOCH_DIR_PREFIX, state.current_epoch));
         Ok(path)

--- a/crates/sui-analytics-indexer/src/handlers/wrapped_object_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/wrapped_object_handler.rs
@@ -3,7 +3,6 @@
 
 use anyhow::Result;
 use std::collections::BTreeMap;
-use std::path::Path;
 use sui_data_ingestion_core::Worker;
 use sui_types::SYSTEM_PACKAGE_ADDRESSES;
 use tokio::sync::Mutex;
@@ -81,8 +80,7 @@ impl AnalyticsHandler<WrappedObjectEntry> for WrappedObjectHandler {
 }
 
 impl WrappedObjectHandler {
-    pub fn new(store_path: &Path, rest_uri: &str) -> Self {
-        let package_store = LocalDBPackageStore::new(&store_path.join("wrapped_object"), rest_uri);
+    pub fn new(package_store: LocalDBPackageStore) -> Self {
         let state = Mutex::new(State {
             wrapped_objects: vec![],
             package_store: package_store.clone(),

--- a/crates/sui-analytics-indexer/src/lib.rs
+++ b/crates/sui-analytics-indexer/src/lib.rs
@@ -1,10 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
 use std::ops::Range;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::OnceLock;
 
 use anyhow::{anyhow, Result};
 use arrow_array::{Array, Int32Array};
@@ -42,11 +42,7 @@ use crate::handlers::transaction_handler::TransactionHandler;
 use crate::handlers::transaction_objects_handler::TransactionObjectsHandler;
 use crate::handlers::wrapped_object_handler::WrappedObjectHandler;
 use crate::handlers::AnalyticsHandler;
-use crate::tables::{
-    CheckpointEntry, DynamicFieldEntry, EventEntry, InputObjectKind, MoveCallEntry,
-    MovePackageEntry, ObjectEntry, ObjectStatus, OwnerType, TransactionEntry,
-    TransactionObjectEntry, WrappedObjectEntry,
-};
+use crate::tables::{InputObjectKind, ObjectStatus, OwnerType};
 use crate::writers::csv_writer::CSVWriter;
 use crate::writers::parquet_writer::ParquetWriter;
 use crate::writers::AnalyticsWriter;
@@ -71,77 +67,6 @@ const MOVE_PACKAGE_PREFIX: &str = "move_package";
 const DYNAMIC_FIELD_PREFIX: &str = "dynamic_field";
 
 const WRAPPED_OBJECT_PREFIX: &str = "wrapped_object";
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AnalyticsIndexerConfig {
-    /// The url of the checkpoint client to connect to.
-    pub rest_url: String,
-    /// The url of the metrics client to connect to.
-    #[serde(default = "default_client_metric_host")]
-    pub client_metric_host: String,
-    /// The port of the metrics client to connect to.
-    #[serde(default = "default_client_metric_port")]
-    pub client_metric_port: u16,
-    /// Remote object store where data gets written to
-    pub remote_store_config: ObjectStoreConfig,
-    /// Remote object store path prefix to use while writing
-    #[serde(default = "default_remote_store_url")]
-    pub remote_store_url: String,
-    /// Directory to contain the package cache for pipelines
-    #[serde(default = "default_package_cache_path")]
-    pub package_cache_path: PathBuf,
-    pub bq_service_account_key_file: Option<String>,
-    pub bq_project_id: Option<String>,
-    pub bq_dataset_id: Option<String>,
-    pub sf_account_identifier: Option<String>,
-    pub sf_warehouse: Option<String>,
-    pub sf_database: Option<String>,
-    pub sf_schema: Option<String>,
-    pub sf_username: Option<String>,
-    pub sf_role: Option<String>,
-    pub sf_password: Option<String>,
-    pub tasks: Vec<Arc<TaskConfig>>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TaskConfig {
-    /// Name of the task. Must be unique per process. Used to identify tasks in the Progress Store.
-    pub task_name: String,
-    /// Type of data to write i.e. checkpoint, object, transaction, etc
-    pub file_type: FileType,
-    /// File format to store data in i.e. csv, parquet, etc
-    #[serde(default = "default_file_format")]
-    pub file_format: FileFormat,
-    /// Number of checkpoints to process before uploading to the datastore.
-    #[serde(default = "default_checkpoint_interval")]
-    pub checkpoint_interval: u64,
-    /// Maximum file size in mb before uploading to the datastore.
-    #[serde(default = "default_max_file_size_mb")]
-    pub max_file_size_mb: u64,
-    /// Checkpoint sequence number to start the download from
-    pub starting_checkpoint_seq_num: Option<u64>,
-    /// Time to process in seconds before uploding to the datastore.
-    #[serde(default = "default_time_interval_s")]
-    pub time_interval_s: u64,
-    /// Root directory to contain the temporary directory for checkpoint entries.
-    #[serde(default = "default_checkpoint_root")]
-    pub checkpoint_root: PathBuf,
-    /// Temporary checkpoint entry directory that is lazily initialized
-    #[serde(skip)]
-    checkpoint_dir: OnceLock<Arc<TempDir>>,
-    /// Remote object store path prefix to use while writing
-    #[serde(default)]
-    remote_store_path_prefix: Option<PathBuf>,
-    pub bq_table_id: Option<String>,
-    pub bq_checkpoint_col_id: Option<String>,
-    #[serde(default)]
-    pub report_bq_max_table_checkpoint: bool,
-    pub sf_table_id: Option<String>,
-    pub sf_checkpoint_col_id: Option<String>,
-    #[serde(default)]
-    pub report_sf_max_table_checkpoint: bool,
-    pub package_id_filter: Option<String>,
-}
 
 fn default_client_metric_host() -> String {
     "127.0.0.1".to_string()
@@ -179,6 +104,118 @@ fn default_time_interval_s() -> u64 {
     600
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JobConfig {
+    /// The url of the checkpoint client to connect to.
+    pub rest_url: String,
+    /// The url of the metrics client to connect to.
+    #[serde(default = "default_client_metric_host")]
+    pub client_metric_host: String,
+    /// The port of the metrics client to connect to.
+    #[serde(default = "default_client_metric_port")]
+    pub client_metric_port: u16,
+    /// Remote object store where data gets written to
+    pub remote_store_config: ObjectStoreConfig,
+    /// Remote object store path prefix to use while writing
+    #[serde(default = "default_remote_store_url")]
+    pub remote_store_url: String,
+    /// Directory to contain the package cache for pipelines
+    #[serde(default = "default_package_cache_path")]
+    pub package_cache_path: PathBuf,
+    /// Root directory to contain the temporary directory for checkpoint entries.
+    #[serde(default = "default_checkpoint_root")]
+    pub checkpoint_root: PathBuf,
+    pub bq_service_account_key_file: Option<String>,
+    pub bq_project_id: Option<String>,
+    pub bq_dataset_id: Option<String>,
+    pub sf_account_identifier: Option<String>,
+    pub sf_warehouse: Option<String>,
+    pub sf_database: Option<String>,
+    pub sf_schema: Option<String>,
+    pub sf_username: Option<String>,
+    pub sf_role: Option<String>,
+    pub sf_password: Option<String>,
+
+    // This is private to enforce using the TaskContext struct
+    #[serde(rename = "tasks")]
+    task_configs: Vec<TaskConfig>,
+}
+
+impl JobConfig {
+    pub async fn create_checkpoint_processors(
+        self,
+        metrics: AnalyticsMetrics,
+    ) -> Result<Vec<Processor>> {
+        let package_store = LocalDBPackageStore::new(&self.package_cache_path, &self.rest_url);
+        let job_config = Arc::new(self);
+        let mut processors = Vec::with_capacity(job_config.task_configs.len());
+        let mut task_names = HashSet::new();
+
+        for task_config in job_config.task_configs.clone() {
+            let task_name = &task_config.task_name;
+
+            if !task_names.insert(task_name.clone()) {
+                return Err(anyhow!("Duplicate task_name '{}' found", task_name));
+            }
+
+            let temp_dir = tempfile::Builder::new()
+                .prefix(&format!("{}-work-dir", task_name))
+                .tempdir_in(&job_config.checkpoint_root)?;
+
+            let task_context = TaskContext {
+                job_config: Arc::clone(&job_config),
+                config: task_config,
+                checkpoint_dir: Arc::new(temp_dir),
+                metrics: metrics.clone(),
+                package_store: package_store.clone(),
+            };
+
+            processors.push(task_context.create_analytics_processor().await?);
+        }
+
+        Ok(processors)
+    }
+
+    // Convenience method to get task configs for compatibility
+    pub fn task_configs(&self) -> &[TaskConfig] {
+        &self.task_configs
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskConfig {
+    /// Name of the task. Must be unique per process. Used to identify tasks in the Progress Store.
+    pub task_name: String,
+    /// Type of data to write i.e. checkpoint, object, transaction, etc
+    pub file_type: FileType,
+    /// File format to store data in i.e. csv, parquet, etc
+    #[serde(default = "default_file_format")]
+    pub file_format: FileFormat,
+    /// Number of checkpoints to process before uploading to the datastore.
+    #[serde(default = "default_checkpoint_interval")]
+    pub checkpoint_interval: u64,
+    /// Maximum file size in mb before uploading to the datastore.
+    #[serde(default = "default_max_file_size_mb")]
+    pub max_file_size_mb: u64,
+    /// Checkpoint sequence number to start the download from
+    pub starting_checkpoint_seq_num: Option<u64>,
+    /// Time to process in seconds before uploding to the datastore.
+    #[serde(default = "default_time_interval_s")]
+    pub time_interval_s: u64,
+    /// Remote object store path prefix to use while writing
+    #[serde(default)]
+    remote_store_path_prefix: Option<PathBuf>,
+    pub bq_table_id: Option<String>,
+    pub bq_checkpoint_col_id: Option<String>,
+    #[serde(default)]
+    pub report_bq_max_table_checkpoint: bool,
+    pub sf_table_id: Option<String>,
+    pub sf_checkpoint_col_id: Option<String>,
+    #[serde(default)]
+    pub report_sf_max_table_checkpoint: bool,
+    pub package_id_filter: Option<String>,
+}
+
 impl TaskConfig {
     pub fn remote_store_path_prefix(&self) -> Result<Option<Path>> {
         self.remote_store_path_prefix
@@ -186,31 +223,198 @@ impl TaskConfig {
             .map(|pb| Ok(Path::from_filesystem_path(pb)?))
             .transpose()
     }
+}
 
-    pub fn checkpoint_dir(&self) -> Result<&std::path::Path> {
-        // If we already have an initialized temp dir, return it
-        if let Some(temp_dir) = self.checkpoint_dir.get() {
-            return Ok(temp_dir.path());
-        }
+pub struct TaskContext {
+    pub config: TaskConfig,
+    pub job_config: Arc<JobConfig>,
+    pub checkpoint_dir: Arc<TempDir>,
+    pub metrics: AnalyticsMetrics,
+    pub package_store: LocalDBPackageStore,
+}
 
-        // Otherwise, create a new temp dir
-        let temp_dir = tempfile::Builder::new()
-            // Task name is validated at start up to ensure it is unique.
-            .prefix(&format!("{}-work-dir", self.task_name))
-            .tempdir_in(&self.checkpoint_root)?;
+impl TaskContext {
+    pub fn checkpoint_dir_path(&self) -> &std::path::Path {
+        self.checkpoint_dir.path()
+    }
 
-        // Try to set it in the OnceLock
-        let new_temp_dir = Arc::new(temp_dir);
-        match self.checkpoint_dir.set(new_temp_dir) {
-            Ok(()) => {
-                // We successfully set the value
-                Ok(self.checkpoint_dir.get().unwrap().path())
+    pub fn task_name(&self) -> &str {
+        &self.config.task_name
+    }
+
+    pub async fn create_analytics_processor(self) -> Result<Processor> {
+        match &self.config.file_type {
+            FileType::Checkpoint => {
+                self.create_processor_for_handler(Box::new(CheckpointHandler::new()))
+                    .await
             }
-            Err(_) => {
-                // Another thread set the value first - use that one
-                Ok(self.checkpoint_dir.get().unwrap().path())
+            FileType::Object => {
+                let package_id_filter = self.config.package_id_filter.clone();
+                let package_store = self.package_store.clone();
+                self.create_processor_for_handler(Box::new(ObjectHandler::new(
+                    package_store,
+                    &package_id_filter,
+                )))
+                .await
+            }
+            FileType::Transaction => {
+                self.create_processor_for_handler(Box::new(TransactionHandler::new()))
+                    .await
+            }
+            FileType::Event => {
+                let package_store = self.package_store.clone();
+                self.create_processor_for_handler(Box::new(EventHandler::new(package_store)))
+                    .await
+            }
+            FileType::TransactionObjects => {
+                self.create_processor_for_handler(Box::new(TransactionObjectsHandler::new()))
+                    .await
+            }
+            FileType::MoveCall => {
+                self.create_processor_for_handler(Box::new(MoveCallHandler::new()))
+                    .await
+            }
+            FileType::MovePackage => {
+                self.create_processor_for_handler(Box::new(PackageHandler::new()))
+                    .await
+            }
+            FileType::DynamicField => {
+                let package_store = self.package_store.clone();
+                self.create_processor_for_handler(Box::new(DynamicFieldHandler::new(package_store)))
+                    .await
+            }
+            FileType::WrappedObject => {
+                let package_store = self.package_store.clone();
+                self.create_processor_for_handler(Box::new(WrappedObjectHandler::new(
+                    package_store,
+                )))
+                .await
             }
         }
+    }
+
+    async fn create_processor_for_handler<T: Serialize + Clone + ParquetSchema + 'static>(
+        self,
+        handler: Box<dyn AnalyticsHandler<T>>,
+    ) -> Result<Processor> {
+        let starting_checkpoint_seq_num = self.get_starting_checkpoint_seq_num().await?;
+        let writer = self.make_writer::<T>(starting_checkpoint_seq_num)?;
+        let max_checkpoint_reader = self.make_max_checkpoint_reader().await?;
+        Processor::new::<T>(
+            handler,
+            writer,
+            max_checkpoint_reader,
+            starting_checkpoint_seq_num,
+            self,
+        )
+        .await
+    }
+
+    async fn get_starting_checkpoint_seq_num(&self) -> Result<u64> {
+        let remote_latest = read_store_for_checkpoint(
+            &self.job_config.remote_store_config,
+            self.config.file_type,
+            self.config.remote_store_path_prefix()?.as_ref(),
+        )
+        .await?;
+
+        Ok(self
+            .config
+            .starting_checkpoint_seq_num
+            .map_or(remote_latest, |start| start.max(remote_latest)))
+    }
+
+    fn make_writer<S: Serialize + ParquetSchema>(
+        &self,
+        starting_checkpoint_seq_num: u64,
+    ) -> Result<Box<dyn AnalyticsWriter<S>>> {
+        Ok(match self.config.file_format {
+            FileFormat::CSV => Box::new(CSVWriter::new(
+                self.checkpoint_dir_path(),
+                self.config.file_type,
+                starting_checkpoint_seq_num,
+            )?),
+            FileFormat::PARQUET => Box::new(ParquetWriter::new(
+                self.checkpoint_dir_path(),
+                self.config.file_type,
+                starting_checkpoint_seq_num,
+            )?),
+        })
+    }
+
+    async fn make_max_checkpoint_reader(&self) -> Result<Box<dyn MaxCheckpointReader>> {
+        let res: Box<dyn MaxCheckpointReader> = if self.config.report_bq_max_table_checkpoint {
+            Box::new(
+                BQMaxCheckpointReader::new(
+                    self.job_config
+                        .bq_service_account_key_file
+                        .as_ref()
+                        .ok_or(anyhow!("Missing gcp key file"))?,
+                    self.job_config
+                        .bq_project_id
+                        .as_ref()
+                        .ok_or(anyhow!("Missing big query project id"))?,
+                    self.job_config
+                        .bq_dataset_id
+                        .as_ref()
+                        .ok_or(anyhow!("Missing big query dataset id"))?,
+                    self.config
+                        .bq_table_id
+                        .as_ref()
+                        .ok_or(anyhow!("Missing big query table id"))?,
+                    self.config
+                        .bq_checkpoint_col_id
+                        .as_ref()
+                        .ok_or(anyhow!("Missing big query checkpoint col id"))?,
+                )
+                .await?,
+            )
+        } else if self.config.report_sf_max_table_checkpoint {
+            Box::new(
+                SnowflakeMaxCheckpointReader::new(
+                    self.job_config
+                        .sf_account_identifier
+                        .as_ref()
+                        .ok_or(anyhow!("Missing sf account identifier"))?,
+                    self.job_config
+                        .sf_warehouse
+                        .as_ref()
+                        .ok_or(anyhow!("Missing sf warehouse"))?,
+                    self.job_config
+                        .sf_database
+                        .as_ref()
+                        .ok_or(anyhow!("Missing sf database"))?,
+                    self.job_config
+                        .sf_schema
+                        .as_ref()
+                        .ok_or(anyhow!("Missing sf schema"))?,
+                    self.job_config
+                        .sf_username
+                        .as_ref()
+                        .ok_or(anyhow!("Missing sf username"))?,
+                    self.job_config
+                        .sf_role
+                        .as_ref()
+                        .ok_or(anyhow!("Missing sf role"))?,
+                    self.job_config
+                        .sf_password
+                        .as_ref()
+                        .ok_or(anyhow!("Missing sf password"))?,
+                    self.config
+                        .sf_table_id
+                        .as_ref()
+                        .ok_or(anyhow!("Missing sf table id"))?,
+                    self.config
+                        .sf_checkpoint_col_id
+                        .as_ref()
+                        .ok_or(anyhow!("Missing sf checkpoint col id"))?,
+                )
+                .await?,
+            )
+        } else {
+            Box::new(NoOpCheckpointReader {})
+        };
+        Ok(res)
     }
 }
 
@@ -560,20 +764,16 @@ impl Processor {
         writer: Box<dyn AnalyticsWriter<S>>,
         max_checkpoint_reader: Box<dyn MaxCheckpointReader>,
         starting_checkpoint_seq_num: CheckpointSequenceNumber,
-        metrics: AnalyticsMetrics,
-        config: Arc<AnalyticsIndexerConfig>,
-        task_config: Arc<TaskConfig>,
+        task: TaskContext,
     ) -> Result<Self> {
-        let task_name = task_config.task_name.clone();
+        let task_name = task.config.task_name.clone();
         let processor = Box::new(
             AnalyticsProcessor::new(
                 handler,
                 writer,
                 max_checkpoint_reader,
                 starting_checkpoint_seq_num,
-                metrics,
-                config,
-                task_config,
+                task,
             )
             .await?,
         );
@@ -616,380 +816,6 @@ pub async fn read_store_for_checkpoint(
         .map(|r| r.end)
         .unwrap_or(0);
     Ok(next_checkpoint_seq_num)
-}
-
-pub async fn make_max_checkpoint_reader(
-    config: &AnalyticsIndexerConfig,
-    task_config: &TaskConfig,
-) -> Result<Box<dyn MaxCheckpointReader>> {
-    let res: Box<dyn MaxCheckpointReader> = if task_config.report_bq_max_table_checkpoint {
-        Box::new(
-            BQMaxCheckpointReader::new(
-                config
-                    .bq_service_account_key_file
-                    .as_ref()
-                    .ok_or(anyhow!("Missing gcp key file"))?,
-                config
-                    .bq_project_id
-                    .as_ref()
-                    .ok_or(anyhow!("Missing big query project id"))?,
-                config
-                    .bq_dataset_id
-                    .as_ref()
-                    .ok_or(anyhow!("Missing big query dataset id"))?,
-                task_config
-                    .bq_table_id
-                    .as_ref()
-                    .ok_or(anyhow!("Missing big query table id"))?,
-                task_config
-                    .bq_checkpoint_col_id
-                    .as_ref()
-                    .ok_or(anyhow!("Missing big query checkpoint col id"))?,
-            )
-            .await?,
-        )
-    } else if task_config.report_sf_max_table_checkpoint {
-        Box::new(
-            SnowflakeMaxCheckpointReader::new(
-                config
-                    .sf_account_identifier
-                    .as_ref()
-                    .ok_or(anyhow!("Missing sf account identifier"))?,
-                config
-                    .sf_warehouse
-                    .as_ref()
-                    .ok_or(anyhow!("Missing sf warehouse"))?,
-                config
-                    .sf_database
-                    .as_ref()
-                    .ok_or(anyhow!("Missing sf database"))?,
-                config
-                    .sf_schema
-                    .as_ref()
-                    .ok_or(anyhow!("Missing sf schema"))?,
-                config
-                    .sf_username
-                    .as_ref()
-                    .ok_or(anyhow!("Missing sf username"))?,
-                config.sf_role.as_ref().ok_or(anyhow!("Missing sf role"))?,
-                config
-                    .sf_password
-                    .as_ref()
-                    .ok_or(anyhow!("Missing sf password"))?,
-                task_config
-                    .sf_table_id
-                    .as_ref()
-                    .ok_or(anyhow!("Missing sf table id"))?,
-                task_config
-                    .sf_checkpoint_col_id
-                    .as_ref()
-                    .ok_or(anyhow!("Missing sf checkpoint col id"))?,
-            )
-            .await?,
-        )
-    } else {
-        Box::new(NoOpCheckpointReader {})
-    };
-    Ok(res)
-}
-
-pub async fn make_checkpoint_processor(
-    config: Arc<AnalyticsIndexerConfig>,
-    task_config: Arc<TaskConfig>,
-    metrics: AnalyticsMetrics,
-) -> Result<Processor> {
-    let handler: Box<dyn AnalyticsHandler<CheckpointEntry>> = Box::new(CheckpointHandler::new());
-    let starting_checkpoint_seq_num =
-        get_starting_checkpoint_seq_num(&config.remote_store_config, &task_config).await?;
-    let writer = make_writer::<CheckpointEntry>(
-        &task_config,
-        FileType::Checkpoint,
-        starting_checkpoint_seq_num,
-    )?;
-    let max_checkpoint_reader = make_max_checkpoint_reader(&config, &task_config).await?;
-    Processor::new::<CheckpointEntry>(
-        handler,
-        writer,
-        max_checkpoint_reader,
-        starting_checkpoint_seq_num,
-        metrics,
-        config,
-        task_config,
-    )
-    .await
-}
-
-pub async fn make_transaction_processor(
-    config: Arc<AnalyticsIndexerConfig>,
-    task_config: Arc<TaskConfig>,
-    metrics: AnalyticsMetrics,
-) -> Result<Processor> {
-    let handler: Box<dyn AnalyticsHandler<TransactionEntry>> = Box::new(TransactionHandler::new());
-    let starting_checkpoint_seq_num =
-        get_starting_checkpoint_seq_num(&config.remote_store_config, &task_config).await?;
-    let writer = make_writer::<TransactionEntry>(
-        &task_config,
-        FileType::Transaction,
-        starting_checkpoint_seq_num,
-    )?;
-    let max_checkpoint_reader = make_max_checkpoint_reader(&config, &task_config).await?;
-    Processor::new::<TransactionEntry>(
-        handler,
-        writer,
-        max_checkpoint_reader,
-        starting_checkpoint_seq_num,
-        metrics,
-        config,
-        task_config,
-    )
-    .await
-}
-
-pub async fn make_object_processor(
-    package_store: LocalDBPackageStore,
-    config: Arc<AnalyticsIndexerConfig>,
-    task_config: Arc<TaskConfig>,
-    metrics: AnalyticsMetrics,
-) -> Result<Processor> {
-    let handler: Box<dyn AnalyticsHandler<ObjectEntry>> = Box::new(ObjectHandler::new(
-        package_store,
-        &task_config.package_id_filter,
-    ));
-    let starting_checkpoint_seq_num =
-        get_starting_checkpoint_seq_num(&config.remote_store_config, &task_config).await?;
-    let writer =
-        make_writer::<ObjectEntry>(&task_config, FileType::Object, starting_checkpoint_seq_num)?;
-    let max_checkpoint_reader = make_max_checkpoint_reader(&config, &task_config).await?;
-    Processor::new::<ObjectEntry>(
-        handler,
-        writer,
-        max_checkpoint_reader,
-        starting_checkpoint_seq_num,
-        metrics,
-        config,
-        task_config,
-    )
-    .await
-}
-
-pub async fn make_event_processor(
-    package_store: LocalDBPackageStore,
-    config: Arc<AnalyticsIndexerConfig>,
-    task_config: Arc<TaskConfig>,
-    metrics: AnalyticsMetrics,
-) -> Result<Processor> {
-    let handler: Box<dyn AnalyticsHandler<EventEntry>> = Box::new(EventHandler::new(package_store));
-    let starting_checkpoint_seq_num =
-        get_starting_checkpoint_seq_num(&config.remote_store_config, &task_config).await?;
-    let writer =
-        make_writer::<EventEntry>(&task_config, FileType::Event, starting_checkpoint_seq_num)?;
-    let max_checkpoint_reader = make_max_checkpoint_reader(&config, &task_config).await?;
-    Processor::new::<EventEntry>(
-        handler,
-        writer,
-        max_checkpoint_reader,
-        starting_checkpoint_seq_num,
-        metrics,
-        config,
-        task_config,
-    )
-    .await
-}
-
-pub async fn make_transaction_objects_processor(
-    config: Arc<AnalyticsIndexerConfig>,
-    task_config: Arc<TaskConfig>,
-    metrics: AnalyticsMetrics,
-) -> Result<Processor> {
-    let starting_checkpoint_seq_num =
-        get_starting_checkpoint_seq_num(&config.remote_store_config, &task_config).await?;
-    let handler = Box::new(TransactionObjectsHandler::new());
-    let writer = make_writer(
-        &task_config,
-        FileType::TransactionObjects,
-        starting_checkpoint_seq_num,
-    )?;
-    let max_checkpoint_reader = make_max_checkpoint_reader(&config, &task_config).await?;
-    Processor::new::<TransactionObjectEntry>(
-        handler,
-        writer,
-        max_checkpoint_reader,
-        starting_checkpoint_seq_num,
-        metrics,
-        config,
-        task_config,
-    )
-    .await
-}
-
-pub async fn make_move_package_processor(
-    config: Arc<AnalyticsIndexerConfig>,
-    task_config: Arc<TaskConfig>,
-    metrics: AnalyticsMetrics,
-) -> Result<Processor> {
-    let handler: Box<dyn AnalyticsHandler<MovePackageEntry>> = Box::new(PackageHandler::new());
-    let starting_checkpoint_seq_num =
-        get_starting_checkpoint_seq_num(&config.remote_store_config, &task_config).await?;
-    let writer = make_writer::<MovePackageEntry>(
-        &task_config,
-        FileType::MovePackage,
-        starting_checkpoint_seq_num,
-    )?;
-    let max_checkpoint_reader = make_max_checkpoint_reader(&config, &task_config).await?;
-    Processor::new::<MovePackageEntry>(
-        handler,
-        writer,
-        max_checkpoint_reader,
-        starting_checkpoint_seq_num,
-        metrics,
-        config,
-        task_config,
-    )
-    .await
-}
-
-pub async fn make_move_call_processor(
-    config: Arc<AnalyticsIndexerConfig>,
-    task_config: Arc<TaskConfig>,
-    metrics: AnalyticsMetrics,
-) -> Result<Processor> {
-    let starting_checkpoint_seq_num =
-        get_starting_checkpoint_seq_num(&config.remote_store_config, &task_config).await?;
-    let handler: Box<dyn AnalyticsHandler<MoveCallEntry>> = Box::new(MoveCallHandler::new());
-    let writer = make_writer::<MoveCallEntry>(
-        &task_config,
-        FileType::MoveCall,
-        starting_checkpoint_seq_num,
-    )?;
-    let max_checkpoint_reader = make_max_checkpoint_reader(&config, &task_config).await?;
-    Processor::new::<MoveCallEntry>(
-        handler,
-        writer,
-        max_checkpoint_reader,
-        starting_checkpoint_seq_num,
-        metrics,
-        config,
-        task_config,
-    )
-    .await
-}
-
-pub async fn make_dynamic_field_processor(
-    package_store: LocalDBPackageStore,
-    config: Arc<AnalyticsIndexerConfig>,
-    task_config: Arc<TaskConfig>,
-    metrics: AnalyticsMetrics,
-) -> Result<Processor> {
-    let starting_checkpoint_seq_num =
-        get_starting_checkpoint_seq_num(&config.remote_store_config, &task_config).await?;
-    let handler: Box<dyn AnalyticsHandler<DynamicFieldEntry>> =
-        Box::new(DynamicFieldHandler::new(package_store));
-    let writer = make_writer::<DynamicFieldEntry>(
-        &task_config,
-        FileType::DynamicField,
-        starting_checkpoint_seq_num,
-    )?;
-    let max_checkpoint_reader = make_max_checkpoint_reader(&config, &task_config).await?;
-    Processor::new::<DynamicFieldEntry>(
-        handler,
-        writer,
-        max_checkpoint_reader,
-        starting_checkpoint_seq_num,
-        metrics,
-        config,
-        task_config,
-    )
-    .await
-}
-
-pub async fn make_wrapped_object_processor(
-    config: Arc<AnalyticsIndexerConfig>,
-    task_config: Arc<TaskConfig>,
-    metrics: AnalyticsMetrics,
-) -> Result<Processor> {
-    let starting_checkpoint_seq_num =
-        get_starting_checkpoint_seq_num(&config.remote_store_config, &task_config).await?;
-    let handler: Box<dyn AnalyticsHandler<WrappedObjectEntry>> = Box::new(
-        WrappedObjectHandler::new(&config.package_cache_path, &config.rest_url),
-    );
-    let writer = make_writer::<WrappedObjectEntry>(
-        &task_config,
-        FileType::WrappedObject,
-        starting_checkpoint_seq_num,
-    )?;
-    let max_checkpoint_reader = make_max_checkpoint_reader(&config, &task_config).await?;
-    Processor::new::<WrappedObjectEntry>(
-        handler,
-        writer,
-        max_checkpoint_reader,
-        starting_checkpoint_seq_num,
-        metrics,
-        config,
-        task_config,
-    )
-    .await
-}
-
-pub fn make_writer<S: Serialize + ParquetSchema>(
-    task_config: &TaskConfig,
-    file_type: FileType,
-    starting_checkpoint_seq_num: u64,
-) -> Result<Box<dyn AnalyticsWriter<S>>> {
-    Ok(match task_config.file_format {
-        FileFormat::CSV => Box::new(CSVWriter::new(
-            task_config.checkpoint_dir()?,
-            file_type,
-            starting_checkpoint_seq_num,
-        )?),
-        FileFormat::PARQUET => Box::new(ParquetWriter::new(
-            task_config.checkpoint_dir()?,
-            file_type,
-            starting_checkpoint_seq_num,
-        )?),
-    })
-}
-
-pub async fn get_starting_checkpoint_seq_num(
-    object_store_config: &ObjectStoreConfig,
-    task_config: &TaskConfig,
-) -> Result<u64> {
-    let remote_latest = read_store_for_checkpoint(
-        object_store_config,
-        task_config.file_type,
-        task_config.remote_store_path_prefix()?.as_ref(),
-    )
-    .await?;
-
-    Ok(task_config
-        .starting_checkpoint_seq_num
-        .map_or(remote_latest, |start| start.max(remote_latest)))
-}
-
-pub async fn make_analytics_processor(
-    package_store: LocalDBPackageStore,
-    config: Arc<AnalyticsIndexerConfig>,
-    task_config: Arc<TaskConfig>,
-    metrics: AnalyticsMetrics,
-) -> Result<Processor> {
-    match task_config.file_type {
-        FileType::Checkpoint => make_checkpoint_processor(config, task_config, metrics).await,
-        FileType::Object => {
-            make_object_processor(package_store, config, task_config, metrics).await
-        }
-        FileType::Transaction => make_transaction_processor(config, task_config, metrics).await,
-        FileType::Event => make_event_processor(package_store, config, task_config, metrics).await,
-        FileType::TransactionObjects => {
-            make_transaction_objects_processor(config, task_config, metrics).await
-        }
-        FileType::MoveCall => make_move_call_processor(config, task_config, metrics).await,
-        FileType::MovePackage => make_move_package_processor(config, task_config, metrics).await,
-        FileType::DynamicField => {
-            make_dynamic_field_processor(package_store, config, task_config, metrics).await
-        }
-        FileType::WrappedObject => {
-            make_wrapped_object_processor(config, task_config, metrics).await
-        }
-    }
 }
 
 pub fn join_paths(base: Option<&Path>, child: &Path) -> Path {

--- a/crates/sui-analytics-indexer/src/lib.rs
+++ b/crates/sui-analytics-indexer/src/lib.rs
@@ -204,7 +204,7 @@ pub struct TaskConfig {
     pub time_interval_s: u64,
     /// Remote object store path prefix to use while writing
     #[serde(default)]
-    remote_store_path_prefix: Option<PathBuf>,
+    remote_store_path_prefix: Option<String>,
     pub bq_table_id: Option<String>,
     pub bq_checkpoint_col_id: Option<String>,
     #[serde(default)]
@@ -220,7 +220,7 @@ impl TaskConfig {
     pub fn remote_store_path_prefix(&self) -> Result<Option<Path>> {
         self.remote_store_path_prefix
             .as_ref()
-            .map(|pb| Ok(Path::from_filesystem_path(pb)?))
+            .map(|pb| Ok(Path::from(pb.as_str())))
             .transpose()
     }
 }

--- a/crates/sui-analytics-indexer/src/main.rs
+++ b/crates/sui-analytics-indexer/src/main.rs
@@ -43,7 +43,10 @@ async fn main() -> Result<()> {
 
     let mut watermarks = HashMap::new();
     for processor in processors.iter() {
-        let watermark = processor.last_committed_checkpoint().unwrap_or_default() + 1;
+        let watermark = processor
+            .last_committed_checkpoint()
+            .map(|seq_num| seq_num + 1)
+            .unwrap_or(0);
         watermarks.insert(processor.task_name.clone(), watermark);
     }
 

--- a/crates/sui-analytics-indexer/src/main.rs
+++ b/crates/sui-analytics-indexer/src/main.rs
@@ -1,13 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use prometheus::Registry;
-use std::{collections::HashMap, env, sync::Arc};
-use sui_analytics_indexer::{
-    analytics_metrics::AnalyticsMetrics, errors::AnalyticsIndexerError, make_analytics_processor,
-    package_store::LocalDBPackageStore, AnalyticsIndexerConfig,
-};
+use std::{collections::HashMap, env};
+use sui_analytics_indexer::{analytics_metrics::AnalyticsMetrics, JobConfig};
 use sui_data_ingestion_core::{
     DataIngestionMetrics, IndexerExecutor, ReaderOptions, ShimIndexerProgressStore, WorkerPool,
 };
@@ -22,8 +19,12 @@ async fn main() -> Result<()> {
 
     let args: Vec<String> = env::args().collect();
     assert_eq!(args.len(), 2, "configuration yaml file is required");
-    let config: AnalyticsIndexerConfig = serde_yaml::from_str(&std::fs::read_to_string(&args[1])?)?;
+
+    // Parse the config
+    let config: JobConfig = serde_yaml::from_str(&std::fs::read_to_string(&args[1])?)?;
     info!("Parsed config: {:#?}", config);
+
+    // Setup metrics
     let registry_service = mysten_metrics::start_prometheus_server(
         format!(
             "{}:{}",
@@ -34,43 +35,30 @@ async fn main() -> Result<()> {
     );
     let registry: Registry = registry_service.default_registry();
     mysten_metrics::init_metrics(&registry);
+    let metrics = AnalyticsMetrics::new(&registry);
+
+    let remote_store_url = config.remote_store_url.clone();
+
+    let processors = config.create_checkpoint_processors(metrics).await?;
 
     let mut watermarks = HashMap::new();
-    let mut processors = Vec::new();
-    let config = Arc::new(config);
-    let metrics = AnalyticsMetrics::new(&registry);
-    let package_store = LocalDBPackageStore::new(&config.package_cache_path, &config.rest_url);
-    for task_config in config.tasks.clone() {
-        let task_name = task_config.task_name.clone();
-        let processor = make_analytics_processor(
-            package_store.clone(),
-            config.clone(),
-            task_config,
-            metrics.clone(),
-        )
-        .await
-        .map_err(|e| AnalyticsIndexerError::GenericError(e.to_string()))?;
+    for processor in processors.iter() {
         let watermark = processor.last_committed_checkpoint().unwrap_or_default() + 1;
-        if watermarks.insert(task_name.clone(), watermark).is_some() {
-            return Err(anyhow!("Duplicate task_name '{}' found", task_name));
-        }
-        processors.push(processor);
+        watermarks.insert(processor.task_name.clone(), watermark);
     }
 
     let progress_store = ShimIndexerProgressStore::new(watermarks);
     let mut executor = IndexerExecutor::new(
         progress_store,
-        config.tasks.len(),
+        processors.len(),
         DataIngestionMetrics::new(&Registry::new()),
     );
 
-    for processor in processors.into_iter() {
+    for processor in processors {
         let task_name = processor.task_name.clone();
         let worker_pool = WorkerPool::new(processor, task_name, 1);
         executor.register(worker_pool).await?;
     }
-
-    let remote_store_url = config.remote_store_url.clone();
 
     let reader_options = ReaderOptions {
         batch_size: 10,


### PR DESCRIPTION
## Description

No-op refactor that reduces overall LoC by like ~200 and makes it easier to change the pipeline initialization code.

* Introduces a new "TaskContext" struct that groups the process-level config with a single task's config, along with other task-specific structs like metrics, them TempDir, etc. This allows us to pass the single context struct everywhere instead of 4+ indepedent structs. 
* Eliminates need for the OnceLock introduced in [pull/21577](https://github.com/MystenLabs/sui/pull/21577)
* Makes it so we only need to define the checkpoint_root config once at the job level instead of repeating it on each task's config.
* "Eagerly" create the checkpoint_dirs when the process starts rather than "lazily"


## Test plan

Manual testing
