### PR TITLE
[CLI] Add `custom-signer` option to sui client commands

### DIFF
--- a/crates/sui/src/client_ptb/ast.rs
+++ b/crates/sui/src/client_ptb/ast.rs
@@ -9,7 +9,7 @@ use move_core_types::parsing::{
 };
 use move_core_types::runtime_value::MoveValue;
 use sui_types::{
-    base_types::{ObjectID, RESOLVED_ASCII_STR, RESOLVED_STD_OPTION, RESOLVED_UTF8_STR},
+    base_types::{ObjectID, RESOLVED_ASCII_STR, RESOLVED_STD_OPTION, RESOLVED_UTF8_STR, SuiAddress},
     id::RESOLVED_SUI_ID,
     Identifier, TypeTag,
 };
@@ -39,7 +39,7 @@ pub const DRY_RUN: &str = "dry-run";
 pub const DEV_INSPECT: &str = "dev-inspect";
 pub const SERIALIZE_UNSIGNED: &str = "serialize-unsigned-transaction";
 pub const SERIALIZE_SIGNED: &str = "serialize-signed-transaction";
-
+pub const CUSTOM_SIGNER: &str = "custom-signer";
 // Types
 pub const U8: &str = "u8";
 pub const U16: &str = "u16";
@@ -79,6 +79,7 @@ pub const COMMANDS: &[&str] = &[
     DEV_INSPECT,
     SERIALIZE_UNSIGNED,
     SERIALIZE_SIGNED,
+    CUSTOM_SIGNER,
 ];
 
 pub fn is_keyword(s: &str) -> bool {
@@ -117,6 +118,8 @@ pub struct ProgramMetadata {
     pub dev_inspect_set: bool,
     pub gas_budget: Option<Spanned<u64>>,
     pub mvr_names: BTreeMap<String, Span>,
+    pub custom_signer_set: bool,
+    pub custom_signer: Option<Spanned<SuiAddress>>,
 }
 
 /// A parsed module access consisting of the address, module name, and function name.

--- a/crates/sui/src/client_ptb/ptb.rs
+++ b/crates/sui/src/client_ptb/ptb.rs
@@ -212,6 +212,7 @@ impl PTB {
                 gas_budget: program_metadata.gas_budget.map(|x| x.value),
                 serialize_unsigned_transaction: program_metadata.serialize_unsigned_set,
                 serialize_signed_transaction: program_metadata.serialize_signed_set,
+                custom_signer: program_metadata.custom_signer.map(|x| x.value),
             },
         };
 

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -3227,6 +3227,7 @@ async fn test_serialize_tx() -> Result<(), anyhow::Error> {
             dev_inspect: false,
             serialize_unsigned_transaction: true,
             serialize_signed_transaction: false,
+            custom_signer: None,
         },
     }
     .execute(context)
@@ -3242,6 +3243,7 @@ async fn test_serialize_tx() -> Result<(), anyhow::Error> {
             dev_inspect: false,
             serialize_unsigned_transaction: false,
             serialize_signed_transaction: true,
+            custom_signer: None,
         },
     }
     .execute(context)
@@ -3258,6 +3260,7 @@ async fn test_serialize_tx() -> Result<(), anyhow::Error> {
             dev_inspect: false,
             serialize_unsigned_transaction: false,
             serialize_signed_transaction: true,
+            custom_signer: None,
         },
     }
     .execute(context)
@@ -4105,6 +4108,7 @@ async fn test_gas_estimation() -> Result<(), anyhow::Error> {
             dev_inspect: false,
             serialize_unsigned_transaction: false,
             serialize_signed_transaction: false,
+            custom_signer: None,
         },
     }
     .execute(context)


### PR DESCRIPTION
## Description 

Add an option `--custom_signer` to sui client to set a custom sender when creating a (serialized unsigned) transaction. This feature enables anyone to create a transaction, that can later be signed by a multisig (or any account that is specified with the `custom_signer` flag).
```
$ sui client call -h
Call Move function

Usage: sui client call [OPTIONS] --package <PACKAGE> --module <MODULE> --function <FUNCTION>

Options:
      --package <PACKAGE>               Object ID of the package, which contains the module
      --module <MODULE>                 The name of the module in the package
      --function <FUNCTION>             Function name in module
      --type-args <TYPE_ARGS>...        Type arguments to the generic function being called. All must be specified, or the call will fail
      --args <ARGS>...                  Simplified ordered args like in the function syntax ObjectIDs, Addresses must be hex strings
      --gas <GAS>                       ID of the gas object for gas payment. If not provided, a gas object with at least gas_budget value will be selected
      --gas-budget <GAS_BUDGET>         An optional gas budget for this transaction (in MIST). If gas budget is not provided, the tool will first perform a dry run to estimate the gas cost,
                                        and then it will execute the transaction. Please note that this incurs a small cost in performance due to the additional dry run call
      --dry-run                         Perform a dry run of the transaction, without executing it
      --dev-inspect                     Perform a dev inspect
      --serialize-unsigned-transaction  Instead of executing the transaction, serialize the bcs bytes of the unsigned transaction data (TransactionData) using base64 encoding, and print out
                                        the string <TX_BYTES>. The string can be used to execute transaction with `sui client execute-signed-tx --tx-bytes <TX_BYTES>`
      --serialize-signed-transaction    Instead of executing the transaction, serialize the bcs bytes of the signed transaction data (SenderSignedData) using base64 encoding, and print out
                                        the string <SIGNED_TX_BYTES>. The string can be used to execute transaction with `sui client execute-combined-signed-tx --signed-tx-bytes
                                        <SIGNED_TX_BYTES>`
      --custom-signer <CUSTOM_SIGNER>   Use a custom signer for the transaction. This option must be used with --serialize-unsigned-transaction since the custom signer's private key is not
                                        available in the keystore. The resulting unsigned transaction can then be signed externally using the custom signer's private key
      --json                            Return command outputs in json format
  -h, --help                            Print help
  -V, --version                         Print version
```

## Test plan 

I used this version of the CLI in our [hackathon project for the Sui Overflow Hackathon](https://github.com/multisig-sui/sui-multisig), where I created different types of transactions that I could sign using a multisig.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI:  Add `--custom-signer` option to `sui client` commands, allowing users to override the default signer address when creating transactions. This enables compatibility with multisig workflows that require specifying a custom sender.
- [ ] Rust SDK:
