### PR TITLE
rpc: enable serving rpc traffic over https

### DIFF
--- a/crates/sui-rpc-api/src/config.rs
+++ b/crates/sui-rpc-api/src/config.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::net::SocketAddr;
+
 #[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
@@ -16,15 +18,49 @@ pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enable_indexing: Option<bool>,
 
-    // Only include this till we have another field that isn't set with a non-default value for
-    // testing
-    #[doc(hidden)]
-    #[serde(skip)]
-    pub _hidden: (),
+    /// Configure the address to listen on for https
+    ///
+    /// Defaults to `0.0.0.0:9443` if not specified.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub https_address: Option<SocketAddr>,
+
+    /// TLS configuration to use for https.
+    ///
+    /// If not provided then the node will not create an https service.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tls: Option<TlsConfig>,
 }
 
 impl Config {
     pub fn enable_indexing(&self) -> bool {
         self.enable_indexing.unwrap_or(false)
+    }
+
+    pub fn https_address(&self) -> SocketAddr {
+        self.https_address
+            .unwrap_or_else(|| SocketAddr::from(([0, 0, 0, 0], 9443)))
+    }
+
+    pub fn tls_config(&self) -> Option<&TlsConfig> {
+        self.tls.as_ref()
+    }
+}
+
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct TlsConfig {
+    /// File path to a PEM formatted TLS certificate chain
+    cert: String,
+    /// File path to a PEM formatted TLS private key
+    key: String,
+}
+
+impl TlsConfig {
+    pub fn cert(&self) -> &str {
+        &self.cert
+    }
+
+    pub fn key(&self) -> &str {
+        &self.key
     }
 }


### PR DESCRIPTION
## Description 

Introduce the ability to serve rpc traffic over https by providing a TLS
cert and private key via config.

The relevant section of the node yaml config:

```
rpc:
  https_address: 0.0.0.0:9443 # This is the default if not provided
  tls:
    cert: /path/to/cert.pem
    key: /path/to/key.pem
```

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
