### PR TITLE
Enable tidehunter with cfg rather then feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -673,7 +673,7 @@ sui-bridge = { path = "crates/sui-bridge" }
 sui-bridge-schema = { path = "crates/sui-bridge-schema" }
 sui-cluster-test = { path = "crates/sui-cluster-test" }
 sui-config = { path = "crates/sui-config" }
-sui-core = { path = "crates/sui-core", features = ["rocksdb"] }
+sui-core = { path = "crates/sui-core" }
 sui-cost = { path = "crates/sui-cost" }
 sui-data-ingestion = { path = "crates/sui-data-ingestion" }
 sui-data-ingestion-core = { path = "crates/sui-data-ingestion-core" }

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -92,10 +92,6 @@ sui-tls.workspace = true
 sui-types.workspace = true
 nonempty.workspace = true
 
-[features]
-tide_hunter = ["typed-store/tide_hunter"]
-rocksdb = []
-
 [dev-dependencies]
 sui-move-build.workspace = true
 clap.workspace = true

--- a/crates/sui-core/build.rs
+++ b/crates/sui-core/build.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 fn main() {
     // This build script enables tidehunter config used to gate tidehunter in sui codebase
     println!("cargo::rerun-if-env-changed=USE_TIDEHUNTER");

--- a/crates/sui-core/build.rs
+++ b/crates/sui-core/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    // This build script enables tidehunter config used to gate tidehunter in sui codebase
+    println!("cargo::rerun-if-env-changed=USE_TIDEHUNTER");
+    println!("cargo::rustc-check-cfg=cfg(tidehunter)");
+    if std::env::var("USE_TIDEHUNTER").is_ok() {
+        println!("cargo::rustc-cfg=tidehunter");
+    }
+}

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -416,7 +416,7 @@ pub struct AuthorityPerEpochStore {
 
 /// AuthorityEpochTables contains tables that contain data that is only valid within an epoch.
 #[derive(DBMapUtils)]
-// #[tidehunter]
+#[cfg_attr(tidehunter, tidehunter)]
 pub struct AuthorityEpochTables {
     /// This is map between the transaction digest and transactions found in the `transaction_lock`.
     #[default_options_override_fn = "signed_transactions_table_default_config"]
@@ -578,7 +578,7 @@ fn pending_consensus_transactions_table_default_config() -> DBOptions {
 }
 
 impl AuthorityEpochTables {
-    #[cfg(any(not(feature = "tide_hunter"), feature = "rocksdb"))]
+    #[cfg(not(tidehunter))]
     pub fn open(epoch: EpochId, parent_path: &Path, db_options: Option<Options>) -> Self {
         Self::open_tables_read_write(
             Self::path(epoch, parent_path),
@@ -588,12 +588,9 @@ impl AuthorityEpochTables {
         )
     }
 
-    #[cfg(all(
-        not(target_os = "windows"),
-        feature = "tide_hunter",
-        not(feature = "rocksdb")
-    ))]
+    #[cfg(tidehunter)]
     pub fn open(epoch: EpochId, parent_path: &Path, db_options: Option<Options>) -> Self {
+        tracing::warn!("AuthorityEpochTables using tidehunter");
         use typed_store::tidehunter_util::{default_cells_per_mutex, KeySpaceConfig, ThConfig};
         const MUTEXES: usize = 1024;
         const LARGE_KEY_LENGTH: usize = 4096 * 2;

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -662,7 +662,7 @@ impl AuthorityStorePruner {
             "Starting object pruning service with num_epochs_to_retain={}",
             config.num_epochs_to_retain
         );
-        #[cfg(all(not(target_os = "windows"), feature = "tide_hunter"))]
+        #[cfg(tidehunter)]
         let config = Self::th_pruning_config();
 
         let tick_duration =

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -51,7 +51,7 @@ impl AuthorityPerpetualTablesOptions {
 
 /// AuthorityPerpetualTables contains data that must be preserved from one epoch to the next.
 #[derive(DBMapUtils)]
-// #[tidehunter]
+#[cfg_attr(tidehunter, tidehunter)]
 pub struct AuthorityPerpetualTables {
     /// This is a map between the object (ID, version) and the latest state of the object, namely the
     /// state that is needed to process new transactions.
@@ -168,7 +168,7 @@ impl AuthorityPerpetualTables {
         parent_path.join("perpetual")
     }
 
-    #[cfg(any(not(feature = "tide_hunter"), feature = "rocksdb"))]
+    #[cfg(not(tidehunter))]
     pub fn open(
         parent_path: &Path,
         db_options_override: Option<AuthorityPerpetualTablesOptions>,
@@ -208,12 +208,9 @@ impl AuthorityPerpetualTables {
         )
     }
 
-    #[cfg(all(
-        not(target_os = "windows"),
-        feature = "tide_hunter",
-        not(feature = "rocksdb")
-    ))]
+    #[cfg(tidehunter)]
     pub fn open(parent_path: &Path, _: Option<AuthorityPerpetualTablesOptions>) -> Self {
+        tracing::warn!("AuthorityPerpetualTables using tidehunter");
         use typed_store::tidehunter_util::{
             default_cells_per_mutex, Bytes, KeySpaceConfig, ThConfig, WalPosition,
         };

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -48,6 +48,3 @@ uint.workspace = true
 # that creates a circular dependency.
 [target.'cfg(msim)'.dependencies]
 msim.workspace = true
-
-[features]
-tide_hunter = ["tidehunter"]

--- a/crates/typed-store/build.rs
+++ b/crates/typed-store/build.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 fn main() {
     // This build script enables tidehunter config used to gate tidehunter in sui codebase
     println!("cargo::rerun-if-env-changed=USE_TIDEHUNTER");

--- a/crates/typed-store/build.rs
+++ b/crates/typed-store/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    // This build script enables tidehunter config used to gate tidehunter in sui codebase
+    println!("cargo::rerun-if-env-changed=USE_TIDEHUNTER");
+    println!("cargo::rustc-check-cfg=cfg(tidehunter)");
+    if std::env::var("USE_TIDEHUNTER").is_ok() {
+        println!("cargo::rustc-cfg=tidehunter");
+    }
+}

--- a/crates/typed-store/src/lib.rs
+++ b/crates/typed-store/src/lib.rs
@@ -16,7 +16,7 @@ pub use traits::{DbIterator, Map};
 pub mod memstore;
 pub mod metrics;
 pub mod rocks;
-#[cfg(all(not(target_os = "windows"), feature = "tide_hunter"))]
+#[cfg(tidehunter)]
 pub mod tidehunter_util;
 mod util;
 pub use metrics::DBMetrics;

--- a/crates/typed-store/tests/macro_tests.rs
+++ b/crates/typed-store/tests/macro_tests.rs
@@ -280,8 +280,8 @@ async fn test_sampling_time() {
     assert!(sampling_interval.sample());
 }
 
-#[cfg(all(not(target_os = "windows"), feature = "tide_hunter"))]
-mod tide_hunter_tests {
+#[cfg(tidehunter)]
+mod tidehunter_tests {
     use super::*;
     use std::collections::BTreeMap;
     use typed_store::tidehunter_util::ThConfig;


### PR DESCRIPTION
This means that even when cargo is run with `--all-features` it won't enable tidehunter by default. This also allows for more concise check for `#[cfg(tidehunter)]` in code.

With this PR to build with tidehunter one needs to run the following
```
USE_TIDEHUNTER=1 cargo --features typed-store/tidehunter <command>
```

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
