### PR TITLE
[CLI] Download dependency before reading manifest files (DVX-746)

### DIFF
--- a/external-crates/move/crates/move-package/src/resolution/resolution_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/resolution_graph.rs
@@ -128,6 +128,14 @@ impl ResolvedGraph {
                         if let PM::DependencyKind::OnChain(_) = internal.kind {
                             continue;
                         }
+                        dependency_cache
+                            .download_and_update_if_remote(
+                                *dep_name,
+                                &internal.kind,
+                                progress_output,
+                            )
+                            .with_context(|| format!("Fetching '{pkg_id}'"))?;
+
                         let dep_path = &resolved_pkg.package_path.join(local_path(&internal.kind));
                         let dep_manifest = parse_move_manifest_from_file(dep_path)?;
                         if dep_name != &dep_manifest.package.name {


### PR DESCRIPTION
## Description 

This fixes a bug where transitive dependencies of externally resolved dependencies are accessed before they are fetched.

## Test plan 

Manual testing

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: Bug fix - transitive dependencies of externally resolved dependencies are fetched before reading
- [ ] Rust SDK:
