### PR TITLE
Pass Arc to Workers instead of reference.

### DIFF
--- a/crates/sui-analytics-indexer/src/analytics_processor.rs
+++ b/crates/sui-analytics-indexer/src/analytics_processor.rs
@@ -52,7 +52,7 @@ const CHECK_FILE_SIZE_ITERATION_CYCLE: u64 = 50;
 #[async_trait::async_trait]
 impl<S: Serialize + ParquetSchema + 'static> Worker for AnalyticsProcessor<S> {
     type Result = ();
-    async fn process_checkpoint(&self, checkpoint_data: &CheckpointData) -> Result<()> {
+    async fn process_checkpoint(&self, checkpoint_data: Arc<CheckpointData>) -> Result<()> {
         // get epoch id, checkpoint sequence number and timestamp, those are important
         // indexes when operating on data
         let epoch: u64 = checkpoint_data.checkpoint_summary.epoch();

--- a/crates/sui-analytics-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/checkpoint_handler.rs
@@ -3,6 +3,7 @@
 
 use anyhow::Result;
 use fastcrypto::traits::EncodeDecodeBase64;
+use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use sui_data_ingestion_core::Worker;
@@ -27,12 +28,9 @@ struct State {
 impl Worker for CheckpointHandler {
     type Result = ();
 
-    async fn process_checkpoint(&self, checkpoint_data: &CheckpointData) -> Result<()> {
-        let CheckpointData {
-            checkpoint_summary,
-            transactions: checkpoint_transactions,
-            ..
-        } = checkpoint_data;
+    async fn process_checkpoint(&self, checkpoint_data: Arc<CheckpointData>) -> Result<()> {
+        let checkpoint_summary = &checkpoint_data.checkpoint_summary;
+        let checkpoint_transactions = &checkpoint_data.transactions;
         self.process_checkpoint_transactions(checkpoint_summary, checkpoint_transactions)
             .await;
         Ok(())

--- a/crates/sui-analytics-indexer/src/handlers/df_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/df_handler.rs
@@ -39,12 +39,9 @@ struct State {
 impl Worker for DynamicFieldHandler {
     type Result = ();
 
-    async fn process_checkpoint(&self, checkpoint_data: &CheckpointData) -> Result<()> {
-        let CheckpointData {
-            checkpoint_summary,
-            transactions: checkpoint_transactions,
-            ..
-        } = checkpoint_data;
+    async fn process_checkpoint(&self, checkpoint_data: Arc<CheckpointData>) -> Result<()> {
+        let checkpoint_summary = &checkpoint_data.checkpoint_summary;
+        let checkpoint_transactions = &checkpoint_data.transactions;
         let mut state = self.state.lock().await;
         for checkpoint_transaction in checkpoint_transactions {
             for object in checkpoint_transaction.output_objects.iter() {

--- a/crates/sui-analytics-indexer/src/handlers/event_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/event_handler.rs
@@ -33,12 +33,9 @@ struct State {
 impl Worker for EventHandler {
     type Result = ();
 
-    async fn process_checkpoint(&self, checkpoint_data: &CheckpointData) -> Result<()> {
-        let CheckpointData {
-            checkpoint_summary,
-            transactions: checkpoint_transactions,
-            ..
-        } = checkpoint_data;
+    async fn process_checkpoint(&self, checkpoint_data: Arc<CheckpointData>) -> Result<()> {
+        let checkpoint_summary = &checkpoint_data.checkpoint_summary;
+        let checkpoint_transactions = &checkpoint_data.transactions;
         let mut state = self.state.lock().await;
         for checkpoint_transaction in checkpoint_transactions {
             for object in checkpoint_transaction.output_objects.iter() {

--- a/crates/sui-analytics-indexer/src/handlers/move_call_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/move_call_handler.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use std::sync::Arc;
 use sui_data_ingestion_core::Worker;
 use tokio::sync::Mutex;
 
@@ -25,12 +26,9 @@ struct State {
 impl Worker for MoveCallHandler {
     type Result = ();
 
-    async fn process_checkpoint(&self, checkpoint_data: &CheckpointData) -> Result<()> {
-        let CheckpointData {
-            checkpoint_summary,
-            transactions: checkpoint_transactions,
-            ..
-        } = checkpoint_data;
+    async fn process_checkpoint(&self, checkpoint_data: Arc<CheckpointData>) -> Result<()> {
+        let checkpoint_summary = &checkpoint_data.checkpoint_summary;
+        let checkpoint_transactions = &checkpoint_data.transactions;
         let mut state = self.state.lock().await;
         for checkpoint_transaction in checkpoint_transactions {
             let move_calls = checkpoint_transaction

--- a/crates/sui-analytics-indexer/src/handlers/object_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/object_handler.rs
@@ -39,12 +39,9 @@ struct State {
 impl Worker for ObjectHandler {
     type Result = ();
 
-    async fn process_checkpoint(&self, checkpoint_data: &CheckpointData) -> Result<()> {
-        let CheckpointData {
-            checkpoint_summary,
-            transactions: checkpoint_transactions,
-            ..
-        } = checkpoint_data;
+    async fn process_checkpoint(&self, checkpoint_data: Arc<CheckpointData>) -> Result<()> {
+        let checkpoint_summary = &checkpoint_data.checkpoint_summary;
+        let checkpoint_transactions = &checkpoint_data.transactions;
         let mut state = self.state.lock().await;
         for checkpoint_transaction in checkpoint_transactions {
             for object in checkpoint_transaction.output_objects.iter() {

--- a/crates/sui-analytics-indexer/src/handlers/package_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/package_handler.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use std::sync::Arc;
 use sui_data_ingestion_core::Worker;
 use sui_types::full_checkpoint_content::CheckpointData;
 use sui_types::full_checkpoint_content::CheckpointTransaction;
@@ -24,12 +25,9 @@ struct State {
 impl Worker for PackageHandler {
     type Result = ();
 
-    async fn process_checkpoint(&self, checkpoint_data: &CheckpointData) -> Result<()> {
-        let CheckpointData {
-            checkpoint_summary,
-            transactions: checkpoint_transactions,
-            ..
-        } = checkpoint_data;
+    async fn process_checkpoint(&self, checkpoint_data: Arc<CheckpointData>) -> Result<()> {
+        let checkpoint_summary = &checkpoint_data.checkpoint_summary;
+        let checkpoint_transactions = &checkpoint_data.transactions;
         let mut state = self.state.lock().await;
         for checkpoint_transaction in checkpoint_transactions {
             self.process_transaction(

--- a/crates/sui-analytics-indexer/src/handlers/transaction_bcs_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/transaction_bcs_handler.rs
@@ -3,6 +3,7 @@
 
 use anyhow::Result;
 use fastcrypto::encoding::{Base64, Encoding};
+use std::sync::Arc;
 use sui_data_ingestion_core::Worker;
 use tokio::sync::Mutex;
 
@@ -24,12 +25,9 @@ pub(crate) struct State {
 impl Worker for TransactionBCSHandler {
     type Result = ();
 
-    async fn process_checkpoint(&self, checkpoint_data: &CheckpointData) -> Result<()> {
-        let CheckpointData {
-            checkpoint_summary,
-            transactions: checkpoint_transactions,
-            ..
-        } = checkpoint_data;
+    async fn process_checkpoint(&self, checkpoint_data: Arc<CheckpointData>) -> Result<()> {
+        let checkpoint_summary = &checkpoint_data.checkpoint_summary;
+        let checkpoint_transactions = &checkpoint_data.transactions;
         let mut state = self.state.lock().await;
         for checkpoint_transaction in checkpoint_transactions {
             self.process_transaction(
@@ -96,6 +94,7 @@ mod tests {
     use crate::handlers::transaction_bcs_handler::TransactionBCSHandler;
     use fastcrypto::encoding::{Base64, Encoding};
     use simulacrum::Simulacrum;
+    use std::sync::Arc;
     use sui_data_ingestion_core::Worker;
     use sui_types::base_types::SuiAddress;
     use sui_types::storage::ReadStore;
@@ -112,13 +111,15 @@ mod tests {
 
         // Create a checkpoint which should include the transaction we executed.
         let checkpoint = sim.create_checkpoint();
-        let checkpoint_data = sim.get_checkpoint_data(
-            checkpoint.clone(),
-            sim.get_checkpoint_contents_by_digest(&checkpoint.content_digest)
-                .unwrap(),
-        )?;
+        let checkpoint_data = Arc::new(
+            sim.get_checkpoint_data(
+                checkpoint.clone(),
+                sim.get_checkpoint_contents_by_digest(&checkpoint.content_digest)
+                    .unwrap(),
+            )?,
+        );
         let txn_handler = TransactionBCSHandler::new();
-        txn_handler.process_checkpoint(&checkpoint_data).await?;
+        txn_handler.process_checkpoint(checkpoint_data).await?;
         let transaction_entries = txn_handler.state.lock().await.transactions.clone();
         assert_eq!(transaction_entries.len(), 1);
         let db_txn = transaction_entries.first().unwrap();

--- a/crates/sui-analytics-indexer/src/handlers/transaction_objects_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/transaction_objects_handler.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use std::sync::Arc;
 use sui_data_ingestion_core::Worker;
 use tokio::sync::Mutex;
 
@@ -26,12 +27,9 @@ struct State {
 impl Worker for TransactionObjectsHandler {
     type Result = ();
 
-    async fn process_checkpoint(&self, checkpoint_data: &CheckpointData) -> Result<()> {
-        let CheckpointData {
-            checkpoint_summary,
-            transactions: checkpoint_transactions,
-            ..
-        } = checkpoint_data;
+    async fn process_checkpoint(&self, checkpoint_data: Arc<CheckpointData>) -> Result<()> {
+        let checkpoint_summary = &checkpoint_data.checkpoint_summary;
+        let checkpoint_transactions = &checkpoint_data.transactions;
         let mut state = self.state.lock().await;
         for checkpoint_transaction in checkpoint_transactions {
             self.process_transaction(

--- a/crates/sui-analytics-indexer/src/handlers/wrapped_object_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/wrapped_object_handler.rs
@@ -32,12 +32,9 @@ struct State {
 impl Worker for WrappedObjectHandler {
     type Result = ();
 
-    async fn process_checkpoint(&self, checkpoint_data: &CheckpointData) -> Result<()> {
-        let CheckpointData {
-            checkpoint_summary,
-            transactions: checkpoint_transactions,
-            ..
-        } = checkpoint_data;
+    async fn process_checkpoint(&self, checkpoint_data: Arc<CheckpointData>) -> Result<()> {
+        let checkpoint_summary = &checkpoint_data.checkpoint_summary;
+        let checkpoint_transactions = &checkpoint_data.transactions;
         let mut state = self.state.lock().await;
         for checkpoint_transaction in checkpoint_transactions {
             for object in checkpoint_transaction.output_objects.iter() {

--- a/crates/sui-analytics-indexer/src/lib.rs
+++ b/crates/sui-analytics-indexer/src/lib.rs
@@ -800,7 +800,7 @@ impl Worker for Processor {
     type Result = ();
 
     #[inline]
-    async fn process_checkpoint(&self, checkpoint_data: &CheckpointData) -> Result<()> {
+    async fn process_checkpoint(&self, checkpoint_data: Arc<CheckpointData>) -> Result<()> {
         self.processor.process_checkpoint(checkpoint_data).await
     }
 }

--- a/crates/sui-data-ingestion-core/src/lib.rs
+++ b/crates/sui-data-ingestion-core/src/lib.rs
@@ -19,6 +19,7 @@ pub use progress_store::{
     ExecutorProgress, FileProgressStore, ProgressStore, ShimIndexerProgressStore, ShimProgressStore,
 };
 pub use reader::ReaderOptions;
+use std::sync::Arc;
 use sui_types::full_checkpoint_content::CheckpointData;
 pub use util::{create_remote_store_client, end_of_epoch_data};
 pub use worker_pool::WorkerPool;
@@ -26,7 +27,7 @@ pub use worker_pool::WorkerPool;
 #[async_trait]
 pub trait Worker: Send + Sync {
     type Result: Send + Sync + Clone;
-    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<Self::Result>;
+    async fn process_checkpoint(&self, checkpoint: Arc<CheckpointData>) -> Result<Self::Result>;
 
     fn preprocess_hook(&self, _: &CheckpointData) -> Result<()> {
         Ok(())

--- a/crates/sui-data-ingestion-core/src/tests.rs
+++ b/crates/sui-data-ingestion-core/src/tests.rs
@@ -10,6 +10,7 @@ use prometheus::Registry;
 use rand::prelude::StdRng;
 use rand::SeedableRng;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 use sui_protocol_config::ProtocolConfig;
 use sui_storage::blob::{Blob, BlobEncoding};
@@ -75,7 +76,7 @@ struct TestWorker;
 #[async_trait]
 impl Worker for TestWorker {
     type Result = ();
-    async fn process_checkpoint(&self, _checkpoint: &CheckpointData) -> Result<()> {
+    async fn process_checkpoint(&self, _checkpoint: Arc<CheckpointData>) -> Result<()> {
         Ok(())
     }
 }

--- a/crates/sui-data-ingestion-core/src/worker_pool.rs
+++ b/crates/sui-data-ingestion-core/src/worker_pool.rs
@@ -84,7 +84,7 @@ impl<W: Worker + 'static> WorkerPool<W> {
                             let result = backoff::future::retry(backoff, || async {
                                 worker
                                     .clone()
-                                    .process_checkpoint(&checkpoint)
+                                    .process_checkpoint(checkpoint.clone())
                                     .await
                                     .map_err(|err| {
                                         info!("transient worker execution error {:?} for checkpoint {}", err, sequence_number);

--- a/crates/sui-data-ingestion/src/workers/archival.rs
+++ b/crates/sui-data-ingestion/src/workers/archival.rs
@@ -10,6 +10,7 @@ use object_store::path::Path;
 use object_store::ObjectStore;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
+use std::sync::Arc;
 use std::io::Cursor;
 use sui_archival::{
     create_file_metadata_from_bytes, finalize_manifest, read_manifest_from_bytes, FileType,
@@ -34,8 +35,8 @@ pub struct ArchivalWorker;
 #[async_trait]
 impl Worker for ArchivalWorker {
     type Result = CheckpointData;
-    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<CheckpointData> {
-        Ok(checkpoint.clone())
+    async fn process_checkpoint(&self, checkpoint: Arc<CheckpointData>) -> Result<CheckpointData> {
+        Ok((*checkpoint).clone())
     }
 }
 

--- a/crates/sui-data-ingestion/src/workers/archival.rs
+++ b/crates/sui-data-ingestion/src/workers/archival.rs
@@ -10,8 +10,8 @@ use object_store::path::Path;
 use object_store::ObjectStore;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-use std::sync::Arc;
 use std::io::Cursor;
+use std::sync::Arc;
 use sui_archival::{
     create_file_metadata_from_bytes, finalize_manifest, read_manifest_from_bytes, FileType,
     Manifest, CHECKPOINT_FILE_MAGIC, SUMMARY_FILE_MAGIC,

--- a/crates/sui-data-ingestion/src/workers/blob.rs
+++ b/crates/sui-data-ingestion/src/workers/blob.rs
@@ -3,11 +3,11 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use std::sync::Arc;
 use bytes::Bytes;
 use object_store::path::Path;
 use object_store::ObjectStore;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use sui_data_ingestion_core::{create_remote_store_client, Worker};
 use sui_storage::blob::{Blob, BlobEncoding};
 use sui_types::full_checkpoint_content::CheckpointData;

--- a/crates/sui-data-ingestion/src/workers/blob.rs
+++ b/crates/sui-data-ingestion/src/workers/blob.rs
@@ -3,6 +3,7 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
+use std::sync::Arc;
 use bytes::Bytes;
 use object_store::path::Path;
 use object_store::ObjectStore;
@@ -34,8 +35,8 @@ impl BlobWorker {
 #[async_trait]
 impl Worker for BlobWorker {
     type Result = ();
-    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<()> {
-        let bytes = Blob::encode(checkpoint, BlobEncoding::Bcs)?.to_bytes();
+    async fn process_checkpoint(&self, checkpoint: Arc<CheckpointData>) -> Result<()> {
+        let bytes = Blob::encode(&checkpoint, BlobEncoding::Bcs)?.to_bytes();
         let location = Path::from(format!(
             "{}.chk",
             checkpoint.checkpoint_summary.sequence_number

--- a/crates/sui-indexer-builder/src/sui_datasource.rs
+++ b/crates/sui-indexer-builder/src/sui_datasource.rs
@@ -187,7 +187,7 @@ pub type CheckpointTxnData = (CheckpointTransaction, u64, u64);
 impl Worker for IndexerWorker<CheckpointTxnData> {
     type Result = ();
 
-    async fn process_checkpoint(&self, checkpoint: &SuiCheckpointData) -> anyhow::Result<()> {
+    async fn process_checkpoint(&self, checkpoint: Arc<SuiCheckpointData>) -> anyhow::Result<()> {
         tracing::trace!(
             "Received checkpoint [{}] {}: {}",
             checkpoint.checkpoint_summary.epoch,

--- a/crates/sui-indexer/src/backfill/backfill_instances/ingestion_backfills/ingestion_backfill_task.rs
+++ b/crates/sui-indexer/src/backfill/backfill_instances/ingestion_backfills/ingestion_backfill_task.rs
@@ -58,8 +58,8 @@ pub struct Adapter<T: IngestionBackfillTrait> {
 #[async_trait::async_trait]
 impl<T: IngestionBackfillTrait> Worker for Adapter<T> {
     type Result = ();
-    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> anyhow::Result<()> {
-        let processed = T::process_checkpoint(checkpoint);
+    async fn process_checkpoint(&self, checkpoint: Arc<CheckpointData>) -> anyhow::Result<()> {
+        let processed = T::process_checkpoint(&checkpoint);
         self.ready_checkpoints
             .insert(checkpoint.checkpoint_summary.sequence_number, processed);
         self.notify.notify_waiters();

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -99,7 +99,7 @@ pub struct CheckpointHandler {
 #[async_trait]
 impl Worker for CheckpointHandler {
     type Result = ();
-    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> anyhow::Result<()> {
+    async fn process_checkpoint(&self, checkpoint: Arc<CheckpointData>) -> anyhow::Result<()> {
         let time_now_ms = chrono::Utc::now().timestamp_millis();
         let cp_download_lag = time_now_ms - checkpoint.checkpoint_summary.timestamp_ms as i64;
         info!(
@@ -121,9 +121,9 @@ impl Worker for CheckpointHandler {
         );
         let checkpoint_data = Self::index_checkpoint(
             &self.state,
-            checkpoint,
+            &checkpoint,
             Arc::new(self.metrics.clone()),
-            Self::index_packages(std::slice::from_ref(checkpoint), &self.metrics),
+            Self::index_packages(std::slice::from_ref(&checkpoint), &self.metrics),
         )
         .await?;
         self.indexed_checkpoint_sender.send(checkpoint_data).await?;

--- a/crates/sui-indexer/src/handlers/objects_snapshot_handler.rs
+++ b/crates/sui-indexer/src/handlers/objects_snapshot_handler.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
-use std::sync::Arc;
 use mysten_metrics::get_metrics;
 use mysten_metrics::metered_channel::Sender;
 use mysten_metrics::spawn_monitored_task;
+use std::sync::Arc;
 use sui_data_ingestion_core::Worker;
 use sui_types::full_checkpoint_content::CheckpointData;
 use tokio_util::sync::CancellationToken;

--- a/crates/sui-indexer/src/handlers/objects_snapshot_handler.rs
+++ b/crates/sui-indexer/src/handlers/objects_snapshot_handler.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
+use std::sync::Arc;
 use mysten_metrics::get_metrics;
 use mysten_metrics::metered_channel::Sender;
 use mysten_metrics::spawn_monitored_task;
@@ -35,10 +36,10 @@ pub struct CheckpointObjectChanges {
 #[async_trait]
 impl Worker for ObjectsSnapshotHandler {
     type Result = ();
-    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> anyhow::Result<()> {
-        let transformed_data = CheckpointHandler::index_objects(checkpoint, &self.metrics).await?;
+    async fn process_checkpoint(&self, checkpoint: Arc<CheckpointData>) -> anyhow::Result<()> {
+        let transformed_data = CheckpointHandler::index_objects(&checkpoint, &self.metrics).await?;
         self.sender
-            .send((CommitterWatermark::from(checkpoint), transformed_data))
+            .send((CommitterWatermark::from(&*checkpoint), transformed_data))
             .await?;
         Ok(())
     }

--- a/crates/sui-network/src/state_sync/worker.rs
+++ b/crates/sui-network/src/state_sync/worker.rs
@@ -3,6 +3,7 @@
 
 use crate::state_sync::metrics::Metrics;
 use anemo::async_trait;
+use std::sync::Arc;
 use sui_archival::reader::ArchiveReader;
 use sui_data_ingestion_core::Worker;
 use sui_types::full_checkpoint_content::CheckpointData;
@@ -15,7 +16,7 @@ pub(crate) struct StateSyncWorker<S>(pub(crate) S, pub(crate) Metrics);
 impl<S: WriteStore + Clone + Send + Sync + 'static> Worker for StateSyncWorker<S> {
     type Result = ();
 
-    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> anyhow::Result<()> {
+    async fn process_checkpoint(&self, checkpoint: Arc<CheckpointData>) -> anyhow::Result<()> {
         let verified_checkpoint = ArchiveReader::get_or_insert_verified_checkpoint(
             &self.0,
             checkpoint.checkpoint_summary.clone(),

--- a/crates/suins-indexer/src/main.rs
+++ b/crates/suins-indexer/src/main.rs
@@ -3,7 +3,6 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use std::sync::Arc;
 use diesel::{dsl::sql, BoolExpressionMethods, ExpressionMethods};
 use diesel_async::{scoped_futures::ScopedFutureExt, AsyncConnection, RunQueryDsl};
 use dotenvy::dotenv;
@@ -11,6 +10,7 @@ use mysten_service::metrics::start_basic_prometheus_server;
 use prometheus::Registry;
 use std::env;
 use std::path::PathBuf;
+use std::sync::Arc;
 use sui_data_ingestion_core::{
     DataIngestionMetrics, FileProgressStore, IndexerExecutor, ReaderOptions, Worker, WorkerPool,
 };

--- a/crates/suins-indexer/src/main.rs
+++ b/crates/suins-indexer/src/main.rs
@@ -3,6 +3,7 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
+use std::sync::Arc;
 use diesel::{dsl::sql, BoolExpressionMethods, ExpressionMethods};
 use diesel_async::{scoped_futures::ScopedFutureExt, AsyncConnection, RunQueryDsl};
 use dotenvy::dotenv;
@@ -108,9 +109,9 @@ impl SuinsIndexerWorker {
 #[async_trait]
 impl Worker for SuinsIndexerWorker {
     type Result = ();
-    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<()> {
+    async fn process_checkpoint(&self, checkpoint: Arc<CheckpointData>) -> Result<()> {
         let checkpoint_seq_number = checkpoint.checkpoint_summary.sequence_number;
-        let (updates, removals) = self.indexer.process_checkpoint(checkpoint);
+        let (updates, removals) = self.indexer.process_checkpoint(&checkpoint);
 
         // every 1000 checkpoints, we will print the checkpoint sequence number
         // to the console to keep track of progress

--- a/examples/custom-indexer/rust/local_reader.rs
+++ b/examples/custom-indexer/rust/local_reader.rs
@@ -4,6 +4,7 @@
 use tokio::sync::oneshot;
 use anyhow::Result;
 use async_trait::async_trait;
+use std::sync::Arc;
 use sui_types::full_checkpoint_content::CheckpointData;
 use sui_data_ingestion_core as sdic;
 use sdic::{Worker, WorkerPool, ReaderOptions};
@@ -17,7 +18,7 @@ struct CustomWorker;
 #[async_trait]
 impl Worker for CustomWorker {
     type Result = ();
-    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<()> {
+    async fn process_checkpoint(&self, checkpoint: Arc<CheckpointData>) -> Result<()> {
         // custom processing logic
         println!("Processing Local checkpoint: {}", checkpoint.checkpoint_summary.to_string());
         Ok(())

--- a/examples/custom-indexer/rust/remote_reader.rs
+++ b/examples/custom-indexer/rust/remote_reader.rs
@@ -3,6 +3,7 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
+use std::sync::Arc;
 use sui_data_ingestion_core::{setup_single_workflow, Worker};
 use sui_types::full_checkpoint_content::CheckpointData;
 
@@ -11,7 +12,7 @@ struct CustomWorker;
 #[async_trait]
 impl Worker for CustomWorker {
     type Result = ();
-    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<()> {
+    async fn process_checkpoint(&self, checkpoint: Arc<CheckpointData>) -> Result<()> {
         // custom processing logic
         // print out the checkpoint number
         println!(


### PR DESCRIPTION
## Description

This is a pre-req which enables Worker impls to spawn sub-tasks that each operate on the same CheckpointData (i.e. to process transactions in parallel). Breaking it into its own PR because it's a no-op refactor.

## Test plan

This change is already running in the live backfill
