### PR TITLE
[consensus] Enable consensus median based timestamp for mainnet

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -231,7 +231,7 @@ const MAX_PROTOCOL_VERSION: u64 = 80;
 //             Enable load_nitro_attestation move function in sui framework in testnet.
 //             Enable consensus garbage collection for mainnet
 //             Enable the new consensus commit rule for mainnet.
-// Version 80:
+// Version 80: Enable median based commit timestamp in consensus on mainnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -3449,7 +3449,9 @@ impl ProtocolConfig {
                     cfg.consensus_gc_depth = Some(60);
                     cfg.feature_flags.consensus_linearize_subdag_v2 = true;
                 }
-                80 => {}
+                80 => {
+                    cfg.feature_flags.consensus_median_based_commit_timestamp = true;
+                }
                 // Use this template when making changes:
                 //
                 //     // modify an existing constant.

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_80.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_80.snap
@@ -75,6 +75,7 @@ feature_flags:
   consensus_zstd_compression: true
   minimize_child_object_mutations: true
   move_native_context: true
+  consensus_median_based_commit_timestamp: true
   normalize_ptb_arguments: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048


### PR DESCRIPTION
## Test plan 

Running in testnet

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [X] Protocol: Enable consensus median based timestamp for mainnet in v80
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
