### PR TITLE
[consensus] add debugging metrics

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -192,7 +192,7 @@ where
             "Invalid own index {}",
             own_index
         );
-        let own_hostname = &committee.authority(own_index).hostname;
+        let own_hostname = committee.authority(own_index).hostname.clone();
         info!(
             "Starting consensus authority {} {}, {:?}, boot counter {}",
             own_index, own_hostname, protocol_config.version, boot_counter
@@ -215,6 +215,18 @@ where
             clock,
         ));
         let start_time = Instant::now();
+
+        context
+            .metrics
+            .node_metrics
+            .authority_index
+            .with_label_values(&[&own_hostname])
+            .set(context.own_index.value() as i64);
+        context
+            .metrics
+            .node_metrics
+            .protocol_version
+            .set(context.protocol_config.version.as_u64() as i64);
 
         let (tx_client, tx_receiver) = TransactionClient::new(context.clone());
         let tx_consumer = TransactionConsumer::new(tx_receiver, context.clone());

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -97,6 +97,8 @@ pub(crate) fn test_metrics() -> Arc<Metrics> {
 }
 
 pub(crate) struct NodeMetrics {
+    pub(crate) authority_index: IntGaugeVec,
+    pub(crate) protocol_version: IntGauge,
     pub(crate) block_commit_latency: Histogram,
     pub(crate) proposed_blocks: IntCounterVec,
     pub(crate) proposed_block_size: Histogram,
@@ -208,6 +210,17 @@ pub(crate) struct NodeMetrics {
 impl NodeMetrics {
     pub(crate) fn new(registry: &Registry) -> Self {
         Self {
+            authority_index: register_int_gauge_vec_with_registry!(
+                "authority_index",
+                "The index of the authority",
+                &["name"],
+                registry,
+            ).unwrap(),
+            protocol_version: register_int_gauge_with_registry!(
+                "protocol_version",
+                "The protocol version used in this epoch",
+                registry,
+            ).unwrap(),
             block_commit_latency: register_histogram_with_registry!(
                 "block_commit_latency",
                 "The time taken between block creation and block commit.",


### PR DESCRIPTION
## Description 

Retrieving the current authority index and protocol version from logs can be a bit slow, so exporting them as metrics. 

## Test plan 

CI
PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
