### PR TITLE
Don't spawn_blocking on cache hit

### DIFF
--- a/crates/sui-json-rpc/src/authority_state.rs
+++ b/crates/sui-json-rpc/src/authority_state.rs
@@ -449,14 +449,11 @@ impl StateRead for AuthorityState {
         coin_type: TypeTag,
     ) -> StateReadResult<TotalBalance> {
         let indexes = self.indexes.clone();
-        Ok(tokio::task::spawn_blocking(move || {
-            indexes
-                .as_ref()
-                .ok_or(SuiError::IndexStoreNotAvailable)?
-                .get_balance(owner, coin_type)
-        })
-        .await
-        .map_err(|e: JoinError| SuiError::ExecutionError(e.to_string()))??)
+        Ok(indexes
+            .as_ref()
+            .ok_or(SuiError::IndexStoreNotAvailable)?
+            .get_balance(owner, coin_type)
+            .await?)
     }
 
     async fn get_all_balance(
@@ -464,14 +461,11 @@ impl StateRead for AuthorityState {
         owner: SuiAddress,
     ) -> StateReadResult<Arc<HashMap<TypeTag, TotalBalance>>> {
         let indexes = self.indexes.clone();
-        Ok(tokio::task::spawn_blocking(move || {
-            indexes
-                .as_ref()
-                .ok_or(SuiError::IndexStoreNotAvailable)?
-                .get_all_balance(owner)
-        })
-        .await
-        .map_err(|e: JoinError| SuiError::ExecutionError(e.to_string()))??)
+        Ok(indexes
+            .as_ref()
+            .ok_or(SuiError::IndexStoreNotAvailable)?
+            .get_all_balance(owner)
+            .await?)
     }
 
     fn get_verified_checkpoint_by_sequence_number(


### PR DESCRIPTION
## Description

I was reviewing how the `get_balance` and `get_all_balances` APIs work and I noticed we were moving to a `spawn_blocking` task, even on a cache hit. This could add substantial unnecessary latency overhead in the high percentiles, especially if a cache hit gets stuck behind some expensive blocking tasks.

This change moves just the expensive DB lookup and aggregation compute to `spawn_blocking` and uses a tokio OnceCell to de-duplicate concurrent in-flight cache misses so we don't do any additional work than we were doing before.

## Test plan

* Manually tested the get_balance and get_all_balances RPC apis
* CI passes

Let me know if there is anything else I should test. I wasn't sure about testing the batch_merge logic specifically which makes this a bit nerve-wracking to merge.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [x] JSON-RPC: Eliminating unnecessary `spawn_blocking` tasks for cache hits on the get_balance and get_all_balances json rpc APIs.
