### PR TITLE
[move-abstract-interpreter] Use shared abstract interpreter in the compiler 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7937,6 +7937,7 @@ dependencies = [
  "hex",
  "insta",
  "lsp-types 0.95.1",
+ "move-abstract-interpreter",
  "move-binary-format",
  "move-borrow-graph",
  "move-bytecode-source-map",

--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -2162,6 +2162,7 @@ dependencies = [
  "hex",
  "insta",
  "lsp-types",
+ "move-abstract-interpreter",
  "move-binary-format",
  "move-borrow-graph",
  "move-bytecode-source-map",

--- a/external-crates/move/crates/move-abstract-interpreter/src/absint.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/absint.rs
@@ -39,31 +39,12 @@ pub trait AbstractInterpreter {
     type InstructionIndex: Copy + Ord;
     type Instruction;
 
-    fn start(&mut self) -> Result<(), Self::Error>;
+    /// Joining two states together, this along with `execute` drives the analysis.
     fn join(
         &mut self,
         pre: &mut Self::State,
         post: &Self::State,
     ) -> Result<JoinResult, Self::Error>;
-
-    /// These visitors are to be used for bookkeeping. They should _not_ be used to modify the state
-    /// in any way related to the analysis.
-    fn visit_block_pre_execution(
-        &mut self,
-        block_id: Self::BlockId,
-        invariant: &mut BlockInvariant<Self::State>,
-    ) -> Result<(), Self::Error>;
-    fn visit_block_post_execution(
-        &mut self,
-        block_id: Self::BlockId,
-        invariant: &mut BlockInvariant<Self::State>,
-    ) -> Result<(), Self::Error>;
-    fn visit_successor(&mut self, block_id: Self::BlockId) -> Result<(), Self::Error>;
-    fn visit_back_edge(
-        &mut self,
-        from: Self::BlockId,
-        to: Self::BlockId,
-    ) -> Result<(), Self::Error>;
 
     /// Execute local@instr found at index local@index in the current basic block from pre-state
     /// local@pre.
@@ -83,6 +64,47 @@ pub trait AbstractInterpreter {
         offset: Self::InstructionIndex,
         instr: &Self::Instruction,
     ) -> Result<(), Self::Error>;
+
+    /// A visitor for starting the analysis. This is called before any blocks are processed.
+    fn start(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// A visitor intended for bookkeeping. They should _not_ be used to modify the state in any
+    /// way related to the analysis.
+    fn visit_block_pre_execution(
+        &mut self,
+        _block_id: Self::BlockId,
+        _invariant: &mut BlockInvariant<Self::State>,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// A visitor intended for bookkeeping. They should _not_ be used to modify the state in any
+    /// way related to the analysis.
+    fn visit_block_post_execution(
+        &mut self,
+        _block_id: Self::BlockId,
+        _invariant: &mut BlockInvariant<Self::State>,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// A visitor intended for bookkeeping. They should _not_ be used to modify the state in any
+    /// way related to the analysis.
+    fn visit_successor(&mut self, _block_id: Self::BlockId) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// A visitor intended for bookkeeping. They should _not_ be used to modify the state in any
+    /// way related to the analysis.
+    fn visit_back_edge(
+        &mut self,
+        _from: Self::BlockId,
+        _to: Self::BlockId,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
 }
 
 /// Analyze procedure local@function_context starting from pre-state local@initial_state.

--- a/external-crates/move/crates/move-abstract-interpreter/src/absint.rs
+++ b/external-crates/move/crates/move-abstract-interpreter/src/absint.rs
@@ -4,11 +4,32 @@
 use crate::control_flow_graph::ControlFlowGraph;
 use std::collections::BTreeMap;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum JoinResult {
     Changed,
     Unchanged,
 }
+
+#[derive(Debug, Clone)]
+pub enum BlockPostCondition<State> {
+    /// Unprocessed block
+    Unprocessed,
+    /// Block has been processed
+    Processed(State),
+}
+
+#[derive(Debug, Clone)]
+pub struct BlockInvariant<State> {
+    /// Precondition of the block
+    pub pre: State,
+    /// Postcondition of the block
+    pub post: BlockPostCondition<State>,
+}
+
+pub type InvariantMap<A> = BTreeMap<
+    <A as AbstractInterpreter>::BlockId,
+    BlockInvariant<<A as AbstractInterpreter>::State>,
+>;
 
 pub trait AbstractInterpreter {
     type Error;
@@ -24,7 +45,19 @@ pub trait AbstractInterpreter {
         pre: &mut Self::State,
         post: &Self::State,
     ) -> Result<JoinResult, Self::Error>;
-    fn visit_block_execution(&mut self, block_id: Self::BlockId) -> Result<(), Self::Error>;
+
+    /// These visitors are to be used for bookkeeping. They should _not_ be used to modify the state
+    /// in any way related to the analysis.
+    fn visit_block_pre_execution(
+        &mut self,
+        block_id: Self::BlockId,
+        invariant: &mut BlockInvariant<Self::State>,
+    ) -> Result<(), Self::Error>;
+    fn visit_block_post_execution(
+        &mut self,
+        block_id: Self::BlockId,
+        invariant: &mut BlockInvariant<Self::State>,
+    ) -> Result<(), Self::Error>;
     fn visit_successor(&mut self, block_id: Self::BlockId) -> Result<(), Self::Error>;
     fn visit_back_edge(
         &mut self,
@@ -44,8 +77,9 @@ pub trait AbstractInterpreter {
     /// (e.g., normalizing the abstract state before a join).
     fn execute(
         &mut self,
-        state: &mut Self::State,
+        block_id: Self::BlockId,
         bounds: (Self::InstructionIndex, Self::InstructionIndex),
+        state: &mut Self::State,
         offset: Self::InstructionIndex,
         instr: &Self::Instruction,
     ) -> Result<(), Self::Error>;
@@ -57,7 +91,7 @@ pub fn analyze_function<A, CFG>(
     cfg: &CFG,
     code: &<CFG as ControlFlowGraph>::Instructions,
     initial_state: A::State,
-) -> Result<(), A::Error>
+) -> Result<InvariantMap<A>, A::Error>
 where
     A: AbstractInterpreter,
     CFG: ControlFlowGraph<
@@ -70,37 +104,41 @@ where
     let mut inv_map = BTreeMap::new();
     let entry_block_id = cfg.entry_block_id();
     let mut next_block = Some(entry_block_id);
-    inv_map.insert(entry_block_id, initial_state);
+    inv_map.insert(
+        entry_block_id,
+        BlockInvariant {
+            pre: initial_state.clone(),
+            post: BlockPostCondition::Unprocessed,
+        },
+    );
 
     while let Some(block_id) = next_block {
-        let block_invariant = match inv_map.get_mut(&block_id) {
-            Some(invariant) => invariant,
-            None => {
-                // This can only happen when all predecessors have errors,
-                // so skip the block and move on to the next one
-                next_block = cfg.next_block(block_id);
-                continue;
-            }
-        };
+        let block_invariant = inv_map.entry(block_id).or_insert_with(|| BlockInvariant {
+            pre: initial_state.clone(),
+            post: BlockPostCondition::Unprocessed,
+        });
 
-        let pre_state = &block_invariant;
-        // Note: this will stop analysis after the first error occurs, to avoid the risk of
-        // subsequent crashes
+        interpreter.visit_block_pre_execution(block_id, block_invariant)?;
+        let pre_state = &block_invariant.pre;
         let post_state = execute_block(interpreter, cfg, code, block_id, pre_state)?;
+        block_invariant.post = BlockPostCondition::Processed(post_state.clone());
+        interpreter.visit_block_post_execution(block_id, block_invariant)?;
 
         let mut next_block_candidate = cfg.next_block(block_id);
         // propagate postcondition of this block to successor blocks
-        for &successor_block_id in cfg.successors(block_id) {
+        for successor_block_id in cfg.successors(block_id) {
             interpreter.visit_successor(successor_block_id)?;
             match inv_map.get_mut(&successor_block_id) {
                 Some(next_block_invariant) => {
-                    let join_result = interpreter.join(next_block_invariant, &post_state)?;
+                    let join_result =
+                        interpreter.join(&mut next_block_invariant.pre, &post_state)?;
                     match join_result {
                         JoinResult::Unchanged => {
                             // Pre is the same after join. Reanalyzing this block would produce
                             // the same post
                         }
                         JoinResult::Changed => {
+                            next_block_invariant.post = BlockPostCondition::Unprocessed;
                             // If the cur->successor is a back edge, jump back to the beginning
                             // of the loop, instead of the normal next block
                             if cfg.is_back_edge(block_id, successor_block_id) {
@@ -114,13 +152,19 @@ where
                 None => {
                     // Haven't visited the next block yet. Use the post of the current block as
                     // its pre
-                    inv_map.insert(successor_block_id, post_state.clone());
+                    inv_map.insert(
+                        successor_block_id,
+                        BlockInvariant {
+                            pre: post_state.clone(),
+                            post: BlockPostCondition::Unprocessed,
+                        },
+                    );
                 }
             }
         }
         next_block = next_block_candidate;
     }
-    Ok(())
+    Ok(inv_map)
 }
 
 fn execute_block<A, CFG>(
@@ -138,11 +182,10 @@ where
             Instruction = A::Instruction,
         >,
 {
-    interpreter.visit_block_execution(block_id)?;
     let mut state_acc = pre_state.clone();
     let bounds = (cfg.block_start(block_id), cfg.block_end(block_id));
     for (offset, instr) in cfg.instructions(code, block_id) {
-        interpreter.execute(&mut state_acc, bounds, offset, instr)?
+        interpreter.execute(block_id, bounds, &mut state_acc, offset, instr)?
     }
     Ok(state_acc)
 }

--- a/external-crates/move/crates/move-bytecode-verifier/src/code_unit_verifier.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/code_unit_verifier.rs
@@ -105,7 +105,7 @@ pub fn verify_function<'env>(
     )?;
 
     if let Some(limit) = verifier_config.max_basic_blocks {
-        if function_context.cfg().blocks().len() > limit {
+        if function_context.cfg().blocks().count() > limit {
             return Err(
                 PartialVMError::new(StatusCode::TOO_MANY_BASIC_BLOCKS).at_code_offset(index, 0)
             );

--- a/external-crates/move/crates/move-bytecode-verifier/src/loop_summary.rs
+++ b/external-crates/move/crates/move-bytecode-verifier/src/loop_summary.rs
@@ -94,10 +94,9 @@ impl LoopSummary {
 
         let mut stack: Vec<Frontier> = cfg
             .successors(root_block)
-            .iter()
             .map(|succ| Visit {
                 from_node: root_node,
-                to_block: *succ,
+                to_block: succ,
             })
             .collect();
 
@@ -140,9 +139,9 @@ impl LoopSummary {
                             parent: from_node,
                         });
 
-                        stack.extend(cfg.successors(to_block).iter().map(|succ| Visit {
+                        stack.extend(cfg.successors(to_block).map(|succ| Visit {
                             from_node: to_node,
-                            to_block: *succ,
+                            to_block: succ,
                         }));
                     }
                 },

--- a/external-crates/move/crates/move-compiler/Cargo.toml
+++ b/external-crates/move/crates/move-compiler/Cargo.toml
@@ -28,6 +28,7 @@ insta.workspace = true
 
 bcs.workspace = true
 
+move-abstract-interpreter.workspace = true
 move-binary-format.workspace = true
 move-core-types.workspace = true
 move-bytecode-verifier.workspace = true

--- a/external-crates/move/crates/move-compiler/src/cfgir/absint.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/absint.rs
@@ -4,55 +4,15 @@
 
 use super::cfg::CFG;
 use crate::{diagnostics::Diagnostics, hlir::ast::*};
-use std::collections::BTreeMap;
+use move_abstract_interpreter::absint;
+use std::{collections::BTreeMap, rc::Rc};
+
+pub use absint::JoinResult;
 
 /// Trait for finite-height abstract domains. Infinite height domains would require a more complex
 /// trait with widening and a partial order.
 pub trait AbstractDomain: Clone + Sized {
     fn join(&mut self, other: &Self) -> JoinResult;
-}
-
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub enum JoinResult {
-    Unchanged,
-    Changed,
-}
-
-#[derive(Clone)]
-enum BlockPostcondition {
-    /// Unprocessed block
-    Unprocessed,
-    /// Analyzing block was successful
-    Success,
-    /// Analyzing block ended in an error
-    Error(Diagnostics),
-}
-
-#[derive(Clone)]
-struct BlockInvariant<State> {
-    /// Precondition of the block
-    pre: State,
-    /// Postcondition of the block---just success/error for now
-    post: BlockPostcondition,
-}
-
-/// A map from block id's to the pre/post of each block after a fixed point is reached.
-type InvariantMap<State> = BTreeMap<Label, BlockInvariant<State>>;
-
-fn collect_states_and_diagnostics<State>(
-    map: InvariantMap<State>,
-) -> (BTreeMap<Label, State>, Diagnostics) {
-    let mut diags = Diagnostics::new();
-    let final_states = map
-        .into_iter()
-        .map(|(lbl, BlockInvariant { pre, post })| {
-            if let BlockPostcondition::Error(ds) = post {
-                diags.extend(ds)
-            }
-            (lbl, pre)
-        })
-        .collect();
-    (final_states, diags)
 }
 
 /// Take a pre-state + instruction and mutate it to produce a post-state
@@ -79,87 +39,169 @@ pub trait TransferFunctions {
     ) -> Diagnostics;
 }
 
-pub trait AbstractInterpreter: TransferFunctions {
-    /// Analyze procedure local@function_context starting from pre-state local@initial_state.
-    fn analyze_function(
-        &mut self,
-        cfg: &dyn CFG,
-        initial_state: Self::State,
-    ) -> (BTreeMap<Label, Self::State>, Diagnostics) {
-        let mut inv_map: InvariantMap<Self::State> = InvariantMap::new();
-        let start = cfg.start_block();
-        let mut next_block = Some(start);
-
-        while let Some(block_label) = next_block {
-            let block_invariant = inv_map
-                .entry(block_label)
-                .or_insert_with(|| BlockInvariant {
-                    pre: initial_state.clone(),
-                    post: BlockPostcondition::Unprocessed,
-                });
-
-            let (post_state, errors) = self.execute_block(cfg, &block_invariant.pre, block_label);
-            block_invariant.post = if errors.is_empty() {
-                BlockPostcondition::Success
-            } else {
-                BlockPostcondition::Error(errors)
-            };
-
-            // propagate postcondition of this block to successor blocks
-            let mut next_block_candidate = cfg.next_block(block_label);
-            for next_block_id in cfg.successors(block_label) {
-                match inv_map.get_mut(next_block_id) {
-                    Some(next_block_invariant) => {
-                        let join_result = {
-                            let old_pre = &mut next_block_invariant.pre;
-                            old_pre.join(&post_state)
-                        };
-                        match join_result {
-                            JoinResult::Unchanged => {
-                                // Pre is the same after join. Reanalyzing this block would produce
-                                // the same post
-                            }
-                            JoinResult::Changed => {
-                                // Pre has changed, the post condition is now unknown for the block
-                                next_block_invariant.post = BlockPostcondition::Unprocessed;
-                                // If the cur->successor is a back edge, jump back to the beginning
-                                // of the loop, instead of the normal next block
-                                if cfg.is_back_edge(block_label, *next_block_id) {
-                                    next_block_candidate = Some(*next_block_id);
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    None => {
-                        // Haven't visited the next block yet. Use the post of the current block as
-                        // its pre
-                        inv_map.insert(
-                            *next_block_id,
-                            BlockInvariant {
-                                pre: post_state.clone(),
-                                post: BlockPostcondition::Success,
-                            },
-                        );
-                    }
+pub fn analyze_function<C: CFG, TF: TransferFunctions>(
+    transfer_functions: &mut TF,
+    cfg: &C,
+    initial_state: TF::State,
+) -> (BTreeMap<Label, TF::State>, Diagnostics) {
+    fn collect_states_and_diagnostics<State>(
+        map: BTreeMap<Label, absint::BlockInvariant<(State, Option<Rc<Diagnostics>>)>>,
+    ) -> (BTreeMap<Label, State>, Diagnostics) {
+        let mut diags = Diagnostics::new();
+        let final_states = map
+            .into_iter()
+            .map(|(lbl, inv)| {
+                let absint::BlockInvariant {
+                    pre: (pre, _pre_diags),
+                    post,
+                } = inv;
+                debug_assert!(_pre_diags.is_none());
+                // can be None for empty blocks
+                if let absint::BlockPostCondition::Processed((_, Some(rc_diags))) = post {
+                    diags.extend(Rc::into_inner(rc_diags).unwrap());
                 }
-            }
-            next_block = next_block_candidate;
-        }
-        collect_states_and_diagnostics(inv_map)
+                (lbl, pre)
+            })
+            .collect();
+        (final_states, diags)
     }
 
-    fn execute_block(
+    let mut interpreter = AbstractInterpreter { transfer_functions };
+    let inv_map = absint::analyze_function(
+        &mut interpreter,
+        &CFGWrapper(cfg),
+        &(),
+        (initial_state, None),
+    )
+    .unwrap();
+    collect_states_and_diagnostics(inv_map)
+}
+
+struct AbstractInterpreter<'a, TF: TransferFunctions> {
+    pub transfer_functions: &'a mut TF,
+}
+
+impl<TF: TransferFunctions> absint::AbstractInterpreter for AbstractInterpreter<'_, TF> {
+    type Error = ();
+    type BlockId = Label;
+
+    type State = (<TF as TransferFunctions>::State, Option<Rc<Diagnostics>>);
+
+    type InstructionIndex = usize;
+    type Instruction = Command;
+
+    fn start(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn join(
         &mut self,
-        cfg: &dyn CFG,
-        pre_state: &Self::State,
-        block_lbl: Label,
-    ) -> (Self::State, Diagnostics) {
-        let mut state = pre_state.clone();
-        let mut diags = Diagnostics::new();
-        for (idx, cmd) in cfg.commands(block_lbl) {
-            diags.extend(self.execute(&mut state, block_lbl, idx, cmd));
+        (pre, _): &mut (TF::State, Option<Rc<Diagnostics>>),
+        (post, _): &(TF::State, Option<Rc<Diagnostics>>),
+    ) -> Result<JoinResult, Self::Error> {
+        Ok(pre.join(post))
+    }
+
+    fn visit_block_pre_execution(
+        &mut self,
+        _block_id: Self::BlockId,
+        invariant: &mut absint::BlockInvariant<(TF::State, Option<Rc<Diagnostics>>)>,
+    ) -> Result<(), Self::Error> {
+        // each block needs its own unique Diagnostics, so set to None to be then initialized
+        // in the `execute`
+        invariant.pre.1 = None;
+        Ok(())
+    }
+
+    fn visit_block_post_execution(
+        &mut self,
+        _block_id: Self::BlockId,
+        _invariant: &mut absint::BlockInvariant<Self::State>,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn visit_successor(&mut self, _block_id: Self::BlockId) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn visit_back_edge(
+        &mut self,
+        _from: Self::BlockId,
+        _to: Self::BlockId,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn execute(
+        &mut self,
+        lbl: Self::BlockId,
+        (start, _stop): (Self::InstructionIndex, Self::InstructionIndex),
+        (state, diags): &mut (TF::State, Option<Rc<Diagnostics>>),
+        idx: Self::InstructionIndex,
+        command: &Self::Instruction,
+    ) -> Result<(), Self::Error> {
+        if idx == start {
+            *diags = Some(Rc::new(Diagnostics::new()));
         }
-        (state, diags)
+        let diags: &mut Diagnostics = Rc::get_mut(diags.as_mut().expect("Set as some"))
+            .expect("unique ownership while iterating through block");
+        diags.extend(self.transfer_functions.execute(state, lbl, idx, command));
+        Ok(())
+    }
+}
+
+struct CFGWrapper<'a, T: CFG>(&'a T);
+impl<T: CFG> move_abstract_interpreter::control_flow_graph::ControlFlowGraph for CFGWrapper<'_, T> {
+    type BlockId = Label;
+    type InstructionIndex = usize;
+    type Instruction = Command;
+    type Instructions = ();
+
+    fn block_start(&self, label: Self::BlockId) -> Self::InstructionIndex {
+        self.0.block_start(label)
+    }
+
+    fn block_end(&self, label: Self::BlockId) -> Self::InstructionIndex {
+        self.0.block_end(label)
+    }
+
+    fn successors(&self, label: Self::BlockId) -> impl Iterator<Item = Self::BlockId> {
+        self.0.successors(label).iter().copied()
+    }
+
+    fn next_block(&self, label: Self::BlockId) -> Option<Self::BlockId> {
+        self.0.next_block(label)
+    }
+
+    fn instructions<'a>(
+        &'a self,
+        _: &'a (),
+        block_id: Self::BlockId,
+    ) -> impl Iterator<Item = (Self::InstructionIndex, &'a Self::Instruction)>
+    where
+        Self::Instruction: 'a,
+    {
+        self.0.commands(block_id)
+    }
+
+    fn blocks(&self) -> impl Iterator<Item = Self::BlockId> {
+        self.0.block_labels()
+    }
+
+    fn num_blocks(&self) -> usize {
+        self.0.num_blocks()
+    }
+
+    fn entry_block_id(&self) -> Self::BlockId {
+        self.0.start_block()
+    }
+
+    fn is_loop_head(&self, label: Self::BlockId) -> bool {
+        self.0.is_loop_head(label)
+    }
+
+    fn is_back_edge(&self, cur: Self::BlockId, next: Self::BlockId) -> bool {
+        self.0.is_back_edge(cur, next)
     }
 }

--- a/external-crates/move/crates/move-compiler/src/cfgir/borrows/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/borrows/mod.rs
@@ -87,8 +87,6 @@ impl TransferFunctions for BorrowSafety {
     }
 }
 
-impl AbstractInterpreter for BorrowSafety {}
-
 pub fn verify(
     context: &super::CFGContext,
     cfg: &super::cfg::MutForwardCFG,
@@ -103,7 +101,7 @@ pub fn verify(
     let mut initial_state = BorrowState::initial(locals, safety.mutably_used.clone(), has_errors);
     initial_state.bind_arguments(&signature.parameters);
     initial_state.canonicalize_locals(&safety.local_numbers);
-    let (final_state, ds) = safety.analyze_function(cfg, initial_state);
+    let (final_state, ds) = analyze_function(&mut safety, cfg, initial_state);
     context.add_diags(ds);
     unused_mut_borrows(context, safety.mutably_used);
     final_state

--- a/external-crates/move/crates/move-compiler/src/cfgir/liveness/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/liveness/mod.rs
@@ -63,8 +63,6 @@ impl TransferFunctions for Liveness {
     }
 }
 
-impl AbstractInterpreter for Liveness {}
-
 //**************************************************************************************************
 // Analysis
 //**************************************************************************************************
@@ -76,7 +74,7 @@ fn analyze(
     let reverse = &mut ReverseCFG::new(cfg, infinite_loop_starts);
     let initial_state = LivenessState::initial();
     let mut liveness = Liveness::new(reverse);
-    let (final_invariants, errors) = liveness.analyze_function(reverse, initial_state);
+    let (final_invariants, errors) = analyze_function(&mut liveness, reverse, initial_state);
     assert!(errors.is_empty());
     (final_invariants, liveness.states)
 }

--- a/external-crates/move/crates/move-compiler/src/cfgir/locals/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/locals/mod.rs
@@ -171,8 +171,6 @@ impl TransferFunctions for LocalsSafety<'_> {
     }
 }
 
-impl AbstractInterpreter for LocalsSafety<'_> {}
-
 pub fn verify(
     context: &super::CFGContext,
     cfg: &super::cfg::MutForwardCFG,
@@ -182,7 +180,7 @@ pub fn verify(
     } = context;
     let initial_state = LocalStates::initial(&signature.parameters, locals);
     let mut locals_safety = LocalsSafety::new(context, locals, signature);
-    let (final_state, ds) = locals_safety.analyze_function(cfg, initial_state);
+    let (final_state, ds) = analyze_function(&mut locals_safety, cfg, initial_state);
     unused_let_muts(context, locals, locals_safety.unused_mut);
     context.add_diags(ds);
     final_state

--- a/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
+++ b/external-crates/move/crates/move-compiler/src/cfgir/visitor.rs
@@ -6,7 +6,7 @@ use std::{collections::BTreeMap, fmt::Debug};
 use crate::{
     cfgir::{
         CFGContext,
-        absint::{AbstractDomain, AbstractInterpreter, JoinResult, TransferFunctions},
+        absint::{AbstractDomain, JoinResult, TransferFunctions, analyze_function},
         ast as G,
         cfg::ImmForwardCFG,
     },
@@ -523,7 +523,7 @@ pub trait SimpleAbsIntConstructor: Sized {
         let Some(mut ai) = Self::new(context, cfg, &mut init_state) else {
             return Diagnostics::new();
         };
-        let (final_state, ds) = ai.analyze_function(cfg, init_state);
+        let (final_state, ds) = analyze_function(&mut ai, cfg, init_state);
         ai.finish(final_state, ds)
     }
 }
@@ -798,7 +798,6 @@ impl<V: SimpleAbsInt> TransferFunctions for V {
         self.finish_command(context, pre)
     }
 }
-impl<V: SimpleAbsInt> AbstractInterpreter for V {}
 
 impl<V: AbstractInterpreterVisitor + 'static> From<V> for AbsIntVisitorObj {
     fn from(value: V) -> Self {

--- a/external-crates/move/crates/move-coverage/src/lcov.rs
+++ b/external-crates/move/crates/move-coverage/src/lcov.rs
@@ -353,7 +353,7 @@ impl FileRecordKeeper {
                     let loc = f_source_map.get_code_location(block_end).unwrap();
                     let line_no = file_mapping.start_position(&loc).line_offset() + 1;
                     block_id += 1;
-                    for &o in cfg.successors(cfg_block_id) {
+                    for o in cfg.successors(cfg_block_id) {
                         self.branches
                             .entry((index as u16, block_end))
                             .or_insert_with(|| BranchInfo::new(line_no, block_id - 1))

--- a/external-crates/move/crates/move-coverage/src/summary.rs
+++ b/external-crates/move/crates/move-coverage/src/summary.rs
@@ -200,7 +200,7 @@ pub fn summarize_path_cov(module: &CompiledModule, trace_map: &TraceMap) -> Modu
                     // get function entry and return points
                     let fn_entry = fn_cfg.block_start(fn_cfg.entry_block_id());
                     let mut fn_returns: BTreeSet<CodeOffset> = BTreeSet::new();
-                    for block_id in fn_cfg.blocks().into_iter() {
+                    for block_id in fn_cfg.blocks() {
                         for i in fn_cfg.block_start(block_id)..=fn_cfg.block_end(block_id) {
                             if let Bytecode::Ret = &code_unit.code[i as usize] {
                                 fn_returns.insert(i);
@@ -213,15 +213,14 @@ pub fn summarize_path_cov(module: &CompiledModule, trace_map: &TraceMap) -> Modu
 
                     let block_to_node: BTreeMap<_, _> = fn_cfg
                         .blocks()
-                        .into_iter()
                         .map(|block_id| (block_id, fn_dgraph.add_node(block_id)))
                         .collect();
 
-                    for block_id in fn_cfg.blocks().into_iter() {
-                        for succ_block_id in fn_cfg.successors(block_id).iter() {
+                    for block_id in fn_cfg.blocks() {
+                        for succ_block_id in fn_cfg.successors(block_id) {
                             fn_dgraph.add_edge(
                                 *block_to_node.get(&block_id).unwrap(),
-                                *block_to_node.get(succ_block_id).unwrap(),
+                                *block_to_node.get(&succ_block_id).unwrap(),
                                 (),
                             );
                         }

--- a/external-crates/move/crates/move-disassembler/src/disassembler.rs
+++ b/external-crates/move/crates/move-disassembler/src/disassembler.rs
@@ -872,7 +872,6 @@ impl Disassembler<'_> {
         let cfg_opt = if self.options.print_basic_blocks {
             let cfg: BTreeMap<_, _> = VMControlFlowGraph::new(&code.code, &code.jump_tables)
                 .blocks()
-                .into_iter()
                 .enumerate()
                 .map(|(block_number, pc_start)| (pc_start, block_number))
                 .collect();

--- a/external-crates/move/crates/move-ir-compiler/src/unit_tests/cfg_tests.rs
+++ b/external-crates/move/crates/move-ir-compiler/src/unit_tests/cfg_tests.rs
@@ -18,7 +18,7 @@ fn cfg_compile_script_ret() {
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
     cfg.display();
-    assert_eq!(cfg.blocks().len(), 1);
+    assert_eq!(cfg.blocks().count(), 1);
     assert_eq!(cfg.num_blocks(), 1);
     assert_eq!(cfg.reachable_from(0).len(), 1);
 }
@@ -39,7 +39,7 @@ fn cfg_compile_script_let() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 1);
+    assert_eq!(cfg.blocks().count(), 1);
     assert_eq!(cfg.num_blocks(), 1);
     assert_eq!(cfg.reachable_from(0).len(), 1);
 }
@@ -63,7 +63,7 @@ fn cfg_compile_if() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 4);
+    assert_eq!(cfg.blocks().count(), 4);
     assert_eq!(cfg.num_blocks(), 4);
     assert_eq!(cfg.reachable_from(0).len(), 4);
 }
@@ -90,7 +90,7 @@ fn cfg_compile_if_else() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 4);
+    assert_eq!(cfg.blocks().count(), 4);
     assert_eq!(cfg.num_blocks(), 4);
     assert_eq!(cfg.reachable_from(0).len(), 4);
 }
@@ -113,7 +113,7 @@ fn cfg_compile_if_else_with_else_return() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 4);
+    assert_eq!(cfg.blocks().count(), 4);
     assert_eq!(cfg.num_blocks(), 4);
     assert_eq!(cfg.reachable_from(0).len(), 4);
 }
@@ -144,7 +144,7 @@ fn cfg_compile_nested_if() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 7);
+    assert_eq!(cfg.blocks().count(), 7);
     assert_eq!(cfg.num_blocks(), 7);
     assert_eq!(cfg.reachable_from(8).len(), 3);
 }
@@ -167,7 +167,7 @@ fn cfg_compile_if_else_with_if_return() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 4);
+    assert_eq!(cfg.blocks().count(), 4);
     assert_eq!(cfg.num_blocks(), 4);
     assert_eq!(cfg.reachable_from(0).len(), 4);
     assert_eq!(cfg.reachable_from(4).len(), 2);
@@ -190,7 +190,7 @@ fn cfg_compile_if_else_with_two_returns() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 4);
+    assert_eq!(cfg.blocks().count(), 4);
     assert_eq!(cfg.num_blocks(), 4);
     assert_eq!(cfg.reachable_from(0).len(), 3);
     assert_eq!(cfg.reachable_from(4).len(), 1);
@@ -217,7 +217,7 @@ fn cfg_compile_if_else_with_else_abort() {
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
     cfg.display();
-    assert_eq!(cfg.blocks().len(), 4);
+    assert_eq!(cfg.blocks().count(), 4);
     assert_eq!(cfg.num_blocks(), 4);
     assert_eq!(cfg.reachable_from(0).len(), 4);
 }
@@ -241,7 +241,7 @@ fn cfg_compile_if_else_with_if_abort() {
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
     cfg.display();
-    assert_eq!(cfg.blocks().len(), 4);
+    assert_eq!(cfg.blocks().count(), 4);
     assert_eq!(cfg.num_blocks(), 4);
     assert_eq!(cfg.reachable_from(0).len(), 4);
     assert_eq!(cfg.reachable_from(4).len(), 2);
@@ -265,7 +265,7 @@ fn cfg_compile_if_else_with_two_aborts() {
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
     cfg.display();
-    assert_eq!(cfg.blocks().len(), 4);
+    assert_eq!(cfg.blocks().count(), 4);
     assert_eq!(cfg.num_blocks(), 4);
     assert_eq!(cfg.reachable_from(0).len(), 3);
     assert_eq!(cfg.reachable_from(4).len(), 1);
@@ -295,7 +295,7 @@ fn cfg_compile_variant_switch_simple() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 3);
+    assert_eq!(cfg.blocks().count(), 3);
     assert_eq!(cfg.num_blocks(), 3);
     assert_eq!(cfg.reachable_from(0).len(), 3);
 }
@@ -325,7 +325,7 @@ fn cfg_compile_variant_switch_simple_unconditional_jump() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 4);
+    assert_eq!(cfg.blocks().count(), 4);
     assert_eq!(cfg.num_blocks(), 4);
     assert_eq!(cfg.reachable_from(0).len(), 3);
 }
@@ -361,7 +361,7 @@ fn cfg_compile_variant_switch() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 6);
+    assert_eq!(cfg.blocks().count(), 6);
     assert_eq!(cfg.num_blocks(), 6);
     assert_eq!(cfg.reachable_from(0).len(), 6);
 }
@@ -397,7 +397,7 @@ fn cfg_compile_variant_switch_with_two_aborts() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 6);
+    assert_eq!(cfg.blocks().count(), 6);
     assert_eq!(cfg.num_blocks(), 6);
     assert_eq!(cfg.reachable_from(0).len(), 5);
 }
@@ -439,7 +439,7 @@ fn cfg_compile_variant_switch_with_return() {
         ";
     let (code, jump_tables) = compile_module_with_single_function(text);
     let cfg: VMControlFlowGraph = VMControlFlowGraph::new(&code, &jump_tables);
-    assert_eq!(cfg.blocks().len(), 7);
+    assert_eq!(cfg.blocks().count(), 7);
     assert_eq!(cfg.num_blocks(), 7);
     assert_eq!(cfg.reachable_from(0).len(), 5);
 }


### PR DESCRIPTION
## Description 

- Use the shared abstract interpreter in the compiler
- Some funny business has to be done to pipe through diagnostics, open to suggestions there--even if it means changing the trait 

## Test plan 

- 👀 
- cargo test

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
