### PR TITLE
[sui-adapter] Add basic package cache

### DIFF
--- a/sui-execution/latest/sui-adapter/src/data_store/cached_data_store.rs
+++ b/sui-execution/latest/sui-adapter/src/data_store/cached_data_store.rs
@@ -1,0 +1,43 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::data_store::PackageStore;
+use std::{cell::RefCell, collections::BTreeMap, rc::Rc};
+use sui_types::{base_types::ObjectID, error::SuiResult, move_package::MovePackage};
+
+pub struct CachedPackageStore<'state> {
+    pub package_store: Box<dyn PackageStore + 'state>,
+    pub package_cache: RefCell<BTreeMap<ObjectID, Option<Rc<MovePackage>>>>,
+    pub max_cache_size: usize,
+}
+
+impl<'state> CachedPackageStore<'state> {
+    pub const DEFAULT_MAX_CACHE_SIZE: usize = 200;
+    pub fn new(package_store: Box<dyn PackageStore + 'state>) -> Self {
+        Self {
+            package_store,
+            package_cache: RefCell::new(BTreeMap::new()),
+            max_cache_size: Self::DEFAULT_MAX_CACHE_SIZE,
+        }
+    }
+
+    pub fn get_package(&self, id: &ObjectID) -> SuiResult<Option<Rc<MovePackage>>> {
+        if let Some(pkg) = self.package_cache.borrow().get(id).cloned() {
+            return Ok(pkg);
+        }
+
+        if self.package_cache.borrow().len() >= self.max_cache_size {
+            self.package_cache.borrow_mut().clear();
+        }
+
+        let pkg = self.package_store.get_package(id)?;
+        self.package_cache.borrow_mut().insert(*id, pkg.clone());
+        Ok(pkg)
+    }
+}
+
+impl PackageStore for CachedPackageStore<'_> {
+    fn get_package(&self, id: &ObjectID) -> SuiResult<Option<Rc<MovePackage>>> {
+        self.get_package(id)
+    }
+}

--- a/sui-execution/latest/sui-adapter/src/data_store/linkage_view.rs
+++ b/sui-execution/latest/sui-adapter/src/data_store/linkage_view.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::programmable_transactions::data_store::PackageStore;
+use crate::data_store::PackageStore;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},

--- a/sui-execution/latest/sui-adapter/src/data_store/mod.rs
+++ b/sui-execution/latest/sui-adapter/src/data_store/mod.rs
@@ -1,0 +1,26 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod cached_data_store;
+pub mod linkage_view;
+pub mod sui_data_store;
+
+use std::rc::Rc;
+use sui_types::{
+    base_types::ObjectID, error::SuiResult, move_package::MovePackage, storage::BackingPackageStore,
+};
+
+// A unifying trait that allows us to load move packages that may not be objects just yet (e.g., if
+// they were published in the current transaction). Note that this needs to load `MovePackage`s and
+// not `MovePackageObject`s.
+pub trait PackageStore {
+    fn get_package(&self, id: &ObjectID) -> SuiResult<Option<Rc<MovePackage>>>;
+}
+
+impl<T: BackingPackageStore> PackageStore for T {
+    fn get_package(&self, id: &ObjectID) -> SuiResult<Option<Rc<MovePackage>>> {
+        Ok(self
+            .get_package_object(id)?
+            .map(|x| Rc::new(x.move_package().clone())))
+    }
+}

--- a/sui-execution/latest/sui-adapter/src/data_store/sui_data_store.rs
+++ b/sui-execution/latest/sui-adapter/src/data_store/sui_data_store.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::programmable_transactions::linkage_view::LinkageView;
+use crate::data_store::{PackageStore, linkage_view::LinkageView};
 use move_binary_format::errors::{Location, PartialVMError, PartialVMResult, VMResult};
 use move_core_types::{
     account_address::AccountAddress, identifier::IdentStr, language_storage::ModuleId,
@@ -9,9 +9,7 @@ use move_core_types::{
 };
 use move_vm_types::data_store::DataStore;
 use std::rc::Rc;
-use sui_types::{
-    base_types::ObjectID, error::SuiResult, move_package::MovePackage, storage::BackingPackageStore,
-};
+use sui_types::{base_types::ObjectID, error::SuiResult, move_package::MovePackage};
 
 // Implementation of the `DataStore` trait for the Move VM.
 // When used during execution it may have a list of new packages that have
@@ -98,21 +96,6 @@ impl DataStore for SuiDataStore<'_, '_> {
         // we cannot panic here because during execution and publishing this is
         // currently called from the publish flow in the Move runtime
         Ok(())
-    }
-}
-
-// A unifying trait that allows us to load move packages that may not be objects just yet (e.g., if
-// they were published in the current transaction). Note that this needs to load `MovePackage`s and
-// not `MovePackageObject`s.
-pub trait PackageStore {
-    fn get_package(&self, id: &ObjectID) -> SuiResult<Option<Rc<MovePackage>>>;
-}
-
-impl<T: BackingPackageStore> PackageStore for T {
-    fn get_package(&self, id: &ObjectID) -> SuiResult<Option<Rc<MovePackage>>> {
-        Ok(self
-            .get_package_object(id)?
-            .map(|x| Rc::new(x.move_package().clone())))
     }
 }
 

--- a/sui-execution/latest/sui-adapter/src/lib.rs
+++ b/sui-execution/latest/sui-adapter/src/lib.rs
@@ -5,6 +5,7 @@
 extern crate sui_types;
 
 pub mod adapter;
+pub mod data_store;
 pub mod error;
 pub mod execution_engine;
 pub mod execution_mode;

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -7,6 +7,10 @@ pub use checked::*;
 mod checked {
     use crate::{
         adapter::new_native_extensions,
+        data_store::{
+            PackageStore, cached_data_store::CachedPackageStore, linkage_view::LinkageView,
+            sui_data_store::SuiDataStore,
+        },
         error::convert_vm_error,
         execution_mode::ExecutionMode,
         execution_value::{
@@ -15,10 +19,6 @@ mod checked {
         },
         gas_charger::GasCharger,
         gas_meter::SuiGasMeter,
-        programmable_transactions::{
-            data_store::{PackageStore, SuiDataStore},
-            linkage_view::LinkageView,
-        },
         type_resolver::TypeTagResolver,
     };
     use move_binary_format::{
@@ -147,7 +147,9 @@ mod checked {
         where
             'a: 'state,
         {
-            let mut linkage_view = LinkageView::new(Box::new(state_view.as_sui_resolver()));
+            let mut linkage_view = LinkageView::new(Box::new(CachedPackageStore::new(Box::new(
+                state_view.as_sui_resolver(),
+            ))));
             let mut input_object_map = BTreeMap::new();
             let inputs = inputs
                 .into_iter()

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
@@ -7,13 +7,14 @@ pub use checked::*;
 mod checked {
     use crate::{
         adapter::substitute_package_id,
+        data_store::sui_data_store::SuiDataStore,
         execution_mode::ExecutionMode,
         execution_value::{
             CommandKind, ExecutionState, ObjectContents, ObjectValue, RawValueType, Value,
             ensure_serialized_size,
         },
         gas_charger::GasCharger,
-        programmable_transactions::{context::*, data_store::SuiDataStore},
+        programmable_transactions::context::*,
         type_resolver::TypeTagResolver,
     };
     use move_binary_format::file_format::AbilitySet;

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/mod.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/mod.rs
@@ -2,6 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod context;
-pub mod data_store;
 pub mod execution;
-pub mod linkage_view;

--- a/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
@@ -1,8 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::data_store::cached_data_store::CachedPackageStore;
+use crate::data_store::linkage_view::LinkageView;
 use crate::programmable_transactions::context::load_type_from_struct;
-use crate::programmable_transactions::linkage_view::LinkageView;
 use move_core_types::annotated_value as A;
 use move_core_types::language_storage::StructTag;
 use move_vm_runtime::move_vm::MoveVM;
@@ -26,7 +27,9 @@ struct NullSuiResolver<'state>(Box<dyn TypeLayoutStore + 'state>);
 
 impl<'state, 'vm> TypeLayoutResolver<'state, 'vm> {
     pub fn new(vm: &'vm MoveVM, state_view: Box<dyn TypeLayoutStore + 'state>) -> Self {
-        let linkage_view = LinkageView::new(Box::new(NullSuiResolver(state_view)));
+        let linkage_view = LinkageView::new(Box::new(CachedPackageStore::new(Box::new(
+            NullSuiResolver(state_view),
+        ))));
         Self { vm, linkage_view }
     }
 }


### PR DESCRIPTION
## Description 

Now that we have the `PackageStore` abstraction in the adapter layer, this adds in a very simple caching layer for `MovePackage`s. Currently the cache size is bounded at 200 packages, after that we drop the cache and reload (we could also go for an LRU if we wanted, but I think that will just be more complexity than is most likely needed here). The cache is only held for the lifetime of the transaction. 

This also does a bit of reorganization around the data store, and related "store" functionality into its own directory under the programmable transactions. 

Next up: will work on refactoring `LinkageView`

## Test plan 

CI


