### PR TITLE
Enable ExecutionTimeEstimate mode for congestion control on mainnet

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -237,6 +237,7 @@ const MAX_PROTOCOL_VERSION: u64 = 83;
 //             Increase threshold for bad nodes that won't be considered leaders in consensus in mainnet
 // Version 82: Relax bounding of size of values created in the adapter.
 // Version 83: Resolve `TypeInput` IDs to defining ID when converting to `TypeTag`s in the adapter.
+//             Enable execution time estimate mode for congestion control on mainnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -3508,6 +3509,17 @@ impl ProtocolConfig {
                 83 => {
                     cfg.feature_flags.resolve_type_input_ids_to_defining_id = true;
                     cfg.transfer_party_transfer_internal_cost_base = Some(52);
+
+                    // Enable execution time estimate mode for congestion control on mainnet.
+                    cfg.feature_flags.per_object_congestion_control_mode =
+                        PerObjectCongestionControlMode::ExecutionTimeEstimate(
+                            ExecutionTimeEstimateParams {
+                                target_utilization: 30,
+                                allowed_txn_cost_overage_burst_limit_us: 100_000, // 100 ms
+                                randomness_scalar: 20,
+                                max_estimate_us: 1_500_000, // 1.5s
+                            },
+                        );
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_83.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_83.snap
@@ -45,7 +45,12 @@ feature_flags:
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
   reject_mutable_random_on_entry_functions: true
-  per_object_congestion_control_mode: TotalGasBudgetWithCap
+  per_object_congestion_control_mode:
+    ExecutionTimeEstimate:
+      target_utilization: 30
+      allowed_txn_cost_overage_burst_limit_us: 100000
+      randomness_scalar: 20
+      max_estimate_us: 1500000
   consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30


### PR DESCRIPTION

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [x] Protocol: Enables ExecutionTimeEstimate mode for congestion control on mainnet.
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
