### PR TITLE
fix: Show the real required byte length

### DIFF
--- a/crates/sui-types/src/crypto.rs
+++ b/crates/sui-types/src/crypto.rs
@@ -652,7 +652,7 @@ where
     if bytes.len() != priv_length + pub_key_length {
         return Err(SuiError::KeyConversionError(format!(
             "Invalid input byte length, expected {}: {}",
-            priv_length,
+            priv_length + pub_key_length,
             bytes.len()
         )));
     }


### PR DESCRIPTION
## Description 

Show the real required byte length for `get_key_pair_from_bytes()`

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
