### PR TITLE
display: replace legacy Display impl with sui-display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14231,6 +14231,7 @@ dependencies = [
  "similar",
  "simulacrum",
  "sui-default-config",
+ "sui-display",
  "sui-framework",
  "sui-graphql-rpc-client",
  "sui-graphql-rpc-headers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14762,6 +14762,7 @@ dependencies = [
  "signature 1.6.4",
  "sui-config",
  "sui-core",
+ "sui-display",
  "sui-json",
  "sui-json-rpc-api",
  "sui-json-rpc-types",

--- a/crates/sui-graphql-e2e-tests/tests/stable/objects/display.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/objects/display.snap
@@ -53,19 +53,19 @@ Response: {
           {
             "display": [
               {
-                "key": "vectors",
-                "value": null,
-                "error": "Vector of name vec is not supported as a Display value"
-              },
-              {
                 "key": "idd",
                 "value": null,
-                "error": "Field 'idd' not found"
+                "error": "'idd' not found in object"
               },
               {
                 "key": "namee",
                 "value": null,
-                "error": "Field 'namee' not found"
+                "error": "'namee' not found in object"
+              },
+              {
+                "key": "vectors",
+                "value": null,
+                "error": "'vec' is a vector, and is not supported in Display"
               }
             ]
           }
@@ -100,24 +100,24 @@ Response: {
           {
             "display": [
               {
-                "key": "vectors",
-                "value": null,
-                "error": "Vector of name vec is not supported as a Display value"
-              },
-              {
                 "key": "idd",
                 "value": null,
-                "error": "Field 'idd' not found"
+                "error": "'idd' not found in object"
               },
               {
                 "key": "namee",
                 "value": null,
-                "error": "Field 'namee' not found"
+                "error": "'namee' not found in object"
               },
               {
                 "key": "nums",
                 "value": "420",
                 "error": null
+              },
+              {
+                "key": "vectors",
+                "value": null,
+                "error": "'vec' is a vector, and is not supported in Display"
               }
             ]
           }
@@ -152,23 +152,13 @@ Response: {
           {
             "display": [
               {
-                "key": "vectors",
-                "value": null,
-                "error": "Vector of name vec is not supported as a Display value"
+                "key": "age",
+                "value": "10",
+                "error": null
               },
               {
-                "key": "idd",
-                "value": null,
-                "error": "Field 'idd' not found"
-              },
-              {
-                "key": "namee",
-                "value": null,
-                "error": "Field 'namee' not found"
-              },
-              {
-                "key": "nums",
-                "value": "420",
+                "key": "base_url",
+                "value": "https://get-a-boar.com/first.png",
                 "error": null
               },
               {
@@ -182,13 +172,43 @@ Response: {
                 "error": null
               },
               {
+                "key": "creator",
+                "value": "Will",
+                "error": null
+              },
+              {
+                "key": "escape_syntax",
+                "value": "{name}",
+                "error": null
+              },
+              {
+                "key": "full_url",
+                "value": "https://get-a-boar.fullurl.com/",
+                "error": null
+              },
+              {
+                "key": "idd",
+                "value": null,
+                "error": "'idd' not found in object"
+              },
+              {
                 "key": "name",
                 "value": "First Boar",
                 "error": null
               },
               {
-                "key": "creator",
-                "value": "Will",
+                "key": "namee",
+                "value": null,
+                "error": "'namee' not found in object"
+              },
+              {
+                "key": "no_template",
+                "value": "https://get-a-boar.com/",
+                "error": null
+              },
+              {
+                "key": "nums",
+                "value": "420",
                 "error": null
               },
               {
@@ -202,29 +222,9 @@ Response: {
                 "error": null
               },
               {
-                "key": "base_url",
-                "value": "https://get-a-boar.com/first.png",
-                "error": null
-              },
-              {
-                "key": "no_template",
-                "value": "https://get-a-boar.com/",
-                "error": null
-              },
-              {
-                "key": "age",
-                "value": "10",
-                "error": null
-              },
-              {
-                "key": "full_url",
-                "value": "https://get-a-boar.fullurl.com/",
-                "error": null
-              },
-              {
-                "key": "escape_syntax",
-                "value": "{name}",
-                "error": null
+                "key": "vectors",
+                "value": null,
+                "error": "'vec' is a vector, and is not supported in Display"
               }
             ]
           }

--- a/crates/sui-graphql-rpc/Cargo.toml
+++ b/crates/sui-graphql-rpc/Cargo.toml
@@ -49,6 +49,7 @@ serde_with.workspace = true
 serde_yaml.workspace = true
 shared-crypto.workspace = true
 similar.workspace = true
+sui-display.workspace = true
 sui-name-service.workspace = true
 sui-pg-db.workspace = true
 sui-sdk.workspace = true
@@ -70,7 +71,6 @@ downcast = "0.11.0"
 sui-default-config.workspace = true
 sui-graphql-rpc-headers.workspace = true
 sui-graphql-rpc-client.workspace = true
-
 
 # TODO: put these behind feature flag to prevent leakage
 # Used for dummy data

--- a/crates/sui-indexer/src/apis/indexer_api.rs
+++ b/crates/sui-indexer/src/apis/indexer_api.rs
@@ -77,7 +77,6 @@ impl IndexerApi {
         let next_cursor = objects.last().map(|o_read| o_read.object_id());
         let mut parallel_tasks = vec![];
         for o in objects {
-            let inner_clone = self.inner.clone();
             let options = options.clone();
             parallel_tasks.push(tokio::task::spawn(async move {
                 match o {
@@ -86,18 +85,10 @@ impl IndexerApi {
                     )),
                     ObjectRead::Exists(object_ref, o, layout) => {
                         if options.show_display {
-                            match inner_clone.get_display_fields(&o, &layout).await {
-                                Ok(rendered_fields) => Ok(SuiObjectResponse::new_with_data(
-                                    (object_ref, o, layout, options, Some(rendered_fields))
-                                        .try_into()?,
-                                )),
-                                Err(e) => Ok(SuiObjectResponse::new(
-                                    Some((object_ref, o, layout, options, None).try_into()?),
-                                    Some(SuiObjectResponseError::DisplayError {
-                                        error: e.to_string(),
-                                    }),
-                                )),
-                            }
+                            Err(IndexerError::NotSupportedError(
+                                "Display fields are not supported".to_owned(),
+                            )
+                            .into())
                         } else {
                             Ok(SuiObjectResponse::new_with_data(
                                 (object_ref, o, layout, options, None).try_into()?,

--- a/crates/sui-json-rpc/Cargo.toml
+++ b/crates/sui-json-rpc/Cargo.toml
@@ -43,6 +43,7 @@ base64.workspace = true
 tap.workspace = true
 
 sui-core.workspace = true
+sui-display.workspace = true
 sui-storage.workspace = true
 sui-types.workspace = true
 sui-json.workspace = true

--- a/crates/sui-json-rpc/src/read_api.rs
+++ b/crates/sui-json-rpc/src/read_api.rs
@@ -1286,7 +1286,7 @@ async fn get_display_object_by_type(
     }
 }
 
-pub fn get_object_type_and_struct(
+fn get_object_type_and_struct(
     o: &Object,
     layout: &Option<MoveStructLayout>,
 ) -> Result<Option<(StructTag, MoveStruct)>, ObjectDisplayError> {
@@ -1309,7 +1309,7 @@ fn get_move_struct(
         .to_move_struct(layout)?)
 }
 
-pub fn get_rendered_fields(
+fn get_rendered_fields(
     fields: VecMap<String, String>,
     move_struct: &MoveStruct,
 ) -> Result<DisplayFieldsResponse, ObjectDisplayError> {


### PR DESCRIPTION
## Description 

Remove support for Display in `sui-indexer`'s JSON-RPC implementation (which is not in use), and use `sui_display::v1` to implement Display everywhere else (JSON-RPC on fullnodes and legacy GraphQL) so we can get rid of the legacy implementation.

This is mostly a behaviour preserving change and clean-up, but it reduces restrictions around running Display on very large objects (too large to deserialize whole), replacing it with a restriction on the overall Display size.

## Test plan 

Existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [x] JSON-RPC: `showDisplay` now works for large objects, replacing the limit on object size with a limit on overall output size.
- [x] GraphQL: `Object.display` now works for large objects, replacing the limit on object size with a limit on overall output size.
- [ ] CLI: 
- [ ] Rust SDK:
