### PR TITLE
[typed store] enable iterator methods for in_memory_db and tidehunter

### DIFF
--- a/crates/typed-store/src/lib.rs
+++ b/crates/typed-store/src/lib.rs
@@ -12,11 +12,16 @@
 pub use rocksdb;
 
 pub mod traits;
-pub use traits::Map;
+pub use traits::{DbIterator, Map};
+pub mod memstore;
 pub mod metrics;
 pub mod rocks;
+#[cfg(all(not(target_os = "windows"), feature = "tide_hunter"))]
+mod tidehunter_util;
+mod util;
 pub use metrics::DBMetrics;
 pub use typed_store_error::TypedStoreError;
+pub use util::be_fix_int_ser;
 
 pub type StoreError = typed_store_error::TypedStoreError;
 

--- a/crates/typed-store/src/rocks/errors.rs
+++ b/crates/typed-store/src/rocks/errors.rs
@@ -91,8 +91,3 @@ pub fn typed_store_err_from_bcs_err(err: bcs::Error) -> TypedStoreError {
 pub fn typed_store_err_from_rocks_err(err: RocksError) -> TypedStoreError {
     TypedStoreError::RocksDBError(format!("{err}"))
 }
-
-#[cfg(all(not(target_os = "windows"), feature = "tide_hunter"))]
-pub fn typed_store_error_from_th_error(err: tidehunter::db::DbError) -> TypedStoreError {
-    TypedStoreError::RocksDBError(format!("tidehunter error: {:?}", err))
-}

--- a/crates/typed-store/src/rocks/rocks_util.rs
+++ b/crates/typed-store/src/rocks/rocks_util.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub(crate) fn apply_range_bounds(
+    mut read_options: rocksdb::ReadOptions,
+    lower_bound: Option<Vec<u8>>,
+    upper_bound: Option<Vec<u8>>,
+) -> rocksdb::ReadOptions {
+    if let Some(lower_bound) = lower_bound {
+        read_options.set_iterate_lower_bound(lower_bound);
+    }
+    if let Some(upper_bound) = upper_bound {
+        read_options.set_iterate_upper_bound(upper_bound);
+    }
+    read_options
+}

--- a/crates/typed-store/src/rocks/safe_iter.rs
+++ b/crates/typed-store/src/rocks/safe_iter.rs
@@ -4,17 +4,17 @@ use std::{marker::PhantomData, sync::Arc};
 
 use bincode::Options;
 use prometheus::{Histogram, HistogramTimer};
-use rocksdb::Direction;
+use rocksdb::{DBWithThreadMode, Direction, MultiThreaded};
 
 use crate::metrics::{DBMetrics, RocksDBPerfContext};
 
-use super::{RawIter, TypedStoreError};
+use super::TypedStoreError;
 use serde::de::DeserializeOwned;
 
 /// An iterator over all key-value pairs in a data map.
 pub struct SafeIter<'a, K, V> {
     cf_name: String,
-    db_iter: RawIter<'a>,
+    db_iter: rocksdb::DBRawIteratorWithThreadMode<'a, DBWithThreadMode<MultiThreaded>>,
     _phantom: PhantomData<(K, V)>,
     direction: Direction,
     is_initialized: bool,
@@ -30,7 +30,7 @@ pub struct SafeIter<'a, K, V> {
 impl<'a, K: DeserializeOwned, V: DeserializeOwned> SafeIter<'a, K, V> {
     pub(super) fn new(
         cf_name: String,
-        db_iter: RawIter<'a>,
+        db_iter: rocksdb::DBRawIteratorWithThreadMode<'a, DBWithThreadMode<MultiThreaded>>,
         _timer: Option<HistogramTimer>,
         _perf_ctx: Option<RocksDBPerfContext>,
         bytes_scanned: Option<Histogram>,

--- a/crates/typed-store/src/tidehunter_util.rs
+++ b/crates/typed-store/src/tidehunter_util.rs
@@ -1,0 +1,53 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use bincode::Options;
+use serde::de::DeserializeOwned;
+use tidehunter::iterators::db_iterator::DbIterator;
+use typed_store_error::TypedStoreError;
+
+pub(crate) fn apply_range_bounds(
+    iterator: &mut DbIterator,
+    lower_bound: Option<Vec<u8>>,
+    upper_bound: Option<Vec<u8>>,
+) {
+    if let Some(lower_bound) = lower_bound {
+        iterator.set_lower_bound(lower_bound);
+    }
+    if let Some(upper_bound) = upper_bound {
+        iterator.set_upper_bound(upper_bound);
+    }
+}
+
+pub(crate) fn transform_th_iterator<K, V>(
+    iterator: impl Iterator<
+        Item = Result<
+            (tidehunter::minibytes::Bytes, tidehunter::minibytes::Bytes),
+            tidehunter::db::DbError,
+        >,
+    >,
+) -> impl Iterator<Item = Result<(K, V), TypedStoreError>>
+where
+    K: DeserializeOwned,
+    V: DeserializeOwned,
+{
+    let config = bincode::DefaultOptions::new()
+        .with_big_endian()
+        .with_fixint_encoding();
+    iterator.map(move |item| {
+        item.map_err(|e| TypedStoreError::RocksDBError(format!("tidehunter error {:?}", e)))
+            .and_then(|(raw_key, raw_value)| {
+                let key = config.deserialize(&raw_key);
+                let value = bcs::from_bytes(&raw_value);
+                match (key, value) {
+                    (Ok(k), Ok(v)) => Ok((k, v)),
+                    (Err(e), _) => Err(TypedStoreError::SerializationError(e.to_string())),
+                    (_, Err(e)) => Err(TypedStoreError::SerializationError(e.to_string())),
+                }
+            })
+    })
+}
+
+pub(crate) fn typed_store_error_from_th_error(err: tidehunter::db::DbError) -> TypedStoreError {
+    TypedStoreError::RocksDBError(format!("tidehunter error: {:?}", err))
+}

--- a/crates/typed-store/src/util.rs
+++ b/crates/typed-store/src/util.rs
@@ -1,0 +1,126 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use bincode::Options;
+use serde::Serialize;
+use std::ops::{Bound, RangeBounds};
+
+#[inline]
+pub fn be_fix_int_ser<S>(t: &S) -> Vec<u8>
+where
+    S: ?Sized + serde::Serialize,
+{
+    bincode::DefaultOptions::new()
+        .with_big_endian()
+        .with_fixint_encoding()
+        .serialize(t)
+        .expect("failed to serialize via be_fix_int_ser method")
+}
+
+pub(crate) fn iterator_bounds<K>(
+    lower_bound: Option<K>,
+    upper_bound: Option<K>,
+) -> (Option<Vec<u8>>, Option<Vec<u8>>)
+where
+    K: Serialize,
+{
+    (
+        lower_bound.map(|b| be_fix_int_ser(&b)),
+        upper_bound.map(|b| be_fix_int_ser(&b)),
+    )
+}
+
+pub(crate) fn iterator_bounds_with_range<K>(
+    range: impl RangeBounds<K>,
+) -> (Option<Vec<u8>>, Option<Vec<u8>>)
+where
+    K: Serialize,
+{
+    let iterator_lower_bound = match range.start_bound() {
+        Bound::Included(lower_bound) => {
+            // Rocksdb lower bound is inclusive by default so nothing to do
+            Some(be_fix_int_ser(&lower_bound))
+            // readopts.set_iterate_lower_bound(key_buf);
+        }
+        Bound::Excluded(lower_bound) => {
+            let mut key_buf = be_fix_int_ser(&lower_bound);
+
+            // Since we want exclusive, we need to increment the key to exclude the previous
+            big_endian_saturating_add_one(&mut key_buf);
+            Some(key_buf)
+            // readopts.set_iterate_lower_bound(key_buf);
+        }
+        Bound::Unbounded => None,
+    };
+    let iterator_upper_bound = match range.end_bound() {
+        Bound::Included(upper_bound) => {
+            let mut key_buf = be_fix_int_ser(&upper_bound);
+
+            // If the key is already at the limit, there's nowhere else to go, so no upper bound
+            if !is_max(&key_buf) {
+                // Since we want exclusive, we need to increment the key to get the upper bound
+                big_endian_saturating_add_one(&mut key_buf);
+                // readopts.set_iterate_upper_bound(key_buf);
+            }
+            Some(key_buf)
+        }
+        Bound::Excluded(upper_bound) => {
+            // Rocksdb upper bound is inclusive by default so nothing to do
+            Some(be_fix_int_ser(&upper_bound))
+            // readopts.set_iterate_upper_bound(key_buf);
+        }
+        Bound::Unbounded => None,
+    };
+    (iterator_lower_bound, iterator_upper_bound)
+}
+
+/// Given a vec<u8>, find the value which is one more than the vector
+/// if the vector was a big endian number.
+/// If the vector is already minimum, don't change it.
+fn big_endian_saturating_add_one(v: &mut [u8]) {
+    if is_max(v) {
+        return;
+    }
+    for i in (0..v.len()).rev() {
+        if v[i] == u8::MAX {
+            v[i] = 0;
+        } else {
+            v[i] += 1;
+            break;
+        }
+    }
+}
+
+/// Check if all the bytes in the vector are 0xFF
+fn is_max(v: &[u8]) -> bool {
+    v.iter().all(|&x| x == u8::MAX)
+}
+
+#[allow(clippy::assign_op_pattern)]
+#[test]
+fn test_helpers() {
+    let v = vec![];
+    assert!(is_max(&v));
+
+    fn check_add(v: Vec<u8>) {
+        let mut v = v;
+        let num = Num32::from_big_endian(&v);
+        big_endian_saturating_add_one(&mut v);
+        assert!(num + 1 == Num32::from_big_endian(&v));
+    }
+
+    uint::construct_uint! {
+        // 32 byte number
+        struct Num32(4);
+    }
+
+    let mut v = vec![255; 32];
+    big_endian_saturating_add_one(&mut v);
+    assert!(Num32::MAX == Num32::from_big_endian(&v));
+
+    check_add(vec![1; 32]);
+    check_add(vec![6; 32]);
+    check_add(vec![254; 32]);
+
+    // TBD: More tests coming with randomized arrays
+}

--- a/crates/typed-store/tests/macro_tests.rs
+++ b/crates/typed-store/tests/macro_tests.rs
@@ -13,11 +13,11 @@ use std::time::Duration;
 use typed_store::metrics::SamplingInterval;
 use typed_store::rocks::list_tables;
 use typed_store::rocks::DBMap;
-use typed_store::rocks::{be_fix_int_ser, MetricConf};
+use typed_store::rocks::MetricConf;
 use typed_store::traits::Map;
 use typed_store::traits::TableSummary;
 use typed_store::traits::TypedStoreDebug;
-use typed_store::DBMapUtils;
+use typed_store::{be_fix_int_ser, DBMapUtils};
 
 fn temp_dir() -> std::path::PathBuf {
     tempfile::tempdir()
@@ -80,7 +80,7 @@ async fn macro_test() {
     for i in kv_range.clone() {
         let key = i.to_string();
         let value = i.to_string();
-        let k_buf = be_fix_int_ser::<String>(&key).unwrap();
+        let k_buf = be_fix_int_ser::<String>(&key);
         let value_buf = bcs::to_bytes::<String>(&value).unwrap();
         raw_key_bytes1 += k_buf.len();
         raw_value_bytes1 += value_buf.len();
@@ -97,7 +97,7 @@ async fn macro_test() {
     for i in kv_range.clone() {
         let key = i;
         let value = i.to_string();
-        let k_buf = be_fix_int_ser(key.borrow()).unwrap();
+        let k_buf = be_fix_int_ser(key.borrow());
         let value_buf = bcs::to_bytes::<String>(&value).unwrap();
         raw_key_bytes2 += k_buf.len();
         raw_value_bytes2 += value_buf.len();


### PR DESCRIPTION
## Description 

PR enables iterator methods for in_memory_db and tidehunter

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
