### PR TITLE
parallelized checkpoint processing

### DIFF
--- a/crates/sui-analytics-indexer/src/main.rs
+++ b/crates/sui-analytics-indexer/src/main.rs
@@ -84,7 +84,7 @@ async fn main() -> Result<()> {
 
     for processor in processors {
         let task_name = processor.task_name.clone();
-        let worker_pool = WorkerPool::new(processor, task_name, 1);
+        let worker_pool = WorkerPool::new(processor, task_name, num_cpus::get());
         executor.register(worker_pool).await?;
     }
 


### PR DESCRIPTION
## Description

Speed up backfills by parallelizing checkpoint processing. This is done by fanning out execution multiple checkpoints in parallel and buffering the results in a BTreeMap to preserve file ordering.
