### PR TITLE
Update transaction input loader logic for ConsensusV2 objects

### DIFF
--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -182,8 +182,21 @@ pub fn update_object_ref_for_testing(object_ref: ObjectRef) -> ObjectRef {
     )
 }
 
-pub type FullObjectRef = (FullObjectID, SequenceNumber, ObjectDigest);
+pub struct FullObjectRef(pub FullObjectID, pub SequenceNumber, pub ObjectDigest);
 
+impl FullObjectRef {
+    pub fn from_fastpath_ref(object_ref: ObjectRef) -> Self {
+        Self(
+            FullObjectID::Fastpath(object_ref.0),
+            object_ref.1,
+            object_ref.2,
+        )
+    }
+
+    pub fn as_object_ref(&self) -> ObjectRef {
+        (self.0.id(), self.1, self.2)
+    }
+}
 /// Represents an distinct stream of object versions for a Shared or ConsensusV2 object,
 /// based on the object ID and start version.
 pub type ConsensusObjectSequenceKey = (ObjectID, SequenceNumber);

--- a/crates/sui-types/src/object.rs
+++ b/crates/sui-types/src/object.rs
@@ -845,7 +845,7 @@ impl ObjectInner {
     }
 
     pub fn compute_full_object_reference(&self) -> FullObjectRef {
-        (self.full_id(), self.version(), self.digest())
+        FullObjectRef(self.full_id(), self.version(), self.digest())
     }
 
     pub fn digest(&self) -> ObjectDigest {

--- a/crates/sui-types/src/programmable_transaction_builder.rs
+++ b/crates/sui-types/src/programmable_transaction_builder.rs
@@ -240,11 +240,9 @@ impl ProgrammableTransactionBuilder {
     ) -> anyhow::Result<()> {
         let rec_arg = self.pure(recipient).unwrap();
         let obj_arg = self.obj(match full_object_ref.0 {
-            FullObjectID::Fastpath(_) => ObjectArg::ImmOrOwnedObject((
-                full_object_ref.0.id(),
-                full_object_ref.1,
-                full_object_ref.2,
-            )),
+            FullObjectID::Fastpath(_) => {
+                ObjectArg::ImmOrOwnedObject(full_object_ref.as_object_ref())
+            }
             FullObjectID::Consensus((id, initial_shared_version)) => ObjectArg::SharedObject {
                 id,
                 initial_shared_version,

--- a/crates/sui-types/src/storage/mod.rs
+++ b/crates/sui-types/src/storage/mod.rs
@@ -117,8 +117,9 @@ pub enum MarkerValue {
     /// An owned object was deleted (or wrapped) at the given version, and is no longer able to be
     /// accessed or used in subsequent transactions.
     OwnedDeleted,
-    /// A shared object was deleted by the transaction and is no longer able to be accessed or
-    /// used in subsequent transactions.
+    /// A shared object was deleted or removed from consensus by the transaction and is no longer
+    /// able to be accessed or used in subsequent transactions.
+    // TODO: Rename this to something more accurate, like "ConsensusUnavailable".
     SharedDeleted(TransactionDigest),
 }
 


### PR DESCRIPTION
Previously this did not correctly account for the possibility of `initial_shared_version` not matching between the requested input and the object that was loaded.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
