### PR TITLE
[typed store] add backoff to safe_drop_db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17474,6 +17474,7 @@ name = "typed-store"
 version = "0.4.0"
 dependencies = [
  "async-trait",
+ "backoff",
  "bcs",
  "bincode",
  "collectable",

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
+backoff.workspace = true
 bcs.workspace = true
 bincode.workspace = true
 collectable.workspace = true


### PR DESCRIPTION
## Description 

Mitigates the race between the destructor and metric threads. Reason: `rocksdb::DB::Destroy` returns an error immediately if any other reference is still alive

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
