### PR TITLE
[move-ide] Disable building of move-analyzer binary in external crates

### DIFF
--- a/external-crates/move/crates/move-analyzer/Cargo.toml
+++ b/external-crates/move/crates/move-analyzer/Cargo.toml
@@ -7,6 +7,10 @@ repository = "https://github.com/move-language/move"
 license = "Apache-2.0"
 publish = false
 edition = "2021"
+# `move-analyzer` binary built directly out of this crate
+# should not be used "as is", as it's sits somewhere
+# in the middle between supporting Sui and not supporting it (fully)
+autobins = false
 
 [dependencies]
 anyhow.workspace = true


### PR DESCRIPTION
## Description 

For full Sui support, `move-analyzer` binary should be built with the following command:
```shell
cargo install --git https://github.com/MystenLabs/sui sui-move-lsp
```

However, prior to this PR, it was also possible to build it with the following command which resulted in a binary that lacked some of the features (e.g., support for implicit deps):
```shell
cargo install --git https://github.com/MystenLabs/sui move-analyzer
````

This was confusing, particularly for people that use `move-analyzer` binary to support editors other than VSCode. Hence the decision to only allow creation of a binary from `sui-move-lsp` crate.


## Test plan 

Verified that the binary can no longer be built from `move-analyzer` external crate
