### PR TITLE
Update simtest reference to new teleport instance

### DIFF
--- a/.github/workflows/simulator-nightly.yml
+++ b/.github/workflows/simulator-nightly.yml
@@ -36,15 +36,15 @@ jobs:
 
     steps:
       - name: Install Teleport
-        uses: teleport-actions/setup@176c25dfcd19cd31a252f275d579822b243e7b9c # pin@v1.0.6
+        uses: teleport-actions/auth@d48447391aa28b202c98ae3f3358097025c32511 # pin@v2.0.4
         with:
-          version: 11.3.1
+          version: 17.4.6
       - name: Authorize against Teleport
         id: auth
-        uses: teleport-actions/auth@9091dad16a564f3c5b9c2ec520b234a4872b6879 # pin@v1
+        uses: teleport-actions/auth@d48447391aa28b202c98ae3f3358097025c32511 # pin@v2.0.4
         with:
           # Specify the publically accessible address of your Teleport proxy.
-          proxy: proxy.mysten-int.com:443
+          proxy: mystenlabs.teleport.sh:443
           # Specify the name of the join token for your bot.
           token: sui-simtest-token
           # Specify the length of time that the generated credentials should be


### PR DESCRIPTION
## Description 

Moves the proxy server to teleport cloud and updates to newest teleport-actions/ auth

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
