### PR TITLE
[json-rpc-types] Return variants in declaration order

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_move.rs
+++ b/crates/sui-json-rpc-types/src/sui_move.rs
@@ -265,15 +265,13 @@ impl<S: Hash + Eq + ToString> From<&NormalizedEnum<S>> for SuiMoveNormalizedEnum
             .iter()
             .map(|(name, _)| name.clone())
             .collect::<Vec<String>>();
-        let variants = variants
-            .into_iter()
-            .map(|(name, fields)| (name, fields))
-            .collect();
+        let variants = variants.into_iter().collect();
         Self {
             abilities: value.abilities.into(),
             type_parameters: value
                 .type_parameters
-                .into_iter()
+                .iter()
+                .copied()
                 .map(SuiMoveStructTypeParameter::from)
                 .collect::<Vec<SuiMoveStructTypeParameter>>(),
             variants,

--- a/crates/sui-json-rpc-types/src/sui_move.rs
+++ b/crates/sui-json-rpc-types/src/sui_move.rs
@@ -79,6 +79,8 @@ pub struct SuiMoveNormalizedEnum {
     pub abilities: SuiMoveAbilitySet,
     pub type_parameters: Vec<SuiMoveStructTypeParameter>,
     pub variants: BTreeMap<String, Vec<SuiMoveNormalizedField>>,
+    #[serde(default)]
+    pub variant_declaration_order: Option<Vec<String>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
@@ -244,29 +246,38 @@ impl<S: Hash + Eq + ToString> From<&NormalizedStruct<S>> for SuiMoveNormalizedSt
 
 impl<S: Hash + Eq + ToString> From<&NormalizedEnum<S>> for SuiMoveNormalizedEnum {
     fn from(value: &NormalizedEnum<S>) -> Self {
+        let variants = value
+            .variants
+            .values()
+            .map(|variant| {
+                (
+                    variant.name.to_string(),
+                    variant
+                        .fields
+                        .0
+                        .values()
+                        .map(|f| SuiMoveNormalizedField::from(&**f))
+                        .collect::<Vec<SuiMoveNormalizedField>>(),
+                )
+            })
+            .collect::<Vec<(String, Vec<SuiMoveNormalizedField>)>>();
+        let variant_declaration_order = variants
+            .iter()
+            .map(|(name, _)| name.clone())
+            .collect::<Vec<String>>();
+        let variants = variants
+            .into_iter()
+            .map(|(name, fields)| (name, fields))
+            .collect();
         Self {
             abilities: value.abilities.into(),
             type_parameters: value
                 .type_parameters
-                .iter()
-                .copied()
+                .into_iter()
                 .map(SuiMoveStructTypeParameter::from)
                 .collect::<Vec<SuiMoveStructTypeParameter>>(),
-            variants: value
-                .variants
-                .values()
-                .map(|variant| {
-                    (
-                        variant.name.to_string(),
-                        variant
-                            .fields
-                            .0
-                            .values()
-                            .map(|f| SuiMoveNormalizedField::from(&**f))
-                            .collect::<Vec<SuiMoveNormalizedField>>(),
-                    )
-                })
-                .collect::<BTreeMap<String, Vec<SuiMoveNormalizedField>>>(),
+            variants,
+            variant_declaration_order: Some(variant_declaration_order),
         }
     }
 }

--- a/crates/sui-json-rpc-types/src/unit_tests/rpc_types_tests.rs
+++ b/crates/sui-json-rpc-types/src/unit_tests/rpc_types_tests.rs
@@ -238,21 +238,21 @@ fn test_move_type_serde() {
         .map(|(name, _)| name.to_string())
         .collect::<Vec<_>>();
     let variants = variants
-    .into_iter()
-    .map(|(name, type_)| {
-        (
-            name.to_string(),
-            type_
-                .into_iter()
-                .enumerate()
-                .map(|(i, t)| SM::SuiMoveNormalizedField {
-                    name: format!("field{}", i),
-                    type_: t,
-                })
-                .collect(),
-        )
-    })
-    .collect();
+        .into_iter()
+        .map(|(name, type_)| {
+            (
+                name.to_string(),
+                type_
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, t)| SM::SuiMoveNormalizedField {
+                        name: format!("field{}", i),
+                        type_: t,
+                    })
+                    .collect(),
+            )
+        })
+        .collect();
 
     let e = SM::SuiMoveNormalizedEnum {
         abilities: SM::SuiMoveAbilitySet {

--- a/crates/sui-json-rpc-types/src/unit_tests/rpc_types_tests.rs
+++ b/crates/sui-json-rpc-types/src/unit_tests/rpc_types_tests.rs
@@ -232,7 +232,12 @@ fn test_move_type_serde() {
                 },
             ],
         ),
-    ]
+    ];
+    let variant_declaration_order = variants
+        .iter()
+        .map(|(name, _)| name.to_string())
+        .collect::<Vec<_>>();
+    let variants = variants
     .into_iter()
     .map(|(name, type_)| {
         (
@@ -255,6 +260,7 @@ fn test_move_type_serde() {
         },
         type_parameters: vec![],
         variants,
+        variant_declaration_order: Some(variant_declaration_order),
     };
 
     acc.push(serde_json::to_string(&e).unwrap());

--- a/crates/sui-json-rpc-types/src/unit_tests/snapshots/sui_json_rpc_types__rpc_types_tests__move_type_serde.snap
+++ b/crates/sui-json-rpc-types/src/unit_tests/snapshots/sui_json_rpc_types__rpc_types_tests__move_type_serde.snap
@@ -19,4 +19,4 @@ expression: "acc.join(\"\\n\")"
 {"Reference":"U8"}
 {"MutableReference":{"Struct":{"address":"0000000000000000000000000000000000000000000000000000000000000002","module":"coin","name":"Coin","typeArguments":["Address"]}}}
 {"abilities":{"abilities":["Copy"]},"typeParameters":[{"constraints":{"abilities":["Drop"]},"isPhantom":false}],"fields":[{"name":"field1","type":"U8"},{"name":"field2","type":"U16"}]}
-{"abilities":{"abilities":["Copy"]},"typeParameters":[],"variants":{"a":[],"b":[{"name":"field0","type":"U16"}],"c":[{"name":"field0","type":"U32"},{"name":"field1","type":{"Struct":{"address":"0000000000000000000000000000000000000000000000000000000000000002","module":"coin","name":"Coin","typeArguments":["Address"]}}}]}}
+{"abilities":{"abilities":["Copy"]},"typeParameters":[],"variants":{"a":[],"b":[{"name":"field0","type":"U16"}],"c":[{"name":"field0","type":"U32"},{"name":"field1","type":{"Struct":{"address":"0000000000000000000000000000000000000000000000000000000000000002","module":"coin","name":"Coin","typeArguments":["Address"]}}}]},"variantDeclarationOrder":["b","a","c"]}

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -9040,6 +9040,16 @@
               "$ref": "#/components/schemas/SuiMoveStructTypeParameter"
             }
           },
+          "variantDeclarationOrder": {
+            "default": null,
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
           "variants": {
             "type": "object",
             "additionalProperties": {


### PR DESCRIPTION
## Description 

A different way of returning variants in order

## Test plan 

Updated existing test that was added in the PR below this one. 

