### PR TITLE
bin-version: remove trailing '-' when GIT_REVISION is empty

### DIFF
--- a/crates/bin-version/src/lib.rs
+++ b/crates/bin-version/src/lib.rs
@@ -23,8 +23,13 @@ macro_rules! bin_version {
     () => {
         $crate::git_revision!();
 
-        const VERSION: &str =
-            $crate::_hidden::concat!(env!("CARGO_PKG_VERSION"), "-", GIT_REVISION);
+        const VERSION: &str = {
+            if GIT_REVISION.is_empty() {
+                env!("CARGO_PKG_VERSION")
+            } else {
+                $crate::_hidden::concat!(env!("CARGO_PKG_VERSION"), "-", GIT_REVISION)
+            }
+        };
     };
 }
 

--- a/crates/sui-core/src/runtime.rs
+++ b/crates/sui-core/src/runtime.rs
@@ -1,16 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
-use std::str::FromStr;
 use sui_config::NodeConfig;
-use tap::TapFallible;
 use tokio::runtime::Runtime;
-use tracing::warn;
 
 pub struct SuiRuntimes {
     // Order in this struct is the order in which runtimes are stopped
-    pub json_rpc: Runtime,
     pub sui_node: Runtime,
     pub metrics: Runtime,
 }
@@ -29,25 +24,6 @@ impl SuiRuntimes {
             .build()
             .unwrap();
 
-        let worker_thread = env::var("RPC_WORKER_THREAD")
-            .ok()
-            .and_then(|o| {
-                usize::from_str(&o)
-                    .tap_err(|e| warn!("Cannot parse RPC_WORKER_THREAD to usize: {e}"))
-                    .ok()
-            })
-            .unwrap_or(num_cpus::get() / 2);
-
-        let json_rpc = tokio::runtime::Builder::new_multi_thread()
-            .thread_name("jsonrpc-runtime")
-            .worker_threads(worker_thread)
-            .enable_all()
-            .build()
-            .unwrap();
-        Self {
-            sui_node,
-            metrics,
-            json_rpc,
-        }
+        Self { sui_node, metrics }
     }
 }

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -179,7 +179,7 @@ pub async fn serve_executor(
     info!("Starting executor server on {}", executor_server_url);
 
     let executor_server_handle = tokio::spawn(async move {
-        sui_rpc_api::RpcService::new_without_version(executor)
+        sui_rpc_api::RpcService::new(executor)
             .start_service(executor_server_url)
             .await;
     });

--- a/crates/sui-indexer/src/test_utils.rs
+++ b/crates/sui-indexer/src/test_utils.rs
@@ -244,7 +244,7 @@ pub async fn set_up(
         .unwrap();
 
     let server_handle = tokio::spawn(async move {
-        sui_rpc_api::RpcService::new_without_version(sim)
+        sui_rpc_api::RpcService::new(sim)
             .start_service(server_url)
             .await;
     });
@@ -278,7 +278,7 @@ pub async fn set_up_with_start_and_end_checkpoints(
         .parse()
         .unwrap();
     let server_handle = tokio::spawn(async move {
-        sui_rpc_api::RpcService::new_without_version(sim)
+        sui_rpc_api::RpcService::new(sim)
             .start_service(server_url)
             .await;
     });

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -56,7 +56,6 @@ use sui_types::messages_consensus::ConsensusTransactionKind;
 use sui_types::sui_system_state::SuiSystemState;
 use sui_types::transaction::VerifiedCertificate;
 use tap::tap::TapFallible;
-use tokio::runtime::Handle;
 use tokio::sync::oneshot;
 use tokio::sync::{broadcast, mpsc, watch, Mutex};
 use tokio::task::{JoinHandle, JoinSet};
@@ -300,12 +299,10 @@ impl SuiNode {
     pub async fn start(
         config: NodeConfig,
         registry_service: RegistryService,
-        custom_rpc_runtime: Option<Handle>,
     ) -> Result<Arc<SuiNode>> {
         Self::start_async(
             config,
             registry_service,
-            custom_rpc_runtime,
             ServerVersion::new("sui-node", "unknown"),
         )
         .await
@@ -449,7 +446,6 @@ impl SuiNode {
     pub async fn start_async(
         config: NodeConfig,
         registry_service: RegistryService,
-        custom_rpc_runtime: Option<Handle>,
         server_version: ServerVersion,
     ) -> Result<Arc<SuiNode>> {
         NodeConfigMetrics::new(&registry_service.default_registry()).record_metrics(&config);
@@ -817,7 +813,6 @@ impl SuiNode {
             &transaction_orchestrator.clone(),
             &config,
             &prometheus_registry,
-            custom_rpc_runtime,
             server_version,
         )
         .await?;
@@ -2204,7 +2199,6 @@ async fn build_http_servers(
     transaction_orchestrator: &Option<Arc<TransactiondOrchestrator<NetworkAuthorityClient>>>,
     config: &NodeConfig,
     prometheus_registry: &Registry,
-    _custom_runtime: Option<Handle>,
     server_version: ServerVersion,
 ) -> Result<(
     HttpServers,

--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -112,14 +112,13 @@ fn main() {
     // if it deadlocks.
     let node_once_cell = Arc::new(AsyncOnceCell::<Arc<sui_node::SuiNode>>::new());
     let node_once_cell_clone = node_once_cell.clone();
-    let rpc_runtime = runtimes.json_rpc.handle().clone();
 
     // let sui-node signal main to shutdown runtimes
     let (runtime_shutdown_tx, runtime_shutdown_rx) = broadcast::channel::<()>(1);
 
     let server_version = ServerVersion::new(env!("CARGO_BIN_NAME"), VERSION);
     runtimes.sui_node.spawn(async move {
-        match sui_node::SuiNode::start_async(config, registry_service, Some(rpc_runtime), server_version).await {
+        match sui_node::SuiNode::start_async(config, registry_service, server_version).await {
             Ok(sui_node) => node_once_cell_clone
                 .set(sui_node)
                 .expect("Failed to set node in AsyncOnceCell"),

--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -5,6 +5,7 @@ use clap::{ArgGroup, Parser};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
+use sui_rpc_api::ServerVersion;
 use tokio::sync::broadcast;
 use tokio::time::sleep;
 use tracing::{error, info};
@@ -116,8 +117,9 @@ fn main() {
     // let sui-node signal main to shutdown runtimes
     let (runtime_shutdown_tx, runtime_shutdown_rx) = broadcast::channel::<()>(1);
 
+    let server_version = ServerVersion::new(env!("CARGO_BIN_NAME"), VERSION);
     runtimes.sui_node.spawn(async move {
-        match sui_node::SuiNode::start_async(config, registry_service, Some(rpc_runtime), VERSION).await {
+        match sui_node::SuiNode::start_async(config, registry_service, Some(rpc_runtime), server_version).await {
             Ok(sui_node) => node_once_cell_clone
                 .set(sui_node)
                 .expect("Failed to set node in AsyncOnceCell"),

--- a/crates/sui-rosetta/src/main.rs
+++ b/crates/sui-rosetta/src/main.rs
@@ -170,7 +170,7 @@ impl RosettaServerCommand {
                     mysten_metrics::start_prometheus_server(config.metrics_address);
                 // Staring a full node for the rosetta server.
                 let rpc_address = format!("http://127.0.0.1:{}", config.json_rpc_address.port());
-                let _node = SuiNode::start(config, registry_service, None).await?;
+                let _node = SuiNode::start(config, registry_service).await?;
 
                 let sui_client = wait_for_sui_client(rpc_address).await;
 

--- a/crates/sui-rpc-api/src/grpc/v2beta/ledger_service/get_service_info.rs
+++ b/crates/sui-rpc-api/src/grpc/v2beta/ledger_service/get_service_info.rs
@@ -30,7 +30,7 @@ pub fn get_service_info(service: &RpcService) -> Result<GetServiceInfoResponse, 
         timestamp: Some(timestamp_ms_to_proto(latest_checkpoint.timestamp_ms)),
         lowest_available_checkpoint,
         lowest_available_checkpoint_objects,
-        server_version: Some(service.software_version().into()),
+        server_version: service.server_version().map(ToString::to_string),
     }
     .pipe(Ok)
 }

--- a/crates/sui-rpc-api/src/lib.rs
+++ b/crates/sui-rpc-api/src/lib.rs
@@ -29,32 +29,53 @@ pub use error::{ErrorDetails, ErrorReason, Result, RpcError};
 pub use metrics::RpcMetrics;
 
 #[derive(Clone)]
+pub struct ServerVersion {
+    pub bin: &'static str,
+    pub version: &'static str,
+}
+
+impl ServerVersion {
+    pub fn new(bin: &'static str, version: &'static str) -> Self {
+        Self { bin, version }
+    }
+}
+
+impl std::fmt::Display for ServerVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.bin)?;
+        f.write_str("/")?;
+        f.write_str(self.version)
+    }
+}
+
+#[derive(Clone)]
 pub struct RpcService {
     reader: StateReader,
     executor: Option<Arc<dyn TransactionExecutor>>,
     subscription_service_handle: Option<SubscriptionServiceHandle>,
     chain_id: sui_types::digests::ChainIdentifier,
-    software_version: &'static str,
+    server_version: Option<ServerVersion>,
     metrics: Option<Arc<RpcMetrics>>,
     config: Config,
 }
 
 impl RpcService {
-    pub fn new(reader: Arc<dyn RpcStateReader>, software_version: &'static str) -> Self {
+    pub fn new(reader: Arc<dyn RpcStateReader>) -> Self {
         let chain_id = reader.get_chain_identifier().unwrap();
         Self {
             reader: StateReader::new(reader),
             executor: None,
             subscription_service_handle: None,
             chain_id,
-            software_version,
+            server_version: None,
             metrics: None,
             config: Config::default(),
         }
     }
 
-    pub fn new_without_version(reader: Arc<dyn RpcStateReader>) -> Self {
-        Self::new(reader, "unknown")
+    pub fn with_server_version(&mut self, server_version: ServerVersion) -> &mut Self {
+        self.server_version = Some(server_version);
+        self
     }
 
     pub fn with_config(&mut self, config: Config) {
@@ -80,8 +101,8 @@ impl RpcService {
         self.chain_id
     }
 
-    pub fn software_version(&self) -> &'static str {
-        self.software_version
+    pub fn server_version(&self) -> Option<&ServerVersion> {
+        self.server_version.as_ref()
     }
 
     pub async fn into_router(self) -> axum::Router {

--- a/crates/sui-rpc-api/src/response.rs
+++ b/crates/sui-rpc-api/src/response.rs
@@ -66,12 +66,12 @@ pub async fn append_info_headers(
         );
     }
 
-    headers.insert(
-        axum::http::header::SERVER,
-        format!("sui-node/{}", state.software_version())
-            .try_into()
-            .expect("server version is a valid HeaderValue"),
-    );
+    if let Some(server_version) = state
+        .server_version()
+        .and_then(|version| version.to_string().try_into().ok())
+    {
+        headers.insert(axum::http::header::SERVER, server_version);
+    }
 
     (headers, response)
 }

--- a/crates/sui-rpc-api/src/service/info.rs
+++ b/crates/sui-rpc-api/src/service/info.rs
@@ -30,7 +30,7 @@ impl RpcService {
             timestamp: Some(timestamp_ms_to_proto(latest_checkpoint.timestamp_ms)),
             lowest_available_checkpoint,
             lowest_available_checkpoint_objects,
-            software_version: Some(self.software_version().into()),
+            software_version: self.server_version().map(ToString::to_string),
         }
         .pipe(Ok)
     }

--- a/crates/sui-swarm/src/memory/container-sim.rs
+++ b/crates/sui-swarm/src/memory/container-sim.rs
@@ -60,9 +60,7 @@ impl Container {
                 let startup_sender = startup_sender.clone();
                 async move {
                     let registry_service = mysten_metrics::RegistryService::new(Registry::new());
-                    let server = SuiNode::start(config, registry_service, None)
-                        .await
-                        .unwrap();
+                    let server = SuiNode::start(config, registry_service).await.unwrap();
 
                     startup_sender.send(Arc::downgrade(&server)).ok();
 

--- a/crates/sui-swarm/src/memory/container.rs
+++ b/crates/sui-swarm/src/memory/container.rs
@@ -98,7 +98,7 @@ impl Container {
                     "Started Prometheus HTTP endpoint. To query metrics use\n\tcurl -s http://{}/metrics",
                     config.metrics_address
                 );
-                let server = SuiNode::start(config, registry_service, None).await.unwrap();
+                let server = SuiNode::start(config, registry_service).await.unwrap();
                 // Notify that we've successfully started the node
                 let _ = startup_sender.send(Arc::downgrade(&server));
                 // run until canceled


### PR DESCRIPTION
## Description 

bin-version: remove trailing '-' when GIT_REVISION is empty

Also do a small cleanup and remove an unused tokio runtime that was being started.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
