### PR TITLE
proto: populate Bcs.name field for core types

### DIFF
--- a/crates/sui-rpc-api/src/proto/rpc/v2beta/checkpoint.rs
+++ b/crates/sui-rpc-api/src/proto/rpc/v2beta/checkpoint.rs
@@ -66,7 +66,9 @@ impl MessageMerge<sui_sdk_types::CheckpointSummary> for CheckpointSummary {
         mask: &crate::field_mask::FieldMaskTree,
     ) {
         if mask.contains(Self::BCS_FIELD.name) {
-            self.bcs = Some(Bcs::serialize(&source).unwrap());
+            let mut bcs = Bcs::serialize(&source).unwrap();
+            bcs.name = Some("CheckpointSummary".to_owned());
+            self.bcs = Some(bcs);
         }
 
         if mask.contains(Self::DIGEST_FIELD.name) {
@@ -491,7 +493,9 @@ impl MessageMerge<sui_sdk_types::CheckpointContents> for CheckpointContents {
         mask: &crate::field_mask::FieldMaskTree,
     ) {
         if mask.contains(Self::BCS_FIELD.name) {
-            self.bcs = Some(Bcs::serialize(&source).unwrap());
+            let mut bcs = Bcs::serialize(&source).unwrap();
+            bcs.name = Some("CheckpointContents".to_owned());
+            self.bcs = Some(bcs);
         }
 
         if mask.contains(Self::DIGEST_FIELD.name) {

--- a/crates/sui-rpc-api/src/proto/rpc/v2beta/effects.rs
+++ b/crates/sui-rpc-api/src/proto/rpc/v2beta/effects.rs
@@ -65,7 +65,9 @@ impl MessageMerge<&sui_sdk_types::TransactionEffects> for TransactionEffects {
         mask: &crate::field_mask::FieldMaskTree,
     ) {
         if mask.contains(Self::BCS_FIELD.name) {
-            self.bcs = Some(super::Bcs::serialize(&source).unwrap());
+            let mut bcs = super::Bcs::serialize(&source).unwrap();
+            bcs.name = Some("TransactionEffects".to_owned());
+            self.bcs = Some(bcs);
         }
 
         if mask.contains(Self::DIGEST_FIELD.name) {

--- a/crates/sui-rpc-api/src/proto/rpc/v2beta/events.rs
+++ b/crates/sui-rpc-api/src/proto/rpc/v2beta/events.rs
@@ -187,7 +187,9 @@ impl MessageMerge<sui_sdk_types::TransactionEvents> for TransactionEvents {
         mask: &crate::field_mask::FieldMaskTree,
     ) {
         if mask.contains(Self::BCS_FIELD.name) {
-            self.bcs = Some(super::Bcs::serialize(&source).unwrap());
+            let mut bcs = super::Bcs::serialize(&source).unwrap();
+            bcs.name = Some("TransactionEvents".to_owned());
+            self.bcs = Some(bcs);
         }
 
         if mask.contains(Self::DIGEST_FIELD.name) {

--- a/crates/sui-rpc-api/src/proto/rpc/v2beta/object.rs
+++ b/crates/sui-rpc-api/src/proto/rpc/v2beta/object.rs
@@ -140,7 +140,9 @@ impl MessageMerge<&Object> for Object {
 impl MessageMerge<sui_sdk_types::Object> for Object {
     fn merge(&mut self, source: sui_sdk_types::Object, mask: &crate::field_mask::FieldMaskTree) {
         if mask.contains(Self::BCS_FIELD.name) {
-            self.bcs = Some(super::Bcs::serialize(&source).unwrap());
+            let mut bcs = super::Bcs::serialize(&source).unwrap();
+            bcs.name = Some("Object".to_owned());
+            self.bcs = Some(bcs);
         }
 
         if mask.contains(Self::DIGEST_FIELD.name) {

--- a/crates/sui-rpc-api/src/proto/rpc/v2beta/transaction.rs
+++ b/crates/sui-rpc-api/src/proto/rpc/v2beta/transaction.rs
@@ -48,7 +48,9 @@ impl MessageMerge<sui_sdk_types::Transaction> for Transaction {
         mask: &crate::field_mask::FieldMaskTree,
     ) {
         if mask.contains(Self::BCS_FIELD.name) {
-            self.bcs = Some(super::Bcs::serialize(&source).unwrap());
+            let mut bcs = super::Bcs::serialize(&source).unwrap();
+            bcs.name = Some("TransactionData".to_owned());
+            self.bcs = Some(bcs);
         }
 
         if mask.contains(Self::DIGEST_FIELD.name) {


### PR DESCRIPTION
## Description 

Based on feedback received, populate the Bcs.name field for core types.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
