### PR TITLE
[indexer-alt][5/n] Parameterize indexer alt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14443,7 +14443,6 @@ dependencies = [
  "sui-indexer-alt-metrics",
  "sui-pg-db",
  "sui-rpc-api",
- "sui-sql-macro",
  "sui-storage",
  "sui-synthetic-ingestion",
  "sui-types",

--- a/crates/sui-indexer-alt-e2e-tests/Cargo.toml
+++ b/crates/sui-indexer-alt-e2e-tests/Cargo.toml
@@ -25,7 +25,7 @@ url.workspace = true
 
 simulacrum.workspace = true
 sui-indexer-alt.workspace = true
-sui-indexer-alt-framework.workspace = true
+sui-indexer-alt-framework = { workspace = true, features = ["postgres"] }
 sui-indexer-alt-graphql.workspace = true
 sui-indexer-alt-jsonrpc.workspace = true
 sui-indexer-alt-reader.workspace = true

--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -12,7 +12,7 @@ use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};
 use diesel_async::RunQueryDsl;
 use simulacrum::Simulacrum;
 use sui_indexer_alt::{config::IndexerConfig, setup_indexer};
-use sui_indexer_alt_framework::{db::schema::watermarks, ingestion::ClientArgs, IndexerArgs};
+use sui_indexer_alt_framework::{ingestion::ClientArgs, postgres::schema::watermarks, IndexerArgs};
 use sui_indexer_alt_graphql::{
     config::RpcConfig as GraphQlConfig, start_rpc as start_graphql, RpcArgs as GraphQlArgs,
 };

--- a/crates/sui-indexer-alt-framework/Cargo.toml
+++ b/crates/sui-indexer-alt-framework/Cargo.toml
@@ -35,19 +35,21 @@ url.workspace = true
 sui-field-count.workspace = true
 sui-indexer-alt-framework-store-traits.workspace = true
 sui-indexer-alt-metrics.workspace = true
-sui-pg-db.workspace = true
 sui-rpc-api.workspace = true
-sui-sql-macro.workspace = true
 sui-storage.workspace = true
 sui-types.workspace = true
+
+sui-pg-db = { workspace = true, optional = true }
 
 [dev-dependencies]
 rand.workspace = true
 telemetry-subscribers.workspace = true
 wiremock.workspace = true
+sui-pg-db.workspace = true
 
 sui-synthetic-ingestion.workspace = true
 
 [features]
 default = ["cluster"]
-cluster = ["dep:tracing-subscriber"]
+cluster = ["dep:tracing-subscriber", "postgres"]
+postgres = ["dep:sui-pg-db"]

--- a/crates/sui-indexer-alt-framework/src/cluster.rs
+++ b/crates/sui-indexer-alt-framework/src/cluster.rs
@@ -178,8 +178,6 @@ mod tests {
     use sui_synthetic_ingestion::synthetic_ingestion;
     use tempfile::tempdir;
 
-    use super::*;
-
     use crate::pipeline::concurrent::{self, ConcurrentConfig};
     use crate::pipeline::Processor;
     use crate::postgres::{
@@ -188,6 +186,8 @@ mod tests {
     };
     use crate::types::full_checkpoint_content::CheckpointData;
     use crate::FieldCount;
+
+    use super::*;
 
     diesel::table! {
         /// Table for storing transaction counts per checkpoint.

--- a/crates/sui-indexer-alt-framework/src/cluster.rs
+++ b/crates/sui-indexer-alt-framework/src/cluster.rs
@@ -15,8 +15,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 use url::Url;
 
+use crate::postgres::{Db, DbArgs};
 use crate::{
-    db::DbArgs,
     ingestion::{ClientArgs, IngestionConfig},
     Indexer, IndexerArgs, IndexerMetrics, Result,
 };
@@ -39,11 +39,11 @@ pub struct Args {
     metrics_args: MetricsArgs,
 }
 
-/// An [IndexerCluster] combines an [Indexer] with a [MetricsService] and a tracing subscriber
-/// (outputting to stderr) to provide observability. It is a useful starting point for an indexer
-/// binary.
+/// An opinionated [IndexerCluster] that spins up an [Indexer] implementation using Postgres as its
+/// store, along with a [MetricsService] and a tracing subscriber (outputting to stderr) to provide
+/// observability. It is a useful starting point for an indexer binary.
 pub struct IndexerCluster {
-    indexer: Indexer,
+    indexer: Indexer<Db>,
     metrics: MetricsService,
 
     /// Cancelling this token signals cancellation to both the indexer and metrics service.
@@ -95,7 +95,7 @@ impl IndexerCluster {
 
         let metrics = MetricsService::new(args.metrics_args, registry, cancel.child_token());
 
-        let indexer = Indexer::new(
+        let indexer = Indexer::new_from_pg(
             database_url,
             db_args,
             args.indexer_args,
@@ -156,7 +156,7 @@ impl IndexerCluster {
 }
 
 impl Deref for IndexerCluster {
-    type Target = Indexer;
+    type Target = Indexer<Db>;
 
     fn deref(&self) -> &Self::Target {
         &self.indexer
@@ -178,16 +178,16 @@ mod tests {
     use sui_synthetic_ingestion::synthetic_ingestion;
     use tempfile::tempdir;
 
-    use crate::db::{
-        temp::{get_available_port, TempDb},
-        Connection, Db,
-    };
+    use super::*;
+
     use crate::pipeline::concurrent::{self, ConcurrentConfig};
     use crate::pipeline::Processor;
+    use crate::postgres::{
+        temp::{get_available_port, TempDb},
+        Connection, Db, DbArgs,
+    };
     use crate::types::full_checkpoint_content::CheckpointData;
     use crate::FieldCount;
-
-    use super::*;
 
     diesel::table! {
         /// Table for storing transaction counts per checkpoint.

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -4,11 +4,6 @@
 use std::{collections::BTreeSet, sync::Arc};
 
 use anyhow::{ensure, Context};
-use diesel::{
-    migration::{self, Migration, MigrationSource},
-    pg::Pg,
-};
-use diesel_migrations::EmbeddedMigrations;
 use futures::future;
 use ingestion::{client::IngestionClient, ClientArgs, IngestionConfig, IngestionService};
 use metrics::IndexerMetrics;
@@ -18,22 +13,20 @@ use pipeline::{
     Processor,
 };
 use prometheus::Registry;
-use sui_indexer_alt_framework_store_traits::{CommitterWatermark, Connection};
+use sui_indexer_alt_framework_store_traits::{
+    CommitterWatermark, Connection, Store, TransactionalStore,
+};
 use sui_indexer_alt_metrics::db::DbConnectionStatsCollector;
 use sui_pg_db::{temp::TempDb, Db, DbArgs};
 use tempfile::tempdir;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
-use url::Url;
 
 pub use anyhow::Result;
 pub use sui_field_count::FieldCount;
 /// External users access the store trait through framework::store
 pub use sui_indexer_alt_framework_store_traits as store;
-/// External users can opt in to a specific implementation through framework::db
-pub use sui_pg_db as db;
-pub use sui_sql_macro::sql;
 pub use sui_types as types;
 
 #[cfg(feature = "cluster")]
@@ -41,11 +34,9 @@ pub mod cluster;
 pub mod ingestion;
 pub mod metrics;
 pub mod pipeline;
+#[cfg(feature = "postgres")]
+pub mod postgres;
 pub mod task;
-
-// TODO (wlmyng)
-// #[cfg(feature = "postgres")]
-const MIGRATIONS: EmbeddedMigrations = sui_pg_db::MIGRATIONS;
 
 /// Command-line arguments for the indexer
 #[derive(clap::Args, Default, Debug, Clone)]
@@ -71,11 +62,11 @@ pub struct IndexerArgs {
     pub skip_watermark: bool,
 }
 
-// TODO (wlmyng): Parameterize over S: Store
-pub struct Indexer {
-    // TODO (wlmyng): rename to `Store`
-    /// Connection pool to the database.
-    db: Db,
+pub struct Indexer<S: Store> {
+    /// The storage backend that the indexer uses to write and query indexed data. This
+    /// generic implementation allows for plugging in different storage solutions that implement the
+    /// `Store` trait.
+    store: S,
 
     /// Prometheus Metrics.
     metrics: Arc<IndexerMetrics>,
@@ -113,31 +104,23 @@ pub struct Indexer {
     handles: Vec<JoinHandle<()>>,
 }
 
-// TODO (wlmyng): non-pg store impl<S: TransactionalStore> Indexer<S> {
-impl Indexer {
-    /// Create a new instance of the indexer framework. `database_url`, `db_args`, `indexer_args,`,
-    /// `client_args`, and `ingestion_config` contain configurations for the following,
-    /// respectively:
+impl<S: Store> Indexer<S> {
+    /// Create a new instance of the indexer framework from a store that implements the `Store`
+    /// trait, along with `indexer_args`, `client_args`, and `ingestion_config`. Together, these
+    /// arguments configure the following:
     ///
-    /// - Connecting to the database,
-    /// - What is indexed (which checkpoints, which pipelines, whether to update the watermarks
-    ///   table) and where to serve metrics from,
+    /// - What is indexed (which checkpoints, which pipelines, whether to track and update
+    ///   watermarks) and where to serve metrics from,
     /// - Where to download checkpoints from,
     /// - Concurrency and buffering parameters for downloading checkpoints.
-    ///
-    /// Optional `migrations` contains the SQL to run in order to bring the database schema up-to-date for
-    /// the specific instance of the indexer, generated using diesel's `embed_migrations!` macro.
-    /// These migrations will be run as part of initializing the indexer if provided.
     ///
     /// After initialization, at least one pipeline must be added using [Self::concurrent_pipeline]
     /// or [Self::sequential_pipeline], before the indexer is started using [Self::run].
     pub async fn new(
-        database_url: Url,
-        db_args: DbArgs,
+        store: S,
         indexer_args: IndexerArgs,
         client_args: ClientArgs,
         ingestion_config: IngestionConfig,
-        migrations: Option<&'static EmbeddedMigrations>,
         registry: &Registry,
         cancel: CancellationToken,
     ) -> Result<Self> {
@@ -148,24 +131,7 @@ impl Indexer {
             skip_watermark,
         } = indexer_args;
 
-        // TODO (wlmyng): This will become an arg into `new`
-        let db = Db::for_write(database_url, db_args) // I guess our store needs a constructor fn
-            .await
-            .context("Failed to connect to database")?;
-
-        // At indexer initialization, we ensure that the DB schema is up-to-date.
-        db.run_migrations(Self::migrations(migrations))
-            .await
-            .context("Failed to run pending migrations")?;
-
         let metrics = IndexerMetrics::new(registry);
-
-        // TODO (wlmyng): Users will be responsible for configuring their registry with db metrics,
-        // if desired
-        registry.register(Box::new(DbConnectionStatsCollector::new(
-            Some("indexer_db"),
-            db.clone(),
-        )))?;
 
         let ingestion_service = IngestionService::new(
             client_args,
@@ -175,7 +141,7 @@ impl Indexer {
         )?;
 
         Ok(Self {
-            db,
+            store,
             metrics,
             ingestion_service,
             first_checkpoint,
@@ -193,32 +159,9 @@ impl Indexer {
         })
     }
 
-    pub async fn new_for_testing(migrations: &'static EmbeddedMigrations) -> (Self, TempDb) {
-        let temp_db = TempDb::new().unwrap();
-        let indexer = Indexer::new(
-            temp_db.database().url().clone(),
-            DbArgs::default(),
-            IndexerArgs::default(),
-            ClientArgs {
-                remote_store_url: None,
-                local_ingestion_path: Some(tempdir().unwrap().into_path()),
-                rpc_api_url: None,
-                rpc_username: None,
-                rpc_password: None,
-            },
-            IngestionConfig::default(),
-            Some(migrations),
-            &Registry::new(),
-            CancellationToken::new(),
-        )
-        .await
-        .unwrap();
-        (indexer, temp_db)
-    }
-
-    /// The database connection pool used by the indexer.
-    pub fn db(&self) -> &Db {
-        &self.db
+    /// The store used by the indexer.
+    pub fn store(&self) -> &S {
+        &self.store
     }
 
     /// The ingestion client used by the indexer to fetch checkpoints.
@@ -252,8 +195,7 @@ impl Indexer {
         config: ConcurrentConfig,
     ) -> Result<()>
     where
-        // TODO (wlmyng): eventually this will be Handler<Store = S>
-        H: concurrent::Handler<Store = Db> + Send + Sync + 'static,
+        H: concurrent::Handler<Store = S> + Send + Sync + 'static,
     {
         let start_from_pruner_watermark = H::PRUNING_REQUIRES_PROCESSED_VALUES;
         let Some(watermark) = self.add_pipeline::<H>(start_from_pruner_watermark).await? else {
@@ -272,59 +214,8 @@ impl Indexer {
             watermark,
             config,
             self.skip_watermark,
-            self.db.clone(),
+            self.store.clone(),
             self.ingestion_service.subscribe().0,
-            self.metrics.clone(),
-            self.cancel.clone(),
-        ));
-
-        Ok(())
-    }
-
-    /// Adds a new pipeline to this indexer and starts it up. Although their tasks have started,
-    /// they will be idle until the ingestion service starts, and serves it checkpoint data.
-    ///
-    /// Sequential pipelines commit checkpoint data in-order which sacrifices throughput, but may
-    /// be required to handle pipelines that modify data in-place (where each update is not an
-    /// insert, but could be a modification of an existing row, where ordering between updates is
-    /// important).
-    ///
-    /// The pipeline can optionally be configured to lag behind the ingestion service by a fixed
-    /// number of checkpoints (configured by `checkpoint_lag`).
-    pub async fn sequential_pipeline<H>(
-        &mut self,
-        handler: H,
-        config: SequentialConfig,
-    ) -> Result<()>
-    where
-        // TODO (wlmyng): eventually this will be Handler<Store = S>
-        // And additionally, S: TransactionalStore
-        H: Handler<Store = Db> + Send + Sync + 'static,
-    {
-        let Some(watermark) = self.add_pipeline::<H>(false).await? else {
-            return Ok(());
-        };
-
-        if self.skip_watermark {
-            warn!(
-                pipeline = H::NAME,
-                "--skip-watermarks enabled and ignored for sequential pipeline"
-            );
-        }
-
-        // For a sequential pipeline, data must be written in the order of checkpoints.
-        // Hence, we do not allow the first_checkpoint override to be in arbitrary positions.
-        self.check_first_checkpoint_consistency::<H>(&watermark)?;
-
-        let (checkpoint_rx, watermark_tx) = self.ingestion_service.subscribe();
-
-        self.handles.push(sequential::pipeline::<H>(
-            handler,
-            watermark,
-            config,
-            self.db.clone(),
-            checkpoint_rx,
-            watermark_tx,
             self.metrics.clone(),
             self.cancel.clone(),
         ));
@@ -396,27 +287,6 @@ impl Indexer {
         }))
     }
 
-    /// Combine the provided `migrations` with the migrations necessary to set up the indexer
-    /// framework. The returned migration source can be passed to [Db::run_migrations] to ensure
-    /// the database's schema is up-to-date for both the indexer framework and the specific
-    /// indexer.
-    pub fn migrations(
-        migrations: Option<&'static EmbeddedMigrations>,
-    ) -> impl MigrationSource<Pg> + Send + Sync + 'static {
-        struct Migrations(Option<&'static EmbeddedMigrations>);
-        impl MigrationSource<Pg> for Migrations {
-            fn migrations(&self) -> migration::Result<Vec<Box<dyn Migration<Pg>>>> {
-                let mut migrations = MIGRATIONS.migrations()?;
-                if let Some(more_migrations) = self.0 {
-                    migrations.extend(more_migrations.migrations()?);
-                }
-                Ok(migrations)
-            }
-        }
-
-        Migrations(migrations)
-    }
-
     /// Update the indexer's first checkpoint based on the watermark for the pipeline by adding for
     /// handler `H` (as long as it's enabled). Returns `Ok(None)` if the pipeline is disabled,
     /// `Ok(Some(None))` if the pipeline is enabled but its watermark is not found, and
@@ -442,7 +312,11 @@ impl Indexer {
             }
         }
 
-        let mut conn = self.db.connect().await.context("Failed DB connection")?;
+        let mut conn = self
+            .store
+            .connect()
+            .await
+            .context("Failed to establish connection to store")?;
 
         let watermark = conn
             .committer_watermark(P::NAME)
@@ -472,151 +346,53 @@ impl Indexer {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use async_trait::async_trait;
-
-    use crate::FieldCount;
-    use crate::{
-        db,
-        store::{CommitterWatermark, Connection},
-        types::full_checkpoint_content::CheckpointData,
-    };
-
-    use super::*;
-
-    #[derive(FieldCount)]
-    struct V {
-        _v: u64,
-    }
-
-    macro_rules! define_test_concurrent_pipeline {
-        ($name:ident) => {
-            define_test_concurrent_pipeline!($name, false);
+impl<T: TransactionalStore> Indexer<T> {
+    /// Adds a new pipeline to this indexer and starts it up. Although their tasks have started,
+    /// they will be idle until the ingestion service starts, and serves it checkpoint data.
+    ///
+    /// Sequential pipelines commit checkpoint data in-order which sacrifices throughput, but may
+    /// be required to handle pipelines that modify data in-place (where each update is not an
+    /// insert, but could be a modification of an existing row, where ordering between updates is
+    /// important).
+    ///
+    /// The pipeline can optionally be configured to lag behind the ingestion service by a fixed
+    /// number of checkpoints (configured by `checkpoint_lag`).
+    pub async fn sequential_pipeline<H>(
+        &mut self,
+        handler: H,
+        config: SequentialConfig,
+    ) -> Result<()>
+    where
+        H: Handler<Store = T> + Send + Sync + 'static,
+    {
+        let Some(watermark) = self.add_pipeline::<H>(false).await? else {
+            return Ok(());
         };
-        ($name:ident, $pruning_requires_processed_values:expr) => {
-            struct $name;
-            impl Processor for $name {
-                const NAME: &'static str = stringify!($name);
-                type Value = V;
-                fn process(
-                    &self,
-                    _checkpoint: &Arc<CheckpointData>,
-                ) -> anyhow::Result<Vec<Self::Value>> {
-                    todo!()
-                }
-            }
 
-            #[async_trait]
-            impl concurrent::Handler for $name {
-                type Store = Db;
-
-                const PRUNING_REQUIRES_PROCESSED_VALUES: bool = $pruning_requires_processed_values;
-                async fn commit<'a>(
-                    _values: &[Self::Value],
-                    _conn: &mut db::Connection<'a>,
-                ) -> anyhow::Result<usize> {
-                    todo!()
-                }
-            }
-        };
-    }
-
-    define_test_concurrent_pipeline!(ConcurrentPipeline1);
-    define_test_concurrent_pipeline!(ConcurrentPipeline2);
-    define_test_concurrent_pipeline!(ConcurrentPipeline3, true);
-
-    #[tokio::test]
-    async fn test_add_new_pipeline() {
-        let (mut indexer, _temp_db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        indexer
-            .concurrent_pipeline(ConcurrentPipeline1, ConcurrentConfig::default())
-            .await
-            .unwrap();
-        assert_eq!(indexer.first_checkpoint_from_watermark, 0);
-    }
-
-    #[tokio::test]
-    async fn test_add_existing_pipeline() {
-        let (mut indexer, _temp_db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        {
-            let watermark = CommitterWatermark::new_for_testing(10);
-            let mut conn = indexer.db().connect().await.unwrap();
-            assert!(conn
-                .set_committer_watermark(ConcurrentPipeline1::NAME, watermark)
-                .await
-                .unwrap());
-        }
-        indexer
-            .concurrent_pipeline(ConcurrentPipeline1, ConcurrentConfig::default())
-            .await
-            .unwrap();
-        assert_eq!(indexer.first_checkpoint_from_watermark, 11);
-    }
-
-    #[tokio::test]
-    async fn test_add_multiple_pipelines() {
-        let (mut indexer, _temp_db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        {
-            let watermark1 = CommitterWatermark::new_for_testing(10);
-            let mut conn = indexer.db().connect().await.unwrap();
-            assert!(conn
-                .set_committer_watermark(ConcurrentPipeline1::NAME, watermark1)
-                .await
-                .unwrap());
-            let watermark2 = CommitterWatermark::new_for_testing(20);
-            assert!(conn
-                .set_committer_watermark(ConcurrentPipeline2::NAME, watermark2)
-                .await
-                .unwrap());
+        if self.skip_watermark {
+            warn!(
+                pipeline = H::NAME,
+                "--skip-watermarks enabled and ignored for sequential pipeline"
+            );
         }
 
-        indexer
-            .concurrent_pipeline(ConcurrentPipeline2, ConcurrentConfig::default())
-            .await
-            .unwrap();
-        assert_eq!(indexer.first_checkpoint_from_watermark, 21);
-        indexer
-            .concurrent_pipeline(ConcurrentPipeline1, ConcurrentConfig::default())
-            .await
-            .unwrap();
-        assert_eq!(indexer.first_checkpoint_from_watermark, 11);
-    }
+        // For a sequential pipeline, data must be written in the order of checkpoints.
+        // Hence, we do not allow the first_checkpoint override to be in arbitrary positions.
+        self.check_first_checkpoint_consistency::<H>(&watermark)?;
 
-    #[tokio::test]
-    async fn test_add_multiple_pipelines_pruning_requires_processed_values() {
-        let (mut indexer, _temp_db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        {
-            let watermark1 = CommitterWatermark::new_for_testing(10);
-            let mut conn = indexer.db().connect().await.unwrap();
-            assert!(conn
-                .set_committer_watermark(ConcurrentPipeline1::NAME, watermark1)
-                .await
-                .unwrap());
-        }
-        indexer
-            .concurrent_pipeline(ConcurrentPipeline1, ConcurrentConfig::default())
-            .await
-            .unwrap();
-        assert_eq!(indexer.first_checkpoint_from_watermark, 11);
+        let (checkpoint_rx, watermark_tx) = self.ingestion_service.subscribe();
 
-        {
-            let watermark3 = CommitterWatermark::new_for_testing(20);
-            let mut conn = indexer.db().connect().await.unwrap();
-            assert!(conn
-                .set_committer_watermark(ConcurrentPipeline3::NAME, watermark3)
-                .await
-                .unwrap());
-            assert!(conn
-                .set_pruner_watermark(ConcurrentPipeline3::NAME, 5)
-                .await
-                .unwrap());
-        }
-        indexer
-            .concurrent_pipeline(ConcurrentPipeline3, ConcurrentConfig::default())
-            .await
-            .unwrap();
+        self.handles.push(sequential::pipeline::<H>(
+            handler,
+            watermark,
+            config,
+            self.store.clone(),
+            checkpoint_rx,
+            watermark_tx,
+            self.metrics.clone(),
+            self.cancel.clone(),
+        ));
 
-        assert_eq!(indexer.first_checkpoint_from_watermark, 5);
+        Ok(())
     }
 }

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -16,9 +16,6 @@ use prometheus::Registry;
 use sui_indexer_alt_framework_store_traits::{
     CommitterWatermark, Connection, Store, TransactionalStore,
 };
-use sui_indexer_alt_metrics::db::DbConnectionStatsCollector;
-use sui_pg_db::{temp::TempDb, Db, DbArgs};
-use tempfile::tempdir;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/collector.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/collector.rs
@@ -197,11 +197,10 @@ pub(super) fn collector<H: Handler + 'static>(
 mod tests {
     use std::time::Duration;
 
+    use sui_pg_db::{Connection, Db};
     use tokio::sync::mpsc;
 
-    use crate::db::Db;
     use crate::{
-        db::Connection,
         metrics::tests::test_metrics,
         pipeline::{concurrent::max_chunk_rows, Processor},
         types::full_checkpoint_content::CheckpointData,

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
@@ -296,7 +296,6 @@ pub(super) fn pruner<H: Handler + Send + Sync + 'static>(
     })
 }
 
-// TODO (wlmyng): non-pg store - requires conn too
 async fn prune_task_impl<H: Handler + Send + Sync + 'static>(
     metrics: Arc<IndexerMetrics>,
     db: H::Store,

--- a/crates/sui-indexer-alt-framework/src/postgres.rs
+++ b/crates/sui-indexer-alt-framework/src/postgres.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result};
 use diesel_migrations::EmbeddedMigrations;
 use prometheus::Registry;
 use sui_indexer_alt_metrics::db::DbConnectionStatsCollector;
-use sui_pg_db::{self as db, temp::TempDb};
+use sui_pg_db::temp::TempDb;
 use tempfile::tempdir;
 use tokio_util::sync::CancellationToken;
 use url::Url;
@@ -51,7 +51,7 @@ impl Indexer<Db> {
 
         // At indexer initialization, we ensure that the DB schema is up-to-date.
         store
-            .run_migrations(db::migrations(migrations))
+            .run_migrations(migrations)
             .await
             .context("Failed to run pending migrations")?;
 
@@ -79,10 +79,7 @@ impl Indexer<Db> {
         let store = Db::for_write(temp_db.database().url().clone(), DbArgs::default())
             .await
             .unwrap();
-        store
-            .run_migrations(db::migrations(Some(migrations)))
-            .await
-            .unwrap();
+        store.run_migrations(Some(migrations)).await.unwrap();
 
         let indexer = Indexer::new(
             store,

--- a/crates/sui-indexer-alt-framework/src/postgres.rs
+++ b/crates/sui-indexer-alt-framework/src/postgres.rs
@@ -1,0 +1,254 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Context, Result};
+use diesel_migrations::EmbeddedMigrations;
+use prometheus::Registry;
+use sui_indexer_alt_metrics::db::DbConnectionStatsCollector;
+use sui_pg_db::{self as db, temp::TempDb};
+use tempfile::tempdir;
+use tokio_util::sync::CancellationToken;
+use url::Url;
+
+use crate::{
+    ingestion::{ClientArgs, IngestionConfig},
+    Indexer, IndexerArgs,
+};
+
+pub use sui_pg_db::*;
+
+/// An opinionated indexer implementation that uses a Postgres database as the store.
+impl Indexer<Db> {
+    /// Create a new instance of the indexer framework. `database_url`, `db_args`, `indexer_args,`,
+    /// `client_args`, and `ingestion_config` contain configurations for the following,
+    /// respectively:
+    ///
+    /// - Connecting to the database,
+    /// - What is indexed (which checkpoints, which pipelines, whether to update the watermarks
+    ///   table) and where to serve metrics from,
+    /// - Where to download checkpoints from,
+    /// - Concurrency and buffering parameters for downloading checkpoints.
+    ///
+    /// Optional `migrations` contains the SQL to run in order to bring the database schema up-to-date for
+    /// the specific instance of the indexer, generated using diesel's `embed_migrations!` macro.
+    /// These migrations will be run as part of initializing the indexer if provided.
+    ///
+    /// After initialization, at least one pipeline must be added using [Self::concurrent_pipeline]
+    /// or [Self::sequential_pipeline], before the indexer is started using [Self::run].
+    pub async fn new_from_pg(
+        database_url: Url,
+        db_args: DbArgs,
+        indexer_args: IndexerArgs,
+        client_args: ClientArgs,
+        ingestion_config: IngestionConfig,
+        migrations: Option<&'static EmbeddedMigrations>,
+        registry: &Registry,
+        cancel: CancellationToken,
+    ) -> Result<Self> {
+        let store = Db::for_write(database_url, db_args) // I guess our store needs a constructor fn
+            .await
+            .context("Failed to connect to database")?;
+
+        // At indexer initialization, we ensure that the DB schema is up-to-date.
+        store
+            .run_migrations(db::migrations(migrations))
+            .await
+            .context("Failed to run pending migrations")?;
+
+        registry.register(Box::new(DbConnectionStatsCollector::new(
+            Some("indexer_db"),
+            store.clone(),
+        )))?;
+
+        Indexer::new(
+            store,
+            indexer_args,
+            client_args,
+            ingestion_config,
+            registry,
+            cancel,
+        )
+        .await
+    }
+
+    /// Create a new temporary database and runs provided migrations in tandem with the migrations
+    /// necessary to support watermark operations on the indexer. The indexer is then instantiated
+    /// and returned along with the temporary database.
+    pub async fn new_for_testing(migrations: &'static EmbeddedMigrations) -> (Indexer<Db>, TempDb) {
+        let temp_db = TempDb::new().unwrap();
+        let store = Db::for_write(temp_db.database().url().clone(), DbArgs::default())
+            .await
+            .unwrap();
+        store
+            .run_migrations(db::migrations(Some(migrations)))
+            .await
+            .unwrap();
+
+        let indexer = Indexer::new(
+            store,
+            IndexerArgs::default(),
+            ClientArgs {
+                remote_store_url: None,
+                local_ingestion_path: Some(tempdir().unwrap().into_path()),
+                rpc_api_url: None,
+                rpc_username: None,
+                rpc_password: None,
+            },
+            IngestionConfig::default(),
+            &Registry::new(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        (indexer, temp_db)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+
+    use async_trait::async_trait;
+    use std::sync::Arc;
+    use sui_indexer_alt_framework_store_traits::{CommitterWatermark, Store};
+    use sui_types::full_checkpoint_content::CheckpointData;
+
+    use super::*;
+
+    use crate::pipeline::concurrent;
+    use crate::{pipeline::Processor, store::Connection, ConcurrentConfig, FieldCount};
+
+    #[derive(FieldCount)]
+    struct V {
+        _v: u64,
+    }
+
+    macro_rules! define_test_concurrent_pipeline {
+        ($name:ident) => {
+            define_test_concurrent_pipeline!($name, false);
+        };
+        ($name:ident, $pruning_requires_processed_values:expr) => {
+            struct $name;
+            impl Processor for $name {
+                const NAME: &'static str = stringify!($name);
+                type Value = V;
+                fn process(
+                    &self,
+                    _checkpoint: &Arc<CheckpointData>,
+                ) -> anyhow::Result<Vec<Self::Value>> {
+                    todo!()
+                }
+            }
+
+            #[async_trait]
+            impl concurrent::Handler for $name {
+                type Store = Db;
+
+                const PRUNING_REQUIRES_PROCESSED_VALUES: bool = $pruning_requires_processed_values;
+                async fn commit<'a>(
+                    _values: &[Self::Value],
+                    _conn: &mut <Self::Store as Store>::Connection<'a>,
+                ) -> anyhow::Result<usize> {
+                    todo!()
+                }
+            }
+        };
+    }
+
+    define_test_concurrent_pipeline!(ConcurrentPipeline1);
+    define_test_concurrent_pipeline!(ConcurrentPipeline2);
+    define_test_concurrent_pipeline!(ConcurrentPipeline3, true);
+
+    #[tokio::test]
+    async fn test_add_new_pipeline() {
+        let (mut indexer, _temp_db) = Indexer::new_for_testing(&MIGRATIONS).await;
+        indexer
+            .concurrent_pipeline(ConcurrentPipeline1, ConcurrentConfig::default())
+            .await
+            .unwrap();
+        assert_eq!(indexer.first_checkpoint_from_watermark, 0);
+    }
+
+    #[tokio::test]
+    async fn test_add_existing_pipeline() {
+        let (mut indexer, _temp_db) = Indexer::new_for_testing(&MIGRATIONS).await;
+        {
+            let watermark = CommitterWatermark::new_for_testing(10);
+            let mut conn = indexer.store().connect().await.unwrap();
+            assert!(conn
+                .set_committer_watermark(ConcurrentPipeline1::NAME, watermark)
+                .await
+                .unwrap());
+        }
+        indexer
+            .concurrent_pipeline(ConcurrentPipeline1, ConcurrentConfig::default())
+            .await
+            .unwrap();
+        assert_eq!(indexer.first_checkpoint_from_watermark, 11);
+    }
+
+    #[tokio::test]
+    async fn test_add_multiple_pipelines() {
+        let (mut indexer, _temp_db) = Indexer::new_for_testing(&MIGRATIONS).await;
+        {
+            let watermark1 = CommitterWatermark::new_for_testing(10);
+            let mut conn = indexer.store().connect().await.unwrap();
+            assert!(conn
+                .set_committer_watermark(ConcurrentPipeline1::NAME, watermark1)
+                .await
+                .unwrap());
+            let watermark2 = CommitterWatermark::new_for_testing(20);
+            assert!(conn
+                .set_committer_watermark(ConcurrentPipeline2::NAME, watermark2)
+                .await
+                .unwrap());
+        }
+
+        indexer
+            .concurrent_pipeline(ConcurrentPipeline2, ConcurrentConfig::default())
+            .await
+            .unwrap();
+        assert_eq!(indexer.first_checkpoint_from_watermark, 21);
+        indexer
+            .concurrent_pipeline(ConcurrentPipeline1, ConcurrentConfig::default())
+            .await
+            .unwrap();
+        assert_eq!(indexer.first_checkpoint_from_watermark, 11);
+    }
+
+    #[tokio::test]
+    async fn test_add_multiple_pipelines_pruning_requires_processed_values() {
+        let (mut indexer, _temp_db) = Indexer::new_for_testing(&MIGRATIONS).await;
+        {
+            let watermark1 = CommitterWatermark::new_for_testing(10);
+            let mut conn = indexer.store().connect().await.unwrap();
+            assert!(conn
+                .set_committer_watermark(ConcurrentPipeline1::NAME, watermark1)
+                .await
+                .unwrap());
+        }
+        indexer
+            .concurrent_pipeline(ConcurrentPipeline1, ConcurrentConfig::default())
+            .await
+            .unwrap();
+        assert_eq!(indexer.first_checkpoint_from_watermark, 11);
+
+        {
+            let watermark3 = CommitterWatermark::new_for_testing(20);
+            let mut conn = indexer.store().connect().await.unwrap();
+            assert!(conn
+                .set_committer_watermark(ConcurrentPipeline3::NAME, watermark3)
+                .await
+                .unwrap());
+            assert!(conn
+                .set_pruner_watermark(ConcurrentPipeline3::NAME, 5)
+                .await
+                .unwrap());
+        }
+        indexer
+            .concurrent_pipeline(ConcurrentPipeline3, ConcurrentConfig::default())
+            .await
+            .unwrap();
+
+        assert_eq!(indexer.first_checkpoint_from_watermark, 5);
+    }
+}

--- a/crates/sui-indexer-alt-reader/src/object_versions.rs
+++ b/crates/sui-indexer-alt-reader/src/object_versions.rs
@@ -276,7 +276,7 @@ mod tests {
         .await
         .unwrap();
 
-        writer.run_migrations(MIGRATIONS).await.unwrap();
+        writer.run_migrations(Some(&MIGRATIONS)).await.unwrap();
         (temp_db, writer, reader)
     }
 

--- a/crates/sui-indexer-alt/Cargo.toml
+++ b/crates/sui-indexer-alt/Cargo.toml
@@ -32,7 +32,7 @@ tracing.workspace = true
 url.workspace = true
 
 sui-default-config.workspace = true
-sui-indexer-alt-framework.workspace = true
+sui-indexer-alt-framework = { workspace = true, features = ["postgres"] }
 sui-indexer-alt-metrics.workspace = true
 sui-indexer-alt-schema.workspace = true
 sui-protocol-config.workspace = true

--- a/crates/sui-indexer-alt/src/args.rs
+++ b/crates/sui-indexer-alt/src/args.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use crate::benchmark::BenchmarkArgs;
 use crate::IndexerArgs;
 use clap::Subcommand;
-use sui_indexer_alt_framework::{db::DbArgs, ingestion::ClientArgs};
+use sui_indexer_alt_framework::{ingestion::ClientArgs, postgres::DbArgs};
 use sui_indexer_alt_metrics::MetricsArgs;
 use url::Url;
 

--- a/crates/sui-indexer-alt/src/benchmark.rs
+++ b/crates/sui-indexer-alt/src/benchmark.rs
@@ -5,9 +5,9 @@ use std::{path::PathBuf, time::Instant};
 
 use prometheus::Registry;
 use sui_indexer_alt_framework::{
-    db::{reset_database, DbArgs},
     ingestion::ClientArgs,
-    Indexer, IndexerArgs,
+    postgres::{self, reset_database, DbArgs},
+    IndexerArgs,
 };
 use sui_indexer_alt_schema::MIGRATIONS;
 use sui_synthetic_ingestion::synthetic_ingestion::read_ingestion_data;
@@ -47,7 +47,7 @@ pub async fn run_benchmark(
     reset_database(
         database_url.clone(),
         db_args.clone(),
-        Some(Indexer::migrations(Some(&MIGRATIONS))),
+        Some(postgres::migrations(Some(&MIGRATIONS))),
     )
     .await?;
 

--- a/crates/sui-indexer-alt/src/benchmark.rs
+++ b/crates/sui-indexer-alt/src/benchmark.rs
@@ -6,7 +6,7 @@ use std::{path::PathBuf, time::Instant};
 use prometheus::Registry;
 use sui_indexer_alt_framework::{
     ingestion::ClientArgs,
-    postgres::{self, reset_database, DbArgs},
+    postgres::{reset_database, DbArgs},
     IndexerArgs,
 };
 use sui_indexer_alt_schema::MIGRATIONS;
@@ -44,12 +44,7 @@ pub async fn run_benchmark(
     let last_checkpoint = *ingestion_data.keys().last().unwrap();
     let num_transactions: usize = ingestion_data.values().map(|c| c.transactions.len()).sum();
 
-    reset_database(
-        database_url.clone(),
-        db_args.clone(),
-        Some(postgres::migrations(Some(&MIGRATIONS))),
-    )
-    .await?;
+    reset_database(database_url.clone(), db_args.clone(), Some(&MIGRATIONS)).await?;
 
     let indexer_args = IndexerArgs {
         first_checkpoint: Some(first_checkpoint),

--- a/crates/sui-indexer-alt/src/bootstrap.rs
+++ b/crates/sui-indexer-alt/src/bootstrap.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use anyhow::{bail, Context, Result};
 use diesel::{OptionalExtension, QueryDsl, SelectableHelper};
 use diesel_async::RunQueryDsl;
+use sui_indexer_alt_framework::postgres::Db;
 use sui_indexer_alt_framework::types::{
     full_checkpoint_content::CheckpointData,
     sui_system_state::{get_sui_system_state, SuiSystemStateTrait},
@@ -29,13 +30,13 @@ use crate::Indexer;
 /// Can be cancelled via the `cancel` token, or through an interrupt signal (which will also cancel
 /// the token).
 pub async fn bootstrap(
-    indexer: &Indexer,
+    indexer: &Indexer<Db>,
     retry_interval: Duration,
     cancel: CancellationToken,
 ) -> Result<StoredGenesis> {
     info!("Bootstrapping indexer with genesis information");
 
-    let Ok(mut conn) = indexer.db().connect().await else {
+    let Ok(mut conn) = indexer.store().connect().await else {
         bail!("Bootstrap failed to get connection for DB");
     };
 

--- a/crates/sui-indexer-alt/src/handlers/coin_balance_buckets.rs
+++ b/crates/sui-indexer-alt/src/handlers/coin_balance_buckets.rs
@@ -7,8 +7,8 @@ use anyhow::{anyhow, bail, Result};
 use diesel::sql_query;
 use diesel_async::RunQueryDsl;
 use sui_indexer_alt_framework::{
-    db::{Connection, Db},
     pipeline::{concurrent::Handler, Processor},
+    postgres::{Connection, Db},
     types::{
         base_types::{ObjectID, SuiAddress},
         full_checkpoint_content::CheckpointData,
@@ -407,7 +407,7 @@ mod tests {
     #[tokio::test]
     async fn test_process_coin_balance_buckets_new_sui_coin() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
         let handler = CoinBalanceBuckets::default();
         let mut builder = TestCheckpointDataBuilder::new(0);
         builder = builder
@@ -447,7 +447,7 @@ mod tests {
     #[tokio::test]
     async fn test_process_coin_balance_buckets_new_other_coin() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
         let handler = CoinBalanceBuckets::default();
         let mut builder = TestCheckpointDataBuilder::new(0);
         let coin_type = TypeTag::from_str("0x0::a::b").unwrap();
@@ -480,7 +480,7 @@ mod tests {
     #[tokio::test]
     async fn test_process_coin_balance_buckets_balance_change() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
         let handler = CoinBalanceBuckets::default();
         let mut builder = TestCheckpointDataBuilder::new(0);
         builder = builder
@@ -611,7 +611,7 @@ mod tests {
     #[tokio::test]
     async fn test_process_coin_balance_buckets_coin_deleted() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
         let handler = CoinBalanceBuckets::default();
         let mut builder = TestCheckpointDataBuilder::new(0);
         builder = builder
@@ -660,7 +660,7 @@ mod tests {
     #[tokio::test]
     async fn test_process_coin_balance_buckets_owner_change() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
         let handler = CoinBalanceBuckets::default();
         let mut builder = TestCheckpointDataBuilder::new(0);
         builder = builder
@@ -715,7 +715,7 @@ mod tests {
     #[tokio::test]
     async fn test_process_coin_balance_buckets_object_owned() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
         let handler = CoinBalanceBuckets::default();
         let mut builder = TestCheckpointDataBuilder::new(0);
         builder = builder

--- a/crates/sui-indexer-alt/src/handlers/cp_sequence_numbers.rs
+++ b/crates/sui-indexer-alt/src/handlers/cp_sequence_numbers.rs
@@ -8,8 +8,8 @@ use anyhow::{bail, Result};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use sui_indexer_alt_framework::{
-    db::{Connection, Db},
     pipeline::{concurrent::Handler, Processor},
+    postgres::{Connection, Db},
     types::full_checkpoint_content::CheckpointData,
 };
 use sui_indexer_alt_schema::cp_sequence_numbers::StoredCpSequenceNumbers;

--- a/crates/sui-indexer-alt/src/handlers/ev_emit_mod.rs
+++ b/crates/sui-indexer-alt/src/handlers/ev_emit_mod.rs
@@ -8,8 +8,8 @@ use anyhow::Result;
 use diesel::{ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use sui_indexer_alt_framework::{
-    db::{Connection, Db},
     pipeline::{concurrent::Handler, Processor},
+    postgres::{Connection, Db},
     types::full_checkpoint_content::CheckpointData,
 };
 use sui_indexer_alt_schema::{events::StoredEvEmitMod, schema::ev_emit_mod};
@@ -114,7 +114,7 @@ mod tests {
     #[tokio::test]
     async fn test_ev_emit_mod_pruning_complains_if_no_mapping() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         let result = EvEmitMod.prune(0, 2, &mut conn).await;
 
@@ -128,7 +128,7 @@ mod tests {
     #[tokio::test]
     async fn test_ev_emit_mod_no_events() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         let checkpoint = Arc::new(
             TestCheckpointDataBuilder::new(0)
@@ -146,7 +146,7 @@ mod tests {
     #[tokio::test]
     async fn test_ev_emit_mod_single_event() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         let checkpoint = Arc::new(
             TestCheckpointDataBuilder::new(0)
@@ -167,7 +167,7 @@ mod tests {
     #[tokio::test]
     async fn test_ev_emit_mod_prune_events() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         // 0th checkpoint has no events
         let mut builder = TestCheckpointDataBuilder::new(0);

--- a/crates/sui-indexer-alt/src/handlers/ev_struct_inst.rs
+++ b/crates/sui-indexer-alt/src/handlers/ev_struct_inst.rs
@@ -7,8 +7,8 @@ use anyhow::{Context, Result};
 use diesel::{ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use sui_indexer_alt_framework::{
-    db::{Connection, Db},
     pipeline::{concurrent::Handler, Processor},
+    postgres::{Connection, Db},
     types::full_checkpoint_content::CheckpointData,
 };
 use sui_indexer_alt_schema::{events::StoredEvStructInst, schema::ev_struct_inst};
@@ -116,7 +116,7 @@ mod tests {
     #[tokio::test]
     async fn test_ev_struct_inst_pruning_complains_if_no_mapping() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         let result = EvStructInst.prune(0, 2, &mut conn).await;
 
@@ -130,7 +130,7 @@ mod tests {
     #[tokio::test]
     async fn test_ev_struct_inst_process_no_events() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         let checkpoint = Arc::new(
             TestCheckpointDataBuilder::new(0)
@@ -148,7 +148,7 @@ mod tests {
     #[tokio::test]
     async fn test_ev_struct_inst_process_single_event() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         let checkpoint = Arc::new(
             TestCheckpointDataBuilder::new(0)
@@ -169,7 +169,7 @@ mod tests {
     #[tokio::test]
     async fn test_ev_struct_inst_prune_events() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         // 0th checkpoint has no events
         let mut builder = TestCheckpointDataBuilder::new(0);

--- a/crates/sui-indexer-alt/src/handlers/kv_checkpoints.rs
+++ b/crates/sui-indexer-alt/src/handlers/kv_checkpoints.rs
@@ -7,8 +7,8 @@ use anyhow::{Context, Result};
 use diesel::{ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use sui_indexer_alt_framework::{
-    db::{Connection, Db},
     pipeline::{concurrent::Handler, Processor},
+    postgres::{Connection, Db},
     types::full_checkpoint_content::CheckpointData,
 };
 use sui_indexer_alt_schema::{checkpoints::StoredCheckpoint, schema::kv_checkpoints};
@@ -80,7 +80,7 @@ mod tests {
     #[tokio::test]
     async fn test_kv_checkpoints_pruning() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         // Create 3 checkpoints
         let mut builder = TestCheckpointDataBuilder::new(0);

--- a/crates/sui-indexer-alt/src/handlers/kv_epoch_ends.rs
+++ b/crates/sui-indexer-alt/src/handlers/kv_epoch_ends.rs
@@ -8,8 +8,8 @@ use anyhow::{bail, Context, Result};
 use diesel::{ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use sui_indexer_alt_framework::{
-    db::{Connection, Db},
     pipeline::{concurrent::Handler, Processor},
+    postgres::{Connection, Db},
     types::{
         event::SystemEpochInfoEvent,
         full_checkpoint_content::CheckpointData,
@@ -181,7 +181,7 @@ mod tests {
     #[tokio::test]
     pub async fn test_kv_epoch_ends_safe_mode() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         let mut builder = TestCheckpointDataBuilder::new(0);
         let checkpoint = Arc::new(builder.advance_epoch(true));
@@ -206,7 +206,7 @@ mod tests {
     #[tokio::test]
     pub async fn test_kv_epoch_ends_same_epoch() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         // Test that there is nothing to commit while we haven't reached epoch end.
         let mut builder = TestCheckpointDataBuilder::new(0);
@@ -260,7 +260,7 @@ mod tests {
     #[tokio::test]
     pub async fn test_kv_epoch_ends_advance_multiple_epochs() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         // Advance epoch three times, 0, 1, 2
         let mut builder = TestCheckpointDataBuilder::new(0);

--- a/crates/sui-indexer-alt/src/handlers/kv_epoch_starts.rs
+++ b/crates/sui-indexer-alt/src/handlers/kv_epoch_starts.rs
@@ -8,8 +8,8 @@ use anyhow::{bail, Context, Result};
 use diesel::{ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use sui_indexer_alt_framework::{
-    db::{Connection, Db},
     pipeline::{concurrent::Handler, Processor},
+    postgres::{Connection, Db},
     types::{
         full_checkpoint_content::CheckpointData,
         sui_system_state::{get_sui_system_state, SuiSystemStateTrait},

--- a/crates/sui-indexer-alt/src/handlers/kv_feature_flags.rs
+++ b/crates/sui-indexer-alt/src/handlers/kv_feature_flags.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use anyhow::{bail, Context, Result};
 use diesel_async::RunQueryDsl;
 use sui_indexer_alt_framework::{
-    db::{Connection, Db},
     pipeline::{concurrent::Handler, Processor},
+    postgres::{Connection, Db},
     types::full_checkpoint_content::CheckpointData,
 };
 use sui_indexer_alt_schema::{

--- a/crates/sui-indexer-alt/src/handlers/kv_objects.rs
+++ b/crates/sui-indexer-alt/src/handlers/kv_objects.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use diesel_async::RunQueryDsl;
 use sui_indexer_alt_framework::{
-    db::{Connection, Db},
     pipeline::{concurrent::Handler, Processor},
+    postgres::{Connection, Db},
     types::full_checkpoint_content::CheckpointData,
 };
 use sui_indexer_alt_schema::{objects::StoredObject, schema::kv_objects};

--- a/crates/sui-indexer-alt/src/handlers/kv_packages.rs
+++ b/crates/sui-indexer-alt/src/handlers/kv_packages.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use anyhow::{anyhow, Result};
 use diesel_async::RunQueryDsl;
 use sui_indexer_alt_framework::{
-    db::{Connection, Db},
     pipeline::{concurrent::Handler, Processor},
+    postgres::{Connection, Db},
     types::{base_types::SuiAddress, full_checkpoint_content::CheckpointData},
 };
 use sui_indexer_alt_schema::{packages::StoredKvPackage, schema::kv_packages};

--- a/crates/sui-indexer-alt/src/handlers/kv_protocol_configs.rs
+++ b/crates/sui-indexer-alt/src/handlers/kv_protocol_configs.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use anyhow::{bail, Context, Result};
 use diesel_async::RunQueryDsl;
 use sui_indexer_alt_framework::{
-    db::{Connection, Db},
     pipeline::{concurrent::Handler, Processor},
+    postgres::{Connection, Db},
     types::full_checkpoint_content::CheckpointData,
 };
 use sui_indexer_alt_schema::{

--- a/crates/sui-indexer-alt/src/handlers/kv_transactions.rs
+++ b/crates/sui-indexer-alt/src/handlers/kv_transactions.rs
@@ -7,8 +7,8 @@ use anyhow::{Context, Result};
 use diesel::{ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use sui_indexer_alt_framework::{
-    db::{Connection, Db},
     pipeline::{concurrent::Handler, Processor},
+    postgres::{Connection, Db},
     types::full_checkpoint_content::CheckpointData,
 };
 use sui_indexer_alt_schema::{schema::kv_transactions, transactions::StoredTransaction};
@@ -108,7 +108,7 @@ mod tests {
     #[tokio::test]
     async fn test_kv_transactions_pruning() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         let mut builder = TestCheckpointDataBuilder::new(0);
         builder = builder.start_transaction(0).finish_transaction();

--- a/crates/sui-indexer-alt/src/handlers/obj_info.rs
+++ b/crates/sui-indexer-alt/src/handlers/obj_info.rs
@@ -198,11 +198,6 @@ impl TryInto<StoredObjInfo> for &ProcessedObjInfo {
 #[cfg(test)]
 mod tests {
     use sui_indexer_alt_framework::{
-<<<<<<< HEAD
-        db,
-=======
-        store::Store,
->>>>>>> d8bf107848 (Parameterize Indexer on Store, framework provides impl for Indexer<Db> if postgres feature flag is specified. Tests in framework will use postgres)
         types::{
             base_types::{dbg_addr, SequenceNumber},
             object::{Authenticator, Owner},

--- a/crates/sui-indexer-alt/src/handlers/obj_info.rs
+++ b/crates/sui-indexer-alt/src/handlers/obj_info.rs
@@ -7,8 +7,8 @@ use anyhow::Result;
 use diesel::sql_query;
 use diesel_async::RunQueryDsl;
 use sui_indexer_alt_framework::{
-    db::{Connection, Db},
     pipeline::{concurrent::Handler, Processor},
+    postgres::{Connection, Db},
     types::{base_types::ObjectID, full_checkpoint_content::CheckpointData, object::Object},
     FieldCount,
 };
@@ -198,7 +198,11 @@ impl TryInto<StoredObjInfo> for &ProcessedObjInfo {
 #[cfg(test)]
 mod tests {
     use sui_indexer_alt_framework::{
+<<<<<<< HEAD
         db,
+=======
+        store::Store,
+>>>>>>> d8bf107848 (Parameterize Indexer on Store, framework provides impl for Indexer<Db> if postgres feature flag is specified. Tests in framework will use postgres)
         types::{
             base_types::{dbg_addr, SequenceNumber},
             object::{Authenticator, Owner},
@@ -212,7 +216,7 @@ mod tests {
 
     // A helper function to return all entries in the obj_info table sorted by object_id and
     // cp_sequence_number.
-    async fn get_all_obj_info(conn: &mut db::Connection<'_>) -> Result<Vec<StoredObjInfo>> {
+    async fn get_all_obj_info(conn: &mut Connection<'_>) -> Result<Vec<StoredObjInfo>> {
         let query = obj_info::table.load(conn).await?;
         Ok(query)
     }
@@ -220,7 +224,7 @@ mod tests {
     #[tokio::test]
     async fn test_process_basics() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
         let obj_info = ObjInfo::default();
         let mut builder = TestCheckpointDataBuilder::new(0);
         builder = builder
@@ -329,7 +333,7 @@ mod tests {
     #[tokio::test]
     async fn test_process_noop() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
         let obj_info = ObjInfo::default();
         // In this checkpoint, an object is created and deleted in the same checkpoint.
         // We expect that no updates are made to the table.
@@ -356,7 +360,7 @@ mod tests {
     #[tokio::test]
     async fn test_process_wrap() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
         let obj_info = ObjInfo::default();
         let mut builder = TestCheckpointDataBuilder::new(0)
             .start_transaction(0)
@@ -427,7 +431,7 @@ mod tests {
     #[tokio::test]
     async fn test_process_shared_object() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
         let obj_info = ObjInfo::default();
         let mut builder = TestCheckpointDataBuilder::new(0)
             .start_transaction(0)
@@ -458,7 +462,7 @@ mod tests {
     #[tokio::test]
     async fn test_process_immutable_object() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
         let obj_info = ObjInfo::default();
         let mut builder = TestCheckpointDataBuilder::new(0)
             .start_transaction(0)
@@ -497,7 +501,7 @@ mod tests {
     #[tokio::test]
     async fn test_process_object_owned_object() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
         let obj_info = ObjInfo::default();
         let mut builder = TestCheckpointDataBuilder::new(0)
             .start_transaction(0)
@@ -539,7 +543,7 @@ mod tests {
     #[tokio::test]
     async fn test_process_consensus_v2_object() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
         let obj_info = ObjInfo::default();
         let mut builder = TestCheckpointDataBuilder::new(0)
             .start_transaction(0)
@@ -591,7 +595,7 @@ mod tests {
     #[tokio::test]
     async fn test_obj_info_batch_prune() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
         let obj_info = ObjInfo::default();
         let mut builder = TestCheckpointDataBuilder::new(0);
         builder = builder
@@ -628,7 +632,7 @@ mod tests {
     #[tokio::test]
     async fn test_obj_info_prune_with_missing_data() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
         let obj_info = ObjInfo::default();
         let mut builder = TestCheckpointDataBuilder::new(0);
         builder = builder

--- a/crates/sui-indexer-alt/src/handlers/obj_versions.rs
+++ b/crates/sui-indexer-alt/src/handlers/obj_versions.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use anyhow::Result;
 use diesel_async::RunQueryDsl;
 use sui_indexer_alt_framework::{
-    db::{Connection, Db},
     pipeline::{concurrent::Handler, Processor},
+    postgres::{Connection, Db},
     types::{effects::TransactionEffectsAPI, full_checkpoint_content::CheckpointData},
 };
 use sui_indexer_alt_schema::{objects::StoredObjVersion, schema::obj_versions};

--- a/crates/sui-indexer-alt/src/handlers/sum_displays.rs
+++ b/crates/sui-indexer-alt/src/handlers/sum_displays.rs
@@ -8,8 +8,8 @@ use diesel::{upsert::excluded, ExpressionMethods};
 use diesel_async::RunQueryDsl;
 use futures::future::try_join_all;
 use sui_indexer_alt_framework::{
-    db::{Connection, Db},
     pipeline::{sequential::Handler, Processor},
+    postgres::{Connection, Db},
     types::{display::DisplayVersionUpdatedEvent, full_checkpoint_content::CheckpointData},
     FieldCount,
 };

--- a/crates/sui-indexer-alt/src/handlers/sum_packages.rs
+++ b/crates/sui-indexer-alt/src/handlers/sum_packages.rs
@@ -8,8 +8,8 @@ use diesel::{upsert::excluded, ExpressionMethods};
 use diesel_async::RunQueryDsl;
 use futures::future::try_join_all;
 use sui_indexer_alt_framework::{
-    db::{Connection, Db},
     pipeline::{sequential::Handler, Processor},
+    postgres::{Connection, Db},
     types::full_checkpoint_content::CheckpointData,
     FieldCount,
 };

--- a/crates/sui-indexer-alt/src/handlers/tx_affected_addresses.rs
+++ b/crates/sui-indexer-alt/src/handlers/tx_affected_addresses.rs
@@ -9,8 +9,8 @@ use diesel::{ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use itertools::Itertools;
 use sui_indexer_alt_framework::{
-    db::{Connection, Db},
     pipeline::{concurrent::Handler, Processor},
+    postgres::{Connection, Db},
     types::{full_checkpoint_content::CheckpointData, object::Owner},
 };
 use sui_indexer_alt_schema::{
@@ -118,7 +118,7 @@ mod tests {
     #[tokio::test]
     async fn test_tx_affected_addresses_pruning_complains_if_no_mapping() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         let result = TxAffectedAddresses.prune(0, 2, &mut conn).await;
 
@@ -132,7 +132,7 @@ mod tests {
     #[tokio::test]
     async fn test_tx_affected_addresses_pruning() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         // 0th checkpoint has 1 transaction
         let mut builder = TestCheckpointDataBuilder::new(0);

--- a/crates/sui-indexer-alt/src/handlers/tx_affected_objects.rs
+++ b/crates/sui-indexer-alt/src/handlers/tx_affected_objects.rs
@@ -8,8 +8,8 @@ use anyhow::Result;
 use diesel::{ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use sui_indexer_alt_framework::{
-    db::{Connection, Db},
     pipeline::{concurrent::Handler, Processor},
+    postgres::{Connection, Db},
     types::{effects::TransactionEffectsAPI, full_checkpoint_content::CheckpointData},
 };
 use sui_indexer_alt_schema::{schema::tx_affected_objects, transactions::StoredTxAffectedObject};
@@ -108,7 +108,7 @@ mod tests {
     #[tokio::test]
     async fn test_tx_affected_objects_pruning_complains_if_no_mapping() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         let result = TxAffectedObjects.prune(0, 2, &mut conn).await;
 
@@ -124,7 +124,7 @@ mod tests {
     #[tokio::test]
     async fn test_tx_affected_objects_pruning() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         let mut builder = TestCheckpointDataBuilder::new(0);
         builder = builder.start_transaction(0).finish_transaction();

--- a/crates/sui-indexer-alt/src/handlers/tx_balance_changes.rs
+++ b/crates/sui-indexer-alt/src/handlers/tx_balance_changes.rs
@@ -8,8 +8,8 @@ use anyhow::{Context, Result};
 use diesel::{ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use sui_indexer_alt_framework::{
-    db::{Connection, Db},
     pipeline::{concurrent::Handler, Processor},
+    postgres::{Connection, Db},
     types::{
         coin::Coin,
         effects::TransactionEffectsAPI,
@@ -148,7 +148,7 @@ mod tests {
     #[tokio::test]
     async fn test_tx_balance_changes_pruning_complains_if_no_mapping() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         let result = TxBalanceChanges.prune(0, 2, &mut conn).await;
 
@@ -164,7 +164,7 @@ mod tests {
     #[tokio::test]
     async fn test_tx_balance_changes_pruning() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         let mut builder = TestCheckpointDataBuilder::new(0);
         builder = builder.start_transaction(0).finish_transaction();

--- a/crates/sui-indexer-alt/src/handlers/tx_calls.rs
+++ b/crates/sui-indexer-alt/src/handlers/tx_calls.rs
@@ -8,8 +8,8 @@ use anyhow::{Ok, Result};
 use diesel::{ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use sui_indexer_alt_framework::{
-    db::{Connection, Db},
     pipeline::{concurrent::Handler, Processor},
+    postgres::{Connection, Db},
     types::{full_checkpoint_content::CheckpointData, transaction::TransactionDataAPI},
 };
 use sui_indexer_alt_schema::{schema::tx_calls, transactions::StoredTxCalls};
@@ -115,7 +115,7 @@ mod tests {
     #[tokio::test]
     async fn test_tx_calls_pruning_complains_if_no_mapping() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         let result = TxCalls.prune(0, 2, &mut conn).await;
 
@@ -131,7 +131,7 @@ mod tests {
     #[tokio::test]
     async fn test_tx_calls_pruning() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         let mut builder = TestCheckpointDataBuilder::new(0);
         builder = builder

--- a/crates/sui-indexer-alt/src/handlers/tx_digests.rs
+++ b/crates/sui-indexer-alt/src/handlers/tx_digests.rs
@@ -8,8 +8,8 @@ use anyhow::Result;
 use diesel::{ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use sui_indexer_alt_framework::{
-    db::{Connection, Db},
     pipeline::{concurrent::Handler, Processor},
+    postgres::{Connection, Db},
     types::full_checkpoint_content::CheckpointData,
 };
 use sui_indexer_alt_schema::{schema::tx_digests, transactions::StoredTxDigest};
@@ -96,7 +96,7 @@ mod tests {
     #[tokio::test]
     async fn test_tx_digests_pruning_complains_if_no_mapping() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         let result = TxDigests.prune(0, 2, &mut conn).await;
 
@@ -112,7 +112,7 @@ mod tests {
     #[tokio::test]
     async fn test_tx_digests_pruning() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         let mut builder = TestCheckpointDataBuilder::new(0);
         builder = builder.start_transaction(0).finish_transaction();

--- a/crates/sui-indexer-alt/src/handlers/tx_kinds.rs
+++ b/crates/sui-indexer-alt/src/handlers/tx_kinds.rs
@@ -8,8 +8,8 @@ use anyhow::Result;
 use diesel::{ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use sui_indexer_alt_framework::{
-    db::{Connection, Db},
     pipeline::{concurrent::Handler, Processor},
+    postgres::{Connection, Db},
     types::full_checkpoint_content::CheckpointData,
 };
 use sui_indexer_alt_schema::{
@@ -107,7 +107,7 @@ mod tests {
     #[tokio::test]
     async fn test_tx_kinds_pruning_complains_if_no_mapping() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         let result = TxKinds.prune(0, 2, &mut conn).await;
 
@@ -123,7 +123,7 @@ mod tests {
     #[tokio::test]
     async fn test_tx_kinds_pruning() {
         let (indexer, _db) = Indexer::new_for_testing(&MIGRATIONS).await;
-        let mut conn = indexer.db().connect().await.unwrap();
+        let mut conn = indexer.store().connect().await.unwrap();
 
         let mut builder = TestCheckpointDataBuilder::new(0);
         builder = builder.start_transaction(0).finish_transaction();

--- a/crates/sui-indexer-alt/src/lib.rs
+++ b/crates/sui-indexer-alt/src/lib.rs
@@ -23,7 +23,7 @@ use sui_indexer_alt_framework::{
         sequential::SequentialConfig,
         CommitterConfig,
     },
-    postgres::{self, Db, DbArgs},
+    postgres::{Db, DbArgs},
     Indexer, IndexerArgs,
 };
 use sui_indexer_alt_metrics::db::DbConnectionStatsCollector;
@@ -102,7 +102,7 @@ pub async fn setup_indexer(
 
     // we want to merge &MIGRATIONS with the migrations from the store
     store
-        .run_migrations(postgres::migrations(Some(&MIGRATIONS)))
+        .run_migrations(Some(&MIGRATIONS))
         .await
         .context("Failed to run pending migrations")?;
 

--- a/crates/sui-indexer-alt/src/lib.rs
+++ b/crates/sui-indexer-alt/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Context;
 use bootstrap::bootstrap;
 use config::{IndexerConfig, PipelineLayer};
 use handlers::{
@@ -16,15 +17,16 @@ use handlers::{
 };
 use prometheus::Registry;
 use sui_indexer_alt_framework::{
-    db::DbArgs,
     ingestion::{ClientArgs, IngestionConfig},
     pipeline::{
         concurrent::{ConcurrentConfig, PrunerConfig},
         sequential::SequentialConfig,
         CommitterConfig,
     },
+    postgres::{self, Db, DbArgs},
     Indexer, IndexerArgs,
 };
+use sui_indexer_alt_metrics::db::DbConnectionStatsCollector;
 use sui_indexer_alt_schema::MIGRATIONS;
 use tokio_util::sync::CancellationToken;
 use url::Url;
@@ -50,7 +52,7 @@ pub async fn setup_indexer(
     with_genesis: bool,
     registry: &Registry,
     cancel: CancellationToken,
-) -> anyhow::Result<Indexer> {
+) -> anyhow::Result<Indexer<Db>> {
     let IndexerConfig {
         ingestion,
         consistency,
@@ -93,13 +95,27 @@ pub async fn setup_indexer(
 
     let retry_interval = ingestion.retry_interval();
 
+    // Prepare the store for the indexer
+    let store = Db::for_write(database_url, db_args)
+        .await
+        .context("Failed to connect to database")?;
+
+    // we want to merge &MIGRATIONS with the migrations from the store
+    store
+        .run_migrations(postgres::migrations(Some(&MIGRATIONS)))
+        .await
+        .context("Failed to run pending migrations")?;
+
+    registry.register(Box::new(DbConnectionStatsCollector::new(
+        Some("indexer_db"),
+        store.clone(),
+    )))?;
+
     let mut indexer = Indexer::new(
-        database_url,
-        db_args,
+        store,
         indexer_args,
         client_args,
         ingestion,
-        Some(&MIGRATIONS),
         registry,
         cancel.clone(),
     )

--- a/crates/sui-indexer-alt/src/main.rs
+++ b/crates/sui-indexer-alt/src/main.rs
@@ -13,7 +13,7 @@ use sui_indexer_alt::args::Command;
 use sui_indexer_alt::config::IndexerConfig;
 use sui_indexer_alt::config::Merge;
 use sui_indexer_alt::setup_indexer;
-use sui_indexer_alt_framework::postgres::{self, reset_database};
+use sui_indexer_alt_framework::postgres::reset_database;
 use sui_indexer_alt_metrics::MetricsService;
 use sui_indexer_alt_schema::MIGRATIONS;
 use tokio::fs;
@@ -124,7 +124,11 @@ async fn main() -> Result<()> {
             reset_database(
                 database_url,
                 db_args,
-                (!skip_migrations).then(|| postgres::migrations(Some(&MIGRATIONS))),
+                if !skip_migrations {
+                    Some(&MIGRATIONS)
+                } else {
+                    None
+                },
             )
             .await?;
         }

--- a/crates/sui-indexer-alt/src/main.rs
+++ b/crates/sui-indexer-alt/src/main.rs
@@ -13,8 +13,7 @@ use sui_indexer_alt::args::Command;
 use sui_indexer_alt::config::IndexerConfig;
 use sui_indexer_alt::config::Merge;
 use sui_indexer_alt::setup_indexer;
-use sui_indexer_alt_framework::db::reset_database;
-use sui_indexer_alt_framework::Indexer;
+use sui_indexer_alt_framework::postgres::{self, reset_database};
 use sui_indexer_alt_metrics::MetricsService;
 use sui_indexer_alt_schema::MIGRATIONS;
 use tokio::fs;
@@ -125,7 +124,7 @@ async fn main() -> Result<()> {
             reset_database(
                 database_url,
                 db_args,
-                (!skip_migrations).then(|| Indexer::migrations(Some(&MIGRATIONS))),
+                (!skip_migrations).then(|| postgres::migrations(Some(&MIGRATIONS))),
             )
             .await?;
         }

--- a/crates/sui-pg-db/src/lib.rs
+++ b/crates/sui-pg-db/src/lib.rs
@@ -273,7 +273,6 @@ mod tests {
     use super::*;
     use diesel::prelude::QueryableByName;
     use diesel_async::RunQueryDsl;
-    use diesel_migrations::EmbeddedMigrations;
 
     #[tokio::test]
     async fn temp_db_smoketest() {


### PR DESCRIPTION
## Description 

Move the `fn migration` in `Indexer` into `sui-pg-db`, since it is now the crate that has the additional migrations needed. The framework provides some convenience functions in implementing `Indexer<Db>`, so users have a quick way to spin up an opinionated indexer. Similar story for `IndexerCluster`. Tests on the framework will use the postgres flavor, so we add `sui-pg-db` as a dev dependency. 

Now, when using the framework, users can leverage `sui-pg-db` through `sui_indexer_alt_framework::postgres::{...}`

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
