### PR TITLE
[effects] Do not expose internal effects state

### DIFF
--- a/crates/sui-types/src/effects/effects_v2.rs
+++ b/crates/sui-types/src/effects/effects_v2.rs
@@ -43,6 +43,8 @@ pub struct TransactionEffectsV2 {
     /// The version number of all the written Move objects by this transaction.
     pub(crate) lamport_version: SequenceNumber,
     /// Objects whose state are changed in the object store.
+    /// This field should not be exposed to the public API.
+    /// Otherwise it will make it harder to use effects of different versions.
     changed_objects: Vec<(ObjectID, EffectsObjectChange)>,
     /// Shared objects that are not mutated in this transaction. Unlike owned objects,
     /// read-only shared objects' version are not committed in the transaction,
@@ -571,10 +573,6 @@ impl TransactionEffectsV2 {
                 self
             );
         }
-    }
-
-    pub fn changed_objects(&self) -> &[(ObjectID, EffectsObjectChange)] {
-        &self.changed_objects
     }
 }
 

--- a/crates/sui-types/src/full_checkpoint_content.rs
+++ b/crates/sui-types/src/full_checkpoint_content.rs
@@ -4,14 +4,11 @@
 use std::collections::{BTreeMap, HashSet};
 
 use crate::base_types::{ObjectID, ObjectRef};
-use crate::effects::{
-    IDOperation, ObjectIn, ObjectOut, TransactionEffects, TransactionEffectsAPI, TransactionEvents,
-};
+use crate::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
 use crate::messages_checkpoint::{CertifiedCheckpointSummary, CheckpointContents};
 use crate::object::Object;
 use crate::storage::BackingPackageStore;
 use crate::transaction::Transaction;
-use itertools::Either;
 use serde::{Deserialize, Serialize};
 use tap::Pipe;
 
@@ -97,56 +94,17 @@ pub struct CheckpointTransaction {
 impl CheckpointTransaction {
     // provide an iterator over all deleted or wrapped objects in this transaction
     pub fn removed_objects_pre_version(&self) -> impl Iterator<Item = &Object> {
-        // Iterator over id and versions for all deleted or wrapped objects
-        match &self.effects {
-            TransactionEffects::V1(v1) => Either::Left(
-                // Effects v1 has deleted and wrapped objects versions as the "new" version, not the
-                // old one that was actually removed. So we need to take these and then look them
-                // up in the `modified_at_versions`.
-                // No need to chain unwrapped_then_deleted because these objects must have been wrapped
-                // before the transaction, hence they will not be in modified_at_versions / input_objects.
-                v1.deleted().iter().chain(v1.wrapped()).map(|(id, _, _)| {
-                    // lookup the old version for mutated objects
-                    let (_, old_version) = v1
-                        .modified_at_versions()
-                        .iter()
-                        .find(|(oid, _old_version)| oid == id)
-                        .expect("deleted/wrapped object must have entry in 'modified_at_versions'");
-                    (id, old_version)
-                }),
-            ),
-            TransactionEffects::V2(v2) => {
-                Either::Right(v2.changed_objects().iter().filter_map(|(id, change)| {
-                    match (
-                        &change.input_state,
-                        &change.output_state,
-                        &change.id_operation,
-                    ) {
-                        // Deleted Objects
-                        (
-                            ObjectIn::Exist(((version, _d), _o)),
-                            ObjectOut::NotExist,
-                            IDOperation::Deleted,
-                        ) => Some((id, version)),
-
-                        // Wrapped Objects
-                        (
-                            ObjectIn::Exist(((version, _), _)),
-                            ObjectOut::NotExist,
-                            IDOperation::None,
-                        ) => Some((id, version)),
-                        _ => None,
-                    }
-                }))
-            }
-        }
-        // Use id and version to lookup in input Objects
-        .map(|(id, version)| {
-            self.input_objects
-                .iter()
-                .find(|o| &o.id() == id && &o.version() == version)
-                .expect("all removed objects should show up in input objects")
-        })
+        // Since each object ID can only show up once in the input_objects, we can just use the
+        // ids of deleted and wrapped objects to lookup the object in the input_objects.
+        self.effects
+            .all_removed_objects()
+            .into_iter() // Use id and version to lookup in input Objects
+            .map(|((id, _, _), _)| {
+                self.input_objects
+                    .iter()
+                    .find(|o| o.id() == id)
+                    .expect("all removed objects should show up in input objects")
+            })
     }
 
     pub fn removed_object_refs_post_version(&self) -> impl Iterator<Item = ObjectRef> {
@@ -157,117 +115,34 @@ impl CheckpointTransaction {
     }
 
     pub fn changed_objects(&self) -> impl Iterator<Item = (&Object, Option<&Object>)> {
-        // Iterator over ((ObjectId, new version), Option<old version>)
-        match &self.effects {
-            TransactionEffects::V1(v1) => Either::Left(
-                v1.created()
+        self.effects
+            .all_changed_objects()
+            .into_iter()
+            .map(|((id, _, _), ..)| {
+                let object = self
+                    .output_objects
                     .iter()
-                    .chain(v1.unwrapped())
-                    .map(|((id, version, _), _)| ((id, version), None))
-                    .chain(v1.mutated().iter().map(|((id, version, _), _)| {
-                        // lookup the old version for mutated objects
-                        let (_, old_version) = v1
-                            .modified_at_versions()
-                            .iter()
-                            .find(|(oid, _old_version)| oid == id)
-                            .expect("mutated object must have entry in modified_at_versions");
+                    .find(|o| o.id() == id)
+                    .expect("changed objects should show up in output objects");
 
-                        ((id, version), Some(old_version))
-                    })),
-            ),
-            TransactionEffects::V2(v2) => {
-                Either::Right(v2.changed_objects().iter().filter_map(|(id, change)| {
-                    match (
-                        &change.input_state,
-                        &change.output_state,
-                        &change.id_operation,
-                    ) {
-                        // Created Objects
-                        (ObjectIn::NotExist, ObjectOut::ObjectWrite(_), IDOperation::Created) => {
-                            Some(((id, &v2.lamport_version), None))
-                        }
-                        (
-                            ObjectIn::NotExist,
-                            ObjectOut::PackageWrite((version, _)),
-                            IDOperation::Created,
-                        ) => Some(((id, version), None)),
+                let old_object = self.input_objects.iter().find(|o| o.id() == id);
 
-                        // Unwrapped Objects
-                        (ObjectIn::NotExist, ObjectOut::ObjectWrite(_), IDOperation::None) => {
-                            Some(((id, &v2.lamport_version), None))
-                        }
-
-                        // Mutated Objects
-                        (ObjectIn::Exist(((old_version, _), _)), ObjectOut::ObjectWrite(_), _) => {
-                            Some(((id, &v2.lamport_version), Some(old_version)))
-                        }
-                        (
-                            ObjectIn::Exist(((old_version, _), _)),
-                            ObjectOut::PackageWrite((version, _)),
-                            _,
-                        ) => Some(((id, version), Some(old_version))),
-
-                        _ => None,
-                    }
-                }))
-            }
-        }
-        // Lookup Objects in output Objects as well as old versions for mutated objects
-        .map(|((id, version), old_version)| {
-            let object = self
-                .output_objects
-                .iter()
-                .find(|o| &o.id() == id && &o.version() == version)
-                .expect("changed objects should show up in output objects");
-
-            let old_object = old_version.map(|old_version| {
-                self.input_objects
-                    .iter()
-                    .find(|o| &o.id() == id && &o.version() == old_version)
-                    .expect("mutated objects should have a previous version in input objects")
-            });
-
-            (object, old_object)
-        })
+                (object, old_object)
+            })
     }
 
     pub fn created_objects(&self) -> impl Iterator<Item = &Object> {
         // Iterator over (ObjectId, version) for created objects
-        match &self.effects {
-            TransactionEffects::V1(v1) => Either::Left(
-                v1.created()
+        self.effects
+            .created()
+            .into_iter()
+            // Lookup Objects in output Objects as well as old versions for mutated objects
+            .map(|((id, version, _), _)| {
+                self.output_objects
                     .iter()
-                    .map(|((id, version, _), _)| (id, version)),
-            ),
-            TransactionEffects::V2(v2) => {
-                Either::Right(v2.changed_objects().iter().filter_map(|(id, change)| {
-                    match (
-                        &change.input_state,
-                        &change.output_state,
-                        &change.id_operation,
-                    ) {
-                        // Created Objects
-                        (ObjectIn::NotExist, ObjectOut::ObjectWrite(_), IDOperation::Created) => {
-                            Some((id, &v2.lamport_version))
-                        }
-                        (
-                            ObjectIn::NotExist,
-                            ObjectOut::PackageWrite((version, _)),
-                            IDOperation::Created,
-                        ) => Some((id, version)),
-
-                        _ => None,
-                    }
-                }))
-            }
-        }
-        // Lookup Objects in output Objects as well as old versions for mutated objects
-        .map(|(id, version)| {
-            self.output_objects
-                .iter()
-                .find(|o| &o.id() == id && &o.version() == version)
-                .expect("created objects should show up in output objects")
-        })
+                    .find(|o| o.id() == id && o.version() == version)
+                    .expect("created objects should show up in output objects")
+            })
     }
 }
 


### PR DESCRIPTION
## Description 

This PR removes all direct uses of the `changed_objects` from effects v2.
We should always access effects through APIs (i.e. effects trait) for reads. Otherwise it will make it difficult to evolve effects.
Most changes are in full_checkpoint_contents. This PR also simplifies these functions a bit.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
