### PR TITLE
[package-alt] Update lockfile design document to describe pinning changes

### DIFF
--- a/external-crates/move/crates/move-package-alt/DESIGN.md
+++ b/external-crates/move/crates/move-package-alt/DESIGN.md
@@ -393,6 +393,7 @@ graph.
 
 2. recursively repin everything
     - explode the manifest dependencies so that there is a dep for every environment
+        - note that we will need to pay attention to `use-environment` here
     - resolve all direct external dependencies into internal dependencies
     - fetch all direct dependencies
         - note that the lockfiles of the dependencies are ignored

--- a/external-crates/move/crates/move-package-alt/DESIGN.md
+++ b/external-crates/move/crates/move-package-alt/DESIGN.md
@@ -1,5 +1,3 @@
-# TODO: careful rollout plan - parallel with extisting system?
-
 # Package Management Alt Design
 
 In this proposal, the `Move.lock` file contains all the information about the published versions of
@@ -14,17 +12,14 @@ stories][notion-userstories] for a walkthrough of usage scenarios.
 [notion-overview]: https://www.notion.so/Package-management-revamp-overview-1aa6d9dcb4e980128c1bc13063c418c7?pvs=21
 [notion-userstories]: https://www.notion.so/Package-management-user-stories-1bd6d9dcb4e98005a4a7ddea4424f757?pvs=21
 
-# Document status
+# TODOs
 
- - 4/25/25
-     - TODO:
-         - sui move build/test now use the default dependencies unless you ask otherwise
-         - two packages share an identity if they have the same original-id in any environment
-         - maybe need to do additional identity checks when running `--publish-unpublished-deps`
-         - cached deps are read-write but you can’t use dirty ones without asking
-         - non-git local deps are a loud warning
- - 5/5/25
-     - Migrated to monorepo
+ - careful rollout plan - parallel with extisting system?
+ - sui move build/test now use the default dependencies unless you ask otherwise
+ - two packages share an identity if they have the same original-id in any environment
+ - maybe need to do additional identity checks when running `--publish-unpublished-deps`
+ - cached deps are read-write but you can’t use dirty ones without asking
+ - non-git local deps are a loud warning
 
 # Points of contention and remaining questions
 


### PR DESCRIPTION
## Description 

Because transitive dependencies may use different names for their dependencies, we need to include the whole package graph in the lock file instead of just a list of resolved dependencies. This PR updates the design doc to include these changes to the lockfile.

There are also some minor cleanups and some removed TODOs.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
