### PR TITLE
Docs: Add note to functions only available on Devnet

### DIFF
--- a/crates/sui-framework/docs/sui/group_ops.md
+++ b/crates/sui-framework/docs/sui/group_ops.md
@@ -311,6 +311,8 @@ Fails if scalar = 0. Else returns 1/scalar * e.
 
 Aborts with <code><a href="../sui/group_ops.md#sui_group_ops_EInputTooLong">EInputTooLong</a></code> if the vectors are too long.
 
+This function is currently only enabled on Devnet.
+
 
 <pre><code><b>public</b>(<a href="../sui/package.md#sui_package">package</a>) <b>fun</b> multi_scalar_multiplicationS, G(type_: u8, scalars: &vector&lt;<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;S&gt;&gt;, elements: &vector&lt;<a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;&gt;): <a href="../sui/group_ops.md#sui_group_ops_Element">sui::group_ops::Element</a>&lt;G&gt;
 </code></pre>

--- a/crates/sui-framework/docs/sui/poseidon.md
+++ b/crates/sui-framework/docs/sui/poseidon.md
@@ -68,6 +68,8 @@ Hash the inputs using poseidon_bn254 and returns a BN254 field element.
 Each element has to be a BN254 field element in canonical representation so it must be smaller than the BN254
 scalar field size which is 21888242871839275222246405745257275088548364400416034343698204186575808495617.
 
+This function is currently only enabled on Devnet.
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/poseidon.md#sui_poseidon_poseidon_bn254">poseidon_bn254</a>(data: &vector&lt;u256&gt;): u256
 </code></pre>

--- a/crates/sui-framework/docs/sui/vdf.md
+++ b/crates/sui-framework/docs/sui/vdf.md
@@ -94,6 +94,8 @@ The discriminant for the class group is pre-computed and fixed. See how this was
 crate. The final selection of the discriminant for Mainnet will be computed and announced under a nothing-up-my-sleeve
 process.
 
+This function is currently only enabled on Devnet.
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/vdf.md#sui_vdf_vdf_verify">vdf_verify</a>(input: &vector&lt;u8&gt;, output: &vector&lt;u8&gt;, proof: &vector&lt;u8&gt;, iterations: u64): bool
 </code></pre>

--- a/crates/sui-framework/docs/sui/vdf.md
+++ b/crates/sui-framework/docs/sui/vdf.md
@@ -35,6 +35,8 @@ title: Module `sui::vdf`
 
 Hash an arbitrary binary <code>message</code> to a class group element to be used as input for <code><a href="../sui/vdf.md#sui_vdf_vdf_verify">vdf_verify</a></code>.
 
+This function is currently only enabled on Devnet.
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="../sui/vdf.md#sui_vdf_hash_to_input">hash_to_input</a>(message: &vector&lt;u8&gt;): vector&lt;u8&gt;
 </code></pre>

--- a/crates/sui-framework/packages/sui-framework/sources/crypto/group_ops.move
+++ b/crates/sui-framework/packages/sui-framework/sources/crypto/group_ops.move
@@ -60,7 +60,7 @@ public(package) fun hash_to<G>(type_: u8, m: &vector<u8>): Element<G> {
 
 /// Aborts with `EInputTooLong` if the vectors are too long.
 ///
-/// This functions is currently only enabled on Devnet.
+/// This function is currently only enabled on Devnet.
 public(package) fun multi_scalar_multiplication<S, G>(
     type_: u8,
     scalars: &vector<Element<S>>,

--- a/crates/sui-framework/packages/sui-framework/sources/crypto/group_ops.move
+++ b/crates/sui-framework/packages/sui-framework/sources/crypto/group_ops.move
@@ -59,6 +59,8 @@ public(package) fun hash_to<G>(type_: u8, m: &vector<u8>): Element<G> {
 }
 
 /// Aborts with `EInputTooLong` if the vectors are too long.
+///
+/// This functions is currently only enabled on Devnet.
 public(package) fun multi_scalar_multiplication<S, G>(
     type_: u8,
     scalars: &vector<Element<S>>,

--- a/crates/sui-framework/packages/sui-framework/sources/crypto/poseidon.move
+++ b/crates/sui-framework/packages/sui-framework/sources/crypto/poseidon.move
@@ -22,6 +22,8 @@ const BN254_MAX: u256 =
 ///
 /// Each element has to be a BN254 field element in canonical representation so it must be smaller than the BN254
 /// scalar field size which is 21888242871839275222246405745257275088548364400416034343698204186575808495617.
+///
+/// This functions is currently only enabled on Devnet.
 public fun poseidon_bn254(data: &vector<u256>): u256 {
     let (mut i, mut b, l) = (0, vector[], data.length());
     assert!(l > 0, EEmptyInput);

--- a/crates/sui-framework/packages/sui-framework/sources/crypto/poseidon.move
+++ b/crates/sui-framework/packages/sui-framework/sources/crypto/poseidon.move
@@ -23,7 +23,7 @@ const BN254_MAX: u256 =
 /// Each element has to be a BN254 field element in canonical representation so it must be smaller than the BN254
 /// scalar field size which is 21888242871839275222246405745257275088548364400416034343698204186575808495617.
 ///
-/// This functions is currently only enabled on Devnet.
+/// This function is currently only enabled on Devnet.
 public fun poseidon_bn254(data: &vector<u256>): u256 {
     let (mut i, mut b, l) = (0, vector[], data.length());
     assert!(l > 0, EEmptyInput);

--- a/crates/sui-framework/packages/sui-framework/sources/crypto/vdf.move
+++ b/crates/sui-framework/packages/sui-framework/sources/crypto/vdf.move
@@ -7,6 +7,8 @@ module sui::vdf;
 const EInvalidInput: u64 = 0;
 
 /// Hash an arbitrary binary `message` to a class group element to be used as input for `vdf_verify`.
+///
+/// This function is currently only enabled on Devnet.
 public fun hash_to_input(message: &vector<u8>): vector<u8> {
     hash_to_input_internal(message)
 }

--- a/crates/sui-framework/packages/sui-framework/sources/crypto/vdf.move
+++ b/crates/sui-framework/packages/sui-framework/sources/crypto/vdf.move
@@ -27,7 +27,7 @@ native fun hash_to_input_internal(message: &vector<u8>): vector<u8>;
 /// crate. The final selection of the discriminant for Mainnet will be computed and announced under a nothing-up-my-sleeve
 /// process.
 ///
-/// This functions is currently only enabled on Devnet.
+/// This function is currently only enabled on Devnet.
 public fun vdf_verify(
     input: &vector<u8>,
     output: &vector<u8>,

--- a/crates/sui-framework/packages/sui-framework/sources/crypto/vdf.move
+++ b/crates/sui-framework/packages/sui-framework/sources/crypto/vdf.move
@@ -26,6 +26,8 @@ native fun hash_to_input_internal(message: &vector<u8>): vector<u8>;
 /// The discriminant for the class group is pre-computed and fixed. See how this was generated in the fastcrypto-vdf
 /// crate. The final selection of the discriminant for Mainnet will be computed and announced under a nothing-up-my-sleeve
 /// process.
+///
+/// This functions is currently only enabled on Devnet.
 public fun vdf_verify(
     input: &vector<u8>,
     output: &vector<u8>,


### PR DESCRIPTION
## Description 

Add a note to the function docs of Sui framework functions that are only enabled on Devnet. Currently, this is oblivious to anyone reading the docs.

## Test plan 

No functional changes, so no tests are needed.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
