### PR TITLE
Update get-coins.mdx

### DIFF
--- a/docs/content/guides/developer/getting-started/get-coins.mdx
+++ b/docs/content/guides/developer/getting-started/get-coins.mdx
@@ -52,7 +52,7 @@ You can request test tokens within [Sui Wallet](https://github.com/MystenLabs/my
 Use the following cURL command to request tokens directly from the faucet server:
 
 ```
-curl --location --request POST 'https://faucet.devnet.sui.io/v1/gas' \
+curl --location --request POST 'https://faucet.devnet.sui.io/v2/gas' \
 --header 'Content-Type: application/json' \
 --data-raw '{
     "FixedAmountRequest": {

--- a/docs/content/guides/developer/getting-started/get-coins.mdx
+++ b/docs/content/guides/developer/getting-started/get-coins.mdx
@@ -61,7 +61,7 @@ curl --location --request POST 'https://faucet.devnet.sui.io/v2/gas' \
 }'
 ```
 
-If you're working with a local network, replace `'https://faucet.devnet.sui.io/v1/gas'` with the appropriate value based on which package runs your network:
+If you're working with a local network, replace `'https://faucet.devnet.sui.io/v2/gas'` with the appropriate value based on which package runs your network:
 
 - `sui-faucet`: `http://127.0.0.1:5003/gas`
 - `sui`: `http://127.0.0.1:9123/gas`


### PR DESCRIPTION
## Description 

Route deprecated. Use `/v2/gas` instead.

## Test plan 

```bash
$ curl --location --request POST 'https://faucet.devnet.sui.io/v1/gas' \
--header 'Content-Type: application/json' \
--data-raw '{
    "FixedAmountRequest": {
        "recipient": "0x.................................."
    }
}'
{"status":{"Failure":{"Internal":"Route deprecated. Use `/v2/gas` instead."}},"coins_sent":null}
```