### PR TITLE
[3/n][object runtime type tags] Add type tags to object runtime update adapter to handle them

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/init/create_object.move
+++ b/crates/sui-adapter-transactional-tests/tests/init/create_object.move
@@ -1,0 +1,17 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test=0x0
+
+//# publish
+module Test::M1 {
+   public struct X has key {
+       id: UID,
+   }
+
+   fun init(ctx: &mut TxContext) { 
+       sui::transfer::transfer(X { id: object::new(ctx) }, ctx.sender());
+   }
+}
+
+//# view-object 1,1

--- a/crates/sui-adapter-transactional-tests/tests/init/create_object.snap
+++ b/crates/sui-adapter-transactional-tests/tests/init/create_object.snap
@@ -1,0 +1,22 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 3 tasks
+
+task 1, lines 6-15:
+//# publish
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6216800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 17:
+//# view-object 1,1
+Owner: Account Address ( _ )
+Version: 2
+Contents: Test::M1::X {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(1,1),
+        },
+    },
+}

--- a/crates/sui-adapter-transactional-tests/tests/init/emit_event.move
+++ b/crates/sui-adapter-transactional-tests/tests/init/emit_event.move
@@ -1,0 +1,17 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test=0x0
+
+//# publish
+module Test::M1 {
+   public struct Event has copy, drop, store {
+       x: u64,
+   }
+
+   fun init(_ctx: &mut TxContext) { 
+       sui::event::emit(Event { x: 1 });
+   }
+}
+
+//# view-object 1,0

--- a/crates/sui-adapter-transactional-tests/tests/init/emit_event.snap
+++ b/crates/sui-adapter-transactional-tests/tests/init/emit_event.snap
@@ -1,0 +1,15 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 3 tasks
+
+task 1, lines 6-15:
+//# publish
+events: Event { package_id: Test, transaction_module: Identifier("M1"), sender: _, type_: StructTag { address: Test, module: Identifier("M1"), name: Identifier("Event"), type_params: [] }, contents: [1, 0, 0, 0, 0, 0, 0, 0] }
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 4689200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 17:
+//# view-object 1,0
+1,0::M1

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1375,6 +1375,7 @@
                 "soft_bundle": false,
                 "throughput_aware_consensus_submission": false,
                 "txn_base_cost_as_multiplier": false,
+                "type_tags_in_object_runtime": false,
                 "uncompressed_g1_group_elements": false,
                 "upgraded_multisig_supported": false,
                 "validate_identifier_inputs": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -694,6 +694,10 @@ struct FeatureFlags {
     // Enable native function for party transfer
     #[serde(skip_serializing_if = "is_false")]
     enable_party_transfer: bool,
+
+    // Signifies the cut-over of using type tags instead of `Type`s in the object runtime.
+    #[serde(skip_serializing_if = "is_false")]
+    type_tags_in_object_runtime: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -1977,6 +1981,10 @@ impl ProtocolConfig {
 
     pub fn enable_party_transfer(&self) -> bool {
         self.feature_flags.enable_party_transfer
+    }
+
+    pub fn type_tags_in_object_runtime(&self) -> bool {
+        self.feature_flags.type_tags_in_object_runtime
     }
 }
 
@@ -3539,6 +3547,7 @@ impl ProtocolConfig {
                     // native function on mainnet.
                     cfg.feature_flags.enable_nitro_attestation_upgraded_parsing = true;
                     cfg.feature_flags.enable_nitro_attestation = true;
+                    cfg.feature_flags.type_tags_in_object_runtime = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_83.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_83.snap
@@ -90,6 +90,7 @@ feature_flags:
   enforce_checkpoint_timestamp_monotonicity: true
   max_ptb_value_size_v2: true
   resolve_type_input_ids_to_defining_id: true
+  type_tags_in_object_runtime: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_83.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_83.snap
@@ -92,6 +92,7 @@ feature_flags:
   enforce_checkpoint_timestamp_monotonicity: true
   max_ptb_value_size_v2: true
   resolve_type_input_ids_to_defining_id: true
+  type_tags_in_object_runtime: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_83.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_83.snap
@@ -97,6 +97,7 @@ feature_flags:
   enforce_checkpoint_timestamp_monotonicity: true
   max_ptb_value_size_v2: true
   resolve_type_input_ids_to_defining_id: true
+  type_tags_in_object_runtime: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/external-crates/move/crates/move-vm-runtime/src/native_functions.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/native_functions.rs
@@ -20,7 +20,8 @@ use move_core_types::{
 };
 use move_vm_config::runtime::VMRuntimeLimitsConfig;
 use move_vm_types::{
-    loaded_data::runtime_types::Type, natives::function::NativeResult, values::Value,
+    data_store::DataStore, loaded_data::runtime_types::Type, natives::function::NativeResult,
+    values::Value,
 };
 use std::{
     cell::RefCell,
@@ -154,6 +155,46 @@ impl<'b> NativeContext<'_, 'b> {
         match self.resolver.type_to_fully_annotated_layout(ty) {
             Ok(ty_layout) => Ok(Some(ty_layout)),
             Err(e) if e.major_status().status_type() == StatusType::InvariantViolation => Err(e),
+            Err(_) => Ok(None),
+        }
+    }
+
+    // TODO: This is a bit hacky right now since we need to pass the store, however this is only
+    // used in test scenarios so we have some special knowledge that makes this work. In the new VM
+    // however this is _MUCH_ nicer as we don't need to pass the datastore as the VM's linkage
+    // tables must have the type present.
+    pub fn type_tag_to_fully_annotated_layout(
+        &self,
+        tag: &TypeTag,
+        store: &impl DataStore,
+    ) -> PartialVMResult<Option<A::MoveTypeLayout>> {
+        match self
+            .resolver
+            .loader()
+            .get_fully_annotated_type_layout(tag, store)
+        {
+            Ok(ty_layout) => Ok(Some(ty_layout)),
+            Err(e) if e.major_status().status_type() == StatusType::InvariantViolation => {
+                Err(e.to_partial())
+            }
+            Err(_) => Ok(None),
+        }
+    }
+
+    // TODO: This is a bit hacky right now since we need to pass the store, however this is only
+    // used in test scenarios so we have some special knowledge that makes this work. In the new VM
+    // however this is _MUCH_ nicer as we don't need to pass the datastore as the VM's linkage
+    // tables must have the type present.
+    pub fn type_tag_to_layout(
+        &self,
+        tag: &TypeTag,
+        store: &impl DataStore,
+    ) -> PartialVMResult<Option<R::MoveTypeLayout>> {
+        match self.resolver.loader().get_type_layout(tag, store) {
+            Ok(ty_layout) => Ok(Some(ty_layout)),
+            Err(e) if e.major_status().status_type() == StatusType::InvariantViolation => {
+                Err(e.to_partial())
+            }
             Err(_) => Ok(None),
         }
     }

--- a/external-crates/move/crates/move-vm-runtime/src/native_functions.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/native_functions.rs
@@ -163,40 +163,30 @@ impl<'b> NativeContext<'_, 'b> {
     // used in test scenarios so we have some special knowledge that makes this work. In the new VM
     // however this is _MUCH_ nicer as we don't need to pass the datastore as the VM's linkage
     // tables must have the type present.
-    pub fn type_tag_to_fully_annotated_layout(
+    pub fn type_tag_to_fully_annotated_layout_for_test_scenario_only(
         &self,
         tag: &TypeTag,
         store: &impl DataStore,
-    ) -> PartialVMResult<Option<A::MoveTypeLayout>> {
-        match self
-            .resolver
+    ) -> PartialVMResult<A::MoveTypeLayout> {
+        self.resolver
             .loader()
             .get_fully_annotated_type_layout(tag, store)
-        {
-            Ok(ty_layout) => Ok(Some(ty_layout)),
-            Err(e) if e.major_status().status_type() == StatusType::InvariantViolation => {
-                Err(e.to_partial())
-            }
-            Err(_) => Ok(None),
-        }
+            .map_err(|e| e.to_partial())
     }
 
     // TODO: This is a bit hacky right now since we need to pass the store, however this is only
     // used in test scenarios so we have some special knowledge that makes this work. In the new VM
     // however this is _MUCH_ nicer as we don't need to pass the datastore as the VM's linkage
     // tables must have the type present.
-    pub fn type_tag_to_layout(
+    pub fn type_tag_to_layout_for_test_scenario_only(
         &self,
         tag: &TypeTag,
         store: &impl DataStore,
-    ) -> PartialVMResult<Option<R::MoveTypeLayout>> {
-        match self.resolver.loader().get_type_layout(tag, store) {
-            Ok(ty_layout) => Ok(Some(ty_layout)),
-            Err(e) if e.major_status().status_type() == StatusType::InvariantViolation => {
-                Err(e.to_partial())
-            }
-            Err(_) => Ok(None),
-        }
+    ) -> PartialVMResult<R::MoveTypeLayout> {
+        self.resolver
+            .loader()
+            .get_type_layout(tag, store)
+            .map_err(|e| e.to_partial())
     }
 
     pub fn type_to_abilities(&self, ty: &Type) -> PartialVMResult<AbilitySet> {

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -15,7 +15,10 @@ mod checked {
         },
         gas_charger::GasCharger,
         gas_meter::SuiGasMeter,
-        programmable_transactions::{data_store::SuiDataStore, linkage_view::LinkageView},
+        programmable_transactions::{
+            data_store::{PackageStore, SuiDataStore},
+            linkage_view::LinkageView,
+        },
         type_resolver::TypeTagResolver,
     };
     use move_binary_format::{
@@ -59,7 +62,7 @@ mod checked {
         metrics::LimitsMetrics,
         move_package::MovePackage,
         object::{Authenticator, Data, MoveObject, Object, ObjectInner, Owner},
-        storage::{BackingPackageStore, DenyListResult, PackageObject},
+        storage::DenyListResult,
         transaction::{Argument, CallArg, ObjectArg},
     };
     use tracing::instrument;
@@ -285,10 +288,10 @@ mod checked {
                     .unwrap_or(*package_id));
             }
 
-            let package = package_for_linkage(&self.linkage_view, package_id)
+            let move_package = get_package(&self.linkage_view, package_id)
                 .map_err(|e| self.convert_vm_error(e))?;
 
-            self.linkage_view.set_linkage(package.move_package())
+            self.linkage_view.set_linkage(&move_package)
         }
 
         /// Load a type using the context's current session.
@@ -341,7 +344,12 @@ mod checked {
             }
             let new_events = events
                 .into_iter()
-                .map(|(ty, tag, value)| {
+                .map(|(tag, value)| {
+                    let ty = unwrap_type_tag_load(
+                        self.protocol_config,
+                        self.load_type_from_struct(&tag)
+                            .map_err(|e| self.convert_vm_error(e)),
+                    )?;
                     let layout = self
                         .vm
                         .get_runtime()
@@ -704,7 +712,7 @@ mod checked {
             let Self {
                 protocol_config,
                 vm,
-                linkage_view,
+                mut linkage_view,
                 mut native_extensions,
                 tx_context,
                 gas_charger,
@@ -839,12 +847,6 @@ mod checked {
             loaded_runtime_objects.extend(loaded_child_objects);
 
             let mut written_objects = BTreeMap::new();
-            for package in new_packages {
-                let package_obj = Object::new_from_package(package, tx_digest);
-                let id = package_obj.id();
-                created_object_ids.insert(id);
-                written_objects.insert(id, package_obj);
-            }
             for (id, additional_write) in additional_writes {
                 let AdditionalWrite {
                     recipient,
@@ -872,7 +874,24 @@ mod checked {
                 }
             }
 
-            for (id, (recipient, ty, value)) in writes {
+            for (id, (recipient, tag, value)) in writes {
+                let ty = unwrap_type_tag_load(
+                    protocol_config,
+                    load_type_from_struct(
+                        vm,
+                        &mut linkage_view,
+                        &new_packages,
+                        &StructTag::from(tag.clone()),
+                    )
+                    .map_err(|e| {
+                        convert_vm_error(
+                            e,
+                            vm,
+                            &linkage_view,
+                            protocol_config.resolve_abort_locations_to_package_id(),
+                        )
+                    }),
+                )?;
                 let abilities = vm.get_runtime().get_type_abilities(&ty).map_err(|e| {
                     convert_vm_error(
                         e,
@@ -908,6 +927,13 @@ mod checked {
                 };
                 let object = Object::new_move(move_object, recipient, tx_digest);
                 written_objects.insert(id, object);
+            }
+
+            for package in new_packages {
+                let package_obj = Object::new_from_package(package, tx_digest);
+                let id = package_obj.id();
+                created_object_ids.insert(id);
+                written_objects.insert(id, package_obj);
             }
 
             // Before finishing, ensure that any shared object taken by value by the transaction is either:
@@ -1023,7 +1049,6 @@ mod checked {
 
         /// Special case errors for type arguments to Move functions
         pub fn convert_type_argument_error(&self, idx: usize, error: VMError) -> ExecutionError {
-            use move_core_types::vm_status::StatusCode;
             use sui_types::execution_status::TypeArgumentError;
             match error.major_status() {
                 StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH => {
@@ -1284,22 +1309,17 @@ mod checked {
 
     /// Fetch the package at `package_id` with a view to using it as a link context.  Produces an error
     /// if the object at that ID does not exist, or is not a package.
-    fn package_for_linkage(
-        linkage_view: &LinkageView,
+    fn get_package(
+        package_store: &dyn PackageStore,
         package_id: ObjectID,
-    ) -> VMResult<PackageObject> {
-        use move_binary_format::errors::PartialVMError;
-        use move_core_types::vm_status::StatusCode;
-
-        match linkage_view.get_package_object(&package_id) {
+    ) -> VMResult<Rc<MovePackage>> {
+        match package_store.get_package(&package_id) {
             Ok(Some(package)) => Ok(package),
             Ok(None) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
                 .with_message(format!("Cannot find link context {package_id} in store"))
                 .finish(Location::Undefined)),
             Err(err) => Err(PartialVMError::new(StatusCode::LINKER_ERROR)
-                .with_message(format!(
-                    "Error loading link context {package_id} from store: {err}"
-                ))
+                .with_message(format!("Error loading {package_id} from store: {err}"))
                 .finish(Location::Undefined)),
         }
     }
@@ -1323,22 +1343,27 @@ mod checked {
 
         // Load the package that the struct is defined in, in storage
         let defining_id = ObjectID::from_address(*address);
-        let package = package_for_linkage(linkage_view, defining_id)?;
+
+        let data_store = SuiDataStore::new(linkage_view, new_packages);
+        let move_package = get_package(&data_store, defining_id)?;
+
+        // Save the link context as we need to set it while loading the struct and we don't want to
+        // clobber it.
+        let saved_linkage = linkage_view.steal_linkage();
 
         // Set the defining package as the link context while loading the
         // struct
         let original_address = linkage_view
-            .set_linkage(package.move_package())
-            .map_err(|e| {
-                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                    .with_message(e.to_string())
-                    .finish(Location::Undefined)
-            })?;
+            .set_linkage(&move_package)
+            .expect("Linkage context was just stolen. Therefore must be empty");
 
         let runtime_id = ModuleId::new(original_address, module.clone());
         let data_store = SuiDataStore::new(linkage_view, new_packages);
         let res = vm.get_runtime().load_type(&runtime_id, name, &data_store);
         linkage_view.reset_linkage();
+        linkage_view
+            .restore_linkage(saved_linkage)
+            .expect("Linkage context was just reset. Therefore must be empty");
         let (idx, struct_type) = res?;
 
         // Recursively load type parameters, if necessary
@@ -1704,6 +1729,17 @@ mod checked {
                 contents,
                 protocol_config,
             )
+        }
+    }
+
+    fn unwrap_type_tag_load(
+        protocol_config: &ProtocolConfig,
+        ty: Result<Type, ExecutionError>,
+    ) -> Result<Type, ExecutionError> {
+        if ty.is_err() && !protocol_config.type_tags_in_object_runtime() {
+            panic!("Failed to load a type tag from the object runtime -- this shouldn't happen")
+        } else {
+            ty
         }
     }
 

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/linkage_view.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/linkage_view.rs
@@ -1,32 +1,31 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    cell::RefCell,
-    collections::{BTreeMap, HashMap, HashSet, hash_map::Entry},
-    str::FromStr,
-};
-
-use crate::execution_value::SuiResolver;
+use crate::programmable_transactions::data_store::PackageStore;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
     language_storage::ModuleId,
     resolver::{LinkageResolver, ModuleResolver},
 };
-use sui_types::storage::{PackageObject, get_module};
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, HashMap, HashSet, hash_map::Entry},
+    rc::Rc,
+    str::FromStr,
+};
 use sui_types::{
     base_types::ObjectID,
     error::{ExecutionError, SuiError, SuiResult},
     move_package::{MovePackage, TypeOrigin, UpgradeInfo},
-    storage::BackingPackageStore,
 };
 
 /// Exposes module and linkage resolution to the Move runtime.  The first by delegating to
 /// `resolver` and the second via linkage information that is loaded from a move package.
 pub struct LinkageView<'state> {
-    /// Interface to resolve packages, modules and resources directly from the store.
-    resolver: Box<dyn SuiResolver + 'state>,
+    /// Interface to resolve packages, modules and resources directly from the store, and possibly
+    /// from other sources (e.g., packages just published).
+    resolver: Box<dyn PackageStore + 'state>,
     /// Information used to change module and type identities during linkage.
     linkage_info: Option<LinkageInfo>,
     /// Cache containing the type origin information from every package that has been set as the
@@ -52,7 +51,7 @@ pub struct LinkageInfo {
 pub struct SavedLinkage(LinkageInfo);
 
 impl<'state> LinkageView<'state> {
-    pub fn new(resolver: Box<dyn SuiResolver + 'state>) -> Self {
+    pub fn new(resolver: Box<dyn PackageStore + 'state>) -> Self {
         Self {
             resolver,
             linkage_info: None,
@@ -239,7 +238,7 @@ impl<'state> LinkageView<'state> {
         }
 
         let storage_id = ObjectID::from(*self.relocate(runtime_id)?.address());
-        let Some(package) = self.resolver.get_package_object(&storage_id)? else {
+        let Some(package) = self.resolver.get_package(&storage_id)? else {
             invariant_violation!("Missing dependent package in store: {storage_id}",)
         };
 
@@ -247,7 +246,7 @@ impl<'state> LinkageView<'state> {
             module_name,
             datatype_name: struct_name,
             package,
-        } in package.move_package().type_origin_table()
+        } in package.type_origin_table()
         {
             if module_name == runtime_id.name().as_str() && struct_name == struct_.as_str() {
                 self.add_type_origin(runtime_id.clone(), struct_.to_owned(), *package)?;
@@ -257,7 +256,7 @@ impl<'state> LinkageView<'state> {
 
         invariant_violation!(
             "{runtime_id}::{struct_} not found in type origin table in {storage_id} (v{})",
-            package.move_package().version(),
+            package.version(),
         )
     }
 }
@@ -292,18 +291,23 @@ impl LinkageResolver for LinkageView<'_> {
     }
 }
 
-// Remaining implementations delegated to state_view
-
 impl ModuleResolver for LinkageView<'_> {
     type Error = SuiError;
 
     fn get_module(&self, id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
-        get_module(self, id)
+        Ok(self
+            .get_package(&ObjectID::from(*id.address()))?
+            .and_then(|package| {
+                package
+                    .serialized_module_map()
+                    .get(id.name().as_str())
+                    .cloned()
+            }))
     }
 }
 
-impl BackingPackageStore for LinkageView<'_> {
-    fn get_package_object(&self, package_id: &ObjectID) -> SuiResult<Option<PackageObject>> {
-        self.resolver.get_package_object(package_id)
+impl PackageStore for LinkageView<'_> {
+    fn get_package(&self, package_id: &ObjectID) -> SuiResult<Option<Rc<MovePackage>>> {
+        self.resolver.get_package(package_id)
     }
 }

--- a/sui-execution/latest/sui-move-natives/src/config.rs
+++ b/sui-execution/latest/sui-move-natives/src/config.rs
@@ -87,7 +87,6 @@ pub fn read_setting_impl(
 
     let read_value_opt = consistent_value_before_current_epoch(
         object_runtime,
-        &field_setting_ty,
         field_setting_tag,
         &field_setting_layout,
         &setting_value_ty,
@@ -111,7 +110,6 @@ pub fn read_setting_impl(
 
 fn consistent_value_before_current_epoch(
     object_runtime: &mut ObjectRuntime,
-    field_setting_ty: &Type,
     field_setting_tag: StructTag,
     field_setting_layout: &R::MoveTypeLayout,
     _setting_value_ty: &Type,
@@ -125,7 +123,6 @@ fn consistent_value_before_current_epoch(
     let Some(field) = object_runtime.config_setting_unsequenced_read(
         config_addr.into(),
         name_df_addr.into(),
-        field_setting_ty,
         field_setting_layout,
         &field_setting_obj_ty,
     ) else {

--- a/sui-execution/latest/sui-move-natives/src/dynamic_field.rs
+++ b/sui-execution/latest/sui-move-natives/src/dynamic_field.rs
@@ -54,7 +54,6 @@ macro_rules! get_or_fetch_object {
         object_runtime.get_or_fetch_child_object(
             $parent,
             $child_id,
-            &child_ty,
             &layout,
             &annotated_layout,
             MoveObjectType::from(tag),
@@ -229,13 +228,7 @@ pub fn add_child_object(
     );
 
     let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
-    object_runtime.add_child_object(
-        parent,
-        child_id,
-        &child_ty,
-        MoveObjectType::from(tag),
-        child,
-    )?;
+    object_runtime.add_child_object(parent, child_id, MoveObjectType::from(tag), child)?;
     Ok(NativeResult::ok(context.gas_used(), smallvec![]))
 }
 

--- a/sui-execution/latest/sui-move-natives/src/event.rs
+++ b/sui-execution/latest/sui-move-natives/src/event.rs
@@ -116,7 +116,7 @@ pub fn emit(
 
     let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
 
-    obj_runtime.emit_event(ty, *tag, event_value)?;
+    obj_runtime.emit_event(*tag, event_value)?;
     Ok(NativeResult::ok(context.gas_used(), smallvec![]))
 }
 
@@ -147,12 +147,16 @@ pub fn get_events_by_type(
     let specialization: VectorSpecialization = (&specified_ty).try_into()?;
     assert!(args.is_empty());
     let object_runtime_ref: &ObjectRuntime = context.extensions().get()?;
+    let specified_type_tag = match context.type_to_type_tag(&specified_ty)? {
+        TypeTag::Struct(s) => *s,
+        _ => return Ok(NativeResult::ok(legacy_test_cost(), smallvec![])),
+    };
     let matched_events = object_runtime_ref
         .state
         .events()
         .iter()
-        .filter_map(|(ty, _, event)| {
-            if specified_ty == *ty {
+        .filter_map(|(tag, event)| {
+            if &specified_type_tag == tag {
                 Some(event.copy_value().unwrap())
             } else {
                 None

--- a/sui-execution/latest/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/latest/sui-move-natives/src/test_scenario.rs
@@ -17,6 +17,7 @@ use move_core_types::{
 };
 use move_vm_runtime::{native_extensions::NativeExtensionMarker, native_functions::NativeContext};
 use move_vm_types::{
+    data_store::DataStore,
     loaded_data::runtime_types::Type,
     natives::function::NativeResult,
     pop_arg,
@@ -30,7 +31,7 @@ use std::{
     thread::LocalKey,
 };
 use sui_types::{
-    base_types::{ObjectID, SequenceNumber, SuiAddress},
+    base_types::{MoveObjectType, ObjectID, SequenceNumber, SuiAddress},
     config,
     digests::{ObjectDigest, TransactionDigest},
     dynamic_field::DynamicFieldInfo,
@@ -307,14 +308,14 @@ pub fn end_transaction(
     let object_runtime_ref: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let mut config_settings = vec![];
     for child in object_runtime_ref.all_active_child_objects() {
-        let s: StructTag = child.move_type.clone().into();
+        let s: StructTag = child.ty.clone().into();
         let is_setting = DynamicFieldInfo::is_dynamic_field(&s)
             && matches!(&s.type_params[1], TypeTag::Struct(s) if config::is_setting(s));
         if is_setting {
             config_settings.push((
                 *child.owner,
                 *child.id,
-                child.move_type.clone(),
+                child.ty.clone(),
                 child.copied_value,
             ));
         }
@@ -380,6 +381,7 @@ pub fn take_from_address_by_id(
     let account: SuiAddress = pop_arg!(args, AccountAddress).into();
     pop_arg!(args, StructRef);
     assert!(args.is_empty());
+    let specified_obj_ty = object_type_of_type(context, &specified_ty)?;
     let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let res = take_from_inventory(
@@ -387,7 +389,7 @@ pub fn take_from_address_by_id(
             inventories
                 .address_inventories
                 .get(&account)
-                .and_then(|inv| inv.get(&specified_ty))
+                .and_then(|inv| inv.get(&specified_obj_ty))
                 .map(|s| s.contains(x))
                 .unwrap_or(false)
         },
@@ -412,12 +414,13 @@ pub fn ids_for_address(
     let specified_ty = get_specified_ty(ty_args);
     let account: SuiAddress = pop_arg!(args, AccountAddress).into();
     assert!(args.is_empty());
+    let specified_obj_ty = object_type_of_type(context, &specified_ty)?;
     let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let ids = inventories
         .address_inventories
         .get(&account)
-        .and_then(|inv| inv.get(&specified_ty))
+        .and_then(|inv| inv.get(&specified_obj_ty))
         .map(|s| s.iter().map(|id| pack_id(*id)).collect::<Vec<Value>>())
         .unwrap_or_default();
     let ids_vector = Vector::pack(VectorSpecialization::Container, ids).unwrap();
@@ -433,11 +436,12 @@ pub fn most_recent_id_for_address(
     let specified_ty = get_specified_ty(ty_args);
     let account: SuiAddress = pop_arg!(args, AccountAddress).into();
     assert!(args.is_empty());
+    let specified_obj_ty = object_type_of_type(context, &specified_ty)?;
     let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let most_recent_id = match inventories.address_inventories.get(&account) {
         None => pack_option(vector_specialization(&specified_ty), None),
-        Some(inv) => most_recent_at_ty(&inventories.taken, inv, specified_ty),
+        Some(inv) => most_recent_at_ty(&inventories.taken, inv, &specified_ty, specified_obj_ty),
     };
     Ok(NativeResult::ok(
         legacy_test_cost(),
@@ -478,13 +482,14 @@ pub fn take_immutable_by_id(
     let id = pop_id(&mut args)?;
     pop_arg!(args, StructRef);
     assert!(args.is_empty());
+    let specified_obj_ty = object_type_of_type(context, &specified_ty)?;
     let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let res = take_from_inventory(
         |x| {
             inventories
                 .immutable_inventory
-                .get(&specified_ty)
+                .get(&specified_obj_ty)
                 .map(|s| s.contains(x))
                 .unwrap_or(false)
         },
@@ -498,7 +503,7 @@ pub fn take_immutable_by_id(
         Ok(value) => {
             inventories
                 .taken_immutable_values
-                .entry(specified_ty)
+                .entry(specified_obj_ty)
                 .or_default()
                 .insert(id, value.copy_value().unwrap());
             NativeResult::ok(legacy_test_cost(), smallvec![value])
@@ -515,12 +520,14 @@ pub fn most_recent_immutable_id(
 ) -> PartialVMResult<NativeResult> {
     let specified_ty = get_specified_ty(ty_args);
     assert!(args.is_empty());
+    let specified_obj_ty = object_type_of_type(context, &specified_ty)?;
     let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let most_recent_id = most_recent_at_ty(
         &inventories.taken,
         &inventories.immutable_inventory,
-        specified_ty,
+        &specified_ty,
+        specified_obj_ty,
     );
     Ok(NativeResult::ok(
         legacy_test_cost(),
@@ -560,13 +567,14 @@ pub fn take_shared_by_id(
     let id = pop_id(&mut args)?;
     pop_arg!(args, StructRef);
     assert!(args.is_empty());
+    let specified_obj_ty = object_type_of_type(context, &specified_ty)?;
     let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let res = take_from_inventory(
         |x| {
             inventories
                 .shared_inventory
-                .get(&specified_ty)
+                .get(&specified_obj_ty)
                 .map(|s| s.contains(x))
                 .unwrap_or(false)
         },
@@ -590,12 +598,14 @@ pub fn most_recent_id_shared(
 ) -> PartialVMResult<NativeResult> {
     let specified_ty = get_specified_ty(ty_args);
     assert!(args.is_empty());
+    let specified_obj_ty = object_type_of_type(context, &specified_ty)?;
     let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
     let inventories = &mut object_runtime.test_inventories;
     let most_recent_id = most_recent_at_ty(
         &inventories.taken,
         &inventories.shared_inventory,
-        specified_ty,
+        &specified_ty,
+        specified_obj_ty,
     );
     Ok(NativeResult::ok(
         legacy_test_cost(),
@@ -782,19 +792,20 @@ fn vector_specialization(ty: &Type) -> VectorSpecialization {
 
 fn most_recent_at_ty(
     taken: &BTreeMap<ObjectID, Owner>,
-    inv: &BTreeMap<Type, Set<ObjectID>>,
-    ty: Type,
+    inv: &BTreeMap<MoveObjectType, Set<ObjectID>>,
+    runtime_ty: &Type,
+    ty: MoveObjectType,
 ) -> Value {
     pack_option(
-        vector_specialization(&ty),
+        vector_specialization(runtime_ty),
         most_recent_at_ty_opt(taken, inv, ty),
     )
 }
 
 fn most_recent_at_ty_opt(
     taken: &BTreeMap<ObjectID, Owner>,
-    inv: &BTreeMap<Type, Set<ObjectID>>,
-    ty: Type,
+    inv: &BTreeMap<MoveObjectType, Set<ObjectID>>,
+    ty: MoveObjectType,
 ) -> Option<Value> {
     let s = inv.get(&ty)?;
     let most_recent_id = s.iter().filter(|id| !taken.contains_key(id)).last()?;
@@ -891,6 +902,15 @@ fn transaction_effects(
     ]))
 }
 
+fn object_type_of_type(context: &NativeContext, ty: &Type) -> PartialVMResult<MoveObjectType> {
+    let TypeTag::Struct(s_tag) = context.type_to_type_tag(ty)? else {
+        return Err(PartialVMError::new(
+            StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
+        ));
+    };
+    Ok(MoveObjectType::from(*s_tag))
+}
+
 fn pack_option(specialization: VectorSpecialization, opt: Option<Value>) -> Value {
     let item = match opt {
         Some(v) => vec![v],
@@ -906,7 +926,7 @@ fn pack_option(specialization: VectorSpecialization, opt: Option<Value>) -> Valu
 fn find_all_wrapped_objects<'a, 'i>(
     context: &NativeContext,
     ids: &'i mut BTreeSet<ObjectID>,
-    new_object_values: impl IntoIterator<Item = (&'a ObjectID, &'a Type, impl Borrow<Value>)>,
+    new_object_values: impl IntoIterator<Item = (&'a ObjectID, &'a MoveObjectType, impl Borrow<Value>)>,
 ) {
     #[derive(Copy, Clone)]
     enum LookingFor {
@@ -982,12 +1002,19 @@ fn find_all_wrapped_objects<'a, 'i>(
 
     let uid = UID::layout();
     for (_id, ty, value) in new_object_values {
-        let Ok(Some(layout)) = context.type_to_type_layout(ty) else {
+        let type_tag = TypeTag::from(ty.clone());
+        // NB: We can get the layout with the `EmptyDataStore` since the types and modules
+        // associated with all of these types must be in the type/module cache in the VM -- THIS IS
+        // BECAUSE WE ARE IN TEST SCENARIO ONLY AND THIS DOES NOT GENERALLY HOLD IN A
+        // MULTI-TRANSACTION SETTING.
+        let Ok(Some(layout)) = context.type_tag_to_layout(&type_tag, &EmptyDataStore) else {
             debug_assert!(false);
             continue;
         };
 
-        let Ok(Some(annotated_layout)) = context.type_to_fully_annotated_layout(ty) else {
+        let Ok(Some(annotated_layout)) =
+            context.type_tag_to_fully_annotated_layout(&type_tag, &EmptyDataStore)
+        else {
             debug_assert!(false);
             continue;
         };
@@ -1003,5 +1030,45 @@ fn find_all_wrapped_objects<'a, 'i>(
             },
         )
         .unwrap();
+    }
+}
+
+// TODO: This can be removed in the new VM as we do not need a "fake" datastore here in order to
+// get the type layout.
+struct EmptyDataStore;
+// All of these should be unreachable
+impl DataStore for EmptyDataStore {
+    fn link_context(&self) -> AccountAddress {
+        AccountAddress::ZERO
+    }
+
+    fn relocate(
+        &self,
+        _module_id: &move_core_types::language_storage::ModuleId,
+    ) -> PartialVMResult<move_core_types::language_storage::ModuleId> {
+        unreachable!("All types must be in the cache since we're in test scenario")
+    }
+
+    fn defining_module(
+        &self,
+        _module_id: &move_core_types::language_storage::ModuleId,
+        _struct_: &move_core_types::identifier::IdentStr,
+    ) -> PartialVMResult<move_core_types::language_storage::ModuleId> {
+        unreachable!("All types must be in the cache since we're in test scenario")
+    }
+
+    fn load_module(
+        &self,
+        _module_id: &move_core_types::language_storage::ModuleId,
+    ) -> move_binary_format::errors::VMResult<Vec<u8>> {
+        unreachable!("All types must be in the cache since we're in test scenario")
+    }
+
+    fn publish_module(
+        &mut self,
+        _module_id: &move_core_types::language_storage::ModuleId,
+        _blob: Vec<u8>,
+    ) -> move_binary_format::errors::VMResult<()> {
+        unreachable!("All types must be in the cache since we're in test scenario")
     }
 }

--- a/sui-execution/latest/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/latest/sui-move-natives/src/test_scenario.rs
@@ -1007,13 +1007,15 @@ fn find_all_wrapped_objects<'a, 'i>(
         // associated with all of these types must be in the type/module cache in the VM -- THIS IS
         // BECAUSE WE ARE IN TEST SCENARIO ONLY AND THIS DOES NOT GENERALLY HOLD IN A
         // MULTI-TRANSACTION SETTING.
-        let Ok(Some(layout)) = context.type_tag_to_layout(&type_tag, &EmptyDataStore) else {
+        let Ok(layout) =
+            context.type_tag_to_layout_for_test_scenario_only(&type_tag, &EmptyDataStore)
+        else {
             debug_assert!(false);
             continue;
         };
 
-        let Ok(Some(annotated_layout)) =
-            context.type_tag_to_fully_annotated_layout(&type_tag, &EmptyDataStore)
+        let Ok(annotated_layout) = context
+            .type_tag_to_fully_annotated_layout_for_test_scenario_only(&type_tag, &EmptyDataStore)
         else {
             debug_assert!(false);
             continue;

--- a/sui-execution/latest/sui-move-natives/src/transfer.rs
+++ b/sui-execution/latest/sui-move-natives/src/transfer.rs
@@ -81,7 +81,6 @@ pub fn receive_object_internal(
         parent,
         child_id,
         child_receiver_sequence_number,
-        &child_ty,
         &layout,
         &annotated_layout,
         MoveObjectType::from(tag),
@@ -331,13 +330,16 @@ fn object_runtime_transfer(
     ty: Type,
     obj: Value,
 ) -> PartialVMResult<TransferResult> {
-    if !matches!(context.type_to_type_tag(&ty)?, TypeTag::Struct(_)) {
-        return Err(
-            PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                .with_message("Sui verifier guarantees this is a struct".to_string()),
-        );
-    }
+    let object_type = match context.type_to_type_tag(&ty)? {
+        TypeTag::Struct(s) => MoveObjectType::from(*s),
+        _ => {
+            return Err(
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message("Sui verifier guarantees this is a struct".to_string()),
+            );
+        }
+    };
 
     let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
-    obj_runtime.transfer(owner, ty, obj)
+    obj_runtime.transfer(owner, object_type, obj)
 }


### PR DESCRIPTION
## Description 

This updates the object runtime to only hold `TypeTag`s (or `MoveObjecType`s where appropriate) instead of VM runtime `Type`s. 

It's generally a pretty straightforward change, however there are a couple places worth calling out specifically and I've done so in-line. 

## Test plan 

CI + adding new tests to make sure type tags coming from the object runtime are correctly resolved in newly-published packages.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [X] Protocol: add a new feature flag that switches the object runtime to using TypeTags instead of VM runtime types.
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
