### PR TITLE
Fix broken “Code of Conduct” link in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,7 @@ Sui is for the community. Contribute for the benefit of all.
 - [Repo contributing guidelines](https://docs.sui.io/contribute-to-sui-repos)
 - [Style guide](https://docs.sui.io/style-guide)
 - [Localization](https://docs.sui.io/localize-sui-docs)
-- [Code of conduct](https://docs.sui.io/contribute/code-of-conduct)
+- [Code of conduct](https://docs.sui.io/code-of-conduct)
 
 ## License
 


### PR DESCRIPTION
## Description 

Replaces the outdated URL `https://docs.sui.io/contribute/code-of-conduct` with the live URL `https://docs.sui.io/code-of-conduct` so contributors can access the Code of Conduct without hitting a 404.






