### PR TITLE
Feature for sui client ptb allowing to call published package during dry-run in the same transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,7 +1828,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "const-str",
  "git-version",
@@ -12500,7 +12500,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "sui"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anemo",
  "anyhow",
@@ -12718,7 +12718,7 @@ dependencies = [
 
 [[package]]
 name = "sui-analytics-indexer"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -12770,7 +12770,7 @@ dependencies = [
 
 [[package]]
 name = "sui-analytics-indexer-derive"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12779,7 +12779,7 @@ dependencies = [
 
 [[package]]
 name = "sui-archival"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -12902,7 +12902,7 @@ dependencies = [
 
 [[package]]
 name = "sui-bridge"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -12953,7 +12953,7 @@ dependencies = [
 
 [[package]]
 name = "sui-bridge-cli"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -13019,7 +13019,7 @@ dependencies = [
 
 [[package]]
 name = "sui-cluster-test"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13211,7 +13211,7 @@ dependencies = [
 
 [[package]]
 name = "sui-data-ingestion"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13306,7 +13306,7 @@ dependencies = [
 
 [[package]]
 name = "sui-default-config"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -13314,7 +13314,7 @@ dependencies = [
 
 [[package]]
 name = "sui-display"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -13325,7 +13325,7 @@ dependencies = [
 
 [[package]]
 name = "sui-e2e-tests"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13473,7 +13473,7 @@ dependencies = [
 
 [[package]]
 name = "sui-faucet"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -13519,14 +13519,14 @@ dependencies = [
 
 [[package]]
 name = "sui-field-count"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "sui-field-count-derive",
 ]
 
 [[package]]
 name = "sui-field-count-derive"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -13554,7 +13554,7 @@ dependencies = [
 
 [[package]]
 name = "sui-framework-snapshot"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -13634,7 +13634,7 @@ dependencies = [
 
 [[package]]
 name = "sui-graphql-rpc"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -13756,7 +13756,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13832,7 +13832,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13904,7 +13904,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-framework"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13944,7 +13944,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-jsonrpc"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -13996,7 +13996,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-metrics"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "axum 0.7.5",
@@ -14039,7 +14039,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-schema"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14258,7 +14258,7 @@ dependencies = [
 
 [[package]]
 name = "sui-kvstore"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14281,7 +14281,7 @@ dependencies = [
 
 [[package]]
 name = "sui-light-client"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14319,7 +14319,7 @@ dependencies = [
 
 [[package]]
 name = "sui-metric-checker"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "backoff",
@@ -14340,7 +14340,7 @@ dependencies = [
 
 [[package]]
 name = "sui-move"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "better_any",
@@ -14381,7 +14381,7 @@ dependencies = [
 
 [[package]]
 name = "sui-move-build"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -14404,7 +14404,7 @@ dependencies = [
 
 [[package]]
 name = "sui-move-lsp"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "bin-version",
  "clap",
@@ -14510,7 +14510,7 @@ dependencies = [
 
 [[package]]
 name = "sui-mvr-graphql-rpc"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -14591,7 +14591,7 @@ dependencies = [
 
 [[package]]
 name = "sui-name-service"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "bcs",
  "move-core-types",
@@ -14644,7 +14644,7 @@ dependencies = [
 
 [[package]]
 name = "sui-node"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -14699,7 +14699,7 @@ dependencies = [
 
 [[package]]
 name = "sui-open-rpc"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14735,7 +14735,7 @@ dependencies = [
 
 [[package]]
 name = "sui-oracle"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14765,7 +14765,7 @@ dependencies = [
 
 [[package]]
 name = "sui-package-dump"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14782,7 +14782,7 @@ dependencies = [
 
 [[package]]
 name = "sui-package-management"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -14823,7 +14823,7 @@ dependencies = [
 
 [[package]]
 name = "sui-pg-db"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "bb8",
@@ -14966,7 +14966,7 @@ dependencies = [
 
 [[package]]
 name = "sui-rosetta"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15059,7 +15059,7 @@ dependencies = [
 
 [[package]]
 name = "sui-rpc-benchmark"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "bb8",
@@ -15083,7 +15083,7 @@ dependencies = [
 
 [[package]]
 name = "sui-rpc-loadgen"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15110,7 +15110,7 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15171,7 +15171,7 @@ dependencies = [
 
 [[package]]
 name = "sui-security-watchdog"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -15218,7 +15218,7 @@ dependencies = [
 
 [[package]]
 name = "sui-single-node-benchmark"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "async-trait",
  "bcs",
@@ -15281,7 +15281,7 @@ dependencies = [
 
 [[package]]
 name = "sui-source-validation"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "colored",
@@ -15351,7 +15351,7 @@ dependencies = [
 
 [[package]]
 name = "sui-sql-macro"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -15414,7 +15414,7 @@ dependencies = [
 
 [[package]]
 name = "sui-surfer"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "async-trait",
  "bcs",
@@ -15536,7 +15536,7 @@ dependencies = [
 
 [[package]]
 name = "sui-test-validator"
-version = "1.45.1"
+version = "1.45.2"
 
 [[package]]
 name = "sui-tls"
@@ -15562,7 +15562,7 @@ dependencies = [
 
 [[package]]
 name = "sui-tool"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anemo",
  "anemo-cli",
@@ -15859,7 +15859,7 @@ dependencies = [
 
 [[package]]
 name = "suins-indexer"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15898,7 +15898,7 @@ dependencies = [
 
 [[package]]
 name = "suiop-cli"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "axum 0.7.5",
@@ -18298,7 +18298,7 @@ dependencies = [
 
 [[package]]
 name = "x"
-version = "1.45.1"
+version = "1.45.2"
 dependencies = [
  "anyhow",
  "camino",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,7 +1828,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "const-str",
  "git-version",
@@ -12500,7 +12500,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "sui"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anemo",
  "anyhow",
@@ -12718,7 +12718,7 @@ dependencies = [
 
 [[package]]
 name = "sui-analytics-indexer"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -12770,7 +12770,7 @@ dependencies = [
 
 [[package]]
 name = "sui-analytics-indexer-derive"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12779,7 +12779,7 @@ dependencies = [
 
 [[package]]
 name = "sui-archival"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -12902,7 +12902,7 @@ dependencies = [
 
 [[package]]
 name = "sui-bridge"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -12953,7 +12953,7 @@ dependencies = [
 
 [[package]]
 name = "sui-bridge-cli"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -13019,7 +13019,7 @@ dependencies = [
 
 [[package]]
 name = "sui-cluster-test"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13211,7 +13211,7 @@ dependencies = [
 
 [[package]]
 name = "sui-data-ingestion"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13306,7 +13306,7 @@ dependencies = [
 
 [[package]]
 name = "sui-default-config"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -13314,7 +13314,7 @@ dependencies = [
 
 [[package]]
 name = "sui-display"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -13325,7 +13325,7 @@ dependencies = [
 
 [[package]]
 name = "sui-e2e-tests"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13473,7 +13473,7 @@ dependencies = [
 
 [[package]]
 name = "sui-faucet"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -13519,14 +13519,14 @@ dependencies = [
 
 [[package]]
 name = "sui-field-count"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "sui-field-count-derive",
 ]
 
 [[package]]
 name = "sui-field-count-derive"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -13554,7 +13554,7 @@ dependencies = [
 
 [[package]]
 name = "sui-framework-snapshot"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -13634,7 +13634,7 @@ dependencies = [
 
 [[package]]
 name = "sui-graphql-rpc"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -13756,7 +13756,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13832,7 +13832,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13904,7 +13904,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-framework"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13944,7 +13944,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-jsonrpc"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -13996,7 +13996,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-metrics"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "axum 0.7.5",
@@ -14039,7 +14039,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-schema"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14258,7 +14258,7 @@ dependencies = [
 
 [[package]]
 name = "sui-kvstore"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14281,7 +14281,7 @@ dependencies = [
 
 [[package]]
 name = "sui-light-client"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14319,7 +14319,7 @@ dependencies = [
 
 [[package]]
 name = "sui-metric-checker"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "backoff",
@@ -14340,7 +14340,7 @@ dependencies = [
 
 [[package]]
 name = "sui-move"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "better_any",
@@ -14381,7 +14381,7 @@ dependencies = [
 
 [[package]]
 name = "sui-move-build"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -14404,7 +14404,7 @@ dependencies = [
 
 [[package]]
 name = "sui-move-lsp"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "bin-version",
  "clap",
@@ -14510,7 +14510,7 @@ dependencies = [
 
 [[package]]
 name = "sui-mvr-graphql-rpc"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -14591,7 +14591,7 @@ dependencies = [
 
 [[package]]
 name = "sui-name-service"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "bcs",
  "move-core-types",
@@ -14644,7 +14644,7 @@ dependencies = [
 
 [[package]]
 name = "sui-node"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -14699,7 +14699,7 @@ dependencies = [
 
 [[package]]
 name = "sui-open-rpc"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14735,7 +14735,7 @@ dependencies = [
 
 [[package]]
 name = "sui-oracle"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14765,7 +14765,7 @@ dependencies = [
 
 [[package]]
 name = "sui-package-dump"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14782,7 +14782,7 @@ dependencies = [
 
 [[package]]
 name = "sui-package-management"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -14823,7 +14823,7 @@ dependencies = [
 
 [[package]]
 name = "sui-pg-db"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "bb8",
@@ -14966,7 +14966,7 @@ dependencies = [
 
 [[package]]
 name = "sui-rosetta"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15059,7 +15059,7 @@ dependencies = [
 
 [[package]]
 name = "sui-rpc-benchmark"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "bb8",
@@ -15083,7 +15083,7 @@ dependencies = [
 
 [[package]]
 name = "sui-rpc-loadgen"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15110,7 +15110,7 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15171,7 +15171,7 @@ dependencies = [
 
 [[package]]
 name = "sui-security-watchdog"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -15218,7 +15218,7 @@ dependencies = [
 
 [[package]]
 name = "sui-single-node-benchmark"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "async-trait",
  "bcs",
@@ -15281,7 +15281,7 @@ dependencies = [
 
 [[package]]
 name = "sui-source-validation"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "colored",
@@ -15351,7 +15351,7 @@ dependencies = [
 
 [[package]]
 name = "sui-sql-macro"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -15414,7 +15414,7 @@ dependencies = [
 
 [[package]]
 name = "sui-surfer"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "async-trait",
  "bcs",
@@ -15536,7 +15536,7 @@ dependencies = [
 
 [[package]]
 name = "sui-test-validator"
-version = "1.45.0"
+version = "1.45.1"
 
 [[package]]
 name = "sui-tls"
@@ -15562,7 +15562,7 @@ dependencies = [
 
 [[package]]
 name = "sui-tool"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anemo",
  "anemo-cli",
@@ -15859,7 +15859,7 @@ dependencies = [
 
 [[package]]
 name = "suins-indexer"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15898,7 +15898,7 @@ dependencies = [
 
 [[package]]
 name = "suiop-cli"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "axum 0.7.5",
@@ -18298,7 +18298,7 @@ dependencies = [
 
 [[package]]
 name = "x"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "anyhow",
  "camino",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,7 +1828,7 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bin-version"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "const-str",
  "git-version",
@@ -12500,7 +12500,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "sui"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anemo",
  "anyhow",
@@ -12718,7 +12718,7 @@ dependencies = [
 
 [[package]]
 name = "sui-analytics-indexer"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "arrow",
@@ -12770,7 +12770,7 @@ dependencies = [
 
 [[package]]
 name = "sui-analytics-indexer-derive"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12779,7 +12779,7 @@ dependencies = [
 
 [[package]]
 name = "sui-archival"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -12902,7 +12902,7 @@ dependencies = [
 
 [[package]]
 name = "sui-bridge"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -12953,7 +12953,7 @@ dependencies = [
 
 [[package]]
 name = "sui-bridge-cli"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -13019,7 +13019,7 @@ dependencies = [
 
 [[package]]
 name = "sui-cluster-test"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13211,7 +13211,7 @@ dependencies = [
 
 [[package]]
 name = "sui-data-ingestion"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13306,7 +13306,7 @@ dependencies = [
 
 [[package]]
 name = "sui-default-config"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -13314,7 +13314,7 @@ dependencies = [
 
 [[package]]
 name = "sui-display"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -13325,7 +13325,7 @@ dependencies = [
 
 [[package]]
 name = "sui-e2e-tests"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13473,7 +13473,7 @@ dependencies = [
 
 [[package]]
 name = "sui-faucet"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -13519,14 +13519,14 @@ dependencies = [
 
 [[package]]
 name = "sui-field-count"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "sui-field-count-derive",
 ]
 
 [[package]]
 name = "sui-field-count-derive"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -13554,7 +13554,7 @@ dependencies = [
 
 [[package]]
 name = "sui-framework-snapshot"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "bcs",
@@ -13634,7 +13634,7 @@ dependencies = [
 
 [[package]]
 name = "sui-graphql-rpc"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -13756,7 +13756,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13832,7 +13832,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13904,7 +13904,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-framework"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13944,7 +13944,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-jsonrpc"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -13996,7 +13996,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-metrics"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "axum 0.7.5",
@@ -14039,7 +14039,7 @@ dependencies = [
 
 [[package]]
 name = "sui-indexer-alt-schema"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14258,7 +14258,7 @@ dependencies = [
 
 [[package]]
 name = "sui-kvstore"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14281,7 +14281,7 @@ dependencies = [
 
 [[package]]
 name = "sui-light-client"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14319,7 +14319,7 @@ dependencies = [
 
 [[package]]
 name = "sui-metric-checker"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "backoff",
@@ -14340,7 +14340,7 @@ dependencies = [
 
 [[package]]
 name = "sui-move"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "better_any",
@@ -14381,7 +14381,7 @@ dependencies = [
 
 [[package]]
 name = "sui-move-build"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -14404,7 +14404,7 @@ dependencies = [
 
 [[package]]
 name = "sui-move-lsp"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "bin-version",
  "clap",
@@ -14510,7 +14510,7 @@ dependencies = [
 
 [[package]]
 name = "sui-mvr-graphql-rpc"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -14591,7 +14591,7 @@ dependencies = [
 
 [[package]]
 name = "sui-name-service"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "bcs",
  "move-core-types",
@@ -14644,7 +14644,7 @@ dependencies = [
 
 [[package]]
 name = "sui-node"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -14699,7 +14699,7 @@ dependencies = [
 
 [[package]]
 name = "sui-open-rpc"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14735,7 +14735,7 @@ dependencies = [
 
 [[package]]
 name = "sui-oracle"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14765,7 +14765,7 @@ dependencies = [
 
 [[package]]
 name = "sui-package-dump"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "bcs",
@@ -14782,7 +14782,7 @@ dependencies = [
 
 [[package]]
 name = "sui-package-management"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -14823,7 +14823,7 @@ dependencies = [
 
 [[package]]
 name = "sui-pg-db"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "bb8",
@@ -14966,7 +14966,7 @@ dependencies = [
 
 [[package]]
 name = "sui-rosetta"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15059,7 +15059,7 @@ dependencies = [
 
 [[package]]
 name = "sui-rpc-benchmark"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "bb8",
@@ -15083,7 +15083,7 @@ dependencies = [
 
 [[package]]
 name = "sui-rpc-loadgen"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15110,7 +15110,7 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15171,7 +15171,7 @@ dependencies = [
 
 [[package]]
 name = "sui-security-watchdog"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -15218,7 +15218,7 @@ dependencies = [
 
 [[package]]
 name = "sui-single-node-benchmark"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "async-trait",
  "bcs",
@@ -15281,7 +15281,7 @@ dependencies = [
 
 [[package]]
 name = "sui-source-validation"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "colored",
@@ -15351,7 +15351,7 @@ dependencies = [
 
 [[package]]
 name = "sui-sql-macro"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "quote",
  "syn 1.0.107",
@@ -15414,7 +15414,7 @@ dependencies = [
 
 [[package]]
 name = "sui-surfer"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "async-trait",
  "bcs",
@@ -15536,7 +15536,7 @@ dependencies = [
 
 [[package]]
 name = "sui-test-validator"
-version = "1.45.2"
+version = "1.45.3"
 
 [[package]]
 name = "sui-tls"
@@ -15562,7 +15562,7 @@ dependencies = [
 
 [[package]]
 name = "sui-tool"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anemo",
  "anemo-cli",
@@ -15859,7 +15859,7 @@ dependencies = [
 
 [[package]]
 name = "suins-indexer"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15898,7 +15898,7 @@ dependencies = [
 
 [[package]]
 name = "suiop-cli"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "axum 0.7.5",
@@ -18298,7 +18298,7 @@ dependencies = [
 
 [[package]]
 name = "x"
-version = "1.45.2"
+version = "1.45.3"
 dependencies = [
  "anyhow",
  "camino",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,7 +214,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by sui-core, sui-faucet, sui-node, sui-tools, sui-sdk, sui-move-build, and sui crates.
-version = "1.45.2"
+version = "1.45.3"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,7 +214,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by sui-core, sui-faucet, sui-node, sui-tools, sui-sdk, sui-move-build, and sui crates.
-version = "1.45.0"
+version = "1.45.1"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,7 +214,7 @@ members = [
 
 [workspace.package]
 # This version string will be inherited by sui-core, sui-faucet, sui-node, sui-tools, sui-sdk, sui-move-build, and sui crates.
-version = "1.45.1"
+version = "1.45.2"
 
 [profile.release]
 # debug = 1 means line charts only, which is minimum needed for good stack traces

--- a/crates/sui-bridge-indexer/src/main.rs
+++ b/crates/sui-bridge-indexer/src/main.rs
@@ -154,7 +154,6 @@ async fn start_watchdog(
         weth_address,
         usdt_address,
         wbtc_address,
-        lbtc_address,
     ) = get_eth_contract_addresses(eth_bridge_proxy_address, &eth_provider).await?;
 
     let eth_vault_balance = EthereumVaultBalance::new(
@@ -187,16 +186,6 @@ async fn start_watchdog(
     .await
     .unwrap_or_else(|e| panic!("Failed to create wbtc vault balance: {}", e));
 
-    let lbtc_vault_balance = EthereumVaultBalance::new(
-        eth_provider.clone(),
-        vault_address,
-        lbtc_address,
-        VaultAsset::LBTC,
-        watchdog_metrics.lbtc_vault_balance.clone(),
-    )
-    .await
-    .unwrap_or_else(|e| panic!("Failed to create lbtc vault balance: {}", e));
-
     let eth_bridge_status = EthBridgeStatus::new(
         eth_provider,
         eth_bridge_proxy_address,
@@ -209,7 +198,6 @@ async fn start_watchdog(
         Box::new(eth_vault_balance),
         Box::new(usdt_vault_balance),
         Box::new(wbtc_vault_balance),
-        Box::new(lbtc_vault_balance),
         Box::new(eth_bridge_status),
         Box::new(sui_bridge_status),
     ];

--- a/crates/sui-bridge-watchdog/eth_vault_balance.rs
+++ b/crates/sui-bridge-watchdog/eth_vault_balance.rs
@@ -17,7 +17,6 @@ pub enum VaultAsset {
     WETH,
     USDT,
     WBTC,
-    LBTC,
 }
 
 pub struct EthereumVaultBalance {

--- a/crates/sui-bridge/src/config.rs
+++ b/crates/sui-bridge/src/config.rs
@@ -272,7 +272,6 @@ impl BridgeNodeConfig {
             _weth_address,
             _usdt_address,
             _wbtc_address,
-            _lbtc_address,
         ) = get_eth_contract_addresses(bridge_proxy_address, &provider).await?;
         let config = EthBridgeConfig::new(config_address, provider.clone());
 

--- a/crates/sui-bridge/src/node.rs
+++ b/crates/sui-bridge/src/node.rs
@@ -165,8 +165,7 @@ async fn start_watchdog(
         _config_address,
         weth_address,
         usdt_address,
-        wbtc_address,
-        lbtc_address,
+        _wbtc_address,
     ) = get_eth_contract_addresses(eth_bridge_proxy_address, &eth_provider)
         .await
         .unwrap_or_else(|e| panic!("get_eth_contract_addresses should not fail: {}", e));
@@ -194,22 +193,12 @@ async fn start_watchdog(
     let wbtc_vault_balance = EthereumVaultBalance::new(
         eth_provider.clone(),
         vault_address,
-        wbtc_address,
+        _wbtc_address,
         VaultAsset::WBTC,
         watchdog_metrics.wbtc_vault_balance.clone(),
     )
     .await
     .unwrap_or_else(|e| panic!("Failed to create wbtc vault balance: {}", e));
-
-    let lbtc_vault_balance = EthereumVaultBalance::new(
-        eth_provider.clone(),
-        vault_address,
-        lbtc_address,
-        VaultAsset::LBTC,
-        watchdog_metrics.lbtc_vault_balance.clone(),
-    )
-    .await
-    .unwrap_or_else(|e| panic!("Failed to create lbtc vault balance: {}", e));
 
     let eth_bridge_status = EthBridgeStatus::new(
         eth_provider,
@@ -226,7 +215,6 @@ async fn start_watchdog(
         Box::new(eth_vault_balance),
         Box::new(usdt_vault_balance),
         Box::new(wbtc_vault_balance),
-        Box::new(lbtc_vault_balance),
         Box::new(eth_bridge_status),
         Box::new(sui_bridge_status),
     ];

--- a/crates/sui-bridge/src/sui_bridge_watchdog/eth_vault_balance.rs
+++ b/crates/sui-bridge/src/sui_bridge_watchdog/eth_vault_balance.rs
@@ -17,7 +17,6 @@ pub enum VaultAsset {
     WETH,
     USDT,
     WBTC,
-    LBTC,
 }
 
 pub struct EthereumVaultBalance {

--- a/crates/sui-bridge/src/sui_bridge_watchdog/metrics.rs
+++ b/crates/sui-bridge/src/sui_bridge_watchdog/metrics.rs
@@ -11,7 +11,6 @@ pub struct WatchdogMetrics {
     pub eth_vault_balance: IntGauge,
     pub usdt_vault_balance: IntGauge,
     pub wbtc_vault_balance: IntGauge,
-    pub lbtc_vault_balance: IntGauge,
     pub total_supplies: IntGaugeVec,
     pub eth_bridge_paused: IntGauge,
     pub sui_bridge_paused: IntGauge,
@@ -35,12 +34,6 @@ impl WatchdogMetrics {
             wbtc_vault_balance: register_int_gauge_with_registry!(
                 "bridge_wbtc_vault_balance",
                 "Current balance of wbtc eth vault",
-                registry,
-            )
-            .unwrap(),
-            lbtc_vault_balance: register_int_gauge_with_registry!(
-                "bridge_lbtc_vault_balance",
-                "Current balance of lbtc eth vault",
                 registry,
             )
             .unwrap(),

--- a/crates/sui-bridge/src/utils.rs
+++ b/crates/sui-bridge/src/utils.rs
@@ -115,7 +115,6 @@ pub async fn get_eth_contract_addresses<P: ethers::providers::JsonRpcClient + 's
     EthAddress,
     EthAddress,
     EthAddress,
-    EthAddress,
 )> {
     let sui_bridge = EthSuiBridge::new(bridge_proxy_address, provider.clone());
     let committee_address: EthAddress = sui_bridge.committee().call().await?;
@@ -128,7 +127,6 @@ pub async fn get_eth_contract_addresses<P: ethers::providers::JsonRpcClient + 's
     let weth_address: EthAddress = vault.w_eth().call().await?;
     let usdt_address: EthAddress = bridge_config.token_address_of(4).call().await?;
     let wbtc_address: EthAddress = bridge_config.token_address_of(1).call().await?;
-    let lbtc_address: EthAddress = bridge_config.token_address_of(6).call().await?;
 
     Ok((
         committee_address,
@@ -138,7 +136,6 @@ pub async fn get_eth_contract_addresses<P: ethers::providers::JsonRpcClient + 's
         weth_address,
         usdt_address,
         wbtc_address,
-        lbtc_address,
     ))
 }
 

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -783,7 +783,7 @@ impl ConsensusConfig {
     }
 
     pub fn max_pending_transactions(&self) -> usize {
-        self.max_pending_transactions.unwrap_or(20_000)
+        self.max_pending_transactions.unwrap_or(40_000)
     }
 
     pub fn submit_delay_step_override(&self) -> Option<Duration> {

--- a/crates/sui-core/src/authority/execution_time_estimator.rs
+++ b/crates/sui-core/src/authority/execution_time_estimator.rs
@@ -349,10 +349,12 @@ impl ExecutionTimeObserver {
         let transaction = ConsensusTransaction::new_execution_time_observation(
             ExecutionTimeObservation::new(epoch_store.name, to_share),
         );
-        if let Err(e) = self
-            .consensus_adapter
-            .submit_to_consensus(&[transaction], &epoch_store)
-        {
+
+        if let Err(e) = self.consensus_adapter.submit_best_effort(
+            &transaction,
+            &epoch_store,
+            Duration::from_secs(5),
+        ) {
             if !matches!(e, SuiError::EpochEnded(_)) {
                 epoch_store
                     .metrics

--- a/crates/sui-core/src/mock_consensus.rs
+++ b/crates/sui-core/src/mock_consensus.rs
@@ -9,6 +9,7 @@ use crate::consensus_handler::SequencedConsensusTransaction;
 use consensus_core::BlockRef;
 use prometheus::Registry;
 use std::sync::{Arc, Weak};
+use std::time::Duration;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::messages_consensus::{ConsensusTransaction, ConsensusTransactionKind};
@@ -118,6 +119,15 @@ impl SubmitToConsensus for MockConsensusClient {
         _epoch_store: &Arc<AuthorityPerEpochStore>,
     ) -> SuiResult {
         self.submit_impl(transactions).map(|_response| ())
+    }
+
+    fn submit_best_effort(
+        &self,
+        transaction: &ConsensusTransaction,
+        _epoch_store: &Arc<AuthorityPerEpochStore>,
+        _timeout: Duration,
+    ) -> SuiResult {
+        self.submit_impl(&[transaction.clone()]).map(|_response| ())
     }
 }
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/MystenLabs/sui/main/LICENSE"
     },
-    "version": "1.45.2"
+    "version": "1.45.3"
   },
   "methods": [
     {

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/MystenLabs/sui/main/LICENSE"
     },
-    "version": "1.45.0"
+    "version": "1.45.1"
   },
   "methods": [
     {

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -12,7 +12,7 @@
       "name": "Apache-2.0",
       "url": "https://raw.githubusercontent.com/MystenLabs/sui/main/LICENSE"
     },
-    "version": "1.45.1"
+    "version": "1.45.2"
   },
   "methods": [
     {

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -3378,6 +3378,9 @@ impl ProtocolConfig {
                     cfg.gas_model_version = Some(10);
 
                     if chain != Chain::Mainnet {
+                        cfg.feature_flags.record_additional_state_digest_in_prologue = true;
+                        cfg.consensus_commit_rate_estimation_window_size = Some(10);
+
                         // Enable execution time estimate mode for congestion control on testnet.
                         cfg.feature_flags.per_object_congestion_control_mode =
                             PerObjectCongestionControlMode::ExecutionTimeEstimate(

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_78.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_78.snap
@@ -81,6 +81,7 @@ feature_flags:
   variant_nodes: true
   consensus_zstd_compression: true
   minimize_child_object_mutations: true
+  record_additional_state_digest_in_prologue: true
   move_native_context: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
@@ -372,3 +373,4 @@ gas_budget_based_txn_cost_cap_factor: 400000
 gas_budget_based_txn_cost_absolute_cap_commit_count: 50
 sip_45_consensus_amplification_threshold: 5
 use_object_per_epoch_marker_table_v2: true
+consensus_commit_rate_estimation_window_size: 10

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -64,7 +64,12 @@ fastcrypto-zkp.workspace = true
 passkey-types.workspace = true
 
 typed-store-error.workspace = true
-derive_more = { workspace = true, features = ["as_ref", "debug", "display", "from"] }
+derive_more = { workspace = true, features = [
+    "as_ref",
+    "debug",
+    "display",
+    "from",
+] }
 proptest.workspace = true
 proptest-derive.workspace = true
 better_any.workspace = true
@@ -103,8 +108,6 @@ harness = false
 
 [features]
 default = []
-tracing = [
-    "move-vm-profiler/tracing",
-    "move-vm-test-utils/tracing",
-]
+tracing = ["move-vm-profiler/tracing", "move-vm-test-utils/tracing"]
 fuzzing = ["move-core-types/fuzzing"]
+testing = []

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -785,7 +785,11 @@ impl ProgrammableMoveCall {
             type_arguments,
             ..
         } = self;
-        let mut packages = BTreeSet::from([*package]);
+        let mut packages = if cfg!(feature = "testing") && *package == ObjectID::ZERO {
+            BTreeSet::new()
+        } else {
+            BTreeSet::from([*package])
+        };
         for type_argument in type_arguments {
             add_type_input_packages(&mut packages, type_argument)
         }

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -2017,7 +2017,9 @@ pub(crate) async fn compile_package(
 
 /// Return the correct implicit dependencies for the [version], producing a warning or error if the
 /// protocol version is unknown or old
-fn implicit_deps_for_protocol_version(version: ProtocolVersion) -> anyhow::Result<Dependencies> {
+pub(crate) fn implicit_deps_for_protocol_version(
+    version: ProtocolVersion,
+) -> anyhow::Result<Dependencies> {
     if version > ProtocolVersion::MAX + 2 {
         eprintln!(
             "[{}]: The network is using protocol version {:?}, but this binary only recognizes protocol version {:?}; \

--- a/crates/sui/src/client_ptb/ast.rs
+++ b/crates/sui/src/client_ptb/ast.rs
@@ -39,6 +39,8 @@ pub const DRY_RUN: &str = "dry-run";
 pub const DEV_INSPECT: &str = "dev-inspect";
 pub const SERIALIZE_UNSIGNED: &str = "serialize-unsigned-transaction";
 pub const SERIALIZE_SIGNED: &str = "serialize-signed-transaction";
+pub const WITH_UNPUBLISHED_DEPENDENCIES: &str = "with-unpublished-dependencies";
+pub const SKIP_DEPENDENCY_VERIFICATION: &str = "skip-dependency-verification";
 
 // Types
 pub const U8: &str = "u8";
@@ -79,6 +81,8 @@ pub const COMMANDS: &[&str] = &[
     DEV_INSPECT,
     SERIALIZE_UNSIGNED,
     SERIALIZE_SIGNED,
+    WITH_UNPUBLISHED_DEPENDENCIES,
+    SKIP_DEPENDENCY_VERIFICATION,
 ];
 
 pub fn is_keyword(s: &str) -> bool {
@@ -116,6 +120,26 @@ pub struct ProgramMetadata {
     pub dry_run_set: bool,
     pub dev_inspect_set: bool,
     pub gas_budget: Option<Spanned<u64>>,
+    pub with_unpublished_dependencies_set: bool,
+    pub skip_dependency_verification_set: bool,
+}
+
+impl Default for ProgramMetadata {
+    fn default() -> Self {
+        Self {
+            preview_set: false,
+            summary_set: false,
+            serialize_unsigned_set: false,
+            serialize_signed_set: false,
+            gas_object_id: None,
+            json_set: false,
+            dry_run_set: false,
+            dev_inspect_set: false,
+            gas_budget: None,
+            with_unpublished_dependencies_set: false,
+            skip_dependency_verification_set: false,
+        }
+    }
 }
 
 /// A parsed module access consisting of the address, module name, and function name.

--- a/crates/sui/src/client_ptb/parser.rs
+++ b/crates/sui/src/client_ptb/parser.rs
@@ -44,6 +44,8 @@ struct ProgramParsingState {
     dev_inspect_set: bool,
     gas_object_id: Option<Spanned<ObjectID>>,
     gas_budget: Option<Spanned<u64>>,
+    with_unpublished_dependencies_set: bool,
+    skip_dependency_verification_set: bool,
 }
 
 impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
@@ -67,6 +69,8 @@ impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
                 dev_inspect_set: false,
                 gas_object_id: None,
                 gas_budget: None,
+                with_unpublished_dependencies_set: false,
+                skip_dependency_verification_set: false,
             },
         })
     }
@@ -115,6 +119,12 @@ impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
                 L(T::Command, A::DEV_INSPECT) => flag!(dev_inspect_set),
                 L(T::Command, A::PREVIEW) => flag!(preview_set),
                 L(T::Command, A::WARN_SHADOWS) => flag!(warn_shadows_set),
+                L(T::Command, A::WITH_UNPUBLISHED_DEPENDENCIES) => {
+                    flag!(with_unpublished_dependencies_set)
+                }
+                L(T::Command, A::SKIP_DEPENDENCY_VERIFICATION) => {
+                    flag!(skip_dependency_verification_set)
+                }
                 L(T::Command, A::GAS_COIN) => {
                     let specifier = try_!(self.parse_gas_specifier());
                     self.state.gas_object_id = Some(specifier);
@@ -212,6 +222,8 @@ impl<'a, I: Iterator<Item = &'a str>> ProgramParser<'a, I> {
                     dry_run_set: self.state.dry_run_set,
                     dev_inspect_set: self.state.dev_inspect_set,
                     gas_budget: self.state.gas_budget,
+                    with_unpublished_dependencies_set: self.state.with_unpublished_dependencies_set,
+                    skip_dependency_verification_set: self.state.skip_dependency_verification_set,
                 },
             ))
         } else {

--- a/crates/sui/src/client_ptb/ptb.rs
+++ b/crates/sui/src/client_ptb/ptb.rs
@@ -101,7 +101,7 @@ impl PTB {
 
         let client = context.get_client().await?;
 
-        let (res, warnings) = Self::build_ptb(program, context, client).await;
+        let (res, warnings) = Self::build_ptb(program, &program_metadata, context, client).await;
 
         // Render warnings
         if !warnings.is_empty() {
@@ -222,6 +222,7 @@ impl PTB {
     /// Exposed for testing
     pub async fn build_ptb(
         program: Program,
+        program_metadata: &ProgramMetadata,
         context: &WalletContext,
         client: SuiClient,
     ) -> (
@@ -236,7 +237,7 @@ impl PTB {
             .map(|(sa, alias)| (alias.alias.clone(), AccountAddress::from(*sa)))
             .collect();
         let builder = PTBBuilder::new(starting_addresses, client.read_api());
-        builder.build(program).await
+        builder.build(program, program_metadata).await
     }
 
     /// Exposed for testing
@@ -415,6 +416,14 @@ pub fn ptb_description() -> clap::Command {
         .arg(arg!(
             --"warn-shadows"
             "Enable shadow warning when the same variable name is declared multiple times. Off by default."
+        ))
+        .arg(arg!(
+            --"with-unpublished-dependencies"
+            "Use unpublished dependencies when publishing or upgrading packages."
+        ))
+        .arg(arg!(
+            --"skip-dependency-verification"
+            "Skip dependency verification when publishing or upgrading packages."
         ))
         .arg(arg!(
             --"json"

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::client_commands::{pkg_tree_shake, SuiClientCommands};
+use crate::client_commands::{
+    implicit_deps_for_protocol_version, pkg_tree_shake, SuiClientCommands,
+};
 use crate::fire_drill::{run_fire_drill, FireDrill};
 use crate::genesis_ceremony::{run, Ceremony};
 use crate::keytool::KeyToolCommand;
@@ -518,8 +520,12 @@ impl SuiCommand {
                         };
 
                         let rerooted_path = move_cli::base::reroot_path(package_path.as_deref())?;
-                        let build_config =
+                        let mut build_config =
                             resolve_lock_file_path(build_config, Some(&rerooted_path))?;
+                        let protocol_config = read_api.get_protocol_config(None).await?;
+                        build_config.implicit_dependencies =
+                            implicit_deps_for_protocol_version(protocol_config.protocol_version)?;
+
                         let mut pkg = SuiBuildConfig {
                             config: build_config,
                             run_bytecode_verifier: true,

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -88,7 +88,7 @@ mod checked {
         /// Additional transfers not from the Move runtime
         additional_transfers: Vec<(/* new owner */ SuiAddress, ObjectValue)>,
         /// Newly published packages
-        new_packages: Vec<MovePackage>,
+        pub new_packages: Vec<MovePackage>,
         /// User events are claimed after each Move call
         user_events: Vec<(ModuleId, StructTag, Vec<u8>)>,
         // runtime data

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
@@ -342,6 +342,18 @@ mod checked {
                     arguments,
                 } = *move_call;
 
+                // no need for extra flag, can't happen without testing feature in transaction
+                let is_init = package == ObjectID::ZERO;
+                let package = if is_init && !context.new_packages.is_empty() {
+                    let package_id = context.new_packages.last().unwrap().id();
+                    context
+                        .linkage_view
+                        .set_linkage(context.new_packages.last().unwrap())?;
+                    package_id
+                } else {
+                    package
+                };
+
                 let module = to_identifier(context, module)?;
                 let function = to_identifier(context, function)?;
 
@@ -366,7 +378,7 @@ mod checked {
                     &function,
                     loaded_type_arguments,
                     arguments,
-                    /* is_init */ false,
+                    is_init,
                     trace_builder_opt,
                 );
 


### PR DESCRIPTION
## Description 

I made it possible for `sui client ptb` to call published or upgraded package in the same transaction for testing purposes. 

The purpose of this feature is to allow testing if packages are working correctly on mainnet without publishing them there. I use it myself for testing some ideas. Usage is simple - after publishing package just use 0x00 to call it. For example:
```bash
sui client ptb --dry-run --with-unpublished-dependencies --skip-dependency-verification \
  --publish "." \
    --assign upgrade_cap \
  --transfer-objects "[upgrade_cap]" @0x10 \
  --move-call "0x00::my_package::hello_world" \
    arg1 arg2
```

I am not experienced enough to fully implement this feature myself to be production ready so I save this PR only as a draft. Feel free to add it yourself or eventually write me instructions what you need to implement it so I'll add missing parts.

Btw: I merge it to mainnet in this PR only because I use it myself in mainnet branch. If you are OK with adding this feature then I can create PR for development branch.