### PR TITLE
[fastpath] disable setting transactions status in block handler

### DIFF
--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -1267,25 +1267,26 @@ impl ConsensusBlockHandler {
             .collect::<Vec<_>>();
         let mut pending_consensus_transactions = vec![];
         let mut executable_transactions = vec![];
-        for (block, transactions) in parsed_transactions {
-            for (idx, parsed) in transactions.into_iter().enumerate() {
-                let position = ConsensusTxPosition {
-                    block,
-                    index: idx as TransactionIndex,
-                };
+        for (_block, transactions) in parsed_transactions {
+            for parsed in transactions {
+                // TODO(fastpath): enable set_consensus_tx_status() after post-commit finalization is implemented.
+                // let position = ConsensusTxPosition {
+                //     block,
+                //     index: idx as TransactionIndex,
+                // };
                 if parsed.rejected {
-                    // TODO(fastpath): unlock rejected transactions.
-                    // TODO(fastpath): maybe avoid parsing blocks twice between commit and transaction handling?
-                    self.epoch_store
-                        .set_consensus_tx_status(position, ConsensusTxStatus::Rejected);
-                    self.metrics
-                        .consensus_block_handler_txn_processed
-                        .with_label_values(&["rejected"])
-                        .inc();
+                    //     // TODO(fastpath): unlock rejected transactions.
+                    //     // TODO(fastpath): maybe avoid parsing blocks twice between commit and transaction handling?
+                    //     self.epoch_store
+                    //         .set_consensus_tx_status(position, ConsensusTxStatus::Rejected);
+                    //     self.metrics
+                    //         .consensus_block_handler_txn_processed
+                    //         .with_label_values(&["rejected"])
+                    //         .inc();
                     continue;
                 }
-                self.epoch_store
-                    .set_consensus_tx_status(position, ConsensusTxStatus::FastpathCertified);
+                // self.epoch_store
+                //     .set_consensus_tx_status(position, ConsensusTxStatus::FastpathCertified);
 
                 self.metrics
                     .consensus_block_handler_txn_processed


### PR DESCRIPTION
## Description 

Before post-commit finalization is implemented, there can be discrepancies in transaction status between block handler vs commit handler.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
