### PR TITLE
Fix analytics pipeline initialization bug

### DIFF
--- a/crates/sui-analytics-indexer/src/lib.rs
+++ b/crates/sui-analytics-indexer/src/lib.rs
@@ -204,7 +204,7 @@ pub struct TaskConfig {
     pub time_interval_s: u64,
     /// Remote object store path prefix to use while writing
     #[serde(default)]
-    remote_store_path_prefix: Option<PathBuf>,
+    remote_store_path_prefix: Option<String>,
     pub bq_table_id: Option<String>,
     pub bq_checkpoint_col_id: Option<String>,
     #[serde(default)]
@@ -220,7 +220,7 @@ impl TaskConfig {
     pub fn remote_store_path_prefix(&self) -> Result<Option<Path>> {
         self.remote_store_path_prefix
             .as_ref()
-            .map(|pb| Ok(Path::from_filesystem_path(pb)?))
+            .map(|pb| Ok(Path::from(pb.as_str())))
             .transpose()
     }
 }

--- a/crates/sui-analytics-indexer/src/main.rs
+++ b/crates/sui-analytics-indexer/src/main.rs
@@ -43,7 +43,10 @@ async fn main() -> Result<()> {
 
     let mut watermarks = HashMap::new();
     for processor in processors.iter() {
-        let watermark = processor.last_committed_checkpoint().unwrap_or_default() + 1;
+        let watermark = processor
+            .last_committed_checkpoint()
+            .map(|seq_num| seq_num + 1)
+            .unwrap_or(0);
         watermarks.insert(processor.task_name.clone(), watermark);
     }
 


### PR DESCRIPTION
## Description

There is a long-standing off-by-1 bug when initializing a new pipeline. The pipeline would be initialized to process checkpoint 1 first instead of checkpoint 0 first in the case where there was no existing state for the pipeline in the object store. This causes a panic which causes the whole process to crash on release builds.

This PR just fixes the off-by-1 bug.

## Test plan

Manually verified the off-by-1 bug no longer occurs
