### PR TITLE
Update broken link to apps folder in Sui environment documentation

### DIFF
--- a/docs/content/references/contribute/sui-environment.mdx
+++ b/docs/content/references/contribute/sui-environment.mdx
@@ -37,7 +37,7 @@ The Sui repo is a monorepo, containing all the source code that is used to build
 
 The root folder of the Sui monorepo has the following top-level folders:
 
-- [apps](https://github.com/MystenLabs/apps): Contains the source code for the main web applications that Mysten Labs runs, `Sui Wallet`.
+- [apps](https://github.com/MystenLabs/apps): Contains the source code for the main web applications that Mysten Labs runs.
 - [consensus](https://github.com/MystenLabs/sui/tree/main/consensus): Contains the source code of consensus.
 - [crates](https://github.com/MystenLabs/sui/tree/main/crates): Contains all the Rust crates that are part of the Sui system.
 - [dapps](https://github.com/MystenLabs/sui/tree/main/dapps): Contains some examples of decentralized applications built on top of Sui, such as Kiosk or Sponsored Transactions.


### PR DESCRIPTION
Replaced the outdated link to the apps folder in the Sui monorepo with the new repository URL (https://github.com/MystenLabs/apps) in the environment setup documentation. This ensures users are directed to the correct location for the main web applications, including Sui Wallet.