### PR TITLE
Update wallet-standard docs to use Standard* imports

### DIFF
--- a/docs/content/standards/wallet-standard.mdx
+++ b/docs/content/standards/wallet-standard.mdx
@@ -62,10 +62,10 @@ Implement these features in your wallet class under the `features` property:
 
 ```tsx
 import {
-  ConnectFeature,
-  ConnectMethod,
-  EventsFeature,
-  EventsOnMethod,
+  StandardConnectFeature,
+  StandardConnectMethod,
+  StandardEventsFeature,
+  StandardEventsOnMethod,
   SuiFeatures,
   SuiSignPersonalMessageMethod,
   SuiSignTransactionMethod,


### PR DESCRIPTION
## Description 
  
Updated import names in documentation to use the `Standard*` prefix in accordance with the latest changes in `@mysten/wallet-standard`.

The following updates were made:  

- `ConnectFeature` → `StandardConnectFeature`  
- `ConnectMethod` → `StandardConnectMethod`  
- `EventsFeature` → `StandardEventsFeature`  
- `EventsOnMethod` → `StandardEventsOnMethod`  

This is a documentation update only, with no functional changes.  

## Test plan 

No testing required as this is a documentation update.

## Release notes

No release notes required as this change only affects documentation.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
