### PR TITLE
[fastpath] finalize transactions in commits

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -307,6 +307,7 @@ where
             context.clone(),
             commit_consumer,
             dag_state.clone(),
+            transaction_certifier.clone(),
             leader_schedule.clone(),
         );
 

--- a/consensus/core/src/commit_finalizer.rs
+++ b/consensus/core/src/commit_finalizer.rs
@@ -1,0 +1,655 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    sync::Arc,
+};
+
+use consensus_config::Stake;
+use mysten_metrics::{
+    monitored_mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+    monitored_scope, spawn_logged_monitored_task,
+};
+
+use crate::{
+    context::Context,
+    error::{ConsensusError, ConsensusResult},
+    stake_aggregator::{QuorumThreshold, StakeAggregator},
+    transaction_certifier::TransactionCertifier,
+    BlockAPI, BlockRef, CommitIndex, CommittedSubDag, Round, TransactionIndex,
+};
+
+/// Number of rounds between the leader that committed a transaction to the latest leader,
+/// where indirect finalization and rejection are allowed and required.
+const INDIRECT_FINALIZE_DEPTH: Round = 3;
+
+/// Number of rounds above the leader that committed a transaction,
+/// where accept votes are collected.
+/// NOTE: it should be possible to remove this limit.
+const VOTE_DEPTH: Round = 1;
+
+pub(crate) struct CommitFinalizerHandle {
+    sender: UnboundedSender<(CommittedSubDag, bool)>,
+}
+
+impl CommitFinalizerHandle {
+    pub(crate) fn send(&self, commit: (CommittedSubDag, bool)) -> ConsensusResult<()> {
+        self.sender.send(commit).map_err(|e| {
+            tracing::warn!("Failed to send to commit finalizer, probably due to shutdown: {e:?}");
+            ConsensusError::Shutdown
+        })
+    }
+}
+
+pub(crate) struct CommitFinalizer {
+    context: Arc<Context>,
+    transaction_certifier: TransactionCertifier,
+    commit_sender: UnboundedSender<CommittedSubDag>,
+
+    last_processed_commit: Option<CommitIndex>,
+    commits: VecDeque<CommitState>,
+    blocks: BTreeMap<BlockRef, BlockState>,
+}
+
+impl CommitFinalizer {
+    fn new(
+        context: Arc<Context>,
+        transaction_certifier: TransactionCertifier,
+        commit_sender: UnboundedSender<CommittedSubDag>,
+    ) -> Self {
+        Self {
+            context,
+            transaction_certifier,
+            commit_sender,
+            last_processed_commit: None,
+            commits: VecDeque::new(),
+            blocks: BTreeMap::new(),
+        }
+    }
+
+    pub(crate) fn start(
+        context: Arc<Context>,
+        transaction_certifier: TransactionCertifier,
+        commit_sender: UnboundedSender<CommittedSubDag>,
+    ) -> CommitFinalizerHandle {
+        let processor = Self::new(context, transaction_certifier, commit_sender);
+        let (sender, receiver) = unbounded_channel("commit_finalizer");
+        let _handle = spawn_logged_monitored_task!(processor.run(receiver), "commit_finalizer");
+        CommitFinalizerHandle { sender }
+    }
+
+    async fn run(mut self, mut receiver: UnboundedReceiver<(CommittedSubDag, bool)>) {
+        if self.context.protocol_config.mysticeti_fastpath() {
+            while let Some((committed_sub_dag, direct)) = receiver.recv().await {
+                let finalized_commits = self.process_commit(committed_sub_dag, direct);
+                for commit in finalized_commits {
+                    if let Err(e) = self.commit_sender.send(commit) {
+                        tracing::warn!(
+                            "Failed to send to commit handler, probably due to shutdown: {e:?}"
+                        );
+                        return;
+                    }
+                }
+            }
+        } else {
+            while let Some((committed_sub_dag, _direct)) = receiver.recv().await {
+                if let Err(e) = self.commit_sender.send(committed_sub_dag) {
+                    tracing::warn!(
+                        "Failed to send to commit handler, probably due to shutdown: {e:?}"
+                    );
+                    return;
+                }
+            }
+        }
+    }
+
+    fn process_commit(
+        &mut self,
+        committed_sub_dag: CommittedSubDag,
+        direct: bool,
+    ) -> Vec<CommittedSubDag> {
+        let _scope = monitored_scope("CommitFinalizer::process_commit");
+
+        if let Some(last_processed_commit) = self.last_processed_commit {
+            assert_eq!(
+                last_processed_commit + 1,
+                committed_sub_dag.commit_ref.index
+            );
+        }
+        self.last_processed_commit = Some(committed_sub_dag.commit_ref.index);
+        self.commits.push_back(CommitState::new(committed_sub_dag));
+
+        let mut finalized_commits = vec![];
+
+        if direct {
+            self.try_direct_finalize();
+            finalized_commits.extend(self.pop_finalized_commits());
+        }
+
+        // If there are remaining commits, initialize them for indirect finalization
+        // and try to indirectly finalize a prefix of them.
+        if !self.commits.is_empty() {
+            self.link_blocks();
+            self.inherit_reject_votes();
+            // Try to indirectly finalize a prefix of the buffered commits.
+            // The last commit cannot be indirectly finalized.
+            for i in 0..(self.commits.len() - 1) {
+                self.try_indirect_finalize_commit(i);
+                let new_finalized_commits = self.pop_finalized_commits();
+                if new_finalized_commits.is_empty() {
+                    // No future commits can be indirectly finalized.
+                    break;
+                }
+                finalized_commits.extend(new_finalized_commits);
+            }
+        }
+
+        // Run TransactionCertifier GC only with finalized commits.
+        // Other blocks can still be used for finalization.
+        if let Some(last_commit) = finalized_commits.last() {
+            let gc_round = last_commit
+                .leader
+                .round
+                .saturating_sub(self.context.protocol_config.consensus_gc_depth());
+            self.transaction_certifier.run_gc(gc_round);
+        }
+
+        finalized_commits
+    }
+
+    // Tries to directly finalize blocks and transactions in the last commit.
+    fn try_direct_finalize(&mut self) {
+        let commit_state = self.commits.back_mut().unwrap();
+        // All blocks in a direct commit are finalized. But the transactions contained in them
+        // may not have been finalized.
+        let pending_blocks = std::mem::take(&mut commit_state.pending_blocks);
+        for block_ref in pending_blocks {
+            let reject_votes = self.transaction_certifier.get_reject_votes(&block_ref)
+                .unwrap_or_else(|| panic!("No vote info found for {block_ref}. It is likely gc'ed or failed to be recovered after crash."));
+            for (transaction_index, stake) in reject_votes {
+                let entry = if stake < self.context.committee.quorum_threshold() {
+                    commit_state
+                        .pending_transactions
+                        .entry(block_ref)
+                        .or_default()
+                } else {
+                    commit_state
+                        .rejected_transactions
+                        .entry(block_ref)
+                        .or_default()
+                };
+                entry.insert(transaction_index);
+            }
+        }
+    }
+
+    // Creates an entry in the blocks map for each block in the commit,
+    // and links each block to its ancestors.
+    fn link_blocks(&mut self) {
+        let commit_state = self.commits.back_mut().unwrap();
+
+        // Link blocks in ascending order of round.
+        let mut blocks = commit_state.commit.blocks.clone();
+        blocks.sort_by_key(|b| b.round());
+
+        for block in blocks {
+            // Initialize the block state.
+            let block_state = self.blocks.entry(block.reference()).or_default();
+            for votes in block.transaction_votes() {
+                block_state
+                    .reject_votes
+                    .entry(votes.block_ref)
+                    .or_default()
+                    .extend(votes.rejects.iter());
+            }
+
+            // Link the block to its ancestors.
+            let block_ref = block.reference();
+            for ancestor in block.ancestors() {
+                // Ancestor may not exist in the blocks map if it has been finalized or gc'ed.
+                if let Some(ancestor_block) = self.blocks.get_mut(ancestor) {
+                    ancestor_block.children.insert(block_ref);
+                }
+            }
+        }
+    }
+
+    // When block A's same authority ancestor block B rejects a transaction, A is implicitly assumed
+    // to reject the transaction as well. Both A and B can link to the block containing
+    // the rejected transaction, because not linking to the same ancestor twice is only an optimization,
+    // not a requirement.
+    //
+    // So to simplify counting accept and reject votes for finalization, make reject votes explicit
+    // in each block state.
+    fn inherit_reject_votes(&mut self) {
+        let commit_state = self.commits.back_mut().unwrap();
+
+        // Inherit from lower round blocks to higher round blocks.
+        let mut blocks = commit_state.commit.blocks.clone();
+        blocks.sort_by_key(|b| b.round());
+
+        for block in blocks {
+            // Inherit reject votes from the ancestor of block's own authority.
+            // own_ancestor should usually be the 1st ancestor.
+            // Also, block verification ensures each authority has at most one ancestor.
+            let Some(own_ancestor) = block
+                .ancestors()
+                .iter()
+                .find(|b| b.author == block.author())
+                .copied()
+            else {
+                continue;
+            };
+            let Some(own_ancestor_rejects) = self
+                .blocks
+                .get(&own_ancestor)
+                .map(|b| b.reject_votes.clone())
+            else {
+                // The ancestor block may have been finalized or gc'ed.
+                continue;
+            };
+            // No reject votes from the ancestor block to inherit.
+            if own_ancestor_rejects.is_empty() {
+                continue;
+            }
+            // Otherwise, inherit the reject votes.
+            let block_state = self.blocks.get_mut(&block.reference()).unwrap();
+            for (block_ref, reject_votes) in own_ancestor_rejects {
+                block_state
+                    .reject_votes
+                    .entry(block_ref)
+                    .or_default()
+                    .extend(reject_votes.iter());
+            }
+        }
+    }
+
+    fn try_indirect_finalize_commit(&mut self, index: usize) {
+        // Optional optimization: re-check pending transactions to see if they are rejected by a quorum now.
+        self.check_pending_transactions(index);
+
+        // Check if remaining pending blocks can be finalized.
+        // If a block is finalized, record its pending and rejected transactions.
+        // The rest of the transactions in the block are indirectly finalized.
+        self.try_indirect_finalize_pending_blocks(index);
+
+        // Check if remaining pending transaction can be finalized.
+        self.try_indirect_finalize_pending_transactions(index);
+
+        // Check if remaining pending transactions can be indirectly rejected.
+        self.try_indirect_reject_pending_transactions(index);
+    }
+
+    fn check_pending_transactions(&mut self, index: usize) {
+        let pending_transactions = self.commits[index]
+            .pending_transactions
+            .keys()
+            .copied()
+            .collect::<Vec<_>>();
+        for block_ref in pending_transactions {
+            let reject_votes: BTreeMap<TransactionIndex, Stake> = self
+                .transaction_certifier
+                .get_reject_votes(&block_ref)
+                .unwrap_or_else(|| panic!("No vote info found for {block_ref}. It is likely gc'ed or failed to be recovered after crash."))
+                .into_iter()
+                .collect();
+            for (transaction_index, stake) in reject_votes {
+                if stake < self.context.committee.quorum_threshold() {
+                    // pending_transactions do not need to be updated in this case,
+                    // whether the transaction exists in pending_transactions or not.
+                    continue;
+                }
+                // Move the rejected transaction from pending_transactions to rejected_transactions.
+                let curr_commit_state = &mut self.commits[index];
+                let pending_transactions = curr_commit_state
+                    .pending_transactions
+                    .get_mut(&block_ref)
+                    .unwrap();
+                pending_transactions.remove(&transaction_index);
+                if pending_transactions.is_empty() {
+                    curr_commit_state.pending_transactions.remove(&block_ref);
+                }
+                curr_commit_state
+                    .rejected_transactions
+                    .entry(block_ref)
+                    .or_default()
+                    .insert(transaction_index);
+            }
+        }
+    }
+
+    fn try_indirect_finalize_pending_blocks(&mut self, index: usize) {
+        let curr_leader_round = self.commits[index].commit.leader.round;
+        let pending_blocks = self.commits[index].pending_blocks.clone();
+        for block_ref in pending_blocks {
+            let (block_finalized, _) =
+                self.try_indirect_finalize_block(curr_leader_round, block_ref, BTreeMap::new());
+            if !block_finalized {
+                continue;
+            }
+            let curr_commit_state = &mut self.commits[index];
+            curr_commit_state.pending_blocks.remove(&block_ref);
+            let reject_votes: BTreeMap<TransactionIndex, Stake> = self
+                .transaction_certifier
+                .get_reject_votes(&block_ref)
+                .unwrap_or_else(|| panic!("No vote info found for {block_ref}. It is likely gc'ed or failed to be recovered after crash."))
+                .into_iter()
+                .collect();
+            for (transaction_index, stake) in reject_votes {
+                let entry = if stake < self.context.committee.quorum_threshold() {
+                    curr_commit_state
+                        .pending_transactions
+                        .entry(block_ref)
+                        .or_default()
+                } else {
+                    curr_commit_state
+                        .rejected_transactions
+                        .entry(block_ref)
+                        .or_default()
+                };
+                entry.insert(transaction_index);
+            }
+        }
+    }
+
+    fn try_indirect_finalize_pending_transactions(&mut self, index: usize) {
+        let curr_leader_round = self.commits[index].commit.leader.round;
+        let pending_transactions = self.commits[index].pending_transactions.clone();
+        for (block_ref, pending_transactions) in pending_transactions {
+            let accept_votes: BTreeMap<TransactionIndex, StakeAggregator<QuorumThreshold>> =
+                pending_transactions
+                    .into_iter()
+                    .map(|transaction_index| (transaction_index, StakeAggregator::new()))
+                    .collect();
+            let (_, finalized_transactions) =
+                self.try_indirect_finalize_block(curr_leader_round, block_ref, accept_votes);
+            if !finalized_transactions.is_empty() {
+                let curr_commit_state = &mut self.commits[index];
+                let undecided_txns = curr_commit_state
+                    .pending_transactions
+                    .get_mut(&block_ref)
+                    .unwrap();
+                for t in finalized_transactions {
+                    undecided_txns.remove(&t);
+                }
+                if undecided_txns.is_empty() {
+                    curr_commit_state.pending_transactions.remove(&block_ref);
+                }
+            }
+        }
+    }
+
+    fn try_indirect_reject_pending_transactions(&mut self, index: usize) {
+        let curr_leader_round = self.commits[index].commit.leader.round;
+        let last_commit_leader_round = self.commits.back().unwrap().commit.leader.round;
+        if curr_leader_round + INDIRECT_FINALIZE_DEPTH <= last_commit_leader_round {
+            let curr_commit_state = &mut self.commits[index];
+            // When the last leader round is no lower than INDIRECT_FINALIZE_DEPTH,
+            // all pending blocks should have been finalized.
+            assert!(curr_commit_state.pending_blocks.is_empty());
+            // All remaining pending transactions are indirectly rejected.
+            let pending_transactions = std::mem::take(&mut curr_commit_state.pending_transactions);
+            for (block_ref, pending_transactions) in pending_transactions {
+                curr_commit_state
+                    .rejected_transactions
+                    .entry(block_ref)
+                    .or_default()
+                    .extend(pending_transactions);
+            }
+        }
+    }
+
+    // Returns if the block is indirectly finalized, and requested transactions in accept_votes
+    // that are indirectly finalized.
+    fn try_indirect_finalize_block(
+        &self,
+        curr_leader_round: Round,
+        block_ref: BlockRef,
+        mut accept_votes: BTreeMap<TransactionIndex, StakeAggregator<QuorumThreshold>>,
+    ) -> (bool, Vec<TransactionIndex>) {
+        let mut finalized_transactions = vec![];
+        let mut to_visit_blocks = self
+            .blocks
+            .get(&block_ref)
+            .unwrap()
+            .children
+            .iter()
+            .filter_map(|b| {
+                if b.round <= curr_leader_round + VOTE_DEPTH {
+                    Some(*b)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        let mut visited = BTreeSet::new();
+        let mut visited_stake = StakeAggregator::<QuorumThreshold>::new();
+        while let Some(block_ref) = to_visit_blocks.pop() {
+            if !visited.insert(block_ref) {
+                continue;
+            }
+            visited_stake.add(block_ref.author, &self.context.committee);
+            let visit_block_state = self.blocks.get(&block_ref).unwrap();
+            let visit_reject_votes = visit_block_state
+                .reject_votes
+                .get(&block_ref)
+                .cloned()
+                .unwrap_or_default();
+            let mut newly_finalized = vec![];
+            for (index, stake) in &mut accept_votes {
+                if visit_reject_votes.contains(index) {
+                    continue;
+                }
+                if !stake.add(block_ref.author, &self.context.committee) {
+                    continue;
+                }
+                newly_finalized.push(*index);
+                finalized_transactions.push(*index);
+            }
+            // There is no need to aggregate additional votes for finalized transactions.
+            for index in newly_finalized {
+                accept_votes.remove(&index);
+            }
+            // End traversing if all blocks and requested transactions have reached quorum.
+            if visited_stake.reached_threshold(&self.context.committee) && accept_votes.is_empty() {
+                break;
+            }
+            // Visit additional blocks.
+            to_visit_blocks.extend(
+                visit_block_state
+                    .children
+                    .iter()
+                    .filter(|b| b.round <= curr_leader_round + VOTE_DEPTH && !visited.contains(*b)),
+            );
+        }
+        (
+            visited_stake.reached_threshold(&self.context.committee),
+            finalized_transactions,
+        )
+    }
+
+    fn pop_finalized_commits(&mut self) -> Vec<CommittedSubDag> {
+        let mut finalized_commits = vec![];
+        while let Some(commit_state) = self.commits.front() {
+            if !commit_state.pending_blocks.is_empty()
+                || !commit_state.pending_transactions.is_empty()
+            {
+                break;
+            }
+            let commit_state = self.commits.pop_front().unwrap();
+            let mut commit = commit_state.commit;
+            for (block_ref, rejected_transactions) in commit_state.rejected_transactions {
+                commit
+                    .rejected_transactions_by_block
+                    .insert(block_ref, rejected_transactions.into_iter().collect());
+            }
+            finalized_commits.push(commit);
+        }
+        finalized_commits
+    }
+}
+
+struct CommitState {
+    commit: CommittedSubDag,
+    // Blocks pending finalization.
+    pending_blocks: BTreeSet<BlockRef>,
+    // Transactions pending finalization, where the block is already finalized.
+    pending_transactions: BTreeMap<BlockRef, BTreeSet<TransactionIndex>>,
+    // Transactions rejected by a quorum or indirectly finalized, per block.
+    rejected_transactions: BTreeMap<BlockRef, BTreeSet<TransactionIndex>>,
+}
+
+impl CommitState {
+    fn new(commit: CommittedSubDag) -> Self {
+        let pending_blocks = commit.blocks.iter().map(|b| b.reference()).collect();
+        Self {
+            commit,
+            pending_blocks,
+            pending_transactions: BTreeMap::new(),
+            rejected_transactions: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Default)]
+struct BlockState {
+    children: BTreeSet<BlockRef>,
+    reject_votes: BTreeMap<BlockRef, BTreeSet<TransactionIndex>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use mysten_metrics::monitored_mpsc;
+    use parking_lot::RwLock;
+
+    use crate::{
+        dag_state::DagState, linearizer::Linearizer, storage::mem_store::MemStore,
+        test_dag_builder::DagBuilder,
+    };
+
+    use super::*;
+
+    struct Fixture {
+        context: Arc<Context>,
+        dag_state: Arc<RwLock<DagState>>,
+        transaction_certifier: TransactionCertifier,
+        linearizer: Linearizer,
+        commit_finalizer: CommitFinalizer,
+    }
+
+    fn create_commit_finalizer_fixture() -> Fixture {
+        let (context, _keys) = Context::new_for_test(4);
+        let context = Arc::new(context);
+        let dag_state = Arc::new(RwLock::new(DagState::new(
+            context.clone(),
+            Arc::new(MemStore::new()),
+        )));
+        let linearizer = Linearizer::new(context.clone(), dag_state.clone());
+        let (blocks_sender, _blocks_receiver) =
+            monitored_mpsc::unbounded_channel("consensus_block_output");
+        let transaction_certifier =
+            TransactionCertifier::new(context.clone(), dag_state.clone(), blocks_sender);
+        let (commit_sender, _commit_receiver) = unbounded_channel("consensus_commit_output");
+        let commit_finalizer = CommitFinalizer::new(
+            context.clone(),
+            transaction_certifier.clone(),
+            commit_sender,
+        );
+        Fixture {
+            context,
+            dag_state,
+            transaction_certifier,
+            linearizer,
+            commit_finalizer,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_direct_finalize_no_reject_votes() {
+        let mut fixture = create_commit_finalizer_fixture();
+
+        // Create a round 1 and 2 blocks with 10 transactions each.
+        let mut dag_builder = DagBuilder::new(fixture.context.clone());
+        dag_builder
+            .layers(1..=2)
+            .num_transactions(10)
+            .build()
+            .persist_layers(fixture.dag_state.clone());
+        let blocks = dag_builder.all_blocks();
+        fixture
+            .transaction_certifier
+            .add_voted_blocks(blocks.iter().map(|b| (b.clone(), vec![])).collect());
+
+        // Select a round 2 block as the leader and create CommittedSubDag.
+        let leader = blocks.iter().find(|b| b.round() == 2).unwrap();
+        let committed_sub_dags = fixture.linearizer.handle_commit(vec![leader.clone()]);
+        assert_eq!(committed_sub_dags.len(), 1);
+        let committed_sub_dag = &committed_sub_dags[0];
+
+        // This committed sub-dag can be directly finalized.
+        let finalized_commits = fixture
+            .commit_finalizer
+            .process_commit(committed_sub_dag.clone(), true);
+        assert_eq!(finalized_commits.len(), 1);
+        let finalized_commit = &finalized_commits[0];
+        assert_eq!(committed_sub_dag, finalized_commit);
+    }
+
+    #[tokio::test]
+    async fn test_indirect_finalize_no_reject_votes() {
+        let mut fixture = create_commit_finalizer_fixture();
+
+        // Create 5 rounds of blocks with 10 transactions each.
+        let mut dag_builder = DagBuilder::new(fixture.context.clone());
+        dag_builder
+            .layers(1..=5)
+            .num_transactions(10)
+            .build()
+            .persist_layers(fixture.dag_state.clone());
+        let blocks = dag_builder.all_blocks();
+        fixture
+            .transaction_certifier
+            .add_voted_blocks(blocks.iter().map(|b| (b.clone(), vec![])).collect());
+
+        // Select a block from round 2-5 as leaders and create CommittedSubDag.
+        let leaders = vec![
+            blocks[5].clone(),
+            blocks[10].clone(),
+            blocks[15].clone(),
+            blocks[16].clone(),
+        ];
+        assert_eq!(
+            leaders.iter().map(|b| b.round()).collect::<Vec<_>>(),
+            vec![2, 3, 4, 5]
+        );
+        let committed_sub_dags = fixture.linearizer.handle_commit(leaders);
+        assert_eq!(committed_sub_dags.len(), 4);
+
+        // Process 1st and 2nd leaders as indirect commits. They will not be finalized.
+        for commit in committed_sub_dags[0..2].iter() {
+            let finalized_commits = fixture
+                .commit_finalizer
+                .process_commit(commit.clone(), false);
+            assert!(
+                finalized_commits.is_empty(),
+                "unexpected commits: {:?}",
+                finalized_commits
+            );
+        }
+
+        // Process 3rd leader as indirect commit. The 1st commit will be finalized.
+        let finalized_commits = fixture
+            .commit_finalizer
+            .process_commit(committed_sub_dags[2].clone(), false);
+        assert_eq!(finalized_commits.len(), 1);
+        assert_eq!(&committed_sub_dags[0], &finalized_commits[0]);
+
+        // Process 4th leader as direct commit. 2nd commit should be finalized.
+        let finalized_commits = fixture
+            .commit_finalizer
+            .process_commit(committed_sub_dags[3].clone(), true);
+        assert_eq!(finalized_commits.len(), 1);
+        assert_eq!(&committed_sub_dags[1], &finalized_commits[0]);
+    }
+}

--- a/consensus/core/src/commit_syncer.rs
+++ b/consensus/core/src/commit_syncer.rs
@@ -686,9 +686,6 @@ impl<C: NetworkClient> CommitSyncer<C> {
         }
 
         // 10. Add blocks in certified commits to the transaction certifier.
-        if inner.context.protocol_config.mysticeti_fastpath() {
-            inner.transaction_certifier.run_gc();
-        }
         for commit in &certified_commits {
             for block in commit.blocks() {
                 // Only account for reject votes in the block, since they may vote on uncommitted

--- a/consensus/core/src/core_thread.rs
+++ b/consensus/core/src/core_thread.rs
@@ -501,6 +501,7 @@ mod test {
             context.clone(),
             commit_consumer,
             dag_state.clone(),
+            transaction_certifier.clone(),
             leader_schedule.clone(),
         );
         let leader_schedule = Arc::new(LeaderSchedule::from_store(

--- a/consensus/core/src/leader_schedule.rs
+++ b/consensus/core/src/leader_schedule.rs
@@ -673,7 +673,7 @@ mod tests {
         let unscored_subdags = vec![CommittedSubDag::new(
             BlockRef::new(1, AuthorityIndex::ZERO, BlockDigest::MIN),
             vec![],
-            vec![],
+            BTreeMap::new(),
             context.clock.timestamp_utc_ms(),
             CommitRef::new(1, CommitDigest::MIN),
             vec![],
@@ -755,7 +755,7 @@ mod tests {
         let leader_block = leader.unwrap();
         let leader_ref = leader_block.reference();
         let commit_index = 1;
-        let rejected_transactions = vec![vec![]; blocks.len()];
+        let rejected_transactions = BTreeMap::new();
 
         let last_commit = TrustedCommit::new_for_test(
             commit_index,

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -45,6 +45,7 @@ mod universal_committer;
 #[path = "tests/randomized_tests.rs"]
 mod randomized_tests;
 
+mod commit_finalizer;
 mod proposed_block_handler;
 mod round_prober;
 mod round_tracker;

--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -1,9 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+};
 
-use consensus_config::{AuthorityIndex, Stake};
+use consensus_config::Stake;
 use itertools::Itertools;
 use parking_lot::RwLock;
 
@@ -12,8 +15,7 @@ use crate::{
     commit::{sort_sub_dag_blocks, Commit, CommittedSubDag, TrustedCommit},
     context::Context,
     dag_state::DagState,
-    leader_schedule::LeaderSchedule,
-    Round, TransactionIndex,
+    Round,
 };
 
 /// The `StorageAPI` trait provides an interface for the block store and has been
@@ -60,20 +62,11 @@ pub(crate) struct Linearizer {
     /// In memory block store representing the dag state
     context: Arc<Context>,
     dag_state: Arc<RwLock<DagState>>,
-    leader_schedule: Arc<LeaderSchedule>,
 }
 
 impl Linearizer {
-    pub(crate) fn new(
-        context: Arc<Context>,
-        dag_state: Arc<RwLock<DagState>>,
-        leader_schedule: Arc<LeaderSchedule>,
-    ) -> Self {
-        Self {
-            dag_state,
-            leader_schedule,
-            context,
-        }
+    pub(crate) fn new(context: Arc<Context>, dag_state: Arc<RwLock<DagState>>) -> Self {
+        Self { context, dag_state }
     }
 
     /// Collect the sub-dag and the corresponding commit from a specific leader excluding any duplicates or
@@ -81,7 +74,6 @@ impl Linearizer {
     fn collect_sub_dag_and_commit(
         &mut self,
         leader_block: VerifiedBlock,
-        reputation_scores_desc: Vec<(AuthorityIndex, u64)>,
     ) -> (CommittedSubDag, TrustedCommit) {
         let _s = self
             .context
@@ -99,7 +91,7 @@ impl Linearizer {
         let last_committed_rounds = dag_state.last_committed_rounds();
 
         // Now linearize the sub-dag starting from the leader block
-        let (to_commit, rejected_transactions) = Self::linearize_sub_dag(
+        let to_commit = Self::linearize_sub_dag(
             &self.context,
             leader_block.clone(),
             last_committed_rounds,
@@ -135,10 +127,10 @@ impl Linearizer {
         let sub_dag = CommittedSubDag::new(
             leader_block.reference(),
             to_commit,
-            rejected_transactions,
+            BTreeMap::new(),
             timestamp_ms,
             commit.reference(),
-            reputation_scores_desc,
+            vec![],
         );
 
         (sub_dag, commit)
@@ -190,7 +182,7 @@ impl Linearizer {
         leader_block: VerifiedBlock,
         last_committed_rounds: Vec<u32>,
         dag_state: &mut impl BlockStoreAPI,
-    ) -> (Vec<VerifiedBlock>, Vec<Vec<TransactionIndex>>) {
+    ) -> Vec<VerifiedBlock> {
         let gc_enabled = dag_state.gc_enabled();
         // The GC round here is calculated based on the last committed round of the leader block. The algorithm will attempt to
         // commit blocks up to this GC round. Once this commit has been processed and written to DagState, then gc round will update
@@ -287,11 +279,7 @@ impl Linearizer {
         // Sort the blocks of the sub-dag blocks
         sort_sub_dag_blocks(&mut to_commit);
 
-        // TODO(fastpath): determine rejected transactions from voting.
-        // Get rejected transactions.
-        let rejected_transactions = vec![vec![]; to_commit.len()];
-
-        (to_commit, rejected_transactions)
+        to_commit
     }
 
     // This function should be called whenever a new commit is observed. This will
@@ -305,27 +293,10 @@ impl Linearizer {
             return vec![];
         }
 
-        // We check whether the leader schedule has been updated. If yes, then we'll send the scores as
-        // part of the first sub dag.
-        let schedule_updated = self
-            .leader_schedule
-            .leader_schedule_updated(&self.dag_state);
-
         let mut committed_sub_dags = vec![];
-        for (i, leader_block) in committed_leaders.into_iter().enumerate() {
-            let reputation_scores_desc = if schedule_updated && i == 0 {
-                self.leader_schedule
-                    .leader_swap_table
-                    .read()
-                    .reputation_scores_desc
-                    .clone()
-            } else {
-                vec![]
-            };
-
+        for leader_block in committed_leaders {
             // Collect the sub-dag generated using each of these leaders and the corresponding commit.
-            let (sub_dag, commit) =
-                self.collect_sub_dag_and_commit(leader_block, reputation_scores_desc);
+            let (sub_dag, commit) = self.collect_sub_dag_and_commit(leader_block);
 
             self.update_blocks_pruned_metric(&sub_dag);
 
@@ -438,6 +409,7 @@ fn median_timestamps_by_stake_inner(
 
 #[cfg(test)]
 mod tests {
+    use consensus_config::AuthorityIndex;
     use rstest::rstest;
 
     use super::*;
@@ -467,11 +439,7 @@ mod tests {
             context.clone(),
             Arc::new(MemStore::new()),
         )));
-        let leader_schedule = Arc::new(LeaderSchedule::new(
-            context.clone(),
-            LeaderSwapTable::default(),
-        ));
-        let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
+        let mut linearizer = Linearizer::new(context.clone(), dag_state.clone());
 
         // Populate fully connected test blocks for round 0 ~ 10, authorities 0 ~ 3.
         let num_rounds: u32 = 10;
@@ -526,75 +494,6 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_handle_commit_with_schedule_update() {
-        telemetry_subscribers::init_for_testing();
-        let num_authorities = 4;
-        let context = Arc::new(Context::new_for_test(num_authorities).0);
-        let dag_state = Arc::new(RwLock::new(DagState::new(
-            context.clone(),
-            Arc::new(MemStore::new()),
-        )));
-        const NUM_OF_COMMITS_PER_SCHEDULE: u64 = 10;
-        let leader_schedule = Arc::new(
-            LeaderSchedule::new(context.clone(), LeaderSwapTable::default())
-                .with_num_commits_per_schedule(NUM_OF_COMMITS_PER_SCHEDULE),
-        );
-        let mut linearizer =
-            Linearizer::new(context.clone(), dag_state.clone(), leader_schedule.clone());
-
-        // Populate fully connected test blocks for round 0 ~ 20, authorities 0 ~ 3.
-        let num_rounds: u32 = 20;
-        let mut dag_builder = DagBuilder::new(context.clone());
-        dag_builder
-            .layers(1..=num_rounds)
-            .build()
-            .persist_layers(dag_state.clone());
-
-        // Take the first 10 leaders
-        let leaders = dag_builder
-            .leader_blocks(1..=10)
-            .into_iter()
-            .map(Option::unwrap)
-            .collect::<Vec<_>>();
-
-        // Create some commits
-        let commits = linearizer.handle_commit(leaders.clone());
-
-        // Write them in DagState
-        dag_state.write().add_scoring_subdags(commits);
-
-        // Now update the leader schedule
-        leader_schedule.update_leader_schedule_v2(&dag_state);
-
-        assert!(
-            leader_schedule.leader_schedule_updated(&dag_state),
-            "Leader schedule should have been updated"
-        );
-
-        // Try to commit now the rest of the 10 leaders
-        let leaders = dag_builder
-            .leader_blocks(11..=20)
-            .into_iter()
-            .map(Option::unwrap)
-            .collect::<Vec<_>>();
-
-        // Now on the commits only the first one should contain the updated scores, the other should be empty
-        let commits = linearizer.handle_commit(leaders.clone());
-        assert_eq!(commits.len(), 10);
-        let scores = vec![
-            (AuthorityIndex::new_for_test(1), 29),
-            (AuthorityIndex::new_for_test(0), 29),
-            (AuthorityIndex::new_for_test(3), 29),
-            (AuthorityIndex::new_for_test(2), 29),
-        ];
-        assert_eq!(commits[0].reputation_scores_desc, scores);
-
-        for commit in commits.into_iter().skip(1) {
-            assert_eq!(commit.reputation_scores_desc, vec![]);
-        }
-    }
-
     #[rstest]
     #[tokio::test]
     async fn test_handle_already_committed(
@@ -617,8 +516,7 @@ mod tests {
             context.clone(),
             LeaderSwapTable::default(),
         ));
-        let mut linearizer =
-            Linearizer::new(context.clone(), dag_state.clone(), leader_schedule.clone());
+        let mut linearizer = Linearizer::new(context.clone(), dag_state.clone());
         let wave_length = DEFAULT_WAVE_LENGTH;
 
         let leader_round_wave_1 = 3;
@@ -763,11 +661,7 @@ mod tests {
             context.clone(),
             Arc::new(MemStore::new()),
         )));
-        let leader_schedule = Arc::new(LeaderSchedule::new(
-            context.clone(),
-            LeaderSwapTable::default(),
-        ));
-        let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
+        let mut linearizer = Linearizer::new(context.clone(), dag_state.clone());
 
         // Authorities of index 0->2 will always creates blocks that see each other, but until round 5 they won't see the blocks of authority 3.
         // For authority 3 we create blocks that connect to all the other authorities.
@@ -904,11 +798,7 @@ mod tests {
             context.clone(),
             Arc::new(MemStore::new()),
         )));
-        let leader_schedule = Arc::new(LeaderSchedule::new(
-            context.clone(),
-            LeaderSwapTable::default(),
-        ));
-        let mut linearizer = Linearizer::new(context.clone(), dag_state.clone(), leader_schedule);
+        let mut linearizer = Linearizer::new(context.clone(), dag_state.clone());
 
         // Authority D will create an "orphaned" block on round 1 as it won't reference to it on the block of round 2. Similar, no other authority will reference to it on round 2.
         // Then on round 3 the authorities A, B & C will link to block D1. Once the DAG gets committed we should see the block D1 getting committed as well. Normally ,as block D2 would

--- a/consensus/core/src/proposed_block_handler.rs
+++ b/consensus/core/src/proposed_block_handler.rs
@@ -54,8 +54,6 @@ impl ProposedBlockHandler {
             return;
         }
         let _scope = monitored_scope("handle_proposed_block");
-        // Run GC first to remove blocks that do not need be voted on.
-        self.transaction_certifier.run_gc();
         self.transaction_certifier
             .add_proposed_block(extended_block.block.clone());
     }

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -224,7 +224,7 @@ impl DagBuilder {
 
             let leader_block_ref = leader_block.reference();
 
-            let (to_commit, rejected_transactions) = Linearizer::linearize_sub_dag(
+            let to_commit = Linearizer::linearize_sub_dag(
                 &self.context.clone(),
                 leader_block.clone(),
                 self.last_committed_rounds.clone(),
@@ -260,7 +260,7 @@ impl DagBuilder {
             let sub_dag = CommittedSubDag::new(
                 leader_block_ref,
                 to_commit,
-                rejected_transactions,
+                BTreeMap::new(),
                 last_timestamp_ms,
                 commit.reference(),
                 vec![],

--- a/consensus/core/src/tests/randomized_tests.rs
+++ b/consensus/core/src/tests/randomized_tests.rs
@@ -61,7 +61,7 @@ async fn test_randomized_dag_all_direct_commit() {
         for (i, leader_block) in sequence.iter().enumerate() {
             // First sequenced leader should be in round 1.
             let leader_round = i as u32 + 1;
-            if let DecidedLeader::Commit(ref block) = leader_block {
+            if let DecidedLeader::Commit(ref block, _direct) = leader_block {
                 assert_eq!(block.round(), leader_round);
                 assert_eq!(
                     block.author(),

--- a/consensus/core/src/universal_committer.rs
+++ b/consensus/core/src/universal_committer.rs
@@ -100,7 +100,8 @@ impl UniversalCommitter {
             if leader.round() == GENESIS_ROUND {
                 continue;
             }
-            let Some(decided_leader) = leader.into_decided_leader() else {
+            let Some(decided_leader) = leader.into_decided_leader(decision == Decision::Direct)
+            else {
                 break;
             };
             Self::update_metrics(&self.context, &decided_leader, decision);

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -1340,6 +1340,8 @@ impl CommitIntervalObserver {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use consensus_core::{
         BlockAPI, CertifiedBlock, CommitDigest, CommitRef, CommittedSubDag, TestBlock, Transaction,
         VerifiedBlock,
@@ -1503,7 +1505,7 @@ mod tests {
         let committed_sub_dag = CommittedSubDag::new(
             leader_block.reference(),
             blocks.clone(),
-            vec![vec![]; blocks.len()],
+            BTreeMap::new(),
             leader_block.timestamp_ms(),
             CommitRef::new(10, CommitDigest::MIN),
             vec![],

--- a/crates/sui-core/src/consensus_types/consensus_output_api.rs
+++ b/crates/sui-core/src/consensus_types/consensus_output_api.rs
@@ -68,10 +68,14 @@ impl ConsensusCommitAPI for consensus_core::CommittedSubDag {
     }
 
     fn transactions(&self) -> Vec<(AuthorityIndex, Vec<ParsedTransaction>)> {
+        let no_transaction = vec![];
         self.blocks
             .iter()
-            .zip(self.rejected_transactions_by_block.iter())
-            .map(|(block, rejected_transactions)| {
+            .map(|block| {
+                let rejected_transactions = self
+                    .rejected_transactions_by_block
+                    .get(&block.reference())
+                    .unwrap_or(&no_transaction);
                 (
                     block.author().value() as AuthorityIndex,
                     parse_block_transactions(block, rejected_transactions),


### PR DESCRIPTION
## Description 

Finalize transactions in a commit. Only send a commit to ConsensusCommitHandler if all its transactions are finalized.
This is not yet crash recovery safe, which will be implemented in the next PR.

TODO: more unit tests with indirect finalization and reject.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
