### PR TITLE
Buffer mysticeti fastpath execution results

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -327,6 +327,7 @@ impl ExecutionTimeObserverConfig {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ExecutionCacheConfig {
@@ -356,6 +357,8 @@ pub enum ExecutionCacheConfig {
         /// Number of uncommitted transactions at which to refuse new transaction
         /// submissions. Defaults to backpressure_threshold if unset.
         backpressure_threshold_for_rpc: Option<u64>,
+
+        fastpath_transaction_outputs_cache_size: Option<u64>,
     },
 }
 
@@ -374,6 +377,7 @@ impl Default for ExecutionCacheConfig {
             effect_cache_size: None,
             events_cache_size: None,
             transaction_objects_cache_size: None,
+            fastpath_transaction_outputs_cache_size: None,
         }
     }
 }
@@ -526,6 +530,19 @@ impl ExecutionCacheConfig {
                     backpressure_threshold_for_rpc,
                     ..
                 } => backpressure_threshold_for_rpc.unwrap_or(self.backpressure_threshold()),
+            })
+    }
+
+    pub fn fastpath_transaction_outputs_cache_size(&self) -> u64 {
+        std::env::var("SUI_FASTPATH_TRANSACTION_OUTPUTS_CACHE_SIZE")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| match self {
+                ExecutionCacheConfig::PassthroughCache => fatal!("invalid cache config"),
+                ExecutionCacheConfig::WritebackCache {
+                    fastpath_transaction_outputs_cache_size,
+                    ..
+                } => fastpath_transaction_outputs_cache_size.unwrap_or(10_000),
             })
     }
 }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -8,6 +8,7 @@ use crate::execution_cache::ExecutionCacheTraitPointers;
 use crate::execution_cache::TransactionCacheRead;
 use crate::execution_scheduler::ExecutionSchedulerAPI;
 use crate::execution_scheduler::ExecutionSchedulerWrapper;
+use crate::execution_scheduler::SchedulingSource;
 use crate::jsonrpc_index::CoinIndexKey2;
 use crate::rpc_index::RpcIndexStore;
 use crate::transaction_outputs::TransactionOutputs;
@@ -206,6 +207,10 @@ mod batch_verification_tests;
 #[cfg(test)]
 #[path = "unit_tests/coin_deny_list_tests.rs"]
 mod coin_deny_list_tests;
+
+#[cfg(test)]
+#[path = "unit_tests/mysticeti_fastpath_execution_tests.rs"]
+mod mysticeti_fastpath_execution_tests;
 
 #[cfg(test)]
 #[path = "unit_tests/auth_unit_test_utils.rs"]
@@ -1281,6 +1286,7 @@ impl AuthorityState {
         certificate: &VerifiedExecutableTransaction,
         mut expected_effects_digest: Option<TransactionEffectsDigest>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
+        scheduling_source: SchedulingSource,
     ) -> SuiResult<(TransactionEffects, Option<ExecutionError>)> {
         let _scope = monitored_scope("Execution::try_execute_immediately");
         let _metrics_guard = self.metrics.internal_execution_latency.start_timer();
@@ -1290,12 +1296,22 @@ impl AuthorityState {
         // prevent concurrent executions of the same tx.
         let tx_guard = epoch_store.acquire_tx_guard(certificate)?;
 
-        // The cert could have been processed by a concurrent attempt of the same cert, so check if
-        // the effects have already been written.
-        if let Some(effects) = self
-            .get_transaction_cache_reader()
-            .get_executed_effects(tx_digest)
+        let tx_cache_reader = self.get_transaction_cache_reader();
+        if epoch_store.protocol_config().mysticeti_fastpath()
+            && !certificate.contains_shared_object()
+            && scheduling_source == SchedulingSource::NonFastPath
         {
+            // If this transaction is not scheduled from fastpath, it must be either
+            // from consensus or from checkpoint, i.e. it must be finalized.
+            // To avoid re-executing fastpath transactions, we always attempt to flush
+            // fastpath outputs if it is already there.
+            // If it does get flushed, the effects will appear in the cache, and we will
+            // skip the execution in the next check.
+            self.get_cache_writer()
+                .flush_fastpath_transaction_outputs(*tx_digest, epoch_store.epoch());
+        }
+
+        if let Some(effects) = tx_cache_reader.get_executed_effects(tx_digest) {
             if let Some(expected_effects_digest) = expected_effects_digest {
                 assert_eq!(
                     effects.digest(),
@@ -1329,6 +1345,7 @@ impl AuthorityState {
                 input_objects,
                 expected_effects_digest,
                 epoch_store,
+                scheduling_source,
             )
             .tap_err(|e| info!("process_certificate failed: {e}"))
             .tap_ok(
@@ -1371,6 +1388,7 @@ impl AuthorityState {
                 &VerifiedExecutableTransaction::new_from_certificate(certificate.clone()),
                 None,
                 &epoch_store,
+                SchedulingSource::NonFastPath,
             )
             .await?;
         let signed_effects = self.sign_effects(effects, &epoch_store)?;
@@ -1436,6 +1454,7 @@ impl AuthorityState {
         input_objects: InputObjects,
         expected_effects_digest: Option<TransactionEffectsDigest>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
+        scheduling_source: SchedulingSource,
     ) -> SuiResult<(TransactionEffects, Option<ExecutionError>)> {
         let process_certificate_start_time = tokio::time::Instant::now();
         let tx_digest = *certificate.digest();
@@ -1493,53 +1512,55 @@ impl AuthorityState {
         fail_point!("crash");
 
         let effects = transaction_outputs.effects.clone();
-        match self.commit_certificate(
-            certificate,
-            transaction_outputs,
-            execution_guard,
-            epoch_store,
-        ) {
-            Err(err) => {
+        if scheduling_source == SchedulingSource::MysticetiFastPath {
+            self.get_cache_writer()
+                .write_fastpath_transaction_outputs(transaction_outputs.into());
+        } else {
+            let commit_result = self.commit_certificate(
+                certificate,
+                transaction_outputs,
+                execution_guard,
+                epoch_store,
+            );
+            if let Err(err) = commit_result {
                 error!(?tx_digest, "Error committing transaction: {err}");
                 tx_guard.release();
                 return Err(err);
             }
-            Ok(_) => {
-                // commit_certificate finished, the tx is fully committed to the store.
-                tx_guard.commit_tx();
+
+            if let TransactionKind::AuthenticatorStateUpdate(auth_state) =
+                certificate.data().transaction_data().kind()
+            {
+                if let Some(err) = &execution_error_opt {
+                    debug_fatal!("Authenticator state update failed: {:?}", err);
+                }
+                epoch_store.update_authenticator_state(auth_state);
+
+                // double check that the signature verifier always matches the authenticator state
+                if cfg!(debug_assertions) {
+                    let authenticator_state = get_authenticator_state(self.get_object_store())
+                        .expect("Read cannot fail")
+                        .expect("Authenticator state must exist");
+
+                    let mut sys_jwks: Vec<_> = authenticator_state
+                        .active_jwks
+                        .into_iter()
+                        .map(|jwk| (jwk.jwk_id, jwk.jwk))
+                        .collect();
+                    let mut active_jwks: Vec<_> = epoch_store
+                        .signature_verifier
+                        .get_jwks()
+                        .into_iter()
+                        .collect();
+                    sys_jwks.sort();
+                    active_jwks.sort();
+
+                    assert_eq!(sys_jwks, active_jwks);
+                }
             }
         }
-
-        if let TransactionKind::AuthenticatorStateUpdate(auth_state) =
-            certificate.data().transaction_data().kind()
-        {
-            if let Some(err) = &execution_error_opt {
-                debug_fatal!("Authenticator state update failed: {:?}", err);
-            }
-            epoch_store.update_authenticator_state(auth_state);
-
-            // double check that the signature verifier always matches the authenticator state
-            if cfg!(debug_assertions) {
-                let authenticator_state = get_authenticator_state(self.get_object_store())
-                    .expect("Read cannot fail")
-                    .expect("Authenticator state must exist");
-
-                let mut sys_jwks: Vec<_> = authenticator_state
-                    .active_jwks
-                    .into_iter()
-                    .map(|jwk| (jwk.jwk_id, jwk.jwk))
-                    .collect();
-                let mut active_jwks: Vec<_> = epoch_store
-                    .signature_verifier
-                    .get_jwks()
-                    .into_iter()
-                    .collect();
-                sys_jwks.sort();
-                active_jwks.sort();
-
-                assert_eq!(sys_jwks, active_jwks);
-            }
-        }
+        // commit_certificate finished, the tx is fully committed to the store.
+        tx_guard.commit_tx();
 
         epoch_store.record_local_execution_time(
             certificate.data().transaction_data(),

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -419,9 +419,11 @@ pub async fn send_consensus(authority: &AuthorityState, cert: &VerifiedCertifica
         .await
         .unwrap();
 
-    authority
-        .execution_scheduler()
-        .enqueue(certs, &authority.epoch_store_for_testing());
+    authority.execution_scheduler().enqueue(
+        certs,
+        &authority.epoch_store_for_testing(),
+        SchedulingSource::NonFastPath,
+    );
 }
 
 pub async fn send_consensus_no_execution(authority: &AuthorityState, cert: &VerifiedCertificate) {

--- a/crates/sui-core/src/authority/test_authority_builder.rs
+++ b/crates/sui-core/src/authority/test_authority_builder.rs
@@ -15,6 +15,7 @@ use crate::epoch::committee_store::CommitteeStore;
 use crate::epoch::epoch_metrics::EpochMetrics;
 use crate::epoch::randomness::RandomnessManager;
 use crate::execution_cache::build_execution_cache;
+use crate::execution_scheduler::SchedulingSource;
 use crate::jsonrpc_index::IndexStore;
 use crate::mock_consensus::{ConsensusMode, MockConsensusClient};
 use crate::module_cache_metrics::ResolverMetrics;
@@ -405,6 +406,7 @@ impl<'a> TestAuthorityBuilder<'a> {
                 ),
                 None,
                 &state.epoch_store_for_testing(),
+                SchedulingSource::NonFastPath,
             )
             .await
             .unwrap();

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -3150,6 +3150,17 @@ mod tests {
         fn multi_get_events(&self, _: &[TransactionDigest]) -> Vec<Option<TransactionEvents>> {
             unimplemented!()
         }
+
+        fn is_tx_fastpath_executed(&self, _: &TransactionDigest) -> bool {
+            unimplemented!()
+        }
+
+        fn notify_read_fastpath_transaction_outputs<'a>(
+            &'a self,
+            _: &'a [TransactionDigest],
+        ) -> BoxFuture<'a, Vec<Arc<crate::transaction_outputs::TransactionOutputs>>> {
+            unimplemented!()
+        }
     }
 
     #[async_trait::async_trait]

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -904,14 +904,7 @@ impl TransactionManagerSender {
     ) {
         while let Some((transactions, scheduling_source)) = recv.recv().await {
             let _guard = monitored_scope("ConsensusHandler::enqueue");
-            match scheduling_source {
-                SchedulingSource::MysticetiFastPath => {
-                    execution_scheduler.enqueue_fastpath(transactions, &epoch_store);
-                }
-                SchedulingSource::NonFastPath => {
-                    execution_scheduler.enqueue(transactions, &epoch_store);
-                }
-            }
+            execution_scheduler.enqueue(transactions, &epoch_store, scheduling_source);
         }
     }
 }

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -55,7 +55,7 @@ use crate::{
     consensus_throughput_calculator::ConsensusThroughputCalculator,
     consensus_types::consensus_output_api::{parse_block_transactions, ConsensusCommitAPI},
     execution_cache::{ObjectCacheRead, TransactionCacheRead},
-    execution_scheduler::{ExecutionSchedulerAPI, ExecutionSchedulerWrapper},
+    execution_scheduler::{ExecutionSchedulerAPI, ExecutionSchedulerWrapper, SchedulingSource},
     scoring_decision::update_low_scoring_authorities,
     wait_for_effects_request::ConsensusTxPosition,
 };
@@ -864,7 +864,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         fail_point!("crash"); // for tests that produce random crashes
 
         self.transaction_manager_sender
-            .send(executable_transactions);
+            .send(executable_transactions, SchedulingSource::NonFastPath);
     }
 }
 
@@ -873,7 +873,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
 #[derive(Clone)]
 pub(crate) struct TransactionManagerSender {
     // Using unbounded channel to avoid blocking consensus commit and transaction handler.
-    sender: monitored_mpsc::UnboundedSender<Vec<VerifiedExecutableTransaction>>,
+    sender: monitored_mpsc::UnboundedSender<(Vec<VerifiedExecutableTransaction>, SchedulingSource)>,
 }
 
 impl TransactionManagerSender {
@@ -886,18 +886,32 @@ impl TransactionManagerSender {
         Self { sender }
     }
 
-    fn send(&self, transactions: Vec<VerifiedExecutableTransaction>) {
-        let _ = self.sender.send(transactions);
+    fn send(
+        &self,
+        transactions: Vec<VerifiedExecutableTransaction>,
+        scheduling_source: SchedulingSource,
+    ) {
+        let _ = self.sender.send((transactions, scheduling_source));
     }
 
     async fn run(
-        mut recv: monitored_mpsc::UnboundedReceiver<Vec<VerifiedExecutableTransaction>>,
+        mut recv: monitored_mpsc::UnboundedReceiver<(
+            Vec<VerifiedExecutableTransaction>,
+            SchedulingSource,
+        )>,
         execution_scheduler: Arc<ExecutionSchedulerWrapper>,
         epoch_store: Arc<AuthorityPerEpochStore>,
     ) {
-        while let Some(transactions) = recv.recv().await {
+        while let Some((transactions, scheduling_source)) = recv.recv().await {
             let _guard = monitored_scope("ConsensusHandler::enqueue");
-            execution_scheduler.enqueue(transactions, &epoch_store);
+            match scheduling_source {
+                SchedulingSource::MysticetiFastPath => {
+                    execution_scheduler.enqueue_fastpath(transactions, &epoch_store);
+                }
+                SchedulingSource::NonFastPath => {
+                    execution_scheduler.enqueue(transactions, &epoch_store);
+                }
+            }
         }
     }
 }
@@ -1317,7 +1331,7 @@ impl ConsensusBlockHandler {
             .consensus_block_handler_fastpath_executions
             .inc_by(executable_transactions.len() as u64);
         self.transaction_manager_sender
-            .send(executable_transactions);
+            .send(executable_transactions, SchedulingSource::MysticetiFastPath);
     }
 }
 
@@ -1716,14 +1730,15 @@ mod tests {
                 continue;
             }
             let digest = t.digest();
-            if let Ok(Ok(_)) = tokio::time::timeout(
+            if tokio::time::timeout(
                 std::time::Duration::from_secs(10),
-                state.notify_read_effects(*digest),
+                state
+                    .get_transaction_cache_reader()
+                    .notify_read_fastpath_transaction_outputs(&[*digest]),
             )
             .await
+            .is_err()
             {
-                // Effects exist as expected.
-            } else {
                 panic!("Transaction {} {} did not execute", i, digest);
             }
         }

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -230,27 +230,37 @@ struct UncommittedData {
     // table as they are flushed to the db.
     pending_transaction_writes: DashMap<TransactionDigest, Arc<TransactionOutputs>>,
 
-    // Transactions outputs from Mysticeti fastpath certified transactions.
+    // Transactions outputs from Mysticeti fastpath certified transaction executions.
     // These outputs are not written to pending_transaction_writes until we are sure
-    // that they will not get rejected by consensus.
-    // TODO(fastpath): We need to find a way to remove entries that did not get
-    // finalized. We could use rejection status from mysticeti, but it is
-    // not 100% reliable due to data races.
-    fastpath_transaction_outputs: DashMap<TransactionDigest, Arc<TransactionOutputs>>,
+    // that they will not get rejected by consensus. This ensures that no dependent
+    // transactions can sign using the outputs of a fastpath certified transaction.
+    // Otherwise it will be challenging to revert them.
+    // We use a cache because it is possible to have entries that are not finalized
+    // due to data races, i.e. a transaction is first fastpath certified, then
+    // rejected through consensus commit, but at the same time it was executed
+    // and outputs are written here. We won't have a chance to remove them anymore.
+    // So we rely on the cache to evict them eventually.
+    // It is also safe to evict a transaction that will eventually be finalized,
+    // as we will just re-execute it.
+    fastpath_transaction_outputs: MokaCache<TransactionDigest, Arc<TransactionOutputs>>,
 
     total_transaction_inserts: AtomicU64,
     total_transaction_commits: AtomicU64,
 }
 
 impl UncommittedData {
-    fn new() -> Self {
+    fn new(config: &ExecutionCacheConfig) -> Self {
         Self {
             objects: DashMap::with_shard_amount(2048),
             markers: DashMap::with_shard_amount(2048),
             transaction_effects: DashMap::with_shard_amount(2048),
             executed_effects_digests: DashMap::with_shard_amount(2048),
             pending_transaction_writes: DashMap::with_shard_amount(2048),
-            fastpath_transaction_outputs: DashMap::with_shard_amount(2048),
+            fastpath_transaction_outputs: MokaCache::builder(8)
+                .max_capacity(randomize_cache_capacity_in_tests(
+                    config.fastpath_transaction_outputs_cache_size(),
+                ))
+                .build(),
             transaction_events: DashMap::with_shard_amount(2048),
             total_transaction_inserts: AtomicU64::new(0),
             total_transaction_commits: AtomicU64::new(0),
@@ -263,7 +273,7 @@ impl UncommittedData {
         self.transaction_effects.clear();
         self.executed_effects_digests.clear();
         self.pending_transaction_writes.clear();
-        self.fastpath_transaction_outputs.clear();
+        self.fastpath_transaction_outputs.invalidate_all();
         self.transaction_events.clear();
         self.total_transaction_inserts
             .store(0, std::sync::atomic::Ordering::Relaxed);
@@ -499,7 +509,7 @@ impl WritebackCache {
             ))
             .build();
         Self {
-            dirty: UncommittedData::new(),
+            dirty: UncommittedData::new(config),
             cached: CachedCommittedData::new(config),
             packages,
             object_locks: ObjectLocks::new(),
@@ -2142,7 +2152,7 @@ impl TransactionCacheRead for WritebackCache {
                         self.dirty
                             .fastpath_transaction_outputs
                             .get(tx_digest)
-                            .map(|o| o.clone())
+                            .clone()
                     })
                     .collect()
             })
@@ -2186,7 +2196,7 @@ impl ExecutionCacheWrite for WritebackCache {
 
     fn flush_fastpath_transaction_outputs(&self, tx_digest: TransactionDigest, epoch_id: EpochId) {
         let outputs = self.dirty.fastpath_transaction_outputs.remove(&tx_digest);
-        if let Some((_, outputs)) = outputs {
+        if let Some(outputs) = outputs {
             debug!(
                 ?tx_digest,
                 "Flushing mysticeti fastpath certified transaction outputs"

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -234,7 +234,7 @@ struct UncommittedData {
     // These outputs are not written to pending_transaction_writes until we are sure
     // that they will not get rejected by consensus.
     // TODO(fastpath): We need to find a way to remove entries that did not get
-    // finalized. We could use rejection status from mystticeti, but it is
+    // finalized. We could use rejection status from mysticeti, but it is
     // not 100% reliable due to data races.
     fastpath_transaction_outputs: DashMap<TransactionDigest, Arc<TransactionOutputs>>,
 

--- a/crates/sui-core/src/execution_driver.rs
+++ b/crates/sui-core/src/execution_driver.rs
@@ -39,6 +39,7 @@ pub async fn execution_process(
         let certificate;
         let expected_effects_digest;
         let txn_ready_time;
+        let scheduling_source;
         let _executing_guard;
         tokio::select! {
             result = rx_ready_certificates.recv() => {
@@ -47,6 +48,7 @@ pub async fn execution_process(
                     expected_effects_digest = pending_cert.expected_effects_digest;
                     txn_ready_time = pending_cert.stats.ready_time.unwrap();
                     _executing_guard = pending_cert.executing_guard;
+                    scheduling_source = pending_cert.scheduling_source;
                 } else {
                     // Should only happen after the AuthorityState has shut down and tx_ready_certificate
                     // has been dropped by TransactionManager.
@@ -121,6 +123,7 @@ pub async fn execution_process(
                 &certificate,
                 expected_effects_digest,
                 &epoch_store_clone,
+                scheduling_source,
             ).await {
                 Err(SuiError::ValidatorHaltedAtEpochEnd) => {
                     warn!("Could not execute transaction {digest:?} because validator is halted at epoch end. certificate={certificate:?}");

--- a/crates/sui-core/src/execution_scheduler/mod.rs
+++ b/crates/sui-core/src/execution_scheduler/mod.rs
@@ -79,18 +79,10 @@ pub(crate) trait ExecutionSchedulerAPI {
         &self,
         certs: Vec<VerifiedExecutableTransaction>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
+        scheduling_source: SchedulingSource,
     ) {
         let certs = certs.into_iter().map(|cert| (cert, None)).collect();
-        self.enqueue_impl(certs, epoch_store, SchedulingSource::NonFastPath)
-    }
-
-    fn enqueue_fastpath(
-        &self,
-        certs: Vec<VerifiedExecutableTransaction>,
-        epoch_store: &Arc<AuthorityPerEpochStore>,
-    ) {
-        let certs = certs.into_iter().map(|cert| (cert, None)).collect();
-        self.enqueue_impl(certs, epoch_store, SchedulingSource::MysticetiFastPath)
+        self.enqueue_impl(certs, epoch_store, scheduling_source)
     }
 
     fn enqueue_with_expected_effects_digest(
@@ -111,6 +103,7 @@ pub(crate) trait ExecutionSchedulerAPI {
     ///
     /// REQUIRED: Shared object locks must be taken before calling enqueueing transactions
     /// with shared objects!
+    /// TODO: Cleanup this API.
     fn enqueue_certificates(
         &self,
         certs: Vec<VerifiedCertificate>,
@@ -120,7 +113,7 @@ pub(crate) trait ExecutionSchedulerAPI {
             .into_iter()
             .map(VerifiedExecutableTransaction::new_from_certificate)
             .collect();
-        self.enqueue(executable_txns, epoch_store)
+        self.enqueue(executable_txns, epoch_store, SchedulingSource::NonFastPath)
     }
 
     fn check_execution_overload(

--- a/crates/sui-core/src/execution_scheduler/transaction_manager.rs
+++ b/crates/sui-core/src/execution_scheduler/transaction_manager.rs
@@ -35,7 +35,7 @@ use sui_config::node::AuthorityOverloadConfig;
 use sui_types::transaction::SenderSignedData;
 use tap::TapOptional;
 
-use super::{ExecutionSchedulerAPI, PendingCertificate, PendingCertificateStats};
+use super::{ExecutionSchedulerAPI, PendingCertificate, PendingCertificateStats, SchedulingSource};
 
 /// Minimum capacity of HashMaps used in TransactionManager.
 const MIN_HASHMAP_CAPACITY: usize = 1000;
@@ -386,6 +386,7 @@ impl ExecutionSchedulerAPI for TransactionManager {
             Option<TransactionEffectsDigest>,
         )>,
         epoch_store: &Arc<AuthorityPerEpochStore>,
+        scheduling_source: SchedulingSource,
     ) {
         let reconfig_lock = self.inner.read();
 
@@ -547,6 +548,7 @@ impl ExecutionSchedulerAPI for TransactionManager {
                     ready_time: None,
                 },
                 executing_guard: None,
+                scheduling_source,
             });
         }
 

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -20,7 +20,7 @@ pub mod db_checkpoint_handler;
 pub mod epoch;
 pub mod execution_cache;
 mod execution_driver;
-mod execution_scheduler;
+pub mod execution_scheduler;
 mod fallback_fetch;
 pub mod global_state_hasher;
 pub mod jsonrpc_index;

--- a/crates/sui-core/src/transaction_outputs.rs
+++ b/crates/sui-core/src/transaction_outputs.rs
@@ -10,6 +10,7 @@ use sui_types::storage::{FullObjectKey, InputKey, MarkerValue, ObjectKey};
 use sui_types::transaction::{TransactionDataAPI, VerifiedTransaction};
 
 /// TransactionOutputs
+#[derive(Debug, Clone)]
 pub struct TransactionOutputs {
     pub transaction: Arc<VerifiedTransaction>,
     pub effects: TransactionEffects,
@@ -188,6 +189,22 @@ impl TransactionOutputs {
             new_locks_to_init,
             written,
             output_keys,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn new_for_testing(transaction: VerifiedTransaction, effects: TransactionEffects) -> Self {
+        Self {
+            transaction: Arc::new(transaction),
+            effects,
+            events: TransactionEvents { data: vec![] },
+            markers: vec![],
+            wrapped: vec![],
+            deleted: vec![],
+            locks_to_delete: vec![],
+            new_locks_to_init: vec![],
+            written: WrittenObjects::new(),
+            output_keys: vec![],
         }
     }
 }

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -8,7 +8,7 @@ use super::*;
 use crate::authority::{authority_tests::init_state_with_objects, AuthorityState};
 use crate::checkpoints::CheckpointServiceNoop;
 use crate::consensus_handler::SequencedConsensusTransaction;
-use crate::execution_scheduler::ExecutionSchedulerAPI;
+use crate::execution_scheduler::{ExecutionSchedulerAPI, SchedulingSource};
 use crate::mock_consensus::with_block_status;
 use consensus_core::{BlockRef, BlockStatus};
 use fastcrypto::traits::KeyPair;
@@ -256,9 +256,11 @@ pub fn make_consensus_adapter_for_test(
             );
 
             if self.execute {
-                self.state
-                    .execution_scheduler()
-                    .enqueue(transactions, epoch_store);
+                self.state.execution_scheduler().enqueue(
+                    transactions,
+                    epoch_store,
+                    SchedulingSource::NonFastPath,
+                );
             }
 
             assert!(

--- a/crates/sui-core/src/unit_tests/mysticeti_fastpath_execution_tests.rs
+++ b/crates/sui-core/src/unit_tests/mysticeti_fastpath_execution_tests.rs
@@ -259,9 +259,11 @@ async fn test_fast_path_then_consensus_execution_e2e() {
     );
 
     let tx_digest = *cert.digest();
-    state
-        .execution_scheduler()
-        .enqueue_fastpath(vec![cert.clone()], &state.epoch_store_for_testing());
+    state.execution_scheduler().enqueue(
+        vec![cert.clone()],
+        &state.epoch_store_for_testing(),
+        SchedulingSource::MysticetiFastPath,
+    );
 
     let outputs = state
         .get_transaction_cache_reader()
@@ -278,9 +280,11 @@ async fn test_fast_path_then_consensus_execution_e2e() {
         .get_transaction_cache_reader()
         .is_tx_already_executed(&tx_digest));
 
-    state
-        .execution_scheduler()
-        .enqueue(vec![cert.clone()], &state.epoch_store_for_testing());
+    state.execution_scheduler().enqueue(
+        vec![cert.clone()],
+        &state.epoch_store_for_testing(),
+        SchedulingSource::NonFastPath,
+    );
 
     let effects_digest = state
         .get_transaction_cache_reader()
@@ -321,9 +325,11 @@ async fn test_consensus_then_fast_path_execution_e2e() {
     );
 
     let tx_digest = *cert.digest();
-    state
-        .execution_scheduler()
-        .enqueue(vec![cert.clone()], &state.epoch_store_for_testing());
+    state.execution_scheduler().enqueue(
+        vec![cert.clone()],
+        &state.epoch_store_for_testing(),
+        SchedulingSource::NonFastPath,
+    );
 
     state
         .get_transaction_cache_reader()
@@ -337,9 +343,11 @@ async fn test_consensus_then_fast_path_execution_e2e() {
         .get_transaction_cache_reader()
         .is_tx_already_executed(&tx_digest));
 
-    state
-        .execution_scheduler()
-        .enqueue_fastpath(vec![cert.clone()], &state.epoch_store_for_testing());
+    state.execution_scheduler().enqueue(
+        vec![cert.clone()],
+        &state.epoch_store_for_testing(),
+        SchedulingSource::MysticetiFastPath,
+    );
     tokio::time::sleep(std::time::Duration::from_secs(3)).await;
     assert!(!state
         .get_transaction_cache_reader()

--- a/crates/sui-core/src/unit_tests/mysticeti_fastpath_execution_tests.rs
+++ b/crates/sui-core/src/unit_tests/mysticeti_fastpath_execution_tests.rs
@@ -1,0 +1,350 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+use sui_test_transaction_builder::TestTransactionBuilder;
+use sui_types::base_types::random_object_ref;
+use sui_types::crypto::get_account_key_pair;
+use sui_types::effects::TestEffectsBuilder;
+use sui_types::executable_transaction::VerifiedExecutableTransaction;
+use sui_types::message_envelope::Message;
+use sui_types::object::Object;
+use sui_types::transaction::VerifiedTransaction;
+use sui_types::utils::to_sender_signed_transaction;
+
+use crate::authority::test_authority_builder::TestAuthorityBuilder;
+use crate::execution_scheduler::{ExecutionSchedulerAPI, SchedulingSource};
+use crate::transaction_outputs::TransactionOutputs;
+
+#[tokio::test]
+async fn test_notify_read_fastpath_transaction_outputs() {
+    let state = TestAuthorityBuilder::new().build().await;
+
+    // Create a test transaction and effects.
+    let (sender, sender_key) = get_account_key_pair();
+    let tx_data = TestTransactionBuilder::new(sender, random_object_ref(), 1)
+        .transfer_sui(None, sender)
+        .build();
+    let tx = VerifiedTransaction::new_unchecked(to_sender_signed_transaction(tx_data, &sender_key));
+    let tx_digest = *tx.digest();
+    let effects = TestEffectsBuilder::new(tx.data()).build();
+    let effects_digest = effects.digest();
+
+    let tx_outputs = Arc::new(TransactionOutputs::new_for_testing(tx, effects));
+
+    assert!(!state
+        .get_transaction_cache_reader()
+        .is_tx_fastpath_executed(&tx_digest));
+
+    // Write fastpath transaction outputs
+    state
+        .get_cache_writer()
+        .write_fastpath_transaction_outputs(tx_outputs);
+
+    // Verify that the transaction is marked as fastpath executed
+    assert!(state
+        .get_transaction_cache_reader()
+        .is_tx_fastpath_executed(&tx_digest));
+
+    assert!(!state
+        .get_transaction_cache_reader()
+        .is_tx_already_executed(&tx_digest));
+
+    // Test notification and reading of fastpath transaction outputs
+    let outputs = state
+        .get_transaction_cache_reader()
+        .notify_read_fastpath_transaction_outputs(&[tx_digest])
+        .await;
+    assert_eq!(outputs.len(), 1);
+    assert_eq!(outputs[0].transaction.digest(), &tx_digest);
+
+    // Test that outputs are not visible in regular transaction outputs until flushed
+    let epoch_id = 0;
+    state
+        .get_cache_writer()
+        .flush_fastpath_transaction_outputs(tx_digest, epoch_id);
+
+    // Verify that the outputs are now available through regular transaction outputs
+    let effects_digests = state
+        .get_transaction_cache_reader()
+        .notify_read_executed_effects_digests(&[tx_digest])
+        .await;
+    assert_eq!(effects_digests.len(), 1);
+    assert_eq!(effects_digests[0], effects_digest);
+}
+
+#[tokio::test]
+async fn test_fast_path_execution() {
+    let (sender, sender_key) = get_account_key_pair();
+    let gas_object = Object::with_owner_for_testing(sender);
+    let gas_object_ref = gas_object.compute_object_reference();
+
+    let state = TestAuthorityBuilder::new()
+        .with_starting_objects(&[gas_object])
+        .build()
+        .await;
+
+    let tx_data = TestTransactionBuilder::new(
+        sender,
+        gas_object_ref,
+        state.reference_gas_price_for_testing().unwrap(),
+    )
+    .transfer_sui(None, sender)
+    .build();
+    let cert = VerifiedExecutableTransaction::new_from_quorum_execution(
+        VerifiedTransaction::new_unchecked(to_sender_signed_transaction(tx_data, &sender_key)),
+        0,
+    );
+
+    let (effects, _) = state
+        .try_execute_immediately(
+            &cert,
+            None,
+            &state.epoch_store_for_testing(),
+            SchedulingSource::MysticetiFastPath,
+        )
+        .await
+        .unwrap();
+
+    let tx_digest = *cert.digest();
+    assert!(state
+        .get_transaction_cache_reader()
+        .is_tx_fastpath_executed(&tx_digest));
+
+    assert!(!state
+        .get_transaction_cache_reader()
+        .is_tx_already_executed(&tx_digest));
+
+    let state_clone = state.clone();
+    let notify_read_task = tokio::spawn(async move {
+        state_clone
+            .get_transaction_cache_reader()
+            .notify_read_executed_effects_digests(&[tx_digest])
+            .await
+    });
+
+    state
+        .get_cache_writer()
+        .flush_fastpath_transaction_outputs(tx_digest, 0);
+
+    let effects_digests = notify_read_task.await.unwrap();
+    assert_eq!(effects_digests.len(), 1);
+    assert_eq!(effects_digests[0], effects.digest());
+}
+
+#[tokio::test]
+async fn test_fast_path_then_consensus_execution() {
+    let (sender, sender_key) = get_account_key_pair();
+    let gas_object = Object::with_owner_for_testing(sender);
+    let gas_object_ref = gas_object.compute_object_reference();
+    let state = TestAuthorityBuilder::new()
+        .with_starting_objects(&[gas_object])
+        .build()
+        .await;
+
+    let tx_data = TestTransactionBuilder::new(
+        sender,
+        gas_object_ref,
+        state.reference_gas_price_for_testing().unwrap(),
+    )
+    .transfer_sui(None, sender)
+    .build();
+    let cert = VerifiedExecutableTransaction::new_from_quorum_execution(
+        VerifiedTransaction::new_unchecked(to_sender_signed_transaction(tx_data, &sender_key)),
+        0,
+    );
+
+    let (effects1, _) = state
+        .try_execute_immediately(
+            &cert,
+            None,
+            &state.epoch_store_for_testing(),
+            SchedulingSource::MysticetiFastPath,
+        )
+        .await
+        .unwrap();
+
+    let (effects2, _) = state
+        .try_execute_immediately(
+            &cert,
+            None,
+            &state.epoch_store_for_testing(),
+            SchedulingSource::NonFastPath,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(effects1.digest(), effects2.digest());
+    let tx_digest = cert.digest();
+    assert!(!state
+        .get_transaction_cache_reader()
+        .is_tx_fastpath_executed(tx_digest));
+    assert!(state
+        .get_transaction_cache_reader()
+        .is_tx_already_executed(tx_digest));
+}
+
+#[tokio::test]
+async fn test_consensus_then_fast_path_execution() {
+    let (sender, sender_key) = get_account_key_pair();
+    let gas_object = Object::with_owner_for_testing(sender);
+    let gas_object_ref = gas_object.compute_object_reference();
+    let state = TestAuthorityBuilder::new()
+        .with_starting_objects(&[gas_object])
+        .build()
+        .await;
+
+    let tx_data = TestTransactionBuilder::new(
+        sender,
+        gas_object_ref,
+        state.reference_gas_price_for_testing().unwrap(),
+    )
+    .transfer_sui(None, sender)
+    .build();
+    let cert = VerifiedExecutableTransaction::new_from_quorum_execution(
+        VerifiedTransaction::new_unchecked(to_sender_signed_transaction(tx_data, &sender_key)),
+        0,
+    );
+
+    let (effects1, _) = state
+        .try_execute_immediately(
+            &cert,
+            None,
+            &state.epoch_store_for_testing(),
+            SchedulingSource::NonFastPath,
+        )
+        .await
+        .unwrap();
+
+    let (effects2, _) = state
+        .try_execute_immediately(
+            &cert,
+            None,
+            &state.epoch_store_for_testing(),
+            SchedulingSource::MysticetiFastPath,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(effects1.digest(), effects2.digest());
+    let tx_digest = cert.digest();
+    assert!(!state
+        .get_transaction_cache_reader()
+        .is_tx_fastpath_executed(tx_digest));
+    assert!(state
+        .get_transaction_cache_reader()
+        .is_tx_already_executed(tx_digest));
+}
+
+#[tokio::test]
+async fn test_fast_path_then_consensus_execution_e2e() {
+    let (sender, sender_key) = get_account_key_pair();
+    let gas_object = Object::with_owner_for_testing(sender);
+    let gas_object_ref = gas_object.compute_object_reference();
+    let state = TestAuthorityBuilder::new()
+        .with_starting_objects(&[gas_object])
+        .build()
+        .await;
+
+    let tx_data = TestTransactionBuilder::new(
+        sender,
+        gas_object_ref,
+        state.reference_gas_price_for_testing().unwrap(),
+    )
+    .transfer_sui(None, sender)
+    .build();
+    let cert = VerifiedExecutableTransaction::new_from_quorum_execution(
+        VerifiedTransaction::new_unchecked(to_sender_signed_transaction(tx_data, &sender_key)),
+        0,
+    );
+
+    let tx_digest = *cert.digest();
+    state
+        .execution_scheduler()
+        .enqueue_fastpath(vec![cert.clone()], &state.epoch_store_for_testing());
+
+    let outputs = state
+        .get_transaction_cache_reader()
+        .notify_read_fastpath_transaction_outputs(&[*cert.digest()])
+        .await
+        .pop()
+        .unwrap();
+    assert_eq!(outputs.transaction.digest(), &tx_digest);
+
+    assert!(state
+        .get_transaction_cache_reader()
+        .is_tx_fastpath_executed(&tx_digest));
+    assert!(!state
+        .get_transaction_cache_reader()
+        .is_tx_already_executed(&tx_digest));
+
+    state
+        .execution_scheduler()
+        .enqueue(vec![cert.clone()], &state.epoch_store_for_testing());
+
+    let effects_digest = state
+        .get_transaction_cache_reader()
+        .notify_read_executed_effects_digests(&[tx_digest])
+        .await
+        .pop()
+        .unwrap();
+
+    assert_eq!(effects_digest, outputs.effects.digest());
+    assert!(!state
+        .get_transaction_cache_reader()
+        .is_tx_fastpath_executed(&tx_digest));
+    assert!(state
+        .get_transaction_cache_reader()
+        .is_tx_already_executed(&tx_digest));
+}
+
+#[tokio::test]
+async fn test_consensus_then_fast_path_execution_e2e() {
+    let (sender, sender_key) = get_account_key_pair();
+    let gas_object = Object::with_owner_for_testing(sender);
+    let gas_object_ref = gas_object.compute_object_reference();
+    let state = TestAuthorityBuilder::new()
+        .with_starting_objects(&[gas_object])
+        .build()
+        .await;
+
+    let tx_data = TestTransactionBuilder::new(
+        sender,
+        gas_object_ref,
+        state.reference_gas_price_for_testing().unwrap(),
+    )
+    .transfer_sui(None, sender)
+    .build();
+    let cert = VerifiedExecutableTransaction::new_from_quorum_execution(
+        VerifiedTransaction::new_unchecked(to_sender_signed_transaction(tx_data, &sender_key)),
+        0,
+    );
+
+    let tx_digest = *cert.digest();
+    state
+        .execution_scheduler()
+        .enqueue(vec![cert.clone()], &state.epoch_store_for_testing());
+
+    state
+        .get_transaction_cache_reader()
+        .notify_read_executed_effects_digests(&[tx_digest])
+        .await;
+
+    assert!(!state
+        .get_transaction_cache_reader()
+        .is_tx_fastpath_executed(&tx_digest));
+    assert!(state
+        .get_transaction_cache_reader()
+        .is_tx_already_executed(&tx_digest));
+
+    state
+        .execution_scheduler()
+        .enqueue_fastpath(vec![cert.clone()], &state.epoch_store_for_testing());
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+    assert!(!state
+        .get_transaction_cache_reader()
+        .is_tx_fastpath_executed(&tx_digest));
+    assert!(state
+        .get_transaction_cache_reader()
+        .is_tx_already_executed(&tx_digest));
+}

--- a/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
+++ b/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
@@ -23,6 +23,7 @@ use crate::authority::test_authority_builder::TestAuthorityBuilder;
 use crate::authority::AuthorityState;
 use crate::authority_client::{AuthorityAPI, NetworkAuthorityClient};
 use crate::authority_server::AuthorityServer;
+use crate::execution_scheduler::SchedulingSource;
 use crate::wait_for_effects_request::{
     ConsensusTxPosition, RejectReason, WaitForEffectsRequest, WaitForEffectsResponse,
 };
@@ -117,7 +118,12 @@ async fn test_wait_for_effects_position_mismatch() {
         let epoch_store = state_clone.epoch_store_for_testing();
         epoch_store.set_consensus_tx_status(tx_position2, ConsensusTxStatus::FastpathCertified);
         state_clone
-            .try_execute_immediately(&transaction, None, &epoch_store)
+            .try_execute_immediately(
+                &transaction,
+                None,
+                &epoch_store,
+                SchedulingSource::NonFastPath,
+            )
             .await
             .unwrap()
             .0
@@ -295,7 +301,12 @@ async fn test_wait_for_effects_fastpath_certified() {
         epoch_store.set_consensus_tx_status(tx_position, ConsensusTxStatus::FastpathCertified);
         tokio::time::sleep(Duration::from_millis(100)).await;
         state_clone
-            .try_execute_immediately(&transaction, None, &epoch_store)
+            .try_execute_immediately(
+                &transaction,
+                None,
+                &epoch_store,
+                SchedulingSource::NonFastPath,
+            )
             .await
             .unwrap()
             .0
@@ -354,7 +365,12 @@ async fn test_wait_for_effects_finalized() {
         epoch_store.set_consensus_tx_status(tx_position, ConsensusTxStatus::Finalized);
         tokio::time::sleep(Duration::from_millis(100)).await;
         state_clone
-            .try_execute_immediately(&transaction, None, &epoch_store)
+            .try_execute_immediately(
+                &transaction,
+                None,
+                &epoch_store,
+                SchedulingSource::NonFastPath,
+            )
             .await
             .unwrap()
             .0
@@ -413,7 +429,12 @@ async fn test_wait_for_effects_expired() {
         tokio::time::sleep(Duration::from_millis(100)).await;
         epoch_store.set_consensus_tx_status(tx_position, ConsensusTxStatus::Finalized);
         state_clone
-            .try_execute_immediately(&transaction, None, &epoch_store)
+            .try_execute_immediately(
+                &transaction,
+                None,
+                &epoch_store,
+                SchedulingSource::NonFastPath,
+            )
             .await
             .unwrap()
             .0

--- a/crates/sui-core/src/validator_tx_finalizer.rs
+++ b/crates/sui-core/src/validator_tx_finalizer.rs
@@ -277,6 +277,7 @@ mod tests {
     use crate::authority::AuthorityState;
     use crate::authority_aggregator::{AuthorityAggregator, AuthorityAggregatorBuilder};
     use crate::authority_client::AuthorityAPI;
+    use crate::execution_scheduler::SchedulingSource;
     use crate::validator_tx_finalizer::ValidatorTxFinalizer;
     use arc_swap::ArcSwap;
     use async_trait::async_trait;
@@ -362,6 +363,7 @@ mod tests {
                     ),
                     None,
                     &epoch_store,
+                    SchedulingSource::NonFastPath,
                 )
                 .await?;
             let events = if effects.events_digest().is_some() {

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -36,6 +36,7 @@ use sui_core::consensus_adapter::ConsensusClient;
 use sui_core::consensus_manager::UpdatableConsensusClient;
 use sui_core::epoch::randomness::RandomnessManager;
 use sui_core::execution_cache::build_execution_cache;
+use sui_core::execution_scheduler::SchedulingSource;
 use sui_core::global_state_hasher::GlobalStateHashMetrics;
 use sui_core::storage::RestReadStore;
 use sui_core::traffic_controller::metrics::TrafficControllerMetrics;
@@ -753,7 +754,12 @@ impl SuiNode {
                     ),
                 );
             state
-                .try_execute_immediately(&transaction, None, &epoch_store)
+                .try_execute_immediately(
+                    &transaction,
+                    None,
+                    &epoch_store,
+                    SchedulingSource::NonFastPath,
+                )
                 .instrument(span)
                 .await
                 .unwrap();

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -14,6 +14,7 @@ use sui_core::checkpoints::checkpoint_executor::CheckpointExecutor;
 use sui_core::consensus_adapter::{
     ConnectionMonitorStatusForTests, ConsensusAdapter, ConsensusAdapterMetrics,
 };
+use sui_core::execution_scheduler::SchedulingSource;
 use sui_core::global_state_hasher::GlobalStateHasher;
 use sui_core::mock_consensus::{ConsensusMode, MockConsensusClient};
 use sui_test_transaction_builder::{PublishData, TestTransactionBuilder};
@@ -117,7 +118,12 @@ impl SingleValidator {
         );
         let effects = self
             .get_validator()
-            .try_execute_immediately(&executable, None, &self.epoch_store)
+            .try_execute_immediately(
+                &executable,
+                None,
+                &self.epoch_store,
+                SchedulingSource::NonFastPath,
+            )
             .await
             .unwrap()
             .0;
@@ -149,7 +155,12 @@ impl SingleValidator {
                     VerifiedCertificate::new_unchecked(cert),
                 );
                 self.get_validator()
-                    .try_execute_immediately(&cert, None, &self.epoch_store)
+                    .try_execute_immediately(
+                        &cert,
+                        None,
+                        &self.epoch_store,
+                        SchedulingSource::NonFastPath,
+                    )
                     .await
                     .unwrap()
                     .0

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -152,6 +152,7 @@ validator_configs:
         transaction_objects_cache_size: ~
         backpressure_threshold: ~
         backpressure_threshold_for_rpc: ~
+        fastpath_transaction_outputs_cache_size: ~
     enable-soft-bundle: true
     enable-validator-tx-finalizer: true
     verifier-signing-config:
@@ -309,6 +310,7 @@ validator_configs:
         transaction_objects_cache_size: ~
         backpressure_threshold: ~
         backpressure_threshold_for_rpc: ~
+        fastpath_transaction_outputs_cache_size: ~
     enable-soft-bundle: true
     enable-validator-tx-finalizer: true
     verifier-signing-config:
@@ -466,6 +468,7 @@ validator_configs:
         transaction_objects_cache_size: ~
         backpressure_threshold: ~
         backpressure_threshold_for_rpc: ~
+        fastpath_transaction_outputs_cache_size: ~
     enable-soft-bundle: true
     enable-validator-tx-finalizer: true
     verifier-signing-config:
@@ -623,6 +626,7 @@ validator_configs:
         transaction_objects_cache_size: ~
         backpressure_threshold: ~
         backpressure_threshold_for_rpc: ~
+        fastpath_transaction_outputs_cache_size: ~
     enable-soft-bundle: true
     enable-validator-tx-finalizer: true
     verifier-signing-config:
@@ -780,6 +784,7 @@ validator_configs:
         transaction_objects_cache_size: ~
         backpressure_threshold: ~
         backpressure_threshold_for_rpc: ~
+        fastpath_transaction_outputs_cache_size: ~
     enable-soft-bundle: true
     enable-validator-tx-finalizer: true
     verifier-signing-config:
@@ -937,6 +942,7 @@ validator_configs:
         transaction_objects_cache_size: ~
         backpressure_threshold: ~
         backpressure_threshold_for_rpc: ~
+        fastpath_transaction_outputs_cache_size: ~
     enable-soft-bundle: true
     enable-validator-tx-finalizer: true
     verifier-signing-config:
@@ -1094,6 +1100,7 @@ validator_configs:
         transaction_objects_cache_size: ~
         backpressure_threshold: ~
         backpressure_threshold_for_rpc: ~
+        fastpath_transaction_outputs_cache_size: ~
     enable-soft-bundle: true
     enable-validator-tx-finalizer: true
     verifier-signing-config:


### PR DESCRIPTION
## Description 

Temporarily put fastpath execution results in a separate in the writeback cache.
These results will be flushed to the normal dirty cache if it ever gets executed from non fastpath.

## Test plan 

Added unittests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
