### PR TITLE
WIP: Embed Jemalloc in Sui Node

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -401,7 +401,8 @@ insta-cmd = "0.6.0"
 integer-encoding = "3.0.1"
 ipnetwork = "0.20.0"
 itertools = "0.13.0"
-jemalloc-ctl = "^0.5"
+tikv-jemalloc-ctl = "^0.5"
+tikv-jemallocator = "^0.5"
 jsonrpsee = { version = "0.24.9", features = [
   "server",
   "macros",

--- a/crates/sui-move/Cargo.toml
+++ b/crates/sui-move/Cargo.toml
@@ -38,7 +38,7 @@ sui-package-management.workspace = true
 better_any = "0.1.1"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemalloc-ctl.workspace = true
+tikv-jemalloc-ctl.workspace = true
 
 [dev-dependencies]
 futures.workspace = true
@@ -54,7 +54,7 @@ mysten-metrics.workspace = true
 sui-macros.workspace = true
 
 [package.metadata.cargo-udeps.ignore]
-normal = ["jemalloc-ctl"]
+normal = ["tikv-jemalloc-ctl"]
 
 [lints]
 workspace = true

--- a/crates/sui-node/Cargo.toml
+++ b/crates/sui-node/Cargo.toml
@@ -34,6 +34,7 @@ serde.workspace = true
 bin-version.workspace = true
 url.workspace = true
 humantime.workspace = true
+tikv-jemallocator = true
 
 sui-tls.workspace = true
 sui-macros.workspace = true

--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -43,6 +43,9 @@ struct Args {
     run_with_range_checkpoint: Option<CheckpointSequenceNumber>,
 }
 
+#[global_allocator]
+static JEMALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 fn main() {
     antithesis_sdk::antithesis_init();
 

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -103,7 +103,7 @@ move-cli.workspace = true
 move-symbol-pool.workspace = true
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemalloc-ctl.workspace = true
+tikv-jemalloc-ctl.workspace = true
 
 [dev-dependencies]
 prometheus.workspace = true
@@ -125,7 +125,7 @@ serde_json.workspace = true
 msim.workspace = true
 
 [package.metadata.cargo-udeps.ignore]
-normal = ["jemalloc-ctl"]
+normal = ["tikv-jemalloc-ctl"]
 
 [[example]]
 name = "generate-genesis-checkpoint"

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -20,7 +20,7 @@ once_cell.workspace = true
 tap.workspace = true
 prometheus.workspace = true
 hdrhistogram.workspace = true
-rocksdb = { version = "0.22.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf"] }
+rocksdb = { version = "0.22.0", default-features = false, features = ["snappy", "lz4", "zstd", "zlib", "multi-threaded-cf", "jemalloc"] }
 serde.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/docker/sui-node-deterministic/Dockerfile
+++ b/docker/sui-node-deterministic/Dockerfile
@@ -9,6 +9,7 @@ FROM stagex/core-clang@sha256:abf6d2868bc441b5910ef28f38123c6053391521948b33eaf6
 FROM stagex/core-llvm@sha256:bc1c6d67aa73a96dd92f5def7e2701de78b0639d0c815d69110fbb9b3b3e85fe AS llvm
 FROM stagex/core-lld@sha256:a5cb61edc071d404cd33cb0b5c7113a334cb90ca203cb40fe6cafd3559b6daa5 AS lld
 FROM stagex/core-libffi@sha256:9acd18e59ca11fa727670725e69a976d96f85a00704dea6ad07870bff2bd4e8b AS libffi
+FROM stagex/core-make@sha256:a47d8f67f8fd74905f724fdc5f0d18e29df96391751754947bdeaba9bef8f7d8 AS make
 
 FROM pallet-rust AS build
 ARG PROFILE
@@ -20,6 +21,7 @@ COPY --from=clang . /
 COPY --from=llvm . /
 COPY --from=lld . /
 COPY --from=libffi . /
+COPY --from=make . /
 
 ENV RUST_BACKTRACE=1
 ENV RUSTFLAGS="-C codegen-units=1"


### PR DESCRIPTION
## Description 

Use the `tikv-jemallocator` crate to define a `#[global_allocator]`, and enable the `jemalloc` feature of `librocksdb-sys` to leverage builtin jemalloc.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [X] Nodes (Validators and Full nodes): Embed Jemalloc instead of using LD_PRELOAD; no change required.
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:

---

This should not be merged as-is as it may affect the performance of nodes even outside of `sui-node-deterministic`. While there should be no noticeable difference, I haven't been able to do a proper comparison by myself. I am requesting help from @jnaulty to get some performance testing on this to see how it compares versus the static glibc malloc.