### PR TITLE
[2/2] Remove indexer references to MVR (on the base one)

### DIFF
--- a/crates/sui-indexer/src/config.rs
+++ b/crates/sui-indexer/src/config.rs
@@ -207,11 +207,6 @@ pub enum Command {
         pruning_options: PruningOptions,
         #[command(flatten)]
         upload_options: UploadOptions,
-        /// If true, the indexer will run in MVR mode. It will only index data to
-        /// `objects_snapshot`, `objects_history`, `packages`, `checkpoints`, and `epochs` to
-        /// support MVR queries.
-        #[clap(long, default_value_t = false)]
-        mvr_mode: bool,
     },
     JsonRpcService(JsonRpcConfig),
     ResetDatabase {

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -51,7 +51,6 @@ pub async fn new_handlers(
     cancel: CancellationToken,
     start_checkpoint_opt: Option<CheckpointSequenceNumber>,
     end_checkpoint_opt: Option<CheckpointSequenceNumber>,
-    mvr_mode: bool,
 ) -> Result<(CheckpointHandler, u64), IndexerError> {
     let start_checkpoint = match start_checkpoint_opt {
         Some(start_checkpoint) => start_checkpoint,
@@ -84,7 +83,6 @@ pub async fn new_handlers(
         cancel.clone(),
         start_checkpoint,
         end_checkpoint_opt,
-        mvr_mode
     ));
     Ok((
         CheckpointHandler::new(state, metrics, indexed_checkpoint_sender),

--- a/crates/sui-indexer/src/handlers/committer.rs
+++ b/crates/sui-indexer/src/handlers/committer.rs
@@ -175,21 +175,22 @@ async fn commit_checkpoints<S>(
         .collect::<Vec<StoredRawCheckpoint>>();
 
     {
-        let _step_1_guard = metrics.checkpoint_db_commit_latency_step_1.start_timer();
-        let mut persist_tasks = Vec::new();
-        // In MVR mode, persist only packages and object history
-        persist_tasks.push(state.persist_packages(packages_batch));
-        persist_tasks.push(state.persist_object_history(object_history_changes_batch.clone()));
-        persist_tasks.push(state.persist_transactions(tx_batch));
-        persist_tasks.push(state.persist_tx_indices(tx_indices_batch));
-        persist_tasks.push(state.persist_events(events_batch));
-        persist_tasks.push(state.persist_event_indices(event_indices_batch));
-        persist_tasks.push(state.persist_displays(display_updates_batch));
-        persist_tasks.push(state.persist_objects(object_changes_batch.clone()));
-        persist_tasks
-            .push(state.persist_full_objects_history(object_history_changes_batch.clone()));
-        persist_tasks.push(state.persist_objects_version(object_versions_batch.clone()));
-        persist_tasks.push(state.persist_raw_checkpoints(raw_checkpoints_batch));
+        let _step_1_guard: prometheus::HistogramTimer =
+            metrics.checkpoint_db_commit_latency_step_1.start_timer();
+
+        let mut persist_tasks = vec![
+            state.persist_packages(packages_batch),
+            state.persist_object_history(object_history_changes_batch.clone()),
+            state.persist_transactions(tx_batch),
+            state.persist_tx_indices(tx_indices_batch),
+            state.persist_events(events_batch),
+            state.persist_event_indices(event_indices_batch),
+            state.persist_displays(display_updates_batch),
+            state.persist_objects(object_changes_batch.clone()),
+            state.persist_full_objects_history(object_history_changes_batch.clone()),
+            state.persist_objects_version(object_versions_batch.clone()),
+            state.persist_raw_checkpoints(raw_checkpoints_batch),
+        ];
 
         if let Some(epoch_data) = epoch.clone() {
             persist_tasks.push(state.persist_epoch(epoch_data));

--- a/crates/sui-indexer/src/handlers/committer.rs
+++ b/crates/sui-indexer/src/handlers/committer.rs
@@ -25,7 +25,6 @@ pub async fn start_tx_checkpoint_commit_task<S>(
     cancel: CancellationToken,
     mut next_checkpoint_sequence_number: CheckpointSequenceNumber,
     end_checkpoint_opt: Option<CheckpointSequenceNumber>,
-    mvr_mode: bool,
 ) -> IndexerResult<()>
 where
     S: IndexerStore + Clone + Sync + Send + 'static,
@@ -62,7 +61,7 @@ where
             // The batch will consist of contiguous checkpoints and at most one epoch boundary at
             // the end.
             if batch.len() == checkpoint_commit_batch_size || epoch.is_some() {
-                commit_checkpoints(&state, batch, epoch, &metrics, mvr_mode).await;
+                commit_checkpoints(&state, batch, epoch, &metrics).await;
                 batch = vec![];
             }
             if let Some(epoch_number) = epoch_number_option {
@@ -82,7 +81,7 @@ where
             }
         }
         if !batch.is_empty() {
-            commit_checkpoints(&state, batch, None, &metrics, mvr_mode).await;
+            commit_checkpoints(&state, batch, None, &metrics).await;
             batch = vec![];
         }
 
@@ -110,7 +109,6 @@ async fn commit_checkpoints<S>(
     indexed_checkpoint_batch: Vec<CheckpointDataToCommit>,
     epoch: Option<EpochToCommit>,
     metrics: &IndexerMetrics,
-    mvr_mode: bool,
 ) where
     S: IndexerStore + Clone + Sync + Send + 'static,
 {
@@ -139,16 +137,14 @@ async fn commit_checkpoints<S>(
             packages,
             epoch: _,
         } = indexed_checkpoint;
-        // In MVR mode, persist only object_history, packages, checkpoints, and epochs
-        if !mvr_mode {
-            tx_batch.push(transactions);
-            events_batch.push(events);
-            tx_indices_batch.push(tx_indices);
-            event_indices_batch.push(event_indices);
-            display_updates_batch.extend(display_updates.into_iter());
-            object_changes_batch.push(object_changes);
-            object_versions_batch.push(object_versions);
-        }
+
+        tx_batch.push(transactions);
+        events_batch.push(events);
+        tx_indices_batch.push(tx_indices);
+        event_indices_batch.push(event_indices);
+        display_updates_batch.extend(display_updates.into_iter());
+        object_changes_batch.push(object_changes);
+        object_versions_batch.push(object_versions);
         object_history_changes_batch.push(object_history_changes);
         checkpoint_batch.push(checkpoint);
         packages_batch.push(packages);
@@ -184,18 +180,16 @@ async fn commit_checkpoints<S>(
         // In MVR mode, persist only packages and object history
         persist_tasks.push(state.persist_packages(packages_batch));
         persist_tasks.push(state.persist_object_history(object_history_changes_batch.clone()));
-        if !mvr_mode {
-            persist_tasks.push(state.persist_transactions(tx_batch));
-            persist_tasks.push(state.persist_tx_indices(tx_indices_batch));
-            persist_tasks.push(state.persist_events(events_batch));
-            persist_tasks.push(state.persist_event_indices(event_indices_batch));
-            persist_tasks.push(state.persist_displays(display_updates_batch));
-            persist_tasks.push(state.persist_objects(object_changes_batch.clone()));
-            persist_tasks
-                .push(state.persist_full_objects_history(object_history_changes_batch.clone()));
-            persist_tasks.push(state.persist_objects_version(object_versions_batch.clone()));
-            persist_tasks.push(state.persist_raw_checkpoints(raw_checkpoints_batch));
-        }
+        persist_tasks.push(state.persist_transactions(tx_batch));
+        persist_tasks.push(state.persist_tx_indices(tx_indices_batch));
+        persist_tasks.push(state.persist_events(events_batch));
+        persist_tasks.push(state.persist_event_indices(event_indices_batch));
+        persist_tasks.push(state.persist_displays(display_updates_batch));
+        persist_tasks.push(state.persist_objects(object_changes_batch.clone()));
+        persist_tasks
+            .push(state.persist_full_objects_history(object_history_changes_batch.clone()));
+        persist_tasks.push(state.persist_objects_version(object_versions_batch.clone()));
+        persist_tasks.push(state.persist_raw_checkpoints(raw_checkpoints_batch));
 
         if let Some(epoch_data) = epoch.clone() {
             persist_tasks.push(state.persist_epoch(epoch_data));

--- a/crates/sui-indexer/tests/ingestion_tests.rs
+++ b/crates/sui-indexer/tests/ingestion_tests.rs
@@ -1,9 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use std::sync::Arc;
-use std::time::Duration;
 
-use diesel::dsl::count_star;
 use diesel::ExpressionMethods;
 use diesel::QueryDsl;
 use diesel_async::RunQueryDsl;
@@ -14,10 +12,6 @@ use sui_indexer::models::{
     checkpoints::StoredCheckpoint, objects::StoredObject, objects::StoredObjectSnapshot,
     transactions::StoredTransaction,
 };
-use sui_indexer::schema::epochs;
-use sui_indexer::schema::events;
-use sui_indexer::schema::full_objects_history;
-use sui_indexer::schema::objects_history;
 use sui_indexer::schema::{checkpoints, objects, objects_snapshot, transactions};
 use sui_indexer::store::indexer_store::IndexerStore;
 use sui_indexer::test_utils::{

--- a/crates/sui-indexer/tests/ingestion_tests.rs
+++ b/crates/sui-indexer/tests/ingestion_tests.rs
@@ -20,7 +20,6 @@ use sui_indexer::schema::full_objects_history;
 use sui_indexer::schema::objects_history;
 use sui_indexer::schema::{checkpoints, objects, objects_snapshot, transactions};
 use sui_indexer::store::indexer_store::IndexerStore;
-use sui_indexer::test_utils::set_up_on_mvr_mode;
 use sui_indexer::test_utils::{
     set_up, set_up_with_start_and_end_checkpoints, wait_for_checkpoint, wait_for_objects_snapshot,
 };
@@ -344,102 +343,5 @@ pub async fn test_epoch_boundary() -> Result<(), IndexerError> {
         .expect("Failed reading checkpoint from PostgresDB");
     assert_eq!(db_checkpoint.sequence_number, 3);
     assert_eq!(db_checkpoint.epoch, 1);
-    Ok(())
-}
-
-#[tokio::test]
-pub async fn test_mvr_mode() -> Result<(), IndexerError> {
-    let tempdir = tempdir().unwrap();
-    let mut sim = Simulacrum::new();
-    let data_ingestion_path = tempdir.path().to_path_buf();
-    sim.set_data_ingestion_path(data_ingestion_path.clone());
-
-    // Create 3 checkpoints and epochs of sequence number 0 through 2 inclusive
-    for _ in 0..=2 {
-        let transfer_recipient = SuiAddress::random_for_testing_only();
-        let (transaction, _) = sim.transfer_txn(transfer_recipient);
-        let (_, err) = sim.execute_transaction(transaction.clone()).unwrap();
-        assert!(err.is_none());
-
-        // creates checkpoint and advances epoch
-        sim.advance_epoch(true);
-    }
-
-    sim.create_checkpoint(); // advance to checkpoint 4 to stabilize indexer
-
-    let (_, pg_store, _, _database) =
-        set_up_on_mvr_mode(Arc::new(sim), data_ingestion_path, true).await;
-    wait_for_checkpoint(&pg_store, 4).await?;
-    let mut connection = pg_store.pool().dedicated_connection().await.unwrap();
-    let db_checkpoint: StoredCheckpoint = checkpoints::table
-        .order(checkpoints::sequence_number.desc())
-        .first::<StoredCheckpoint>(&mut connection)
-        .await
-        .expect("Failed reading checkpoint from PostgresDB");
-    let db_epoch = epochs::table
-        .order(epochs::epoch.desc())
-        .select(epochs::epoch)
-        .first::<i64>(&mut connection)
-        .await
-        .expect("Failed reading epoch from PostgresDB");
-
-    assert_eq!(db_checkpoint.sequence_number, 4);
-    assert_eq!(db_checkpoint.epoch, db_epoch);
-
-    // Check that other tables have not been written to
-    assert_eq!(
-        0_i64,
-        transactions::table
-            .select(count_star())
-            .first::<i64>(&mut connection)
-            .await
-            .expect("Failed to count * transactions")
-    );
-    assert_eq!(
-        0_i64,
-        events::table
-            .select(count_star())
-            .first::<i64>(&mut connection)
-            .await
-            .expect("Failed to count * transactions")
-    );
-    assert_eq!(
-        0_i64,
-        full_objects_history::table
-            .select(count_star())
-            .first::<i64>(&mut connection)
-            .await
-            .expect("Failed to count * transactions")
-    );
-
-    // Check that objects_history is being correctly pruned. At epoch 3, we should only have data
-    // between 2 and 3 inclusive.
-    loop {
-        let history_objects = objects_history::table
-            .select(objects_history::checkpoint_sequence_number)
-            .load::<i64>(&mut connection)
-            .await?;
-
-        let has_invalid_entries = history_objects.iter().any(|&elem| elem < 2);
-
-        if !has_invalid_entries {
-            // No more invalid entries found, exit the loop
-            break;
-        }
-
-        tokio::time::sleep(Duration::from_secs(1)).await;
-    }
-
-    // After the loop, verify all entries are within expected range
-    let final_check = objects_history::table
-        .select(objects_history::checkpoint_sequence_number)
-        .order_by(objects_history::checkpoint_sequence_number.asc())
-        .load::<i64>(&mut connection)
-        .await?;
-
-    for elem in final_check {
-        assert!(elem >= 2);
-    }
-
     Ok(())
 }


### PR DESCRIPTION
## Description 

Similar as #21732 , removes code variants that were used to test the core indexer behaviour with mvr variant.

## Test plan 

Hopefully CI passes 🤞 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
