### PR TITLE
Create method to pass Arc<Checkpoint> to workers

### DIFF
--- a/crates/sui-data-ingestion-core/src/lib.rs
+++ b/crates/sui-data-ingestion-core/src/lib.rs
@@ -11,6 +11,8 @@ mod tests;
 mod util;
 mod worker_pool;
 
+use std::sync::Arc;
+
 use anyhow::Result;
 use async_trait::async_trait;
 pub use executor::{setup_single_workflow, IndexerExecutor, MAX_CHECKPOINTS_IN_PROGRESS};
@@ -26,7 +28,18 @@ pub use worker_pool::WorkerPool;
 #[async_trait]
 pub trait Worker: Send + Sync {
     type Result: Send + Sync + Clone;
-    async fn process_checkpoint(&self, checkpoint: &CheckpointData) -> Result<Self::Result>;
+    async fn process_checkpoint_arc(
+        &self,
+        checkpoint: Arc<CheckpointData>,
+    ) -> Result<Self::Result> {
+        self.process_checkpoint(&checkpoint).await
+    }
+    /// There is no need to implement this if you implement process_checkpoint_arc. The WorkerPool
+    /// will only call process_checkpoint_arc. This method was left in place for backwards
+    /// compatibiity.
+    async fn process_checkpoint(&self, _checkpoint_data: &CheckpointData) -> Result<Self::Result> {
+        panic!("process_checkpoint not implemented")
+    }
 
     fn preprocess_hook(&self, _: &CheckpointData) -> Result<()> {
         Ok(())

--- a/crates/sui-data-ingestion-core/src/worker_pool.rs
+++ b/crates/sui-data-ingestion-core/src/worker_pool.rs
@@ -84,7 +84,7 @@ impl<W: Worker + 'static> WorkerPool<W> {
                             let result = backoff::future::retry(backoff, || async {
                                 worker
                                     .clone()
-                                    .process_checkpoint(&checkpoint)
+                                    .process_checkpoint_arc(checkpoint.clone())
                                     .await
                                     .map_err(|err| {
                                         info!("transient worker execution error {:?} for checkpoint {}", err, sequence_number);


### PR DESCRIPTION
## Description

Backwards compatible change that allows workers to get the Arc<CheckpointData> rather than the &CheckpointData. Enables parallelization within the worker.
