### PR TITLE
[json-rpc-types] Return variants in declaration order

### DIFF
--- a/crates/sui-json-rpc-types/src/unit_tests/rpc_types_tests.rs
+++ b/crates/sui-json-rpc-types/src/unit_tests/rpc_types_tests.rs
@@ -248,7 +248,7 @@ fn test_move_type_serde() {
             abilities: vec![SM::SuiMoveAbility::Copy],
         },
         type_parameters: vec![],
-        variants,
+        variants: SM::SuiMoveNormalizedEnumVariants(variants),
     };
 
     acc.push(serde_json::to_string(&e).unwrap());

--- a/crates/sui-json-rpc-types/src/unit_tests/snapshots/sui_json_rpc_types__rpc_types_tests__move_type_serde.snap
+++ b/crates/sui-json-rpc-types/src/unit_tests/snapshots/sui_json_rpc_types__rpc_types_tests__move_type_serde.snap
@@ -19,4 +19,4 @@ expression: "acc.join(\"\\n\")"
 {"Reference":"U8"}
 {"MutableReference":{"Struct":{"address":"0000000000000000000000000000000000000000000000000000000000000002","module":"coin","name":"Coin","typeArguments":["Address"]}}}
 {"abilities":{"abilities":["Copy"]},"typeParameters":[{"constraints":{"abilities":["Drop"]},"isPhantom":false}],"fields":[{"name":"field1","type":"U8"},{"name":"field2","type":"U16"}]}
-{"abilities":{"abilities":["Copy"]},"typeParameters":[],"variants":{"a":[],"b":[{"name":"field0","type":"U16"}],"c":[{"name":"field0","type":"U32"},{"name":"field1","type":{"Struct":{"address":"0000000000000000000000000000000000000000000000000000000000000002","module":"coin","name":"Coin","typeArguments":["Address"]}}}]}}
+{"abilities":{"abilities":["Copy"]},"typeParameters":[],"variants":{"b":[{"name":"field0","type":"U16"}],"a":[],"c":[{"name":"field0","type":"U32"},{"name":"field1","type":{"Struct":{"address":"0000000000000000000000000000000000000000000000000000000000000002","module":"coin","name":"Coin","typeArguments":["Address"]}}}]}}


### PR DESCRIPTION
## Description 

Updates `variants` field of the `SuiMoveNormalizedEnum` to return the variants in order but in the same format (as a map) as before.

Adding @mlegner as a reviewer as well as this may have some effects on the Walrus side in the CLI. 

## Test plan 

Updated snapshot of test for this. Note that the only thing that changed was the order of the field.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
