### PR TITLE
[cli] Allow upgrade-capability to be passed as `-c` short flag

### DIFF
--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -460,7 +460,7 @@ pub enum SuiClientCommands {
         package_path: PathBuf,
 
         /// ID of the upgrade capability for the package being upgraded.
-        #[clap(long)]
+        #[clap(long, short = 'c')]
         upgrade_capability: ObjectID,
 
         /// Package build options


### PR DESCRIPTION
## Description 

This PP adds `-c` as a short flag for `--upgrade-capability`.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Added the `-c` short flag for the  `sui client upgrade` command to pass the upgrade capability.
- [ ] Rust SDK:
