### PR TITLE
Make max checkpoints configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13755,6 +13755,7 @@ dependencies = [
  "mysten-metrics",
  "notify",
  "object_store",
+ "once_cell",
  "prometheus",
  "rand 0.8.5",
  "serde",

--- a/crates/sui-data-ingestion-core/Cargo.toml
+++ b/crates/sui-data-ingestion-core/Cargo.toml
@@ -28,6 +28,7 @@ tempfile.workspace = true
 tap.workspace = true
 sui-protocol-config.workspace = true
 sui-rpc-api.workspace = true
+once_cell.workspace = true
 
 [dev-dependencies]
 rand.workspace = true

--- a/crates/sui-data-ingestion-core/src/reader.rs
+++ b/crates/sui-data-ingestion-core/src/reader.rs
@@ -80,7 +80,7 @@ impl CheckpointReader {
     /// Reads files in a local directory, validates them, and forwards `CheckpointData` to the executor.
     async fn read_local_files(&self) -> Result<Vec<Arc<CheckpointData>>> {
         let mut checkpoints = vec![];
-        for offset in 0..MAX_CHECKPOINTS_IN_PROGRESS {
+        for offset in 0..*MAX_CHECKPOINTS_IN_PROGRESS {
             let sequence_number = self.current_checkpoint_number + offset as u64;
             if self.exceeds_capacity(sequence_number) {
                 break;
@@ -97,7 +97,7 @@ impl CheckpointReader {
     }
 
     fn exceeds_capacity(&self, checkpoint_number: CheckpointSequenceNumber) -> bool {
-        ((MAX_CHECKPOINTS_IN_PROGRESS as u64 + self.last_pruned_watermark) <= checkpoint_number)
+        ((*MAX_CHECKPOINTS_IN_PROGRESS as u64 + self.last_pruned_watermark) <= checkpoint_number)
             || self.data_limiter.exceeds()
     }
 
@@ -328,8 +328,8 @@ impl CheckpointReader {
         mpsc::Sender<CheckpointSequenceNumber>,
         oneshot::Sender<()>,
     ) {
-        let (checkpoint_sender, checkpoint_recv) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
-        let (processed_sender, processed_receiver) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
+        let (checkpoint_sender, checkpoint_recv) = mpsc::channel(*MAX_CHECKPOINTS_IN_PROGRESS);
+        let (processed_sender, processed_receiver) = mpsc::channel(*MAX_CHECKPOINTS_IN_PROGRESS);
         let (exit_sender, exit_receiver) = oneshot::channel();
         let reader = Self {
             path,

--- a/crates/sui-data-ingestion-core/src/reducer.rs
+++ b/crates/sui-data-ingestion-core/src/reducer.rs
@@ -19,7 +19,7 @@ pub(crate) async fn reduce<W: Worker>(
 ) -> Result<()> {
     // convert to a stream of MAX size. This way, each iteration of the loop will process all ready messages
     let mut stream =
-        ReceiverStream::new(progress_receiver).ready_chunks(MAX_CHECKPOINTS_IN_PROGRESS);
+        ReceiverStream::new(progress_receiver).ready_chunks(*MAX_CHECKPOINTS_IN_PROGRESS);
     let mut unprocessed = HashMap::new();
     let mut batch = vec![];
     let mut progress_update = None;

--- a/crates/sui-data-ingestion-core/src/worker_pool.rs
+++ b/crates/sui-data-ingestion-core/src/worker_pool.rs
@@ -54,8 +54,8 @@ impl<W: Worker + 'static> WorkerPool<W> {
             "Starting indexing pipeline {} with concurrency {}. Current watermark is {}.",
             self.task_name, self.concurrency, watermark
         );
-        let (progress_sender, mut progress_receiver) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
-        let (reducer_sender, reducer_receiver) = mpsc::channel(MAX_CHECKPOINTS_IN_PROGRESS);
+        let (progress_sender, mut progress_receiver) = mpsc::channel(*MAX_CHECKPOINTS_IN_PROGRESS);
+        let (reducer_sender, reducer_receiver) = mpsc::channel(*MAX_CHECKPOINTS_IN_PROGRESS);
         let mut workers = vec![];
         let mut idle: BTreeSet<_> = (0..self.concurrency).collect();
         let mut checkpoints = VecDeque::new();
@@ -65,7 +65,7 @@ impl<W: Worker + 'static> WorkerPool<W> {
         // spawn child workers
         for worker_id in 0..self.concurrency {
             let (worker_sender, mut worker_recv) =
-                mpsc::channel::<Arc<CheckpointData>>(MAX_CHECKPOINTS_IN_PROGRESS);
+                mpsc::channel::<Arc<CheckpointData>>(*MAX_CHECKPOINTS_IN_PROGRESS);
             let (term_sender, mut term_receiver) = oneshot::channel::<()>();
             let cloned_progress_sender = progress_sender.clone();
             let task_name = self.task_name.clone();


### PR DESCRIPTION
## Description

The 10k limit for in-flight checkpoints is way too high for the analytics indexer. If there is any slowdown in any part of the pipelines we end up having a massive spike from ~2gb to ~60gb memory consumption.

I found we can far better throughput and lower and more predictable memory use if I increase the default batch_size (which is the number of concurrent GCS downloads) from 10 to 1000 (going beyond 1000 just increased memory use without increasing throughput) and limiting the number of checkpoints actually being worked on to ~100. This makes sense to me because:

- I/O is the primary bottleneck and a single GCP instance can handle way more than 10 concurrent GCS downloads (this was probably different on the old, non-GCS infra). It's fine to have a large number of completed downloads in this buffer, it just costs a predictable and small amount of memory.
- Throwing `~<num_cpus>*10` compute tasks at the tokio pool is plenty to ensure the CPUs stay busy. Creating more tasks than that is what causes extreme memory explosions when one of the pipelines slows down.

## Test plan

This code change is already live and after reducing this limit to 100 the backfill has been stable and fast.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
