### PR TITLE
Update name of "shared deletion" indicators across the codebase

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -5830,8 +5830,8 @@ impl NodeStateDump {
                         shared_objects.push(ObjDumpFormat::new(w))
                     }
                 }
-                InputSharedObject::ReadDeleted(..)
-                | InputSharedObject::MutateDeleted(..)
+                InputSharedObject::ReadConsensusStreamEnded(..)
+                | InputSharedObject::MutateConsensusStreamEnded(..)
                 | InputSharedObject::Cancelled(..) => (), // TODO: consider record congested objects.
             }
         }

--- a/crates/sui-core/src/checkpoints/causal_order.rs
+++ b/crates/sui-core/src/checkpoints/causal_order.rs
@@ -138,14 +138,16 @@ impl RWLockDependencyBuilder {
                             .or_default()
                             .push(obj_key);
                     }
-                    InputSharedObject::ReadDeleted(oid, version) => read_version
+                    InputSharedObject::ReadConsensusStreamEnded(oid, version) => read_version
                         .entry(ObjectKey(oid, version))
                         .or_default()
                         .push(*effect.transaction_digest()),
-                    InputSharedObject::MutateDeleted(oid, version) => overwrite_versions
-                        .entry(*effect.transaction_digest())
-                        .or_default()
-                        .push(ObjectKey(oid, version)),
+                    InputSharedObject::MutateConsensusStreamEnded(oid, version) => {
+                        overwrite_versions
+                            .entry(*effect.transaction_digest())
+                            .or_default()
+                            .push(ObjectKey(oid, version))
+                    }
                     InputSharedObject::Cancelled(..) => (), // TODO: confirm that consensus_commit_prologue is always at the beginning of the checkpoint, so that cancelled txn don't need to worry about dependency.
                 }
             }

--- a/crates/sui-core/src/congestion_tracker.rs
+++ b/crates/sui-core/src/congestion_tracker.rs
@@ -100,8 +100,8 @@ impl CongestionTracker {
                             InputSharedObject::Mutate((id, _, _)) => Some(id),
                             InputSharedObject::Cancelled(_, _)
                             | InputSharedObject::ReadOnly(_)
-                            | InputSharedObject::ReadDeleted(_, _)
-                            | InputSharedObject::MutateDeleted(_, _) => None,
+                            | InputSharedObject::ReadConsensusStreamEnded(_, _)
+                            | InputSharedObject::MutateConsensusStreamEnded(_, _) => None,
                         })
                         .collect::<Vec<_>>(),
                 ));

--- a/crates/sui-core/src/unit_tests/shared_object_deletion_tests.rs
+++ b/crates/sui-core/src/unit_tests/shared_object_deletion_tests.rs
@@ -561,7 +561,7 @@ impl TestRunner {
     ) -> Option<TransactionDigest> {
         self.authority_state
             .get_object_cache_reader()
-            .get_deleted_shared_object_previous_tx_digest(object_key, epoch)
+            .get_consensus_stream_end_tx_digest(object_key, epoch)
     }
 }
 

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -1269,11 +1269,11 @@ UnchangedSharedKind:
             - TYPENAME: SequenceNumber
             - TYPENAME: ObjectDigest
     1:
-      MutateDeleted:
+      MutateConsensusStreamEnded:
         NEWTYPE:
           TYPENAME: SequenceNumber
     2:
-      ReadDeleted:
+      ReadConsensusStreamEnded:
         NEWTYPE:
           TYPENAME: SequenceNumber
     3:

--- a/crates/sui-graphql-rpc/src/types/unchanged_shared_object.rs
+++ b/crates/sui-graphql-rpc/src/types/unchanged_shared_object.rs
@@ -13,6 +13,7 @@ use super::{object_read::ObjectRead, sui_address::SuiAddress, uint53::UInt53};
 #[derive(Union)]
 pub(crate) enum UnchangedSharedObject {
     Read(SharedObjectRead),
+    // TODO: Update `Delete` to `ConsensusStreamEnded` to account for ConsensusV2 objects.
     Delete(SharedObjectDelete),
     Cancelled(SharedObjectCancelled),
 }
@@ -71,13 +72,13 @@ impl UnchangedSharedObject {
                 },
             })),
 
-            I::ReadDeleted(id, v) => Ok(U::Delete(SharedObjectDelete {
+            I::ReadConsensusStreamEnded(id, v) => Ok(U::Delete(SharedObjectDelete {
                 address: id.into(),
                 version: v.value().into(),
                 mutable: false,
             })),
 
-            I::MutateDeleted(id, v) => Ok(U::Delete(SharedObjectDelete {
+            I::MutateConsensusStreamEnded(id, v) => Ok(U::Delete(SharedObjectDelete {
                 address: id.into(),
                 version: v.value().into(),
                 mutable: true,

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -1016,7 +1016,10 @@ impl TryFrom<TransactionEffects> for SuiTransactionBlockEffects {
                     effect
                         .input_shared_objects()
                         .into_iter()
-                        .map(|kind| kind.object_ref())
+                        .map(|kind| {
+                            #[allow(deprecated)]
+                            kind.object_ref()
+                        })
                         .collect(),
                 ),
                 transaction_digest: *effect.transaction_digest(),

--- a/crates/sui-mvr-graphql-rpc/src/types/unchanged_shared_object.rs
+++ b/crates/sui-mvr-graphql-rpc/src/types/unchanged_shared_object.rs
@@ -13,6 +13,7 @@ use super::{object_read::ObjectRead, sui_address::SuiAddress, uint53::UInt53};
 #[derive(Union)]
 pub(crate) enum UnchangedSharedObject {
     Read(SharedObjectRead),
+    // TODO: Update `Delete` to `ConsensusStreamEnded` to account for ConsensusV2 objects.
     Delete(SharedObjectDelete),
     Cancelled(SharedObjectCancelled),
 }
@@ -71,13 +72,13 @@ impl UnchangedSharedObject {
                 },
             })),
 
-            I::ReadDeleted(id, v) => Ok(U::Delete(SharedObjectDelete {
+            I::ReadConsensusStreamEnded(id, v) => Ok(U::Delete(SharedObjectDelete {
                 address: id.into(),
                 version: v.value().into(),
                 mutable: false,
             })),
 
-            I::MutateDeleted(id, v) => Ok(U::Delete(SharedObjectDelete {
+            I::MutateConsensusStreamEnded(id, v) => Ok(U::Delete(SharedObjectDelete {
                 address: id.into(),
                 version: v.value().into(),
                 mutable: true,

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -1789,7 +1789,7 @@ impl LocalExec {
                     let (digest, version) = deleted_shared_info_map.get(id).unwrap();
                     Some(ObjectReadResult::new(
                         *kind,
-                        ObjectReadResultKind::DeletedSharedObject(*version, *digest),
+                        ObjectReadResultKind::ObjectConsensusStreamEnded(*version, *digest),
                     ))
                 }
             })

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -407,8 +407,8 @@ mod checked {
                         system_transaction,
                     )?;
                 }
-                // We skip checking a deleted shared object because it no longer exists
-                ObjectReadResultKind::DeletedSharedObject(_, _) => (),
+                // We skip checking a removed consensus object because it no longer exists.
+                ObjectReadResultKind::ObjectConsensusStreamEnded(_, _) => (),
                 // We skip checking shared objects from cancelled transactions since we are not reading it.
                 ObjectReadResultKind::CancelledTransactionSharedObject(_) => (),
             }

--- a/crates/sui-types/src/effects/effects_v1.rs
+++ b/crates/sui-types/src/effects/effects_v1.rs
@@ -320,8 +320,8 @@ impl TransactionEffectsAPI for TransactionEffectsV1 {
             InputSharedObject::ReadOnly(obj_ref) => {
                 self.shared_objects.push(obj_ref);
             }
-            InputSharedObject::ReadDeleted(id, version)
-            | InputSharedObject::MutateDeleted(id, version) => {
+            InputSharedObject::ReadConsensusStreamEnded(id, version)
+            | InputSharedObject::MutateConsensusStreamEnded(id, version) => {
                 self.shared_objects
                     .push((id, version, ObjectDigest::OBJECT_DIGEST_DELETED));
             }

--- a/crates/sui-types/src/execution.rs
+++ b/crates/sui-types/src/execution.rs
@@ -17,22 +17,23 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::time::Duration;
 
-/// A type containing all of the information needed to work with a deleted shared object in
-/// execution and when committing the execution effects of the transaction. This holds:
-/// 0. The object ID of the deleted shared object.
-/// 1. The version of the shared object.
-/// 2. Whether the object appeared as mutable (or owned) in the transaction, or as a read-only shared object.
-/// 3. The transaction digest of the previous transaction that used this shared object mutably or
+/// A type containing all of the information needed to work in execution with an object whose
+/// consensus stream is ended, and when committing the execution effects of the transaction.
+/// This holds:
+/// 0. The object ID.
+/// 1. The version.
+/// 2. Whether the object appeared as mutable (or owned) in the transaction, or as read-only.
+/// 3. The transaction digest of the previous transaction that used this object mutably or
 ///    took it by value.
-pub type DeletedSharedObjectInfo = (ObjectID, SequenceNumber, bool, TransactionDigest);
+pub type ConsensusStreamEndedInfo = (ObjectID, SequenceNumber, bool, TransactionDigest);
 
-/// A sequence of information about deleted shared objects in the transaction's inputs.
-pub type DeletedSharedObjects = Vec<DeletedSharedObjectInfo>;
+/// A sequence of information about removed consensus objects in the transaction's inputs.
+pub type ConsensusStreamEndedObjects = Vec<ConsensusStreamEndedInfo>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SharedInput {
     Existing(ObjectRef),
-    Deleted(DeletedSharedObjectInfo),
+    ConsensusStreamEnded(ConsensusStreamEndedInfo),
     Cancelled((ObjectID, SequenceNumber)),
 }
 

--- a/crates/sui-types/src/storage/mod.rs
+++ b/crates/sui-types/src/storage/mod.rs
@@ -117,10 +117,9 @@ pub enum MarkerValue {
     /// An owned object was deleted (or wrapped) at the given version, and is no longer able to be
     /// accessed or used in subsequent transactions.
     OwnedDeleted,
-    /// A shared object was deleted or removed from consensus by the transaction and is no longer
-    /// able to be accessed or used in subsequent transactions.
-    // TODO: Rename this to something more accurate, like "ConsensusUnavailable".
-    SharedDeleted(TransactionDigest),
+    /// A consensus object was deleted or removed from consensus by the transaction and is no longer
+    /// able to be accessed or used in subsequent transactions with the same initial shared version.
+    ConsensusStreamEnded(TransactionDigest),
 }
 
 /// DeleteKind together with the old sequence number prior to the deletion, if available.

--- a/crates/sui-types/src/sui_sdk_types_conversions.rs
+++ b/crates/sui-types/src/sui_sdk_types_conversions.rs
@@ -428,8 +428,12 @@ impl From<UnchangedSharedKind> for crate::effects::UnchangedSharedKind {
             UnchangedSharedKind::ReadOnlyRoot { version, digest } => {
                 Self::ReadOnlyRoot((version.into(), digest.into()))
             }
-            UnchangedSharedKind::MutateDeleted { version } => Self::MutateDeleted(version.into()),
-            UnchangedSharedKind::ReadDeleted { version } => Self::ReadDeleted(version.into()),
+            UnchangedSharedKind::MutateDeleted { version } => {
+                Self::MutateConsensusStreamEnded(version.into())
+            }
+            UnchangedSharedKind::ReadDeleted { version } => {
+                Self::ReadConsensusStreamEnded(version.into())
+            }
             UnchangedSharedKind::Canceled { version } => Self::Cancelled(version.into()),
             UnchangedSharedKind::PerEpochConfig => Self::PerEpochConfig,
         }
@@ -445,12 +449,16 @@ impl From<crate::effects::UnchangedSharedKind> for UnchangedSharedKind {
                     digest: digest.into(),
                 }
             }
-            crate::effects::UnchangedSharedKind::MutateDeleted(version) => Self::MutateDeleted {
-                version: version.into(),
-            },
-            crate::effects::UnchangedSharedKind::ReadDeleted(version) => Self::ReadDeleted {
-                version: version.into(),
-            },
+            crate::effects::UnchangedSharedKind::MutateConsensusStreamEnded(version) => {
+                Self::MutateDeleted {
+                    version: version.into(),
+                }
+            }
+            crate::effects::UnchangedSharedKind::ReadConsensusStreamEnded(version) => {
+                Self::ReadDeleted {
+                    version: version.into(),
+                }
+            }
             crate::effects::UnchangedSharedKind::Cancelled(version) => Self::Canceled {
                 version: version.into(),
             },

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -3042,9 +3042,8 @@ pub struct ObjectReadResult {
 pub enum ObjectReadResultKind {
     Object(Object),
     // The version of the object that the transaction intended to read, and the digest of the tx
-    // that deleted it.
-    // TODO: Rename this to something more accurate, like "UnavailableConsensusObject".
-    DeletedSharedObject(SequenceNumber, TransactionDigest),
+    // that removed it from consensus.
+    ObjectConsensusStreamEnded(SequenceNumber, TransactionDigest),
     // A shared object in a cancelled transaction. The sequence number embeds cancellation reason.
     CancelledTransactionSharedObject(SequenceNumber),
 }
@@ -3055,8 +3054,8 @@ impl std::fmt::Debug for ObjectReadResultKind {
             ObjectReadResultKind::Object(obj) => {
                 write!(f, "Object({:?})", obj.compute_object_reference())
             }
-            ObjectReadResultKind::DeletedSharedObject(seq, digest) => {
-                write!(f, "DeletedSharedObject({}, {:?})", seq, digest)
+            ObjectReadResultKind::ObjectConsensusStreamEnded(seq, digest) => {
+                write!(f, "ObjectConsensusStreamEnded({}, {:?})", seq, digest)
             }
             ObjectReadResultKind::CancelledTransactionSharedObject(seq) => {
                 write!(f, "CancelledTransactionSharedObject({})", seq)
@@ -3075,10 +3074,10 @@ impl ObjectReadResult {
     pub fn new(input_object_kind: InputObjectKind, object: ObjectReadResultKind) -> Self {
         if let (
             InputObjectKind::ImmOrOwnedMoveObject(_),
-            ObjectReadResultKind::DeletedSharedObject(_, _),
+            ObjectReadResultKind::ObjectConsensusStreamEnded(_, _),
         ) = (&input_object_kind, &object)
         {
-            panic!("only shared objects can be DeletedSharedObject");
+            panic!("only consensus objects can be ObjectConsensusStreamEnded");
         }
 
         if let (
@@ -3086,7 +3085,7 @@ impl ObjectReadResult {
             ObjectReadResultKind::CancelledTransactionSharedObject(_),
         ) = (&input_object_kind, &object)
         {
-            panic!("only shared objects can be CancelledTransactionSharedObject");
+            panic!("only consensus objects can be CancelledTransactionSharedObject");
         }
 
         Self {
@@ -3102,7 +3101,7 @@ impl ObjectReadResult {
     pub fn as_object(&self) -> Option<&Object> {
         match &self.object {
             ObjectReadResultKind::Object(object) => Some(object),
-            ObjectReadResultKind::DeletedSharedObject(_, _) => None,
+            ObjectReadResultKind::ObjectConsensusStreamEnded(_, _) => None,
             ObjectReadResultKind::CancelledTransactionSharedObject(_) => None,
         }
     }
@@ -3123,7 +3122,7 @@ impl ObjectReadResult {
             }
             (
                 InputObjectKind::ImmOrOwnedMoveObject(_),
-                ObjectReadResultKind::DeletedSharedObject(_, _),
+                ObjectReadResultKind::ObjectConsensusStreamEnded(_, _),
             ) => unreachable!(),
             (
                 InputObjectKind::ImmOrOwnedMoveObject(_),
@@ -3137,13 +3136,13 @@ impl ObjectReadResult {
         self.input_object_kind.is_shared_object()
     }
 
-    pub fn is_deleted_shared_object(&self) -> bool {
-        self.deletion_info().is_some()
+    pub fn is_consensus_stream_ended(&self) -> bool {
+        self.consensus_stream_end_info().is_some()
     }
 
-    pub fn deletion_info(&self) -> Option<(SequenceNumber, TransactionDigest)> {
+    pub fn consensus_stream_end_info(&self) -> Option<(SequenceNumber, TransactionDigest)> {
         match &self.object {
-            ObjectReadResultKind::DeletedSharedObject(v, tx) => Some((*v, *tx)),
+            ObjectReadResultKind::ObjectConsensusStreamEnded(v, tx) => Some((*v, *tx)),
             _ => None,
         }
     }
@@ -3164,7 +3163,7 @@ impl ObjectReadResult {
             }
             (
                 InputObjectKind::ImmOrOwnedMoveObject(_),
-                ObjectReadResultKind::DeletedSharedObject(_, _),
+                ObjectReadResultKind::ObjectConsensusStreamEnded(_, _),
             ) => unreachable!(),
             (
                 InputObjectKind::ImmOrOwnedMoveObject(_),
@@ -3186,8 +3185,8 @@ impl ObjectReadResult {
                 ObjectReadResultKind::Object(obj) => {
                     SharedInput::Existing(obj.compute_object_reference())
                 }
-                ObjectReadResultKind::DeletedSharedObject(seq, digest) => {
-                    SharedInput::Deleted((id, *seq, mutable, *digest))
+                ObjectReadResultKind::ObjectConsensusStreamEnded(seq, digest) => {
+                    SharedInput::ConsensusStreamEnded((id, *seq, mutable, *digest))
                 }
                 ObjectReadResultKind::CancelledTransactionSharedObject(seq) => {
                     SharedInput::Cancelled((id, *seq))
@@ -3199,7 +3198,7 @@ impl ObjectReadResult {
     pub fn get_previous_transaction(&self) -> Option<TransactionDigest> {
         match &self.object {
             ObjectReadResultKind::Object(obj) => Some(obj.previous_transaction),
-            ObjectReadResultKind::DeletedSharedObject(_, digest) => Some(*digest),
+            ObjectReadResultKind::ObjectConsensusStreamEnded(_, digest) => Some(*digest),
             ObjectReadResultKind::CancelledTransactionSharedObject(_) => None,
         }
     }
@@ -3269,10 +3268,10 @@ impl InputObjects {
         self.objects.is_empty()
     }
 
-    pub fn contains_deleted_objects(&self) -> bool {
+    pub fn contains_consensus_stream_ended_objects(&self) -> bool {
         self.objects
             .iter()
-            .any(|obj| obj.is_deleted_shared_object())
+            .any(|obj| obj.is_consensus_stream_ended())
     }
 
     // Returns IDs of objects responsible for a tranaction being cancelled, and the corresponding
@@ -3364,13 +3363,13 @@ impl InputObjects {
                     }
                     (
                         InputObjectKind::ImmOrOwnedMoveObject(_),
-                        ObjectReadResultKind::DeletedSharedObject(_, _),
+                        ObjectReadResultKind::ObjectConsensusStreamEnded(_, _),
                     ) => {
                         unreachable!()
                     }
                     (
                         InputObjectKind::SharedMoveObject { .. },
-                        ObjectReadResultKind::DeletedSharedObject(_, _),
+                        ObjectReadResultKind::ObjectConsensusStreamEnded(_, _),
                     ) => None,
                     (
                         InputObjectKind::SharedMoveObject { mutable, .. },
@@ -3409,7 +3408,7 @@ impl InputObjects {
                 ObjectReadResultKind::Object(object) => {
                     object.data.try_as_move().map(MoveObject::version)
                 }
-                ObjectReadResultKind::DeletedSharedObject(v, _) => Some(*v),
+                ObjectReadResultKind::ObjectConsensusStreamEnded(v, _) => Some(*v),
                 ObjectReadResultKind::CancelledTransactionSharedObject(_) => None,
             })
             .chain(receiving_objects.iter().map(|object_ref| object_ref.1));
@@ -3425,7 +3424,7 @@ impl InputObjects {
         )
     }
 
-    pub fn deleted_consensus_objects(&self) -> BTreeMap<ObjectID, SequenceNumber> {
+    pub fn consensus_stream_ended_objects(&self) -> BTreeMap<ObjectID, SequenceNumber> {
         self.objects
             .iter()
             .filter_map(|obj| {
@@ -3435,7 +3434,7 @@ impl InputObjects {
                     ..
                 } = obj.input_object_kind
                 {
-                    obj.is_deleted_shared_object()
+                    obj.is_consensus_stream_ended()
                         .then_some((id, initial_shared_version))
                 } else {
                     None

--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -112,7 +112,7 @@ mod checked {
         let shared_object_refs = input_objects.filter_shared_objects();
         let receiving_objects = transaction_kind.receiving_objects();
         let mut transaction_dependencies = input_objects.transaction_dependencies();
-        let contains_deleted_input = input_objects.contains_deleted_objects();
+        let contains_stream_ended_input = input_objects.contains_consensus_stream_ended_objects();
         let cancelled_objects = input_objects.get_cancelled_objects();
 
         let mut temporary_store = TemporaryStore::new(
@@ -165,7 +165,7 @@ mod checked {
             metrics,
             enable_expensive_checks,
             deny_cert,
-            contains_deleted_input,
+            contains_stream_ended_input,
             cancelled_objects,
             trace_builder_opt,
         );

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -45,7 +45,7 @@ pub struct TemporaryStore<'backing> {
     store: &'backing dyn BackingStore,
     tx_digest: TransactionDigest,
     input_objects: BTreeMap<ObjectID, Object>,
-    deleted_consensus_objects: BTreeMap<ObjectID, SequenceNumber /* start_version */>,
+    stream_ended_consensus_objects: BTreeMap<ObjectID, SequenceNumber /* start_version */>,
     /// The version to assign to all objects written by the transaction using this store.
     lamport_timestamp: SequenceNumber,
     mutable_input_refs: BTreeMap<ObjectID, (VersionDigest, Owner)>, // Inputs that are mutable
@@ -86,7 +86,7 @@ impl<'backing> TemporaryStore<'backing> {
     ) -> Self {
         let mutable_input_refs = input_objects.mutable_inputs();
         let lamport_timestamp = input_objects.lamport_timestamp(&receiving_objects);
-        let deleted_consensus_objects = input_objects.deleted_consensus_objects();
+        let stream_ended_consensus_objects = input_objects.consensus_stream_ended_objects();
         let objects = input_objects.into_object_map();
         #[cfg(debug_assertions)]
         {
@@ -107,7 +107,7 @@ impl<'backing> TemporaryStore<'backing> {
             store,
             tx_digest,
             input_objects: objects,
-            deleted_consensus_objects,
+            stream_ended_consensus_objects,
             lamport_timestamp,
             mutable_input_refs,
             execution_results: ExecutionResultsV2::default(),
@@ -145,7 +145,7 @@ impl<'backing> TemporaryStore<'backing> {
         let results = self.execution_results;
         InnerTemporaryStore {
             input_objects: self.input_objects,
-            deleted_consensus_objects: self.deleted_consensus_objects,
+            stream_ended_consensus_objects: self.stream_ended_consensus_objects,
             mutable_inputs: self.mutable_input_refs,
             written: results.written_objects,
             events: TransactionEvents {

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -77,7 +77,7 @@ impl<'backing> TemporaryStore<'backing> {
     ) -> Self {
         let mutable_input_refs = input_objects.mutable_inputs();
         let lamport_timestamp = input_objects.lamport_timestamp(&[]);
-        let deleted_consensus_objects = input_objects.deleted_consensus_objects();
+        let deleted_consensus_objects = input_objects.consensus_stream_ended_objects();
         let objects = input_objects.into_object_map();
 
         Self {
@@ -148,7 +148,7 @@ impl<'backing> TemporaryStore<'backing> {
     pub fn into_inner(self) -> InnerTemporaryStore {
         InnerTemporaryStore {
             input_objects: self.input_objects,
-            deleted_consensus_objects: self.deleted_consensus_objects,
+            stream_ended_consensus_objects: self.deleted_consensus_objects,
             mutable_inputs: self.mutable_input_refs,
             written: self
                 .written
@@ -267,7 +267,7 @@ impl<'backing> TemporaryStore<'backing> {
             .into_iter()
             .map(|shared_input| match shared_input {
                 SharedInput::Existing(oref) => oref,
-                SharedInput::Deleted(_) => {
+                SharedInput::ConsensusStreamEnded(_) => {
                     unreachable!("Shared object deletion not supported in effects v1")
                 }
                 SharedInput::Cancelled(_) => {

--- a/sui-execution/v1/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v1/sui-adapter/src/execution_engine.rs
@@ -84,7 +84,7 @@ mod checked {
         let shared_object_refs = input_objects.filter_shared_objects();
         let receiving_objects = transaction_kind.receiving_objects();
         let mut transaction_dependencies = input_objects.transaction_dependencies();
-        let contains_deleted_input = input_objects.contains_deleted_objects();
+        let contains_deleted_input = input_objects.contains_consensus_stream_ended_objects();
         let cancelled_objects = input_objects.get_cancelled_objects();
 
         let mut temporary_store = TemporaryStore::new(

--- a/sui-execution/v1/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v1/sui-adapter/src/temporary_store.rs
@@ -73,7 +73,7 @@ impl<'backing> TemporaryStore<'backing> {
     ) -> Self {
         let mutable_input_refs = input_objects.mutable_inputs();
         let lamport_timestamp = input_objects.lamport_timestamp(&receiving_objects);
-        let deleted_consensus_objects = input_objects.deleted_consensus_objects();
+        let deleted_consensus_objects = input_objects.consensus_stream_ended_objects();
         let objects = input_objects.into_object_map();
         Self {
             store,
@@ -114,7 +114,7 @@ impl<'backing> TemporaryStore<'backing> {
         let results = self.execution_results;
         InnerTemporaryStore {
             input_objects: self.input_objects,
-            deleted_consensus_objects: self.deleted_consensus_objects,
+            stream_ended_consensus_objects: self.deleted_consensus_objects,
             mutable_inputs: self.mutable_input_refs,
             written: results.written_objects,
             events: TransactionEvents {
@@ -218,7 +218,7 @@ impl<'backing> TemporaryStore<'backing> {
                 .into_iter()
                 .map(|shared_input| match shared_input {
                     SharedInput::Existing(oref) => oref,
-                    SharedInput::Deleted(_) => {
+                    SharedInput::ConsensusStreamEnded(_) => {
                         unreachable!("Shared object deletion not supported in effects v1")
                     }
                     SharedInput::Cancelled(_) => {

--- a/sui-execution/v2/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/v2/sui-adapter/src/execution_engine.rs
@@ -95,7 +95,7 @@ mod checked {
         let shared_object_refs = input_objects.filter_shared_objects();
         let receiving_objects = transaction_kind.receiving_objects();
         let mut transaction_dependencies = input_objects.transaction_dependencies();
-        let contains_deleted_input = input_objects.contains_deleted_objects();
+        let contains_deleted_input = input_objects.contains_consensus_stream_ended_objects();
         let cancelled_objects = input_objects.get_cancelled_objects();
 
         let mut temporary_store = TemporaryStore::new(

--- a/sui-execution/v2/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v2/sui-adapter/src/temporary_store.rs
@@ -75,7 +75,7 @@ impl<'backing> TemporaryStore<'backing> {
     ) -> Self {
         let mutable_input_refs = input_objects.mutable_inputs();
         let lamport_timestamp = input_objects.lamport_timestamp(&receiving_objects);
-        let deleted_consensus_objects = input_objects.deleted_consensus_objects();
+        let deleted_consensus_objects = input_objects.consensus_stream_ended_objects();
         let objects = input_objects.into_object_map();
         #[cfg(debug_assertions)]
         {
@@ -133,7 +133,7 @@ impl<'backing> TemporaryStore<'backing> {
         InnerTemporaryStore {
             input_objects: self.input_objects,
             mutable_inputs: self.mutable_input_refs,
-            deleted_consensus_objects: self.deleted_consensus_objects,
+            stream_ended_consensus_objects: self.deleted_consensus_objects,
             written: results.written_objects,
             events: TransactionEvents {
                 data: results.user_events,
@@ -236,7 +236,7 @@ impl<'backing> TemporaryStore<'backing> {
                 .into_iter()
                 .map(|shared_input| match shared_input {
                     SharedInput::Existing(oref) => oref,
-                    SharedInput::Deleted(_) => {
+                    SharedInput::ConsensusStreamEnded(_) => {
                         unreachable!("Shared object deletion not supported in effects v1")
                     }
                     SharedInput::Cancelled(_) => {


### PR DESCRIPTION
## Description 

These are now referred to as "consensus stream ended" (or similar). ConsensusV2 objects may be removed from consensus without being deleted.

Note:
- GraphQL RPC updates are left for a future PR.
- Actual implementation of marker table writes when a ConsensusV2 object is transferred to a different owner type is left for a future PR.

## Test plan 

Name changes only

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
