### PR TITLE
[telemetry] Fix varint deprecation warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2344,9 +2344,9 @@ dependencies = [
 
 [[package]]
 name = "bytes-varint"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c1820c7c366b9d26c47143e1604454105a59969aade54e4f695d96acc8332f"
+checksum = "2e95ba58c659da9789048773ebecf5bd17fe7d3858b10f693bb579912f0d55ed"
 dependencies = [
  "bytes",
 ]
@@ -17560,7 +17560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/crates/telemetry-subscribers/Cargo.toml
+++ b/crates/telemetry-subscribers/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { workspace = true, features = ["full"] }
 futures.workspace = true
 clap.workspace = true
 bytes.workspace = true
-bytes-varint = { version = "1" }
+bytes-varint = { version = "1.1.0" }
 
 # must use same version as opentelemetry for tonic and prost, so we can't use from
 # workspace

--- a/crates/telemetry-subscribers/src/bin/import-trace.rs
+++ b/crates/telemetry-subscribers/src/bin/import-trace.rs
@@ -104,7 +104,7 @@ where
     let mut cursor = Cursor::new(buffer);
 
     while cursor.has_remaining() {
-        let len = cursor.get_u64_varint().unwrap() as usize;
+        let len = cursor.try_get_u64_varint().unwrap() as usize;
 
         if cursor.remaining() < len {
             return Err(io::Error::new(


### PR DESCRIPTION
## Description 

This PR uses `try_get_u64_varint` function instead of the `get_u64_varint` function which was deprecated. Sometimes clippy complains so decided to fix it.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
