### PR TITLE
[typed store] use weak ref for metrics thread

### DIFF
--- a/crates/typed-store/src/rocks/tests.rs
+++ b/crates/typed-store/src/rocks/tests.rs
@@ -115,6 +115,16 @@ async fn test_contains_key() {
 }
 
 #[tokio::test]
+async fn test_safe_drop_db() {
+    let path = temp_dir();
+    {
+        let db: DBMap<i32, String> = open_map(path.clone(), Some("table"));
+        db.insert(&777, &"123".to_string()).unwrap();
+    }
+    assert!(safe_drop_db(path).is_ok());
+}
+
+#[tokio::test]
 async fn test_multi_contain() {
     let db = open_map(temp_dir(), None);
 


### PR DESCRIPTION
## Description 

Regular Arc causes `safe_drop_db` call to fail with `lock hold by current process` exception



---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
