### PR TITLE
Remove object size bounds on system transactions (#22173)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16281,6 +16281,7 @@ dependencies = [
  "move-core-types",
  "move-vm-profiler",
  "move-vm-test-utils",
+ "mysten-common",
  "mysten-metrics",
  "mysten-network",
  "nonempty",

--- a/crates/sui-indexer-alt/src/handlers/coin_balance_buckets.rs
+++ b/crates/sui-indexer-alt/src/handlers/coin_balance_buckets.rs
@@ -359,6 +359,7 @@ mod tests {
                     SequenceNumber::new(),
                     bcs::to_bytes(&Object::new_gas_for_testing()).unwrap(),
                     &ProtocolConfig::get_for_max_version_UNSAFE(),
+                    /* system_mutation */ false,
                 )
                 .unwrap(),
                 Owner::AddressOwner(SuiAddress::ZERO),

--- a/crates/sui-json-rpc-types/src/sui_object.rs
+++ b/crates/sui-json-rpc-types/src/sui_object.rs
@@ -620,6 +620,7 @@ impl TryInto<Object> for SuiObjectData {
                     o.version,
                     o.bcs_bytes,
                     &protocol_config,
+                    /* system_mutation */ false,
                 )?
             }),
             Some(SuiRawData::Package(p)) => Data::Package(MovePackage::new(

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1302,6 +1302,7 @@
                 "advance_epoch_start_time_in_safe_mode": true,
                 "advance_to_highest_supported_protocol_version": false,
                 "allow_receiving_object_id": false,
+                "allow_unbounded_system_objects": false,
                 "authority_capabilities_v2": false,
                 "ban_entry_init": false,
                 "bridge": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -240,6 +240,7 @@ const MAX_PROTOCOL_VERSION: u64 = 84;
 //             Enable execution time estimate mode for congestion control on mainnet.
 //             Enable nitro attestation upgraded parsing and mainnet.
 // Version 84: Limit number of stored execution time observations between epochs.
+//             Remove restrictions on objects created in system transactions.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -695,6 +696,10 @@ struct FeatureFlags {
     // Enable native function for party transfer
     #[serde(skip_serializing_if = "is_false")]
     enable_party_transfer: bool,
+
+    // Allow objects created or mutated in system transactions to exceed the max object size limit.
+    #[serde(skip_serializing_if = "is_false")]
+    allow_unbounded_system_objects: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -1985,6 +1990,10 @@ impl ProtocolConfig {
 
     pub fn enable_party_transfer(&self) -> bool {
         self.feature_flags.enable_party_transfer
+    }
+
+    pub fn allow_unbounded_system_objects(&self) -> bool {
+        self.feature_flags.allow_unbounded_system_objects
     }
 }
 
@@ -3565,6 +3574,7 @@ impl ProtocolConfig {
                                 stored_observations_limit: 20,
                             },
                         );
+                    cfg.feature_flags.allow_unbounded_system_objects = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_84.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_84.snap
@@ -91,6 +91,7 @@ feature_flags:
   enforce_checkpoint_timestamp_monotonicity: true
   max_ptb_value_size_v2: true
   resolve_type_input_ids_to_defining_id: true
+  allow_unbounded_system_objects: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_84.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_84.snap
@@ -93,6 +93,7 @@ feature_flags:
   enforce_checkpoint_timestamp_monotonicity: true
   max_ptb_value_size_v2: true
   resolve_type_input_ids_to_defining_id: true
+  allow_unbounded_system_objects: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_84.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_84.snap
@@ -98,6 +98,7 @@ feature_flags:
   enforce_checkpoint_timestamp_monotonicity: true
   max_ptb_value_size_v2: true
   resolve_type_input_ids_to_defining_id: true
+  allow_unbounded_system_objects: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -56,6 +56,7 @@ sui-protocol-config.workspace = true
 shared-crypto.workspace = true
 mysten-network.workspace = true
 mysten-metrics.workspace = true
+mysten-common.workspace = true
 parking_lot.workspace = true
 sui-macros.workspace = true
 sui-enum-compat-util.workspace = true

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -157,9 +157,7 @@ impl SuiSystemStateWrapper {
             field.value.system_state_version()
         );
         let new_contents = bcs::to_bytes(&field).expect("bcs serialization should never fail");
-        move_object
-            .update_contents(new_contents, protocol_config)
-            .expect("Update sui system object content cannot fail since it should be small");
+        move_object.update_contents_advance_epoch_safe_mode(new_contents, protocol_config);
     }
 }
 

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -854,7 +854,7 @@ mod checked {
                 } = additional_write;
                 // safe given the invariant that the runtime correctly propagates has_public_transfer
                 let move_object = unsafe {
-                    create_written_object(
+                    create_written_object::<Mode>(
                         vm,
                         &linkage_view,
                         protocol_config,
@@ -895,7 +895,7 @@ mod checked {
                 };
                 // safe because has_public_transfer has been determined by the abilities
                 let move_object = unsafe {
-                    create_written_object(
+                    create_written_object::<Mode>(
                         vm,
                         &linkage_view,
                         protocol_config,
@@ -1665,7 +1665,7 @@ mod checked {
     ///
     /// This function assumes proper generation of has_public_transfer, either from the abilities of
     /// the StructTag, or from the runtime correctly propagating from the inputs
-    unsafe fn create_written_object(
+    unsafe fn create_written_object<Mode: ExecutionMode>(
         vm: &MoveVM,
         linkage_view: &LinkageView,
         protocol_config: &ProtocolConfig,
@@ -1703,6 +1703,7 @@ mod checked {
                 old_obj_ver.unwrap_or_default(),
                 contents,
                 protocol_config,
+                Mode::packages_are_predefined(),
             )
         }
     }

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
@@ -1371,6 +1371,7 @@ mod checked {
             old_obj_ver.unwrap_or_default(),
             contents,
             protocol_config,
+            /* system_mutation */ false,
         )
     }
 }

--- a/sui-execution/v1/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v1/sui-adapter/src/programmable_transactions/context.rs
@@ -1359,6 +1359,7 @@ mod checked {
             old_obj_ver.unwrap_or_default(),
             contents,
             protocol_config,
+            /* system_mutation */ false,
         )
     }
 

--- a/sui-execution/v2/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v2/sui-adapter/src/programmable_transactions/context.rs
@@ -1416,6 +1416,7 @@ mod checked {
             old_obj_ver.unwrap_or_default(),
             contents,
             protocol_config,
+            /* system_mutation */ false,
         )
     }
 


### PR DESCRIPTION
Allows objects created/mutated by system transactions to not be bounded by normal limits and brings it in-line with the rest of the way we treat system transactions and limit interactions.

CI

---

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [X] Protocol: Allow larger objects to be created by system transactions
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
