### PR TITLE
[tidehunter] add support for AuthorityEpochTables

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -493,6 +493,7 @@ mod tests {
 
     use consensus_config::{local_committee_and_keys, Parameters};
     use mysten_metrics::monitored_mpsc::UnboundedReceiver;
+    use mysten_metrics::RegistryService;
     use prometheus::Registry;
     use rstest::rstest;
     use sui_protocol_config::ProtocolConfig;
@@ -561,7 +562,7 @@ mod tests {
     ) {
         telemetry_subscribers::init_for_testing();
         let db_registry = Registry::new();
-        DBMetrics::init(&db_registry);
+        DBMetrics::init(RegistryService::new(db_registry));
 
         const NUM_OF_AUTHORITIES: usize = 4;
         let (committee, keypairs) = local_committee_and_keys(0, [1; NUM_OF_AUTHORITIES].to_vec());
@@ -672,7 +673,7 @@ mod tests {
     ) {
         telemetry_subscribers::init_for_testing();
         let db_registry = Registry::new();
-        DBMetrics::init(&db_registry);
+        DBMetrics::init(RegistryService::new(db_registry));
 
         let (committee, keypairs) = local_committee_and_keys(0, vec![1; num_authorities]);
         let protocol_config: ProtocolConfig = ProtocolConfig::get_for_max_version_UNSAFE();
@@ -769,7 +770,7 @@ mod tests {
     async fn test_amnesia_recovery_success(#[values(0, 5, 10)] gc_depth: u32) {
         telemetry_subscribers::init_for_testing();
         let db_registry = Registry::new();
-        DBMetrics::init(&db_registry);
+        DBMetrics::init(RegistryService::new(db_registry));
 
         const NUM_OF_AUTHORITIES: usize = 4;
         let (committee, keypairs) = local_committee_and_keys(0, [1; NUM_OF_AUTHORITIES].to_vec());

--- a/consensus/simtests/src/tests/simtests.rs
+++ b/consensus/simtests/src/tests/simtests.rs
@@ -7,6 +7,7 @@ mod test {
         Authority, AuthorityIndex, AuthorityKeyPair, Committee, Epoch, NetworkKeyPair,
         ProtocolKeyPair, Stake,
     };
+    use mysten_metrics::RegistryService;
     use mysten_network::Multiaddr;
     use prometheus::Registry;
     use rand::{rngs::StdRng, SeedableRng as _};
@@ -44,7 +45,7 @@ mod test {
         for median_based_timestamp in vec![true, false] {
             tracing::info!("Running with median_based_timestamp = {median_based_timestamp}");
             let db_registry = Registry::new();
-            DBMetrics::init(&db_registry);
+            DBMetrics::init(RegistryService::new(db_registry));
 
             const NUM_OF_AUTHORITIES: usize = 10;
             let (committee, keypairs) =

--- a/crates/mysten-metrics/src/lib.rs
+++ b/crates/mysten-metrics/src/lib.rs
@@ -461,7 +461,7 @@ pub type RegistryID = Uuid;
 /// A service to manage the prometheus registries. This service allow us to create
 /// a new Registry on demand and keep it accessible for processing/polling.
 /// The service can be freely cloned/shared across threads.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct RegistryService {
     // Holds a Registry that is supposed to be used
     default_registry: Registry,

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -412,6 +412,7 @@ pub struct AuthorityPerEpochStore {
 
 /// AuthorityEpochTables contains tables that contain data that is only valid within an epoch.
 #[derive(DBMapUtils)]
+// #[tidehunter]
 pub struct AuthorityEpochTables {
     /// This is map between the transaction digest and transactions found in the `transaction_lock`.
     #[default_options_override_fn = "signed_transactions_table_default_config"]
@@ -573,12 +574,208 @@ fn pending_consensus_transactions_table_default_config() -> DBOptions {
 }
 
 impl AuthorityEpochTables {
+    #[cfg(any(not(feature = "tide_hunter"), feature = "rocksdb"))]
     pub fn open(epoch: EpochId, parent_path: &Path, db_options: Option<Options>) -> Self {
         Self::open_tables_read_write(
             Self::path(epoch, parent_path),
             MetricConf::new("epoch"),
             db_options,
             None,
+        )
+    }
+
+    #[cfg(all(
+        not(target_os = "windows"),
+        feature = "tide_hunter",
+        not(feature = "rocksdb")
+    ))]
+    pub fn open(epoch: EpochId, parent_path: &Path, db_options: Option<Options>) -> Self {
+        use typed_store::tidehunter_util::{default_cells_per_mutex, KeySpaceConfig, ThConfig};
+        const MUTEXES: usize = 1024;
+        const LARGE_KEY_LENGTH: usize = 4096 * 2;
+        let digest_prefix = vec![0, 0, 0, 0, 0, 0, 0, 32];
+        let configs = vec![
+            (
+                "signed_transactions".to_string(),
+                ThConfig::new_with_rm_prefix(
+                    32,
+                    MUTEXES,
+                    default_cells_per_mutex(),
+                    KeySpaceConfig::default(),
+                    digest_prefix.clone(),
+                ),
+            ),
+            (
+                "owned_object_locked_transactions".to_string(),
+                ThConfig::new(32 + 8 + 32 + 8, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "effects_signatures".to_string(),
+                ThConfig::new_with_rm_prefix(
+                    32,
+                    MUTEXES,
+                    default_cells_per_mutex(),
+                    KeySpaceConfig::default(),
+                    digest_prefix.clone(),
+                ),
+            ),
+            (
+                "signed_effects_digests".to_string(),
+                ThConfig::new_with_rm_prefix(
+                    32,
+                    MUTEXES,
+                    default_cells_per_mutex(),
+                    KeySpaceConfig::default(),
+                    digest_prefix.clone(),
+                ),
+            ),
+            (
+                "transaction_cert_signatures".to_string(),
+                ThConfig::new_with_rm_prefix(
+                    32,
+                    MUTEXES,
+                    default_cells_per_mutex(),
+                    KeySpaceConfig::default(),
+                    digest_prefix.clone(),
+                ),
+            ),
+            (
+                "next_shared_object_versions_v2".to_string(),
+                ThConfig::new(32 + 8, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "consensus_message_processed".to_string(),
+                ThConfig::new(LARGE_KEY_LENGTH, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "pending_consensus_transactions".to_string(),
+                ThConfig::new(LARGE_KEY_LENGTH, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "last_consensus_stats".to_string(),
+                ThConfig::new(8, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "reconfig_state".to_string(),
+                ThConfig::new(8, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "end_of_publish".to_string(),
+                ThConfig::new(104, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "builder_digest_to_checkpoint".to_string(),
+                ThConfig::new_with_rm_prefix(
+                    32,
+                    MUTEXES,
+                    default_cells_per_mutex(),
+                    KeySpaceConfig::default(),
+                    digest_prefix.clone(),
+                ),
+            ),
+            (
+                "transaction_key_to_digest".to_string(),
+                ThConfig::new(1 + 32, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "pending_checkpoint_signatures".to_string(),
+                ThConfig::new(8 + 8, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "builder_checkpoint_summary_v2".to_string(),
+                ThConfig::new(8, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "state_hash_by_checkpoint".to_string(),
+                ThConfig::new(8, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "running_root_accumulators".to_string(),
+                ThConfig::new(8, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "authority_capabilities".to_string(),
+                ThConfig::new(104, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "authority_capabilities_v2".to_string(),
+                ThConfig::new(104, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "override_protocol_upgrade_buffer_stake".to_string(),
+                ThConfig::new(8, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "executed_transactions_to_checkpoint".to_string(),
+                ThConfig::new_with_rm_prefix(
+                    32,
+                    MUTEXES,
+                    default_cells_per_mutex(),
+                    KeySpaceConfig::default(),
+                    digest_prefix.clone(),
+                ),
+            ),
+            (
+                "pending_jwks".to_string(),
+                ThConfig::new(LARGE_KEY_LENGTH, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "active_jwks".to_string(),
+                ThConfig::new(LARGE_KEY_LENGTH, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "deferred_transactions".to_string(),
+                ThConfig::new(1 + 8 + 8, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "deferred_transactions".to_string(),
+                ThConfig::new(1 + 8 + 8, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "dkg_processed_messages_v2".to_string(),
+                ThConfig::new(2, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "dkg_used_messages_v2".to_string(),
+                ThConfig::new(8, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "dkg_confirmations_v2".to_string(),
+                ThConfig::new(2, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "dkg_output".to_string(),
+                ThConfig::new(8, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "randomness_next_round".to_string(),
+                ThConfig::new(8, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "randomness_highest_completed_round".to_string(),
+                ThConfig::new(8, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "randomness_last_round_timestamp".to_string(),
+                ThConfig::new(8, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "congestion_control_object_debts".to_string(),
+                ThConfig::new(32, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "congestion_control_randomness_object_debts".to_string(),
+                ThConfig::new(32, MUTEXES, default_cells_per_mutex()),
+            ),
+            (
+                "execution_time_observations".to_string(),
+                ThConfig::new(8 + 4, MUTEXES, default_cells_per_mutex()),
+            ),
+        ];
+        Self::open_tables_read_write(
+            Self::path(epoch, parent_path),
+            MetricConf::new("epoch"),
+            configs.into_iter().collect(),
         )
     }
 

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -461,7 +461,7 @@ impl SuiNode {
         );
 
         // Initialize metrics to track db usage before creating any stores
-        DBMetrics::init(&prometheus_registry);
+        DBMetrics::init(registry_service.clone());
 
         // Initialize Mysten metrics.
         mysten_metrics::init_metrics(&prometheus_registry);

--- a/crates/typed-store-derive/src/lib.rs
+++ b/crates/typed-store-derive/src/lib.rs
@@ -373,7 +373,7 @@ pub fn derive_dbmap_utils_general(input: TokenStream) -> TokenStream {
                         )*
                     );
                     let key_shape = builder.build();
-                    let inner_db = typed_store::tidehunter_util::open(path.as_path(), key_shape);
+                    let inner_db = typed_store::tidehunter_util::open(path.as_path(), key_shape, metric_conf.db_name.clone());
                     let db = std::sync::Arc::new(typed_store::rocks::Database::new(
                         typed_store::rocks::Storage::TideHunter(inner_db),
                         metric_conf));

--- a/crates/typed-store/src/tidehunter_util.rs
+++ b/crates/typed-store/src/tidehunter_util.rs
@@ -3,6 +3,7 @@
 
 use crate::DBMetrics;
 use bincode::Options;
+use prometheus::Registry;
 use serde::de::DeserializeOwned;
 use std::path::Path;
 use std::sync::Arc;
@@ -26,9 +27,12 @@ pub struct ThConfig {
     pub prefix: Option<Vec<u8>>,
 }
 
-pub fn open(path: &Path, key_shape: KeyShape) -> Arc<Db> {
+pub fn open(path: &Path, key_shape: KeyShape, db_name: String) -> Arc<Db> {
     std::fs::create_dir_all(path).expect("failed to open tidehunter db");
-    let metrics = Metrics::new_in(&DBMetrics::get().registry);
+    let registry_service = &DBMetrics::get().registry_serivce;
+    let registry = Registry::new_custom(Some(db_name), None).expect("failed to create registry");
+    registry_service.add(registry.clone());
+    let metrics = Metrics::new_in(&registry);
     let db = Db::open(path, key_shape, Arc::new(thdb_config()), metrics)
         .expect("failed to open tidehunter db");
     db.start_periodic_snapshot();

--- a/crates/typed-store/tests/macro_tests.rs
+++ b/crates/typed-store/tests/macro_tests.rs
@@ -302,7 +302,7 @@ mod tide_hunter_tests {
         ];
         let db = ThTable::open_tables_read_write(
             primary_path.clone(),
-            MetricConf::default(),
+            MetricConf::new("test_th"),
             BTreeMap::from_iter(configs),
         );
         let (key, value) = ("key".to_string(), "value".to_string());


### PR DESCRIPTION
## Description 

adds support for AuthorityEpochTables

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
