### PR TITLE
fix(rpc-alt): fix CoinMetadata and Display data-loader ordering

### DIFF
--- a/crates/sui-indexer-alt-jsonrpc/src/data/coin_metadata.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/coin_metadata.rs
@@ -1,10 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::{BTreeSet, HashMap},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
 use async_graphql::dataloader::Loader;
 use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl};
@@ -61,7 +58,7 @@ impl Loader<CoinMetadataKey> for PgReader {
                 let params: Vec<TypeTag> = vec![tag.clone().into()];
                 bcs::to_bytes(&params)
             })
-            .collect::<Result<BTreeSet<_>, _>>()
+            .collect::<Result<Vec<_>, _>>()
             .map_err(|e| Arc::new(Error::Serde(e.into())))?;
 
         let query = candidates

--- a/crates/sui-indexer-alt-jsonrpc/src/data/displays.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/displays.rs
@@ -1,10 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::{BTreeSet, HashMap},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
 use async_graphql::dataloader::Loader;
 use diesel::{ExpressionMethods, QueryDsl};
@@ -44,7 +41,7 @@ impl Loader<DisplayKey> for PgReader {
         let types = keys
             .iter()
             .map(|d| bcs::to_bytes(&d.0))
-            .collect::<Result<BTreeSet<_>, _>>()?;
+            .collect::<Result<Vec<_>, _>>()?;
 
         let displays: Vec<StoredDisplay> = conn
             .results(d::sum_displays.filter(d::object_type.eq_any(types.clone())))


### PR DESCRIPTION
## Description

Both these data-loaders follow a pattern where they generate some probes into the DB, based on the data loader key, form a set of these to query the DB with and then later try to zip that set with the original sequence of keys they were generated from.

If that sequence of keys is in a different order or contains duplicates, then keys are going to end up mis-aligned with their equivalent probes.

## Test plan

:eyes:

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
