### PR TITLE
[chore] Fix toml tonic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2942,7 +2942,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tonic 0.13.0",
+ "tonic 0.13.1",
  "tonic-build 0.13.0",
  "tonic-rustls",
  "tower 0.5.2",
@@ -8698,7 +8698,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tokio-stream",
- "tonic 0.13.0",
+ "tonic 0.13.1",
  "tonic-health",
  "tower 0.5.2",
  "tower-http",
@@ -13914,7 +13914,7 @@ dependencies = [
  "test-cluster",
  "tokio",
  "tokio-stream",
- "tonic 0.13.0",
+ "tonic 0.13.1",
  "tracing",
  "url",
 ]
@@ -14024,7 +14024,7 @@ dependencies = [
  "test-cluster",
  "thiserror 1.0.69",
  "tokio",
- "tonic 0.13.0",
+ "tonic 0.13.1",
  "tower 0.5.2",
  "tower-http",
  "tracing",
@@ -14483,7 +14483,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tonic 0.13.0",
+ "tonic 0.13.1",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -14635,7 +14635,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tonic 0.13.0",
+ "tonic 0.13.1",
  "tracing",
  "url",
 ]
@@ -15198,7 +15198,7 @@ dependencies = [
  "telemetry-subscribers",
  "tempfile",
  "tokio",
- "tonic 0.13.0",
+ "tonic 0.13.1",
  "tonic-build 0.13.0",
  "tower 0.5.2",
  "tracing",
@@ -15656,7 +15656,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
- "tonic 0.13.0",
+ "tonic 0.13.1",
  "tonic-build 0.13.0",
  "tonic-health",
  "tonic-reflection",
@@ -15715,7 +15715,7 @@ dependencies = [
  "sui-types",
  "telemetry-subscribers",
  "tokio",
- "tonic 0.13.0",
+ "tonic 0.13.1",
  "tracing",
 ]
 
@@ -16372,7 +16372,7 @@ dependencies = [
  "tap",
  "thiserror 1.0.69",
  "tokio",
- "tonic 0.13.0",
+ "tonic 0.13.1",
  "tracing",
  "typed-store-error",
  "url",
@@ -17461,8 +17461,26 @@ dependencies = [
 [[package]]
 name = "tonic"
 version = "0.13.0"
+source = "git+https://github.com/hyperium/tonic.git?rev=fee9c130c86a365b039f3e70a72a94ea28a9aaa9#fee9c130c86a365b039f3e70a72a94ea28a9aaa9"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85839f0b32fd242bb3209262371d07feda6d780d16ee9d2bc88581b89da1549b"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
  "async-trait",
  "axum 0.8.3",
@@ -17527,7 +17545,7 @@ dependencies = [
  "prost 0.13.3",
  "tokio",
  "tokio-stream",
- "tonic 0.13.0",
+ "tonic 0.13.1",
 ]
 
 [[package]]
@@ -17540,7 +17558,7 @@ dependencies = [
  "prost-types 0.13.3",
  "tokio",
  "tokio-stream",
- "tonic 0.13.0",
+ "tonic 0.13.1",
 ]
 
 [[package]]
@@ -17562,7 +17580,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tokio-stream",
- "tonic 0.13.0",
+ "tonic 0.13.1",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2943,7 +2943,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic 0.13.1",
- "tonic-build 0.13.0",
+ "tonic-build 0.13.1",
  "tonic-rustls",
  "tower 0.5.2",
  "tower-http",
@@ -15199,7 +15199,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tonic 0.13.1",
- "tonic-build 0.13.0",
+ "tonic-build 0.13.1",
  "tower 0.5.2",
  "tracing",
 ]
@@ -15657,7 +15657,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic 0.13.1",
- "tonic-build 0.13.0",
+ "tonic-build 0.13.1",
  "tonic-health",
  "tonic-reflection",
  "tonic-web",
@@ -17460,24 +17460,6 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.13.0"
-source = "git+https://github.com/hyperium/tonic.git?rev=fee9c130c86a365b039f3e70a72a94ea28a9aaa9#fee9c130c86a365b039f3e70a72a94ea28a9aaa9"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "http 1.1.0",
- "http-body 1.0.1",
- "http-body-util",
- "percent-encoding",
- "pin-project",
- "tokio-stream",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
@@ -17524,9 +17506,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85f0383fadd15609306383a90e85eaed44169f931a5d2be1b42c76ceff1825e"
+checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -17538,9 +17520,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-health"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b322337dbd837f3dec2c0d29074da49ec80b7ead45ec1c56d6805c43f370f5"
+checksum = "cb87334d340313fefa513b6e60794d44a86d5f039b523229c99c323e4e19ca4b"
 dependencies = [
  "prost 0.13.3",
  "tokio",
@@ -17550,9 +17532,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-reflection"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88fa815be858816dad226a49439ee90b7bcf81ab55bee72fdb217f1e6778c3ca"
+checksum = "f9687bd5bfeafebdded2356950f278bba8226f0b32109537c4253406e09aafe1"
 dependencies = [
  "prost 0.13.3",
  "prost-types 0.13.3",
@@ -17563,8 +17545,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-rustls"
-version = "0.1.0"
-source = "git+https://github.com/bmwill/tonic-rustls?rev=77c3334b8aa00a982fb432d77c768c41aab1b05e#77c3334b8aa00a982fb432d77c768c41aab1b05e"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733d45643fe455d5e4cc3a469537063248dddc166c7acfb406bd0c9054c2fd10"
 dependencies = [
  "async-stream",
  "bytes",
@@ -17589,8 +17572,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-web"
-version = "0.13.0"
-source = "git+https://github.com/hyperium/tonic.git?rev=fee9c130c86a365b039f3e70a72a94ea28a9aaa9#fee9c130c86a365b039f3e70a72a94ea28a9aaa9"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "774cad0f35370f81b6c59e3a1f5d0c3188bdb4a2a1b8b7f0921c860bfbd3aec6"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -17598,7 +17582,7 @@ dependencies = [
  "http-body 1.0.1",
  "pin-project",
  "tokio-stream",
- "tonic 0.13.0",
+ "tonic 0.13.1",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -539,12 +539,11 @@ tonic = { version = "0.13.1", features = [
   "transport",
   "tls-webpki-roots",
 ] }
-tonic-build = { version = "0.13", features = ["prost", "transport"] }
-tonic-health = "0.13"
-tonic-reflection = "0.13"
-tonic-web = { git = "https://github.com/hyperium/tonic.git", rev = "fee9c130c86a365b039f3e70a72a94ea28a9aaa9" }
-# tonic-rustls = "0.1.0"
-tonic-rustls = { git = "https://github.com/bmwill/tonic-rustls", rev = "77c3334b8aa00a982fb432d77c768c41aab1b05e" }
+tonic-build = { version = "0.13.1", features = ["prost", "transport"] }
+tonic-health = "0.13.1"
+tonic-reflection = "0.13.1"
+tonic-web = "0.13.1"
+tonic-rustls = "0.2.0"
 tower = { version = "0.5", features = [
   "full",
   "util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -534,7 +534,7 @@ tokio-stream = { version = "0.1.14", features = ["sync", "net"] }
 tokio-util = "0.7.10"
 toml = { version = "0.7.4", features = ["preserve_order"] }
 toml_edit = { version = "0.19.10" }
-tonic = { version = "0.13.0", features = [
+tonic = { version = "0.13.1", features = [
   "zstd",
   "transport",
   "tls-webpki-roots",
@@ -773,9 +773,6 @@ sui-execution = { path = "sui-execution" }
 # move-stdlib = { path = "external-crates/move/move-stdlib" }
 # move-vm-runtime = { path = "external-crates/move/move-vm/runtime" }
 # move-bytecode-verifier = { path = "external-crates/move/move-bytecode-verifier" }
-
-[patch.'https://github.com/hyperium/tonic.git']
-tonic = "0.13"
 
 [patch.crates-io]
 async-graphql = { git = "https://github.com/amnn/async-graphql", branch = "v7.0.1-react-18" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -534,7 +534,7 @@ tokio-stream = { version = "0.1.14", features = ["sync", "net"] }
 tokio-util = "0.7.10"
 toml = { version = "0.7.4", features = ["preserve_order"] }
 toml_edit = { version = "0.19.10" }
-tonic = { version = "0.13", features = [
+tonic = { version = "0.13.0", features = [
   "zstd",
   "transport",
   "tls-webpki-roots",


### PR DESCRIPTION
## Description 

This bumps the patch for `tonic` to `v0.13.1` as folks cannot do `cargo install --git ....`.

Should close #22198 and #22162

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
