### PR TITLE
[consensus] Remove unused consensus clients

### DIFF
--- a/crates/sui-core/src/consensus_manager/mod.rs
+++ b/crates/sui-core/src/consensus_manager/mod.rs
@@ -79,9 +79,7 @@ impl ProtocolManager {
 pub struct ConsensusManager {
     consensus_config: ConsensusConfig,
     mysticeti_manager: ProtocolManager,
-    mysticeti_client: Arc<LazyMysticetiClient>,
     active: parking_lot::Mutex<bool>,
-    consensus_client: Arc<UpdatableConsensusClient>,
 }
 
 impl ConsensusManager {
@@ -89,7 +87,6 @@ impl ConsensusManager {
         node_config: &NodeConfig,
         consensus_config: &ConsensusConfig,
         registry_service: &RegistryService,
-        consensus_client: Arc<UpdatableConsensusClient>,
     ) -> Self {
         let metrics = Arc::new(ConsensusManagerMetrics::new(
             &registry_service.default_registry(),
@@ -105,9 +102,7 @@ impl ConsensusManager {
         Self {
             consensus_config: consensus_config.clone(),
             mysticeti_manager,
-            mysticeti_client,
             active: parking_lot::Mutex::new(false),
-            consensus_client,
         }
     }
 
@@ -130,7 +125,6 @@ impl ConsensusManagerTrait for ConsensusManager {
             assert!(!*active, "Cannot start consensus. It is already running!");
             info!("Starting consensus ...");
             *active = true;
-            self.consensus_client.set(self.mysticeti_client.clone());
             &self.mysticeti_manager
         };
 
@@ -153,7 +147,6 @@ impl ConsensusManagerTrait for ConsensusManager {
         if prev_active {
             self.mysticeti_manager.shutdown().await;
         }
-        self.consensus_client.clear();
     }
 
     async fn is_running(&self) -> bool {

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1230,8 +1230,7 @@ impl SuiNode {
             client.clone(),
             checkpoint_store.clone(),
         ));
-        let consensus_manager =
-            ConsensusManager::new(&config, consensus_config, registry_service, client);
+        let consensus_manager = ConsensusManager::new(&config, consensus_config, registry_service);
 
         // This only gets started up once, not on every epoch. (Make call to remove every epoch.)
         let consensus_store_pruner = ConsensusStorePruner::new(


### PR DESCRIPTION
## Description 

The fields appear to be unused.
Can I remove them?

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
