### PR TITLE
Encapsulate and share package cache

### DIFF
--- a/crates/sui-analytics-indexer/src/analytics_metrics.rs
+++ b/crates/sui-analytics-indexer/src/analytics_metrics.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #![allow(dead_code)]
 use prometheus::{
-    register_int_counter_vec_with_registry, register_int_gauge_vec_with_registry, IntCounterVec,
-    IntGaugeVec, Registry,
+    register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
+    register_int_gauge_vec_with_registry, HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec,
+    Registry,
 };
 
 #[derive(Clone)]
@@ -12,6 +13,7 @@ pub struct AnalyticsMetrics {
     pub last_uploaded_checkpoint: IntGaugeVec,
     pub max_checkpoint_on_store: IntGaugeVec,
     pub total_too_large_to_deserialize: IntCounterVec,
+    pub file_size_bytes: HistogramVec,
 }
 
 impl AnalyticsMetrics {
@@ -42,6 +44,25 @@ impl AnalyticsMetrics {
                 "total_too_large_to_deserialize",
                 "Total number of rows skipped due to size.",
                 &["data_type"],
+                registry,
+            )
+            .unwrap(),
+            file_size_bytes: register_histogram_vec_with_registry!(
+                HistogramOpts::new("file_size_bytes", "Size of generated files in bytes.",)
+                    .buckets(vec![
+                        1_000.0,         // 1 KB
+                        10_000.0,        // 10 KB
+                        100_000.0,       // 100 KB
+                        1_000_000.0,     // 1 MB
+                        10_000_000.0,    // 10 MB
+                        50_000_000.0,    // 50 MB
+                        100_000_000.0,   // 100 MB
+                        250_000_000.0,   // 250 MB
+                        500_000_000.0,   // 500 MB
+                        1_000_000_000.0, // 1 GB
+                        2_000_000_000.0, // 2 GB
+                    ]),
+                &["source"],
                 registry,
             )
             .unwrap(),

--- a/crates/sui-analytics-indexer/src/handlers/object_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/object_handler.rs
@@ -1,13 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use anyhow::Result;
 use sui_data_ingestion_core::Worker;
 use sui_types::{TypeTag, SYSTEM_PACKAGE_ADDRESSES};
 use tokio::sync::Mutex;
 
 use sui_json_rpc_types::SuiMoveStruct;
-use sui_package_resolver::Resolver;
 use sui_types::base_types::ObjectID;
 use sui_types::effects::TransactionEffects;
 use sui_types::full_checkpoint_content::{CheckpointData, CheckpointTransaction};
@@ -19,7 +20,7 @@ use crate::handlers::{
 };
 use crate::AnalyticsMetrics;
 
-use crate::package_store::{LocalDBPackageStore, PackageCache};
+use crate::package_store::PackageCache;
 use crate::tables::{ObjectEntry, ObjectStatus};
 use crate::FileType;
 
@@ -27,12 +28,11 @@ pub struct ObjectHandler {
     state: Mutex<State>,
     package_filter: Option<ObjectID>,
     metrics: AnalyticsMetrics,
+    package_cache: Arc<PackageCache>,
 }
 
 struct State {
     objects: Vec<ObjectEntry>,
-    package_store: LocalDBPackageStore,
-    resolver: Resolver<PackageCache>,
 }
 
 #[async_trait::async_trait]
@@ -48,7 +48,7 @@ impl Worker for ObjectHandler {
         let mut state = self.state.lock().await;
         for checkpoint_transaction in checkpoint_transactions {
             for object in checkpoint_transaction.output_objects.iter() {
-                state.package_store.update(object)?;
+                self.package_cache.update(object)?;
             }
             self.process_transaction(
                 checkpoint_summary.epoch,
@@ -60,7 +60,7 @@ impl Worker for ObjectHandler {
             )
             .await?;
             if checkpoint_summary.end_of_epoch_data.is_some() {
-                state
+                self.package_cache
                     .resolver
                     .package_store()
                     .evict(SYSTEM_PACKAGE_ADDRESSES.iter().copied());
@@ -88,21 +88,18 @@ impl AnalyticsHandler<ObjectEntry> for ObjectHandler {
 
 impl ObjectHandler {
     pub fn new(
-        package_store: LocalDBPackageStore,
+        package_cache: Arc<PackageCache>,
         package_filter: &Option<String>,
         metrics: AnalyticsMetrics,
     ) -> Self {
-        let state = State {
-            objects: vec![],
-            package_store: package_store.clone(),
-            resolver: Resolver::new(PackageCache::new(package_store)),
-        };
+        let state = State { objects: vec![] };
         Self {
             state: Mutex::new(state),
             package_filter: package_filter
                 .clone()
                 .map(|x| ObjectID::from_hex_literal(&x).unwrap()),
             metrics,
+            package_cache,
         }
     }
     async fn process_transaction(
@@ -158,7 +155,6 @@ impl ObjectHandler {
         &self,
         type_tag: &TypeTag,
         original_package_id: ObjectID,
-        state: &mut State,
     ) -> Result<bool> {
         use std::collections::BTreeSet;
         use tokio::task::JoinSet;
@@ -182,8 +178,8 @@ impl ObjectHandler {
         let mut original_ids = JoinSet::new();
 
         for id in package_ids {
-            let package_store = state.package_store.clone();
-            original_ids.spawn(async move { package_store.get_original_package_id(id).await });
+            let package_cache = self.package_cache.clone();
+            original_ids.spawn(async move { package_cache.get_original_package_id(id).await });
         }
 
         // Check if any resolved ID matches our target
@@ -215,7 +211,7 @@ impl ObjectHandler {
             .struct_tag()
             .and_then(|tag| object.data.try_as_move().map(|mo| (tag, mo.contents())))
         {
-            match get_move_struct(&tag, contents, &state.resolver).await {
+            match get_move_struct(&tag, contents, &self.package_cache.resolver).await {
                 Ok(move_struct) => Some(move_struct),
                 Err(err)
                     if err
@@ -255,14 +251,14 @@ impl ObjectHandler {
 
         let is_match = if let Some(package_id) = self.package_filter {
             if let Some(object_type) = object_type {
-                let original_package_id = state
-                    .package_store
+                let original_package_id = self
+                    .package_cache
                     .get_original_package_id(package_id.into())
                     .await?;
 
                 // Check if any type parameter matches the package filter
                 let type_tag: TypeTag = object_type.clone().into();
-                self.check_type_hierarchy(&type_tag, original_package_id, state)
+                self.check_type_hierarchy(&type_tag, original_package_id)
                     .await?
             } else {
                 false
@@ -338,18 +334,13 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let registry = Registry::new();
         let metrics = AnalyticsMetrics::new(&registry);
-        let package_store = LocalDBPackageStore::new(temp_dir.path(), "http://localhost:9000");
-        let handler = ObjectHandler::new(package_store, &Some("0xabc".to_string()), metrics);
-        let mut state = handler.state.lock().await;
+        let package_cache = Arc::new(PackageCache::new(temp_dir.path(), "http://localhost:9000"));
+        let handler = ObjectHandler::new(package_cache, &Some("0xabc".to_string()), metrics);
 
         // 1. Direct match
         let type_tag = create_struct_tag("0xabc", "module", "Type", vec![]);
         assert!(handler
-            .check_type_hierarchy(
-                &type_tag,
-                ObjectID::from_hex_literal("0xabc").unwrap(),
-                &mut state
-            )
+            .check_type_hierarchy(&type_tag, ObjectID::from_hex_literal("0xabc").unwrap(),)
             .await
             .unwrap());
 
@@ -357,11 +348,7 @@ mod tests {
         let inner_type = create_struct_tag("0xabc", "module", "Inner", vec![]);
         let type_tag = create_struct_tag("0xcde", "module", "Type", vec![inner_type]);
         assert!(handler
-            .check_type_hierarchy(
-                &type_tag,
-                ObjectID::from_hex_literal("0xabc").unwrap(),
-                &mut state
-            )
+            .check_type_hierarchy(&type_tag, ObjectID::from_hex_literal("0xabc").unwrap(),)
             .await
             .unwrap());
 
@@ -370,33 +357,21 @@ mod tests {
         let vector_type = TypeTag::Vector(Box::new(inner_type));
         let type_tag = create_struct_tag("0xcde", "module", "Type", vec![vector_type]);
         assert!(handler
-            .check_type_hierarchy(
-                &type_tag,
-                ObjectID::from_hex_literal("0xabc").unwrap(),
-                &mut state
-            )
+            .check_type_hierarchy(&type_tag, ObjectID::from_hex_literal("0xabc").unwrap(),)
             .await
             .unwrap());
 
         // 4. No match
         let type_tag = create_struct_tag("0xcde", "module", "Type", vec![]);
         assert!(!handler
-            .check_type_hierarchy(
-                &type_tag,
-                ObjectID::from_hex_literal("0xabc").unwrap(),
-                &mut state
-            )
+            .check_type_hierarchy(&type_tag, ObjectID::from_hex_literal("0xabc").unwrap(),)
             .await
             .unwrap());
 
         // 5. Primitive type
         let type_tag = TypeTag::U64;
         assert!(!handler
-            .check_type_hierarchy(
-                &type_tag,
-                ObjectID::from_hex_literal("0xabc").unwrap(),
-                &mut state
-            )
+            .check_type_hierarchy(&type_tag, ObjectID::from_hex_literal("0xabc").unwrap(),)
             .await
             .unwrap());
     }

--- a/crates/sui-analytics-indexer/src/lib.rs
+++ b/crates/sui-analytics-indexer/src/lib.rs
@@ -15,7 +15,7 @@ use handlers::transaction_bcs_handler::TransactionBCSHandler;
 use num_enum::IntoPrimitive;
 use num_enum::TryFromPrimitive;
 use object_store::path::Path;
-use package_store::LocalDBPackageStore;
+use package_store::PackageCache;
 use serde::{Deserialize, Serialize};
 use snowflake_api::{QueryResult, SnowflakeApi};
 use strum_macros::EnumIter;
@@ -173,7 +173,7 @@ impl JobConfig {
         self,
         metrics: AnalyticsMetrics,
     ) -> Result<Vec<Processor>> {
-        let package_store = LocalDBPackageStore::new(&self.package_cache_path, &self.rest_url);
+        let package_cache = Arc::new(PackageCache::new(&self.package_cache_path, &self.rest_url));
         let job_config = Arc::new(self);
         let mut processors = Vec::with_capacity(job_config.task_configs.len());
         let mut task_names = HashSet::new();
@@ -194,7 +194,7 @@ impl JobConfig {
                 config: task_config,
                 checkpoint_dir: Arc::new(temp_dir),
                 metrics: metrics.clone(),
-                package_store: package_store.clone(),
+                package_cache: package_cache.clone(),
             };
 
             processors.push(task_context.create_analytics_processor().await?);
@@ -257,7 +257,7 @@ pub struct TaskContext {
     pub job_config: Arc<JobConfig>,
     pub checkpoint_dir: Arc<TempDir>,
     pub metrics: AnalyticsMetrics,
-    pub package_store: LocalDBPackageStore,
+    pub package_cache: Arc<PackageCache>,
 }
 
 impl TaskContext {
@@ -277,10 +277,10 @@ impl TaskContext {
             }
             FileType::Object => {
                 let package_id_filter = self.config.package_id_filter.clone();
-                let package_store = self.package_store.clone();
+                let package_cache = self.package_cache.clone();
                 let metrics = self.metrics.clone();
                 self.create_processor_for_handler(Box::new(ObjectHandler::new(
-                    package_store,
+                    package_cache,
                     &package_id_filter,
                     metrics,
                 )))
@@ -295,8 +295,8 @@ impl TaskContext {
                     .await
             }
             FileType::Event => {
-                let package_store = self.package_store.clone();
-                self.create_processor_for_handler(Box::new(EventHandler::new(package_store)))
+                let package_cache = self.package_cache.clone();
+                self.create_processor_for_handler(Box::new(EventHandler::new(package_cache)))
                     .await
             }
             FileType::TransactionObjects => {
@@ -312,15 +312,15 @@ impl TaskContext {
                     .await
             }
             FileType::DynamicField => {
-                let package_store = self.package_store.clone();
-                self.create_processor_for_handler(Box::new(DynamicFieldHandler::new(package_store)))
+                let package_cache = self.package_cache.clone();
+                self.create_processor_for_handler(Box::new(DynamicFieldHandler::new(package_cache)))
                     .await
             }
             FileType::WrappedObject => {
-                let package_store = self.package_store.clone();
+                let package_cache = self.package_cache.clone();
                 let metrics = self.metrics.clone();
                 self.create_processor_for_handler(Box::new(WrappedObjectHandler::new(
-                    package_store,
+                    package_cache,
                     metrics,
                 )))
                 .await

--- a/crates/sui-analytics-indexer/src/lib.rs
+++ b/crates/sui-analytics-indexer/src/lib.rs
@@ -115,6 +115,10 @@ fn default_max_file_size_mb() -> u64 {
     100
 }
 
+fn default_max_row_count() -> usize {
+    100000
+}
+
 fn default_time_interval_s() -> u64 {
     600
 }
@@ -224,6 +228,9 @@ pub struct TaskConfig {
     /// Maximum file size in mb before uploading to the datastore.
     #[serde(default = "default_max_file_size_mb")]
     pub max_file_size_mb: u64,
+    /// Maximum number of rows before uploading to the datastore.
+    #[serde(default = "default_max_row_count")]
+    pub max_row_count: usize,
     /// Checkpoint sequence number to start the download from
     pub starting_checkpoint_seq_num: Option<u64>,
     /// Time to process in seconds before uploding to the datastore.

--- a/crates/sui-analytics-indexer/src/writers/csv_writer.rs
+++ b/crates/sui-analytics-indexer/src/writers/csv_writer.rs
@@ -24,6 +24,7 @@ pub(crate) struct CSVWriter {
     writer: Writer<File>,
     epoch: EpochId,
     checkpoint_range: Range<u64>,
+    row_count: usize,
 }
 
 impl CSVWriter {
@@ -45,6 +46,7 @@ impl CSVWriter {
             writer,
             epoch: 0,
             checkpoint_range,
+            row_count: 0,
         })
     }
 
@@ -86,6 +88,7 @@ impl<S: Serialize + ParquetSchema> AnalyticsWriter<S> for CSVWriter {
         for row in rows {
             self.writer.serialize(row)?;
         }
+        self.row_count += rows.len();
         Ok(())
     }
 
@@ -110,6 +113,7 @@ impl<S: Serialize + ParquetSchema> AnalyticsWriter<S> for CSVWriter {
             self.epoch,
             self.checkpoint_range.clone(),
         )?;
+        self.row_count = 0;
         Ok(())
     }
 
@@ -117,5 +121,9 @@ impl<S: Serialize + ParquetSchema> AnalyticsWriter<S> for CSVWriter {
         let file_path = self.file_path(self.epoch, self.checkpoint_range.clone())?;
         let len = fs::metadata(file_path)?.len();
         Ok(Some(len))
+    }
+
+    fn rows(&self) -> Result<usize> {
+        Ok(self.row_count)
     }
 }

--- a/crates/sui-analytics-indexer/src/writers/mod.rs
+++ b/crates/sui-analytics-indexer/src/writers/mod.rs
@@ -20,4 +20,6 @@ pub trait AnalyticsWriter<S: Serialize + ParquetSchema>: Send + Sync + 'static {
     fn reset(&mut self, epoch_num: EpochId, start_checkpoint_seq_num: u64) -> Result<()>;
     /// Approx size in bytes of the current staging file if available
     fn file_size(&self) -> Result<Option<u64>>;
+    /// Number of rows accumulated since last flush
+    fn rows(&self) -> Result<usize>;
 }


### PR DESCRIPTION
## Description

This change ensures all pipelines run using the same LRU package cache instance. Previously, all of the pipelines would have their own instance which bloats memory use.

## Test plan

It's already running in the backfill stack
