### PR TITLE
[move][vm] Add defining-id cache and cached-type lookup

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/runtime.rs
@@ -487,6 +487,13 @@ impl VMRuntime {
             .load_type_by_name(struct_name, module_id, data_store)
     }
 
+    /// Attempt to load a type tag to a `Type` without loading any additional modules.
+    /// This may fail if the type tag is not already loaded in the VM.
+    /// NB: the type tag _must_ be defining ID based.
+    pub fn try_load_cached_type(&self, type_tag: &TypeTag) -> VMResult<Option<Type>> {
+        self.loader.try_load_cached_type(type_tag)
+    }
+
     pub fn execute_function_bypass_visibility(
         &self,
         module: &ModuleId,


### PR DESCRIPTION
## Description 

Add a defining-id cache in the `ModuleCache` to allow for cached type resolution for typetags. This will then be used in the PR above this adding type tags to the object runtime.

## Test plan 

CI + CI/sandbox tests 

