### PR TITLE
[move] Move bump toml edit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7705,7 +7705,7 @@ dependencies = [
  "serde_yaml 0.8.26",
  "similar",
  "tempfile",
- "toml_edit 0.14.4",
+ "toml_edit 0.22.24",
  "walkdir",
 ]
 
@@ -7982,7 +7982,7 @@ dependencies = [
  "sha2 0.9.9",
  "tempfile",
  "toml 0.5.11",
- "toml_edit 0.14.4",
+ "toml_edit 0.22.24",
  "treeline",
  "vfs",
  "walkdir",
@@ -7998,7 +7998,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml 0.5.11",
- "toml_edit 0.14.4",
+ "toml_edit 0.22.24",
 ]
 
 [[package]]
@@ -10072,7 +10072,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.22.22",
+ "toml_edit 0.22.24",
 ]
 
 [[package]]
@@ -16850,7 +16850,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.8",
- "toml_edit 0.22.22",
+ "toml_edit 0.22.24",
 ]
 
 [[package]]
@@ -16865,18 +16865,6 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
-dependencies = [
- "combine",
- "indexmap 1.9.3",
- "itertools 0.10.5",
  "serde",
 ]
 
@@ -16907,15 +16895,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap 2.8.0",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.8",
- "winnow 0.6.20",
+ "winnow 0.7.3",
 ]
 
 [[package]]
@@ -18371,15 +18359,6 @@ name = "winnow"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -610,16 +610,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
-
-[[package]]
 name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2025,7 +2015,7 @@ dependencies = [
  "serde_yaml",
  "similar",
  "tempfile",
- "toml_edit 0.14.4",
+ "toml_edit 0.22.24",
  "walkdir",
 ]
 
@@ -2354,7 +2344,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "toml",
- "toml_edit 0.14.4",
+ "toml_edit 0.22.24",
  "treeline",
  "vfs",
  "walkdir",
@@ -2370,7 +2360,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml",
- "toml_edit 0.14.4",
+ "toml_edit 0.22.24",
 ]
 
 [[package]]
@@ -3660,6 +3650,9 @@ name = "serde_spanned"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde_with"
@@ -4119,16 +4112,7 @@ name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
-
-[[package]]
-name = "toml_edit"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
 dependencies = [
- "combine",
- "indexmap 1.9.3",
- "itertools 0.10.5",
  "serde",
 ]
 
@@ -4140,7 +4124,20 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.8.0",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+dependencies = [
+ "indexmap 2.8.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.7.4",
 ]
 
 [[package]]
@@ -4657,6 +4654,15 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
 ]

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -105,7 +105,7 @@ serde-name = "0.1.1"
 serde-reflection = "0.5"
 serde_bytes = "0.11.5"
 serde_json = "1.0.64"
-serde_spanned = "0.6.8"
+serde_spanned = { version = "0.6.8", features = ["serde"] }
 serde_yaml = "0.8.26"
 serde_with = "3.9.0"
 sha2 = "0.9.3"
@@ -123,7 +123,7 @@ thiserror = "1.0.24"
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 tokio = { version = "1.18.2", features = ["full"] }
 toml = "0.5.8"
-toml_edit =  { version = "0.14.3", features = ["easy"] }
+toml_edit =  { version = "0.22.24", features = ["serde", "default"] }
 tracing = "0.1.26"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 treeline = "0.1.0"

--- a/external-crates/move/crates/move-package-alt/src/package/lockfile.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/lockfile.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use serde_spanned::Spanned;
 use toml_edit::{
     visit_mut::{visit_table_like_kv_mut, visit_table_mut, VisitMut},
-    Document, InlineTable, Item, KeyMut, Table, Value,
+    DocumentMut, InlineTable, Item, KeyMut, Table, Value,
 };
 
 use crate::{
@@ -175,7 +175,7 @@ impl<F: MoveFlavor> Publication<F> {
 
 /// Replace every inline table in [toml] with an implicit standard table (implicit tables are not
 /// included if they have no keys directly inside them)
-fn expand_toml(toml: &mut Document) {
+fn expand_toml(toml: &mut DocumentMut) {
     struct Expander;
 
     impl VisitMut for Expander {

--- a/external-crates/move/crates/move-package/src/compilation/build_plan.rs
+++ b/external-crates/move/crates/move-package/src/compilation/build_plan.rs
@@ -25,7 +25,7 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
 };
-use toml_edit::{value, Document};
+use toml_edit::{value, DocumentMut};
 use vfs::VfsPath;
 
 use super::{
@@ -292,7 +292,7 @@ impl<'a> BuildPlan<'a> {
     pub fn record_package_edition(&self, edition: Edition) -> anyhow::Result<()> {
         let move_toml_path = resolve_move_manifest_path(&self.root_package_path());
         let mut toml = std::fs::read_to_string(move_toml_path.clone())?
-            .parse::<Document>()
+            .parse::<DocumentMut>()
             .expect("Failed to read TOML file to update edition");
         toml[PACKAGE_NAME][EDITION_NAME] = value(edition.to_string());
         std::fs::write(move_toml_path, toml.to_string())?;

--- a/external-crates/move/crates/move-package/src/lock_file/schema.rs
+++ b/external-crates/move/crates/move-package/src/lock_file/schema.rs
@@ -249,7 +249,7 @@ pub fn update_dependency_graph(
     use toml_edit::value;
     let mut toml_string = String::new();
     file.read_to_string(&mut toml_string)?;
-    let mut toml = toml_string.parse::<toml_edit::Document>()?;
+    let mut toml = toml_string.parse::<toml_edit::DocumentMut>()?;
     let move_table = toml
         .entry("move")
         .or_insert(Item::Table(toml_edit::Table::new()))
@@ -297,7 +297,7 @@ pub fn update_compiler_toolchain(
 ) -> Result<()> {
     let mut toml_string = String::new();
     file.read_to_string(&mut toml_string)?;
-    let mut toml = toml_string.parse::<toml_edit::Document>()?;
+    let mut toml = toml_string.parse::<toml_edit::DocumentMut>()?;
     let move_table = toml["move"].as_table_mut().ok_or(std::fmt::Error)?;
     let toolchain_version = toml::Value::try_from(ToolchainVersion {
         compiler_version,
@@ -355,10 +355,10 @@ pub enum ManagedAddressUpdate {
 /// for preparing package publishing and package upgrades. Invariant: callers maintain a valid
 /// hex `id`.
 pub fn set_original_id(file: &mut LockFile, environment: &str, id: &str) -> Result<()> {
-    use toml_edit::{value, Document};
+    use toml_edit::{value, DocumentMut};
     let mut toml_string = String::new();
     file.read_to_string(&mut toml_string)?;
-    let mut toml = toml_string.parse::<Document>()?;
+    let mut toml = toml_string.parse::<DocumentMut>()?;
     let env_table = toml
         .get_mut(ENV_TABLE_NAME)
         .and_then(|item| item.as_table_mut())
@@ -382,11 +382,11 @@ pub fn update_managed_address(
     environment: &str,
     managed_address_update: ManagedAddressUpdate,
 ) -> Result<()> {
-    use toml_edit::{value, Document, Table};
+    use toml_edit::{value, DocumentMut, Table};
 
     let mut toml_string = String::new();
     file.read_to_string(&mut toml_string)?;
-    let mut toml = toml_string.parse::<Document>()?;
+    let mut toml = toml_string.parse::<DocumentMut>()?;
 
     let env_table = toml
         .entry(ENV_TABLE_NAME)

--- a/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
@@ -1306,7 +1306,7 @@ impl DependencyGraph {
         let mut dev_dependencies = None;
         let mut packages = None;
         if !writer.is_empty() {
-            let toml = writer.parse::<toml_edit::Document>()?;
+            let toml = writer.parse::<toml_edit::DocumentMut>()?;
             if let Some(value) = toml.get("dependencies").and_then(|v| v.as_value()) {
                 dependencies = Some(value.clone());
             }


### PR DESCRIPTION
## Description 

This PR bumps the `toml-edit` version to a newer one which has support for spans and `serde_spanned`. We want to use that in the new move-package-alt, so this PR separates this change from others.

## Test plan 

Existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
