### PR TITLE
Enable TLS by default for validator gRPC client

### DIFF
--- a/crates/mysten-network/src/multiaddr.rs
+++ b/crates/mysten-network/src/multiaddr.rs
@@ -215,6 +215,20 @@ impl Multiaddr {
 
         new
     }
+
+    pub fn rewrite_http_to_https(&self) -> Self {
+        let mut new = Self::empty();
+
+        for component in self.iter() {
+            if let Protocol::Http = component {
+                new.push(Protocol::Https);
+            } else {
+                new.push(component);
+            }
+        }
+
+        new
+    }
 }
 
 impl std::fmt::Display for Multiaddr {

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -306,6 +306,7 @@ pub fn make_network_authority_clients_with_network_config(
     for (name, (_state, network_metadata)) in committee.validators() {
         let address = network_metadata.network_address.clone();
         let address = address.rewrite_udp_to_tcp();
+        let address = address.rewrite_http_to_https();
         let tls_config = network_metadata
             .network_public_key
             .as_ref()

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -304,9 +304,11 @@ pub fn make_network_authority_clients_with_network_config(
 ) -> BTreeMap<AuthorityName, NetworkAuthorityClient> {
     let mut authority_clients = BTreeMap::new();
     for (name, (_state, network_metadata)) in committee.validators() {
-        let address = network_metadata.network_address.clone();
-        let address = address.rewrite_udp_to_tcp();
-        let address = address.rewrite_http_to_https();
+        let address = network_metadata
+            .network_address
+            .clone()
+            .rewrite_udp_to_tcp()
+            .rewrite_http_to_https();
         let tls_config = network_metadata
             .network_public_key
             .as_ref()

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -21,6 +21,7 @@ use sui_types::{
     error::{SuiError, SuiResult},
     transaction::*,
 };
+use tap::TapFallible;
 
 use crate::authority_client::tonic::IntoRequest;
 use sui_network::tonic::metadata::KeyAndValueRef;
@@ -305,23 +306,30 @@ pub fn make_network_authority_clients_with_network_config(
     for (name, (_state, network_metadata)) in committee.validators() {
         let address = network_metadata.network_address.clone();
         let address = address.rewrite_udp_to_tcp();
-        // TODO: Enable TLS on this interface with below config, once support is rolled out to validators.
-        // let tls_config = network_metadata.network_public_key.as_ref().map(|key| {
-        //     sui_tls::create_rustls_client_config(
-        //         key.clone(),
-        //         sui_tls::SUI_VALIDATOR_SERVER_NAME.to_string(),
-        //         None,
-        //     )
-        // });
-        // TODO: Change below code to generate a SuiError if no valid TLS config is available.
-        let maybe_channel = network_config.connect_lazy(&address, None).map_err(|e| {
-            tracing::error!(
-                address = %address,
-                name = %name,
-                "unable to create authority client: {e}"
-            );
-            e.to_string().into()
-        });
+        let tls_config = network_metadata
+            .network_public_key
+            .as_ref()
+            .map(|key| {
+                sui_tls::create_rustls_client_config(
+                    key.clone(),
+                    sui_tls::SUI_VALIDATOR_SERVER_NAME.to_string(),
+                    None,
+                )
+            })
+            .ok_or(SuiError::from("network public key is not available"));
+        let maybe_channel = tls_config
+            .and_then(|tls_config| {
+                network_config
+                    .connect_lazy(&address, Some(tls_config))
+                    .map_err(|e| e.to_string().into())
+            })
+            .tap_err(|e| {
+                tracing::error!(
+                    address = %address,
+                    name = %name,
+                    "unable to create authority client: {e}"
+                )
+            });
         let client = NetworkAuthorityClient::new_lazy(maybe_channel);
         authority_clients.insert(*name, client);
     }

--- a/crates/sui-swarm/src/memory/node.rs
+++ b/crates/sui-swarm/src/memory/node.rs
@@ -106,7 +106,11 @@ impl Node {
         }
 
         if is_validator {
-            let network_address = self.config().network_address().clone();
+            let network_address = self
+                .config()
+                .network_address()
+                .clone()
+                .rewrite_http_to_https();
             let tls_config = sui_tls::create_rustls_client_config(
                 self.config().network_key_pair().public().to_owned(),
                 sui_tls::SUI_VALIDATOR_SERVER_NAME.to_string(),

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -112,9 +112,6 @@ async fn make_clients(
             sui_tls::SUI_VALIDATOR_SERVER_NAME.to_string(),
             None,
         );
-        tracing::info!(
-            "connecting to validator at address {net_addr:?} with config {tls_config:?}"
-        );
         let channel = net_config
             .connect(&net_addr, Some(tls_config))
             .await

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -105,14 +105,13 @@ async fn make_clients(
 
     for validator in active_validators {
         let net_addr = Multiaddr::try_from(validator.net_address).unwrap();
-        // TODO: Enable TLS on this interface with below config, once support is rolled out to validators.
-        // let tls_config = sui_tls::create_rustls_client_config(
-        //     sui_types::crypto::NetworkPublicKey::from_bytes(&validator.network_pubkey_bytes)?,
-        //     sui_tls::SUI_VALIDATOR_SERVER_NAME.to_string(),
-        //     None,
-        // );
+        let tls_config = sui_tls::create_rustls_client_config(
+            sui_types::crypto::NetworkPublicKey::from_bytes(&validator.network_pubkey_bytes)?,
+            sui_tls::SUI_VALIDATOR_SERVER_NAME.to_string(),
+            None,
+        );
         let channel = net_config
-            .connect_lazy(&net_addr, None)
+            .connect_lazy(&net_addr, Some(tls_config))
             .map_err(|err| anyhow!(err.to_string()))?;
         let client = NetworkAuthorityClient::new(channel);
         let public_key_bytes =

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -113,12 +113,8 @@ async fn make_clients(
             None,
         );
         let channel = net_config
-            .connect(&net_addr, Some(tls_config))
-            .await
-            .map_err(|err| {
-                tracing::error!("error connecting: {err:?}");
-                anyhow!(err.to_string())
-            })?;
+            .connect_lazy(&net_addr, Some(tls_config))
+            .map_err(|err| anyhow!(err.to_string()))?;
         let client = NetworkAuthorityClient::new(channel);
         let public_key_bytes =
             AuthorityPublicKeyBytes::from_bytes(&validator.protocol_pubkey_bytes)?;


### PR DESCRIPTION

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [x] gRPC: Enables TLS on connections to validators over the gRPC interface.
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Enables TLS on connections to validators over the gRPC interface.
- [ ] Rust SDK:
