### PR TITLE
[CLI] Fix the --dump-bytecode-as-base64 to work with implicit deps

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -2027,7 +2027,9 @@ pub(crate) async fn compile_package(
 
 /// Return the correct implicit dependencies for the [version], producing a warning or error if the
 /// protocol version is unknown or old
-fn implicit_deps_for_protocol_version(version: ProtocolVersion) -> anyhow::Result<Dependencies> {
+pub(crate) fn implicit_deps_for_protocol_version(
+    version: ProtocolVersion,
+) -> anyhow::Result<Dependencies> {
     if version > ProtocolVersion::MAX + 2 {
         eprintln!(
             "[{}]: The network is using protocol version {:?}, but this binary only recognizes protocol version {:?}; \

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -519,8 +519,10 @@ impl SuiCommand {
                         };
 
                         let rerooted_path = move_cli::base::reroot_path(package_path.as_deref())?;
-                        let build_config =
+                        let mut build_config =
                             resolve_lock_file_path(build_config, Some(&rerooted_path))?;
+                        build_config.implicit_dependencies =
+                            implicit_deps(latest_system_packages());
                         let mut pkg = SuiBuildConfig {
                             config: build_config,
                             run_bytecode_verifier: true,

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::client_commands::{pkg_tree_shake, SuiClientCommands};
+use crate::client_commands::{
+    implicit_deps_for_protocol_version, pkg_tree_shake, SuiClientCommands,
+};
 use crate::fire_drill::{run_fire_drill, FireDrill};
 use crate::genesis_ceremony::{run, Ceremony};
 use crate::keytool::KeyToolCommand;
@@ -521,8 +523,10 @@ impl SuiCommand {
                         let rerooted_path = move_cli::base::reroot_path(package_path.as_deref())?;
                         let mut build_config =
                             resolve_lock_file_path(build_config, Some(&rerooted_path))?;
+                        let protocol_config = read_api.get_protocol_config(None).await?;
                         build_config.implicit_dependencies =
-                            implicit_deps(latest_system_packages());
+                            implicit_deps_for_protocol_version(protocol_config.protocol_version)?;
+
                         let mut pkg = SuiBuildConfig {
                             config: build_config,
                             run_bytecode_verifier: true,


### PR DESCRIPTION
## Description 

The `--dump-bytecode-as-base64` lives in the `sui_commands.rs` in the CLI because of the need to pass in a client to have access to the network. We forgot to add the implicit deps flag there, which this PR fixes.

Should fix and close #21581

## Test plan 

Locally

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
