### PR TITLE
jsonrpc-alt: assorted reader clean-ups

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -288,6 +288,7 @@ impl OffchainCluster {
 
         let jsonrpc = start_rpc(
             Some(database_url.clone()),
+            None,
             DbArgs::default(),
             rpc_args,
             NodeArgs::default(),

--- a/crates/sui-indexer-alt-e2e-tests/tests/fn_delegation_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/fn_delegation_tests.rs
@@ -63,6 +63,7 @@ impl FnDelegationTestCluster {
 
         let rpc_handle = start_rpc(
             None,
+            None,
             DbArgs::default(),
             rpc_args,
             NodeArgs {

--- a/crates/sui-indexer-alt-jsonrpc/src/args.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/args.rs
@@ -27,6 +27,11 @@ pub enum Command {
         )]
         database_url: Url,
 
+        /// Bigtable instance ID to make KV store requests to. If this is not provided, KV store
+        /// requests will be made to the database.
+        #[clap(long)]
+        bigtable_instance: Option<String>,
+
         #[command(flatten)]
         db_args: DbArgs,
 

--- a/crates/sui-indexer-alt-jsonrpc/src/config.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/config.rs
@@ -32,9 +32,6 @@ pub struct RpcConfig {
     /// including transaction execution, dry-running, and delegation coin queries etc.
     pub node: NodeConfig,
 
-    /// Configuration for bigtable kv store, if it is used.
-    pub bigtable: Option<BigtableConfig>,
-
     /// Configuring limits for the package resolver.
     pub package_resolver: sui_package_resolver::Limits,
 }
@@ -56,10 +53,6 @@ pub struct RpcLayer {
 
     /// Configuration for transaction execution, dry-running, and delegation coin queries etc.
     pub node: NodeLayer,
-
-    /// Configuration for bigtable kv store, if it is used.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub bigtable: Option<BigtableConfig>,
 
     /// Configuring limits for the package resolver.
     pub package_resolver: PackageResolverLayer,
@@ -183,13 +176,6 @@ pub struct NodeLayer {
 }
 
 #[DefaultConfig]
-#[derive(Clone, Default, Debug)]
-pub struct BigtableConfig {
-    /// The instance id of the Bigtable instance to connect to.
-    pub instance_id: String,
-}
-
-#[DefaultConfig]
 #[derive(Clone, Debug)]
 pub struct PackageResolverLayer {
     pub max_type_argument_depth: usize,
@@ -210,7 +196,6 @@ impl RpcLayer {
             transactions: TransactionsConfig::default().into(),
             name_service: NameServiceConfig::default().into(),
             coins: CoinsConfig::default().into(),
-            bigtable: None,
             package_resolver: PackageResolverLayer::default(),
             node: NodeConfig::default().into(),
             extra: Default::default(),
@@ -225,7 +210,6 @@ impl RpcLayer {
             name_service: self.name_service.finish(NameServiceConfig::default()),
             coins: self.coins.finish(CoinsConfig::default()),
             node: self.node.finish(NodeConfig::default()),
-            bigtable: self.bigtable,
             package_resolver: self.package_resolver.finish(),
         }
     }
@@ -330,7 +314,6 @@ impl Default for RpcConfig {
             name_service: NameServiceConfig::default(),
             coins: CoinsConfig::default(),
             node: NodeConfig::default(),
-            bigtable: None,
             package_resolver: PackageResolverLayer::default().finish(),
         }
     }

--- a/crates/sui-indexer-alt-jsonrpc/src/context.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/context.rs
@@ -58,9 +58,9 @@ impl Context {
         db_args: DbArgs,
         config: RpcConfig,
         metrics: Arc<RpcMetrics>,
+        slow_request_threshold: Duration,
         registry: &Registry,
         cancel: CancellationToken,
-        slow_request_threshold: Duration,
     ) -> Result<Self, Error> {
         let pg_reader = PgReader::new(
             database_url,

--- a/crates/sui-indexer-alt-jsonrpc/src/data/bigtable_reader.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/bigtable_reader.rs
@@ -5,30 +5,42 @@ use std::fmt::Debug;
 use std::future::Future;
 use std::time::{Duration, Instant};
 
+use anyhow::anyhow;
 use async_graphql::dataloader::DataLoader;
 use prometheus::Registry;
-use sui_kvstore::BigTableClient;
+use sui_kvstore::{BigTableClient, Checkpoint, KeyValueStoreReader, TransactionData};
+use sui_types::digests::TransactionDigest;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+use sui_types::object::Object;
+use sui_types::storage::ObjectKey;
 use tracing::warn;
 
 use crate::data::error::Error;
 
-/// A reader backed by Bigtable kv store.
-/// In order to use this reader, the environment variable `GOOGLE_APPLICATION_CREDENTIALS`
-/// must be set to the path of the credentials file.
+/// A reader backed by BigTable KV store.
+///
+/// In order to use this reader, the environment variable `GOOGLE_APPLICATION_CREDENTIALS` must be
+/// set to the path of the credentials file.
 #[derive(Clone)]
-pub struct BigtableReader(pub(crate) BigTableClient, pub(crate) Duration);
+pub struct BigtableReader {
+    client: BigTableClient,
+
+    /// Requests to BigTable that take longer than this threshold will be logged.
+    slow_request_threshold: Duration,
+}
 
 impl BigtableReader {
     pub(crate) async fn new(
         instance_id: String,
         registry: &Registry,
-        threshold: Duration,
+        slow_request_threshold: Duration,
     ) -> Result<Self, Error> {
         if std::env::var("GOOGLE_APPLICATION_CREDENTIALS").is_err() {
-            return Err(Error::BigtableCreate(anyhow::anyhow!(
+            return Err(Error::BigtableCreate(anyhow!(
                 "Environment variable GOOGLE_APPLICATION_CREDENTIALS is not set"
             )));
         }
+
         let client = BigTableClient::new_remote(
             instance_id,
             true,
@@ -38,7 +50,11 @@ impl BigtableReader {
         )
         .await
         .map_err(Error::BigtableCreate)?;
-        Ok(Self(client, threshold))
+
+        Ok(Self {
+            client,
+            slow_request_threshold,
+        })
     }
 
     /// Create a data loader backed by this reader.
@@ -46,26 +62,67 @@ impl BigtableReader {
         DataLoader::new(self.clone(), tokio::spawn)
     }
 
-    pub(crate) async fn timed_load<F, T, E, A: Debug>(
+    /// Multi-get checkpoints by sequence number.
+    pub(crate) async fn checkpoints(
         &self,
-        method_name: &str,
-        args: &A,
-        load: F,
-    ) -> Result<T, E>
-    where
-        F: Future<Output = Result<T, E>>,
-    {
-        let start = Instant::now();
-        let result = load.await;
-        let elapsed = start.elapsed();
-
-        if elapsed > self.1 {
-            warn!(
-                "BigTableClient load '{}' with args '{:?}' took {:?}, which exceeds the threshold of {:?}",
-                method_name, args, elapsed, self.1
-            );
-        }
-
-        result
+        keys: &[CheckpointSequenceNumber],
+    ) -> Result<Vec<Checkpoint>, Error> {
+        measure(
+            self.slow_request_threshold,
+            "checkpoints",
+            &keys,
+            self.client.clone().get_checkpoints(keys),
+        )
+        .await
     }
+
+    /// Multi-get transactions by transaction digest.
+    pub(crate) async fn transactions(
+        &self,
+        keys: &[TransactionDigest],
+    ) -> Result<Vec<TransactionData>, Error> {
+        measure(
+            self.slow_request_threshold,
+            "transactions",
+            &keys,
+            self.client.clone().get_transactions(keys),
+        )
+        .await
+    }
+
+    /// Multi-get objects by object ID and version.
+    pub(crate) async fn objects(&self, keys: &[ObjectKey]) -> Result<Vec<Object>, Error> {
+        measure(
+            self.slow_request_threshold,
+            "objects",
+            &keys,
+            self.client.clone().get_objects(keys),
+        )
+        .await
+    }
+}
+
+/// Run the `load` future, measuring how long it takes. If it takes longer than
+/// `slow_request_threshold`, log a warning with the details of the request.
+async fn measure<T, A: Debug>(
+    slow_request_threshold: Duration,
+    method: &str,
+    args: &A,
+    load: impl Future<Output = anyhow::Result<T>>,
+) -> Result<T, Error> {
+    let start = Instant::now();
+    let result = load.await;
+    let elapsed = start.elapsed();
+
+    if elapsed > slow_request_threshold {
+        warn!(
+            elapsed_ms = elapsed.as_millis(),
+            threshold_ms = slow_request_threshold.as_millis(),
+            method,
+            ?args,
+            "Slow Bigtable request"
+        );
+    }
+
+    result.map_err(Error::BigtableRead)
 }

--- a/crates/sui-indexer-alt-jsonrpc/src/data/pg_reader.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data/pg_reader.rs
@@ -114,16 +114,16 @@ impl Connection<'_> {
     {
         let query = query.limit(1);
         let query_debug = diesel::debug_query(&query).to_string();
-        debug!("{}", query_debug);
-        let timer = self.metrics.db_latency.start_timer();
+        debug!("{query_debug}");
 
+        let timer = self.metrics.db_latency.start_timer();
         let res = query.get_result(&mut self.conn).await;
-        let elapsed_seconds = timer.stop_and_record();
-        let threshold_seconds = self.slow_query_threshold.as_secs() as f64;
-        if elapsed_seconds > threshold_seconds {
+        let elapsed_ms = timer.stop_and_record() * 1000.0;
+        let threshold_ms = self.slow_query_threshold.as_millis() as f64;
+        if elapsed_ms > threshold_ms {
             warn!(
-                elapsed_seconds,
-                threshold_seconds,
+                elapsed_ms,
+                threshold_ms,
                 query = query_debug,
                 "Slow database query detected!",
             );
@@ -147,17 +147,17 @@ impl Connection<'_> {
         ST: 'static,
     {
         let query_debug = diesel::debug_query(&query).to_string();
-        debug!("{}", query_debug);
-        let timer = self.metrics.db_latency.start_timer();
+        debug!("{query_debug}");
 
+        let timer = self.metrics.db_latency.start_timer();
         let res = query.get_results(&mut self.conn).await;
-        let elapsed_seconds = timer.stop_and_record();
-        let threshold_seconds = self.slow_query_threshold.as_secs() as f64;
-        if elapsed_seconds > threshold_seconds {
+        let elapsed_ms = timer.stop_and_record() * 1000.0;
+        let threshold_ms = self.slow_query_threshold.as_millis() as f64;
+        if elapsed_ms > threshold_ms {
             warn!(
-                elapsed_seconds,
+                elapsed_ms,
+                threshold_ms,
                 query = query_debug,
-                threshold_seconds,
                 "Slow database query detected!",
             );
         }

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -233,6 +233,10 @@ pub struct NodeArgs {
 /// The only exception is the `DelegationCoins` module, which is controlled by `node_args.fullnode_rpc_url`,
 /// which can be omitted to disable reads from this RPC.
 ///
+/// KV queries can optionally be served by a Bigtable instance, if `bigtable_instance` is provided.
+/// Otherwise these requests are served by the database. If a `bigtable_instance` is provided, the
+/// `GOOGLE_APPLICATION_CREDENTIALS` environment variable must point to the credentials JSON file.
+///
 /// Access to writes (executing and dry-running transactions) is controlled by `node_args.fullnode_rpc_url`,
 /// which can be omitted to disable writes from this RPC.
 ///
@@ -240,6 +244,7 @@ pub struct NodeArgs {
 /// and will clean these up on shutdown as well.
 pub async fn start_rpc(
     database_url: Option<Url>,
+    bigtable_instance: Option<String>,
     db_args: DbArgs,
     rpc_args: RpcArgs,
     node_args: NodeArgs,
@@ -254,6 +259,7 @@ pub async fn start_rpc(
 
     let context = Context::new(
         database_url,
+        bigtable_instance,
         db_args,
         rpc_config,
         rpc.metrics(),

--- a/crates/sui-indexer-alt-jsonrpc/src/main.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/main.rs
@@ -26,6 +26,7 @@ async fn main() -> anyhow::Result<()> {
     match args.command {
         Command::Rpc {
             database_url,
+            bigtable_instance,
             db_args,
             rpc_args,
             system_package_task_args,
@@ -66,6 +67,7 @@ async fn main() -> anyhow::Result<()> {
 
             let h_rpc = start_rpc(
                 Some(database_url),
+                bigtable_instance,
                 db_args,
                 rpc_args,
                 node_args,

--- a/crates/sui-indexer-alt-jsonrpc/src/metrics/middleware.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/metrics/middleware.rs
@@ -47,7 +47,7 @@ pin_project! {
         method: Cow<'a, str>,
         // RPC request params for logging
         params: Option<Cow<'a, RawValue>>,
-        // Threshold in ms for logging slow requests
+        // Threshold for logging slow requests
         slow_request_threshold: Duration,
         #[pin]
         inner: F,


### PR DESCRIPTION
## Description 

Various clean-ups for JSONRPC-alt's readers, ahead of factoring them out into their own crate to re-use in GraphQL:

- Avoid copying `RpcArgs` to get one field from it out, by introducing an accessor function for that field.
- Clean up a stale comment.
- Standardise slow request threshold logs (parameter order and units).
- Encapsulate logging within `BigtableReader`.
- Standardise `warn` message for `BigtableReader` to appear like the same message in `PgReader`.
- Configure Bigtable's `instance-id` using a CLI arg, rather than in the TOML, as it is conceptually closest to `--database-url` (parameters related to connections conventionally go in the CLI args, because it's more common to configure them differently for different instances that are otherwise configured the same).

## Test plan 

Existing tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
