### PR TITLE
[indexer-alt] add temp obj_info pipeline to config

### DIFF
--- a/crates/sui-indexer-alt/src/config.rs
+++ b/crates/sui-indexer-alt/src/config.rs
@@ -116,6 +116,7 @@ pub struct PipelineLayer {
     // Consistent pipelines
     pub coin_balance_buckets: Option<CommitterLayer>,
     pub obj_info: Option<CommitterLayer>,
+    pub obj_info_temp: Option<CommitterLayer>,
 
     // Sequential pipelines
     pub sum_displays: Option<SequentialLayer>,
@@ -279,6 +280,7 @@ impl PipelineLayer {
         PipelineLayer {
             coin_balance_buckets: Some(Default::default()),
             obj_info: Some(Default::default()),
+            obj_info_temp: None,
             sum_displays: Some(Default::default()),
             sum_packages: Some(Default::default()),
             cp_sequence_numbers: Some(Default::default()),
@@ -402,6 +404,7 @@ impl Merge for PipelineLayer {
         PipelineLayer {
             coin_balance_buckets: self.coin_balance_buckets.merge(other.coin_balance_buckets),
             obj_info: self.obj_info.merge(other.obj_info),
+            obj_info_temp: self.obj_info_temp.merge(other.obj_info_temp),
             sum_displays: self.sum_displays.merge(other.sum_displays),
             sum_packages: self.sum_packages.merge(other.sum_packages),
             cp_sequence_numbers: self.cp_sequence_numbers.merge(other.cp_sequence_numbers),

--- a/crates/sui-indexer-alt/src/lib.rs
+++ b/crates/sui-indexer-alt/src/lib.rs
@@ -88,6 +88,7 @@ pub async fn setup_indexer(
         kv_protocol_configs,
         kv_transactions,
         obj_info,
+        obj_info_temp,
         obj_versions,
         obj_versions_sentinel_backfill,
         tx_affected_addresses,
@@ -190,7 +191,6 @@ pub async fn setup_indexer(
     }
 
     // Consistent pipelines
-    let obj_info_temp = obj_info.clone();
     add_consistent!(CoinBalanceBuckets::default(), coin_balance_buckets);
     add_consistent!(ObjInfo::default(), obj_info);
     // TODO: Remove this once the backfill is complete.


### PR DESCRIPTION
## Description 

I realized the previous PR #21619 did not include `obj_info_temp`  in the pipeline layer config so the config wouldn't be passed in properly. This PR fixes that.

## Test plan 

Ran indexer locally with a config for `obj_info_temp` pipeline.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
