### PR TITLE
[kv store] add binary subcommand to fetch entries from tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14847,6 +14847,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "bcs",
+ "clap",
  "gcp_auth",
  "http 1.1.0",
  "prometheus",

--- a/crates/sui-kvstore/Cargo.toml
+++ b/crates/sui-kvstore/Cargo.toml
@@ -11,6 +11,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 base64.workspace = true
 bcs.workspace = true
+clap.workspace = true
 http.workspace = true
 gcp_auth.workspace = true
 prometheus.workspace = true

--- a/crates/sui-kvstore/src/lib.rs
+++ b/crates/sui-kvstore/src/lib.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 pub use bigtable::client::BigTableClient;
 pub use bigtable::progress_store::BigTableProgressStore;
 pub use bigtable::worker::KvWorker;
+use serde::{Deserialize, Serialize};
 use sui_types::base_types::ObjectID;
 use sui_types::committee::EpochId;
 use sui_types::crypto::AuthorityStrongQuorumSignInfo;
@@ -49,14 +50,14 @@ pub trait KeyValueStoreWriter {
     async fn save_epoch(&mut self, epoch: EpochInfo) -> Result<()>;
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Checkpoint {
     pub summary: CheckpointSummary,
     pub contents: CheckpointContents,
     pub signatures: AuthorityStrongQuorumSignInfo,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TransactionData {
     pub transaction: Transaction,
     pub effects: TransactionEffects,

--- a/crates/sui-kvstore/src/main.rs
+++ b/crates/sui-kvstore/src/main.rs
@@ -1,44 +1,111 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use anyhow::Result;
+use clap::{Parser, Subcommand};
 use prometheus::Registry;
+use std::io::{self, Write};
+use std::str::FromStr;
 use sui_data_ingestion_core::{DataIngestionMetrics, IndexerExecutor, ReaderOptions, WorkerPool};
-use sui_kvstore::{BigTableClient, BigTableProgressStore, KvWorker};
+use sui_kvstore::{BigTableClient, BigTableProgressStore, KeyValueStoreReader, KvWorker};
+use sui_types::base_types::ObjectID;
+use sui_types::digests::TransactionDigest;
+use sui_types::storage::ObjectKey;
 use telemetry_subscribers::TelemetryConfig;
 use tokio::sync::oneshot;
+
+#[derive(Parser)]
+struct App {
+    instance_id: String,
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommand)]
+pub enum Command {
+    Ingestion {
+        network: String,
+    },
+    Fetch {
+        #[command(subcommand)]
+        entry: Entry,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum Entry {
+    Object { id: String, version: u64 },
+    Epoch { id: u64 },
+    Checkpoint { id: u64 },
+    Transaction { id: String },
+    Watermark,
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let _guard = TelemetryConfig::new().with_env().init();
-    let args: Vec<String> = std::env::args().collect();
-    if args.len() < 3 {
-        eprintln!("Please provide BigTable instance id and network name");
-        std::process::exit(1);
+    let app = App::parse();
+    match app.command {
+        Some(Command::Ingestion { network }) => {
+            let client = BigTableClient::new_remote(
+                app.instance_id,
+                false,
+                None,
+                "ingestion".to_string(),
+                None,
+            )
+            .await?;
+            let (_exit_sender, exit_receiver) = oneshot::channel();
+            let mut executor = IndexerExecutor::new(
+                BigTableProgressStore::new(client.clone()),
+                1,
+                DataIngestionMetrics::new(&Registry::new()),
+            );
+            let worker_pool = WorkerPool::new(KvWorker { client }, "bigtable".to_string(), 50);
+            executor.register(worker_pool).await?;
+            executor
+                .run(
+                    tempfile::tempdir()?.into_path(),
+                    Some(format!("https://checkpoints.{}.sui.io", network)),
+                    vec![],
+                    ReaderOptions::default(),
+                    exit_receiver,
+                )
+                .await?;
+        }
+        Some(Command::Fetch { entry }) => {
+            let mut client =
+                BigTableClient::new_remote(app.instance_id, true, None, "cli".to_string(), None)
+                    .await?;
+            let result = match entry {
+                Entry::Epoch { id } => client.get_epoch(id).await?.map(|e| bcs::to_bytes(&e)),
+                Entry::Object { id, version } => {
+                    let objects = client
+                        .get_objects(&[ObjectKey(ObjectID::from_str(&id)?, version.into())])
+                        .await?;
+                    objects.first().map(bcs::to_bytes)
+                }
+                Entry::Checkpoint { id } => {
+                    let checkpoints = client.get_checkpoints(&[id]).await?;
+                    checkpoints.first().map(bcs::to_bytes)
+                }
+                Entry::Transaction { id } => {
+                    let transactions = client
+                        .get_transactions(&[TransactionDigest::from_str(&id)?])
+                        .await?;
+                    transactions.first().map(bcs::to_bytes)
+                }
+                Entry::Watermark => {
+                    let watermark = client.get_latest_checkpoint().await?;
+                    println!("watermark is {}", watermark);
+                    return Ok(());
+                }
+            };
+            match result {
+                Some(bytes) => io::stdout().write_all(&bytes?)?,
+                None => println!("not found"),
+            }
+        }
+        None => println!("no command provided"),
     }
-    let instance_id = args[1].to_string();
-    let network = args[2].to_string();
-    assert!(
-        network == "mainnet" || network == "testnet",
-        "Invalid network name"
-    );
-    let client = BigTableClient::new_local(instance_id).await?;
-
-    let (_exit_sender, exit_receiver) = oneshot::channel();
-    let mut executor = IndexerExecutor::new(
-        BigTableProgressStore::new(client.clone()),
-        1,
-        DataIngestionMetrics::new(&Registry::new()),
-    );
-    let worker_pool = WorkerPool::new(KvWorker { client }, "bigtable".to_string(), 50);
-    executor.register(worker_pool).await?;
-    executor
-        .run(
-            tempfile::tempdir()?.into_path(),
-            Some(format!("https://checkpoints.{}.sui.io", network)),
-            vec![],
-            ReaderOptions::default(),
-            exit_receiver,
-        )
-        .await?;
     Ok(())
 }


### PR DESCRIPTION
## Description 

adds ability to do point lookups with read only access to kv store binary

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
