### PR TITLE
[rpc-alt] respect configured dynamic-fields page sizes

### DIFF
--- a/crates/sui-indexer-alt-jsonrpc/src/api/objects/filter.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/objects/filter.rs
@@ -263,7 +263,21 @@ pub(super) async fn owned_objects(
             by_sequential_scan(ctx, owner, &f.to_raw(ctx)?, cursor, limit).await
         }
         filter => {
-            by_type_indices(ctx, owner, StoredOwnerKind::Address, filter, cursor, limit).await
+            let (default_page_size, max_page_size) = (
+                ctx.config().objects.default_page_size,
+                ctx.config().objects.max_page_size,
+            );
+            by_type_indices(
+                ctx,
+                owner,
+                StoredOwnerKind::Address,
+                filter,
+                cursor,
+                limit,
+                default_page_size,
+                max_page_size,
+            )
+            .await
         }
     }
 }
@@ -277,6 +291,10 @@ pub(crate) async fn dynamic_fields(
     cursor: Option<String>,
     limit: Option<usize>,
 ) -> Result<ObjectIDs, RpcError<Error>> {
+    let (default_page_size, max_page_size) = (
+        ctx.config().dynamic_fields.default_page_size,
+        ctx.config().dynamic_fields.max_page_size,
+    );
     by_type_indices(
         ctx,
         owner.into(),
@@ -289,6 +307,8 @@ pub(crate) async fn dynamic_fields(
         })),
         cursor,
         limit,
+        default_page_size,
+        max_page_size,
     )
     .await
 }
@@ -461,6 +481,8 @@ async fn by_type_indices(
     filter: &Option<SuiObjectDataFilter>,
     cursor: Option<String>,
     limit: Option<usize>,
+    default_page_size: usize,
+    max_page_size: usize,
 ) -> Result<ObjectIDs, RpcError<Error>> {
     use obj_info::dsl as o;
 
@@ -478,14 +500,8 @@ async fn by_type_indices(
         };
     }
 
-    let config = &ctx.config().objects;
-    let page: Page<Cursor> = Page::from_params(
-        config.default_page_size,
-        config.max_page_size,
-        cursor,
-        limit,
-        None,
-    )?;
+    let page: Page<Cursor> =
+        Page::from_params(default_page_size, max_page_size, cursor, limit, None)?;
 
     let mut query = candidates
         .select(candidates!(object_id, cp_sequence_number))


### PR DESCRIPTION
## Description 

I noticed the page size config for dynamic fields is superseded by object config. This PR fixes that.

## Test plan 

Locally checked that the config now works.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
