### PR TITLE
[static ptb] Make linkage context immutable during loading types

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/data_cache.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/data_cache.rs
@@ -80,8 +80,8 @@ impl<S: MoveResolver> TransactionDataCache<S> {
 
 // `DataStore` implementation for the `TransactionDataCache`
 impl<S: MoveResolver> DataStore for TransactionDataCache<S> {
-    fn link_context(&self) -> AccountAddress {
-        self.remote.link_context()
+    fn link_context(&self) -> PartialVMResult<AccountAddress> {
+        Ok(self.remote.link_context())
     }
 
     fn relocate(&self, module_id: &ModuleId) -> PartialVMResult<ModuleId> {

--- a/external-crates/move/crates/move-vm-runtime/src/interpreter.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/interpreter.rs
@@ -115,6 +115,9 @@ impl Interpreter {
             runtime_limits_config: loader.vm_config().runtime_limits_config.clone(),
         };
 
+        let link_context = data_store
+            .link_context()
+            .map_err(|e| e.finish(Location::Undefined))?;
         open_initial_frame!(
             tracer,
             &args,
@@ -122,7 +125,7 @@ impl Interpreter {
             &function,
             loader,
             gas_meter,
-            data_store.link_context()
+            link_context
         );
 
         if function.is_native() {
@@ -132,7 +135,9 @@ impl Interpreter {
                     .push(arg)
                     .map_err(|e| e.finish(Location::Undefined))?;
             }
-            let link_context = data_store.link_context();
+            let link_context = data_store
+                .link_context()
+                .map_err(|e| e.finish(Location::Undefined))?;
             let resolver = function.get_resolver(link_context, loader);
 
             let return_values = interpreter
@@ -188,7 +193,9 @@ impl Interpreter {
                 .map_err(|e| self.set_location(e))?;
         }
 
-        let link_context = data_store.link_context();
+        let link_context = data_store
+            .link_context()
+            .map_err(|e| e.finish(Location::Undefined))?;
         let mut current_frame = self
             .make_new_frame(function, ty_args, locals)
             .map_err(|err| self.set_location(err))?;

--- a/external-crates/move/crates/move-vm-types/src/data_store.rs
+++ b/external-crates/move/crates/move-vm-types/src/data_store.rs
@@ -18,7 +18,7 @@ pub trait DataStore {
     /// storage that they are loaded from as returned by `relocate`.  Implementors of `DataStore`
     /// are required to keep the link context stable for the duration of
     /// `Interpreter::execute_main`.
-    fn link_context(&self) -> AccountAddress;
+    fn link_context(&self) -> PartialVMResult<AccountAddress>;
 
     /// Translate the runtime `module_id` to the on-chain `ModuleId` that it should be loaded from.
     fn relocate(&self, module_id: &ModuleId) -> PartialVMResult<ModuleId>;

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/data_store.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/data_store.rs
@@ -46,8 +46,11 @@ impl<'state, 'a> SuiDataStore<'state, 'a> {
 // TODO: `DataStore` will be reworked and this is likely to disappear.
 //       Leaving this comment around until then as testament to better days to come...
 impl DataStore for SuiDataStore<'_, '_> {
-    fn link_context(&self) -> AccountAddress {
-        self.linkage_view.link_context()
+    fn link_context(&self) -> PartialVMResult<AccountAddress> {
+        self.linkage_view.link_context().map_err(|e| {
+            PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                .with_message(e.to_string())
+        })
     }
 
     fn relocate(&self, module_id: &ModuleId) -> PartialVMResult<ModuleId> {

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
@@ -387,7 +387,7 @@ mod checked {
                     trace_builder_opt,
                 );
 
-                context.linkage_view.reset_linkage();
+                context.linkage_view.reset_linkage()?;
                 return_values?
             }
             Command::Publish(modules, dep_ids) => execute_move_publish::<Mode>(
@@ -593,7 +593,7 @@ mod checked {
         let res = publish_and_verify_modules(context, runtime_id, &modules).and_then(|_| {
             init_modules::<Mode>(context, argument_updates, &modules, trace_builder_opt)
         });
-        context.linkage_view.reset_linkage();
+        context.linkage_view.reset_linkage()?;
         if res.is_err() {
             context.pop_package();
         }
@@ -701,7 +701,7 @@ mod checked {
 
         context.linkage_view.set_linkage(&package)?;
         let res = publish_and_verify_modules(context, runtime_id, &modules);
-        context.linkage_view.reset_linkage();
+        context.linkage_view.reset_linkage()?;
         res?;
 
         check_compatibility(

--- a/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
@@ -36,7 +36,7 @@ impl LayoutResolver for TypeLayoutResolver<'_, '_> {
         &mut self,
         struct_tag: &StructTag,
     ) -> Result<A::MoveDatatypeLayout, SuiError> {
-        let Ok(ty) = load_type_from_struct(self.vm, &mut self.linkage_view, &[], struct_tag) else {
+        let Ok(ty) = load_type_from_struct(self.vm, &self.linkage_view, &[], struct_tag) else {
             return Err(SuiError::FailObjectLayout {
                 st: format!("{}", struct_tag),
             });


### PR DESCRIPTION
## Description 

- Switched to making the linkage immutable during loading types
- Made internal borrow errors invariant violations for consistency 

## Test plan 

- 📎 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
