### PR TITLE
[move-model-2] Replace const generics with trait-based markers 

### DIFF
--- a/external-crates/move/crates/move-model-2/Cargo.toml
+++ b/external-crates/move/crates/move-model-2/Cargo.toml
@@ -3,7 +3,7 @@ name = "move-model-2"
 version = "0.1.0"
 authors = ["The Move Contributors"]
 publish = false
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 [dependencies]

--- a/external-crates/move/crates/move-model-2/src/compiled_model.rs
+++ b/external-crates/move/crates/move-model-2/src/compiled_model.rs
@@ -1,14 +1,14 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::model::{self, WITHOUT_SOURCE};
+use crate::model::{self, WithoutSource};
 
-pub type Model = model::Model<WITHOUT_SOURCE>;
-pub type Package<'a> = model::Package<'a, WITHOUT_SOURCE>;
-pub type Module<'a> = model::Module<'a, WITHOUT_SOURCE>;
-pub type Member<'a> = model::Member<'a, WITHOUT_SOURCE>;
-pub type Datatype<'a> = model::Datatype<'a, WITHOUT_SOURCE>;
-pub type Struct<'a> = model::Struct<'a, WITHOUT_SOURCE>;
-pub type Enum<'a> = model::Enum<'a, WITHOUT_SOURCE>;
-pub type Variant<'a> = model::Variant<'a, WITHOUT_SOURCE>;
-pub type Function<'a> = model::Function<'a, WITHOUT_SOURCE>;
+pub type Model = model::Model<WithoutSource>;
+pub type Package<'a> = model::Package<'a, WithoutSource>;
+pub type Module<'a> = model::Module<'a, WithoutSource>;
+pub type Member<'a> = model::Member<'a, WithoutSource>;
+pub type Datatype<'a> = model::Datatype<'a, WithoutSource>;
+pub type Struct<'a> = model::Struct<'a, WithoutSource>;
+pub type Enum<'a> = model::Enum<'a, WithoutSource>;
+pub type Variant<'a> = model::Variant<'a, WithoutSource>;
+pub type Function<'a> = model::Function<'a, WithoutSource>;

--- a/external-crates/move/crates/move-model-2/src/compiled_model.rs
+++ b/external-crates/move/crates/move-model-2/src/compiled_model.rs
@@ -42,7 +42,7 @@ impl Model {
             .map(|(a, n)| (*n, *a))
             .collect();
         let mut model = Self {
-            has_source: false,
+            has_source: AlwaysNone::new(),
             files: AlwaysNone::new(),
             root_package_name: None,
             root_named_address_map,

--- a/external-crates/move/crates/move-model-2/src/compiled_model.rs
+++ b/external-crates/move/crates/move-model-2/src/compiled_model.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    model::{self, PackageData, WithoutSource},
+    model::{self, PackageData},
     normalized, serializable_signatures,
+    source_kind::{AlwaysNone, WithoutSource},
 };
 use move_binary_format::CompiledModule;
 use move_core_types::account_address::AccountAddress;
@@ -41,10 +42,11 @@ impl Model {
             .map(|(a, n)| (*n, *a))
             .collect();
         let mut model = Self {
-            files: None,
+            has_source: false,
+            files: AlwaysNone::new(),
             root_package_name: None,
             root_named_address_map,
-            info: None,
+            info: AlwaysNone::new(),
             compiled,
             packages,
             serializable_signatures: OnceCell::new(),

--- a/external-crates/move/crates/move-model-2/src/compiled_model.rs
+++ b/external-crates/move/crates/move-model-2/src/compiled_model.rs
@@ -4,12 +4,12 @@
 use crate::{
     model::{self, PackageData},
     normalized, serializable_signatures,
-    source_kind::{AlwaysNone, WithoutSource},
+    source_kind::WithoutSource,
 };
 use move_binary_format::CompiledModule;
 use move_core_types::account_address::AccountAddress;
 use move_symbol_pool::Symbol;
-use std::{cell::OnceCell, collections::BTreeMap};
+use std::{cell::OnceCell, collections::BTreeMap, mem::MaybeUninit};
 
 pub type Model = model::Model<WithoutSource>;
 pub type Package<'a> = model::Package<'a, WithoutSource>;
@@ -42,11 +42,11 @@ impl Model {
             .map(|(a, n)| (*n, *a))
             .collect();
         let mut model = Self {
-            has_source: AlwaysNone::new(),
-            files: AlwaysNone::new(),
+            has_source: false,
+            files: MaybeUninit::uninit(),
             root_package_name: None,
             root_named_address_map,
-            info: AlwaysNone::new(),
+            info: MaybeUninit::uninit(),
             compiled,
             packages,
             serializable_signatures: OnceCell::new(),

--- a/external-crates/move/crates/move-model-2/src/compiled_model.rs
+++ b/external-crates/move/crates/move-model-2/src/compiled_model.rs
@@ -4,12 +4,12 @@
 use crate::{
     model::{self, PackageData},
     normalized, serializable_signatures,
-    source_kind::WithoutSource,
+    source_kind::{Uninit, WithoutSource},
 };
 use move_binary_format::CompiledModule;
 use move_core_types::account_address::AccountAddress;
 use move_symbol_pool::Symbol;
-use std::{cell::OnceCell, collections::BTreeMap, mem::MaybeUninit};
+use std::{cell::OnceCell, collections::BTreeMap};
 
 pub type Model = model::Model<WithoutSource>;
 pub type Package<'a> = model::Package<'a, WithoutSource>;
@@ -43,10 +43,10 @@ impl Model {
             .collect();
         let mut model = Self {
             has_source: false,
-            files: MaybeUninit::uninit(),
+            files: Uninit::new(),
             root_package_name: None,
             root_named_address_map,
-            info: MaybeUninit::uninit(),
+            info: Uninit::new(),
             compiled,
             packages,
             serializable_signatures: OnceCell::new(),

--- a/external-crates/move/crates/move-model-2/src/compiled_model.rs
+++ b/external-crates/move/crates/move-model-2/src/compiled_model.rs
@@ -1,7 +1,14 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::model::{self, WithoutSource};
+use crate::{
+    model::{self, PackageData, WithoutSource},
+    normalized, serializable_signatures,
+};
+use move_binary_format::CompiledModule;
+use move_core_types::account_address::AccountAddress;
+use move_symbol_pool::Symbol;
+use std::{cell::OnceCell, collections::BTreeMap};
 
 pub type Model = model::Model<WithoutSource>;
 pub type Package<'a> = model::Package<'a, WithoutSource>;
@@ -12,3 +19,77 @@ pub type Struct<'a> = model::Struct<'a, WithoutSource>;
 pub type Enum<'a> = model::Enum<'a, WithoutSource>;
 pub type Variant<'a> = model::Variant<'a, WithoutSource>;
 pub type Function<'a> = model::Function<'a, WithoutSource>;
+pub type CompiledConstant<'a> = model::CompiledConstant<'a, WithoutSource>;
+
+impl Model {
+    pub fn from_compiled(
+        named_address_reverse_map: &BTreeMap<AccountAddress, Symbol>,
+        modules: Vec<CompiledModule>,
+    ) -> Self {
+        let compiled = normalized::Packages::new(&modules);
+        let packages = compiled
+            .packages
+            .values()
+            .map(|package| {
+                let addr = package.package;
+                let data = PackageData::from_compiled(named_address_reverse_map, package);
+                (addr, data)
+            })
+            .collect();
+        let root_named_address_map = named_address_reverse_map
+            .iter()
+            .map(|(a, n)| (*n, *a))
+            .collect();
+        let mut model = Self {
+            files: None,
+            root_package_name: None,
+            root_named_address_map,
+            info: None,
+            compiled,
+            packages,
+            serializable_signatures: OnceCell::new(),
+            _phantom: std::marker::PhantomData,
+        };
+        model.compute_dependencies();
+        model.compute_function_dependencies();
+        model.check_invariants();
+        model
+    }
+
+    pub fn serializable_signatures(&self) -> &serializable_signatures::Packages {
+        self.serializable_signatures
+            .get_or_init(|| serializable_signatures::Packages::from(&self.compiled))
+    }
+}
+
+impl<'a> Module<'a> {
+    pub fn maybe_member(&self, name: impl Into<Symbol>) -> Option<Member<'a>> {
+        let name = name.into();
+        self.maybe_struct(name)
+            .map(Member::Struct)
+            .or_else(|| self.maybe_enum(name).map(Member::Enum))
+            .or_else(|| self.maybe_function(name).map(Member::Function))
+    }
+
+    pub fn member(&self, name: impl Into<Symbol>) -> Member<'a> {
+        self.maybe_member(name).unwrap()
+    }
+
+    pub fn constants(&self) -> impl Iterator<Item = CompiledConstant<'a>> + '_ {
+        self.compiled
+            .constants
+            .iter()
+            .enumerate()
+            .map(|(idx, compiled)| CompiledConstant {
+                module: *self,
+                compiled,
+                data: &self.data.constants[idx],
+            })
+    }
+}
+
+impl<'a> Function<'a> {
+    pub fn compiled(&self) -> &'a normalized::Function {
+        self.compiled.unwrap()
+    }
+}

--- a/external-crates/move/crates/move-model-2/src/lib.rs
+++ b/external-crates/move/crates/move-model-2/src/lib.rs
@@ -9,6 +9,7 @@ pub mod display;
 pub mod model;
 pub mod normalized;
 pub mod serializable_signatures;
+pub mod source_kind;
 pub mod source_model;
 
 pub use normalized::ModuleId;

--- a/external-crates/move/crates/move-model-2/src/model.rs
+++ b/external-crates/move/crates/move-model-2/src/model.rs
@@ -70,6 +70,13 @@ pub struct Model<K: SourceKind + ?Sized> {
     pub(crate) _phantom: std::marker::PhantomData<K>,
 }
 
+/// Represents the model data for a package.
+/// Extra functionality is provided in the case that  the `Model` had source information
+/// (`WithSource`) or did not (`WithoutSource`). If you need to "forget" which case you are in,
+/// `to_dyn` and `as_dyn` effectively "drop" the source information annotation. This can let values
+/// with different source information to be used together.
+/// Conversely, if you need to "remember" which case you are in, you can use `kind` to to case on the presence source information. This can let you access the extra functionality provided by
+/// the `source_model` or `compiled_model`.
 pub struct Package<'a, K: SourceKind + ?Sized> {
     pub(crate) addr: AccountAddress,
     // TODO name. We likely want the package name from the root package's named address map
@@ -78,6 +85,13 @@ pub struct Package<'a, K: SourceKind + ?Sized> {
     pub(crate) data: &'a PackageData<K>,
 }
 
+/// Represents the model data for a module.
+/// Extra functionality is provided in the case that  the `Model` had source information
+/// (`WithSource`) or did not (`WithoutSource`). If you need to "forget" which case you are in,
+/// `to_dyn` and `as_dyn` effectively "drop" the source information annotation. This can let values
+/// with different source information to be used together.
+/// Conversely, if you need to "remember" which case you are in, you can use `kind` to to case on the presence source information. This can let you access the extra functionality provided by
+/// the `source_model` or `compiled_model`.
 pub struct Module<'a, K: SourceKind + ?Sized> {
     pub(crate) id: ModuleId,
     pub(crate) package: Package<'a, K>,
@@ -85,6 +99,13 @@ pub struct Module<'a, K: SourceKind + ?Sized> {
     pub(crate) data: &'a ModuleData<K>,
 }
 
+/// Represents the model data for a module member.
+/// Extra functionality is provided in the case that  the `Model` had source information
+/// (`WithSource`) or did not (`WithoutSource`). If you need to "forget" which case you are in,
+/// `to_dyn` and `as_dyn` effectively "drop" the source information annotation. This can let values
+/// with different source information to be used together.
+/// Conversely, if you need to "remember" which case you are in, you can use `kind` to to case on the presence source information. This can let you access the extra functionality provided by
+/// the `source_model` or `compiled_model`.
 pub enum Member<'a, K: SourceKind + ?Sized> {
     Struct(Struct<'a, K>),
     Enum(Enum<'a, K>),
@@ -92,11 +113,25 @@ pub enum Member<'a, K: SourceKind + ?Sized> {
     NamedConstant(source_model::NamedConstant<'a>),
 }
 
+/// Represents the model data for a module type declaration (struct or enum).
+/// Extra functionality is provided in the case that  the `Model` had source information
+/// (`WithSource`) or did not (`WithoutSource`). If you need to "forget" which case you are in,
+/// `to_dyn` and `as_dyn` effectively "drop" the source information annotation. This can let values
+/// with different source information to be used together.
+/// Conversely, if you need to "remember" which case you are in, you can use `kind` to to case on the presence source information. This can let you access the extra functionality provided by
+/// the `source_model` or `compiled_model`.
 pub enum Datatype<'a, K: SourceKind + ?Sized> {
     Struct(Struct<'a, K>),
     Enum(Enum<'a, K>),
 }
 
+/// Represents the model data for a struct declaration.
+/// Extra functionality is provided in the case that  the `Model` had source information
+/// (`WithSource`) or did not (`WithoutSource`). If you need to "forget" which case you are in,
+/// `to_dyn` and `as_dyn` effectively "drop" the source information annotation. This can let values
+/// with different source information to be used together.
+/// Conversely, if you need to "remember" which case you are in, you can use `kind` to to case on the presence source information. This can let you access the extra functionality provided by
+/// the `source_model` or `compiled_model`.
 pub struct Struct<'a, K: SourceKind + ?Sized> {
     pub(crate) name: Symbol,
     pub(crate) module: Module<'a, K>,
@@ -105,6 +140,13 @@ pub struct Struct<'a, K: SourceKind + ?Sized> {
     pub(crate) data: &'a StructData,
 }
 
+/// Represents the model data for an enum declaration.
+/// Extra functionality is provided in the case that  the `Model` had source information
+/// (`WithSource`) or did not (`WithoutSource`). If you need to "forget" which case you are in,
+/// `to_dyn` and `as_dyn` effectively "drop" the source information annotation. This can let values
+/// with different source information to be used together.
+/// Conversely, if you need to "remember" which case you are in, you can use `kind` to to case on the presence source information. This can let you access the extra functionality provided by
+/// the `source_model` or `compiled_model`.
 pub struct Enum<'a, K: SourceKind + ?Sized> {
     pub(crate) name: Symbol,
     pub(crate) module: Module<'a, K>,
@@ -113,12 +155,26 @@ pub struct Enum<'a, K: SourceKind + ?Sized> {
     pub(crate) data: &'a EnumData,
 }
 
+/// Represents the model data for an enum's variant declaration.
+/// Extra functionality is provided in the case that  the `Model` had source information
+/// (`WithSource`) or did not (`WithoutSource`). If you need to "forget" which case you are in,
+/// `to_dyn` and `as_dyn` effectively "drop" the source information annotation. This can let values
+/// with different source information to be used together.
+/// Conversely, if you need to "remember" which case you are in, you can use `kind` to to case on the presence source information. This can let you access the extra functionality provided by
+/// the `source_model` or `compiled_model`.
 pub struct Variant<'a, K: SourceKind + ?Sized> {
     pub(crate) name: Symbol,
     pub(crate) enum_: Enum<'a, K>,
     pub(crate) compiled: &'a normalized::Variant,
 }
 
+/// Represents the model data for a function declaration.
+/// Extra functionality is provided in the case that  the `Model` had source information
+/// (`WithSource`) or did not (`WithoutSource`). If you need to "forget" which case you are in,
+/// `to_dyn` and `as_dyn` effectively "drop" the source information annotation. This can let values
+/// with different source information to be used together.
+/// Conversely, if you need to "remember" which case you are in, you can use `kind` to to case on the presence source information. This can let you access the extra functionality provided by
+/// the `source_model` or `compiled_model`.
 pub struct Function<'a, K: SourceKind + ?Sized> {
     pub(crate) name: Symbol,
     pub(crate) module: Module<'a, K>,
@@ -128,6 +184,15 @@ pub struct Function<'a, K: SourceKind + ?Sized> {
     pub(crate) data: &'a FunctionData,
 }
 
+/// Represents the model data for a module's constant present in the `CompiledModule`. Not all
+/// constants at the source level are present in the `CompiledModule` depending on optimizations.
+/// For source level constants, see `source_model::NamedConstant` and `source_model::Constant`.
+/// Extra functionality is provided in the case that  the `Model` had source information
+/// (`WithSource`) or did not (`WithoutSource`). If you need to "forget" which case you are in,
+/// `to_dyn` and `as_dyn` effectively "drop" the source information annotation. This can let values
+/// with different source information to be used together.
+/// Conversely, if you need to "remember" which case you are in, you can use `kind` to to case on the presence source information. This can let you access the extra functionality provided by
+/// the `source_model` or `compiled_model`.
 pub struct CompiledConstant<'a, K: SourceKind + ?Sized> {
     pub(crate) module: Module<'a, K>,
     pub(crate) compiled: &'a normalized::Constant,
@@ -318,10 +383,6 @@ impl<'a, K: SourceKind + ?Sized> Package<'a, K> {
             })
         }
     }
-
-    pub fn to_dyn(self) -> Package<'a, dyn SourceKind> {
-        unsafe { std::mem::transmute::<Self, Package<'a, dyn SourceKind>>(self) }
-    }
 }
 
 impl<'a, K: SourceKind + ?Sized> Module<'a, K> {
@@ -449,10 +510,6 @@ impl<'a, K: SourceKind + ?Sized> Module<'a, K> {
             })
         }
     }
-
-    pub fn to_dyn(self) -> Module<'a, dyn SourceKind> {
-        unsafe { std::mem::transmute::<Self, Module<'a, dyn SourceKind>>(self) }
-    }
 }
 
 impl<'a, K: SourceKind + ?Sized> Struct<'a, K> {
@@ -488,10 +545,6 @@ impl<'a, K: SourceKind + ?Sized> Struct<'a, K> {
                 std::mem::transmute::<Self, Struct<'a, WithoutSource>>(self)
             })
         }
-    }
-
-    pub fn to_dyn(self) -> Struct<'a, dyn SourceKind> {
-        unsafe { std::mem::transmute::<Self, Struct<'a, dyn SourceKind>>(self) }
     }
 }
 
@@ -574,10 +627,6 @@ impl<'a, K: SourceKind + ?Sized> Variant<'a, K> {
             })
         }
     }
-
-    pub fn to_dyn(self) -> Variant<'a, dyn SourceKind> {
-        unsafe { std::mem::transmute::<Self, Variant<'a, dyn SourceKind>>(self) }
-    }
 }
 
 impl<'a, K: SourceKind + ?Sized> Function<'a, K> {
@@ -624,10 +673,6 @@ impl<'a, K: SourceKind + ?Sized> Function<'a, K> {
                 std::mem::transmute::<Self, Function<'a, WithoutSource>>(self)
             })
         }
-    }
-
-    pub fn to_dyn(self) -> Function<'a, dyn SourceKind> {
-        unsafe { std::mem::transmute::<Self, Function<'a, dyn SourceKind>>(self) }
     }
 }
 
@@ -1122,65 +1167,33 @@ fn annotated_constant_layout(ty: &normalized::Type) -> runtime_value::MoveTypeLa
 // Derive
 //**************************************************************************************************
 
-impl<K: SourceKind + ?Sized> Clone for Package<'_, K> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl<K: SourceKind + ?Sized> Copy for Package<'_, K> {}
+macro_rules! derive_all {
+    ($item:ident) => {
+        impl<K: SourceKind + ?Sized> Clone for $item<'_, K> {
+            fn clone(&self) -> Self {
+                *self
+            }
+        }
+        impl<K: SourceKind + ?Sized> Copy for $item<'_, K> {}
 
-impl<K: SourceKind + ?Sized> Clone for Module<'_, K> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl<K: SourceKind + ?Sized> Copy for Module<'_, K> {}
+        impl<'a, K: SourceKind + ?Sized> $item<'a, K> {
+            pub fn as_dyn(&self) -> &$item<'a, dyn SourceKind> {
+                unsafe { std::mem::transmute::<&$item<'a, K>, &$item<'a, dyn SourceKind>>(self) }
+            }
 
-impl<K: SourceKind + ?Sized> Clone for Member<'_, K> {
-    fn clone(&self) -> Self {
-        *self
-    }
+            pub fn to_dyn(self) -> $item<'a, dyn SourceKind> {
+                unsafe { std::mem::transmute::<$item<'a, K>, $item<'a, dyn SourceKind>>(self) }
+            }
+        }
+    };
 }
-impl<K: SourceKind + ?Sized> Copy for Member<'_, K> {}
 
-impl<K: SourceKind + ?Sized> Clone for Datatype<'_, K> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl<K: SourceKind + ?Sized> Copy for Datatype<'_, K> {}
-
-impl<K: SourceKind + ?Sized> Clone for Struct<'_, K> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl<K: SourceKind + ?Sized> Copy for Struct<'_, K> {}
-
-impl<K: SourceKind + ?Sized> Clone for Enum<'_, K> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl<K: SourceKind + ?Sized> Copy for Enum<'_, K> {}
-
-impl<K: SourceKind + ?Sized> Clone for Variant<'_, K> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl<K: SourceKind + ?Sized> Copy for Variant<'_, K> {}
-
-impl<K: SourceKind + ?Sized> Clone for Function<'_, K> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl<K: SourceKind + ?Sized> Copy for Function<'_, K> {}
-
-impl Clone for CompiledConstant<'_, WithSource> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl Copy for CompiledConstant<'_, WithSource> {}
+derive_all!(Package);
+derive_all!(Module);
+derive_all!(Member);
+derive_all!(Datatype);
+derive_all!(Struct);
+derive_all!(Enum);
+derive_all!(Variant);
+derive_all!(Function);
+derive_all!(CompiledConstant);

--- a/external-crates/move/crates/move-model-2/src/model.rs
+++ b/external-crates/move/crates/move-model-2/src/model.rs
@@ -4,14 +4,13 @@
 use std::{
     cell::OnceCell,
     collections::{BTreeMap, BTreeSet},
-    mem::MaybeUninit,
     sync::Arc,
 };
 
 use crate::{
     normalized::{self, ModuleId, QualifiedMemberId, TModuleId},
     serializable_signatures,
-    source_kind::{AnyKind, SourceKind, WithSource, WithoutSource},
+    source_kind::{AnyKind, SourceKind, Uninit, WithSource, WithoutSource},
     source_model,
 };
 use indexmap::IndexMap;
@@ -1004,13 +1003,13 @@ impl ModuleData<WithoutSource> {
             .map(|name| (name, FunctionData::new()))
             .collect();
         Self {
-            ident: MaybeUninit::uninit(),
+            ident: Uninit::new(),
             structs,
             enums,
             functions,
             constants,
-            named_constants: MaybeUninit::uninit(),
-            constant_names: MaybeUninit::uninit(),
+            named_constants: Uninit::new(),
+            constant_names: Uninit::new(),
             // computed later
             deps: BTreeMap::new(),
             used_by: BTreeMap::new(),

--- a/external-crates/move/crates/move-model-2/src/model.rs
+++ b/external-crates/move/crates/move-model-2/src/model.rs
@@ -41,6 +41,10 @@ pub enum Kind<TWithSource, TWithout> {
     WithoutSource(TWithout),
 }
 
+/// The model for a set of packages. Allows for ergonomic access to packages, modules, and
+/// module members. If source files are present, the Move package system can be used to generate
+/// a `Model<WithSource>` via `Model::from_source`. If no source files are present, a model can be
+/// generated directly from the `CompiledModule`s via `Model::from_compiled`.
 pub struct Model<K: SourceKind> {
     pub(crate) has_source: bool,
     pub(crate) files: K::FromSource<MappedFiles>,
@@ -53,13 +57,22 @@ pub struct Model<K: SourceKind> {
     pub(crate) _phantom: std::marker::PhantomData<K>,
 }
 
+macro_rules! shared_comments {
+    () => {
+        "
+Extra functionality is provided in the case that the `Model` had source information
+(`WithSource`) or did not (`WithoutSource`). If you need to \"forget\" which case you are in,
+`to_any` and `as_any` return a common type that can let values with different source information
+to be in tandem, e.g. as different arms in an `if-else`.
+Conversely, if you need to \"remember\" which case you are in, you can use `kind` to to case on
+the presence source information. This can let you access the extra functionality provided by
+the `source_model` or `compiled_model`.
+"
+    };
+}
+
 /// Represents the model data for a package.
-/// Extra functionality is provided in the case that  the `Model` had source information
-/// (`WithSource`) or did not (`WithoutSource`). If you need to "forget" which case you are in,
-/// `to_dyn` and `as_dyn` effectively "drop" the source information annotation. This can let values
-/// with different source information to be used together.
-/// Conversely, if you need to "remember" which case you are in, you can use `kind` to to case on the presence source information. This can let you access the extra functionality provided by
-/// the `source_model` or `compiled_model`.
+#[doc = shared_comments!()]
 pub struct Package<'a, K: SourceKind> {
     pub(crate) addr: AccountAddress,
     // TODO name. We likely want the package name from the root package's named address map
@@ -69,12 +82,7 @@ pub struct Package<'a, K: SourceKind> {
 }
 
 /// Represents the model data for a module.
-/// Extra functionality is provided in the case that  the `Model` had source information
-/// (`WithSource`) or did not (`WithoutSource`). If you need to "forget" which case you are in,
-/// `to_dyn` and `as_dyn` effectively "drop" the source information annotation. This can let values
-/// with different source information to be used together.
-/// Conversely, if you need to "remember" which case you are in, you can use `kind` to to case on the presence source information. This can let you access the extra functionality provided by
-/// the `source_model` or `compiled_model`.
+#[doc = shared_comments!()]
 pub struct Module<'a, K: SourceKind> {
     pub(crate) id: ModuleId,
     pub(crate) package: Package<'a, K>,
@@ -83,12 +91,7 @@ pub struct Module<'a, K: SourceKind> {
 }
 
 /// Represents the model data for a module member.
-/// Extra functionality is provided in the case that  the `Model` had source information
-/// (`WithSource`) or did not (`WithoutSource`). If you need to "forget" which case you are in,
-/// `to_dyn` and `as_dyn` effectively "drop" the source information annotation. This can let values
-/// with different source information to be used together.
-/// Conversely, if you need to "remember" which case you are in, you can use `kind` to to case on the presence source information. This can let you access the extra functionality provided by
-/// the `source_model` or `compiled_model`.
+#[doc = shared_comments!()]
 pub enum Member<'a, K: SourceKind> {
     Struct(Struct<'a, K>),
     Enum(Enum<'a, K>),
@@ -97,24 +100,14 @@ pub enum Member<'a, K: SourceKind> {
 }
 
 /// Represents the model data for a module type declaration (struct or enum).
-/// Extra functionality is provided in the case that  the `Model` had source information
-/// (`WithSource`) or did not (`WithoutSource`). If you need to "forget" which case you are in,
-/// `to_dyn` and `as_dyn` effectively "drop" the source information annotation. This can let values
-/// with different source information to be used together.
-/// Conversely, if you need to "remember" which case you are in, you can use `kind` to to case on the presence source information. This can let you access the extra functionality provided by
-/// the `source_model` or `compiled_model`.
+#[doc = shared_comments!()]
 pub enum Datatype<'a, K: SourceKind> {
     Struct(Struct<'a, K>),
     Enum(Enum<'a, K>),
 }
 
 /// Represents the model data for a struct declaration.
-/// Extra functionality is provided in the case that  the `Model` had source information
-/// (`WithSource`) or did not (`WithoutSource`). If you need to "forget" which case you are in,
-/// `to_dyn` and `as_dyn` effectively "drop" the source information annotation. This can let values
-/// with different source information to be used together.
-/// Conversely, if you need to "remember" which case you are in, you can use `kind` to to case on the presence source information. This can let you access the extra functionality provided by
-/// the `source_model` or `compiled_model`.
+#[doc = shared_comments!()]
 pub struct Struct<'a, K: SourceKind> {
     pub(crate) name: Symbol,
     pub(crate) module: Module<'a, K>,
@@ -124,12 +117,7 @@ pub struct Struct<'a, K: SourceKind> {
 }
 
 /// Represents the model data for an enum declaration.
-/// Extra functionality is provided in the case that  the `Model` had source information
-/// (`WithSource`) or did not (`WithoutSource`). If you need to "forget" which case you are in,
-/// `to_dyn` and `as_dyn` effectively "drop" the source information annotation. This can let values
-/// with different source information to be used together.
-/// Conversely, if you need to "remember" which case you are in, you can use `kind` to to case on the presence source information. This can let you access the extra functionality provided by
-/// the `source_model` or `compiled_model`.
+#[doc = shared_comments!()]
 pub struct Enum<'a, K: SourceKind> {
     pub(crate) name: Symbol,
     pub(crate) module: Module<'a, K>,
@@ -139,12 +127,7 @@ pub struct Enum<'a, K: SourceKind> {
 }
 
 /// Represents the model data for an enum's variant declaration.
-/// Extra functionality is provided in the case that  the `Model` had source information
-/// (`WithSource`) or did not (`WithoutSource`). If you need to "forget" which case you are in,
-/// `to_dyn` and `as_dyn` effectively "drop" the source information annotation. This can let values
-/// with different source information to be used together.
-/// Conversely, if you need to "remember" which case you are in, you can use `kind` to to case on the presence source information. This can let you access the extra functionality provided by
-/// the `source_model` or `compiled_model`.
+#[doc = shared_comments!()]
 pub struct Variant<'a, K: SourceKind> {
     pub(crate) name: Symbol,
     pub(crate) enum_: Enum<'a, K>,
@@ -152,12 +135,7 @@ pub struct Variant<'a, K: SourceKind> {
 }
 
 /// Represents the model data for a function declaration.
-/// Extra functionality is provided in the case that  the `Model` had source information
-/// (`WithSource`) or did not (`WithoutSource`). If you need to "forget" which case you are in,
-/// `to_dyn` and `as_dyn` effectively "drop" the source information annotation. This can let values
-/// with different source information to be used together.
-/// Conversely, if you need to "remember" which case you are in, you can use `kind` to to case on the presence source information. This can let you access the extra functionality provided by
-/// the `source_model` or `compiled_model`.
+#[doc = shared_comments!()]
 pub struct Function<'a, K: SourceKind> {
     pub(crate) name: Symbol,
     pub(crate) module: Module<'a, K>,
@@ -170,12 +148,7 @@ pub struct Function<'a, K: SourceKind> {
 /// Represents the model data for a module's constant present in the `CompiledModule`. Not all
 /// constants at the source level are present in the `CompiledModule` depending on optimizations.
 /// For source level constants, see `source_model::NamedConstant` and `source_model::Constant`.
-/// Extra functionality is provided in the case that  the `Model` had source information
-/// (`WithSource`) or did not (`WithoutSource`). If you need to "forget" which case you are in,
-/// `to_dyn` and `as_dyn` effectively "drop" the source information annotation. This can let values
-/// with different source information to be used together.
-/// Conversely, if you need to "remember" which case you are in, you can use `kind` to to case on the presence source information. This can let you access the extra functionality provided by
-/// the `source_model` or `compiled_model`.
+#[doc = shared_comments!()]
 pub struct CompiledConstant<'a, K: SourceKind> {
     pub(crate) module: Module<'a, K>,
     pub(crate) compiled: &'a normalized::Constant,
@@ -1156,7 +1129,7 @@ macro_rules! derive_all {
                 unsafe { std::mem::transmute::<&$item<'a, K>, &$item<'a, AnyKind>>(self) }
             }
 
-            pub fn to_dyn(self) -> $item<'a, AnyKind> {
+            pub fn to_any(self) -> $item<'a, AnyKind> {
                 unsafe { std::mem::transmute::<$item<'a, K>, $item<'a, AnyKind>>(self) }
             }
         }

--- a/external-crates/move/crates/move-model-2/src/model.rs
+++ b/external-crates/move/crates/move-model-2/src/model.rs
@@ -189,6 +189,7 @@ impl<K: SourceKind> Model<K> {
         let package = self.maybe_package(&address)?;
         package.maybe_module(name)
     }
+
     pub fn module(&self, module: impl TModuleId) -> Module<K> {
         self.maybe_module(module).unwrap()
     }
@@ -1115,6 +1116,9 @@ fn annotated_constant_layout(ty: &normalized::Type) -> runtime_value::MoveTypeLa
 // Derive
 //**************************************************************************************************
 
+// We derive Clone and Copy manually to avoid needlessly requiring `Clone` and `Copy` on
+// `K: SourceKind`. This isn't super important now, but can be very annoying if we
+// ever use `dyn SourceKind` in the future.
 macro_rules! derive_all {
     ($item:ident) => {
         impl<K: SourceKind> Clone for $item<'_, K> {

--- a/external-crates/move/crates/move-model-2/src/normalized.rs
+++ b/external-crates/move/crates/move-model-2/src/normalized.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_binary_format::{normalized, CompiledModule};
+use move_binary_format::{CompiledModule, normalized};
 use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
 use move_symbol_pool::Symbol;
 use std::collections::BTreeMap;

--- a/external-crates/move/crates/move-model-2/src/serializable_signatures.rs
+++ b/external-crates/move/crates/move-model-2/src/serializable_signatures.rs
@@ -6,8 +6,9 @@
 //! datatypes (structs and enums).
 
 use crate::{
+    TModuleId,
     normalized::{self, ModuleId},
-    source_model, TModuleId,
+    source_model,
 };
 use indexmap::IndexMap;
 use move_binary_format::file_format;

--- a/external-crates/move/crates/move-model-2/src/source_kind.rs
+++ b/external-crates/move/crates/move-model-2/src/source_kind.rs
@@ -36,6 +36,8 @@ impl SourceKind for AnyKind {
     type FromSource<T> = Option<T>;
 }
 
+/// Indicates a populated field of `T`. We use `Option<T>` instead of `T` so that we can safely
+/// use `std::mem::transmute` into an `Option<T>` when "upcasting" `WithSource` to `AnyKind`.
 #[derive(Clone, Copy)]
 pub struct AlwaysSome<T>(Option<T>);
 
@@ -59,6 +61,8 @@ impl<T> Deref for AlwaysSome<T> {
     }
 }
 
+// Indicates an empty field of `T`. We use `Option<T>` instead of `T` so that we can safely
+// use `std::mem::transmute` into an `Option<T>` when "upcasting" `WithSource` to `AnyKind`.
 #[derive(Clone, Copy)]
 pub struct AlwaysNone<T>(Option<T>);
 

--- a/external-crates/move/crates/move-model-2/src/source_kind.rs
+++ b/external-crates/move/crates/move-model-2/src/source_kind.rs
@@ -1,0 +1,69 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{borrow::Borrow, ops::Deref};
+
+/// Simple sealing trait that prevents other types from implementing `SourceKind`.
+mod private {
+    pub trait Sealed {}
+}
+
+pub trait SourceKind: private::Sealed + 'static {
+    type FromSource<T>;
+}
+
+#[derive(Clone, Copy)]
+pub struct WithSource;
+
+impl private::Sealed for WithSource {}
+impl SourceKind for WithSource {
+    type FromSource<T> = AlwaysSome<T>;
+}
+
+#[derive(Clone, Copy)]
+pub struct WithoutSource;
+
+impl private::Sealed for WithoutSource {}
+impl SourceKind for WithoutSource {
+    type FromSource<T> = AlwaysNone<T>;
+}
+
+#[derive(Clone, Copy)]
+pub struct AnyKind;
+
+impl private::Sealed for AnyKind {}
+impl SourceKind for AnyKind {
+    type FromSource<T> = Option<T>;
+}
+
+#[derive(Clone, Copy)]
+pub struct AlwaysSome<T>(Option<T>);
+
+impl<T> AlwaysSome<T> {
+    pub fn new(value: T) -> Self {
+        Self(Some(value))
+    }
+}
+
+impl<T> Borrow<T> for AlwaysSome<T> {
+    fn borrow(&self) -> &T {
+        self.0.as_ref().unwrap()
+    }
+}
+
+impl<T> Deref for AlwaysSome<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref().unwrap()
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct AlwaysNone<T>(Option<T>);
+
+impl<T> AlwaysNone<T> {
+    pub fn new() -> Self {
+        Self(None)
+    }
+}

--- a/external-crates/move/crates/move-model-2/src/source_kind.rs
+++ b/external-crates/move/crates/move-model-2/src/source_kind.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{borrow::Borrow, ops::Deref};
+use std::mem::MaybeUninit;
 
 /// Simple sealing trait that prevents other types from implementing `SourceKind`.
 mod private {
@@ -17,7 +17,7 @@ pub struct WithSource;
 
 impl private::Sealed for WithSource {}
 impl SourceKind for WithSource {
-    type FromSource<T> = AlwaysSome<T>;
+    type FromSource<T> = T;
 }
 
 #[derive(Clone, Copy)]
@@ -25,7 +25,9 @@ pub struct WithoutSource;
 
 impl private::Sealed for WithoutSource {}
 impl SourceKind for WithoutSource {
-    type FromSource<T> = AlwaysNone<T>;
+    // We use `MaybeUninit` to ensure it has the same size as `T` which allows for upcasting from
+    // `WithoutSource`` to `AnyKind`` safely.
+    type FromSource<T> = MaybeUninit<T>;
 }
 
 #[derive(Clone, Copy)]
@@ -33,41 +35,5 @@ pub struct AnyKind;
 
 impl private::Sealed for AnyKind {}
 impl SourceKind for AnyKind {
-    type FromSource<T> = Option<T>;
-}
-
-/// Indicates a populated field of `T`. We use `Option<T>` instead of `T` so that we can safely
-/// use `std::mem::transmute` into an `Option<T>` when "upcasting" `WithSource` to `AnyKind`.
-#[derive(Clone, Copy)]
-pub struct AlwaysSome<T>(Option<T>);
-
-impl<T> AlwaysSome<T> {
-    pub fn new(value: T) -> Self {
-        Self(Some(value))
-    }
-}
-
-impl<T> Borrow<T> for AlwaysSome<T> {
-    fn borrow(&self) -> &T {
-        self.0.as_ref().unwrap()
-    }
-}
-
-impl<T> Deref for AlwaysSome<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        self.0.as_ref().unwrap()
-    }
-}
-
-// Indicates an empty field of `T`. We use `Option<T>` instead of `T` so that we can safely
-// use `std::mem::transmute` into an `Option<T>` when "upcasting" `WithSource` to `AnyKind`.
-#[derive(Clone, Copy)]
-pub struct AlwaysNone<T>(Option<T>);
-
-impl<T> AlwaysNone<T> {
-    pub fn new() -> Self {
-        Self(None)
-    }
+    type FromSource<T> = MaybeUninit<T>;
 }

--- a/external-crates/move/crates/move-model-2/src/source_kind.rs
+++ b/external-crates/move/crates/move-model-2/src/source_kind.rs
@@ -25,9 +25,17 @@ pub struct WithoutSource;
 
 impl private::Sealed for WithoutSource {}
 impl SourceKind for WithoutSource {
-    // We use `MaybeUninit` to ensure it has the same size as `T` which allows for upcasting from
+    // We use `Uninit` to ensure it has the same size as `T` which allows for upcasting from
     // `WithoutSource`` to `AnyKind`` safely.
-    type FromSource<T> = MaybeUninit<T>;
+    type FromSource<T> = Uninit<T>;
+}
+
+pub struct Uninit<T>(MaybeUninit<T>);
+
+impl<T> Uninit<T> {
+    pub fn new() -> Self {
+        Self(MaybeUninit::uninit())
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/external-crates/move/crates/move-model-2/src/source_model.rs
+++ b/external-crates/move/crates/move-model-2/src/source_model.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     TModuleId,
-    model::{self, NamedConstantData, PackageData, WithSource},
+    model::{self, NamedConstantData, PackageData, SourceKind, WithSource},
     normalized, serializable_signatures,
 };
 use move_compiler::{
@@ -17,7 +17,7 @@ use move_compiler::{
 };
 use move_core_types::{account_address::AccountAddress, runtime_value};
 use move_symbol_pool::Symbol;
-use std::{cell::OnceCell, collections::BTreeMap, path::PathBuf, sync::Arc};
+use std::{cell::OnceCell, collections::BTreeMap, ops::Deref, path::PathBuf, sync::Arc};
 
 pub type Model = model::Model<WithSource>;
 pub type Package<'a> = model::Package<'a, WithSource>;
@@ -310,6 +310,14 @@ impl<'a> NamedConstant<'a> {
 //**************************************************************************************************
 // Derive
 //**************************************************************************************************
+
+impl Deref for Model {
+    type Target = model::Model<dyn SourceKind>;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { std::mem::transmute::<&Self, &model::Model<dyn SourceKind>>(self) }
+    }
+}
 
 impl Clone for Constant<'_> {
     fn clone(&self) -> Self {

--- a/external-crates/move/crates/move-model-2/src/source_model.rs
+++ b/external-crates/move/crates/move-model-2/src/source_model.rs
@@ -5,7 +5,7 @@ use crate::{
     TModuleId,
     model::{self, NamedConstantData, PackageData},
     normalized, serializable_signatures,
-    source_kind::{AlwaysSome, WithSource},
+    source_kind::WithSource,
 };
 use move_compiler::{
     compiled_unit::CompiledUnit,
@@ -118,11 +118,11 @@ impl Model {
             })
             .collect();
         let mut model = Self {
-            has_source: AlwaysSome::new(()),
-            files: AlwaysSome::new(files),
+            has_source: true,
+            files,
             root_package_name,
             root_named_address_map,
-            info: AlwaysSome::new(info),
+            info,
             compiled,
             packages,
             serializable_signatures: OnceCell::new(),

--- a/external-crates/move/crates/move-model-2/src/source_model.rs
+++ b/external-crates/move/crates/move-model-2/src/source_model.rs
@@ -1,7 +1,23 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::model::{self, WithSource};
+use crate::{
+    TModuleId,
+    model::{self, CompiledConstant, Constant, PackageData, WithSource},
+    normalized, serializable_signatures,
+};
+use move_compiler::{
+    compiled_unit::CompiledUnit,
+    expansion::ast as E,
+    naming::ast as N,
+    shared::{
+        files::MappedFiles,
+        program_info::{ConstantInfo, FunctionInfo, ModuleInfo, TypingProgramInfo},
+    },
+};
+use move_core_types::{account_address::AccountAddress, runtime_value};
+use move_symbol_pool::Symbol;
+use std::{cell::OnceCell, collections::BTreeMap, path::PathBuf, sync::Arc};
 
 pub type Model = model::Model<WithSource>;
 pub type Package<'a> = model::Package<'a, WithSource>;
@@ -13,3 +29,261 @@ pub type Enum<'a> = model::Enum<'a, WithSource>;
 pub type Variant<'a> = model::Variant<'a, WithSource>;
 pub type Function<'a> = model::Function<'a, WithSource>;
 pub type NamedConstant<'a> = model::NamedConstant<'a>;
+
+impl Model {
+    pub fn from_source(
+        files: MappedFiles,
+        root_package_name: Option<Symbol>,
+        root_named_address_map: BTreeMap<Symbol, AccountAddress>,
+        info: Arc<TypingProgramInfo>,
+        compiled_units_vec: Vec<(/* file */ PathBuf, CompiledUnit)>,
+    ) -> anyhow::Result<Self> {
+        let mut compiled_units = BTreeMap::new();
+        for (fname, unit) in compiled_units_vec {
+            let package_name = unit.package_name();
+            let addr = unit.address.into_inner();
+            let name = unit.name;
+            let package = compiled_units.entry(addr).or_insert_with(BTreeMap::new);
+            if let Some((prev_f, prev)) = package.insert(name, (fname.clone(), unit)) {
+                anyhow::bail!(
+                    "Duplicate module {}::{}. \n\
+                    One in package {} in file {}. \n\
+                    And one in package {} in file {}",
+                    prev.address,
+                    prev.name,
+                    prev.package_name()
+                        .as_ref()
+                        .map(|s| s.as_str())
+                        .unwrap_or("UNKNOWN"),
+                    prev_f.display(),
+                    package_name
+                        .as_ref()
+                        .map(|s| s.as_str())
+                        .unwrap_or("UNKNOWN"),
+                    fname.display(),
+                );
+            }
+        }
+        let compiled_units = compiled_units
+            .into_iter()
+            .map(|(addr, units)| (addr, units.into_iter().map(|(n, (_f, u))| (n, u)).collect()))
+            .collect::<BTreeMap<_, BTreeMap<_, _>>>();
+        let root_named_address_reverse_map = root_named_address_map
+            .iter()
+            .map(|(n, a)| (*a, *n))
+            .collect::<BTreeMap<_, _>>();
+        let ident_map = info
+            .modules
+            .key_cloned_iter()
+            .map(|(ident, _)| (ident.module_id(), ident))
+            .collect::<BTreeMap<_, _>>();
+        let compiled_modules = compiled_units
+            .iter()
+            .flat_map(|(_addr, units)| units.values().map(|unit| &unit.module));
+        let compiled = normalized::Packages::new(compiled_modules);
+        let packages = compiled
+            .packages
+            .iter()
+            .map(|(addr, units)| {
+                let name = root_named_address_reverse_map.get(addr).copied();
+                let data = PackageData::from_source(
+                    name,
+                    *addr,
+                    &ident_map,
+                    &info,
+                    &compiled_units[addr],
+                    units,
+                );
+                (*addr, data)
+            })
+            .collect();
+        let mut model = Self {
+            files: Some(files),
+            root_package_name,
+            root_named_address_map,
+            info: Some(info),
+            compiled,
+            packages,
+            serializable_signatures: OnceCell::new(),
+            _phantom: std::marker::PhantomData,
+        };
+        model.compute_dependencies();
+        model.compute_function_dependencies();
+        model.check_invariants();
+        Ok(model)
+    }
+
+    pub fn files(&self) -> &MappedFiles {
+        self.files.as_ref().unwrap()
+    }
+
+    pub fn serializable_signatures(&self) -> &serializable_signatures::Packages {
+        self.serializable_signatures.get_or_init(|| {
+            let mut info = serializable_signatures::Packages::from(&self.compiled);
+            info.annotate(self);
+            info
+        })
+    }
+}
+
+impl<'a> Module<'a> {
+    pub fn ident(&self) -> &'a E::ModuleIdent {
+        self.data.ident.as_ref().unwrap()
+    }
+
+    pub fn info(&self) -> &'a ModuleInfo {
+        self.model()
+            .info
+            .as_ref()
+            .unwrap()
+            .modules
+            .get(self.ident())
+            .unwrap()
+    }
+
+    pub fn source_path(&self) -> Symbol {
+        self.model()
+            .files
+            .as_ref()
+            .unwrap()
+            .filename(&self.info().defined_loc.file_hash())
+    }
+
+    pub fn maybe_member(&self, name: impl Into<Symbol>) -> Option<Member<'a>> {
+        let name = name.into();
+        self.maybe_struct(name)
+            .map(Member::Struct)
+            .or_else(|| self.maybe_enum(name).map(Member::Enum))
+            .or_else(|| self.maybe_function(name).map(Member::Function))
+            .or_else(|| self.maybe_named_constant(name).map(Member::NamedConstant))
+    }
+
+    pub fn member(&self, name: impl Into<Symbol>) -> Member<'a> {
+        self.maybe_member(name).unwrap()
+    }
+
+    pub fn maybe_named_constant(&self, name: impl Into<Symbol>) -> Option<NamedConstant<'a>> {
+        let name = name.into();
+        let data = &self.data.named_constants.as_ref().unwrap().get(&name)?;
+        let compiled = data
+            .compiled_index
+            .map(|idx| &*self.compiled.constants[idx.0 as usize]);
+        Some(NamedConstant {
+            name,
+            module: *self,
+            compiled,
+            data,
+        })
+    }
+
+    pub fn named_constant(&self, name: impl Into<Symbol>) -> NamedConstant<'a> {
+        self.maybe_named_constant(name).unwrap()
+    }
+
+    pub fn named_constants(&self) -> impl Iterator<Item = NamedConstant<'a>> + '_ {
+        self.data
+            .named_constants
+            .as_ref()
+            .unwrap()
+            .keys()
+            .copied()
+            .map(|name| self.named_constant(name))
+    }
+
+    pub fn constants(&self) -> impl Iterator<Item = Constant<'a>> + '_ {
+        self.compiled
+            .constants
+            .iter()
+            .enumerate()
+            .map(
+                |(idx, compiled)| match self.data.constant_names.as_ref().unwrap()[idx] {
+                    Some(name) => Constant::Named(self.named_constant(name)),
+                    None => Constant::Compiled(CompiledConstant {
+                        module: *self,
+                        compiled,
+                        data: &self.data.constants[idx],
+                    }),
+                },
+            )
+    }
+}
+
+impl<'a> Struct<'a> {
+    pub fn info(&self) -> &'a N::StructDefinition {
+        self.module.info().structs.get_(&self.name).unwrap()
+    }
+}
+
+impl<'a> Enum<'a> {
+    pub fn info(&self) -> &'a N::EnumDefinition {
+        self.module.info().enums.get_(&self.name).unwrap()
+    }
+}
+
+impl<'a> Variant<'a> {
+    pub fn info(&self) -> &'a N::VariantDefinition {
+        self.enum_.info().variants.get_(&self.name).unwrap()
+    }
+}
+
+impl<'a> Function<'a> {
+    pub fn info(&self) -> &'a FunctionInfo {
+        self.module.info().functions.get_(&self.name).unwrap()
+    }
+}
+
+impl<'a> Constant<'a> {
+    pub fn module(&self) -> Module<'a> {
+        match self {
+            Constant::Compiled(c) => c.module,
+            Constant::Named(c) => c.module,
+        }
+    }
+
+    pub fn compiled(&self) -> Option<&'a normalized::Constant> {
+        match self {
+            Constant::Compiled(c) => Some(c.compiled),
+            Constant::Named(c) => c.compiled,
+        }
+    }
+
+    pub fn value(&self) -> &'a runtime_value::MoveValue {
+        match self {
+            Constant::Compiled(c) => c.value(),
+            Constant::Named(c) => c.value(),
+        }
+    }
+}
+
+impl<'a> NamedConstant<'a> {
+    pub fn name(&self) -> Symbol {
+        self.name
+    }
+
+    pub fn package(&self) -> Package<'a> {
+        self.module.package()
+    }
+
+    pub fn model(&self) -> &'a Model {
+        self.module.model()
+    }
+
+    pub fn module(&self) -> Module<'a> {
+        self.module
+    }
+
+    pub fn info(&self) -> &'a ConstantInfo {
+        self.module.info().constants.get_(&self.name).unwrap()
+    }
+
+    /// Not all source constants have a compiled representation
+    pub fn compiled(&self) -> Option<&'a normalized::Constant> {
+        self.compiled
+    }
+
+    pub fn value(&self) -> &'a runtime_value::MoveValue {
+        // we normally don't write delegates into ProgramInfo, but we are doing so here for parity
+        // with CompiledConstant
+        self.info().value.get().unwrap()
+    }
+}

--- a/external-crates/move/crates/move-model-2/src/source_model.rs
+++ b/external-crates/move/crates/move-model-2/src/source_model.rs
@@ -118,7 +118,7 @@ impl Model {
             })
             .collect();
         let mut model = Self {
-            has_source: true,
+            has_source: AlwaysSome::new(()),
             files: AlwaysSome::new(files),
             root_package_name,
             root_named_address_map,

--- a/external-crates/move/crates/move-model-2/src/source_model.rs
+++ b/external-crates/move/crates/move-model-2/src/source_model.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     TModuleId,
-    model::{self, CompiledConstant, Constant, PackageData, WithSource},
+    model::{self, NamedConstantData, PackageData, WithSource},
     normalized, serializable_signatures,
 };
 use move_compiler::{
@@ -28,7 +28,26 @@ pub type Struct<'a> = model::Struct<'a, WithSource>;
 pub type Enum<'a> = model::Enum<'a, WithSource>;
 pub type Variant<'a> = model::Variant<'a, WithSource>;
 pub type Function<'a> = model::Function<'a, WithSource>;
-pub type NamedConstant<'a> = model::NamedConstant<'a>;
+
+pub enum Constant<'a> {
+    Compiled(CompiledConstant<'a>),
+    Named(NamedConstant<'a>),
+}
+
+pub type CompiledConstant<'a> = model::CompiledConstant<'a, WithSource>;
+
+pub struct NamedConstant<'a> {
+    pub(crate) name: Symbol,
+    pub(crate) module: Module<'a>,
+    // There is no guarantee a source constant will have a compiled representation
+    pub(crate) compiled: Option<&'a normalized::Constant>,
+    #[allow(unused)]
+    pub(crate) data: &'a NamedConstantData,
+}
+
+//**************************************************************************************************
+// API
+//**************************************************************************************************
 
 impl Model {
     pub fn from_source(
@@ -287,3 +306,21 @@ impl<'a> NamedConstant<'a> {
         self.info().value.get().unwrap()
     }
 }
+
+//**************************************************************************************************
+// Derive
+//**************************************************************************************************
+
+impl Clone for Constant<'_> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl Copy for Constant<'_> {}
+
+impl Clone for NamedConstant<'_> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl Copy for NamedConstant<'_> {}

--- a/external-crates/move/crates/move-model-2/src/source_model.rs
+++ b/external-crates/move/crates/move-model-2/src/source_model.rs
@@ -1,15 +1,15 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::model::{self, WITH_SOURCE};
+use crate::model::{self, WithSource};
 
-pub type Model = model::Model<WITH_SOURCE>;
-pub type Package<'a> = model::Package<'a, WITH_SOURCE>;
-pub type Module<'a> = model::Module<'a, WITH_SOURCE>;
-pub type Member<'a> = model::Member<'a, WITH_SOURCE>;
-pub type Datatype<'a> = model::Datatype<'a, WITH_SOURCE>;
-pub type Struct<'a> = model::Struct<'a, WITH_SOURCE>;
-pub type Enum<'a> = model::Enum<'a, WITH_SOURCE>;
-pub type Variant<'a> = model::Variant<'a, WITH_SOURCE>;
-pub type Function<'a> = model::Function<'a, WITH_SOURCE>;
+pub type Model = model::Model<WithSource>;
+pub type Package<'a> = model::Package<'a, WithSource>;
+pub type Module<'a> = model::Module<'a, WithSource>;
+pub type Member<'a> = model::Member<'a, WithSource>;
+pub type Datatype<'a> = model::Datatype<'a, WithSource>;
+pub type Struct<'a> = model::Struct<'a, WithSource>;
+pub type Enum<'a> = model::Enum<'a, WithSource>;
+pub type Variant<'a> = model::Variant<'a, WithSource>;
+pub type Function<'a> = model::Function<'a, WithSource>;
 pub type NamedConstant<'a> = model::NamedConstant<'a>;


### PR DESCRIPTION
## Description 

- Replaces the const generic based markers with trait based ones. 
- The benefit of which is that we can "upcast" into `Model<AnyKind>` so that functions can return either. Today you cannot write `if cond { Model::from_source(...) } else { Model::from_compiled(...) }` and that can be potentially limiting 
- Originally I tried using `dyn SourceKind` but this still requires manual upcasting unless [CoerceUnsized](https://doc.rust-lang.org/std/ops/trait.CoerceUnsized.html) is stabilized. Since it requires manual upcasting, I instead opted for a "parent" type of `AnyKind`. 
  - The additional benefit of not using `dyn SourceKind` is that I can have an associated type for the `FormSource` annotations, this ensures that they are correctly instantiated always

## Test plan 

- 👀 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
