### PR TITLE
Always acknowledge handled consensus commits

### DIFF
--- a/consensus/core/src/commit_consumer.rs
+++ b/consensus/core/src/commit_consumer.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, RwLock};
 use tokio::sync::watch;
 
 use mysten_metrics::monitored_mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use tracing::{debug, info};
 
 use crate::{block::CertifiedBlocksOutput, CommitIndex, CommittedSubDag};
 
@@ -74,6 +75,7 @@ impl CommitConsumerMonitor {
     }
 
     pub fn set_highest_handled_commit(&self, highest_handled_commit: CommitIndex) {
+        debug!("Highest handled commit set to {}", highest_handled_commit);
         self.highest_handled_commit
             .send_replace(highest_handled_commit);
     }
@@ -101,6 +103,11 @@ impl CommitConsumerMonitor {
             "highest_known_commit_at_startup can only be set once"
         );
         *commit = highest_observed_commit_at_startup;
+
+        info!(
+            "Highest observed commit at startup set to {}",
+            highest_observed_commit_at_startup
+        );
     }
 
     pub(crate) async fn replay_complete(&self) {

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -905,8 +905,8 @@ impl MysticetiConsensusHandler {
                     consensus_handler
                         .handle_consensus_commit(consensus_commit)
                         .await;
-                    commit_consumer_monitor.set_highest_handled_commit(commit_index);
                 }
+                commit_consumer_monitor.set_highest_handled_commit(commit_index);
             }
         }));
         if consensus_block_handler.enabled() {


### PR DESCRIPTION
## Description 

Otherwise, replaying commits that Sui consensus handler already observed do not update this watermark, so waiting on `replay_complete()` never finishes.

## Test plan 

CI
```
python ./scripts/simtest/seed-search.py test_simulated_load_rolling_restarts_all_validators --test simtest --num-seeds 2000
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
