### PR TITLE
Rewrite parquet writer to use less memory

### DIFF
--- a/crates/sui-analytics-indexer/src/analytics_metrics.rs
+++ b/crates/sui-analytics-indexer/src/analytics_metrics.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #![allow(dead_code)]
 use prometheus::{
-    register_int_counter_vec_with_registry, register_int_gauge_vec_with_registry, IntCounterVec,
-    IntGaugeVec, Registry,
+    register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
+    register_int_gauge_vec_with_registry, HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec,
+    Registry,
 };
 
 #[derive(Clone)]
@@ -12,6 +13,7 @@ pub struct AnalyticsMetrics {
     pub last_uploaded_checkpoint: IntGaugeVec,
     pub max_checkpoint_on_store: IntGaugeVec,
     pub total_too_large_to_deserialize: IntCounterVec,
+    pub file_size_bytes: HistogramVec,
 }
 
 impl AnalyticsMetrics {
@@ -42,6 +44,25 @@ impl AnalyticsMetrics {
                 "total_too_large_to_deserialize",
                 "Total number of rows skipped due to size.",
                 &["data_type"],
+                registry,
+            )
+            .unwrap(),
+            file_size_bytes: register_histogram_vec_with_registry!(
+                HistogramOpts::new("file_size_bytes", "Size of generated files in bytes.",)
+                    .buckets(vec![
+                        1_000.0,         // 1 KB
+                        10_000.0,        // 10 KB
+                        100_000.0,       // 100 KB
+                        1_000_000.0,     // 1 MB
+                        10_000_000.0,    // 10 MB
+                        50_000_000.0,    // 50 MB
+                        100_000_000.0,   // 100 MB
+                        250_000_000.0,   // 250 MB
+                        500_000_000.0,   // 500 MB
+                        1_000_000_000.0, // 1 GB
+                        2_000_000_000.0, // 2 GB
+                    ]),
+                &["source"],
                 registry,
             )
             .unwrap(),

--- a/crates/sui-analytics-indexer/src/lib.rs
+++ b/crates/sui-analytics-indexer/src/lib.rs
@@ -115,6 +115,10 @@ fn default_max_file_size_mb() -> u64 {
     100
 }
 
+fn default_max_row_count() -> usize {
+    100000
+}
+
 fn default_time_interval_s() -> u64 {
     600
 }
@@ -224,6 +228,9 @@ pub struct TaskConfig {
     /// Maximum file size in mb before uploading to the datastore.
     #[serde(default = "default_max_file_size_mb")]
     pub max_file_size_mb: u64,
+    /// Maximum number of rows before uploading to the datastore.
+    #[serde(default = "default_max_row_count")]
+    pub max_row_count: usize,
     /// Checkpoint sequence number to start the download from
     pub starting_checkpoint_seq_num: Option<u64>,
     /// Time to process in seconds before uploding to the datastore.

--- a/crates/sui-analytics-indexer/src/writers/csv_writer.rs
+++ b/crates/sui-analytics-indexer/src/writers/csv_writer.rs
@@ -24,6 +24,7 @@ pub(crate) struct CSVWriter {
     writer: Writer<File>,
     epoch: EpochId,
     checkpoint_range: Range<u64>,
+    row_count: usize,
 }
 
 impl CSVWriter {
@@ -45,6 +46,7 @@ impl CSVWriter {
             writer,
             epoch: 0,
             checkpoint_range,
+            row_count: 0,
         })
     }
 
@@ -86,6 +88,7 @@ impl<S: Serialize + ParquetSchema> AnalyticsWriter<S> for CSVWriter {
         for row in rows {
             self.writer.serialize(row)?;
         }
+        self.row_count += rows.len();
         Ok(())
     }
 
@@ -110,6 +113,7 @@ impl<S: Serialize + ParquetSchema> AnalyticsWriter<S> for CSVWriter {
             self.epoch,
             self.checkpoint_range.clone(),
         )?;
+        self.row_count = 0;
         Ok(())
     }
 
@@ -117,5 +121,9 @@ impl<S: Serialize + ParquetSchema> AnalyticsWriter<S> for CSVWriter {
         let file_path = self.file_path(self.epoch, self.checkpoint_range.clone())?;
         let len = fs::metadata(file_path)?.len();
         Ok(Some(len))
+    }
+
+    fn rows(&self) -> Result<usize> {
+        Ok(self.row_count)
     }
 }

--- a/crates/sui-analytics-indexer/src/writers/mod.rs
+++ b/crates/sui-analytics-indexer/src/writers/mod.rs
@@ -20,4 +20,6 @@ pub trait AnalyticsWriter<S: Serialize + ParquetSchema>: Send + Sync + 'static {
     fn reset(&mut self, epoch_num: EpochId, start_checkpoint_seq_num: u64) -> Result<()>;
     /// Approx size in bytes of the current staging file if available
     fn file_size(&self) -> Result<Option<u64>>;
+    /// Number of rows accumulated since last flush
+    fn rows(&self) -> Result<usize>;
 }


### PR DESCRIPTION
## Description

This PR makes two significant improvements:

1. It adds a row counter to the parquet writer that allows us to flush after "N" rows have been buffered in memory. Previously we were going back checkpoint count which could be unpredictable. Large checkpoints were blowing up these buffers and causing use to hit an internal buffer size limit in arrow. We still only try to flush at the checkpoint interval, which should be fine so long as a single checkpoint fits in memory.

```
thread 'tokio-runtime-worker' panicked at /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/arrow-array-54.2.0/src/builder/generic_bytes_builder.rs:86:57:
byte array offset overflow
stack backtrace:
2025-04-21T17:42:19.534828Z ERROR telemetry_subscribers: panicked at /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/arrow-array-54.2.0/src/builder/generic_bytes_builder.rs:86:57:
byte array offset overflow panic.file="/usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/arrow-array-54.2.0/src/builder/generic_bytes_builder.rs" panic.line=86 panic.column=57
   0:     0x57321600fb7a - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::hfc616348d9ad0abc
   1:     0x57321603db33 - core::fmt::write::h7ca648217bc79799
   2:     0x57321600b4a3 - std::io::Write::write_fmt::h7960c58bfa5ccbcb
   3:     0x57321600f9c2 - std::sys::backtrace::BacktraceLock::print::h3fb349e80cbe0423
   4:     0x573216010d60 - std::panicking::default_hook::{{closure}}::h3366e5842cba645d
   5:     0x573216010b40 - std::panicking::default_hook::hd7573a5d4879884b
   6:     0x573214b3d5c6 - telemetry_subscribers::set_panic_hook::{{closure}}::h2c961ffe2a74469e
   7:     0x573216011593 - std::panicking::rust_panic_with_hook::h66e909d048c263a9
   8:     0x57321601126a - std::panicking::begin_panic_handler::{{closure}}::h8d9aa8be7e8634cf
   9:     0x573216010089 - std::sys::backtrace::__rust_end_short_backtrace::h7d7e47ef99abf6aa
  10:     0x573216010efd - rust_begin_unwind
```

2. It "streams" the rows into the arrow column builders as they are created instead of buffering them all in a vec and allocating a massive arrow column all at once during the flush. I believe this will put less pressure on the allocator since it doesn't require finding massive contiguous chunks of free memory on flush. See this code I eliminated from the diff for reference:

```
 $variant(_) => {
                    let array = <$types>::from(
                        $column
                            .into_iter()
                            .flat_map(|value| match value {
                                $variant(value) => Some(value),
                                _ => None,
                            })
                            .collect::<Vec<_>>(),
                    );
                    $target_vector.push(Arc::new(array) as ArrayRef);
                }
```

That code would call [here](https://docs.rs/arrow-array/55.0.0/src/arrow_array/array/byte_array.rs.html#203) which I believe is pre-allocating a contiguous buffer to fit the entire column.

I also added a file size histogram metric which is useful to help monitor and tune the row count values.

## Test plan

This is running in the backfill stacks now and data is still coming through to snowflake. Memory use is now stable and the system no longer crashes when processing large checkpoints.
