### PR TITLE
[indexer-alt] move checkpoint_input_objects fn into framework out of …

### DIFF
--- a/crates/sui-indexer-alt/src/handlers/coin_balance_buckets.rs
+++ b/crates/sui-indexer-alt/src/handlers/coin_balance_buckets.rs
@@ -24,6 +24,8 @@ use sui_indexer_alt_schema::{
 
 use crate::consistent_pruning::{PruningInfo, PruningLookupTable};
 
+use super::checkpoint_input_objects;
+
 /// This handler is used to track the balance buckets of address-owned coins.
 /// The balance bucket is calculated using log10 of the coin balance.
 /// Whenever a coin object's presence, owner or balance bucket changes,
@@ -58,7 +60,7 @@ impl Processor for CoinBalanceBuckets {
 
     fn process(&self, checkpoint: &Arc<CheckpointData>) -> Result<Vec<Self::Value>> {
         let cp_sequence_number = checkpoint.checkpoint_summary.sequence_number;
-        let checkpoint_input_objects = checkpoint.checkpoint_input_objects();
+        let checkpoint_input_objects = checkpoint_input_objects(checkpoint);
         let latest_live_output_objects: BTreeMap<_, _> = checkpoint
             .latest_live_output_objects()
             .into_iter()

--- a/crates/sui-indexer-alt/src/handlers/mod.rs
+++ b/crates/sui-indexer-alt/src/handlers/mod.rs
@@ -22,3 +22,58 @@ pub(crate) mod tx_balance_changes;
 pub(crate) mod tx_calls;
 pub(crate) mod tx_digests;
 pub(crate) mod tx_kinds;
+
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+};
+
+use sui_indexer_alt_framework::types::{
+    base_types::{ObjectID, SequenceNumber},
+    effects::TransactionEffectsAPI,
+    full_checkpoint_content::CheckpointData,
+    object::Object,
+};
+
+/// Returns the first appearance of all objects that were used as inputs to the transactions in the
+/// checkpoint. These are objects that existed prior to the checkpoint, and excludes objects that
+/// were created or unwrapped within the checkpoint.
+pub(crate) fn checkpoint_input_objects(
+    checkpoint: &Arc<CheckpointData>,
+) -> BTreeMap<ObjectID, &Object> {
+    let mut output_objects_seen = HashSet::new();
+    let mut checkpoint_input_objects = BTreeMap::new();
+    for tx in checkpoint.transactions.iter() {
+        let input_objects_map: BTreeMap<(ObjectID, SequenceNumber), &Object> = tx
+            .input_objects
+            .iter()
+            .map(|obj| ((obj.id(), obj.version()), obj))
+            .collect();
+
+        for change in tx.effects.object_changes() {
+            let id = change.id;
+            // Handle input objects - only track first appearance
+            if let Some(version) = change.input_version {
+                // If the object appears in `checkpoint_object_changes`, it was an input object that
+                // was previously modified or unwrapped. In both cases, we'd ignore this newer
+                // entry
+                if output_objects_seen.contains(&id) || checkpoint_input_objects.contains_key(&id) {
+                    continue;
+                }
+
+                let input_obj = input_objects_map
+                                .get(&(id, version))
+                                .copied()
+                                .unwrap_or_else(|| panic!(
+                                    "Object {id} at version {version} referenced in tx.effects.object_changes() not found in tx.input_objects"
+                                ));
+                checkpoint_input_objects.insert(id, input_obj);
+            }
+        }
+
+        for obj in tx.output_objects.iter() {
+            output_objects_seen.insert(obj.id());
+        }
+    }
+    checkpoint_input_objects
+}

--- a/crates/sui-indexer-alt/src/handlers/obj_info.rs
+++ b/crates/sui-indexer-alt/src/handlers/obj_info.rs
@@ -16,6 +16,8 @@ use sui_indexer_alt_schema::{objects::StoredObjInfo, schema::obj_info};
 
 use crate::consistent_pruning::{PruningInfo, PruningLookupTable};
 
+use super::checkpoint_input_objects;
+
 #[derive(Default)]
 pub(crate) struct ObjInfo {
     pruning_lookup_table: Arc<PruningLookupTable>,
@@ -38,7 +40,7 @@ impl Processor for ObjInfo {
     // TODO: Add tests for this function and the pruner.
     fn process(&self, checkpoint: &Arc<CheckpointData>) -> Result<Vec<Self::Value>> {
         let cp_sequence_number = checkpoint.checkpoint_summary.sequence_number;
-        let checkpoint_input_objects = checkpoint.checkpoint_input_objects();
+        let checkpoint_input_objects = checkpoint_input_objects(checkpoint);
         let latest_live_output_objects = checkpoint
             .latest_live_output_objects()
             .into_iter()
@@ -670,5 +672,46 @@ mod tests {
 
         // Now we can prune checkpoint 2, as well as 3.
         obj_info.prune(2, 4, &mut conn).await.unwrap();
+    }
+
+    /// In our processing logic, we consider objects that appear as input to the checkpoint but not
+    /// in the output as wrapped or deleted. This emits a tombstone row. Meanwhile, the remote store
+    /// containing `CheckpointData` used to include unchanged shared objects in the `input_objects`
+    /// of a `CheckpointTransaction`. Because these read-only shared objects were not modified, they
+    ///were not included in `output_objects`. But that means within our pipeline, these object
+    /// states were incorrectly treated as deleted, and thus every transaction read emitted a
+    /// tombstone row. This test validates that unless an object appears as an input object from
+    /// `tx.effects.object_changes`, we do not consider it within our pipeline.
+    ///
+    /// Use the checkpoint builder to create a shared object. Then, remove this from the checkpoint,
+    /// and replace it with a transaction that takes the shared object as read-only.
+    #[tokio::test]
+    async fn test_process_unchanged_shared_object() {
+        let obj_info = ObjInfo::default();
+        let mut builder = TestCheckpointDataBuilder::new(0)
+            .start_transaction(0)
+            .create_shared_object(0)
+            .finish_transaction();
+
+        // Get the shared object from the transaction's output_objects
+        let shared_obj = builder
+            .transactions_mut()
+            .pop() // Remove and get the transaction
+            .unwrap()
+            .output_objects
+            .into_iter()
+            .find(|obj| obj.id() == TestCheckpointDataBuilder::derive_object_id(0))
+            .unwrap();
+
+        // Create a new transaction that will "read" the shared object. This emulates a shared
+        // object appearing as an input object, but missing from `tx.effects`.
+        let mut builder = builder.start_transaction(0).finish_transaction();
+        if let Some(tx) = builder.transactions_mut().last_mut() {
+            tx.input_objects.push(shared_obj);
+        }
+
+        let checkpoint = builder.build_checkpoint();
+        let result = obj_info.process(&Arc::new(checkpoint)).unwrap();
+        assert_eq!(result.len(), 0);
     }
 }

--- a/crates/sui-indexer-alt/src/handlers/obj_info_temp.rs
+++ b/crates/sui-indexer-alt/src/handlers/obj_info_temp.rs
@@ -16,6 +16,8 @@ use sui_indexer_alt_schema::{objects::StoredObjInfoTemp, schema::obj_info_temp};
 
 use crate::consistent_pruning::{PruningInfo, PruningLookupTable};
 
+use super::checkpoint_input_objects;
+
 #[derive(Default)]
 pub(crate) struct ObjInfoTemp {
     pruning_lookup_table: Arc<PruningLookupTable>,
@@ -38,7 +40,8 @@ impl Processor for ObjInfoTemp {
     // TODO: Add tests for this function and the pruner.
     fn process(&self, checkpoint: &Arc<CheckpointData>) -> Result<Vec<Self::Value>> {
         let cp_sequence_number = checkpoint.checkpoint_summary.sequence_number;
-        let checkpoint_input_objects = checkpoint.checkpoint_input_objects();
+        let checkpoint_input_objects: BTreeMap<ObjectID, &Object> =
+            checkpoint_input_objects(checkpoint);
         let latest_live_output_objects = checkpoint
             .latest_live_output_objects()
             .into_iter()

--- a/crates/sui-types/src/full_checkpoint_content.rs
+++ b/crates/sui-types/src/full_checkpoint_content.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 
-use crate::base_types::{ObjectID, ObjectRef};
+use crate::base_types::ObjectRef;
 use crate::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
 use crate::messages_checkpoint::{CertifiedCheckpointSummary, CheckpointContents};
 use crate::object::Object;
@@ -46,26 +46,6 @@ impl CheckpointData {
             }
         }
         eventually_removed_object_refs.into_values().collect()
-    }
-
-    /// Returns all objects that are used as input to the transactions in the checkpoint,
-    /// and already exist prior to the checkpoint.
-    pub fn checkpoint_input_objects(&self) -> BTreeMap<ObjectID, &Object> {
-        let mut output_objects_seen = HashSet::new();
-        let mut checkpoint_input_objects = BTreeMap::new();
-        for tx in self.transactions.iter() {
-            for obj in tx.input_objects.iter() {
-                let id = obj.id();
-                if output_objects_seen.contains(&id) || checkpoint_input_objects.contains_key(&id) {
-                    continue;
-                }
-                checkpoint_input_objects.insert(id, obj);
-            }
-            for obj in tx.output_objects.iter() {
-                output_objects_seen.insert(obj.id());
-            }
-        }
-        checkpoint_input_objects
     }
 
     pub fn all_objects(&self) -> Vec<&Object> {

--- a/crates/sui-types/src/test_checkpoint_data_builder.rs
+++ b/crates/sui-types/src/test_checkpoint_data_builder.rs
@@ -594,6 +594,16 @@ impl TestCheckpointDataBuilder {
     pub fn derive_address(address_idx: u8) -> SuiAddress {
         dbg_addr(address_idx)
     }
+
+    /// Get mutable access to all transactions in the current checkpoint
+    pub fn transactions_mut(&mut self) -> &mut Vec<CheckpointTransaction> {
+        &mut self.checkpoint_builder.transactions
+    }
+
+    /// Get mutable access to a specific transaction by index
+    pub fn transaction_mut(&mut self, idx: usize) -> Option<&mut CheckpointTransaction> {
+        self.checkpoint_builder.transactions.get_mut(idx)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
…sui-types, use object_changes api (#21721)

## Description 

Move checkpoint_input_objects fn into framework out of sui-types. use tx.effects.object_changes() as source of truth.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
