### PR TITLE
[consensus] Return consensus position when calling submit_transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16263,6 +16263,7 @@ dependencies = [
  "chrono",
  "ciborium",
  "consensus-config",
+ "consensus-core",
  "coset",
  "criterion",
  "derive_more 1.0.0",

--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -28,7 +28,11 @@ pub(crate) struct TransactionsGuard {
     // A TransactionsGuard may be partially consumed by `TransactionConsumer`, in which case, this holds the remaining transactions.
     transactions: Vec<Transaction>,
 
-    included_in_block_ack: oneshot::Sender<(BlockRef, oneshot::Receiver<BlockStatus>)>,
+    included_in_block_ack: oneshot::Sender<(
+        BlockRef,
+        Vec<TransactionIndex>,
+        oneshot::Receiver<BlockStatus>,
+    )>,
 }
 
 /// The TransactionConsumer is responsible for fetching the next transactions to be included for the block proposals.
@@ -107,8 +111,15 @@ impl TransactionConsumer {
 
             total_bytes += transactions_bytes;
 
-            // The transactions can be consumed, register its ack.
-            acks.push(t.included_in_block_ack);
+            // Calculate indices for this batch
+            let start_idx = transactions.len() as TransactionIndex;
+            let indices: Vec<TransactionIndex> = (0..t.transactions.len())
+                .map(|i| start_idx + i as TransactionIndex)
+                .collect();
+
+            // The transactions can be consumed, register its ack and transaction
+            // indices to be sent with the ack.
+            acks.push((t.included_in_block_ack, indices));
             transactions.extend(t.transactions);
             None
         };
@@ -136,7 +147,7 @@ impl TransactionConsumer {
             Box::new(move |block_ref: BlockRef| {
                 let mut block_status_subscribers = block_status_subscribers.lock();
 
-                for ack in acks {
+                for (ack, tx_indices) in acks {
                     let (status_tx, status_rx) = oneshot::channel();
 
                     if gc_enabled {
@@ -150,7 +161,7 @@ impl TransactionConsumer {
                         status_tx.send(BlockStatus::Sequenced(block_ref)).ok();
                     }
 
-                    let _ = ack.send((block_ref, status_rx));
+                    let _ = ack.send((block_ref, tx_indices, status_rx));
                 }
             }),
             limit_reached,
@@ -262,8 +273,14 @@ impl TransactionClient {
     pub async fn submit(
         &self,
         transactions: Vec<Vec<u8>>,
-    ) -> Result<(BlockRef, oneshot::Receiver<BlockStatus>), ClientError> {
-        // TODO: Support returning the block refs for transactions that span multiple blocks
+    ) -> Result<
+        (
+            BlockRef,
+            Vec<TransactionIndex>,
+            oneshot::Receiver<BlockStatus>,
+        ),
+        ClientError,
+    > {
         let included_in_block = self.submit_no_wait(transactions).await?;
         included_in_block
             .await
@@ -283,7 +300,14 @@ impl TransactionClient {
     pub(crate) async fn submit_no_wait(
         &self,
         transactions: Vec<Vec<u8>>,
-    ) -> Result<oneshot::Receiver<(BlockRef, oneshot::Receiver<BlockStatus>)>, ClientError> {
+    ) -> Result<
+        oneshot::Receiver<(
+            BlockRef,
+            Vec<TransactionIndex>,
+            oneshot::Receiver<BlockStatus>,
+        )>,
+        ClientError,
+    > {
         let (included_in_block_ack_send, included_in_block_ack_receive) = oneshot::channel();
 
         let mut bundle_size = 0;
@@ -478,7 +502,7 @@ mod tests {
         // Now iterate over all the waiters. Everyone should have been acknowledged.
         let mut block_status_waiters = Vec::new();
         while let Some(result) = included_in_block_waiters.next().await {
-            let (block_ref, block_status_waiter) =
+            let (block_ref, _tx_indices, block_status_waiter) =
                 result.expect("Block inclusion waiter shouldn't fail");
             block_status_waiters.push((block_ref, block_status_waiter));
         }
@@ -548,7 +572,7 @@ mod tests {
         // Now iterate over all the waiters. Everyone should have been acknowledged.
         let mut block_status_waiters = Vec::new();
         while let Some(result) = included_in_block_waiters.next().await {
-            let (block_ref, block_status_waiter) =
+            let (block_ref, _tx_indices, block_status_waiter) =
                 result.expect("Block inclusion waiter shouldn't fail");
             block_status_waiters.push((block_ref, block_status_waiter));
         }

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -340,10 +340,6 @@ impl LocalValidatorAggregatorProxy {
             .submit_transaction(
                 SubmitTxRequest {
                     transaction: tx.clone(),
-                    include_events: true,
-                    include_input_objects: false,
-                    include_output_objects: false,
-                    include_auxiliary_data: false,
                 },
                 SubmitTransactionOptions::default(),
             )

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -28,8 +28,9 @@ use sui_network::tonic::transport::Channel;
 use sui_types::messages_grpc::{
     HandleCertificateRequestV3, HandleCertificateResponseV2, HandleCertificateResponseV3,
     HandleSoftBundleCertificatesRequestV3, HandleSoftBundleCertificatesResponseV3,
-    HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse, RawSubmitTxRequest,
-    RawSubmitTxResponse, SystemStateRequest, TransactionInfoRequest, TransactionInfoResponse,
+    HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse, RawGetEffectsRequest,
+    RawGetEffectsResponse, RawSubmitTxRequest, RawSubmitTxResponse, SystemStateRequest,
+    TransactionInfoRequest, TransactionInfoResponse,
 };
 
 #[async_trait]
@@ -39,6 +40,12 @@ pub trait AuthorityAPI {
         request: RawSubmitTxRequest,
         client_addr: Option<SocketAddr>,
     ) -> Result<RawSubmitTxResponse, SuiError>;
+
+    async fn get_effects(
+        &self,
+        request: RawGetEffectsRequest,
+        client_addr: Option<SocketAddr>,
+    ) -> Result<RawGetEffectsResponse, SuiError>;
 
     /// Initiate a new transaction to a Sui or Primary account.
     async fn handle_transaction(
@@ -165,6 +172,22 @@ impl AuthorityAPI for NetworkAuthorityClient {
 
         self.client()?
             .submit_transaction(request)
+            .await
+            .map(tonic::Response::into_inner)
+            .map_err(Into::into)
+    }
+
+    /// Get effects for a submmitted transaction to the Sui network.
+    async fn get_effects(
+        &self,
+        request: RawGetEffectsRequest,
+        client_addr: Option<SocketAddr>,
+    ) -> Result<RawGetEffectsResponse, SuiError> {
+        let mut request = request.into_request();
+        insert_metadata(&mut request, client_addr);
+
+        self.client()?
+            .get_effects(request)
             .await
             .map(tonic::Response::into_inner)
             .map_err(Into::into)

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -22,9 +22,6 @@ use sui_network::{
     tonic,
 };
 use sui_types::messages_grpc::{
-    HandleCertificateRequestV3, HandleCertificateResponseV3, RawSubmitTxResponse,
-};
-use sui_types::messages_grpc::{
     HandleCertificateResponseV2, HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse,
     SubmitCertificateResponse, SystemStateRequest, TransactionInfoRequest, TransactionInfoResponse,
 };
@@ -34,7 +31,7 @@ use sui_types::messages_grpc::{
 use sui_types::multiaddr::Multiaddr;
 use sui_types::sui_system_state::SuiSystemState;
 use sui_types::traffic_control::{ClientIdSource, PolicyConfig, RemoteFirewallConfig, Weight};
-use sui_types::{effects::TransactionEffectsAPI, messages_grpc::SubmitTxResponse};
+use sui_types::{effects::TransactionEffectsAPI, messages_grpc::GetEffectsResponse};
 use sui_types::{error::*, transaction::*};
 use sui_types::{
     fp_ensure,
@@ -43,10 +40,18 @@ use sui_types::{
     },
 };
 use sui_types::{
+    messages_consensus::ConsensusTxPosition,
+    messages_grpc::{
+        HandleCertificateRequestV3, HandleCertificateResponseV3, RawGetEffectsResponse,
+        RawSubmitTxRequest, RawSubmitTxResponse,
+    },
+};
+use sui_types::{
     messages_consensus::{ConsensusTransaction, ConsensusTransactionKind},
-    messages_grpc::RawSubmitTxRequest,
+    messages_grpc::RawGetEffectsRequest,
 };
 use tap::TapFallible;
+use tokio::sync::oneshot;
 use tonic::metadata::{Ascii, MetadataValue};
 use tracing::{error, error_span, info, Instrument};
 
@@ -525,6 +530,97 @@ impl ValidatorService {
                 error: e.to_string(),
             }
         })?;
+        transaction.validity_check(epoch_store.protocol_config(), epoch_store.epoch())?;
+
+        // Check system overload
+        let overload_check_res = self.state.check_system_overload(
+            &*consensus_adapter,
+            transaction.data(),
+            state.check_system_overload_at_signing(),
+        );
+        if let Err(error) = overload_check_res {
+            metrics
+                .num_rejected_tx_during_overload
+                .with_label_values(&[error.as_ref()])
+                .inc();
+            return Err(error.into());
+        }
+
+        let _handle_tx_metrics_guard = metrics.handle_submit_transaction_latency.start_timer();
+
+        let transaction = {
+            let _metrics_guard = metrics.tx_verification_latency.start_timer();
+            epoch_store.verify_transaction(transaction).tap_err(|_| {
+                metrics.signature_errors.inc();
+            })?
+        };
+
+        // Enable Trace Propagation across spans/processes using tx_digest
+        let tx_digest = transaction.digest();
+        let _span = error_span!("validator_state_submit_transaction", ?tx_digest);
+
+        // TODO(fastpath): Skip checking for execution effects
+        // Effects are useless in mfp if they cannot be mapped to a consensus
+        // position
+        let _ = state
+            .handle_vote_transaction(&epoch_store, transaction.clone())
+            .tap_err(|e| {
+                if let SuiError::ValidatorHaltedAtEpochEnd = e {
+                    metrics.num_rejected_tx_in_epoch_boundary.inc();
+                }
+            })?;
+
+        let _latency_metric_guard = metrics
+            .handle_submit_transaction_consensus_latency
+            .start_timer();
+        let span = error_span!("submit_transaction", tx_digest = ?transaction.digest());
+        self.handle_submit_to_consensus_for_position(
+            nonempty![ConsensusTransaction::new_user_transaction_message(
+                &self.state.name,
+                transaction.into()
+            )],
+            &epoch_store,
+        )
+        .instrument(span)
+        .await
+        .and_then(|(mut resp, spam_weight)| {
+            // Only submitting a single tx so we should get back a single consensus position
+            let consensus_position = resp.remove(0);
+
+            let submit_transaction_response = RawSubmitTxResponse::into_raw(consensus_position)?;
+
+            Ok((
+                tonic::Response::new(submit_transaction_response),
+                spam_weight,
+            ))
+        })
+    }
+
+    async fn handle_get_effects(
+        &self,
+        request: tonic::Request<RawGetEffectsRequest>,
+    ) -> WrappedServiceResponse<RawGetEffectsResponse> {
+        let Self {
+            state,
+            consensus_adapter,
+            metrics,
+            traffic_controller: _,
+            client_id_source: _,
+        } = self.clone();
+        let epoch_store = state.load_epoch_store_one_call_per_task();
+        if !epoch_store.protocol_config().mysticeti_fastpath() {
+            return Err(SuiError::UnsupportedFeatureError {
+                error: "Mysticeti fastpath".to_string(),
+            }
+            .into());
+        }
+
+        let request = request.into_inner();
+        let transaction = bcs::from_bytes::<Transaction>(&request.transaction).map_err(|e| {
+            SuiError::TransactionDeserializationError {
+                error: e.to_string(),
+            }
+        })?;
         let include_events = request.include_events;
         let include_input_objects = request.include_input_objects;
         let include_output_objects = request.include_output_objects;
@@ -564,6 +660,7 @@ impl ValidatorService {
                     metrics.num_rejected_tx_in_epoch_boundary.inc();
                 }
             })?;
+
         // Fetch remaining fields if the transaction has been executed.
         if let Some((effects, events)) = tx_output {
             let input_objects = include_input_objects
@@ -573,8 +670,8 @@ impl ValidatorService {
                 .then(|| state.get_transaction_output_objects(&effects))
                 .and_then(Result::ok);
 
-            return Ok((
-                tonic::Response::new(RawSubmitTxResponse::into_raw(
+            Ok((
+                tonic::Response::new(RawGetEffectsResponse::into_raw(
                     effects,
                     include_events,
                     Some(events),
@@ -582,47 +679,13 @@ impl ValidatorService {
                     output_objects,
                 )?),
                 Weight::zero(),
-            ));
-        }
-
-        let _latency_metric_guard = metrics
-            .handle_submit_transaction_consensus_latency
-            .start_timer();
-        let span = error_span!("submit_transaction", tx_digest = ?transaction.digest());
-        self.handle_submit_to_consensus(
-            nonempty![ConsensusTransaction::new_user_transaction_message(
-                &self.state.name,
-                transaction.into()
-            )],
-            include_events,
-            include_input_objects,
-            include_output_objects,
-            false,
-            &epoch_store,
-            true,
-        )
-        .instrument(span)
-        .await
-        .and_then(|(resp, spam_weight)| {
-            let transaction_response = resp
-                .expect(
-                    "handle_submit_to_consensus should not return none with wait_for_effects=true",
-                )
-                .remove(0);
-
-            let submit_transaction_response = RawSubmitTxResponse::into_raw(
-                transaction_response.effects,
-                include_events,
-                transaction_response.events,
-                transaction_response.input_objects,
-                transaction_response.output_objects,
-            )?;
-
-            Ok((
-                tonic::Response::new(submit_transaction_response),
-                spam_weight,
             ))
-        })
+        } else {
+            Err(SuiError::TransactionEffectsNotFound {
+                digest: *transaction.digest(),
+            }
+            .into())
+        }
     }
 
     // In addition to the response from handling the certificates,
@@ -777,6 +840,50 @@ impl ValidatorService {
         Ok((responses, weight))
     }
 
+    async fn handle_submit_to_consensus_for_position(
+        &self,
+        consensus_transactions: NonEmpty<ConsensusTransaction>,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) -> Result<(Vec<ConsensusTxPosition>, Weight), tonic::Status> {
+        let consensus_transactions: Vec<_> = consensus_transactions.into();
+        let (tx_consensus_positions, rx_consensus_positions) = oneshot::channel();
+        {
+            // code block within reconfiguration lock
+            let reconfiguration_lock = epoch_store.get_reconfig_state_read_lock_guard();
+            if !reconfiguration_lock.should_accept_user_certs() {
+                self.metrics.num_rejected_cert_in_epoch_boundary.inc();
+                return Err(SuiError::ValidatorHaltedAtEpochEnd.into());
+            }
+
+            // TODO(fastpath): Should we resubmit anyways as the caller needs a consensus position?
+            // Check if all transactions are already processed
+            if epoch_store.all_external_consensus_messages_processed(
+                consensus_transactions.iter().map(|tx| tx.key()),
+            )? {
+                return Err(SuiError::FailedToSubmitToConsensus(
+                    "Transactions already processed by consensus".to_string(),
+                )
+                .into());
+            }
+
+            // Submit to consensus and wait for position
+            let _metrics_guard = self.metrics.consensus_latency.start_timer();
+
+            self.consensus_adapter.submit_batch(
+                &consensus_transactions,
+                Some(&reconfiguration_lock),
+                epoch_store,
+                Some(tx_consensus_positions),
+            )?;
+        }
+
+        let consensus_positions = rx_consensus_positions.await.map_err(|_| {
+            SuiError::FailedToSubmitToConsensus("Failed to get consensus position".to_string())
+        })?;
+
+        Ok((consensus_positions, Weight::zero()))
+    }
+
     async fn handle_submit_to_consensus(
         &self,
         consensus_transactions: NonEmpty<ConsensusTransaction>,
@@ -786,7 +893,7 @@ impl ValidatorService {
         _include_auxiliary_data: bool,
         epoch_store: &Arc<AuthorityPerEpochStore>,
         wait_for_effects: bool,
-    ) -> Result<(Option<Vec<SubmitTxResponse>>, Weight), tonic::Status> {
+    ) -> Result<(Option<Vec<GetEffectsResponse>>, Weight), tonic::Status> {
         let consensus_transactions: Vec<_> = consensus_transactions.into();
         {
             // code block within reconfiguration lock
@@ -809,6 +916,7 @@ impl ValidatorService {
                     &consensus_transactions,
                     Some(&reconfiguration_lock),
                     epoch_store,
+                    None,
                 )?;
                 // Do not wait for the result, because the transaction might have already executed.
                 // Instead, check or wait for the existence of certificate effects below.
@@ -879,7 +987,7 @@ impl ValidatorService {
                     // TODO(fastpath): Make sure consensus handler does this for a UserTransaction.
                 }
 
-                Ok::<_, SuiError>(SubmitTxResponse {
+                Ok::<_, SuiError>(GetEffectsResponse {
                     effects,
                     events,
                     input_objects,
@@ -909,6 +1017,13 @@ impl ValidatorService {
         request: tonic::Request<RawSubmitTxRequest>,
     ) -> WrappedServiceResponse<RawSubmitTxResponse> {
         self.handle_submit_transaction(request).await
+    }
+
+    async fn handle_get_effects_impl(
+        &self,
+        request: tonic::Request<RawGetEffectsRequest>,
+    ) -> WrappedServiceResponse<RawGetEffectsResponse> {
+        self.handle_get_effects(request).await
     }
 
     async fn submit_certificate_impl(
@@ -1434,6 +1549,23 @@ impl Validator for ValidatorService {
             // NB: traffic tally wrapping handled within the task rather than on task exit
             // to prevent an attacker from subverting traffic control by severing the connection
             handle_with_decoration!(validator_service, handle_submit_transaction_impl, request)
+        })
+        .await
+        .unwrap()
+    }
+
+    async fn get_effects(
+        &self,
+        request: tonic::Request<RawGetEffectsRequest>,
+    ) -> Result<tonic::Response<RawGetEffectsResponse>, tonic::Status> {
+        let validator_service = self.clone();
+
+        // Spawns a task which handles the transaction effects. The task will unconditionally continue
+        // processing in the event that the client connection is dropped.
+        spawn_monitored_task!(async move {
+            // NB: traffic tally wrapping handled within the task rather than on task exit
+            // to prevent an attacker from subverting traffic control by severing the connection
+            handle_with_decoration!(validator_service, handle_get_effects_impl, request)
         })
         .await
         .unwrap()

--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -19,7 +19,7 @@ use sui_config::{ConsensusConfig, NodeConfig};
 use sui_protocol_config::ProtocolVersion;
 use sui_types::committee::EpochId;
 use sui_types::error::SuiResult;
-use sui_types::messages_consensus::ConsensusTransaction;
+use sui_types::messages_consensus::{ConsensusTransaction, ConsensusTxPosition};
 use tokio::sync::{Mutex, MutexGuard};
 use tokio::time::{sleep, timeout};
 use tracing::info;
@@ -215,7 +215,7 @@ impl ConsensusClient for UpdatableConsensusClient {
         &self,
         transactions: &[ConsensusTransaction],
         epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> SuiResult<BlockStatusReceiver> {
+    ) -> SuiResult<(Vec<ConsensusTxPosition>, BlockStatusReceiver)> {
         let client = self.get().await;
         client.submit(transactions, epoch_store).await
     }

--- a/crates/sui-core/src/epoch/randomness.rs
+++ b/crates/sui-core/src/epoch/randomness.rs
@@ -854,7 +854,12 @@ mod tests {
                     tx_consensus.try_send(transactions.to_vec()).unwrap();
                     true
                 })
-                .returning(|_, _| Ok(with_block_status(BlockStatus::Sequenced(BlockRef::MIN))));
+                .returning(|_, _| {
+                    Ok((
+                        Vec::new(),
+                        with_block_status(BlockStatus::Sequenced(BlockRef::MIN)),
+                    ))
+                });
 
             let state = TestAuthorityBuilder::new()
                 .with_protocol_config(protocol_config.clone())
@@ -1002,9 +1007,10 @@ mod tests {
                     true
                 })
                 .returning(|_, _| {
-                    Ok(with_block_status(consensus_core::BlockStatus::Sequenced(
-                        BlockRef::MIN,
-                    )))
+                    Ok((
+                        Vec::new(),
+                        with_block_status(consensus_core::BlockStatus::Sequenced(BlockRef::MIN)),
+                    ))
                 });
 
             let state = TestAuthorityBuilder::new()

--- a/crates/sui-core/src/mock_consensus.rs
+++ b/crates/sui-core/src/mock_consensus.rs
@@ -12,7 +12,9 @@ use std::sync::{Arc, Weak};
 use std::time::Duration;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
-use sui_types::messages_consensus::{ConsensusTransaction, ConsensusTransactionKind};
+use sui_types::messages_consensus::{
+    ConsensusTransaction, ConsensusTransactionKind, ConsensusTxPosition,
+};
 use sui_types::transaction::{VerifiedCertificate, VerifiedTransaction};
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
@@ -99,16 +101,20 @@ impl MockConsensusClient {
         }
     }
 
-    fn submit_impl(&self, transactions: &[ConsensusTransaction]) -> SuiResult<BlockStatusReceiver> {
+    fn submit_impl(
+        &self,
+        transactions: &[ConsensusTransaction],
+    ) -> SuiResult<(Vec<ConsensusTxPosition>, BlockStatusReceiver)> {
         // TODO: maybe support multi-transactions and remove this check
         assert!(transactions.len() == 1);
         let transaction = &transactions[0];
         self.tx_sender
             .try_send(transaction.clone())
             .map_err(|_| SuiError::from("MockConsensusClient channel overflowed"))?;
-        Ok(with_block_status(consensus_core::BlockStatus::Sequenced(
-            BlockRef::MIN,
-        )))
+        Ok((
+            Vec::new(),
+            with_block_status(consensus_core::BlockStatus::Sequenced(BlockRef::MIN)),
+        ))
     }
 }
 
@@ -137,7 +143,7 @@ impl ConsensusClient for MockConsensusClient {
         &self,
         transactions: &[ConsensusTransaction],
         _epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> SuiResult<BlockStatusReceiver> {
+    ) -> SuiResult<(Vec<ConsensusTxPosition>, BlockStatusReceiver)> {
         self.submit_impl(transactions)
     }
 }

--- a/crates/sui-core/src/mysticeti_adapter.rs
+++ b/crates/sui-core/src/mysticeti_adapter.rs
@@ -7,7 +7,7 @@ use arc_swap::{ArcSwapOption, Guard};
 use consensus_core::{ClientError, TransactionClient};
 use sui_types::{
     error::{SuiError, SuiResult},
-    messages_consensus::{ConsensusTransaction, ConsensusTransactionKind},
+    messages_consensus::{ConsensusTransaction, ConsensusTransactionKind, ConsensusTxPosition},
 };
 use tap::prelude::*;
 use tokio::time::{sleep, Instant};
@@ -80,7 +80,7 @@ impl ConsensusClient for LazyMysticetiClient {
         &self,
         transactions: &[ConsensusTransaction],
         _epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) -> SuiResult<BlockStatusReceiver> {
+    ) -> SuiResult<(Vec<ConsensusTxPosition>, BlockStatusReceiver)> {
         // TODO(mysticeti): confirm comment is still true
         // The retrieved TransactionClient can be from the past epoch. Submit would fail after
         // Mysticeti shuts down, so there should be no correctness issue.
@@ -89,7 +89,7 @@ impl ConsensusClient for LazyMysticetiClient {
             .iter()
             .map(|t| bcs::to_bytes(t).expect("Serializing consensus transaction cannot fail"))
             .collect::<Vec<_>>();
-        let (block_ref, status_waiter) = client
+        let (block_ref, tx_indices, status_waiter) = client
             .as_ref()
             .expect("Client should always be returned")
             .submit(transactions_bytes)
@@ -129,6 +129,15 @@ impl ConsensusClient for LazyMysticetiClient {
             let transaction_key = SequencedConsensusTransactionKey::External(transactions[0].key());
             tracing::info!("Transaction {transaction_key:?} was included in {block_ref}",)
         };
-        Ok(status_waiter)
+
+        // Calculate consensus tx positions
+        let mut consensus_positions = Vec::new();
+        for index in tx_indices {
+            consensus_positions.push(ConsensusTxPosition {
+                index,
+                block: block_ref,
+            });
+        }
+        Ok((consensus_positions, status_waiter))
     }
 }

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -11,13 +11,15 @@ use std::{
 use crate::authority::test_authority_builder::TestAuthorityBuilder;
 use crate::{authority::AuthorityState, authority_client::AuthorityAPI};
 use async_trait::async_trait;
+use consensus_core::BlockRef;
 use mysten_metrics::spawn_monitored_task;
 use sui_config::genesis::Genesis;
 use sui_types::{
     crypto::AuthorityKeyPair,
     error::SuiError,
-    executable_transaction::VerifiedExecutableTransaction,
     messages_checkpoint::{CheckpointRequest, CheckpointResponse},
+    messages_consensus::ConsensusTxPosition,
+    messages_grpc::{RawSubmitTxRequest, RawSubmitTxResponse},
     transaction::{CertifiedTransaction, Transaction, VerifiedTransaction},
 };
 use sui_types::{
@@ -32,7 +34,7 @@ use sui_types::{
     messages_grpc::{
         HandleCertificateResponseV2, HandleSoftBundleCertificatesRequestV3,
         HandleSoftBundleCertificatesResponseV3, HandleTransactionResponse, ObjectInfoRequest,
-        ObjectInfoResponse, RawSubmitTxRequest, RawSubmitTxResponse, SystemStateRequest,
+        ObjectInfoResponse, RawGetEffectsRequest, RawGetEffectsResponse, SystemStateRequest,
         TransactionInfoRequest, TransactionInfoResponse,
     },
     sui_system_state::SuiSystemState,
@@ -81,7 +83,7 @@ impl AuthorityAPI for LocalAuthorityClient {
         let transaction = epoch_store
             .verify_transaction(deserialized_transaction.clone())
             .map(|_| VerifiedTransaction::new_from_verified(deserialized_transaction))?;
-        let tx_output = state.handle_vote_transaction(&epoch_store, transaction.clone())?;
+        let _tx_output = state.handle_vote_transaction(&epoch_store, transaction.clone())?;
         if self.fault_config.fail_after_vote_transaction {
             return Err(SuiError::GenericAuthorityError {
                 error: "Mock error after vote transaction in submit_transaction".to_owned(),
@@ -93,6 +95,33 @@ impl AuthorityAPI for LocalAuthorityClient {
             });
         }
 
+        // No submission to consensus is needed for test authority client, return
+        // dummy consensus position
+        // TODO(fastpath): Return the actual consensus position
+        let consensus_position = ConsensusTxPosition {
+            block: BlockRef::MIN,
+            index: 0,
+        };
+
+        RawSubmitTxResponse::into_raw(consensus_position)
+    }
+
+    async fn get_effects(
+        &self,
+        request: RawGetEffectsRequest,
+        _client_addr: Option<SocketAddr>,
+    ) -> Result<RawGetEffectsResponse, SuiError> {
+        let state = self.state.clone();
+        let epoch_store = self.state.load_epoch_store_one_call_per_task();
+        let deserialized_transaction = bcs::from_bytes::<Transaction>(&request.transaction)
+            .map_err(|e| SuiError::TransactionDeserializationError {
+                error: e.to_string(),
+            })?;
+        let transaction = epoch_store
+            .verify_transaction(deserialized_transaction.clone())
+            .map(|_| VerifiedTransaction::new_from_verified(deserialized_transaction))?;
+        let tx_output = state.handle_vote_transaction(&epoch_store, transaction.clone())?;
+
         if let Some((effects, events)) = tx_output {
             let input_objects = request
                 .include_input_objects
@@ -103,7 +132,7 @@ impl AuthorityAPI for LocalAuthorityClient {
                 .then(|| state.get_transaction_output_objects(&effects))
                 .and_then(Result::ok);
 
-            return Ok(RawSubmitTxResponse {
+            return Ok(RawGetEffectsResponse {
                 effects: bcs::to_bytes(&effects)
                     .map_err(|e| SuiError::TransactionEffectsSerializationError {
                         error: e.to_string(),
@@ -135,69 +164,11 @@ impl AuthorityAPI for LocalAuthorityClient {
                     })
                     .collect::<Result<_, _>>()?,
             });
+        } else {
+            return Err(SuiError::TransactionEffectsNotFound {
+                digest: *transaction.digest(),
+            });
         }
-
-        let effects = self
-            .state
-            .execute_transaction(
-                &VerifiedExecutableTransaction::new_from_consensus(
-                    transaction.clone(),
-                    epoch_store.epoch(),
-                ),
-                &epoch_store,
-            )
-            .await?;
-        let events = (request.include_events && effects.events_digest().is_some())
-            .then(|| {
-                self.state
-                    .get_transaction_events(effects.transaction_digest())
-            })
-            .transpose()?;
-
-        let input_objects = request
-            .include_input_objects
-            .then(|| self.state.get_transaction_input_objects(&effects))
-            .and_then(Result::ok);
-
-        let output_objects = request
-            .include_output_objects
-            .then(|| self.state.get_transaction_output_objects(&effects))
-            .and_then(Result::ok);
-
-        Ok::<_, SuiError>(RawSubmitTxResponse {
-            effects: bcs::to_bytes(&effects)
-                .map_err(|e| SuiError::TransactionEffectsSerializationError {
-                    error: e.to_string(),
-                })?
-                .into(),
-            events: events
-                .map(|e| {
-                    bcs::to_bytes(&e).map(|v| v.into()).map_err(|e| {
-                        SuiError::TransactionEventsSerializationError {
-                            error: e.to_string(),
-                        }
-                    })
-                })
-                .transpose()?,
-            input_objects: input_objects
-                .unwrap_or_default()
-                .into_iter()
-                .map(|obj| {
-                    bcs::to_bytes(&obj).map_err(|e| SuiError::ObjectSerializationError {
-                        error: e.to_string(),
-                    })
-                })
-                .collect::<Result<_, _>>()?,
-            output_objects: output_objects
-                .unwrap_or_default()
-                .into_iter()
-                .map(|obj| {
-                    bcs::to_bytes(&obj).map_err(|e| SuiError::ObjectSerializationError {
-                        error: e.to_string(),
-                    })
-                })
-                .collect::<Result<_, _>>()?,
-        })
     }
 
     async fn handle_transaction(
@@ -436,6 +407,14 @@ impl AuthorityAPI for MockAuthorityApi {
         unimplemented!();
     }
 
+    async fn get_effects(
+        &self,
+        _request: RawGetEffectsRequest,
+        _client_addr: Option<SocketAddr>,
+    ) -> Result<RawGetEffectsResponse, SuiError> {
+        unimplemented!()
+    }
+
     /// Initiate a new transaction to a Sui or Primary account.
     async fn handle_transaction(
         &self,
@@ -537,6 +516,14 @@ impl AuthorityAPI for HandleTransactionTestAuthorityClient {
         _request: RawSubmitTxRequest,
         _client_addr: Option<SocketAddr>,
     ) -> Result<RawSubmitTxResponse, SuiError> {
+        unimplemented!()
+    }
+
+    async fn get_effects(
+        &self,
+        _request: RawGetEffectsRequest,
+        _client_addr: Option<SocketAddr>,
+    ) -> Result<RawGetEffectsResponse, SuiError> {
         unimplemented!()
     }
 

--- a/crates/sui-core/src/transaction_driver/message_types.rs
+++ b/crates/sui-core/src/transaction_driver/message_types.rs
@@ -11,11 +11,6 @@ use sui_types::{
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct SubmitTxRequest {
     pub transaction: Transaction,
-
-    pub include_events: bool,
-    pub include_input_objects: bool,
-    pub include_output_objects: bool,
-    pub include_auxiliary_data: bool,
 }
 
 impl SubmitTxRequest {
@@ -26,9 +21,6 @@ impl SubmitTxRequest {
                     error: e.to_string(),
                 })?
                 .into(),
-            include_events: self.include_events,
-            include_input_objects: self.include_input_objects,
-            include_output_objects: self.include_output_objects,
         })
     }
 }

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -201,7 +201,7 @@ pub fn make_consensus_adapter_for_test(
             &self,
             transactions: &[ConsensusTransaction],
             epoch_store: &Arc<AuthorityPerEpochStore>,
-        ) -> SuiResult<BlockStatusReceiver> {
+        ) -> SuiResult<(Vec<ConsensusTxPosition>, BlockStatusReceiver)> {
             let sequenced_transactions: Vec<SequencedConsensusTransaction> = transactions
                 .iter()
                 .map(|txn| SequencedConsensusTransaction::new_test(txn.clone()))
@@ -264,7 +264,10 @@ pub fn make_consensus_adapter_for_test(
                 !self.mock_block_status_receivers.lock().is_empty(),
                 "No mock submit responses left"
             );
-            Ok(self.mock_block_status_receivers.lock().remove(0))
+            Ok((
+                Vec::new(),
+                self.mock_block_status_receivers.lock().remove(0),
+            ))
         }
     }
     let epoch_store = state.epoch_store_for_testing();
@@ -326,6 +329,7 @@ async fn submit_transaction_to_consensus_adapter() {
             transaction.clone(),
             Some(&epoch_store.get_reconfig_state_read_lock_guard()),
             &epoch_store,
+            None,
         )
         .unwrap();
     waiter.await.unwrap();
@@ -371,6 +375,7 @@ async fn submit_multiple_transactions_to_consensus_adapter() {
             &transactions,
             Some(&epoch_store.get_reconfig_state_read_lock_guard()),
             &epoch_store,
+            None,
         )
         .unwrap();
     waiter.await.unwrap();
@@ -456,6 +461,7 @@ async fn submit_checkpoint_signature_to_consensus_adapter() {
                 &transactions,
                 Some(&epoch_store.get_reconfig_state_read_lock_guard()),
                 &epoch_store,
+                None,
             )
             .unwrap();
         waiter.await.unwrap();

--- a/crates/sui-core/src/validator_tx_finalizer.rs
+++ b/crates/sui-core/src/validator_tx_finalizer.rs
@@ -303,8 +303,9 @@ mod tests {
     use sui_types::messages_grpc::{
         HandleCertificateRequestV3, HandleCertificateResponseV2, HandleCertificateResponseV3,
         HandleSoftBundleCertificatesRequestV3, HandleSoftBundleCertificatesResponseV3,
-        HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse, RawSubmitTxRequest,
-        RawSubmitTxResponse, SystemStateRequest, TransactionInfoRequest, TransactionInfoResponse,
+        HandleTransactionResponse, ObjectInfoRequest, ObjectInfoResponse, RawGetEffectsRequest,
+        RawGetEffectsResponse, RawSubmitTxRequest, RawSubmitTxResponse, SystemStateRequest,
+        TransactionInfoRequest, TransactionInfoResponse,
     };
     use sui_types::object::Object;
     use sui_types::sui_system_state::SuiSystemState;
@@ -327,6 +328,14 @@ mod tests {
             _request: RawSubmitTxRequest,
             _client_addr: Option<SocketAddr>,
         ) -> Result<RawSubmitTxResponse, SuiError> {
+            unimplemented!();
+        }
+
+        async fn get_effects(
+            &self,
+            _request: RawGetEffectsRequest,
+            _client_addr: Option<SocketAddr>,
+        ) -> Result<RawGetEffectsResponse, SuiError> {
             unimplemented!();
         }
 

--- a/crates/sui-network/build.rs
+++ b/crates/sui-network/build.rs
@@ -35,6 +35,15 @@ fn main() -> Result<()> {
         )
         .method(
             Method::builder()
+                .name("get_effects")
+                .route_name("GetEffects")
+                .input_type("sui_types::messages_grpc::RawGetEffectsRequest")
+                .output_type("sui_types::messages_grpc::RawGetEffectsResponse")
+                .codec_path(prost_codec_path)
+                .build(),
+        )
+        .method(
+            Method::builder()
                 .name("transaction")
                 .route_name("Transaction")
                 .input_type("sui_types::transaction::Transaction")

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -422,7 +422,7 @@ impl SuiNode {
                                     info!("Submitting JWK to consensus: {:?}", id);
 
                                     let txn = ConsensusTransaction::new_jwk_fetched(authority, id, jwk);
-                                    consensus_adapter.submit(txn, None, &epoch_store)
+                                    consensus_adapter.submit(txn, None, &epoch_store, None)
                                         .tap_err(|e| warn!("Error when submitting JWKs to consensus {:?}", e))
                                         .ok();
                                 }
@@ -1766,7 +1766,7 @@ impl SuiNode {
                 info!(?transaction, "submitting capabilities to consensus");
                 components
                     .consensus_adapter
-                    .submit(transaction, None, &cur_epoch_store)?;
+                    .submit(transaction, None, &cur_epoch_store, None)?;
             }
 
             let stop_condition = checkpoint_executor.run_epoch(run_with_range).await;

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -20,6 +20,7 @@ byteorder.workspace = true
 bytes.workspace = true
 chrono.workspace = true
 consensus-config.workspace = true
+consensus-core.workspace = true
 num_enum.workspace = true
 im.workspace = true
 itertools.workspace = true
@@ -68,7 +69,12 @@ fastcrypto-zkp.workspace = true
 passkey-types.workspace = true
 
 typed-store-error.workspace = true
-derive_more = { workspace = true, features = ["as_ref", "debug", "display", "from"] }
+derive_more = { workspace = true, features = [
+    "as_ref",
+    "debug",
+    "display",
+    "from",
+] }
 proptest.workspace = true
 proptest-derive.workspace = true
 better_any.workspace = true
@@ -108,8 +114,5 @@ harness = false
 
 [features]
 default = []
-tracing = [
-    "move-vm-profiler/tracing",
-    "move-vm-test-utils/tracing",
-]
+tracing = ["move-vm-profiler/tracing", "move-vm-test-utils/tracing"]
 fuzzing = ["move-core-types/fuzzing"]

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -497,6 +497,8 @@ pub enum SuiError {
     TransactionsNotFound { digests: Vec<TransactionDigest> },
     #[error("Could not find the referenced transaction events [{digest:?}].")]
     TransactionEventsNotFound { digest: TransactionDigest },
+    #[error("Could not find the referenced transaction effects [{digest:?}].")]
+    TransactionEffectsNotFound { digest: TransactionDigest },
     #[error(
         "Attempt to move to `Executed` state an transaction that has already been executed: {:?}.",
         digest
@@ -560,6 +562,16 @@ pub enum SuiError {
     TransactionOrchestratorLocalExecutionError { error: String },
 
     // Errors returned by authority and client read API's
+    #[error(
+        "Failure serializing consensus position in the requested format: {:?}",
+        error
+    )]
+    ConsensusPositionSerializationError { error: String },
+    #[error(
+        "Failure deserializing consensus position from the provided format: {:?}",
+        error
+    )]
+    ConsensusPositionDeserializationError { error: String },
     #[error("Failure serializing transaction in the requested format: {:?}", error)]
     TransactionSerializationError { error: String },
     #[error(

--- a/crates/sui-types/src/messages_consensus.rs
+++ b/crates/sui-types/src/messages_consensus.rs
@@ -11,6 +11,7 @@ use crate::supported_protocol_versions::{
 };
 use crate::transaction::{CertifiedTransaction, Transaction};
 use byteorder::{BigEndian, ReadBytesExt};
+use consensus_core::BlockRef;
 use fastcrypto::error::FastCryptoResult;
 use fastcrypto::groups::bls12381;
 use fastcrypto_tbls::dkg_v1;
@@ -35,6 +36,14 @@ pub type TransactionIndex = u16;
 
 /// Non-decreasing timestamp produced by consensus in ms.
 pub type TimestampMs = u64;
+
+#[derive(Clone, Default, Debug, Serialize, Deserialize)]
+pub struct ConsensusTxPosition {
+    // Block containing a transaction.
+    pub block: BlockRef,
+    // Index of the transaction in the block.
+    pub index: TransactionIndex,
+}
 
 /// Only commit_timestamp_ms is passed to the move call currently.
 /// However we include epoch and round to make sure each ConsensusCommitPrologue has a unique tx digest.

--- a/crates/sui-types/src/messages_grpc.rs
+++ b/crates/sui-types/src/messages_grpc.rs
@@ -8,6 +8,7 @@ use crate::effects::{
     VerifiedSignedTransactionEffects,
 };
 use crate::error::SuiError;
+use crate::messages_consensus::ConsensusTxPosition;
 use crate::object::Object;
 use crate::transaction::{CertifiedTransaction, SenderSignedData, SignedTransaction};
 use bytes::Bytes;
@@ -226,6 +227,48 @@ pub struct HandleCertificateRequestV3 {
 pub struct RawSubmitTxRequest {
     #[prost(bytes = "bytes", tag = "1")]
     pub transaction: Bytes,
+}
+
+#[derive(Clone, prost::Message)]
+pub struct RawSubmitTxResponse {
+    // Serialized Consensus Position
+    #[prost(bytes = "bytes", tag = "1")]
+    pub consensus_position: Bytes,
+}
+
+impl RawSubmitTxResponse {
+    pub fn into_raw(consensus_position: ConsensusTxPosition) -> Result<Self, SuiError> {
+        Ok(Self {
+            consensus_position: bcs::to_bytes(&consensus_position)
+                .map_err(|e| SuiError::ConsensusPositionSerializationError {
+                    error: e.to_string(),
+                })?
+                .into(),
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SubmitTxResponse {
+    pub consensus_position: ConsensusTxPosition,
+}
+
+impl SubmitTxResponse {
+    pub fn from_bytes(consensus_position: Bytes) -> Result<Self, SuiError> {
+        Ok(Self {
+            consensus_position: bcs::from_bytes(&consensus_position).map_err(|e| {
+                SuiError::ConsensusPositionDeserializationError {
+                    error: e.to_string(),
+                }
+            })?,
+        })
+    }
+}
+
+#[derive(Clone, prost::Message)]
+pub struct RawGetEffectsRequest {
+    #[prost(bytes = "bytes", tag = "1")]
+    pub transaction: Bytes,
     #[prost(bool, tag = "2")]
     pub include_events: bool,
     #[prost(bool, tag = "3")]
@@ -234,7 +277,7 @@ pub struct RawSubmitTxRequest {
     pub include_output_objects: bool,
 }
 
-/// Serialized response type for submit transaction validator API.
+/// Serialized response type for get effects validator API.
 ///
 /// The corresponding request type allows for a client to request events as well as
 /// input/output objects from a transaction's execution. Given Validators operate with very
@@ -242,7 +285,7 @@ pub struct RawSubmitTxRequest {
 /// the transaction has been executed locally on the validator and will not be returned for
 /// requests to previously executed transactions.
 #[derive(Clone, prost::Message)]
-pub struct RawSubmitTxResponse {
+pub struct RawGetEffectsResponse {
     // Serialized TransactionEffects
     #[prost(bytes = "bytes", tag = "1")]
     pub effects: Bytes,
@@ -265,7 +308,7 @@ pub struct RawSubmitTxResponse {
     pub output_objects: Vec<Vec<u8>>,
 }
 
-impl RawSubmitTxResponse {
+impl RawGetEffectsResponse {
     pub fn into_raw(
         effects: TransactionEffects,
         include_events: bool,
@@ -315,7 +358,7 @@ impl RawSubmitTxResponse {
 }
 
 #[derive(Clone, Debug)]
-pub struct SubmitTxResponse {
+pub struct GetEffectsResponse {
     pub effects: TransactionEffects,
     pub events: Option<TransactionEvents>,
     pub input_objects: Option<Vec<Object>>,
@@ -323,7 +366,7 @@ pub struct SubmitTxResponse {
     pub auxiliary_data: Option<Vec<u8>>,
 }
 
-impl SubmitTxResponse {
+impl GetEffectsResponse {
     pub fn from_bytes(
         effects: Bytes,
         include_events: bool,


### PR DESCRIPTION
## Description 

Moved logic from old `submit_transaction` path to `get_effects`. New submit_transaction path will only submit transaction to consensus and get back the consensus position. get_effects will not submit to consensus and will just check if effects are available to be returned. This path may be deprecated if we don't have any use for it once wait_for_effects is in. 

ConsensusTxPosition is based on the tx indices calculated while transactions are being pulled when the block is being generated in try_new_block. There is no guarantee that a returned ConsensusTxPosition will be sequenced and it is up to the client to retry and get a new consensus position if needed.

## Test plan 

Still working on adding tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
