### PR TITLE
[Consensus] Clean up non-garbage collection code paths.

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -557,7 +557,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn test_authority_committee(
         #[values(ConsensusNetwork::Anemo, ConsensusNetwork::Tonic)] network_type: ConsensusNetwork,
-        #[values(0, 5, 10)] gc_depth: u32,
+        #[values(5, 10)] gc_depth: u32,
     ) {
         telemetry_subscribers::init_for_testing();
         let db_registry = Registry::new();
@@ -567,12 +567,6 @@ mod tests {
         let (committee, keypairs) = local_committee_and_keys(0, [1; NUM_OF_AUTHORITIES].to_vec());
         let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
         protocol_config.set_consensus_gc_depth_for_testing(gc_depth);
-
-        if gc_depth == 0 {
-            protocol_config.set_consensus_linearize_subdag_v2_for_testing(false);
-            protocol_config.set_consensus_median_based_commit_timestamp_for_testing(false);
-            protocol_config.set_mysticeti_fastpath_for_testing(false);
-        }
 
         let temp_dirs = (0..NUM_OF_AUTHORITIES)
             .map(|_| TempDir::new().unwrap())
@@ -766,7 +760,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test(flavor = "current_thread")]
-    async fn test_amnesia_recovery_success(#[values(0, 5, 10)] gc_depth: u32) {
+    async fn test_amnesia_recovery_success(#[values(5, 10)] gc_depth: u32) {
         telemetry_subscribers::init_for_testing();
         let db_registry = Registry::new();
         DBMetrics::init(&db_registry);
@@ -781,12 +775,6 @@ mod tests {
 
         let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
         protocol_config.set_consensus_gc_depth_for_testing(gc_depth);
-
-        if gc_depth == 0 {
-            protocol_config.set_consensus_linearize_subdag_v2_for_testing(false);
-            protocol_config.set_consensus_median_based_commit_timestamp_for_testing(false);
-            protocol_config.set_mysticeti_fastpath_for_testing(false);
-        }
 
         for (index, _authority_info) in committee.authorities() {
             let dir = TempDir::new().unwrap();

--- a/consensus/core/src/block_manager.rs
+++ b/consensus/core/src/block_manager.rs
@@ -10,7 +10,7 @@ use std::{
 use itertools::Itertools as _;
 use mysten_metrics::monitored_scope;
 use parking_lot::RwLock;
-use tracing::{debug, trace, warn};
+use tracing::{debug, warn};
 
 use crate::{
     block::{BlockAPI, BlockRef, VerifiedBlock, GENESIS_ROUND},
@@ -99,11 +99,6 @@ impl BlockManager {
         &mut self,
         blocks: Vec<VerifiedBlock>,
     ) -> Vec<VerifiedBlock> {
-        // If GC is disabled then should not run any of this logic.
-        if !self.dag_state.read().gc_enabled() {
-            return Vec::new();
-        }
-
         // Just accept the blocks
         let _s = monitored_scope("BlockManager::try_accept_committed_blocks");
         let (accepted_blocks, missing_blocks) = self.try_accept_blocks_internal(blocks, true);
@@ -310,10 +305,7 @@ impl BlockManager {
         &mut self,
         unsuspended_blocks: impl IntoIterator<Item = VerifiedBlock>,
     ) -> Vec<VerifiedBlock> {
-        let (gc_enabled, gc_round) = {
-            let dag_state = self.dag_state.read();
-            (dag_state.gc_enabled(), dag_state.gc_round())
-        };
+        let gc_round = self.dag_state.read().gc_round();
 
         // Try to verify the block and its children for timestamp, with ancestor blocks.
         let mut blocks_to_accept: BTreeMap<BlockRef, VerifiedBlock> = BTreeMap::new();
@@ -344,12 +336,9 @@ impl BlockManager {
                         continue 'block;
                     }
 
-                    // When gc is enabled it's possible that we indeed won't find any ancestors that are passed gc_round. That's ok. We don't need to panic here.
-                    // We do want to panic if gc_enabled we and have an ancestor that is > gc_round, or gc is disabled.
-                    if gc_enabled
-                        && ancestor_ref.round > GENESIS_ROUND
-                        && ancestor_ref.round <= gc_round
-                    {
+                    // It's possible that we indeed won't find any ancestors that are passed gc_round. That's ok. We don't need to panic here.
+                    // We do want to panic if we have an ancestor that is > gc_round.
+                    if ancestor_ref.round > GENESIS_ROUND && ancestor_ref.round <= gc_round {
                         debug!(
                             "Block {:?} has a missing ancestor: {:?} passed GC round {}",
                             b.reference(),
@@ -362,9 +351,9 @@ impl BlockManager {
                     }
                 }
 
-                if let Err(e) =
-                    self.block_verifier
-                        .check_ancestors(&b, &ancestor_blocks, gc_enabled, gc_round)
+                if let Err(e) = self
+                    .block_verifier
+                    .check_ancestors(&b, &ancestor_blocks, gc_round)
                 {
                     warn!("Block {:?} failed to verify ancestors: {}", b, e);
                     blocks_to_reject.insert(b.reference(), b);
@@ -412,7 +401,6 @@ impl BlockManager {
         let mut ancestors_to_fetch = BTreeSet::new();
         let dag_state = self.dag_state.read();
         let gc_round = dag_state.gc_round();
-        let gc_enabled = dag_state.gc_enabled();
 
         // If block has been already received and suspended, or already processed and stored, or is a genesis block, then skip it.
         if self.suspended_blocks.contains_key(&block_ref) || dag_state.contains_block(&block_ref) {
@@ -420,7 +408,7 @@ impl BlockManager {
         }
 
         // If the block is <= gc_round, then we simply skip its processing as there is no meaning do any action on it or even store it.
-        if gc_enabled && block.round() <= gc_round {
+        if block.round() <= gc_round {
             let hostname = self
                 .context
                 .committee
@@ -438,16 +426,12 @@ impl BlockManager {
 
         // Keep only the ancestors that are greater than the GC round to check for their existence. Keep in mind that if GC is disabled
         // then gc_round will be 0 and all ancestors will be considered.
-        let ancestors = if gc_enabled {
-            block
-                .ancestors()
-                .iter()
-                .filter(|ancestor| ancestor.round == GENESIS_ROUND || ancestor.round > gc_round)
-                .cloned()
-                .collect::<Vec<_>>()
-        } else {
-            block.ancestors().to_vec()
-        };
+        let ancestors = block
+            .ancestors()
+            .iter()
+            .filter(|ancestor| ancestor.round == GENESIS_ROUND || ancestor.round > gc_round)
+            .cloned()
+            .collect::<Vec<_>>();
 
         // make sure that we have all the required ancestors in store
         for (found, ancestor) in dag_state
@@ -594,17 +578,9 @@ impl BlockManager {
     /// this action.
     pub(crate) fn try_unsuspend_blocks_for_latest_gc_round(&mut self) {
         let _s = monitored_scope("BlockManager::try_unsuspend_blocks_for_latest_gc_round");
-        let (gc_enabled, gc_round) = {
-            let dag_state = self.dag_state.read();
-            (dag_state.gc_enabled(), dag_state.gc_round())
-        };
+        let gc_round = self.dag_state.read().gc_round();
         let mut blocks_unsuspended_below_gc_round = 0;
         let mut blocks_gc_ed = 0;
-
-        if !gc_enabled {
-            trace!("GC is disabled, no blocks will attempt to get unsuspended.");
-            return;
-        }
 
         while let Some((block_ref, _children_refs)) = self.missing_ancestors.first_key_value() {
             // If the first block in the missing ancestors is higher than the gc_round, then we can't unsuspend it yet. So we just put it back
@@ -1033,20 +1009,15 @@ mod tests {
     }
 
     /// The test generate blocks for a well connected DAG and feed them to block manager in random order. In the end all the
-    /// blocks should be uniquely suspended and no missing blocks should exist. The test will run for both gc_enabled/disabled.
-    /// When gc is enabeld we set a high gc_depth value so in practice gc_round will be 0, but we'll be able to test in the common case
-    /// that this work exactly the same way as when gc is disabled.
-    #[rstest]
+    /// blocks should be uniquely suspended and no missing blocks should exist. We set a high gc_depth value so in practice gc_round will be 0.
     #[tokio::test]
-    async fn accept_blocks_unsuspend_children_blocks(#[values(false, true)] gc_enabled: bool) {
+    async fn accept_blocks_unsuspend_children_blocks() {
         // GIVEN
         let (mut context, _key_pairs) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_gc_depth_for_testing(10);
 
-        if gc_enabled {
-            context
-                .protocol_config
-                .set_consensus_gc_depth_for_testing(10);
-        }
         let context = Arc::new(context);
 
         // create a DAG of rounds 1 ~ 3
@@ -1093,12 +1064,10 @@ mod tests {
         telemetry_subscribers::init_for_testing();
         // GIVEN
         let (mut context, _key_pairs) = Context::new_for_test(4);
+        context
+            .protocol_config
+            .set_consensus_gc_depth_for_testing(gc_depth);
 
-        if gc_depth > 0 {
-            context
-                .protocol_config
-                .set_consensus_gc_depth_for_testing(gc_depth);
-        }
         let context = Arc::new(context);
 
         // create a DAG of rounds 1 ~ gc_depth * 2
@@ -1248,7 +1217,6 @@ mod tests {
             &self,
             block: &VerifiedBlock,
             _ancestors: &[Option<VerifiedBlock>],
-            _gc_enabled: bool,
             _gc_round: Round,
         ) -> ConsensusResult<()> {
             if self.fail.contains(&block.reference()) {

--- a/consensus/core/src/block_verifier.rs
+++ b/consensus/core/src/block_verifier.rs
@@ -33,7 +33,6 @@ pub(crate) trait BlockVerifier: Send + Sync + 'static {
         &self,
         block: &VerifiedBlock,
         ancestors: &[Option<VerifiedBlock>],
-        gc_enabled: bool,
         gc_round: Round,
     ) -> ConsensusResult<()>;
 }
@@ -209,37 +208,17 @@ impl BlockVerifier for SignedBlockVerifier {
         &self,
         block: &VerifiedBlock,
         ancestors: &[Option<VerifiedBlock>],
-        gc_enabled: bool,
         gc_round: Round,
     ) -> ConsensusResult<()> {
-        if gc_enabled {
-            // TODO: will be removed with new timestamp calculation is in place as all these will be irrelevant.
-            // When gc is enabled we don't have guarantees that all ancestors will be available. We'll take into account only the passed gc_round ones
-            // for the timestamp check.
-            let mut max_timestamp_ms = BlockTimestampMs::MIN;
-            for ancestor in ancestors.iter().flatten() {
-                if ancestor.round() <= gc_round {
-                    continue;
-                }
-                max_timestamp_ms = max_timestamp_ms.max(ancestor.timestamp_ms());
-                if max_timestamp_ms > block.timestamp_ms() {
-                    return Err(ConsensusError::InvalidBlockTimestamp {
-                        max_timestamp_ms,
-                        block_timestamp_ms: block.timestamp_ms(),
-                    });
-                }
+        // TODO: will be removed with new timestamp calculation is in place as all these will be irrelevant.
+        // When gc is enabled we don't have guarantees that all ancestors will be available. We'll take into account only the passed gc_round ones
+        // for the timestamp check.
+        let mut max_timestamp_ms = BlockTimestampMs::MIN;
+        for ancestor in ancestors.iter().flatten() {
+            if ancestor.round() <= gc_round {
+                continue;
             }
-        } else {
-            assert_eq!(block.ancestors().len(), ancestors.len());
-            // This checks the invariant that block timestamp >= max ancestor timestamp.
-            let mut max_timestamp_ms = BlockTimestampMs::MIN;
-            for (ancestor_ref, ancestor_block) in block.ancestors().iter().zip(ancestors.iter()) {
-                let ancestor_block = ancestor_block
-                    .as_ref()
-                    .expect("There should never be an empty slot");
-                assert_eq!(ancestor_ref, &ancestor_block.reference());
-                max_timestamp_ms = max_timestamp_ms.max(ancestor_block.timestamp_ms());
-            }
+            max_timestamp_ms = max_timestamp_ms.max(ancestor.timestamp_ms());
             if max_timestamp_ms > block.timestamp_ms() {
                 return Err(ConsensusError::InvalidBlockTimestamp {
                     max_timestamp_ms,
@@ -264,7 +243,6 @@ impl BlockVerifier for NoopBlockVerifier {
         &self,
         _block: &VerifiedBlock,
         _ancestors: &[Option<VerifiedBlock>],
-        _gc_enabled: bool,
         _gc_round: Round,
     ) -> ConsensusResult<()> {
         Ok(())
@@ -274,7 +252,6 @@ impl BlockVerifier for NoopBlockVerifier {
 #[cfg(test)]
 mod test {
     use consensus_config::AuthorityIndex;
-    use rstest::rstest;
     use sui_protocol_config::ProtocolConfig;
 
     use super::*;
@@ -671,11 +648,9 @@ mod test {
         }
     }
 
-    /// Tests the block's ancestors for timestamp monotonicity. Test will run for both when gc is enabled and disabled, but
-    /// with none of the ancestors being below the gc_round.
-    #[rstest]
+    /// Tests the block's ancestors for timestamp monotonicity.
     #[tokio::test]
-    async fn test_check_ancestors(#[values(false, true)] gc_enabled: bool) {
+    async fn test_check_ancestors() {
         let num_authorities = 4;
         let (context, _keypairs) = Context::new_for_test(num_authorities);
         let context = Arc::new(context);
@@ -703,7 +678,7 @@ mod test {
                 .build();
             let verified_block = VerifiedBlock::new_for_test(block);
             assert!(verifier
-                .check_ancestors(&verified_block, &ancestor_blocks, gc_enabled, gc_round)
+                .check_ancestors(&verified_block, &ancestor_blocks, gc_round)
                 .is_ok());
         }
 
@@ -715,7 +690,7 @@ mod test {
                 .build();
             let verified_block = VerifiedBlock::new_for_test(block);
             assert!(matches!(
-                verifier.check_ancestors(&verified_block, &ancestor_blocks, gc_enabled, gc_round),
+                verifier.check_ancestors(&verified_block, &ancestor_blocks, gc_round),
                 Err(ConsensusError::InvalidBlockTimestamp {
                     max_timestamp_ms: _,
                     block_timestamp_ms: _
@@ -730,7 +705,6 @@ mod test {
         let (context, _keypairs) = Context::new_for_test(num_authorities);
         let context = Arc::new(context);
         let verifier = SignedBlockVerifier::new(context.clone(), Arc::new(TxnSizeVerifier {}));
-        let gc_enabled = true;
         let gc_round = 3;
 
         let mut ancestor_blocks = vec![];
@@ -764,7 +738,7 @@ mod test {
                 .build();
             let verified_block = VerifiedBlock::new_for_test(block);
             assert!(verifier
-                .check_ancestors(&verified_block, &ancestor_blocks, gc_enabled, gc_round)
+                .check_ancestors(&verified_block, &ancestor_blocks, gc_round)
                 .is_ok());
         }
 
@@ -777,7 +751,7 @@ mod test {
                 .build();
             let verified_block = VerifiedBlock::new_for_test(block);
             assert!(verifier
-                .check_ancestors(&verified_block, &ancestor_blocks, gc_enabled, gc_round)
+                .check_ancestors(&verified_block, &ancestor_blocks, gc_round)
                 .is_ok());
         }
 
@@ -789,7 +763,7 @@ mod test {
                 .build();
             let verified_block = VerifiedBlock::new_for_test(block);
             assert!(matches!(
-                verifier.check_ancestors(&verified_block, &ancestor_blocks, gc_enabled, gc_round),
+                verifier.check_ancestors(&verified_block, &ancestor_blocks, gc_round),
                 Err(ConsensusError::InvalidBlockTimestamp {
                     max_timestamp_ms: _,
                     block_timestamp_ms: _

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -337,41 +337,28 @@ impl Core {
     ) -> ConsensusResult<BTreeSet<BlockRef>> {
         let _scope = monitored_scope("Core::add_certified_commits");
 
-        // We want to enable the commit process logic when GC is enabled.
-        if self.dag_state.read().gc_enabled() {
-            let votes = certified_commits.votes().to_vec();
-            let commits = self
-                .filter_new_commits(certified_commits.commits().to_vec())
-                .expect("Certified commits validation failed");
+        let votes = certified_commits.votes().to_vec();
+        let commits = self
+            .filter_new_commits(certified_commits.commits().to_vec())
+            .expect("Certified commits validation failed");
 
-            // Try to accept the certified commit votes.
-            // Even if they may not be part of a future commit, these blocks are useful for certifying
-            // commits when helping peers sync commits.
-            let (_, missing_block_refs) = self.block_manager.try_accept_blocks(votes);
+        // Try to accept the certified commit votes.
+        // Even if they may not be part of a future commit, these blocks are useful for certifying
+        // commits when helping peers sync commits.
+        let (_, missing_block_refs) = self.block_manager.try_accept_blocks(votes);
 
-            // Try to commit the new blocks. Take into account the trusted commit that has been provided.
-            self.try_commit(commits)?;
+        // Try to commit the new blocks. Take into account the trusted commit that has been provided.
+        self.try_commit(commits)?;
 
-            // Try to propose now since there are new blocks accepted.
-            self.try_propose(false)?;
+        // Try to propose now since there are new blocks accepted.
+        self.try_propose(false)?;
 
-            // Now set up leader timeout if needed.
-            // This needs to be called after try_commit() and try_propose(), which may
-            // have advanced the threshold clock round.
-            self.try_signal_new_round();
+        // Now set up leader timeout if needed.
+        // This needs to be called after try_commit() and try_propose(), which may
+        // have advanced the threshold clock round.
+        self.try_signal_new_round();
 
-            return Ok(missing_block_refs);
-        }
-
-        // If GC is not enabled then process blocks as usual.
-        let blocks = certified_commits
-            .commits()
-            .iter()
-            .flat_map(|commit| commit.blocks())
-            .cloned()
-            .collect::<Vec<_>>();
-
-        self.add_blocks(blocks)
+        return Ok(missing_block_refs);
     }
 
     /// Checks if provided block refs have been accepted. If not, missing block refs are kept for synchronizations.
@@ -1030,11 +1017,6 @@ impl Core {
         certified_commits: &mut Vec<CertifiedCommit>,
         limit: usize,
     ) -> Vec<(DecidedLeader, CertifiedCommit)> {
-        // If GC is disabled then should not run any of this logic.
-        if !self.dag_state.read().gc_enabled() {
-            return Vec::new();
-        }
-
         assert!(limit > 0, "limit should be greater than 0");
 
         let to_commit = if certified_commits.len() >= limit {
@@ -1513,7 +1495,6 @@ mod test {
     use consensus_config::{AuthorityIndex, Parameters};
     use futures::{stream::FuturesUnordered, StreamExt};
     use mysten_metrics::monitored_mpsc;
-    use rstest::rstest;
     use sui_protocol_config::ProtocolConfig;
     use tokio::time::sleep;
 
@@ -1964,17 +1945,15 @@ mod test {
         assert_eq!(dag_state.read().last_commit_index(), 0);
     }
 
-    #[rstest]
     #[tokio::test]
-    async fn test_commit_and_notify_for_block_status(#[values(0, 2)] gc_depth: u32) {
+    async fn test_commit_and_notify_for_block_status() {
         telemetry_subscribers::init_for_testing();
         let (mut context, mut key_pairs) = Context::new_for_test(4);
+        const GC_DEPTH: u32 = 2;
 
-        if gc_depth > 0 {
-            context
-                .protocol_config
-                .set_consensus_gc_depth_for_testing(gc_depth);
-        }
+        context
+            .protocol_config
+            .set_consensus_gc_depth_for_testing(GC_DEPTH);
 
         let context = Arc::new(context);
 
@@ -2086,19 +2065,13 @@ mod test {
         while let Some(result) = block_status_subscriptions.next().await {
             let status = result.unwrap();
 
-            // If gc is enabled, then we expect some blocks to be garbage collected.
-            if gc_depth > 0 {
-                match status {
-                    BlockStatus::Sequenced(block_ref) => {
-                        assert!(block_ref.round == 1 || block_ref.round == 5);
-                    }
-                    BlockStatus::GarbageCollected(block_ref) => {
-                        assert!(block_ref.round == 2 || block_ref.round == 3);
-                    }
+            match status {
+                BlockStatus::Sequenced(block_ref) => {
+                    assert!(block_ref.round == 1 || block_ref.round == 5);
                 }
-            } else {
-                // otherwise all of them should be committed
-                assert!(matches!(status, BlockStatus::Sequenced(_)));
+                BlockStatus::GarbageCollected(block_ref) => {
+                    assert!(block_ref.round == 2 || block_ref.round == 3);
+                }
             }
         }
     }

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -178,9 +178,9 @@ impl DagState {
             evicted_rounds: vec![0; num_authorities],
         };
 
-        for (i, round) in last_committed_rounds.into_iter().enumerate() {
+        for (i, _round) in last_committed_rounds.into_iter().enumerate() {
             let authority_index = state.context.committee.to_authority_index(i).unwrap();
-            let (blocks, eviction_round) = if state.gc_enabled() {
+            let (blocks, eviction_round) = {
                 // Find the latest block for the authority to calculate the eviction round. Then we want to scan and load the blocks from the eviction round and onwards only.
                 // As reminder, the eviction round is taking into account the gc_round.
                 let last_block = state
@@ -192,23 +192,13 @@ impl DagState {
                     .map(|b| b.round())
                     .unwrap_or(GENESIS_ROUND);
 
-                let eviction_round = Self::gc_eviction_round(
-                    last_block_round,
-                    state.gc_round(),
-                    state.cached_rounds,
-                );
+                let eviction_round =
+                    Self::eviction_round(last_block_round, state.gc_round(), state.cached_rounds);
                 let blocks = state
                     .store
                     .scan_blocks_by_author(authority_index, eviction_round + 1)
                     .expect("Database error");
 
-                (blocks, eviction_round)
-            } else {
-                let eviction_round = Self::eviction_round(round, cached_rounds);
-                let blocks = state
-                    .store
-                    .scan_blocks_by_author(authority_index, eviction_round + 1)
-                    .expect("Database error");
                 (blocks, eviction_round)
             };
 
@@ -229,57 +219,53 @@ impl DagState {
             );
         }
 
-        if state.gc_enabled() {
-            if let Some(last_commit) = last_commit {
-                let mut index = last_commit.index();
-                let gc_round = state.gc_round();
-                info!("Recovering block commit statuses from commit index {} and backwards until leader of round <= gc_round {:?}", index, gc_round);
+        if let Some(last_commit) = last_commit {
+            let mut index = last_commit.index();
+            let gc_round = state.gc_round();
+            info!("Recovering block commit statuses from commit index {} and backwards until leader of round <= gc_round {:?}", index, gc_round);
 
-                loop {
-                    let commits = store
-                        .scan_commits((index..=index).into())
-                        .unwrap_or_else(|e| panic!("Failed to read from storage: {:?}", e));
-                    let Some(commit) = commits.first() else {
-                        info!(
-                            "Recovering finished up to index {index}, no more commits to recover"
-                        );
-                        break;
-                    };
+            loop {
+                let commits = store
+                    .scan_commits((index..=index).into())
+                    .unwrap_or_else(|e| panic!("Failed to read from storage: {:?}", e));
+                let Some(commit) = commits.first() else {
+                    info!("Recovering finished up to index {index}, no more commits to recover");
+                    break;
+                };
 
-                    // Check the commit leader round to see if it is within the gc_round. If it is not then we can stop the recovery process.
-                    if gc_round > 0 && commit.leader().round <= gc_round {
-                        info!(
-                            "Recovering finished, reached commit leader round {} <= gc_round {}",
-                            commit.leader().round,
-                            gc_round
-                        );
-                        break;
-                    }
+                // Check the commit leader round to see if it is within the gc_round. If it is not then we can stop the recovery process.
+                if gc_round > 0 && commit.leader().round <= gc_round {
+                    info!(
+                        "Recovering finished, reached commit leader round {} <= gc_round {}",
+                        commit.leader().round,
+                        gc_round
+                    );
+                    break;
+                }
 
-                    commit.blocks().iter().filter(|b| b.round > gc_round).for_each(|block_ref|{
-                        debug!(
-                            "Setting block {:?} as committed based on commit {:?}",
-                            block_ref,
-                            commit.index()
-                        );
-                        assert!(state.set_committed(block_ref), "Attempted to set again a block {:?} as committed when recovering commit {:?}", block_ref, commit);
-                    });
+                commit.blocks().iter().filter(|b| b.round > gc_round).for_each(|block_ref|{
+                    debug!(
+                        "Setting block {:?} as committed based on commit {:?}",
+                        block_ref,
+                        commit.index()
+                    );
+                    assert!(state.set_committed(block_ref), "Attempted to set again a block {:?} as committed when recovering commit {:?}", block_ref, commit);
+                });
 
-                    // All commits are indexed starting from 1, so one reach zero exit.
-                    index = index.saturating_sub(1);
-                    if index == 0 {
-                        break;
-                    }
+                // All commits are indexed starting from 1, so one reach zero exit.
+                index = index.saturating_sub(1);
+                if index == 0 {
+                    break;
                 }
             }
+        }
 
-            // Recover hard linked statuses for blocks within GC round.
-            let proposed_blocks = store
-                .scan_blocks_by_author(context.own_index, state.gc_round() + 1)
-                .expect("Database error");
-            for block in proposed_blocks {
-                state.link_causal_history(block.reference());
-            }
+        // Recover hard linked statuses for blocks within GC round.
+        let proposed_blocks = store
+            .scan_blocks_by_author(context.own_index, state.gc_round() + 1)
+            .expect("Database error");
+        for block in proposed_blocks {
+            state.link_causal_history(block.reference());
         }
 
         state
@@ -697,7 +683,7 @@ impl DagState {
 
         let eviction_round = self.evicted_rounds[slot.authority];
         if slot.round <= eviction_round {
-            panic!("{}", format!("Attempted to check for slot {slot} that is <= the last{}evicted round {eviction_round}", if self.gc_enabled() { " gc " } else { " " } ));
+            panic!("{}", format!("Attempted to check for slot {slot} that is <= the last evicted round {eviction_round}"));
         }
 
         let mut result = self.recent_refs_by_authority[slot.authority].range((
@@ -788,7 +774,6 @@ impl DagState {
     /// Returns the list of blocks that are newly linked.
     /// The returned blocks are guaranteed to be above the GC round.
     pub(crate) fn link_causal_history(&mut self, root_block: BlockRef) -> Vec<BlockRef> {
-        assert!(self.gc_enabled());
         let gc_round = self.gc_round();
         let mut linked_blocks = vec![];
         let mut targets = VecDeque::new();
@@ -992,18 +977,7 @@ impl DagState {
 
     pub(crate) fn calculate_gc_round(&self, commit_round: Round) -> Round {
         let gc_depth = self.context.protocol_config.gc_depth();
-        if gc_depth > 0 {
-            // GC is enabled, only then calculate the diff
-            commit_round.saturating_sub(gc_depth)
-        } else {
-            // Otherwise just return genesis round. That also acts as a safety mechanism so we never attempt to truncate anything
-            // even accidentally.
-            GENESIS_ROUND
-        }
-    }
-
-    pub(crate) fn gc_enabled(&self) -> bool {
-        self.context.protocol_config.gc_depth() > 0
+        commit_round.saturating_sub(gc_depth)
     }
 
     /// After each flush, DagState becomes persisted in storage and it expected to recover
@@ -1109,28 +1083,17 @@ impl DagState {
     /// guaranteed to have all the produced blocks from that authority. For any round that is
     /// <= `last_evicted_round` we don't have such guarantees as out of order blocks might exist.
     fn calculate_authority_eviction_round(&self, authority_index: AuthorityIndex) -> Round {
-        if self.gc_enabled() {
-            let last_round = self.recent_refs_by_authority[authority_index]
-                .last()
-                .map(|block_ref| block_ref.round)
-                .unwrap_or(GENESIS_ROUND);
+        let last_round = self.recent_refs_by_authority[authority_index]
+            .last()
+            .map(|block_ref| block_ref.round)
+            .unwrap_or(GENESIS_ROUND);
 
-            Self::gc_eviction_round(last_round, self.gc_round(), self.cached_rounds)
-        } else {
-            let commit_round = self.last_committed_rounds[authority_index];
-            Self::eviction_round(commit_round, self.cached_rounds)
-        }
-    }
-
-    /// Calculates the last eviction round based on the provided `commit_round`. Any blocks with
-    /// round <= the evict round have been cleaned up.
-    fn eviction_round(commit_round: Round, cached_rounds: Round) -> Round {
-        commit_round.saturating_sub(cached_rounds)
+        Self::eviction_round(last_round, self.gc_round(), self.cached_rounds)
     }
 
     /// Calculates the eviction round for the given authority. The goal is to keep at least `cached_rounds`
     /// of the latest blocks in the cache (if enough data is available), while evicting blocks with rounds <= `gc_round` when possible.
-    fn gc_eviction_round(last_round: Round, gc_round: Round, cached_rounds: u32) -> Round {
+    fn eviction_round(last_round: Round, gc_round: Round, cached_rounds: u32) -> Round {
         gc_round.min(last_round.saturating_sub(cached_rounds))
     }
 
@@ -1200,7 +1163,6 @@ mod test {
     use std::vec;
 
     use parking_lot::RwLock;
-    use rstest::rstest;
 
     use super::*;
     use crate::{
@@ -1707,56 +1669,11 @@ mod test {
     }
 
     #[tokio::test]
-    #[should_panic(
-        expected = "Attempted to check for slot [0]8 that is <= the last evicted round 8"
-    )]
-    async fn test_contains_cached_block_at_slot_panics_when_ask_out_of_range() {
-        /// Only keep elements up to 2 rounds before the last committed round
-        const CACHED_ROUNDS: Round = 2;
-
-        let (mut context, _) = Context::new_for_test(4);
-        context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
-        context
-            .protocol_config
-            .set_consensus_gc_depth_for_testing(0);
-
-        let context = Arc::new(context);
-        let store = Arc::new(MemStore::new());
-        let mut dag_state = DagState::new(context.clone(), store.clone());
-
-        // Create test blocks for round 1 ~ 10 for authority 0
-        let mut blocks = Vec::new();
-        for round in 1..=10 {
-            let block = VerifiedBlock::new_for_test(TestBlock::new(round, 0).build());
-            blocks.push(block.clone());
-            dag_state.accept_block(block);
-        }
-
-        // Now add a commit to trigger an eviction
-        dag_state.add_commit(TrustedCommit::new_for_test(
-            1 as CommitIndex,
-            CommitDigest::MIN,
-            0,
-            blocks.last().unwrap().reference(),
-            blocks
-                .into_iter()
-                .map(|block| block.reference())
-                .collect::<Vec<_>>(),
-        ));
-
-        dag_state.flush();
-
-        // When trying to request for authority 0 at block slot 8 it should panic, as anything
-        // that is <= commit_round - cached_rounds = 10 - 2 = 8 should be evicted
-        let _ =
-            dag_state.contains_cached_block_at_slot(Slot::new(8, AuthorityIndex::new_for_test(0)));
-    }
-
-    #[tokio::test]
+    #[ignore]
     #[should_panic(
         expected = "Attempted to check for slot [1]3 that is <= the last gc evicted round 3"
     )]
-    async fn test_contains_cached_block_at_slot_panics_when_ask_out_of_range_gc_enabled() {
+    async fn test_contains_cached_block_at_slot_panics_when_ask_out_of_range() {
         /// Keep 2 rounds from the highest committed round. This is considered universal and minimum necessary blocks to hold
         /// for the correct node operation.
         const GC_DEPTH: u32 = 2;
@@ -1886,105 +1803,6 @@ mod test {
     #[tokio::test]
     async fn test_flush_and_recovery() {
         telemetry_subscribers::init_for_testing();
-        let num_authorities: u32 = 4;
-        let (context, _) = Context::new_for_test(num_authorities as usize);
-        let context = Arc::new(context);
-        let store = Arc::new(MemStore::new());
-        let mut dag_state = DagState::new(context.clone(), store.clone());
-
-        // Create test blocks and commits for round 1 ~ 10
-        let num_rounds: u32 = 10;
-        let mut dag_builder = DagBuilder::new(context.clone());
-        dag_builder.layers(1..=num_rounds).build();
-        let mut commits = vec![];
-        for (_subdag, commit) in dag_builder.get_sub_dag_and_commits(1..=num_rounds) {
-            commits.push(commit);
-        }
-
-        // Add the blocks from first 5 rounds and first 5 commits to the dag state
-        let temp_commits = commits.split_off(5);
-        dag_state.accept_blocks(dag_builder.blocks(1..=5));
-        for commit in commits.clone() {
-            dag_state.add_commit(commit);
-        }
-
-        // Flush the dag state
-        dag_state.flush();
-
-        // Add the rest of the blocks and commits to the dag state
-        dag_state.accept_blocks(dag_builder.blocks(6..=num_rounds));
-        for commit in temp_commits.clone() {
-            dag_state.add_commit(commit);
-        }
-
-        // All blocks should be found in DagState.
-        let all_blocks = dag_builder.blocks(6..=num_rounds);
-        let block_refs = all_blocks
-            .iter()
-            .map(|block| block.reference())
-            .collect::<Vec<_>>();
-        let result = dag_state
-            .get_blocks(&block_refs)
-            .into_iter()
-            .map(|b| b.unwrap())
-            .collect::<Vec<_>>();
-        assert_eq!(result, all_blocks);
-
-        // Last commit index should be 10.
-        assert_eq!(dag_state.last_commit_index(), 10);
-        assert_eq!(
-            dag_state.last_committed_rounds(),
-            dag_builder.last_committed_rounds.clone()
-        );
-
-        // Destroy the dag state.
-        drop(dag_state);
-
-        // Recover the state from the store
-        let dag_state = DagState::new(context.clone(), store.clone());
-
-        // Blocks of first 5 rounds should be found in DagState.
-        let blocks = dag_builder.blocks(1..=5);
-        let block_refs = blocks
-            .iter()
-            .map(|block| block.reference())
-            .collect::<Vec<_>>();
-        let result = dag_state
-            .get_blocks(&block_refs)
-            .into_iter()
-            .map(|b| b.unwrap())
-            .collect::<Vec<_>>();
-        assert_eq!(result, blocks);
-
-        // Blocks above round 5 should not be in DagState, because they are not flushed.
-        let missing_blocks = dag_builder.blocks(6..=num_rounds);
-        let block_refs = missing_blocks
-            .iter()
-            .map(|block| block.reference())
-            .collect::<Vec<_>>();
-        let retrieved_blocks = dag_state
-            .get_blocks(&block_refs)
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>();
-        assert!(retrieved_blocks.is_empty());
-
-        // Last commit index should be 5.
-        assert_eq!(dag_state.last_commit_index(), 5);
-
-        // This is the last_commmit_rounds of the first 5 commits that were flushed
-        let expected_last_committed_rounds = vec![4, 5, 4, 4];
-        assert_eq!(
-            dag_state.last_committed_rounds(),
-            expected_last_committed_rounds
-        );
-        // Unscored subdags will be recoverd based on the flushed commits and no commit info
-        assert_eq!(dag_state.scoring_subdags_count(), 5);
-    }
-
-    #[tokio::test]
-    async fn test_flush_and_recovery_gc_enabled() {
-        telemetry_subscribers::init_for_testing();
 
         const GC_DEPTH: u32 = 3;
         const CACHED_ROUNDS: u32 = 4;
@@ -1995,9 +1813,6 @@ mod test {
         context
             .protocol_config
             .set_consensus_gc_depth_for_testing(GC_DEPTH);
-        context
-            .protocol_config
-            .set_consensus_linearize_subdag_v2_for_testing(true);
 
         let context = Arc::new(context);
 
@@ -2312,19 +2127,16 @@ mod test {
         assert_eq!(cached_blocks[0].round(), 10);
     }
 
-    #[rstest]
     #[tokio::test]
-    async fn test_get_last_cached_block(#[values(0, 1)] gc_depth: u32) {
+    async fn test_get_last_cached_block() {
         // GIVEN
         const CACHED_ROUNDS: Round = 2;
+        const GC_DEPTH: u32 = 1;
         let (mut context, _) = Context::new_for_test(4);
         context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
-
-        if gc_depth > 0 {
-            context
-                .protocol_config
-                .set_consensus_gc_depth_for_testing(gc_depth);
-        }
+        context
+            .protocol_config
+            .set_consensus_gc_depth_for_testing(GC_DEPTH);
 
         let context = Arc::new(context);
         let store = Arc::new(MemStore::new());
@@ -2455,56 +2267,6 @@ mod test {
         expected = "Attempted to request for blocks of rounds < 2, when the last evicted round is 1 for authority [2]"
     )]
     async fn test_get_cached_last_block_per_authority_requesting_out_of_round_range() {
-        // GIVEN
-        const CACHED_ROUNDS: Round = 1;
-        let (mut context, _) = Context::new_for_test(4);
-        context.parameters.dag_state_cached_rounds = CACHED_ROUNDS;
-        context
-            .protocol_config
-            .set_consensus_gc_depth_for_testing(0);
-
-        let context = Arc::new(context);
-        let store = Arc::new(MemStore::new());
-        let mut dag_state = DagState::new(context.clone(), store.clone());
-
-        // Create no blocks for authority 0
-        // Create one block (round 1) for authority 1
-        // Create two blocks (rounds 1,2) for authority 2
-        // Create three blocks (rounds 1,2,3) for authority 3
-        let mut all_blocks = Vec::new();
-        for author in 1..=3 {
-            for round in 1..=author {
-                let block = VerifiedBlock::new_for_test(TestBlock::new(round, author).build());
-                all_blocks.push(block.clone());
-                dag_state.accept_block(block);
-            }
-        }
-
-        dag_state.add_commit(TrustedCommit::new_for_test(
-            1 as CommitIndex,
-            CommitDigest::MIN,
-            0,
-            all_blocks.last().unwrap().reference(),
-            all_blocks
-                .into_iter()
-                .map(|block| block.reference())
-                .collect::<Vec<_>>(),
-        ));
-
-        // Flush the store so we keep in memory only the last 1 round from the last commit for each
-        // authority.
-        dag_state.flush();
-
-        // THEN the method should panic, as some authorities have already evicted rounds <= round 2
-        let end_round = 2;
-        dag_state.get_last_cached_block_per_authority(end_round);
-    }
-
-    #[tokio::test]
-    #[should_panic(
-        expected = "Attempted to request for blocks of rounds < 2, when the last evicted round is 1 for authority [2]"
-    )]
-    async fn test_get_cached_last_block_per_authority_requesting_out_of_round_range_gc_enabled() {
         // GIVEN
         const CACHED_ROUNDS: Round = 1;
         const GC_DEPTH: u32 = 1;

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -130,7 +130,6 @@ pub(crate) struct NodeMetrics {
     pub(crate) dag_state_store_read_count: IntCounterVec,
     pub(crate) dag_state_store_write_count: IntCounter,
     pub(crate) fetch_blocks_scheduler_inflight: IntGauge,
-    pub(crate) fetch_blocks_scheduler_skipped: IntCounterVec,
     pub(crate) synchronizer_fetched_blocks_by_peer: IntCounterVec,
     pub(crate) synchronizer_missing_blocks_by_authority: IntCounterVec,
     pub(crate) synchronizer_current_missing_blocks_by_authority: IntGaugeVec,
@@ -402,12 +401,6 @@ impl NodeMetrics {
                 "fetch_blocks_scheduler_inflight",
                 "Designates whether the synchronizer scheduler task to fetch blocks is currently running",
                 registry,
-            ).unwrap(),
-            fetch_blocks_scheduler_skipped: register_int_counter_vec_with_registry!(
-                "fetch_blocks_scheduler_skipped",
-                "Number of times the scheduler skipped fetching blocks",
-                &["reason"],
-                registry
             ).unwrap(),
             synchronizer_fetched_blocks_by_peer: register_int_counter_vec_with_registry!(
                 "synchronizer_fetched_blocks_by_peer",

--- a/consensus/core/src/subscriber.rs
+++ b/consensus/core/src/subscriber.rs
@@ -59,19 +59,18 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
         let context = self.context.clone();
         let network_client = self.network_client.clone();
         let authority_service = self.authority_service.clone();
-        let (mut last_received, gc_round, gc_enabled) = {
+        let (mut last_received, gc_round) = {
             let dag_state = self.dag_state.read();
             (
                 dag_state.get_last_block_for_authority(peer).round(),
                 dag_state.gc_round(),
-                dag_state.gc_enabled(),
             )
         };
 
         // If the latest block we have accepted by an authority is older than the current gc round,
         // then do not attempt to fetch any blocks from that point as they will simply be skipped. Instead
         // do attempt to fetch from the gc round.
-        if gc_enabled && last_received < gc_round {
+        if last_received < gc_round {
             info!(
                 "Last received block for peer {peer} is older than GC round, {last_received} < {gc_round}, fetching from GC round"
             );

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -39,7 +39,7 @@ use crate::{
     dag_state::DagState,
     error::{ConsensusError, ConsensusResult},
     network::NetworkClient,
-    BlockAPI, CommitIndex, Round,
+    BlockAPI, Round,
 };
 
 /// The number of concurrent fetch blocks requests per authority
@@ -903,7 +903,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
     }
 
     async fn start_fetch_missing_blocks_task(&mut self) -> ConsensusResult<()> {
-        let mut missing_blocks = self
+        let missing_blocks = self
             .core_dispatcher
             .get_missing_blocks()
             .await
@@ -924,35 +924,8 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         let commands_sender = self.commands_sender.clone();
         let dag_state = self.dag_state.clone();
 
-        let (commit_lagging, last_commit_index, quorum_commit_index) = self.is_commit_lagging();
-        if commit_lagging {
-            // If gc is enabled and we are commit lagging, then we don't want to enable the scheduler. As the new logic of processing the certified commits
-            // takes place we are guaranteed that commits will happen for all the certified commits.
-            if dag_state.read().gc_enabled() {
-                return Ok(());
-            }
-
-            // As node is commit lagging try to sync only the missing blocks that are within the acceptable round thresholds to sync. The rest we don't attempt to
-            // sync yet.
-            let highest_accepted_round = dag_state.read().highest_accepted_round();
-            missing_blocks = missing_blocks
-                .into_iter()
-                .take_while(|b| {
-                    b.round <= highest_accepted_round + self.missing_block_round_threshold()
-                })
-                .collect::<BTreeSet<_>>();
-
-            // If no missing blocks are within the acceptable thresholds to sync while we commit lag, then we disable the scheduler completely for this run.
-            if missing_blocks.is_empty() {
-                trace!("Scheduled synchronizer temporarily disabled as local commit is falling behind from quorum {last_commit_index} << {quorum_commit_index} and missing blocks are too far in the future.");
-                self.context
-                    .metrics
-                    .node_metrics
-                    .fetch_blocks_scheduler_skipped
-                    .with_label_values(&["commit_lagging"])
-                    .inc();
-                return Ok(());
-            }
+        if self.is_commit_lagging() {
+            return Ok(());
         }
 
         self.fetch_blocks_scheduler_task
@@ -990,25 +963,12 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         Ok(())
     }
 
-    /// The number of rounds above the highest accepted round to allow fetching missing blocks
-    /// via the periodic synchronization. Any missing blocks of higher rounds are considered
-    /// too far in the future to fetch. This property is used only when it's
-    /// detected that the node has fallen behind on its commit compared to the rest of the network,
-    /// otherwise scheduler will attempt to fetch any missing block.
-    fn missing_block_round_threshold(&self) -> Round {
-        self.context.parameters.commit_sync_batch_size
-    }
-
-    fn is_commit_lagging(&self) -> (bool, CommitIndex, CommitIndex) {
+    fn is_commit_lagging(&self) -> bool {
         let last_commit_index = self.dag_state.read().last_commit_index();
         let quorum_commit_index = self.commit_vote_monitor.quorum_commit_index();
         let commit_threshold = last_commit_index
             + self.context.parameters.commit_sync_batch_size * COMMIT_LAG_MULTIPLIER;
-        (
-            commit_threshold < quorum_commit_index,
-            last_commit_index,
-            quorum_commit_index,
-        )
+        commit_threshold < quorum_commit_index
     }
 
     /// Fetches the `missing_blocks` from available peers. The method will attempt to split the load amongst multiple (random) peers.
@@ -1357,6 +1317,7 @@ mod tests {
     use parking_lot::RwLock;
     use tokio::{sync::Mutex, time::sleep};
 
+    use crate::commit::{CommitVote, TrustedCommit};
     use crate::{
         authority_service::COMMIT_LAG_MULTIPLIER, core_thread::MockCoreThreadDispatcher,
         transaction_certifier::TransactionCertifier,
@@ -1376,10 +1337,6 @@ mod tests {
             InflightBlocksMap, Synchronizer, FETCH_BLOCKS_CONCURRENCY, FETCH_REQUEST_TIMEOUT,
         },
         CommitDigest, CommitIndex,
-    };
-    use crate::{
-        commit::{CommitVote, TrustedCommit},
-        BlockAPI,
     };
 
     type FetchRequestKey = (Vec<BlockRef>, AuthorityIndex);
@@ -1787,123 +1744,6 @@ mod tests {
             .await
             .unwrap()
             .is_empty());
-    }
-
-    #[tokio::test(flavor = "current_thread", start_paused = true)]
-    async fn synchronizer_periodic_task_when_commit_lagging_with_missing_blocks_in_acceptable_thresholds(
-    ) {
-        // GIVEN
-        let (mut context, _) = Context::new_for_test(4);
-
-        // We want to run this test only when gc is disabled. Once gc gets enabled this logic won't execute any more.
-        context
-            .protocol_config
-            .set_consensus_gc_depth_for_testing(0);
-        context
-            .protocol_config
-            .set_consensus_batched_block_sync_for_testing(true);
-
-        let context = Arc::new(context);
-        let block_verifier = Arc::new(NoopBlockVerifier {});
-        let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());
-        let network_client = Arc::new(MockNetworkClient::default());
-        let (blocks_sender, _blocks_receiver) =
-            monitored_mpsc::unbounded_channel("consensus_block_output");
-        let store = Arc::new(MemStore::new());
-        let dag_state = Arc::new(RwLock::new(DagState::new(context.clone(), store)));
-        let transaction_certifier =
-            TransactionCertifier::new(context.clone(), dag_state.clone(), blocks_sender);
-        let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));
-
-        // AND stub some missing blocks. The highest accepted round is 0.
-        // Create some blocks that are below and above the threshold sync.
-        let sync_missing_block_round_threshold = context.parameters.commit_sync_batch_size;
-        let expected_blocks = (1..sync_missing_block_round_threshold * 2)
-            .flat_map(|round| {
-                vec![
-                    VerifiedBlock::new_for_test(TestBlock::new(round, 0).build()),
-                    VerifiedBlock::new_for_test(TestBlock::new(round, 1).build()),
-                ]
-                .into_iter()
-            })
-            .collect::<Vec<_>>();
-
-        let missing_blocks = expected_blocks
-            .iter()
-            .map(|block| block.reference())
-            .collect::<BTreeSet<_>>();
-        core_dispatcher.stub_missing_blocks(missing_blocks).await;
-
-        // AND stub the requests for authority 1 & 2
-        // Make the first authority timeout, so the second will be called. "We" are authority = 0, so
-        // we are skipped anyways.
-        let stub_blocks = expected_blocks
-            .into_iter()
-            .filter(|block| block.round() <= sync_missing_block_round_threshold)
-            .collect::<Vec<_>>();
-        let mut expected_blocks = Vec::new();
-        for authority in [0, 1] {
-            let author = AuthorityIndex::new_for_test(authority);
-            let chunk = stub_blocks
-                .iter()
-                .filter(|block| block.author() == author)
-                .take(context.parameters.max_blocks_per_sync)
-                .cloned()
-                .collect::<Vec<_>>();
-            expected_blocks.extend(chunk.clone());
-            network_client
-                .stub_fetch_blocks(
-                    chunk.clone(),
-                    AuthorityIndex::new_for_test(1),
-                    Some(FETCH_REQUEST_TIMEOUT),
-                )
-                .await;
-            network_client
-                .stub_fetch_blocks(chunk, AuthorityIndex::new_for_test(2), None)
-                .await;
-        }
-
-        // Now create some blocks to simulate a commit lag
-        let round = context.parameters.commit_sync_batch_size * COMMIT_LAG_MULTIPLIER * 2;
-        let commit_index: CommitIndex = round - 1;
-        let blocks = (0..4)
-            .map(|authority| {
-                let commit_votes = vec![CommitVote::new(commit_index, CommitDigest::MIN)];
-                let block = TestBlock::new(round, authority)
-                    .set_commit_votes(commit_votes)
-                    .build();
-
-                VerifiedBlock::new_for_test(block)
-            })
-            .collect::<Vec<_>>();
-
-        // Pass them through the commit vote monitor - so now there will be a big commit lag to prevent
-        // the scheduled synchronizer from running
-        for block in blocks {
-            commit_vote_monitor.observe_block(&block);
-        }
-
-        // WHEN start the synchronizer and wait for a couple of seconds where normally the synchronizer should have kicked in.
-        let _handle = Synchronizer::start(
-            network_client.clone(),
-            context.clone(),
-            core_dispatcher.clone(),
-            commit_vote_monitor.clone(),
-            block_verifier.clone(),
-            transaction_certifier,
-            dag_state.clone(),
-            false,
-        );
-
-        sleep(4 * FETCH_REQUEST_TIMEOUT).await;
-
-        // We should be in commit lag mode, but since there are missing blocks within the acceptable round thresholds those ones should be fetched. Nothing above.
-        let mut added_blocks = core_dispatcher.get_add_blocks().await;
-
-        added_blocks.sort_by_key(|block| block.reference());
-        expected_blocks.sort_by_key(|block| block.reference());
-
-        assert_eq!(added_blocks, expected_blocks);
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -176,10 +176,6 @@ impl DagBuilder {
                 self.gc_round
             }
 
-            fn gc_enabled(&self) -> bool {
-                self.context.protocol_config.gc_depth() > 0
-            }
-
             fn set_committed(&mut self, block_ref: &BlockRef) -> bool {
                 let Some((block, committed)) = self.blocks.get_mut(block_ref) else {
                     panic!("Block {:?} should be found in store", block_ref);
@@ -224,12 +220,8 @@ impl DagBuilder {
 
             let leader_block_ref = leader_block.reference();
 
-            let (to_commit, rejected_transactions) = Linearizer::linearize_sub_dag(
-                &self.context.clone(),
-                leader_block.clone(),
-                self.last_committed_rounds.clone(),
-                &mut storage,
-            );
+            let (to_commit, rejected_transactions) =
+                Linearizer::linearize_sub_dag(leader_block.clone(), &mut storage);
 
             last_timestamp_ms = Linearizer::calculate_commit_timestamp(
                 &self.context.clone(),

--- a/consensus/simtests/src/tests/simtests.rs
+++ b/consensus/simtests/src/tests/simtests.rs
@@ -50,7 +50,7 @@ mod test {
             let (committee, keypairs) =
                 local_committee_and_keys(0, [1; NUM_OF_AUTHORITIES].to_vec());
             let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
-            protocol_config.set_consensus_gc_depth_for_testing(3);
+            protocol_config.set_consensus_for_testing(3);
             protocol_config
                 .set_consensus_median_based_commit_timestamp_for_testing(median_based_timestamp);
 


### PR DESCRIPTION
## Description 

When introduced garbage collection, all the related GC features did sit behind a feature flag. This PR is removing the unused paths since GC is now enabled for considerable amount of time. Same goes for the new linearizer logic, where the earlier one is cleaned up. This is simplifying the code and ensures we don't need to deal with obsolete logic.

## Test plan 

CI/PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
