### PR TITLE
[vm][move-vm][rewrite] Replace type depth cache with LRU cache in dispatch tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7450,6 +7450,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+dependencies = [
+ "hashbrown 0.15.2",
+]
+
+[[package]]
 name = "lsp-server"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8556,6 +8565,7 @@ dependencies = [
  "hex",
  "indexmap 2.8.0",
  "lasso",
+ "lru 0.13.0",
  "move-abstract-interpreter",
  "move-binary-format",
  "move-bytecode-verifier",

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -1946,6 +1946,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+dependencies = [
+ "hashbrown 0.15.2",
+]
+
+[[package]]
 name = "lsp-server"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2950,6 +2959,7 @@ dependencies = [
  "hex",
  "indexmap 2.8.0",
  "lasso",
+ "lru 0.13.0",
  "memory-stats",
  "move-abstract-interpreter",
  "move-binary-format",
@@ -3749,7 +3759,7 @@ dependencies = [
  "indoc",
  "instability",
  "itertools 0.13.0",
- "lru",
+ "lru 0.12.5",
  "paste",
  "strum 0.26.3",
  "unicode-segmentation",

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -80,6 +80,7 @@ leb128 = "0.2.5"
 lasso = { version = "0.7.3", features = ["multi-threaded", "inline-more"] }
 libfuzzer-sys = "0.4"
 log = { version = "0.4.14", features = ["serde"] }
+lru = "0.13.0"
 lsp-server = "0.7.6"
 lsp-types = "0.95.1"
 memory-stats = "1.0.0"

--- a/external-crates/move/crates/move-vm-runtime/Cargo.toml
+++ b/external-crates/move/crates/move-vm-runtime/Cargo.toml
@@ -20,6 +20,7 @@ fail.workspace = true
 hex.workspace = true
 indexmap.workspace = true
 lasso.workspace = true
+lru.workspace = true
 once_cell.workspace = true
 parking_lot.workspace = true
 serde.workspace = true

--- a/external-crates/move/crates/move-vm-runtime/src/execution/dispatch_tables.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/dispatch_tables.rs
@@ -36,8 +36,11 @@ use move_core_types::{
 
 use move_vm_config::runtime::VMConfig;
 
+use lru::LruCache;
+
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
+    num::NonZeroUsize,
     sync::Arc,
 };
 
@@ -63,7 +66,7 @@ pub struct VMDispatchTables {
     /// avoid grabbing write-locks and toward the possibility these may change based on linkage
     /// (e.g., type ugrades or similar).
     /// [SAFETY] Ordering of inner maps is not guaranteed
-    pub(crate) type_depths: BTreeMap<OriginalId, DefinitionMap<DepthFormula>>,
+    pub(crate) type_depths: LruCache<VirtualTableKey, DepthFormula>,
     /// Defining ID Set -- a set of all defining IDs on any types mentioned in the package.
     /// [SAFETY] Ordering is not guaranteed
     pub(crate) defining_id_origins: BTreeMap<DefiningTypeId, OriginalId>,
@@ -120,6 +123,10 @@ pub struct DepthFormula {
     pub constant: Option<u64>,
 }
 
+/// Size of the type depth LRU
+/// TODO(vm-rewrite): find a good bound for this
+const TYPE_DEPTH_LRU_SIZE: usize = 16_384;
+
 // -------------------------------------------------------------------------------------------------
 // Impls
 // -------------------------------------------------------------------------------------------------
@@ -157,7 +164,7 @@ impl VMDispatchTables {
             vm_config,
             loaded_packages,
             defining_id_origins,
-            type_depths: BTreeMap::new(),
+            type_depths: LruCache::new(NonZeroUsize::new(TYPE_DEPTH_LRU_SIZE).unwrap()),
         })
     }
 
@@ -423,59 +430,46 @@ impl VMDispatchTables {
     // These functions compute the depth of the specified type, plus cache the depth formula of any
     // uncached subtypes they find along the way.
 
-    fn cached_type_depth(&self, datatype: &VirtualTableKey) -> Option<&DepthFormula> {
-        let package = self.type_depths.get(&datatype.package_key)?;
-        package.get(&datatype.inner_pkg_key)
+    fn cached_type_depth(&mut self, datatype: &VirtualTableKey) -> Option<&DepthFormula> {
+        self.type_depths.get(datatype)
     }
 
     pub fn calculate_depth_of_type(
         &mut self,
         datatype_name: &VirtualTableKey,
     ) -> PartialVMResult<DepthFormula> {
-        let mut depth_cache = HashMap::new();
-        let depth_formula =
-            self.calculate_depth_of_datatype_and_cache(datatype_name, &mut depth_cache)?;
-        for (datatype_key, depth) in depth_cache {
-            self.type_depths
-                .entry(datatype_key.package_key)
-                .or_default()
-                .insert(datatype_key.inner_pkg_key, depth)?;
-        }
+        let depth_formula = self.calculate_depth_of_datatype_and_cache(datatype_name)?;
         Ok(depth_formula)
     }
 
     fn calculate_depth_of_datatype_and_cache(
-        &self,
+        &mut self,
         datatype_name: &VirtualTableKey,
-        depth_cache: &mut HashMap<VirtualTableKey, DepthFormula>,
     ) -> PartialVMResult<DepthFormula> {
         // If we've already computed this datatypes depth, no more work remains to be done.
         if let Some(form) = self.cached_type_depth(datatype_name) {
             return Ok(form.clone());
         }
-        if let Some(form) = depth_cache.get(datatype_name) {
-            return Ok(form.clone());
-        }
 
-        let datatype = self.resolve_type(&datatype_name)?.to_ref();
+        let datatype = self.resolve_type(datatype_name)?.to_ref();
         let formulas = match datatype.datatype_info.inner_ref() {
             // The depth of enum is calculated as the maximum depth of any of its variants.
             Datatype::Enum(enum_type) => enum_type
                 .variants
                 .iter()
                 .flat_map(|variant_type| variant_type.fields.iter())
-                .map(|field_type| self.calculate_depth_of_type_and_cache(field_type, depth_cache))
+                .map(|field_type| self.calculate_depth_of_type_and_cache(field_type))
                 .collect::<PartialVMResult<Vec<_>>>()?,
             Datatype::Struct(struct_type) => struct_type
                 .fields
                 .iter()
-                .map(|field_type| self.calculate_depth_of_type_and_cache(field_type, depth_cache))
+                .map(|field_type| self.calculate_depth_of_type_and_cache(field_type))
                 .collect::<PartialVMResult<Vec<_>>>()?,
         };
         let mut formula = DepthFormula::normalize(formulas);
         // add 1 for the struct/variant itself
         formula.add(1);
-        let prev = depth_cache.insert(datatype_name.clone(), formula.clone());
+        let prev = self.type_depths.put(datatype_name.clone(), formula.clone());
         if prev.is_some() {
             return Err(
                 PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
@@ -486,9 +480,8 @@ impl VMDispatchTables {
     }
 
     fn calculate_depth_of_type_and_cache(
-        &self,
+        &mut self,
         ty: &ArenaType,
-        depth_cache: &mut HashMap<VirtualTableKey, DepthFormula>,
     ) -> PartialVMResult<DepthFormula> {
         Ok(match ty {
             ArenaType::Bool
@@ -502,15 +495,14 @@ impl VMDispatchTables {
             | ArenaType::U256 => DepthFormula::constant(1),
             // we should not see the reference here, we could instead give an invariant violation
             ArenaType::Vector(ty) | ArenaType::Reference(ty) | ArenaType::MutableReference(ty) => {
-                let mut inner = self.calculate_depth_of_type_and_cache(ty, depth_cache)?;
+                let mut inner = self.calculate_depth_of_type_and_cache(ty)?;
                 // add 1 for the vector itself
                 inner.add(1);
                 inner
             }
             ArenaType::TyParam(ty_idx) => DepthFormula::type_parameter(*ty_idx),
-            ArenaType::Datatype(cache_idx) => {
-                let datatype_formula =
-                    self.calculate_depth_of_datatype_and_cache(cache_idx, depth_cache)?;
+            ArenaType::Datatype(datatype_key) => {
+                let datatype_formula = self.calculate_depth_of_datatype_and_cache(datatype_key)?;
                 debug_assert!(datatype_formula.terms.is_empty());
                 datatype_formula
             }
@@ -521,14 +513,10 @@ impl VMDispatchTables {
                     .enumerate()
                     .map(|(idx, ty)| {
                         let var = idx as TypeParameterIndex;
-                        Ok((
-                            var,
-                            self.calculate_depth_of_type_and_cache(ty, depth_cache)?,
-                        ))
+                        Ok((var, self.calculate_depth_of_type_and_cache(ty)?))
                     })
                     .collect::<PartialVMResult<BTreeMap<_, _>>>()?;
-                let datatype_formula =
-                    self.calculate_depth_of_datatype_and_cache(cache_idx, depth_cache)?;
+                let datatype_formula = self.calculate_depth_of_datatype_and_cache(cache_idx)?;
 
                 datatype_formula.subst(ty_arg_map)?
             }
@@ -1062,17 +1050,6 @@ impl<T> DefinitionMap<T> {
     /// Retrieve a key from the definition map.
     pub fn get(&self, key: &IntraPackageKey) -> Option<&T> {
         self.0.get(key)
-    }
-
-    /// Private to this module, as it is only used in depth formula calculations.
-    fn insert(&mut self, key: IntraPackageKey, value: T) -> PartialVMResult<()> {
-        if self.0.insert(key, value).is_some() {
-            return Err(
-                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                    .with_message(format!("Duplicate key {}", key.to_string()?)),
-            );
-        }
-        Ok(())
     }
 }
 


### PR DESCRIPTION
## Description 

Replace type depth cache with LRU cache in dispatch tables

## Test plan 

Tests still work

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
