### PR TITLE
[vm][move-vm][rewrite] Add message for VM errors when available in transactional tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16650,9 +16650,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/128_params_and_128_locals.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/128_params_and_128_locals.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_bounds/128_params_and_128_locals.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/1_param_and_255_locals.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/1_param_and_255_locals.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_bounds/1_param_and_255_locals.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_few_type_actuals.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_few_type_actuals.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_few_type_actuals.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: undefined,
     indices: [],
     offsets: [],
+    message: "expected 1 type parameters got 0 (Struct)",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_few_type_actuals_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_few_type_actuals_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_few_type_actuals_enum.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: undefined,
     indices: [],
     offsets: [],
+    message: "expected 1 type parameters got 0 (Struct)",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_many_type_actuals.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_many_type_actuals.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_many_type_actuals.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: undefined,
     indices: [],
     offsets: [],
+    message: "expected 0 type parameters got 1",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_many_type_actuals_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_many_type_actuals_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_bounds/too_many_type_actuals_enum.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: undefined,
     indices: [],
     offsets: [],
+    message: "expected 0 type parameters got 1",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_enum_and_struct_names.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_enum_and_struct_names.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_enum_and_struct_names.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_enum_name.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_enum_name.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_enum_name.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_field_name.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_field_name.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_field_name.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_field_name_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_field_name_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_field_name_enum.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_function_name.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_function_name.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_function_name.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_struct_name.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_struct_name.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_struct_name.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_variant_name.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_variant_name.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_duplication/duplicate_variant_name.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/empty_enums.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/empty_enums.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_duplication/empty_enums.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: undefined,
     indices: [],
     offsets: [],
+    message: "Enum type with no variants",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/empty_structs.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/empty_structs.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_duplication/empty_structs.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/friend_decl_duplicated.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/check_duplication/friend_decl_duplicated.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/check_duplication/friend_decl_duplicated.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/if_branch_diverges_5.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/if_branch_diverges_5.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/control_flow/if_branch_diverges_5.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: undefined,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 10)],
+    message: "Index 12 out of bounds for 12 at bytecode offset 10 in function 0 while indexing code definition pool",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/if_branch_diverges_6.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/if_branch_diverges_6.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/control_flow/if_branch_diverges_6.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: undefined,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 12)],
+    message: "Index 14 out of bounds for 14 at bytecode offset 12 in function 0 while indexing code definition pool",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/if_branch_diverges_8.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/control_flow/if_branch_diverges_8.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/control_flow/if_branch_diverges_8.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: undefined,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 15)],
+    message: "Index 16 out of bounds for 16 at bytecode offset 15 in function 0 while indexing code definition pool",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/access_friend_function_invalid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/access_friend_function_invalid.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/dependencies/access_friend_function_invalid.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/access_private_function.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/dependencies/access_private_function.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/dependencies/access_private_function.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/enum_match_out_of_bounds.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/enum_match_out_of_bounds.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/enum_defs/enum_match_out_of_bounds.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: undefined,
     indices: [(VariantTag, 2)],
     offsets: [],
+    message: "Jump table length 2 does not equal number of variants 3",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/ref_in_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/enum_defs/ref_in_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/enum_defs/ref_in_enum.mvir
 ---
 processed 4 tasks
 
@@ -12,6 +11,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M1,
     indices: [(FieldDefinition, 0), (VariantTag, 0), (EnumDefinition, 0)],
     offsets: [],
+    message: "reference not allowed",
 }
 
 task 1, lines 6-9:
@@ -22,6 +22,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M2,
     indices: [(FieldDefinition, 0), (VariantTag, 0), (EnumDefinition, 0)],
     offsets: [],
+    message: "reference not allowed",
 }
 
 task 2, lines 11-14:
@@ -32,6 +33,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M3,
     indices: [(FieldDefinition, 0), (VariantTag, 0), (EnumDefinition, 0)],
     offsets: [],
+    message: "reference not allowed",
 }
 
 task 3, lines 16-19:
@@ -42,4 +44,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M4,
     indices: [(FieldDefinition, 0), (VariantTag, 0), (EnumDefinition, 0)],
     offsets: [],
+    message: "reference not allowed",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/friends/friend_decl_different_address.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/friends/friend_decl_different_address.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/friends/friend_decl_different_address.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/friends/friend_decl_self.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/friends/friend_decl_self.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/friends/friend_decl_self.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/complex_1.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/complex_1.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/complex_1.mvir
 ---
 processed 3 tasks
 
@@ -12,6 +11,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x6::M,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f1#1 --StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(1)])--> f2#0], nodes: [f3#0, f2#1, f2#0, f1#1]",
 }
 
 task 1, lines 53-70:
@@ -22,6 +22,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x7::M2,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f1#0 --StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(0)])--> f0#0], nodes: [f1#0, f0#0]",
 }
 
 task 2, lines 72-122:
@@ -32,4 +33,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x8::M3,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f1#1 --StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(1)])--> f2#0], nodes: [f3#0, f2#1, f2#0, f1#1]",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/complex_1_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/complex_1_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/complex_1_enum.mvir
 ---
 processed 3 tasks
 
@@ -12,6 +11,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x6::M,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f1#1 --StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(1)])--> f2#0], nodes: [f3#0, f2#1, f2#0, f1#1]",
 }
 
 task 1, lines 53-70:
@@ -22,6 +22,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x7::M2,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f1#0 --StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(0)])--> f0#0], nodes: [f1#0, f0#0]",
 }
 
 task 2, lines 72-122:
@@ -32,4 +33,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x8::M3,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f1#1 --StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(1)])--> f2#0], nodes: [f3#0, f2#1, f2#0, f1#1]",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_shifting.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_shifting.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_shifting.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x6::M,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f1#2 --StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(2)])--> f2#2], nodes: [f2#1, f1#1, f0#2, f2#2, f1#2, f0#0, f2#0, f1#0, f0#1]",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_shifting_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_shifting_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_three_args_type_con_shifting_enum.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x6::M,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f1#2 --StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(2)])--> f2#2], nodes: [f2#1, f1#1, f0#2, f2#2, f1#2, f0#0, f2#0, f1#0, f0#1]",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_type_con.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_type_con.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_type_con.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x6::M,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f1#1 --StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(1)])--> f0#1], nodes: [f1#1, f0#0, f1#0, f0#1]",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_type_con_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_type_con_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_two_args_swapping_type_con_enum.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x6::M,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f1#1 --StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(1)])--> f0#1], nodes: [f1#1, f0#0, f1#0, f0#1]",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_type_con.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_type_con.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_type_con.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x6::M,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f0#0 --StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(0)])--> f1#0], nodes: [f1#0, f0#0]",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_type_con_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_type_con_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/mutually_recursive_type_con_enum.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x6::M,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f0#0 --StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(0)])--> f1#0], nodes: [f1#0, f0#0]",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_1.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_1.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_1.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x1::M,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f0#0 --StructInstantiation(DatatypeHandleIndex(0), [StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(0)])])--> f0#0], nodes: [f0#0]",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_1_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_1_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_1_enum.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x6::M,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f0#0 --StructInstantiation(DatatypeHandleIndex(0), [StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(0)])])--> f0#0], nodes: [f0#0]",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x6::M,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f0#0 --StructInstantiation(DatatypeHandleIndex(1), [U64, StructInstantiation(DatatypeHandleIndex(0), [StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(0)])])])--> f0#0], nodes: [f0#0]",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2_enum.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x1::M,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f0#0 --StructInstantiation(DatatypeHandleIndex(1), [U64, StructInstantiation(DatatypeHandleIndex(0), [StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(0)])])])--> f0#0], nodes: [f0#0]",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2_enum_struct.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2_enum_struct.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/nested_types_2_enum_struct.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x6::M,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f0#0 --StructInstantiation(DatatypeHandleIndex(1), [U64, StructInstantiation(DatatypeHandleIndex(0), [StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(0)])])])--> f0#0], nodes: [f0#0]",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_infinite_type_terminates.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_infinite_type_terminates.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_infinite_type_terminates.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x6::M,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f1#0 --StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(0)])--> f1#0], nodes: [f1#0]",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_one_arg_type_con.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_one_arg_type_con.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_one_arg_type_con.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x6::M,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f0#0 --StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(0)])--> f0#0], nodes: [f0#0]",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_one_arg_type_con_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_one_arg_type_con_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_one_arg_type_con_enum.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x6::M,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f0#0 --StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(0)])--> f0#0], nodes: [f0#0]",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_two_args_swapping_type_con.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_two_args_swapping_type_con.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_two_args_swapping_type_con.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x1::M,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f0#1 --StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(1)])--> f0#0], nodes: [f0#0, f0#1]",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_two_args_swapping_type_con_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_two_args_swapping_type_con_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/recursive_two_args_swapping_type_con_enum.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x6::M,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f0#1 --StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(1)])--> f0#0], nodes: [f0#0, f0#1]",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/two_loops.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/two_loops.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/two_loops.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x6::M,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f1#0 --StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(0)])--> f1#0], nodes: [f1#0]",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/two_loops_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/two_loops_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/instantiation_loops/two_loops_enum.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x6::M,
     indices: [],
     offsets: [],
+    message: "edges with constructors: [f1#0 --StructInstantiation(DatatypeHandleIndex(0), [TypeParameter(0)])--> f1#0], nodes: [f1#0]",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/abort_unreleased_reference.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/abort_unreleased_reference.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/abort_unreleased_reference.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Function execution failed with VMError: {
     location: 0x42::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 5)],
+    message: "0000000000000000000000000000000000000000000000000000000000000042::m::foo at offset 5",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/abort_unused_resource.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/abort_unused_resource.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/abort_unused_resource.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_enum_resource.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_enum_resource.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_enum_resource.mvir
 ---
 processed 3 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_in_one_if_branch.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_in_one_if_branch.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_in_one_if_branch.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_resource.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_resource.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_resource.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_wrong_if_branch.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_wrong_if_branch.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_wrong_if_branch.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_wrong_if_branch_no_else.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_wrong_if_branch_no_else.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/assign_wrong_if_branch_no_else.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/branch_assigns_then_moves.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/branch_assigns_then_moves.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/branch_assigns_then_moves.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/else_assigns_if_doesnt.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/else_assigns_if_doesnt.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/else_assigns_if_doesnt.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/else_moves_if_doesnt.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/else_moves_if_doesnt.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/else_moves_if_doesnt.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/enum_non_drop_assignment.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/locals_safety/enum_non_drop_assignment.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/locals_safety/enum_non_drop_assignment.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_field_after_local.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_field_after_local.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_field_after_local.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_local_after_move.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_local_after_move.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_local_after_move.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_local_struct_invalidated.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_local_struct_invalidated.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/assign_local_struct_invalidated.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_if.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_if.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_if.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_return_mutable_borrow_bad.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_return_mutable_borrow_bad.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/borrow_return_mutable_borrow_bad.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_field_invalid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_field_invalid.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_field_invalid.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_indirect_invalid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_indirect_invalid.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_indirect_invalid.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_invalid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_invalid.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/copy_loc_borrowed_invalid.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_copy_bad.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_copy_bad.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_copy_bad.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_eq_bad.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_eq_bad.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/deref_eq_bad.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/enum_variant_factor.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/enum_variant_factor.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/enum_variant_factor.mvir
 ---
 processed 7 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/eq_bad.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/eq_bad.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/eq_bad.mvir
 ---
 processed 4 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_1.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_1.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_1.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_2.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_2.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_2.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_2_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_2_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/reference_safety/factor_invalid_2_enum.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/signer_double_signer.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/signer_double_signer.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/script_signature/signer_double_signer.mvir
 ---
 processed 3 tasks
 
@@ -12,6 +11,7 @@ Error: Function execution failed with VMError: {
     location: undefined,
     indices: [],
     offsets: [],
+    message: "argument length mismatch: expected 2 got 1",
 }
 
 task 1, lines 10-17:
@@ -22,4 +22,5 @@ Error: Function execution failed with VMError: {
     location: undefined,
     indices: [],
     offsets: [],
+    message: "argument length mismatch: expected 3 got 2",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/struct_arguments.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/script_signature/struct_arguments.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/script_signature/struct_arguments.mvir
 ---
 processed 3 tasks
 
@@ -12,6 +11,7 @@ Error: Function execution failed with VMError: {
     location: 0x43::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000043::m::foo at offset 1",
 }
 
 task 2, line 24:
@@ -22,4 +22,5 @@ Error: Function execution failed with VMError: {
     location: 0x42::M,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000042::M::foo at offset 1",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/all_as_resource.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/all_as_resource.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/all_as_resource.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x1::M,
     indices: [(Signature, 1), (FunctionDefinition, 0)],
     offsets: [],
+    message: "expected type with abilities [Key, ] got type actual TypeParameter(0) with incompatible abilities []",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/all_as_unrestricted.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/all_as_unrestricted.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/all_as_unrestricted.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x1::M,
     indices: [(Signature, 1), (FunctionDefinition, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, Drop, ] got type actual TypeParameter(0) with incompatible abilities []",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/check_constraints_script.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/check_constraints_script.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/check_constraints_script.mvir
 ---
 processed 9 tasks
 
@@ -12,6 +11,7 @@ Error: Function execution failed with VMError: {
     location: 0x2::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000002::m::foo at offset 1",
 }
 
 task 2, lines 28-35:
@@ -22,6 +22,7 @@ Error: Function execution failed with VMError: {
     location: 0x3::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000003::m::foo at offset 1",
 }
 
 task 3, lines 37-44:
@@ -32,6 +33,7 @@ Error: Function execution failed with VMError: {
     location: 0x4::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000004::m::foo at offset 1",
 }
 
 task 4, lines 46-53:
@@ -42,6 +44,7 @@ Error: Function execution failed with VMError: {
     location: 0x5::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000005::m::foo at offset 1",
 }
 
 task 5, lines 55-62:
@@ -52,6 +55,7 @@ Error: Function execution failed with VMError: {
     location: 0x6::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000006::m::foo at offset 1",
 }
 
 task 6, lines 64-71:
@@ -62,6 +66,7 @@ Error: Function execution failed with VMError: {
     location: 0x7::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000007::m::foo at offset 1",
 }
 
 task 7, lines 73-80:
@@ -72,6 +77,7 @@ Error: Function execution failed with VMError: {
     location: 0x8::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000008::m::foo at offset 1",
 }
 
 task 8, lines 82-89:
@@ -82,4 +88,5 @@ Error: Function execution failed with VMError: {
     location: 0x9::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000009::m::foo at offset 1",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/check_constraints_script_invalid.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/check_constraints_script_invalid.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/check_constraints_script_invalid.mvir
 ---
 processed 9 tasks
 
@@ -12,6 +11,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::m,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities [Drop, ]",
 }
 
 task 2, lines 26-33:
@@ -22,6 +22,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::m,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Drop, ] got type actual TypeParameter(0) with incompatible abilities [Copy, Store, ]",
 }
 
 task 3, lines 35-42:
@@ -32,6 +33,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::m,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Store, ] got type actual TypeParameter(0) with incompatible abilities [Key, ]",
 }
 
 task 4, lines 44-51:
@@ -42,6 +44,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::m,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Key, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 5, lines 53-60:
@@ -52,6 +55,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::m,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual StructInstantiation(DatatypeHandleIndex(1), [TypeParameter(0)]) with incompatible abilities []",
 }
 
 task 6, lines 62-69:
@@ -62,6 +66,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::m,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Drop, ] got type actual StructInstantiation(DatatypeHandleIndex(1), [TypeParameter(0)]) with incompatible abilities []",
 }
 
 task 7, lines 71-78:
@@ -72,6 +77,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::m,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Store, ] got type actual StructInstantiation(DatatypeHandleIndex(1), [TypeParameter(0)]) with incompatible abilities []",
 }
 
 task 8, lines 80-87:
@@ -82,4 +88,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::m,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Key, ] got type actual StructInstantiation(DatatypeHandleIndex(1), [TypeParameter(0)]) with incompatible abilities []",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_as_type_actual_for_bytecode_instruction.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_as_type_actual_for_bytecode_instruction.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/reference_as_type_actual_for_bytecode_instruction.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x1::M,
     indices: [(Signature, 3), (FunctionDefinition, 1)],
     offsets: [],
+    message: "reference not allowed",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_as_type_actual_for_struct.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_as_type_actual_for_struct.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/reference_as_type_actual_for_struct.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x1::M,
     indices: [],
     offsets: [],
+    message: "reference not allowed",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_as_type_actual_in_struct_inst_for_bytecode_instruction.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_as_type_actual_in_struct_inst_for_bytecode_instruction.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/reference_as_type_actual_in_struct_inst_for_bytecode_instruction.mvir
 ---
 processed 5 tasks
 
@@ -12,6 +11,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x1::M,
     indices: [],
     offsets: [],
+    message: "reference not allowed",
 }
 
 task 1, lines 15-29:
@@ -22,6 +22,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x1::M,
     indices: [(Signature, 2), (FunctionDefinition, 0)],
     offsets: [],
+    message: "reference not allowed",
 }
 
 task 2, lines 31-43:
@@ -32,6 +33,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x1::M,
     indices: [(Signature, 2), (FunctionDefinition, 0)],
     offsets: [],
+    message: "reference not allowed",
 }
 
 task 3, lines 45-54:
@@ -42,6 +44,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x1::M,
     indices: [],
     offsets: [],
+    message: "reference not allowed",
 }
 
 task 4, lines 56-65:
@@ -52,4 +55,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x1::M,
     indices: [],
     offsets: [],
+    message: "reference not allowed",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_in_fields.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/reference_in_fields.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/reference_in_fields.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M,
     indices: [(FieldDefinition, 0), (StructDefinition, 0)],
     offsets: [],
+    message: "reference not allowed",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/resource_as_unrestricted.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/resource_as_unrestricted.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/resource_as_unrestricted.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x1::M,
     indices: [(Signature, 1), (FunctionDefinition, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, Drop, ] got type actual Struct(DatatypeHandleIndex(1)) with incompatible abilities []",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/two_type_actuals_reverse_order.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/two_type_actuals_reverse_order.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/two_type_actuals_reverse_order.mvir
 ---
 processed 2 tasks
 
@@ -12,6 +11,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x1::M,
     indices: [(Signature, 1), (FunctionDefinition, 0)],
     offsets: [],
+    message: "expected type with abilities [Key, ] got type actual Bool with incompatible abilities [Copy, Drop, Store, ]",
 }
 
 task 1, lines 13-24:
@@ -22,4 +22,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x1::M2,
     indices: [(Signature, 1), (FunctionDefinition, 0)],
     offsets: [],
+    message: "expected type with abilities [Key, ] got type actual Bool with incompatible abilities [Copy, Drop, Store, ]",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/unrestricted_as_resource.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/unrestricted_as_resource.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/unrestricted_as_resource.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x1::M,
     indices: [(Signature, 1), (FunctionDefinition, 0)],
     offsets: [],
+    message: "expected type with abilities [Key, ] got type actual Bool with incompatible abilities [Copy, Drop, Store, ]",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/vector_ops_invalid_type_args.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/signature/vector_ops_invalid_type_args.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/signature/vector_ops_invalid_type_args.mvir
 ---
 processed 3 tasks
 
@@ -12,6 +11,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::m,
     indices: [(Signature, 0), (FunctionDefinition, 0)],
     offsets: [],
+    message: "expected 1 type token for vector operations, got 2",
 }
 
 task 1, lines 11-20:
@@ -22,6 +22,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::m,
     indices: [(Signature, 0), (FunctionDefinition, 0)],
     offsets: [],
+    message: "expected 1 type token for vector operations, got 0",
 }
 
 task 2, lines 21-30:
@@ -32,4 +33,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::m,
     indices: [(Signature, 0), (FunctionDefinition, 0)],
     offsets: [],
+    message: "reference not allowed at offset 0 ",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/abort_negative_stack_size.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/abort_negative_stack_size.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/abort_negative_stack_size.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/abort_no_return.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/abort_no_return.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/abort_no_return.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Function execution failed with VMError: {
     location: 0x42::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000042::m::foo at offset 1",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/abort_positive_stack_size.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/abort_positive_stack_size.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/abort_positive_stack_size.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/cast_negative_stack.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/cast_negative_stack.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/cast_negative_stack.mvir
 ---
 processed 6 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/cast_positive_stack.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/cast_positive_stack.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/cast_positive_stack.mvir
 ---
 processed 6 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/exp_in_if_and_else_branch.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/exp_in_if_and_else_branch.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/exp_in_if_and_else_branch.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_call_negative_stack_err_1.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_call_negative_stack_err_1.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_call_negative_stack_err_1.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_call_negative_stack_err_2.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_call_negative_stack_err_2.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_call_negative_stack_err_2.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_composition_pos_and_neg_stack_err.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_composition_pos_and_neg_stack_err.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_composition_pos_and_neg_stack_err.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_composition_positive_stack_err_1.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_composition_positive_stack_err_1.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_composition_positive_stack_err_1.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_composition_positive_stack_err_2.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_composition_positive_stack_err_2.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/stack_usage_verifier/function_composition_positive_stack_err_2.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/struct_defs/ref_in_struct.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/struct_defs/ref_in_struct.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/struct_defs/ref_in_struct.mvir
 ---
 processed 4 tasks
 
@@ -12,6 +11,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M1,
     indices: [(FieldDefinition, 0), (StructDefinition, 0)],
     offsets: [],
+    message: "reference not allowed",
 }
 
 task 1, lines 6-9:
@@ -22,6 +22,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M2,
     indices: [(FieldDefinition, 0), (StructDefinition, 0)],
     offsets: [],
+    message: "reference not allowed",
 }
 
 task 2, lines 11-14:
@@ -32,6 +33,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M3,
     indices: [(FieldDefinition, 0), (StructDefinition, 0)],
     offsets: [],
+    message: "reference not allowed",
 }
 
 task 3, lines 16-19:
@@ -42,4 +44,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M4,
     indices: [(FieldDefinition, 0), (StructDefinition, 0)],
     offsets: [],
+    message: "reference not allowed",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_local_resource.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_local_resource.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_local_resource.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_local_resource_twice.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_local_resource_twice.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_local_resource_twice.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_resource_type.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_resource_type.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_resource_type.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_resource_type_enum.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_resource_type_enum.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_resource_type_enum.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_wrong_type.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_wrong_type.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/assign_wrong_type.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/boolean_not_non_boolean.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/boolean_not_non_boolean.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/boolean_not_non_boolean.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/cant_deref_resource.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/cant_deref_resource.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/cant_deref_resource.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/casting_operators_types_mismatch.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/casting_operators_types_mismatch.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/casting_operators_types_mismatch.mvir
 ---
 processed 18 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/deref_non_reference.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/deref_non_reference.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/deref_non_reference.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/deref_not_reference_bad.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/deref_not_reference_bad.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/deref_not_reference_bad.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/equality_one_ref.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/equality_one_ref.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/equality_one_ref.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/equality_resource_values.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/equality_resource_values.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/equality_resource_values.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/freeze_makes_imm.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/freeze_makes_imm.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/freeze_makes_imm.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/freeze_on_imm.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/freeze_on_imm.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/freeze_on_imm.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/freeze_wrong_type.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/freeze_wrong_type.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/freeze_wrong_type.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_call.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_call.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_call.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_struct_non_nominal_resource.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_struct_non_nominal_resource.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_struct_non_nominal_resource.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_type_param_all.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_type_param_all.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_type_param_all.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_type_param_resource.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_type_param_resource.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_type_param_resource.mvir
 ---
 processed 1 task
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_unpack.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_unpack.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_abilities_unpack.mvir
 ---
 processed 2 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_import_function.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_import_function.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/generic_import_function.mvir
 ---
 processed 3 tasks
 
@@ -12,6 +11,7 @@ Error: Function execution failed with VMError: {
     location: 0x1::M,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000001::M::foo at offset 1",
 }
 
 task 2, lines 32-41:
@@ -22,4 +22,5 @@ Error: Function execution failed with VMError: {
     location: 0x1::M,
     indices: [],
     offsets: [(FunctionDefinitionIndex(1), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000001::M::bar at offset 1",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_enum_with_refs.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_enum_with_refs.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_enum_with_refs.mvir
 ---
 processed 9 tasks
 
@@ -22,6 +21,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::O,
     indices: [],
     offsets: [],
+    message: "reference not allowed",
 }
 
 task 2, lines 25-28:
@@ -32,6 +32,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::O,
     indices: [(FieldDefinition, 0), (VariantTag, 0), (EnumDefinition, 0)],
     offsets: [],
+    message: "reference not allowed",
 }
 
 task 3, lines 30-40:
@@ -52,6 +53,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::O,
     indices: [],
     offsets: [],
+    message: "reference not allowed",
 }
 
 task 5, lines 54-60:
@@ -62,6 +64,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::O,
     indices: [(FieldDefinition, 0), (VariantTag, 0), (EnumDefinition, 0)],
     offsets: [],
+    message: "reference not allowed",
 }
 
 task 6, lines 62-72:
@@ -82,6 +85,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::O,
     indices: [(FieldDefinition, 0), (VariantTag, 0), (EnumDefinition, 0)],
     offsets: [],
+    message: "reference not allowed",
 }
 
 task 8, lines 86-89:
@@ -92,4 +96,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::O,
     indices: [(FieldDefinition, 0), (VariantTag, 0), (EnumDefinition, 0)],
     offsets: [],
+    message: "reference not allowed",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_generic_enum_invalid_type_arguments.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_generic_enum_invalid_type_arguments.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_generic_enum_invalid_type_arguments.mvir
 ---
 processed 9 tasks
 
@@ -42,6 +41,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::O,
     indices: [(Signature, 1), (FunctionDefinition, 0)],
     offsets: [],
+    message: "expected 1 type argument(s), got 2 at offset 1 ",
 }
 
 task 4, lines 49-59:
@@ -52,6 +52,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: undefined,
     indices: [],
     offsets: [],
+    message: "expected 1 type parameters got 2",
 }
 
 task 5, lines 61-71:
@@ -62,6 +63,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: undefined,
     indices: [],
     offsets: [],
+    message: "expected 1 type parameters got 2",
 }
 
 task 7, lines 79-90:

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_non_generic_enum_generically.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_non_generic_enum_generically.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/pack_non_generic_enum_generically.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::O,
     indices: [(Signature, 1), (FunctionDefinition, 0)],
     offsets: [],
+    message: "expected 0 type argument(s), got 1 at offset 1 ",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/bytecode_ops_abilities_bad.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/bytecode_ops_abilities_bad.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/bytecode_ops_abilities_bad.mvir
 ---
 processed 12 tasks
 
@@ -52,6 +51,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x1::M9,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Store, ] got type actual StructInstantiation(DatatypeHandleIndex(0), [Struct(DatatypeHandleIndex(2)), Struct(DatatypeHandleIndex(2))]) with incompatible abilities []",
 }
 
 task 7, lines 82-94:
@@ -102,4 +102,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::M9,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Store, ] got type actual StructInstantiation(DatatypeHandleIndex(0), [Struct(DatatypeHandleIndex(2)), Struct(DatatypeHandleIndex(2))]) with incompatible abilities []",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/constraints_abilities_bad.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/constraints_abilities_bad.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/constraints_abilities_bad.mvir
 ---
 processed 12 tasks
 
@@ -12,6 +11,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::M2,
     indices: [(FieldDefinition, 0), (StructDefinition, 1)],
     offsets: [],
+    message: "expected type with abilities [Copy, Drop, Store, Key, ] got type actual StructInstantiation(DatatypeHandleIndex(2), [Struct(DatatypeHandleIndex(3)), Struct(DatatypeHandleIndex(3))]) with incompatible abilities []",
 }
 
 task 2, lines 17-34:
@@ -22,6 +22,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x3::M3,
     indices: [(FieldDefinition, 0), (StructDefinition, 5)],
     offsets: [],
+    message: "expected type with abilities [Drop, ] got type actual StructInstantiation(DatatypeHandleIndex(0), [Struct(DatatypeHandleIndex(6)), Struct(DatatypeHandleIndex(6))]) with incompatible abilities []",
 }
 
 task 3, lines 36-46:
@@ -32,6 +33,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x4::M4,
     indices: [(Signature, 0), (FunctionDefinition, 1)],
     offsets: [],
+    message: "expected type with abilities [Copy, Drop, Store, Key, ] got type actual StructInstantiation(DatatypeHandleIndex(0), [Struct(DatatypeHandleIndex(1)), Struct(DatatypeHandleIndex(1))]) with incompatible abilities [] at offset 0 ",
 }
 
 task 5, lines 60-75:
@@ -42,6 +44,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x6::M5,
     indices: [(Signature, 0), (FunctionDefinition, 1)],
     offsets: [],
+    message: "expected type with abilities [Drop, ] got type actual StructInstantiation(DatatypeHandleIndex(0), [Struct(DatatypeHandleIndex(1)), Struct(DatatypeHandleIndex(1))]) with incompatible abilities [] at offset 0 ",
 }
 
 task 7, lines 83-91:
@@ -52,6 +55,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x8::M2,
     indices: [(FieldDefinition, 0), (VariantTag, 0), (EnumDefinition, 1)],
     offsets: [],
+    message: "expected type with abilities [Copy, Drop, Store, Key, ] got type actual StructInstantiation(DatatypeHandleIndex(2), [Struct(DatatypeHandleIndex(3)), Struct(DatatypeHandleIndex(3))]) with incompatible abilities []",
 }
 
 task 8, lines 93-112:
@@ -62,6 +66,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x9::M3,
     indices: [(FieldDefinition, 0), (VariantTag, 0), (EnumDefinition, 5)],
     offsets: [],
+    message: "expected type with abilities [Drop, ] got type actual StructInstantiation(DatatypeHandleIndex(0), [Struct(DatatypeHandleIndex(6)), Struct(DatatypeHandleIndex(6))]) with incompatible abilities []",
 }
 
 task 9, lines 114-124:
@@ -72,6 +77,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x10::M4,
     indices: [(Signature, 0), (FunctionDefinition, 1)],
     offsets: [],
+    message: "expected type with abilities [Copy, Drop, Store, Key, ] got type actual StructInstantiation(DatatypeHandleIndex(0), [Struct(DatatypeHandleIndex(1)), Struct(DatatypeHandleIndex(1))]) with incompatible abilities [] at offset 0 ",
 }
 
 task 11, lines 138-153:
@@ -82,4 +88,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x12::M5,
     indices: [(Signature, 0), (FunctionDefinition, 1)],
     offsets: [],
+    message: "expected type with abilities [Drop, ] got type actual StructInstantiation(DatatypeHandleIndex(0), [Struct(DatatypeHandleIndex(1)), Struct(DatatypeHandleIndex(1))]) with incompatible abilities [] at offset 0 ",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/fields_abilities_bad.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/fields_abilities_bad.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/fields_abilities_bad.mvir
 ---
 processed 10 tasks
 

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/struct_definition_bad.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/struct_definition_bad.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/phantom_params/struct_definition_bad.mvir
 ---
 processed 12 tasks
 
@@ -12,6 +11,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x1::M1,
     indices: [(FieldDefinition, 0), (StructDefinition, 0)],
     offsets: [],
+    message: "phantom type parameter cannot be used in non-phantom position",
 }
 
 task 1, lines 13-19:
@@ -22,6 +22,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x1::M2,
     indices: [(FieldDefinition, 0), (StructDefinition, 0)],
     offsets: [],
+    message: "phantom type parameter cannot be used in non-phantom position",
 }
 
 task 2, lines 21-28:
@@ -32,6 +33,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x1::M3,
     indices: [(FieldDefinition, 0), (StructDefinition, 1)],
     offsets: [],
+    message: "phantom type parameter cannot be used in non-phantom position",
 }
 
 task 3, lines 30-39:
@@ -42,6 +44,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x1::M4,
     indices: [(FieldDefinition, 0), (StructDefinition, 2)],
     offsets: [],
+    message: "phantom type parameter cannot be used in non-phantom position",
 }
 
 task 4, lines 41-47:
@@ -52,6 +55,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x1::M5,
     indices: [(FieldDefinition, 0), (StructDefinition, 0)],
     offsets: [],
+    message: "phantom type parameter cannot be used in non-phantom position",
 }
 
 task 5, lines 49-56:
@@ -62,6 +66,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x1::M6,
     indices: [(FieldDefinition, 0), (StructDefinition, 1)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 6, lines 58-68:
@@ -72,6 +77,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::M1,
     indices: [(FieldDefinition, 0), (VariantTag, 0), (EnumDefinition, 0)],
     offsets: [],
+    message: "phantom type parameter cannot be used in non-phantom position",
 }
 
 task 7, lines 70-76:
@@ -82,6 +88,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::M2,
     indices: [(FieldDefinition, 0), (VariantTag, 0), (EnumDefinition, 0)],
     offsets: [],
+    message: "phantom type parameter cannot be used in non-phantom position",
 }
 
 task 8, lines 78-85:
@@ -92,6 +99,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::M3,
     indices: [(FieldDefinition, 0), (VariantTag, 0), (EnumDefinition, 1)],
     offsets: [],
+    message: "phantom type parameter cannot be used in non-phantom position",
 }
 
 task 9, lines 87-96:
@@ -102,6 +110,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::M4,
     indices: [(FieldDefinition, 0), (VariantTag, 0), (EnumDefinition, 2)],
     offsets: [],
+    message: "phantom type parameter cannot be used in non-phantom position",
 }
 
 task 10, lines 98-104:
@@ -112,6 +121,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::M5,
     indices: [(FieldDefinition, 0), (VariantTag, 0), (EnumDefinition, 0)],
     offsets: [],
+    message: "phantom type parameter cannot be used in non-phantom position",
 }
 
 task 11, lines 106-113:
@@ -122,4 +132,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::M6,
     indices: [(FieldDefinition, 0), (VariantTag, 0), (EnumDefinition, 1)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/ref_type_param.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/ref_type_param.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/ref_type_param.mvir
 ---
 processed 8 tasks
 
@@ -12,6 +11,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M1,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 1, lines 12-21:
@@ -22,6 +22,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M2,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 2, lines 23-32:
@@ -32,6 +33,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: undefined,
     indices: [],
     offsets: [],
+    message: "expected 1 type parameters got 0 (Struct)",
 }
 
 task 3, lines 34-44:
@@ -42,6 +44,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M4,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 4, lines 46-55:
@@ -52,6 +55,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x43::M1,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 5, lines 57-66:
@@ -62,6 +66,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x43::M2,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 6, lines 68-77:
@@ -72,6 +77,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: undefined,
     indices: [],
     offsets: [],
+    message: "expected 1 type parameters got 0 (Struct)",
 }
 
 task 7, lines 79-89:
@@ -82,4 +88,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x43::M4,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/ref_type_param_exploits.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/ref_type_param_exploits.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/ref_type_param_exploits.mvir
 ---
 processed 10 tasks
 
@@ -12,6 +11,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M1,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 1, lines 13-23:
@@ -22,6 +22,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M2,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 2, lines 25-36:
@@ -32,6 +33,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M3,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Store, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 3, lines 38-54:
@@ -42,6 +44,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M4,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 4, lines 56-72:
@@ -52,6 +55,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M5,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 5, lines 74-86:
@@ -62,6 +66,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x43::M1,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 6, lines 88-98:
@@ -72,6 +77,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x43::M2,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 7, lines 100-112:
@@ -82,6 +88,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x43::M3,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Store, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 8, lines 114-130:
@@ -92,6 +99,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x43::M4,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 9, lines 132-148:
@@ -102,4 +110,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x43::M5,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_does_not_have_store.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_does_not_have_store.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/signer_does_not_have_store.mvir
 ---
 processed 1 task
 
@@ -12,4 +11,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M,
     indices: [(Signature, 0), (FunctionDefinition, 1)],
     offsets: [],
+    message: "expected type with abilities [Store, ] got type actual StructInstantiation(DatatypeHandleIndex(0), [Signer]) with incompatible abilities [] at offset 0 ",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_non_generic_enum_generically.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_non_generic_enum_generically.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/unpack_non_generic_enum_generically.mvir
 ---
 processed 9 tasks
 
@@ -12,6 +11,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::ByValue,
     indices: [(Signature, 2), (FunctionDefinition, 0)],
     offsets: [],
+    message: "expected 0 type argument(s), got 1 at offset 1 ",
 }
 
 task 1, lines 14-25:
@@ -22,6 +22,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::ByImmRef,
     indices: [(Signature, 2), (FunctionDefinition, 0)],
     offsets: [],
+    message: "expected 0 type argument(s), got 1 at offset 1 ",
 }
 
 task 2, lines 27-38:
@@ -32,6 +33,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::ByMutRef,
     indices: [(Signature, 2), (FunctionDefinition, 0)],
     offsets: [],
+    message: "expected 0 type argument(s), got 1 at offset 1 ",
 }
 
 task 3, lines 40-51:
@@ -42,6 +44,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::ByValue,
     indices: [(Signature, 2), (FunctionDefinition, 0)],
     offsets: [],
+    message: "expected 0 type argument(s), got 1 at offset 1 ",
 }
 
 task 4, lines 53-64:
@@ -52,6 +55,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::ByImmRef,
     indices: [(Signature, 2), (FunctionDefinition, 0)],
     offsets: [],
+    message: "expected 0 type argument(s), got 1 at offset 1 ",
 }
 
 task 5, lines 66-77:
@@ -62,6 +66,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::ByMutRef,
     indices: [(Signature, 2), (FunctionDefinition, 0)],
     offsets: [],
+    message: "expected 0 type argument(s), got 1 at offset 1 ",
 }
 
 task 6, lines 79-90:
@@ -72,6 +77,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::ByValue,
     indices: [(Signature, 2), (FunctionDefinition, 0)],
     offsets: [],
+    message: "expected 0 type argument(s), got 1 at offset 1 ",
 }
 
 task 7, lines 92-103:
@@ -82,6 +88,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::ByImmRef,
     indices: [(Signature, 2), (FunctionDefinition, 0)],
     offsets: [],
+    message: "expected 0 type argument(s), got 1 at offset 1 ",
 }
 
 task 8, lines 105-116:
@@ -92,4 +99,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x2::ByMutRef,
     indices: [(Signature, 2), (FunctionDefinition, 0)],
     offsets: [],
+    message: "expected 0 type argument(s), got 1 at offset 1 ",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/variant_switch_partial_enum_switch.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/variant_switch_partial_enum_switch.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/variant_switch_partial_enum_switch.mvir
 ---
 processed 3 tasks
 
@@ -12,6 +11,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: undefined,
     indices: [(VariantTag, 0)],
     offsets: [],
+    message: "Jump table length 0 does not equal number of variants 1",
 }
 
 task 2, lines 30-43:
@@ -22,4 +22,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: undefined,
     indices: [(VariantTag, 1)],
     offsets: [],
+    message: "Jump table length 1 does not equal number of variants 2",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_type_param.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_type_param.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_type_param.mvir
 ---
 processed 6 tasks
 
@@ -12,6 +11,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M1,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 1, lines 12-21:
@@ -22,6 +22,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M2,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 2, lines 23-32:
@@ -32,6 +33,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M3,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 3, lines 34-43:
@@ -42,6 +44,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x43::M1,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 4, lines 45-54:
@@ -52,6 +55,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x43::M2,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 5, lines 56-65:
@@ -62,4 +66,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x43::M3,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }

--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_type_param_exploits.snap
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_type_param_exploits.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/move-transactional-test-runner/src/framework.rs
-input_file: crates/bytecode-verifier-transactional-tests/tests/type_safety/vector_type_param_exploits.mvir
 ---
 processed 4 tasks
 
@@ -12,6 +11,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M1,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, Drop, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 1, lines 13-22:
@@ -22,6 +22,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M2,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Drop, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 2, lines 24-40:
@@ -32,6 +33,7 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M3,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }
 
 task 3, lines 42-58:
@@ -42,4 +44,5 @@ Error: Unable to publish module '00000000000000000000000000000000000000000000000
     location: 0x42::M4,
     indices: [(Signature, 0), (FunctionHandle, 0)],
     offsets: [],
+    message: "expected type with abilities [Copy, ] got type actual TypeParameter(0) with incompatible abilities []",
 }

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/derived_line_number_assertion.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/derived_line_number_assertion.snap
@@ -11,4 +11,5 @@ Error: Function execution failed with VMError: {
     location: 0x42::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000042::m::f at offset 1",
 }

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/derived_line_number_raw_abort.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/derived_line_number_raw_abort.snap
@@ -11,4 +11,5 @@ Error: Function execution failed with VMError: {
     location: 0x42::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000042::m::f at offset 1",
 }

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/error_annotation.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/error_annotation.snap
@@ -11,4 +11,5 @@ Error: Function execution failed with VMError: {
     location: 0x42::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000042::m::f at offset 1",
 }

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/error_annotation_abort.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/error_annotation_abort.snap
@@ -11,4 +11,5 @@ Error: Function execution failed with VMError: {
     location: 0x42::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000042::m::f at offset 1",
 }

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/macro_call_line_number_abort.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/macro_call_line_number_abort.snap
@@ -11,6 +11,7 @@ Error: Function execution failed with VMError: {
     location: 0x42::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000042::m::t_a at offset 1",
 }
 
 task 3, line 27:
@@ -21,4 +22,5 @@ Error: Function execution failed with VMError: {
     location: 0x42::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(1), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000042::m::t_calls_a at offset 1",
 }

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/macro_call_line_number_assertion.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/constants/macro_call_line_number_assertion.snap
@@ -11,6 +11,7 @@ Error: Function execution failed with VMError: {
     location: 0x42::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000042::m::t_a at offset 1",
 }
 
 task 3, line 27:
@@ -21,4 +22,5 @@ Error: Function execution failed with VMError: {
     location: 0x42::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(1), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000042::m::t_calls_a at offset 1",
 }

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/binop_aborts.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/binop_aborts.snap
@@ -11,6 +11,7 @@ Error: Function execution failed with VMError: {
     location: 0x43::test0,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000043::test0::main at offset 1",
 }
 
 task 2, lines 22-29:
@@ -21,6 +22,7 @@ Error: Function execution failed with VMError: {
     location: 0x42::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000042::m::aborter at offset 1",
 }
 
 task 3, lines 31-37:
@@ -51,6 +53,7 @@ Error: Function execution failed with VMError: {
     location: 0x47::test4,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000047::test4::test at offset 1",
 }
 
 task 6, lines 55-61:
@@ -61,6 +64,7 @@ Error: Function execution failed with VMError: {
     location: 0x48::test5,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000048::test5::test at offset 1",
 }
 
 task 7, lines 63-69:

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/short_circuiting_invalid.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/evaluation_order/short_circuiting_invalid.snap
@@ -11,6 +11,7 @@ Error: Function execution failed with VMError: {
     location: 0x42::X,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000042::X::error at offset 1",
 }
 
 task 2, lines 19-25:
@@ -21,6 +22,7 @@ Error: Function execution failed with VMError: {
     location: 0x42::X,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000042::X::error at offset 1",
 }
 
 task 3, lines 27-33:
@@ -31,6 +33,7 @@ Error: Function execution failed with VMError: {
     location: 0x42::X,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000042::X::error at offset 1",
 }
 
 task 4, lines 35-41:
@@ -41,6 +44,7 @@ Error: Function execution failed with VMError: {
     location: 0x42::X,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000042::X::error at offset 1",
 }
 
 task 5, lines 43-48:
@@ -51,4 +55,5 @@ Error: Function execution failed with VMError: {
     location: 0xb::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "000000000000000000000000000000000000000000000000000000000000000b::m::main at offset 1",
 }

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/functions/large_enum.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/functions/large_enum.snap
@@ -19,4 +19,5 @@ Error: Function execution failed with VMError: {
     location: undefined,
     indices: [],
     offsets: [],
+    message: "entry point functions cannot have non-serializable return types",
 }

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/macros/break_from_macro_arg.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/macros/break_from_macro_arg.snap
@@ -11,4 +11,5 @@ Error: Function execution failed with VMError: {
     location: 0x2a::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 24)],
+    message: "000000000000000000000000000000000000000000000000000000000000002a::m::t at offset 24",
 }

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/macros/method_is_by_value.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/macros/method_is_by_value.snap
@@ -11,6 +11,7 @@ Error: Function execution failed with VMError: {
     location: 0x2a::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "000000000000000000000000000000000000000000000000000000000000002a::m::x_abort at offset 1",
 }
 
 task 3, line 39:
@@ -21,6 +22,7 @@ Error: Function execution failed with VMError: {
     location: 0x2a::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(1), 1)],
+    message: "000000000000000000000000000000000000000000000000000000000000002a::m::id_abort at offset 1",
 }
 
 task 4, line 41:
@@ -31,6 +33,7 @@ Error: Function execution failed with VMError: {
     location: 0x2a::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(4), 1)],
+    message: "000000000000000000000000000000000000000000000000000000000000002a::m::aborts2_not_0 at offset 1",
 }
 
 task 5, line 43:
@@ -41,4 +44,5 @@ Error: Function execution failed with VMError: {
     location: 0x2a::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(5), 1)],
+    message: "000000000000000000000000000000000000000000000000000000000000002a::m::aborts2_not_1 at offset 1",
 }

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/macros/method_is_by_value_even_when_ignored.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/macros/method_is_by_value_even_when_ignored.snap
@@ -11,6 +11,7 @@ Error: Function execution failed with VMError: {
     location: 0x2a::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "000000000000000000000000000000000000000000000000000000000000002a::m::x_abort at offset 1",
 }
 
 task 3, line 31:
@@ -21,4 +22,5 @@ Error: Function execution failed with VMError: {
     location: 0x2a::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(1), 1)],
+    message: "000000000000000000000000000000000000000000000000000000000000002a::m::id_abort at offset 1",
 }

--- a/external-crates/move/crates/move-compiler-transactional-tests/tests/operators/casting_operators.snap
+++ b/external-crates/move/crates/move-compiler-transactional-tests/tests/operators/casting_operators.snap
@@ -11,6 +11,7 @@ Error: Function execution failed with VMError: {
     location: 0x7::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u64(256) to u8",
 }
 
 task 7, lines 190-196:
@@ -21,6 +22,7 @@ Error: Function execution failed with VMError: {
     location: 0x8::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u64(303) to u8",
 }
 
 task 8, lines 198-204:
@@ -31,6 +33,7 @@ Error: Function execution failed with VMError: {
     location: 0x9::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(256) to u8",
 }
 
 task 9, lines 206-212:
@@ -41,6 +44,7 @@ Error: Function execution failed with VMError: {
     location: 0xa::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(56432) to u8",
 }
 
 task 10, lines 214-220:
@@ -51,6 +55,7 @@ Error: Function execution failed with VMError: {
     location: 0xb::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u64(18446744073709551615) to u8",
 }
 
 task 11, lines 222-228:
@@ -61,6 +66,7 @@ Error: Function execution failed with VMError: {
     location: 0xc::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(340282366920938463463374607431768211455) to u8",
 }
 
 task 12, lines 230-236:
@@ -71,6 +77,7 @@ Error: Function execution failed with VMError: {
     location: 0xd::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u16(2561) to u8",
 }
 
 task 13, lines 238-244:
@@ -81,6 +88,7 @@ Error: Function execution failed with VMError: {
     location: 0xe::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u16(65532) to u8",
 }
 
 task 14, lines 246-252:
@@ -91,6 +99,7 @@ Error: Function execution failed with VMError: {
     location: 0xf::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u32(256123) to u8",
 }
 
 task 15, lines 254-262:
@@ -101,6 +110,7 @@ Error: Function execution failed with VMError: {
     location: 0x10::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u256(11579208923731619542357098500868790785326998466564056403945758400791312963993) to u8",
 }
 
 task 16, lines 263-269:
@@ -111,6 +121,7 @@ Error: Function execution failed with VMError: {
     location: 0x11::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u64(256343532) to u16",
 }
 
 task 17, lines 271-277:
@@ -121,6 +132,7 @@ Error: Function execution failed with VMError: {
     location: 0x12::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u64(3564603) to u16",
 }
 
 task 18, lines 279-285:
@@ -131,6 +143,7 @@ Error: Function execution failed with VMError: {
     location: 0x13::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(256666765790535666) to u16",
 }
 
 task 19, lines 287-293:
@@ -141,6 +154,7 @@ Error: Function execution failed with VMError: {
     location: 0x14::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(256765735666) to u16",
 }
 
 task 20, lines 295-301:
@@ -151,6 +165,7 @@ Error: Function execution failed with VMError: {
     location: 0x15::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u64(18446744073709551615) to u16",
 }
 
 task 21, lines 303-309:
@@ -161,6 +176,7 @@ Error: Function execution failed with VMError: {
     location: 0x16::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(340282366920938463463374607431768211455) to u16",
 }
 
 task 22, lines 311-317:
@@ -171,6 +187,7 @@ Error: Function execution failed with VMError: {
     location: 0x17::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u32(429496729) to u16",
 }
 
 task 23, lines 319-325:
@@ -181,6 +198,7 @@ Error: Function execution failed with VMError: {
     location: 0x18::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u32(42949629) to u16",
 }
 
 task 24, lines 327-335:
@@ -191,6 +209,7 @@ Error: Function execution failed with VMError: {
     location: 0x19::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u256(115792089237316195423570985008687907853269984665640564039457584007913129639) to u16",
 }
 
 task 25, lines 336-342:
@@ -201,6 +220,7 @@ Error: Function execution failed with VMError: {
     location: 0x1a::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u64(4294967295644) to u32",
 }
 
 task 27, lines 352-358:
@@ -211,6 +231,7 @@ Error: Function execution failed with VMError: {
     location: 0x1c::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(256666765790535666) to u32",
 }
 
 task 28, lines 360-366:
@@ -221,6 +242,7 @@ Error: Function execution failed with VMError: {
     location: 0x1d::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(25676573566896) to u32",
 }
 
 task 29, lines 368-374:
@@ -231,6 +253,7 @@ Error: Function execution failed with VMError: {
     location: 0x1e::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u64(18446744073709551615) to u32",
 }
 
 task 30, lines 376-382:
@@ -241,6 +264,7 @@ Error: Function execution failed with VMError: {
     location: 0x1f::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(340282366920938463463374607431768211455) to u32",
 }
 
 task 31, lines 384-392:
@@ -251,6 +275,7 @@ Error: Function execution failed with VMError: {
     location: 0x20::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u256(115792089237316195423570985008687907853269984665640564039457584007913129639) to u32",
 }
 
 task 32, lines 393-399:
@@ -261,6 +286,7 @@ Error: Function execution failed with VMError: {
     location: 0x21::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(18446744073709551616) to u64",
 }
 
 task 33, lines 401-407:
@@ -271,6 +297,7 @@ Error: Function execution failed with VMError: {
     location: 0x22::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(18446744073709551647) to u64",
 }
 
 task 34, lines 409-415:
@@ -281,4 +308,5 @@ Error: Function execution failed with VMError: {
     location: 0x23::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(340282366920938463463374607431768211455) to u64",
 }

--- a/external-crates/move/crates/move-transactional-test-runner/src/vm_test_harness.rs
+++ b/external-crates/move/crates/move-transactional-test-runner/src/vm_test_harness.rs
@@ -442,14 +442,22 @@ pub fn format_vm_error(e: &VMError) -> String {
         Location::Undefined => "undefined".to_owned(),
         Location::Module(id) => format!("0x{}::{}", id.address().short_str_lossless(), id.name()),
     };
-    // message: {message:?},
+    let message = if let Some(msg) = e.message() {
+        format!(
+            "
+    message: {:?},",
+            msg
+        )
+    } else {
+        "".to_string()
+    };
     format!(
         "{{
     major_status: {major_status:?},
     sub_status: {sub_status:?},
     location: {location_string},
     indices: {indices:?},
-    offsets: {offsets:?},
+    offsets: {offsets:?},{message}
 }}",
         major_status = e.major_status(),
         sub_status = e.sub_status(),
@@ -457,7 +465,7 @@ pub fn format_vm_error(e: &VMError) -> String {
         // TODO maybe include source map info?
         indices = e.indices(),
         offsets = e.offsets(),
-        // message = e.message(),
+        message = message,
     )
 }
 

--- a/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/example.snap
+++ b/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/example.snap
@@ -11,6 +11,7 @@ Error: Function execution failed with VMError: {
     location: 0x42::N,
     indices: [],
     offsets: [(FunctionDefinitionIndex(2), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000042::N::ex at offset 1",
 }
 
 task 6, line 53:

--- a/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/linkage_specification.snap
+++ b/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/linkage_specification.snap
@@ -11,4 +11,5 @@ Error: Function execution failed with VMError: {
     location: 0x42::N,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000042::N::make at offset 1",
 }

--- a/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/publish_and_call_fail.snap
+++ b/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/publish_and_call_fail.snap
@@ -11,6 +11,7 @@ Error: Function execution failed with VMError: {
     location: 0x42::n,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000042::n::make at offset 1",
 }
 
 task 2, line 8:
@@ -21,4 +22,5 @@ Error: Function execution failed with VMError: {
     location: undefined,
     indices: [],
     offsets: [],
+    message: "Cannot find package 0000000000000000000000000000000000000000000000000000000000000042 in data cache",
 }

--- a/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/publish_and_call_invalid.snap
+++ b/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/publish_and_call_invalid.snap
@@ -11,4 +11,5 @@ Error: Function execution failed with VMError: {
     location: undefined,
     indices: [],
     offsets: [],
+    message: "Could not find function 0000000000000000000000000000000000000000000000000000000000000042::m::d",
 }

--- a/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/publish_and_call_linkage_spec.snap
+++ b/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/publish_and_call_linkage_spec.snap
@@ -16,6 +16,7 @@ Error: Function execution failed with VMError: {
     location: 0x42::n,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000042::n::make at offset 1",
 }
 
 task 3, line 13:
@@ -30,4 +31,5 @@ Error: Function execution failed with VMError: {
     location: undefined,
     indices: [],
     offsets: [],
+    message: "Cannot find package 0000000000000000000000000000000000000000000000000000000000000002 in data cache",
 }

--- a/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/simple_call.move
+++ b/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/simple_call.move
@@ -1,0 +1,6 @@
+//# init
+
+//# run
+module 0x5::m {
+    fun main() {}
+}

--- a/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/simple_call.snap
+++ b/external-crates/move/crates/move-transactional-test-runner/tests/vm_test_harness/simple_call.snap
@@ -1,0 +1,4 @@
+---
+source: crates/move-transactional-test-runner/src/framework.rs
+---
+processed 2 tasks

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_out_of_bound.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/builtins/vector_ops_out_of_bound.snap
@@ -11,6 +11,7 @@ Error: Function execution failed with VMError: {
     location: 0x5::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 7)],
+    message: "Vector index out of bounds",
 }
 
 task 1, lines 15-28:
@@ -21,6 +22,7 @@ Error: Function execution failed with VMError: {
     location: 0x6::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 7)],
+    message: "Vector index out of bounds",
 }
 
 task 2, lines 29-41:

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/commands/abort_in_module.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/commands/abort_in_module.snap
@@ -11,4 +11,5 @@ Error: Function execution failed with VMError: {
     location: 0x5::M,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000005::M::foo at offset 1",
 }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/control_flow/fields_packed_in_order.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/control_flow/fields_packed_in_order.snap
@@ -11,4 +11,5 @@ Error: Function execution failed with VMError: {
     location: 0x6::M,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "0000000000000000000000000000000000000000000000000000000000000006::M::error at offset 1",
 }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/expected_0_args_got_1.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/expected_0_args_got_1.snap
@@ -11,4 +11,5 @@ Error: Function execution failed with VMError: {
     location: undefined,
     indices: [],
     offsets: [],
+    message: "argument length mismatch: expected 0 got 1",
 }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/expected_0_signer_args_got_1_ok.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/expected_0_signer_args_got_1_ok.snap
@@ -11,4 +11,5 @@ Error: Function execution failed with VMError: {
     location: undefined,
     indices: [],
     offsets: [],
+    message: "argument length mismatch: expected 0 got 1",
 }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/expected_1_arg_got_0.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/expected_1_arg_got_0.snap
@@ -11,4 +11,5 @@ Error: Function execution failed with VMError: {
     location: undefined,
     indices: [],
     offsets: [],
+    message: "argument length mismatch: expected 1 got 0",
 }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/expected_1_arg_got_2.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/expected_1_arg_got_2.snap
@@ -11,4 +11,5 @@ Error: Function execution failed with VMError: {
     location: undefined,
     indices: [],
     offsets: [],
+    message: "argument length mismatch: expected 1 got 2",
 }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/expected_2_args_got_3.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/expected_2_args_got_3.snap
@@ -11,4 +11,5 @@ Error: Function execution failed with VMError: {
     location: undefined,
     indices: [],
     offsets: [],
+    message: "argument length mismatch: expected 2 got 3",
 }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/expected_2_signer_args_got_1.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/expected_2_signer_args_got_1.snap
@@ -11,4 +11,5 @@ Error: Function execution failed with VMError: {
     location: undefined,
     indices: [],
     offsets: [],
+    message: "argument length mismatch: expected 2 got 1",
 }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/expected_u64_addr_got_addr.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/entry_points/expected_u64_addr_got_addr.snap
@@ -11,4 +11,5 @@ Error: Function execution failed with VMError: {
     location: undefined,
     indices: [],
     offsets: [],
+    message: "argument length mismatch: expected 2 got 1",
 }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/enum_variant_jump_same_label.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/enum_variant_jump_same_label.snap
@@ -75,6 +75,7 @@ Error: Function execution failed with VMError: {
     location: 0x6::Enums,
     indices: [],
     offsets: [(FunctionDefinitionIndex(3), 3)],
+    message: "tag mismatch: expected 1, got 0",
 }
 
 task 4, line 103:
@@ -85,4 +86,5 @@ Error: Function execution failed with VMError: {
     location: 0x6::Enums,
     indices: [],
     offsets: [(FunctionDefinitionIndex(3), 3)],
+    message: "tag mismatch: expected 1, got 2",
 }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/enum_variant_mismatch.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/enum_variant_mismatch.snap
@@ -51,4 +51,5 @@ Error: Function execution failed with VMError: {
     location: 0x6::MonomorphicEnums,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 6)],
+    message: "tag mismatch: expected 0, got 1",
 }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/enum_variant_tag_unpack_invalid.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/enum_variant_tag_unpack_invalid.snap
@@ -11,6 +11,7 @@ Error: Function execution failed with VMError: {
     location: 0x6::Enums,
     indices: [],
     offsets: [(FunctionDefinitionIndex(4), 1)],
+    message: "Variant tag mismatch: expected 1, got 0",
 }
 
 task 3, line 224:
@@ -21,6 +22,7 @@ Error: Function execution failed with VMError: {
     location: 0x6::Enums,
     indices: [],
     offsets: [(FunctionDefinitionIndex(5), 1)],
+    message: "Variant tag mismatch: expected 1, got 0",
 }
 
 task 4, line 226:
@@ -31,6 +33,7 @@ Error: Function execution failed with VMError: {
     location: 0x6::Enums,
     indices: [],
     offsets: [(FunctionDefinitionIndex(3), 1)],
+    message: "tag mismatch: expected 1, got 0",
 }
 
 task 5, line 228:
@@ -41,6 +44,7 @@ Error: Function execution failed with VMError: {
     location: 0x6::Enums,
     indices: [],
     offsets: [(FunctionDefinitionIndex(1), 1)],
+    message: "Variant tag mismatch: expected 0, got 1",
 }
 
 task 6, line 230:
@@ -51,6 +55,7 @@ Error: Function execution failed with VMError: {
     location: 0x6::Enums,
     indices: [],
     offsets: [(FunctionDefinitionIndex(2), 1)],
+    message: "Variant tag mismatch: expected 0, got 1",
 }
 
 task 7, line 232:
@@ -61,6 +66,7 @@ Error: Function execution failed with VMError: {
     location: 0x6::Enums,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "tag mismatch: expected 0, got 1",
 }
 
 task 8, line 234:
@@ -71,6 +77,7 @@ Error: Function execution failed with VMError: {
     location: 0x6::Enums,
     indices: [],
     offsets: [(FunctionDefinitionIndex(10), 1)],
+    message: "Variant tag mismatch: expected 1, got 0",
 }
 
 task 9, line 236:
@@ -81,6 +88,7 @@ Error: Function execution failed with VMError: {
     location: 0x6::Enums,
     indices: [],
     offsets: [(FunctionDefinitionIndex(11), 1)],
+    message: "Variant tag mismatch: expected 1, got 0",
 }
 
 task 10, line 238:
@@ -91,6 +99,7 @@ Error: Function execution failed with VMError: {
     location: 0x6::Enums,
     indices: [],
     offsets: [(FunctionDefinitionIndex(9), 1)],
+    message: "tag mismatch: expected 1, got 0",
 }
 
 task 11, line 240:
@@ -101,6 +110,7 @@ Error: Function execution failed with VMError: {
     location: 0x6::Enums,
     indices: [],
     offsets: [(FunctionDefinitionIndex(7), 1)],
+    message: "Variant tag mismatch: expected 0, got 1",
 }
 
 task 12, line 242:
@@ -111,6 +121,7 @@ Error: Function execution failed with VMError: {
     location: 0x6::Enums,
     indices: [],
     offsets: [(FunctionDefinitionIndex(8), 1)],
+    message: "Variant tag mismatch: expected 0, got 1",
 }
 
 task 13, line 244:
@@ -121,4 +132,5 @@ Error: Function execution failed with VMError: {
     location: 0x6::Enums,
     indices: [],
     offsets: [(FunctionDefinitionIndex(6), 1)],
+    message: "tag mismatch: expected 0, got 1",
 }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/mono/enum_decl_monomorphic_mismatched_variants.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/mono/enum_decl_monomorphic_mismatched_variants.snap
@@ -11,4 +11,5 @@ Error: Function execution failed with VMError: {
     location: 0x6::MonomorphicEnums,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 11)],
+    message: "tag mismatch: expected 0, got 1",
 }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/enums/poly/enum_decl_poly_mismatched_variants.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/enums/poly/enum_decl_poly_mismatched_variants.snap
@@ -11,4 +11,5 @@ Error: Function execution failed with VMError: {
     location: 0x6::PolymorphicEnums,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 11)],
+    message: "tag mismatch: expected 0, got 1",
 }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/instructions/casting_operators.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/instructions/casting_operators.snap
@@ -11,6 +11,7 @@ Error: Function execution failed with VMError: {
     location: 0xc::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u64(256) to u8",
 }
 
 task 7, lines 204-213:
@@ -21,6 +22,7 @@ Error: Function execution failed with VMError: {
     location: 0xd::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u64(303) to u8",
 }
 
 task 8, lines 215-224:
@@ -31,6 +33,7 @@ Error: Function execution failed with VMError: {
     location: 0xe::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(256) to u8",
 }
 
 task 9, lines 226-235:
@@ -41,6 +44,7 @@ Error: Function execution failed with VMError: {
     location: 0x15::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(56432) to u8",
 }
 
 task 10, lines 237-246:
@@ -51,6 +55,7 @@ Error: Function execution failed with VMError: {
     location: 0x16::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u16(256) to u8",
 }
 
 task 11, lines 248-257:
@@ -61,6 +66,7 @@ Error: Function execution failed with VMError: {
     location: 0x17::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u16(303) to u8",
 }
 
 task 12, lines 259-268:
@@ -71,6 +77,7 @@ Error: Function execution failed with VMError: {
     location: 0x18::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u32(256) to u8",
 }
 
 task 13, lines 270-279:
@@ -81,6 +88,7 @@ Error: Function execution failed with VMError: {
     location: 0x19::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u32(303) to u8",
 }
 
 task 14, lines 281-290:
@@ -91,6 +99,7 @@ Error: Function execution failed with VMError: {
     location: 0x1a::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u64(18446744073709551615) to u8",
 }
 
 task 15, lines 292-301:
@@ -101,6 +110,7 @@ Error: Function execution failed with VMError: {
     location: 0x1b::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(340282366920938463463374607431768211455) to u8",
 }
 
 task 16, lines 303-312:
@@ -111,6 +121,7 @@ Error: Function execution failed with VMError: {
     location: 0x1c::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u16(65535) to u8",
 }
 
 task 17, lines 314-325:
@@ -121,6 +132,7 @@ Error: Function execution failed with VMError: {
     location: 0x1d::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u32(4294967295) to u8",
 }
 
 task 18, lines 326-335:
@@ -131,6 +143,7 @@ Error: Function execution failed with VMError: {
     location: 0x1e::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(18446744073709551616) to u64",
 }
 
 task 19, lines 337-346:
@@ -141,6 +154,7 @@ Error: Function execution failed with VMError: {
     location: 0x25::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(18446744073709551647) to u64",
 }
 
 task 20, lines 348-357:
@@ -151,6 +165,7 @@ Error: Function execution failed with VMError: {
     location: 0x26::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(340282366920938463463374607431768211455) to u64",
 }
 
 task 21, lines 359-368:
@@ -161,6 +176,7 @@ Error: Function execution failed with VMError: {
     location: 0x27::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u256(18446744073709551647) to u64",
 }
 
 task 22, lines 370-379:
@@ -171,6 +187,7 @@ Error: Function execution failed with VMError: {
     location: 0x28::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(18446744073709551647) to u64",
 }
 
 task 23, lines 381-392:
@@ -181,6 +198,7 @@ Error: Function execution failed with VMError: {
     location: 0x29::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u256(57896044618658097711785492504343953926634992332820282019728792003956564819967) to u64",
 }
 
 task 24, lines 393-402:
@@ -191,6 +209,7 @@ Error: Function execution failed with VMError: {
     location: 0x2a::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(18446744073709551616) to u16",
 }
 
 task 25, lines 404-413:
@@ -201,6 +220,7 @@ Error: Function execution failed with VMError: {
     location: 0x2b::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(18446744073709551647) to u16",
 }
 
 task 26, lines 415-424:
@@ -211,6 +231,7 @@ Error: Function execution failed with VMError: {
     location: 0x2c::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(340282366920938463463374607431768211455) to u16",
 }
 
 task 27, lines 426-435:
@@ -221,6 +242,7 @@ Error: Function execution failed with VMError: {
     location: 0x2d::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u256(18446744073709551647) to u16",
 }
 
 task 28, lines 437-446:
@@ -231,6 +253,7 @@ Error: Function execution failed with VMError: {
     location: 0x2e::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(18446744073709551647) to u16",
 }
 
 task 29, lines 448-457:
@@ -241,6 +264,7 @@ Error: Function execution failed with VMError: {
     location: 0x35::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u256(57896044618658097711785492504343953926634992332820282019728792003956564819967) to u16",
 }
 
 task 30, lines 459-468:
@@ -251,6 +275,7 @@ Error: Function execution failed with VMError: {
     location: 0x36::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u32(2561233) to u16",
 }
 
 task 31, lines 470-481:
@@ -261,6 +286,7 @@ Error: Function execution failed with VMError: {
     location: 0x37::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u32(4294967295) to u16",
 }
 
 task 32, lines 482-491:
@@ -271,6 +297,7 @@ Error: Function execution failed with VMError: {
     location: 0x38::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(18446744073709551616) to u32",
 }
 
 task 33, lines 493-502:
@@ -281,6 +308,7 @@ Error: Function execution failed with VMError: {
     location: 0x39::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(18446744073709551647) to u32",
 }
 
 task 34, lines 504-513:
@@ -291,6 +319,7 @@ Error: Function execution failed with VMError: {
     location: 0x3a::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(340282366920938463463374607431768211455) to u32",
 }
 
 task 35, lines 515-524:
@@ -301,6 +330,7 @@ Error: Function execution failed with VMError: {
     location: 0x3b::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u256(18446744073709551647) to u32",
 }
 
 task 36, lines 526-535:
@@ -311,6 +341,7 @@ Error: Function execution failed with VMError: {
     location: 0x3c::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u128(18446744073709551647) to u32",
 }
 
 task 37, lines 537-546:
@@ -321,4 +352,5 @@ Error: Function execution failed with VMError: {
     location: 0x3d::m,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 1)],
+    message: "Cannot cast u256(57896044618658097711785492504343953926634992332820282019728792003956564819967) to u32",
 }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/instructions/equality_reference_value.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/instructions/equality_reference_value.snap
@@ -15,4 +15,5 @@ Error: Function execution failed with VMError: {
     location: 0x6::test,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 10)],
+    message: "0000000000000000000000000000000000000000000000000000000000000006::test::test at offset 10",
 }

--- a/external-crates/move/crates/move-vm-transactional-tests/tests/references/borrow_in_loop.snap
+++ b/external-crates/move/crates/move-vm-transactional-tests/tests/references/borrow_in_loop.snap
@@ -21,6 +21,7 @@ Error: Function execution failed with VMError: {
     location: undefined,
     indices: [],
     offsets: [],
+    message: "Cannot find package 0000000000000000000000000000000000000000000000000000000000000042 in data cache",
 }
 
 task 2, lines 27-45:


### PR DESCRIPTION
## Description 

Add `message` for VM errors when available in transactional tests

## Test plan 

Tests updated

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
