### PR TITLE
pick(#22053) async-graphql: Patch to upgrade to React 18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -870,8 +870,7 @@ dependencies = [
 [[package]]
 name = "async-graphql"
 version = "7.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16926f97f683ff3b47b035cc79622f3d6a374730b07a5d9051e81e88b5f1904"
+source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18#3fa614a54b4bda9efc9cad6f11579a328bfe35d0"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
@@ -910,8 +909,7 @@ dependencies = [
 [[package]]
 name = "async-graphql-axum"
 version = "7.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3415c9dbaf54397292da0bb81a907e2b989661ce068e4ccfebac33dc9e245e"
+source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18#3fa614a54b4bda9efc9cad6f11579a328bfe35d0"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -928,8 +926,7 @@ dependencies = [
 [[package]]
 name = "async-graphql-derive"
 version = "7.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a7349168b79030e3172a620f4f0e0062268a954604e41475eff082380fe505"
+source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18#3fa614a54b4bda9efc9cad6f11579a328bfe35d0"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
@@ -945,8 +942,7 @@ dependencies = [
 [[package]]
 name = "async-graphql-parser"
 version = "7.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fdc0adf9f53c2b65bb0ff5170cba1912299f248d0e48266f444b6f005deb1d"
+source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18#3fa614a54b4bda9efc9cad6f11579a328bfe35d0"
 dependencies = [
  "async-graphql-value",
  "pest",
@@ -957,8 +953,7 @@ dependencies = [
 [[package]]
 name = "async-graphql-value"
 version = "7.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf4d4e86208f4f9b81a503943c07e6e7f29ad3505e6c9ce6431fe64dc241681"
+source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18#3fa614a54b4bda9efc9cad6f11579a328bfe35d0"
 dependencies = [
  "bytes",
  "indexmap 2.8.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -761,3 +761,6 @@ sui-execution = { path = "sui-execution" }
 tonic = "0.13"
 
 [patch.crates-io]
+async-graphql = { git = "https://github.com/amnn/async-graphql", branch = "v7.0.1-react-18" }
+async-graphql-axum = { git = "https://github.com/amnn/async-graphql", branch = "v7.0.1-react-18" }
+async-graphql-value = { git = "https://github.com/amnn/async-graphql", branch = "v7.0.1-react-18" }


### PR DESCRIPTION
## Description

Patch to fix:

https://github.com/async-graphql/async-graphql/issues/1703,

Cherry-picking the fix from:

https://github.com/async-graphql/async-graphql/pull/1705

Until it is merged, at which point we can upgrade our dependency.

## Test plan

Run the GraphQL service locally, and confirm that its GraphiQL IDE works now.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK: