### PR TITLE
Allow mutations of select larger system objects

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -700,6 +700,11 @@ struct FeatureFlags {
     // Allow objects created or mutated in system transactions to exceed the max object size limit.
     #[serde(skip_serializing_if = "is_false")]
     allow_unbounded_system_objects: bool,
+
+    // Allow system objects that may exceed the max object size limit to be mutated by non-system
+    // transactions.
+    #[serde(skip_serializing_if = "is_false")]
+    allow_unbounded_system_object_mutations: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -1994,6 +1999,12 @@ impl ProtocolConfig {
 
     pub fn allow_unbounded_system_objects(&self) -> bool {
         self.feature_flags.allow_unbounded_system_objects
+    }
+
+    pub fn allow_unbounded_system_object_mutations(&self) -> bool {
+        self.feature_flags
+            .allow_unbounded_system_object_mutations
+     
     }
 }
 
@@ -3580,6 +3591,7 @@ impl ProtocolConfig {
                     if chain != Chain::Mainnet && chain != Chain::Testnet {
                         cfg.feature_flags.enable_party_transfer = true;
                     }
+                    cfg.feature_flags.allow_unbounded_system_object_mutations = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_85.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_85.snap
@@ -92,6 +92,7 @@ feature_flags:
   max_ptb_value_size_v2: true
   resolve_type_input_ids_to_defining_id: true
   allow_unbounded_system_objects: true
+  allow_unbounded_system_object_mutations: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_85.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_85.snap
@@ -94,6 +94,7 @@ feature_flags:
   max_ptb_value_size_v2: true
   resolve_type_input_ids_to_defining_id: true
   allow_unbounded_system_objects: true
+  allow_unbounded_system_object_mutations: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_85.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_85.snap
@@ -100,6 +100,7 @@ feature_flags:
   resolve_type_input_ids_to_defining_id: true
   enable_party_transfer: true
   allow_unbounded_system_objects: true
+  allow_unbounded_system_object_mutations: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-types/src/lib.rs
+++ b/crates/sui-types/src/lib.rs
@@ -7,6 +7,8 @@
     rust_2021_compatibility
 )]
 
+use std::collections::BTreeSet;
+
 use base_types::{SequenceNumber, SuiAddress};
 use move_binary_format::file_format::{AbilitySet, SignatureToken};
 use move_binary_format::CompiledModule;
@@ -19,6 +21,7 @@ use object::OBJECT_START_VERSION;
 use base_types::ObjectID;
 
 pub use mysten_network::multiaddr;
+use once_cell::sync::Lazy;
 
 use crate::base_types::{RESOLVED_ASCII_STR, RESOLVED_UTF8_STR};
 use crate::{base_types::RESOLVED_STD_OPTION, id::RESOLVED_SUI_ID};
@@ -131,6 +134,18 @@ built_in_ids! {
     SUI_BRIDGE_ADDRESS / SUI_BRIDGE_OBJECT_ID = 0x9;
     SUI_DENY_LIST_ADDRESS / SUI_DENY_LIST_OBJECT_ID = 0x403;
 }
+
+/// The set of well-known system (Move) objects
+pub static KNOWN_SYSTEM_OBJECTS: Lazy<BTreeSet<ObjectID>> = Lazy::new(|| {
+    BTreeSet::from([
+        SUI_SYSTEM_STATE_OBJECT_ID,
+        SUI_CLOCK_OBJECT_ID,
+        SUI_AUTHENTICATOR_STATE_OBJECT_ID,
+        SUI_RANDOMNESS_STATE_OBJECT_ID,
+        SUI_BRIDGE_OBJECT_ID,
+        SUI_DENY_LIST_OBJECT_ID,
+    ])
+});
 
 pub const SUI_SYSTEM_STATE_OBJECT_SHARED_VERSION: SequenceNumber = OBJECT_START_VERSION;
 pub const SUI_CLOCK_OBJECT_SHARED_VERSION: SequenceNumber = OBJECT_START_VERSION;

--- a/crates/sui-types/src/sui_system_state/mod.rs
+++ b/crates/sui-types/src/sui_system_state/mod.rs
@@ -43,6 +43,9 @@ pub const SUI_SYSTEM_MODULE_NAME: &IdentStr = ident_str!("sui_system");
 pub const ADVANCE_EPOCH_FUNCTION_NAME: &IdentStr = ident_str!("advance_epoch");
 pub const ADVANCE_EPOCH_SAFE_MODE_FUNCTION_NAME: &IdentStr = ident_str!("advance_epoch_safe_mode");
 
+pub const SUI_SYSTEM_STATE_INNER_V1: &IdentStr = ident_str!("SuiSystemStateInnerV1");
+pub const SUI_SYSTEM_STATE_INNER_V2: &IdentStr = ident_str!("SuiSystemStateInnerV2");
+
 #[cfg(msim)]
 pub const SUI_SYSTEM_STATE_SIM_TEST_V1: u64 = 18446744073709551605; // u64::MAX - 10
 #[cfg(msim)]
@@ -219,6 +222,13 @@ impl SuiSystemState {
     pub fn version(&self) -> u64 {
         self.system_state_version()
     }
+}
+
+pub fn is_sui_system_inner_state_type(tag: &StructTag) -> bool {
+    tag.address == SUI_SYSTEM_ADDRESS
+        && tag.module.as_ident_str() == SUI_SYSTEM_MODULE_NAME
+        && (tag.name.as_ident_str() == SUI_SYSTEM_STATE_INNER_V1
+            || tag.name.as_ident_str() == SUI_SYSTEM_STATE_INNER_V2)
 }
 
 pub fn get_sui_system_state_wrapper(


### PR DESCRIPTION
## Description 

Since we allow larger objects coming from system transactions, some user transactions may need/want to mutate them and we should support that.

This only allows this for a select few objects (well known objects + the inner system state dynamic field).

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [X] Protocol: Allow user transactions to mutate larger system objects.
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
