### PR TITLE
[Consensus] exercise low gc_depth for simtests and antithesis.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14788,6 +14788,7 @@ dependencies = [
  "clap",
  "insta",
  "move-vm-config",
+ "once_cell",
  "schemars",
  "serde",
  "serde-env",

--- a/crates/sui-protocol-config/Cargo.toml
+++ b/crates/sui-protocol-config/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 workspace = true
 
 [dependencies]
+once_cell.workspace = true
 serde.workspace = true
 tracing.workspace = true
 serde_with.workspace = true

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use once_cell::sync::Lazy;
 use std::{
     cell::RefCell,
     collections::BTreeSet,
@@ -10,6 +9,7 @@ use std::{
 
 use clap::*;
 use move_vm_config::verifier::VerifierConfig;
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use sui_protocol_config_macros::{

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use once_cell::sync::Lazy;
 use std::{
     cell::RefCell,
     collections::BTreeSet,
@@ -1813,9 +1814,9 @@ impl ProtocolConfig {
     }
 
     pub fn gc_depth(&self) -> u32 {
-        if cfg!(msim) {
+        if cfg!(msim) || in_antithesis() {
             // exercise a very low gc_depth
-            5
+            3
         } else {
             self.consensus_gc_depth.unwrap_or(0)
         }
@@ -3718,6 +3719,18 @@ pub fn is_mysticeti_fpc_enabled_in_env() -> Option<bool> {
         }
     }
     None
+}
+
+#[inline(always)]
+pub fn in_antithesis() -> bool {
+    static IN_ANTITHESIS: Lazy<bool> = Lazy::new(|| {
+        let in_antithesis = std::env::var("ANTITHESIS_OUTPUT_DIR").is_ok();
+        if in_antithesis {
+            warn!("Detected that we are running in antithesis");
+        }
+        in_antithesis
+    });
+    *IN_ANTITHESIS
 }
 
 #[cfg(all(test, not(msim)))]


### PR DESCRIPTION
## Description 

For the `simtests` and `antithesis` environments we would like to exercise an as much low as possible GC so we can stress the limits of GC.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
