### PR TITLE
[move-ide] Added a fix to better handle  mvr dependencies

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
   "publisher": "mysten",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "preview": true,
   "repository": {
     "url": "https://github.com/MystenLabs/sui.git",

--- a/external-crates/move/crates/move-analyzer/src/symbols/compilation.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols/compilation.rs
@@ -162,12 +162,14 @@ pub fn get_compiled_pkg(
     lint: LintLevel,
     implicit_deps: Dependencies,
 ) -> Result<(Option<CompiledPkgInfo>, BTreeMap<PathBuf, Vec<Diagnostic>>)> {
+    let cached_deps_exist = has_precompiled_deps(pkg_path, packages_info.clone());
     let build_config = move_package::BuildConfig {
         test_mode: true,
         install_dir: Some(tempdir().unwrap().path().to_path_buf()),
         default_flavor: Some(Flavor::Sui),
         lint_flag: lint.into(),
-        skip_fetch_latest_git_deps: has_precompiled_deps(pkg_path, packages_info.clone()),
+        force_lock_file: cached_deps_exist,
+        skip_fetch_latest_git_deps: cached_deps_exist,
         implicit_dependencies: implicit_deps,
         ..Default::default()
     };

--- a/external-crates/move/crates/move-package/src/lib.rs
+++ b/external-crates/move/crates/move-package/src/lib.rs
@@ -118,6 +118,11 @@ pub struct BuildConfig {
     /// Additional dependencies to be automatically included in every package
     #[clap(skip)]
     pub implicit_dependencies: Dependencies,
+
+    /// Forces use of lock file without checking if it needs to be updated
+    /// (regenerates it only if it doesn't exist)
+    #[clap(skip)]
+    pub force_lock_file: bool,
 }
 
 #[derive(
@@ -290,6 +295,7 @@ impl BuildConfig {
             writer,
             install_dir.clone(),
             self.implicit_dependencies.clone(),
+            self.force_lock_file,
         );
         let (dependency_graph, modified) = dep_graph_builder.get_graph(
             &DependencyKind::default(),

--- a/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
@@ -202,6 +202,9 @@ pub struct DependencyGraphBuilder<Progress: Write> {
     /// Set of implicit dependencies to add to every package
     /// Invariant: all dependencies are Internal deps with dep_override set
     implicit_deps: Dependencies,
+    /// Forces use of lock file without checking if it needs to be updated
+    /// (regenerates it only if it doesn't exist)
+    force_lock_file: bool,
 }
 
 impl<Progress: Write> DependencyGraphBuilder<Progress> {
@@ -210,6 +213,7 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
         progress_output: Progress,
         install_dir: PathBuf,
         implicit_deps: Dependencies,
+        force_lock_file: bool,
     ) -> Self {
         for (name, dep) in implicit_deps.iter() {
             assert!(
@@ -224,6 +228,7 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
             visited_dependencies: VecDeque::new(),
             install_dir,
             implicit_deps,
+            force_lock_file,
         }
     }
 
@@ -258,6 +263,30 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
             })
             .unwrap_or(None);
 
+        let root_pkg_id = custom_resolve_pkg_id(&root_manifest).with_context(|| {
+            format!(
+                "Resolving package name for '{}'",
+                root_manifest.package.name
+            )
+        })?;
+
+        let root_pkg_name = root_manifest.package.name;
+        if self.force_lock_file {
+            if let Some((_, _, Some(lock_string))) = digest_and_lock_contents {
+                eprintln!("Force-reading from lock file");
+                return Ok((
+                    DependencyGraph::read_from_lock(
+                        root_path,
+                        root_pkg_id,
+                        root_pkg_name,
+                        &mut lock_string.as_bytes(), // safe since old_deps_digest exists
+                        None,
+                    )?,
+                    false,
+                ));
+            }
+        }
+
         // implicits deps should be skipped if the manifest contains any of them
         // explicitly (or if the manifest is for a system package).
         let explicit_implicits: Vec<&Symbol> = self
@@ -289,14 +318,6 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
         }
 
         // collect sub-graphs for "regular" and "dev" dependencies
-        let root_pkg_id = custom_resolve_pkg_id(&root_manifest).with_context(|| {
-            format!(
-                "Resolving package name for '{}'",
-                root_manifest.package.name
-            )
-        })?;
-
-        let root_pkg_name = root_manifest.package.name;
         let (mut dep_graphs, resolved_id_deps, mut dep_names, mut overrides) = self
             .collect_graphs(
                 parent,

--- a/external-crates/move/crates/move-package/src/resolution/mod.rs
+++ b/external-crates/move/crates/move-package/src/resolution/mod.rs
@@ -39,6 +39,7 @@ pub fn download_dependency_repos<Progress: Write>(
         progress_output,
         install_dir,
         build_options.implicit_dependencies.clone(),
+        build_options.force_lock_file,
     );
     let (graph, _) = dep_graph_builder.get_graph(
         &DependencyKind::default(),

--- a/external-crates/move/crates/move-package/tests/test_additional_addresses.rs
+++ b/external-crates/move/crates/move-package/tests/test_additional_addresses.rs
@@ -32,6 +32,7 @@ fn test_additional_addresses() {
         std::io::sink(),
         tempdir().unwrap().path().to_path_buf(),
         /* implicit_deps */ Dependencies::default(),
+        /* force_lock_file */ false,
     );
     let (dg, _) = dep_graph_builder
         .get_graph(
@@ -95,6 +96,7 @@ fn test_additional_addresses_already_assigned_same_value() {
         std::io::sink(),
         tempdir().unwrap().path().to_path_buf(),
         /* implicit_deps */ Dependencies::default(),
+        /* force_lock_file */ false,
     );
     let (dg, _) = dep_graph_builder
         .get_graph(
@@ -144,6 +146,7 @@ fn test_additional_addresses_already_assigned_different_value() {
         std::io::sink(),
         tempdir().unwrap().path().to_path_buf(),
         /* implicit_deps */ Dependencies::default(),
+        /* force_lock_file */ false,
     );
     let (dg, _) = dep_graph_builder
         .get_graph(

--- a/external-crates/move/crates/move-package/tests/test_dependency_graph.rs
+++ b/external-crates/move/crates/move-package/tests/test_dependency_graph.rs
@@ -44,6 +44,7 @@ fn no_dep_graph() {
         std::io::sink(),
         tempfile::tempdir().unwrap().path().to_path_buf(),
         Dependencies::default(), /* implicit deps */
+        /* force_lock_file */ false,
     );
     let (graph, _) = dep_graph_builder
         .get_graph(
@@ -167,6 +168,7 @@ fn always_deps() {
         std::io::sink(),
         tempfile::tempdir().unwrap().path().to_path_buf(),
         /* implicit_deps */ Dependencies::default(),
+        /* force_lock_file */ false,
     );
     let (graph, _) = dep_graph_builder
         .get_graph(
@@ -584,6 +586,7 @@ fn immediate_dependencies() {
         std::io::sink(),
         tempfile::tempdir().unwrap().path().to_path_buf(),
         /* implicit_deps */ Dependencies::default(),
+        /* force_lock_file */ false,
     );
     let (graph, _) = dep_graph_builder
         .get_graph(

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move@compiled.snap
@@ -33,5 +33,6 @@ CompiledPackageInfo {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move@resolved.snap
@@ -42,6 +42,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "test": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move@compiled.snap
@@ -35,5 +35,6 @@ CompiledPackageInfo {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move@resolved.snap
@@ -42,6 +42,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "test": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move@compiled.snap
@@ -35,5 +35,6 @@ CompiledPackageInfo {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move@resolved.snap
@@ -42,6 +42,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "test": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_test_mode/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_test_mode/Move@compiled.snap
@@ -35,5 +35,6 @@ CompiledPackageInfo {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/dep_dev_dep_diamond/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/dep_dev_dep_diamond/Move@resolved.snap
@@ -131,6 +131,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/dep_good_digest/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/dep_good_digest/Move@resolved.snap
@@ -62,6 +62,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move@compiled.snap
@@ -36,5 +36,6 @@ CompiledPackageInfo {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move@resolved.snap
@@ -106,6 +106,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_dev_override_with_reg/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_dev_override_with_reg/Move@resolved.snap
@@ -112,6 +112,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_no_conflict/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_no_conflict/Move@resolved.snap
@@ -110,6 +110,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override/Move@resolved.snap
@@ -116,6 +116,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override_root/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override_root/Move@resolved.snap
@@ -132,6 +132,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_nested_override/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_nested_override/Move@resolved.snap
@@ -158,6 +158,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_override/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_override/Move@resolved.snap
@@ -114,6 +114,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_transitive_nested_override/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_transitive_nested_override/Move@resolved.snap
@@ -150,6 +150,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_two_nested_overrides/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_two_nested_overrides/Move@resolved.snap
@@ -166,6 +166,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_with_deps/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_with_deps/Move@resolved.snap
@@ -166,6 +166,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dual_override/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dual_override/Move@resolved.snap
@@ -166,6 +166,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move@compiled.snap
@@ -36,5 +36,6 @@ CompiledPackageInfo {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move@resolved.snap
@@ -106,6 +106,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v1/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v1/Move@resolved.snap
@@ -142,6 +142,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v2/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v2/Move@resolved.snap
@@ -142,6 +142,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/direct_and_indirect_dep/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/direct_and_indirect_dep/Move@resolved.snap
@@ -106,6 +106,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/external/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/external/Move@resolved.snap
@@ -84,6 +84,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move@resolved.snap
@@ -122,6 +122,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/external_overlap/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_overlap/Move@resolved.snap
@@ -92,6 +92,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/external_package_batch_response/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_package_batch_response/Move@resolved.snap
@@ -86,6 +86,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "Root": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/external_resolver_config/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_resolver_config/Move@resolved.snap
@@ -42,6 +42,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "Root": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/override/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/override/Move@resolved.snap
@@ -83,6 +83,7 @@ ResolvedGraph {
                 },
             ),
         },
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/override_dep_1/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/override_dep_1/Move@resolved.snap
@@ -135,6 +135,7 @@ ResolvedGraph {
                 },
             ),
         },
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/override_dep_2/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/override_dep_2/Move@resolved.snap
@@ -135,6 +135,7 @@ ResolvedGraph {
                 },
             ),
         },
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/override_root_1/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/override_root_1/Move@resolved.snap
@@ -127,6 +127,7 @@ ResolvedGraph {
                 },
             ),
         },
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/override_root_2/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/override_root_2/Move@resolved.snap
@@ -135,6 +135,7 @@ ResolvedGraph {
                 },
             ),
         },
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/simple/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/simple/Move@resolved.snap
@@ -109,6 +109,7 @@ ResolvedGraph {
                 },
             ),
         },
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/transitive/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/transitive/Move@resolved.snap
@@ -143,6 +143,7 @@ ResolvedGraph {
                 },
             ),
         },
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock/Move@resolved.snap
@@ -80,6 +80,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "C": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock_no_manifest/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock_no_manifest/Move@resolved.snap
@@ -80,6 +80,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "C": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename/Move@resolved.snap
@@ -80,6 +80,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "C": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename_one/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename_one/Move@compiled.snap
@@ -37,5 +37,6 @@ CompiledPackageInfo {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move@resolved.snap
@@ -88,6 +88,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "MoveNursery": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_deps_shared_override/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_deps_shared_override/Move@resolved.snap
@@ -122,6 +122,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "More": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_pruned_override/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_pruned_override/Move@resolved.snap
@@ -106,6 +106,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move@compiled.snap
@@ -35,5 +35,6 @@ CompiledPackageInfo {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move@resolved.snap
@@ -62,6 +62,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move@compiled.snap
@@ -35,5 +35,6 @@ CompiledPackageInfo {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move@resolved.snap
@@ -62,6 +62,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_multiple_of_same_name/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_multiple_of_same_name/Move@resolved.snap
@@ -62,6 +62,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move@compiled.snap
@@ -35,5 +35,6 @@ CompiledPackageInfo {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move@resolved.snap
@@ -62,6 +62,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_reassigned_address/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_reassigned_address/Move@resolved.snap
@@ -62,6 +62,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_renamed/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_renamed/Move@compiled.snap
@@ -35,5 +35,6 @@ CompiledPackageInfo {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_unification_across_local_renamings/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_unification_across_local_renamings/Move@resolved.snap
@@ -62,6 +62,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "OtherDep": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_with_scripts/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_with_scripts/Move@compiled.snap
@@ -35,5 +35,6 @@ CompiledPackageInfo {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024/Move@resolved.snap
@@ -42,6 +42,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_alpha/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_alpha/Move@resolved.snap
@@ -42,6 +42,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_beta/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_beta/Move@resolved.snap
@@ -42,6 +42,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_legacy/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_legacy/Move@resolved.snap
@@ -42,6 +42,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_global_storage/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_global_storage/Move@resolved.snap
@@ -42,6 +42,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_sui/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_sui/Move@resolved.snap
@@ -42,6 +42,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_invalid_identifier_package_name/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_invalid_identifier_package_name/Move@resolved.snap
@@ -42,6 +42,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "®´∑œ": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_minimal_manifest/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_minimal_manifest/Move@resolved.snap
@@ -42,6 +42,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "name": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move@compiled.snap
@@ -36,5 +36,6 @@ CompiledPackageInfo {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move@resolved.snap
@@ -106,6 +106,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A-resolved": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name_override/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name_override/Move@resolved.snap
@@ -114,6 +114,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A-resolved": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version/Move@resolved.snap
@@ -84,6 +84,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond/Move@resolved.snap
@@ -112,6 +112,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep/Move@resolved.snap
@@ -130,6 +130,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep_success/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep_success/Move@resolved.snap
@@ -132,6 +132,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_external/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_external/Move@resolved.snap
@@ -112,6 +112,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_override/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_override/Move@resolved.snap
@@ -120,6 +120,7 @@ ResolvedGraph {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
     package_table: {
         "A": Package {

--- a/external-crates/move/crates/move-package/tests/test_sources/test_symlinks/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/test_symlinks/Move@compiled.snap
@@ -35,5 +35,6 @@ CompiledPackageInfo {
             lint: false,
         },
         implicit_dependencies: {},
+        force_lock_file: false,
     },
 }


### PR DESCRIPTION
## Description 

By default, package manager runs all external resolvers on each build. This slows down `move-analyzer` to the point of it becoming unusable. This PR adds support for running external resolvers only on the fist build of Move source code done by `move-analyzer` (a flag added to package manager allows to unconditionally read from the lock file if it exits, without checking its freshness).

## Test plan 

Verified that build time in VSCode drops from 2-3 seconds to ~100ms withe MVR dependencies present
