### PR TITLE
[sui][cli] Add ability to specify network in command

### DIFF
--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -388,7 +388,7 @@ pub fn new_wallet_context_from_cluster(
         wallet_config_path
     );
 
-    WalletContext::new(&wallet_config_path, None, None).unwrap_or_else(|e| {
+    WalletContext::new(&wallet_config_path).unwrap_or_else(|e| {
         panic!(
             "Failed to init wallet context from path {:?}, error: {e}",
             wallet_config_path

--- a/crates/sui-faucet/src/server.rs
+++ b/crates/sui-faucet/src/server.rs
@@ -79,11 +79,10 @@ pub fn create_wallet_context(
 ) -> Result<WalletContext, anyhow::Error> {
     let wallet_conf = config_dir.join(SUI_CLIENT_CONFIG);
     info!("Initialize wallet from config path: {:?}", wallet_conf);
-    WalletContext::new(
-        &wallet_conf,
-        Some(Duration::from_secs(timeout_secs)),
-        Some(1000),
-    )
+    WalletContext::new(&wallet_conf).map(|ctx| {
+        ctx.with_request_timeout(Duration::from_secs(timeout_secs))
+            .with_max_concurrent_requests(1000)
+    })
 }
 
 async fn handle_error(error: BoxError) -> impl IntoResponse {

--- a/crates/sui-oracle/src/main.rs
+++ b/crates/sui-oracle/src/main.rs
@@ -25,12 +25,8 @@ async fn main() -> anyhow::Result<()> {
 
     let config = OracleNodeConfig::load(&args.oracle_config_path)?;
 
-    let wallet_ctx = WalletContext::new(
-        &args.client_config_path,
-        // TODO make this configurable
-        Some(Duration::from_secs(10)), // request times out after 10 secs
-        None,
-    )?;
+    let wallet_ctx =
+        WalletContext::new(&args.client_config_path)?.with_request_timeout(Duration::from_secs(10)); // request times out after 10 secs
 
     // Init metrics server
     let registry_service = start_prometheus_server(config.metrics_address);

--- a/crates/sui-sdk/examples/utils.rs
+++ b/crates/sui-sdk/examples/utils.rs
@@ -311,7 +311,8 @@ pub fn retrieve_wallet() -> Result<WalletContext, anyhow::Error> {
     client_config.active_address = Some(default_active_address);
     client_config.save(&wallet_conf)?;
 
-    let wallet = WalletContext::new(&wallet_conf, Some(std::time::Duration::from_secs(60)), None)?;
+    let wallet =
+        WalletContext::new(&wallet_conf)?.with_request_timeout(std::time::Duration::from_secs(60));
 
     Ok(wallet)
 }

--- a/crates/sui-sdk/src/wallet_context.rs
+++ b/crates/sui-sdk/src/wallet_context.rs
@@ -67,6 +67,10 @@ impl WalletContext {
         self.config.keystore.addresses()
     }
 
+    pub fn get_env_override(&self) -> Option<String> {
+        self.env_override.clone()
+    }
+
     pub async fn get_client(&self) -> Result<SuiClient, anyhow::Error> {
         let read = self.client.read().await;
 

--- a/crates/sui-sdk/src/wallet_context.rs
+++ b/crates/sui-sdk/src/wallet_context.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::sui_client_config::SuiClientConfig;
+use crate::sui_client_config::{SuiClientConfig, SuiEnv};
 use crate::SuiClient;
 use anyhow::anyhow;
 use shared_crypto::intent::Intent;
@@ -25,14 +25,11 @@ pub struct WalletContext {
     request_timeout: Option<std::time::Duration>,
     client: Arc<RwLock<Option<SuiClient>>>,
     max_concurrent_requests: Option<u64>,
+    env_override: Option<String>,
 }
 
 impl WalletContext {
-    pub fn new(
-        config_path: &Path,
-        request_timeout: Option<std::time::Duration>,
-        max_concurrent_requests: Option<u64>,
-    ) -> Result<Self, anyhow::Error> {
+    pub fn new(config_path: &Path) -> Result<Self, anyhow::Error> {
         let config: SuiClientConfig = PersistedConfig::read(config_path).map_err(|err| {
             anyhow!(
                 "Cannot open wallet config file at {:?}. Err: {err}",
@@ -43,11 +40,27 @@ impl WalletContext {
         let config = config.persisted(config_path);
         let context = Self {
             config,
-            request_timeout,
+            request_timeout: None,
             client: Default::default(),
-            max_concurrent_requests,
+            max_concurrent_requests: None,
+            env_override: None,
         };
         Ok(context)
+    }
+
+    pub fn with_request_timeout(mut self, request_timeout: std::time::Duration) -> Self {
+        self.request_timeout = Some(request_timeout);
+        self
+    }
+
+    pub fn with_max_concurrent_requests(mut self, max_concurrent_requests: u64) -> Self {
+        self.max_concurrent_requests = Some(max_concurrent_requests);
+        self
+    }
+
+    pub fn with_env_override(mut self, env_override: String) -> Self {
+        self.env_override = Some(env_override);
+        self
     }
 
     pub fn get_addresses(&self) -> Vec<SuiAddress> {
@@ -62,12 +75,24 @@ impl WalletContext {
         } else {
             drop(read);
             let client = self
-                .config
                 .get_active_env()?
                 .create_rpc_client(self.request_timeout, self.max_concurrent_requests)
                 .await?;
             self.client.write().await.insert(client).clone()
         })
+    }
+
+    pub fn get_active_env(&self) -> Result<&SuiEnv, anyhow::Error> {
+        if self.env_override.is_some() {
+            self.config.get_env(&self.env_override).ok_or_else(|| {
+                anyhow!(
+                    "Environment configuration not found for env [{}]",
+                    self.env_override.as_deref().unwrap_or("None")
+                )
+            })
+        } else {
+            self.config.get_active_env()
+        }
     }
 
     // TODO: Ger rid of mut

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -718,7 +718,7 @@ impl SuiClientCommands {
                     profile_output,
                     config_objects: None,
                 };
-                let rpc = context.config.get_active_env()?.rpc.clone();
+                let rpc = context.get_active_env()?.rpc.clone();
                 let _command_result =
                     sui_replay::execute_replay_command(Some(rpc), false, false, None, None, cmd)
                         .await?;
@@ -740,7 +740,7 @@ impl SuiClientCommands {
                     config_objects: None,
                 };
 
-                let rpc = context.config.get_active_env()?.rpc.clone();
+                let rpc = context.get_active_env()?.rpc.clone();
                 let _command_result =
                     sui_replay::execute_replay_command(Some(rpc), false, false, None, None, cmd)
                         .await?;
@@ -757,7 +757,7 @@ impl SuiClientCommands {
                     num_tasks: 16,
                     persist_path: None,
                 };
-                let rpc = context.config.get_active_env()?.rpc.clone();
+                let rpc = context.get_active_env()?.rpc.clone();
                 let _command_result =
                     sui_replay::execute_replay_command(Some(rpc), false, false, None, None, cmd)
                         .await?;
@@ -775,7 +775,7 @@ impl SuiClientCommands {
                     terminate_early,
                     max_tasks: 16,
                 };
-                let rpc = context.config.get_active_env()?.rpc.clone();
+                let rpc = context.get_active_env()?.rpc.clone();
                 let _command_result =
                     sui_replay::execute_replay_command(Some(rpc), false, false, None, None, cmd)
                         .await?;
@@ -930,11 +930,7 @@ impl SuiClientCommands {
                 } else {
                     None
                 };
-                let env_alias = context
-                    .config
-                    .get_active_env()
-                    .map(|e| e.alias.clone())
-                    .ok();
+                let env_alias = context.get_active_env().map(|e| e.alias.clone()).ok();
                 let verify =
                     check_dep_verification_flags(skip_dependency_verification, verify_deps)?;
 
@@ -1536,7 +1532,7 @@ impl SuiClientCommands {
                     );
                     url
                 } else {
-                    let active_env = context.config.get_active_env();
+                    let active_env = context.get_active_env();
 
                     if let Ok(env) = active_env {
                         let network = match env.rpc.as_str() {

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1691,12 +1691,12 @@ impl SuiClientCommands {
                 context.config.save()?;
                 SuiClientCommandResult::NewEnv(env)
             }
-            SuiClientCommands::ActiveEnv => {
-                SuiClientCommandResult::ActiveEnv(context.config.active_env.clone())
-            }
+            SuiClientCommands::ActiveEnv => SuiClientCommandResult::ActiveEnv(
+                context.get_active_env().ok().map(|e| e.alias.clone()),
+            ),
             SuiClientCommands::Envs => SuiClientCommandResult::Envs(
                 context.config.envs.clone(),
-                context.config.active_env.clone(),
+                context.get_active_env().ok().map(|e| e.alias.clone()),
             ),
             SuiClientCommands::VerifySource {
                 package_path,

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -147,7 +147,7 @@ pub struct SuiEnvConfig {
     #[clap(long = "client.config")]
     config: Option<PathBuf>,
     /// The Sui environment to use. This must be present in the current config file.
-    #[clap(long = "env")]
+    #[clap(long = "client.env")]
     env: Option<String>,
 }
 
@@ -527,7 +527,7 @@ impl SuiCommand {
                                 bail!(
                                     "`sui move build --dump-bytecode-as-base64` requires a connection to the network. \
                                      Current active network is {} but failed to connect to it.", 
-                                     context.config.active_env.as_ref().unwrap()
+                                     context.get_active_env()?.alias
                                 );
                             };
 

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -140,6 +140,17 @@ impl IndexerArgs {
     }
 }
 
+#[derive(Parser)]
+#[clap(rename_all = "kebab-case")]
+pub struct SuiEnvConfig {
+    /// Sets the file storing the state of our user accounts (an empty one will be created if missing)
+    #[clap(long = "client.config")]
+    config: Option<PathBuf>,
+    /// The Sui environment to use. This must be present in the current config file.
+    #[clap(long = "env")]
+    env: Option<String>,
+}
+
 #[allow(clippy::large_enum_variant)]
 #[derive(Parser)]
 #[clap(rename_all = "kebab-case")]
@@ -280,9 +291,8 @@ pub enum SuiCommand {
     /// Client for interacting with the Sui network.
     #[clap(name = "client")]
     Client {
-        /// Sets the file storing the state of our user accounts (an empty one will be created if missing)
-        #[clap(long = "client.config")]
-        config: Option<PathBuf>,
+        #[clap(flatten)]
+        config: SuiEnvConfig,
         #[clap(subcommand)]
         cmd: Option<SuiClientCommands>,
         /// Return command outputs in json format.
@@ -312,10 +322,8 @@ pub enum SuiCommand {
         /// Path to a package which the command should be run with respect to.
         #[clap(long = "path", short = 'p', global = true)]
         package_path: Option<PathBuf>,
-        /// Sets the file storing the state of our user accounts (an empty one will be created if missing)
-        /// Only used when the `--dump-bytecode-as-base64` is set.
-        #[clap(long = "client.config")]
-        config: Option<PathBuf>,
+        #[clap(flatten)]
+        config: SuiEnvConfig,
         /// Package build options
         #[clap(flatten)]
         build_config: BuildConfig,
@@ -440,10 +448,15 @@ impl SuiCommand {
                 json,
                 accept_defaults,
             } => {
-                let config_path = config.unwrap_or(sui_config_dir()?.join(SUI_CLIENT_CONFIG));
+                let config_path = config
+                    .config
+                    .unwrap_or(sui_config_dir()?.join(SUI_CLIENT_CONFIG));
                 prompt_if_no_config(&config_path, accept_defaults).await?;
                 if let Some(cmd) = cmd {
-                    let mut context = WalletContext::new(&config_path, None, None)?;
+                    let mut context = WalletContext::new(&config_path)?;
+                    if let Some(env_override) = config.env {
+                        context = context.with_env_override(env_override);
+                    }
                     if let Ok(client) = context.get_client().await {
                         if let Err(e) = client.check_api_version() {
                             eprintln!("{}", format!("[warning] {e}").yellow().bold());
@@ -466,7 +479,7 @@ impl SuiCommand {
             } => {
                 let config_path = config.unwrap_or(sui_config_dir()?.join(SUI_CLIENT_CONFIG));
                 prompt_if_no_config(&config_path, accept_defaults).await?;
-                let mut context = WalletContext::new(&config_path, None, None)?;
+                let mut context = WalletContext::new(&config_path)?;
                 if let Some(cmd) = cmd {
                     if let Ok(client) = context.get_client().await {
                         if let Err(e) = client.check_api_version() {
@@ -500,13 +513,22 @@ impl SuiCommand {
                             // for tests it's useful to ignore the chain id!
                             (None, None)
                         } else {
-                            let config =
-                                client_config.unwrap_or(sui_config_dir()?.join(SUI_CLIENT_CONFIG));
+                            let config = client_config
+                                .config
+                                .unwrap_or(sui_config_dir()?.join(SUI_CLIENT_CONFIG));
                             prompt_if_no_config(&config, false).await?;
-                            let context = WalletContext::new(&config, None, None)?;
+                            let mut context = WalletContext::new(&config)?;
+
+                            if let Some(env_override) = client_config.env {
+                                context = context.with_env_override(env_override);
+                            }
 
                             let Ok(client) = context.get_client().await else {
-                                bail!("`sui move build --dump-bytecode-as-base64` requires a connection to the network. Current active network is {} but failed to connect to it.", context.config.active_env.as_ref().unwrap());
+                                bail!(
+                                    "`sui move build --dump-bytecode-as-base64` requires a connection to the network. \
+                                     Current active network is {} but failed to connect to it.", 
+                                     context.config.active_env.as_ref().unwrap()
+                                );
                             };
 
                             if let Err(e) = client.check_api_version() {
@@ -594,14 +616,14 @@ impl SuiCommand {
 
                 let config_path =
                     client_config.unwrap_or(sui_config_dir()?.join(SUI_CLIENT_CONFIG));
-                let mut context = WalletContext::new(&config_path, None, None)?;
+                let mut context = WalletContext::new(&config_path)?;
                 if let Ok(client) = context.get_client().await {
                     if let Err(e) = client.check_api_version() {
                         eprintln!("{}", format!("[warning] {e}").yellow().bold());
                     }
                 }
                 let rgp = context.get_reference_gas_price().await?;
-                let rpc_url = &context.config.get_active_env()?.rpc;
+                let rpc_url = &context.get_active_env()?.rpc;
                 println!("rpc_url: {}", rpc_url);
                 let bridge_metrics = Arc::new(BridgeMetrics::new_for_testing());
                 let sui_bridge_client = SuiBridgeClient::new(rpc_url, bridge_metrics).await?;

--- a/crates/sui/src/validator_commands.rs
+++ b/crates/sui/src/validator_commands.rs
@@ -545,7 +545,7 @@ impl SuiValidatorCommand {
                     bail!("Address {} is not in the committee", address);
                 }
                 println!("Starting bridge committee registration for Sui validator: {address}, with bridge public key: {} and url: {}", ecdsa_keypair.public, bridge_authority_url);
-                let sui_rpc_url = &context.config.get_active_env().unwrap().rpc;
+                let sui_rpc_url = &context.get_active_env().unwrap().rpc;
                 let bridge_metrics = Arc::new(BridgeMetrics::new_for_testing());
                 let bridge_client = SuiBridgeClient::new(sui_rpc_url, bridge_metrics).await?;
                 let bridge = bridge_client
@@ -607,7 +607,7 @@ impl SuiValidatorCommand {
                     validator_address,
                     print_unsigned_transaction_only,
                 )?;
-                let sui_rpc_url = &context.config.get_active_env().unwrap().rpc;
+                let sui_rpc_url = &context.get_active_env().unwrap().rpc;
                 let bridge_metrics = Arc::new(BridgeMetrics::new_for_testing());
                 let bridge_client = SuiBridgeClient::new(sui_rpc_url, bridge_metrics).await?;
                 let committee_members = bridge_client

--- a/crates/sui/tests/shell_tests/env_overrides/basic_override.sh
+++ b/crates/sui/tests/shell_tests/env_overrides/basic_override.sh
@@ -1,0 +1,16 @@
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+sui client --client.config config.yaml switch --env base
+
+sui client --client.config config.yaml envs
+sui client --client.config config.yaml --client.env one envs
+sui client --client.config config.yaml --client.env two envs
+
+sui client --client.config config.yaml active-env
+sui client --client.config config.yaml --client.env one active-env
+sui client --client.config config.yaml --client.env two active-env
+
+# Unknown name -- Should give you None and nothing active
+sui client --client.config config.yaml --client.env not_an_env envs
+sui client --client.config config.yaml --client.env not_an_env active-env

--- a/crates/sui/tests/shell_tests/env_overrides/config.yaml
+++ b/crates/sui/tests/shell_tests/env_overrides/config.yaml
@@ -1,0 +1,17 @@
+keystore:
+  File: ~
+envs:
+  - alias: base 
+    rpc: "https://custom.rpc.node.base:443"
+    ws: ~
+    basic_auth: ~
+  - alias: one
+    rpc: "https://custom.rpc.node.one:443"
+    ws: ~
+    basic_auth: ~
+  - alias: two
+    rpc: "https://custom.rpc.node.two:443"
+    ws: ~
+    basic_auth: ~
+active_env: base
+active_address: "0x0000000000000000000000000000000000000000000000000000000000000000"

--- a/crates/sui/tests/snapshots/shell_tests__env_overrides__basic_override.sh.snap
+++ b/crates/sui/tests/snapshots/shell_tests__env_overrides__basic_override.sh.snap
@@ -1,0 +1,61 @@
+---
+source: crates/sui/tests/shell_tests.rs
+description: tests/shell_tests/env_overrides/basic_override.sh
+---
+----- script -----
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+sui client --client.config config.yaml switch --env base
+
+sui client --client.config config.yaml envs
+sui client --client.config config.yaml --client.env one envs
+sui client --client.config config.yaml --client.env two envs
+
+sui client --client.config config.yaml active-env
+sui client --client.config config.yaml --client.env one active-env
+sui client --client.config config.yaml --client.env two active-env
+
+# Unknown name -- error
+sui client --client.config config.yaml --client.env not_an_env envs
+sui client --client.config config.yaml --client.env not_an_env active-env
+
+----- results -----
+success: true
+exit_code: 0
+----- stdout -----
+Active environment switched to [base]
+╭───────┬──────────────────────────────────┬────────╮
+│ alias │ url                              │ active │
+├───────┼──────────────────────────────────┼────────┤
+│ base  │ https://custom.rpc.node.base:443 │ *      │
+│ one   │ https://custom.rpc.node.one:443  │        │
+│ two   │ https://custom.rpc.node.two:443  │        │
+╰───────┴──────────────────────────────────┴────────╯
+╭───────┬──────────────────────────────────┬────────╮
+│ alias │ url                              │ active │
+├───────┼──────────────────────────────────┼────────┤
+│ base  │ https://custom.rpc.node.base:443 │        │
+│ one   │ https://custom.rpc.node.one:443  │ *      │
+│ two   │ https://custom.rpc.node.two:443  │        │
+╰───────┴──────────────────────────────────┴────────╯
+╭───────┬──────────────────────────────────┬────────╮
+│ alias │ url                              │ active │
+├───────┼──────────────────────────────────┼────────┤
+│ base  │ https://custom.rpc.node.base:443 │        │
+│ one   │ https://custom.rpc.node.one:443  │        │
+│ two   │ https://custom.rpc.node.two:443  │ *      │
+╰───────┴──────────────────────────────────┴────────╯
+base
+one
+two
+╭───────┬──────────────────────────────────┬────────╮
+│ alias │ url                              │ active │
+├───────┼──────────────────────────────────┼────────┤
+│ base  │ https://custom.rpc.node.base:443 │        │
+│ one   │ https://custom.rpc.node.one:443  │        │
+│ two   │ https://custom.rpc.node.two:443  │        │
+╰───────┴──────────────────────────────────┴────────╯
+None
+
+----- stderr -----

--- a/crates/sui/tests/snapshots/shell_tests__env_overrides__basic_override.sh.snap
+++ b/crates/sui/tests/snapshots/shell_tests__env_overrides__basic_override.sh.snap
@@ -16,7 +16,7 @@ sui client --client.config config.yaml active-env
 sui client --client.config config.yaml --client.env one active-env
 sui client --client.config config.yaml --client.env two active-env
 
-# Unknown name -- error
+# Unknown name -- Should give you None and nothing active
 sui client --client.config config.yaml --client.env not_an_env envs
 sui client --client.config config.yaml --client.env not_an_env active-env
 

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -1191,7 +1191,7 @@ impl TestClusterBuilder {
             .unwrap();
 
         let wallet_conf = swarm.dir().join(SUI_CLIENT_CONFIG);
-        let wallet = WalletContext::new(&wallet_conf, None, None).unwrap();
+        let wallet = WalletContext::new(&wallet_conf).unwrap();
 
         TestCluster {
             swarm,


### PR DESCRIPTION
## Description

This enables the ability for `move` and `client` subcommands to accept a `--client.env <network-name>` flag to use the specified `network-name` for the single command (overriding the current active-env).

`network-name` must be a valid environment in the current config in order to be used. E.g., a raw RPC URL for the `--client.env` name is invalid.


## Test plan 

Added test to make sure the `--client.env` flag properly overrides the environment. The best way I could find to test this in a repeatable/sane way was with `envs` and `active-env` calls. 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: Add `--client.env` flag to `client` and `move` subcommands to allow for selecting a specific environment for a single CLI command. 
- [X] Rust SDK: Update arguments to `WalletContext::new` so it only takes the path to the config. Additional configurations (timeout, max concurrent connections, etc) can then be set on the context after it has been created. 
