### PR TITLE
simple fix

### DIFF
--- a/crates/sui-replay-2/src/lib.rs
+++ b/crates/sui-replay-2/src/lib.rs
@@ -30,7 +30,7 @@ pub struct ReplayConfig {
     #[arg(long, short, default_value = "false")]
     pub show_effects: bool,
     /// Verify transaction execution matches what was executed on chain.
-    #[arg(long, short, default_value = "true")]
+    #[arg(long, short, default_value = "false")]
     pub verify: bool,
     // Enable tracing for tests
     #[arg(long = "trace-execution", default_value = None)]


### PR DESCRIPTION
## Description 

I changed the `verify` flag to be `true` by default but it's not possible to make it `false` the way the flag is declared.
So reverting back to the old behavior where you have to pass `-v` or `--verify` to verify the transaction

## Test plan 

tried...

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
