### PR TITLE
[typed store] add tidehunter option to DBMapUtils macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -663,7 +663,7 @@ sui-benchmark = { path = "crates/sui-benchmark" }
 sui-bridge = { path = "crates/sui-bridge" }
 sui-cluster-test = { path = "crates/sui-cluster-test" }
 sui-config = { path = "crates/sui-config" }
-sui-core = { path = "crates/sui-core" }
+sui-core = { path = "crates/sui-core", features = ["rocksdb"] }
 sui-cost = { path = "crates/sui-cost" }
 sui-data-ingestion = { path = "crates/sui-data-ingestion" }
 sui-data-ingestion-core = { path = "crates/sui-data-ingestion-core" }

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -93,6 +93,10 @@ sui-tls.workspace = true
 sui-types.workspace = true
 nonempty.workspace = true
 
+[features]
+tide_hunter = ["typed-store/tide_hunter"]
+rocksdb = []
+
 [dev-dependencies]
 sui-move-build.workspace = true
 clap.workspace = true

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -643,6 +643,17 @@ impl AuthorityStorePruner {
         Ok(pruned_checkpoint + delta)
     }
 
+    #[allow(clippy::all)]
+    #[allow(dead_code)]
+    fn th_pruning_config() -> AuthorityStorePruningConfig {
+        let mut config = AuthorityStorePruningConfig::default();
+        config.num_epochs_to_retain = u64::MAX;
+        config.num_epochs_to_retain_for_checkpoints = None;
+        config.num_epochs_to_retain_for_indexes = None;
+        config.periodic_compaction_threshold_days = None;
+        config
+    }
+
     fn setup_pruning(
         config: AuthorityStorePruningConfig,
         epoch_duration_ms: u64,
@@ -659,6 +670,8 @@ impl AuthorityStorePruner {
             "Starting object pruning service with num_epochs_to_retain={}",
             config.num_epochs_to_retain
         );
+        #[cfg(all(not(target_os = "windows"), feature = "tide_hunter"))]
+        let config = Self::th_pruning_config();
 
         let tick_duration =
             Duration::from_millis(Self::pruning_tick_duration_ms(epoch_duration_ms));

--- a/crates/typed-store-derive/src/lib.rs
+++ b/crates/typed-store-derive/src/lib.rs
@@ -172,10 +172,17 @@ struct ExtractedStructInfo {
     deprecated_cfs: Vec<Ident>,
 }
 
-#[proc_macro_derive(DBMapUtils, attributes(default_options_override_fn, rename))]
+#[proc_macro_derive(
+    DBMapUtils,
+    attributes(default_options_override_fn, rename, tidehunter)
+)]
 pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
     let name = &input.ident;
+    let is_tidehunter = input
+        .attrs
+        .iter()
+        .any(|attr| attr.path.is_ident("tidehunter"));
     let generics = &input.generics;
     let generics_names = extract_generics_names(generics);
 
@@ -213,9 +220,7 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
     let secondary_db_map_struct_name: proc_macro2::TokenStream =
         secondary_db_map_struct_name_str.parse().unwrap();
 
-    TokenStream::from(quote! {
-        // <----------- This section generates the core open logic for opening DBMaps -------------->
-
+    let base_code = quote! {
         /// Create an intermediate struct used to open the DBMap tables in primary mode
         /// This is only used internally
         struct #intermediate_db_map_struct_name #generics {
@@ -225,138 +230,20 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
         }
 
         impl <
-                #(
-                    #generics_names: #generics_bounds_token,
-                )*
-            > #intermediate_db_map_struct_name #generics {
-            /// Opens a set of tables in read-write mode
-            /// If as_secondary_with_path is set, the DB is opened in read only mode with the path specified
-            pub fn open_tables_impl(
-                path: std::path::PathBuf,
-                as_secondary_with_path: Option<std::path::PathBuf>,
-                metric_conf: typed_store::rocks::MetricConf,
-                global_db_options_override: Option<typed_store::rocksdb::Options>,
-                tables_db_options_override: Option<typed_store::rocks::DBMapTableConfigMap>,
-                remove_deprecated_tables: bool,
-            ) -> Self {
-                let path = &path;
-                let default_cf_opt = if let Some(opt) = global_db_options_override.as_ref() {
-                    typed_store::rocks::DBOptions {
-                        options: opt.clone(),
-                        rw_options: typed_store::rocks::default_db_options().rw_options,
-                    }
-                } else {
-                    typed_store::rocks::default_db_options()
-                };
-                let (db, rwopt_cfs) = {
-                    let opt_cfs = match tables_db_options_override {
-                        None => [
-                            #(
-                                (stringify!(#cf_names).to_owned(), #default_options_override_fn_names()),
-                            )*
-                        ],
-                        Some(o) => [
-                            #(
-                                (stringify!(#cf_names).to_owned(), o.to_map().get(stringify!(#cf_names)).unwrap_or(&default_cf_opt).clone()),
-                            )*
-                        ]
-                    };
-                    // Safe to call unwrap because we will have at least one field_name entry in the struct
-                    let rwopt_cfs: std::collections::HashMap<String, typed_store::rocks::ReadWriteOptions> = opt_cfs.iter().map(|q| (q.0.as_str().to_string(), q.1.rw_options.clone())).collect();
-                    let opt_cfs: Vec<_> = opt_cfs.iter().map(|q| (q.0.as_str(), q.1.options.clone())).collect();
-                    let db = match as_secondary_with_path.clone() {
-                        Some(p) => typed_store::rocks::open_cf_opts_secondary(path, Some(&p), global_db_options_override, metric_conf, &opt_cfs),
-                        _ => typed_store::rocks::open_cf_opts(path, global_db_options_override, metric_conf, &opt_cfs)
-                    };
-                    db.map(|d| (d, rwopt_cfs))
-                }.expect(&format!("Cannot open DB at {:?}", path));
-                let deprecated_tables = vec![#(stringify!(#deprecated_cfs),)*];
-                let (
-                        #(
-                            #field_names
-                        ),*
-                ) = (#(
-                        DBMap::#inner_types::reopen(&db, Some(stringify!(#cf_names)), rwopt_cfs.get(stringify!(#cf_names)).unwrap_or(&typed_store::rocks::ReadWriteOptions::default()), remove_deprecated_tables && deprecated_tables.contains(&stringify!(#cf_names))).expect(&format!("Cannot open {} CF.", stringify!(#cf_names))[..])
-                    ),*);
-
-                if as_secondary_with_path.is_none() && remove_deprecated_tables {
-                    #(
-                        db.drop_cf(stringify!(#deprecated_cfs)).expect("failed to drop a deprecated cf");
-                    )*
-                }
-                Self {
-                    #(
-                        #field_names,
-                    )*
-                }
-            }
-        }
-
-
-        // <----------- This section generates the read-write open logic and other common utils -------------->
-
-        impl <
-                #(
-                    #generics_names: #generics_bounds_token,
-                )*
-            > #name #generics {
-            /// Opens a set of tables in read-write mode
-            /// Only one process is allowed to do this at a time
-            /// `global_db_options_override` apply to the whole DB
-            /// `tables_db_options_override` apply to each table. If `None`, the attributes from `default_options_override_fn` are used if any
-            #[allow(unused_parens)]
-            pub fn open_tables_read_write(
-                path: std::path::PathBuf,
-                metric_conf: typed_store::rocks::MetricConf,
-                global_db_options_override: Option<typed_store::rocksdb::Options>,
-                tables_db_options_override: Option<typed_store::rocks::DBMapTableConfigMap>
-            ) -> Self {
-                let inner = #intermediate_db_map_struct_name::open_tables_impl(path, None, metric_conf, global_db_options_override, tables_db_options_override, false);
-                Self {
-                    #(
-                        #field_names: inner.#field_names,
-                    )*
-                }
-            }
-
-            #[allow(unused_parens)]
-            pub fn open_tables_read_write_with_deprecation_option(
-                path: std::path::PathBuf,
-                metric_conf: typed_store::rocks::MetricConf,
-                global_db_options_override: Option<typed_store::rocksdb::Options>,
-                tables_db_options_override: Option<typed_store::rocks::DBMapTableConfigMap>,
-                remove_deprecated_tables: bool,
-            ) -> Self {
-                let inner = #intermediate_db_map_struct_name::open_tables_impl(path, None, metric_conf, global_db_options_override, tables_db_options_override, remove_deprecated_tables);
-                Self {
-                    #(
-                        #field_names: inner.#field_names,
-                    )*
-                }
-            }
-
+            #(
+                #generics_names: #generics_bounds_token,
+            )*
+        > #name #generics {
             /// Returns a list of the tables name and type pairs
             pub fn describe_tables() -> std::collections::BTreeMap<String, (String, String)> {
                 vec![#(
                     (stringify!(#field_names).to_owned(), (stringify!(#key_names).to_owned(), stringify!(#value_names).to_owned())),
                 )*].into_iter().collect()
             }
-
-            /// This opens the DB in read only mode and returns a struct which exposes debug features
-            pub fn get_read_only_handle (
-                primary_path: std::path::PathBuf,
-                with_secondary_path: Option<std::path::PathBuf>,
-                global_db_options_override: Option<typed_store::rocksdb::Options>,
-                metric_conf: typed_store::rocks::MetricConf,
-                ) -> #secondary_db_map_struct_name #generics {
-                #secondary_db_map_struct_name::open_tables_read_only(primary_path, with_secondary_path, metric_conf, global_db_options_override)
-            }
         }
+    };
 
-
-        // <----------- This section generates the features that use read-only open logic -------------->
-        /// Create an intermediate struct used to open the DBMap tables in secondary mode
-        /// This is only used internally
+    let secondary_code = quote! {
         pub struct #secondary_db_map_struct_name #generics {
             #(
                 pub #field_names : DBMap #inner_types,
@@ -454,5 +341,214 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                 Ok(())
             }
         }
-    })
+    };
+
+    if is_tidehunter {
+        TokenStream::from(quote! {
+            #base_code
+            impl <
+                    #(
+                        #generics_names: #generics_bounds_token,
+                    )*
+                > #intermediate_db_map_struct_name #generics {
+                /// Opens a set of tables in read-write mode
+                /// If as_secondary_with_path is set, the DB is opened in read only mode with the path specified
+                pub fn open_tables_impl(
+                    path: std::path::PathBuf,
+                    metric_conf: typed_store::rocks::MetricConf,
+                    cf_configs: std::collections::BTreeMap<String, typed_store::tidehunter_util::ThConfig>,
+                ) -> Self {
+                    let mut builder = typed_store::tidehunter_util::KeyShapeBuilder::new();
+                    let (
+                        #(
+                            #field_names,
+                        )*
+                    ) = (
+                        #(
+                            typed_store::tidehunter_util::add_key_space(
+                                &mut builder,
+                                stringify!(#cf_names),
+                                &cf_configs[stringify!(#cf_names)],
+                            ),
+                        )*
+                    );
+                    let key_shape = builder.build();
+                    let inner_db = typed_store::tidehunter_util::open(path.as_path(), key_shape);
+                    let db = std::sync::Arc::new(typed_store::rocks::Database::new(
+                        typed_store::rocks::Storage::TideHunter(inner_db),
+                        metric_conf));
+                    let (
+                        #(
+                            #field_names
+                        ),*
+                    ) = (#(
+                        DBMap::#inner_types::reopen_th(
+                            db.clone(), stringify!(#cf_names), #field_names,
+                            cf_configs[stringify!(#cf_names)].prefix.clone()
+                        )
+                    ),*);
+                    Self {
+                        #(
+                            #field_names,
+                        )*
+                    }
+                }
+            }
+
+            impl <
+                #(
+                    #generics_names: #generics_bounds_token,
+                )*
+            > #name #generics {
+                pub fn open_tables_read_write(
+                    path: std::path::PathBuf,
+                    metric_conf: typed_store::rocks::MetricConf,
+                    cf_configs: std::collections::BTreeMap<String, typed_store::tidehunter_util::ThConfig>,
+                ) -> Self {
+                    let inner = #intermediate_db_map_struct_name::open_tables_impl(path, metric_conf, cf_configs);
+                    Self {
+                        #(
+                            #field_names: inner.#field_names,
+                        )*
+                    }
+                }
+
+                pub fn get_read_only_handle (
+                    _: std::path::PathBuf,
+                    _: Option<std::path::PathBuf>,
+                    _: Option<typed_store::rocksdb::Options>,
+                    _: typed_store::rocks::MetricConf,
+                ) -> #secondary_db_map_struct_name #generics {
+                    unimplemented!("read only mode is not supported for TideHunter");
+                }
+            }
+
+            pub struct #secondary_db_map_struct_name;
+        })
+    } else {
+        TokenStream::from(quote! {
+            #base_code
+
+            impl <
+                    #(
+                        #generics_names: #generics_bounds_token,
+                    )*
+                > #intermediate_db_map_struct_name #generics {
+                /// Opens a set of tables in read-write mode
+                /// If as_secondary_with_path is set, the DB is opened in read only mode with the path specified
+                pub fn open_tables_impl(
+                    path: std::path::PathBuf,
+                    as_secondary_with_path: Option<std::path::PathBuf>,
+                    metric_conf: typed_store::rocks::MetricConf,
+                    global_db_options_override: Option<typed_store::rocksdb::Options>,
+                    tables_db_options_override: Option<typed_store::rocks::DBMapTableConfigMap>,
+                    remove_deprecated_tables: bool,
+                ) -> Self {
+                    let path = &path;
+                    let default_cf_opt = if let Some(opt) = global_db_options_override.as_ref() {
+                        typed_store::rocks::DBOptions {
+                            options: opt.clone(),
+                            rw_options: typed_store::rocks::default_db_options().rw_options,
+                        }
+                    } else {
+                        typed_store::rocks::default_db_options()
+                    };
+                    let (db, rwopt_cfs) = {
+                        let opt_cfs = match tables_db_options_override {
+                            None => [
+                                #(
+                                    (stringify!(#cf_names).to_owned(), #default_options_override_fn_names()),
+                                )*
+                            ],
+                            Some(o) => [
+                                #(
+                                    (stringify!(#cf_names).to_owned(), o.to_map().get(stringify!(#cf_names)).unwrap_or(&default_cf_opt).clone()),
+                                )*
+                            ]
+                        };
+                        // Safe to call unwrap because we will have at least one field_name entry in the struct
+                        let rwopt_cfs: std::collections::HashMap<String, typed_store::rocks::ReadWriteOptions> = opt_cfs.iter().map(|q| (q.0.as_str().to_string(), q.1.rw_options.clone())).collect();
+                        let opt_cfs: Vec<_> = opt_cfs.iter().map(|q| (q.0.as_str(), q.1.options.clone())).collect();
+                        let db = match as_secondary_with_path.clone() {
+                            Some(p) => typed_store::rocks::open_cf_opts_secondary(path, Some(&p), global_db_options_override, metric_conf, &opt_cfs),
+                            _ => typed_store::rocks::open_cf_opts(path, global_db_options_override, metric_conf, &opt_cfs)
+                        };
+                        db.map(|d| (d, rwopt_cfs))
+                    }.expect(&format!("Cannot open DB at {:?}", path));
+                    let deprecated_tables = vec![#(stringify!(#deprecated_cfs),)*];
+                    let (
+                            #(
+                                #field_names
+                            ),*
+                    ) = (#(
+                            DBMap::#inner_types::reopen(&db, Some(stringify!(#cf_names)), rwopt_cfs.get(stringify!(#cf_names)).unwrap_or(&typed_store::rocks::ReadWriteOptions::default()), remove_deprecated_tables && deprecated_tables.contains(&stringify!(#cf_names))).expect(&format!("Cannot open {} CF.", stringify!(#cf_names))[..])
+                        ),*);
+
+                    if as_secondary_with_path.is_none() && remove_deprecated_tables {
+                        #(
+                            db.drop_cf(stringify!(#deprecated_cfs)).expect("failed to drop a deprecated cf");
+                        )*
+                    }
+                    Self {
+                        #(
+                            #field_names,
+                        )*
+                    }
+                }
+            }
+
+            // <----------- This section generates the read-write open logic and other common utils -------------->
+            impl <
+                    #(
+                        #generics_names: #generics_bounds_token,
+                    )*
+                > #name #generics {
+                /// Opens a set of tables in read-write mode
+                /// Only one process is allowed to do this at a time
+                /// `global_db_options_override` apply to the whole DB
+                /// `tables_db_options_override` apply to each table. If `None`, the attributes from `default_options_override_fn` are used if any
+                #[allow(unused_parens)]
+                pub fn open_tables_read_write(
+                    path: std::path::PathBuf,
+                    metric_conf: typed_store::rocks::MetricConf,
+                    global_db_options_override: Option<typed_store::rocksdb::Options>,
+                    tables_db_options_override: Option<typed_store::rocks::DBMapTableConfigMap>
+                ) -> Self {
+                    let inner = #intermediate_db_map_struct_name::open_tables_impl(path, None, metric_conf, global_db_options_override, tables_db_options_override, false);
+                    Self {
+                        #(
+                            #field_names: inner.#field_names,
+                        )*
+                    }
+                }
+
+                #[allow(unused_parens)]
+                pub fn open_tables_read_write_with_deprecation_option(
+                    path: std::path::PathBuf,
+                    metric_conf: typed_store::rocks::MetricConf,
+                    global_db_options_override: Option<typed_store::rocksdb::Options>,
+                    tables_db_options_override: Option<typed_store::rocks::DBMapTableConfigMap>,
+                    remove_deprecated_tables: bool,
+                ) -> Self {
+                    let inner = #intermediate_db_map_struct_name::open_tables_impl(path, None, metric_conf, global_db_options_override, tables_db_options_override, remove_deprecated_tables);
+                    Self {
+                        #(
+                            #field_names: inner.#field_names,
+                        )*
+                    }
+                }
+
+                /// This opens the DB in read only mode and returns a struct which exposes debug features
+                pub fn get_read_only_handle (
+                    primary_path: std::path::PathBuf,
+                    with_secondary_path: Option<std::path::PathBuf>,
+                    global_db_options_override: Option<typed_store::rocksdb::Options>,
+                    metric_conf: typed_store::rocks::MetricConf,
+                    ) -> #secondary_db_map_struct_name #generics {
+                    #secondary_db_map_struct_name::open_tables_read_only(primary_path, with_secondary_path, metric_conf, global_db_options_override)
+                }
+            }
+            #secondary_code
+        })
+    }
 }

--- a/crates/typed-store/src/lib.rs
+++ b/crates/typed-store/src/lib.rs
@@ -17,7 +17,7 @@ pub mod memstore;
 pub mod metrics;
 pub mod rocks;
 #[cfg(all(not(target_os = "windows"), feature = "tide_hunter"))]
-mod tidehunter_util;
+pub mod tidehunter_util;
 mod util;
 pub use metrics::DBMetrics;
 pub use typed_store_error::TypedStoreError;

--- a/crates/typed-store/src/rocks/mod.rs
+++ b/crates/typed-store/src/rocks/mod.rs
@@ -14,7 +14,7 @@ pub use crate::rocks::options::{
 use crate::rocks::safe_iter::{SafeIter, SafeRevIter};
 #[cfg(all(not(target_os = "windows"), feature = "tide_hunter"))]
 use crate::tidehunter_util::{
-    apply_range_bounds, transform_th_iterator, typed_store_error_from_th_error,
+    apply_range_bounds, transform_th_iterator, transform_th_key, typed_store_error_from_th_error,
 };
 use crate::util::{be_fix_int_ser, iterator_bounds, iterator_bounds_with_range};
 use crate::{
@@ -83,7 +83,7 @@ pub enum ColumnFamily {
     Rocks(String),
     InMemory(String),
     #[cfg(all(not(target_os = "windows"), feature = "tide_hunter"))]
-    TideHunter(KeySpace),
+    TideHunter((KeySpace, Option<Vec<u8>>)),
 }
 
 impl std::fmt::Debug for ColumnFamily {
@@ -159,7 +159,7 @@ impl Deref for GetResult<'_> {
 }
 
 impl Database {
-    fn new(storage: Storage, metric_conf: MetricConf) -> Self {
+    pub fn new(storage: Storage, metric_conf: MetricConf) -> Self {
         DBMetrics::get().increment_num_active_dbs(&metric_conf.db_name);
         Self {
             storage,
@@ -183,8 +183,8 @@ impl Database {
                 Ok(db.get(cf_name, key).map(GetResult::InMemory))
             }
             #[cfg(all(not(target_os = "windows"), feature = "tide_hunter"))]
-            (Storage::TideHunter(db), ColumnFamily::TideHunter(ks)) => Ok(db
-                .get(*ks, key.as_ref())
+            (Storage::TideHunter(db), ColumnFamily::TideHunter((ks, prefix))) => Ok(db
+                .get(*ks, &transform_th_key(key.as_ref(), prefix))
                 .map_err(typed_store_error_from_th_error)?
                 .map(GetResult::TideHunter)),
 
@@ -225,9 +225,9 @@ impl Database {
                 .map(|r| Ok(r.map(GetResult::InMemory)))
                 .collect(),
             #[cfg(all(not(target_os = "windows"), feature = "tide_hunter"))]
-            (Storage::TideHunter(db), ColumnFamily::TideHunter(ks)) => {
+            (Storage::TideHunter(db), ColumnFamily::TideHunter((ks, prefix))) => {
                 let res = keys.into_iter().map(|k| {
-                    db.get(*ks, k.as_ref())
+                    db.get(*ks, &transform_th_key(k.as_ref(), prefix))
                         .map_err(typed_store_error_from_th_error)
                 });
                 res.into_iter()
@@ -276,8 +276,8 @@ impl Database {
                 Ok(())
             }
             #[cfg(all(not(target_os = "windows"), feature = "tide_hunter"))]
-            (Storage::TideHunter(db), ColumnFamily::TideHunter(ks)) => db
-                .remove(*ks, key.as_ref().to_vec())
+            (Storage::TideHunter(db), ColumnFamily::TideHunter((ks, prefix))) => db
+                .remove(*ks, transform_th_key(key.as_ref(), prefix))
                 .map_err(typed_store_error_from_th_error),
             _ => Err(TypedStoreError::RocksDBError(
                 "typed store invariant violation".to_string(),
@@ -312,8 +312,8 @@ impl Database {
                 Ok(())
             }
             #[cfg(all(not(target_os = "windows"), feature = "tide_hunter"))]
-            (Storage::TideHunter(db), ColumnFamily::TideHunter(ks)) => db
-                .insert(*ks, key, value)
+            (Storage::TideHunter(db), ColumnFamily::TideHunter((ks, prefix))) => db
+                .insert(*ks, transform_th_key(&key, prefix), value)
                 .map_err(typed_store_error_from_th_error),
             _ => Err(TypedStoreError::RocksDBError(
                 "typed store invariant violation".to_string(),
@@ -569,6 +569,22 @@ impl<K, V> DBMap<K, V> {
             ColumnFamily::Rocks(cf_key.to_string()),
             is_deprecated,
         ))
+    }
+
+    #[cfg(all(not(target_os = "windows"), feature = "tide_hunter"))]
+    pub fn reopen_th(
+        db: Arc<Database>,
+        cf_name: &str,
+        ks: KeySpace,
+        prefix: Option<Vec<u8>>,
+    ) -> Self {
+        DBMap::new(
+            db,
+            &ReadWriteOptions::default(),
+            cf_name,
+            ColumnFamily::TideHunter((ks, prefix.clone())),
+            false,
+        )
     }
 
     pub fn cf_name(&self) -> &str {
@@ -1016,11 +1032,11 @@ impl<K, V> DBMap<K, V> {
             }
             #[cfg(all(not(target_os = "windows"), feature = "tide_hunter"))]
             Storage::TideHunter(db) => match &self.column_family {
-                ColumnFamily::TideHunter(ks) => {
+                ColumnFamily::TideHunter((ks, prefix)) => {
                     let mut iter = db.iterator(*ks);
                     apply_range_bounds(&mut iter, it_lower_bound, it_upper_bound);
                     iter.reverse();
-                    Ok(Box::new(transform_th_iterator(iter)))
+                    Ok(Box::new(transform_th_iterator(iter, prefix)))
                 }
                 _ => unreachable!("storage backend invariant violation"),
             },
@@ -1188,8 +1204,8 @@ impl DBBatch {
                         b.delete_cf(name, k_buf)
                     }
                     #[cfg(all(not(target_os = "windows"), feature = "tide_hunter"))]
-                    (StorageWriteBatch::TideHunter(b), ColumnFamily::TideHunter(ks)) => {
-                        b.delete(*ks, k_buf)
+                    (StorageWriteBatch::TideHunter(b), ColumnFamily::TideHunter((ks, prefix))) => {
+                        b.delete(*ks, transform_th_key(&k_buf, prefix))
                     }
                     _ => Err(TypedStoreError::RocksDBError(
                         "typed store invariant violation".to_string(),
@@ -1256,8 +1272,8 @@ impl DBBatch {
                         b.put_cf(name, k_buf, v_buf)
                     }
                     #[cfg(all(not(target_os = "windows"), feature = "tide_hunter"))]
-                    (StorageWriteBatch::TideHunter(b), ColumnFamily::TideHunter(ks)) => {
-                        b.write(*ks, k_buf.to_vec(), v_buf.to_vec())
+                    (StorageWriteBatch::TideHunter(b), ColumnFamily::TideHunter((ks, prefix))) => {
+                        b.write(*ks, transform_th_key(&k_buf, prefix), v_buf.to_vec())
                     }
                     _ => Err(TypedStoreError::RocksDBError(
                         "typed store invariant violation".to_string(),
@@ -1483,7 +1499,9 @@ where
             Storage::InMemory(db) => db.iterator(&self.cf, None, None, false),
             #[cfg(all(not(target_os = "windows"), feature = "tide_hunter"))]
             Storage::TideHunter(db) => match &self.column_family {
-                ColumnFamily::TideHunter(ks) => Box::new(transform_th_iterator(db.iterator(*ks))),
+                ColumnFamily::TideHunter((ks, prefix)) => {
+                    Box::new(transform_th_iterator(db.iterator(*ks), prefix))
+                }
                 _ => unreachable!("storage backend invariant violation"),
             },
         }
@@ -1516,10 +1534,10 @@ where
             Storage::InMemory(db) => db.iterator(&self.cf, lower_bound, upper_bound, false),
             #[cfg(all(not(target_os = "windows"), feature = "tide_hunter"))]
             Storage::TideHunter(db) => match &self.column_family {
-                ColumnFamily::TideHunter(ks) => {
+                ColumnFamily::TideHunter((ks, prefix)) => {
                     let mut iter = db.iterator(*ks);
                     apply_range_bounds(&mut iter, lower_bound, upper_bound);
-                    Box::new(transform_th_iterator(iter))
+                    Box::new(transform_th_iterator(iter, prefix))
                 }
                 _ => unreachable!("storage backend invariant violation"),
             },
@@ -1549,10 +1567,10 @@ where
             Storage::InMemory(db) => db.iterator(&self.cf, lower_bound, upper_bound, false),
             #[cfg(all(not(target_os = "windows"), feature = "tide_hunter"))]
             Storage::TideHunter(db) => match &self.column_family {
-                ColumnFamily::TideHunter(ks) => {
+                ColumnFamily::TideHunter((ks, prefix)) => {
                     let mut iter = db.iterator(*ks);
                     apply_range_bounds(&mut iter, lower_bound, upper_bound);
-                    Box::new(transform_th_iterator(iter))
+                    Box::new(transform_th_iterator(iter, prefix))
                 }
                 _ => unreachable!("storage backend invariant violation"),
             },

--- a/crates/typed-store/src/tidehunter_util.rs
+++ b/crates/typed-store/src/tidehunter_util.rs
@@ -2,9 +2,63 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bincode::Options;
+use prometheus::Registry;
 use serde::de::DeserializeOwned;
+use std::path::Path;
+use std::sync::Arc;
+use tidehunter::config::Config;
+use tidehunter::db::Db;
 use tidehunter::iterators::db_iterator::DbIterator;
+use tidehunter::key_shape::{KeyShape, KeySpace};
+use tidehunter::metrics::Metrics;
+pub use tidehunter::{
+    key_shape::{KeyShapeBuilder, KeySpaceConfig},
+    minibytes::Bytes,
+    WalPosition,
+};
 use typed_store_error::TypedStoreError;
+
+pub struct ThConfig {
+    key_size: usize,
+    mutexes: usize,
+    per_mutex: usize,
+    config: KeySpaceConfig,
+    pub prefix: Option<Vec<u8>>,
+}
+
+pub fn open(path: &Path, key_shape: KeyShape) -> Arc<Db> {
+    std::fs::create_dir_all(path).expect("failed to open tidehunter db");
+    // TODO: fix metrics initialization
+    let metrics = Metrics::new_in(&Registry::default());
+    let db = Db::open(path, key_shape, Arc::new(thdb_config()), metrics)
+        .expect("failed to open tidehunter db");
+    db.start_periodic_snapshot();
+    db
+}
+
+pub fn add_key_space(builder: &mut KeyShapeBuilder, name: &str, config: &ThConfig) -> KeySpace {
+    builder.add_key_space_config(
+        name,
+        config.key_size,
+        config.mutexes,
+        config.per_mutex,
+        config.config.clone(),
+    )
+}
+
+fn thdb_config() -> Config {
+    Config {
+        frag_size: 1024 * 1024 * 1024,
+        // run snapshot every 64 Gb written to wal
+        snapshot_written_bytes: 64 * 1024 * 1024 * 1024,
+        // force unloading dirty index entries if behind 128 Gb of wal
+        snapshot_unload_threshold: 128 * 1024 * 1024 * 1024,
+        unload_jitter_pct: 30,
+        max_dirty_keys: 1024,
+        max_maps: 8, // 8Gb of mapped space
+        ..Config::default()
+    }
+}
 
 pub(crate) fn apply_range_bounds(
     iterator: &mut DbIterator,
@@ -19,14 +73,15 @@ pub(crate) fn apply_range_bounds(
     }
 }
 
-pub(crate) fn transform_th_iterator<K, V>(
+pub(crate) fn transform_th_iterator<'a, K, V>(
     iterator: impl Iterator<
-        Item = Result<
-            (tidehunter::minibytes::Bytes, tidehunter::minibytes::Bytes),
-            tidehunter::db::DbError,
-        >,
-    >,
-) -> impl Iterator<Item = Result<(K, V), TypedStoreError>>
+            Item = Result<
+                (tidehunter::minibytes::Bytes, tidehunter::minibytes::Bytes),
+                tidehunter::db::DbError,
+            >,
+        > + 'a,
+    prefix: &'a Option<Vec<u8>>,
+) -> impl Iterator<Item = Result<(K, V), TypedStoreError>> + 'a
 where
     K: DeserializeOwned,
     V: DeserializeOwned,
@@ -37,7 +92,15 @@ where
     iterator.map(move |item| {
         item.map_err(|e| TypedStoreError::RocksDBError(format!("tidehunter error {:?}", e)))
             .and_then(|(raw_key, raw_value)| {
-                let key = config.deserialize(&raw_key);
+                let key = match prefix {
+                    Some(prefix) => {
+                        let mut buffer = Vec::with_capacity(raw_key.len() + prefix.len());
+                        buffer.extend_from_slice(prefix);
+                        buffer.extend_from_slice(&raw_key);
+                        config.deserialize(&buffer)
+                    }
+                    None => config.deserialize(&raw_key),
+                };
                 let value = bcs::from_bytes(&raw_value);
                 match (key, value) {
                     (Ok(k), Ok(v)) => Ok((k, v)),
@@ -48,6 +111,60 @@ where
     })
 }
 
+pub(crate) fn transform_th_key(key: &[u8], prefix: &Option<Vec<u8>>) -> Vec<u8> {
+    match prefix {
+        Some(prefix) => key[prefix.len()..].to_vec(),
+        None => key.to_vec(),
+    }
+}
+
 pub(crate) fn typed_store_error_from_th_error(err: tidehunter::db::DbError) -> TypedStoreError {
     TypedStoreError::RocksDBError(format!("tidehunter error: {:?}", err))
+}
+
+impl ThConfig {
+    pub fn new(key_size: usize, mutexes: usize, per_mutex: usize) -> Self {
+        Self {
+            key_size,
+            mutexes,
+            per_mutex,
+            config: KeySpaceConfig::default(),
+            prefix: None,
+        }
+    }
+
+    pub fn new_with_config(
+        key_size: usize,
+        mutexes: usize,
+        per_mutex: usize,
+        config: KeySpaceConfig,
+    ) -> Self {
+        Self {
+            key_size,
+            mutexes,
+            per_mutex,
+            config,
+            prefix: None,
+        }
+    }
+
+    pub fn new_with_rm_prefix(
+        key_size: usize,
+        mutexes: usize,
+        per_mutex: usize,
+        config: KeySpaceConfig,
+        prefix: Vec<u8>,
+    ) -> Self {
+        Self {
+            key_size,
+            mutexes,
+            per_mutex,
+            config,
+            prefix: Some(prefix),
+        }
+    }
+}
+
+pub fn default_cells_per_mutex() -> usize {
+    8
 }

--- a/crates/typed-store/tests/macro_tests.rs
+++ b/crates/typed-store/tests/macro_tests.rs
@@ -279,3 +279,35 @@ async fn test_sampling_time() {
     tokio::task::yield_now().await;
     assert!(sampling_interval.sample());
 }
+
+#[cfg(all(not(target_os = "windows"), feature = "tide_hunter"))]
+mod tide_hunter_tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use typed_store::tidehunter_util::ThConfig;
+
+    #[derive(DBMapUtils)]
+    #[tidehunter]
+    struct ThTable {
+        table1: DBMap<String, String>,
+        table2: DBMap<i32, String>,
+    }
+
+    #[tokio::test]
+    async fn test_tidehunter_map() {
+        let primary_path = temp_dir();
+        let configs = vec![
+            ("table1".to_string(), ThConfig::new(11, 1, 1)),
+            ("table2".to_string(), ThConfig::new(11, 1, 1)),
+        ];
+        let db = ThTable::open_tables_read_write(
+            primary_path.clone(),
+            MetricConf::default(),
+            BTreeMap::from_iter(configs),
+        );
+        let (key, value) = ("key".to_string(), "value".to_string());
+        db.table1.insert(&key, &value).unwrap();
+        let result = db.table1.get(&key).unwrap();
+        assert_eq!(result, Some(value));
+    }
+}


### PR DESCRIPTION
## Description 

Notes:
* added TH support to DBMapUtils macros
* added rm_prefix support to TH's column family
* alternative AuthorityPerpetualTables::open implementation for TH
* to enable TH locally:
    - uncomment `//#[tidehunter]` at the top of the `AuthorityPerpetualTables` struct definition
    - enable the `tide_hunter` feature for `sui-core` in `Cargo.toml`


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
