### PR TITLE
Adding a dockerfile for sui-analytics-indexer

### DIFF
--- a/docker/sui-analytics-indexer/Dockerfile
+++ b/docker/sui-analytics-indexer/Dockerfile
@@ -1,0 +1,19 @@
+FROM rust:1.85-bullseye as build
+
+ARG PROFILE=release
+WORKDIR /work
+
+RUN apt-get update && apt-get install -y cmake clang
+
+COPY .git/ .git/
+COPY Cargo.toml Cargo.lock ./
+COPY consensus consensus
+COPY crates crates
+COPY sui-execution sui-execution
+COPY external-crates external-crates
+
+RUN cargo build --profile ${PROFILE} --bin sui-analytics-indexer
+
+FROM debian:12-slim as deploy
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
+COPY --from=build --chmod=755 /work/target/release/sui-analytics-indexer /opt/sui/bin/sui-analytics-indexer


### PR DESCRIPTION
## Description

Adding a Dockerfile to enable running sui-analytics-indexer in Kubernetes.

## Test plan

I have a branch of sui-operations where I am working on a Pulumi stack where I have tested this.
