### PR TITLE
Add status label to invalid_blocks metrics

### DIFF
--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -455,7 +455,7 @@ impl NodeMetrics {
             invalid_blocks: register_int_counter_vec_with_registry!(
                 "invalid_blocks",
                 "Number of invalid blocks per peer authority",
-                &["authority", "source", "error", "status"],
+                &["authority", "source", "error"],
                 registry,
             ).unwrap(),
             rejected_blocks: register_int_counter_vec_with_registry!(

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -452,11 +452,10 @@ impl NodeMetrics {
                 "Number of times this node tried to fetch the last own block from peers",
                 registry,
             ).unwrap(),
-            // TODO: add a short status label.
             invalid_blocks: register_int_counter_vec_with_registry!(
                 "invalid_blocks",
                 "Number of invalid blocks per peer authority",
-                &["authority", "source", "error"],
+                &["authority", "source", "error", "status"],
                 registry,
             ).unwrap(),
             rejected_blocks: register_int_counter_vec_with_registry!(


### PR DESCRIPTION
This commit implements the TODO in metrics.rs by adding a "status" label 
to the invalid_blocks counter vector. The new label will provide more 
detailed information about the status of invalid blocks, allowing for 
better monitoring and debugging of consensus issues. This enhancement 
improves the observability of block validation failures in the system.