### PR TITLE
indexer-alt: Clean-ups from #21721

### DIFF
--- a/crates/sui-indexer-alt/src/handlers/coin_balance_buckets.rs
+++ b/crates/sui-indexer-alt/src/handlers/coin_balance_buckets.rs
@@ -60,7 +60,7 @@ impl Processor for CoinBalanceBuckets {
 
     fn process(&self, checkpoint: &Arc<CheckpointData>) -> Result<Vec<Self::Value>> {
         let cp_sequence_number = checkpoint.checkpoint_summary.sequence_number;
-        let checkpoint_input_objects = checkpoint_input_objects(checkpoint);
+        let checkpoint_input_objects = checkpoint_input_objects(checkpoint)?;
         let latest_live_output_objects: BTreeMap<_, _> = checkpoint
             .latest_live_output_objects()
             .into_iter()

--- a/crates/sui-indexer-alt/src/handlers/mod.rs
+++ b/crates/sui-indexer-alt/src/handlers/mod.rs
@@ -1,10 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::{btree_map::Entry, BTreeMap, HashSet},
-    sync::Arc,
-};
+use std::collections::{btree_map::Entry, BTreeMap, HashSet};
 
 use anyhow::Context;
 use sui_indexer_alt_framework::types::{
@@ -41,7 +38,7 @@ pub(crate) mod tx_kinds;
 /// checkpoint. These are objects that existed prior to the checkpoint, and excludes objects that
 /// were created or unwrapped within the checkpoint.
 pub(crate) fn checkpoint_input_objects(
-    checkpoint: &Arc<CheckpointData>,
+    checkpoint: &CheckpointData,
 ) -> anyhow::Result<BTreeMap<ObjectID, &Object>> {
     let mut output_objects_seen = HashSet::new();
     let mut checkpoint_input_objects = BTreeMap::new();
@@ -88,4 +85,181 @@ pub(crate) fn checkpoint_input_objects(
     }
 
     Ok(checkpoint_input_objects)
+}
+
+#[cfg(test)]
+mod tests {
+    use sui_indexer_alt_framework::types::{
+        object::Owner, test_checkpoint_data_builder::TestCheckpointDataBuilder,
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_checkpoint_input_objects_simple() {
+        const OWNED_MODIFIED: u64 = 0;
+        const OWNED_CREATED: u64 = 1;
+        const OWNED_WRAP: u64 = 2;
+        const OWNED_UNWRAP: u64 = 3;
+        const OWNED_DELETE: u64 = 4;
+        const FROZEN_READ: u64 = 5;
+        const SHARED_MODIFIED: u64 = 6;
+        const SHARED_READ: u64 = 7;
+
+        let mut builder = TestCheckpointDataBuilder::new(0);
+
+        // Set-up state in an initial checkpoint.
+        builder = builder
+            .start_transaction(0)
+            .create_owned_object(OWNED_MODIFIED)
+            .create_owned_object(OWNED_WRAP)
+            .create_owned_object(OWNED_UNWRAP)
+            .create_owned_object(OWNED_DELETE)
+            .create_owned_object(FROZEN_READ)
+            .create_shared_object(SHARED_MODIFIED)
+            .create_shared_object(SHARED_READ)
+            .finish_transaction()
+            .start_transaction(0)
+            .change_object_owner(FROZEN_READ, Owner::Immutable)
+            .wrap_object(OWNED_UNWRAP)
+            .finish_transaction();
+
+        let setup = builder.build_checkpoint();
+
+        // Operate on the objects in the checkpoint we're going to test.
+        builder = builder
+            .start_transaction(0)
+            .mutate_owned_object(OWNED_MODIFIED)
+            .create_owned_object(OWNED_CREATED)
+            .finish_transaction()
+            .start_transaction(0)
+            .wrap_object(OWNED_WRAP)
+            .unwrap_object(OWNED_UNWRAP)
+            .finish_transaction()
+            .start_transaction(0)
+            .delete_object(OWNED_DELETE)
+            .read_frozen_object(FROZEN_READ)
+            .finish_transaction()
+            .start_transaction(0)
+            .mutate_shared_object(SHARED_MODIFIED)
+            .read_shared_object(SHARED_READ)
+            .finish_transaction();
+
+        let checkpoint = builder.build_checkpoint();
+
+        eprintln!("Checkpoint: {checkpoint:#?}");
+
+        let setup_versions: BTreeMap<_, _> = setup
+            .transactions
+            .iter()
+            .flat_map(|tx| {
+                tx.effects
+                    .object_changes()
+                    .into_iter()
+                    .filter_map(|c| Some((c.id, c.output_version?.value())))
+            })
+            .collect();
+
+        let setup_version = |idx: u64| -> Option<u64> {
+            setup_versions
+                .get(&TestCheckpointDataBuilder::derive_object_id(idx))
+                .copied()
+        };
+
+        let inputs = checkpoint_input_objects(&checkpoint).unwrap();
+        let input_version = |idx: u64| -> Option<u64> {
+            inputs
+                .get(&TestCheckpointDataBuilder::derive_object_id(idx))
+                .map(|obj| obj.version().value())
+        };
+
+        assert_eq!(input_version(OWNED_MODIFIED), setup_version(OWNED_MODIFIED));
+        assert_eq!(input_version(OWNED_CREATED), None);
+        assert_eq!(input_version(OWNED_WRAP), setup_version(OWNED_WRAP));
+        assert_eq!(input_version(OWNED_UNWRAP), None);
+        assert_eq!(input_version(OWNED_DELETE), setup_version(OWNED_DELETE));
+        assert_eq!(
+            input_version(SHARED_MODIFIED),
+            setup_version(SHARED_MODIFIED)
+        );
+
+        // Frozen inputs and read-only shared inputs don't show up in object changes, so they
+        // aren't going to be treated as a checkpoint input object.
+        //
+        // (Frozen inputs only show up in the transaction data and unchanged shared inputs show up
+        // in their own effects field for unchanged shared inputs).
+        assert_eq!(input_version(FROZEN_READ), None);
+        assert_eq!(input_version(SHARED_READ), None);
+    }
+
+    #[test]
+    fn test_checkpoint_input_repeated_modification() {
+        let mut builder = TestCheckpointDataBuilder::new(0);
+
+        // Set-up state in an initial checkpoint.
+        builder = builder
+            .start_transaction(0)
+            .create_owned_object(0)
+            .finish_transaction();
+
+        let setup = builder.build_checkpoint();
+
+        // Modify the same object multiple times in the checkpoint we're going to test.
+        builder = builder
+            .start_transaction(0)
+            .mutate_owned_object(0)
+            .finish_transaction()
+            .start_transaction(0)
+            .mutate_owned_object(0)
+            .finish_transaction()
+            .start_transaction(0)
+            .mutate_owned_object(0)
+            .finish_transaction();
+
+        let checkpoint = builder.build_checkpoint();
+
+        let id = TestCheckpointDataBuilder::derive_object_id(0);
+        let setup_version = setup.transactions[0].output_objects[0].version();
+
+        let inputs = checkpoint_input_objects(&checkpoint).unwrap();
+        let input_version = inputs.get(&id).map(|obj| obj.version());
+        assert_eq!(input_version, Some(setup_version));
+    }
+
+    #[test]
+    fn test_checkpoint_input_objects_wrap_unwrap() {
+        let mut builder = TestCheckpointDataBuilder::new(0);
+
+        // Set-up state in an initial checkpoint.
+        builder = builder
+            .start_transaction(0)
+            .create_owned_object(0)
+            .finish_transaction();
+
+        let setup = builder.build_checkpoint();
+
+        // Repeatedly wrap and unwrap the same object in the checkpoint we're going to test.
+        builder = builder
+            .start_transaction(0)
+            .wrap_object(0)
+            .finish_transaction()
+            .start_transaction(0)
+            .unwrap_object(0)
+            .finish_transaction()
+            .start_transaction(0)
+            .wrap_object(0)
+            .finish_transaction()
+            .start_transaction(0)
+            .unwrap_object(0)
+            .finish_transaction();
+
+        let checkpoint = builder.build_checkpoint();
+
+        let id = TestCheckpointDataBuilder::derive_object_id(0);
+        let setup_version = setup.transactions[0].output_objects[0].version();
+
+        let inputs = checkpoint_input_objects(&checkpoint).unwrap();
+        let input_version = inputs.get(&id).map(|obj| obj.version());
+        assert_eq!(input_version, Some(setup_version));
+    }
 }

--- a/crates/sui-indexer-alt/src/handlers/mod.rs
+++ b/crates/sui-indexer-alt/src/handlers/mod.rs
@@ -1,6 +1,19 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{
+    collections::{btree_map::Entry, BTreeMap, HashSet},
+    sync::Arc,
+};
+
+use anyhow::Context;
+use sui_indexer_alt_framework::types::{
+    base_types::{ObjectID, SequenceNumber},
+    effects::TransactionEffectsAPI,
+    full_checkpoint_content::CheckpointData,
+    object::Object,
+};
+
 pub(crate) mod coin_balance_buckets;
 pub(crate) mod cp_sequence_numbers;
 pub(crate) mod ev_emit_mod;
@@ -24,24 +37,12 @@ pub(crate) mod tx_calls;
 pub(crate) mod tx_digests;
 pub(crate) mod tx_kinds;
 
-use std::{
-    collections::{BTreeMap, HashSet},
-    sync::Arc,
-};
-
-use sui_indexer_alt_framework::types::{
-    base_types::{ObjectID, SequenceNumber},
-    effects::TransactionEffectsAPI,
-    full_checkpoint_content::CheckpointData,
-    object::Object,
-};
-
 /// Returns the first appearance of all objects that were used as inputs to the transactions in the
 /// checkpoint. These are objects that existed prior to the checkpoint, and excludes objects that
 /// were created or unwrapped within the checkpoint.
 pub(crate) fn checkpoint_input_objects(
     checkpoint: &Arc<CheckpointData>,
-) -> BTreeMap<ObjectID, &Object> {
+) -> anyhow::Result<BTreeMap<ObjectID, &Object>> {
     let mut output_objects_seen = HashSet::new();
     let mut checkpoint_input_objects = BTreeMap::new();
     for tx in checkpoint.transactions.iter() {
@@ -53,28 +54,38 @@ pub(crate) fn checkpoint_input_objects(
 
         for change in tx.effects.object_changes() {
             let id = change.id;
-            // Handle input objects - only track first appearance
-            if let Some(version) = change.input_version {
-                // If the object appears in `checkpoint_object_changes`, it was an input object that
-                // was previously modified or unwrapped. In both cases, we'd ignore this newer
-                // entry
-                if output_objects_seen.contains(&id) || checkpoint_input_objects.contains_key(&id) {
-                    continue;
-                }
 
-                let input_obj = input_objects_map
-                                .get(&(id, version))
-                                .copied()
-                                .unwrap_or_else(|| panic!(
-                                    "Object {id} at version {version} referenced in tx.effects.object_changes() not found in tx.input_objects"
-                                ));
-                checkpoint_input_objects.insert(id, input_obj);
+            let Some(version) = change.input_version else {
+                continue;
+            };
+
+            // This object was previously modified, created, or unwrapped in the checkpoint, so
+            // this version is not a checkpoint input.
+            if output_objects_seen.contains(&id) {
+                continue;
+            }
+
+            // Make sure this object has not already been recorded as an input.
+            let Entry::Vacant(entry) = checkpoint_input_objects.entry(id) else {
+                continue;
+            };
+
+            let input_obj = input_objects_map
+                .get(&(id, version))
+                .copied()
+                .with_context(|| format!(
+                    "Object {id} at version {version} referenced in effects not found in input_objects"
+                ))?;
+
+            entry.insert(input_obj);
+        }
+
+        for change in tx.effects.object_changes() {
+            if change.output_version.is_some() {
+                output_objects_seen.insert(change.id);
             }
         }
-
-        for obj in tx.output_objects.iter() {
-            output_objects_seen.insert(obj.id());
-        }
     }
-    checkpoint_input_objects
+
+    Ok(checkpoint_input_objects)
 }

--- a/crates/sui-indexer-alt/src/handlers/obj_info.rs
+++ b/crates/sui-indexer-alt/src/handlers/obj_info.rs
@@ -693,28 +693,18 @@ mod tests {
         let obj_info = ObjInfo::default();
         let mut builder = TestCheckpointDataBuilder::new(0)
             .start_transaction(0)
-            .create_shared_object(0)
+            .create_shared_object(1)
             .finish_transaction();
 
-        // Get the shared object from the transaction's output_objects
-        let shared_obj = builder
-            .transactions_mut()
-            .pop() // Remove and get the transaction
-            .unwrap()
-            .output_objects
-            .into_iter()
-            .find(|obj| obj.id() == TestCheckpointDataBuilder::derive_object_id(0))
-            .unwrap();
+        builder.build_checkpoint();
 
-        // Create a new transaction that will "read" the shared object. This emulates a shared
-        // object appearing as an input object, but missing from `tx.effects`.
-        let mut builder = builder.start_transaction(0).finish_transaction();
-        if let Some(tx) = builder.transactions_mut().last_mut() {
-            tx.input_objects.push(shared_obj);
-        }
+        builder = builder
+            .start_transaction(0)
+            .read_shared_object(1)
+            .finish_transaction();
 
         let checkpoint = builder.build_checkpoint();
         let result = obj_info.process(&Arc::new(checkpoint)).unwrap();
-        assert_eq!(result.len(), 0);
+        assert!(result.is_empty());
     }
 }

--- a/crates/sui-indexer-alt/src/handlers/obj_info.rs
+++ b/crates/sui-indexer-alt/src/handlers/obj_info.rs
@@ -40,7 +40,7 @@ impl Processor for ObjInfo {
     // TODO: Add tests for this function and the pruner.
     fn process(&self, checkpoint: &Arc<CheckpointData>) -> Result<Vec<Self::Value>> {
         let cp_sequence_number = checkpoint.checkpoint_summary.sequence_number;
-        let checkpoint_input_objects = checkpoint_input_objects(checkpoint);
+        let checkpoint_input_objects = checkpoint_input_objects(checkpoint)?;
         let latest_live_output_objects = checkpoint
             .latest_live_output_objects()
             .into_iter()

--- a/crates/sui-indexer-alt/src/handlers/obj_info.rs
+++ b/crates/sui-indexer-alt/src/handlers/obj_info.rs
@@ -253,7 +253,7 @@ mod tests {
 
         builder = builder
             .start_transaction(0)
-            .mutate_object(0)
+            .mutate_owned_object(0)
             .finish_transaction();
         let checkpoint2 = builder.build_checkpoint();
         let result = obj_info.process(&Arc::new(checkpoint2)).unwrap();

--- a/crates/sui-indexer-alt/src/handlers/obj_info_temp.rs
+++ b/crates/sui-indexer-alt/src/handlers/obj_info_temp.rs
@@ -255,7 +255,7 @@ mod tests {
 
         builder = builder
             .start_transaction(0)
-            .mutate_object(0)
+            .mutate_owned_object(0)
             .finish_transaction();
         let checkpoint2 = builder.build_checkpoint();
         let result = obj_info_temp.process(&Arc::new(checkpoint2)).unwrap();

--- a/crates/sui-indexer-alt/src/handlers/obj_info_temp.rs
+++ b/crates/sui-indexer-alt/src/handlers/obj_info_temp.rs
@@ -40,8 +40,7 @@ impl Processor for ObjInfoTemp {
     // TODO: Add tests for this function and the pruner.
     fn process(&self, checkpoint: &Arc<CheckpointData>) -> Result<Vec<Self::Value>> {
         let cp_sequence_number = checkpoint.checkpoint_summary.sequence_number;
-        let checkpoint_input_objects: BTreeMap<ObjectID, &Object> =
-            checkpoint_input_objects(checkpoint);
+        let checkpoint_input_objects = checkpoint_input_objects(checkpoint)?;
         let latest_live_output_objects = checkpoint
             .latest_live_output_objects()
             .into_iter()


### PR DESCRIPTION
## Description 

Couple of clean-ups on top of the new `obj_info` pipelines:

- Move `use` above `mod`.
- Early return style inside the loop body.
- Use `entry` API to reduce number of hash table look ups.
- Return a `Result` instead of panicking.
- Use `object_changes` to figure out what the output objects are, (not `tx.output_objects`).
- Adding true support for reading frozen objects and modifying shared inputs to `TestCheckpointBuilder`, and use it to write tests directly for `checkpoint_input_objects` and update the tests for handlers.


## Test plan 

```
sui$ cargo nextest run -p sui-indexer-alt
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
