### PR TITLE
[normalized module] Restructure equality for explicit treatment of maps

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_move.rs
+++ b/crates/sui-json-rpc-types/src/sui_move.rs
@@ -18,6 +18,7 @@ use serde_with::serde_as;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::fmt::{Display, Formatter, Write};
+use std::hash::Hash;
 use sui_macros::EnumVariantOrder;
 use tracing::warn;
 
@@ -192,7 +193,7 @@ impl<S: std::hash::Hash + Eq + ToString> From<&NormalizedModule<S>> for SuiMoveN
     }
 }
 
-impl<S: ToString> From<&NormalizedFunction<S>> for SuiMoveNormalizedFunction {
+impl<S: Hash + Eq + ToString> From<&NormalizedFunction<S>> for SuiMoveNormalizedFunction {
     fn from(function: &NormalizedFunction<S>) -> Self {
         Self {
             visibility: match function.visibility {
@@ -221,7 +222,7 @@ impl<S: ToString> From<&NormalizedFunction<S>> for SuiMoveNormalizedFunction {
     }
 }
 
-impl<S: ToString> From<&NormalizedStruct<S>> for SuiMoveNormalizedStruct {
+impl<S: Hash + Eq + ToString> From<&NormalizedStruct<S>> for SuiMoveNormalizedStruct {
     fn from(struct_: &NormalizedStruct<S>) -> Self {
         Self {
             abilities: struct_.abilities.into(),
@@ -233,14 +234,15 @@ impl<S: ToString> From<&NormalizedStruct<S>> for SuiMoveNormalizedStruct {
                 .collect::<Vec<SuiMoveStructTypeParameter>>(),
             fields: struct_
                 .fields
-                .iter()
+                .0
+                .values()
                 .map(|f| SuiMoveNormalizedField::from(&**f))
                 .collect::<Vec<SuiMoveNormalizedField>>(),
         }
     }
 }
 
-impl<S: ToString> From<&NormalizedEnum<S>> for SuiMoveNormalizedEnum {
+impl<S: Hash + Eq + ToString> From<&NormalizedEnum<S>> for SuiMoveNormalizedEnum {
     fn from(value: &NormalizedEnum<S>) -> Self {
         Self {
             abilities: value.abilities.into(),
@@ -252,14 +254,15 @@ impl<S: ToString> From<&NormalizedEnum<S>> for SuiMoveNormalizedEnum {
                 .collect::<Vec<SuiMoveStructTypeParameter>>(),
             variants: value
                 .variants
-                .iter()
+                .values()
                 .map(|variant| {
                     (
                         variant.name.to_string(),
                         variant
                             .fields
-                            .iter()
-                            .map(SuiMoveNormalizedField::from)
+                            .0
+                            .values()
+                            .map(|f| SuiMoveNormalizedField::from(&**f))
                             .collect::<Vec<SuiMoveNormalizedField>>(),
                     )
                 })

--- a/external-crates/move/crates/move-binary-format/src/compatibility.rs
+++ b/external-crates/move/crates/move-binary-format/src/compatibility.rs
@@ -151,7 +151,7 @@ impl Compatibility {
             ) {
                 context.struct_type_param_mismatch(name, old_struct, new_struct);
             }
-            if new_struct.fields != old_struct.fields {
+            if !new_struct.fields.equivalent(&old_struct.fields) {
                 // Fields changed. Code in this module will fail at runtime if it tries to
                 // read a previously published struct value
                 // TODO: this is a stricter definition than required. We could in principle
@@ -193,14 +193,15 @@ impl Compatibility {
                 context.enum_new_variant(name, old_enum, new_enum);
             }
 
-            for (tag, old_variant) in old_enum.variants.iter().enumerate() {
+            for (tag, (_old_name, old_variant)) in old_enum.variants.iter().enumerate() {
                 // If the new enum has fewer variants than the old one, datatype_layout is false
                 // and we don't need to check the rest of the variants.
-                let Some(new_variant) = new_enum.variants.get(tag) else {
+                let Some((_new_name, new_variant)) = new_enum.variants.get_index(tag) else {
                     context.enum_variant_missing(name, old_enum, tag);
                     continue;
                 };
                 if new_variant.name != old_variant.name {
+                    debug_assert_ne!(_new_name, _old_name);
                     // TODO: Variant renamed. This is a stricter definition than required.
                     // We could in principle choose that changing the name (but not position or
                     // type) of a variant is compatible. The VM does not care about the name of a
@@ -208,7 +209,8 @@ impl Compatibility {
                     // presumably would.
                     context.enum_variant_mismatch(name, old_enum, new_enum, tag);
                 }
-                if new_variant.fields != old_variant.fields {
+                debug_assert_eq!(_new_name, _old_name);
+                if !new_variant.fields.equivalent(&old_variant.fields) {
                     // Fields changed. Code in this module will fail at runtime if it tries to
                     // read a previously published enum value
                     // TODO: this is a stricter definition than required. We could in principle
@@ -406,7 +408,7 @@ impl InclusionCheck {
                 Mark::New(name, new) => context.struct_new(name, new),
                 Mark::Missing(name, old) => context.struct_missing(name, old),
                 Mark::Existing(name, old, new) => {
-                    if old != new {
+                    if !old.equivalent(new) {
                         context.struct_change(name, old, new);
                     }
                 }
@@ -419,7 +421,7 @@ impl InclusionCheck {
                 Mark::New(name, new) => context.enum_new(name, new),
                 Mark::Missing(name, old) => context.enum_missing(name, old),
                 Mark::Existing(name, old, new) => {
-                    if old != new {
+                    if !old.equivalent(new) {
                         context.enum_change(name, old);
                     }
                 }
@@ -432,7 +434,7 @@ impl InclusionCheck {
                 Mark::New(name, new) => context.function_new(name, new),
                 Mark::Missing(name, old) => context.function_missing(name, old),
                 Mark::Existing(name, old, new) => {
-                    if !old.equals(new) {
+                    if !old.equivalent(new) {
                         context.function_change(name, old, new);
                     }
                 }

--- a/external-crates/move/crates/move-binary-format/src/compatibility.rs
+++ b/external-crates/move/crates/move-binary-format/src/compatibility.rs
@@ -208,8 +208,9 @@ impl Compatibility {
                     // variant if it's non-public (it's purely informational), but clients
                     // presumably would.
                     context.enum_variant_mismatch(name, old_enum, new_enum, tag);
+                } else {
+                    debug_assert_eq!(_new_name, _old_name);
                 }
-                debug_assert_eq!(_new_name, _old_name);
                 if !new_variant.fields.equivalent(&old_variant.fields) {
                     // Fields changed. Code in this module will fail at runtime if it tries to
                     // read a previously published enum value

--- a/external-crates/move/crates/move-binary-format/src/normalized.rs
+++ b/external-crates/move/crates/move-binary-format/src/normalized.rs
@@ -28,7 +28,7 @@ pub trait StringPool {
     fn as_ident_str<'a>(&'a self, s: &'a Self::String) -> &'a IdentStr;
 }
 
-#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ModuleId<S> {
     pub address: AccountAddress,
     pub name: S,
@@ -83,7 +83,7 @@ pub type Signature<S> = Rc<Vec<Rc<Type<S>>>>;
 
 #[cfg_attr(test, derive(Clone))]
 #[derive(Debug)]
-struct Tables<S> {
+struct Tables<S: Hash + Eq> {
     empty_signature: Signature<S>,
     signatures: Vec<Signature<S>>,
     constants: Vec<Rc<Constant<S>>>,
@@ -102,7 +102,7 @@ pub struct Module<S: Hash + Eq> {
     code_included: bool,
     pub id: ModuleId<S>,
     pub file_format_version: u32,
-    pub dependencies: Vec<ModuleId<S>>,
+    pub immediate_dependencies: Vec<ModuleId<S>>,
     pub friends: Vec<ModuleId<S>>,
     pub structs: IndexMap<S, Rc<Struct<S>>>,
     pub enums: IndexMap<S, Rc<Enum<S>>>,
@@ -112,7 +112,7 @@ pub struct Module<S: Hash + Eq> {
 
 /// Normalized version of a `Constant`.
 #[cfg_attr(test, derive(Clone))]
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug)]
 pub struct Constant<S> {
     pub type_: Type<S>,
     pub data: Vec<u8>,
@@ -121,12 +121,12 @@ pub struct Constant<S> {
 /// Normalized version of a `StructDefinition`. Not safe to compare without an associated
 /// `ModuleId` or `Module`.
 #[cfg_attr(test, derive(Clone))]
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct Struct<S> {
+#[derive(Debug)]
+pub struct Struct<S: Hash + Eq> {
     pub name: S,
     pub abilities: AbilitySet,
     pub type_parameters: Vec<DatatypeTyParameter>,
-    pub fields: Vec<Rc<Field<S>>>,
+    pub fields: IndexMap<S, Rc<Field<S>>>,
 }
 
 /// Normalized version of a `FieldDefinition`. The `name` is included even though it is
@@ -134,7 +134,7 @@ pub struct Struct<S> {
 /// want a change from `Account { bal: u64, seq: u64 }` to `Account { seq: u64, bal: u64 }` to be
 /// marked as incompatible. Not safe to compare without an enclosing `Struct`.
 #[cfg_attr(test, derive(Clone))]
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug)]
 pub struct Field<S> {
     pub name: S,
     pub type_: Type<S>,
@@ -144,7 +144,7 @@ pub struct Field<S> {
 /// `ModuleId` or `Module`.
 #[cfg_attr(test, derive(Clone))]
 #[derive(Debug)]
-pub struct Function<S> {
+pub struct Function<S: Hash + Eq> {
     pub name: S,
     pub visibility: Visibility,
     pub is_entry: bool,
@@ -159,42 +159,42 @@ pub struct Function<S> {
 /// Normalized version of a `EnumDefinition`. Not safe to compare without an associated
 /// `ModuleId` or `Module`.
 #[cfg_attr(test, derive(Clone))]
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct Enum<S> {
+#[derive(Debug)]
+pub struct Enum<S: Hash + Eq> {
     pub name: S,
     pub abilities: AbilitySet,
     pub type_parameters: Vec<DatatypeTyParameter>,
-    pub variants: Vec<Rc<Variant<S>>>,
+    pub variants: IndexMap<S, Rc<Variant<S>>>,
 }
 
 /// Normalized version of a `VariantDefinition`. Not safe to compare without an associated
 /// `ModuleId` or `Module`.
 #[cfg_attr(test, derive(Clone))]
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct Variant<S> {
+#[derive(Debug)]
+pub struct Variant<S: Hash + Eq> {
     pub name: S,
-    pub fields: Vec<Field<S>>,
+    pub fields: IndexMap<S, Rc<Field<S>>>,
 }
 
 /// Normalized version of a `VariantJumpTable`. Not safe to compare without an associated
 /// `ModuleId` or `Module`.
 #[cfg_attr(test, derive(Clone))]
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct VariantJumpTable<S> {
+#[derive(Debug)]
+pub struct VariantJumpTable<S: Hash + Eq> {
     pub enum_: Rc<Enum<S>>,
     pub jump_table: JumpTableInner,
 }
 
 pub type ConstantRef<S> = Rc<Constant<S>>;
 
-#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
-pub struct StructRef<S> {
+#[derive(Clone, Debug)]
+pub struct StructRef<S: Hash + Eq> {
     pub struct_: Rc<Struct<S>>,
     pub type_arguments: Signature<S>,
 }
 
-#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
-pub struct FieldRef<S> {
+#[derive(Clone, Debug)]
+pub struct FieldRef<S: Hash + Eq> {
     pub struct_: Rc<Struct<S>>,
     pub field: Rc<Field<S>>,
     /// Type arguments to the struct
@@ -210,7 +210,7 @@ pub struct FieldRef<S> {
 //   - The callee is in the same package as this call, in which case the callee couldn't have changed; or
 //   - The callee was in a different package and therefore public, and therefore the API of that
 //   function must not have changed by compatibility rules.
-#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct FunctionRef<S> {
     pub module: ModuleId<S>,
     pub function: S,
@@ -218,8 +218,8 @@ pub struct FunctionRef<S> {
 }
 
 /// Normalized version of a `VariantRef` and `VariantInstantiationHandle`.
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct VariantRef<S> {
+#[derive(Clone, Debug)]
+pub struct VariantRef<S: Hash + Eq> {
     pub enum_: Rc<Enum<S>>,
     pub variant: Rc<Variant<S>>,
     /// The type arguments to the enum
@@ -229,8 +229,8 @@ pub struct VariantRef<S> {
 pub type VariantJumpTableRef<S> = Rc<VariantJumpTable<S>>;
 
 /// Normalized representation of bytecode.
-#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
-pub enum Bytecode<S> {
+#[derive(Clone, Debug)]
+pub enum Bytecode<S: Hash + Eq> {
     Pop,
     Ret,
     BrTrue(CodeOffset),
@@ -561,12 +561,44 @@ impl<S> Datatype<S> {
     }
 }
 
-impl<S> Tables<S> {
+fn vec_ordered_equivalent<T, P: FnMut(&T, &T) -> bool>(
+    a: &[T],
+    b: &[T],
+    mut equivalent: P,
+) -> bool {
+    a.len() == b.len() && a.iter().zip(b).all(|(a, b)| equivalent(a, b))
+}
+
+fn map_ordered_equivalent<K: Eq, V, P: FnMut(&V, &V) -> bool>(
+    a: &IndexMap<K, V>,
+    b: &IndexMap<K, V>,
+    mut equivalent: P,
+) -> bool {
+    a.len() == b.len()
+        && a.iter()
+            .zip(b)
+            .all(|((k1, v1), (k2, v2))| k1 == k2 && equivalent(v1, v2))
+}
+
+fn map_keyed_equivalent<K: Hash + Eq, V, P: FnMut(&V, &V) -> bool>(
+    a: &IndexMap<K, V>,
+    b: &IndexMap<K, V>,
+    mut equivalent: P,
+) -> bool {
+    a.len() == b.len()
+        && a.iter()
+            .all(|(k, v1)| b.get(k).map_or(false, |v2| equivalent(v1, v2)))
+}
+
+impl<S: Hash + Eq> Tables<S> {
     fn new<Pool: StringPool<String = S>>(
         pool: &mut Pool,
         m: &CompiledModule,
         include_code: bool,
-    ) -> Self {
+    ) -> Self
+    where
+        S: Clone,
+    {
         let mut tables = Tables {
             empty_signature: Rc::new(vec![]),
             signatures: Vec::new(),
@@ -624,7 +656,7 @@ impl<S: Hash + Eq> Module<S> {
             .into_iter()
             .map(|f| ModuleId::new(pool, &f))
             .collect();
-        let dependencies = m
+        let immediate_dependencies = m
             .immediate_dependencies()
             .into_iter()
             .map(|d| ModuleId::new(pool, &d))
@@ -659,7 +691,7 @@ impl<S: Hash + Eq> Module<S> {
             structs,
             enums,
             functions,
-            dependencies,
+            immediate_dependencies,
             constants,
         }
     }
@@ -674,23 +706,13 @@ impl<S: Hash + Eq> Module<S> {
 
     /// Panics if called with `include_code` set to `false`.
     /// Note this checks the order of functions, structs, and enums in the module.
-    pub fn equals(&self, other: &Self) -> bool {
-        fn function_equals<S: Hash + Eq>(
-            functions: &IndexMap<S, Rc<Function<S>>>,
-            other_functions: &IndexMap<S, Rc<Function<S>>>,
-        ) -> bool {
-            functions.len() == other_functions.len()
-                && functions
-                    .iter()
-                    .zip(other_functions)
-                    .all(|((n1, f1), (n2, f2))| n1 == n2 && f1.equals(f2))
-        }
+    pub fn equivalent(&self, other: &Self) -> bool {
         let Self {
             tables: _,
             code_included,
             id,
             file_format_version,
-            dependencies,
+            immediate_dependencies,
             friends,
             structs,
             enums,
@@ -703,12 +725,12 @@ impl<S: Hash + Eq> Module<S> {
         }
         id == &other.id
             && file_format_version == &other.file_format_version
-            && dependencies == &other.dependencies
+            && immediate_dependencies == &other.immediate_dependencies
             && friends == &other.friends
-            && structs == &other.structs
-            && enums == &other.enums
-            && function_equals(functions, &other.functions)
-            && constants == &other.constants
+            && map_keyed_equivalent(structs, &other.structs, |s1, s2| s1.equivalent(s2))
+            && map_keyed_equivalent(enums, &other.enums, |e1, e2| e1.equivalent(e2))
+            && map_keyed_equivalent(functions, &other.functions, |f1, f2| f1.equivalent(f2))
+            && vec_ordered_equivalent(constants, &other.constants, |c1, c2| c1.equivalent(c2))
     }
 }
 
@@ -723,25 +745,39 @@ impl<S> Constant<S> {
             data: constant.data.clone(),
         }
     }
+
+    pub fn equivalent(&self, other: &Self) -> bool
+    where
+        S: Eq,
+    {
+        let Self { type_, data } = self;
+        type_ == &other.type_ && data == &other.data
+    }
 }
 
-impl<S> Struct<S> {
+impl<S: Hash + Eq> Struct<S> {
     /// Create a `Struct` for `StructDefinition` `def` in module `m`. Panics if `def` is a
     /// a native struct definition.
     fn new<Pool: StringPool<String = S>>(
         pool: &mut Pool,
         m: &CompiledModule,
         def: &StructDefinition,
-    ) -> Self {
+    ) -> Self
+    where
+        S: Clone,
+    {
         let handle = m.datatype_handle_at(def.struct_handle);
         let fields = match &def.field_information {
             StructFieldInformation::Native => {
                 // Pretend for compatibility checking no fields
-                vec![]
+                IndexMap::new()
             }
             StructFieldInformation::Declared(fields) => fields
                 .iter()
-                .map(|f| Rc::new(Field::new(pool, m, f)))
+                .map(|f| {
+                    let f = Field::new(pool, m, f);
+                    (f.name.clone(), Rc::new(f))
+                })
                 .collect(),
         };
         let name = pool.intern(m.identifier_at(handle.name));
@@ -755,6 +791,19 @@ impl<S> Struct<S> {
 
     pub fn type_param_constraints(&self) -> impl ExactSizeIterator<Item = &AbilitySet> {
         self.type_parameters.iter().map(|param| &param.constraints)
+    }
+
+    pub fn equivalent(&self, other: &Self) -> bool {
+        let Self {
+            name,
+            abilities,
+            type_parameters,
+            fields,
+        } = self;
+        name == &other.name
+            && abilities == &other.abilities
+            && type_parameters == &other.type_parameters
+            && map_ordered_equivalent(fields, &other.fields, |f1, f2| f1.equivalent(f2))
     }
 }
 
@@ -770,9 +819,17 @@ impl<S> Field<S> {
             type_: Type::new(pool, m, &f.signature.0),
         }
     }
+
+    pub fn equivalent(&self, other: &Self) -> bool
+    where
+        S: Eq,
+    {
+        let Self { name, type_ } = self;
+        name == &other.name && type_ == &other.type_
+    }
 }
 
-impl<S> Function<S> {
+impl<S: Hash + Eq> Function<S> {
     /// Create a `FunctionSignature` for `FunctionHandle` `f` in module `m`.
     fn new<Pool: StringPool<String = S>>(
         tables: &Tables<S>,
@@ -824,10 +881,7 @@ impl<S> Function<S> {
     }
 
     /// Should not be called if `code_included` is `false`--will panic in debug builds.
-    pub fn equals(&self, other: &Self) -> bool
-    where
-        S: Eq,
-    {
+    pub fn equivalent(&self, other: &Self) -> bool {
         let Self {
             name,
             visibility,
@@ -849,24 +903,30 @@ impl<S> Function<S> {
             && type_parameters == &other.type_parameters
             && parameters == &other.parameters
             && return_ == &other.return_
-            && jump_tables == &other.jump_tables
-            && code == &other.code
+            && vec_ordered_equivalent(jump_tables, &other.jump_tables, |j1, j2| j1.equivalent(j2))
+            && vec_ordered_equivalent(code, &other.code, |b1, b2| b1.equivalent(b2))
     }
 }
 
-impl<S> Enum<S> {
+impl<S: Hash + Eq> Enum<S> {
     pub fn new<Pool: StringPool<String = S>>(
         pool: &mut Pool,
         m: &CompiledModule,
         def: &EnumDefinition,
-    ) -> Self {
+    ) -> Self
+    where
+        S: Clone,
+    {
         let handle = m.datatype_handle_at(def.enum_handle);
         let name = pool.intern(m.identifier_at(handle.name));
         let variants = def
             .variants
             .iter()
-            .map(|v| Rc::new(Variant::new(pool, m, v)))
-            .collect::<Vec<_>>();
+            .map(|v| {
+                let v = Variant::new(pool, m, v);
+                (v.name.clone(), Rc::new(v))
+            })
+            .collect();
         Enum {
             name,
             abilities: handle.abilities,
@@ -874,22 +934,51 @@ impl<S> Enum<S> {
             variants,
         }
     }
+
+    pub fn equivalent(&self, other: &Self) -> bool {
+        let Self {
+            name,
+            abilities,
+            type_parameters,
+            variants,
+        } = self;
+        name == &other.name
+            && abilities == &other.abilities
+            && type_parameters == &other.type_parameters
+            && map_ordered_equivalent(variants, &other.variants, |v1, v2| v1.equivalent(v2))
+    }
 }
 
-impl<S> Variant<S> {
+impl<S: Hash + Eq> Variant<S> {
     pub fn new<Pool: StringPool<String = S>>(
         pool: &mut Pool,
         m: &CompiledModule,
         v: &VariantDefinition,
-    ) -> Self {
+    ) -> Self
+    where
+        S: Clone,
+    {
         Self {
             name: pool.intern(m.identifier_at(v.variant_name)),
-            fields: v.fields.iter().map(|f| Field::new(pool, m, f)).collect(),
+            fields: v
+                .fields
+                .iter()
+                .map(|f| {
+                    let f = Field::new(pool, m, f);
+                    (f.name.clone(), Rc::new(f))
+                })
+                .collect(),
         }
+    }
+
+    pub fn equivalent(&self, other: &Self) -> bool {
+        let Self { name, fields } = self;
+        name == &other.name
+            && map_ordered_equivalent(fields, &other.fields, |f1, f2| f1.equivalent(f2))
     }
 }
 
-impl<S> VariantJumpTable<S> {
+impl<S: Hash + Eq> VariantJumpTable<S> {
     fn new(tables: &Tables<S>, jt: &file_format::VariantJumpTable) -> Self {
         let enum_ = tables.enum_defs[jt.head_enum.0 as usize].clone();
         Self {
@@ -897,9 +986,14 @@ impl<S> VariantJumpTable<S> {
             jump_table: jt.jump_table.clone(),
         }
     }
+
+    pub fn equivalent(&self, other: &Self) -> bool {
+        let Self { enum_, jump_table } = self;
+        enum_.name == other.enum_.name && jump_table == &other.jump_table
+    }
 }
 
-impl<S> StructRef<S> {
+impl<S: Hash + Eq> StructRef<S> {
     fn new(
         tables: &Tables<S>,
         struct_handle: StructDefinitionIndex,
@@ -927,9 +1021,17 @@ impl<S> StructRef<S> {
             Some(struct_instantiation.type_parameters),
         )
     }
+
+    pub fn equivalent(&self, other: &Self) -> bool {
+        let Self {
+            struct_,
+            type_arguments,
+        } = self;
+        struct_.name == other.struct_.name && type_arguments == &other.type_arguments
+    }
 }
 
-impl<S> FieldRef<S> {
+impl<S: Hash + Eq> FieldRef<S> {
     fn new(
         tables: &Tables<S>,
         m: &CompiledModule,
@@ -958,9 +1060,20 @@ impl<S> FieldRef<S> {
             Some(field_instantiation.type_parameters),
         )
     }
+
+    pub fn equivalent(&self, other: &Self) -> bool {
+        let Self {
+            struct_,
+            field,
+            instantiation,
+        } = self;
+        struct_.name == other.struct_.name
+            && field.name == other.field.name
+            && instantiation == &other.instantiation
+    }
 }
 
-impl<S> FunctionRef<S> {
+impl<S: Hash + Eq> FunctionRef<S> {
     fn new<Pool: StringPool<String = S>>(
         tables: &Tables<S>,
         pool: &mut Pool,
@@ -1000,9 +1113,20 @@ impl<S> FunctionRef<S> {
             Some(function_instantiation.type_parameters),
         )
     }
+
+    pub fn equivalent(&self, other: &Self) -> bool {
+        let Self {
+            module,
+            function,
+            type_arguments,
+        } = self;
+        module == &other.module
+            && function == &other.function
+            && type_arguments == &other.type_arguments
+    }
 }
 
-impl<S> VariantRef<S> {
+impl<S: Hash + Eq> VariantRef<S> {
     fn new(
         tables: &Tables<S>,
         enum_def: EnumDefinitionIndex,
@@ -1049,9 +1173,20 @@ impl<S> VariantRef<S> {
             Some(enum_instantiation.type_parameters),
         )
     }
+
+    pub fn equivalent(&self, other: &Self) -> bool {
+        let Self {
+            enum_,
+            variant,
+            instantiation,
+        } = self;
+        enum_.name == other.enum_.name
+            && variant.name == other.variant.name
+            && instantiation == &other.instantiation
+    }
 }
 
-impl<S> Bytecode<S> {
+impl<S: Hash + Eq> Bytecode<S> {
     fn new<Pool: StringPool<String = S>>(
         tables: &Tables<S>,
         pool: &mut Pool,
@@ -1204,9 +1339,95 @@ impl<S> Bytecode<S> {
             FB::VariantSwitch(jti) => B::VariantSwitch(jump_tables[jti.0 as usize].clone()),
         }
     }
+
+    pub fn equivalent(&self, other: &Self) -> bool {
+        use Bytecode as B;
+        match (self, other) {
+            (B::Pop, B::Pop)
+            | (B::Ret, B::Ret)
+            | (B::CastU8, B::CastU8)
+            | (B::CastU64, B::CastU64)
+            | (B::CastU128, B::CastU128)
+            | (B::LdTrue, B::LdTrue)
+            | (B::LdFalse, B::LdFalse)
+            | (B::ReadRef, B::ReadRef)
+            | (B::WriteRef, B::WriteRef)
+            | (B::FreezeRef, B::FreezeRef)
+            | (B::Add, B::Add)
+            | (B::Sub, B::Sub)
+            | (B::Mul, B::Mul)
+            | (B::Mod, B::Mod)
+            | (B::Div, B::Div)
+            | (B::BitOr, B::BitOr)
+            | (B::BitAnd, B::BitAnd)
+            | (B::Xor, B::Xor)
+            | (B::Or, B::Or)
+            | (B::And, B::And)
+            | (B::Not, B::Not)
+            | (B::Eq, B::Eq)
+            | (B::Neq, B::Neq)
+            | (B::Lt, B::Lt)
+            | (B::Gt, B::Gt)
+            | (B::Le, B::Le)
+            | (B::Ge, B::Ge)
+            | (B::Abort, B::Abort)
+            | (B::Nop, B::Nop)
+            | (B::Shl, B::Shl)
+            | (B::Shr, B::Shr)
+            | (B::CastU16, B::CastU16)
+            | (B::CastU32, B::CastU32)
+            | (B::CastU256, B::CastU256) => true,
+            (B::BrTrue(x), B::BrTrue(y))
+            | (B::BrFalse(x), B::BrFalse(y))
+            | (B::Branch(x), B::Branch(y)) => x == y,
+            (B::LdU8(x), B::LdU8(y)) => x == y,
+            (B::LdU64(x), B::LdU64(y)) => x == y,
+            (B::LdU128(x), B::LdU128(y)) => x == y,
+            (B::LdConst(x), B::LdConst(y)) => x.equivalent(y),
+            (B::CopyLoc(x), B::CopyLoc(y)) => x == y,
+            (B::MoveLoc(x), B::MoveLoc(y)) => x == y,
+            (B::StLoc(x), B::StLoc(y)) => x == y,
+            (B::Call(x), B::Call(y)) => x.equivalent(y),
+            (B::Pack(x), B::Pack(y)) => x.equivalent(y),
+            (B::Unpack(x), B::Unpack(y)) => x.equivalent(y),
+            (B::MutBorrowLoc(x), B::MutBorrowLoc(y)) => x == y,
+            (B::ImmBorrowLoc(x), B::ImmBorrowLoc(y)) => x == y,
+            (B::MutBorrowField(x), B::MutBorrowField(y)) => x.equivalent(y),
+            (B::ImmBorrowField(x), B::ImmBorrowField(y)) => x.equivalent(y),
+            (B::VecPack(x), B::VecPack(y)) => x == y,
+            (B::VecLen(x), B::VecLen(y)) => x == y,
+            (B::VecImmBorrow(x), B::VecImmBorrow(y)) => x == y,
+            (B::VecMutBorrow(x), B::VecMutBorrow(y)) => x == y,
+            (B::VecPushBack(x), B::VecPushBack(y)) => x == y,
+            (B::VecPopBack(x), B::VecPopBack(y)) => x == y,
+            (B::VecUnpack(x), B::VecUnpack(y)) => x == y,
+            (B::VecSwap(x), B::VecSwap(y)) => x == y,
+            (B::LdU16(x), B::LdU16(y)) => x == y,
+            (B::LdU32(x), B::LdU32(y)) => x == y,
+            (B::LdU256(x), B::LdU256(y)) => x == y,
+            (B::PackVariant(x), B::PackVariant(y)) => x.equivalent(y),
+            (B::UnpackVariant(x), B::UnpackVariant(y)) => x.equivalent(y),
+            (B::UnpackVariantImmRef(x), B::UnpackVariantImmRef(y)) => x.equivalent(y),
+            (B::UnpackVariantMutRef(x), B::UnpackVariantMutRef(y)) => x.equivalent(y),
+            (B::VariantSwitch(x), B::VariantSwitch(y)) => x.equivalent(y),
+            (B::MutBorrowGlobalDeprecated(x), B::MutBorrowGlobalDeprecated(y)) => x.equivalent(y),
+            (B::ImmBorrowGlobalDeprecated(x), B::ImmBorrowGlobalDeprecated(y)) => x.equivalent(y),
+            (B::ExistsDeprecated(x), B::ExistsDeprecated(y)) => x.equivalent(y),
+            (B::MoveFromDeprecated(x), B::MoveFromDeprecated(y)) => x.equivalent(y),
+            (B::MoveToDeprecated(x), B::MoveToDeprecated(y)) => x.equivalent(y),
+            (a, b) => {
+                // the variants must be different
+                debug_assert_ne!(std::mem::discriminant(a), std::mem::discriminant(b));
+                false
+            }
+        }
+    }
 }
 
-fn signature_to_single_type<S>(tables: &Tables<S>, sig_idx: SignatureIndex) -> Rc<Type<S>> {
+fn signature_to_single_type<S: Hash + Eq>(
+    tables: &Tables<S>,
+    sig_idx: SignatureIndex,
+) -> Rc<Type<S>> {
     tables.signatures[sig_idx.0 as usize][0].clone()
 }
 
@@ -1262,7 +1483,7 @@ impl<S: std::fmt::Display> std::fmt::Display for Datatype<S> {
 
 #[test]
 fn sizes() {
-    #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     struct Big([u8; 1024]);
 
     assert_eq!(std::mem::size_of::<Type<Big>>(), 16);

--- a/external-crates/move/crates/move-binary-format/src/unit_tests/compatibility_tests.rs
+++ b/external-crates/move/crates/move-binary-format/src/unit_tests/compatibility_tests.rs
@@ -1008,7 +1008,7 @@ fn check_exact_and_unchange_same_module_permutations() {
         Visibility::Private as u8,
         Permutation::new(vec![1, 0]),
     ));
-    assert!(!m2.equals(&m3));
+    assert!(!m2.equivalent(&m3));
     assert!(InclusionCheck::Equal.check(&m2, &m3).is_ok());
     assert!(InclusionCheck::Equal.check(&m3, &m2).is_ok());
     // double inclusion

--- a/external-crates/move/crates/move-bytecode-utils/src/layout.rs
+++ b/external-crates/move/crates/move-bytecode-utils/src/layout.rs
@@ -332,7 +332,8 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
         check_depth!(depth);
         let fields = normalized_struct
             .fields
-            .iter()
+            .0
+            .values()
             .map(|f| {
                 self.build_normalized_type_layout(&f.type_, type_arguments, depth)
                     .map(|value| Named {
@@ -353,12 +354,13 @@ impl<'a, T: GetModule> SerdeLayoutBuilder<'a, T> {
         check_depth!(depth);
         let variants = normalized_enum
             .variants
-            .iter()
+            .values()
             .enumerate()
             .map(|(i, v)| {
                 let fields = v
                     .fields
-                    .iter()
+                    .0
+                    .values()
                     .map(|f| {
                         self.build_normalized_type_layout(&f.type_, type_arguments, depth)
                             .map(|value| Named {


### PR DESCRIPTION
## Description 

- Separates changes from #21778 that are a bit more involved than I would have hoped
- Adds more uses of IndexMap and explicit indications of how equality is treated, whether it is this sort of "set based", key-value equality OR if it should be treated as an ordered, indexed collection.

## Test plan 

- Ran tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
