### PR TITLE
[Consensus] enable consensus garbage collection on mainnet.

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -228,7 +228,13 @@ const MAX_PROTOCOL_VERSION: u64 = 79;
 //             Enable execution time estimate mode for congestion control on testnet.
 // Version 79: Enable median based commit timestamp in consensus on testnet.
 //             Increase threshold for bad nodes that won't be considered leaders in consensus in testnet
+<<<<<<< HEAD
 //             Enable load_nitro_attestation move function in sui framework in testnet.
+=======
+//             Enable consensus garbage collection for mainnet
+//             Enable the new consensus commit rule for mainnet.
+
+>>>>>>> ffb5f97685 ([chore] enable consensus garbage collection on mainnet.)
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 
@@ -3431,6 +3437,9 @@ impl ProtocolConfig {
                         cfg.feature_flags.enable_nitro_attestation = true
                     }
                     cfg.feature_flags.normalize_ptb_arguments = true;
+                    
+                    cfg.consensus_gc_depth = Some(60);
+                    cfg.feature_flags.consensus_linearize_subdag_v2 = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -3437,7 +3437,7 @@ impl ProtocolConfig {
                         cfg.feature_flags.enable_nitro_attestation = true
                     }
                     cfg.feature_flags.normalize_ptb_arguments = true;
-                    
+
                     cfg.consensus_gc_depth = Some(60);
                     cfg.feature_flags.consensus_linearize_subdag_v2 = true;
                 }

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -228,13 +228,10 @@ const MAX_PROTOCOL_VERSION: u64 = 79;
 //             Enable execution time estimate mode for congestion control on testnet.
 // Version 79: Enable median based commit timestamp in consensus on testnet.
 //             Increase threshold for bad nodes that won't be considered leaders in consensus in testnet
-<<<<<<< HEAD
 //             Enable load_nitro_attestation move function in sui framework in testnet.
-=======
 //             Enable consensus garbage collection for mainnet
 //             Enable the new consensus commit rule for mainnet.
 
->>>>>>> ffb5f97685 ([chore] enable consensus garbage collection on mainnet.)
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
 

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_79.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_79.snap
@@ -69,6 +69,7 @@ feature_flags:
   consensus_smart_ancestor_selection: true
   consensus_round_prober_probe_accepted_rounds: true
   native_charging_v2: true
+  consensus_linearize_subdag_v2: true
   convert_type_argument_error: true
   variant_nodes: true
   consensus_zstd_compression: true
@@ -360,6 +361,7 @@ max_soft_bundle_size: 5
 bridge_should_try_to_finalize_committee: true
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 37000000
 max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 7400000
+consensus_gc_depth: 60
 gas_budget_based_txn_cost_cap_factor: 400000
 gas_budget_based_txn_cost_absolute_cap_commit_count: 50
 sip_45_consensus_amplification_threshold: 5


### PR DESCRIPTION
## Description 

Enables consensus garbage collection and new linearizer logic in mainnet.

## Test plan 

CI/PT/Antithesis

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [x] Protocol: Enable consensus garbage collection and new linearizer logic in mainnet
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
