### PR TITLE
Use 32 bytes key for event_2 table with tidehunter

### DIFF
--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -308,7 +308,7 @@ impl AuthorityPerpetualTables {
             (
                 "events_2".to_string(),
                 ThConfig::new_with_rm_prefix(
-                    32 + 8,
+                    32,
                     MUTEXES,
                     default_cells_per_mutex(),
                     KeySpaceConfig::default(),


### PR DESCRIPTION
This is the correct key size in this table, otherwise it fails unit tests that uses this table