### PR TITLE
Share new execution time observations unidirectionally

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -251,13 +251,13 @@ pub struct ExecutionTimeObserverConfig {
     /// Unless target object utilization is exceeded by at least this amount, no observation
     /// will be shared with consensus.
     ///
-    /// If unspecified, this will default to `100` milliseconds.
+    /// If unspecified, this will default to `500` milliseconds.
     pub observation_sharing_object_utilization_threshold: Option<Duration>,
 
     /// Unless the current local observation differs from the last one we shared by at least this
     /// percentage, no observation will be shared with consensus.
     ///
-    /// If unspecified, this will default to `0.05`.
+    /// If unspecified, this will default to `0.1`.
     pub observation_sharing_diff_threshold: Option<f64>,
 
     /// Minimum interval between sharing multiple observations of the same key.

--- a/crates/sui-core/src/authority/execution_time_estimator.rs
+++ b/crates/sui-core/src/authority/execution_time_estimator.rs
@@ -71,6 +71,36 @@ pub struct LocalObservations {
     last_shared: Option<(Duration, Instant)>,
 }
 
+impl LocalObservations {
+    fn diff_exceeds_threshold(
+        &self,
+        new_average: Duration,
+        threshold: f64,
+        min_interval: Duration,
+    ) -> bool {
+        let Some((last_shared, last_shared_timestamp)) = self.last_shared else {
+            // Diff threshold exceeded by default if we haven't shared anything yet.
+            return true;
+        };
+
+        if last_shared_timestamp.elapsed() < min_interval {
+            return false;
+        }
+
+        if threshold >= 0.0 {
+            // Positive threshold requires upward change.
+            new_average
+                .checked_sub(last_shared)
+                .map_or(false, |diff| diff > last_shared.mul_f64(threshold))
+        } else {
+            // Negative threshold requires downward change.
+            last_shared
+                .checked_sub(new_average)
+                .map_or(false, |diff| diff > last_shared.mul_f64(-threshold))
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ObjectUtilization {
     excess_execution_time: Duration,
@@ -319,37 +349,45 @@ impl ExecutionTimeObserver {
             // - the tx has at least one mutable shared object with utilization that's too high
             // TODO: Consider only sharing observations that disagree with consensus estimate.
             let new_average = local_observation.moving_average.get_average();
-            let diff_exceeds_threshold =
-                local_observation
-                    .last_shared
-                    .is_none_or(|(last_shared, last_shared_timestamp)| {
-                        let diff = last_shared.abs_diff(new_average);
-                        diff >= new_average
-                            .mul_f64(self.config.observation_sharing_diff_threshold())
-                            && last_shared_timestamp.elapsed()
-                                >= self.config.observation_sharing_min_interval()
-                    });
-            let utilization_exceeds_threshold = max_excess_per_object_execution_time
+            let mut should_share = false;
+
+            // Share upward adjustments if an object is overutilized.
+            if max_excess_per_object_execution_time
                 >= self
                     .config
-                    .observation_sharing_object_utilization_threshold();
-            if diff_exceeds_threshold && (utilization_exceeds_threshold || uses_indebted_object) {
-                debug!("sharing new execution time observation for {key:?}: {new_average:?}");
-                if utilization_exceeds_threshold {
-                    epoch_store
-                        .metrics
-                        .epoch_execution_time_observations_sharing_reason
-                        .with_label_values(&["utilization"])
-                        .inc();
-                }
-                if uses_indebted_object {
-                    epoch_store
-                        .metrics
-                        .epoch_execution_time_observations_sharing_reason
-                        .with_label_values(&["indebted"])
-                        .inc();
-                }
+                    .observation_sharing_object_utilization_threshold()
+                && local_observation.diff_exceeds_threshold(
+                    new_average,
+                    self.config.observation_sharing_diff_threshold(),
+                    self.config.observation_sharing_min_interval(),
+                )
+            {
+                should_share = true;
+                epoch_store
+                    .metrics
+                    .epoch_execution_time_observations_sharing_reason
+                    .with_label_values(&["utilization"])
+                    .inc();
+            };
 
+            // Share downward adjustments if an object is indebted.
+            if uses_indebted_object
+                && local_observation.diff_exceeds_threshold(
+                    new_average,
+                    -self.config.observation_sharing_diff_threshold(),
+                    self.config.observation_sharing_min_interval(),
+                )
+            {
+                should_share = true;
+                epoch_store
+                    .metrics
+                    .epoch_execution_time_observations_sharing_reason
+                    .with_label_values(&["indebted"])
+                    .inc();
+            }
+
+            if should_share {
+                debug!("sharing new execution time observation for {key:?}: {new_average:?}");
                 to_share.push((key, new_average));
                 local_observation.last_shared = Some((new_average, Instant::now()));
             }
@@ -939,9 +977,10 @@ mod tests {
         let package = ObjectID::random();
         let module = "test_module".to_string();
         let function = "test_function".to_string();
+        let shared_object_id = ObjectID::random();
         let ptb = ProgrammableTransaction {
             inputs: vec![CallArg::Object(ObjectArg::SharedObject {
-                id: ObjectID::random(),
+                id: shared_object_id,
                 initial_shared_version: SequenceNumber::new(),
                 mutable: true,
             })],
@@ -972,7 +1011,7 @@ mod tests {
             .last_shared
             .is_none());
 
-        // Second observation - no time has passed, so now utilization is high; should share
+        // Second observation - no time has passed, so now utilization is high; should share upward change
         let timings = vec![ExecutionTiming::Success(Duration::from_secs(1))];
         observer.record_local_observations(&ptb, &timings, Duration::from_secs(2));
         assert_eq!(
@@ -986,8 +1025,7 @@ mod tests {
             Duration::from_secs(2)
         );
 
-        // Third execution still with high utilization - time has passed but not enough to clear excess
-        // when accounting for the new observation; should share
+        // Third execution with significant upward diff and high utilization - should share again
         tokio::time::advance(Duration::from_secs(5)).await;
         let timings = vec![ExecutionTiming::Success(Duration::from_secs(3))];
         observer.record_local_observations(&ptb, &timings, Duration::from_secs(5));
@@ -1002,7 +1040,23 @@ mod tests {
             Duration::from_secs(3)
         );
 
-        // Fourth execution after utilization drops - should not share, even though diff still high
+        // Fourth execution with significant downward diff but still overutilized - should NOT share downward change
+        // (downward changes are only shared for indebted objects, not overutilized ones)
+        tokio::time::advance(Duration::from_millis(150)).await;
+        let timings = vec![ExecutionTiming::Success(Duration::from_millis(100))];
+        observer.record_local_observations(&ptb, &timings, Duration::from_millis(500));
+        assert_eq!(
+            observer
+                .local_observations
+                .get(&key)
+                .unwrap()
+                .last_shared
+                .unwrap()
+                .0,
+            Duration::from_secs(3) // still the old value, no sharing of downward change
+        );
+
+        // Fifth execution after utilization drops - should not share upward diff since not overutilized
         tokio::time::advance(Duration::from_secs(60)).await;
         let timings = vec![ExecutionTiming::Success(Duration::from_secs(11))];
         observer.record_local_observations(&ptb, &timings, Duration::from_secs(11));
@@ -1014,7 +1068,126 @@ mod tests {
                 .last_shared
                 .unwrap()
                 .0,
-            Duration::from_secs(3) // still the old value
+            Duration::from_secs(3) // still the old value, no sharing when not overutilized
+        );
+    }
+
+    #[tokio::test]
+    async fn test_record_local_observations_with_indebted_objects() {
+        telemetry_subscribers::init_for_testing();
+
+        let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+            config.set_per_object_congestion_control_mode_for_testing(
+                PerObjectCongestionControlMode::ExecutionTimeEstimate(
+                    ExecutionTimeEstimateParams {
+                        target_utilization: 100,
+                        allowed_txn_cost_overage_burst_limit_us: 0,
+                        randomness_scalar: 0,
+                        max_estimate_us: u64::MAX,
+                        stored_observations_num_included_checkpoints: 10,
+                        stored_observations_limit: u64::MAX,
+                    },
+                ),
+            );
+            config
+        });
+
+        let mock_consensus_client = MockConsensusClient::new();
+        let authority = TestAuthorityBuilder::new().build().await;
+        let epoch_store = authority.epoch_store_for_testing();
+        let consensus_adapter = Arc::new(ConsensusAdapter::new(
+            Arc::new(mock_consensus_client),
+            CheckpointStore::new_for_tests(),
+            authority.name,
+            Arc::new(ConnectionMonitorStatusForTests {}),
+            100_000,
+            100_000,
+            None,
+            None,
+            ConsensusAdapterMetrics::new_test(),
+            epoch_store.protocol_config().clone(),
+        ));
+        let mut observer = ExecutionTimeObserver::new_for_testing(
+            epoch_store.clone(),
+            Box::new(consensus_adapter.clone()),
+            Duration::from_millis(500), // Low utilization threshold to enable overutilized sharing initially
+        );
+
+        // Create a simple PTB with one move call and one mutable shared input
+        let package = ObjectID::random();
+        let module = "test_module".to_string();
+        let function = "test_function".to_string();
+        let shared_object_id = ObjectID::random();
+        let ptb = ProgrammableTransaction {
+            inputs: vec![CallArg::Object(ObjectArg::SharedObject {
+                id: shared_object_id,
+                initial_shared_version: SequenceNumber::new(),
+                mutable: true,
+            })],
+            commands: vec![Command::MoveCall(Box::new(ProgrammableMoveCall {
+                package,
+                module: module.clone(),
+                function: function.clone(),
+                type_arguments: vec![],
+                arguments: vec![],
+            }))],
+        };
+        let key = ExecutionTimeObservationKey::MoveEntryPoint {
+            package,
+            module: module.clone(),
+            function: function.clone(),
+            type_arguments: vec![],
+        };
+
+        tokio::time::pause();
+
+        // First observation - should not share due to low utilization
+        let timings = vec![ExecutionTiming::Success(Duration::from_secs(1))];
+        observer.record_local_observations(&ptb, &timings, Duration::from_secs(1));
+        assert!(observer
+            .local_observations
+            .get(&key)
+            .unwrap()
+            .last_shared
+            .is_none());
+
+        // Second observation - no time has passed, so now utilization is high; should share upward change
+        let timings = vec![ExecutionTiming::Success(Duration::from_secs(2))];
+        observer.record_local_observations(&ptb, &timings, Duration::from_secs(2));
+        assert_eq!(
+            observer
+                .local_observations
+                .get(&key)
+                .unwrap()
+                .last_shared
+                .unwrap()
+                .0,
+            Duration::from_millis(1500) // (1s + 2s) / 2 = 1.5s
+        );
+
+        // Mark the shared object as indebted and increase utilization threshold to prevent overutilized sharing
+        observer.update_indebted_objects(vec![shared_object_id]);
+        observer
+            .config
+            .observation_sharing_object_utilization_threshold = Some(Duration::from_secs(1000));
+
+        // Wait for min interval and record a significant downward change
+        // This should share because the object is indebted
+        tokio::time::advance(Duration::from_secs(60)).await;
+        let timings = vec![ExecutionTiming::Success(Duration::from_millis(300))];
+        observer.record_local_observations(&ptb, &timings, Duration::from_millis(300));
+
+        // Moving average should be (1s + 2s + 0.3s) / 3 = 1.1s
+        // This downward change should have been shared for indebted object
+        assert_eq!(
+            observer
+                .local_observations
+                .get(&key)
+                .unwrap()
+                .last_shared
+                .unwrap()
+                .0,
+            Duration::from_millis(1100)
         );
     }
 

--- a/crates/sui-core/src/authority/execution_time_estimator.rs
+++ b/crates/sui-core/src/authority/execution_time_estimator.rs
@@ -91,12 +91,12 @@ impl LocalObservations {
             // Positive threshold requires upward change.
             new_average
                 .checked_sub(last_shared)
-                .map_or(false, |diff| diff > last_shared.mul_f64(threshold))
+                .is_some_and(|diff| diff > last_shared.mul_f64(threshold))
         } else {
             // Negative threshold requires downward change.
             last_shared
                 .checked_sub(new_average)
-                .map_or(false, |diff| diff > last_shared.mul_f64(-threshold))
+                .is_some_and(|diff| diff > last_shared.mul_f64(-threshold))
         }
     }
 }


### PR DESCRIPTION
## Description 

- Share upward observations only for overutilized objects
- Share downward observations only for indebted objects

## Test plan 

added unit test

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
