### PR TITLE
[CLI] removed scary external resolver output

### DIFF
--- a/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
@@ -1464,8 +1464,6 @@ impl DependencyGraph {
 
         // Present the stderr from the resolver, whether the process succeeded or not.
         if !output.stderr.is_empty() {
-            let stderr_label = format!("{resolver} stderr:").red();
-            writeln!(progress_output, "{stderr_label}")?;
             progress_output.write_all(&output.stderr)?;
         }
 

--- a/external-crates/move/crates/move-package/tests/test_sources/external/Move@progress.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/external/Move@progress.snap
@@ -2,7 +2,6 @@
 source: crates/move-package/tests/test_runner.rs
 ---
 RESOLVING DEPENDENCIES IN A FROM Root WITH ../resolvers/successful.sh
-../resolvers/successful.sh stderr:
 Successful External Resolver
 PWD:     $ROOT/external-crates/move/crates/move-package/tests/test_sources/external
 Type:    dependencies

--- a/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move@progress.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move@progress.snap
@@ -2,13 +2,11 @@
 source: crates/move-package/tests/test_runner.rs
 ---
 RESOLVING DEPENDENCIES IN A FROM Root WITH ../resolvers/successful.sh
-../resolvers/successful.sh stderr:
 Successful External Resolver
 PWD:     $ROOT/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep
 Type:    dependencies
 Package: A
 RESOLVING DEV-DEPENDENCIES IN B FROM Root WITH ../resolvers/successful.sh
-../resolvers/successful.sh stderr:
 Successful External Resolver
 PWD:     $ROOT/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep
 Type:    dev-dependencies

--- a/external-crates/move/crates/move-package/tests/test_sources/external_failing/Move@progress.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_failing/Move@progress.snap
@@ -2,5 +2,4 @@
 source: crates/move-package/tests/test_runner.rs
 ---
 RESOLVING DEPENDENCIES IN A FROM Root WITH ../resolvers/failing.sh
-../resolvers/failing.sh stderr:
 Failed to resolve dependencies for A

--- a/external-crates/move/crates/move-package/tests/test_sources/external_package_batch_response/Move@progress.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_package_batch_response/Move@progress.snap
@@ -2,7 +2,6 @@
 source: crates/move-package/tests/test_runner.rs
 ---
 RESOLVING DEPENDENCIES IN Anything FROM Root WITH ../resolvers/successful_package_batch_response.sh
-../resolvers/successful_package_batch_response.sh stderr:
 Successful External Resolver
 PWD:     $ROOT/external-crates/move/crates/move-package/tests/test_sources/external_package_batch_response
 Type:    dependencies


### PR DESCRIPTION
## Description 

Currently if an external resolver outputs anything it is marked as an error; this PR removes that line. The output from the resolver is still printed, and if the resolver exits with an error code, that is still reported as an error.

## Test plan 

No additional tests; change is trivial.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: remove spurious error message for external resolvers
- [ ] Rust SDK:
