### PR TITLE
[mysticeti-fp] Implement wait_for_effects grpc API

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -219,6 +219,7 @@ mod authority_store_migrations;
 pub mod authority_store_pruner;
 pub mod authority_store_tables;
 pub mod authority_store_types;
+pub mod consensus_tx_status_cache;
 pub mod epoch_start_configuration;
 pub mod execution_time_estimator;
 pub mod shared_object_congestion_tracker;

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -922,9 +922,7 @@ impl AuthorityPerEpochStore {
             };
 
         let consensus_tx_status_cache = if protocol_config.mysticeti_fastpath() {
-            Some(ConsensusTxStatusCache::new(
-                protocol_config.gc_depth() as u64
-            ))
+            Some(ConsensusTxStatusCache::new())
         } else {
             None
         };

--- a/crates/sui-core/src/authority/consensus_tx_status_cache.rs
+++ b/crates/sui-core/src/authority/consensus_tx_status_cache.rs
@@ -15,15 +15,10 @@ use crate::wait_for_effects_request::ConsensusTxPosition;
 pub(crate) enum ConsensusTxStatus {
     // Transaction is voted to accept by a quorum of validators on fastpath.
     FastpathCertified,
-    // Transaction is rejected by a quorum of validators,
-    // on fastpath or post commit.
-    QuorumRejected,
+    // Transaction is rejected, either by a quorum of validators or indirectly post-commit.
+    Rejected,
     // Transaction is finalized post commit.
     Finalized,
-    // Transaction does not have a quorum of rejected votes,
-    // but indirectly rejected poast commit.
-    // TODO(fastpath): Set this properly from consensus.
-    IndirectlyRejected,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/sui-core/src/authority/consensus_tx_status_cache.rs
+++ b/crates/sui-core/src/authority/consensus_tx_status_cache.rs
@@ -4,7 +4,7 @@
 use parking_lot::RwLock;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::time::Duration;
-use sui_types::error::SuiError;
+use sui_types::error::{SuiError, SuiResult};
 use tokio::time::sleep;
 use tracing::debug;
 

--- a/crates/sui-core/src/authority/consensus_tx_status_cache.rs
+++ b/crates/sui-core/src/authority/consensus_tx_status_cache.rs
@@ -183,7 +183,7 @@ impl ConsensusTxStatusCache {
             if position.block.round as u64
                 > last_committed_leader_round + CONSENSUS_STATUS_RETENTION_ROUNDS
             {
-                return Err(SuiError::InvalidTransactionPosition {
+                return Err(SuiError::ValidatorConsensusLagging {
                     round: position.block.round as u64,
                     last_committed_round: last_committed_leader_round,
                 });

--- a/crates/sui-core/src/authority/consensus_tx_status_cache.rs
+++ b/crates/sui-core/src/authority/consensus_tx_status_cache.rs
@@ -14,7 +14,7 @@ use crate::wait_for_effects_request::ConsensusTxPosition;
 /// The number of consensus rounds to retain transaction status information before garbage collection.
 /// Used to expire positions from old rounds, as well as to check if a transaction is too far ahead of the last committed round.
 /// Assuming a max round rate of 15/sec, this allows status updates to be valid within a window of ~25-30 seconds.
-const CONSENSUS_STATUS_RETENTION_ROUNDS: u64 = 400;
+pub(crate) const CONSENSUS_STATUS_RETENTION_ROUNDS: u64 = 400;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ConsensusTxStatus {

--- a/crates/sui-core/src/authority/consensus_tx_status_cache.rs
+++ b/crates/sui-core/src/authority/consensus_tx_status_cache.rs
@@ -92,6 +92,11 @@ impl ConsensusTxStatusCache {
             let inner = self.inner.read();
             if let Some(status) = inner.transaction_status.get(&transaction_position) {
                 if Some(status) != old_status.as_ref() {
+                    if let Some(old_status) = old_status {
+                        // The only scenario where the status may change, is when the transaction
+                        // is initially fastpath certified, and then later finalized or rejected.
+                        assert_eq!(old_status, ConsensusTxStatus::FastpathCertified);
+                    }
                     return NotifyReadConsensusTxStatusResult::Status(status.clone());
                 }
             }

--- a/crates/sui-core/src/authority/consensus_tx_status_cache.rs
+++ b/crates/sui-core/src/authority/consensus_tx_status_cache.rs
@@ -121,6 +121,8 @@ impl ConsensusTxStatusCache {
         transaction_position: ConsensusTxPosition,
         old_status: Option<ConsensusTxStatus>,
     ) -> NotifyReadConsensusTxStatusResult {
+        // TODO(fastpath): We should track the typical distance between the last committed round
+        // and the requested round notified as metrics.
         let registration = self.status_notify_read.register_one(&transaction_position);
         let mut round_rx = self.last_committed_leader_round_rx.clone();
         {

--- a/crates/sui-core/src/authority/consensus_tx_status_cache.rs
+++ b/crates/sui-core/src/authority/consensus_tx_status_cache.rs
@@ -97,7 +97,7 @@ impl ConsensusTxStatusCache {
                         // is initially fastpath certified, and then later finalized or rejected.
                         assert_eq!(old_status, ConsensusTxStatus::FastpathCertified);
                     }
-                    return NotifyReadConsensusTxStatusResult::Status(status);
+                    return NotifyReadConsensusTxStatusResult::Status(*status);
                 }
             }
             // Inner read lock dropped here.

--- a/crates/sui-core/src/authority/consensus_tx_status_cache.rs
+++ b/crates/sui-core/src/authority/consensus_tx_status_cache.rs
@@ -1,0 +1,300 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use parking_lot::RwLock;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::time::Duration;
+use tokio::time::sleep;
+use tracing::debug;
+
+use mysten_common::sync::notify_read::NotifyRead;
+
+use crate::wait_for_effects_request::ConsensusTxPosition;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ConsensusTxStatus {
+    // Transaction is voted to accept by a quorum of validators on fastpath.
+    FastpathCertified,
+    // Transaction is rejected by a quorum of validators,
+    // on fastpath or post commit.
+    QuorumRejected,
+    // Transaction is finalized post commit.
+    Finalized,
+    // Transaction does not have a quorum of rejected votes,
+    // but indirectly rejected poast commit.
+    // TODO(fastpath): Set this properly from consensus.
+    IndirectlyRejected,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum NotifyReadConsensusTxStatusResult {
+    // The consensus position to be read has been updated with a new status.
+    Status(ConsensusTxStatus),
+    // The consensus position to be read has expired.
+    // Provided with the last committed round that was used to check for expiration.
+    Expired(u64),
+}
+
+#[derive(Default)]
+pub(crate) struct ConsensusTxStatusCache {
+    inner: RwLock<Inner>,
+    status_notify_read: NotifyRead<ConsensusTxPosition, ConsensusTxStatus>,
+    /// The depth of the garbage collection.
+    /// We use this to expire positions from old rounds.
+    gc_depth: u64,
+}
+
+#[derive(Default)]
+struct Inner {
+    /// A map of transaction position to its status from consensus.
+    transaction_status: HashMap<ConsensusTxPosition, ConsensusTxStatus>,
+    /// A map of consensus round to all transactions that were updated in that round.
+    round_lookup_map: BTreeMap<u64, HashSet<ConsensusTxPosition>>,
+    /// The last round that was committed, serving as a watermark for expired transactions.
+    last_committed_round: Option<u64>,
+}
+
+impl ConsensusTxStatusCache {
+    pub fn new(gc_depth: u64) -> Self {
+        Self {
+            gc_depth,
+            ..Default::default()
+        }
+    }
+
+    pub fn set_transaction_status(
+        &self,
+        transaction_position: ConsensusTxPosition,
+        status: ConsensusTxStatus,
+    ) {
+        let mut inner = self.inner.write();
+        if let Some(last_committed_round) = inner.last_committed_round {
+            if transaction_position.block.round as u64 + self.gc_depth < last_committed_round {
+                return;
+            }
+        }
+        let old_status = inner
+            .transaction_status
+            .insert(transaction_position, status.clone());
+        if old_status.is_none() {
+            inner
+                .round_lookup_map
+                .entry(transaction_position.block.round as u64)
+                .or_default()
+                .insert(transaction_position);
+        }
+        self.status_notify_read
+            .notify(&transaction_position, &status);
+    }
+
+    pub async fn notify_read_transaction_status(
+        &self,
+        transaction_position: ConsensusTxPosition,
+        old_status: Option<ConsensusTxStatus>,
+    ) -> NotifyReadConsensusTxStatusResult {
+        let registration = self.status_notify_read.register_one(&transaction_position);
+        {
+            let inner = self.inner.read();
+            if let Some(status) = inner.transaction_status.get(&transaction_position) {
+                if Some(status) != old_status.as_ref() {
+                    return NotifyReadConsensusTxStatusResult::Status(status.clone());
+                }
+            }
+            // Inner read lock dropped here.
+        }
+
+        let expiration_check = async {
+            loop {
+                {
+                    let inner = self.inner.read();
+                    if let Some(last_committed_round) = inner.last_committed_round {
+                        if transaction_position.block.round as u64 + self.gc_depth
+                            < last_committed_round
+                        {
+                            return last_committed_round;
+                        }
+                    }
+                }
+                sleep(Duration::from_millis(50)).await;
+            }
+        };
+        tokio::select! {
+            status = registration => NotifyReadConsensusTxStatusResult::Status(status),
+            last_committed_round = expiration_check => NotifyReadConsensusTxStatusResult::Expired(last_committed_round),
+        }
+    }
+
+    pub async fn update_last_committed_round(&self, round: u64) {
+        debug!("Updating last committed round: {}", round);
+        let mut inner = self.inner.write();
+        while let Some(&next_round) = inner.round_lookup_map.keys().next() {
+            if next_round + self.gc_depth < round {
+                let transactions = inner.round_lookup_map.remove(&next_round).unwrap();
+                for tx in transactions {
+                    inner.transaction_status.remove(&tx);
+                }
+            } else {
+                break;
+            }
+        }
+        inner.last_committed_round = Some(round);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use consensus_core::BlockRef;
+    use sui_types::messages_consensus::TransactionIndex;
+
+    const GC_DEPTH: u64 = 10;
+
+    fn create_test_tx_position(round: u64, index: u64) -> ConsensusTxPosition {
+        ConsensusTxPosition {
+            block: BlockRef {
+                round: round as u32,
+                author: Default::default(),
+                digest: Default::default(),
+            },
+            index: index as TransactionIndex,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_set_and_get_transaction_status() {
+        let cache = ConsensusTxStatusCache::new(GC_DEPTH);
+        let tx_pos = create_test_tx_position(1, 0);
+
+        // Set initial status
+        cache.set_transaction_status(tx_pos, ConsensusTxStatus::FastpathCertified);
+
+        // Read status immediately
+        let result = cache.notify_read_transaction_status(tx_pos, None).await;
+        assert!(matches!(
+            result,
+            NotifyReadConsensusTxStatusResult::Status(ConsensusTxStatus::FastpathCertified)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_status_notification() {
+        let cache = Arc::new(ConsensusTxStatusCache::new(GC_DEPTH));
+        let tx_pos = create_test_tx_position(1, 0);
+
+        // Spawn a task that waits for status update
+        let cache_clone = cache.clone();
+        let handle = tokio::spawn(async move {
+            cache_clone
+                .notify_read_transaction_status(tx_pos, None)
+                .await
+        });
+
+        // Small delay to ensure the task is waiting
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        // Set the status
+        cache.set_transaction_status(tx_pos, ConsensusTxStatus::Finalized);
+
+        // Verify the notification was received
+        let result = handle.await.unwrap();
+        assert!(matches!(
+            result,
+            NotifyReadConsensusTxStatusResult::Status(ConsensusTxStatus::Finalized)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_round_expiration() {
+        let cache = ConsensusTxStatusCache::new(GC_DEPTH);
+        let tx_pos = create_test_tx_position(1, 0);
+
+        // Set initial status
+        cache.set_transaction_status(tx_pos, ConsensusTxStatus::FastpathCertified);
+
+        // Update last committed round to trigger expiration
+        cache.update_last_committed_round(GC_DEPTH + 2).await;
+
+        // Try to read status - should be expired
+        let result = cache.notify_read_transaction_status(tx_pos, None).await;
+        assert!(matches!(
+            result,
+            NotifyReadConsensusTxStatusResult::Expired(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_multiple_status_updates() {
+        let cache = ConsensusTxStatusCache::new(GC_DEPTH);
+        let tx_pos = create_test_tx_position(1, 0);
+
+        // Set initial status
+        cache.set_transaction_status(tx_pos, ConsensusTxStatus::FastpathCertified);
+
+        // Update status
+        cache.set_transaction_status(tx_pos, ConsensusTxStatus::Finalized);
+
+        // Read with old status
+        let result = cache
+            .notify_read_transaction_status(tx_pos, Some(ConsensusTxStatus::FastpathCertified))
+            .await;
+        assert!(matches!(
+            result,
+            NotifyReadConsensusTxStatusResult::Status(ConsensusTxStatus::Finalized)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_expired_rounds() {
+        let cache = ConsensusTxStatusCache::new(GC_DEPTH);
+
+        // Add transactions for multiple rounds
+        for round in 1..=5 {
+            let tx_pos = create_test_tx_position(round, 0);
+            cache.set_transaction_status(tx_pos, ConsensusTxStatus::FastpathCertified);
+        }
+
+        // Update last committed round to expire early rounds
+        cache.update_last_committed_round(GC_DEPTH + 3).await;
+
+        // Verify early rounds are cleaned up
+        let inner = cache.inner.read();
+        assert!(!inner.round_lookup_map.contains_key(&1));
+        assert!(!inner.round_lookup_map.contains_key(&2));
+        assert!(inner.round_lookup_map.contains_key(&4));
+        assert!(inner.round_lookup_map.contains_key(&5));
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_operations() {
+        let cache = Arc::new(ConsensusTxStatusCache::new(GC_DEPTH));
+        let tx_pos = create_test_tx_position(1, 0);
+
+        // Spawn multiple tasks that wait for status
+        let mut handles = vec![];
+        for _ in 0..3 {
+            let cache_clone = cache.clone();
+            handles.push(tokio::spawn(async move {
+                cache_clone
+                    .notify_read_transaction_status(tx_pos, None)
+                    .await
+            }));
+        }
+
+        // Small delay to ensure tasks are waiting
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        // Set the status
+        cache.set_transaction_status(tx_pos, ConsensusTxStatus::Finalized);
+
+        // Verify all notifications were received
+        for handle in handles {
+            let result = handle.await.unwrap();
+            assert!(matches!(
+                result,
+                NotifyReadConsensusTxStatusResult::Status(ConsensusTxStatus::Finalized)
+            ));
+        }
+    }
+}

--- a/crates/sui-core/src/authority/consensus_tx_status_cache.rs
+++ b/crates/sui-core/src/authority/consensus_tx_status_cache.rs
@@ -11,7 +11,7 @@ use mysten_common::sync::notify_read::NotifyRead;
 
 use crate::wait_for_effects_request::ConsensusTxPosition;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ConsensusTxStatus {
     // Transaction is voted to accept by a quorum of validators on fastpath.
     FastpathCertified,
@@ -70,7 +70,7 @@ impl ConsensusTxStatusCache {
         }
         let old_status = inner
             .transaction_status
-            .insert(transaction_position, status.clone());
+            .insert(transaction_position, status);
         if old_status.is_none() {
             inner
                 .round_lookup_map
@@ -97,7 +97,7 @@ impl ConsensusTxStatusCache {
                         // is initially fastpath certified, and then later finalized or rejected.
                         assert_eq!(old_status, ConsensusTxStatus::FastpathCertified);
                     }
-                    return NotifyReadConsensusTxStatusResult::Status(status.clone());
+                    return NotifyReadConsensusTxStatusResult::Status(status);
                 }
             }
             // Inner read lock dropped here.

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -1191,7 +1191,6 @@ impl ValidatorService {
         let response = WaitForEffectsResponse::Executed {
             effects_digest,
             details,
-            finalized: cur_status == ConsensusTxStatus::Finalized,
         };
         Ok(response)
     }

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -1189,6 +1189,7 @@ impl ValidatorService {
         let response = WaitForEffectsResponse::Executed {
             effects_digest,
             details,
+            finalized: cur_status == ConsensusTxStatus::Finalized,
         };
         Ok(response)
     }

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -1100,6 +1100,8 @@ impl ValidatorService {
                 actual_epoch: request.epoch,
             });
         }
+        consensus_tx_status_cache.check_position_too_ahead(&request.transaction_position)?;
+
         // Because we need to associate effects with a specific transaction position,
         // we need to first make sure that this specific position is accepted by consensus,
         // either with fastpath certified or post-commit finalized.

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -1113,12 +1113,10 @@ impl ValidatorService {
         );
         let mut cur_status = match first_status {
             NotifyReadConsensusTxStatusResult::Status(status) => match status {
-                ConsensusTxStatus::QuorumRejected | ConsensusTxStatus::IndirectlyRejected => {
-                    let is_quorum = status == ConsensusTxStatus::QuorumRejected;
+                ConsensusTxStatus::Rejected => {
                     let response = WaitForEffectsResponse::Rejected {
                         // TODO(fastpath): Add reject reason.
                         reason: RejectReason::None,
-                        is_quorum,
                     };
                     return Ok(response);
                 }
@@ -1144,11 +1142,8 @@ impl ValidatorService {
                     );
                     match second_status {
                         NotifyReadConsensusTxStatusResult::Status(status) => {
-                            if status == ConsensusTxStatus::IndirectlyRejected {
-                                return Ok(WaitForEffectsResponse::Rejected {
-                                    reason: RejectReason::None,
-                                    is_quorum: false,
-                                });
+                            if status == ConsensusTxStatus::Rejected {
+                                return Ok(WaitForEffectsResponse::Rejected { reason: RejectReason::None });
                             }
                             assert!(matches!(status, ConsensusTxStatus::Finalized));
                             // Update the current status so that notify_read_transaction_status will no

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -15,26 +15,30 @@ use std::{
     io,
     net::{IpAddr, SocketAddr},
     sync::Arc,
-    time::SystemTime,
+    time::{Duration, SystemTime},
 };
 use sui_network::{
     api::{Validator, ValidatorServer},
     tonic,
 };
-use sui_types::messages_grpc::{
-    HandleCertificateRequestV3, HandleCertificateResponseV3, RawSubmitTxResponse,
-};
-use sui_types::messages_grpc::{
-    HandleCertificateResponseV2, HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse,
-    SubmitCertificateResponse, SystemStateRequest, TransactionInfoRequest, TransactionInfoResponse,
-};
-use sui_types::messages_grpc::{
-    HandleSoftBundleCertificatesRequestV3, HandleSoftBundleCertificatesResponseV3,
-};
-use sui_types::multiaddr::Multiaddr;
 use sui_types::sui_system_state::SuiSystemState;
 use sui_types::traffic_control::{ClientIdSource, PolicyConfig, RemoteFirewallConfig, Weight};
+use sui_types::{
+    effects::TransactionEffects,
+    messages_grpc::{
+        HandleCertificateRequestV3, HandleCertificateResponseV3, RawSubmitTxResponse,
+        RawWaitForEffectsRequest, RawWaitForEffectsResponse,
+    },
+};
 use sui_types::{effects::TransactionEffectsAPI, messages_grpc::SubmitTxResponse};
+use sui_types::{
+    effects::TransactionEvents,
+    messages_grpc::{
+        HandleCertificateResponseV2, HandleTransactionResponse, ObjectInfoRequest,
+        ObjectInfoResponse, SubmitCertificateResponse, SystemStateRequest, TransactionInfoRequest,
+        TransactionInfoResponse,
+    },
+};
 use sui_types::{error::*, transaction::*};
 use sui_types::{
     fp_ensure,
@@ -42,24 +46,37 @@ use sui_types::{
         CheckpointRequest, CheckpointRequestV2, CheckpointResponse, CheckpointResponseV2,
     },
 };
+use sui_types::{message_envelope::Message, multiaddr::Multiaddr};
 use sui_types::{
     messages_consensus::{ConsensusTransaction, ConsensusTransactionKind},
     messages_grpc::RawSubmitTxRequest,
 };
+use sui_types::{
+    messages_grpc::{
+        HandleSoftBundleCertificatesRequestV3, HandleSoftBundleCertificatesResponseV3,
+    },
+    object::Object,
+};
 use tap::TapFallible;
+use tokio::time::timeout;
 use tonic::metadata::{Ascii, MetadataValue};
-use tracing::{error, error_span, info, Instrument};
+use tracing::{debug, error, error_span, info, Instrument};
 
 use crate::{
-    authority::authority_per_epoch_store::AuthorityPerEpochStore, checkpoints::CheckpointStore,
+    authority::{
+        authority_per_epoch_store::AuthorityPerEpochStore,
+        consensus_tx_status_cache::NotifyReadConsensusTxStatusResult,
+    },
+    checkpoints::CheckpointStore,
     mysticeti_adapter::LazyMysticetiClient,
+    wait_for_effects_request::{
+        EffectsDetails, RejectReason, WaitForEffectsRequest, WaitForEffectsResponse,
+    },
 };
 use crate::{
-    authority::AuthorityState,
+    authority::{consensus_tx_status_cache::ConsensusTxStatus, AuthorityState},
     consensus_adapter::{ConsensusAdapter, ConsensusAdapterMetrics},
-    traffic_controller::parse_ip,
-    traffic_controller::policies::TrafficTally,
-    traffic_controller::TrafficController,
+    traffic_controller::{parse_ip, policies::TrafficTally, TrafficController},
 };
 use crate::{
     consensus_adapter::ConnectionMonitorStatusForTests,
@@ -72,6 +89,10 @@ use tonic::transport::server::TcpConnectInfo;
 #[cfg(test)]
 #[path = "unit_tests/server_tests.rs"]
 mod server_tests;
+
+#[cfg(test)]
+#[path = "unit_tests/wait_for_effects_tests.rs"]
+mod wait_for_effects_tests;
 
 pub struct AuthorityServerHandle {
     server_handle: mysten_network::server::Server,
@@ -521,7 +542,8 @@ impl ValidatorService {
 
         let request = request.into_inner();
         let transaction = bcs::from_bytes::<Transaction>(&request.transaction).map_err(|e| {
-            SuiError::TransactionDeserializationError {
+            SuiError::GrpcMessageDeserializeError {
+                type_info: "RawSubmitTxRequest.transaction".to_string(),
                 error: e.to_string(),
             }
         })?;
@@ -892,6 +914,37 @@ impl ValidatorService {
 
         Ok((Some(responses), Weight::zero()))
     }
+
+    async fn collect_effects_data(
+        &self,
+        effects: &TransactionEffects,
+        include_events: bool,
+        include_input_objects: bool,
+        include_output_objects: bool,
+    ) -> SuiResult<(Option<TransactionEvents>, Vec<Object>, Vec<Object>)> {
+        let events = if include_events && effects.events_digest().is_some() {
+            Some(
+                self.state
+                    .get_transaction_events(effects.transaction_digest())?,
+            )
+        } else {
+            None
+        };
+
+        let input_objects = if include_input_objects {
+            self.state.get_transaction_input_objects(effects)?
+        } else {
+            vec![]
+        };
+
+        let output_objects = if include_output_objects {
+            self.state.get_transaction_output_objects(effects)?
+        } else {
+            vec![]
+        };
+
+        Ok((events, input_objects, output_objects))
+    }
 }
 
 type WrappedServiceResponse<T> = Result<(tonic::Response<T>, Weight), tonic::Status>;
@@ -1008,6 +1061,141 @@ impl ValidatorService {
                 spam_weight,
             )
         })
+    }
+
+    async fn wait_for_effects_impl(
+        &self,
+        request: tonic::Request<RawWaitForEffectsRequest>,
+    ) -> WrappedServiceResponse<RawWaitForEffectsResponse> {
+        let request: WaitForEffectsRequest = request.into_inner().try_into()?;
+        let response = timeout(
+            // TODO(fastpath): Tune this once we have a good estimate of the typical delay.
+            Duration::from_secs(10),
+            self.wait_for_effects_response(request),
+        )
+        .await
+        .map_err(|_| tonic::Status::internal("Timeout waiting for effects"))??
+        .try_into()?;
+        Ok((
+            tonic::Response::new(response),
+            // TODO(fastpath): Implement spam weight
+            Weight::zero(),
+        ))
+    }
+
+    // TODO(fastpath): Add metrics.
+    async fn wait_for_effects_response(
+        &self,
+        request: WaitForEffectsRequest,
+    ) -> SuiResult<WaitForEffectsResponse> {
+        let epoch_store = self.state.load_epoch_store_one_call_per_task();
+        let Some(consensus_tx_status_cache) = epoch_store.consensus_tx_status_cache.as_ref() else {
+            return Err(SuiError::UnsupportedFeatureError {
+                error: "Mysticeti fastpath".to_string(),
+            });
+        };
+        if request.epoch != epoch_store.epoch() {
+            return Err(SuiError::WrongEpoch {
+                expected_epoch: epoch_store.epoch(),
+                actual_epoch: request.epoch,
+            });
+        }
+        // Because we need to associate effects with a specific transaction position,
+        // we need to first make sure that this specific position is accepted by consensus,
+        // either with fastpath certified or post-commit finalized.
+        let first_status = consensus_tx_status_cache
+            .notify_read_transaction_status(request.transaction_position, None)
+            .await;
+        debug!(
+            tx_digest = ?request.transaction_digest,
+            "Observed consensus transaction status: {:?}",
+            first_status
+        );
+        let mut cur_status = match first_status {
+            NotifyReadConsensusTxStatusResult::Status(status) => match status {
+                ConsensusTxStatus::QuorumRejected | ConsensusTxStatus::IndirectlyRejected => {
+                    let is_quorum = status == ConsensusTxStatus::QuorumRejected;
+                    let response = WaitForEffectsResponse::Rejected {
+                        // TODO(fastpath): Add reject reason.
+                        reason: RejectReason::None,
+                        is_quorum,
+                    };
+                    return Ok(response);
+                }
+                ConsensusTxStatus::FastpathCertified | ConsensusTxStatus::Finalized => status,
+            },
+            NotifyReadConsensusTxStatusResult::Expired(round) => {
+                return Ok(WaitForEffectsResponse::Expired(round));
+            }
+        };
+        // Now that we know the transaction position is accepted by consensus,
+        // we can wait for the effects to be executed.
+        // In the meantime, however, if the initial status is fastpath certified,
+        // it is still possible that the transaction is rejected post commit.
+        // So we need to keep checking the status until it is finalized.
+        let effects = loop {
+            let transactions = [request.transaction_digest];
+            tokio::select! {
+                second_status = consensus_tx_status_cache.notify_read_transaction_status(request.transaction_position, Some(cur_status)) => {
+                    debug!(
+                        tx_digest = ?request.transaction_digest,
+                        "Observed consensus transaction status: {:?}",
+                        second_status
+                    );
+                    match second_status {
+                        NotifyReadConsensusTxStatusResult::Status(status) => {
+                            if status == ConsensusTxStatus::IndirectlyRejected {
+                                return Ok(WaitForEffectsResponse::Rejected {
+                                    reason: RejectReason::None,
+                                    is_quorum: false,
+                                });
+                            }
+                            assert!(matches!(status, ConsensusTxStatus::Finalized));
+                            // Update the current status so that notify_read_transaction_status will no
+                            // longer be triggered again after the transaction is finalized.
+                            cur_status = status;
+                            continue;
+                        }
+                        NotifyReadConsensusTxStatusResult::Expired(round) => {
+                            return Ok(WaitForEffectsResponse::Expired(round));
+                        }
+                    }
+                },
+                mut effects = self.state
+                    .get_transaction_cache_reader()
+                    .notify_read_executed_effects(&transactions) => {
+                    debug!(
+                        tx_digest = ?request.transaction_digest,
+                        "Observed executed effects",
+                    );
+                    break effects.pop().unwrap();
+                },
+            }
+        };
+        let effects_digest = effects.digest();
+        let details = if request.include_details {
+            let (events, input_objects, output_objects) = self
+                .collect_effects_data(
+                    &effects,
+                    request.include_details,
+                    request.include_details,
+                    request.include_details,
+                )
+                .await?;
+            Some(Box::new(EffectsDetails {
+                effects,
+                events,
+                input_objects,
+                output_objects,
+            }))
+        } else {
+            None
+        };
+        let response = WaitForEffectsResponse::Executed {
+            effects_digest,
+            details,
+        };
+        Ok(response)
     }
 
     async fn soft_bundle_validity_check(
@@ -1290,7 +1478,7 @@ impl ValidatorService {
                             let Some(client_ip) = header_contents.get(contents_len - num_hops)
                             else {
                                 error!(
-                                    "x-forwarded-for header value of {:?} contains {} values, but {} hops were specificed. \
+                                    "x-forwarded-for header value of {:?} contains {} values, but {} hops were specified. \
                                     Expected at least {} values. Skipping traffic controller request handling.",
                                     header_contents,
                                     contents_len,
@@ -1485,6 +1673,13 @@ impl Validator for ValidatorService {
         request: tonic::Request<HandleCertificateRequestV3>,
     ) -> Result<tonic::Response<HandleCertificateResponseV3>, tonic::Status> {
         handle_with_decoration!(self, handle_certificate_v3_impl, request)
+    }
+
+    async fn wait_for_effects(
+        &self,
+        request: tonic::Request<RawWaitForEffectsRequest>,
+    ) -> Result<tonic::Response<RawWaitForEffectsResponse>, tonic::Status> {
+        handle_with_decoration!(self, wait_for_effects_impl, request)
     }
 
     async fn handle_soft_bundle_certificates_v3(

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -1165,6 +1165,8 @@ impl ValidatorService {
                         tx_digest = ?request.transaction_digest,
                         "Observed executed effects",
                     );
+                    // unwrap is safe because notify_read_executed_effects is expected
+                    // to return the same amount of effects as the provided transactions.
                     break effects.pop().unwrap();
                 },
             }

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -70,7 +70,7 @@ use crate::{
     checkpoints::CheckpointStore,
     mysticeti_adapter::LazyMysticetiClient,
     wait_for_effects_request::{
-        EffectsDetails, RejectReason, WaitForEffectsRequest, WaitForEffectsResponse,
+        ExecutedData, RejectReason, WaitForEffectsRequest, WaitForEffectsResponse,
     },
 };
 use crate::{
@@ -1177,7 +1177,7 @@ impl ValidatorService {
                     request.include_details,
                 )
                 .await?;
-            Some(Box::new(EffectsDetails {
+            Some(Box::new(ExecutedData {
                 effects,
                 events,
                 input_objects,

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -580,7 +580,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         if let Some(consensus_tx_status_cache) = self.epoch_store.consensus_tx_status_cache.as_ref()
         {
             consensus_tx_status_cache
-                .update_last_committed_round(last_committed_round)
+                .update_last_committed_leader_round(last_committed_round)
                 .await;
         }
 

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -32,6 +32,7 @@ use sui_types::{
     messages_consensus::{
         AuthorityIndex, ConsensusDeterminedVersionAssignments, ConsensusTransaction,
         ConsensusTransactionKey, ConsensusTransactionKind, ExecutionTimeObservation,
+        TransactionIndex,
     },
     sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait,
     transaction::{SenderSignedData, VerifiedTransaction},
@@ -46,6 +47,7 @@ use crate::{
             ExecutionIndicesWithStats,
         },
         backpressure::{BackpressureManager, BackpressureSubscriber},
+        consensus_tx_status_cache::ConsensusTxStatus,
         epoch_start_configuration::EpochStartConfigTrait,
         AuthorityMetrics, AuthorityState,
     },
@@ -55,6 +57,7 @@ use crate::{
     execution_cache::{ObjectCacheRead, TransactionCacheRead},
     scoring_decision::update_low_scoring_authorities,
     transaction_manager::TransactionManager,
+    wait_for_effects_request::ConsensusTxPosition,
 };
 
 pub struct ConsensusHandlerInitializer {
@@ -419,7 +422,7 @@ mod additional_consensus_state {
             }
 
             /// Returns all accepted and rejected transactions per block in the commit in deterministic order.
-            fn transactions(&self) -> Vec<(AuthorityIndex, Vec<ParsedTransaction>)> {
+            fn transactions(&self) -> Vec<(consensus_core::BlockRef, Vec<ParsedTransaction>)> {
                 vec![]
             }
 
@@ -574,6 +577,13 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
 
         let last_committed_round = self.last_consensus_stats.index.last_committed_round;
 
+        if let Some(consensus_tx_status_cache) = self.epoch_store.consensus_tx_status_cache.as_ref()
+        {
+            consensus_tx_status_cache
+                .update_last_committed_round(last_committed_round)
+                .await;
+        }
+
         let commit_info = if self
             .epoch_store
             .protocol_config()
@@ -703,16 +713,33 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         {
             let span = trace_span!("ConsensusHandler::HandleCommit::process_consensus_txns");
             let _guard = span.enter();
-            for (authority_index, parsed_transactions) in consensus_commit.transactions() {
+            for (block, parsed_transactions) in consensus_commit.transactions() {
+                let author = block.author.value();
                 // TODO: consider only messages within 1~3 rounds of the leader?
-                self.last_consensus_stats
-                    .stats
-                    .inc_num_messages(authority_index as usize);
-                for parsed in parsed_transactions {
-                    // Skip executing rejected transactions. Unlocking is the responsibility of the
-                    // consensus transaction handler.
-                    if parsed.rejected {
-                        continue;
+                self.last_consensus_stats.stats.inc_num_messages(author);
+                for (tx_index, parsed) in parsed_transactions.into_iter().enumerate() {
+                    if matches!(
+                        parsed.transaction.kind,
+                        ConsensusTransactionKind::UserTransaction(_)
+                    ) {
+                        let position = ConsensusTxPosition {
+                            block,
+                            index: tx_index as TransactionIndex,
+                        };
+                        if parsed.rejected {
+                            self.epoch_store.set_consensus_tx_status(
+                                position,
+                                ConsensusTxStatus::QuorumRejected,
+                            );
+                            // Skip executing rejected transactions. Unlocking is the responsibility of the
+                            // consensus transaction handler.
+                            continue;
+                        } else {
+                            self.epoch_store.set_consensus_tx_status(
+                                position,
+                                ConsensusTxStatus::FastpathCertified,
+                            );
+                        }
                     }
                     let kind = classify(&parsed.transaction);
                     self.metrics
@@ -731,7 +758,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                     ) {
                         self.last_consensus_stats
                             .stats
-                            .inc_num_user_transactions(authority_index as usize);
+                            .inc_num_user_transactions(author);
                     }
                     if let ConsensusTransactionKind::RandomnessStateUpdate(randomness_round, _) =
                         &parsed.transaction.kind
@@ -745,7 +772,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                     } else {
                         let transaction =
                             SequencedConsensusTransactionKind::External(parsed.transaction);
-                        transactions.push((transaction, authority_index));
+                        transactions.push((transaction, author as u32));
                     }
                 }
             }
@@ -1236,44 +1263,57 @@ impl ConsensusBlockHandler {
         let parsed_transactions = blocks_output
             .blocks
             .into_iter()
-            .flat_map(|certified_block| {
-                parse_block_transactions(&certified_block.block, &certified_block.rejected)
+            .map(|certified_block| {
+                let block_ref = certified_block.block.reference();
+                let transactions =
+                    parse_block_transactions(&certified_block.block, &certified_block.rejected);
+                (block_ref, transactions)
             })
             .collect::<Vec<_>>();
         let mut pending_consensus_transactions = vec![];
-        let executable_transactions: Vec<_> = parsed_transactions
-            .into_iter()
-            .filter_map(|parsed| {
-                // TODO(fastpath): unlock rejected transactions.
-                // TODO(fastpath): maybe avoid parsing blocks twice between commit and transaction handling?
+        let mut executable_transactions = vec![];
+        for (block, transactions) in parsed_transactions {
+            for (idx, parsed) in transactions.into_iter().enumerate() {
+                let position = ConsensusTxPosition {
+                    block,
+                    index: idx as TransactionIndex,
+                };
                 if parsed.rejected {
+                    // TODO(fastpath): unlock rejected transactions.
+                    // TODO(fastpath): maybe avoid parsing blocks twice between commit and transaction handling?
+                    self.epoch_store
+                        .set_consensus_tx_status(position, ConsensusTxStatus::QuorumRejected);
                     self.metrics
                         .consensus_block_handler_txn_processed
                         .with_label_values(&["rejected"])
                         .inc();
-                    return None;
+                    continue;
+                } else {
+                    self.epoch_store
+                        .set_consensus_tx_status(position, ConsensusTxStatus::Finalized);
                 }
                 self.metrics
                     .consensus_block_handler_txn_processed
                     .with_label_values(&["certified"])
                     .inc();
-                match &parsed.transaction.kind {
-                    ConsensusTransactionKind::UserTransaction(tx) => {
-                        // TODO(fastpath): use a separate function to check if a transaction should be executed in fastpath.
-                        if tx.contains_shared_object() {
-                            return None;
-                        }
-                        pending_consensus_transactions.push(parsed.transaction.clone());
-                        let tx = VerifiedTransaction::new_unchecked(*tx.clone());
-                        Some(VerifiedExecutableTransaction::new_from_consensus(
+                if let ConsensusTransactionKind::UserTransaction(tx) = &parsed.transaction.kind {
+                    // TODO(fastpath): use a separate function to check if a transaction should be executed in fastpath.
+                    // If we do schedule a fast-path transaction for execution, we also need to
+                    // track it in case we need to revert it later due to post-commit reject.
+                    if tx.contains_shared_object() {
+                        continue;
+                    }
+                    pending_consensus_transactions.push(parsed.transaction.clone());
+                    let tx = VerifiedTransaction::new_unchecked(*tx.clone());
+                    executable_transactions.push(
+                        VerifiedExecutableTransaction::new_from_consensus(
                             tx,
                             self.epoch_store.epoch(),
-                        ))
-                    }
-                    _ => None,
+                        ),
+                    );
                 }
-            })
-            .collect();
+            }
+        }
 
         if pending_consensus_transactions.is_empty() {
             return;

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -723,6 +723,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                         index: tx_index as TransactionIndex,
                     };
                     if parsed.rejected {
+                        // TODO(fastpath): Add metrics for rejected transactions.
                         if parsed.transaction.kind.is_user_transaction() {
                             self.epoch_store
                                 .set_consensus_tx_status(position, ConsensusTxStatus::Rejected);
@@ -732,10 +733,8 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                         continue;
                     }
                     if parsed.transaction.kind.is_user_transaction() {
-                        self.epoch_store.set_consensus_tx_status(
-                            position,
-                            ConsensusTxStatus::FastpathCertified,
-                        );
+                        self.epoch_store
+                            .set_consensus_tx_status(position, ConsensusTxStatus::Finalized);
                     }
                     let kind = classify(&parsed.transaction);
                     self.metrics
@@ -1286,7 +1285,7 @@ impl ConsensusBlockHandler {
                     continue;
                 }
                 self.epoch_store
-                    .set_consensus_tx_status(position, ConsensusTxStatus::Finalized);
+                    .set_consensus_tx_status(position, ConsensusTxStatus::FastpathCertified);
 
                 self.metrics
                     .consensus_block_handler_txn_processed

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -728,8 +728,8 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                             self.epoch_store
                                 .set_consensus_tx_status(position, ConsensusTxStatus::Rejected);
                         }
-                        // Skip executing rejected transactions. Unlocking is the responsibility of the
-                        // consensus transaction handler.
+                        // Skip executing rejected transactions.
+                        // TODO(fastpath): Handle unlocking.
                         continue;
                     }
                     if parsed.transaction.kind.is_user_transaction() {

--- a/crates/sui-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/sui-core/src/consensus_types/consensus_output_api.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::{cmp::Ordering, fmt::Display};
 
-use consensus_core::{BlockAPI, CommitDigest, TransactionIndex, VerifiedBlock};
+use consensus_core::{BlockAPI, BlockRef, CommitDigest, TransactionIndex, VerifiedBlock};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::{
     digests::ConsensusCommitDigest,
@@ -30,7 +30,7 @@ pub(crate) trait ConsensusCommitAPI: Display {
     fn commit_sub_dag_index(&self) -> u64;
 
     /// Returns all accepted and rejected transactions per block in the commit in deterministic order.
-    fn transactions(&self) -> Vec<(AuthorityIndex, Vec<ParsedTransaction>)>;
+    fn transactions(&self) -> Vec<(BlockRef, Vec<ParsedTransaction>)>;
 
     /// Returns the digest of consensus output.
     fn consensus_digest(&self, protocol_config: &ProtocolConfig) -> ConsensusCommitDigest;
@@ -67,13 +67,13 @@ impl ConsensusCommitAPI for consensus_core::CommittedSubDag {
         self.commit_ref.index.into()
     }
 
-    fn transactions(&self) -> Vec<(AuthorityIndex, Vec<ParsedTransaction>)> {
+    fn transactions(&self) -> Vec<(BlockRef, Vec<ParsedTransaction>)> {
         self.blocks
             .iter()
             .zip(self.rejected_transactions_by_block.iter())
             .map(|(block, rejected_transactions)| {
                 (
-                    block.author().value() as AuthorityIndex,
+                    block.reference(),
                     parse_block_transactions(block, rejected_transactions),
                 )
             })

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -47,6 +47,7 @@ pub mod transaction_orchestrator;
 mod transaction_outputs;
 pub mod validator_tx_finalizer;
 pub mod verify_indexes;
+mod wait_for_effects_request;
 
 #[cfg(test)]
 #[path = "unit_tests/congestion_control_tests.rs"]

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -18,6 +18,7 @@ use sui_types::{
     error::SuiError,
     executable_transaction::VerifiedExecutableTransaction,
     messages_checkpoint::{CheckpointRequest, CheckpointResponse},
+    messages_grpc::{RawWaitForEffectsRequest, RawWaitForEffectsResponse},
     transaction::{CertifiedTransaction, Transaction, VerifiedTransaction},
 };
 use sui_types::{
@@ -272,6 +273,14 @@ impl AuthorityAPI for LocalAuthorityClient {
         unimplemented!()
     }
 
+    async fn wait_for_effects(
+        &self,
+        _request: RawWaitForEffectsRequest,
+        _client_addr: Option<SocketAddr>,
+    ) -> Result<RawWaitForEffectsResponse, SuiError> {
+        unimplemented!()
+    }
+
     async fn handle_object_info_request(
         &self,
         request: ObjectInfoRequest,
@@ -470,6 +479,14 @@ impl AuthorityAPI for MockAuthorityApi {
         unimplemented!()
     }
 
+    async fn wait_for_effects(
+        &self,
+        _request: RawWaitForEffectsRequest,
+        _client_addr: Option<SocketAddr>,
+    ) -> Result<RawWaitForEffectsResponse, SuiError> {
+        unimplemented!()
+    }
+
     /// Handle Object information requests for this account.
     async fn handle_object_info_request(
         &self,
@@ -575,6 +592,14 @@ impl AuthorityAPI for HandleTransactionTestAuthorityClient {
         _request: HandleSoftBundleCertificatesRequestV3,
         _client_addr: Option<SocketAddr>,
     ) -> Result<HandleSoftBundleCertificatesResponseV3, SuiError> {
+        unimplemented!()
+    }
+
+    async fn wait_for_effects(
+        &self,
+        _request: RawWaitForEffectsRequest,
+        _client_addr: Option<SocketAddr>,
+    ) -> Result<RawWaitForEffectsResponse, SuiError> {
         unimplemented!()
     }
 

--- a/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
+++ b/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
@@ -203,7 +203,7 @@ async fn test_wait_for_effects_post_commit_rejected() {
         let epoch_store = state_clone.epoch_store_for_testing();
         epoch_store.set_consensus_tx_status(tx_position, ConsensusTxStatus::FastpathCertified);
         tokio::time::sleep(Duration::from_millis(100)).await;
-        epoch_store.set_consensus_tx_status(tx_position, ConsensusTxStatus::IndirectlyRejected);
+        epoch_store.set_consensus_tx_status(tx_position, ConsensusTxStatus::Rejected);
     });
 
     let response = test_context
@@ -215,10 +215,9 @@ async fn test_wait_for_effects_post_commit_rejected() {
         .unwrap();
 
     match response {
-        WaitForEffectsResponse::Rejected { reason, is_quorum } => {
+        WaitForEffectsResponse::Rejected { reason } => {
             // TODO(fastpath): Test reject reason.
             assert_eq!(reason, RejectReason::None);
-            assert!(!is_quorum);
         }
         _ => panic!("Expected Rejected response"),
     }
@@ -298,7 +297,7 @@ async fn test_wait_for_effects_quorum_rejected() {
     tokio::spawn(async move {
         tokio::time::sleep(Duration::from_millis(100)).await;
         let epoch_store = state_clone.epoch_store_for_testing();
-        epoch_store.set_consensus_tx_status(tx_position, ConsensusTxStatus::QuorumRejected);
+        epoch_store.set_consensus_tx_status(tx_position, ConsensusTxStatus::Rejected);
     });
 
     let response = test_context
@@ -310,9 +309,8 @@ async fn test_wait_for_effects_quorum_rejected() {
         .unwrap();
 
     match response {
-        WaitForEffectsResponse::Rejected { reason, is_quorum } => {
+        WaitForEffectsResponse::Rejected { reason } => {
             assert_eq!(reason, RejectReason::None);
-            assert!(is_quorum);
         }
         _ => panic!("Expected Rejected response"),
     }

--- a/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
+++ b/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
@@ -365,11 +365,9 @@ async fn test_wait_for_effects_fastpath_certified() {
         WaitForEffectsResponse::Executed {
             details,
             effects_digest,
-            finalized,
         } => {
             assert!(details.is_none());
             assert_eq!(effects_digest, exec_effects.digest());
-            assert!(!finalized);
         }
         _ => panic!("Expected Executed response"),
     }
@@ -426,11 +424,9 @@ async fn test_wait_for_effects_finalized() {
         WaitForEffectsResponse::Executed {
             details,
             effects_digest,
-            finalized,
         } => {
             assert!(details.is_none());
             assert_eq!(effects_digest, exec_effects.digest());
-            assert!(finalized);
         }
         _ => panic!("Expected Executed response"),
     }

--- a/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
+++ b/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
@@ -1,0 +1,427 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use consensus_core::{BlockRef, TransactionIndex};
+use fastcrypto::traits::KeyPair;
+use sui_test_transaction_builder::TestTransactionBuilder;
+use sui_types::base_types::{ObjectRef, SuiAddress, TransactionDigest};
+use sui_types::crypto::{get_account_key_pair, AccountKeyPair};
+use sui_types::executable_transaction::VerifiedExecutableTransaction;
+use sui_types::message_envelope::Message;
+use sui_types::messages_grpc::RawWaitForEffectsRequest;
+use sui_types::object::Object;
+use sui_types::transaction::VerifiedTransaction;
+use sui_types::utils::to_sender_signed_transaction;
+
+use crate::authority::consensus_tx_status_cache::ConsensusTxStatus;
+use crate::authority::test_authority_builder::TestAuthorityBuilder;
+use crate::authority::AuthorityState;
+use crate::authority_client::{AuthorityAPI, NetworkAuthorityClient};
+use crate::authority_server::AuthorityServer;
+use crate::wait_for_effects_request::{
+    ConsensusTxPosition, RejectReason, WaitForEffectsRequest, WaitForEffectsResponse,
+};
+
+use super::AuthorityServerHandle;
+
+struct TestContext {
+    state: Arc<AuthorityState>,
+    _server_handle: AuthorityServerHandle,
+    client: NetworkAuthorityClient,
+    sender: SuiAddress,
+    keypair: AccountKeyPair,
+    gas_object_ref: ObjectRef,
+}
+
+impl TestContext {
+    async fn new() -> Self {
+        let (sender, keypair) = get_account_key_pair();
+        let gas_object = Object::with_owner_for_testing(sender);
+        let gas_object_ref = gas_object.compute_object_reference();
+        let state = TestAuthorityBuilder::new()
+            .with_starting_objects(&[gas_object])
+            .build()
+            .await;
+        let server_handle = AuthorityServer::new_for_test(state.clone())
+            .spawn_for_test()
+            .await
+            .unwrap();
+        let client = NetworkAuthorityClient::connect(
+            server_handle.address(),
+            Some(state.config.network_key_pair().public().to_owned()),
+        )
+        .await
+        .unwrap();
+
+        Self {
+            state,
+            _server_handle: server_handle,
+            client,
+            sender,
+            keypair,
+            gas_object_ref,
+        }
+    }
+
+    fn build_test_transaction(&self) -> VerifiedExecutableTransaction {
+        let tx_data = TestTransactionBuilder::new(
+            self.sender,
+            self.gas_object_ref,
+            self.state.reference_gas_price_for_testing().unwrap(),
+        )
+        .transfer_sui(None, self.sender)
+        .build();
+        let tx = to_sender_signed_transaction(tx_data, &self.keypair);
+        VerifiedExecutableTransaction::new_from_checkpoint(
+            VerifiedTransaction::new_unchecked(tx),
+            self.state.epoch_store_for_testing().epoch(),
+            1,
+        )
+    }
+}
+
+#[tokio::test]
+async fn test_wait_for_effects_basic() {
+    // This test exercises the normal happy path where the transaction is fastpath certified through consensus,
+    // then executed.
+    // wait_for_effects() will return Executed response with the effects.
+    let test_context = TestContext::new().await;
+
+    let transaction = test_context.build_test_transaction();
+    let tx_digest = *transaction.digest();
+    let tx_position = ConsensusTxPosition {
+        block: BlockRef::MIN,
+        index: TransactionIndex::MIN,
+    };
+
+    let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
+        epoch: 0,
+        transaction_digest: tx_digest,
+        transaction_position: tx_position,
+        include_details: true,
+    })
+    .unwrap();
+
+    let state_clone = test_context.state.clone();
+    let exec_handle = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let epoch_store = state_clone.epoch_store_for_testing();
+        epoch_store.set_consensus_tx_status(tx_position, ConsensusTxStatus::FastpathCertified);
+        state_clone
+            .try_execute_immediately(&transaction, None, &epoch_store)
+            .await
+            .unwrap()
+            .0
+    });
+
+    let response: WaitForEffectsResponse = test_context
+        .client
+        .wait_for_effects(request, None)
+        .await
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    let exec_effects = exec_handle.await.unwrap();
+    match response {
+        WaitForEffectsResponse::Executed { details, .. } => {
+            let details = details.unwrap();
+            assert_eq!(details.effects, exec_effects);
+        }
+        _ => panic!("Expected Executed response"),
+    }
+}
+
+#[tokio::test]
+async fn test_wait_for_effects_position_mismatch() {
+    // This test exercise the path where if the position of the transaction
+    // triggered the execution differs from the position in the request,
+    // the request will timeout.
+    let test_context = TestContext::new().await;
+
+    let transaction = test_context.build_test_transaction();
+    let tx_digest = *transaction.digest();
+    let tx_position1 = ConsensusTxPosition {
+        block: BlockRef::MIN,
+        index: TransactionIndex::MIN,
+    };
+    let tx_position2 = ConsensusTxPosition {
+        block: BlockRef::MIN,
+        index: TransactionIndex::MIN + 1,
+    };
+
+    let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
+        epoch: 0,
+        transaction_digest: tx_digest,
+        transaction_position: tx_position1,
+        include_details: true,
+    })
+    .unwrap();
+
+    let state_clone = test_context.state.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let epoch_store = state_clone.epoch_store_for_testing();
+        epoch_store.set_consensus_tx_status(tx_position2, ConsensusTxStatus::FastpathCertified);
+        state_clone
+            .try_execute_immediately(&transaction, None, &epoch_store)
+            .await
+            .unwrap()
+            .0
+    });
+
+    let response = test_context.client.wait_for_effects(request, None).await;
+
+    assert!(response.is_err());
+}
+
+#[tokio::test]
+async fn test_wait_for_effects_post_commit_rejected() {
+    let test_context = TestContext::new().await;
+
+    let transaction = test_context.build_test_transaction();
+    let tx_digest = *transaction.digest();
+    let tx_position = ConsensusTxPosition {
+        block: BlockRef::MIN,
+        index: TransactionIndex::MIN,
+    };
+
+    let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
+        epoch: 0,
+        transaction_digest: tx_digest,
+        transaction_position: tx_position,
+        include_details: true,
+    })
+    .unwrap();
+
+    let state_clone = test_context.state.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let epoch_store = state_clone.epoch_store_for_testing();
+        epoch_store.set_consensus_tx_status(tx_position, ConsensusTxStatus::FastpathCertified);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        epoch_store.set_consensus_tx_status(tx_position, ConsensusTxStatus::IndirectlyRejected);
+    });
+
+    let response = test_context
+        .client
+        .wait_for_effects(request, None)
+        .await
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    match response {
+        WaitForEffectsResponse::Rejected { reason, is_quorum } => {
+            // TODO(fastpath): Test reject reason.
+            assert_eq!(reason, RejectReason::None);
+            assert!(!is_quorum);
+        }
+        _ => panic!("Expected Rejected response"),
+    }
+}
+
+#[tokio::test]
+async fn test_wait_for_effects_epoch_mismatch() {
+    // This test exercises the path where the epoch of the request does not match the epoch
+    // of the authority.
+    let test_context = TestContext::new().await;
+
+    let tx_digest = TransactionDigest::random();
+    let tx_position = ConsensusTxPosition {
+        block: BlockRef::MIN,
+        index: TransactionIndex::MIN,
+    };
+
+    let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
+        epoch: 1,
+        transaction_digest: tx_digest,
+        transaction_position: tx_position,
+        include_details: true,
+    })
+    .unwrap();
+
+    let response = test_context.client.wait_for_effects(request, None).await;
+
+    assert!(response.is_err());
+}
+
+#[tokio::test]
+async fn test_wait_for_effects_timeout() {
+    // This test exercises the path where the transaction is never executed.
+    // The request will timeout.
+    let test_context = TestContext::new().await;
+
+    let tx_digest = TransactionDigest::random();
+    let tx_position = ConsensusTxPosition {
+        block: BlockRef::MIN,
+        index: TransactionIndex::MIN,
+    };
+
+    let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
+        epoch: 0,
+        transaction_digest: tx_digest,
+        transaction_position: tx_position,
+        include_details: true,
+    })
+    .unwrap();
+
+    let response = test_context.client.wait_for_effects(request, None).await;
+
+    assert!(response.is_err());
+}
+
+#[tokio::test]
+async fn test_wait_for_effects_quorum_rejected() {
+    // This test exercises the path where the transaction is rejected by a quorum in consensus.
+    let test_context = TestContext::new().await;
+
+    let transaction = test_context.build_test_transaction();
+    let tx_digest = *transaction.digest();
+    let tx_position = ConsensusTxPosition {
+        block: BlockRef::MIN,
+        index: TransactionIndex::MIN,
+    };
+
+    let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
+        epoch: 0,
+        transaction_digest: tx_digest,
+        transaction_position: tx_position,
+        include_details: true,
+    })
+    .unwrap();
+
+    let state_clone = test_context.state.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let epoch_store = state_clone.epoch_store_for_testing();
+        epoch_store.set_consensus_tx_status(tx_position, ConsensusTxStatus::QuorumRejected);
+    });
+
+    let response = test_context
+        .client
+        .wait_for_effects(request, None)
+        .await
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    match response {
+        WaitForEffectsResponse::Rejected { reason, is_quorum } => {
+            assert_eq!(reason, RejectReason::None);
+            assert!(is_quorum);
+        }
+        _ => panic!("Expected Rejected response"),
+    }
+}
+
+#[tokio::test]
+async fn test_wait_for_effects_finalized() {
+    telemetry_subscribers::init_for_testing();
+    // This test exercises the path where the transaction is first fastpath certified,
+    // then finalized, and then executed.
+    let test_context = TestContext::new().await;
+
+    let transaction = test_context.build_test_transaction();
+    let tx_digest = *transaction.digest();
+    let tx_position = ConsensusTxPosition {
+        block: BlockRef::MIN,
+        index: TransactionIndex::MIN,
+    };
+
+    let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
+        epoch: 0,
+        transaction_digest: tx_digest,
+        transaction_position: tx_position,
+        // Also test the case where details are not requested.
+        include_details: false,
+    })
+    .unwrap();
+
+    let state_clone = test_context.state.clone();
+    let exec_handle = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let epoch_store = state_clone.epoch_store_for_testing();
+        epoch_store.set_consensus_tx_status(tx_position, ConsensusTxStatus::FastpathCertified);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        epoch_store.set_consensus_tx_status(tx_position, ConsensusTxStatus::Finalized);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        state_clone
+            .try_execute_immediately(&transaction, None, &epoch_store)
+            .await
+            .unwrap()
+            .0
+    });
+
+    let response = test_context
+        .client
+        .wait_for_effects(request, None)
+        .await
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    let exec_effects = exec_handle.await.unwrap();
+    match response {
+        WaitForEffectsResponse::Executed {
+            details,
+            effects_digest,
+        } => {
+            assert!(details.is_none());
+            assert_eq!(effects_digest, exec_effects.digest());
+        }
+        _ => panic!("Expected Executed response"),
+    }
+}
+
+#[tokio::test]
+async fn test_wait_for_effects_expired() {
+    let test_context = TestContext::new().await;
+
+    let transaction = test_context.build_test_transaction();
+    let tx_digest = *transaction.digest();
+    let tx_position = ConsensusTxPosition {
+        block: BlockRef::MIN,
+        index: TransactionIndex::MIN,
+    };
+
+    let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
+        epoch: 0,
+        transaction_digest: tx_digest,
+        transaction_position: tx_position,
+        include_details: true,
+    })
+    .unwrap();
+
+    let state_clone = test_context.state.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let epoch_store = state_clone.epoch_store_for_testing();
+        epoch_store
+            .consensus_tx_status_cache
+            .as_ref()
+            .unwrap()
+            .update_last_committed_round(epoch_store.protocol_config().gc_depth() as u64 + 1)
+            .await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        epoch_store.set_consensus_tx_status(tx_position, ConsensusTxStatus::Finalized);
+        state_clone
+            .try_execute_immediately(&transaction, None, &epoch_store)
+            .await
+            .unwrap()
+            .0
+    });
+
+    let response = test_context
+        .client
+        .wait_for_effects(request, None)
+        .await
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    assert!(matches!(response, WaitForEffectsResponse::Expired(_)));
+}

--- a/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
+++ b/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
@@ -84,58 +84,6 @@ impl TestContext {
 }
 
 #[tokio::test]
-async fn test_wait_for_effects_basic() {
-    // This test exercises the normal happy path where the transaction is fastpath certified through consensus,
-    // then executed.
-    // wait_for_effects() will return Executed response with the effects.
-    let test_context = TestContext::new().await;
-
-    let transaction = test_context.build_test_transaction();
-    let tx_digest = *transaction.digest();
-    let tx_position = ConsensusTxPosition {
-        block: BlockRef::MIN,
-        index: TransactionIndex::MIN,
-    };
-
-    let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
-        epoch: 0,
-        transaction_digest: tx_digest,
-        transaction_position: tx_position,
-        include_details: true,
-    })
-    .unwrap();
-
-    let state_clone = test_context.state.clone();
-    let exec_handle = tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        let epoch_store = state_clone.epoch_store_for_testing();
-        epoch_store.set_consensus_tx_status(tx_position, ConsensusTxStatus::FastpathCertified);
-        state_clone
-            .try_execute_immediately(&transaction, None, &epoch_store)
-            .await
-            .unwrap()
-            .0
-    });
-
-    let response: WaitForEffectsResponse = test_context
-        .client
-        .wait_for_effects(request, None)
-        .await
-        .unwrap()
-        .try_into()
-        .unwrap();
-
-    let exec_effects = exec_handle.await.unwrap();
-    match response {
-        WaitForEffectsResponse::Executed { details, .. } => {
-            let details = details.unwrap();
-            assert_eq!(details.effects, exec_effects);
-        }
-        _ => panic!("Expected Executed response"),
-    }
-}
-
-#[tokio::test]
 async fn test_wait_for_effects_position_mismatch() {
     // This test exercise the path where if the position of the transaction
     // triggered the execution differs from the position in the request,
@@ -318,7 +266,6 @@ async fn test_wait_for_effects_quorum_rejected() {
 
 #[tokio::test]
 async fn test_wait_for_effects_fastpath_certified() {
-    telemetry_subscribers::init_for_testing();
     // This test exercises the path where the transaction is first fastpath certified,
     // then executed right away.
     let test_context = TestContext::new().await;

--- a/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
+++ b/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
@@ -16,7 +16,9 @@ use sui_types::object::Object;
 use sui_types::transaction::VerifiedTransaction;
 use sui_types::utils::to_sender_signed_transaction;
 
-use crate::authority::consensus_tx_status_cache::ConsensusTxStatus;
+use crate::authority::consensus_tx_status_cache::{
+    ConsensusTxStatus, CONSENSUS_STATUS_RETENTION_ROUNDS,
+};
 use crate::authority::test_authority_builder::TestAuthorityBuilder;
 use crate::authority::AuthorityState;
 use crate::authority_client::{AuthorityAPI, NetworkAuthorityClient};
@@ -406,7 +408,7 @@ async fn test_wait_for_effects_expired() {
             .consensus_tx_status_cache
             .as_ref()
             .unwrap()
-            .update_last_committed_leader_round(epoch_store.protocol_config().gc_depth() as u64 + 1)
+            .update_last_committed_leader_round(CONSENSUS_STATUS_RETENTION_ROUNDS + 1)
             .await;
         tokio::time::sleep(Duration::from_millis(100)).await;
         epoch_store.set_consensus_tx_status(tx_position, ConsensusTxStatus::Finalized);

--- a/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
+++ b/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
@@ -406,7 +406,7 @@ async fn test_wait_for_effects_expired() {
             .consensus_tx_status_cache
             .as_ref()
             .unwrap()
-            .update_last_committed_round(epoch_store.protocol_config().gc_depth() as u64 + 1)
+            .update_last_committed_leader_round(epoch_store.protocol_config().gc_depth() as u64 + 1)
             .await;
         tokio::time::sleep(Duration::from_millis(100)).await;
         epoch_store.set_consensus_tx_status(tx_position, ConsensusTxStatus::Finalized);

--- a/crates/sui-core/src/validator_tx_finalizer.rs
+++ b/crates/sui-core/src/validator_tx_finalizer.rs
@@ -304,7 +304,8 @@ mod tests {
         HandleCertificateRequestV3, HandleCertificateResponseV2, HandleCertificateResponseV3,
         HandleSoftBundleCertificatesRequestV3, HandleSoftBundleCertificatesResponseV3,
         HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse, RawSubmitTxRequest,
-        RawSubmitTxResponse, SystemStateRequest, TransactionInfoRequest, TransactionInfoResponse,
+        RawSubmitTxResponse, RawWaitForEffectsRequest, RawWaitForEffectsResponse,
+        SystemStateRequest, TransactionInfoRequest, TransactionInfoResponse,
     };
     use sui_types::object::Object;
     use sui_types::sui_system_state::SuiSystemState;
@@ -385,6 +386,14 @@ mod tests {
             _request: HandleCertificateRequestV3,
             _client_addr: Option<SocketAddr>,
         ) -> Result<HandleCertificateResponseV3, SuiError> {
+            unimplemented!()
+        }
+
+        async fn wait_for_effects(
+            &self,
+            _request: RawWaitForEffectsRequest,
+            _client_addr: Option<SocketAddr>,
+        ) -> Result<RawWaitForEffectsResponse, SuiError> {
             unimplemented!()
         }
 

--- a/crates/sui-core/src/wait_for_effects_request.rs
+++ b/crates/sui-core/src/wait_for_effects_request.rs
@@ -1,0 +1,314 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use consensus_core::{BlockRef, TransactionIndex};
+use serde::{Deserialize, Serialize};
+use sui_types::{
+    committee::EpochId,
+    digests::{TransactionDigest, TransactionEffectsDigest},
+    effects::{TransactionEffects, TransactionEvents},
+    error::SuiError,
+    messages_consensus::Round,
+    messages_grpc::{
+        RawRejectReason, RawWaitForEffectsRequest, RawWaitForEffectsResponse,
+        RawWaitForEffectsResponseDetails, RawWaitForEffectsResponseExecuted,
+        RawWaitForEffectsResponseInner, RawWaitForEffectsResponseRejected,
+    },
+    object::Object,
+};
+
+/// The position of a transaction in the consensus.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) struct ConsensusTxPosition {
+    pub block: BlockRef,
+    pub index: TransactionIndex,
+}
+
+pub(crate) struct WaitForEffectsRequest {
+    pub epoch: EpochId,
+    pub transaction_digest: TransactionDigest,
+    pub transaction_position: ConsensusTxPosition,
+    /// Whether to include details of the effects,
+    /// including the effects content, events, input objects, and output objects.
+    pub include_details: bool,
+}
+
+pub(crate) struct EffectsDetails {
+    pub effects: TransactionEffects,
+    pub events: Option<TransactionEvents>,
+    pub input_objects: Vec<Object>,
+    pub output_objects: Vec<Object>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RejectReason {
+    // Transaction is not voted to be rejected locally.
+    None,
+    // Rejected due to lock conflict.
+    LockConflict(String),
+    // Rejected due to package verification.
+    PackageVerification(String),
+    // Rejected due to overload.
+    Overload(String),
+    // Rejected due to coin deny list.
+    CoinDenyList,
+}
+
+pub(crate) enum WaitForEffectsResponse {
+    Executed {
+        effects_digest: TransactionEffectsDigest,
+        details: Option<Box<EffectsDetails>>,
+    },
+    Rejected {
+        // The rejection reason known locally.
+        reason: RejectReason,
+        // Whether the rejection is due to a quorum of reject votes.
+        is_quorum: bool,
+    },
+    // The transaction position is expired at the committed round.
+    Expired(Round),
+}
+
+impl TryFrom<RawWaitForEffectsRequest> for WaitForEffectsRequest {
+    type Error = SuiError;
+
+    fn try_from(value: RawWaitForEffectsRequest) -> Result<Self, Self::Error> {
+        let transaction_digest = bcs::from_bytes(&value.transaction_digest).map_err(|err| {
+            SuiError::GrpcMessageDeserializeError {
+                type_info: "RawWaitForEffectsRequest.transaction_digest".to_string(),
+                error: err.to_string(),
+            }
+        })?;
+        let transaction_position = bcs::from_bytes(&value.transaction_position).map_err(|err| {
+            SuiError::GrpcMessageDeserializeError {
+                type_info: "RawWaitForEffectsRequest.transaction_position".to_string(),
+                error: err.to_string(),
+            }
+        })?;
+        Ok(Self {
+            epoch: value.epoch,
+            transaction_digest,
+            transaction_position,
+            include_details: value.include_details,
+        })
+    }
+}
+
+impl TryFrom<RawWaitForEffectsResponse> for WaitForEffectsResponse {
+    type Error = SuiError;
+
+    fn try_from(value: RawWaitForEffectsResponse) -> Result<Self, Self::Error> {
+        match value.inner {
+            Some(RawWaitForEffectsResponseInner::Executed(executed)) => {
+                let effects_digest = bcs::from_bytes(&executed.effects_digest).map_err(|err| {
+                    SuiError::GrpcMessageDeserializeError {
+                        type_info: "RawWaitForEffectsResponse.effects_digest".to_string(),
+                        error: err.to_string(),
+                    }
+                })?;
+                let details = if let Some(details) = executed.details {
+                    let effects = bcs::from_bytes(&details.effects).map_err(|err| {
+                        SuiError::GrpcMessageDeserializeError {
+                            type_info: "RawWaitForEffectsResponse.details.effects".to_string(),
+                            error: err.to_string(),
+                        }
+                    })?;
+                    let events = if let Some(events) = details.events {
+                        Some(bcs::from_bytes(&events).map_err(|err| {
+                            SuiError::GrpcMessageDeserializeError {
+                                type_info: "RawWaitForEffectsResponse.details.events".to_string(),
+                                error: err.to_string(),
+                            }
+                        })?)
+                    } else {
+                        None
+                    };
+                    let mut input_objects = Vec::with_capacity(details.input_objects.len());
+                    for object in details.input_objects {
+                        input_objects.push(bcs::from_bytes(&object).map_err(|err| {
+                            SuiError::GrpcMessageDeserializeError {
+                                type_info: "RawWaitForEffectsResponse.input_objects".to_string(),
+                                error: err.to_string(),
+                            }
+                        })?);
+                    }
+                    let mut output_objects = Vec::with_capacity(details.output_objects.len());
+                    for object in details.output_objects {
+                        output_objects.push(bcs::from_bytes(&object).map_err(|err| {
+                            SuiError::GrpcMessageDeserializeError {
+                                type_info: "RawWaitForEffectsResponse.output_objects".to_string(),
+                                error: err.to_string(),
+                            }
+                        })?);
+                    }
+                    Some(Box::new(EffectsDetails {
+                        effects,
+                        events,
+                        input_objects,
+                        output_objects,
+                    }))
+                } else {
+                    None
+                };
+                Ok(Self::Executed {
+                    effects_digest,
+                    details,
+                })
+            }
+            Some(RawWaitForEffectsResponseInner::Rejected(rejected)) => {
+                let raw_reason = RawRejectReason::try_from(rejected.reason).map_err(|err| {
+                    SuiError::GrpcMessageDeserializeError {
+                        type_info: "RawWaitForEffectsResponse.rejected.reason".to_string(),
+                        error: err.to_string(),
+                    }
+                })?;
+                let reason = match raw_reason {
+                    RawRejectReason::None => RejectReason::None,
+                    RawRejectReason::LockConflict => {
+                        RejectReason::LockConflict(rejected.message.unwrap_or_default())
+                    }
+                    RawRejectReason::PackageVerification => {
+                        RejectReason::PackageVerification(rejected.message.unwrap_or_default())
+                    }
+                    RawRejectReason::Overload => {
+                        RejectReason::Overload(rejected.message.unwrap_or_default())
+                    }
+                    RawRejectReason::CoinDenyList => RejectReason::CoinDenyList,
+                };
+                Ok(Self::Rejected {
+                    reason,
+                    is_quorum: rejected.is_quorum,
+                })
+            }
+            Some(RawWaitForEffectsResponseInner::Expired(round)) => Ok(Self::Expired(round)),
+            None => Err(SuiError::GrpcMessageDeserializeError {
+                type_info: "RawWaitForEffectsResponse.inner".to_string(),
+                error: "RawWaitForEffectsResponse.inner is None".to_string(),
+            }),
+        }
+    }
+}
+
+impl TryFrom<WaitForEffectsRequest> for RawWaitForEffectsRequest {
+    type Error = SuiError;
+
+    fn try_from(value: WaitForEffectsRequest) -> Result<Self, Self::Error> {
+        let transaction_digest = bcs::to_bytes(&value.transaction_digest)
+            .map_err(|err| SuiError::GrpcMessageSerializeError {
+                type_info: "RawWaitForEffectsRequest.transaction_digest".to_string(),
+                error: err.to_string(),
+            })?
+            .into();
+        let transaction_position = bcs::to_bytes(&value.transaction_position)
+            .map_err(|err| SuiError::GrpcMessageSerializeError {
+                type_info: "RawWaitForEffectsRequest.transaction_position".to_string(),
+                error: err.to_string(),
+            })?
+            .into();
+        Ok(Self {
+            epoch: value.epoch,
+            transaction_digest,
+            transaction_position,
+            include_details: value.include_details,
+        })
+    }
+}
+
+impl TryFrom<WaitForEffectsResponse> for RawWaitForEffectsResponse {
+    type Error = SuiError;
+
+    fn try_from(value: WaitForEffectsResponse) -> Result<Self, Self::Error> {
+        let inner = match value {
+            WaitForEffectsResponse::Executed {
+                effects_digest,
+                details,
+            } => {
+                let effects_digest = bcs::to_bytes(&effects_digest)
+                    .map_err(|err| SuiError::GrpcMessageSerializeError {
+                        type_info: "RawWaitForEffectsResponse.effects_digest".to_string(),
+                        error: err.to_string(),
+                    })?
+                    .into();
+                let details = if let Some(details) = details {
+                    let effects = bcs::to_bytes(&details.effects)
+                        .map_err(|err| SuiError::GrpcMessageSerializeError {
+                            type_info: "RawWaitForEffectsResponse.details.effects".to_string(),
+                            error: err.to_string(),
+                        })?
+                        .into();
+                    let events = if let Some(events) = &details.events {
+                        Some(
+                            bcs::to_bytes(events)
+                                .map_err(|err| SuiError::GrpcMessageSerializeError {
+                                    type_info: "RawWaitForEffectsResponse.details.events"
+                                        .to_string(),
+                                    error: err.to_string(),
+                                })?
+                                .into(),
+                        )
+                    } else {
+                        None
+                    };
+                    let mut input_objects = Vec::with_capacity(details.input_objects.len());
+                    for object in details.input_objects {
+                        input_objects.push(
+                            bcs::to_bytes(&object)
+                                .map_err(|err| SuiError::GrpcMessageSerializeError {
+                                    type_info: "RawWaitForEffectsResponse.input_objects"
+                                        .to_string(),
+                                    error: err.to_string(),
+                                })?
+                                .into(),
+                        );
+                    }
+                    let mut output_objects = Vec::with_capacity(details.output_objects.len());
+                    for object in details.output_objects {
+                        output_objects.push(
+                            bcs::to_bytes(&object)
+                                .map_err(|err| SuiError::GrpcMessageSerializeError {
+                                    type_info: "RawWaitForEffectsResponse.output_objects"
+                                        .to_string(),
+                                    error: err.to_string(),
+                                })?
+                                .into(),
+                        );
+                    }
+                    Some(RawWaitForEffectsResponseDetails {
+                        effects,
+                        events,
+                        input_objects,
+                        output_objects,
+                    })
+                } else {
+                    None
+                };
+                RawWaitForEffectsResponseInner::Executed(RawWaitForEffectsResponseExecuted {
+                    effects_digest,
+                    details,
+                })
+            }
+            WaitForEffectsResponse::Rejected { reason, is_quorum } => {
+                let (reason, message) = match reason {
+                    RejectReason::None => (RawRejectReason::None, None),
+                    RejectReason::LockConflict(message) => {
+                        (RawRejectReason::LockConflict, Some(message))
+                    }
+                    RejectReason::PackageVerification(message) => {
+                        (RawRejectReason::PackageVerification, Some(message))
+                    }
+                    RejectReason::Overload(message) => (RawRejectReason::Overload, Some(message)),
+                    RejectReason::CoinDenyList => (RawRejectReason::CoinDenyList, None),
+                };
+                RawWaitForEffectsResponseInner::Rejected(RawWaitForEffectsResponseRejected {
+                    reason: reason as i32,
+                    message,
+                    is_quorum,
+                })
+            }
+            WaitForEffectsResponse::Expired(round) => {
+                RawWaitForEffectsResponseInner::Expired(round)
+            }
+        };
+        Ok(RawWaitForEffectsResponse { inner: Some(inner) })
+    }
+}

--- a/crates/sui-core/src/wait_for_effects_request.rs
+++ b/crates/sui-core/src/wait_for_effects_request.rs
@@ -57,7 +57,6 @@ pub(crate) enum WaitForEffectsResponse {
     Executed {
         effects_digest: TransactionEffectsDigest,
         details: Option<Box<ExecutedData>>,
-        finalized: bool,
     },
     Rejected {
         // The rejection reason known locally.
@@ -151,7 +150,6 @@ impl TryFrom<RawWaitForEffectsResponse> for WaitForEffectsResponse {
                 Ok(Self::Executed {
                     effects_digest,
                     details,
-                    finalized: executed.finalized,
                 })
             }
             Some(RawValidatorTransactionStatus::Rejected(rejected)) => {
@@ -218,7 +216,6 @@ impl TryFrom<WaitForEffectsResponse> for RawWaitForEffectsResponse {
             WaitForEffectsResponse::Executed {
                 effects_digest,
                 details,
-                finalized,
             } => {
                 let effects_digest = bcs::to_bytes(&effects_digest)
                     .map_err(|err| SuiError::GrpcMessageSerializeError {
@@ -282,7 +279,6 @@ impl TryFrom<WaitForEffectsResponse> for RawWaitForEffectsResponse {
                 RawValidatorTransactionStatus::Executed(RawExecutedStatus {
                     effects_digest,
                     details,
-                    finalized,
                 })
             }
             WaitForEffectsResponse::Rejected { reason } => {

--- a/crates/sui-core/src/wait_for_effects_request.rs
+++ b/crates/sui-core/src/wait_for_effects_request.rs
@@ -58,6 +58,7 @@ pub(crate) enum WaitForEffectsResponse {
     Executed {
         effects_digest: TransactionEffectsDigest,
         details: Option<Box<EffectsDetails>>,
+        finalized: bool,
     },
     Rejected {
         // The rejection reason known locally.
@@ -151,6 +152,7 @@ impl TryFrom<RawWaitForEffectsResponse> for WaitForEffectsResponse {
                 Ok(Self::Executed {
                     effects_digest,
                     details,
+                    finalized: executed.finalized,
                 })
             }
             Some(RawWaitForEffectsResponseInner::Rejected(rejected)) => {
@@ -217,6 +219,7 @@ impl TryFrom<WaitForEffectsResponse> for RawWaitForEffectsResponse {
             WaitForEffectsResponse::Executed {
                 effects_digest,
                 details,
+                finalized,
             } => {
                 let effects_digest = bcs::to_bytes(&effects_digest)
                     .map_err(|err| SuiError::GrpcMessageSerializeError {
@@ -280,6 +283,7 @@ impl TryFrom<WaitForEffectsResponse> for RawWaitForEffectsResponse {
                 RawWaitForEffectsResponseInner::Executed(RawWaitForEffectsResponseExecuted {
                     effects_digest,
                     details,
+                    finalized,
                 })
             }
             WaitForEffectsResponse::Rejected { reason } => {

--- a/crates/sui-network/build.rs
+++ b/crates/sui-network/build.rs
@@ -35,6 +35,15 @@ fn main() -> Result<()> {
         )
         .method(
             Method::builder()
+                .name("wait_for_effects")
+                .route_name("WaitForEffects")
+                .input_type("sui_types::messages_grpc::RawWaitForEffectsRequest")
+                .output_type("sui_types::messages_grpc::RawWaitForEffectsResponse")
+                .codec_path(prost_codec_path)
+                .build(),
+        )
+        .method(
+            Method::builder()
                 .name("transaction")
                 .route_name("Transaction")
                 .input_type("sui_types::transaction::Transaction")

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -702,6 +702,16 @@ pub enum SuiError {
 
     #[error("Nitro attestation verify failed: {0}")]
     NitroAttestationFailedToVerify(String),
+
+    // TODO: Use a nested enum for the different reasons for rejection instead of a string.
+    #[error("Transaction rejected by consensus, reason: {reason}")]
+    TransactionRejectedByConsensus { reason: String },
+
+    #[error("Failed to serialize {type_info:?}, error: {error:?}")]
+    GrpcMessageSerializeError { type_info: String, error: String },
+
+    #[error("Failed to deserialize {type_info:?}, error: {error:?}")]
+    GrpcMessageDeserializeError { type_info: String, error: String },
 }
 
 #[repr(u64)]

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -708,6 +708,12 @@ pub enum SuiError {
 
     #[error("Failed to deserialize {type_info:?}, error: {error:?}")]
     GrpcMessageDeserializeError { type_info: String, error: String },
+
+    #[error("Transaction position is too far ahead: {round:?}, last committed round: {last_committed_round:?}")]
+    InvalidTransactionPosition {
+        round: u64,
+        last_committed_round: u64,
+    },
 }
 
 #[repr(u64)]

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -703,10 +703,6 @@ pub enum SuiError {
     #[error("Nitro attestation verify failed: {0}")]
     NitroAttestationFailedToVerify(String),
 
-    // TODO: Use a nested enum for the different reasons for rejection instead of a string.
-    #[error("Transaction rejected by consensus, reason: {reason}")]
-    TransactionRejectedByConsensus { reason: String },
-
     #[error("Failed to serialize {type_info:?}, error: {error:?}")]
     GrpcMessageSerializeError { type_info: String, error: String },
 

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -709,8 +709,10 @@ pub enum SuiError {
     #[error("Failed to deserialize {type_info:?}, error: {error:?}")]
     GrpcMessageDeserializeError { type_info: String, error: String },
 
-    #[error("Transaction position is too far ahead: {round:?}, last committed round: {last_committed_round:?}")]
-    InvalidTransactionPosition {
+    #[error(
+        "Validator consensus rounds are lagging behind. last committed leader round: {last_committed_round:?}, requested round: {round:?}"
+    )]
+    ValidatorConsensusLagging {
         round: u64,
         last_committed_round: u64,
     },

--- a/crates/sui-types/src/messages_consensus.rs
+++ b/crates/sui-types/src/messages_consensus.rs
@@ -372,6 +372,10 @@ impl ConsensusTransactionKind {
                 | ConsensusTransactionKind::RandomnessDkgConfirmation(_, _)
         )
     }
+
+    pub fn is_user_transaction(&self) -> bool {
+        matches!(self, ConsensusTransactionKind::UserTransaction(_))
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -435,7 +439,7 @@ impl VersionedDkgConfirmation {
     pub fn sender(&self) -> u16 {
         match self {
             VersionedDkgConfirmation::V0() => {
-                panic!("BUG: invalid VersionedDkgConfimation version")
+                panic!("BUG: invalid VersionedDkgConfirmation version")
             }
             VersionedDkgConfirmation::V1(msg) => msg.sender,
         }
@@ -444,7 +448,7 @@ impl VersionedDkgConfirmation {
     pub fn num_of_complaints(&self) -> usize {
         match self {
             VersionedDkgConfirmation::V0() => {
-                panic!("BUG: invalid VersionedDkgConfimation version")
+                panic!("BUG: invalid VersionedDkgConfirmation version")
             }
             VersionedDkgConfirmation::V1(msg) => msg.complaints.len(),
         }

--- a/crates/sui-types/src/messages_grpc.rs
+++ b/crates/sui-types/src/messages_grpc.rs
@@ -423,6 +423,10 @@ pub struct RawWaitForEffectsRequest {
 
 #[derive(Clone, prost::Message)]
 pub struct RawWaitForEffectsResponse {
+    // In order to represent an enum in protobuf, we need to use oneof.
+    // However, oneof also allows the value to be unset, which corresponds to None value.
+    // Hence, we need to use Option type for `inner`.
+    // We expect the value to be set in a valid response.
     #[prost(oneof = "RawValidatorTransactionStatus", tags = "1, 2, 3")]
     pub inner: Option<RawValidatorTransactionStatus>,
 }

--- a/crates/sui-types/src/messages_grpc.rs
+++ b/crates/sui-types/src/messages_grpc.rs
@@ -441,6 +441,8 @@ pub struct RawWaitForEffectsResponseExecuted {
     pub effects_digest: Bytes,
     #[prost(message, optional, tag = "2")]
     pub details: Option<RawWaitForEffectsResponseDetails>,
+    #[prost(bool, tag = "3")]
+    pub finalized: bool,
 }
 
 #[derive(Clone, prost::Message)]

--- a/crates/sui-types/src/messages_grpc.rs
+++ b/crates/sui-types/src/messages_grpc.rs
@@ -443,8 +443,6 @@ pub struct RawExecutedStatus {
     pub effects_digest: Bytes,
     #[prost(message, optional, tag = "2")]
     pub details: Option<RawExecutedData>,
-    #[prost(bool, tag = "3")]
-    pub finalized: bool,
 }
 
 #[derive(Clone, prost::Message)]

--- a/crates/sui-types/src/messages_grpc.rs
+++ b/crates/sui-types/src/messages_grpc.rs
@@ -461,8 +461,6 @@ pub struct RawWaitForEffectsResponseRejected {
     pub reason: i32,
     #[prost(string, optional, tag = "2")]
     pub message: Option<String>, // Only for string-carrying variants
-    #[prost(bool, tag = "3")]
-    pub is_quorum: bool,
 }
 
 #[derive(Clone, Debug, prost::Enumeration)]

--- a/crates/sui-types/src/messages_grpc.rs
+++ b/crates/sui-types/src/messages_grpc.rs
@@ -8,6 +8,7 @@ use crate::effects::{
     VerifiedSignedTransactionEffects,
 };
 use crate::error::SuiError;
+use crate::messages_consensus::Round;
 use crate::object::Object;
 use crate::transaction::{CertifiedTransaction, SenderSignedData, SignedTransaction};
 use bytes::Bytes;
@@ -185,7 +186,7 @@ pub struct SystemStateRequest {
     pub _unused: bool,
 }
 
-/// Response type for version 3 of the handle certifacte validator API.
+/// Response type for version 3 of the handle certificate validator API.
 ///
 /// The corresponding version 3 request type allows for a client to request events as well as
 /// input/output objects from a transaction's execution. Given Validators operate with very
@@ -275,7 +276,8 @@ impl RawSubmitTxResponse {
     ) -> Result<Self, SuiError> {
         Ok(Self {
             effects: bcs::to_bytes(&effects)
-                .map_err(|e| SuiError::TransactionEffectsSerializationError {
+                .map_err(|e| SuiError::GrpcMessageSerializeError {
+                    type_info: "RawSubmitTxResponse.effects".to_string(),
                     error: e.to_string(),
                 })?
                 .into(),
@@ -283,7 +285,8 @@ impl RawSubmitTxResponse {
                 events
                     .map(|e| {
                         bcs::to_bytes(&e)
-                            .map_err(|e| SuiError::TransactionEventsSerializationError {
+                            .map_err(|e| SuiError::GrpcMessageSerializeError {
+                                type_info: "RawSubmitTxResponse.events".to_string(),
                                 error: e.to_string(),
                             })
                             .map(Bytes::from)
@@ -296,7 +299,8 @@ impl RawSubmitTxResponse {
                 .unwrap_or_default()
                 .into_iter()
                 .map(|obj| {
-                    bcs::to_bytes(&obj).map_err(|e| SuiError::ObjectSerializationError {
+                    bcs::to_bytes(&obj).map_err(|e| SuiError::GrpcMessageSerializeError {
+                        type_info: "RawSubmitTxResponse.input_objects".to_string(),
                         error: e.to_string(),
                     })
                 })
@@ -305,7 +309,8 @@ impl RawSubmitTxResponse {
                 .unwrap_or_default()
                 .into_iter()
                 .map(|obj| {
-                    bcs::to_bytes(&obj).map_err(|e| SuiError::ObjectSerializationError {
+                    bcs::to_bytes(&obj).map_err(|e| SuiError::GrpcMessageSerializeError {
+                        type_info: "RawSubmitTxResponse.output_objects".to_string(),
                         error: e.to_string(),
                     })
                 })
@@ -337,7 +342,8 @@ impl SubmitTxResponse {
     ) -> Result<Self, SuiError> {
         Ok(Self {
             effects: bcs::from_bytes(&effects).map_err(|e| {
-                SuiError::TransactionEffectsDeserializationError {
+                SuiError::GrpcMessageDeserializeError {
+                    type_info: "SubmitTxResponse.effects".to_string(),
                     error: e.to_string(),
                 }
             })?,
@@ -345,7 +351,8 @@ impl SubmitTxResponse {
                 events
                     .map(|events| {
                         bcs::from_bytes(&events).map_err(|e| {
-                            SuiError::TransactionEventsDeserializationError {
+                            SuiError::GrpcMessageDeserializeError {
+                                type_info: "SubmitTxResponse.events".to_string(),
                                 error: e.to_string(),
                             }
                         })
@@ -360,7 +367,8 @@ impl SubmitTxResponse {
                         .into_iter()
                         .map(|object| {
                             bcs::from_bytes(&object).map_err(|e| {
-                                SuiError::ObjectSerializationError {
+                                SuiError::GrpcMessageDeserializeError {
+                                    type_info: "SubmitTxResponse.input_objects".to_string(),
                                     error: e.to_string(),
                                 }
                             })
@@ -376,7 +384,8 @@ impl SubmitTxResponse {
                         .into_iter()
                         .map(|object| {
                             bcs::from_bytes(&object).map_err(|e| {
-                                SuiError::ObjectSerializationError {
+                                SuiError::GrpcMessageDeserializeError {
+                                    type_info: "SubmitTxResponse.output_objects".to_string(),
                                     error: e.to_string(),
                                 }
                             })
@@ -393,6 +402,82 @@ impl SubmitTxResponse {
             },
         })
     }
+}
+
+#[derive(Clone, prost::Message)]
+pub struct RawWaitForEffectsRequest {
+    #[prost(uint64, tag = "1")]
+    pub epoch: u64,
+
+    #[prost(bytes = "bytes", tag = "2")]
+    pub transaction_digest: Bytes,
+
+    #[prost(bytes = "bytes", tag = "3")]
+    pub transaction_position: Bytes,
+
+    #[prost(bool, tag = "4")]
+    pub include_details: bool,
+}
+
+#[derive(Clone, prost::Message)]
+pub struct RawWaitForEffectsResponse {
+    #[prost(oneof = "RawWaitForEffectsResponseInner", tags = "1, 2, 3")]
+    pub inner: Option<RawWaitForEffectsResponseInner>,
+}
+
+#[derive(Clone, prost::Oneof)]
+pub enum RawWaitForEffectsResponseInner {
+    #[prost(message, tag = "1")]
+    Executed(RawWaitForEffectsResponseExecuted),
+    #[prost(message, tag = "2")]
+    Rejected(RawWaitForEffectsResponseRejected),
+    #[prost(uint64, tag = "3")]
+    Expired(Round),
+}
+
+#[derive(Clone, prost::Message)]
+pub struct RawWaitForEffectsResponseExecuted {
+    #[prost(bytes = "bytes", tag = "1")]
+    pub effects_digest: Bytes,
+    #[prost(message, optional, tag = "2")]
+    pub details: Option<RawWaitForEffectsResponseDetails>,
+}
+
+#[derive(Clone, prost::Message)]
+pub struct RawWaitForEffectsResponseDetails {
+    #[prost(bytes = "bytes", tag = "1")]
+    pub effects: Bytes,
+    #[prost(bytes = "bytes", optional, tag = "2")]
+    pub events: Option<Bytes>,
+    #[prost(bytes = "bytes", repeated, tag = "3")]
+    pub input_objects: Vec<Bytes>,
+    #[prost(bytes = "bytes", repeated, tag = "4")]
+    pub output_objects: Vec<Bytes>,
+}
+
+#[derive(Clone, prost::Message)]
+pub struct RawWaitForEffectsResponseRejected {
+    #[prost(enumeration = "RawRejectReason", tag = "1")]
+    pub reason: i32,
+    #[prost(string, optional, tag = "2")]
+    pub message: Option<String>, // Only for string-carrying variants
+    #[prost(bool, tag = "3")]
+    pub is_quorum: bool,
+}
+
+#[derive(Clone, Debug, prost::Enumeration)]
+#[repr(i32)]
+pub enum RawRejectReason {
+    // Transaction is not voted to be rejected locally.
+    None = 0,
+    // Rejected due to lock conflict.
+    LockConflict = 1,
+    // Rejected due to package verification.
+    PackageVerification = 2,
+    // Rejected due to overload.
+    Overload = 3,
+    // Rejected due to coin deny list.
+    CoinDenyList = 4,
 }
 
 impl From<HandleCertificateResponseV3> for HandleCertificateResponseV2 {

--- a/crates/sui-types/src/messages_grpc.rs
+++ b/crates/sui-types/src/messages_grpc.rs
@@ -415,38 +415,40 @@ pub struct RawWaitForEffectsRequest {
     #[prost(bytes = "bytes", tag = "3")]
     pub transaction_position: Bytes,
 
+    /// Whether to include details of the effects,
+    /// including the effects content, events, input objects, and output objects.
     #[prost(bool, tag = "4")]
     pub include_details: bool,
 }
 
 #[derive(Clone, prost::Message)]
 pub struct RawWaitForEffectsResponse {
-    #[prost(oneof = "RawWaitForEffectsResponseInner", tags = "1, 2, 3")]
-    pub inner: Option<RawWaitForEffectsResponseInner>,
+    #[prost(oneof = "RawValidatorTransactionStatus", tags = "1, 2, 3")]
+    pub inner: Option<RawValidatorTransactionStatus>,
 }
 
 #[derive(Clone, prost::Oneof)]
-pub enum RawWaitForEffectsResponseInner {
+pub enum RawValidatorTransactionStatus {
     #[prost(message, tag = "1")]
-    Executed(RawWaitForEffectsResponseExecuted),
+    Executed(RawExecutedStatus),
     #[prost(message, tag = "2")]
-    Rejected(RawWaitForEffectsResponseRejected),
+    Rejected(RawRejectedStatus),
     #[prost(uint64, tag = "3")]
     Expired(Round),
 }
 
 #[derive(Clone, prost::Message)]
-pub struct RawWaitForEffectsResponseExecuted {
+pub struct RawExecutedStatus {
     #[prost(bytes = "bytes", tag = "1")]
     pub effects_digest: Bytes,
     #[prost(message, optional, tag = "2")]
-    pub details: Option<RawWaitForEffectsResponseDetails>,
+    pub details: Option<RawExecutedData>,
     #[prost(bool, tag = "3")]
     pub finalized: bool,
 }
 
 #[derive(Clone, prost::Message)]
-pub struct RawWaitForEffectsResponseDetails {
+pub struct RawExecutedData {
     #[prost(bytes = "bytes", tag = "1")]
     pub effects: Bytes,
     #[prost(bytes = "bytes", optional, tag = "2")]
@@ -458,7 +460,7 @@ pub struct RawWaitForEffectsResponseDetails {
 }
 
 #[derive(Clone, prost::Message)]
-pub struct RawWaitForEffectsResponseRejected {
+pub struct RawRejectedStatus {
     #[prost(enumeration = "RawRejectReason", tag = "1")]
     pub reason: i32,
     #[prost(string, optional, tag = "2")]


### PR DESCRIPTION
## Description 

This PR implements the wait_for_effects gRPC API on validators to support the second query for mysticeti-fastpath, that is waiting for effects on a validator.
The implementation matches the design in https://www.notion.so/mystenlabs/Transaction-Driver-Mysticeti-FPC-client-1356d9dcb4e980559ee1cb5331fbe439?pvs=4#1de6d9dcb4e980238247e5f9553d934f.
A status cache is introduced to remember the current consensus status of for each consensus position (instead of transaction digest). The cache is GCed periodically. When waiting for effects, we first acquire the first status update to ensure that it is not rejected by consensus, then we wait for effects while making sure it is not eventually rejected post-commit.
In the new request, use a single boolean `include_details` to indicate whether we want all detailed data, including effects itself, instead of having individual bools.
Later on when we call this in TransactionDriver, we could sample validators so that most validators only need to return the effects digest, while only at least one needs to return the actual data.

## Test plan 

Added tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [x] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
