### PR TITLE
[consensus] Update round tracker from block manager accepted blocks

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -271,8 +271,14 @@ where
                 .is_zero();
         info!("Sync last known own block: {sync_last_known_own_block}");
 
-        let block_manager =
-            BlockManager::new(context.clone(), dag_state.clone(), block_verifier.clone());
+        let round_tracker = Arc::new(RwLock::new(PeerRoundTracker::new(context.clone())));
+
+        let block_manager = BlockManager::new(
+            context.clone(),
+            dag_state.clone(),
+            block_verifier.clone(),
+            round_tracker.clone(),
+        );
 
         let leader_schedule = Arc::new(LeaderSchedule::from_store(
             context.clone(),
@@ -289,8 +295,6 @@ where
             store.clone(),
             leader_schedule.clone(),
         );
-
-        let round_tracker = Arc::new(RwLock::new(PeerRoundTracker::new(context.clone())));
 
         let core = Core::new(
             context.clone(),

--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -340,12 +340,11 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             excluded_ancestors.truncate(excluded_ancestors_limit);
         }
 
+        // Update round tracker from excluded ancestors only. The block itself was
+        // updated in round tracker from block manager.
         self.round_tracker
             .write()
-            .update_from_accepted_block(&ExtendedBlock {
-                block: verified_block,
-                excluded_ancestors: excluded_ancestors.clone(),
-            });
+            .update_from_excluded_ancestors(verified_block.author(), &excluded_ancestors);
 
         self.context
             .metrics

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -479,10 +479,12 @@ mod test {
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
         let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store.clone())));
+        let round_tracker = Arc::new(RwLock::new(PeerRoundTracker::new(context.clone())));
         let block_manager = BlockManager::new(
             context.clone(),
             dag_state.clone(),
             Arc::new(NoopBlockVerifier),
+            round_tracker.clone(),
         );
         let (_transaction_client, tx_receiver) = TransactionClient::new(context.clone());
         let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
@@ -508,7 +510,6 @@ mod test {
             context.clone(),
             dag_state.clone(),
         ));
-        let round_tracker = Arc::new(RwLock::new(PeerRoundTracker::new(context.clone())));
         let core = Core::new(
             context.clone(),
             leader_schedule,

--- a/consensus/core/src/tests/randomized_tests.rs
+++ b/consensus/core/src/tests/randomized_tests.rs
@@ -15,6 +15,7 @@ use crate::{
     context::Context,
     dag_state::DagState,
     leader_schedule::{LeaderSchedule, LeaderSwapTable},
+    round_tracker::PeerRoundTracker,
     storage::mem_store::MemStore,
     test_dag::create_random_dag,
     universal_committer::{
@@ -197,10 +198,13 @@ fn authority_setup(num_authorities: usize, authority_index: u32) -> AuthorityTes
             .with_pipeline(true)
             .build();
 
+    let round_tracker = Arc::new(RwLock::new(PeerRoundTracker::new(context.clone())));
+
     let block_manager = BlockManager::new(
         context.clone(),
         dag_state.clone(),
         Arc::new(NoopBlockVerifier),
+        round_tracker,
     );
 
     AuthorityTestFixture {


### PR DESCRIPTION
## Description 

This will allow round tracker to be updated from blocks synced via commit sync or live sync in addition to the already tracked paths of block subscription and proposed blocks.

## Test plan 

pending ptn run

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
