### PR TITLE
Fix marker table handling in transfer-to-object for `ConsensusV2` objects

### DIFF
--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -279,7 +279,7 @@ pub trait ObjectCacheRead: Send + Sync {
                     .get_object(&input_key.id().id())
                     .map(|obj| obj.version() >= input_key.version().unwrap())
                     .unwrap_or(false)
-                    || self.have_deleted_fastpath_object_at_version_or_after(
+                    || self.fastpath_stream_ended_at_version_or_after(
                         input_key.id().id(),
                         input_key.version().unwrap(),
                         epoch,
@@ -391,7 +391,7 @@ pub trait ObjectCacheRead: Send + Sync {
         )
     }
 
-    fn have_deleted_fastpath_object_at_version_or_after(
+    fn fastpath_stream_ended_at_version_or_after(
         &self,
         object_id: ObjectID,
         version: SequenceNumber,
@@ -400,7 +400,7 @@ pub trait ObjectCacheRead: Send + Sync {
         let full_id = FullObjectID::Fastpath(object_id); // function explicilty assumes "fastpath"
         matches!(
             self.get_latest_marker(full_id, epoch_id),
-            Some((marker_version, MarkerValue::OwnedDeleted)) if marker_version >= version
+            Some((marker_version, MarkerValue::FastpathStreamEnded)) if marker_version >= version
         )
     }
 

--- a/crates/sui-core/src/unit_tests/transfer_to_object_tests.rs
+++ b/crates/sui-core/src/unit_tests/transfer_to_object_tests.rs
@@ -1769,8 +1769,8 @@ async fn test_have_deleted_owned_object() {
 
         assert!(cache.get_object(&new_child.0.0).is_some());
         // Should not show as deleted for either versions
-        assert!(!cache.have_deleted_fastpath_object_at_version_or_after(new_child.0.0, new_child.0.1, 0));
-        assert!(!cache.have_deleted_fastpath_object_at_version_or_after(new_child.0.0, child.0.1, 0));
+        assert!(!cache.fastpath_stream_ended_at_version_or_after(new_child.0.0, new_child.0.1, 0));
+        assert!(!cache.fastpath_stream_ended_at_version_or_after(new_child.0.0, child.0.1, 0));
 
         let effects = runner
             .run({
@@ -1787,13 +1787,13 @@ async fn test_have_deleted_owned_object() {
 
         let deleted_child = effects.deleted().into_iter().find(|(id, _, _)| *id == new_child.0 .0).unwrap();
         assert!(cache.get_object(&deleted_child.0).is_none());
-        assert!(cache.have_deleted_fastpath_object_at_version_or_after(deleted_child.0, deleted_child.1, 0));
-        assert!(cache.have_deleted_fastpath_object_at_version_or_after(deleted_child.0, new_child.0.1, 0));
-        assert!(cache.have_deleted_fastpath_object_at_version_or_after(deleted_child.0, child.0.1, 0));
+        assert!(cache.fastpath_stream_ended_at_version_or_after(deleted_child.0, deleted_child.1, 0));
+        assert!(cache.fastpath_stream_ended_at_version_or_after(deleted_child.0, new_child.0.1, 0));
+        assert!(cache.fastpath_stream_ended_at_version_or_after(deleted_child.0, child.0.1, 0));
         // Should not show as deleted for versions after this though
-        assert!(!cache.have_deleted_fastpath_object_at_version_or_after(deleted_child.0, deleted_child.1.next(), 0));
+        assert!(!cache.fastpath_stream_ended_at_version_or_after(deleted_child.0, deleted_child.1.next(), 0));
         // Should not show as deleted for other epochs outside of our current epoch too
-        assert!(!cache.have_deleted_fastpath_object_at_version_or_after(deleted_child.0, deleted_child.1, 1));
+        assert!(!cache.fastpath_stream_ended_at_version_or_after(deleted_child.0, deleted_child.1, 1));
     }
     }
 }

--- a/crates/sui-types/src/effects/effects_v1.rs
+++ b/crates/sui-types/src/effects/effects_v1.rs
@@ -199,6 +199,11 @@ impl TransactionEffectsAPI for TransactionEffectsV1 {
         vec![]
     }
 
+    fn transferred_to_consensus(&self) -> Vec<ObjectRef> {
+        // ConsensusV2 objects cannot exist with effects v1
+        vec![]
+    }
+
     fn object_changes(&self) -> Vec<ObjectChange> {
         let modified_at: BTreeMap<_, _> = self.modified_at_versions.iter().copied().collect();
 

--- a/crates/sui-types/src/effects/effects_v2.rs
+++ b/crates/sui-types/src/effects/effects_v2.rs
@@ -279,6 +279,26 @@ impl TransactionEffectsAPI for TransactionEffectsV2 {
             .collect()
     }
 
+    fn transferred_to_consensus(&self) -> Vec<ObjectRef> {
+        self.changed_objects
+            .iter()
+            .filter_map(|(id, change)| {
+                match (
+                    &change.input_state,
+                    &change.output_state,
+                    &change.id_operation,
+                ) {
+                    (
+                        ObjectIn::Exist((_, Owner::AddressOwner(_) | Owner::ObjectOwner(_))),
+                        ObjectOut::ObjectWrite((object_digest, Owner::ConsensusV2 { .. })),
+                        IDOperation::None,
+                    ) => Some((*id, self.lamport_version, *object_digest)),
+                    _ => None,
+                }
+            })
+            .collect()
+    }
+
     fn object_changes(&self) -> Vec<ObjectChange> {
         self.changed_objects
             .iter()

--- a/crates/sui-types/src/effects/mod.rs
+++ b/crates/sui-types/src/effects/mod.rs
@@ -336,6 +336,7 @@ pub trait TransactionEffectsAPI {
     fn unwrapped_then_deleted(&self) -> Vec<ObjectRef>;
     fn wrapped(&self) -> Vec<ObjectRef>;
     fn transferred_from_consensus(&self) -> Vec<ObjectRef>;
+    fn transferred_to_consensus(&self) -> Vec<ObjectRef>;
 
     fn object_changes(&self) -> Vec<ObjectChange>;
 

--- a/crates/sui-types/src/storage/mod.rs
+++ b/crates/sui-types/src/storage/mod.rs
@@ -114,9 +114,10 @@ pub enum MarkerValue {
     /// An object was received at the given version in the transaction and is no longer able
     /// to be received at that version in subequent transactions.
     Received,
-    /// An owned object was deleted (or wrapped) at the given version, and is no longer able to be
-    /// accessed or used in subsequent transactions.
-    OwnedDeleted,
+    /// A fastpath object was deleted, wrapped, or transferred to consensus at the given
+    /// vesrion, and is no longer able to be accessed or used in subsequent transactions via
+    /// fastpath unless/until it is returned to fastpath.
+    FastpathStreamEnded,
     /// A consensus object was deleted or removed from consensus by the transaction and is no longer
     /// able to be accessed or used in subsequent transactions with the same initial shared version.
     ConsensusStreamEnded(TransactionDigest),


### PR DESCRIPTION
`OwnedDeleted` marker is renamed to `FastpathStreamEnded` because it is written in many cases besides the deletion of an owned object.

We now also write the marker when a fastpath object is transferred to consensus, so that transfer-to-object can correctly check at execution time whether a receiving object is available.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
