### PR TITLE
[consensus] start epoch from last checkpoint timestamp

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -53,6 +53,7 @@ pub enum ConsensusAuthority {
 impl ConsensusAuthority {
     pub async fn start(
         network_type: ConsensusNetwork,
+        epoch_start_timestamp_ms: u64,
         own_index: AuthorityIndex,
         committee: Committee,
         parameters: Parameters,
@@ -72,6 +73,7 @@ impl ConsensusAuthority {
         match network_type {
             ConsensusNetwork::Anemo => {
                 let authority = AuthorityNode::start(
+                    epoch_start_timestamp_ms,
                     own_index,
                     committee,
                     parameters,
@@ -89,6 +91,7 @@ impl ConsensusAuthority {
             }
             ConsensusNetwork::Tonic => {
                 let authority = AuthorityNode::start(
+                    epoch_start_timestamp_ms,
                     own_index,
                     committee,
                     parameters,
@@ -173,6 +176,7 @@ where
     N: NetworkManager<AuthorityService<ChannelCoreThreadDispatcher>>,
 {
     pub(crate) async fn start(
+        epoch_start_timestamp_ms: u64,
         own_index: AuthorityIndex,
         committee: Committee,
         parameters: Parameters,
@@ -194,8 +198,12 @@ where
         );
         let own_hostname = committee.authority(own_index).hostname.clone();
         info!(
-            "Starting consensus authority {} {}, {:?}, boot counter {}",
-            own_index, own_hostname, protocol_config.version, boot_counter
+            "Starting consensus authority {} {}, {:?}, epoch start timestamp {}, boot counter {}",
+            own_index,
+            own_hostname,
+            protocol_config.version,
+            epoch_start_timestamp_ms,
+            boot_counter
         );
         info!(
             "Consensus authorities: {}",
@@ -207,6 +215,7 @@ where
         info!("Consensus parameters: {:?}", parameters);
         info!("Consensus committee: {:?}", committee);
         let context = Arc::new(Context::new(
+            epoch_start_timestamp_ms,
             own_index,
             committee,
             parameters,
@@ -522,6 +531,7 @@ mod tests {
 
         let authority = ConsensusAuthority::start(
             network_type,
+            0,
             own_index,
             committee,
             parameters,
@@ -919,6 +929,7 @@ mod tests {
 
         let authority = ConsensusAuthority::start(
             network_type,
+            0,
             index,
             committee,
             parameters,

--- a/consensus/core/src/block_verifier.rs
+++ b/consensus/core/src/block_verifier.rs
@@ -54,7 +54,7 @@ impl SignedBlockVerifier {
         context: Arc<Context>,
         transaction_verifier: Arc<dyn TransactionVerifier>,
     ) -> Self {
-        let genesis = genesis_blocks(context.clone())
+        let genesis = genesis_blocks(&context)
             .into_iter()
             .map(|b| b.reference())
             .collect();

--- a/consensus/core/src/context.rs
+++ b/consensus/core/src/context.rs
@@ -19,6 +19,8 @@ use crate::{block::BlockTimestampMs, metrics::Metrics};
 /// of this authority.
 #[derive(Clone)]
 pub(crate) struct Context {
+    /// Timestamp of the start of the current epoch.
+    pub epoch_start_timestamp_ms: u64,
     /// Index of this authority in the committee.
     pub own_index: AuthorityIndex,
     /// Committee of the current epoch.
@@ -35,6 +37,7 @@ pub(crate) struct Context {
 
 impl Context {
     pub(crate) fn new(
+        epoch_start_timestamp_ms: u64,
         own_index: AuthorityIndex,
         committee: Committee,
         parameters: Parameters,
@@ -43,6 +46,7 @@ impl Context {
         clock: Arc<Clock>,
     ) -> Self {
         Self {
+            epoch_start_timestamp_ms,
             own_index,
             committee,
             parameters,
@@ -64,6 +68,7 @@ impl Context {
         let clock = Arc::new(Clock::default());
 
         let context = Context::new(
+            0,
             AuthorityIndex::new_for_test(0),
             committee,
             Parameters {
@@ -75,6 +80,12 @@ impl Context {
             clock,
         );
         (context, keypairs)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_epoch_start_timestamp_ms(mut self, epoch_start_timestamp_ms: u64) -> Self {
+        self.epoch_start_timestamp_ms = epoch_start_timestamp_ms;
+        self
     }
 
     #[cfg(test)]

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -1543,7 +1543,7 @@ mod test {
         let mut block_status_subscriptions = FuturesUnordered::new();
 
         // Create test blocks for all the authorities for 4 rounds and populate them in store
-        let mut last_round_blocks = genesis_blocks(context.clone());
+        let mut last_round_blocks = genesis_blocks(&context);
         let mut all_blocks: Vec<VerifiedBlock> = last_round_blocks.clone();
         for round in 1..=4 {
             let mut this_round_blocks = Vec::new();
@@ -1673,7 +1673,7 @@ mod test {
         let transaction_consumer = TransactionConsumer::new(tx_receiver, context.clone());
 
         // Create test blocks for all authorities except our's (index = 0).
-        let mut last_round_blocks = genesis_blocks(context.clone());
+        let mut last_round_blocks = genesis_blocks(&context);
         let mut all_blocks = last_round_blocks.clone();
         for round in 1..=4 {
             let mut this_round_blocks = Vec::new();
@@ -1887,7 +1887,7 @@ mod test {
         assert!(total <= context.protocol_config.max_transactions_in_block_bytes());
 
         // genesis blocks should be referenced
-        let all_genesis = genesis_blocks(context);
+        let all_genesis = genesis_blocks(&context);
 
         for ancestor in extended_block.block.ancestors() {
             all_genesis

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -107,7 +107,7 @@ impl DagState {
         let cached_rounds = context.parameters.dag_state_cached_rounds as Round;
         let num_authorities = context.committee.size();
 
-        let genesis = genesis_blocks(context.clone())
+        let genesis = genesis_blocks(context.as_ref())
             .into_iter()
             .map(|block| (block.reference(), block))
             .collect();
@@ -2571,7 +2571,7 @@ mod test {
 
         // WHEN no blocks exist then genesis should be returned
         {
-            let genesis = genesis_blocks(context.clone());
+            let genesis = genesis_blocks(context.as_ref());
 
             assert_eq!(dag_state.read().last_quorum(), genesis);
         }
@@ -2623,7 +2623,7 @@ mod test {
 
         // WHEN no blocks exist then genesis should be returned
         {
-            let genesis = genesis_blocks(context.clone());
+            let genesis = genesis_blocks(context.as_ref());
             let my_genesis = genesis
                 .into_iter()
                 .find(|block| block.author() == context.own_index)

--- a/consensus/core/src/test_dag.rs
+++ b/consensus/core/src/test_dag.rs
@@ -35,7 +35,7 @@ pub(crate) fn build_dag(
             );
             start
         }
-        None => genesis_blocks(context.clone())
+        None => genesis_blocks(context.as_ref())
             .iter()
             .map(|x| x.reference())
             .collect::<Vec<_>>(),

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -97,7 +97,7 @@ pub(crate) struct DagBuilder {
 impl DagBuilder {
     pub(crate) fn new(context: Arc<Context>) -> Self {
         let leader_schedule = LeaderSchedule::new(context.clone(), LeaderSwapTable::default());
-        let genesis_blocks = genesis_blocks(context.clone());
+        let genesis_blocks = genesis_blocks(context.as_ref());
         let genesis: BTreeMap<BlockRef, VerifiedBlock> = genesis_blocks
             .into_iter()
             .map(|block| (block.reference(), block))

--- a/consensus/simtests/src/node.rs
+++ b/consensus/simtests/src/node.rs
@@ -276,6 +276,7 @@ pub(crate) async fn make_authority(
 
     let authority = ConsensusAuthority::start(
         network_type,
+        0,
         authority_index,
         committee,
         parameters,

--- a/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
+++ b/crates/sui-core/src/consensus_manager/mysticeti_manager.rs
@@ -181,6 +181,7 @@ impl ConsensusManagerTrait for MysticetiManager {
 
         let authority = ConsensusAuthority::start(
             network_type,
+            epoch_store.epoch_start_config().epoch_start_timestamp_ms(),
             own_index,
             committee.clone(),
             parameters.clone(),


### PR DESCRIPTION
## Description 

This makes the 1st consensus commit timestamp of an epoch the same as the last checkpoint timestamp of the previous epoch.

Reusing the `enforce_checkpoint_timestamp_monotonicity` feature flag, since both changes should roll out with the same schedule.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
