### PR TITLE
[cli] Try to fix the `sui-move-build --dump-bytecode-as-base64 --ignore-chain`

### DIFF
--- a/crates/sui-move/src/build.rs
+++ b/crates/sui-move/src/build.rs
@@ -22,6 +22,7 @@ pub struct Build {
     /// Whether we are printing in base64.
     #[clap(long, global = true)]
     pub dump_bytecode_as_base64: bool,
+    /// [Mainly for testing, not recommended for production]
     /// Don't specialize the package to the active chain when dumping bytecode as Base64. This
     /// allows building to proceed without a network connection or active environment, but it
     /// will not be able to automatically determine the addresses of its dependencies.

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -533,9 +533,7 @@ impl SuiCommand {
                                 )?;
                         } else {
                             build_config.implicit_dependencies =
-                                implicit_deps_for_protocol_version(
-                                    sui_protocol_config::ProtocolVersion::max(),
-                                )?;
+                                implicit_deps(latest_system_packages());
                         }
 
                         let mut pkg = SuiBuildConfig {

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -498,33 +498,45 @@ impl SuiCommand {
                         // (e.g., testnet, mainnet) from the Move.lock under automated address management.
                         // In addition, tree shaking also requires a network as it needs to fetch
                         // on-chain linkage table of package dependencies.
-                        let config =
-                            client_config.unwrap_or(sui_config_dir()?.join(SUI_CLIENT_CONFIG));
-                        prompt_if_no_config(&config, false).await?;
-                        let context = WalletContext::new(&config, None, None)?;
-
-                        let Ok(client) = context.get_client().await else {
-                            bail!("`sui move build --dump-bytecode-as-base64` requires a connection to the network. Current active network is {} but failed to connect to it.", context.config.active_env.as_ref().unwrap());
-                        };
-                        let read_api = client.read_api();
-
-                        if let Err(e) = client.check_api_version() {
-                            eprintln!("{}", format!("[warning] {e}").yellow().bold());
-                        }
-
-                        let chain_id = if build.ignore_chain {
+                        let (chain_id, client) = if build.ignore_chain {
                             // for tests it's useful to ignore the chain id!
-                            None
+                            (None, None)
                         } else {
-                            read_api.get_chain_identifier().await.ok()
+                            let config =
+                                client_config.unwrap_or(sui_config_dir()?.join(SUI_CLIENT_CONFIG));
+                            prompt_if_no_config(&config, false).await?;
+                            let context = WalletContext::new(&config, None, None)?;
+
+                            let Ok(client) = context.get_client().await else {
+                                bail!("`sui move build --dump-bytecode-as-base64` requires a connection to the network. Current active network is {} but failed to connect to it.", context.config.active_env.as_ref().unwrap());
+                            };
+
+                            if let Err(e) = client.check_api_version() {
+                                eprintln!("{}", format!("[warning] {e}").yellow().bold());
+                            }
+
+                            (
+                                client.read_api().get_chain_identifier().await.ok(),
+                                Some(client),
+                            )
                         };
 
                         let rerooted_path = move_cli::base::reroot_path(package_path.as_deref())?;
                         let mut build_config =
                             resolve_lock_file_path(build_config, Some(&rerooted_path))?;
-                        let protocol_config = read_api.get_protocol_config(None).await?;
-                        build_config.implicit_dependencies =
-                            implicit_deps_for_protocol_version(protocol_config.protocol_version)?;
+                        if let Some(client) = &client {
+                            let protocol_config =
+                                client.read_api().get_protocol_config(None).await?;
+                            build_config.implicit_dependencies =
+                                implicit_deps_for_protocol_version(
+                                    protocol_config.protocol_version,
+                                )?;
+                        } else {
+                            build_config.implicit_dependencies =
+                                implicit_deps_for_protocol_version(
+                                    sui_protocol_config::ProtocolVersion::max(),
+                                )?;
+                        }
 
                         let mut pkg = SuiBuildConfig {
                             config: build_config,
@@ -541,7 +553,10 @@ impl SuiCommand {
                             check_unpublished_dependencies(&pkg.dependency_ids.unpublished)?;
                         }
 
-                        pkg_tree_shake(read_api, with_unpublished_deps, &mut pkg).await?;
+                        if let Some(client) = client {
+                            pkg_tree_shake(client.read_api(), with_unpublished_deps, &mut pkg)
+                                .await?;
+                        }
 
                         println!(
                             "{}",


### PR DESCRIPTION
## Description 

This PR tries to fix a bug in the `sui move build --dump-bytecode-as-base64 --ignore-chain` as the previous code did not correctly account for `--ignore-chain` flag. The main issue is that when `--ignore-chain` is used, the tree shaking algorithm will not work anymore.

Should fix #21846 

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
