### PR TITLE
[move-ide] Publish with recently implemented macro fix

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
   "publisher": "mysten",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "preview": true,
   "repository": {
     "url": "https://github.com/MystenLabs/sui.git",


### PR DESCRIPTION
## Description 

In order to publish the extension, we need to bump its version number. The reason for publishing is a recent fix to `move-analyzer` implemented by @tnowacki (great thanks!) in https://github.com/MystenLabs/sui/pull/21633

## Test plan 

Tested in https://github.com/MystenLabs/sui/pull/21633
