### PR TITLE
Tolerate db error when getting full checkpoint contents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12268,6 +12268,7 @@ dependencies = [
  "sui-transaction-checks",
  "sui-types",
  "tracing",
+ "typed-store-error",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12268,7 +12268,6 @@ dependencies = [
  "sui-transaction-checks",
  "sui-types",
  "tracing",
- "typed-store-error",
 ]
 
 [[package]]

--- a/crates/simulacrum/Cargo.toml
+++ b/crates/simulacrum/Cargo.toml
@@ -32,4 +32,3 @@ sui-genesis-builder.workspace = true
 sui-execution.workspace = true
 sui-swarm-config.workspace = true
 sui-transaction-checks.workspace = true
-typed-store-error.workspace = true

--- a/crates/simulacrum/Cargo.toml
+++ b/crates/simulacrum/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
-async-trait.workspace = true   
+async-trait.workspace = true
 anyhow.workspace = true
 bcs.workspace = true
 fastcrypto.workspace = true
@@ -32,3 +32,4 @@ sui-genesis-builder.workspace = true
 sui-execution.workspace = true
 sui-swarm-config.workspace = true
 sui-transaction-checks.workspace = true
+typed-store-error.workspace = true

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -582,9 +582,9 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
 
     fn get_full_checkpoint_contents(
         &self,
+        _sequence_number: Option<sui_types::messages_checkpoint::CheckpointSequenceNumber>,
         _digest: &sui_types::messages_checkpoint::CheckpointContentsDigest,
-    ) -> Result<Option<sui_types::messages_checkpoint::FullCheckpointContents>, TypedStoreError>
-    {
+    ) -> Option<sui_types::messages_checkpoint::FullCheckpointContents> {
         todo!()
     }
 }

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -44,7 +44,6 @@ use sui_types::{
     signature::VerifyParams,
     transaction::{Transaction, VerifiedTransaction},
 };
-use typed_store_error::TypedStoreError;
 
 use self::epoch_state::EpochState;
 pub use self::store::in_mem_store::InMemoryStore;
@@ -570,14 +569,6 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
         event_digest: &sui_types::digests::TransactionDigest,
     ) -> Option<sui_types::effects::TransactionEvents> {
         self.store().get_transaction_events(event_digest)
-    }
-
-    fn get_full_checkpoint_contents_by_sequence_number(
-        &self,
-        _sequence_number: sui_types::messages_checkpoint::CheckpointSequenceNumber,
-    ) -> Result<Option<sui_types::messages_checkpoint::FullCheckpointContents>, TypedStoreError>
-    {
-        todo!()
     }
 
     fn get_full_checkpoint_contents(

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -44,6 +44,7 @@ use sui_types::{
     signature::VerifyParams,
     transaction::{Transaction, VerifiedTransaction},
 };
+use typed_store_error::TypedStoreError;
 
 use self::epoch_state::EpochState;
 pub use self::store::in_mem_store::InMemoryStore;
@@ -574,14 +575,16 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
     fn get_full_checkpoint_contents_by_sequence_number(
         &self,
         _sequence_number: sui_types::messages_checkpoint::CheckpointSequenceNumber,
-    ) -> Option<sui_types::messages_checkpoint::FullCheckpointContents> {
+    ) -> Result<Option<sui_types::messages_checkpoint::FullCheckpointContents>, TypedStoreError>
+    {
         todo!()
     }
 
     fn get_full_checkpoint_contents(
         &self,
         _digest: &sui_types::messages_checkpoint::CheckpointContentsDigest,
-    ) -> Option<sui_types::messages_checkpoint::FullCheckpointContents> {
+    ) -> Result<Option<sui_types::messages_checkpoint::FullCheckpointContents>, TypedStoreError>
+    {
         todo!()
     }
 }

--- a/crates/sui-archival/src/tests.rs
+++ b/crates/sui-archival/src/tests.rs
@@ -217,7 +217,7 @@ async fn test_archive_reader_e2e() -> Result<(), anyhow::Error> {
         .get_checkpoint_by_sequence_number(0)
         .context("Missing genesis checkpoint")?;
     let genesis_checkpoint_content = test_store
-        .get_full_checkpoint_contents_by_sequence_number(0)
+        .get_full_checkpoint_contents_by_sequence_number(0)?
         .context("Missing genesis checkpoint")?;
     let read_store = SharedInMemoryStore::default();
     read_store.inner_mut().insert_genesis_state(
@@ -276,7 +276,7 @@ async fn test_verify_archive_with_oneshot_store() -> Result<(), anyhow::Error> {
         .get_checkpoint_by_sequence_number(0)
         .context("Missing genesis checkpoint")?;
     let genesis_checkpoint_content = test_store
-        .get_full_checkpoint_contents_by_sequence_number(0)
+        .get_full_checkpoint_contents_by_sequence_number(0)?
         .context("Missing genesis checkpoint")?;
     let mut read_store = SingleCheckpointSharedInMemoryStore::default();
     read_store.insert_genesis_state(
@@ -350,7 +350,7 @@ async fn test_verify_archive_with_oneshot_store_bad_data() -> Result<(), anyhow:
         .get_checkpoint_by_sequence_number(0)
         .context("Missing genesis checkpoint")?;
     let genesis_checkpoint_content = test_store
-        .get_full_checkpoint_contents_by_sequence_number(0)
+        .get_full_checkpoint_contents_by_sequence_number(0)?
         .context("Missing genesis checkpoint")?;
     let mut read_store = SingleCheckpointSharedInMemoryStore::default();
     read_store.insert_genesis_state(

--- a/crates/sui-archival/src/tests.rs
+++ b/crates/sui-archival/src/tests.rs
@@ -217,7 +217,7 @@ async fn test_archive_reader_e2e() -> Result<(), anyhow::Error> {
         .get_checkpoint_by_sequence_number(0)
         .context("Missing genesis checkpoint")?;
     let genesis_checkpoint_content = test_store
-        .get_full_checkpoint_contents_by_sequence_number(0)?
+        .get_full_checkpoint_contents(Some(0), &genesis_checkpoint.content_digest)
         .context("Missing genesis checkpoint")?;
     let read_store = SharedInMemoryStore::default();
     read_store.inner_mut().insert_genesis_state(
@@ -276,7 +276,7 @@ async fn test_verify_archive_with_oneshot_store() -> Result<(), anyhow::Error> {
         .get_checkpoint_by_sequence_number(0)
         .context("Missing genesis checkpoint")?;
     let genesis_checkpoint_content = test_store
-        .get_full_checkpoint_contents_by_sequence_number(0)?
+        .get_full_checkpoint_contents(Some(0), &genesis_checkpoint.content_digest)
         .context("Missing genesis checkpoint")?;
     let mut read_store = SingleCheckpointSharedInMemoryStore::default();
     read_store.insert_genesis_state(
@@ -350,7 +350,7 @@ async fn test_verify_archive_with_oneshot_store_bad_data() -> Result<(), anyhow:
         .get_checkpoint_by_sequence_number(0)
         .context("Missing genesis checkpoint")?;
     let genesis_checkpoint_content = test_store
-        .get_full_checkpoint_contents_by_sequence_number(0)?
+        .get_full_checkpoint_contents(Some(0), &genesis_checkpoint.content_digest)
         .context("Missing genesis checkpoint")?;
     let mut read_store = SingleCheckpointSharedInMemoryStore::default();
     read_store.insert_genesis_state(

--- a/crates/sui-archival/src/writer.rs
+++ b/crates/sui-archival/src/writer.rs
@@ -411,7 +411,7 @@ impl ArchiveWriter {
             if let Some(checkpoint_summary) =
                 store.get_checkpoint_by_sequence_number(checkpoint_sequence_number)
             {
-                if let Some(checkpoint_contents) =
+                if let Ok(Some(checkpoint_contents)) =
                     store.get_full_checkpoint_contents(&checkpoint_summary.content_digest)
                 {
                     checkpoint_writer

--- a/crates/sui-archival/src/writer.rs
+++ b/crates/sui-archival/src/writer.rs
@@ -411,9 +411,10 @@ impl ArchiveWriter {
             if let Some(checkpoint_summary) =
                 store.get_checkpoint_by_sequence_number(checkpoint_sequence_number)
             {
-                if let Ok(Some(checkpoint_contents)) =
-                    store.get_full_checkpoint_contents(&checkpoint_summary.content_digest)
-                {
+                if let Some(checkpoint_contents) = store.get_full_checkpoint_contents(
+                    Some(checkpoint_sequence_number),
+                    &checkpoint_summary.content_digest,
+                ) {
                     checkpoint_writer
                         .write(checkpoint_contents, checkpoint_summary.into_inner())?;
                     checkpoint_sequence_number = checkpoint_sequence_number

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -648,7 +648,9 @@ impl CheckpointExecutor {
         if let Some(full_contents) = self
             .checkpoint_store
             .get_full_checkpoint_contents_by_sequence_number(seq)
-            .expect("Failed to get checkpoint contents from store")
+            .tap_err(|e| debug_fatal!("Failed to get checkpoint contents from store: {e}"))
+            .ok()
+            .flatten()
             .tap_some(|_| debug!("loaded full checkpoint contents in bulk for sequence {seq}"))
         {
             let num_txns = full_contents.size();
@@ -948,7 +950,7 @@ impl CheckpointExecutor {
     ) -> Vec<RandomnessRound> {
         if let Some(version_specific_data) = checkpoint
             .version_specific_data(self.epoch_store.protocol_config())
-            .expect("unable to get verison_specific_data")
+            .expect("unable to get version_specific_data")
         {
             // With version-specific data, randomness rounds are stored in checkpoint summary.
             version_specific_data.into_v1().randomness_rounds

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/mod.rs
@@ -115,6 +115,8 @@ macro_rules! finish_stage {
 pub struct CheckpointExecutor {
     epoch_store: Arc<AuthorityPerEpochStore>,
     state: Arc<AuthorityState>,
+    // TODO: We should use RocksDbStore in the executor
+    // to consolidate DB accesses.
     checkpoint_store: Arc<CheckpointStore>,
     object_cache_reader: Arc<dyn ObjectCacheRead>,
     transaction_cache_reader: Arc<dyn TransactionCacheRead>,
@@ -645,6 +647,8 @@ impl CheckpointExecutor {
             .expect("checkpoint contents not found");
 
         // attempt to load full checkpoint contents in bulk
+        // Tolerate db error in case of data corruption.
+        // We will fall back to loading items one-by-one below in case of error.
         if let Some(full_contents) = self
             .checkpoint_store
             .get_full_checkpoint_contents_by_sequence_number(seq)
@@ -697,6 +701,8 @@ impl CheckpointExecutor {
             )
         } else {
             // load items one-by-one
+            // TODO: If we used RocksDbStore in the executor instead,
+            // all the logic below could be removed.
 
             let digests = checkpoint_contents.inner();
 

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -132,16 +132,15 @@ impl ReadStore for RocksDbStore {
     fn get_full_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
-    ) -> Option<FullCheckpointContents> {
+    ) -> Result<Option<FullCheckpointContents>, TypedStoreError> {
         self.checkpoint_store
             .get_full_checkpoint_contents_by_sequence_number(sequence_number)
-            .expect("db error")
     }
 
     fn get_full_checkpoint_contents(
         &self,
         digest: &CheckpointContentsDigest,
-    ) -> Option<FullCheckpointContents> {
+    ) -> Result<Option<FullCheckpointContents>, TypedStoreError> {
         // First look to see if we saved the complete contents already.
         if let Some(seq_num) = self
             .checkpoint_store
@@ -150,10 +149,9 @@ impl ReadStore for RocksDbStore {
         {
             let contents = self
                 .checkpoint_store
-                .get_full_checkpoint_contents_by_sequence_number(seq_num)
-                .expect("db error");
+                .get_full_checkpoint_contents_by_sequence_number(seq_num)?;
             if contents.is_some() {
-                return contents;
+                return Ok(contents);
             }
         }
 
@@ -187,6 +185,7 @@ impl ReadStore for RocksDbStore {
                     transactions.into_iter(),
                 ))
             })
+            .pipe(Ok)
     }
 
     fn get_committee(&self, epoch: EpochId) -> Option<Arc<Committee>> {
@@ -432,7 +431,7 @@ impl ReadStore for RestReadStore {
     fn get_full_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
-    ) -> Option<FullCheckpointContents> {
+    ) -> Result<Option<FullCheckpointContents>, TypedStoreError> {
         self.rocks
             .get_full_checkpoint_contents_by_sequence_number(sequence_number)
     }
@@ -440,7 +439,7 @@ impl ReadStore for RestReadStore {
     fn get_full_checkpoint_contents(
         &self,
         digest: &CheckpointContentsDigest,
-    ) -> Option<FullCheckpointContents> {
+    ) -> Result<Option<FullCheckpointContents>, TypedStoreError> {
         self.rocks.get_full_checkpoint_contents(digest)
     }
 }

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -131,14 +131,6 @@ impl ReadStore for RocksDbStore {
         }
     }
 
-    fn get_full_checkpoint_contents_by_sequence_number(
-        &self,
-        sequence_number: CheckpointSequenceNumber,
-    ) -> Result<Option<FullCheckpointContents>, TypedStoreError> {
-        self.checkpoint_store
-            .get_full_checkpoint_contents_by_sequence_number(sequence_number)
-    }
-
     fn get_full_checkpoint_contents(
         &self,
         sequence_number: Option<CheckpointSequenceNumber>,
@@ -448,14 +440,6 @@ impl ReadStore for RestReadStore {
 
     fn get_events(&self, digest: &TransactionDigest) -> Option<TransactionEvents> {
         self.rocks.get_events(digest)
-    }
-
-    fn get_full_checkpoint_contents_by_sequence_number(
-        &self,
-        sequence_number: CheckpointSequenceNumber,
-    ) -> Result<Option<FullCheckpointContents>, TypedStoreError> {
-        self.rocks
-            .get_full_checkpoint_contents_by_sequence_number(sequence_number)
     }
 
     fn get_full_checkpoint_contents(

--- a/crates/sui-network/src/state_sync/mod.rs
+++ b/crates/sui-network/src/state_sync/mod.rs
@@ -49,6 +49,7 @@
 
 use anemo::{types::PeerEvent, PeerId, Request, Response, Result};
 use futures::{stream::FuturesOrdered, FutureExt, StreamExt};
+use mysten_common::debug_fatal;
 use rand::Rng;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::{
@@ -560,6 +561,7 @@ where
                         .unwrap_or_else(|| panic!("store should contain checkpoint {n}"));
                     self.store
                         .get_full_checkpoint_contents(&checkpoint.content_digest)
+                        .unwrap()
                         .unwrap_or_else(|| {
                             panic!(
                                 "store should contain checkpoint contents for {:?}",
@@ -1358,7 +1360,16 @@ where
     let digest = checkpoint.content_digest;
     if let Some(contents) = store
         .get_full_checkpoint_contents_by_sequence_number(*checkpoint.sequence_number())
-        .or_else(|| store.get_full_checkpoint_contents(&digest))
+        .tap_err(|e| debug_fatal!("Failed to get checkpoint contents by sequence number: {e}"))
+        .ok()
+        .flatten()
+        .or_else(|| {
+            store
+                .get_full_checkpoint_contents(&digest)
+                .tap_err(|e| debug_fatal!("Failed to get checkpoint contents by digest: {e}"))
+                .ok()
+                .flatten()
+        })
     {
         debug!("store already contains checkpoint contents");
         return Some(contents);

--- a/crates/sui-network/src/state_sync/server.rs
+++ b/crates/sui-network/src/state_sync/server.rs
@@ -124,7 +124,10 @@ where
         &self,
         request: Request<CheckpointContentsDigest>,
     ) -> Result<Response<Option<FullCheckpointContents>>, Status> {
-        let contents = self.store.get_full_checkpoint_contents(request.inner());
+        let contents = self
+            .store
+            .get_full_checkpoint_contents(request.inner())
+            .map_err(|e| Status::internal(e.to_string()))?;
         Ok(Response::new(contents))
     }
 }

--- a/crates/sui-network/src/state_sync/server.rs
+++ b/crates/sui-network/src/state_sync/server.rs
@@ -126,8 +126,7 @@ where
     ) -> Result<Response<Option<FullCheckpointContents>>, Status> {
         let contents = self
             .store
-            .get_full_checkpoint_contents(request.inner())
-            .map_err(|e| Status::internal(e.to_string()))?;
+            .get_full_checkpoint_contents(None, request.inner());
         Ok(Response::new(contents))
     }
 }

--- a/crates/sui-network/src/state_sync/tests.rs
+++ b/crates/sui-network/src/state_sync/tests.rs
@@ -720,8 +720,14 @@ async fn sync_with_checkpoints_watermark() {
             let content_digest = contents.into_checkpoint_contents_digest();
             store_1
                 .get_full_checkpoint_contents(&content_digest)
+                .unwrap()
                 .unwrap();
-            assert_eq!(store_2.get_full_checkpoint_contents(&content_digest), None);
+            assert_eq!(
+                store_2
+                    .get_full_checkpoint_contents(&content_digest)
+                    .unwrap(),
+                None
+            );
         }
     })
     .await
@@ -772,7 +778,7 @@ async fn sync_with_checkpoints_watermark() {
     );
     tokio::spawn(event_loop_3.start());
 
-    // Peer 3 is able to sync checkpoint 1 with teh help from Peer 2
+    // Peer 3 is able to sync checkpoint 1 with the help from Peer 2
     timeout(Duration::from_secs(1), async {
         assert_eq!(
             subscriber_3.recv().await.unwrap().data(),
@@ -816,8 +822,14 @@ async fn sync_with_checkpoints_watermark() {
             assert_eq!(subscriber_2.recv().await.unwrap().data(), checkpoint.data());
             assert_eq!(subscriber_3.recv().await.unwrap().data(), checkpoint.data());
             let content_digest = contents.into_checkpoint_contents_digest();
-            store_2.get_full_checkpoint_contents(&content_digest);
-            store_3.get_full_checkpoint_contents(&content_digest);
+            store_2
+                .get_full_checkpoint_contents(&content_digest)
+                .unwrap()
+                .unwrap();
+            store_3
+                .get_full_checkpoint_contents(&content_digest)
+                .unwrap()
+                .unwrap();
         }
     })
     .await

--- a/crates/sui-network/src/state_sync/tests.rs
+++ b/crates/sui-network/src/state_sync/tests.rs
@@ -719,13 +719,10 @@ async fn sync_with_checkpoints_watermark() {
             assert_eq!(subscriber_1.recv().await.unwrap().data(), checkpoint.data());
             let content_digest = contents.into_checkpoint_contents_digest();
             store_1
-                .get_full_checkpoint_contents(&content_digest)
-                .unwrap()
+                .get_full_checkpoint_contents(None, &content_digest)
                 .unwrap();
             assert_eq!(
-                store_2
-                    .get_full_checkpoint_contents(&content_digest)
-                    .unwrap(),
+                store_2.get_full_checkpoint_contents(None, &content_digest),
                 None
             );
         }
@@ -786,7 +783,7 @@ async fn sync_with_checkpoints_watermark() {
         );
         let content_digest = contents[1].clone().into_checkpoint_contents_digest();
         store_3
-            .get_full_checkpoint_contents(&content_digest)
+            .get_full_checkpoint_contents(None, &content_digest)
             .unwrap();
     })
     .await
@@ -823,12 +820,10 @@ async fn sync_with_checkpoints_watermark() {
             assert_eq!(subscriber_3.recv().await.unwrap().data(), checkpoint.data());
             let content_digest = contents.into_checkpoint_contents_digest();
             store_2
-                .get_full_checkpoint_contents(&content_digest)
-                .unwrap()
+                .get_full_checkpoint_contents(None, &content_digest)
                 .unwrap();
             store_3
-                .get_full_checkpoint_contents(&content_digest)
-                .unwrap()
+                .get_full_checkpoint_contents(None, &content_digest)
                 .unwrap();
         }
     })
@@ -904,7 +899,7 @@ async fn sync_with_checkpoints_watermark() {
             assert_eq!(subscriber_4.recv().await.unwrap().data(), checkpoint.data());
             let content_digest = contents.into_checkpoint_contents_digest();
             store_4
-                .get_full_checkpoint_contents(&content_digest)
+                .get_full_checkpoint_contents(None, &content_digest)
                 .unwrap();
         }
     })

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -1151,7 +1151,7 @@ pub async fn dump_checkpoints_from_archive(
     {
         let mut content = serde_json::to_string(
             &store
-                .get_full_checkpoint_contents_by_sequence_number(key.sequence_number)
+                .get_full_checkpoint_contents(Some(key.sequence_number), &key.content_digest)
                 .unwrap()
                 .unwrap(),
         )?;

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -1152,7 +1152,6 @@ pub async fn dump_checkpoints_from_archive(
         let mut content = serde_json::to_string(
             &store
                 .get_full_checkpoint_contents(Some(key.sequence_number), &key.content_digest)
-                .unwrap()
                 .unwrap(),
         )?;
         content.truncate(max_content_length);

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -1152,6 +1152,7 @@ pub async fn dump_checkpoints_from_archive(
         let mut content = serde_json::to_string(
             &store
                 .get_full_checkpoint_contents_by_sequence_number(key.sequence_number)
+                .unwrap()
                 .unwrap(),
         )?;
         content.truncate(max_content_length);

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -49,7 +49,6 @@ use sui_types::transaction::TransactionDataAPI;
 use sui_types::transaction::TransactionKind;
 use sui_types::transaction::{InputObjects, TransactionData};
 use test_adapter::{SuiTestAdapter, PRE_COMPILED};
-use typed_store::TypedStoreError;
 
 #[cfg_attr(not(msim), tokio::main)]
 #[cfg_attr(msim, msim::main)]
@@ -367,14 +366,6 @@ impl ReadStore for ValidatorWithFullnode {
         self.validator
             .get_transaction_cache_reader()
             .get_events(digest)
-    }
-
-    fn get_full_checkpoint_contents_by_sequence_number(
-        &self,
-        _sequence_number: sui_types::messages_checkpoint::CheckpointSequenceNumber,
-    ) -> Result<Option<sui_types::messages_checkpoint::FullCheckpointContents>, TypedStoreError>
-    {
-        todo!()
     }
 
     fn get_full_checkpoint_contents(

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -49,6 +49,7 @@ use sui_types::transaction::TransactionDataAPI;
 use sui_types::transaction::TransactionKind;
 use sui_types::transaction::{InputObjects, TransactionData};
 use test_adapter::{SuiTestAdapter, PRE_COMPILED};
+use typed_store::TypedStoreError;
 
 #[cfg_attr(not(msim), tokio::main)]
 #[cfg_attr(msim, msim::main)]
@@ -371,14 +372,16 @@ impl ReadStore for ValidatorWithFullnode {
     fn get_full_checkpoint_contents_by_sequence_number(
         &self,
         _sequence_number: sui_types::messages_checkpoint::CheckpointSequenceNumber,
-    ) -> Option<sui_types::messages_checkpoint::FullCheckpointContents> {
+    ) -> Result<Option<sui_types::messages_checkpoint::FullCheckpointContents>, TypedStoreError>
+    {
         todo!()
     }
 
     fn get_full_checkpoint_contents(
         &self,
         _digest: &CheckpointContentsDigest,
-    ) -> Option<sui_types::messages_checkpoint::FullCheckpointContents> {
+    ) -> Result<Option<sui_types::messages_checkpoint::FullCheckpointContents>, TypedStoreError>
+    {
         todo!()
     }
 }

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -379,9 +379,9 @@ impl ReadStore for ValidatorWithFullnode {
 
     fn get_full_checkpoint_contents(
         &self,
+        _sequence_number: Option<sui_types::messages_checkpoint::CheckpointSequenceNumber>,
         _digest: &CheckpointContentsDigest,
-    ) -> Result<Option<sui_types::messages_checkpoint::FullCheckpointContents>, TypedStoreError>
-    {
+    ) -> Option<sui_types::messages_checkpoint::FullCheckpointContents> {
         todo!()
     }
 }

--- a/crates/sui-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/sui-transactional-test-runner/src/simulator_persisted_store.rs
@@ -32,12 +32,12 @@ use sui_types::{
     transaction::VerifiedTransaction,
 };
 use tempfile::tempdir;
+use typed_store::DBMapUtils;
 use typed_store::Map;
 use typed_store::{
     metrics::SamplingInterval,
     rocks::{DBMap, MetricConf},
 };
-use typed_store::{DBMapUtils, TypedStoreError};
 
 use super::SimulatorStore;
 
@@ -616,14 +616,6 @@ impl ReadStore for PersistedStoreInnerReadOnlyWrapper {
             .events
             .get(event_digest)
             .expect("Fatal: DB read failed")
-    }
-
-    fn get_full_checkpoint_contents_by_sequence_number(
-        &self,
-        _sequence_number: CheckpointSequenceNumber,
-    ) -> Result<Option<sui_types::messages_checkpoint::FullCheckpointContents>, TypedStoreError>
-    {
-        todo!()
     }
 
     fn get_full_checkpoint_contents(

--- a/crates/sui-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/sui-transactional-test-runner/src/simulator_persisted_store.rs
@@ -628,9 +628,9 @@ impl ReadStore for PersistedStoreInnerReadOnlyWrapper {
 
     fn get_full_checkpoint_contents(
         &self,
+        _sequence_number: Option<CheckpointSequenceNumber>,
         _digest: &CheckpointContentsDigest,
-    ) -> Result<Option<sui_types::messages_checkpoint::FullCheckpointContents>, TypedStoreError>
-    {
+    ) -> Option<sui_types::messages_checkpoint::FullCheckpointContents> {
         todo!()
     }
 }

--- a/crates/sui-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/sui-transactional-test-runner/src/simulator_persisted_store.rs
@@ -32,12 +32,12 @@ use sui_types::{
     transaction::VerifiedTransaction,
 };
 use tempfile::tempdir;
-use typed_store::DBMapUtils;
 use typed_store::Map;
 use typed_store::{
     metrics::SamplingInterval,
     rocks::{DBMap, MetricConf},
 };
+use typed_store::{DBMapUtils, TypedStoreError};
 
 use super::SimulatorStore;
 
@@ -621,14 +621,16 @@ impl ReadStore for PersistedStoreInnerReadOnlyWrapper {
     fn get_full_checkpoint_contents_by_sequence_number(
         &self,
         _sequence_number: CheckpointSequenceNumber,
-    ) -> Option<sui_types::messages_checkpoint::FullCheckpointContents> {
+    ) -> Result<Option<sui_types::messages_checkpoint::FullCheckpointContents>, TypedStoreError>
+    {
         todo!()
     }
 
     fn get_full_checkpoint_contents(
         &self,
         _digest: &CheckpointContentsDigest,
-    ) -> Option<sui_types::messages_checkpoint::FullCheckpointContents> {
+    ) -> Result<Option<sui_types::messages_checkpoint::FullCheckpointContents>, TypedStoreError>
+    {
         todo!()
     }
 }

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -101,7 +101,6 @@ use sui_types::{BRIDGE_ADDRESS, MOVE_STDLIB_PACKAGE_ID};
 use sui_types::{DEEPBOOK_ADDRESS, SUI_DENY_LIST_OBJECT_ID};
 use sui_types::{DEEPBOOK_PACKAGE_ID, SUI_RANDOMNESS_STATE_OBJECT_ID};
 use tempfile::{tempdir, NamedTempFile};
-use typed_store::TypedStoreError;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum FakeID {
@@ -2587,15 +2586,6 @@ impl ReadStore for SuiTestAdapter {
 
     fn get_events(&self, digest: &TransactionDigest) -> Option<TransactionEvents> {
         self.executor.get_events(digest)
-    }
-
-    fn get_full_checkpoint_contents_by_sequence_number(
-        &self,
-        sequence_number: CheckpointSequenceNumber,
-    ) -> Result<Option<sui_types::messages_checkpoint::FullCheckpointContents>, TypedStoreError>
-    {
-        self.executor
-            .get_full_checkpoint_contents_by_sequence_number(sequence_number)
     }
 
     fn get_full_checkpoint_contents(

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -101,6 +101,7 @@ use sui_types::{BRIDGE_ADDRESS, MOVE_STDLIB_PACKAGE_ID};
 use sui_types::{DEEPBOOK_ADDRESS, SUI_DENY_LIST_OBJECT_ID};
 use sui_types::{DEEPBOOK_PACKAGE_ID, SUI_RANDOMNESS_STATE_OBJECT_ID};
 use tempfile::{tempdir, NamedTempFile};
+use typed_store::TypedStoreError;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum FakeID {
@@ -2591,7 +2592,8 @@ impl ReadStore for SuiTestAdapter {
     fn get_full_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
-    ) -> Option<sui_types::messages_checkpoint::FullCheckpointContents> {
+    ) -> Result<Option<sui_types::messages_checkpoint::FullCheckpointContents>, TypedStoreError>
+    {
         self.executor
             .get_full_checkpoint_contents_by_sequence_number(sequence_number)
     }
@@ -2599,7 +2601,8 @@ impl ReadStore for SuiTestAdapter {
     fn get_full_checkpoint_contents(
         &self,
         digest: &CheckpointContentsDigest,
-    ) -> Option<sui_types::messages_checkpoint::FullCheckpointContents> {
+    ) -> Result<Option<sui_types::messages_checkpoint::FullCheckpointContents>, TypedStoreError>
+    {
         self.executor.get_full_checkpoint_contents(digest)
     }
 }

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -2600,9 +2600,10 @@ impl ReadStore for SuiTestAdapter {
 
     fn get_full_checkpoint_contents(
         &self,
+        sequence_number: Option<CheckpointSequenceNumber>,
         digest: &CheckpointContentsDigest,
-    ) -> Result<Option<sui_types::messages_checkpoint::FullCheckpointContents>, TypedStoreError>
-    {
-        self.executor.get_full_checkpoint_contents(digest)
+    ) -> Option<sui_types::messages_checkpoint::FullCheckpointContents> {
+        self.executor
+            .get_full_checkpoint_contents(sequence_number, digest)
     }
 }

--- a/crates/sui-types/src/storage/read_store.rs
+++ b/crates/sui-types/src/storage/read_store.rs
@@ -142,14 +142,14 @@ pub trait ReadStore: ObjectStore {
     fn get_full_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
-    ) -> Option<FullCheckpointContents>;
+    ) -> Result<Option<FullCheckpointContents>, TypedStoreError>;
 
     /// Get a "full" checkpoint for purposes of state-sync
     /// "full" checkpoints include: header, contents, transactions, effects
     fn get_full_checkpoint_contents(
         &self,
         digest: &CheckpointContentsDigest,
-    ) -> Option<FullCheckpointContents>;
+    ) -> Result<Option<FullCheckpointContents>, TypedStoreError>;
 
     // Fetch all checkpoint data
     // TODO fix return type to not be anyhow
@@ -319,14 +319,14 @@ impl<T: ReadStore + ?Sized> ReadStore for &T {
     fn get_full_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
-    ) -> Option<FullCheckpointContents> {
+    ) -> Result<Option<FullCheckpointContents>, TypedStoreError> {
         (*self).get_full_checkpoint_contents_by_sequence_number(sequence_number)
     }
 
     fn get_full_checkpoint_contents(
         &self,
         digest: &CheckpointContentsDigest,
-    ) -> Option<FullCheckpointContents> {
+    ) -> Result<Option<FullCheckpointContents>, TypedStoreError> {
         (*self).get_full_checkpoint_contents(digest)
     }
 
@@ -429,14 +429,14 @@ impl<T: ReadStore + ?Sized> ReadStore for Box<T> {
     fn get_full_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
-    ) -> Option<FullCheckpointContents> {
+    ) -> Result<Option<FullCheckpointContents>, TypedStoreError> {
         (**self).get_full_checkpoint_contents_by_sequence_number(sequence_number)
     }
 
     fn get_full_checkpoint_contents(
         &self,
         digest: &CheckpointContentsDigest,
-    ) -> Option<FullCheckpointContents> {
+    ) -> Result<Option<FullCheckpointContents>, TypedStoreError> {
         (**self).get_full_checkpoint_contents(digest)
     }
 
@@ -539,14 +539,14 @@ impl<T: ReadStore + ?Sized> ReadStore for Arc<T> {
     fn get_full_checkpoint_contents_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
-    ) -> Option<FullCheckpointContents> {
+    ) -> Result<Option<FullCheckpointContents>, TypedStoreError> {
         (**self).get_full_checkpoint_contents_by_sequence_number(sequence_number)
     }
 
     fn get_full_checkpoint_contents(
         &self,
         digest: &CheckpointContentsDigest,
-    ) -> Option<FullCheckpointContents> {
+    ) -> Result<Option<FullCheckpointContents>, TypedStoreError> {
         (**self).get_full_checkpoint_contents(digest)
     }
 

--- a/crates/sui-types/src/storage/read_store.rs
+++ b/crates/sui-types/src/storage/read_store.rs
@@ -138,13 +138,6 @@ pub trait ReadStore: ObjectStore {
     //
 
     /// Get a "full" checkpoint for purposes of state-sync
-    /// "full" checkpoints include: header, contents, transactions, effects
-    fn get_full_checkpoint_contents_by_sequence_number(
-        &self,
-        sequence_number: CheckpointSequenceNumber,
-    ) -> Result<Option<FullCheckpointContents>, TypedStoreError>;
-
-    /// Get a "full" checkpoint for purposes of state-sync
     /// "full" checkpoints include: header, contents, transactions, effects.
     /// sequence_number is optional since we can always query it using the digest.
     /// However if it is provided, we can avoid an extra db lookup.
@@ -319,13 +312,6 @@ impl<T: ReadStore + ?Sized> ReadStore for &T {
         (*self).multi_get_events(event_digests)
     }
 
-    fn get_full_checkpoint_contents_by_sequence_number(
-        &self,
-        sequence_number: CheckpointSequenceNumber,
-    ) -> Result<Option<FullCheckpointContents>, TypedStoreError> {
-        (*self).get_full_checkpoint_contents_by_sequence_number(sequence_number)
-    }
-
     fn get_full_checkpoint_contents(
         &self,
         sequence_number: Option<CheckpointSequenceNumber>,
@@ -430,13 +416,6 @@ impl<T: ReadStore + ?Sized> ReadStore for Box<T> {
         (**self).multi_get_events(event_digests)
     }
 
-    fn get_full_checkpoint_contents_by_sequence_number(
-        &self,
-        sequence_number: CheckpointSequenceNumber,
-    ) -> Result<Option<FullCheckpointContents>, TypedStoreError> {
-        (**self).get_full_checkpoint_contents_by_sequence_number(sequence_number)
-    }
-
     fn get_full_checkpoint_contents(
         &self,
         sequence_number: Option<CheckpointSequenceNumber>,
@@ -539,13 +518,6 @@ impl<T: ReadStore + ?Sized> ReadStore for Arc<T> {
         event_digests: &[TransactionDigest],
     ) -> Vec<Option<TransactionEvents>> {
         (**self).multi_get_events(event_digests)
-    }
-
-    fn get_full_checkpoint_contents_by_sequence_number(
-        &self,
-        sequence_number: CheckpointSequenceNumber,
-    ) -> Result<Option<FullCheckpointContents>, TypedStoreError> {
-        (**self).get_full_checkpoint_contents_by_sequence_number(sequence_number)
     }
 
     fn get_full_checkpoint_contents(

--- a/crates/sui-types/src/storage/shared_in_memory_store.rs
+++ b/crates/sui-types/src/storage/shared_in_memory_store.rs
@@ -17,7 +17,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tap::Pipe;
 use tracing::error;
-use typed_store_error::TypedStoreError;
 
 #[derive(Clone, Debug, Default)]
 pub struct SharedInMemoryStore(Arc<std::sync::RwLock<InMemoryStore>>);
@@ -64,17 +63,6 @@ impl ReadStore for SharedInMemoryStore {
 
     fn get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber> {
         Ok(self.inner().get_lowest_available_checkpoint())
-    }
-
-    fn get_full_checkpoint_contents_by_sequence_number(
-        &self,
-        sequence_number: CheckpointSequenceNumber,
-    ) -> Result<Option<FullCheckpointContents>, TypedStoreError> {
-        self.inner()
-            .full_checkpoint_contents
-            .get(&sequence_number)
-            .cloned()
-            .pipe(Ok)
     }
 
     fn get_full_checkpoint_contents(
@@ -483,14 +471,6 @@ impl ReadStore for SingleCheckpointSharedInMemoryStore {
 
     fn get_lowest_available_checkpoint(&self) -> Result<CheckpointSequenceNumber> {
         self.0.get_lowest_available_checkpoint()
-    }
-
-    fn get_full_checkpoint_contents_by_sequence_number(
-        &self,
-        sequence_number: CheckpointSequenceNumber,
-    ) -> Result<Option<FullCheckpointContents>, TypedStoreError> {
-        self.0
-            .get_full_checkpoint_contents_by_sequence_number(sequence_number)
     }
 
     fn get_full_checkpoint_contents(


### PR DESCRIPTION
## Description 

We have seen cases where there is db correction when trying to deserialize full checkpoint content from db.
Since this is not required by the protocol, we could tolerate the error. This would allow the node to re-fetch these contents.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
