### PR TITLE
Re-execute all pending consensus transactions at startup

### DIFF
--- a/crates/sui-core/src/checkpoints/checkpoint_executor/utils.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/utils.rs
@@ -422,6 +422,7 @@ impl PipelineHandle {
 impl Drop for PipelineHandle {
     fn drop(&mut self) {
         if !std::thread::panicking() {
+            // TODO: Add comments explain why this guarantee holds.
             assert_eq!(
                 self.cur_stage,
                 PipelineStage::End,

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -2642,6 +2642,7 @@ impl CheckpointService {
 
         // If this times out, the validator may still start up. The worst that can
         // happen is that we will crash later on (due to missing transactions).
+        // TODO: Explain why it will crash later on.
         if tokio::time::timeout(
             Duration::from_secs(120),
             self.wait_for_rebuilt_checkpoints(),
@@ -2659,6 +2660,7 @@ impl CheckpointService {
 impl CheckpointService {
     /// Waits until all checkpoints had been built before the node restarted
     /// are rebuilt.
+    /// TODO: Add comments explain why we need to wait for checkpoints to be rebuilt.
     pub async fn wait_for_rebuilt_checkpoints(&self) {
         let highest_previously_built_seq = self.highest_previously_built_seq;
         let mut rx = self.highest_currently_built_seq_tx.subscribe();


### PR DESCRIPTION
## Description 

Looks like later on the code will also attempt to rebuild all checkpoints, which depends on all pending transactions executed. Antithesis starts to report failures after the previous change.
So this PR partially revert the code, but with some important differences:
1. Instead of just re-scheduling transactions with locally signed effects, we schedule all fast-path pending consensus transactions.
2. We no longer wait here. Instead, when it rebuild all checkpoints, it will wait anyway.

## Test plan 

Let's see if antithesis would be happy after this.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
