### PR TITLE
[move-compiler] Fix annotation support for macro lambdas

### DIFF
--- a/external-crates/move/crates/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/ast.rs
@@ -396,6 +396,8 @@ pub struct Lambda {
     pub return_label: BlockLabel,
     pub use_fun_color: Color,
     pub body: Box<Exp>,
+    // collected during expansion
+    pub extra_annotations: Vec<Spanned<(Vec<Type>, Type)>>,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -1840,22 +1842,40 @@ impl AstDebug for Exp_ {
 
 impl AstDebug for Lambda {
     fn ast_debug(&self, w: &mut AstWriter) {
+        struct LambdaAnnot<'a>(&'a (Vec<Type>, Type));
+        impl AstDebug for LambdaAnnot<'_> {
+            fn ast_debug(&self, w: &mut AstWriter) {
+                let (args, result) = &self.0;
+                w.write("|");
+                w.comma(args, |w, ty| ty.ast_debug(w));
+                w.write("|");
+                result.ast_debug(w);
+            }
+        }
+
         let Lambda {
             parameters: sp!(_, bs),
             return_type,
             return_label,
             use_fun_color,
             body: e,
+            extra_annotations,
         } = self;
         return_label.ast_debug(w);
         w.write(": ");
-        bs.ast_debug(w);
-        if let Some(ty) = return_type {
-            w.write(" -> ");
-            ty.ast_debug(w);
+        let mut display: Box<dyn FnOnce(&mut AstWriter)> = Box::new(|w: &mut AstWriter| {
+            bs.ast_debug(w);
+            if let Some(ty) = return_type {
+                w.write(" -> ");
+                ty.ast_debug(w);
+            }
+            w.write(format!("use_funs#{}", use_fun_color));
+            e.ast_debug(w);
+        });
+        for annot in extra_annotations {
+            display = Box::new(|w: &mut AstWriter| w.annotate(display, &LambdaAnnot(annot)));
         }
-        w.write(format!("use_funs#{}", use_fun_color));
-        e.ast_debug(w);
+        display(w)
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/ast.rs
@@ -396,7 +396,9 @@ pub struct Lambda {
     pub return_label: BlockLabel,
     pub use_fun_color: Color,
     pub body: Box<Exp>,
-    // collected during expansion
+    // collected during expansion. Conceptually we could handle this by eta-expanding the lambda
+    // invocation, so that `$f` becomes `|...|$f(...)`, but due to the limited nature here, just
+    // collecting the annotations is easier
     pub extra_annotations: Vec<Spanned<(Vec<Type>, Type)>>,
 }
 
@@ -1872,7 +1874,7 @@ impl AstDebug for Lambda {
             w.write(format!("use_funs#{}", use_fun_color));
             e.ast_debug(w);
         });
-        for annot in extra_annotations {
+        for sp!(_, annot) in extra_annotations {
             display = Box::new(|w: &mut AstWriter| w.annotate(display, &LambdaAnnot(annot)));
         }
         display(w)

--- a/external-crates/move/crates/move-compiler/src/naming/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/ast.rs
@@ -396,7 +396,9 @@ pub struct Lambda {
     pub return_label: BlockLabel,
     pub use_fun_color: Color,
     pub body: Box<Exp>,
-    // collected during expansion. Conceptually we could handle this by eta-expanding the lambda
+    // Collected during macro expansion. These additional annotations can come from `Annotate` or
+    // more subtly by passing a lambda from one macro to another.
+    // Conceptually we could handle this by eta-expanding the lambda
     // invocation, so that `$f` becomes `|...|$f(...)`, but due to the limited nature here, just
     // collecting the annotations is easier
     pub extra_annotations: Vec<Spanned<(Vec<Type>, Type)>>,

--- a/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/resolve_use_funs.rs
@@ -349,6 +349,7 @@ fn exp(context: &mut Context, sp!(_, e_): &mut N::Exp) {
             return_label: _,
             use_fun_color: _,
             body: e,
+            extra_annotations: _,
         }) => exp(context, e),
         N::Exp_::IfElse(econd, et, ef_opt) => {
             exp(context, econd);

--- a/external-crates/move/crates/move-compiler/src/naming/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/naming/translate.rs
@@ -2766,6 +2766,7 @@ fn exp(context: &mut Context, e: Box<E::Exp>) -> Box<N::Exp> {
                     return_label,
                     use_fun_color: 0, // used in macro expansion
                     body,
+                    extra_annotations: vec![], // used in macro expansion
                 }),
             }
         }
@@ -4325,6 +4326,7 @@ fn remove_unused_bindings_exp(
             return_type: _,
             use_fun_color: _,
             body,
+            extra_annotations: _,
         }) => {
             for (lvs, _) in parameters {
                 remove_unused_bindings_lvalues(context, used, lvs)

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -2138,6 +2138,7 @@ pub fn check_call_arity<S: std::fmt::Display, F: Fn() -> S>(
     context: &mut Context,
     loc: Loc,
     msg: F,
+    arity_loc: Option<Loc>,
     arity: usize,
     argloc: Loc,
     given_len: usize,
@@ -2156,11 +2157,17 @@ pub fn check_call_arity<S: std::fmt::Display, F: Fn() -> S>(
         arity,
         given_len
     );
-    context.add_diag(diag!(
-        code,
-        (loc, cmsg),
-        (argloc, format!("Found {} argument(s) here", given_len)),
-    ));
+    let args_msg = format!("Found {} argument(s) here", given_len);
+    let diag = match arity_loc {
+        None => diag!(code, (loc, cmsg), (argloc, args_msg)),
+        Some(arity_loc) => diag!(
+            code,
+            (loc, cmsg),
+            (arity_loc, format!("Expected {} argument(s)", arity)),
+            (argloc, args_msg)
+        ),
+    };
+    context.add_diag(diag);
 }
 
 //**************************************************************************************************

--- a/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
@@ -1007,7 +1007,7 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
                 .into_iter()
                 .map(|sp!(loc, (ps, r))| (sp(loc, ps), r))
                 .unzip();
-            let all_param_tys = {
+            let mut all_param_tys = {
                 extra_param_tys.push(sp(tfunloc, param_tys));
                 extra_param_tys
             };
@@ -1051,6 +1051,10 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
             }
 
             let all_param_tys_annot = {
+                // we have a vector of annotations of all parameters, we will split these
+                // into the individual annotations for each parameter.
+                // If there is a length mismatch, we will have an error already but there
+                // might be some strange edge cases to fix
                 let num_params = all_param_tys
                     .iter()
                     .map(|sp!(_, tys)| tys.len())

--- a/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
@@ -20,7 +20,7 @@ use move_ir_types::location::*;
 use move_proc_macros::growing_stack;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
-type LambdaMap = BTreeMap<Var_, (N::Lambda, Vec<Type>, Type)>;
+type LambdaMap = BTreeMap<Var_, (N::Lambda, Loc, Vec<Type>, Type)>;
 type ArgMap = BTreeMap<Var_, (N::Exp, Type)>;
 struct ParamInfo {
     argument: Option<EvalStrategy<Loc, Loc>>,
@@ -135,7 +135,7 @@ pub(crate) fn call(
             Arg::ByName((e, ty)) => (EvalStrategy::ByName(e.loc), ty.clone()),
         };
         let unfolded = core::unfold_type(&context.subst, arg_ty);
-        if let sp!(_, Type_::Fun(param_tys, result_ty)) = unfolded {
+        if let sp!(tfunloc, Type_::Fun(param_tys, result_ty)) = unfolded {
             let arg_exp = match arg {
                 Arg::ByValue(_) => {
                     assert!(
@@ -147,7 +147,15 @@ pub(crate) fn call(
                 Arg::ByName((e, _)) => e,
             };
             if let Some(v) = param {
-                bind_lambda(context, &mut lambdas, v, arg_exp, param_tys, *result_ty)?
+                bind_lambda(
+                    context,
+                    &mut lambdas,
+                    v,
+                    arg_exp,
+                    tfunloc,
+                    param_tys,
+                    *result_ty,
+                )?
             }
         } else {
             match arg {
@@ -275,12 +283,13 @@ fn bind_lambda(
     lambdas: &mut LambdaMap,
     param: Var_,
     arg: N::Exp,
+    tfunloc: Loc,
     param_ty: Vec<Type>,
     result_ty: Type,
 ) -> Option<()> {
     match arg.value {
         N::Exp_::Lambda(lambda) => {
-            lambdas.insert(param, (lambda, param_ty, result_ty));
+            lambdas.insert(param, (lambda, tfunloc, param_ty, result_ty));
             Some(())
         }
         _ => {
@@ -661,6 +670,7 @@ fn recolor_exp(ctx: &mut Recolor, sp!(_, e_): &mut N::Exp) {
             return_label,
             use_fun_color,
             body,
+            extra_annotations: _,
         }) => {
             ctx.add_block_label(*return_label);
             for (lvs, _) in &*parameters {
@@ -969,8 +979,12 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
         ///////
         N::Exp_::Var(sp!(_, v_)) if context.lambdas.contains_key(v_) => {
             context.mark_used(v_);
-            let (lambda, _, _) = context.lambdas.get(v_).unwrap();
-            *e_ = N::Exp_::Lambda(lambda.clone());
+            let (lambda, tfunloc, args, ret) = context.lambdas.get(v_).unwrap();
+            let mut lambda = lambda.clone();
+            lambda
+                .extra_annotations
+                .push(sp(*tfunloc, (args.clone(), ret.clone())));
+            *e_ = N::Exp_::Lambda(lambda);
         }
         N::Exp_::VarCall(sp!(_, v_), sp!(argloc, es)) if context.lambdas.contains_key(v_) => {
             context.mark_used(v_);
@@ -983,10 +997,24 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
                     return_label,
                     use_fun_color,
                     body: mut lambda_body,
+                    extra_annotations,
                 },
+                tfunloc,
                 param_tys,
                 result_ty,
             ) = context.lambdas.get(v_).unwrap().clone();
+            let (mut extra_param_tys, mut extra_result_tys): (Vec<_>, Vec<_>) = extra_annotations
+                .into_iter()
+                .map(|sp!(loc, (ps, r))| (sp(loc, ps), r))
+                .unzip();
+            let all_param_tys = {
+                extra_param_tys.push(sp(tfunloc, param_tys));
+                extra_param_tys
+            };
+            let all_result_ty = {
+                extra_result_tys.push(result_ty);
+                extra_result_tys
+            };
             // recolor in case the lambda is used more than once
             let next_color = context.core.next_variable_color();
             let reloc_clever_errors = None;
@@ -1010,14 +1038,36 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
             context.core.set_max_variable_color(recolor.max_color());
             // check arity before expanding
             let argloc = *argloc;
-            core::check_call_arity(
-                context.core,
-                *eloc,
-                || format!("Invalid lambda call of '{}'", v_.name),
-                param_tys.len(),
-                argloc,
-                es.len(),
-            );
+            for sp!(annot_loc, annot) in &all_param_tys {
+                core::check_call_arity(
+                    context.core,
+                    *eloc,
+                    || format!("Invalid lambda call of '{}'", v_.name),
+                    Some(*annot_loc),
+                    annot.len(),
+                    argloc,
+                    es.len(),
+                );
+            }
+
+            let all_param_tys_annot = {
+                let num_params = all_param_tys
+                    .iter()
+                    .map(|sp!(_, tys)| tys.len())
+                    .max()
+                    .unwrap();
+                let annots = (0..num_params)
+                    .map(|_| {
+                        all_param_tys
+                            .iter_mut()
+                            .filter_map(|sp!(_, tys)| tys.pop())
+                            .collect::<Vec<_>>()
+                    })
+                    .rev()
+                    .collect::<Vec<_>>();
+                assert!(all_param_tys.iter().all(|sp!(_, tys)| tys.is_empty()));
+                annots
+            };
             // expand the call, replacing with a dummy value to take the args by value
             let N::Exp_::VarCall(_, sp!(_, args)) =
                 std::mem::replace(e_, /* dummy */ N::Exp_::UnresolvedError)
@@ -1025,7 +1075,9 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
                 unreachable!()
             };
             let body_loc = lambda_body.loc;
-            let annot_body = Box::new(sp(body_loc, N::Exp_::Annotate(lambda_body, result_ty)));
+            let annot_body = all_result_ty.into_iter().fold(lambda_body, |body, ty| {
+                Box::new(sp(body_loc, N::Exp_::Annotate(body, ty)))
+            });
             let labeled_seq = VecDeque::from([sp(body_loc, N::SequenceItem_::Seq(annot_body))]);
             let labeled_body_ = N::Exp_::Block(N::Block {
                 name: Some(return_label),
@@ -1043,11 +1095,13 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
             let mut result: VecDeque<_> = lambda_params
                 .into_iter()
                 .zip(args)
-                .zip(param_tys)
-                .map(|(((lvs, _lv_ty_opt), arg), param_ty)| {
-                    let param_loc = param_ty.loc;
+                .zip(all_param_tys_annot)
+                .map(|(((lvs, _lv_ty_opt), arg), param_ty_annots)| {
                     let arg = Box::new(arg);
-                    let annot_arg = Box::new(sp(param_loc, N::Exp_::Annotate(arg, param_ty)));
+                    let param_loc = param_ty_annots.last().unwrap().loc;
+                    let annot_arg = param_ty_annots.into_iter().fold(arg, |arg, param_ty| {
+                        Box::new(sp(param_ty.loc, N::Exp_::Annotate(arg, param_ty)))
+                    });
                     sp(param_loc, N::SequenceItem_::Bind(lvs, annot_arg))
                 })
                 .collect();

--- a/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
@@ -10,7 +10,7 @@ use crate::{
         self as N, BlockLabel, Color, MatchArm_, TParamID, Type, Type_, UseFuns, Var, Var_,
     },
     parser::ast::FunctionName,
-    shared::{ide::IDEAnnotation, program_info::FunctionInfo, unique_map::UniqueMap, AstDebug},
+    shared::{ide::IDEAnnotation, program_info::FunctionInfo, unique_map::UniqueMap},
     typing::{
         ast as T,
         core::{self, TParamSubst},

--- a/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
@@ -10,7 +10,7 @@ use crate::{
         self as N, BlockLabel, Color, MatchArm_, TParamID, Type, Type_, UseFuns, Var, Var_,
     },
     parser::ast::FunctionName,
-    shared::{ide::IDEAnnotation, program_info::FunctionInfo, unique_map::UniqueMap},
+    shared::{ide::IDEAnnotation, program_info::FunctionInfo, unique_map::UniqueMap, AstDebug},
     typing::{
         ast as T,
         core::{self, TParamSubst},
@@ -1060,15 +1060,15 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
                     .map(|sp!(_, tys)| tys.len())
                     .max()
                     .unwrap();
-                let annots = (0..num_params)
+                let mut annots = (0..num_params)
                     .map(|_| {
                         all_param_tys
                             .iter_mut()
                             .filter_map(|sp!(_, tys)| tys.pop())
                             .collect::<Vec<_>>()
                     })
-                    .rev()
                     .collect::<Vec<_>>();
+                annots.reverse();
                 assert!(all_param_tys.iter().all(|sp!(_, tys)| tys.is_empty()));
                 annots
             };

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -4406,7 +4406,7 @@ fn make_arg_types<S: std::fmt::Display, F: Fn() -> S>(
     mut given: Vec<Type>,
 ) -> Vec<Type> {
     let given_len = given.len();
-    core::check_call_arity(context, loc, msg, arity, argloc, given_len);
+    core::check_call_arity(context, loc, msg, None, arity, argloc, given_len);
     while given.len() < arity {
         given.push(context.error_type(argloc))
     }
@@ -4566,6 +4566,7 @@ fn macro_call_impl(
         context,
         loc,
         || format!("Invalid call of '{}::{}'", &m, &f),
+        None,
         parameters.len(),
         argloc,
         args.len(),

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -4747,9 +4747,58 @@ fn expand_macro(
 /// 1) We can track the use_fun_scope, which is used for resolving method calls correctly
 /// 2) After substitution, we can mark the Block as coming from a macro expansion which is used
 ///    for tracking recursive macro calls
-fn convert_macro_arg_to_block(context: &Context, sp!(loc, ne_): N::Exp) -> N::Exp {
+fn convert_macro_arg_to_block(context: &mut Context, sp!(loc, ne_): N::Exp) -> N::Exp {
+    fn is_lambda(ne_: &N::Exp_) -> bool {
+        match ne_ {
+            N::Exp_::Lambda(_) => true,
+            N::Exp_::Annotate(e, _) => is_lambda(&e.value),
+            _ => false,
+        }
+    }
+
+    fn gather_lambda_annotations(
+        context: &mut Context,
+        loc: Loc,
+        ne_: N::Exp_,
+        mut extra_annotations: Vec<Type>,
+    ) -> N::Exp_ {
+        match ne_ {
+            N::Exp_::Lambda(lambda) if extra_annotations.is_empty() => N::Exp_::Lambda(lambda),
+            N::Exp_::Lambda(mut lambda) => {
+                let param_tys = lambda
+                    .parameters
+                    .value
+                    .iter()
+                    .map(|(sp!(loc, _), _)| core::make_tvar(context, *loc))
+                    .collect::<Vec<_>>();
+                let res_ty = core::make_tvar(context, lambda.body.loc);
+                let tfun = sp(loc, Type_::Fun(param_tys.clone(), Box::new(res_ty.clone())));
+                for annot in extra_annotations {
+                    let annot_loc = annot.loc;
+                    subtype(
+                        context,
+                        annot_loc,
+                        || "Invalid annotation for lambda",
+                        tfun.clone(),
+                        annot,
+                    );
+                }
+                lambda.extra_annotations.push(sp(loc, (param_tys, res_ty)));
+                N::Exp_::Lambda(lambda)
+            }
+
+            N::Exp_::Annotate(e, annot) => {
+                extra_annotations.push(annot);
+                let sp!(eloc, e_) = *e;
+                gather_lambda_annotations(context, eloc, e_, extra_annotations)
+            }
+            _ => unreachable!(),
+        }
+    }
+
     let ne_ = match ne_ {
-        N::Exp_::Block(_) | N::Exp_::Lambda(_) | N::Exp_::UnresolvedError => ne_,
+        _ if is_lambda(&ne_) => gather_lambda_annotations(context, loc, ne_, vec![]),
+        N::Exp_::Block(_) | N::Exp_::UnresolvedError => ne_,
         ne_ => {
             let color = context.current_call_color();
             let seq_ = VecDeque::from([sp(loc, N::SequenceItem_::Seq(Box::new(sp(loc, ne_))))]);

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/macro_types.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/macro_types.move
@@ -1,0 +1,28 @@
+#[allow(ide_path_autocomplete)]
+module a::collection {
+
+    public struct Content has store {
+        content: Option<u64>,
+    }
+
+    public struct Collection<phantom T> {
+        items: vector<Content>,
+        cost: u64,
+    }
+
+    public fun do_stuff<T>(
+        collection: &mut Collection<T>,
+        count: u64,
+    ) {
+        std::u64::do!(count, |_| {
+            let content = new_empty_content();
+            collection.items.push_back(content);
+        });
+    }
+
+    fun new_empty_content(): Content {
+        Content {
+            content: option::none(),
+        }
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/macro_types.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/macro_types.move
@@ -26,3 +26,27 @@ module a::collection {
         }
     }
 }
+
+
+#[allow(ide_path_autocomplete)]
+module std::my_macros {
+    public macro fun range_do<$T, $R: drop>($start: $T, $stop: $T, $f: |$T| -> $R) {
+        let mut i = $start;
+        let stop = $stop;
+        while (i < stop) {
+            $f(i);
+            i = i + 1;
+        }
+    }
+
+    public macro fun do<$T, $R: drop>($stop: $T, $f: |$T| -> $R) {
+        range_do!(0, $stop, $f)
+    }
+}
+
+#[allow(ide_path_autocomplete)]
+module std::u64 {
+    public macro fun do<$R: drop>($stop: u64, $f: |u64| -> $R) {
+        std::my_macros::do!($stop, $f)
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/macro_types.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/macro_types.snap
@@ -10,3 +10,15 @@ warning[W10007]: issue with attribute value
   │
 1 │ #[allow(ide_path_autocomplete)]
   │         ^^^^^^^^^^^^^^^^^^^^^ Unknown warning filter 'ide_path_autocomplete'
+
+warning[W10007]: issue with attribute value
+   ┌─ tests/move_2024/ide_mode/macro_types.move:31:9
+   │
+31 │ #[allow(ide_path_autocomplete)]
+   │         ^^^^^^^^^^^^^^^^^^^^^ Unknown warning filter 'ide_path_autocomplete'
+
+warning[W10007]: issue with attribute value
+   ┌─ tests/move_2024/ide_mode/macro_types.move:47:9
+   │
+47 │ #[allow(ide_path_autocomplete)]
+   │         ^^^^^^^^^^^^^^^^^^^^^ Unknown warning filter 'ide_path_autocomplete'

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/macro_types.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/macro_types.snap
@@ -1,0 +1,12 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+warning[W10007]: issue with attribute value
+  ┌─ tests/move_2024/ide_mode/macro_types.move:1:9
+  │
+1 │ #[allow(ide_path_autocomplete)]
+  │         ^^^^^^^^^^^^^^^^^^^^^ Unknown warning filter 'ide_path_autocomplete'

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/macro_types@ide.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/macro_types@ide.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-compiler/tests/move_check_testsuite.rs
-assertion_line: 252
 info:
   flavor: core
   edition: 2024.alpha
@@ -13,13 +12,15 @@ note[I15002]: IDE macro call info
     │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ macro call info
     │
     = Called std::macros::do
-    = Type arguments: u64, _|_
+    = Type arguments: u64, ()
 
-error[E04010]: cannot infer type
-    ┌─ /Users/tmn/sui/external-crates/move/crates/move-stdlib/sources/u64.move:105:5
-    │
-105 │     std::macros::do!($stop, $f)
-    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Could not infer this type. Try adding an annotation
+warning[W09009]: unused struct field
+   ┌─ tests/move_2024/ide_mode/macro_types.move:10:9
+   │
+10 │         cost: u64,
+   │         ^^^^ The 'cost' field of the 'Collection' type is unused
+   │
+   = This warning can be suppressed with '#[allow(unused_field)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 note[I15002]: IDE macro call info
    ┌─ tests/move_2024/ide_mode/macro_types.move:17:9
@@ -31,16 +32,7 @@ note[I15002]: IDE macro call info
    │ ╰──────────^ macro call info
    │  
    = Called std::u64::do
-   = Type arguments: _|_
-
-error[E04010]: cannot infer type
-   ┌─ tests/move_2024/ide_mode/macro_types.move:17:9
-   │  
-17 │ ╭         std::u64::do!(count, |_| {
-18 │ │             let content = new_empty_content();
-19 │ │             collection.items.push_back(content);
-20 │ │         });
-   │ ╰──────────^ Could not infer this type. Try adding an annotation
+   = Type arguments: ()
 
 note[I15001]: IDE dot autocomplete
    ┌─ tests/move_2024/ide_mode/macro_types.move:19:23

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/macro_types@ide.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/macro_types@ide.snap
@@ -5,15 +5,6 @@ info:
   edition: 2024.alpha
   lint: false
 ---
-note[I15002]: IDE macro call info
-    ┌─ /Users/tmn/sui/external-crates/move/crates/move-stdlib/sources/u64.move:105:5
-    │
-105 │     std::macros::do!($stop, $f)
-    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ macro call info
-    │
-    = Called std::macros::do
-    = Type arguments: u64, ()
-
 warning[W09009]: unused struct field
    ┌─ tests/move_2024/ide_mode/macro_types.move:10:9
    │
@@ -59,16 +50,25 @@ note[I15001]: IDE dot autocomplete
    │                              ^^^^^^^^^ Possible dot names: 'std::vector::all', 'std::vector::any', 'std::vector::append', 'std::vector::borrow', 'std::vector::borrow_mut', 'std::vector::contains', 'std::vector::count', 'std::vector::destroy', 'std::vector::destroy_empty', 'std::vector::do', 'std::vector::do_mut', 'std::vector::do_ref', 'std::vector::filter', 'std::vector::find_index', 'std::vector::flatten', 'std::vector::fold', 'std::vector::index_of', 'std::vector::insert', 'std::vector::is_empty', 'std::vector::length', 'std::vector::map', 'std::vector::map_ref', 'std::vector::partition', 'std::vector::pop_back', 'std::vector::push_back', 'std::vector::remove', 'std::vector::reverse', 'std::vector::swap', 'std::vector::swap_remove', 'std::ascii::to_ascii_string', 'std::string::to_string', 'std::ascii::try_to_ascii_string', 'std::string::try_to_string', 'std::vector::zip_do', 'std::vector::zip_do_mut', 'std::vector::zip_do_ref', 'std::vector::zip_do_reverse', 'std::vector::zip_map', or 'std::vector::zip_map_ref'
 
 note[I15003]: IDE expanded lambda
-   ┌─ /Users/tmn/sui/external-crates/move/crates/move-stdlib/sources/macros.move:91:9
+   ┌─ tests/move_2024/ide_mode/macro_types.move:37:13
    │
-91 │         $f(i);
-   │         ^^^^^ expanded lambda
+37 │             $f(i);
+   │             ^^^^^ expanded lambda
 
 note[I15002]: IDE macro call info
-    ┌─ /Users/tmn/sui/external-crates/move/crates/move-stdlib/sources/macros.move:112:5
-    │
-112 │     range_do!(0, $stop, $f)
-    │     ^^^^^^^^^^^^^^^^^^^^^^^ macro call info
-    │
-    = Called std::macros::range_do
-    = Type arguments: u64, ()
+   ┌─ tests/move_2024/ide_mode/macro_types.move:43:9
+   │
+43 │         range_do!(0, $stop, $f)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^ macro call info
+   │
+   = Called std::my_macros::range_do
+   = Type arguments: u64, ()
+
+note[I15002]: IDE macro call info
+   ┌─ tests/move_2024/ide_mode/macro_types.move:50:9
+   │
+50 │         std::my_macros::do!($stop, $f)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ macro call info
+   │
+   = Called std::my_macros::do
+   = Type arguments: u64, ()

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/macro_types@ide.snap.new
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/macro_types@ide.snap.new
@@ -1,0 +1,82 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+assertion_line: 252
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+note[I15002]: IDE macro call info
+    ┌─ /Users/tmn/sui/external-crates/move/crates/move-stdlib/sources/u64.move:105:5
+    │
+105 │     std::macros::do!($stop, $f)
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ macro call info
+    │
+    = Called std::macros::do
+    = Type arguments: u64, _|_
+
+error[E04010]: cannot infer type
+    ┌─ /Users/tmn/sui/external-crates/move/crates/move-stdlib/sources/u64.move:105:5
+    │
+105 │     std::macros::do!($stop, $f)
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Could not infer this type. Try adding an annotation
+
+note[I15002]: IDE macro call info
+   ┌─ tests/move_2024/ide_mode/macro_types.move:17:9
+   │  
+17 │ ╭         std::u64::do!(count, |_| {
+18 │ │             let content = new_empty_content();
+19 │ │             collection.items.push_back(content);
+20 │ │         });
+   │ ╰──────────^ macro call info
+   │  
+   = Called std::u64::do
+   = Type arguments: _|_
+
+error[E04010]: cannot infer type
+   ┌─ tests/move_2024/ide_mode/macro_types.move:17:9
+   │  
+17 │ ╭         std::u64::do!(count, |_| {
+18 │ │             let content = new_empty_content();
+19 │ │             collection.items.push_back(content);
+20 │ │         });
+   │ ╰──────────^ Could not infer this type. Try adding an annotation
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/macro_types.move:19:23
+   │
+19 │             collection.items.push_back(content);
+   │                       ^ Possible dot names: 'a::collection::do_stuff', 'cost', or 'items'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/macro_types.move:19:24
+   │
+19 │             collection.items.push_back(content);
+   │                        ^^^^^ Possible dot names: 'a::collection::do_stuff', 'cost', or 'items'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/macro_types.move:19:29
+   │
+19 │             collection.items.push_back(content);
+   │                             ^ Possible dot names: 'std::vector::all', 'std::vector::any', 'std::vector::append', 'std::vector::borrow', 'std::vector::borrow_mut', 'std::vector::contains', 'std::vector::count', 'std::vector::destroy', 'std::vector::destroy_empty', 'std::vector::do', 'std::vector::do_mut', 'std::vector::do_ref', 'std::vector::filter', 'std::vector::find_index', 'std::vector::flatten', 'std::vector::fold', 'std::vector::index_of', 'std::vector::insert', 'std::vector::is_empty', 'std::vector::length', 'std::vector::map', 'std::vector::map_ref', 'std::vector::partition', 'std::vector::pop_back', 'std::vector::push_back', 'std::vector::remove', 'std::vector::reverse', 'std::vector::swap', 'std::vector::swap_remove', 'std::ascii::to_ascii_string', 'std::string::to_string', 'std::ascii::try_to_ascii_string', 'std::string::try_to_string', 'std::vector::zip_do', 'std::vector::zip_do_mut', 'std::vector::zip_do_ref', 'std::vector::zip_do_reverse', 'std::vector::zip_map', or 'std::vector::zip_map_ref'
+
+note[I15001]: IDE dot autocomplete
+   ┌─ tests/move_2024/ide_mode/macro_types.move:19:30
+   │
+19 │             collection.items.push_back(content);
+   │                              ^^^^^^^^^ Possible dot names: 'std::vector::all', 'std::vector::any', 'std::vector::append', 'std::vector::borrow', 'std::vector::borrow_mut', 'std::vector::contains', 'std::vector::count', 'std::vector::destroy', 'std::vector::destroy_empty', 'std::vector::do', 'std::vector::do_mut', 'std::vector::do_ref', 'std::vector::filter', 'std::vector::find_index', 'std::vector::flatten', 'std::vector::fold', 'std::vector::index_of', 'std::vector::insert', 'std::vector::is_empty', 'std::vector::length', 'std::vector::map', 'std::vector::map_ref', 'std::vector::partition', 'std::vector::pop_back', 'std::vector::push_back', 'std::vector::remove', 'std::vector::reverse', 'std::vector::swap', 'std::vector::swap_remove', 'std::ascii::to_ascii_string', 'std::string::to_string', 'std::ascii::try_to_ascii_string', 'std::string::try_to_string', 'std::vector::zip_do', 'std::vector::zip_do_mut', 'std::vector::zip_do_ref', 'std::vector::zip_do_reverse', 'std::vector::zip_map', or 'std::vector::zip_map_ref'
+
+note[I15003]: IDE expanded lambda
+   ┌─ /Users/tmn/sui/external-crates/move/crates/move-stdlib/sources/macros.move:91:9
+   │
+91 │         $f(i);
+   │         ^^^^^ expanded lambda
+
+note[I15002]: IDE macro call info
+    ┌─ /Users/tmn/sui/external-crates/move/crates/move-stdlib/sources/macros.move:112:5
+    │
+112 │     range_do!(0, $stop, $f)
+    │     ^^^^^^^^^^^^^^^^^^^^^^^ macro call info
+    │
+    = Called std::macros::range_do
+    = Type arguments: u64, ()

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/annotated_lambda.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/annotated_lambda.move
@@ -4,7 +4,7 @@ module a::m {
     }
 
     fun t() {
-        // cannot annotate a lambda this way
-        call!((|| 1 : || -> u64))
+        // this sort of annotation is now supported
+        call!((|| 1 : || -> u64));
     }
 }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/annotated_lambda.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/annotated_lambda.snap
@@ -5,8 +5,4 @@ info:
   edition: 2024.alpha
   lint: false
 ---
-error[E04032]: unable to expand macro function
-  ┌─ tests/move_2024/typing/annotated_lambda.move:8:15
-  │
-8 │         call!((|| 1 : || -> u64))
-  │               ^^^^^^^^^^^^^^^^^^ Unable to bind lambda to parameter '$f'. The lambda must be passed directly
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/annotated_lambda_type_inference.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/annotated_lambda_type_inference.move
@@ -1,0 +1,16 @@
+// tests that type annotations are persisted on lambdas when passing from one macro to another
+// ensures that _ is instantiated separately each time
+
+module a::m;
+
+macro fun do2($f: |u32| -> u64, $g: |u16| -> u64): u64 {
+    $f(0xFFFF_FFFF) + $g(0xFFFF)
+}
+
+macro fun double($f: |_| -> u64): u64 {
+    do2!($f, $f)
+}
+
+fun t2() {
+    double!(|x| x as u64);
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/annotated_lambda_type_inference.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/annotated_lambda_type_inference.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/annotated_lambda_type_inference_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/annotated_lambda_type_inference_invalid.move
@@ -1,0 +1,40 @@
+// tests that type annotations are persisted on lambdas when passing from one macro to another
+
+module a::m;
+
+macro fun do_u32($f: |u32| -> u64, $arg: _): u64 {
+    $f($arg)
+}
+
+macro fun do_u16($f: |u16| -> u64, $arg: _): u64 {
+    do_u32!($f, $arg)
+}
+
+fun t() {
+    do_u16!(|x| x as u64, 0xFFFF_FFFF);
+}
+
+
+macro fun do2($f: |u32| -> u64, $g: |u16| -> u64): u64 {
+    $f(0) + $g(0)
+}
+
+macro fun double($f: |u16| -> u64): u64 {
+    do2!($f, $f)
+}
+
+fun t2() {
+    double!(|x| x as u64);
+}
+
+macro fun do2_invalid($f: |u32| -> u64, $g: |u16| -> u64): u64 {
+    $f(0xFFFF_FFFF) + $g(0xFFFF_FFFF)
+}
+
+macro fun double_under($f: |_| -> u64): u64 {
+    do2_invalid!($f, $f)
+}
+
+fun t3() {
+    double_under!(|x| x as u64);
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/annotated_lambda_type_inference_invalid.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/annotated_lambda_type_inference_invalid.snap
@@ -1,0 +1,53 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+error[E04007]: incompatible types
+  ┌─ tests/move_2024/typing/annotated_lambda_type_inference_invalid.move:5:23
+  │
+5 │ macro fun do_u32($f: |u32| -> u64, $arg: _): u64 {
+  │                       ^^^
+  │                       │
+  │                       Invalid type annotation
+  │                       Expected: 'u32'
+  ·
+9 │ macro fun do_u16($f: |u16| -> u64, $arg: _): u64 {
+  │                       --- Given: 'u16'
+
+error[E04021]: invalid number after type inference
+   ┌─ tests/move_2024/typing/annotated_lambda_type_inference_invalid.move:14:27
+   │
+ 9 │ macro fun do_u16($f: |u16| -> u64, $arg: _): u64 {
+   │                       --- Expected a literal of type 'u16', but the value is too large.
+   ·
+14 │     do_u16!(|x| x as u64, 0xFFFF_FFFF);
+   │                           ^^^^^^^^^^^
+   │                           │
+   │                           Invalid numerical literal
+   │                           Annotating the literal might help inference: '4294967295u32'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/annotated_lambda_type_inference_invalid.move:18:20
+   │
+18 │ macro fun do2($f: |u32| -> u64, $g: |u16| -> u64): u64 {
+   │                    ^^^
+   │                    │
+   │                    Invalid type annotation
+   │                    Expected: 'u32'
+   ·
+22 │ macro fun double($f: |u16| -> u64): u64 {
+   │                       --- Given: 'u16'
+
+error[E04021]: invalid number after type inference
+   ┌─ tests/move_2024/typing/annotated_lambda_type_inference_invalid.move:31:26
+   │
+30 │ macro fun do2_invalid($f: |u32| -> u64, $g: |u16| -> u64): u64 {
+   │                                              --- Expected a literal of type 'u16', but the value is too large.
+31 │     $f(0xFFFF_FFFF) + $g(0xFFFF_FFFF)
+   │                          ^^^^^^^^^^^
+   │                          │
+   │                          Invalid numerical literal
+   │                          Annotating the literal might help inference: '4294967295u32'

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/lambda_expression_annotation.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/lambda_expression_annotation.move
@@ -1,0 +1,16 @@
+// tests the validity of adding annotations on the entirety of a lambda
+
+module 0x42::m;
+
+macro fun do<$T, $R>($f: |$T| -> $R, $arg: $T): $R {
+    $f($arg)
+}
+
+fun main() {
+    do!((|x| { x }: |u8| -> u8), 42);
+    do!(((|x| { x }: |bool| -> bool): |bool| -> bool), false);
+    do!(
+        ((|_| { vector[] }: |vector<vector<u8>>| -> vector<u8>): |vector<vector<u8>>| -> vector<u8>),
+        vector[]
+    );
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/lambda_expression_annotation.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/lambda_expression_annotation.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/lambda_expression_annotation_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/lambda_expression_annotation_invalid.move
@@ -1,0 +1,33 @@
+// tests invalid annotations on the entirety of a lambda
+
+module 0x42::m;
+
+macro fun do<$T, $R>($f: |$T| -> $R, $arg: $T): $R {
+    $f($arg)
+}
+
+macro fun do2<$T, $R>($f: |$T, $T| -> $R, $arg: $T): $R {
+    $f($arg, $arg)
+}
+
+
+fun bad_types() {
+    do!((|x| { x }: |u8| -> u16), 42);
+    do!(((|x| { x }: |bool| -> u8): |u8| -> bool), false);
+}
+
+fun non_lambda() {
+    do!((|x| { x }: u8), 42);
+    do!(((|x| { x }: bool): |bool| -> bool), false);
+}
+
+fun bad_arity() {
+    do!((|x| { x }: |u8, u8| -> u8), 42);
+    do2!((|x, y| { x + y }: |u8| -> u8), 42);
+
+    do!(((|_| { false }: |u8| -> bool): |u8, u8| -> bool), 0);
+    do!(((|_| { false }: |u8, u8| -> bool): |u8| -> bool), 0);
+
+    do2!(((|_, _| { false }: |u8| -> bool): |u8, u8| -> bool), 0);
+    do2!(((|_, _| { false }: |u8, u8| -> bool): |u8| -> bool), 0);
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/lambda_expression_annotation_invalid.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/lambda_expression_annotation_invalid.snap
@@ -1,0 +1,123 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/lambda_expression_annotation_invalid.move:15:14
+   │
+15 │     do!((|x| { x }: |u8| -> u16), 42);
+   │              ^^^^^   --     --- Expected: 'u16'
+   │              │       │       
+   │              │       Given: 'u8'
+   │              Invalid type annotation
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/lambda_expression_annotation_invalid.move:16:5
+   │
+16 │     do!(((|x| { x }: |bool| -> u8): |u8| -> bool), false);
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │     │                                │             │
+   │     │                                │             Expected: 'bool'
+   │     │                                Given: 'u8'
+   │     Invalid type annotation
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/lambda_expression_annotation_invalid.move:16:12
+   │
+16 │     do!(((|x| { x }: |bool| -> u8): |u8| -> bool), false);
+   │            ^                         --            ----- Given: 'bool'
+   │            │                         │              
+   │            │                         Expected: 'u8'
+   │            Invalid type annotation
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/lambda_expression_annotation_invalid.move:16:22
+   │
+16 │     do!(((|x| { x }: |bool| -> u8): |u8| -> bool), false);
+   │                      ^^^^^^^^^^^^    -- Expected: 'u8'
+   │                      ││               
+   │                      │Given: 'bool'
+   │                      Invalid annotation for lambda
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/lambda_expression_annotation_invalid.move:20:21
+   │
+20 │     do!((|x| { x }: u8), 42);
+   │          ---------  ^^
+   │          │          │
+   │          │          Invalid annotation for lambda
+   │          │          Expected: 'u8'
+   │          Given: '|_| -> _'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/lambda_expression_annotation_invalid.move:21:22
+   │
+21 │     do!(((|x| { x }: bool): |bool| -> bool), false);
+   │           ---------  ^^^^
+   │           │          │
+   │           │          Invalid annotation for lambda
+   │           │          Expected: 'bool'
+   │           Given: '|bool| -> bool'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/lambda_expression_annotation_invalid.move:25:21
+   │
+25 │     do!((|x| { x }: |u8, u8| -> u8), 42);
+   │          ---------  ^^^^^^^^^^^^^^
+   │          │          │
+   │          │          Invalid annotation for lambda
+   │          │          Expected a lambda with 2 arguments: '|u8, u8| -> u8'
+   │          Given lambda with 1 arguments: '|_| -> _'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/lambda_expression_annotation_invalid.move:26:29
+   │
+26 │     do2!((|x, y| { x + y }: |u8| -> u8), 42);
+   │           ----------------  ^^^^^^^^^^
+   │           │                 │
+   │           │                 Invalid annotation for lambda
+   │           │                 Expected a lambda with 1 arguments: '|u8| -> u8'
+   │           Given lambda with 2 arguments: '|_, _| -> _'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/lambda_expression_annotation_invalid.move:28:41
+   │
+28 │     do!(((|_| { false }: |u8| -> bool): |u8, u8| -> bool), 0);
+   │           -------------                 ^^^^^^^^^^^^^^^^
+   │           │                             │
+   │           │                             Invalid annotation for lambda
+   │           │                             Expected a lambda with 2 arguments: '|u8, u8| -> bool'
+   │           Given lambda with 1 arguments: '|_| -> _'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/lambda_expression_annotation_invalid.move:29:26
+   │
+29 │     do!(((|_| { false }: |u8, u8| -> bool): |u8| -> bool), 0);
+   │           -------------  ^^^^^^^^^^^^^^^^
+   │           │              │
+   │           │              Invalid annotation for lambda
+   │           │              Expected a lambda with 2 arguments: '|u8, u8| -> bool'
+   │           Given lambda with 1 arguments: '|u8| -> bool'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/lambda_expression_annotation_invalid.move:31:30
+   │
+31 │     do2!(((|_, _| { false }: |u8| -> bool): |u8, u8| -> bool), 0);
+   │            ----------------  ^^^^^^^^^^^^
+   │            │                 │
+   │            │                 Invalid annotation for lambda
+   │            │                 Expected a lambda with 1 arguments: '|u8| -> bool'
+   │            Given lambda with 2 arguments: '|u8, u8| -> bool'
+
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/lambda_expression_annotation_invalid.move:32:49
+   │
+32 │     do2!(((|_, _| { false }: |u8, u8| -> bool): |u8| -> bool), 0);
+   │            ----------------                     ^^^^^^^^^^^^
+   │            │                                    │
+   │            │                                    Invalid annotation for lambda
+   │            │                                    Expected a lambda with 1 arguments: '|u8| -> bool'
+   │            Given lambda with 2 arguments: '|_, _| -> _'

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/macros_lambdas_checked_invalid_arity.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/macros_lambdas_checked_invalid_arity.snap
@@ -30,31 +30,40 @@ error[E04007]: incompatible types
    │                -------- Given: 'vector<u8>'
 
 error[E04017]: too many arguments
-  ┌─ tests/move_2024/typing/macros_lambdas_checked_invalid_arity.move:3:9
-  │
-3 │         $f(0);
-  │         ^^^^^
-  │         │ │
-  │         │ Found 1 argument(s) here
-  │         Invalid lambda call of '$f'. The call expected 0 argument(s) but got 1
+   ┌─ tests/move_2024/typing/macros_lambdas_checked_invalid_arity.move:3:9
+   │
+ 3 │         $f(0);
+   │         ^^^^^
+   │         │ │
+   │         │ Found 1 argument(s) here
+   │         Invalid lambda call of '$f'. The call expected 0 argument(s) but got 1
+   ·
+10 │             || vector[], // invalid
+   │             ----------- Expected 0 argument(s)
 
 error[E04016]: too few arguments
-  ┌─ tests/move_2024/typing/macros_lambdas_checked_invalid_arity.move:3:9
-  │
-3 │         $f(0);
-  │         ^^^^^
-  │         │ │
-  │         │ Found 1 argument(s) here
-  │         Invalid lambda call of '$f'. The call expected 2 argument(s) but got 1
+   ┌─ tests/move_2024/typing/macros_lambdas_checked_invalid_arity.move:3:9
+   │
+ 3 │         $f(0);
+   │         ^^^^^
+   │         │ │
+   │         │ Found 1 argument(s) here
+   │         Invalid lambda call of '$f'. The call expected 2 argument(s) but got 1
+   ·
+15 │             |_, _| vector[], // invalid
+   │             --------------- Expected 2 argument(s)
 
 error[E04016]: too few arguments
-  ┌─ tests/move_2024/typing/macros_lambdas_checked_invalid_arity.move:4:9
-  │
-4 │         $g(0, 1);
-  │         ^^^^^^^^
-  │         │ │
-  │         │ Found 2 argument(s) here
-  │         Invalid lambda call of '$g'. The call expected 3 argument(s) but got 2
+   ┌─ tests/move_2024/typing/macros_lambdas_checked_invalid_arity.move:4:9
+   │
+ 4 │         $g(0, 1);
+   │         ^^^^^^^^
+   │         │ │
+   │         │ Found 2 argument(s) here
+   │         Invalid lambda call of '$g'. The call expected 3 argument(s) but got 2
+   ·
+26 │             |a, b, _| vector[(a as u8), (b as u8)], // invalid
+   │             -------------------------------------- Expected 3 argument(s)
 
 error[E04007]: incompatible types
    ┌─ tests/move_2024/typing/macros_lambdas_checked_invalid_arity.move:9:9

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/mismatched_lambda_arity.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/mismatched_lambda_arity.snap
@@ -8,6 +8,8 @@ info:
 error[E04016]: too few arguments
   ┌─ tests/move_2024/typing/mismatched_lambda_arity.move:3:9
   │
+2 │     macro fun foo($f: |u64, u64| -> u64) {
+  │                       ----------------- Expected 2 argument(s)
 3 │         $f();
   │         ^^^^
   │         │ │
@@ -17,6 +19,9 @@ error[E04016]: too few arguments
 error[E04016]: too few arguments
   ┌─ tests/move_2024/typing/mismatched_lambda_arity.move:4:9
   │
+2 │     macro fun foo($f: |u64, u64| -> u64) {
+  │                       ----------------- Expected 2 argument(s)
+3 │         $f();
 4 │         $f(0);
   │         ^^^^^
   │         │ │
@@ -26,6 +31,9 @@ error[E04016]: too few arguments
 error[E04017]: too many arguments
   ┌─ tests/move_2024/typing/mismatched_lambda_arity.move:5:9
   │
+2 │     macro fun foo($f: |u64, u64| -> u64) {
+  │                       ----------------- Expected 2 argument(s)
+  ·
 5 │         $f(0, 1, 2);
   │         ^^^^^^^^^^^
   │         │ │


### PR DESCRIPTION
## Description 

- The compiler now supports type annotations on lambdas, e.g. `(|x| { x }: |u64| -> u64)`
- This support was added simply because it is the same issue around dropping types on lambdas during expansion

## Test plan 

- New IDE test
- New annotations tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: Fixes Move Analyzer issues around macros. Move now supports type annotations on lambdas.
- [ ] Rust SDK:
