### PR TITLE
[tidehunter] add open option for consensus db

### DIFF
--- a/consensus/core/build.rs
+++ b/consensus/core/build.rs
@@ -15,7 +15,11 @@ fn main() -> Result<()> {
     build_anemo_services(&out_dir);
 
     println!("cargo:rerun-if-changed=build.rs");
-
+    println!("cargo::rerun-if-env-changed=USE_TIDEHUNTER");
+    println!("cargo::rustc-check-cfg=cfg(tidehunter)");
+    if std::env::var("USE_TIDEHUNTER").is_ok() {
+        println!("cargo::rustc-cfg=tidehunter");
+    }
     Ok(())
 }
 

--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -25,6 +25,7 @@ use crate::{
 
 /// Persistent storage with RocksDB.
 #[derive(DBMapUtils)]
+#[cfg_attr(tidehunter, tidehunter)]
 pub(crate) struct RocksDBStore {
     /// Stores SignedBlock by refs.
     blocks: DBMap<(Round, AuthorityIndex, BlockDigest), Bytes>,
@@ -48,6 +49,7 @@ impl RocksDBStore {
     const COMMIT_INFO_CF: &'static str = "commit_info";
 
     /// Creates a new instance of RocksDB storage.
+    #[cfg(not(tidehunter))]
     pub(crate) fn new(path: &str) -> Self {
         // Consensus data has high write throughput (all transactions) and is rarely read
         // (only during recovery and when helping peers catch up).
@@ -76,6 +78,27 @@ impl RocksDBStore {
             metrics_conf,
             Some(db_options.options),
             Some(column_family_options),
+        )
+    }
+
+    #[cfg(tidehunter)]
+    pub(crate) fn new(path: &str) -> Self {
+        tracing::warn!("Consensus RocksDBStore using tidehunter");
+        use typed_store::tidehunter_util::{default_cells_per_mutex, ThConfig};
+        let config = ThConfig::new(4, 1024, default_cells_per_mutex());
+        let cfs = [
+            Self::BLOCKS_CF,
+            Self::DIGESTS_BY_AUTHORITIES_CF,
+            Self::COMMITS_CF,
+            Self::COMMIT_VOTES_CF,
+            Self::COMMIT_INFO_CF,
+        ];
+        let configs = cfs.iter().map(|cf| (cf.to_string(), config.clone()));
+        Self::open_tables_read_write(
+            path.into(),
+            MetricConf::new("consensus")
+                .with_sampling(SamplingInterval::new(Duration::from_secs(60), 0)),
+            configs.collect(),
         )
     }
 }

--- a/crates/typed-store/src/tidehunter_util.rs
+++ b/crates/typed-store/src/tidehunter_util.rs
@@ -19,6 +19,7 @@ pub use tidehunter::{
 };
 use typed_store_error::TypedStoreError;
 
+#[derive(Clone)]
 pub struct ThConfig {
     key_size: usize,
     mutexes: usize,


### PR DESCRIPTION
## Description 

Allow compiling the consensus DB with the TideHunter option as the primary database

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
