### PR TITLE
[sui-move] Allow coverage gathering in release builds

### DIFF
--- a/crates/sui-move/Cargo.toml
+++ b/crates/sui-move/Cargo.toml
@@ -58,3 +58,6 @@ normal = ["jemalloc-ctl"]
 
 [lints]
 workspace = true
+
+[features]
+tracing = []

--- a/crates/sui-move/src/unit_test.rs
+++ b/crates/sui-move/src/unit_test.rs
@@ -43,9 +43,10 @@ impl Test {
         build_config: BuildConfig,
     ) -> anyhow::Result<UnitTestResult> {
         let compute_coverage = self.test.compute_coverage;
-        if !cfg!(debug_assertions) && compute_coverage {
+        if !cfg!(feature = "tracing") && compute_coverage {
             return Err(anyhow::anyhow!(
-                "The --coverage flag is currently supported only in debug builds. Please build the Sui CLI from source in debug mode."
+                "The --coverage flag is currently supported only in builds built with the `tracing` feature enabled. \
+                Please build the Sui CLI from source with `--features tracing` to use this flag."
             ));
         }
         // save disassembly if trace execution is enabled

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -144,4 +144,5 @@ harness = false
 tracing = [
     "sui-types/tracing",
     "sui-execution/tracing",
+    "sui-move/tracing",
 ]


### PR DESCRIPTION
## Description 

There was a remaining check in `sui-move/src/unit-test.rs` that checked for debug builds if you wanted to collect coverage, however this is no longer true or necessary since we enabled this with the `tracing` feature flag.

Updated this locally and verified that it both works in release builds with the tracing feature enabled, and that if you try to collect coverage in a build not built with the `tracing` featur e that you get the error. 

## Test plan 

Ran it locally.

