### PR TITLE
[CherryPick][CLI] Support for MVR in `sui client ptb` (#21609)

### DIFF
--- a/crates/sui/src/client_ptb/ast.rs
+++ b/crates/sui/src/client_ptb/ast.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fmt;
+use std::{collections::BTreeMap, fmt};
 
 use move_core_types::parsing::{
     address::{NumericalAddress, ParsedAddress},
@@ -116,6 +116,7 @@ pub struct ProgramMetadata {
     pub dry_run_set: bool,
     pub dev_inspect_set: bool,
     pub gas_budget: Option<Spanned<u64>>,
+    pub mvr_names: BTreeMap<String, Span>,
 }
 
 /// A parsed module access consisting of the address, module name, and function name.

--- a/crates/sui/src/client_ptb/lexer.rs
+++ b/crates/sui/src/client_ptb/lexer.rs
@@ -233,6 +233,7 @@ impl<'l, I: Iterator<Item = &'l str>> Iterator for Lexer<'l, I> {
             sp!(_, ">") => token!(T::RAngle),
             sp!(_, "@") => token!(T::At),
             sp!(_, ".") => token!(T::Dot),
+            sp!(_, "/") => token!(T::ForwardSlash),
 
             sp!(_, "'" | "\"") => self.string(c),
 

--- a/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_commands.snap
+++ b/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_commands.snap
@@ -42,6 +42,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -83,6 +84,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -133,6 +135,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -202,6 +205,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -262,6 +266,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -337,6 +342,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -406,6 +412,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -466,6 +473,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -535,6 +543,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -595,6 +604,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -643,6 +653,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -710,6 +721,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -824,6 +836,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -915,6 +928,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1006,6 +1020,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1048,6 +1063,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1115,6 +1131,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1167,6 +1184,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1219,6 +1237,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1305,6 +1324,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1363,6 +1383,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1427,6 +1448,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1460,6 +1482,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1485,6 +1508,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1510,6 +1534,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1535,6 +1560,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -1560,6 +1586,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
 ]

--- a/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_mvr_names_invalid.snap
+++ b/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_mvr_names_invalid.snap
@@ -1,0 +1,168 @@
+---
+source: crates/sui/src/client_ptb/parser.rs
+expression: parsed
+---
+[
+    PTBError {
+        message: "Invalid MVR package reference",
+        span: Span {
+            start: 6,
+            end: 6,
+        },
+        help: Some(
+            "MVR packages must contain a slash and be in the format '(@<domain>|<domain>.sui)/<package>[/<version>]'",
+        ),
+        severity: Error,
+    },
+    PTBError {
+        message: "Invalid MVR package reference",
+        span: Span {
+            start: 4,
+            end: 4,
+        },
+        help: Some(
+            "MVR packages must contain a slash and be in the format '(@<domain>|<domain>.sui)/<package>[/<version>]'",
+        ),
+        severity: Error,
+    },
+    PTBError {
+        message: "Invalid MVR package reference",
+        span: Span {
+            start: 4,
+            end: 5,
+        },
+        help: Some(
+            "MVR packages must contain a slash and be in the format '(@<domain>|<domain>.sui)/<package>[/<version>]'",
+        ),
+        severity: Error,
+    },
+    PTBError {
+        message: "Invalid MVR package reference",
+        span: Span {
+            start: 7,
+            end: 7,
+        },
+        help: Some(
+            "MVR packages must contain a slash and be in the format '(@<domain>|<domain>.sui)/<package>[/<version>]'",
+        ),
+        severity: Error,
+    },
+    PTBError {
+        message: "Invalid MVR package reference",
+        span: Span {
+            start: 4,
+            end: 5,
+        },
+        help: Some(
+            "MVR packages must contain a slash and be in the format '(@<domain>|<domain>.sui)/<package>[/<version>]'",
+        ),
+        severity: Error,
+    },
+    PTBError {
+        message: "Expected a MVR domain name but got end of input",
+        span: Span {
+            start: 1,
+            end: 1,
+        },
+        help: None,
+        severity: Error,
+    },
+    PTBError {
+        message: "Expected a MVR domain name but got '@'",
+        span: Span {
+            start: 1,
+            end: 2,
+        },
+        help: None,
+        severity: Error,
+    },
+    PTBError {
+        message: "Expected a MVR domain name but got '/'",
+        span: Span {
+            start: 1,
+            end: 2,
+        },
+        help: None,
+        severity: Error,
+    },
+    PTBError {
+        message: "Expected a MVR domain name but got '@'",
+        span: Span {
+            start: 1,
+            end: 2,
+        },
+        help: None,
+        severity: Error,
+    },
+    PTBError {
+        message: "Expected a MVR domain name but got '@'",
+        span: Span {
+            start: 1,
+            end: 2,
+        },
+        help: None,
+        severity: Error,
+    },
+    PTBError {
+        message: "Expected a MVR domain name but got '/'",
+        span: Span {
+            start: 1,
+            end: 2,
+        },
+        help: None,
+        severity: Error,
+    },
+    PTBError {
+        message: "Unexpected '/'",
+        span: Span {
+            start: 0,
+            end: 1,
+        },
+        help: Some(
+            "Value addresses can either be a variable in-scope, or a numerical address, e.g., 0xc0ffee",
+        ),
+        severity: Error,
+    },
+    PTBError {
+        message: "Unexpected input \"-\"",
+        span: Span {
+            start: 0,
+            end: 1,
+        },
+        help: Some(
+            "Value addresses can either be a variable in-scope, or a numerical address, e.g., 0xc0ffee",
+        ),
+        severity: Error,
+    },
+    PTBError {
+        message: "Unexpected input \"/\"",
+        span: Span {
+            start: 1,
+            end: 2,
+        },
+        help: Some(
+            "Value addresses can either be a variable in-scope, or a numerical address, e.g., 0xc0ffee",
+        ),
+        severity: Error,
+    },
+    PTBError {
+        message: "Unexpected input \"/\"",
+        span: Span {
+            start: 1,
+            end: 2,
+        },
+        help: Some(
+            "Value addresses can either be a variable in-scope, or a numerical address, e.g., 0xc0ffee",
+        ),
+        severity: Error,
+    },
+    PTBError {
+        message: "Expected a valid MVR version, but got identifier 'b'",
+        span: Span {
+            start: 9,
+            end: 10,
+        },
+        help: None,
+        severity: Error,
+    },
+]

--- a/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_mvr_names_valid.snap
+++ b/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_mvr_names_valid.snap
@@ -1,0 +1,87 @@
+---
+source: crates/sui/src/client_ptb/parser.rs
+expression: parsed
+---
+[
+    Spanned {
+        span: Span {
+            start: 0,
+            end: 1,
+        },
+        value: Named(
+            "@1/foo",
+        ),
+    },
+    Spanned {
+        span: Span {
+            start: 0,
+            end: 3,
+        },
+        value: Named(
+            "1.sui/foo",
+        ),
+    },
+    Spanned {
+        span: Span {
+            start: 0,
+            end: 3,
+        },
+        value: Named(
+            "1.sui/foo/1",
+        ),
+    },
+    Spanned {
+        span: Span {
+            start: 0,
+            end: 3,
+        },
+        value: Named(
+            "1.sui/3/1",
+        ),
+    },
+    Spanned {
+        span: Span {
+            start: 0,
+            end: 1,
+        },
+        value: Named(
+            "1.sui/3/1",
+        ),
+    },
+    Spanned {
+        span: Span {
+            start: 0,
+            end: 1,
+        },
+        value: Named(
+            "@foo/bar",
+        ),
+    },
+    Spanned {
+        span: Span {
+            start: 0,
+            end: 1,
+        },
+        value: Named(
+            "@foo/bar/1",
+        ),
+    },
+    Spanned {
+        span: Span {
+            start: 0,
+            end: 3,
+        },
+        value: Named(
+            "foo.sui/bar",
+        ),
+    },
+    Spanned {
+        span: Span {
+            start: 0,
+            end: 3,
+        },
+        value: Named(
+            "foo.sui/bar/1",
+        ),
+    },
+]

--- a/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_publish.snap
+++ b/crates/sui/src/client_ptb/snapshots/sui__client_ptb__parser__tests__parse_publish.snap
@@ -42,6 +42,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
     (
@@ -83,6 +84,7 @@ expression: parsed
                     value: 1,
                 },
             ),
+            mvr_names: {},
         },
     ),
 ]

--- a/crates/sui/src/client_ptb/token.rs
+++ b/crates/sui/src/client_ptb/token.rs
@@ -45,6 +45,8 @@ pub enum Token {
     At,
     /// .
     Dot,
+    /// /
+    ForwardSlash,
 
     /// End of input.
     Eof,
@@ -101,6 +103,7 @@ impl fmt::Display for Lexeme<'_> {
             T::RAngle => write!(f, "'>'"),
             T::At => write!(f, "'@'"),
             T::Dot => write!(f, "'.'"),
+            T::ForwardSlash => write!(f, "'/'"),
             T::Unexpected => write!(f, "input {:?}", self.1),
             T::UnfinishedString => write!(f, "unfinished string {:?}", format!("{}...", self.1)),
             T::EarlyEof | T::Eof => write!(f, "end of input"),
@@ -130,6 +133,7 @@ impl fmt::Display for Token {
             T::RAngle => write!(f, "'>'"),
             T::At => write!(f, "'@'"),
             T::Dot => write!(f, "'.'"),
+            T::ForwardSlash => write!(f, "'/'"),
             T::Eof => write!(f, "end of input"),
             T::Unexpected => write!(f, "unexpected input"),
             T::UnfinishedString => write!(f, "an unfinished string"),

--- a/crates/sui/src/lib.rs
+++ b/crates/sui/src/lib.rs
@@ -12,6 +12,7 @@ pub mod genesis_ceremony;
 pub mod genesis_inspector;
 pub mod key_identity;
 pub mod keytool;
+pub mod mvr_resolver;
 pub mod sui_commands;
 pub mod upgrade_compatibility;
 pub mod validator_commands;

--- a/crates/sui/src/mvr_resolver.rs
+++ b/crates/sui/src/mvr_resolver.rs
@@ -1,0 +1,106 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Error;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::collections::{BTreeMap, BTreeSet};
+use sui_protocol_config::Chain;
+use sui_sdk::apis::ReadApi;
+use sui_types::{base_types::ObjectID, digests::ChainIdentifier};
+
+const MVR_RESOLVER_MAINNET_URL: &str = "https://mainnet.mvr.mystenlabs.com";
+const MVR_RESOLVER_TESTNET_URL: &str = "https://testnet.mvr.mystenlabs.com";
+
+#[derive(Debug, Serialize)]
+pub struct MvrResolver {
+    pub names: BTreeSet<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ResolvedNames {
+    pub resolution: BTreeMap<String, PackageId>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PackageId {
+    pub package_id: ObjectID,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NamesRequest {
+    pub names: BTreeSet<String>,
+}
+
+impl MvrResolver {
+    /// Call this function before calling resolve_names to avoid making a call to the resolver if
+    /// not needed.
+    pub fn should_resolve(&self) -> bool {
+        !self.names.is_empty()
+    }
+
+    /// Given a set of MVR names, resolve them to their corresponding package IDs. Note that this
+    /// API will error if the resolved list length does not match with the given input.
+    pub async fn resolve_names(&self, read_api: &ReadApi) -> Result<ResolvedNames, Error> {
+        if self.names.is_empty() {
+            return Ok(ResolvedNames {
+                resolution: BTreeMap::new(),
+            });
+        }
+
+        let request = reqwest::Client::new();
+        let (url, chain) = mvr_req_url(read_api).await?;
+        let json_body = json!(NamesRequest {
+            names: self.names.clone()
+        });
+        let response = request
+            .post(format!("{url}/v1/resolution/bulk"))
+            .header("Content-Type", "application/json")
+            .json(&json_body)
+            .send()
+            .await?;
+
+        let resolved_addresses: ResolvedNames = response.json().await?;
+
+        anyhow::ensure!(
+            resolved_addresses.resolution.len() == self.names.len(),
+            "Could not find package id for {} for {chain} enviroment",
+            self.names
+                .difference(
+                    &resolved_addresses
+                        .resolution
+                        .keys()
+                        .cloned()
+                        .collect::<BTreeSet<_>>()
+                )
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+
+        Ok(resolved_addresses)
+    }
+}
+
+/// Based on the chain id of the current set environment, return the correct MVR URL to use for
+/// resolution.
+async fn mvr_req_url(read_api: &ReadApi) -> Result<(&'static str, &'static str), Error> {
+    let chain_id = read_api.get_chain_identifier().await?;
+    let chain = ChainIdentifier::from_chain_short_id(&chain_id);
+
+    if let Some(chain) = chain {
+        let chain = chain.chain();
+        match chain {
+            Chain::Mainnet => Ok((MVR_RESOLVER_MAINNET_URL, "mainnet")),
+            Chain::Testnet => Ok((MVR_RESOLVER_TESTNET_URL, "testnet")),
+            Chain::Unknown => {
+                anyhow::bail!("Unsupported chain identifier: {:?}", chain);
+            }
+        }
+    } else {
+        anyhow::bail!(
+            "Unsupported chain: {chain_id}. Only mainnet/testnet are supported for \
+            MVR resolution",
+        )
+    }
+}

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -523,7 +523,7 @@ async fn test_ptb_publish_and_complex_arg_resolution() -> Result<(), anyhow::Err
         .iter()
         .find(|refe| matches!(refe.owner, Owner::Immutable))
         .unwrap();
-    let package_id_str = package.reference.object_id.to_string();
+    let package_id_str = package.reference.object_id;
 
     let start_call_result = SuiClientCommands::Call {
         package: package.reference.object_id,
@@ -1217,7 +1217,7 @@ async fn test_delete_shared_object() -> Result<(), anyhow::Error> {
 
     // Start and then receive the object
     let start_call_result = SuiClientCommands::Call {
-        package: (*package_id.object_id).into(),
+        package: package_id.object_id,
         module: "sod".to_string(),
         function: "start".to_string(),
         type_args: vec![],
@@ -1237,7 +1237,7 @@ async fn test_delete_shared_object() -> Result<(), anyhow::Error> {
     };
 
     let delete_result = SuiClientCommands::Call {
-        package: (*package_id.object_id).into(),
+        package: package_id.object_id,
         module: "sod".to_string(),
         function: "delete".to_string(),
         type_args: vec![],
@@ -1322,7 +1322,7 @@ async fn test_receive_argument() -> Result<(), anyhow::Error> {
 
     // Start and then receive the object
     let start_call_result = SuiClientCommands::Call {
-        package: (*package_id.object_id).into(),
+        package: package_id.object_id,
         module: "tto".to_string(),
         function: "start".to_string(),
         type_args: vec![],
@@ -1359,7 +1359,7 @@ async fn test_receive_argument() -> Result<(), anyhow::Error> {
         };
 
     let receive_result = SuiClientCommands::Call {
-        package: (*package_id.object_id).into(),
+        package: package_id.object_id,
         module: "tto".to_string(),
         function: "receiver".to_string(),
         type_args: vec![],
@@ -1447,7 +1447,7 @@ async fn test_receive_argument_by_immut_ref() -> Result<(), anyhow::Error> {
 
     // Start and then receive the object
     let start_call_result = SuiClientCommands::Call {
-        package: (*package_id.object_id).into(),
+        package: package_id.object_id,
         module: "tto".to_string(),
         function: "start".to_string(),
         type_args: vec![],
@@ -1484,7 +1484,7 @@ async fn test_receive_argument_by_immut_ref() -> Result<(), anyhow::Error> {
         };
 
     let receive_result = SuiClientCommands::Call {
-        package: (*package_id.object_id).into(),
+        package: package_id.object_id,
         module: "tto".to_string(),
         function: "invalid_call_immut_ref".to_string(),
         type_args: vec![],
@@ -1572,7 +1572,7 @@ async fn test_receive_argument_by_mut_ref() -> Result<(), anyhow::Error> {
 
     // Start and then receive the object
     let start_call_result = SuiClientCommands::Call {
-        package: (*package_id.object_id).into(),
+        package: package_id.object_id,
         module: "tto".to_string(),
         function: "start".to_string(),
         type_args: vec![],
@@ -1609,7 +1609,7 @@ async fn test_receive_argument_by_mut_ref() -> Result<(), anyhow::Error> {
         };
 
     let receive_result = SuiClientCommands::Call {
-        package: (*package_id.object_id).into(),
+        package: package_id.object_id,
         module: "tto".to_string(),
         function: "invalid_call_mut_ref".to_string(),
         type_args: vec![],

--- a/crates/sui/tests/ptb_files_tests.rs
+++ b/crates/sui/tests/ptb_files_tests.rs
@@ -12,6 +12,7 @@ const TEST_DIR: &str = "tests";
 #[cfg(not(msim))]
 #[tokio::main]
 async fn test_ptb_files(path: &Path) -> datatest_stable::Result<()> {
+    use std::collections::BTreeMap;
     use sui::client_ptb::ptb::{to_source_string, PTB};
     use sui::client_ptb::{error::build_error_reports, ptb::PTBPreview};
     use test_cluster::TestClusterBuilder;
@@ -63,7 +64,7 @@ async fn test_ptb_files(path: &Path) -> datatest_stable::Result<()> {
     let context = &test_cluster.wallet;
     let client = context.get_client().await?;
 
-    let (built_ptb, warnings) = PTB::build_ptb(program, context, client).await;
+    let (built_ptb, warnings) = PTB::build_ptb(program, BTreeMap::new(), client).await;
 
     if !warnings.is_empty() {
         let rendered = build_error_reports(&file_contents, warnings);


### PR DESCRIPTION
## Description 

This PR adds support for MVR in `sui client ptb`.

## Test plan 

Existing tests and added new tests for parsing mvr names.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: The `sui client ptb` now supports passing MVR name registered packages for package IDs and type tags.
- [ ] Rust SDK: