### PR TITLE
Add input object notify in the writeback cache

### DIFF
--- a/crates/sui-core/src/execution_cache/unit_tests/notify_read_input_objects_tests.rs
+++ b/crates/sui-core/src/execution_cache/unit_tests/notify_read_input_objects_tests.rs
@@ -1,12 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Copyright (c) Mysten Labs, Inc.
-// SPDX-License-Identifier: Apache-2.0
-
 use crate::authority::authority_store_tables::AuthorityPerpetualTables;
 
 use super::*;
+use futures::FutureExt;
 use std::path::Path;
 use std::time::Duration;
 use sui_framework::BuiltInFramework;
@@ -45,12 +43,10 @@ async fn test_immediate_return_canceled_shared() {
     let epoch = &0;
 
     // Should return immediately since canceled shared objects are always available
-    let result = timeout(
-        Duration::from_secs(1),
-        cache.notify_read_input_objects(&[canceled_key], &receiving_keys, epoch),
-    )
-    .await
-    .unwrap();
+    let result = cache
+        .notify_read_input_objects(&[canceled_key], &receiving_keys, epoch)
+        .now_or_never()
+        .unwrap();
     assert_eq!(result.len(), 1);
 
     let congested_key = InputKey::VersionedObject {
@@ -58,12 +54,10 @@ async fn test_immediate_return_canceled_shared() {
         version: SequenceNumber::CONGESTED,
     };
 
-    let result = timeout(
-        Duration::from_secs(1),
-        cache.notify_read_input_objects(&[congested_key], &receiving_keys, epoch),
-    )
-    .await
-    .unwrap();
+    let result = cache
+        .notify_read_input_objects(&[congested_key], &receiving_keys, epoch)
+        .now_or_never()
+        .unwrap();
     assert_eq!(result.len(), 1);
 
     let randomness_unavailable_key = InputKey::VersionedObject {
@@ -71,12 +65,10 @@ async fn test_immediate_return_canceled_shared() {
         version: SequenceNumber::RANDOMNESS_UNAVAILABLE,
     };
 
-    let result = timeout(
-        Duration::from_secs(1),
-        cache.notify_read_input_objects(&[randomness_unavailable_key], &receiving_keys, epoch),
-    )
-    .await
-    .unwrap();
+    let result = cache
+        .notify_read_input_objects(&[randomness_unavailable_key], &receiving_keys, epoch)
+        .now_or_never()
+        .unwrap();
     assert_eq!(result.len(), 1);
 }
 
@@ -98,12 +90,10 @@ async fn test_immediate_return_cached_object() {
     let epoch = &0;
 
     // Should return immediately since object is in cache
-    let result = timeout(
-        Duration::from_secs(1),
-        cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch),
-    )
-    .await
-    .unwrap();
+    let result = cache
+        .notify_read_input_objects(&input_keys, &receiving_keys, epoch)
+        .now_or_never()
+        .unwrap();
 
     assert_eq!(result.len(), 1);
 }
@@ -119,12 +109,10 @@ async fn test_immediate_return_cached_package() {
     let epoch = &0;
 
     // Should return immediately since system package is available by default.
-    let result = timeout(
-        Duration::from_secs(1),
-        cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch),
-    )
-    .await
-    .unwrap();
+    let result = cache
+        .notify_read_input_objects(&input_keys, &receiving_keys, epoch)
+        .now_or_never()
+        .unwrap();
 
     assert_eq!(result.len(), 1);
 }
@@ -151,12 +139,10 @@ async fn test_immediate_return_consensus_stream_ended() {
     let receiving_keys = HashSet::new();
 
     // Should return immediately since object is marked as consensus stream ended
-    let result = timeout(
-        Duration::from_secs(1),
-        cache.notify_read_input_objects(&input_keys, &receiving_keys, &epoch),
-    )
-    .await
-    .unwrap();
+    let result = cache
+        .notify_read_input_objects(&input_keys, &receiving_keys, &epoch)
+        .now_or_never()
+        .unwrap();
 
     assert_eq!(result.len(), 1);
 }
@@ -329,12 +315,10 @@ async fn test_receiving_object_higher_version() {
     let epoch = &0;
 
     // Should return immediately since a higher version exists for receiving object
-    let result = timeout(
-        Duration::from_secs(1),
-        cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch),
-    )
-    .await
-    .unwrap();
+    let result = cache
+        .notify_read_input_objects(&input_keys, &receiving_keys, epoch)
+        .now_or_never()
+        .unwrap();
 
     assert_eq!(result.len(), 1);
 }

--- a/crates/sui-core/src/execution_cache/unit_tests/notify_read_input_objects_tests.rs
+++ b/crates/sui-core/src/execution_cache/unit_tests/notify_read_input_objects_tests.rs
@@ -1,0 +1,340 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::authority::authority_store_tables::AuthorityPerpetualTables;
+
+use super::*;
+use std::path::Path;
+use std::time::Duration;
+use sui_framework::BuiltInFramework;
+use sui_move_build::BuildConfig;
+use sui_swarm_config::network_config_builder::ConfigBuilder;
+use sui_types::base_types::{ObjectID, SequenceNumber, SuiAddress};
+use sui_types::object::{Object, Owner};
+use sui_types::storage::InputKey;
+use sui_types::SUI_FRAMEWORK_PACKAGE_ID;
+use tempfile::tempdir;
+use tokio::time::timeout;
+
+async fn create_writeback_cache() -> Arc<WritebackCache> {
+    let path = tempdir().unwrap();
+    let tables = Arc::new(AuthorityPerpetualTables::open(path.path(), None));
+    let config = ConfigBuilder::new_with_temp_dir().build();
+    let store = AuthorityStore::open_with_committee_for_testing(
+        tables,
+        config.committee_with_network().committee(),
+        &config.genesis,
+    )
+    .await
+    .unwrap();
+    Arc::new(WritebackCache::new_for_tests(store))
+}
+
+#[tokio::test]
+async fn test_immediate_return_canceled_shared() {
+    let cache = create_writeback_cache().await;
+
+    let canceled_key = InputKey::VersionedObject {
+        id: FullObjectID::new(ObjectID::random(), Some(SequenceNumber::from(1))),
+        version: SequenceNumber::CANCELLED_READ,
+    };
+    let receiving_keys = HashSet::new();
+    let epoch = &0;
+
+    // Should return immediately since canceled shared objects are always available
+    let result = timeout(
+        Duration::from_secs(1),
+        cache.notify_read_input_objects(&[canceled_key], &receiving_keys, epoch),
+    )
+    .await
+    .unwrap();
+    assert_eq!(result.len(), 1);
+
+    let congested_key = InputKey::VersionedObject {
+        id: FullObjectID::new(ObjectID::random(), Some(SequenceNumber::from(1))),
+        version: SequenceNumber::CONGESTED,
+    };
+
+    let result = timeout(
+        Duration::from_secs(1),
+        cache.notify_read_input_objects(&[congested_key], &receiving_keys, epoch),
+    )
+    .await
+    .unwrap();
+    assert_eq!(result.len(), 1);
+
+    let randomness_unavailable_key = InputKey::VersionedObject {
+        id: FullObjectID::new(ObjectID::random(), Some(SequenceNumber::from(1))),
+        version: SequenceNumber::RANDOMNESS_UNAVAILABLE,
+    };
+
+    let result = timeout(
+        Duration::from_secs(1),
+        cache.notify_read_input_objects(&[randomness_unavailable_key], &receiving_keys, epoch),
+    )
+    .await
+    .unwrap();
+    assert_eq!(result.len(), 1);
+}
+
+#[tokio::test]
+async fn test_immediate_return_cached_object() {
+    let cache = create_writeback_cache().await;
+
+    let object_id = ObjectID::random();
+    let version = SequenceNumber::from(1);
+    let object = Object::with_id_owner_version_for_testing(object_id, version, Owner::Immutable);
+
+    cache.write_object_entry(&object_id, version, ObjectEntry::Object(object));
+
+    let input_keys = vec![InputKey::VersionedObject {
+        id: FullObjectID::new(object_id, None),
+        version,
+    }];
+    let receiving_keys = HashSet::new();
+    let epoch = &0;
+
+    // Should return immediately since object is in cache
+    let result = timeout(
+        Duration::from_secs(1),
+        cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.len(), 1);
+}
+
+#[tokio::test]
+async fn test_immediate_return_cached_package() {
+    let cache = create_writeback_cache().await;
+
+    let input_keys = vec![InputKey::Package {
+        id: SUI_FRAMEWORK_PACKAGE_ID,
+    }];
+    let receiving_keys = HashSet::new();
+    let epoch = &0;
+
+    // Should return immediately since system package is available by default.
+    let result = timeout(
+        Duration::from_secs(1),
+        cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.len(), 1);
+}
+
+#[tokio::test]
+async fn test_immediate_return_consensus_stream_ended() {
+    let cache = create_writeback_cache().await;
+
+    let object_id = ObjectID::random();
+    let version = SequenceNumber::from(1);
+    let epoch = 0;
+
+    // Write consensus stream ended marker
+    cache.write_marker_value(
+        epoch,
+        FullObjectKey::new(FullObjectID::new(object_id, Some(version)), version),
+        MarkerValue::ConsensusStreamEnded(TransactionDigest::random()),
+    );
+
+    let input_keys = vec![InputKey::VersionedObject {
+        id: FullObjectID::new(object_id, Some(version)),
+        version,
+    }];
+    let receiving_keys = HashSet::new();
+
+    // Should return immediately since object is marked as consensus stream ended
+    let result = timeout(
+        Duration::from_secs(1),
+        cache.notify_read_input_objects(&input_keys, &receiving_keys, &epoch),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.len(), 1);
+}
+
+#[tokio::test]
+async fn test_wait_for_object() {
+    let cache = create_writeback_cache().await;
+
+    let object_id = ObjectID::random();
+    let version = SequenceNumber::from(1);
+
+    let input_keys = vec![InputKey::VersionedObject {
+        id: FullObjectID::new(object_id, Some(version)),
+        version,
+    }];
+    let receiving_keys = HashSet::new();
+    let epoch = &0;
+
+    let result = timeout(
+        Duration::from_secs(3),
+        cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch),
+    )
+    .await;
+    assert!(result.is_err());
+
+    // Write an older version of the object.
+    tokio::spawn({
+        let cache = cache.clone();
+        async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let object = Object::with_id_owner_version_for_testing(
+                object_id,
+                SequenceNumber::from(0),
+                Owner::Shared {
+                    initial_shared_version: version,
+                },
+            );
+            cache.write_object_entry(&object_id, version, ObjectEntry::Object(object));
+        }
+    });
+    let result = timeout(
+        Duration::from_secs(3),
+        cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch),
+    )
+    .await;
+    assert!(result.is_err());
+
+    // Write the correct version of the object.
+    tokio::spawn({
+        let cache = cache.clone();
+        async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let object = Object::with_id_owner_version_for_testing(
+                object_id,
+                version,
+                Owner::Shared {
+                    initial_shared_version: version,
+                },
+            );
+            cache.write_object_entry(&object_id, version, ObjectEntry::Object(object));
+        }
+    });
+    let result = timeout(
+        Duration::from_secs(3),
+        cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch),
+    )
+    .await
+    .unwrap();
+    assert_eq!(result.len(), 1);
+}
+
+#[tokio::test]
+async fn test_wait_for_package() {
+    let cache = create_writeback_cache().await;
+
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../examples/move/basics");
+    let compiled_modules = BuildConfig::new_for_testing()
+        .build(&path)
+        .unwrap()
+        .into_modules();
+    let package = Object::new_package_for_testing(
+        &compiled_modules,
+        TransactionDigest::genesis_marker(),
+        BuiltInFramework::genesis_move_packages(),
+    )
+    .unwrap();
+    let package_id = package.id();
+    let version = package.version();
+
+    let input_keys = vec![InputKey::Package { id: package_id }];
+    let receiving_keys = HashSet::new();
+    let epoch = &0;
+
+    // Start notification future
+    let notification = cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch);
+
+    // Write package after small delay
+    tokio::spawn({
+        let cache = cache.clone();
+        async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            cache.write_object_entry(&package_id, version, ObjectEntry::Object(package));
+        }
+    });
+
+    // Should complete once package is written
+    let result = timeout(Duration::from_secs(1), notification).await.unwrap();
+
+    assert_eq!(result.len(), 1);
+}
+
+#[tokio::test]
+async fn test_wait_for_consensus_stream_end() {
+    let cache = create_writeback_cache().await;
+
+    let object_id = ObjectID::random();
+    let version = SequenceNumber::from(1);
+    let epoch = &0;
+
+    let input_keys = vec![InputKey::VersionedObject {
+        id: FullObjectID::new(object_id, Some(version)),
+        version,
+    }];
+    let receiving_keys = HashSet::new();
+
+    // Start notification future
+    let notification = cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch);
+
+    // Write consensus stream ended marker after small delay
+    tokio::spawn({
+        let cache = cache.clone();
+        async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            cache.write_marker_value(
+                *epoch,
+                FullObjectKey::new(FullObjectID::new(object_id, Some(version)), version),
+                MarkerValue::ConsensusStreamEnded(TransactionDigest::random()),
+            );
+        }
+    });
+
+    // Should complete once marker is written
+    let result = timeout(Duration::from_secs(1), notification).await.unwrap();
+
+    assert_eq!(result.len(), 1);
+}
+
+#[tokio::test]
+async fn test_receiving_object_higher_version() {
+    let cache = create_writeback_cache().await;
+
+    let object_id = ObjectID::random();
+    let requested_version = SequenceNumber::from(1);
+    let higher_version = SequenceNumber::from(2);
+    let object = Object::with_id_owner_version_for_testing(
+        object_id,
+        higher_version,
+        Owner::AddressOwner(SuiAddress::default()),
+    );
+
+    // Write higher version to cache
+    cache.write_object_entry(&object_id, higher_version, ObjectEntry::Object(object));
+
+    let input_keys = vec![InputKey::VersionedObject {
+        id: FullObjectID::new(object_id, None),
+        version: requested_version,
+    }];
+    let mut receiving_keys = HashSet::new();
+    receiving_keys.insert(input_keys[0]);
+    let epoch = &0;
+
+    // Should return immediately since a higher version exists for receiving object
+    let result = timeout(
+        Duration::from_secs(1),
+        cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result.len(), 1);
+}

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -56,8 +56,7 @@ use moka::sync::SegmentedCache as MokaCache;
 use mysten_common::random_util::randomize_cache_capacity_in_tests;
 use mysten_common::sync::notify_read::NotifyRead;
 use parking_lot::Mutex;
-use prometheus::Registry;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::hash::Hash;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
@@ -77,7 +76,7 @@ use sui_types::message_envelope::Message;
 use sui_types::messages_checkpoint::CheckpointSequenceNumber;
 use sui_types::object::Object;
 use sui_types::storage::{
-    FullObjectKey, MarkerValue, ObjectKey, ObjectOrTombstone, ObjectStore, PackageObject,
+    FullObjectKey, InputKey, MarkerValue, ObjectKey, ObjectOrTombstone, ObjectStore, PackageObject,
 };
 use sui_types::sui_system_state::{get_sui_system_state, SuiSystemState};
 use sui_types::transaction::{VerifiedSignedTransaction, VerifiedTransaction};
@@ -97,6 +96,10 @@ use super::{
 #[cfg(test)]
 #[path = "unit_tests/writeback_cache_tests.rs"]
 pub mod writeback_cache_tests;
+
+#[cfg(test)]
+#[path = "unit_tests/notify_read_input_objects_tests.rs"]
+mod notify_read_input_objects_tests;
 
 #[derive(Clone, PartialEq, Eq)]
 enum ObjectEntry {
@@ -194,7 +197,7 @@ impl IsNewer for LatestObjectCacheEntry {
 
 type MarkerKey = (EpochId, FullObjectID);
 
-/// UncommitedData stores execution outputs that are not yet written to the db. Entries in this
+/// UncommittedData stores execution outputs that are not yet written to the db. Entries in this
 /// struct can only be purged after they are committed.
 struct UncommittedData {
     /// The object dirty set. All writes go into this table first. After we flush the data to the
@@ -426,6 +429,7 @@ pub struct WritebackCache {
     object_locks: ObjectLocks,
 
     executed_effects_digests_notify_read: NotifyRead<TransactionDigest, TransactionEffectsDigest>,
+    object_notify_read: NotifyRead<InputKey, ()>,
     store: Arc<AuthorityStore>,
     backpressure_threshold: u64,
     backpressure_manager: Arc<BackpressureManager>,
@@ -487,6 +491,7 @@ impl WritebackCache {
             packages,
             object_locks: ObjectLocks::new(),
             executed_effects_digests_notify_read: NotifyRead::new(),
+            object_notify_read: NotifyRead::new(),
             store,
             backpressure_manager,
             backpressure_threshold: config.backpressure_threshold(),
@@ -494,11 +499,11 @@ impl WritebackCache {
         }
     }
 
-    pub fn new_for_tests(store: Arc<AuthorityStore>, registry: &Registry) -> Self {
+    pub fn new_for_tests(store: Arc<AuthorityStore>) -> Self {
         Self::new(
             &Default::default(),
             store,
-            ExecutionCacheMetrics::new(registry).into(),
+            ExecutionCacheMetrics::new(&prometheus::Registry::new()).into(),
             BackpressureManager::new_for_tests(),
         )
     }
@@ -555,7 +560,22 @@ impl WritebackCache {
             // See the comment in `MonotonicCache::insert`.
             .ok();
 
-        entry.insert(version, object);
+        entry.insert(version, object.clone());
+
+        if let ObjectEntry::Object(object) = &object {
+            if object.is_package() {
+                self.object_notify_read
+                    .notify(&InputKey::Package { id: *object_id }, &());
+            } else if !object.is_child_object() {
+                self.object_notify_read.notify(
+                    &InputKey::VersionedObject {
+                        id: object.full_id(),
+                        version: object.version(),
+                    },
+                    &(),
+                );
+            }
+        }
     }
 
     fn write_marker_value(
@@ -572,6 +592,19 @@ impl WritebackCache {
             .or_default()
             .value_mut()
             .insert(object_key.version(), marker_value);
+        // It is possible for a transaction to use a consensus stream ended
+        // object in the input, hence we must notify that it is now available
+        // at the assigned version, so that any transaction waiting for this
+        // object version can start execution.
+        if matches!(marker_value, MarkerValue::ConsensusStreamEnded(_)) {
+            self.object_notify_read.notify(
+                &InputKey::VersionedObject {
+                    id: object_key.id(),
+                    version: object_key.version(),
+                },
+                &(),
+            );
+        }
     }
 
     // lock both the dirty and committed sides of the cache, and then pass the entries to
@@ -944,7 +977,7 @@ impl WritebackCache {
                 // This can happen in the following rare case:
                 // All transactions in the checkpoint are committed to the db (by commit_transaction_outputs,
                 // called in CheckpointExecutor::process_executed_transactions), but the process crashes before
-                // the checkpoint water mark is bumped. We will then re-commit thhe checkpoint at startup,
+                // the checkpoint water mark is bumped. We will then re-commit the checkpoint at startup,
                 // despite that all transactions are already executed.
                 warn!("Attempt to commit unknown transaction {:?}", tx);
                 continue;
@@ -1219,7 +1252,7 @@ impl WritebackCache {
     fn revert_state_update_impl(&self, tx: &TransactionDigest) {
         // TODO: remove revert_state_update_impl entirely, and simply drop all dirty
         // state when clear_state_end_of_epoch_impl is called.
-        // Futher, once we do this, we can delay the insertion of the transaction into
+        // Further, once we do this, we can delay the insertion of the transaction into
         // pending_consensus_transactions until after the transaction has executed.
         let Some((_, outputs)) = self.dirty.pending_transaction_writes.remove(tx) else {
             assert!(
@@ -1764,6 +1797,86 @@ impl ObjectCacheRead for WritebackCache {
             .perpetual_tables
             .get_highest_pruned_checkpoint()
             .expect("db error")
+    }
+
+    fn notify_read_input_objects<'a>(
+        &'a self,
+        input_and_receiving_keys: &'a [InputKey],
+        receiving_keys: &'a HashSet<InputKey>,
+        epoch: &'a EpochId,
+    ) -> BoxFuture<'a, Vec<()>> {
+        self.object_notify_read
+            .read(input_and_receiving_keys, |keys| {
+                let mut results = vec![None; keys.len()];
+
+                let (keys_with_version, keys_without_version): (Vec<_>, Vec<_>) = keys
+                    .iter()
+                    .enumerate()
+                    .filter(|(idx, key)| {
+                        if key.is_cancelled() {
+                            // Shared objects in canceled transactions are always available.
+                            results[*idx] = Some(());
+                            false
+                        } else {
+                            true
+                        }
+                    })
+                    .partition(|(_, key)| key.version().is_some());
+                let versioned_object_keys: Vec<_> = keys_with_version
+                    .iter()
+                    .map(|(_, key)| ObjectKey(key.id().id(), key.version().unwrap()))
+                    .collect();
+                ObjectCacheRead::multi_get_objects_by_key(self, &versioned_object_keys)
+                    .into_iter()
+                    .zip(keys_with_version.iter())
+                    .for_each(|(o, (idx, input_key))| match o {
+                        Some(_) => results[*idx] = Some(()),
+                        None => {
+                            if receiving_keys.contains(input_key) {
+                                // There could be a more recent version of this object, and the object at the
+                                // specified version could have already been pruned. In such a case `has_key` will
+                                // be false, but since this is a receiving object we should mark it as available if
+                                // we can determine that an object with a version greater than or equal to the
+                                // specified version exists or was deleted. We will then let mark it as available
+                                // to let the transaction through so it can fail at execution.
+                                let is_available =
+                                    ObjectCacheRead::get_object(self, &input_key.id().id())
+                                        .map(|obj| obj.version() >= input_key.version().unwrap())
+                                        .unwrap_or(false)
+                                        || self.fastpath_stream_ended_at_version_or_after(
+                                            input_key.id().id(),
+                                            input_key.version().unwrap(),
+                                            *epoch,
+                                        );
+                                if is_available {
+                                    results[*idx] = Some(());
+                                }
+                            } else if self
+                                .get_consensus_stream_end_tx_digest(
+                                    FullObjectKey::new(
+                                        input_key.id(),
+                                        input_key.version().unwrap(),
+                                    ),
+                                    *epoch,
+                                )
+                                .is_some()
+                            {
+                                // If the object is an already-removed consensus object, mark it as available if the
+                                // version for that object is in the marker table.
+                                results[*idx] = Some(());
+                            }
+                        }
+                    });
+                keys_without_version.iter().for_each(|(idx, key)| {
+                    // unwrap is safe since this only errors when the object is not a package,
+                    // which is impossible if we have a certificate for execution.
+                    if self.get_package_object(&key.id().id()).unwrap().is_some() {
+                        results[*idx] = Some(());
+                    }
+                });
+                results
+            })
+            .boxed()
     }
 }
 


### PR DESCRIPTION
## Description 

This PR adds an object notify in the writeback cache. It will allow us to replace transaction manager.
A transaction to be scheduled will call the notify wait to wait for input object to become available.
The notify wait function is very similar to `multi_input_objects_available` in execution cache.

## Test plan 

Added tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
