### PR TITLE
[move][move-compiler] Add modes to compiler

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/analysis/parsing_analysis.rs
+++ b/external-crates/move/crates/move-analyzer/src/analysis/parsing_analysis.rs
@@ -117,6 +117,7 @@ impl<'a> ParsingAnalysisContext<'a> {
             | A::DefinesPrimitive(..)
             | A::Deprecation { .. }
             | A::Error { .. }
+            | A::Mode { .. }
             | A::Syntax { .. }
             | A::Allow { .. }
             | A::LintAllow { .. } => (),
@@ -126,8 +127,7 @@ impl<'a> ParsingAnalysisContext<'a> {
                     self.parsed_attr_symbols(parsed);
                 }
             }
-            A::VerifyOnly => {}
-            A::Test | A::TestOnly | A::RandomTest => {}
+            A::Test | A::RandomTest => {}
             A::ExpectedFailure {
                 minor_status,
                 failure_kind,
@@ -201,7 +201,7 @@ impl<'a> ParsingAnalysisContext<'a> {
         mod_def
             .attributes
             .iter()
-            .for_each(|sp!(_, attrs)| attrs.iter().for_each(|a| self.attr_symbols(a)));
+            .for_each(|sp!(_, attrs)| attrs.0.iter().for_each(|a| self.attr_symbols(a)));
 
         // location of the latest use declaration (if any)
         let mut latest_use_loc = Loc::new(mod_def.loc.file_hash(), 0, 0);
@@ -232,9 +232,9 @@ impl<'a> ParsingAnalysisContext<'a> {
                         }
                     };
 
-                    fun.attributes
-                        .iter()
-                        .for_each(|sp!(_, attrs)| attrs.iter().for_each(|a| self.attr_symbols(a)));
+                    fun.attributes.iter().for_each(|sp!(_, attrs)| {
+                        attrs.0.iter().for_each(|a| self.attr_symbols(a))
+                    });
 
                     for (_, x, t) in fun.signature.parameters.iter() {
                         update_cursor!(IDENT, self.cursor, x, Parameter);
@@ -266,9 +266,9 @@ impl<'a> ParsingAnalysisContext<'a> {
                         }
                     };
 
-                    sdef.attributes
-                        .iter()
-                        .for_each(|sp!(_, attrs)| attrs.iter().for_each(|a| self.attr_symbols(a)));
+                    sdef.attributes.iter().for_each(|sp!(_, attrs)| {
+                        attrs.0.iter().for_each(|a| self.attr_symbols(a))
+                    });
 
                     match &sdef.fields {
                         P::StructFields::Named(v) => v.iter().for_each(|(_, x, t)| {
@@ -296,9 +296,9 @@ impl<'a> ParsingAnalysisContext<'a> {
                         }
                     };
 
-                    edef.attributes
-                        .iter()
-                        .for_each(|sp!(_, attrs)| attrs.iter().for_each(|a| self.attr_symbols(a)));
+                    edef.attributes.iter().for_each(|sp!(_, attrs)| {
+                        attrs.0.iter().for_each(|a| self.attr_symbols(a))
+                    });
 
                     let P::EnumDefinition { variants, .. } = edef;
                     for variant in variants {
@@ -338,9 +338,9 @@ impl<'a> ParsingAnalysisContext<'a> {
                         }
                     };
 
-                    c.attributes
-                        .iter()
-                        .for_each(|sp!(_, attrs)| attrs.iter().for_each(|a| self.attr_symbols(a)));
+                    c.attributes.iter().for_each(|sp!(_, attrs)| {
+                        attrs.0.iter().for_each(|a| self.attr_symbols(a))
+                    });
 
                     self.type_symbols(&c.signature);
                     self.exp_symbols(&c.value);
@@ -669,7 +669,7 @@ impl<'a> ParsingAnalysisContext<'a> {
         use_decl
             .attributes
             .iter()
-            .for_each(|sp!(_, attrs)| attrs.iter().for_each(|a| self.attr_symbols(a)));
+            .for_each(|sp!(_, attrs)| attrs.0.iter().for_each(|a| self.attr_symbols(a)));
 
         update_cursor!(self.cursor, sp(use_decl.loc, use_decl.use_.clone()), Use);
 

--- a/external-crates/move/crates/move-cli/tests/build_tests/dependency_deprecated_attributes/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/dependency_deprecated_attributes/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "A"
+edition = "2024.beta"
+
+[addresses]
+A = "0x1"
+
+[dependencies]
+Dep = { local = "./dep" }

--- a/external-crates/move/crates/move-cli/tests/build_tests/dependency_deprecated_attributes/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/dependency_deprecated_attributes/args.exp
@@ -1,0 +1,9 @@
+Command `build -v --mode verify_only`:
+INCLUDING DEPENDENCY Dep
+BUILDING A
+warning[W00001]: DEPRECATED. will be removed
+   ┌─ ./sources/l.move:16:3
+   │
+16 │ #[verify_only]
+   │   ^^^^^^^^^^^ The 'verify_only' attribute has been deprecated along with specification blocks
+

--- a/external-crates/move/crates/move-cli/tests/build_tests/dependency_deprecated_attributes/args.txt
+++ b/external-crates/move/crates/move-cli/tests/build_tests/dependency_deprecated_attributes/args.txt
@@ -1,0 +1,1 @@
+build -v --mode verify_only

--- a/external-crates/move/crates/move-cli/tests/build_tests/dependency_deprecated_attributes/dep/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/dependency_deprecated_attributes/dep/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Dep"
+edition = "2024.beta"
+
+[addresses]
+A = "_"

--- a/external-crates/move/crates/move-cli/tests/build_tests/dependency_deprecated_attributes/dep/sources/m.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/dependency_deprecated_attributes/dep/sources/m.move
@@ -1,0 +1,12 @@
+module A::m;
+
+#[verify_only]
+public struct Bar() has drop;
+
+
+public fun make_bar(): Bar {
+    Bar()
+}
+
+#[verify_only]
+public fun verify_fun() { }

--- a/external-crates/move/crates/move-cli/tests/build_tests/dependency_deprecated_attributes/sources/l.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/dependency_deprecated_attributes/sources/l.move
@@ -1,0 +1,17 @@
+module A::l;
+
+use A::m as am;
+
+#[allow(unused_function)]
+fun f() {
+    am::make_bar();
+    am::verify_fun();
+    l<am::Bar>();
+    verify_fun();
+}
+
+#[allow(unused_function, unused_type_parameter)]
+fun l<T>() { }
+
+#[verify_only]
+fun verify_fun() {  }

--- a/external-crates/move/crates/move-cli/tests/build_tests/help/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/help/args.exp
@@ -53,6 +53,8 @@ Options:
           If `true`, disable linters
       --lint
           If `true`, enables extra linters
+      --mode <MODE>
+          Arbitrary mode -- this will be used to enable or filter user-defined `#[mode(<MODE>)]` annodations during compiltaion
   -h, --help
           Print help
   -V, --version

--- a/external-crates/move/crates/move-cli/tests/build_tests/modes/Move.toml
+++ b/external-crates/move/crates/move-cli/tests/build_tests/modes/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "foo"
+edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+
+[dependencies]
+
+[addresses]
+
+[dev-addresses]
+std = "0x1"

--- a/external-crates/move/crates/move-cli/tests/build_tests/modes/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/modes/args.exp
@@ -1,0 +1,65 @@
+Command `build --mode spec`:
+BUILDING foo
+error[E03009]: unbound variable
+  ┌─ ./sources/foo.move:5:11
+  │
+5 │     abort(invalid_code);
+  │           ^^^^^^^^^^^^ Unbound variable 'invalid_code'
+
+error[E03009]: unbound variable
+   ┌─ ./sources/foo.move:10:11
+   │
+10 │     abort(invalid_code);
+   │           ^^^^^^^^^^^^ Unbound variable 'invalid_code'
+
+Command `build --mode test`:
+BUILDING foo
+error[E10005]: unable to generate test
+  ┌─ ./sources/foo.move:1:14
+  │
+1 │ module 0x42::foo;
+  │              ^^^ Compilation in test mode requires passing the UnitTest module in the Move stdlib as a dependency
+
+error[E03009]: unbound variable
+  ┌─ ./sources/foo.move:5:11
+  │
+5 │     abort(invalid_code);
+  │           ^^^^^^^^^^^^ Unbound variable 'invalid_code'
+
+error[E03009]: unbound variable
+   ┌─ ./sources/foo.move:15:11
+   │
+15 │     abort(invalid_code);
+   │           ^^^^^^^^^^^^ Unbound variable 'invalid_code'
+
+Command `build --mode test --mode spec`:
+BUILDING foo
+error[E10005]: unable to generate test
+  ┌─ ./sources/foo.move:1:14
+  │
+1 │ module 0x42::foo;
+  │              ^^^ Compilation in test mode requires passing the UnitTest module in the Move stdlib as a dependency
+
+error[E03009]: unbound variable
+  ┌─ ./sources/foo.move:5:11
+  │
+5 │     abort(invalid_code);
+  │           ^^^^^^^^^^^^ Unbound variable 'invalid_code'
+
+error[E03009]: unbound variable
+   ┌─ ./sources/foo.move:10:11
+   │
+10 │     abort(invalid_code);
+   │           ^^^^^^^^^^^^ Unbound variable 'invalid_code'
+
+error[E02001]: duplicate declaration, item, or annotation
+   ┌─ ./sources/foo.move:14:12
+   │
+ 9 │ public fun bar() {
+   │            --- Alias previously defined here
+   ·
+14 │ public fun bar() {
+   │            ^^^ Duplicate module member or alias 'bar'. Top level names in a namespace must be unique
+
+Command `build`:
+BUILDING foo

--- a/external-crates/move/crates/move-cli/tests/build_tests/modes/args.txt
+++ b/external-crates/move/crates/move-cli/tests/build_tests/modes/args.txt
@@ -1,0 +1,4 @@
+build --mode spec
+build --mode test
+build --mode test --mode spec
+build

--- a/external-crates/move/crates/move-cli/tests/build_tests/modes/sources/foo.move
+++ b/external-crates/move/crates/move-cli/tests/build_tests/modes/sources/foo.move
@@ -1,0 +1,16 @@
+module 0x42::foo;
+
+#[mode(spec, test)]
+public fun foo() {
+    abort(invalid_code);
+}
+
+#[mode(spec)]
+public fun bar() {
+    abort(invalid_code);
+}
+
+#[mode(test)]
+public fun bar() {
+    abort(invalid_code);
+}

--- a/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
+++ b/external-crates/move/crates/move-compiler/src/command_line/compiler.rs
@@ -890,7 +890,7 @@ pub fn move_check_for_errors(
 
         let (compiler, cfgir) = compiler.run::<PASS_CFGIR>()?.into_ast();
         let compilation_env = compiler.compilation_env();
-        if compilation_env.flags().is_testing() {
+        if compilation_env.test_mode() {
             unit_test::plan_builder::construct_test_plan(compilation_env, None, &cfgir);
         }
 
@@ -984,7 +984,7 @@ fn run(
                         pre_compiled_lib.clone(),
                         prog,
                     );
-                    let prog = verification_attribute_filter::program(compilation_env, prog);
+                    let prog = mode_attribute_filter::program(compilation_env, prog);
                     expansion::translate::program(compilation_env, pre_compiled_lib.clone(), prog)
                 };
                 rec(

--- a/external-crates/move/crates/move-compiler/src/diagnostics/warning_filters.rs
+++ b/external-crates/move/crates/move-compiler/src/diagnostics/warning_filters.rs
@@ -6,7 +6,7 @@ use crate::{
         codes::{Category, DiagnosticInfo, ExternalPrefix, Severity, UnusedItem},
         Diagnostic, DiagnosticCode,
     },
-    shared::{known_attributes, AstDebug},
+    shared::{known_attributes, AstDebug, CompilationEnv},
 };
 use move_symbol_pool::Symbol;
 use std::{
@@ -269,6 +269,16 @@ impl WarningFiltersBuilder {
             filters: BTreeMap::new(),
             for_dependency: true,
         }
+    }
+
+    pub fn new_all_filter_alls(env: &CompilationEnv) -> Self {
+        let mut all_filter_alls = WarningFiltersBuilder::new_for_dependency();
+        for prefix in env.known_filter_names() {
+            for f in env.filter_from_str(prefix, FILTER_ALL) {
+                all_filter_alls.add(f);
+            }
+        }
+        all_filter_alls
     }
 
     pub fn is_filtered(&self, diag: &Diagnostic) -> bool {

--- a/external-crates/move/crates/move-compiler/src/expansion/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/ast.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     shared::{
         ast_debug::*,
-        known_attributes::{AttributeKind, KnownAttribute},
+        known_attributes::{AttributeKind, KnownAttribute, ModeAttribute},
         unique_map::UniqueMap,
         unique_set::UniqueSet,
         *,
@@ -538,9 +538,13 @@ impl Hash for Address {
 
 impl Attributes {
     pub fn is_test_or_test_only(&self) -> bool {
-        self.contains_key_(&known_attributes::AttributeKind_::TestOnly)
-            || self.contains_key_(&known_attributes::AttributeKind_::RandTest)
-            || self.contains_key_(&known_attributes::AttributeKind_::Test)
+        let Some(attr) = self.get_(&known_attributes::AttributeKind_::Mode) else {
+            return false;
+        };
+        let KnownAttribute::Mode(ModeAttribute { modes }) = &attr.value else {
+            unreachable!()
+        };
+        modes.contains(&sp(Loc::invalid(), ModeAttribute::TEST.into()))
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/expansion/attributes.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/attributes.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeSet;
+
 use crate::{
     diag,
     expansion::{
@@ -12,7 +14,8 @@ use crate::{
     parser::ast as P,
     shared::{
         known_attributes::{
-            self as A, AttributeKind_, AttributePosition, KnownAttribute, TestingAttribute,
+            self as A, AttributeKind, AttributeKind_, AttributePosition, KnownAttribute,
+            ModeAttribute, TestingAttribute,
         },
         unique_map::UniqueMap,
         Name,
@@ -21,25 +24,37 @@ use crate::{
 
 use move_core_types::vm_status::StatusCode;
 use move_ir_types::location::*;
+use move_symbol_pool::Symbol;
 
 pub fn expand_attributes(
     context: &mut Context,
     attr_position: AttributePosition,
     attribute_vec: Vec<P::Attributes>,
 ) -> E::Attributes {
-    let mut attr_map = UniqueMap::new();
+    let mut attributes: Vec<(AttributeKind, Spanned<KnownAttribute>)> = vec![];
     for sp!(_, attrs) in attribute_vec {
         let attrs = attrs
+            .0
             .into_iter()
             .filter_map(|attr| attribute(context, attr_position, attr))
             .collect::<Vec<_>>();
-        for attr in attrs {
-            if !validate_position(context, &attr_position, &attr)
-                || !no_conflicts(context, &attr_position, &attr_map, &attr)
-                || !insert_attribute(context, &mut attr_map, attr)
-            {
-                continue;
-            }
+        let attrs = attrs
+            .into_iter()
+            .filter(|attr| validate_position(context, &attr_position, attr))
+            .map(|attr| {
+                let attr_kind = sp(attr.loc, attr.value.attribute_kind());
+                (attr_kind, attr)
+            })
+            .collect::<Vec<_>>();
+        attributes.extend(attrs);
+    }
+
+    let attributes = collect_modes(context, &attr_position, attributes);
+
+    let mut attr_map = UniqueMap::new();
+    for (kind, attr) in attributes {
+        if check_conflicts(context, &attr_position, &attr_map, &attr) {
+            insert_attribute(context, &mut attr_map, kind, attr);
         }
     }
     attr_map
@@ -76,9 +91,67 @@ fn validate_position(
         true
     }
 }
+/// Checks there are no mode conflicts, including duplicates or testing definitions.
+fn collect_modes(
+    context: &mut Context,
+    posn: &AttributePosition,
+    attributes: Vec<(AttributeKind, Spanned<KnownAttribute>)>,
+) -> Vec<(AttributeKind, Spanned<KnownAttribute>)> {
+    use AttributeKind_ as K;
+    let (mode_attrs, mut attributes): (Vec<(AttributeKind, Spanned<KnownAttribute>)>, _) =
+        attributes
+            .into_iter()
+            .partition(|(kind, _)| matches!(kind.value, K::Mode));
+    let mut modes: BTreeSet<Spanned<Symbol>> = BTreeSet::new();
+    let mut attr_loc = None;
+    for (_, mode) in mode_attrs {
+        let sp!(loc, KnownAttribute::Mode(mode_attr)) = mode else {
+            unreachable!()
+        };
+        let ModeAttribute { modes: new_modes } = mode_attr;
+        for mode in new_modes {
+            if let Some(prev) = modes.get(&mode) {
+                let msg = format!("{posn} annotated with duplicate mode '{mode}'");
+                let prev_msg = "Previously annotated here";
+                let mut diag = diag!(
+                    Attributes::ValueWarning,
+                    (mode.loc, msg),
+                    (prev.loc, prev_msg)
+                );
+                let has_test_attribute = attributes
+                    .iter()
+                    .any(|(kind, _)| matches!(kind.value, K::Test | K::RandTest));
+                // Carve-out additional note for `test` and `random-test`
+                if mode.value.as_str() == "test" && has_test_attribute {
+                    let msg = format!(
+                        "Attributes '#[{}]' and '#[{}]' implicitly specify '#[{}({})]'",
+                        A::TestingAttribute::TEST,
+                        A::TestingAttribute::RAND_TEST,
+                        A::ModeAttribute::MODE,
+                        A::ModeAttribute::TEST
+                    );
+                    diag.add_note(msg);
+                }
+                context.add_diag(diag);
+            } else {
+                attr_loc.get_or_insert(loc);
+                modes.insert(mode);
+            }
+        }
+    }
 
-// Checks there are no conlficting definitions (though does not check for duplicates)".
-fn no_conflicts(
+    if !modes.is_empty() {
+        let loc = attr_loc.expect("Bad logic in mode resolution");
+        let attr_kind = sp(loc, AttributeKind_::Mode);
+        let attr = KnownAttribute::Mode(ModeAttribute { modes });
+        attributes.push((attr_kind, sp(loc, attr)));
+    }
+    attributes
+}
+
+/// Checks there are no conflicting definitions (though does not check for duplicates).
+/// This also ensures that the modes are compatible for testing definitions.
+fn check_conflicts(
     context: &mut Context,
     posn: &AttributePosition,
     attr_map: &E::Attributes,
@@ -105,32 +178,30 @@ fn no_conflicts(
         | KA::Diagnostic(..)
         | KA::Error(..)
         | KA::External(..)
-        | KA::Syntax(..)
-        | KA::Verification(..) => vec![],
+        | KA::Mode(..)
+        | KA::Syntax(..) => vec![],
         KA::Testing(test_attr) => match test_attr {
             crate::shared::known_attributes::TestingAttribute::ExpectedFailure(..) => vec![],
             crate::shared::known_attributes::TestingAttribute::Test => {
-                matching_kinds(attr_map, &[K::TestOnly, K::RandTest])
-            }
-            crate::shared::known_attributes::TestingAttribute::TestOnly => {
-                matching_kinds(attr_map, &[K::Test, K::RandTest])
+                matching_kinds(attr_map, &[K::RandTest])
             }
             crate::shared::known_attributes::TestingAttribute::RandTest => {
-                matching_kinds(attr_map, &[K::Test, K::TestOnly])
+                matching_kinds(attr_map, &[K::Test])
             }
         },
     };
     if !conflicts.is_empty() {
-        for (prev_loc, prev_kind) in conflicts {
+        for (conflict_loc, conflict_kind) in conflicts {
             let msg = format!(
-                "{posn} annotated as both #[{}] and #[{prev_kind}]. You need to declare it as either one or the other",
-                attr.name()
+                "{posn} annotated as both #[{}] and #[{conflict_kind}]. \
+                You need to declare it as either one or the other",
+                attr.name(),
             );
             let prev_msg = "Previously annotated here";
             context.add_diag(diag!(
                 Attributes::InvalidUsage,
                 (*attr_loc, msg),
-                (prev_loc, prev_msg)
+                (conflict_loc, prev_msg)
             ));
         }
         false
@@ -142,23 +213,22 @@ fn no_conflicts(
 fn insert_attribute(
     context: &mut Context,
     attr_map: &mut E::Attributes,
+    attr_kind: AttributeKind,
     sp!(attr_loc, attr): Spanned<KnownAttribute>,
-) -> bool {
-    let attr_kind = sp(attr_loc, attr.attribute_kind());
+) {
     if let Some(prev_loc) = attr_map.get_loc(&attr_kind) {
         let msg = format!("Duplicate attribute '{attr_kind}' attached to the same item");
         let prev_msg = "Attribute previously given here".to_string();
-        context.add_diag(diag!(
+        let diag = diag!(
             Attributes::Duplicate,
             (attr_loc, msg),
             (*prev_loc, prev_msg)
-        ));
-        false
+        );
+        context.add_diag(diag);
     } else {
         attr_map
             .add(attr_kind, sp(attr_loc, attr))
             .expect("ICE: failed insert");
-        true
     }
 }
 
@@ -216,14 +286,15 @@ fn attribute(
             let attrs = unique_ext_attributes(context, attrs);
             KA::External(A::ExternalAttribute { attrs })
         }
+        PA::Mode { modes } => KA::Mode(A::ModeAttribute { modes }),
         PA::Syntax { kind } => KA::Syntax(A::SyntaxAttribute { kind }),
-        PA::VerifyOnly => KA::Verification(A::VerificationAttribute::VerifyOnly),
+        // -- allow --
         PA::Allow { allow_set } => KA::Diagnostic(A::DiagnosticAttribute::Allow { allow_set }),
         PA::LintAllow { allow_set } => {
             KA::Diagnostic(A::DiagnosticAttribute::LintAllow { allow_set })
         }
+        // -- testing --
         PA::Test => KA::Testing(A::TestingAttribute::Test),
-        PA::TestOnly => KA::Testing(A::TestingAttribute::TestOnly),
         PA::ExpectedFailure {
             failure_kind,
             minor_status,

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -5,7 +5,7 @@
 use crate::{
     diag,
     diagnostics::{
-        warning_filters::{WarningFilters, WarningFiltersBuilder, WarningFiltersTable, FILTER_ALL},
+        warning_filters::{WarningFilters, WarningFiltersBuilder, WarningFiltersTable},
         Diagnostic, DiagnosticReporter, Diagnostics,
     },
     editions::{self, Edition, FeatureGate, Flavor},
@@ -94,12 +94,7 @@ impl<'env> Context<'env, '_> {
         address_conflicts: BTreeSet<Symbol>,
     ) -> Self {
         let mut warning_filters_table = WarningFiltersTable::new();
-        let mut all_filter_alls = WarningFiltersBuilder::new_for_dependency();
-        for prefix in compilation_env.known_filter_names() {
-            for f in compilation_env.filter_from_str(prefix, FILTER_ALL) {
-                all_filter_alls.add(f);
-            }
-        }
+        let all_filter_alls = WarningFiltersBuilder::new_all_filter_alls(compilation_env);
         let all_filter_alls = warning_filters_table.add(all_filter_alls);
         let reporter = compilation_env.diagnostic_reporter_at_top_level();
         let defn_context = DefnContext {
@@ -634,7 +629,7 @@ pub fn program(
     //
     for (mident, module) in lib_module_map {
         if let Err((mident, old_loc)) = source_module_map.add(mident, module) {
-            if !context.env().flags().sources_shadow_deps() {
+            if !context.env().sources_shadow_deps() {
                 duplicate_module(&mut context, &source_module_map, mident, old_loc)
             }
         }

--- a/external-crates/move/crates/move-compiler/src/parser/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/mod.rs
@@ -8,9 +8,9 @@ pub mod comments;
 pub(crate) mod filter;
 pub mod keywords;
 pub mod lexer;
+pub(crate) mod mode_attribute_filter;
 pub(crate) mod syntax;
 mod token_set;
-pub(crate) mod verification_attribute_filter;
 
 use crate::{
     parser::{self, ast::PackageDefinition, syntax::parse_file_string},
@@ -159,7 +159,7 @@ fn ensure_targets_deps_dont_intersect(
     if intersection.is_empty() {
         return Ok(());
     }
-    if compilation_env.flags().sources_shadow_deps() {
+    if compilation_env.sources_shadow_deps() {
         deps.retain(|p| !intersection.contains(&&p.path.as_str().to_owned()));
         return Ok(());
     }

--- a/external-crates/move/crates/move-compiler/src/parser/mode_attribute_filter.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/mode_attribute_filter.rs
@@ -1,9 +1,5 @@
-// Copyright (c) The Diem Core Contributors
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
-
-use move_ir_types::location::Loc;
-use move_symbol_pool::Symbol;
 
 use crate::{
     diag,
@@ -12,8 +8,13 @@ use crate::{
         ast as P,
         filter::{filter_program, FilterContext},
     },
-    shared::{known_attributes, CompilationEnv},
+    shared::{known_attributes::ModeAttribute, CompilationEnv},
 };
+
+use move_ir_types::location::{sp, Loc};
+use move_symbol_pool::Symbol;
+
+use std::collections::BTreeSet;
 
 struct Context<'env> {
     env: &'env CompilationEnv,
@@ -43,31 +44,43 @@ impl FilterContext for Context<'_> {
         self.is_source_def = is_source_def;
     }
 
-    // An AST element should be removed if:
-    // * It is annotated #[verify_only] and verify mode is not set
+    // An AST element should be removed if no compiler mode is set for it.
     fn should_remove_by_attributes(&mut self, attrs: &[P::Attributes]) -> bool {
-        use known_attributes::VerificationAttribute;
-        let flattened_attrs: Vec<_> = attrs.iter().flat_map(verification_attributes).collect();
-        let is_verify_only_loc = flattened_attrs.iter().map(|attr| attr.0).next();
-        let should_remove = is_verify_only_loc.is_some();
-        // TODO this is a bit of a hack
-        // but we don't have a better way of suppressing this unless the filtering was done after
-        // expansion
-        // Ideally we would just have a warning filter scope here
-        // (but again, need expansion for that)
+        let modes = attrs
+            .iter()
+            .flat_map(|attr| attr.value.modes())
+            .collect::<BTreeSet<_>>();
+
+        if modes.is_empty() {
+            return false;
+        };
+
+        // TODO: This is a bit of a hack but we don't have a better way of suppressing this unless
+        // the filtering was done after expansion. We could also us a filtering warning scope here.
         let silence_warning =
             !self.is_source_def || self.env.package_config(self.current_package).is_dependency;
+
         if !silence_warning {
-            if let Some(loc) = is_verify_only_loc {
+            // Report `verify_only` deprecation -- but only for the first one.
+            if let Some(sp!(loc, _)) =
+                modes.get(&sp(Loc::invalid(), ModeAttribute::VERIFY_ONLY.into()))
+            {
                 let msg = format!(
                     "The '{}' attribute has been deprecated along with specification blocks",
-                    VerificationAttribute::VERIFY_ONLY
+                    ModeAttribute::VERIFY_ONLY
                 );
                 self.reporter
-                    .add_diag(diag!(Uncategorized::DeprecatedWillBeRemoved, (loc, msg)));
+                    .add_diag(diag!(Uncategorized::DeprecatedWillBeRemoved, (*loc, msg)));
             }
         }
-        should_remove
+
+        let modes = modes
+            .into_iter()
+            .map(|mode| mode.value)
+            .collect::<BTreeSet<_>>();
+
+        // If the compiler mode intersects with these modes, we should keep this
+        self.env.modes().intersection(&modes).next().is_none()
     }
 }
 
@@ -81,28 +94,4 @@ impl FilterContext for Context<'_> {
 pub fn program(compilation_env: &CompilationEnv, prog: P::Program) -> P::Program {
     let mut context = Context::new(compilation_env);
     filter_program(&mut context, prog)
-}
-
-fn verification_attributes(attrs: &P::Attributes) -> Vec<(Loc, known_attributes::AttributeKind_)> {
-    attrs
-        .value
-        .iter()
-        .filter_map(|attr| match attr.value {
-            P::Attribute_::VerifyOnly => {
-                Some((attr.loc, known_attributes::AttributeKind_::VerifyOnly))
-            }
-            P::Attribute_::BytecodeInstruction
-            | P::Attribute_::DefinesPrimitive(..)
-            | P::Attribute_::Deprecation { .. }
-            | P::Attribute_::Error { .. }
-            | P::Attribute_::External { .. }
-            | P::Attribute_::Syntax { .. }
-            | P::Attribute_::Allow { .. }
-            | P::Attribute_::LintAllow { .. }
-            | P::Attribute_::Test
-            | P::Attribute_::TestOnly
-            | P::Attribute_::ExpectedFailure { .. }
-            | P::Attribute_::RandomTest => None,
-        })
-        .collect()
 }

--- a/external-crates/move/crates/move-compiler/src/parser/syntax.rs
+++ b/external-crates/move/crates/move-compiler/src/parser/syntax.rs
@@ -8,7 +8,11 @@
 
 use crate::{
     diag,
-    diagnostics::{codes::Category, Diagnostic, DiagnosticReporter, Diagnostics},
+    diagnostics::{
+        codes::Category,
+        warning_filters::{WarningFiltersBuilder, WarningFiltersTable},
+        Diagnostic, DiagnosticReporter, Diagnostics,
+    },
     editions::{Edition, FeatureGate, UPGRADE_NOTE},
     parser::{ast::*, attributes::to_known_attributes, format_one_of, lexer::*, token_set::*},
     shared::{string_utils::*, *},
@@ -1185,7 +1189,7 @@ fn parse_attributes(context: &mut Context) -> Result<Vec<Attributes>, Box<Diagno
                 .into_iter()
                 .flat_map(|attr| to_known_attributes(context, attr))
                 .collect::<Vec<_>>();
-            sp(loc, attrs)
+            sp(loc, Attributes_(attrs))
         })
         .collect::<Vec<_>>();
     Ok(attributes)
@@ -4766,6 +4770,14 @@ fn consume_spec_string(context: &mut Context) -> Result<Spanned<String>, Box<Dia
 //      File =
 //          (<Attributes> (<AddressBlock> | <Module> ))*
 fn parse_file(context: &mut Context) -> Vec<Definition> {
+    // If this is a dependency, do not report warnings in it.
+    let config = context.env.package_config(context.current_package);
+    let mut table = WarningFiltersTable::new();
+    if config.is_dependency {
+        let all_filters_all = table.add(WarningFiltersBuilder::new_all_filter_alls(context.env));
+        context.reporter.push_warning_filter_scope(all_filters_all);
+    }
+
     let mut defs = vec![];
     while context.tokens.peek() != Tok::EOF {
         if let Err(diag) = parse_file_def(context, &mut defs) {
@@ -4775,6 +4787,11 @@ fn parse_file(context: &mut Context) -> Vec<Definition> {
             skip_to_next_desired_tok_or_eof(context, &TokenSet::from(&[Tok::Spec, Tok::Module]));
         }
     }
+
+    if config.is_dependency {
+        context.reporter.pop_warning_filter_scope();
+    }
+
     defs
 }
 

--- a/external-crates/move/crates/move-compiler/src/shared/known_attributes.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/known_attributes.rs
@@ -25,9 +25,9 @@ pub enum KnownAttribute {
     Diagnostic(DiagnosticAttribute),
     Error(ErrorAttribute),
     External(ExternalAttribute),
+    Mode(ModeAttribute),
     Syntax(SyntaxAttribute),
     Testing(TestingAttribute),
-    Verification(VerificationAttribute),
 }
 
 /// A full summary of all attribute kinds, used for looking up an individual attribute and
@@ -42,11 +42,10 @@ pub enum AttributeKind_ {
     ExpectedFailure,
     External,
     LintAllow,
+    Mode,
     RandTest,
     Syntax,
     Test,
-    TestOnly,
-    VerifyOnly,
 }
 
 pub type AttributeKind = Spanned<AttributeKind_>;
@@ -90,6 +89,12 @@ pub struct ExternalAttribute {
     pub attrs: ExternalAttributeEntries,
 }
 
+// Sets a mode, such as "test" or "verify", which will only be build when compiled in that mode.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModeAttribute {
+    pub modes: BTreeSet<Name>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SyntaxAttribute {
     pub kind: Name,
@@ -99,8 +104,6 @@ pub struct SyntaxAttribute {
 pub enum TestingAttribute {
     // Is a test that will be run
     Test,
-    // Can be called by other testing code, and included in compilation in test mode
-    TestOnly,
     // This test is expected to fail
     ExpectedFailure(Box<ExpectedFailure>),
     // This is a test that uses randomly-generated arguments
@@ -127,12 +130,6 @@ pub enum MinorCode_ {
 }
 
 pub type MinorCode = Spanned<MinorCode_>;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum VerificationAttribute {
-    /// Deprecated spec verification annotation
-    VerifyOnly,
-}
 
 // -----------------------------------------------
 // External Attributes
@@ -204,12 +201,11 @@ impl AttributeKind_ {
             AttributeKind_::Error => ErrorAttribute::ERROR,
             AttributeKind_::ExpectedFailure => TestingAttribute::EXPECTED_FAILURE,
             AttributeKind_::External => ExternalAttribute::EXTERNAL,
+            AttributeKind_::Mode => ModeAttribute::MODE,
             AttributeKind_::LintAllow => DiagnosticAttribute::LINT_ALLOW,
             AttributeKind_::RandTest => TestingAttribute::RAND_TEST,
             AttributeKind_::Syntax => SyntaxAttribute::SYNTAX,
             AttributeKind_::Test => TestingAttribute::TEST,
-            AttributeKind_::TestOnly => TestingAttribute::TEST_ONLY,
-            AttributeKind_::VerifyOnly => VerificationAttribute::VERIFY_ONLY,
         }
     }
 }
@@ -223,8 +219,8 @@ impl KnownAttribute {
             Self::Diagnostic(attr) => attr.name(),
             Self::Error(attr) => attr.name(),
             Self::External(attr) => attr.name(),
+            Self::Mode(attr) => attr.name(),
             Self::Syntax(attr) => attr.name(),
-            Self::Verification(attr) => attr.name(),
             Self::Testing(attr) => attr.name(),
         }
     }
@@ -237,8 +233,8 @@ impl KnownAttribute {
             Self::Diagnostic(attr) => attr.expected_positions(),
             Self::Error(attr) => attr.expected_positions(),
             Self::External(attr) => attr.expected_positions(),
+            Self::Mode(attr) => attr.expected_positions(),
             Self::Syntax(attr) => attr.expected_positions(),
-            Self::Verification(attr) => attr.expected_positions(),
             Self::Testing(attr) => attr.expected_positions(),
         }
     }
@@ -251,8 +247,8 @@ impl KnownAttribute {
             Self::Diagnostic(attr) => attr.attribute_kind(),
             Self::Error(attr) => attr.attribute_kind(),
             Self::External(attr) => attr.attribute_kind(),
+            Self::Mode(attr) => attr.attribute_kind(),
             Self::Syntax(attr) => attr.attribute_kind(),
-            Self::Verification(attr) => attr.attribute_kind(),
             Self::Testing(attr) => attr.attribute_kind(),
         }
     }
@@ -413,6 +409,37 @@ impl ExternalAttributeEntry_ {
     }
 }
 
+impl ModeAttribute {
+    pub const TEST_ONLY: &'static str = "test_only";
+    pub const VERIFY_ONLY: &'static str = "verify_only";
+    pub const TEST: &'static str = "test";
+    pub const MODE: &'static str = "mode";
+
+    pub const fn name(&self) -> &str {
+        Self::MODE
+    }
+
+    pub fn expected_positions(&self) -> &'static BTreeSet<AttributePosition> {
+        static MODE_POSITIONS: Lazy<BTreeSet<AttributePosition>> = Lazy::new(|| {
+            BTreeSet::from([
+                AttributePosition::AddressBlock,
+                AttributePosition::Module,
+                AttributePosition::Use,
+                AttributePosition::Friend,
+                AttributePosition::Constant,
+                AttributePosition::Struct,
+                AttributePosition::Enum,
+                AttributePosition::Function,
+            ])
+        });
+        &MODE_POSITIONS
+    }
+
+    pub const fn attribute_kind(&self) -> AttributeKind_ {
+        AttributeKind_::Mode
+    }
+}
+
 impl SyntaxAttribute {
     pub const SYNTAX: &'static str = "syntax";
     pub const INDEX: &'static str = "index";
@@ -442,7 +469,6 @@ impl TestingAttribute {
     // Testing annotation names
     pub const TEST: &'static str = "test";
     pub const RAND_TEST: &'static str = "random_test";
-    pub const TEST_ONLY: &'static str = "test_only";
     pub const EXPECTED_FAILURE: &'static str = "expected_failure";
 
     // Failure kinds
@@ -459,31 +485,17 @@ impl TestingAttribute {
     pub const fn name(&self) -> &str {
         match self {
             Self::Test => Self::TEST,
-            Self::TestOnly => Self::TEST_ONLY,
             Self::ExpectedFailure { .. } => Self::EXPECTED_FAILURE,
             Self::RandTest => Self::RAND_TEST,
         }
     }
 
     pub fn expected_positions(&self) -> &'static BTreeSet<AttributePosition> {
-        static TEST_ONLY_POSITIONS: Lazy<BTreeSet<AttributePosition>> = Lazy::new(|| {
-            BTreeSet::from([
-                AttributePosition::AddressBlock,
-                AttributePosition::Module,
-                AttributePosition::Use,
-                AttributePosition::Friend,
-                AttributePosition::Constant,
-                AttributePosition::Struct,
-                AttributePosition::Enum,
-                AttributePosition::Function,
-            ])
-        });
         static TEST_POSITIONS: Lazy<BTreeSet<AttributePosition>> =
             Lazy::new(|| BTreeSet::from([AttributePosition::Function]));
         static EXPECTED_FAILURE_POSITIONS: Lazy<BTreeSet<AttributePosition>> =
             Lazy::new(|| BTreeSet::from([AttributePosition::Function]));
         match self {
-            TestingAttribute::TestOnly => &TEST_ONLY_POSITIONS,
             TestingAttribute::Test | TestingAttribute::RandTest => &TEST_POSITIONS,
             TestingAttribute::ExpectedFailure { .. } => &EXPECTED_FAILURE_POSITIONS,
         }
@@ -508,7 +520,6 @@ impl TestingAttribute {
     pub fn attribute_kind(&self) -> AttributeKind_ {
         match self {
             TestingAttribute::Test => AttributeKind_::Test,
-            TestingAttribute::TestOnly => AttributeKind_::TestOnly,
             TestingAttribute::ExpectedFailure(..) => AttributeKind_::ExpectedFailure,
             TestingAttribute::RandTest => AttributeKind_::RandTest,
         }
@@ -553,40 +564,6 @@ static EXPECTED_FAILURE_ALL_KEYS: Lazy<BTreeSet<String>> = Lazy::new(|| {
     keys
 });
 
-impl VerificationAttribute {
-    pub const VERIFY_ONLY: &'static str = "verify_only";
-
-    pub const fn name(&self) -> &str {
-        match self {
-            Self::VerifyOnly => Self::VERIFY_ONLY,
-        }
-    }
-
-    pub fn expected_positions(&self) -> &'static BTreeSet<AttributePosition> {
-        static VERIFY_ONLY_POSITIONS: Lazy<BTreeSet<AttributePosition>> = Lazy::new(|| {
-            BTreeSet::from([
-                AttributePosition::AddressBlock,
-                AttributePosition::Module,
-                AttributePosition::Use,
-                AttributePosition::Friend,
-                AttributePosition::Constant,
-                AttributePosition::Struct,
-                AttributePosition::Enum,
-                AttributePosition::Function,
-            ])
-        });
-        match self {
-            Self::VerifyOnly => &VERIFY_ONLY_POSITIONS,
-        }
-    }
-
-    pub fn attribute_kind(&self) -> AttributeKind_ {
-        match self {
-            VerificationAttribute::VerifyOnly => AttributeKind_::VerifyOnly,
-        }
-    }
-}
-
 //**************************************************************************************************
 // Display
 //**************************************************************************************************
@@ -616,9 +593,9 @@ impl fmt::Display for KnownAttribute {
             Self::Diagnostic(a) => a.fmt(f),
             Self::Error(a) => a.fmt(f),
             Self::External(a) => a.fmt(f),
+            Self::Mode(a) => a.fmt(f),
             Self::Syntax(a) => a.fmt(f),
             Self::Testing(a) => a.fmt(f),
-            Self::Verification(a) => a.fmt(f),
         }
     }
 }
@@ -659,6 +636,12 @@ impl fmt::Display for ExternalAttribute {
     }
 }
 
+impl fmt::Display for ModeAttribute {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
 impl fmt::Display for SyntaxAttribute {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.name())
@@ -666,12 +649,6 @@ impl fmt::Display for SyntaxAttribute {
 }
 
 impl fmt::Display for TestingAttribute {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.name())
-    }
-}
-
-impl fmt::Display for VerificationAttribute {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.name())
     }
@@ -726,7 +703,6 @@ impl_from_for_known_attribute! {
     ExternalAttribute => External,
     SyntaxAttribute => Syntax,
     TestingAttribute => Testing,
-    VerificationAttribute => Verification,
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -765,6 +741,19 @@ impl AstDebug for DeprecationAttribute {
             w.write(std::str::from_utf8(note).unwrap());
             w.write(")");
         }
+    }
+}
+
+impl AstDebug for ModeAttribute {
+    fn ast_debug(&self, w: &mut AstWriter) {
+        w.write(self.name());
+        w.write("(");
+        let ModeAttribute { modes } = self;
+        w.write("mode(");
+        w.comma(modes, |w, mode| {
+            w.write(format!("{mode}"));
+        });
+        w.write(")");
     }
 }
 
@@ -834,19 +823,10 @@ impl AstDebug for SyntaxAttribute {
     }
 }
 
-impl AstDebug for VerificationAttribute {
-    fn ast_debug(&self, w: &mut AstWriter) {
-        match self {
-            VerificationAttribute::VerifyOnly => w.write("verify_only"),
-        }
-    }
-}
-
 impl AstDebug for TestingAttribute {
     fn ast_debug(&self, w: &mut AstWriter) {
         match self {
             TestingAttribute::Test => w.write("test"),
-            TestingAttribute::TestOnly => w.write("test_only"),
             TestingAttribute::ExpectedFailure(exp) => {
                 w.write("expected_failure(");
                 exp.ast_debug(w);
@@ -872,9 +852,9 @@ impl AstDebug for KnownAttribute {
             KnownAttribute::Diagnostic(attr) => attr.ast_debug(w),
             KnownAttribute::Error(attr) => attr.ast_debug(w),
             KnownAttribute::External(attr) => attr.ast_debug(w),
+            KnownAttribute::Mode(attr) => attr.ast_debug(w),
             KnownAttribute::Syntax(attr) => attr.ast_debug(w),
             KnownAttribute::Testing(attr) => attr.ast_debug(w),
-            KnownAttribute::Verification(attr) => attr.ast_debug(w),
         }
     }
 }

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -215,6 +215,7 @@ pub struct PackagePaths<Path: Into<Symbol> = Symbol, NamedAddress: Into<Symbol> 
 
 pub struct CompilationEnv {
     flags: Flags,
+    modes: BTreeSet<Symbol>,
     top_level_warning_filter_scope: Option<&'static WarningFiltersBuilder>,
     diags: RwLock<Diagnostics>,
     visitors: Visitors,
@@ -294,8 +295,12 @@ impl CompilationEnv {
         if flags.json_errors() {
             diags.set_format(DiagnosticsFormat::JSON);
         }
+
+        let modes = Self::compute_modes(&flags);
+
         Self {
             flags,
+            modes,
             top_level_warning_filter_scope,
             diags: RwLock::new(diags),
             visitors: Visitors::new(visitors),
@@ -309,6 +314,24 @@ impl CompilationEnv {
             ide_information: RwLock::new(IDEInfo::new()),
             files_to_compile,
         }
+    }
+
+    fn compute_modes(flags: &Flags) -> BTreeSet<Symbol> {
+        let mut modes = flags
+            .modes
+            .clone()
+            .into_iter()
+            .collect::<BTreeSet<Symbol>>();
+        if flags.test {
+            modes.insert("test".into());
+        }
+        if flags.ide_mode {
+            modes.insert("ide".into());
+        }
+        if flags.ide_test_mode {
+            modes.insert("ide_test".into());
+        }
+        modes
     }
 
     pub fn add_source_file(
@@ -438,10 +461,6 @@ impl CompilationEnv {
         Ok(())
     }
 
-    pub fn flags(&self) -> &Flags {
-        &self.flags
-    }
-
     pub fn visitors(&self) -> &Visitors {
         &self.visitors
     }
@@ -543,11 +562,36 @@ impl CompilationEnv {
         }
     }
 
-    // -- IDE Information --
+    // -- Flag Information --
+
+    pub fn sources_shadow_deps(&self) -> bool {
+        self.flags.sources_shadow_deps()
+    }
+
+    pub fn bytecode_version(&self) -> Option<u32> {
+        self.flags.bytecode_version()
+    }
+
+    // -- Mode Information --
 
     pub fn ide_mode(&self) -> bool {
-        self.flags.ide_mode()
+        self.flags.ide_mode() || self.modes().contains(&"ide".into())
     }
+
+    pub fn keep_testing_functions(&self) -> bool {
+        self.flags.keep_testing_functions()
+    }
+
+    pub fn test_mode(&self) -> bool {
+        // This is technically redundant, but we are better safe than sorry.
+        self.flags.is_testing() || self.modes().contains(&"test".into())
+    }
+
+    pub fn modes(&self) -> &BTreeSet<Symbol> {
+        &self.modes
+    }
+
+    // -- IDE Information --
 
     pub fn ide_information(&self) -> std::sync::RwLockReadGuard<'_, IDEInfo> {
         self.ide_information.read().unwrap()
@@ -651,6 +695,16 @@ pub struct Flags {
     /// If set, we are in IDE mode.
     #[clap(skip = false)]
     ide_mode: bool,
+
+    /// Arbitrary mode -- this will be used to enable or filter user-defined `#[mode(<MODE>)]`
+    /// annodations during compiltaion.
+    #[arg(
+        long = "mode",
+        value_name = "MODE",
+        value_parser = parse_symbol,
+        action = ArgAction::Append
+    )]
+    modes: Vec<Symbol>,
 }
 
 impl Flags {
@@ -665,6 +719,7 @@ impl Flags {
             keep_testing_functions: false,
             ide_mode: false,
             ide_test_mode: false,
+            modes: vec![],
         }
     }
 
@@ -679,6 +734,7 @@ impl Flags {
             keep_testing_functions: false,
             ide_mode: false,
             ide_test_mode: false,
+            modes: vec![],
         }
     }
 
@@ -731,6 +787,13 @@ impl Flags {
         }
     }
 
+    pub fn set_modes(self, value: Vec<Symbol>) -> Self {
+        Self {
+            modes: value,
+            ..self
+        }
+    }
+
     pub fn is_empty(&self) -> bool {
         self == &Self::empty()
     }
@@ -770,6 +833,14 @@ impl Flags {
     pub fn ide_mode(&self) -> bool {
         self.ide_mode
     }
+
+    pub fn mode(&self, mode: Symbol) -> bool {
+        self.modes.iter().any(|m| *m == mode)
+    }
+}
+
+fn parse_symbol(s: &str) -> Result<Symbol, String> {
+    Ok(Symbol::from(s))
 }
 
 //**************************************************************************************************

--- a/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/to_bytecode/translate.rs
@@ -220,7 +220,7 @@ fn module(
         }
     ) = ident;
     let ir_module = IR::ModuleDefinition {
-        specified_version: compilation_env.flags().bytecode_version(),
+        specified_version: compilation_env.bytecode_version(),
         loc: ident_loc,
         identifier: IR::ModuleIdent {
             address: MoveAddress::new(addr_bytes.into_bytes()),

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -23,7 +23,7 @@ use crate::{
     },
     shared::{
         ide::{AutocompleteMethod, IDEAnnotation, IDEInfo},
-        known_attributes::TestingAttribute,
+        known_attributes::{ModeAttribute, TestingAttribute},
         matching::{new_match_var_name, MatchContext},
         program_info::*,
         string_utils::{debug_print, format_oxford_list},
@@ -2061,7 +2061,7 @@ pub fn public_testing_visibility(
     callee_entry: Option<Loc>,
 ) -> Option<PublicForTesting> {
     // is_testing && (is_entry || is_sui_init)
-    if !env.flags().is_testing() {
+    if !env.test_mode() {
         return None;
     }
 
@@ -2090,7 +2090,7 @@ fn report_visibility_error_(
         (call_loc, call_msg),
         (vis_loc, vis_msg),
     );
-    if context.env().flags().is_testing() {
+    if context.env().test_mode() {
         if let Some(case) = public_for_testing {
             let (test_loc, test_msg) = match case {
                 PublicForTesting::Entry(entry_loc) => {
@@ -2099,7 +2099,7 @@ fn report_visibility_error_(
                     but only from testing contexts, e.g. '#[{}]' or '#[{}]'",
                         ENTRY_MODIFIER,
                         TestingAttribute::TEST,
-                        TestingAttribute::TEST_ONLY,
+                        ModeAttribute::TEST_ONLY,
                     );
                     (entry_loc, entry_msg)
                 }

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -4820,8 +4820,8 @@ pub fn collect_known_attribute_module_members(
         | Deprecation(_)
         | Diagnostic(_)
         | Error(_)
-        | Syntax(_)
-        | Verification(_) => {
+        | Mode(_)
+        | Syntax(_) => {
             // No nested module accesses.
         }
         Testing(test_attr) => {

--- a/external-crates/move/crates/move-compiler/src/unit_test/plan_builder.rs
+++ b/external-crates/move/crates/move-compiler/src/unit_test/plan_builder.rs
@@ -93,7 +93,7 @@ pub fn construct_test_plan(
     package_filter: Option<Symbol>,
     prog: &G::Program,
 ) -> Option<Vec<ModuleTestPlan>> {
-    if !compilation_env.flags().is_testing() {
+    if !compilation_env.test_mode() {
         return None;
     }
 
@@ -161,7 +161,6 @@ fn build_test_info<'func>(
     let test_attribute_opt = get_attrs(AttributeKind_::Test);
     let random_test_attribute_opt = get_attrs(AttributeKind_::RandTest);
     let expected_failure_attribute_opt = get_attrs(AttributeKind_::ExpectedFailure);
-    let test_only_attribute_opt = get_attrs(AttributeKind_::TestOnly);
 
     let (test_attribute, is_random_test) = if let Some(test_attribute) = test_attribute_opt {
         ice_assert!(
@@ -187,17 +186,6 @@ fn build_test_info<'func>(
         }
         return None;
     };
-
-    // A #[test] function cannot also be annotated #[test_only]
-    if test_only_attribute_opt.is_some() {
-        ice_assert!(
-            context.reporter,
-            false,
-            fn_loc,
-            "Found test_only and test or rand_test attributes"
-        );
-        return None;
-    }
 
     let mut arguments = Vec::new();
     if is_random_test {

--- a/external-crates/move/crates/move-compiler/tests/move_2024/unit_test/random_test_invalid@unit_test.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/unit_test/random_test_invalid@unit_test.snap
@@ -21,6 +21,16 @@ error[E02015]: invalid attribute
   │
   = Input values will be randomly generated for this test.
 
+warning[W10007]: issue with attribute value
+   ┌─ tests/move_2024/unit_test/random_test_invalid.move:11:7
+   │
+10 │     #[random_test]
+   │       ----------- Previously annotated here
+11 │     #[test]
+   │       ^^^^ function annotated with duplicate mode 'test'
+   │
+   = Attributes '#[test]' and '#[random_test]' implicitly specify '#[mode(test)]'
+
 error[E10004]: invalid usage of known attribute
    ┌─ tests/move_2024/unit_test/random_test_invalid.move:11:7
    │
@@ -37,6 +47,16 @@ error[E10005]: unable to generate test
 15 │     #[test]
 16 │     fun quxz() { }
    │         ---- Error found in this test
+
+warning[W10007]: issue with attribute value
+   ┌─ tests/move_2024/unit_test/random_test_invalid.move:15:7
+   │
+14 │     #[random_test]
+   │       ----------- Previously annotated here
+15 │     #[test]
+   │       ^^^^ function annotated with duplicate mode 'test'
+   │
+   = Attributes '#[test]' and '#[random_test]' implicitly specify '#[mode(test)]'
 
 error[E10004]: invalid usage of known attribute
    ┌─ tests/move_2024/unit_test/random_test_invalid.move:15:7
@@ -55,13 +75,15 @@ error[E10005]: unable to generate test
 20 │     fun bar() { }
    │         --- Error found in this test
 
-error[E10004]: invalid usage of known attribute
+warning[W10007]: issue with attribute value
    ┌─ tests/move_2024/unit_test/random_test_invalid.move:19:7
    │
 18 │     #[random_test]
    │       ----------- Previously annotated here
 19 │     #[test_only]
-   │       ^^^^^^^^^ function annotated as both #[test_only] and #[random_test]. You need to declare it as either one or the other
+   │       ^^^^^^^^^ function annotated with duplicate mode 'test'
+   │
+   = Attributes '#[test]' and '#[random_test]' implicitly specify '#[mode(test)]'
 
 error[E10005]: unable to generate test
    ┌─ tests/move_2024/unit_test/random_test_invalid.move:24:16

--- a/external-crates/move/crates/move-compiler/tests/move_check/unit_test/multiple_errors@unit_test.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/unit_test/multiple_errors@unit_test.snap
@@ -14,6 +14,16 @@ warning[W10007]: issue with attribute value
    │       Arguments are no longer supported in `#[test]` attributes
    │       Ignoring these arguments
 
+warning[W10007]: issue with attribute value
+   ┌─ tests/move_check/unit_test/multiple_errors.move:21:7
+   │
+20 │     #[test]
+   │       ---- Previously annotated here
+21 │     #[test]
+   │       ^^^^ function annotated with duplicate mode 'test'
+   │
+   = Attributes '#[test]' and '#[random_test]' implicitly specify '#[mode(test)]'
+
 error[E10001]: invalid duplicate attribute
    ┌─ tests/move_check/unit_test/multiple_errors.move:21:7
    │
@@ -22,13 +32,15 @@ error[E10001]: invalid duplicate attribute
 21 │     #[test]
    │       ^^^^ Duplicate attribute 'test' attached to the same item
 
-error[E10004]: invalid usage of known attribute
+warning[W10007]: issue with attribute value
    ┌─ tests/move_check/unit_test/multiple_errors.move:26:7
    │
 25 │     #[test]
    │       ---- Previously annotated here
 26 │     #[test_only]
-   │       ^^^^^^^^^ function annotated as both #[test_only] and #[test]. You need to declare it as either one or the other
+   │       ^^^^^^^^^ function annotated with duplicate mode 'test'
+   │
+   = Attributes '#[test]' and '#[random_test]' implicitly specify '#[mode(test)]'
 
 warning[W10007]: issue with attribute value
    ┌─ tests/move_check/unit_test/multiple_errors.move:31:5

--- a/external-crates/move/crates/move-compiler/tests/move_check/unit_test/multiple_test_annotations@unit_test.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/unit_test/multiple_test_annotations@unit_test.snap
@@ -23,6 +23,16 @@ warning[W10007]: issue with attribute value
   │       Arguments are no longer supported in `#[test]` attributes
   │       Ignoring these arguments
 
+warning[W10007]: issue with attribute value
+  ┌─ tests/move_check/unit_test/multiple_test_annotations.move:6:7
+  │
+5 │     #[test(_a=@0x1)]
+  │       ------------- Previously annotated here
+6 │     #[test(_b=@0x2)]
+  │       ^^^^^^^^^^^^^ function annotated with duplicate mode 'test'
+  │
+  = Attributes '#[test]' and '#[random_test]' implicitly specify '#[mode(test)]'
+
 error[E10001]: invalid duplicate attribute
   ┌─ tests/move_check/unit_test/multiple_test_annotations.move:6:7
   │
@@ -48,6 +58,16 @@ warning[W10007]: issue with attribute value
    │       │
    │       Arguments are no longer supported in `#[test]` attributes
    │       Ignoring these arguments
+
+warning[W10007]: issue with attribute value
+   ┌─ tests/move_check/unit_test/multiple_test_annotations.move:10:7
+   │
+ 9 │     #[test]
+   │       ---- Previously annotated here
+10 │     #[test(_a=@0x1, _b=@0x2)]
+   │       ^^^^^^^^^^^^^^^^^^^^^^ function annotated with duplicate mode 'test'
+   │
+   = Attributes '#[test]' and '#[random_test]' implicitly specify '#[mode(test)]'
 
 error[E10001]: invalid duplicate attribute
    ┌─ tests/move_check/unit_test/multiple_test_annotations.move:10:7

--- a/external-crates/move/crates/move-compiler/tests/move_check/unit_test/test_and_test_only_annotation@unit_test.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/unit_test/test_and_test_only_annotation@unit_test.snap
@@ -14,13 +14,15 @@ warning[W10007]: issue with attribute value
   │       Arguments are no longer supported in `#[test]` attributes
   │       Ignoring these arguments
 
-error[E10004]: invalid usage of known attribute
+warning[W10007]: issue with attribute value
   ┌─ tests/move_check/unit_test/test_and_test_only_annotation.move:5:7
   │
 4 │     #[test(_a=@0x1, _b=@0x2)]
   │       ---------------------- Previously annotated here
 5 │     #[test_only]
-  │       ^^^^^^^^^ function annotated as both #[test_only] and #[test]. You need to declare it as either one or the other
+  │       ^^^^^^^^^ function annotated with duplicate mode 'test'
+  │
+  = Attributes '#[test]' and '#[random_test]' implicitly specify '#[mode(test)]'
 
 warning[W10007]: issue with attribute value
   ┌─ tests/move_check/unit_test/test_and_test_only_annotation.move:6:5

--- a/external-crates/move/crates/move-compiler/tests/move_check/verification/double_annotation.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/verification/double_annotation.snap
@@ -12,9 +12,9 @@ warning[W00001]: DEPRECATED. will be removed
   │       ^^^^^^^^^^^ The 'verify_only' attribute has been deprecated along with specification blocks
 
 warning[W00001]: DEPRECATED. will be removed
-  ┌─ tests/move_check/verification/double_annotation.move:7:7
+  ┌─ tests/move_check/verification/double_annotation.move:8:7
   │
-7 │     #[verify_only]
+8 │     #[verify_only]
   │       ^^^^^^^^^^^ The 'verify_only' attribute has been deprecated along with specification blocks
 
 warning[W00001]: DEPRECATED. will be removed
@@ -24,7 +24,7 @@ warning[W00001]: DEPRECATED. will be removed
    │       ^^^^^^^^^^^ The 'verify_only' attribute has been deprecated along with specification blocks
 
 warning[W00001]: DEPRECATED. will be removed
-   ┌─ tests/move_check/verification/double_annotation.move:17:7
+   ┌─ tests/move_check/verification/double_annotation.move:18:7
    │
-17 │     #[verify_only]
+18 │     #[verify_only]
    │       ^^^^^^^^^^^ The 'verify_only' attribute has been deprecated along with specification blocks

--- a/external-crates/move/crates/move-model-2/src/summary.rs
+++ b/external-crates/move/crates/move-model-2/src/summary.rs
@@ -15,9 +15,11 @@ use move_binary_format::file_format;
 use move_compiler::{
     expansion::ast as E,
     naming::ast as N,
-    parser::ast as P,
-    parser::ast::DocComment,
-    shared::{known_attributes as KA, program_info::FunctionInfo},
+    parser::ast::{self as P, DocComment},
+    shared::{
+        known_attributes::{self as KA, AttributeKind_, ModeAttribute},
+        program_info::FunctionInfo,
+    },
 };
 use move_core_types::{account_address::AccountAddress, vm_status::StatusCode};
 use move_symbol_pool::Symbol;
@@ -773,9 +775,12 @@ fn doc_comment(doc: &DocComment) -> Option<String> {
 }
 
 fn attributes(attributes: &E::Attributes) -> Vec<Attribute> {
+    let has_test_attr = attributes
+        .iter()
+        .any(|(_, kind, _)| matches!(kind, AttributeKind_::Test | AttributeKind_::RandTest));
     attributes
         .iter()
-        .map(|(_, _, a)| attribute(&a.value))
+        .map(|(_, _, a)| attribute(&has_test_attr, &a.value))
         .collect()
 }
 
@@ -800,7 +805,7 @@ fn ext_attribute(entry: &KA::ExternalAttributeEntry) -> Attribute {
     }
 }
 
-fn attribute(k: &KA::KnownAttribute) -> Attribute {
+fn attribute(has_test_attr: &bool, k: &KA::KnownAttribute) -> Attribute {
     match k {
         // --- name-only ---
         KA::KnownAttribute::BytecodeInstruction(_) => {
@@ -809,14 +814,17 @@ fn attribute(k: &KA::KnownAttribute) -> Attribute {
         KA::KnownAttribute::Testing(KA::TestingAttribute::Test) => {
             Attribute::Name(KA::TestingAttribute::TEST.into())
         }
-        KA::KnownAttribute::Testing(KA::TestingAttribute::TestOnly) => {
-            Attribute::Name(KA::TestingAttribute::TEST_ONLY.into())
-        }
         KA::KnownAttribute::Testing(KA::TestingAttribute::RandTest) => {
             Attribute::Name(KA::TestingAttribute::RAND_TEST.into())
         }
-        KA::KnownAttribute::Verification(KA::VerificationAttribute::VerifyOnly) => {
-            Attribute::Name(KA::VerificationAttribute::VERIFY_ONLY.into())
+        KA::KnownAttribute::Mode(KA::ModeAttribute { modes }) => {
+            // TODO: This should remove `test` if  `testing` is enabled.
+            let inner = modes
+                .iter()
+                .filter(|name| !*has_test_attr || (name.value.as_str() != ModeAttribute::TEST))
+                .map(|name| Attribute::Name(name.value))
+                .collect();
+            Attribute::Parameterized(KA::ModeAttribute::MODE.into(), inner)
         }
 
         // --- assigned or name ---

--- a/external-crates/move/crates/move-package/src/lib.rs
+++ b/external-crates/move/crates/move-package/src/lib.rs
@@ -20,6 +20,7 @@ use move_compiler::{
 };
 use move_core_types::account_address::AccountAddress;
 use move_model_2::source_model;
+use move_symbol_pool::Symbol;
 use resolution::{dependency_graph::DependencyGraphBuilder, resolution_graph::ResolvedGraph};
 use serde::{Deserialize, Serialize};
 use source_package::{
@@ -114,6 +115,17 @@ pub struct BuildConfig {
 
     #[clap(flatten)]
     pub lint_flag: LintFlag,
+
+    /// Arbitrary mode -- this will be used to enable or filter user-defined `#[mode(<MODE>)]`
+    /// annodations during compiltaion.
+    #[arg(
+        long = "mode",
+        value_name = "MODE",
+        value_parser = parse_symbol,
+        action = ArgAction::Append,
+        global = true
+    )]
+    pub modes: Vec<Symbol>,
 
     /// Additional dependencies to be automatically included in every package
     #[clap(skip)]
@@ -323,7 +335,7 @@ impl BuildConfig {
     }
 
     pub fn compiler_flags(&self) -> Flags {
-        let flags = if self.test_mode {
+        let flags = if self.test_mode || self.modes.contains(&"test".into()) {
             Flags::testing()
         } else {
             Flags::empty()
@@ -332,6 +344,7 @@ impl BuildConfig {
             .set_warnings_are_errors(self.warnings_are_errors)
             .set_json_errors(self.json_errors)
             .set_silence_warnings(self.silence_warnings)
+            .set_modes(self.modes.clone())
     }
 
     pub fn update_lock_file_toolchain_version(
@@ -368,4 +381,8 @@ impl BuildConfig {
         lock.commit(lock_file)?;
         Ok(())
     }
+}
+
+fn parse_symbol(s: &str) -> Result<Symbol, String> {
+    Ok(Symbol::from(s))
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move@compiled.snap
@@ -32,6 +32,7 @@ CompiledPackageInfo {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps/Move@resolved.snap
@@ -41,6 +41,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move@compiled.snap
@@ -34,6 +34,7 @@ CompiledPackageInfo {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_assigned/Move@resolved.snap
@@ -41,6 +41,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move@compiled.snap
@@ -34,6 +34,7 @@ CompiledPackageInfo {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_address_not_assigned_with_dev_assignment/Move@resolved.snap
@@ -41,6 +41,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_test_mode/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/basic_no_deps_test_mode/Move@compiled.snap
@@ -34,6 +34,7 @@ CompiledPackageInfo {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/dep_dev_dep_diamond/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/dep_dev_dep_diamond/Move@resolved.snap
@@ -130,6 +130,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/dep_good_digest/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/dep_good_digest/Move@resolved.snap
@@ -61,6 +61,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move@compiled.snap
@@ -35,6 +35,7 @@ CompiledPackageInfo {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_backflow_resolution/Move@resolved.snap
@@ -105,6 +105,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_dev_override_with_reg/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_dev_override_with_reg/Move@resolved.snap
@@ -111,6 +111,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_no_conflict/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_no_conflict/Move@resolved.snap
@@ -109,6 +109,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override/Move@resolved.snap
@@ -115,6 +115,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override_root/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_external_override_root/Move@resolved.snap
@@ -131,6 +131,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_nested_override/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_nested_override/Move@resolved.snap
@@ -157,6 +157,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_override/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_override/Move@resolved.snap
@@ -113,6 +113,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_transitive_nested_override/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_transitive_nested_override/Move@resolved.snap
@@ -149,6 +149,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_two_nested_overrides/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_two_nested_overrides/Move@resolved.snap
@@ -165,6 +165,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_with_deps/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dep_with_deps/Move@resolved.snap
@@ -165,6 +165,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dual_override/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_dual_override/Move@resolved.snap
@@ -165,6 +165,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move@compiled.snap
@@ -35,6 +35,7 @@ CompiledPackageInfo {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_no_conflict/Move@resolved.snap
@@ -105,6 +105,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v1/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v1/Move@resolved.snap
@@ -141,6 +141,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v2/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/diamond_problem_with_and_without_override_v2/Move@resolved.snap
@@ -141,6 +141,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/direct_and_indirect_dep/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/direct_and_indirect_dep/Move@resolved.snap
@@ -105,6 +105,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/external/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/external/Move@resolved.snap
@@ -83,6 +83,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_dev_dep/Move@resolved.snap
@@ -121,6 +121,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/external_overlap/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_overlap/Move@resolved.snap
@@ -91,6 +91,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/external_package_batch_response/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_package_batch_response/Move@resolved.snap
@@ -85,6 +85,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/external_resolver_config/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/external_resolver_config/Move@resolved.snap
@@ -41,6 +41,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/override/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/override/Move@resolved.snap
@@ -61,6 +61,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {
             "I1": Internal(
                 InternalDependency {

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/override_dep_1/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/override_dep_1/Move@resolved.snap
@@ -113,6 +113,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {
             "I1": Internal(
                 InternalDependency {

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/override_dep_2/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/override_dep_2/Move@resolved.snap
@@ -113,6 +113,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {
             "I1": Internal(
                 InternalDependency {

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/override_root_1/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/override_root_1/Move@resolved.snap
@@ -105,6 +105,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {
             "I1": Internal(
                 InternalDependency {

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/override_root_2/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/override_root_2/Move@resolved.snap
@@ -113,6 +113,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {
             "I1": Internal(
                 InternalDependency {

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/simple/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/simple/Move@resolved.snap
@@ -87,6 +87,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {
             "I1": Internal(
                 InternalDependency {

--- a/external-crates/move/crates/move-package/tests/test_sources/implicits/transitive/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/implicits/transitive/Move@resolved.snap
@@ -121,6 +121,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {
             "I1": Internal(
                 InternalDependency {

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock/Move@resolved.snap
@@ -79,6 +79,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock_no_manifest/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_from_lock_no_manifest/Move@resolved.snap
@@ -79,6 +79,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename/Move@resolved.snap
@@ -79,6 +79,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename_one/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/multiple_deps_rename_one/Move@compiled.snap
@@ -36,6 +36,7 @@ CompiledPackageInfo {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_deps_git_local/Move@resolved.snap
@@ -87,6 +87,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_deps_shared_override/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_deps_shared_override/Move@resolved.snap
@@ -121,6 +121,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/nested_pruned_override/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/nested_pruned_override/Move@resolved.snap
@@ -105,6 +105,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move@compiled.snap
@@ -34,6 +34,7 @@ CompiledPackageInfo {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep/Move@resolved.snap
@@ -61,6 +61,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move@compiled.snap
@@ -34,6 +34,7 @@ CompiledPackageInfo {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_assigned_address/Move@resolved.snap
@@ -61,6 +61,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_multiple_of_same_name/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_multiple_of_same_name/Move@resolved.snap
@@ -61,6 +61,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move@compiled.snap
@@ -34,6 +34,7 @@ CompiledPackageInfo {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_override/Move@resolved.snap
@@ -61,6 +61,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_reassigned_address/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_reassigned_address/Move@resolved.snap
@@ -61,6 +61,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_renamed/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_renamed/Move@compiled.snap
@@ -34,6 +34,7 @@ CompiledPackageInfo {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_unification_across_local_renamings/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_unification_across_local_renamings/Move@resolved.snap
@@ -61,6 +61,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_with_scripts/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_with_scripts/Move@compiled.snap
@@ -34,6 +34,7 @@ CompiledPackageInfo {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024/Move@resolved.snap
@@ -41,6 +41,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_alpha/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_alpha/Move@resolved.snap
@@ -41,6 +41,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_beta/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_2024_beta/Move@resolved.snap
@@ -41,6 +41,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_legacy/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_edition_legacy/Move@resolved.snap
@@ -41,6 +41,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_global_storage/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_global_storage/Move@resolved.snap
@@ -41,6 +41,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_sui/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_flavor_sui/Move@resolved.snap
@@ -41,6 +41,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_invalid_identifier_package_name/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_invalid_identifier_package_name/Move@resolved.snap
@@ -41,6 +41,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/parsing_minimal_manifest/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/parsing_minimal_manifest/Move@resolved.snap
@@ -41,6 +41,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move@compiled.snap
@@ -35,6 +35,7 @@ CompiledPackageInfo {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
 }

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name/Move@resolved.snap
@@ -105,6 +105,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name_override/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_pkg_name_override/Move@resolved.snap
@@ -113,6 +113,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version/Move@resolved.snap
@@ -83,6 +83,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond/Move@resolved.snap
@@ -111,6 +111,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep/Move@resolved.snap
@@ -129,6 +129,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep_success/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_deep_success/Move@resolved.snap
@@ -131,6 +131,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_external/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_external/Move@resolved.snap
@@ -111,6 +111,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_override/Move@resolved.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/resolve_version_diamond_override/Move@resolved.snap
@@ -119,6 +119,7 @@ ResolvedGraph {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
     package_table: {

--- a/external-crates/move/crates/move-package/tests/test_sources/test_symlinks/Move@compiled.snap
+++ b/external-crates/move/crates/move-package/tests/test_sources/test_symlinks/Move@compiled.snap
@@ -34,6 +34,7 @@ CompiledPackageInfo {
             no_lint: false,
             lint: false,
         },
+        modes: [],
         implicit_dependencies: {},
     },
 }


### PR DESCRIPTION
## Description 

This adds modes to the compiler. Note this does not currently poison non-test modes, but it is possible we should before landing it.

## Test plan 

New tests, plus existing ones.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
