### PR TITLE
[move] Rename poorly named function for creating vectors of values

### DIFF
--- a/external-crates/move/crates/move-vm-types/src/values/value_tests.rs
+++ b/external-crates/move/crates/move-vm-types/src/values/value_tests.rs
@@ -194,8 +194,8 @@ fn legacy_val_abstract_memory_size_consistency() -> PartialVMResult<()> {
         Value::vector_u256([1, 2, 3, 4].iter().map(|q| U256::from(*q as u64))),
         Value::struct_(Struct::pack([])),
         Value::struct_(Struct::pack([Value::u8(0), Value::bool(false)])),
-        Value::vector_for_testing_only([]),
-        Value::vector_for_testing_only([Value::u8(0), Value::u8(1)]),
+        Value::vector_value([]),
+        Value::vector_value([Value::u8(0), Value::u8(1)]),
     ];
 
     let mut locals = Locals::new(vals.len());

--- a/external-crates/move/crates/move-vm-types/src/values/values_impl.rs
+++ b/external-crates/move/crates/move-vm-types/src/values/values_impl.rs
@@ -1424,7 +1424,7 @@ impl Value {
     }
 
     // REVIEW: This API can break
-    pub fn vector_for_testing_only(it: impl IntoIterator<Item = Value>) -> Self {
+    pub fn vector_value(it: impl IntoIterator<Item = Value>) -> Self {
         Self(ValueImpl::Container(Container::Vec(Rc::new(RefCell::new(
             it.into_iter().map(|v| v.0).collect(),
         )))))

--- a/external-crates/move/move-execution/v0/crates/move-stdlib-natives/src/unit_test.rs
+++ b/external-crates/move/move-execution/v0/crates/move-stdlib-natives/src/unit_test.rs
@@ -47,7 +47,7 @@ fn native_create_signers_for_testing(
     debug_assert!(args.len() == 1);
 
     let num_signers = pop_arg!(args, u64);
-    let signers = Value::vector_for_testing_only(
+    let signers = Value::vector_value(
         (0..num_signers).map(|i| Value::signer(AccountAddress::new(to_le_bytes(i)))),
     );
 

--- a/external-crates/move/move-execution/v0/crates/move-vm-types/src/values/value_tests.rs
+++ b/external-crates/move/move-execution/v0/crates/move-vm-types/src/values/value_tests.rs
@@ -194,8 +194,8 @@ fn legacy_val_abstract_memory_size_consistency() -> PartialVMResult<()> {
         Value::vector_u256([1, 2, 3, 4].iter().map(|q| U256::from(*q as u64))),
         Value::struct_(Struct::pack([])),
         Value::struct_(Struct::pack([Value::u8(0), Value::bool(false)])),
-        Value::vector_for_testing_only([]),
-        Value::vector_for_testing_only([Value::u8(0), Value::u8(1)]),
+        Value::vector_value([]),
+        Value::vector_value([Value::u8(0), Value::u8(1)]),
     ];
 
     let mut locals = Locals::new(vals.len());

--- a/external-crates/move/move-execution/v0/crates/move-vm-types/src/values/values_impl.rs
+++ b/external-crates/move/move-execution/v0/crates/move-vm-types/src/values/values_impl.rs
@@ -1424,7 +1424,7 @@ impl Value {
     }
 
     // REVIEW: This API can break
-    pub fn vector_for_testing_only(it: impl IntoIterator<Item = Value>) -> Self {
+    pub fn vector_value(it: impl IntoIterator<Item = Value>) -> Self {
         Self(ValueImpl::Container(Container::Vec(Rc::new(RefCell::new(
             it.into_iter().map(|v| v.0).collect(),
         )))))

--- a/external-crates/move/move-execution/v1/crates/move-stdlib-natives/src/unit_test.rs
+++ b/external-crates/move/move-execution/v1/crates/move-stdlib-natives/src/unit_test.rs
@@ -47,7 +47,7 @@ fn native_create_signers_for_testing(
     debug_assert!(args.len() == 1);
 
     let num_signers = pop_arg!(args, u64);
-    let signers = Value::vector_for_testing_only(
+    let signers = Value::vector_value(
         (0..num_signers).map(|i| Value::signer(AccountAddress::new(to_le_bytes(i)))),
     );
 

--- a/external-crates/move/move-execution/v1/crates/move-vm-types/src/values/value_tests.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-types/src/values/value_tests.rs
@@ -194,8 +194,8 @@ fn legacy_val_abstract_memory_size_consistency() -> PartialVMResult<()> {
         Value::vector_u256([1, 2, 3, 4].iter().map(|q| U256::from(*q as u64))),
         Value::struct_(Struct::pack([])),
         Value::struct_(Struct::pack([Value::u8(0), Value::bool(false)])),
-        Value::vector_for_testing_only([]),
-        Value::vector_for_testing_only([Value::u8(0), Value::u8(1)]),
+        Value::vector_value([]),
+        Value::vector_value([Value::u8(0), Value::u8(1)]),
     ];
 
     let mut locals = Locals::new(vals.len());

--- a/external-crates/move/move-execution/v1/crates/move-vm-types/src/values/values_impl.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-types/src/values/values_impl.rs
@@ -1424,7 +1424,7 @@ impl Value {
     }
 
     // REVIEW: This API can break
-    pub fn vector_for_testing_only(it: impl IntoIterator<Item = Value>) -> Self {
+    pub fn vector_value(it: impl IntoIterator<Item = Value>) -> Self {
         Self(ValueImpl::Container(Container::Vec(Rc::new(RefCell::new(
             it.into_iter().map(|v| v.0).collect(),
         )))))

--- a/external-crates/move/move-execution/v2/crates/move-stdlib-natives/src/unit_test.rs
+++ b/external-crates/move/move-execution/v2/crates/move-stdlib-natives/src/unit_test.rs
@@ -47,7 +47,7 @@ fn native_create_signers_for_testing(
     debug_assert!(args.len() == 1);
 
     let num_signers = pop_arg!(args, u64);
-    let signers = Value::vector_for_testing_only(
+    let signers = Value::vector_value(
         (0..num_signers).map(|i| Value::signer(AccountAddress::new(to_le_bytes(i)))),
     );
 

--- a/external-crates/move/move-execution/v2/crates/move-vm-types/src/values/value_tests.rs
+++ b/external-crates/move/move-execution/v2/crates/move-vm-types/src/values/value_tests.rs
@@ -194,8 +194,8 @@ fn legacy_val_abstract_memory_size_consistency() -> PartialVMResult<()> {
         Value::vector_u256([1, 2, 3, 4].iter().map(|q| U256::from(*q as u64))),
         Value::struct_(Struct::pack([])),
         Value::struct_(Struct::pack([Value::u8(0), Value::bool(false)])),
-        Value::vector_for_testing_only([]),
-        Value::vector_for_testing_only([Value::u8(0), Value::u8(1)]),
+        Value::vector_value([]),
+        Value::vector_value([Value::u8(0), Value::u8(1)]),
     ];
 
     let mut locals = Locals::new(vals.len());

--- a/external-crates/move/move-execution/v2/crates/move-vm-types/src/values/values_impl.rs
+++ b/external-crates/move/move-execution/v2/crates/move-vm-types/src/values/values_impl.rs
@@ -1424,7 +1424,7 @@ impl Value {
     }
 
     // REVIEW: This API can break
-    pub fn vector_for_testing_only(it: impl IntoIterator<Item = Value>) -> Self {
+    pub fn vector_value(it: impl IntoIterator<Item = Value>) -> Self {
         Self(ValueImpl::Container(Container::Vec(Rc::new(RefCell::new(
             it.into_iter().map(|v| v.0).collect(),
         )))))

--- a/sui-execution/latest/sui-move-natives/src/crypto/nitro_attestation.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/nitro_attestation.rs
@@ -148,5 +148,5 @@ fn to_indexed_struct(pcrs: Vec<Vec<u8>>) -> PartialVMResult<Value> {
             Value::vector_u8(pcr.to_vec()),
         ])));
     }
-    Ok(Value::vector_for_testing_only(indexed_struct))
+    Ok(Value::vector_value(indexed_struct))
 }

--- a/sui-execution/latest/sui-move-natives/src/event.rs
+++ b/sui-execution/latest/sui-move-natives/src/event.rs
@@ -158,6 +158,6 @@ pub fn get_events_by_type(
         .collect::<Vec<_>>();
     Ok(NativeResult::ok(
         legacy_test_cost(),
-        smallvec![Value::vector_for_testing_only(matched_events)],
+        smallvec![Value::vector_value(matched_events)],
     ))
 }

--- a/sui-execution/latest/sui-move-natives/src/event.rs
+++ b/sui-execution/latest/sui-move-natives/src/event.rs
@@ -156,8 +156,19 @@ pub fn get_events_by_type(
             }
         })
         .collect::<Vec<_>>();
+
+    // Should never be None at this point, but if it is, use the default value for the max
+    // depth.
+    debug_assert!(context
+        .runtime_limits_config()
+        .max_value_nest_depth
+        .is_some());
+    let max_value_nest_depth = context
+        .runtime_limits_config()
+        .max_value_nest_depth
+        .unwrap_or(/* DEFAULT_MAX_VALUE_DEPTH */ 128);
     Ok(NativeResult::ok(
         legacy_test_cost(),
-        smallvec![Value::vector_value(matched_events)],
+        smallvec![Value::vector_value(matched_events, max_value_nest_depth)?],
     ))
 }

--- a/sui-execution/latest/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/latest/sui-move-natives/src/test_scenario.rs
@@ -420,7 +420,7 @@ pub fn ids_for_address(
         .and_then(|inv| inv.get(&specified_ty))
         .map(|s| s.iter().map(|id| pack_id(*id)).collect::<Vec<Value>>())
         .unwrap_or_default();
-    let ids_vector = Value::vector_for_testing_only(ids);
+    let ids_vector = Value::vector_value(ids);
     Ok(NativeResult::ok(legacy_test_cost(), smallvec![ids_vector]))
 }
 
@@ -813,11 +813,11 @@ fn pack_id(a: impl Into<AccountAddress>) -> Value {
 }
 
 fn pack_ids(items: impl IntoIterator<Item = impl Into<AccountAddress>>) -> Value {
-    Value::vector_for_testing_only(items.into_iter().map(pack_id))
+    Value::vector_value(items.into_iter().map(pack_id))
 }
 
 fn pack_vec_map(items: impl IntoIterator<Item = (Value, Value)>) -> Value {
-    Value::struct_(values::Struct::pack(vec![Value::vector_for_testing_only(
+    Value::struct_(values::Struct::pack(vec![Value::vector_value(
         items
             .into_iter()
             .map(|(k, v)| Value::struct_(values::Struct::pack(vec![k, v]))),
@@ -877,9 +877,7 @@ fn pack_option(opt: Option<Value>) -> Value {
         Some(v) => vec![v],
         None => vec![],
     };
-    Value::struct_(values::Struct::pack(vec![Value::vector_for_testing_only(
-        item,
-    )]))
+    Value::struct_(values::Struct::pack(vec![Value::vector_value(item)]))
 }
 
 fn find_all_wrapped_objects<'a, 'i>(

--- a/sui-execution/v0/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/v0/sui-move-natives/src/test_scenario.rs
@@ -302,7 +302,7 @@ pub fn ids_for_address(
         .and_then(|inv| inv.get(&specified_ty))
         .map(|s| s.keys().map(|id| pack_id(*id)).collect::<Vec<Value>>())
         .unwrap_or_default();
-    let ids_vector = Value::vector_for_testing_only(ids);
+    let ids_vector = Value::vector_value(ids);
     Ok(NativeResult::ok(legacy_test_cost(), smallvec![ids_vector]))
 }
 
@@ -574,11 +574,11 @@ fn pack_id(a: impl Into<AccountAddress>) -> Value {
 }
 
 fn pack_ids(items: impl IntoIterator<Item = impl Into<AccountAddress>>) -> Value {
-    Value::vector_for_testing_only(items.into_iter().map(pack_id))
+    Value::vector_value(items.into_iter().map(pack_id))
 }
 
 fn pack_vec_map(items: impl IntoIterator<Item = (Value, Value)>) -> Value {
-    Value::struct_(values::Struct::pack(vec![Value::vector_for_testing_only(
+    Value::struct_(values::Struct::pack(vec![Value::vector_value(
         items
             .into_iter()
             .map(|(k, v)| Value::struct_(values::Struct::pack(vec![k, v]))),
@@ -635,9 +635,7 @@ fn pack_option(opt: Option<Value>) -> Value {
         Some(v) => vec![v],
         None => vec![],
     };
-    Value::struct_(values::Struct::pack(vec![Value::vector_for_testing_only(
-        item,
-    )]))
+    Value::struct_(values::Struct::pack(vec![Value::vector_value(item)]))
 }
 
 fn find_all_wrapped_objects<'a, 'i>(

--- a/sui-execution/v1/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/v1/sui-move-natives/src/test_scenario.rs
@@ -297,7 +297,7 @@ pub fn ids_for_address(
         .and_then(|inv| inv.get(&specified_ty))
         .map(|s| s.keys().map(|id| pack_id(*id)).collect::<Vec<Value>>())
         .unwrap_or_default();
-    let ids_vector = Value::vector_for_testing_only(ids);
+    let ids_vector = Value::vector_value(ids);
     Ok(NativeResult::ok(legacy_test_cost(), smallvec![ids_vector]))
 }
 
@@ -569,11 +569,11 @@ fn pack_id(a: impl Into<AccountAddress>) -> Value {
 }
 
 fn pack_ids(items: impl IntoIterator<Item = impl Into<AccountAddress>>) -> Value {
-    Value::vector_for_testing_only(items.into_iter().map(pack_id))
+    Value::vector_value(items.into_iter().map(pack_id))
 }
 
 fn pack_vec_map(items: impl IntoIterator<Item = (Value, Value)>) -> Value {
-    Value::struct_(values::Struct::pack(vec![Value::vector_for_testing_only(
+    Value::struct_(values::Struct::pack(vec![Value::vector_value(
         items
             .into_iter()
             .map(|(k, v)| Value::struct_(values::Struct::pack(vec![k, v]))),
@@ -630,9 +630,7 @@ fn pack_option(opt: Option<Value>) -> Value {
         Some(v) => vec![v],
         None => vec![],
     };
-    Value::struct_(values::Struct::pack(vec![Value::vector_for_testing_only(
-        item,
-    )]))
+    Value::struct_(values::Struct::pack(vec![Value::vector_value(item)]))
 }
 
 fn find_all_wrapped_objects<'a, 'i>(

--- a/sui-execution/v2/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/v2/sui-move-natives/src/test_scenario.rs
@@ -299,7 +299,7 @@ pub fn ids_for_address(
         .and_then(|inv| inv.get(&specified_ty))
         .map(|s| s.iter().map(|id| pack_id(*id)).collect::<Vec<Value>>())
         .unwrap_or_default();
-    let ids_vector = Value::vector_for_testing_only(ids);
+    let ids_vector = Value::vector_value(ids);
     Ok(NativeResult::ok(legacy_test_cost(), smallvec![ids_vector]))
 }
 
@@ -571,11 +571,11 @@ fn pack_id(a: impl Into<AccountAddress>) -> Value {
 }
 
 fn pack_ids(items: impl IntoIterator<Item = impl Into<AccountAddress>>) -> Value {
-    Value::vector_for_testing_only(items.into_iter().map(pack_id))
+    Value::vector_value(items.into_iter().map(pack_id))
 }
 
 fn pack_vec_map(items: impl IntoIterator<Item = (Value, Value)>) -> Value {
-    Value::struct_(values::Struct::pack(vec![Value::vector_for_testing_only(
+    Value::struct_(values::Struct::pack(vec![Value::vector_value(
         items
             .into_iter()
             .map(|(k, v)| Value::struct_(values::Struct::pack(vec![k, v]))),
@@ -632,9 +632,7 @@ fn pack_option(opt: Option<Value>) -> Value {
         Some(v) => vec![v],
         None => vec![],
     };
-    Value::struct_(values::Struct::pack(vec![Value::vector_for_testing_only(
-        item,
-    )]))
+    Value::struct_(values::Struct::pack(vec![Value::vector_value(item)]))
 }
 
 fn find_all_wrapped_objects<'a, 'i>(


### PR DESCRIPTION
## Description 

Just renames the function as it's fine to use, and just really badly named...

Renames `Value::vector_for_testing_only` => `Value::vector_value`.

## Test plan 

CI

