### PR TITLE
[move-ide] Added option to disable auto-imports during auto-completion

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -57,6 +57,11 @@
       "type": "object",
       "title": "Move",
       "properties": {
+        "move.auto-imports": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Enable/disable auto-imports during auto-completion"
+        },
         "move.force-bundled": {
           "type": "boolean",
           "default": false,

--- a/external-crates/move/crates/move-analyzer/editors/code/src/configuration.ts
+++ b/external-crates/move/crates/move-analyzer/editors/code/src/configuration.ts
@@ -8,7 +8,8 @@ import * as path from 'path';
 
 export const MOVE_CONF_NAME = 'move';
 export const LINT_OPT = 'lint';
-export const FORCE_BUNDLED = 'force-bundled';
+export const AUTO_IMPORTS_OPT = 'auto-imports';
+export const FORCE_BUNDLED_OPT = 'force-bundled';
 export const TYPE_HINTS_OPT = 'inlay-hints.type';
 export const PARAM_HINTS_OPT = 'inlay-hints.param';
 export const SUI_PATH_OPT = 'sui.path';
@@ -75,16 +76,20 @@ export class Configuration {
         return this.configuration.get(LINT_OPT) ?? 'default';
     }
 
+    get autoImports(): boolean {
+        return this.configuration.get(AUTO_IMPORTS_OPT) ?? true;
+    }
+
     get forceBundled(): boolean {
-        return this.configuration.get(FORCE_BUNDLED) ?? false;
+        return this.configuration.get(FORCE_BUNDLED_OPT) ?? false;
     }
 
     get inlayHintsForType(): boolean {
-        return this.configuration.get(TYPE_HINTS_OPT) ?? false;
+        return this.configuration.get(TYPE_HINTS_OPT) ?? true;
     }
 
     get inlayHintsForParam(): boolean {
-        return this.configuration.get(PARAM_HINTS_OPT) ?? false;
+        return this.configuration.get(PARAM_HINTS_OPT) ?? true;
     }
 
 

--- a/external-crates/move/crates/move-analyzer/editors/code/src/context.ts
+++ b/external-crates/move/crates/move-analyzer/editors/code/src/context.ts
@@ -4,7 +4,8 @@
 
 import {
     MOVE_CONF_NAME, LINT_OPT, TYPE_HINTS_OPT, PARAM_HINTS_OPT,
-    SUI_PATH_OPT, SERVER_PATH_OPT, FORCE_BUNDLED, Configuration,
+    SUI_PATH_OPT, SERVER_PATH_OPT, FORCE_BUNDLED_OPT, Configuration,
+    AUTO_IMPORTS_OPT,
 } from './configuration';
 import * as childProcess from 'child_process';
 import * as vscode from 'vscode';
@@ -76,6 +77,8 @@ export class Context {
 
     private lintLevel: string;
 
+    private autoImports: boolean;
+
     private inlayHintsType: boolean;
 
     private inlayHintsParam: boolean;
@@ -100,6 +103,7 @@ export class Context {
         this.configuration = new Configuration();
         log.info(`configuration: ${this.configuration.toString()}`);
         this.lintLevel = this.configuration.lint;
+        this.autoImports = this.configuration.autoImports;
         this.inlayHintsType = this.configuration.inlayHintsForType;
         this.inlayHintsParam = this.configuration.inlayHintsForParam;
         // Default to configuration.serverPath but may change during server installation
@@ -193,6 +197,7 @@ export class Context {
             traceOutputChannel: this.traceOutputChannel,
             initializationOptions: {
                 lintLevel: this.lintLevel,
+                autoImports: this.autoImports,
                 inlayHintsType: this.inlayHintsType,
                 inlayHintsParam: this.inlayHintsParam,
             },
@@ -242,11 +247,13 @@ export class Context {
             const server_path_conf = MOVE_CONF_NAME.concat('.').concat(SERVER_PATH_OPT);
             const sui_path_conf = MOVE_CONF_NAME.concat('.').concat(SUI_PATH_OPT);
             const lint_conf = MOVE_CONF_NAME.concat('.').concat(LINT_OPT);
-            const force_bundled_conf = MOVE_CONF_NAME.concat('.').concat(FORCE_BUNDLED);
+            const auto_imports_conf = MOVE_CONF_NAME.concat('.').concat(AUTO_IMPORTS_OPT);
+            const force_bundled_conf = MOVE_CONF_NAME.concat('.').concat(FORCE_BUNDLED_OPT);
             const type_hints_conf = MOVE_CONF_NAME.concat('.').concat(TYPE_HINTS_OPT);
             const param_hints_conf = MOVE_CONF_NAME.concat('.').concat(PARAM_HINTS_OPT);
 
             const optionsChanged = event.affectsConfiguration(lint_conf) ||
+                event.affectsConfiguration(auto_imports_conf) ||
                 event.affectsConfiguration(type_hints_conf) ||
                 event.affectsConfiguration(param_hints_conf);
             const pathsChanged = event.affectsConfiguration(server_path_conf) ||
@@ -258,6 +265,7 @@ export class Context {
                 log.info(`configuration: ${this.configuration.toString()}`);
 
                 this.lintLevel = this.configuration.lint;
+                this.autoImports = this.configuration.autoImports;
                 this.inlayHintsType = this.configuration.inlayHintsForType;
                 this.inlayHintsParam = this.configuration.inlayHintsForParam;
                 try {

--- a/external-crates/move/crates/move-analyzer/src/analyzer.rs
+++ b/external-crates/move/crates/move-analyzer/src/analyzer.rs
@@ -177,6 +177,12 @@ pub fn run(implicit_deps: Dependencies) {
     let context = Context {
         connection,
         symbols: symbols_map.clone(),
+        auto_imports: initialize_params
+            .initialization_options
+            .as_ref()
+            .and_then(|init_options| init_options.get("autoImports"))
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or_default(),
         inlay_type_hints: initialize_params
             .initialization_options
             .as_ref()
@@ -191,6 +197,10 @@ pub fn run(implicit_deps: Dependencies) {
             .unwrap_or_default(),
     };
 
+    eprintln!(
+        "auto imports during auto-completion enabled: {}",
+        context.auto_imports
+    );
     eprintln!("inlay type hints enabled: {}", context.inlay_type_hints);
     eprintln!("inlay param hints enabled: {}", context.inlay_param_hints);
 
@@ -316,7 +326,6 @@ fn on_request(
             ide_files_root.clone(),
             pkg_dependencies,
             implicit_deps,
-            true, // auto-imports enabled
         ),
         lsp_types::request::GotoDefinition::METHOD => {
             symbols::on_go_to_def_request(context, request);

--- a/external-crates/move/crates/move-analyzer/src/completions/mod.rs
+++ b/external-crates/move/crates/move-analyzer/src/completions/mod.rs
@@ -81,7 +81,6 @@ pub fn on_completion_request(
     ide_files_root: VfsPath,
     pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgInfo>>>,
     implicit_deps: Dependencies,
-    auto_import: bool,
 ) {
     eprintln!("handling completion request");
     let parameters = serde_json::from_value::<CompletionParams>(request.params.clone())
@@ -107,7 +106,7 @@ pub fn on_completion_request(
         &path,
         pos,
         implicit_deps,
-        auto_import,
+        context.auto_imports,
     )
     .unwrap_or_default();
     let completions_len = completions.len();

--- a/external-crates/move/crates/move-analyzer/src/context.rs
+++ b/external-crates/move/crates/move-analyzer/src/context.rs
@@ -16,6 +16,8 @@ pub struct Context {
     pub connection: Connection,
     /// Symbolication information
     pub symbols: Arc<Mutex<BTreeMap<PathBuf, Symbols>>>,
+    /// Are auto-imports offered as suggestions during auto-completion?
+    pub auto_imports: bool,
     /// Are inlay type hints enabled?
     pub inlay_type_hints: bool,
     /// Are param type hints enabled?


### PR DESCRIPTION
## Description 

This PR introduces a Move plugin option to disable auto-imports during auto-completion. The two main reasons are:
- the auto-completion list gets much longer with auto-imports and if someone does not want them, it may get annoying
- it's easy to introduce edits to a file this way and formatting of these edits is at the moment rather rudimentary

## Test plan 

Tested manually that the option works
