### PR TITLE
[indexer alt] - make ClientArgs derive default

### DIFF
--- a/crates/sui-bridge-indexer-alt/src/main.rs
+++ b/crates/sui-bridge-indexer-alt/src/main.rs
@@ -63,10 +63,7 @@ async fn main() -> Result<(), anyhow::Error> {
         indexer_args,
         ClientArgs {
             remote_store_url: Some(remote_store_url),
-            local_ingestion_path: None,
-            rpc_api_url: None,
-            rpc_username: None,
-            rpc_password: None,
+            ..Default::default()
         },
         Default::default(),
         Some(&MIGRATIONS),

--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -136,10 +136,7 @@ impl FullCluster {
 
         let client_args = ClientArgs {
             local_ingestion_path: Some(temp_dir.path().to_owned()),
-            remote_store_url: None,
-            rpc_api_url: None,
-            rpc_username: None,
-            rpc_password: None,
+            ..Default::default()
         };
 
         let offchain = OffchainCluster::new(

--- a/crates/sui-indexer-alt-e2e-tests/tests/transactional_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/transactional_tests.rs
@@ -137,10 +137,7 @@ async fn cluster(config: &OffChainConfig) -> Arc<OffchainCluster> {
 
     let client_args = ClientArgs {
         local_ingestion_path: Some(config.data_ingestion_path.clone()),
-        remote_store_url: None,
-        rpc_api_url: None,
-        rpc_username: None,
-        rpc_password: None,
+        ..Default::default()
     };
 
     // The test config includes every pipeline, we configure its consistent range using the

--- a/crates/sui-indexer-alt-framework/src/cluster.rs
+++ b/crates/sui-indexer-alt-framework/src/cluster.rs
@@ -276,10 +276,7 @@ mod tests {
         let args = Args {
             client_args: ClientArgs {
                 local_ingestion_path: Some(checkpoint_dir.path().to_owned()),
-                remote_store_url: None,
-                rpc_api_url: None,
-                rpc_username: None,
-                rpc_password: None,
+                ..Default::default()
             },
             indexer_args: IndexerArgs {
                 first_checkpoint: Some(0),

--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -30,7 +30,7 @@ mod rpc_client;
 #[cfg(test)]
 mod test_utils;
 
-#[derive(clap::Args, Clone, Debug)]
+#[derive(clap::Args, Clone, Debug, Default)]
 #[group(required = true)]
 pub struct ClientArgs {
     /// Remote Store to fetch checkpoints from.
@@ -225,10 +225,7 @@ mod tests {
         IngestionService::new(
             ClientArgs {
                 remote_store_url: Some(Url::parse(&uri).unwrap()),
-                local_ingestion_path: None,
-                rpc_api_url: None,
-                rpc_username: None,
-                rpc_password: None,
+                ..Default::default()
             },
             IngestionConfig {
                 checkpoint_buffer_size,

--- a/crates/sui-indexer-alt-framework/src/postgres.rs
+++ b/crates/sui-indexer-alt-framework/src/postgres.rs
@@ -85,11 +85,8 @@ impl Indexer<Db> {
             store,
             IndexerArgs::default(),
             ClientArgs {
-                remote_store_url: None,
                 local_ingestion_path: Some(tempdir().unwrap().keep()),
-                rpc_api_url: None,
-                rpc_username: None,
-                rpc_password: None,
+                ..Default::default()
             },
             IngestionConfig::default(),
             &Registry::new(),

--- a/crates/sui-indexer-alt/src/benchmark.rs
+++ b/crates/sui-indexer-alt/src/benchmark.rs
@@ -54,11 +54,8 @@ pub async fn run_benchmark(
     };
 
     let client_args = ClientArgs {
-        remote_store_url: None,
         local_ingestion_path: Some(ingestion_path.clone()),
-        rpc_api_url: None,
-        rpc_username: None,
-        rpc_password: None,
+        ..Default::default()
     };
 
     let cur_time = Instant::now();


### PR DESCRIPTION
## Description 

Make ClientArg derive Default so we can omit optional fields.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
