### PR TITLE
jsonrpc: prefetch objects for balance change calculations 

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -5607,6 +5607,13 @@ impl TransactionKeyValueStoreTrait for AuthorityState {
             .get_object_by_key(&object_id, version))
     }
 
+    #[instrument(skip_all)]
+    async fn multi_get_objects(&self, object_keys: &[ObjectKey]) -> SuiResult<Vec<Option<Object>>> {
+        Ok(self
+            .get_object_cache_reader()
+            .multi_get_objects_by_key(object_keys))
+    }
+
     #[instrument(skip(self))]
     async fn multi_get_transaction_checkpoint(
         &self,

--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -500,6 +500,7 @@ mod tests {
             ) -> SuiResult<Option<CheckpointSequenceNumber>>;
 
             async fn get_object(&self, object_id: ObjectID, version: SequenceNumber) -> SuiResult<Option<Object>>;
+            async fn multi_get_objects(&self, object_keys: &[sui_types::storage::ObjectKey]) -> SuiResult<Vec<Option<Object>>>;
 
             async fn multi_get_transaction_checkpoint(
                 &self,

--- a/crates/sui-storage/tests/key_value_tests.rs
+++ b/crates/sui-storage/tests/key_value_tests.rs
@@ -199,6 +199,13 @@ impl TransactionKeyValueStoreTrait for MockTxStore {
         Ok(self.objects.get(&ObjectKey(object_id, version)).cloned())
     }
 
+    async fn multi_get_objects(&self, object_keys: &[ObjectKey]) -> SuiResult<Vec<Option<Object>>> {
+        Ok(object_keys
+            .iter()
+            .map(|key| self.objects.get(key).cloned())
+            .collect())
+    }
+
     async fn multi_get_transaction_checkpoint(
         &self,
         digests: &[TransactionDigest],
@@ -542,7 +549,7 @@ fn test_key_to_path_and_back() {
         key
     );
 
-    let key = Key::ObjectKey(ObjectID::random(), SequenceNumber::from_u64(42));
+    let key = Key::ObjectKey(ObjectKey(ObjectID::random(), SequenceNumber::from_u64(42)));
     let path_elts = key.to_path_elements();
     assert_eq!(
         path_elements_to_key(path_elts.0.as_str(), path_elts.1).unwrap(),


### PR DESCRIPTION
## Description 

Prefetch objects needed for balance change calculations as well as
leveraging multi_get_objects in order to parallelize the fetching of
objects.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
