### PR TITLE
[cli] Add `sender` to `ptb` help menu

### DIFF
--- a/crates/sui/src/client_ptb/ptb.rs
+++ b/crates/sui/src/client_ptb/ptb.rs
@@ -473,8 +473,8 @@ pub fn ptb_description() -> clap::Command {
             "Instead of executing the transaction, print its digest."
         ))
         .arg(arg!(
-            --"sender"
-            "Set the sender to a specific address instead of the active address."
+            --"sender" <SENDER>
+            "Set the sender to this address instead of the active address."
         ))
         .arg(arg!(
             --"serialize-unsigned-transaction"

--- a/crates/sui/src/client_ptb/ptb.rs
+++ b/crates/sui/src/client_ptb/ptb.rs
@@ -473,6 +473,10 @@ pub fn ptb_description() -> clap::Command {
             "Instead of executing the transaction, print its digest."
         ))
         .arg(arg!(
+            --"sender"
+            "Set the sender to a specific address instead of the active address."
+        ))
+        .arg(arg!(
             --"serialize-unsigned-transaction"
             "Instead of executing the transaction, serialize the bcs bytes of the unsigned \
             transaction data using base64 encoding."


### PR DESCRIPTION
## Description 

A previous PR #22272 added support for setting the `sender` in a transaction. This PR adds this new argument to the ptb help menu. 

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Added a new `--sender` argument for transactions to set the sender to a specific address.
- [ ] Rust SDK:
