### PR TITLE
Make analytics indexer batch size configurable

### DIFF
--- a/crates/sui-analytics-indexer/src/lib.rs
+++ b/crates/sui-analytics-indexer/src/lib.rs
@@ -83,6 +83,10 @@ fn default_checkpoint_root() -> PathBuf {
     PathBuf::from("/tmp")
 }
 
+fn default_batch_size() -> usize {
+    10
+}
+
 fn default_remote_store_url() -> String {
     "https://checkpoints.mainnet.sui.io".to_string()
 }
@@ -119,6 +123,9 @@ pub struct JobConfig {
     pub client_metric_port: u16,
     /// Remote object store where data gets written to
     pub remote_store_config: ObjectStoreConfig,
+    /// Number of checkpoints to process in parallel.
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
     /// Remote object store path prefix to use while writing
     #[serde(default = "default_remote_store_url")]
     pub remote_store_url: String,

--- a/crates/sui-analytics-indexer/src/main.rs
+++ b/crates/sui-analytics-indexer/src/main.rs
@@ -38,6 +38,7 @@ async fn main() -> Result<()> {
     let metrics = AnalyticsMetrics::new(&registry);
 
     let remote_store_url = config.remote_store_url.clone();
+    let batch_size = config.batch_size;
 
     let processors = config.create_checkpoint_processors(metrics).await?;
 
@@ -64,7 +65,7 @@ async fn main() -> Result<()> {
     }
 
     let reader_options = ReaderOptions {
-        batch_size: 10,
+        batch_size,
         ..Default::default()
     };
 


### PR DESCRIPTION
## Description

This just makes the checkpoint reader's batch size configurable (while defaulting to the same value as before). I want to try and see if tuning it can speed up the backfill.

## Test plan

I am going to adjust this and monitor the slope of the last_checkpoint_updated graph and the cpu utilization of the pod.
