### PR TITLE
[move-ide] Fixed auto-completion for unresolved method chains

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
   "publisher": "mysten",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "preview": true,
   "repository": {
     "url": "https://github.com/MystenLabs/sui.git",

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -3868,7 +3868,9 @@ fn method_call(
     let (m, f, fty, usage) =
         match method_call_resolve(context, call_loc, &edotted, method, ty_args_opt) {
             ResolvedMethodCall::Resolved(m, f, fty, usage) => (*m, f, fty, usage),
-            ResolvedMethodCall::UnknownName if context.env().ide_mode() => {
+            ResolvedMethodCall::InvalidBaseType | ResolvedMethodCall::UnknownName
+                if context.env().ide_mode() =>
+            {
                 // Even if the method name fails to resolve, we want autocomplete information.
                 edotted.autocomplete_last = Some(method.loc);
                 let err_ty = context.error_type(call_loc);

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/wrong_completion_before_dot_call.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/wrong_completion_before_dot_call.move
@@ -1,0 +1,20 @@
+#[allow(ide_path_autocomplete)]
+module a::m {
+
+    public struct SomeStruct {
+        some_field: u64,
+    }
+
+    public fun bar(_some_struct: &SomeStruct):u64 {
+        42
+    }
+
+    public fun foo(some_struct: &mut SomeStruct): u64 {
+        // Auto-completion after some_struct. did not work here before,
+        // but it worked if the other some_struct access
+        // is not a dot call but rather a field access
+        some_struct.
+        some_struct.bar()
+    }
+
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/wrong_completion_before_dot_call.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/wrong_completion_before_dot_call.snap
@@ -1,0 +1,19 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+warning[W10007]: issue with attribute value
+  ┌─ tests/move_2024/ide_mode/wrong_completion_before_dot_call.move:1:9
+  │
+1 │ #[allow(ide_path_autocomplete)]
+  │         ^^^^^^^^^^^^^^^^^^^^^ Unknown warning filter 'ide_path_autocomplete'
+
+error[E03010]: unbound field
+   ┌─ tests/move_2024/ide_mode/wrong_completion_before_dot_call.move:16:9
+   │  
+16 │ ╭         some_struct.
+17 │ │         some_struct.bar()
+   │ ╰───────────────────^ Unbound field 'some_struct' in 'a::m::SomeStruct'

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/wrong_completion_before_dot_call@ide.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/wrong_completion_before_dot_call@ide.snap
@@ -1,0 +1,25 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+error[E03010]: unbound field
+   ┌─ tests/move_2024/ide_mode/wrong_completion_before_dot_call.move:16:9
+   │  
+16 │ ╭         some_struct.
+17 │ │         some_struct.bar()
+   │ ╰───────────────────^ Unbound field 'some_struct' in 'a::m::SomeStruct'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/wrong_completion_before_dot_call.move:16:20
+   │
+16 │         some_struct.
+   │                    ^ Possible dot names: 'a::m::bar', 'a::m::foo', or 'some_field'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/wrong_completion_before_dot_call.move:17:9
+   │
+17 │         some_struct.bar()
+   │         ^^^^^^^^^^^ Possible dot names: 'a::m::bar', 'a::m::foo', or 'some_field'


### PR DESCRIPTION
## Description 

When method's access chain was incorrect, no auto-completion was generated even for correctly typed prefix of this chain, such as in this example:
```move
    public struct SomeStruct {
        some_field: u64,
    }

    public fun bar(_some_struct: &SomeStruct):u64 {
        42
    }

    public fun foo(some_struct: &mut SomeStruct): u64 {
        some_struct.
        some_struct.bar()
    }
```
Additionally, this behavior was inconsistent with the auto-completion behavior for a similar chain but ending in a (supposed) field access instead of a method call, where auto-completion for the dot following the first `some_struct` would be generated:
```move
    public fun foo(some_struct: &mut SomeStruct): u64 {
        some_struct.
        some_struct.some_field
    }
```
This PR fixes this issue

## Test plan 

Added a new test. All tests must pass
