### PR TITLE
Remove shared object version assignments on fullnodes, fix debug assertion

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1433,9 +1433,9 @@ impl AuthorityPerEpochStore {
         Ok(())
     }
 
-    pub(crate) fn remove_shared_version_assignments<'a>(
+    pub(crate) fn remove_shared_version_assignments(
         &self,
-        keys: impl IntoIterator<Item = &'a TransactionKey>,
+        keys: impl IntoIterator<Item = TransactionKey>,
     ) {
         self.consensus_output_cache
             .remove_shared_object_assignments(keys);

--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -455,13 +455,10 @@ impl ConsensusOutputCache {
         );
     }
 
-    pub fn remove_shared_object_assignments<'a>(
-        &self,
-        keys: impl IntoIterator<Item = &'a TransactionKey>,
-    ) {
+    pub fn remove_shared_object_assignments(&self, keys: impl IntoIterator<Item = TransactionKey>) {
         let mut removed_count = 0;
         for tx_key in keys {
-            if self.shared_version_assignments.remove(tx_key).is_some() {
+            if self.shared_version_assignments.remove(&tx_key).is_some() {
                 removed_count += 1;
             }
         }
@@ -717,7 +714,8 @@ impl ConsensusOutputQuarantine {
                     output
                         .pending_checkpoints
                         .iter()
-                        .flat_map(|c| c.roots().iter()),
+                        .flat_map(|c| c.roots().iter())
+                        .copied(),
                 );
                 output.write_to_batch(epoch_store, batch)?;
             } else {


### PR DESCRIPTION
The previous debug assertion was not 100% reliable due to otherwise harmless races between CheckpointExecutor and ConsensusHandler. The assertion is now relaxed in order to catch gross leaks.

Also, we previously did not remove version assignments on fullnodes at all!
