### PR TITLE
Implement authentication checks for ConsensusV2 objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12491,6 +12491,7 @@ dependencies = [
  "move-vm-profiler",
  "move-vm-runtime",
  "move-vm-types",
+ "mysten-common",
  "mysten-metrics",
  "parking_lot 0.12.3",
  "serde",

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1662,6 +1662,8 @@ impl AuthorityState {
         tx_data.validity_check(epoch_store.protocol_config())?;
 
         // The cost of partially re-auditing a transaction before execution is tolerated.
+        // This step is required for correctness because, for example, ConsensusV2 object
+        // owner may have changed between signing and execution.
         let (gas_status, input_objects) = sui_transaction_checks::check_certificate_input(
             certificate,
             input_objects,

--- a/crates/sui-core/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_tests.rs
@@ -390,7 +390,7 @@ pub fn init_move_call_transaction(
 async fn do_transaction_test_skip_cert_checks(
     pre_sign_mutations: impl Fn(&mut TransactionData),
     post_sign_mutations: impl Fn(&mut Transaction),
-    err_check: impl Fn(&SuiError) + Clone + 'static,
+    err_check: impl Fn(&SuiError),
 ) {
     let (sender1, sender_key1): (_, AccountKeyPair) = get_key_pair();
     let (sender2, sender_key2): (_, AccountKeyPair) = get_key_pair();
@@ -410,7 +410,7 @@ async fn do_transaction_test_skip_cert_checks(
 async fn do_transaction_test(
     pre_sign_mutations: impl Fn(&mut TransactionData),
     post_sign_mutations: impl Fn(&mut Transaction),
-    err_check: impl Fn(&SuiError) + Clone + 'static,
+    err_check: impl Fn(&SuiError),
 ) {
     let (sender1, sender_key1): (_, AccountKeyPair) = get_key_pair();
     let (sender2, sender_key2): (_, AccountKeyPair) = get_key_pair();

--- a/crates/sui-core/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_tests.rs
@@ -13,6 +13,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::ops::Deref;
 use sui_types::crypto::{PublicKey, SuiSignature, ToFromBytes, ZkLoginPublicIdentifier};
 use sui_types::messages_grpc::HandleSoftBundleCertificatesRequestV3;
+use sui_types::object::Authenticator;
 use sui_types::utils::get_one_zklogin_inputs;
 use sui_types::{
     authenticator_state::ActiveJwk,
@@ -71,7 +72,6 @@ pub use crate::authority::authority_test_utils::init_state_with_ids;
 #[sim_test]
 async fn test_handle_transfer_transaction_bad_signature() {
     do_transaction_test(
-        1,
         |_| {},
         |mut_tx| {
             let (_unknown_address, unknown_key): (_, AccountKeyPair) = get_key_pair();
@@ -89,7 +89,6 @@ async fn test_handle_transfer_transaction_bad_signature() {
 #[sim_test]
 async fn test_handle_transfer_transaction_no_signature() {
     do_transaction_test(
-        1,
         |_| {},
         |tx| {
             *tx.data_mut_for_testing().tx_signatures_mut_for_testing() = vec![];
@@ -110,7 +109,6 @@ async fn test_handle_transfer_transaction_no_signature() {
 #[sim_test]
 async fn test_handle_transfer_transaction_extra_signature() {
     do_transaction_test(
-        1,
         |_| {},
         |tx| {
             let sigs = tx.data_mut_for_testing().tx_signatures_mut_for_testing();
@@ -132,7 +130,6 @@ async fn test_handle_transfer_transaction_extra_signature() {
 #[sim_test]
 async fn test_empty_gas_data() {
     do_transaction_test_skip_cert_checks(
-        0,
         |tx| {
             tx.gas_data_mut().payment = vec![];
         },
@@ -152,7 +149,6 @@ async fn test_empty_gas_data() {
 #[sim_test]
 async fn test_duplicate_gas_data() {
     do_transaction_test_skip_cert_checks(
-        0,
         |tx| {
             let gas_data = tx.gas_data_mut();
             let new_gas = gas_data.payment[0];
@@ -174,7 +170,6 @@ async fn test_duplicate_gas_data() {
 #[sim_test]
 async fn test_gas_wrong_owner_matches_sender() {
     do_transaction_test(
-        1,
         |tx| {
             let gas_data = tx.gas_data_mut();
             let (new_addr, _): (_, AccountKeyPair) = get_key_pair();
@@ -192,7 +187,6 @@ async fn test_gas_wrong_owner_matches_sender() {
 #[sim_test]
 async fn test_gas_wrong_owner() {
     do_transaction_test(
-        1,
         |tx| {
             let gas_data = tx.gas_data_mut();
             let (new_addr, _): (_, AccountKeyPair) = get_key_pair();
@@ -283,7 +277,6 @@ async fn test_user_sends_end_of_epoch_transaction() {
 
 async fn test_user_sends_system_transaction_impl(transaction_kind: TransactionKind) {
     do_transaction_test_skip_cert_checks(
-        0,
         |tx| {
             *tx.kind_mut() = transaction_kind.clone();
         },
@@ -300,19 +293,54 @@ async fn test_user_sends_system_transaction_impl(transaction_kind: TransactionKi
     .await;
 }
 
+#[tokio::test]
+async fn test_sender_is_not_consensus_v2_owner() {
+    telemetry_subscribers::init_for_testing();
+
+    let (sender1, sender_key1): (_, AccountKeyPair) = get_key_pair();
+    let (sender2, sender_key2): (_, AccountKeyPair) = get_key_pair();
+    let start_version = SequenceNumber::new();
+    let err_check = |err: &SuiError| {
+        assert_matches!(
+            err,
+            SuiError::UserInputError {
+                error: UserInputError::IncorrectUserSignature { .. }
+            }
+        );
+    };
+    do_transaction_test_impl(
+        false, // can't test forged cert handling because consensus doesn't function in this test
+        &[(sender1, sender_key1), (sender2, sender_key2)],
+        Object::with_id_owner_version_for_testing(
+            ObjectID::random(),
+            start_version.next(),
+            Owner::ConsensusV2 {
+                start_version,
+                authenticator: Box::new(Authenticator::SingleOwner(sender1)),
+            },
+        ),
+        |_| {},
+        |_| {},
+        1,
+        1,
+        err_check,
+    )
+    .await
+}
+
 pub fn init_transfer_transaction(
     pre_sign_mutations: impl Fn(&mut TransactionData),
     sender: SuiAddress,
     secret: &AccountKeyPair,
     recipient: SuiAddress,
-    object_ref: ObjectRef,
+    full_object_ref: FullObjectRef,
     gas_object_ref: ObjectRef,
     gas_budget: u64,
     gas_price: u64,
 ) -> Transaction {
-    let mut data = TransactionData::new_transfer(
+    let mut data = TransactionData::new_transfer_full(
         recipient,
-        object_ref,
+        full_object_ref,
         sender,
         gas_object_ref,
         gas_budget,
@@ -326,10 +354,23 @@ pub fn init_move_call_transaction(
     pre_sign_mutations: impl Fn(&mut TransactionData),
     sender: SuiAddress,
     secret: &AccountKeyPair,
+    full_object_ref: FullObjectRef,
     gas_object_ref: ObjectRef,
     gas_budget: u64,
     gas_price: u64,
 ) -> Transaction {
+    let call_arg = CallArg::Object(match full_object_ref.0 {
+        FullObjectID::Fastpath(_) => ObjectArg::ImmOrOwnedObject((
+            full_object_ref.0.id(),
+            full_object_ref.1,
+            full_object_ref.2,
+        )),
+        FullObjectID::Consensus((id, initial_shared_version)) => ObjectArg::SharedObject {
+            id,
+            initial_shared_version,
+            mutable: true,
+        },
+    });
     let mut data = TransactionData::new_move_call(
         sender,
         SUI_SYSTEM_PACKAGE_ID,
@@ -337,7 +378,7 @@ pub fn init_move_call_transaction(
         ident_str!("request_add_validator").to_owned(),
         vec![],
         gas_object_ref,
-        vec![CallArg::SUI_SYSTEM_MUT],
+        vec![CallArg::SUI_SYSTEM_MUT, call_arg],
         gas_budget,
         gas_price,
     )
@@ -347,81 +388,94 @@ pub fn init_move_call_transaction(
 }
 
 async fn do_transaction_test_skip_cert_checks(
-    expected_sig_errors: u64,
     pre_sign_mutations: impl Fn(&mut TransactionData),
     post_sign_mutations: impl Fn(&mut Transaction),
-    err_check: impl Fn(&SuiError),
+    err_check: impl Fn(&SuiError) + Clone + 'static,
 ) {
+    let (sender1, sender_key1): (_, AccountKeyPair) = get_key_pair();
+    let (sender2, sender_key2): (_, AccountKeyPair) = get_key_pair();
     do_transaction_test_impl(
-        expected_sig_errors,
         false,
+        &[(sender1, sender_key1), (sender2, sender_key2)],
+        Object::with_id_owner_for_testing(ObjectID::random(), sender1),
         pre_sign_mutations,
         post_sign_mutations,
+        0,
+        1,
         err_check,
     )
     .await
 }
 
 async fn do_transaction_test(
-    expected_sig_errors: u64,
     pre_sign_mutations: impl Fn(&mut TransactionData),
     post_sign_mutations: impl Fn(&mut Transaction),
-    err_check: impl Fn(&SuiError),
+    err_check: impl Fn(&SuiError) + Clone + 'static,
 ) {
+    let (sender1, sender_key1): (_, AccountKeyPair) = get_key_pair();
+    let (sender2, sender_key2): (_, AccountKeyPair) = get_key_pair();
     do_transaction_test_impl(
-        expected_sig_errors,
         true,
+        &[(sender1, sender_key1), (sender2, sender_key2)],
+        Object::with_id_owner_for_testing(ObjectID::random(), sender1),
         pre_sign_mutations,
         post_sign_mutations,
+        0,
+        1,
         err_check,
     )
     .await
 }
 
 async fn do_transaction_test_impl(
-    _expected_sig_errors: u64,
     check_forged_cert: bool,
+    senders: &[(SuiAddress, AccountKeyPair)],
+    input_object: Object,
     pre_sign_mutations: impl Fn(&mut TransactionData),
     post_sign_mutations: impl Fn(&mut Transaction),
+    transfer_sender: usize,
+    move_call_sender: usize,
     err_check: impl Fn(&SuiError),
 ) {
     telemetry_subscribers::init_for_testing();
-    let (sender1, sender_key1): (_, AccountKeyPair) = get_key_pair();
-    let (sender2, sender_key2): (_, AccountKeyPair) = get_key_pair();
+
     let recipient = dbg_addr(2);
-    let object_id = ObjectID::random();
-    let gas_object_id1 = ObjectID::random();
-    let gas_object_id2 = ObjectID::random();
-    let authority_state = init_state_with_ids(vec![
-        (sender1, object_id),
-        (sender1, gas_object_id1),
-        (sender2, gas_object_id2),
-    ])
+    let input_object_id = input_object.id();
+    let mut gas_object_ids = Vec::new();
+    let authority_state = init_state_with_ids(senders.iter().map(|(sender, _)| {
+        let object_id = ObjectID::random();
+        gas_object_ids.push(object_id);
+        (*sender, object_id)
+    }))
     .await;
+    authority_state.insert_genesis_object(input_object).await;
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
-    let object = authority_state.get_object(&object_id).await.unwrap();
-    let gas_object1 = authority_state.get_object(&gas_object_id1).await.unwrap();
-    let gas_object2 = authority_state.get_object(&gas_object_id2).await.unwrap();
+    let object = authority_state.get_object(&input_object_id).await.unwrap();
+    let mut gas_objects = Vec::new();
+    for id in gas_object_ids {
+        gas_objects.push(authority_state.get_object(&id).await.unwrap());
+    }
 
     // Execute the test with two transactions, one transfer and one move call.
     // The move call contains access to a shared object.
     // We test both txs and expect the same error.
     let mut transfer_transaction = init_transfer_transaction(
         &pre_sign_mutations,
-        sender1,
-        &sender_key1,
+        senders[transfer_sender].0,
+        &senders[transfer_sender].1,
         recipient,
-        object.compute_object_reference(),
-        gas_object1.compute_object_reference(),
+        object.compute_full_object_reference(),
+        gas_objects[transfer_sender].compute_object_reference(),
         rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         rgp,
     );
 
     let mut move_call_transaction = init_move_call_transaction(
         &pre_sign_mutations,
-        sender2,
-        &sender_key2,
-        gas_object2.compute_object_reference(),
+        senders[move_call_sender].0,
+        &senders[move_call_sender].1,
+        object.compute_full_object_reference(),
+        gas_objects[move_call_sender].compute_object_reference(),
         rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         rgp,
     );
@@ -456,7 +510,7 @@ async fn do_transaction_test_impl(
         err_check(&err);
     }
 
-    check_locks(authority_state.clone(), vec![object_id]).await;
+    check_locks(authority_state.clone(), vec![input_object_id]).await;
 
     // now verify that the same transactions are rejected if false certificates are somehow formed and sent
     if check_forged_cert {
@@ -1405,7 +1459,7 @@ async fn test_very_large_certificate() {
         sender,
         &sender_key,
         recipient,
-        object.compute_object_reference(),
+        object.compute_full_object_reference(),
         gas_object.compute_object_reference(),
         rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         rgp,
@@ -1488,7 +1542,7 @@ async fn test_handle_certificate_errors() {
         sender,
         &sender_key,
         recipient,
-        object.compute_object_reference(),
+        object.compute_full_object_reference(),
         gas_object.compute_object_reference(),
         rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
         rgp,

--- a/crates/sui-core/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_tests.rs
@@ -442,12 +442,15 @@ async fn do_transaction_test_impl(
     let recipient = dbg_addr(2);
     let input_object_id = input_object.id();
     let mut gas_object_ids = Vec::new();
-    let authority_state = init_state_with_ids(senders.iter().map(|(sender, _)| {
-        let object_id = ObjectID::random();
-        gas_object_ids.push(object_id);
-        (*sender, object_id)
-    }))
-    .await;
+    let init_state_input: Vec<_> = senders
+        .iter()
+        .map(|(sender, _)| {
+            let object_id = ObjectID::random();
+            gas_object_ids.push(object_id);
+            (*sender, object_id)
+        })
+        .collect();
+    let authority_state = init_state_with_ids(init_state_input).await;
     authority_state.insert_genesis_object(input_object).await;
     let rgp = authority_state.reference_gas_price_for_testing().unwrap();
     let object = authority_state.get_object(&input_object_id).await.unwrap();

--- a/crates/sui-core/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_tests.rs
@@ -309,7 +309,7 @@ async fn test_sender_is_not_consensus_v2_owner() {
         );
     };
     do_transaction_test_impl(
-        false, // can't test forged cert handling because consensus doesn't function in this test
+        false,
         &[(sender1, sender_key1), (sender2, sender_key2)],
         Object::with_id_owner_version_for_testing(
             ObjectID::random(),

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -545,6 +545,17 @@ impl Owner {
         }
     }
 
+    // Returns the object's Authenticator, if it has one.
+    pub fn authenticator(&self) -> Option<&Authenticator> {
+        match self {
+            Self::ConsensusV2 { authenticator, .. } => Some(authenticator.as_ref()),
+            Self::Immutable
+            | Self::AddressOwner(_)
+            | Self::ObjectOwner(_)
+            | Self::Shared { .. } => None,
+        }
+    }
+
     pub fn is_immutable(&self) -> bool {
         matches!(self, Owner::Immutable)
     }

--- a/crates/sui-types/src/programmable_transaction_builder.rs
+++ b/crates/sui-types/src/programmable_transaction_builder.rs
@@ -10,7 +10,7 @@ use move_core_types::{ident_str, identifier::Identifier, language_storage::TypeT
 use serde::Serialize;
 
 use crate::{
-    base_types::{ObjectID, ObjectRef, SuiAddress},
+    base_types::{FullObjectID, FullObjectRef, ObjectID, ObjectRef, SuiAddress},
     move_package::PACKAGE_MODULE_NAME,
     transaction::{Argument, CallArg, Command, ObjectArg, ProgrammableTransaction},
     SUI_FRAMEWORK_PACKAGE_ID,
@@ -227,6 +227,30 @@ impl ProgrammableTransactionBuilder {
     ) -> anyhow::Result<()> {
         let rec_arg = self.pure(recipient).unwrap();
         let obj_arg = self.obj(ObjectArg::ImmOrOwnedObject(object_ref));
+        self.commands
+            .push(Command::TransferObjects(vec![obj_arg?], rec_arg));
+        Ok(())
+    }
+
+    // TODO: Merge with `transfer_object` above and update existing callers.
+    pub fn transfer_object_full(
+        &mut self,
+        recipient: SuiAddress,
+        full_object_ref: FullObjectRef,
+    ) -> anyhow::Result<()> {
+        let rec_arg = self.pure(recipient).unwrap();
+        let obj_arg = self.obj(match full_object_ref.0 {
+            FullObjectID::Fastpath(_) => ObjectArg::ImmOrOwnedObject((
+                full_object_ref.0.id(),
+                full_object_ref.1,
+                full_object_ref.2,
+            )),
+            FullObjectID::Consensus((id, initial_shared_version)) => ObjectArg::SharedObject {
+                id,
+                initial_shared_version,
+                mutable: true,
+            },
+        });
         self.commands
             .push(Command::TransferObjects(vec![obj_arg?], rec_arg));
         Ok(())

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -1785,6 +1785,25 @@ impl TransactionData {
         Self::new_programmable(sender, vec![gas_payment], pt, gas_budget, gas_price)
     }
 
+    // TODO: Merge with `new_transfer` above and update existing callers.
+    pub fn new_transfer_full(
+        recipient: SuiAddress,
+        full_object_ref: FullObjectRef,
+        sender: SuiAddress,
+        gas_payment: ObjectRef,
+        gas_budget: u64,
+        gas_price: u64,
+    ) -> Self {
+        let pt = {
+            let mut builder = ProgrammableTransactionBuilder::new();
+            builder
+                .transfer_object_full(recipient, full_object_ref)
+                .unwrap();
+            builder.finish()
+        };
+        Self::new_programmable(sender, vec![gas_payment], pt, gas_budget, gas_price)
+    }
+
     pub fn new_transfer_sui(
         recipient: SuiAddress,
         sender: SuiAddress,

--- a/sui-execution/latest/sui-adapter/Cargo.toml
+++ b/sui-execution/latest/sui-adapter/Cargo.toml
@@ -23,6 +23,7 @@ move-bytecode-verifier-meter.workspace = true
 move-core-types.workspace = true
 move-trace-format.workspace = true
 move-vm-config.workspace = true
+mysten-common.workspace = true
 mysten-metrics.workspace = true
 
 move-bytecode-verifier = { path = "../../../external-crates/move/crates/move-bytecode-verifier" }

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -45,11 +45,11 @@ mod checked {
     };
     use move_vm_types::data_store::DataStore;
     use move_vm_types::loaded_data::runtime_types::Type;
+    use mysten_common::debug_fatal;
     use sui_move_natives::object_runtime::{
         self, get_all_uids, max_event_error, LoadedRuntimeObject, ObjectRuntime, RuntimeResults,
     };
     use sui_protocol_config::ProtocolConfig;
-    use sui_types::execution::ExecutionResults;
     use sui_types::storage::{DenyListResult, PackageObject};
     use sui_types::{
         balance::Balance,
@@ -65,6 +65,7 @@ mod checked {
         transaction::{Argument, CallArg, ObjectArg},
     };
     use sui_types::{error::command_argument_error, execution_status::CommandArgumentError};
+    use sui_types::{execution::ExecutionResults, object::Authenticator};
     use tracing::instrument;
 
     /// Maintains all runtime state specific to programmable transactions
@@ -624,6 +625,7 @@ mod checked {
             let mut loaded_runtime_objects = BTreeMap::new();
             let mut additional_writes = BTreeMap::new();
             let mut by_value_shared_objects = BTreeSet::new();
+            let mut authenticator_objects = BTreeMap::new();
             for input in inputs.into_iter().chain(std::iter::once(gas)) {
                 let InputValue {
                     object_metadata:
@@ -650,6 +652,8 @@ mod checked {
                     add_additional_write(&mut additional_writes, owner, object_value)?;
                 } else if owner.is_shared() {
                     by_value_shared_objects.insert(id);
+                } else if owner.authenticator().is_some() {
+                    authenticator_objects.insert(id, owner.clone());
                 }
             }
             // check for unused values
@@ -841,6 +845,35 @@ mod checked {
                             ),
                         ));
                     }
+                }
+            }
+
+            // Before finishing, enforce restrictions on transfer and deletion for objects configured
+            // with authenticators.
+            for (id, original_owner) in authenticator_objects {
+                let authenticator = original_owner.authenticator().expect("verified before adding to `authenticator_objects` that these have authenticators");
+
+                match authenticator {
+                    Authenticator::SingleOwner(owner) => {
+                        // Already verified in pre-execution checks that tx sender is the object owner.
+                        // SingleOwner is allowed to do anything with the object.
+                        if ref_context.borrow().sender() != *owner {
+                            debug_fatal!("transaction with a singly owned input object where the tx sender is not the owner should never be executed");
+                            return Err(ExecutionError::new(
+                                ExecutionErrorKind::SharedObjectOperationNotAllowed,
+                                Some(
+                                    format!("Shared object operation on {} not allowed: \
+                                             transaction with singly owned input object must be sent by the owner", id).into(),
+                                ),
+                            ));
+                        }
+                    } // Future authenticators with fewer permissions should be checked here. For
+                      // example, transfers and wraps can be detected by comparing `original_owner`
+                      // with:
+                      // let new_owner = written_objects.get(&id).map(|obj| obj.owner);
+                      //
+                      // Deletions can be detected with:
+                      // let deleted = deleted_object_ids.contains(&id);
                 }
             }
 


### PR DESCRIPTION
Verify object ownership at signing time.

No checks currently needed post-execution becuase SingleOwner has all permissions, but added a placeholder for the future.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
