### PR TITLE
Fix writer blocking tokio worker threads

### DIFF
--- a/crates/sui-analytics-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/checkpoint_handler.rs
@@ -27,9 +27,9 @@ impl AnalyticsHandler<CheckpointEntry> for CheckpointHandler {
     async fn process_checkpoint(
         &self,
         checkpoint_data: &Arc<CheckpointData>,
-    ) -> Result<Vec<CheckpointEntry>> {
-        let checkpoint_entry = process_checkpoint_data(&checkpoint_data);
-        Ok(vec![checkpoint_entry])
+    ) -> Result<Box<dyn Iterator<Item = CheckpointEntry> + Send + Sync>> {
+        let checkpoint_entry = process_checkpoint_data(checkpoint_data);
+        Ok(Box::new(std::iter::once(checkpoint_entry)))
     }
 
     fn file_type(&self) -> Result<FileType> {

--- a/crates/sui-analytics-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/checkpoint_handler.rs
@@ -28,7 +28,7 @@ impl AnalyticsHandler<CheckpointEntry> for CheckpointHandler {
         &self,
         checkpoint_data: &Arc<CheckpointData>,
     ) -> Result<Vec<CheckpointEntry>> {
-        let checkpoint_entry = process_checkpoint_data(checkpoint_data);
+        let checkpoint_entry = process_checkpoint_data(&checkpoint_data);
         Ok(vec![checkpoint_entry])
     }
 

--- a/crates/sui-analytics-indexer/src/writers/csv_writer.rs
+++ b/crates/sui-analytics-indexer/src/writers/csv_writer.rs
@@ -84,11 +84,13 @@ impl<S: Serialize + ParquetSchema> AnalyticsWriter<S> for CSVWriter {
         Ok(FileFormat::CSV)
     }
 
-    fn write(&mut self, rows: &[S]) -> Result<()> {
+    fn write(&mut self, rows: Box<dyn Iterator<Item = S> + Send + Sync>) -> Result<()> {
+        let mut count = 0;
         for row in rows {
             self.writer.serialize(row)?;
+            count += 1;
         }
-        self.row_count += rows.len();
+        self.row_count += count;
         Ok(())
     }
 

--- a/crates/sui-analytics-indexer/src/writers/mod.rs
+++ b/crates/sui-analytics-indexer/src/writers/mod.rs
@@ -13,7 +13,7 @@ pub trait AnalyticsWriter<S: Serialize + ParquetSchema>: Send + Sync + 'static {
     /// File format i.e. csv, parquet, etc
     fn file_format(&self) -> Result<FileFormat>;
     /// Persist given rows into a file
-    fn write(&mut self, rows: &[S]) -> Result<()>;
+    fn write(&mut self, rows: Box<dyn Iterator<Item = S> + Send + Sync>) -> Result<()>;
     /// Flush the current file
     fn flush(&mut self, end_checkpoint_seq_num: u64) -> Result<bool>;
     /// Reset internal state with given epoch and checkpoint sequence number


### PR DESCRIPTION
## Description

We were writing to the parquet file from an async block, which can block the tokio threads for a long time and cause issues with throughput/stalled pipelines. This moves the blocking write to a tokio blocking task.
