### PR TITLE
[json-rpc-types] Add test for `SuiMoveType`s and json format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14173,6 +14173,7 @@ dependencies = [
  "colored",
  "enum_dispatch",
  "fastcrypto",
+ "insta",
  "itertools 0.13.0",
  "json_to_table",
  "move-binary-format",

--- a/crates/sui-json-rpc-types/Cargo.toml
+++ b/crates/sui-json-rpc-types/Cargo.toml
@@ -34,3 +34,6 @@ mysten-metrics.workspace = true
 sui-types.workspace = true
 sui-json.workspace = true
 sui-package-resolver.workspace = true
+
+[dev-dependencies]
+insta.workspace = true

--- a/crates/sui-json-rpc-types/src/unit_tests/rpc_types_tests.rs
+++ b/crates/sui-json-rpc-types/src/unit_tests/rpc_types_tests.rs
@@ -146,6 +146,117 @@ fn test_serde() {
 }
 
 #[test]
+fn test_move_type_serde() {
+    use crate::sui_move as SM;
+    use crate::sui_move::SuiMoveNormalizedType as SNT;
+    let test_types = vec![
+        SNT::Bool,
+        SNT::U8,
+        SNT::U16,
+        SNT::U32,
+        SNT::U64,
+        SNT::U128,
+        SNT::U256,
+        SNT::Address,
+        SNT::Signer,
+        SNT::Vector(Box::new(SNT::U8)),
+        SNT::Struct {
+            address: SUI_FRAMEWORK_ADDRESS.to_string(),
+            module: "coin".to_owned(),
+            name: "Coin".to_owned(),
+            type_arguments: vec![SNT::Address],
+        },
+        SNT::Vector(Box::new(SNT::U16)),
+        SNT::Vector(Box::new(SNT::Vector(Box::new(SNT::U8)))),
+        SNT::TypeParameter(0),
+        SNT::Reference(Box::new(SNT::U8)),
+        SNT::MutableReference(Box::new(SNT::Struct {
+            address: SUI_FRAMEWORK_ADDRESS.to_string(),
+            module: "coin".to_owned(),
+            name: "Coin".to_owned(),
+            type_arguments: vec![SNT::Address],
+        })),
+    ];
+
+    let mut acc = vec![];
+
+    for value in test_types {
+        let json = serde_json::to_string(&value).unwrap();
+        acc.push(json);
+    }
+
+    let s = SM::SuiMoveNormalizedStruct {
+        abilities: SM::SuiMoveAbilitySet {
+            abilities: vec![SM::SuiMoveAbility::Copy],
+        },
+        type_parameters: vec![SM::SuiMoveStructTypeParameter {
+            constraints: SM::SuiMoveAbilitySet {
+                abilities: vec![SM::SuiMoveAbility::Drop],
+            },
+            is_phantom: false,
+        }],
+        fields: vec![
+            SM::SuiMoveNormalizedField {
+                name: "field1".to_string(),
+                type_: SNT::U8,
+            },
+            SM::SuiMoveNormalizedField {
+                name: "field2".to_string(),
+                type_: SNT::U16,
+            },
+        ],
+    };
+
+    let json = serde_json::to_string(&s).unwrap();
+    acc.push(json);
+
+    // NB: variants declaration and lexicographic ordering are different here
+    let variants = vec![
+        ("b", vec![SNT::U16]),
+        ("a", vec![]),
+        (
+            "c",
+            vec![
+                SNT::U32,
+                SNT::Struct {
+                    address: SUI_FRAMEWORK_ADDRESS.to_string(),
+                    module: "coin".to_owned(),
+                    name: "Coin".to_owned(),
+                    type_arguments: vec![SNT::Address],
+                },
+            ],
+        ),
+    ]
+    .into_iter()
+    .map(|(name, type_)| {
+        (
+            name.to_string(),
+            type_
+                .into_iter()
+                .enumerate()
+                .map(|(i, t)| SM::SuiMoveNormalizedField {
+                    name: format!("field{}", i),
+                    type_: t,
+                })
+                .collect(),
+        )
+    })
+    .collect();
+
+    let e = SM::SuiMoveNormalizedEnum {
+        abilities: SM::SuiMoveAbilitySet {
+            abilities: vec![SM::SuiMoveAbility::Copy],
+        },
+        type_parameters: vec![],
+        variants,
+    };
+
+    acc.push(serde_json::to_string(&e).unwrap());
+
+    insta::assert_snapshot!(acc.join("\n"));
+}
+
+#[test]
 fn test_serde_bytearray() {
     // ensure that we serialize byte arrays as number array
     let test_values = MoveValue::Vector(vec![MoveValue::U8(1), MoveValue::U8(2), MoveValue::U8(3)]);

--- a/crates/sui-json-rpc-types/src/unit_tests/snapshots/sui_json_rpc_types__rpc_types_tests__move_type_serde.snap
+++ b/crates/sui-json-rpc-types/src/unit_tests/snapshots/sui_json_rpc_types__rpc_types_tests__move_type_serde.snap
@@ -1,0 +1,22 @@
+---
+source: crates/sui-json-rpc-types/src/unit_tests/rpc_types_tests.rs
+expression: "acc.join(\"\\n\")"
+---
+"Bool"
+"U8"
+"U16"
+"U32"
+"U64"
+"U128"
+"U256"
+"Address"
+"Signer"
+{"Vector":"U8"}
+{"Struct":{"address":"0000000000000000000000000000000000000000000000000000000000000002","module":"coin","name":"Coin","typeArguments":["Address"]}}
+{"Vector":"U16"}
+{"Vector":{"Vector":"U8"}}
+{"TypeParameter":0}
+{"Reference":"U8"}
+{"MutableReference":{"Struct":{"address":"0000000000000000000000000000000000000000000000000000000000000002","module":"coin","name":"Coin","typeArguments":["Address"]}}}
+{"abilities":{"abilities":["Copy"]},"typeParameters":[{"constraints":{"abilities":["Drop"]},"isPhantom":false}],"fields":[{"name":"field1","type":"U8"},{"name":"field2","type":"U16"}]}
+{"abilities":{"abilities":["Copy"]},"typeParameters":[],"variants":{"a":[],"b":[{"name":"field0","type":"U16"}],"c":[{"name":"field0","type":"U32"},{"name":"field1","type":{"Struct":{"address":"0000000000000000000000000000000000000000000000000000000000000002","module":"coin","name":"Coin","typeArguments":["Address"]}}}]}}


### PR DESCRIPTION
## Description 

This adds a snapshot test to ensure stability of the json-formatted types. 

## Test plan 

It's just tests!

