### PR TITLE
[move-values] Clean up vector pack

### DIFF
--- a/external-crates/move/crates/move-stdlib-natives/src/vector.rs
+++ b/external-crates/move/crates/move-stdlib-natives/src/vector.rs
@@ -43,7 +43,10 @@ pub fn native_empty(
 
     native_charge_gas_early_exit!(context, gas_params.base);
 
-    NativeResult::map_partial_vm_result_one(context.gas_used(), Vector::empty(&ty_args[0]))
+    NativeResult::map_partial_vm_result_one(
+        context.gas_used(),
+        (&ty_args[0]).try_into().and_then(Vector::empty),
+    )
 }
 
 pub fn make_native_empty(gas_params: EmptyGasParameters) -> NativeFunction {

--- a/external-crates/move/crates/move-vm-runtime/src/interpreter.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/interpreter.rs
@@ -27,7 +27,7 @@ use move_vm_types::{
     loaded_data::runtime_types::Type,
     values::{
         self, IntegerValue, Locals, Reference, Struct, StructRef, VMValueCast, Value, Variant,
-        VariantRef, Vector, VectorRef,
+        VariantRef, Vector, VectorRef, VectorSpecialization,
     },
     views::TypeView,
 };
@@ -1271,7 +1271,8 @@ impl Frame {
                     interpreter.operand_stack.last_n(*num as usize)?,
                 )?;
                 let elements = interpreter.operand_stack.popn(*num as u16)?;
-                let value = Vector::pack(&ty, elements)?;
+                let specialization: VectorSpecialization = (&ty).try_into()?;
+                let value = Vector::pack(specialization, elements)?;
                 interpreter.operand_stack.push(value)?;
             }
             Bytecode::VecLen(si) => {

--- a/external-crates/move/crates/move-vm-types/src/values/value_tests.rs
+++ b/external-crates/move/crates/move-vm-types/src/values/value_tests.rs
@@ -194,8 +194,8 @@ fn legacy_val_abstract_memory_size_consistency() -> PartialVMResult<()> {
         Value::vector_u256([1, 2, 3, 4].iter().map(|q| U256::from(*q as u64))),
         Value::struct_(Struct::pack([])),
         Value::struct_(Struct::pack([Value::u8(0), Value::bool(false)])),
-        Value::vector_for_testing_only([]),
-        Value::vector_for_testing_only([Value::u8(0), Value::u8(1)]),
+        Vector::pack(VectorSpecialization::Container, [])?,
+        Vector::pack(VectorSpecialization::U8, [Value::u8(0), Value::u8(1)])?,
     ];
 
     let mut locals = Locals::new(vals.len());

--- a/sui-execution/latest/sui-move-natives/src/config.rs
+++ b/sui-execution/latest/sui-move-natives/src/config.rs
@@ -184,6 +184,6 @@ fn unpack_option(option: Value, type_param: &Type) -> PartialVMResult<Option<Val
 
 fn option_none(type_param: &Type) -> PartialVMResult<Value> {
     Ok(Value::struct_(Struct::pack(vec![Vector::empty(
-        type_param,
+        type_param.try_into()?,
     )?])))
 }

--- a/sui-execution/latest/sui-move-natives/src/crypto/nitro_attestation.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/nitro_attestation.rs
@@ -8,7 +8,7 @@ use move_vm_types::{
     loaded_data::runtime_types::Type,
     natives::function::NativeResult,
     pop_arg,
-    values::{Struct, Value, Vector, VectorRef},
+    values::{Struct, Value, Vector, VectorRef, VectorSpecialization},
 };
 use std::collections::VecDeque;
 use sui_types::nitro_attestation::{parse_nitro_attestation, verify_nitro_attestation};
@@ -119,16 +119,15 @@ pub fn load_nitro_attestation_internal(
 
 // Build an Option<vector<u8>> value
 fn to_option_vector_u8(value: Option<Vec<u8>>) -> PartialVMResult<Value> {
-    let vector_u8_type = Type::Vector(Box::new(Type::U8));
     match value {
         // Some(<vector<u8>>) = { vector[ <vector<u8>> ] }
         Some(vec) => Ok(Value::struct_(Struct::pack(vec![Vector::pack(
-            &vector_u8_type,
+            VectorSpecialization::Container,
             vec![Value::vector_u8(vec)],
         )?]))),
         // None = { vector[ ] }
         None => Ok(Value::struct_(Struct::pack(vec![Vector::empty(
-            &vector_u8_type,
+            VectorSpecialization::Container,
         )?]))),
     }
 }
@@ -148,5 +147,5 @@ fn to_indexed_struct(pcrs: Vec<Vec<u8>>) -> PartialVMResult<Value> {
             Value::vector_u8(pcr.to_vec()),
         ])));
     }
-    Ok(Value::vector_for_testing_only(indexed_struct))
+    Vector::pack(VectorSpecialization::Container, indexed_struct)
 }


### PR DESCRIPTION
## Description 

- Remove the need for a `Type` in `Vector::pack` by adding a new `VectorSpecialization` enum
- Removed `Value::vector_for_testing_only`

## Test plan 

- Updated tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
