### PR TITLE
Fix debug assert

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3213,12 +3213,16 @@ impl AuthorityState {
             // if we built the last checkpoint locally (as opposed to receiving it from a peer),
             // then all shared_version_assignments except the one for the ChangeEpoch transaction
             // should have been removed
-            let num_shared_version_assignments = cur_epoch_store.num_shared_version_assignments();
+            let shared_version_assignments = cur_epoch_store.inspect_shared_version_assignments();
             // Note that while 1 is the typical value, 0 is possible if the node restarts after
             // committing the last checkpoint but before reconfiguring.
-            if num_shared_version_assignments > 1 {
+            if shared_version_assignments.len() > 1 {
+                let keys = shared_version_assignments.keys().collect::<Vec<_>>();
                 // If this happens in prod, we have a memory leak, but not a correctness issue.
-                debug_fatal!("all shared_version_assignments should have been removed (num_shared_version_assignments: {num_shared_version_assignments})");
+                debug_fatal!(
+                    "all shared_version_assignments should have been removed: {:?}",
+                    keys
+                );
             }
         }
 

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1276,7 +1276,9 @@ impl AuthorityPerEpochStore {
         let system_state = match system_state {
             SuiSystemState::V2(system_state) => system_state,
             SuiSystemState::V1(_) => {
-                error!("`PerObjectCongestionControlMode::ExecutionTimeEstimate` cannot load execution time observations to SuiSystemState because it has an old version. This should not happen outside tests.");
+                if committee.epoch() > 1 {
+                    error!("`PerObjectCongestionControlMode::ExecutionTimeEstimate` cannot load execution time observations to SuiSystemState because it has an old version. This should not happen outside tests.");
+                }
                 return itertools::Either::Left(std::iter::empty());
             }
             #[cfg(msim)]
@@ -1432,8 +1434,11 @@ impl AuthorityPerEpochStore {
             .remove_shared_object_assignments(keys);
     }
 
-    pub fn num_shared_version_assignments(&self) -> usize {
-        self.consensus_output_cache.num_shared_version_assignments()
+    pub fn inspect_shared_version_assignments(
+        &self,
+    ) -> HashMap<TransactionKey, Vec<(ConsensusObjectSequenceKey, SequenceNumber)>> {
+        self.consensus_output_cache
+            .inspect_shared_version_assignments(10)
     }
 
     pub fn revert_executed_transaction(&self, tx_digest: &TransactionDigest) -> SuiResult {

--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -414,8 +414,19 @@ impl ConsensusOutputCache {
         }
     }
 
-    pub fn num_shared_version_assignments(&self) -> usize {
-        self.shared_version_assignments.len()
+    // Used for debugging only.
+    pub fn inspect_shared_version_assignments(
+        &self,
+        n: usize,
+    ) -> HashMap<TransactionKey, Vec<(ConsensusObjectSequenceKey, SequenceNumber)>> {
+        self.shared_version_assignments
+            .iter()
+            .take(n)
+            .map(|e| {
+                let (key, locks) = (e.key(), e.value());
+                (*key, locks.clone())
+            })
+            .collect()
     }
 
     pub fn get_assigned_shared_object_versions(


### PR DESCRIPTION
slow.rs workload transactions shouldn't abort, but they can be cancelled
