### PR TITLE
[CLI] New Command to remove an address in sui client

### DIFF
--- a/crates/sui-keys/src/keystore.rs
+++ b/crates/sui-keys/src/keystore.rs
@@ -32,6 +32,7 @@ pub enum Keystore {
 #[enum_dispatch]
 pub trait AccountKeystore: Send + Sync {
     fn add_key(&mut self, alias: Option<String>, keypair: SuiKeyPair) -> Result<(), anyhow::Error>;
+    fn remove_key(&mut self, address: SuiAddress) -> Result<(), anyhow::Error>;
     fn keys(&self) -> Vec<PublicKey>;
     fn get_key(&self, address: &SuiAddress) -> Result<&SuiKeyPair, anyhow::Error>;
 
@@ -221,6 +222,13 @@ impl AccountKeystore for FileBasedKeystore {
             },
         );
         self.keys.insert(address, keypair);
+        self.save()?;
+        Ok(())
+    }
+
+    fn remove_key(&mut self, address: SuiAddress) -> Result<(), anyhow::Error> {
+        self.aliases.remove(&address);
+        self.keys.remove(&address);
         self.save()?;
         Ok(())
     }
@@ -492,6 +500,12 @@ impl AccountKeystore for InMemKeystore {
         };
         self.aliases.insert(address, alias);
         self.keys.insert(address, keypair);
+        Ok(())
+    }
+
+    fn remove_key(&mut self, address: SuiAddress) -> Result<(), anyhow::Error> {
+        self.aliases.remove(&address);
+        self.keys.remove(&address);
         Ok(())
     }
 

--- a/crates/sui-keys/tests/tests.rs
+++ b/crates/sui-keys/tests/tests.rs
@@ -279,3 +279,31 @@ fn get_alias_by_address_test() {
     let address = generate_new_key(SignatureScheme::ED25519, None, None).unwrap();
     assert!(keystore.get_alias_by_address(&address.0).is_err())
 }
+
+#[test]
+fn remove_key_test() {
+    let temp_dir = TempDir::new().unwrap();
+    let keystore_path = temp_dir.path().join("sui.keystore");
+    let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path).unwrap());
+
+    let (addr, _, _) = keystore
+        .generate_and_add_new_key(
+            SignatureScheme::ED25519,
+            Some("test_key".to_string()),
+            None,
+            None,
+        )
+        .unwrap();
+
+    let mut aliases_path = keystore_path.clone();
+    aliases_path.set_extension("aliases");
+
+    let aliases_content = fs::read_to_string(&aliases_path).unwrap();
+    assert!(aliases_content.contains("test_key"));
+
+    keystore.remove_key(addr).unwrap();
+
+    // Verify alias is removed from file
+    let aliases_content = fs::read_to_string(&aliases_path).unwrap();
+    assert!(!aliases_content.contains("test_key"));
+}

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -550,6 +550,10 @@ pub enum SuiClientCommands {
         profile_output: Option<PathBuf>,
     },
 
+    /// Remove an existing address by its alias or hexadecimal string.
+    #[clap(name = "remove-address")]
+    RemoveAddress { alias_or_address: String },
+
     /// Replay a given transaction to view transaction effects. Set environment variable MOVE_VM_STEP=1 to debug.
     #[clap(name = "replay-transaction")]
     ReplayTransaction {
@@ -1495,6 +1499,23 @@ impl SuiClientCommands {
                     recovery_phrase: phrase,
                 })
             }
+
+            SuiClientCommands::RemoveAddress { alias_or_address } => {
+                let address: SuiAddress = match context
+                    .config
+                    .keystore
+                    .get_address_by_alias(alias_or_address.clone())
+                {
+                    Ok(addr) => *addr,
+                    Err(_) => SuiAddress::from_str(&alias_or_address)
+                        .map_err(|e| anyhow!("Invalid value: {}", e))?,
+                };
+
+                context.config.keystore.remove_key(address)?;
+
+                SuiClientCommandResult::RemoveAddress(RemoveAddressOutput { alias_or_address })
+            }
+
             SuiClientCommands::Gas { address } => {
                 let address = get_identity_address(address, context)?;
                 let coins = context
@@ -2164,6 +2185,25 @@ impl Display for SuiClientCommandResult {
 
                 write!(f, "{}", table)?
             }
+            SuiClientCommandResult::RemoveAddress(remove_address) => {
+                let mut builder = TableBuilder::default();
+                builder.push_record(vec![remove_address.alias_or_address.as_str()]);
+
+                let mut table = builder.build();
+                table.with(TableStyle::rounded());
+                table.with(TablePanel::header("removed the keypair from keystore."));
+
+                table.with(
+                    TableModify::new(TableCell::new(0, 0))
+                        .with(TableBorder::default().corner_bottom_right('┬')),
+                );
+                table.with(
+                    TableModify::new(TableCell::new(0, 0))
+                        .with(TableBorder::default().corner_top_right('─')),
+                );
+
+                write!(f, "{}", table)?
+            }
             SuiClientCommandResult::Object(object_read) => match object_read.object() {
                 Ok(obj) => {
                     let object = ObjectOutput::from(obj);
@@ -2473,6 +2513,7 @@ impl SuiClientCommandResult {
             | SuiClientCommandResult::NoOutput
             | SuiClientCommandResult::Object(_)
             | SuiClientCommandResult::Objects(_)
+            | SuiClientCommandResult::RemoveAddress(_)
             | SuiClientCommandResult::RawObject(_)
             | SuiClientCommandResult::SerializedSignedTransaction(_)
             | SuiClientCommandResult::SerializedUnsignedTransaction(_)
@@ -2507,6 +2548,12 @@ pub struct NewAddressOutput {
     pub address: SuiAddress,
     pub key_scheme: SignatureScheme,
     pub recovery_phrase: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoveAddressOutput {
+    pub alias_or_address: String,
 }
 
 #[derive(Serialize)]
@@ -2624,6 +2671,7 @@ pub enum SuiClientCommandResult {
     Object(SuiObjectResponse),
     Objects(Vec<SuiObjectResponse>),
     RawObject(SuiObjectResponse),
+    RemoveAddress(RemoveAddressOutput),
     SerializedSignedTransaction(SenderSignedData),
     SerializedUnsignedTransaction(TransactionData),
     Switch(SwitchResponse),

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1508,7 +1508,7 @@ impl SuiClientCommands {
                 {
                     Ok(addr) => *addr,
                     Err(_) => SuiAddress::from_str(&alias_or_address)
-                        .map_err(|e| anyhow!("Invalid value: {}", e))?,
+                        .map_err(|e| anyhow!("Invalid address or alias: {}", e))?,
                 };
 
                 context.config.keystore.remove_key(address)?;

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -2717,6 +2717,33 @@ async fn test_new_address_command_by_flag() -> Result<(), anyhow::Error> {
 }
 
 #[sim_test]
+async fn test_remove_address_command() -> Result<(), anyhow::Error> {
+    let mut cluster = TestClusterBuilder::new().build().await;
+    let context = cluster.wallet_mut();
+
+    let addr = context.config.keystore.addresses().get(1).cloned().unwrap();
+
+    SuiClientCommands::RemoveAddress {
+        alias_or_address: addr.to_string(),
+    }
+    .execute(context)
+    .await?;
+
+    assert_eq!(
+        context
+            .config
+            .keystore
+            .addresses()
+            .iter()
+            .filter(|k| *k == &addr)
+            .count(),
+        0
+    );
+
+    Ok(())
+}
+
+#[sim_test]
 async fn test_active_address_command() -> Result<(), anyhow::Error> {
     let mut cluster = TestClusterBuilder::new().build().await;
     let context = cluster.wallet_mut();


### PR DESCRIPTION
## Description 

Remove an existing address by its alias or hexadecimal string

Usage: `sui client remove-address  <ALIAS_OR_ADDRESS>`

Closes #21845

---

## Release notes

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Added the `sui client remove-address` command to the CLI.
- [ ] Rust SDK:
