### PR TITLE
Merge input object available with notify_read check

### DIFF
--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -9,6 +9,8 @@ use crate::authority::epoch_start_configuration::EpochStartConfiguration;
 use crate::authority::AuthorityStore;
 use crate::global_state_hasher::GlobalStateHashStore;
 use crate::transaction_outputs::TransactionOutputs;
+use either::Either;
+use itertools::Itertools;
 use mysten_common::fatal;
 use sui_types::bridge::Bridge;
 
@@ -235,40 +237,47 @@ pub trait ObjectCacheRead: Send + Sync {
         Ok(result)
     }
 
-    /// Used by transaction manager to determine if input objects are ready. Distinct from multi_get_object_by_key
+    /// Used by execution scheduler to determine if input objects are ready. Distinct from multi_get_object_by_key
     /// because it also consults markers to handle the case where an object will never become available (e.g.
     /// because it has been received by some other transaction already).
     fn multi_input_objects_available(
         &self,
         keys: &[InputKey],
-        receiving_objects: HashSet<InputKey>,
-        epoch: EpochId,
+        receiving_objects: &HashSet<InputKey>,
+        epoch: &EpochId,
     ) -> Vec<bool> {
-        let (keys_with_version, keys_without_version): (Vec<_>, Vec<_>) = keys
-            .iter()
-            .enumerate()
-            .partition(|(_, key)| key.version().is_some());
+        let mut results = vec![false; keys.len()];
+        let non_canceled_keys = keys.iter().enumerate().filter(|(idx, key)| {
+            if key.is_cancelled() {
+                // Shared objects in canceled transactions are always available.
+                results[*idx] = true;
+                false
+            } else {
+                true
+            }
+        });
+        let (move_object_keys, package_object_keys): (Vec<_>, Vec<_>) = non_canceled_keys
+            .partition_map(|(idx, key)| match key {
+                InputKey::VersionedObject { id, version } => Either::Left((idx, (id, version))),
+                InputKey::Package { id } => Either::Right((idx, id)),
+            });
 
-        let mut versioned_results = vec![];
-        for ((idx, input_key), has_key) in keys_with_version.iter().zip(
+        for ((idx, (id, version)), has_key) in move_object_keys.iter().zip(
             self.multi_object_exists_by_key(
-                &keys_with_version
+                &move_object_keys
                     .iter()
-                    .map(|(_, k)| ObjectKey(k.id().id(), k.version().unwrap()))
+                    .map(|(_, k)| ObjectKey(k.0.id(), *k.1))
                     .collect::<Vec<_>>(),
             )
             .into_iter(),
         ) {
-            assert!(
-                input_key.version().is_none() || input_key.version().unwrap().is_valid(),
-                "Shared objects in cancelled transaction should always be available immediately,
-                 but it appears that transaction manager is waiting for {:?} to become available",
-                input_key
-            );
             // If the key exists at the specified version, then the object is available.
             if has_key {
-                versioned_results.push((*idx, true))
-            } else if receiving_objects.contains(input_key) {
+                results[*idx] = true;
+            } else if receiving_objects.contains(&InputKey::VersionedObject {
+                id: **id,
+                version: **version,
+            }) {
                 // There could be a more recent version of this object, and the object at the
                 // specified version could have already been pruned. In such a case `has_key` will
                 // be false, but since this is a receiving object we should mark it as available if
@@ -276,46 +285,28 @@ pub trait ObjectCacheRead: Send + Sync {
                 // specified version exists or was deleted. We will then let mark it as available
                 // to let the transaction through so it can fail at execution.
                 let is_available = self
-                    .get_object(&input_key.id().id())
-                    .map(|obj| obj.version() >= input_key.version().unwrap())
+                    .get_object(&id.id())
+                    .map(|obj| obj.version() >= **version)
                     .unwrap_or(false)
-                    || self.fastpath_stream_ended_at_version_or_after(
-                        input_key.id().id(),
-                        input_key.version().unwrap(),
-                        epoch,
-                    );
-                versioned_results.push((*idx, is_available));
-            } else if self
-                .get_consensus_stream_end_tx_digest(
-                    FullObjectKey::new(input_key.id(), input_key.version().unwrap()),
-                    epoch,
-                )
-                .is_some()
-            {
+                    || self.fastpath_stream_ended_at_version_or_after(id.id(), **version, *epoch);
+                results[*idx] = is_available;
+            } else {
                 // If the object is an already-removed consensus object, mark it as available if the
                 // version for that object is in the marker table.
-                versioned_results.push((*idx, true));
-            } else {
-                versioned_results.push((*idx, false));
+                let is_consensus_stream_ended = self
+                    .get_consensus_stream_end_tx_digest(FullObjectKey::new(**id, **version), *epoch)
+                    .is_some();
+                results[*idx] = is_consensus_stream_ended;
             }
         }
 
-        let unversioned_results = keys_without_version.into_iter().map(|(idx, key)| {
-            (
-                idx,
-                match self.get_latest_object_ref_or_tombstone(key.id().id()) {
-                    None => false,
-                    Some(entry) => entry.2.is_alive(),
-                },
-            )
+        package_object_keys.into_iter().for_each(|(idx, id)| {
+            // unwrap is safe since this only errors when the object is not a package,
+            // which is impossible if we have a certificate for execution.
+            results[idx] = self.get_package_object(id).unwrap().is_some();
         });
 
-        let mut results = versioned_results
-            .into_iter()
-            .chain(unversioned_results)
-            .collect::<Vec<_>>();
-        results.sort_by_key(|(idx, _)| *idx);
-        results.into_iter().map(|(_, result)| result).collect()
+        results
     }
 
     /// Return the object with version less then or eq to the provided seq number.
@@ -419,7 +410,7 @@ pub trait ObjectCacheRead: Send + Sync {
         input_and_receiving_keys: &'a [InputKey],
         receiving_keys: &'a HashSet<InputKey>,
         epoch: &'a EpochId,
-    ) -> BoxFuture<'a, Vec<()>>;
+    ) -> BoxFuture<'a, ()>;
 }
 
 pub trait TransactionCacheRead: Send + Sync {

--- a/crates/sui-core/src/execution_cache/unit_tests/notify_read_input_objects_tests.rs
+++ b/crates/sui-core/src/execution_cache/unit_tests/notify_read_input_objects_tests.rs
@@ -43,33 +43,30 @@ async fn test_immediate_return_canceled_shared() {
     let epoch = &0;
 
     // Should return immediately since canceled shared objects are always available
-    let result = cache
+    cache
         .notify_read_input_objects(&[canceled_key], &receiving_keys, epoch)
         .now_or_never()
         .unwrap();
-    assert_eq!(result.len(), 1);
 
     let congested_key = InputKey::VersionedObject {
         id: FullObjectID::new(ObjectID::random(), Some(SequenceNumber::from(1))),
         version: SequenceNumber::CONGESTED,
     };
 
-    let result = cache
+    cache
         .notify_read_input_objects(&[congested_key], &receiving_keys, epoch)
         .now_or_never()
         .unwrap();
-    assert_eq!(result.len(), 1);
 
     let randomness_unavailable_key = InputKey::VersionedObject {
         id: FullObjectID::new(ObjectID::random(), Some(SequenceNumber::from(1))),
         version: SequenceNumber::RANDOMNESS_UNAVAILABLE,
     };
 
-    let result = cache
+    cache
         .notify_read_input_objects(&[randomness_unavailable_key], &receiving_keys, epoch)
         .now_or_never()
         .unwrap();
-    assert_eq!(result.len(), 1);
 }
 
 #[tokio::test]
@@ -90,12 +87,10 @@ async fn test_immediate_return_cached_object() {
     let epoch = &0;
 
     // Should return immediately since object is in cache
-    let result = cache
+    cache
         .notify_read_input_objects(&input_keys, &receiving_keys, epoch)
         .now_or_never()
         .unwrap();
-
-    assert_eq!(result.len(), 1);
 }
 
 #[tokio::test]
@@ -109,12 +104,10 @@ async fn test_immediate_return_cached_package() {
     let epoch = &0;
 
     // Should return immediately since system package is available by default.
-    let result = cache
+    cache
         .notify_read_input_objects(&input_keys, &receiving_keys, epoch)
         .now_or_never()
         .unwrap();
-
-    assert_eq!(result.len(), 1);
 }
 
 #[tokio::test]
@@ -139,12 +132,10 @@ async fn test_immediate_return_consensus_stream_ended() {
     let receiving_keys = HashSet::new();
 
     // Should return immediately since object is marked as consensus stream ended
-    let result = cache
+    cache
         .notify_read_input_objects(&input_keys, &receiving_keys, &epoch)
         .now_or_never()
         .unwrap();
-
-    assert_eq!(result.len(), 1);
 }
 
 #[tokio::test]
@@ -205,13 +196,12 @@ async fn test_wait_for_object() {
             cache.write_object_entry(&object_id, version, ObjectEntry::Object(object));
         }
     });
-    let result = timeout(
+    timeout(
         Duration::from_secs(3),
         cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch),
     )
     .await
     .unwrap();
-    assert_eq!(result.len(), 1);
 }
 
 #[tokio::test]
@@ -249,9 +239,7 @@ async fn test_wait_for_package() {
     });
 
     // Should complete once package is written
-    let result = timeout(Duration::from_secs(1), notification).await.unwrap();
-
-    assert_eq!(result.len(), 1);
+    timeout(Duration::from_secs(1), notification).await.unwrap();
 }
 
 #[tokio::test]
@@ -285,9 +273,7 @@ async fn test_wait_for_consensus_stream_end() {
     });
 
     // Should complete once marker is written
-    let result = timeout(Duration::from_secs(1), notification).await.unwrap();
-
-    assert_eq!(result.len(), 1);
+    timeout(Duration::from_secs(1), notification).await.unwrap();
 }
 
 #[tokio::test]
@@ -315,10 +301,8 @@ async fn test_receiving_object_higher_version() {
     let epoch = &0;
 
     // Should return immediately since a higher version exists for receiving object
-    let result = cache
+    cache
         .notify_read_input_objects(&input_keys, &receiving_keys, epoch)
         .now_or_never()
         .unwrap();
-
-    assert_eq!(result.len(), 1);
 }

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -1804,78 +1804,15 @@ impl ObjectCacheRead for WritebackCache {
         input_and_receiving_keys: &'a [InputKey],
         receiving_keys: &'a HashSet<InputKey>,
         epoch: &'a EpochId,
-    ) -> BoxFuture<'a, Vec<()>> {
+    ) -> BoxFuture<'a, ()> {
         self.object_notify_read
             .read(input_and_receiving_keys, |keys| {
-                let mut results = vec![None; keys.len()];
-
-                let (keys_with_version, keys_without_version): (Vec<_>, Vec<_>) = keys
-                    .iter()
-                    .enumerate()
-                    .filter(|(idx, key)| {
-                        if key.is_cancelled() {
-                            // Shared objects in canceled transactions are always available.
-                            results[*idx] = Some(());
-                            false
-                        } else {
-                            true
-                        }
-                    })
-                    .partition(|(_, key)| key.version().is_some());
-                let versioned_object_keys: Vec<_> = keys_with_version
-                    .iter()
-                    .map(|(_, key)| ObjectKey(key.id().id(), key.version().unwrap()))
-                    .collect();
-                ObjectCacheRead::multi_get_objects_by_key(self, &versioned_object_keys)
+                self.multi_input_objects_available(keys, receiving_keys, epoch)
                     .into_iter()
-                    .zip(keys_with_version.iter())
-                    .for_each(|(o, (idx, input_key))| match o {
-                        Some(_) => results[*idx] = Some(()),
-                        None => {
-                            if receiving_keys.contains(input_key) {
-                                // There could be a more recent version of this object, and the object at the
-                                // specified version could have already been pruned. In such a case `has_key` will
-                                // be false, but since this is a receiving object we should mark it as available if
-                                // we can determine that an object with a version greater than or equal to the
-                                // specified version exists or was deleted. We will then let mark it as available
-                                // to let the transaction through so it can fail at execution.
-                                let is_available =
-                                    ObjectCacheRead::get_object(self, &input_key.id().id())
-                                        .map(|obj| obj.version() >= input_key.version().unwrap())
-                                        .unwrap_or(false)
-                                        || self.fastpath_stream_ended_at_version_or_after(
-                                            input_key.id().id(),
-                                            input_key.version().unwrap(),
-                                            *epoch,
-                                        );
-                                if is_available {
-                                    results[*idx] = Some(());
-                                }
-                            } else if self
-                                .get_consensus_stream_end_tx_digest(
-                                    FullObjectKey::new(
-                                        input_key.id(),
-                                        input_key.version().unwrap(),
-                                    ),
-                                    *epoch,
-                                )
-                                .is_some()
-                            {
-                                // If the object is an already-removed consensus object, mark it as available if the
-                                // version for that object is in the marker table.
-                                results[*idx] = Some(());
-                            }
-                        }
-                    });
-                keys_without_version.iter().for_each(|(idx, key)| {
-                    // unwrap is safe since this only errors when the object is not a package,
-                    // which is impossible if we have a certificate for execution.
-                    if self.get_package_object(&key.id().id()).unwrap().is_some() {
-                        results[*idx] = Some(());
-                    }
-                });
-                results
+                    .map(|available| if available { Some(()) } else { None })
+                    .collect::<Vec<_>>()
             })
+            .map(|_| ())
             .boxed()
     }
 }

--- a/crates/sui-core/src/transaction_manager.rs
+++ b/crates/sui-core/src/transaction_manager.rs
@@ -507,8 +507,8 @@ impl TransactionManager {
             .object_cache_read
             .multi_input_objects_available(
                 &input_object_cache_misses,
-                receiving_objects,
-                epoch_store.epoch(),
+                &receiving_objects,
+                &epoch_store.epoch(),
             )
             .into_iter()
             .zip(input_object_cache_misses);


### PR DESCRIPTION
## Description 

This PR merges the implementation of multi_input_objects_available with the check inside notify_read_input_objects.
The implementation is mostly identical semantically with one difference which is that we need to filter out cancelations there (TxManager already filters it out hence it was not there).

Also made some simplifications such as version unwrapping, package object fetching, and results formation and etc.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
