### PR TITLE
Move is_system_tx() to TransactionData

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1828,7 +1828,7 @@ impl AuthorityState {
             });
         }
 
-        if transaction.kind().is_system_tx() {
+        if transaction.is_system_tx() {
             return Err(SuiError::UnsupportedFeatureError {
                 error: "dry-exec does not support system transactions".to_string(),
             });
@@ -2041,7 +2041,7 @@ impl AuthorityState {
         &self,
         transaction: TransactionData,
     ) -> SuiResult<SimulateTransactionResult> {
-        if transaction.kind().is_system_tx() {
+        if transaction.is_system_tx() {
             return Err(SuiError::UnsupportedFeatureError {
                 error: "simulate does not support system transactions".to_string(),
             });
@@ -2189,12 +2189,6 @@ impl AuthorityState {
             });
         }
 
-        if transaction_kind.is_system_tx() {
-            return Err(SuiError::UnsupportedFeatureError {
-                error: "system transactions are not supported".to_string(),
-            });
-        }
-
         let show_raw_txn_data_and_effects = show_raw_txn_data_and_effects.unwrap_or(false);
         let skip_checks = skip_checks.unwrap_or(true);
         let reference_gas_price = epoch_store.reference_gas_price();
@@ -2217,6 +2211,12 @@ impl AuthorityState {
             },
             expiration: TransactionExpiration::None,
         });
+
+        if transaction.is_system_tx() {
+            return Err(SuiError::UnsupportedFeatureError {
+                error: "system transactions are not supported".to_string(),
+            });
+        }
 
         let raw_txn_data = if show_raw_txn_data_and_effects {
             bcs::to_bytes(&transaction).map_err(|_| SuiError::TransactionSerializationError {

--- a/crates/sui-replay-2/src/execution.rs
+++ b/crates/sui-replay-2/src/execution.rs
@@ -76,7 +76,7 @@ pub fn execute_transaction_to_effects(
     let protocol_config = &executor.protocol_config;
     let epoch = expected_effects.executed_epoch();
     let epoch_start_timestamp = env.epoch_timestamp(epoch)?;
-    let gas_status = if txn_data.kind().is_system_tx() {
+    let gas_status = if txn_data.is_system_tx() {
         SuiGasStatus::new_unmetered()
     } else {
         let reference_gas_price = env.rgp(epoch)?;

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -764,7 +764,7 @@ impl LocalExec {
         let expensive_checks = true;
         let transaction_kind = override_transaction_kind.unwrap_or(tx_info.kind.clone());
         let certificate_deny_set = HashSet::new();
-        let gas_status = if tx_info.kind.is_system_tx() {
+        let gas_status = if tx_info.is_system_tx() {
             SuiGasStatus::new_unmetered()
         } else {
             SuiGasStatus::new(

--- a/crates/sui-replay/src/types.rs
+++ b/crates/sui-replay/src/types.rs
@@ -16,7 +16,7 @@ use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress, Ver
 use sui_types::digests::{ObjectDigest, TransactionDigest};
 use sui_types::error::{SuiError, SuiObjectResponseError, SuiResult, UserInputError};
 use sui_types::object::Object;
-use sui_types::transaction::{InputObjectKind, SenderSignedData, TransactionKind};
+use sui_types::transaction::{is_system_tx, InputObjectKind, SenderSignedData, TransactionKind};
 use thiserror::Error;
 use tokio::time::Duration;
 use tracing::{error, warn};
@@ -66,6 +66,12 @@ pub struct OnChainTransactionInfo {
     pub reference_gas_price: u64,
     #[serde(default = "unspecified_chain")]
     pub chain: Chain,
+}
+
+impl OnChainTransactionInfo {
+    pub fn is_system_tx(&self) -> bool {
+        is_system_tx(&self.kind, self.sender)
+    }
 }
 
 fn unspecified_chain() -> Chain {

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -62,7 +62,7 @@ mod checked {
             gas,
             transaction.gas_budget(),
             transaction.gas_price(),
-            transaction.kind(),
+            transaction,
         )
     }
 
@@ -162,13 +162,6 @@ mod checked {
         _receiving_objects: ReceivingObjects,
     ) -> SuiResult<CheckedInputObjects> {
         kind.validity_check(config)?;
-        if kind.is_system_tx() {
-            return Err(UserInputError::Unsupported(format!(
-                "Transaction kind {} is not supported in dev-inspect",
-                kind
-            ))
-            .into());
-        }
         let mut used_objects: HashSet<SuiAddress> = HashSet::new();
         for input_object in input_objects.iter() {
             let Some(object) = input_object.as_object() else {
@@ -337,9 +330,9 @@ mod checked {
         gas: &[ObjectRef],
         gas_budget: u64,
         gas_price: u64,
-        tx_kind: &TransactionKind,
+        tx: &TransactionData,
     ) -> SuiResult<SuiGasStatus> {
-        if tx_kind.is_system_tx() {
+        if tx.is_system_tx() {
             Ok(SuiGasStatus::new_unmetered())
         } else {
             let gas_status =


### PR DESCRIPTION
This will be used by accumulator settlement transactions, which will just be ordinary PTBs (with `sender = 0x0`) instead of custom transaction types
