### PR TITLE
[consensus] fix processing of fetched blocks

### DIFF
--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -133,6 +133,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) synchronizer_current_missing_blocks_by_authority: IntGaugeVec,
     pub(crate) synchronizer_fetched_blocks_by_authority: IntCounterVec,
     pub(crate) synchronizer_fetch_failures: IntCounterVec,
+    pub(crate) synchronizer_process_fetched_failures: IntCounterVec,
     pub(crate) network_received_excluded_ancestors_from_authority: IntCounterVec,
     pub(crate) network_excluded_ancestors_sent_to_fetch: IntCounterVec,
     pub(crate) network_excluded_ancestors_count_by_authority: IntCounterVec,
@@ -414,6 +415,12 @@ impl NodeMetrics {
             synchronizer_fetch_failures: register_int_counter_vec_with_registry!(
                 "synchronizer_fetch_failures",
                 "Number of fetch failures against each peer",
+                &["peer", "type"],
+                registry,
+            ).unwrap(),
+            synchronizer_process_fetched_failures: register_int_counter_vec_with_registry!(
+                "synchronizer_process_fetched_failures",
+                "Number of failures for processing fetched blocks against each peer",
                 &["peer", "type"],
                 registry,
             ).unwrap(),


### PR DESCRIPTION
## Description 

Remove a few validation checks for fetched blocks which are incompatible with the new synchronization batching logic.

Reduce SYNCHRONIZER_TIMEOUT / PERIODIC_FETCH_INTERVAL: reduce the lag of periodic background fetching.
Reduce MAX_RETRIES: it is unnecessary to retry failures during "live" block sync too hard, since the blocks can arrive on its own or via periodic fetch.

## Test plan 

Deployed to Mysten-3 on testnet.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
