### PR TITLE
Cherry-pick TLS client disable #22010 to 1.48

### DIFF
--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -21,7 +21,6 @@ use sui_types::{
     error::{SuiError, SuiResult},
     transaction::*,
 };
-use tap::TapFallible;
 
 use crate::authority_client::tonic::IntoRequest;
 use sui_network::tonic::metadata::KeyAndValueRef;
@@ -304,35 +303,25 @@ pub fn make_network_authority_clients_with_network_config(
 ) -> BTreeMap<AuthorityName, NetworkAuthorityClient> {
     let mut authority_clients = BTreeMap::new();
     for (name, (_state, network_metadata)) in committee.validators() {
-        let address = network_metadata
-            .network_address
-            .clone()
-            .rewrite_udp_to_tcp()
-            .rewrite_http_to_https();
-        let tls_config = network_metadata
-            .network_public_key
-            .as_ref()
-            .map(|key| {
-                sui_tls::create_rustls_client_config(
-                    key.clone(),
-                    sui_tls::SUI_VALIDATOR_SERVER_NAME.to_string(),
-                    None,
-                )
-            })
-            .ok_or(SuiError::from("network public key is not available"));
-        let maybe_channel = tls_config
-            .and_then(|tls_config| {
-                network_config
-                    .connect_lazy(&address, Some(tls_config))
-                    .map_err(|e| e.to_string().into())
-            })
-            .tap_err(|e| {
-                tracing::error!(
-                    address = %address,
-                    name = %name,
-                    "unable to create authority client: {e}"
-                )
-            });
+        let address = network_metadata.network_address.clone();
+        let address = address.rewrite_udp_to_tcp();
+        // TODO: Enable TLS on this interface with below config, once support is rolled out to validators.
+        // let tls_config = network_metadata.network_public_key.as_ref().map(|key| {
+        //     sui_tls::create_rustls_client_config(
+        //         key.clone(),
+        //         sui_tls::SUI_VALIDATOR_SERVER_NAME.to_string(),
+        //         None,
+        //     )
+        // });
+        // TODO: Change below code to generate a SuiError if no valid TLS config is available.
+        let maybe_channel = network_config.connect_lazy(&address, None).map_err(|e| {
+            tracing::error!(
+                address = %address,
+                name = %name,
+                "unable to create authority client: {e}"
+            );
+            e.to_string().into()
+        });
         let client = NetworkAuthorityClient::new_lazy(maybe_channel);
         authority_clients.insert(*name, client);
     }

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -104,16 +104,15 @@ async fn make_clients(
         .active_validators;
 
     for validator in active_validators {
-        let net_addr = Multiaddr::try_from(validator.net_address)
-            .unwrap()
-            .rewrite_http_to_https();
-        let tls_config = sui_tls::create_rustls_client_config(
-            sui_types::crypto::NetworkPublicKey::from_bytes(&validator.network_pubkey_bytes)?,
-            sui_tls::SUI_VALIDATOR_SERVER_NAME.to_string(),
-            None,
-        );
+        let net_addr = Multiaddr::try_from(validator.net_address).unwrap();
+        // TODO: Enable TLS on this interface with below config, once support is rolled out to validators.
+        // let tls_config = sui_tls::create_rustls_client_config(
+        //     sui_types::crypto::NetworkPublicKey::from_bytes(&validator.network_pubkey_bytes)?,
+        //     sui_tls::SUI_VALIDATOR_SERVER_NAME.to_string(),
+        //     None,
+        // );
         let channel = net_config
-            .connect_lazy(&net_addr, Some(tls_config))
+            .connect_lazy(&net_addr, None)
             .map_err(|err| anyhow!(err.to_string()))?;
         let client = NetworkAuthorityClient::new(channel);
         let public_key_bytes =


### PR DESCRIPTION
Cherry-pick TLS client disable #22010 to 1.48

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
