### PR TITLE
indexer-alt: retry all checkpoint fetch errors

### DIFF
--- a/crates/sui-indexer-alt-framework/src/ingestion/local_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/local_client.rs
@@ -41,7 +41,6 @@ pub(crate) mod tests {
     use crate::ingestion::test_utils::test_checkpoint_data;
     use crate::metrics::tests::test_metrics;
     use sui_storage::blob::{Blob, BlobEncoding};
-    use tokio_util::sync::CancellationToken;
 
     #[tokio::test]
     async fn local_test_fetch() {
@@ -51,10 +50,8 @@ pub(crate) mod tests {
         tokio::fs::write(&path, &test_checkpoint).await.unwrap();
 
         let local_client = IngestionClient::new_local(tempdir, test_metrics());
-        let checkpoint = local_client
-            .fetch(1, &CancellationToken::new())
-            .await
-            .unwrap();
+        let checkpoint = local_client.fetch(1).await.unwrap();
+
         assert_eq!(
             Blob::encode(&*checkpoint, BlobEncoding::Bcs)
                 .unwrap()

--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -332,28 +332,6 @@ mod tests {
         broadcaster.await.unwrap();
     }
 
-    /// If fetching the checkpoint throws an unexpected error, the whole pipeline will be shut
-    /// down.
-    #[tokio::test]
-    async fn shutdown_on_unexpected_error() {
-        telemetry_subscribers::init_for_testing();
-
-        let server = MockServer::start().await;
-        respond_with(&server, status(StatusCode::IM_A_TEAPOT)).await;
-
-        let cancel = CancellationToken::new();
-        let mut ingestion_service = test_ingestion(server.uri(), 1, 1, cancel.clone()).await;
-
-        let (rx, _) = ingestion_service.subscribe();
-        let subscriber = test_subscriber(usize::MAX, rx, cancel.clone()).await;
-        let (regulator, broadcaster) = ingestion_service.run(0..).await.unwrap();
-
-        cancel.cancelled().await;
-        subscriber.await.unwrap();
-        regulator.await.unwrap();
-        broadcaster.await.unwrap();
-    }
-
     /// The service will retry fetching a checkpoint that does not exist, in this test, the 4th
     /// checkpoint will return 404 a couple of times, before eventually succeeding.
     #[tokio::test]


### PR DESCRIPTION
## Description

Previously, the indexing framework would only retry a subset of remote checkpoint fetching errors, and would wind down the indexer in response to others.

This change makes it so that all errors (except "not found" errors) are treated as transient and are retried with an exponential back-off. It also simplifies the logic around cancellation, pulling it out from the ingestion client, and introducing an outer, wrapping `select!` statement that checks for cancellation instead.

## Test plan

Updtaed tests:

```
sui$ cargo nextest run         \
  -p sui-indexer-alt-framework \
  -p sui-indexer-alt           \
  -p sui-indexer-alt-e2e-tests
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
