### PR TITLE
Add limit to number of stored execution time observations (#22167)

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -517,6 +517,8 @@ mod test {
                         allowed_txn_cost_overage_burst_limit_us: rng.gen_range(0..500_000),
                         randomness_scalar: rng.gen_range(10..=50),
                         max_estimate_us: 1_500_000,
+                        stored_observations_num_included_checkpoints: 10,
+                        stored_observations_limit: rng.gen_range(1..=20),
                     },
                 ),
             ]

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -5001,22 +5001,18 @@ impl AuthorityState {
         end_of_epoch_observation_keys: Vec<ExecutionTimeObservationKey>,
         last_checkpoint_before_end_of_epoch: CheckpointSequenceNumber,
     ) -> Option<EndOfEpochTransactionKind> {
-        if !matches!(
-            epoch_store
-                .protocol_config()
-                .per_object_congestion_control_mode(),
-            PerObjectCongestionControlMode::ExecutionTimeEstimate(_)
-        ) {
+        let PerObjectCongestionControlMode::ExecutionTimeEstimate(params) = epoch_store
+            .protocol_config()
+            .per_object_congestion_control_mode()
+        else {
             return None;
-        }
-
-        // TODO: Make this a protocol config.
-        const NUM_INCLUDED_CHECKPOINTS: u64 = 10;
+        };
 
         // Load tx in the last N checkpoints before end-of-epoch, and save only the
         // execution time observations for commands in these checkpoints.
         let start_checkpoint = std::cmp::max(
-            last_checkpoint_before_end_of_epoch.saturating_sub(NUM_INCLUDED_CHECKPOINTS - 1),
+            last_checkpoint_before_end_of_epoch
+                .saturating_sub(params.stored_observations_num_included_checkpoints - 1),
             // If we have <N checkpoints in the epoch, use all of them.
             epoch_store
                 .epoch()
@@ -5101,7 +5097,10 @@ impl AuthorityState {
         let tx = EndOfEpochTransactionKind::new_store_execution_time_observations(
             epoch_store
                 .get_end_of_epoch_execution_time_observations()
-                .filter_and_sort_v1(|(key, _)| included_execution_time_observations.contains(key)),
+                .filter_and_sort_v1(
+                    |(key, _)| included_execution_time_observations.contains(key),
+                    params.stored_observations_limit.try_into().unwrap(),
+                ),
         );
         info!("Creating StoreExecutionTimeObservations tx");
         Some(tx)

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -905,6 +905,7 @@ impl AuthorityPerEpochStore {
                         &protocol_config,
                         committee.clone(),
                         &*object_store,
+                        &metrics,
                     )
                     // Load observations stored during the current epoch.
                     .chain(execution_time_observations.into_iter().flat_map(
@@ -1269,6 +1270,7 @@ impl AuthorityPerEpochStore {
         protocol_config: &ProtocolConfig,
         committee: Arc<Committee>,
         object_store: &dyn ObjectStore,
+        metrics: &EpochMetrics,
     ) -> impl Iterator<Item = (AuthorityIndex, u64, ExecutionTimeObservationKey, Duration)> {
         if !matches!(
             protocol_config.per_object_congestion_control_mode(),
@@ -1314,6 +1316,9 @@ impl AuthorityPerEpochStore {
             "loaded stored execution time observations for {} keys",
             stored_observations.len()
         );
+        metrics
+            .epoch_execution_time_observations_loaded
+            .set(stored_observations.len() as i64);
         assert_reachable!("successfully loads stored execution time observations");
 
         // Make a single flattened iterator with every stored observation, for consumption

--- a/crates/sui-core/src/authority/execution_time_estimator.rs
+++ b/crates/sui-core/src/authority/execution_time_estimator.rs
@@ -653,6 +653,8 @@ mod tests {
                         allowed_txn_cost_overage_burst_limit_us: 0,
                         randomness_scalar: 100,
                         max_estimate_us: u64::MAX,
+                        stored_observations_num_included_checkpoints: 10,
+                        stored_observations_limit: u64::MAX,
                     },
                 ),
             );
@@ -785,6 +787,8 @@ mod tests {
                         allowed_txn_cost_overage_burst_limit_us: 0,
                         randomness_scalar: 0,
                         max_estimate_us: u64::MAX,
+                        stored_observations_num_included_checkpoints: 10,
+                        stored_observations_limit: u64::MAX,
                     },
                 ),
             );
@@ -879,6 +883,8 @@ mod tests {
                         allowed_txn_cost_overage_burst_limit_us: 0,
                         randomness_scalar: 0,
                         max_estimate_us: u64::MAX,
+                        stored_observations_num_included_checkpoints: 10,
+                        stored_observations_limit: u64::MAX,
                     },
                 ),
             );
@@ -1111,6 +1117,8 @@ mod tests {
                 // Not used in this test.
                 allowed_txn_cost_overage_burst_limit_us: 0,
                 randomness_scalar: 0,
+                stored_observations_num_included_checkpoints: 10,
+                stored_observations_limit: u64::MAX,
             },
             std::iter::empty(),
         );

--- a/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
+++ b/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
@@ -727,6 +727,8 @@ mod object_cost_tests {
                 allowed_txn_cost_overage_burst_limit_us: 0,
                 max_estimate_us: u64::MAX,
                 randomness_scalar: 0,
+                stored_observations_num_included_checkpoints: 10,
+                stored_observations_limit: u64::MAX,
             }),
         )]
         mode: PerObjectCongestionControlMode,
@@ -855,6 +857,8 @@ mod object_cost_tests {
                 allowed_txn_cost_overage_burst_limit_us: 0,
                 randomness_scalar: 0,
                 max_estimate_us: u64::MAX,
+                stored_observations_num_included_checkpoints: 10,
+                stored_observations_limit: u64::MAX,
             }),
         )]
         mode: PerObjectCongestionControlMode,
@@ -1025,6 +1029,8 @@ mod object_cost_tests {
                 allowed_txn_cost_overage_burst_limit_us: 1_500_000,
                 randomness_scalar: 0,
                 max_estimate_us: u64::MAX,
+                stored_observations_num_included_checkpoints: 10,
+                stored_observations_limit: u64::MAX,
             }),
         )]
         mode: PerObjectCongestionControlMode,
@@ -1217,6 +1223,8 @@ mod object_cost_tests {
                 allowed_txn_cost_overage_burst_limit_us: 0,
                 randomness_scalar: 0,
                 max_estimate_us: u64::MAX,
+                stored_observations_num_included_checkpoints: 10,
+                stored_observations_limit: u64::MAX,
             }),
         )]
         mode: PerObjectCongestionControlMode,
@@ -1386,6 +1394,8 @@ mod object_cost_tests {
                 allowed_txn_cost_overage_burst_limit_us: 1_600 * 5,
                 randomness_scalar: 0,
                 max_estimate_us: u64::MAX,
+                stored_observations_num_included_checkpoints: 10,
+                stored_observations_limit: u64::MAX,
             }),
         )]
         mode: PerObjectCongestionControlMode,

--- a/crates/sui-core/src/epoch/epoch_metrics.rs
+++ b/crates/sui-core/src/epoch/epoch_metrics.rs
@@ -128,6 +128,9 @@ pub struct EpochMetrics {
     /// Note: This metric is disabled by default as it may have very large cardinality.
     pub epoch_execution_time_observer_object_utilization: CounterVec,
 
+    /// The number of execution time observations loaded at start of epoch.
+    pub epoch_execution_time_observations_loaded: IntGauge,
+
     /// The number of consensus output items in the quarantine.
     pub consensus_quarantine_queue_size: IntGauge,
 
@@ -292,6 +295,12 @@ impl EpochMetrics {
                 "epoch_execution_time_observer_object_utilization",
                 "Per-object utilization for objects that were overutilized at least once at some point in their lifetime",
                 &["object_id"],
+                registry
+            )
+            .unwrap(),
+            epoch_execution_time_observations_loaded: register_int_gauge_with_registry!(
+                "epoch_execution_time_observations_loaded",
+                "The number of execution time observations loaded at start of epoch",
                 registry
             )
             .unwrap(),

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1294,7 +1294,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "83",
+              "maxSupportedProtocolVersion": "84",
               "protocolVersion": "6",
               "featureFlags": {
                 "accept_passkey_in_multisig": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -18,7 +18,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-const MAX_PROTOCOL_VERSION: u64 = 83;
+const MAX_PROTOCOL_VERSION: u64 = 84;
 
 // Record history of protocol version allocations here:
 //
@@ -239,6 +239,7 @@ const MAX_PROTOCOL_VERSION: u64 = 83;
 // Version 83: Resolve `TypeInput` IDs to defining ID when converting to `TypeTag`s in the adapter.
 //             Enable execution time estimate mode for congestion control on mainnet.
 //             Enable nitro attestation upgraded parsing and mainnet.
+// Version 84: Limit number of stored execution time observations between epochs.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -735,6 +736,13 @@ pub struct ExecutionTimeEstimateParams {
 
     // Absolute maximum allowed transaction duration estimate (in microseconds).
     pub max_estimate_us: u64,
+
+    // Number of the final checkpoints in an epoch whose observations should be
+    // stored for use in the next epoch.
+    pub stored_observations_num_included_checkpoints: u64,
+
+    // Absolute limit on the number of saved observations at end of epoch.
+    pub stored_observations_limit: u64,
 }
 
 // The config for per object congestion control in consensus handler.
@@ -3482,6 +3490,8 @@ impl ProtocolConfig {
                                     allowed_txn_cost_overage_burst_limit_us: 100_000, // 100 ms
                                     randomness_scalar: 20,
                                     max_estimate_us: 1_500_000, // 1.5s
+                                    stored_observations_num_included_checkpoints: 10,
+                                    stored_observations_limit: u64::MAX,
                                 },
                             );
                     }
@@ -3529,6 +3539,8 @@ impl ProtocolConfig {
                                 allowed_txn_cost_overage_burst_limit_us: 100_000, // 100 ms
                                 randomness_scalar: 20,
                                 max_estimate_us: 1_500_000, // 1.5s
+                                stored_observations_num_included_checkpoints: 10,
+                                stored_observations_limit: u64::MAX,
                             },
                         );
 
@@ -3539,6 +3551,20 @@ impl ProtocolConfig {
                     // native function on mainnet.
                     cfg.feature_flags.enable_nitro_attestation_upgraded_parsing = true;
                     cfg.feature_flags.enable_nitro_attestation = true;
+                }
+                84 => {
+                    // Limit the number of stored execution time observations at end of epoch.
+                    cfg.feature_flags.per_object_congestion_control_mode =
+                        PerObjectCongestionControlMode::ExecutionTimeEstimate(
+                            ExecutionTimeEstimateParams {
+                                target_utilization: 30,
+                                allowed_txn_cost_overage_burst_limit_us: 100_000, // 100 ms
+                                randomness_scalar: 20,
+                                max_estimate_us: 1_500_000, // 1.5s
+                                stored_observations_num_included_checkpoints: 10,
+                                stored_observations_limit: 20,
+                            },
+                        );
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_83.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_83.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
-snapshot_kind: text
 ---
 version: 83
 feature_flags:
@@ -54,6 +53,8 @@ feature_flags:
       allowed_txn_cost_overage_burst_limit_us: 100000
       randomness_scalar: 20
       max_estimate_us: 1500000
+      stored_observations_num_included_checkpoints: 10
+      stored_observations_limit: 18446744073709551615
   consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_84.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_84.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 78
+version: 84
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true
@@ -39,12 +39,13 @@ feature_flags:
   verify_legacy_zklogin_address: true
   recompute_has_public_transfer_in_execution: true
   accept_zklogin_in_multisig: true
-  accept_passkey_in_multisig: true
   include_consensus_digest_in_prologue: true
   hardened_otw_check: true
   allow_receiving_object_id: true
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
+  enable_nitro_attestation: true
+  enable_nitro_attestation_upgraded_parsing: true
   reject_mutable_random_on_entry_functions: true
   per_object_congestion_control_mode:
     ExecutionTimeEstimate:
@@ -53,7 +54,7 @@ feature_flags:
       randomness_scalar: 20
       max_estimate_us: 1500000
       stored_observations_num_included_checkpoints: 10
-      stored_observations_limit: 18446744073709551615
+      stored_observations_limit: 20
   consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30
@@ -67,7 +68,6 @@ feature_flags:
   mysticeti_num_leaders_per_round: 1
   soft_bundle: true
   enable_coin_deny_list_v2: true
-  passkey_auth: true
   rethrow_serialization_type_layout_errors: true
   consensus_distributed_vote_scoring_strategy: true
   consensus_round_prober: true
@@ -85,6 +85,12 @@ feature_flags:
   minimize_child_object_mutations: true
   record_additional_state_digest_in_prologue: true
   move_native_context: true
+  consensus_median_based_commit_timestamp: true
+  normalize_ptb_arguments: true
+  consensus_batched_block_sync: true
+  enforce_checkpoint_timestamp_monotonicity: true
+  max_ptb_value_size_v2: true
+  resolve_type_input_ids_to_defining_id: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -163,6 +169,7 @@ obj_access_cost_mutate_per_byte: 40
 obj_access_cost_delete_per_byte: 40
 obj_access_cost_verify_per_byte: 200
 max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
 gas_model_version: 10
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50
@@ -204,6 +211,7 @@ object_borrow_uid_cost_base: 52
 object_delete_impl_cost_base: 52
 object_record_new_uid_cost_base: 52
 transfer_transfer_internal_cost_base: 52
+transfer_party_transfer_internal_cost_base: 52
 transfer_freeze_object_cost_base: 52
 transfer_share_object_cost_base: 52
 transfer_receive_object_cost_base: 52
@@ -348,7 +356,7 @@ vector_swap_base_cost: 52
 debug_print_base_cost: 52
 debug_print_stack_trace_base_cost: 52
 execution_version: 3
-consensus_bad_nodes_stake_threshold: 20
+consensus_bad_nodes_stake_threshold: 30
 max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_79.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_79.snap
@@ -53,6 +53,8 @@ feature_flags:
       allowed_txn_cost_overage_burst_limit_us: 100000
       randomness_scalar: 20
       max_estimate_us: 1500000
+      stored_observations_num_included_checkpoints: 10
+      stored_observations_limit: 18446744073709551615
   consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_80.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_80.snap
@@ -53,6 +53,8 @@ feature_flags:
       allowed_txn_cost_overage_burst_limit_us: 100000
       randomness_scalar: 20
       max_estimate_us: 1500000
+      stored_observations_num_included_checkpoints: 10
+      stored_observations_limit: 18446744073709551615
   consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_81.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_81.snap
@@ -53,6 +53,8 @@ feature_flags:
       allowed_txn_cost_overage_burst_limit_us: 100000
       randomness_scalar: 20
       max_estimate_us: 1500000
+      stored_observations_num_included_checkpoints: 10
+      stored_observations_limit: 18446744073709551615
   consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_82.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_82.snap
@@ -53,6 +53,8 @@ feature_flags:
       allowed_txn_cost_overage_burst_limit_us: 100000
       randomness_scalar: 20
       max_estimate_us: 1500000
+      stored_observations_num_included_checkpoints: 10
+      stored_observations_limit: 18446744073709551615
   consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_83.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_83.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
-snapshot_kind: text
 ---
 version: 83
 feature_flags:
@@ -55,6 +54,8 @@ feature_flags:
       allowed_txn_cost_overage_burst_limit_us: 100000
       randomness_scalar: 20
       max_estimate_us: 1500000
+      stored_observations_num_included_checkpoints: 10
+      stored_observations_limit: 18446744073709551615
   consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_84.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_84.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 78
+version: 84
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true
@@ -45,6 +45,8 @@ feature_flags:
   allow_receiving_object_id: true
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
+  enable_nitro_attestation: true
+  enable_nitro_attestation_upgraded_parsing: true
   reject_mutable_random_on_entry_functions: true
   per_object_congestion_control_mode:
     ExecutionTimeEstimate:
@@ -53,7 +55,7 @@ feature_flags:
       randomness_scalar: 20
       max_estimate_us: 1500000
       stored_observations_num_included_checkpoints: 10
-      stored_observations_limit: 18446744073709551615
+      stored_observations_limit: 20
   consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30
@@ -85,6 +87,12 @@ feature_flags:
   minimize_child_object_mutations: true
   record_additional_state_digest_in_prologue: true
   move_native_context: true
+  consensus_median_based_commit_timestamp: true
+  normalize_ptb_arguments: true
+  consensus_batched_block_sync: true
+  enforce_checkpoint_timestamp_monotonicity: true
+  max_ptb_value_size_v2: true
+  resolve_type_input_ids_to_defining_id: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -163,6 +171,7 @@ obj_access_cost_mutate_per_byte: 40
 obj_access_cost_delete_per_byte: 40
 obj_access_cost_verify_per_byte: 200
 max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
 gas_model_version: 10
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50
@@ -204,6 +213,7 @@ object_borrow_uid_cost_base: 52
 object_delete_impl_cost_base: 52
 object_record_new_uid_cost_base: 52
 transfer_transfer_internal_cost_base: 52
+transfer_party_transfer_internal_cost_base: 52
 transfer_freeze_object_cost_base: 52
 transfer_share_object_cost_base: 52
 transfer_receive_object_cost_base: 52
@@ -348,7 +358,7 @@ vector_swap_base_cost: 52
 debug_print_base_cost: 52
 debug_print_stack_trace_base_cost: 52
 execution_version: 3
-consensus_bad_nodes_stake_threshold: 20
+consensus_bad_nodes_stake_threshold: 30
 max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_78.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_78.snap
@@ -55,6 +55,8 @@ feature_flags:
       allowed_txn_cost_overage_burst_limit_us: 100000
       randomness_scalar: 20
       max_estimate_us: 1500000
+      stored_observations_num_included_checkpoints: 10
+      stored_observations_limit: 18446744073709551615
   consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_79.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_79.snap
@@ -55,6 +55,8 @@ feature_flags:
       allowed_txn_cost_overage_burst_limit_us: 100000
       randomness_scalar: 20
       max_estimate_us: 1500000
+      stored_observations_num_included_checkpoints: 10
+      stored_observations_limit: 18446744073709551615
   consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_80.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_80.snap
@@ -55,6 +55,8 @@ feature_flags:
       allowed_txn_cost_overage_burst_limit_us: 100000
       randomness_scalar: 20
       max_estimate_us: 1500000
+      stored_observations_num_included_checkpoints: 10
+      stored_observations_limit: 18446744073709551615
   consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_81.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_81.snap
@@ -55,6 +55,8 @@ feature_flags:
       allowed_txn_cost_overage_burst_limit_us: 100000
       randomness_scalar: 20
       max_estimate_us: 1500000
+      stored_observations_num_included_checkpoints: 10
+      stored_observations_limit: 18446744073709551615
   consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_82.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_82.snap
@@ -55,6 +55,8 @@ feature_flags:
       allowed_txn_cost_overage_burst_limit_us: 100000
       randomness_scalar: 20
       max_estimate_us: 1500000
+      stored_observations_num_included_checkpoints: 10
+      stored_observations_limit: 18446744073709551615
   consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_83.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_83.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
-snapshot_kind: text
 ---
 version: 83
 feature_flags:
@@ -57,6 +56,8 @@ feature_flags:
       allowed_txn_cost_overage_burst_limit_us: 100000
       randomness_scalar: 20
       max_estimate_us: 1500000
+      stored_observations_num_included_checkpoints: 10
+      stored_observations_limit: 18446744073709551615
   consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_84.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_84.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 78
+version: 84
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true
@@ -43,8 +43,12 @@ feature_flags:
   include_consensus_digest_in_prologue: true
   hardened_otw_check: true
   allow_receiving_object_id: true
+  enable_poseidon: true
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
+  enable_group_ops_native_function_msm: true
+  enable_nitro_attestation: true
+  enable_nitro_attestation_upgraded_parsing: true
   reject_mutable_random_on_entry_functions: true
   per_object_congestion_control_mode:
     ExecutionTimeEstimate:
@@ -53,7 +57,7 @@ feature_flags:
       randomness_scalar: 20
       max_estimate_us: 1500000
       stored_observations_num_included_checkpoints: 10
-      stored_observations_limit: 18446744073709551615
+      stored_observations_limit: 20
   consensus_choice: Mysticeti
   consensus_network: Tonic
   zklogin_max_epoch_upper_bound_delta: 30
@@ -61,6 +65,7 @@ feature_flags:
   reshare_at_same_initial_version: true
   resolve_abort_locations_to_package_id: true
   mysticeti_use_committed_subdag_digest: true
+  enable_vdf: true
   record_consensus_determined_version_assignments_in_prologue: true
   fresh_vm_on_framework_upgrade: true
   prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
@@ -68,10 +73,12 @@ feature_flags:
   soft_bundle: true
   enable_coin_deny_list_v2: true
   passkey_auth: true
+  authority_capabilities_v2: true
   rethrow_serialization_type_layout_errors: true
   consensus_distributed_vote_scoring_strategy: true
   consensus_round_prober: true
   validate_identifier_inputs: true
+  mysticeti_fastpath: true
   relocate_event_module: true
   uncompressed_g1_group_elements: true
   disallow_new_modules_in_deps_only_packages: true
@@ -85,6 +92,12 @@ feature_flags:
   minimize_child_object_mutations: true
   record_additional_state_digest_in_prologue: true
   move_native_context: true
+  consensus_median_based_commit_timestamp: true
+  normalize_ptb_arguments: true
+  consensus_batched_block_sync: true
+  enforce_checkpoint_timestamp_monotonicity: true
+  max_ptb_value_size_v2: true
+  resolve_type_input_ids_to_defining_id: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000
@@ -163,6 +176,7 @@ obj_access_cost_mutate_per_byte: 40
 obj_access_cost_delete_per_byte: 40
 obj_access_cost_verify_per_byte: 200
 max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
 gas_model_version: 10
 obj_data_cost_refundable: 100
 obj_metadata_cost_non_refundable: 50
@@ -204,6 +218,7 @@ object_borrow_uid_cost_base: 52
 object_delete_impl_cost_base: 52
 object_record_new_uid_cost_base: 52
 transfer_transfer_internal_cost_base: 52
+transfer_party_transfer_internal_cost_base: 52
 transfer_freeze_object_cost_base: 52
 transfer_share_object_cost_base: 52
 transfer_receive_object_cost_base: 52
@@ -273,6 +288,7 @@ hash_blake2b256_data_cost_per_block: 2
 hash_keccak256_cost_base: 10
 hash_keccak256_data_cost_per_byte: 2
 hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_base: 260
 poseidon_bn254_cost_per_block: 388
 group_ops_bls12381_decode_scalar_cost: 7
 group_ops_bls12381_decode_g1_cost: 2848
@@ -314,6 +330,8 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
+vdf_verify_vdf_cost: 1500
+vdf_hash_to_input_cost: 100
 nitro_attestation_parse_base_cost: 2650
 nitro_attestation_parse_cost_per_byte: 50
 nitro_attestation_verify_base_cost: 2481600
@@ -348,7 +366,7 @@ vector_swap_base_cost: 52
 debug_print_base_cost: 52
 debug_print_stack_trace_base_cost: 52
 execution_version: 3
-consensus_bad_nodes_stake_threshold: 20
+consensus_bad_nodes_stake_threshold: 30
 max_jwk_votes_per_validator_per_epoch: 240
 max_age_of_jwk_in_epochs: 1
 random_beacon_reduction_allowed_delta: 800

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -6,7 +6,7 @@ ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 83
+  protocol_version: 84
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
   stake_subsidy_start_epoch: 0

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -3,7 +3,7 @@ source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis.sui_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 83
+protocol_version: 84
 system_state_version: 1
 validators:
   total_stake: 20000000000000000
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0xb2f1db3cc4285768b15ecf89ddb966fdf3b7131a852df07e220952344e08742d"
+            id: "0x0b8f6872780497d46028718b252ce9768a413e4afb6c33be64b5cd53c869f090"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x72c405e1e6d5aed909249f19b91e8e99be6d80319267e1b2baedd14197169a54"
+      operation_cap_id: "0x5a301696456b25f2c236f05a5ad7152b6d2c8fd8c403c3de0b9fede29330c99f"
       gas_price: 1000
       staking_pool:
-        id: "0xbc5c3844befe5b0b33a9702c763eb6ecf4dbf1d4dec407a2ee780df87f20dca2"
+        id: "0xeb3440c886a8ab43e4f144a21ed2c147bc96ef639df9539721fceb774a06e05f"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0xf6a72f2683a50de9208e6b59edfe9a60f719aad1af53742fc3017de9d52e1291"
+          id: "0xa1311024d60fa6e8ea5071c9be8d5a700fa39ee5619a26d73f2e05af0abd770a"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x41d0d51aa62701b37d44e49befb6b0dc4444485e1e1e12618f7f3539e8f5eabb"
+            id: "0xa859772ad202e5fc2aa5e8d52ac6929620f5831381c76dda43cc62dfd04ad77a"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0xf6408f4c7a77ae130f4fd353361098be461057069b3c0686bc7117626c1ff101"
+          id: "0xc325e6610bc193da0f6a7d282454fe1dee4c1243aa60e762bed38d118c972f1a"
         size: 0
   pending_active_validators:
     contents:
-      id: "0xb54e5918015d34e5221d7b86f17e25b3039d20526f41a0b854bda4ac2a09a423"
+      id: "0xa63bcdac127e4dd54e25f13cdd786e52decd70d2af2950a70a3d9aacf7d0f718"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x7303a3f3e2f5b3a8f297aa795903bb593942eb310e39aeac98d8a53c72bd848c"
+    id: "0x7dec1d150d7cf226f424ca3228010804a651cb715151af99d7912d9fce0df5cd"
     size: 1
   inactive_validators:
-    id: "0x3698080e9ca960a57a87a206b846956e55f18c8a7296951fd29291bb34d38ad0"
+    id: "0x2d681e250a100a460fafda3adea955735f136d12b3a9977b4f94c43d5d5f3e27"
     size: 0
   validator_candidates:
-    id: "0x8ec6c14f1ca4bf7faa63063964bc573170493924553d631447fb84f2c49c8245"
+    id: "0xd7ad8d3ca439a704b99a3b7b3567604cbde87eec66fee60e088498a4b9f70724"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x14fc580ee7e556f3ac8a32f41c5521e0d4d0d66ea905bedab4fbb3bafcad091a"
+      id: "0xd384dc69f2a842513015fb8051b0a5d77a4c6adde76e3fec3f114975e9bbbf10"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0xb26fabbac902fba60145eb3fef7a73c1d1ed1769fce36f32fddca42c34f8aa87"
+      id: "0xccfe8ab3e028073531a368b0b3eb86661434746304fe6706111134eb619384c0"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x915782bb19fe208b3978be819e42e6e728d86d22ec615671b6813ea000f09a2c"
+      id: "0x5011e1a5dfcf93a1dddb825f1d9e0e7948126f53f898f3f94fa7c8dd758483d9"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,5 +332,5 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0xe6526c753f74a68581b82b42c42fca82b6751be9de8cf478a354fd84989b9bd4"
+    id: "0x4091ff82ac20ad186370a1777132fd7b910845b630ff33b522e47b7b75bb59a1"
   size: 0

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -242,7 +242,7 @@ impl StoredExecutionTimeObservations {
         }
     }
 
-    pub fn filter_and_sort_v1<P>(&self, predicate: P) -> Self
+    pub fn filter_and_sort_v1<P>(&self, predicate: P, limit: usize) -> Self
     where
         P: FnMut(&&(ExecutionTimeObservationKey, Vec<(AuthorityName, Duration)>)) -> bool,
     {
@@ -252,6 +252,7 @@ impl StoredExecutionTimeObservations {
                     .iter()
                     .filter(predicate)
                     .sorted_by_key(|(key, _)| key)
+                    .take(limit)
                     .cloned()
                     .collect(),
             ),


### PR DESCRIPTION
Cherry-pick #22167 into 1.49

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
