### PR TITLE
[docs] Fix formatting and improve tip message 

### DIFF
--- a/docs/content/concepts/cryptography/passkeys.mdx
+++ b/docs/content/concepts/cryptography/passkeys.mdx
@@ -17,7 +17,7 @@ Refer to the [Typescript SDK support](https://sdk.mystenlabs.com/typescript/cryp
 
 :::info
 Passkey support is available in beta in Sui Devnet and Testnet. The Mainnet release is yet to be scheduled.  
-::: 
+:::
 
 ## Benefits of using passkey
 

--- a/docs/content/concepts/sui-architecture/transaction-lifecycle.mdx
+++ b/docs/content/concepts/sui-architecture/transaction-lifecycle.mdx
@@ -83,7 +83,7 @@ Eventually, the Full node collects effects signatures from a supermajority of va
 
 An effects certificate is a guarantee of transaction finality.
 
-::: 
+:::
 
 After you or a Full node observes an effects certificate, you are guaranteed that the transaction is going to be included in a checkpoint, which means that the transaction cannot be reverted.
 

--- a/docs/content/standards/deepbookv3-sdk/orders.mdx
+++ b/docs/content/standards/deepbookv3-sdk/orders.mdx
@@ -37,10 +37,8 @@ placeMarketOrder({ params: PlaceMarketOrderParams });
 
 Use `cancelOrder` to cancel an existing order that is identified by the `orderId` thqt you provide. The call returns a function that takes a `Transaction` object.
 
-::: warn
-
+:::warning
 The `orderId` is the protocol `orderId` generated during order placement, which is different from the client `orderId`.
-
 :::
 
 **Parameters**

--- a/docs/content/standards/deepbookv3-sdk/pools.mdx
+++ b/docs/content/standards/deepbookv3-sdk/pools.mdx
@@ -9,9 +9,10 @@ Pools are shared objects that represent a market. See [Query the Pool](../deepbo
 
 The DeepBookV3 SDK exposes functions that you can call to read the state of a pool. These functions typically require a `managerKey`, `coinKey`, `poolKey`, or a combination of these. For details on these keys, see [DeepBookV3 SDK](../deepbookv3-sdk.mdx#keys). The SDK includes some default keys that you can view in the `constants.ts` file.
 
-::: tip
-Decimal adjust all input quantities. All outputs are decimal adjusted.
+:::tip SDK Unit Handling
+Input amounts, quantities, and prices should be provided in standard decimal format (e.g., `10.5` SUI, `0.00001` nBTC). The SDK handles conversion to base units internally. Returned amounts are also in standard decimal format.
 :::
+
 
 ### account
 


### PR DESCRIPTION
## Description 

This PR fixes `tip` and `warning` formatting to render correctly. Added new, improved `tip` for how the SDK handles decimals. The previous message was confusing and did not explain how the decimals should be adjusted. 

## Test plan 

I build it locally and tested the formatting. 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
