### PR TITLE
[formatter] Bugfix: prettier-extension updated path to fsPath to prevent an infinite loop in Windows

### DIFF
--- a/external-crates/move/tooling/prettier-extension/src/extension.js
+++ b/external-crates/move/tooling/prettier-extension/src/extension.js
@@ -89,8 +89,8 @@ async function findMatchingConfig(documentUri) {
 		};
 	}
 
-	const root = workspaceFolder.uri.path;
-	let lookup = documentUri.path;
+	const root = workspaceFolder.uri.fsPath;
+	let lookup = documentUri.fsPath;
 	let search = {};
 
 	// go back in the directory until the root is found; or until we find the


### PR DESCRIPTION
## Description 

Changed the "path" to "fsPath" to resolve an infinite loop issue, triggered by the "path" prefixing "/" at the start of the string. This behavior is specific to Windows systems.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
