### PR TITLE
feat: increase the range of counter in RandomGenerator

### DIFF
--- a/crates/sui-framework/packages/sui-framework/sources/random.move
+++ b/crates/sui-framework/packages/sui-framework/sources/random.move
@@ -130,7 +130,7 @@ public fun update_randomness_state_for_testing(
 /// Unique randomness generator, derived from the global randomness.
 public struct RandomGenerator has drop {
     seed: vector<u8>,
-    counter: u16,
+    counter: u32,
     buffer: vector<u8>,
 }
 
@@ -296,7 +296,7 @@ public fun generator_seed(r: &RandomGenerator): &vector<u8> {
 }
 
 #[test_only]
-public fun generator_counter(r: &RandomGenerator): u16 {
+public fun generator_counter(r: &RandomGenerator): u32 {
     r.counter
 }
 


### PR DESCRIPTION
## Description 

  Increased the range of the counter attribute in the RandomGenerator struct of the random module, changing its type to u32. This change was made to prevent errors in tests caused by exceeding the previous range of the counter.

## Test plan 

I haven't tested this change yet. Let me know if you have any suggestions for specific test cases.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
