### PR TITLE
Update oracle.mdx - broken URL to Switchboard oracle

### DIFF
--- a/docs/content/guides/developer/app-examples/oracle.mdx
+++ b/docs/content/guides/developer/app-examples/oracle.mdx
@@ -13,7 +13,7 @@ The guides in this section demonstrate how to create basic oracle services for y
 | [**Pyth**](https://www.pyth.network/) | Pyth is a blockchain oracle for market data. Check the [Sui guide](https://docs.pyth.network/price-feeds/use-real-time-data/sui) on the Pyth website to learn how to integrate into your Sui projects. |
 | [**Stork**](https://www.stork.network/) | Stork is an open data marketplace designed to address the limitations of traditional blockchain oracles. Check the [Stork documentation](https://docs.stork.network/) for implementation details. |
 | [**Supra**](https://supra.com/data) | Supra is a decentralized oracle network designed to connect blockchain smart contracts with real-world data, enhancing the functionality of decentralized applications (dApps) across various blockchain ecosystems. Check the [Index Fund](https://docs.supra.com/dev-resources/guides/move/building-a-crypto-index-fund-smart-contract-on-sui-blockchain-move) and [Crowdfunding](https://docs.supra.com/dev-resources/guides/move/crowdfunding-smart-contracts-on-sui-blockchain-move) examples for how to integrate with Sui. |
-| [**Switchboard**](https://switchboard.xyz/) | Switchboard is a permissionless oracle network that seamlessly connects dApps to real-world data. Check the [On Sui](https://docs.switchboard.xyz/docs/switchboard/readme/on-sui) guide for integration details. |
+| [**Switchboard**](https://switchboard.xyz/) | Switchboard is a permissionless oracle network that seamlessly connects dApps to real-world data. Check the [On Sui](https://docs.switchboard.xyz/product-documentation/data-feeds/sui) guide for integration details. |
 
 ## Oracle guides
 


### PR DESCRIPTION
Just fixed the URL pointing to the Switchboard oracle's guide for Sui. 
