### PR TITLE
update fixed_point32 deprecation message

### DIFF
--- a/crates/sui-framework/packages/move-stdlib/sources/fixed_point32.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/fixed_point32.move
@@ -5,7 +5,7 @@
 /// a 32-bit fractional part.
 #[
     deprecated(
-        note = b"Use `std::uq32_32` instead. If you need to convert from a `FixedPoint32` to a `UQ32_32`, you can use the `std::fixed_point32::get_raw_value` with `std::uq32_32::from_raw_value`.",
+        note = b"Use `std::uq32_32` instead. If you need to convert from a `FixedPoint32` to a `UQ32_32`, you can use the `std::fixed_point32::get_raw_value` with `std::uq32_32::from_raw`.",
     ),
 ]
 module std::fixed_point32;


### PR DESCRIPTION
## Description 

This PR changes wording of the deprecation message for `fixed_point32.move` because it includes wrong function called `from_raw_value` which it should be `from_raw`.

## Test plan 

There is no tests needed for this change.