### PR TITLE
Fix typos in comments and documentation

### DIFF
--- a/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/struct_kind_inference.mvir
+++ b/external-crates/move/crates/bytecode-verifier-transactional-tests/tests/type_safety/struct_kind_inference.mvir
@@ -4,7 +4,7 @@ module 0x1.M1 {
     struct MyResource { b: bool }
     struct S<T> { t: T }
 
-    // verifer should reject; didn't move resource;
+    // verifier should reject; didn't move resource;
     public p(s: Self.S<Self.MyResource>) {
     label b0:
         return;
@@ -67,7 +67,7 @@ module 0x2.M1 {
     enum MyResource { V{ b: bool } }
     enum S<T> { V{ t: T } }
 
-    // verifer should reject; didn't move resource;
+    // verifier should reject; didn't move resource;
     public p(s: Self.S<Self.MyResource>) {
     label b0:
         return;

--- a/external-crates/move/crates/move-cli/src/sandbox/cli.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/cli.rs
@@ -93,7 +93,7 @@ pub enum SandboxCommand {
         )]
         type_args: Vec<TypeTag>,
         /// Maximum number of gas units to be consumed by execution.
-        /// When the budget is exhaused, execution will abort.
+        /// When the budget is exhausted, execution will abort.
         /// By default, no `gas-budget` is specified and gas metering is disabled.
         #[clap(long = "gas-budget", short = 'g')]
         gas_budget: Option<u64>,

--- a/external-crates/move/crates/move-ir-to-bytecode/src/compiler.rs
+++ b/external-crates/move/crates/move-ir-to-bytecode/src/compiler.rs
@@ -152,7 +152,7 @@ struct FunctionFrame {
     local_types: Signature,
     // i64 to allow the bytecode verifier to catch errors of
     // - negative stack sizes
-    // - excessivley large stack sizes
+    // - excessively large stack sizes
     // The max stack depth of the file_format is set as u16.
     // Theoretically, we could use a BigInt here, but that is probably overkill for any testing
     max_stack_depth: i64,

--- a/external-crates/move/crates/move-package/src/resolution/resolution_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/resolution_graph.rs
@@ -361,7 +361,7 @@ impl Package {
     /// Associates addresses with named packages in the `resolving_table`.
     /// Addresses may be pulled in from two sources:
     /// - The [addresses] section `Move.toml`.
-    /// - Adresses (package IDs) in the `Move.lock` associated with published packages for `chain_id`.
+    /// - Addresses (package IDs) in the `Move.lock` associated with published packages for `chain_id`.
     ///
     /// Addresses are pulled from the `Move.lock` only when a package is published or upgraded on-chain.
     /// Local builds only consult the `Move.toml` manifest.


### PR DESCRIPTION
## Description 

This PR fixes several typos in comments and documentation:

- Corrects spelling of "excessively" in move-ir-to-bytecode
- Fixes "exhausted" spelling in move-cli sandbox comments  
- Corrects "Addresses" spelling in resolution_graph.rs
- Minor formatting fixes in verifier comments

No functional changes, just documentation improvements.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
