### PR TITLE
[1/n][move-core-types-cleanup] Remove `ResourceResolver` trait

### DIFF
--- a/crates/sui-replay-2/src/execution.rs
+++ b/crates/sui-replay-2/src/execution.rs
@@ -9,11 +9,7 @@ use crate::{
 use move_binary_format::CompiledModule;
 use move_bytecode_source_map::utils::serialize_to_json_string;
 use move_command_line_common::files::MOVE_BYTECODE_EXTENSION;
-use move_core_types::{
-    account_address::AccountAddress,
-    language_storage::{ModuleId, StructTag},
-    resolver::{ModuleResolver, ResourceResolver},
-};
+use move_core_types::{language_storage::ModuleId, resolver::ModuleResolver};
 use move_disassembler::disassembler::Disassembler;
 use move_ir_types::location::Spanned;
 use move_trace_format::format::MoveTraceBuilder;
@@ -370,21 +366,6 @@ impl ParentSync for ReplayStore<'_> {
         unreachable!(
             "unexpected ParentSync::get_latest_parent_entry_ref_deprecated({})",
             object_id,
-        )
-    }
-}
-
-impl ResourceResolver for ReplayStore<'_> {
-    type Error = ReplayError;
-
-    fn get_resource(
-        &self,
-        address: &AccountAddress,
-        typ: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        unreachable!(
-            "unexpected ResourceResolver::get_resource({}, {})",
-            address, typ
         )
     }
 }

--- a/external-crates/move/crates/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -10,8 +10,8 @@ use move_command_line_common::files::MOVE_COMPILED_EXTENSION;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::Identifier,
-    language_storage::{ModuleId, StructTag},
-    resolver::{LinkageResolver, ModuleResolver, ResourceResolver},
+    language_storage::ModuleId,
+    resolver::{LinkageResolver, ModuleResolver},
 };
 use move_disassembler::disassembler::Disassembler;
 use move_ir_types::location::Spanned;
@@ -240,18 +240,6 @@ impl ModuleResolver for OnDiskStateView {
     type Error = anyhow::Error;
     fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
         self.get_module_bytes(module_id)
-    }
-}
-
-impl ResourceResolver for OnDiskStateView {
-    type Error = anyhow::Error;
-
-    fn get_resource(
-        &self,
-        _address: &AccountAddress,
-        _struct_tag: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        unimplemented!()
     }
 }
 

--- a/external-crates/move/crates/move-core-types/src/resolver.rs
+++ b/external-crates/move/crates/move-core-types/src/resolver.rs
@@ -2,11 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    account_address::AccountAddress,
-    identifier::IdentStr,
-    language_storage::{ModuleId, StructTag},
-};
+use crate::{account_address::AccountAddress, identifier::IdentStr, language_storage::ModuleId};
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -57,55 +53,17 @@ pub trait ModuleResolver {
     fn get_module(&self, id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error>;
 }
 
-/// A persistent storage backend that can resolve resources by address + type
-/// Storage backends should return
-///   - Ok(Some(..)) if the data exists
-///   - Ok(None)     if the data does not exist
-///   - Err(..)      only when something really wrong happens, for example
-///                    - invariants are broken and observable from the storage side
-///                      (this is not currently possible as ModuleId and StructTag
-///                       are always structurally valid)
-///                    - storage encounters internal error
-pub trait ResourceResolver {
-    type Error: Debug;
-
-    fn get_resource(
-        &self,
-        address: &AccountAddress,
-        typ: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error>;
-}
-
 /// A persistent storage implementation that can resolve both resources and modules
 pub trait MoveResolver:
-    LinkageResolver<Error = Self::Err>
-    + ModuleResolver<Error = Self::Err>
-    + ResourceResolver<Error = Self::Err>
+    LinkageResolver<Error = Self::Err> + ModuleResolver<Error = Self::Err>
 {
     type Err: Debug;
 }
 
-impl<
-        E: Debug,
-        T: LinkageResolver<Error = E>
-            + ModuleResolver<Error = E>
-            + ResourceResolver<Error = E>
-            + ?Sized,
-    > MoveResolver for T
+impl<E: Debug, T: LinkageResolver<Error = E> + ModuleResolver<Error = E> + ?Sized> MoveResolver
+    for T
 {
     type Err = E;
-}
-
-impl<T: ResourceResolver + ?Sized> ResourceResolver for &T {
-    type Error = T::Error;
-
-    fn get_resource(
-        &self,
-        address: &AccountAddress,
-        tag: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        (**self).get_resource(address, tag)
-    }
 }
 
 impl<T: ModuleResolver + ?Sized> ModuleResolver for &T {

--- a/external-crates/move/crates/move-vm-integration-tests/src/tests/bad_storage_tests.rs
+++ b/external-crates/move/crates/move-vm-integration-tests/src/tests/bad_storage_tests.rs
@@ -7,8 +7,8 @@ use move_binary_format::errors::{Location, PartialVMError, VMError};
 use move_core_types::{
     account_address::AccountAddress,
     identifier::Identifier,
-    language_storage::{ModuleId, StructTag},
-    resolver::{LinkageResolver, ModuleResolver, ResourceResolver},
+    language_storage::ModuleId,
+    resolver::{LinkageResolver, ModuleResolver},
     vm_status::{StatusCode, StatusType},
 };
 use move_vm_runtime::move_vm::MoveVM;
@@ -396,18 +396,6 @@ impl ModuleResolver for BogusStorage {
     type Error = VMError;
 
     fn get_module(&self, _module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
-        Err(PartialVMError::new(self.bad_status_code).finish(Location::Undefined))
-    }
-}
-
-impl ResourceResolver for BogusStorage {
-    type Error = VMError;
-
-    fn get_resource(
-        &self,
-        _address: &AccountAddress,
-        _tag: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
         Err(PartialVMError::new(self.bad_status_code).finish(Location::Undefined))
     }
 }

--- a/external-crates/move/crates/move-vm-integration-tests/src/tests/loader_tests.rs
+++ b/external-crates/move/crates/move-vm-integration-tests/src/tests/loader_tests.rs
@@ -19,7 +19,7 @@ use move_core_types::{
     ident_str,
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, TypeTag},
-    resolver::{LinkageResolver, ModuleResolver, ResourceResolver},
+    resolver::{LinkageResolver, ModuleResolver},
     runtime_value::MoveValue,
 };
 use move_vm_config::{runtime::VMConfig, verifier::VerifierConfig};
@@ -360,19 +360,6 @@ impl ModuleResolver for RelinkingStore {
 
     fn get_module(&self, id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
         self.store.get_module(id)
-    }
-}
-
-/// Implement by forwarding to the underlying in memory storage
-impl ResourceResolver for RelinkingStore {
-    type Error = ();
-
-    fn get_resource(
-        &self,
-        address: &AccountAddress,
-        typ: &move_core_types::language_storage::StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.store.get_resource(address, typ)
     }
 }
 

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/vm_arguments_tests.rs
@@ -18,8 +18,8 @@ use move_binary_format::{
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
-    language_storage::{ModuleId, StructTag, TypeTag},
-    resolver::{LinkageResolver, ModuleResolver, ResourceResolver},
+    language_storage::{ModuleId, TypeTag},
+    resolver::{LinkageResolver, ModuleResolver},
     runtime_value::{serialize_values, MoveValue},
     u256::U256,
     vm_status::{StatusCode, StatusType},
@@ -155,18 +155,6 @@ impl ModuleResolver for RemoteStore {
     type Error = VMError;
     fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
         Ok(self.modules.get(module_id).cloned())
-    }
-}
-
-impl ResourceResolver for RemoteStore {
-    type Error = VMError;
-
-    fn get_resource(
-        &self,
-        _address: &AccountAddress,
-        _tag: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        Ok(None)
     }
 }
 

--- a/external-crates/move/crates/move-vm-test-utils/src/storage.rs
+++ b/external-crates/move/crates/move-vm-test-utils/src/storage.rs
@@ -7,8 +7,8 @@ use move_core_types::{
     account_address::AccountAddress,
     effects::{AccountChangeSet, ChangeSet, Op},
     identifier::Identifier,
-    language_storage::{ModuleId, StructTag},
-    resolver::{LinkageResolver, ModuleResolver, MoveResolver, ResourceResolver},
+    language_storage::ModuleId,
+    resolver::{LinkageResolver, ModuleResolver, MoveResolver},
 };
 use std::{
     collections::{btree_map, BTreeMap},
@@ -33,18 +33,6 @@ impl ModuleResolver for BlankStorage {
     type Error = ();
 
     fn get_module(&self, _module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
-        Ok(None)
-    }
-}
-
-impl ResourceResolver for BlankStorage {
-    type Error = ();
-
-    fn get_resource(
-        &self,
-        _address: &AccountAddress,
-        _tag: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
         Ok(None)
     }
 }
@@ -80,18 +68,6 @@ impl<S: ModuleResolver> ModuleResolver for DeltaStorage<'_, '_, S> {
         }
 
         self.base.get_module(module_id)
-    }
-}
-
-impl<S: ResourceResolver> ResourceResolver for DeltaStorage<'_, '_, S> {
-    type Error = S::Error;
-
-    fn get_resource(
-        &self,
-        _address: &AccountAddress,
-        _tag: &StructTag,
-    ) -> Result<Option<Vec<u8>>, S::Error> {
-        unreachable!()
     }
 }
 
@@ -225,17 +201,5 @@ impl ModuleResolver for InMemoryStorage {
             return Ok(account_storage.modules.get(module_id.name()).cloned());
         }
         Ok(None)
-    }
-}
-
-impl ResourceResolver for InMemoryStorage {
-    type Error = ();
-
-    fn get_resource(
-        &self,
-        _address: &AccountAddress,
-        _tag: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        unreachable!()
     }
 }

--- a/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/external-crates/move/move-execution/v0/crates/move-vm-runtime/src/unit_tests/vm_arguments_tests.rs
@@ -18,8 +18,8 @@ use move_binary_format::{
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
-    language_storage::{ModuleId, StructTag, TypeTag},
-    resolver::{LinkageResolver, ModuleResolver, ResourceResolver},
+    language_storage::{ModuleId, TypeTag},
+    resolver::{LinkageResolver, ModuleResolver},
     runtime_value::{serialize_values, MoveValue},
     u256::U256,
     vm_status::{StatusCode, StatusType},
@@ -155,18 +155,6 @@ impl ModuleResolver for RemoteStore {
     type Error = VMError;
     fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
         Ok(self.modules.get(module_id).cloned())
-    }
-}
-
-impl ResourceResolver for RemoteStore {
-    type Error = VMError;
-
-    fn get_resource(
-        &self,
-        _address: &AccountAddress,
-        _tag: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        Ok(None)
     }
 }
 

--- a/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/external-crates/move/move-execution/v1/crates/move-vm-runtime/src/unit_tests/vm_arguments_tests.rs
@@ -18,8 +18,8 @@ use move_binary_format::{
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
-    language_storage::{ModuleId, StructTag, TypeTag},
-    resolver::{LinkageResolver, ModuleResolver, ResourceResolver},
+    language_storage::{ModuleId, TypeTag},
+    resolver::{LinkageResolver, ModuleResolver},
     runtime_value::{serialize_values, MoveValue},
     u256::U256,
     vm_status::{StatusCode, StatusType},
@@ -155,18 +155,6 @@ impl ModuleResolver for RemoteStore {
     type Error = VMError;
     fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
         Ok(self.modules.get(module_id).cloned())
-    }
-}
-
-impl ResourceResolver for RemoteStore {
-    type Error = VMError;
-
-    fn get_resource(
-        &self,
-        _address: &AccountAddress,
-        _tag: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        Ok(None)
     }
 }
 

--- a/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/external-crates/move/move-execution/v2/crates/move-vm-runtime/src/unit_tests/vm_arguments_tests.rs
@@ -18,8 +18,8 @@ use move_binary_format::{
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
-    language_storage::{ModuleId, StructTag, TypeTag},
-    resolver::{LinkageResolver, ModuleResolver, ResourceResolver},
+    language_storage::{ModuleId, TypeTag},
+    resolver::{LinkageResolver, ModuleResolver},
     runtime_value::{serialize_values, MoveValue},
     u256::U256,
     vm_status::{StatusCode, StatusType},
@@ -155,18 +155,6 @@ impl ModuleResolver for RemoteStore {
     type Error = VMError;
     fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
         Ok(self.modules.get(module_id).cloned())
-    }
-}
-
-impl ResourceResolver for RemoteStore {
-    type Error = VMError;
-
-    fn get_resource(
-        &self,
-        _address: &AccountAddress,
-        _tag: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        Ok(None)
     }
 }
 

--- a/sui-execution/latest/sui-adapter/src/execution_value.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_value.rs
@@ -2,26 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::file_format::AbilitySet;
-use move_core_types::{identifier::IdentStr, resolver::ResourceResolver};
+use move_core_types::identifier::IdentStr;
 use move_vm_types::loaded_data::runtime_types::Type;
 use serde::Deserialize;
 use sui_types::{
     base_types::{ObjectID, SequenceNumber, SuiAddress},
     coin::Coin,
-    error::{ExecutionError, ExecutionErrorKind, SuiError},
+    error::{ExecutionError, ExecutionErrorKind},
     execution_status::CommandArgumentError,
     object::Owner,
     storage::{BackingPackageStore, ChildObjectResolver, StorageView},
     transfer::Receiving,
 };
 
-pub trait SuiResolver: ResourceResolver<Error = SuiError> + BackingPackageStore {
+pub trait SuiResolver: BackingPackageStore {
     fn as_backing_package_store(&self) -> &dyn BackingPackageStore;
 }
 
 impl<T> SuiResolver for T
 where
-    T: ResourceResolver<Error = SuiError>,
     T: BackingPackageStore,
 {
     fn as_backing_package_store(&self) -> &dyn BackingPackageStore {

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/linkage_view.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/linkage_view.rs
@@ -11,8 +11,8 @@ use crate::execution_value::SuiResolver;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
-    language_storage::{ModuleId, StructTag},
-    resolver::{LinkageResolver, ModuleResolver, ResourceResolver},
+    language_storage::ModuleId,
+    resolver::{LinkageResolver, ModuleResolver},
 };
 use sui_types::storage::{get_module, PackageObject};
 use sui_types::{
@@ -293,18 +293,6 @@ impl LinkageResolver for LinkageView<'_> {
 }
 
 // Remaining implementations delegated to state_view
-
-impl ResourceResolver for LinkageView<'_> {
-    type Error = SuiError;
-
-    fn get_resource(
-        &self,
-        address: &AccountAddress,
-        typ: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.resolver.get_resource(address, typ)
-    }
-}
 
 impl ModuleResolver for LinkageView<'_> {
     type Error = SuiError;

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -2,9 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::gas_charger::GasCharger;
-use move_core_types::account_address::AccountAddress;
-use move_core_types::language_storage::StructTag;
-use move_core_types::resolver::ResourceResolver;
 use mysten_metrics::monitored_scope;
 use parking_lot::RwLock;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
@@ -25,11 +22,10 @@ use sui_types::sui_system_state::{get_sui_system_state_wrapper, AdvanceEpochPara
 use sui_types::{
     base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest},
     effects::EffectsObjectChange,
-    error::{ExecutionError, SuiError, SuiResult},
-    fp_bail,
+    error::{ExecutionError, SuiResult},
     gas::GasCostSummary,
+    object::Object,
     object::Owner,
-    object::{Data, Object},
     storage::{BackingPackageStore, ChildObjectResolver, ParentSync, Storage},
     transaction::InputObjects,
     SUI_DENY_LIST_OBJECT_ID,
@@ -1075,44 +1071,6 @@ impl BackingPackageStore for TemporaryStore<'_> {
                     }
                 }
             })
-        }
-    }
-}
-
-impl ResourceResolver for TemporaryStore<'_> {
-    type Error = SuiError;
-
-    fn get_resource(
-        &self,
-        address: &AccountAddress,
-        struct_tag: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        let object = match self.read_object(&ObjectID::from(*address)) {
-            Some(x) => x,
-            None => match self.read_object(&ObjectID::from(*address)) {
-                None => return Ok(None),
-                Some(x) => {
-                    if !x.is_immutable() {
-                        fp_bail!(SuiError::ExecutionInvariantViolation);
-                    }
-                    x
-                }
-            },
-        };
-
-        match &object.data {
-            Data::Move(m) => {
-                assert!(
-                    m.is_type(struct_tag),
-                    "Invariant violation: ill-typed object in storage \
-                    or bad object request from caller"
-                );
-                Ok(Some(m.contents().to_vec()))
-            }
-            other => unimplemented!(
-                "Bad object lookup: expected Move object, but got {:?}",
-                other
-            ),
         }
     }
 }

--- a/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
@@ -3,10 +3,8 @@
 
 use crate::programmable_transactions::context::load_type_from_struct;
 use crate::programmable_transactions::linkage_view::LinkageView;
-use move_core_types::account_address::AccountAddress;
 use move_core_types::annotated_value as A;
 use move_core_types::language_storage::StructTag;
-use move_core_types::resolver::ResourceResolver;
 use move_vm_runtime::move_vm::MoveVM;
 use sui_types::base_types::ObjectID;
 use sui_types::error::SuiResult;
@@ -57,17 +55,5 @@ impl LayoutResolver for TypeLayoutResolver<'_, '_> {
 impl BackingPackageStore for NullSuiResolver<'_> {
     fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObject>> {
         self.0.get_package_object(package_id)
-    }
-}
-
-impl ResourceResolver for NullSuiResolver<'_> {
-    type Error = SuiError;
-
-    fn get_resource(
-        &self,
-        _address: &AccountAddress,
-        _typ: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        Ok(None)
     }
 }

--- a/sui-execution/v0/sui-adapter/src/execution_value.rs
+++ b/sui-execution/v0/sui-adapter/src/execution_value.rs
@@ -2,26 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::file_format::AbilitySet;
-use move_core_types::{identifier::IdentStr, resolver::ResourceResolver};
+use move_core_types::identifier::IdentStr;
 use move_vm_types::loaded_data::runtime_types::Type;
 use serde::Deserialize;
 use sui_types::{
     base_types::{ObjectID, SequenceNumber, SuiAddress},
     coin::Coin,
-    error::{ExecutionError, ExecutionErrorKind, SuiError},
+    error::{ExecutionError, ExecutionErrorKind},
     execution_status::CommandArgumentError,
     object::Owner,
     storage::{BackingPackageStore, ChildObjectResolver, StorageView},
     transfer::Receiving,
 };
 
-pub trait SuiResolver: ResourceResolver<Error = SuiError> + BackingPackageStore {
+pub trait SuiResolver: BackingPackageStore {
     fn as_backing_package_store(&self) -> &dyn BackingPackageStore;
 }
 
 impl<T> SuiResolver for T
 where
-    T: ResourceResolver<Error = SuiError>,
     T: BackingPackageStore,
 {
     fn as_backing_package_store(&self) -> &dyn BackingPackageStore {

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/linkage_view.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/linkage_view.rs
@@ -11,8 +11,8 @@ use crate::execution_value::SuiResolver;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
-    language_storage::{ModuleId, StructTag},
-    resolver::{LinkageResolver, ModuleResolver, ResourceResolver},
+    language_storage::ModuleId,
+    resolver::{LinkageResolver, ModuleResolver},
 };
 use sui_types::storage::{get_module, PackageObject};
 use sui_types::{
@@ -326,18 +326,6 @@ impl LinkageResolver for LinkageView<'_> {
 }
 
 // Remaining implementations delegated to state_view
-
-impl ResourceResolver for LinkageView<'_> {
-    type Error = SuiError;
-
-    fn get_resource(
-        &self,
-        address: &AccountAddress,
-        typ: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.resolver.get_resource(address, typ)
-    }
-}
 
 impl ModuleResolver for LinkageView<'_> {
     type Error = SuiError;

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -2,9 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::gas_charger::GasCharger;
-use move_core_types::account_address::AccountAddress;
-use move_core_types::language_storage::StructTag;
-use move_core_types::resolver::ResourceResolver;
 use parking_lot::RwLock;
 use std::collections::{BTreeMap, HashSet};
 use sui_protocol_config::ProtocolConfig;
@@ -22,9 +19,8 @@ use sui_types::{
         ObjectDigest, ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest,
         VersionDigest,
     },
-    error::{ExecutionError, SuiError, SuiResult},
+    error::{ExecutionError, SuiResult},
     event::Event,
-    fp_bail,
     gas::GasCostSummary,
     object::Owner,
     object::{Data, Object},
@@ -1045,44 +1041,6 @@ impl BackingPackageStore for TemporaryStore<'_> {
                     }
                 }
             })
-        }
-    }
-}
-
-impl ResourceResolver for TemporaryStore<'_> {
-    type Error = SuiError;
-
-    fn get_resource(
-        &self,
-        address: &AccountAddress,
-        struct_tag: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        let object = match self.read_object(&ObjectID::from(*address)) {
-            Some(x) => x,
-            None => match self.read_object(&ObjectID::from(*address)) {
-                None => return Ok(None),
-                Some(x) => {
-                    if !x.is_immutable() {
-                        fp_bail!(SuiError::ExecutionInvariantViolation);
-                    }
-                    x
-                }
-            },
-        };
-
-        match &object.data {
-            Data::Move(m) => {
-                assert!(
-                    m.is_type(struct_tag),
-                    "Invariant violation: ill-typed object in storage \
-                or bad object request from caller"
-                );
-                Ok(Some(m.contents().to_vec()))
-            }
-            other => unimplemented!(
-                "Bad object lookup: expected Move object, but got {:?}",
-                other
-            ),
         }
     }
 }

--- a/sui-execution/v0/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/v0/sui-adapter/src/type_layout_resolver.rs
@@ -6,10 +6,8 @@ use crate::programmable_transactions::{
     context::load_type,
     linkage_view::{LinkageInfo, LinkageView},
 };
-use move_core_types::account_address::AccountAddress;
 use move_core_types::annotated_value as A;
 use move_core_types::language_storage::{StructTag, TypeTag};
-use move_core_types::resolver::ResourceResolver;
 use move_vm_runtime::{move_vm::MoveVM, session::Session};
 use sui_types::base_types::ObjectID;
 use sui_types::error::SuiResult;
@@ -62,17 +60,5 @@ impl LayoutResolver for TypeLayoutResolver<'_, '_> {
 impl BackingPackageStore for NullSuiResolver<'_> {
     fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObject>> {
         self.0.get_package_object(package_id)
-    }
-}
-
-impl ResourceResolver for NullSuiResolver<'_> {
-    type Error = SuiError;
-
-    fn get_resource(
-        &self,
-        _address: &AccountAddress,
-        _typ: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        Ok(None)
     }
 }

--- a/sui-execution/v1/sui-adapter/src/execution_value.rs
+++ b/sui-execution/v1/sui-adapter/src/execution_value.rs
@@ -2,26 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::file_format::AbilitySet;
-use move_core_types::{identifier::IdentStr, resolver::ResourceResolver};
+use move_core_types::identifier::IdentStr;
 use move_vm_types::loaded_data::runtime_types::Type;
 use serde::Deserialize;
 use sui_types::{
     base_types::{ObjectID, SequenceNumber, SuiAddress},
     coin::Coin,
-    error::{ExecutionError, ExecutionErrorKind, SuiError},
+    error::{ExecutionError, ExecutionErrorKind},
     execution_status::CommandArgumentError,
     object::Owner,
     storage::{BackingPackageStore, ChildObjectResolver, StorageView},
     transfer::Receiving,
 };
 
-pub trait SuiResolver: ResourceResolver<Error = SuiError> + BackingPackageStore {
+pub trait SuiResolver: BackingPackageStore {
     fn as_backing_package_store(&self) -> &dyn BackingPackageStore;
 }
 
 impl<T> SuiResolver for T
 where
-    T: ResourceResolver<Error = SuiError>,
     T: BackingPackageStore,
 {
     fn as_backing_package_store(&self) -> &dyn BackingPackageStore {

--- a/sui-execution/v1/sui-adapter/src/programmable_transactions/linkage_view.rs
+++ b/sui-execution/v1/sui-adapter/src/programmable_transactions/linkage_view.rs
@@ -11,8 +11,8 @@ use crate::execution_value::SuiResolver;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
-    language_storage::{ModuleId, StructTag},
-    resolver::{LinkageResolver, ModuleResolver, ResourceResolver},
+    language_storage::ModuleId,
+    resolver::{LinkageResolver, ModuleResolver},
 };
 use sui_types::storage::{get_module, PackageObject};
 use sui_types::{
@@ -293,18 +293,6 @@ impl LinkageResolver for LinkageView<'_> {
 }
 
 // Remaining implementations delegated to state_view
-
-impl ResourceResolver for LinkageView<'_> {
-    type Error = SuiError;
-
-    fn get_resource(
-        &self,
-        address: &AccountAddress,
-        typ: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.resolver.get_resource(address, typ)
-    }
-}
 
 impl ModuleResolver for LinkageView<'_> {
     type Error = SuiError;

--- a/sui-execution/v1/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v1/sui-adapter/src/temporary_store.rs
@@ -2,9 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::gas_charger::GasCharger;
-use move_core_types::account_address::AccountAddress;
-use move_core_types::language_storage::StructTag;
-use move_core_types::resolver::ResourceResolver;
 use parking_lot::RwLock;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use sui_protocol_config::ProtocolConfig;
@@ -24,11 +21,10 @@ use sui_types::sui_system_state::{get_sui_system_state_wrapper, AdvanceEpochPara
 use sui_types::{
     base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest},
     effects::EffectsObjectChange,
-    error::{ExecutionError, SuiError, SuiResult},
-    fp_bail,
+    error::{ExecutionError, SuiResult},
     gas::GasCostSummary,
+    object::Object,
     object::Owner,
-    object::{Data, Object},
     storage::{BackingPackageStore, ChildObjectResolver, ParentSync, Storage},
     transaction::InputObjects,
 };
@@ -1159,44 +1155,6 @@ impl BackingPackageStore for TemporaryStore<'_> {
                     }
                 }
             })
-        }
-    }
-}
-
-impl ResourceResolver for TemporaryStore<'_> {
-    type Error = SuiError;
-
-    fn get_resource(
-        &self,
-        address: &AccountAddress,
-        struct_tag: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        let object = match self.read_object(&ObjectID::from(*address)) {
-            Some(x) => x,
-            None => match self.read_object(&ObjectID::from(*address)) {
-                None => return Ok(None),
-                Some(x) => {
-                    if !x.is_immutable() {
-                        fp_bail!(SuiError::ExecutionInvariantViolation);
-                    }
-                    x
-                }
-            },
-        };
-
-        match &object.data {
-            Data::Move(m) => {
-                assert!(
-                    m.is_type(struct_tag),
-                    "Invariant violation: ill-typed object in storage \
-                or bad object request from caller"
-                );
-                Ok(Some(m.contents().to_vec()))
-            }
-            other => unimplemented!(
-                "Bad object lookup: expected Move object, but got {:?}",
-                other
-            ),
         }
     }
 }

--- a/sui-execution/v1/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/v1/sui-adapter/src/type_layout_resolver.rs
@@ -3,10 +3,8 @@
 
 use crate::programmable_transactions::context::load_type_from_struct;
 use crate::programmable_transactions::linkage_view::LinkageView;
-use move_core_types::account_address::AccountAddress;
 use move_core_types::annotated_value as A;
 use move_core_types::language_storage::StructTag;
-use move_core_types::resolver::ResourceResolver;
 use move_vm_runtime::move_vm::MoveVM;
 use sui_types::base_types::ObjectID;
 use sui_types::error::SuiResult;
@@ -56,17 +54,5 @@ impl LayoutResolver for TypeLayoutResolver<'_, '_> {
 impl BackingPackageStore for NullSuiResolver<'_> {
     fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObject>> {
         self.0.get_package_object(package_id)
-    }
-}
-
-impl ResourceResolver for NullSuiResolver<'_> {
-    type Error = SuiError;
-
-    fn get_resource(
-        &self,
-        _address: &AccountAddress,
-        _typ: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        Ok(None)
     }
 }

--- a/sui-execution/v2/sui-adapter/src/execution_value.rs
+++ b/sui-execution/v2/sui-adapter/src/execution_value.rs
@@ -2,26 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::file_format::AbilitySet;
-use move_core_types::{identifier::IdentStr, resolver::ResourceResolver};
+use move_core_types::identifier::IdentStr;
 use move_vm_types::loaded_data::runtime_types::Type;
 use serde::Deserialize;
 use sui_types::{
     base_types::{ObjectID, SequenceNumber, SuiAddress},
     coin::Coin,
-    error::{ExecutionError, ExecutionErrorKind, SuiError},
+    error::{ExecutionError, ExecutionErrorKind},
     execution_status::CommandArgumentError,
     object::Owner,
     storage::{BackingPackageStore, ChildObjectResolver, StorageView},
     transfer::Receiving,
 };
 
-pub trait SuiResolver: ResourceResolver<Error = SuiError> + BackingPackageStore {
+pub trait SuiResolver: BackingPackageStore {
     fn as_backing_package_store(&self) -> &dyn BackingPackageStore;
 }
 
 impl<T> SuiResolver for T
 where
-    T: ResourceResolver<Error = SuiError>,
     T: BackingPackageStore,
 {
     fn as_backing_package_store(&self) -> &dyn BackingPackageStore {

--- a/sui-execution/v2/sui-adapter/src/programmable_transactions/linkage_view.rs
+++ b/sui-execution/v2/sui-adapter/src/programmable_transactions/linkage_view.rs
@@ -11,8 +11,8 @@ use crate::execution_value::SuiResolver;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
-    language_storage::{ModuleId, StructTag},
-    resolver::{LinkageResolver, ModuleResolver, ResourceResolver},
+    language_storage::ModuleId,
+    resolver::{LinkageResolver, ModuleResolver},
 };
 use sui_types::storage::{get_module, PackageObject};
 use sui_types::{
@@ -293,18 +293,6 @@ impl LinkageResolver for LinkageView<'_> {
 }
 
 // Remaining implementations delegated to state_view
-
-impl ResourceResolver for LinkageView<'_> {
-    type Error = SuiError;
-
-    fn get_resource(
-        &self,
-        address: &AccountAddress,
-        typ: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.resolver.get_resource(address, typ)
-    }
-}
 
 impl ModuleResolver for LinkageView<'_> {
     type Error = SuiError;

--- a/sui-execution/v2/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v2/sui-adapter/src/temporary_store.rs
@@ -2,9 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::gas_charger::GasCharger;
-use move_core_types::account_address::AccountAddress;
-use move_core_types::language_storage::StructTag;
-use move_core_types::resolver::ResourceResolver;
 use parking_lot::RwLock;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use sui_protocol_config::ProtocolConfig;
@@ -24,11 +21,10 @@ use sui_types::sui_system_state::{get_sui_system_state_wrapper, AdvanceEpochPara
 use sui_types::{
     base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest},
     effects::EffectsObjectChange,
-    error::{ExecutionError, SuiError, SuiResult},
-    fp_bail,
+    error::{ExecutionError, SuiResult},
     gas::GasCostSummary,
+    object::Object,
     object::Owner,
-    object::{Data, Object},
     storage::{BackingPackageStore, ChildObjectResolver, ParentSync, Storage},
     transaction::InputObjects,
 };
@@ -1213,44 +1209,6 @@ impl BackingPackageStore for TemporaryStore<'_> {
                     }
                 }
             })
-        }
-    }
-}
-
-impl ResourceResolver for TemporaryStore<'_> {
-    type Error = SuiError;
-
-    fn get_resource(
-        &self,
-        address: &AccountAddress,
-        struct_tag: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        let object = match self.read_object(&ObjectID::from(*address)) {
-            Some(x) => x,
-            None => match self.read_object(&ObjectID::from(*address)) {
-                None => return Ok(None),
-                Some(x) => {
-                    if !x.is_immutable() {
-                        fp_bail!(SuiError::ExecutionInvariantViolation);
-                    }
-                    x
-                }
-            },
-        };
-
-        match &object.data {
-            Data::Move(m) => {
-                assert!(
-                    m.is_type(struct_tag),
-                    "Invariant violation: ill-typed object in storage \
-                    or bad object request from caller"
-                );
-                Ok(Some(m.contents().to_vec()))
-            }
-            other => unimplemented!(
-                "Bad object lookup: expected Move object, but got {:?}",
-                other
-            ),
         }
     }
 }

--- a/sui-execution/v2/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/v2/sui-adapter/src/type_layout_resolver.rs
@@ -3,10 +3,8 @@
 
 use crate::programmable_transactions::context::load_type_from_struct;
 use crate::programmable_transactions::linkage_view::LinkageView;
-use move_core_types::account_address::AccountAddress;
 use move_core_types::annotated_value as A;
 use move_core_types::language_storage::StructTag;
-use move_core_types::resolver::ResourceResolver;
 use move_vm_runtime::move_vm::MoveVM;
 use sui_types::base_types::ObjectID;
 use sui_types::error::SuiResult;
@@ -56,17 +54,5 @@ impl LayoutResolver for TypeLayoutResolver<'_, '_> {
 impl BackingPackageStore for NullSuiResolver<'_> {
     fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObject>> {
         self.0.get_package_object(package_id)
-    }
-}
-
-impl ResourceResolver for NullSuiResolver<'_> {
-    type Error = SuiError;
-
-    fn get_resource(
-        &self,
-        _address: &AccountAddress,
-        _typ: &StructTag,
-    ) -> Result<Option<Vec<u8>>, Self::Error> {
-        Ok(None)
     }
 }


### PR DESCRIPTION
This trait is no longer used and is just a dangling trait that is not used for anything and just gets in the way. Remove it to clean things up.


## Test plan 

CI
