### PR TITLE
display-v2: parser metering

### DIFF
--- a/crates/sui-display/src/v2/error.rs
+++ b/crates/sui-display/src/v2/error.rs
@@ -21,6 +21,12 @@ pub enum Error {
     #[error("Odd number of characters in hex {0}")]
     OddHexLiteral(OwnedLexeme),
 
+    #[error("Display format is nested too deeply")]
+    TooDeep,
+
+    #[error("Display format contains too many elements")]
+    TooBig,
+
     #[error("Unexpected end-of-string, expected {expect}")]
     UnexpectedEos { expect: ExpectedSet },
 

--- a/crates/sui-display/src/v2/meter.rs
+++ b/crates/sui-display/src/v2/meter.rs
@@ -1,0 +1,74 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::error::Error;
+
+/// Limits that the parser enforces while parsing potentially multiple Display formats.
+pub(crate) struct Limits {
+    /// Maximum number of times the parser can recurse into nested structures. Depth does not
+    /// account for all nodes, only nodes that can be contained within themselves.
+    pub max_depth: usize,
+
+    /// Maximum number of AST nodes that can be allocated during parsing. This counts all values
+    /// that are instances of AST types (but not, for example, `Vec<T>`).
+    pub max_nodes: usize,
+}
+
+/// The available budget left for limits that are tracked across all invocations to the parser for
+/// a single Display.
+pub(crate) struct Budget {
+    pub nodes: usize,
+}
+
+pub(crate) struct Meter<'b> {
+    depth_budget: usize,
+    budget: &'b mut Budget,
+}
+
+impl Limits {
+    pub fn budget(&self) -> Budget {
+        Budget {
+            nodes: self.max_nodes,
+        }
+    }
+}
+
+impl<'b> Meter<'b> {
+    pub fn new(max_depth: usize, budget: &'b mut Budget) -> Self {
+        Meter {
+            depth_budget: max_depth,
+            budget,
+        }
+    }
+
+    /// Create a nested meter, with a reduced depth budget.
+    pub fn nest(&mut self) -> Result<Meter<'_>, Error> {
+        if self.depth_budget == 0 {
+            return Err(Error::TooDeep);
+        }
+
+        Ok(Meter {
+            depth_budget: self.depth_budget - 1,
+            budget: self.budget,
+        })
+    }
+
+    /// Signal that a node has been allocated.
+    pub fn alloc(&mut self) -> Result<(), Error> {
+        if self.budget.nodes == 0 {
+            return Err(Error::TooBig);
+        }
+
+        self.budget.nodes -= 1;
+        Ok(())
+    }
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Self {
+            max_depth: 32,
+            max_nodes: 32768,
+        }
+    }
+}

--- a/crates/sui-display/src/v2/mod.rs
+++ b/crates/sui-display/src/v2/mod.rs
@@ -3,5 +3,6 @@
 
 pub(crate) mod error;
 pub(crate) mod lexer;
+pub(crate) mod meter;
 pub(crate) mod parser;
 pub(crate) mod peek;


### PR DESCRIPTION
## Description 

Count the number of AST nodes parsed, and the depth that the parser reaches, and make sure they stay within limits, to avoid display strings using too many resources during parsing.

## Test plan 

New unit tests:

```
sui$ cargo nextest run -p sui-display -- test_metering
```

## Stack

- #22216
- #22280

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
