### PR TITLE
fix dynamic example error

### DIFF
--- a/docs/content/concepts/graphql-rpc.mdx
+++ b/docs/content/concepts/graphql-rpc.mdx
@@ -124,8 +124,8 @@ query DynamicField {
   ) {
     dynamicField(
       name: {
-        type: "0x2::kiosk::Listing",
-        bcs: "NLArx1UJguOUYmXgNG8Pv8KbKXLjWtCi6i0Yeq1VhfwA",
+        type: "0x2::kiosk::Lock",
+        bcs: "NLArx1UJguOUYmXgNG8Pv8KbKXLjWtCi6i0Yeq1Vhfw=",
       }
     ) {
       ...DynamicFieldSelect

--- a/docs/content/guides/developer/getting-started/graphql-rpc.mdx
+++ b/docs/content/guides/developer/getting-started/graphql-rpc.mdx
@@ -208,8 +208,8 @@ query DynamicField {
   ) {
     dynamicField(
       name: {
-        type: "0x2::kiosk::Listing",
-        bcs: "NLArx1UJguOUYmXgNG8Pv8KbKXLjWtCi6i0Yeq1VhfwA",
+        type: "0x2::kiosk::Lock",
+        bcs: "NLArx1UJguOUYmXgNG8Pv8KbKXLjWtCi6i0Yeq1Vhfw=",
       }
     ) {
       ...DynamicFieldSelect


### PR DESCRIPTION
## Description 

I modified the type in `dynamicField` and the values in `bcs`, which allows the query to retrieve the values.
The issue appeared in the sections from these two links: [GraphQL Fragments](https://docs.sui.io/concepts/graphql-rpc#fragments) and [Fetching a Dynamic Field on an Object](https://docs.sui.io/guides/developer/getting-started/graphql-rpc#fetching-a-dynamic-field-on-an-object).
