### PR TITLE
Protocol gate unbounded system objects (#22187)

### DIFF
--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -157,7 +157,9 @@ impl SuiSystemStateWrapper {
             field.value.system_state_version()
         );
         let new_contents = bcs::to_bytes(&field).expect("bcs serialization should never fail");
-        move_object.update_contents_advance_epoch_safe_mode(new_contents, protocol_config);
+        move_object
+            .update_contents_advance_epoch_safe_mode(new_contents, protocol_config)
+            .expect("Update sui system object content cannot fail since it should be small or unbounded");
     }
 }
 


### PR DESCRIPTION
## Description 

Forgot to add in the protocol gating when switching from a larger bound to a feature flag. This adds in the proper protocol gating. This is a reverse cherry pick so this has already landed in the release branch.

## Test plan 

CI
