### PR TITLE
Rename the ConsensusV2 ownership enum to the more-accurate Authorizer

### DIFF
--- a/crates/sui-core/src/generate_format.rs
+++ b/crates/sui-core/src/generate_format.rs
@@ -293,7 +293,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<GenesisObject>(&samples).unwrap();
     tracer.trace_type::<CheckpointCommitment>(&samples).unwrap();
     tracer
-        .trace_type::<sui_types::object::Authenticator>(&samples)
+        .trace_type::<sui_types::object::Authorizer>(&samples)
         .unwrap();
 
     tracer.registry()

--- a/crates/sui-core/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_tests.rs
@@ -13,7 +13,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::ops::Deref;
 use sui_types::crypto::{PublicKey, SuiSignature, ToFromBytes, ZkLoginPublicIdentifier};
 use sui_types::messages_grpc::HandleSoftBundleCertificatesRequestV3;
-use sui_types::object::Authenticator;
+use sui_types::object::Authorizer;
 use sui_types::utils::get_one_zklogin_inputs;
 use sui_types::{
     authenticator_state::ActiveJwk,
@@ -316,7 +316,7 @@ async fn test_sender_is_not_consensus_v2_owner() {
             start_version.next(),
             Owner::ConsensusV2 {
                 start_version,
-                authenticator: Box::new(Authenticator::SingleOwner(sender1)),
+                authorizer: Box::new(Authorizer::SingleOwner(sender1)),
             },
         ),
         |_| {},

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -29,12 +29,6 @@ Argument:
         TUPLE:
           - U16
           - U16
-Authenticator:
-  ENUM:
-    0:
-      SingleOwner:
-        NEWTYPE:
-          TYPENAME: SuiAddress
 AuthenticatorStateExpire:
   STRUCT:
     - min_epoch: U64
@@ -59,6 +53,12 @@ AuthorityQuorumSignInfo:
           CONTENT: U8
           SIZE: 48
     - signers_map: BYTES
+Authorizer:
+  ENUM:
+    0:
+      SingleOwner:
+        NEWTYPE:
+          TYPENAME: SuiAddress
 CallArg:
   ENUM:
     0:
@@ -851,8 +851,8 @@ Owner:
         STRUCT:
           - start_version:
               TYPENAME: SequenceNumber
-          - authenticator:
-              TYPENAME: Authenticator
+          - authorizer:
+              TYPENAME: Authorizer
 PackageUpgradeError:
   ENUM:
     0:

--- a/crates/sui-graphql-rpc/src/types/object.rs
+++ b/crates/sui-graphql-rpc/src/types/object.rs
@@ -15,7 +15,7 @@ use super::display::{Display, DisplayEntry};
 use super::dynamic_field::{DynamicField, DynamicFieldName};
 use super::move_object::MoveObject;
 use super::move_package::MovePackage;
-use super::owner::{Authenticator, OwnerImpl};
+use super::owner::{Authorizer, OwnerImpl};
 use super::stake::StakedSui;
 use super::sui_address::addr;
 use super::suins_registration::{DomainFormat, SuinsRegistration};
@@ -181,12 +181,12 @@ pub(crate) struct AddressOwner {
 }
 
 /// A ConsensusV2 object is an object that is automatically versioned by the consensus protocol
-/// and allows different authentication modes based on the chosen authenticator.
-/// (Initially, only single-owner authentication is supported.)
+/// and allows different authorization modes based on the chosen authorizer.
+/// (Initially, only single-owner authorization is supported.)
 #[derive(SimpleObject, Clone)]
 pub(crate) struct ConsensusV2 {
     start_version: UInt53,
-    authenticator: Option<Authenticator>,
+    authorizer: Option<Authorizer>,
 }
 
 /// Filter for a point query of an Object.
@@ -625,11 +625,11 @@ impl ObjectImpl<'_> {
             })),
             O::ConsensusV2 {
                 start_version,
-                authenticator,
+                authorizer,
             } => Some(ObjectOwner::ConsensusV2(ConsensusV2 {
                 start_version: start_version.value().into(),
-                authenticator: Some(Authenticator::SingleOwner(Address {
-                    address: SuiAddress::from(*authenticator.as_single_owner()),
+                authorizer: Some(Authorizer::SingleOwner(Address {
+                    address: SuiAddress::from(*authorizer.as_single_owner()),
                     checkpoint_viewed_at: self.0.checkpoint_viewed_at,
                 })),
             })),

--- a/crates/sui-graphql-rpc/src/types/owner.rs
+++ b/crates/sui-graphql-rpc/src/types/owner.rs
@@ -137,9 +137,9 @@ pub(crate) enum IOwner {
     SuinsRegistration(SuinsRegistration),
 }
 
-/// An Authenticator represents the access control rules for a ConsensusV2 object.
+/// An Authorizer represents the access control rules for a ConsensusV2 object.
 #[derive(Clone, Debug, Union)]
-pub(crate) enum Authenticator {
+pub(crate) enum Authorizer {
     /// The object is fully owned by a single address.
     SingleOwner(Address),
 }

--- a/crates/sui-indexer-alt-schema/src/objects.rs
+++ b/crates/sui-indexer-alt-schema/src/objects.rs
@@ -96,8 +96,8 @@ impl StoredObjInfo {
                 Owner::AddressOwner(a) => Some(a.to_vec()),
                 Owner::ObjectOwner(o) => Some(o.to_vec()),
                 Owner::Shared { .. } | Owner::Immutable { .. } => None,
-                Owner::ConsensusV2 { authenticator, .. } => {
-                    Some(authenticator.as_single_owner().to_vec())
+                Owner::ConsensusV2 { authorizer, .. } => {
+                    Some(authorizer.as_single_owner().to_vec())
                 }
             },
 

--- a/crates/sui-indexer-alt/src/handlers/coin_balance_buckets.rs
+++ b/crates/sui-indexer-alt/src/handlers/coin_balance_buckets.rs
@@ -278,9 +278,9 @@ impl TryInto<StoredCoinBalanceBucket> for &ProcessedCoinBalanceBucket {
 pub(crate) fn get_coin_owner(object: &Object) -> Option<(StoredCoinOwnerKind, SuiAddress)> {
     match object.owner() {
         Owner::AddressOwner(owner_id) => Some((StoredCoinOwnerKind::Fastpath, *owner_id)),
-        Owner::ConsensusV2 { authenticator, .. } => Some((
+        Owner::ConsensusV2 { authorizer, .. } => Some((
             StoredCoinOwnerKind::Consensus,
-            *authenticator.as_single_owner(),
+            *authorizer.as_single_owner(),
         )),
         Owner::Immutable | Owner::ObjectOwner(_) | Owner::Shared { .. } => None,
     }
@@ -310,7 +310,7 @@ mod tests {
             base_types::{dbg_addr, MoveObjectType, ObjectID, SequenceNumber, SuiAddress},
             digests::TransactionDigest,
             gas_coin::GAS,
-            object::{Authenticator, MoveObject, Object},
+            object::{Authorizer, MoveObject, Object},
             test_checkpoint_data_builder::TestCheckpointDataBuilder,
         },
         Indexer,
@@ -394,7 +394,7 @@ mod tests {
             id,
             SequenceNumber::new(),
             Owner::ConsensusV2 {
-                authenticator: Box::new(Authenticator::SingleOwner(addr1)),
+                authorizer: Box::new(Authorizer::SingleOwner(addr1)),
                 start_version: SequenceNumber::new(),
             },
         );

--- a/crates/sui-indexer-alt/src/handlers/obj_info.rs
+++ b/crates/sui-indexer-alt/src/handlers/obj_info.rs
@@ -200,7 +200,7 @@ mod tests {
     use sui_indexer_alt_framework::{
         types::{
             base_types::{dbg_addr, SequenceNumber},
-            object::{Authenticator, Owner},
+            object::{Authorizer, Owner},
             test_checkpoint_data_builder::TestCheckpointDataBuilder,
         },
         Indexer,
@@ -555,7 +555,7 @@ mod tests {
                 0,
                 Owner::ConsensusV2 {
                     start_version: SequenceNumber::from_u64(1),
-                    authenticator: Box::new(Authenticator::SingleOwner(dbg_addr(0))),
+                    authorizer: Box::new(Authorizer::SingleOwner(dbg_addr(0))),
                 },
             )
             .finish_transaction();

--- a/crates/sui-indexer/src/types.rs
+++ b/crates/sui-indexer/src/types.rs
@@ -255,9 +255,9 @@ pub fn owner_to_owner_info(owner: &Owner) -> (OwnerType, Option<SuiAddress>) {
         Owner::Shared { .. } => (OwnerType::Shared, None),
         Owner::Immutable => (OwnerType::Immutable, None),
         // ConsensusV2 objects are treated as singly-owned for now in indexers.
-        // This will need to be updated if additional Authenticators are added.
-        Owner::ConsensusV2 { authenticator, .. } => {
-            (OwnerType::Address, Some(*authenticator.as_single_owner()))
+        // This will need to be updated if additional Authorizers are added.
+        Owner::ConsensusV2 { authorizer, .. } => {
+            (OwnerType::Address, Some(*authorizer.as_single_owner()))
         }
     }
 }

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -5350,7 +5350,15 @@
       "AdditionalConsensusStateDigest": {
         "$ref": "#/components/schemas/Digest"
       },
-      "Authenticator": {
+      "AuthorityPublicKeyBytes": {
+        "description": "Defines the compressed version of the public key that we pass around in Sui",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Base64"
+          }
+        ]
+      },
+      "Authorizer": {
         "oneOf": [
           {
             "description": "The contained SuiAddress exclusively has all permissions: read, write, delete, transfer",
@@ -5364,14 +5372,6 @@
               }
             },
             "additionalProperties": false
-          }
-        ]
-      },
-      "AuthorityPublicKeyBytes": {
-        "description": "Defines the compressed version of the public key that we pass around in Sui",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Base64"
           }
         ]
       },
@@ -7872,7 +7872,7 @@
             ]
           },
           {
-            "description": "Object is sequenced via consensus. Ownership is managed by the configured authenticator.\n\nNote: wondering what happened to `V1`? `Shared` above was the V1 of consensus objects.",
+            "description": "Object is sequenced via consensus. Ownership is managed by the configured authorizer.\n\nNote: wondering what happened to `V1`? `Shared` above was the V1 of consensus objects.",
             "type": "object",
             "required": [
               "ConsensusV2"
@@ -7881,15 +7881,15 @@
               "ConsensusV2": {
                 "type": "object",
                 "required": [
-                  "authenticator",
+                  "authorizer",
                   "start_version"
                 ],
                 "properties": {
-                  "authenticator": {
-                    "description": "The authentication mode of the object",
+                  "authorizer": {
+                    "description": "The authorization mode of the object.",
                     "allOf": [
                       {
-                        "$ref": "#/components/schemas/Authenticator"
+                        "$ref": "#/components/schemas/Authorizer"
                       }
                     ]
                   },

--- a/crates/sui-oracle/src/lib.rs
+++ b/crates/sui-oracle/src/lib.rs
@@ -704,7 +704,7 @@ async fn get_object_arg(
         }
         | Owner::ConsensusV2 {
             start_version: initial_shared_version,
-            authenticator: _,
+            authorizer: _,
         } => ObjectArg::SharedObject {
             id,
             initial_shared_version,

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -483,7 +483,7 @@ impl TransactionBuilder {
             }
             | Owner::ConsensusV2 {
                 start_version: initial_shared_version,
-                authenticator: _,
+                authorizer: _,
             } => ObjectArg::SharedObject {
                 id,
                 initial_shared_version,
@@ -640,7 +640,7 @@ impl TransactionBuilder {
                 }
                 | Owner::ConsensusV2 {
                     start_version: initial_shared_version,
-                    authenticator: _,
+                    authorizer: _,
                 } => ObjectArg::SharedObject {
                     id: upgrade_capability.object_ref().0,
                     initial_shared_version,

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -15,7 +15,7 @@ mod checked {
     use sui_types::error::{SuiResult, UserInputError, UserInputResult};
     use sui_types::executable_transaction::VerifiedExecutableTransaction;
     use sui_types::metrics::BytecodeVerifierMetrics;
-    use sui_types::object::Authenticator;
+    use sui_types::object::Authorizer;
     use sui_types::transaction::{
         CheckedInputObjects, InputObjectKind, InputObjects, ObjectReadResult, ObjectReadResultKind,
         ReceivingObjectReadResult, ReceivingObjects, TransactionData, TransactionDataAPI,
@@ -556,14 +556,14 @@ mod checked {
                     }
                     Owner::ConsensusV2 {
                         start_version: actual_initial_shared_version,
-                        authenticator,
+                        authorizer,
                     } => {
                         fp_ensure!(
                             input_initial_shared_version == *actual_initial_shared_version,
                             UserInputError::SharedObjectStartingVersionMismatch
                         );
-                        match authenticator.as_ref() {
-                            Authenticator::SingleOwner(actual_owner) => {
+                        match authorizer.as_ref() {
+                            Authorizer::SingleOwner(actual_owner) => {
                                 // Check the owner is correct.
                                 fp_ensure!(
                                     owner == actual_owner,

--- a/crates/sui-types/src/sui_sdk_types_conversions.rs
+++ b/crates/sui-types/src/sui_sdk_types_conversions.rs
@@ -137,7 +137,7 @@ impl From<crate::object::Owner> for Owner {
             // TODO: Corresponding types need to be added to sui-sdk-types.
             crate::object::Owner::ConsensusV2 {
                 start_version: _,
-                authenticator: _,
+                authorizer: _,
             } => todo!(),
         }
     }

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -1955,7 +1955,7 @@ impl TransactionData {
                 }
                 | Owner::ConsensusV2 {
                     start_version: initial_shared_version,
-                    authenticator: _,
+                    authorizer: _,
                 } => ObjectArg::SharedObject {
                     id: upgrade_capability.0,
                     initial_shared_version,

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/mod.rs
@@ -276,14 +276,14 @@ impl<'a> ObjectRuntime<'a> {
                 (Owner::Shared { .. }, Owner::Shared { .. }) => TransferResult::SameOwner,
                 (
                     Owner::ConsensusV2 {
-                        authenticator: new_authenticator,
+                        authorizer: new_authorizer,
                         ..
                     },
                     Owner::ConsensusV2 {
-                        authenticator: old_authenticator,
+                        authorizer: old_authorizer,
                         ..
                     },
-                ) if new_authenticator == old_authenticator => TransferResult::SameOwner,
+                ) if new_authorizer == old_authorizer => TransferResult::SameOwner,
                 (new, old) if new == old => TransferResult::SameOwner,
                 _ => TransferResult::OwnerChanged,
             }

--- a/sui-execution/latest/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/latest/sui-move-natives/src/test_scenario.rs
@@ -231,12 +231,12 @@ pub fn end_transaction(
                     .or_default()
                     .insert(id);
             }
-            Owner::ConsensusV2 { authenticator, .. } => {
+            Owner::ConsensusV2 { authorizer, .. } => {
                 // Treat ConsensusV2 objects the same as address-owned for now. This will have
-                // to be revisited when other Authenticators are added.
+                // to be revisited when other Authorizers are added.
                 inventories
                     .address_inventories
-                    .entry(*authenticator.as_single_owner())
+                    .entry(*authorizer.as_single_owner())
                     .or_default()
                     .entry(ty)
                     .or_default()
@@ -874,10 +874,10 @@ fn transaction_effects(
             Owner::Shared { .. } => shared.push(id),
             Owner::Immutable => frozen.push(id),
             // Treat ConsensusV2 objects the same as address-owned for now. This will have
-            // to be revisited when other Authenticators are added.
-            Owner::ConsensusV2 { authenticator, .. } => transferred_to_account.push((
+            // to be revisited when other Authorizers are added.
+            Owner::ConsensusV2 { authorizer, .. } => transferred_to_account.push((
                 pack_id(id),
-                Value::address((*authenticator.as_single_owner()).into()),
+                Value::address((*authorizer.as_single_owner()).into()),
             )),
         }
     }

--- a/sui-execution/latest/sui-move-natives/src/transfer.rs
+++ b/sui-execution/latest/sui-move-natives/src/transfer.rs
@@ -19,7 +19,7 @@ use smallvec::smallvec;
 use std::collections::VecDeque;
 use sui_types::{
     base_types::{MoveObjectType, ObjectID, SequenceNumber},
-    object::{Authenticator, Owner},
+    object::{Authorizer, Owner},
 };
 
 const E_SHARED_NON_NEW_OBJECT: u64 = 0;
@@ -232,7 +232,7 @@ pub fn party_transfer_internal(
     // transaction are written to storage.
     let owner = Owner::ConsensusV2 {
         start_version: SequenceNumber::new(),
-        authenticator: Box::new(Authenticator::SingleOwner(address.into())),
+        authorizer: Box::new(Authorizer::SingleOwner(address.into())),
     };
     object_runtime_transfer(context, owner, ty, obj)?;
     let cost = context.gas_used();


### PR DESCRIPTION
## Test plan 

Mechanical renames only.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
