### PR TITLE
[CLI] Support for MVR in `sui client ptb`

### DIFF
--- a/crates/sui/src/client_ptb/ast.rs
+++ b/crates/sui/src/client_ptb/ast.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fmt;
+use std::{collections::BTreeMap, fmt};
 
 use move_core_types::parsing::{
     address::{NumericalAddress, ParsedAddress},
@@ -116,6 +116,7 @@ pub struct ProgramMetadata {
     pub dry_run_set: bool,
     pub dev_inspect_set: bool,
     pub gas_budget: Option<Spanned<u64>>,
+    pub mvr_names: BTreeMap<String, Span>,
 }
 
 /// A parsed module access consisting of the address, module name, and function name.

--- a/crates/sui/src/client_ptb/lexer.rs
+++ b/crates/sui/src/client_ptb/lexer.rs
@@ -233,6 +233,7 @@ impl<'l, I: Iterator<Item = &'l str>> Iterator for Lexer<'l, I> {
             sp!(_, ">") => token!(T::RAngle),
             sp!(_, "@") => token!(T::At),
             sp!(_, ".") => token!(T::Dot),
+            sp!(_, "/") => token!(T::ForwardSlash),
 
             sp!(_, "'" | "\"") => self.string(c),
 

--- a/crates/sui/src/client_ptb/parser.rs
+++ b/crates/sui/src/client_ptb/parser.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::iter::Peekable;
+use std::{collections::BTreeMap, iter::Peekable};
 
 use move_core_types::parsing::{
     address::{NumericalAddress, ParsedAddress},
@@ -34,6 +34,7 @@ pub struct ProgramParser<'a, I: Iterator<Item = &'a str>> {
 struct ProgramParsingState {
     parsed: Vec<Spanned<ParsedPTBCommand>>,
     errors: Vec<PTBError>,
+    mvr_names_with_span: BTreeMap<String, Span>,
     preview_set: bool,
     summary_set: bool,
     warn_shadows_set: bool,
@@ -44,6 +45,12 @@ struct ProgramParsingState {
     dev_inspect_set: bool,
     gas_object_id: Option<Spanned<ObjectID>>,
     gas_budget: Option<Spanned<u64>>,
+}
+
+macro_rules! mvr_ident {
+    () => {
+        Token::Ident | Token::Number | Token::HexNumber
+    };
 }
 
 impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
@@ -57,6 +64,7 @@ impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
             state: ProgramParsingState {
                 parsed: Vec::new(),
                 errors: Vec::new(),
+                mvr_names_with_span: BTreeMap::new(),
                 preview_set: false,
                 summary_set: false,
                 warn_shadows_set: false,
@@ -212,6 +220,7 @@ impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
                     dry_run_set: self.state.dry_run_set,
                     dev_inspect_set: self.state.dev_inspect_set,
                     gas_budget: self.state.gas_budget,
+                    mvr_names: self.state.mvr_names_with_span,
                 },
             ))
         } else {
@@ -416,7 +425,7 @@ impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
                 self.parse_number(sp.wrap(&number))?
             }
 
-            L(T::At, _) => self.parse_address_literal()?.map(V::Address),
+            L(T::At, _) => self.parse_address_literal()?.map(V::Address).widen_span(sp),
 
             L(T::Ident, A::NONE) => {
                 self.bump();
@@ -486,7 +495,7 @@ impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
                 sp.wrap(ParsedType::Vector(Box::new(ty)))
             }
 
-            L(T::Ident | T::Number | T::HexNumber, _) => 'fq: {
+            L(T::At | T::Ident | T::Number | T::HexNumber, _) => 'fq: {
                 let sp!(_, module_access) = self.parse_module_access()?;
                 let sp!(_, address) = module_access.address;
                 let sp!(_, module_name) = module_access.module_name;
@@ -643,33 +652,134 @@ impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
         })
     }
 
-    /// Parse a numerical or named address.
+    fn parse_mvr_address(
+        &mut self,
+        prefix: Option<Spanned<&str>>,
+    ) -> PTBResult<Spanned<ParsedAddress>> {
+        use Lexeme as L;
+        use Token as T;
+
+        let mut address = String::new();
+        let start_sp = prefix.map(|p| p.span).unwrap_or_else(|| self.peek().span);
+
+        // Step 1: parse before `/` in the MVR name
+        match prefix {
+            // No @ prefix
+            Some(sp!(_, prefix)) => {
+                address.push_str(prefix);
+                // parse .sui
+                self.expect(T::Dot)?;
+                address.push('.');
+                match self.peek() {
+                    sp!(sp, L(T::Ident, s)) => {
+                        if s != "sui" {
+                            error!(sp => help: { "Expected 'sui' extension" },
+                            "Expected a valid MVR top level domain"
+                            );
+                        }
+                        self.bump();
+                        address.push_str(s);
+                    }
+                    sp!(sp, l) => {
+                        error!(
+                            sp,
+                            "Expected a valid MVR domain extension ('.sui') but got {}", l
+                        )
+                    }
+                }
+            }
+            // @ prefixed MVR name
+            None => {
+                self.expect(T::At)?;
+                address.push('@');
+                match self.peek() {
+                    sp!(_, L(mvr_ident!(), nm)) => {
+                        self.bump();
+                        address.push_str(nm);
+                    }
+                    sp!(sp, l) => {
+                        error!(sp, "Expected a MVR domain name but got {l}")
+                    }
+                }
+            }
+        }
+
+        self.expect(T::ForwardSlash).map_err(|e| {
+            err!(e.span => help: {
+                "MVR packages must contain a slash and be in the format '(@<domain>|<domain>.sui)/<package>[/<version>]'"
+            }, "Invalid MVR package reference")
+        })?;
+        address.push('/');
+
+        // Step 2: post slash -- package name
+        match self.peek() {
+            sp!(_, L(mvr_ident!(), s)) => {
+                address.push_str(s);
+                self.bump();
+            }
+            sp!(sp, l) => {
+                error!(sp, "Expected a valid MVR package name, but got {l}")
+            }
+        }
+
+        // Step 3: post package name -- possible version
+        if let sp!(_, L(T::ForwardSlash, _)) = self.peek() {
+            address.push('/');
+            self.bump();
+            match self.peek() {
+                sp!(_, L(T::Number, s)) => {
+                    address.push_str(s);
+                    self.bump();
+                }
+                sp!(sp, l) => {
+                    error!(sp, "Expected a valid MVR version, but got {l}")
+                }
+            }
+        }
+        let end_sp = self.peek().span;
+
+        self.state
+            .mvr_names_with_span
+            .entry(address.clone())
+            .or_insert_with(|| start_sp.widen(end_sp));
+        Ok(start_sp.widen(end_sp).wrap(ParsedAddress::Named(address)))
+    }
+
+    /// Parse a numerical, named address, or mvr address.
     fn parse_address(&mut self) -> PTBResult<Spanned<ParsedAddress>> {
         use Lexeme as L;
         use Token as T;
 
         let sp!(sp, lexeme) = self.peek();
         let addr = match lexeme {
-            L(T::Ident, name) => {
+            L(T::At, _) => self.parse_mvr_address(None)?.value,
+            L(t @ (mvr_ident!()), contents) => {
                 self.bump();
-                ParsedAddress::Named(name.to_owned())
+                if let sp!(s, L(T::Dot, _)) = self.peek() {
+                    self.parse_mvr_address(Some(Spanned {
+                        span: s,
+                        value: contents,
+                    }))?
+                    .value
+                } else {
+                    match t {
+                        T::Ident => ParsedAddress::Named(contents.to_owned()),
+                        T::Number => {
+                            let number = format!("{contents}");
+                            NumericalAddress::parse_str(&number)
+                                .map_err(|e| err!(sp, "Failed to parse address {number:?}: {e}"))
+                                .map(ParsedAddress::Numerical)?
+                        }
+                        T::HexNumber => {
+                            let number = format!("0x{contents}");
+                            NumericalAddress::parse_str(&number)
+                                .map_err(|e| err!(sp, "Failed to parse address {number:?}: {e}"))
+                                .map(ParsedAddress::Numerical)?
+                        }
+                        _ => unreachable!(),
+                    }
+                }
             }
-
-            L(T::Number, number) => {
-                self.bump();
-                NumericalAddress::parse_str(number)
-                    .map_err(|e| err!(sp, "Failed to parse address {number:?}: {e}"))
-                    .map(ParsedAddress::Numerical)?
-            }
-
-            L(T::HexNumber, number) => {
-                self.bump();
-                let number = format!("0x{number}");
-                NumericalAddress::parse_str(&number)
-                    .map_err(|e| err!(sp, "Failed to parse address {number:?}: {e}"))
-                    .map(ParsedAddress::Numerical)?
-            }
-
             unexpected => error!(
                 sp => help: {
                     "Value addresses can either be a variable in-scope, or a numerical address, \
@@ -1019,6 +1129,59 @@ mod tests {
             let x = shlex::split(input).unwrap();
             let parser = ProgramParser::new(x.iter().map(|x| x.as_str())).unwrap();
             let result = parser.parse().unwrap_err();
+            parsed.push(result);
+        }
+        insta::assert_debug_snapshot!(parsed);
+    }
+
+    #[test]
+    fn parse_mvr_names_invalid() {
+        let invalid_inputs = vec![
+            "@0xab5",
+            "@0x1",
+            "@0x4@3",
+            "foo.sui",
+            "@foo.sui/bar",
+            "@",
+            "@@",
+            "@/",
+            "@@/",
+            "@@/@",
+            "@/@",
+            "/1",
+            "-",
+            "-/",
+            "-/-",
+            "@foo/bar/b",
+        ];
+        let mut parsed = Vec::new();
+        for input in invalid_inputs {
+            let x = shlex::split(input).unwrap();
+            let mut parser = ProgramParser::new(x.iter().map(|x| x.as_str())).unwrap();
+            let result = parser.parse_address().unwrap_err();
+            parsed.push(result);
+        }
+        insta::assert_debug_snapshot!(parsed);
+    }
+
+    #[test]
+    fn parse_mvr_names_valid() {
+        let valid_inputs = vec![
+            "@0x1/foo",
+            "0x1.sui/foo",
+            "0x1.sui/foo/1",
+            "0x1.sui/0x3/1",
+            "1.sui/0x3/1",
+            "@foo/bar",
+            "@foo/bar/1",
+            "foo.sui/bar",
+            "foo.sui/bar/1",
+        ];
+        let mut parsed = Vec::new();
+        for input in valid_inputs {
+            let x = shlex::split(input).unwrap();
+            let mut parser = ProgramParser::new(x.iter().map(|x| x.as_str())).unwrap();
+            let result = parser.parse_address().unwrap();
             parsed.push(result);
         }
         insta::assert_debug_snapshot!(parsed);

--- a/crates/sui/src/client_ptb/parser.rs
+++ b/crates/sui/src/client_ptb/parser.rs
@@ -765,7 +765,7 @@ impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
                     match t {
                         T::Ident => ParsedAddress::Named(contents.to_owned()),
                         T::Number => {
-                            let number = format!("{contents}");
+                            let number = contents.to_string();
                             NumericalAddress::parse_str(&number)
                                 .map_err(|e| err!(sp, "Failed to parse address {number:?}: {e}"))
                                 .map(ParsedAddress::Numerical)?

--- a/crates/sui/src/client_ptb/ptb.rs
+++ b/crates/sui/src/client_ptb/ptb.rs
@@ -150,9 +150,7 @@ impl PTB {
                 .await?;
             let mut mvr_data: BTreeMap<String, AddressData> = BTreeMap::new();
             for (name, package_id) in resolved.resolution {
-                let span = mvr_names
-                    .get(&name)
-                    .unwrap_or_else(|| &Span { start: 0, end: 0 });
+                let span = mvr_names.get(&name).unwrap_or(&Span { start: 0, end: 0 });
                 let pkg = resolve_package(client.read_api(), package_id.package_id, *span).await?;
                 let type_origin_id_map = pkg.type_origin_map();
                 mvr_data.insert(name, AddressData::MovePackage((pkg, type_origin_id_map)));

--- a/crates/sui/src/client_ptb/ptb.rs
+++ b/crates/sui/src/client_ptb/ptb.rs
@@ -5,11 +5,12 @@ use crate::{
     client_commands::{dry_run_or_execute_or_serialize, Opts, OptsWithGas, SuiClientCommandResult},
     client_ptb::{
         ast::{ParsedProgram, Program},
-        builder::PTBBuilder,
-        error::{build_error_reports, PTBError},
+        builder::{resolve_package, PTBBuilder},
+        error::{build_error_reports, PTBError, Span},
         token::{Lexeme, Token},
     },
     displays::Pretty,
+    mvr_resolver::MvrResolver,
     sp,
 };
 
@@ -18,12 +19,15 @@ use anyhow::{anyhow, ensure, Error};
 use clap::{arg, Args, ValueHint};
 use move_core_types::account_address::AccountAddress;
 use serde::Serialize;
+use std::collections::BTreeMap;
 use sui_json_rpc_types::{SuiExecutionStatus, SuiTransactionBlockEffectsAPI};
 use sui_keys::keystore::AccountKeystore;
 use sui_sdk::{wallet_context::WalletContext, SuiClient};
 use sui_types::{
+    base_types::ObjectID,
     digests::TransactionDigest,
     gas::GasCostSummary,
+    move_package::MovePackage,
     transaction::{ProgrammableTransaction, TransactionKind},
 };
 
@@ -44,6 +48,28 @@ pub struct Summary {
     pub digest: TransactionDigest,
     pub status: SuiExecutionStatus,
     pub gas_cost: GasCostSummary,
+}
+
+/// An enum holding either an account address or a move package information. The Move Package data
+/// is used to resolve the origin id for a typetag, in the `PTBBuilder`.
+#[derive(Clone, Debug)]
+pub enum AddressData {
+    /// The account address
+    AccountAddress(AccountAddress),
+    /// The MovePackage itself and the TypeOrigin table in a (module, type) -> origin ID map.
+    MovePackage((MovePackage, BTreeMap<(String, String), ObjectID>)),
+}
+
+impl AddressData {
+    /// Return the account address
+    pub fn address(&self) -> Option<AccountAddress> {
+        match self {
+            AddressData::AccountAddress(account_address) => Some(*account_address),
+            AddressData::MovePackage((pkg, _)) => {
+                AccountAddress::from_bytes(pkg.id().into_bytes()).ok()
+            }
+        }
+    }
 }
 
 impl PTB {
@@ -101,7 +127,41 @@ impl PTB {
 
         let client = context.get_client().await?;
 
-        let (res, warnings) = Self::build_ptb(program, context, client).await;
+        let mut starting_addresses: BTreeMap<String, AddressData> = context
+            .config
+            .keystore
+            .addresses_with_alias()
+            .into_iter()
+            .map(|(sa, alias)| {
+                (
+                    alias.alias.clone(),
+                    AddressData::AccountAddress(AccountAddress::from(*sa)),
+                )
+            })
+            .collect();
+
+        let mvr_names = program_metadata.mvr_names.clone();
+        let mvr_resolver = MvrResolver {
+            names: program_metadata.mvr_names.into_keys().collect(),
+        };
+        if mvr_resolver.should_resolve() {
+            let resolved = mvr_resolver
+                .resolve_names(context.get_client().await?.read_api())
+                .await?;
+            let mut mvr_data: BTreeMap<String, AddressData> = BTreeMap::new();
+            for (name, package_id) in resolved.resolution {
+                let span = mvr_names
+                    .get(&name)
+                    .unwrap_or_else(|| &Span { start: 0, end: 0 });
+                let pkg = resolve_package(client.read_api(), package_id.package_id, *span).await?;
+                let type_origin_id_map = pkg.type_origin_map();
+                mvr_data.insert(name, AddressData::MovePackage((pkg, type_origin_id_map)));
+            }
+
+            starting_addresses.extend(mvr_data);
+        }
+
+        let (res, warnings) = Self::build_ptb(program, starting_addresses, client).await;
 
         // Render warnings
         if !warnings.is_empty() {
@@ -219,27 +279,20 @@ impl PTB {
         Ok(())
     }
 
-    /// Exposed for testing
+    // Also used in testing, thus public
     pub async fn build_ptb(
         program: Program,
-        context: &WalletContext,
+        starting_addresses: BTreeMap<String, AddressData>,
         client: SuiClient,
     ) -> (
         Result<ProgrammableTransaction, Vec<PTBError>>,
         Vec<PTBError>,
     ) {
-        let starting_addresses = context
-            .config
-            .keystore
-            .addresses_with_alias()
-            .into_iter()
-            .map(|(sa, alias)| (alias.alias.clone(), AccountAddress::from(*sa)))
-            .collect();
         let builder = PTBBuilder::new(starting_addresses, client.read_api());
         builder.build(program).await
     }
 
-    /// Exposed for testing
+    // Also used in testing, thus public
     pub fn parse_ptb_commands(args: Vec<String>) -> Result<ParsedProgram, Vec<PTBError>> {
         ProgramParser::new(args.iter().map(|s| s.as_str()))
             .map_err(|e| vec![e])

--- a/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_commands.snap
+++ b/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_commands.snap
@@ -42,6 +42,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -83,6 +84,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -133,6 +135,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -202,6 +205,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -262,6 +266,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -337,6 +342,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -406,6 +412,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -466,6 +473,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -535,6 +543,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -595,6 +604,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -643,6 +653,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -710,6 +721,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -824,6 +836,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -915,6 +928,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1006,6 +1020,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1048,6 +1063,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1115,6 +1131,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1167,6 +1184,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1219,6 +1237,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1305,6 +1324,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1363,6 +1383,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1427,6 +1448,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1460,6 +1482,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1485,6 +1508,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1510,6 +1534,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1535,6 +1560,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1560,6 +1586,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
 ]

--- a/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_mvr_names_invalid.snap
+++ b/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_mvr_names_invalid.snap
@@ -1,0 +1,168 @@
+---
+source: crates/sui/src/client_ptb/parser.rs
+expression: parsed
+---
+[
+    PTBError {
+        message: "Invalid MVR package reference",
+        span: Span {
+            start: 6,
+            end: 6,
+        },
+        help: Some(
+            "MVR packages must contain a slash and be in the format '(@<domain>|<domain>.sui)/<package>[/<version>]'",
+        ),
+        severity: Error,
+    },
+    PTBError {
+        message: "Invalid MVR package reference",
+        span: Span {
+            start: 4,
+            end: 4,
+        },
+        help: Some(
+            "MVR packages must contain a slash and be in the format '(@<domain>|<domain>.sui)/<package>[/<version>]'",
+        ),
+        severity: Error,
+    },
+    PTBError {
+        message: "Invalid MVR package reference",
+        span: Span {
+            start: 4,
+            end: 5,
+        },
+        help: Some(
+            "MVR packages must contain a slash and be in the format '(@<domain>|<domain>.sui)/<package>[/<version>]'",
+        ),
+        severity: Error,
+    },
+    PTBError {
+        message: "Invalid MVR package reference",
+        span: Span {
+            start: 7,
+            end: 7,
+        },
+        help: Some(
+            "MVR packages must contain a slash and be in the format '(@<domain>|<domain>.sui)/<package>[/<version>]'",
+        ),
+        severity: Error,
+    },
+    PTBError {
+        message: "Invalid MVR package reference",
+        span: Span {
+            start: 4,
+            end: 5,
+        },
+        help: Some(
+            "MVR packages must contain a slash and be in the format '(@<domain>|<domain>.sui)/<package>[/<version>]'",
+        ),
+        severity: Error,
+    },
+    PTBError {
+        message: "Expected a MVR domain name but got end of input",
+        span: Span {
+            start: 1,
+            end: 1,
+        },
+        help: None,
+        severity: Error,
+    },
+    PTBError {
+        message: "Expected a MVR domain name but got '@'",
+        span: Span {
+            start: 1,
+            end: 2,
+        },
+        help: None,
+        severity: Error,
+    },
+    PTBError {
+        message: "Expected a MVR domain name but got '/'",
+        span: Span {
+            start: 1,
+            end: 2,
+        },
+        help: None,
+        severity: Error,
+    },
+    PTBError {
+        message: "Expected a MVR domain name but got '@'",
+        span: Span {
+            start: 1,
+            end: 2,
+        },
+        help: None,
+        severity: Error,
+    },
+    PTBError {
+        message: "Expected a MVR domain name but got '@'",
+        span: Span {
+            start: 1,
+            end: 2,
+        },
+        help: None,
+        severity: Error,
+    },
+    PTBError {
+        message: "Expected a MVR domain name but got '/'",
+        span: Span {
+            start: 1,
+            end: 2,
+        },
+        help: None,
+        severity: Error,
+    },
+    PTBError {
+        message: "Unexpected '/'",
+        span: Span {
+            start: 0,
+            end: 1,
+        },
+        help: Some(
+            "Value addresses can either be a variable in-scope, or a numerical address, e.g., 0xc0ffee",
+        ),
+        severity: Error,
+    },
+    PTBError {
+        message: "Unexpected input \"-\"",
+        span: Span {
+            start: 0,
+            end: 1,
+        },
+        help: Some(
+            "Value addresses can either be a variable in-scope, or a numerical address, e.g., 0xc0ffee",
+        ),
+        severity: Error,
+    },
+    PTBError {
+        message: "Unexpected input \"/\"",
+        span: Span {
+            start: 1,
+            end: 2,
+        },
+        help: Some(
+            "Value addresses can either be a variable in-scope, or a numerical address, e.g., 0xc0ffee",
+        ),
+        severity: Error,
+    },
+    PTBError {
+        message: "Unexpected input \"/\"",
+        span: Span {
+            start: 1,
+            end: 2,
+        },
+        help: Some(
+            "Value addresses can either be a variable in-scope, or a numerical address, e.g., 0xc0ffee",
+        ),
+        severity: Error,
+    },
+    PTBError {
+        message: "Expected a valid MVR version, but got identifier 'b'",
+        span: Span {
+            start: 9,
+            end: 10,
+        },
+        help: None,
+        severity: Error,
+    },
+]

--- a/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_mvr_names_valid.snap
+++ b/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_mvr_names_valid.snap
@@ -1,0 +1,87 @@
+---
+source: crates/sui/src/client_ptb/parser.rs
+expression: parsed
+---
+[
+    Spanned {
+        span: Span {
+            start: 0,
+            end: 1,
+        },
+        value: Named(
+            "@1/foo",
+        ),
+    },
+    Spanned {
+        span: Span {
+            start: 0,
+            end: 3,
+        },
+        value: Named(
+            "1.sui/foo",
+        ),
+    },
+    Spanned {
+        span: Span {
+            start: 0,
+            end: 3,
+        },
+        value: Named(
+            "1.sui/foo/1",
+        ),
+    },
+    Spanned {
+        span: Span {
+            start: 0,
+            end: 3,
+        },
+        value: Named(
+            "1.sui/3/1",
+        ),
+    },
+    Spanned {
+        span: Span {
+            start: 0,
+            end: 1,
+        },
+        value: Named(
+            "1.sui/3/1",
+        ),
+    },
+    Spanned {
+        span: Span {
+            start: 0,
+            end: 1,
+        },
+        value: Named(
+            "@foo/bar",
+        ),
+    },
+    Spanned {
+        span: Span {
+            start: 0,
+            end: 1,
+        },
+        value: Named(
+            "@foo/bar/1",
+        ),
+    },
+    Spanned {
+        span: Span {
+            start: 0,
+            end: 3,
+        },
+        value: Named(
+            "foo.sui/bar",
+        ),
+    },
+    Spanned {
+        span: Span {
+            start: 0,
+            end: 3,
+        },
+        value: Named(
+            "foo.sui/bar/1",
+        ),
+    },
+]

--- a/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_publish.snap
+++ b/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_publish.snap
@@ -42,6 +42,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -83,6 +84,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
 ]

--- a/crates/sui/src/client_ptb/token.rs
+++ b/crates/sui/src/client_ptb/token.rs
@@ -45,6 +45,8 @@ pub enum Token {
     At,
     /// .
     Dot,
+    /// /
+    ForwardSlash,
 
     /// End of input.
     Eof,
@@ -101,6 +103,7 @@ impl fmt::Display for Lexeme<'_> {
             T::RAngle => write!(f, "'>'"),
             T::At => write!(f, "'@'"),
             T::Dot => write!(f, "'.'"),
+            T::ForwardSlash => write!(f, "'/'"),
             T::Unexpected => write!(f, "input {:?}", self.1),
             T::UnfinishedString => write!(f, "unfinished string {:?}", format!("{}...", self.1)),
             T::EarlyEof | T::Eof => write!(f, "end of input"),
@@ -130,6 +133,7 @@ impl fmt::Display for Token {
             T::RAngle => write!(f, "'>'"),
             T::At => write!(f, "'@'"),
             T::Dot => write!(f, "'.'"),
+            T::ForwardSlash => write!(f, "'/'"),
             T::Eof => write!(f, "end of input"),
             T::Unexpected => write!(f, "unexpected input"),
             T::UnfinishedString => write!(f, "an unfinished string"),

--- a/crates/sui/src/lib.rs
+++ b/crates/sui/src/lib.rs
@@ -12,6 +12,7 @@ pub mod genesis_ceremony;
 pub mod genesis_inspector;
 pub mod key_identity;
 pub mod keytool;
+pub mod mvr_resolver;
 pub mod sui_commands;
 pub mod upgrade_compatibility;
 pub mod validator_commands;

--- a/crates/sui/src/mvr_resolver.rs
+++ b/crates/sui/src/mvr_resolver.rs
@@ -1,0 +1,106 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Error;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::collections::{BTreeMap, BTreeSet};
+use sui_protocol_config::Chain;
+use sui_sdk::apis::ReadApi;
+use sui_types::{base_types::ObjectID, digests::ChainIdentifier};
+
+const MVR_RESOLVER_MAINNET_URL: &str = "https://mainnet.mvr.mystenlabs.com";
+const MVR_RESOLVER_TESTNET_URL: &str = "https://testnet.mvr.mystenlabs.com";
+
+#[derive(Debug, Serialize)]
+pub struct MvrResolver {
+    pub names: BTreeSet<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ResolvedNames {
+    pub resolution: BTreeMap<String, PackageId>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PackageId {
+    pub package_id: ObjectID,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NamesRequest {
+    pub names: BTreeSet<String>,
+}
+
+impl MvrResolver {
+    /// Call this function before calling resolve_names to avoid making a call to the resolver if
+    /// not needed.
+    pub fn should_resolve(&self) -> bool {
+        !self.names.is_empty()
+    }
+
+    /// Given a set of MVR names, resolve them to their corresponding package IDs. Note that this
+    /// API will error if the resolved list length does not match with the given input.
+    pub async fn resolve_names(&self, read_api: &ReadApi) -> Result<ResolvedNames, Error> {
+        if self.names.is_empty() {
+            return Ok(ResolvedNames {
+                resolution: BTreeMap::new(),
+            });
+        }
+
+        let request = reqwest::Client::new();
+        let (url, chain) = mvr_req_url(read_api).await?;
+        let json_body = json!(NamesRequest {
+            names: self.names.clone()
+        });
+        let response = request
+            .post(format!("{url}/v1/resolution/bulk"))
+            .header("Content-Type", "application/json")
+            .json(&json_body)
+            .send()
+            .await?;
+
+        let resolved_addresses: ResolvedNames = response.json().await?;
+
+        anyhow::ensure!(
+            resolved_addresses.resolution.len() == self.names.len(),
+            "Could not find package id for {} for {chain} enviroment",
+            self.names
+                .difference(
+                    &resolved_addresses
+                        .resolution
+                        .keys()
+                        .cloned()
+                        .collect::<BTreeSet<_>>()
+                )
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+
+        Ok(resolved_addresses)
+    }
+}
+
+/// Based on the chain id of the current set environment, return the correct MVR URL to use for
+/// resolution.
+async fn mvr_req_url(read_api: &ReadApi) -> Result<(&'static str, &'static str), Error> {
+    let chain_id = read_api.get_chain_identifier().await?;
+    let chain = ChainIdentifier::from_chain_short_id(&chain_id);
+
+    if let Some(chain) = chain {
+        let chain = chain.chain();
+        match chain {
+            Chain::Mainnet => Ok((MVR_RESOLVER_MAINNET_URL, "mainnet")),
+            Chain::Testnet => Ok((MVR_RESOLVER_TESTNET_URL, "testnet")),
+            Chain::Unknown => {
+                anyhow::bail!("Unsupported chain identifier: {:?}", chain);
+            }
+        }
+    } else {
+        anyhow::bail!(
+            "Unsupported chain: {chain_id}. Only mainnet/testnet are supported for \
+            MVR resolution",
+        )
+    }
+}

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -523,7 +523,7 @@ async fn test_ptb_publish_and_complex_arg_resolution() -> Result<(), anyhow::Err
         .iter()
         .find(|refe| matches!(refe.owner, Owner::Immutable))
         .unwrap();
-    let package_id_str = package.reference.object_id.to_string();
+    let package_id_str = package.reference.object_id;
 
     let start_call_result = SuiClientCommands::Call {
         package: package.reference.object_id,
@@ -1217,7 +1217,7 @@ async fn test_delete_shared_object() -> Result<(), anyhow::Error> {
 
     // Start and then receive the object
     let start_call_result = SuiClientCommands::Call {
-        package: (*package_id.object_id).into(),
+        package: package_id.object_id,
         module: "sod".to_string(),
         function: "start".to_string(),
         type_args: vec![],
@@ -1237,7 +1237,7 @@ async fn test_delete_shared_object() -> Result<(), anyhow::Error> {
     };
 
     let delete_result = SuiClientCommands::Call {
-        package: (*package_id.object_id).into(),
+        package: package_id.object_id,
         module: "sod".to_string(),
         function: "delete".to_string(),
         type_args: vec![],
@@ -1322,7 +1322,7 @@ async fn test_receive_argument() -> Result<(), anyhow::Error> {
 
     // Start and then receive the object
     let start_call_result = SuiClientCommands::Call {
-        package: (*package_id.object_id).into(),
+        package: package_id.object_id,
         module: "tto".to_string(),
         function: "start".to_string(),
         type_args: vec![],
@@ -1359,7 +1359,7 @@ async fn test_receive_argument() -> Result<(), anyhow::Error> {
         };
 
     let receive_result = SuiClientCommands::Call {
-        package: (*package_id.object_id).into(),
+        package: package_id.object_id,
         module: "tto".to_string(),
         function: "receiver".to_string(),
         type_args: vec![],
@@ -1447,7 +1447,7 @@ async fn test_receive_argument_by_immut_ref() -> Result<(), anyhow::Error> {
 
     // Start and then receive the object
     let start_call_result = SuiClientCommands::Call {
-        package: (*package_id.object_id).into(),
+        package: package_id.object_id,
         module: "tto".to_string(),
         function: "start".to_string(),
         type_args: vec![],
@@ -1484,7 +1484,7 @@ async fn test_receive_argument_by_immut_ref() -> Result<(), anyhow::Error> {
         };
 
     let receive_result = SuiClientCommands::Call {
-        package: (*package_id.object_id).into(),
+        package: package_id.object_id,
         module: "tto".to_string(),
         function: "invalid_call_immut_ref".to_string(),
         type_args: vec![],
@@ -1572,7 +1572,7 @@ async fn test_receive_argument_by_mut_ref() -> Result<(), anyhow::Error> {
 
     // Start and then receive the object
     let start_call_result = SuiClientCommands::Call {
-        package: (*package_id.object_id).into(),
+        package: package_id.object_id,
         module: "tto".to_string(),
         function: "start".to_string(),
         type_args: vec![],
@@ -1609,7 +1609,7 @@ async fn test_receive_argument_by_mut_ref() -> Result<(), anyhow::Error> {
         };
 
     let receive_result = SuiClientCommands::Call {
-        package: (*package_id.object_id).into(),
+        package: package_id.object_id,
         module: "tto".to_string(),
         function: "invalid_call_mut_ref".to_string(),
         type_args: vec![],

--- a/crates/sui/tests/ptb_files_tests.rs
+++ b/crates/sui/tests/ptb_files_tests.rs
@@ -12,6 +12,7 @@ const TEST_DIR: &str = "tests";
 #[cfg(not(msim))]
 #[tokio::main]
 async fn test_ptb_files(path: &Path) -> datatest_stable::Result<()> {
+    use std::collections::BTreeMap;
     use sui::client_ptb::ptb::{to_source_string, PTB};
     use sui::client_ptb::{error::build_error_reports, ptb::PTBPreview};
     use test_cluster::TestClusterBuilder;
@@ -63,7 +64,7 @@ async fn test_ptb_files(path: &Path) -> datatest_stable::Result<()> {
     let context = &test_cluster.wallet;
     let client = context.get_client().await?;
 
-    let (built_ptb, warnings) = PTB::build_ptb(program, context, client).await;
+    let (built_ptb, warnings) = PTB::build_ptb(program, BTreeMap::new(), client).await;
 
     if !warnings.is_empty() {
         let rendered = build_error_reports(&file_contents, warnings);


### PR DESCRIPTION
## Description 

This PR adds support for MVR in `sui client ptb`.

## Test plan 

Existing tests and added new tests for parsing mvr names.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: The `sui client ptb` now supports passing MVR name registered packages for package IDs and type tags.
- [ ] Rust SDK:
