### PR TITLE
Implement naive balance withdraw scheduler

### DIFF
--- a/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/balance_read.rs
+++ b/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/balance_read.rs
@@ -1,0 +1,129 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(test)]
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+#[cfg(test)]
+use parking_lot::RwLock;
+use sui_types::base_types::{ObjectID, SequenceNumber};
+
+use crate::execution_cache::ObjectCacheRead;
+
+#[allow(dead_code)]
+pub(crate) trait AccountBalanceRead: Send + Sync {
+    fn get_account_balance(
+        &self,
+        account_id: &ObjectID,
+        // Version of the accumulator root object, used to
+        // bound the version when we look for child account objects.
+        accumulator_version: SequenceNumber,
+    ) -> u64;
+}
+
+impl AccountBalanceRead for Arc<dyn ObjectCacheRead> {
+    fn get_account_balance(
+        &self,
+        account_id: &ObjectID,
+        accumulator_version: SequenceNumber,
+    ) -> u64 {
+        self.find_object_lt_or_eq_version(*account_id, accumulator_version)
+            .map(|_obj| {
+                // TODO: Get the balance from the object.
+                0
+            })
+            .unwrap_or_default()
+    }
+}
+
+// Mock implementation of a balance account book for testing.
+// Allows setting the balance for a given account at different accumulator versions.
+#[cfg(test)]
+pub(crate) struct MockBalanceRead {
+    inner: Arc<RwLock<MockBalanceReadInner>>,
+}
+
+#[cfg(test)]
+struct MockBalanceReadInner {
+    balances: BTreeMap<ObjectID, BTreeMap<SequenceNumber, u64>>,
+}
+
+#[cfg(test)]
+impl MockBalanceRead {
+    pub(crate) fn new(
+        init_version: SequenceNumber,
+        init_balances: BTreeMap<ObjectID, u64>,
+    ) -> Self {
+        let read = Self {
+            inner: Arc::new(RwLock::new(MockBalanceReadInner {
+                balances: BTreeMap::new(),
+            })),
+        };
+        let balance_changes = init_balances
+            .iter()
+            .map(|(account_id, balance)| (*account_id, *balance as i128))
+            .collect::<BTreeMap<_, _>>();
+        read.settle_balance_changes(init_version, balance_changes);
+        read
+    }
+
+    pub(crate) fn settle_balance_changes(
+        &self,
+        new_accumulator_version: SequenceNumber,
+        balance_changes: BTreeMap<ObjectID, i128>,
+    ) {
+        self.inner
+            .write()
+            .settle_balance_changes(new_accumulator_version, balance_changes);
+    }
+}
+
+#[cfg(test)]
+impl MockBalanceReadInner {
+    fn settle_balance_changes(
+        &mut self,
+        new_accumulator_version: SequenceNumber,
+        balance_changes: BTreeMap<ObjectID, i128>,
+    ) {
+        for (account_id, balance_change) in balance_changes {
+            let balance = self.get_account_balance(&account_id, new_accumulator_version);
+            let new_balance = balance as i128 + balance_change;
+            assert!(new_balance >= 0);
+            self.balances
+                .entry(account_id)
+                .or_default()
+                .insert(new_accumulator_version, new_balance as u64);
+        }
+    }
+
+    fn get_account_balance(
+        &self,
+        account_id: &ObjectID,
+        accumulator_version: SequenceNumber,
+    ) -> u64 {
+        let Some(account_balances) = self.balances.get(account_id) else {
+            return 0;
+        };
+        account_balances
+            .range(..=accumulator_version)
+            .last()
+            .map(|(_, balance)| *balance)
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+impl AccountBalanceRead for MockBalanceRead {
+    /// Mimic the behavior of child object read.
+    /// Find the balance for the given account at the max version
+    /// less or equal to the given accumulator version.
+    fn get_account_balance(
+        &self,
+        account_id: &ObjectID,
+        accumulator_version: SequenceNumber,
+    ) -> u64 {
+        let inner = self.inner.read();
+        inner.get_account_balance(account_id, accumulator_version)
+    }
+}

--- a/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/mod.rs
+++ b/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/mod.rs
@@ -1,0 +1,51 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+
+use sui_types::{
+    base_types::{ObjectID, SequenceNumber},
+    digests::TransactionDigest,
+};
+
+mod balance_read;
+mod naive_scheduler;
+pub(crate) mod scheduler;
+#[cfg(test)]
+mod tests;
+
+/// The result of scheduling the withdraw reservations for a transaction.
+#[allow(dead_code)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub(crate) enum ScheduleResult {
+    /// We know for sure that the withdraw reservations in this transactions all have enough balance.
+    /// This transaction can be executed normally as soon as its object dependencies are ready.
+    SufficientBalance,
+    /// We know for sure that the withdraw reservations in this transactions do not all have enough balance.
+    /// This transaction should result in an execution failure without actually executing it, similar to
+    /// how transaction cancellation works.
+    InsufficientBalance,
+    /// The consensus commit batch of this transaction has already been scheduled in the past.
+    /// The caller should stop the scheduling of this transaction.
+    /// This is to avoid scheduling the same transaction multiple times.
+    AlreadyScheduled,
+}
+
+/// Details regarding a balance settlement, generated when a settlement transaction has been executed
+/// and committed to the writeback cache.
+#[allow(dead_code)]
+pub(crate) struct BalanceSettlement {
+    /// The accumulator version at which the settlement was committed.
+    /// i.e. the root accumulator object is now at this version after the settlement.
+    pub accumulator_version: SequenceNumber,
+    /// The balance changes for each account object ID.
+    pub balance_changes: BTreeMap<ObjectID, i128>,
+}
+
+/// Details regarding all balance withdraw reservations in a transaction.
+#[allow(dead_code)]
+#[derive(Clone)]
+pub(crate) struct TxBalanceWithdraw {
+    pub tx_digest: TransactionDigest,
+    pub reservations: BTreeMap<ObjectID, u64>,
+}

--- a/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/naive_scheduler.rs
+++ b/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/naive_scheduler.rs
@@ -1,0 +1,89 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::BTreeMap, sync::Arc};
+
+use parking_lot::Mutex;
+use sui_types::base_types::SequenceNumber;
+use tokio::sync::watch;
+
+use crate::execution_scheduler::balance_withdraw_scheduler::{
+    balance_read::AccountBalanceRead,
+    scheduler::{BalanceWithdrawSchedulerTrait, WithdrawReservations},
+    BalanceSettlement, ScheduleResult,
+};
+
+/// A naive implementation of the balance withdraw scheduler that does not attempt to optimize the scheduling.
+/// For each withdraw reservation, it will always wait until the dependent accumulator object is available,
+/// and then check if the balance is sufficient.
+/// This implementation is simple and easy to understand, but it is not efficient.
+/// It is only used to unblock further development of the balance withdraw scheduler.
+#[allow(dead_code)]
+pub(crate) struct NaiveBalanceWithdrawScheduler {
+    balance_read: Arc<dyn AccountBalanceRead>,
+    last_settled_version_sender: watch::Sender<SequenceNumber>,
+    last_settled_version_receiver: Mutex<Option<watch::Receiver<SequenceNumber>>>,
+}
+
+impl NaiveBalanceWithdrawScheduler {
+    #[allow(dead_code)]
+    pub fn new(
+        balance_read: Arc<dyn AccountBalanceRead>,
+        last_settled_accumulator_version: SequenceNumber,
+    ) -> Arc<Self> {
+        let (last_settled_version_sender, last_settled_version_receiver) =
+            watch::channel(last_settled_accumulator_version);
+        Arc::new(Self {
+            balance_read,
+            last_settled_version_sender,
+            last_settled_version_receiver: Mutex::new(Some(last_settled_version_receiver)),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl BalanceWithdrawSchedulerTrait for NaiveBalanceWithdrawScheduler {
+    async fn schedule_withdraws(&self, withdraws: WithdrawReservations) {
+        let mut receiver = self.last_settled_version_receiver.lock().take().unwrap();
+        loop {
+            let last_settled_version = *receiver.borrow_and_update();
+            if last_settled_version >= withdraws.accumulator_version {
+                break;
+            }
+            if receiver.changed().await.is_err() {
+                *self.last_settled_version_receiver.lock() = Some(receiver);
+                return;
+            }
+        }
+        *self.last_settled_version_receiver.lock() = Some(receiver);
+
+        let mut cur_balances = BTreeMap::new();
+        for (withdraw, sender) in withdraws.withdraws.into_iter().zip(withdraws.senders) {
+            let mut success = true;
+            for (object_id, amount) in &withdraw.reservations {
+                let balance = cur_balances.entry(*object_id).or_insert_with(|| {
+                    self.balance_read
+                        .get_account_balance(object_id, withdraws.accumulator_version)
+                });
+                if *balance < *amount {
+                    success = false;
+                    break;
+                }
+            }
+            if success {
+                for (object_id, amount) in withdraw.reservations {
+                    *cur_balances.get_mut(&object_id).unwrap() -= amount;
+                }
+                let _ = sender.send(ScheduleResult::SufficientBalance);
+            } else {
+                let _ = sender.send(ScheduleResult::InsufficientBalance);
+            }
+        }
+    }
+
+    async fn settle_balances(&self, settlement: BalanceSettlement) {
+        let _ = self
+            .last_settled_version_sender
+            .send(settlement.accumulator_version);
+    }
+}

--- a/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/scheduler.rs
+++ b/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/scheduler.rs
@@ -1,0 +1,156 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::BTreeMap, sync::Arc};
+
+use crate::execution_scheduler::balance_withdraw_scheduler::{
+    balance_read::AccountBalanceRead, naive_scheduler::NaiveBalanceWithdrawScheduler,
+    BalanceSettlement, ScheduleResult, TxBalanceWithdraw,
+};
+use mysten_metrics::monitored_mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use sui_types::{base_types::SequenceNumber, digests::TransactionDigest};
+use tokio::sync::oneshot;
+
+#[allow(dead_code)]
+#[async_trait::async_trait]
+pub(crate) trait BalanceWithdrawSchedulerTrait: Send + Sync {
+    async fn schedule_withdraws(&self, withdraws: WithdrawReservations);
+    async fn settle_balances(&self, settlement: BalanceSettlement);
+}
+
+#[allow(dead_code)]
+pub(crate) struct WithdrawReservations {
+    pub accumulator_version: SequenceNumber,
+    pub withdraws: Vec<TxBalanceWithdraw>,
+    pub senders: Vec<oneshot::Sender<ScheduleResult>>,
+}
+
+#[allow(dead_code)]
+#[derive(Clone)]
+pub(crate) struct BalanceWithdrawScheduler {
+    inner: Arc<dyn BalanceWithdrawSchedulerTrait>,
+    /// Use channels to process withdraws and settlements asynchronously without blocking the caller.
+    withdraw_sender: UnboundedSender<WithdrawReservations>,
+    settlement_sender: UnboundedSender<BalanceSettlement>,
+}
+
+impl WithdrawReservations {
+    #[allow(dead_code)]
+    pub fn new(
+        accumulator_version: SequenceNumber,
+        withdraws: Vec<TxBalanceWithdraw>,
+    ) -> (
+        Self,
+        BTreeMap<TransactionDigest, oneshot::Receiver<ScheduleResult>>,
+    ) {
+        let (senders, receivers) = withdraws
+            .iter()
+            .map(|withdraw| {
+                let (sender, receiver) = oneshot::channel();
+                (sender, (withdraw.tx_digest, receiver))
+            })
+            .unzip();
+        (
+            Self {
+                accumulator_version,
+                withdraws,
+                senders,
+            },
+            receivers,
+        )
+    }
+}
+
+impl BalanceWithdrawScheduler {
+    #[allow(dead_code)]
+    pub fn new(
+        balance_read: Arc<dyn AccountBalanceRead>,
+        init_accumulator_version: SequenceNumber,
+    ) -> Arc<Self> {
+        let inner = NaiveBalanceWithdrawScheduler::new(balance_read, init_accumulator_version);
+        let (withdraw_sender, withdraw_receiver) =
+            unbounded_channel("withdraw_scheduler_withdraws");
+        let (settlement_sender, settlement_receiver) =
+            unbounded_channel("withdraw_scheduler_settlements");
+        let scheduler = Arc::new(Self {
+            inner,
+            withdraw_sender,
+            settlement_sender,
+        });
+        tokio::spawn(scheduler.clone().process_withdraw_task(withdraw_receiver));
+        tokio::spawn(
+            scheduler
+                .clone()
+                .process_settlement_task(settlement_receiver, init_accumulator_version),
+        );
+        scheduler
+    }
+
+    /// This function will be called either by ConsensusHandler or the CheckpointExecutor.
+    /// It will be called at most once per consensus commit batch that all reads the same root accumulator version.
+    /// If a consensus commit batch does not contain any withdraw reservations, it can skip calling this function.
+    /// It must be called sequentially in order to correctly schedule withdraws.
+    /// It is OK to call this function multiple times for the same accumulator version (which will happen between
+    /// the calls to the function by ConsensusHandler and the CheckpointExecutor).
+    #[allow(dead_code)]
+    pub fn schedule_withdraws(
+        &self,
+        accumulator_version: SequenceNumber,
+        withdraws: Vec<TxBalanceWithdraw>,
+    ) -> BTreeMap<TransactionDigest, oneshot::Receiver<ScheduleResult>> {
+        let (reservations, receivers) = WithdrawReservations::new(accumulator_version, withdraws);
+        if let Err(err) = self.withdraw_sender.send(reservations) {
+            tracing::error!("Failed to send withdraw reservations: {:?}", err);
+        }
+        receivers
+    }
+
+    /// This function is called whenever a new version of the accumulator root object is committed
+    /// in the writeback cache.
+    /// It is OK to call this function out of order, as the implementation will handle the out of order calls.
+    /// It must be called once for each version of the accumulator root object.
+    #[allow(dead_code)]
+    pub fn settle_balances(&self, settlement: BalanceSettlement) {
+        if let Err(err) = self.settlement_sender.send(settlement) {
+            tracing::error!("Failed to send balance settlement: {:?}", err);
+        }
+    }
+
+    async fn process_withdraw_task(
+        self: Arc<Self>,
+        mut withdraw_receiver: UnboundedReceiver<WithdrawReservations>,
+    ) {
+        let mut last_scheduled_version = None;
+        while let Some(event) = withdraw_receiver.recv().await {
+            if let Some(last_scheduled_version) = last_scheduled_version {
+                if event.accumulator_version <= last_scheduled_version {
+                    // It is possible to receive withdraw reservations for the same accumulator version
+                    // multiple times due to the race between consensus and checkpoint execution.
+                    // Hence we may receive a version from the past after the version is updated.
+                    for sender in event.senders {
+                        let _ = sender.send(ScheduleResult::AlreadyScheduled);
+                    }
+                    continue;
+                }
+            }
+            last_scheduled_version = Some(event.accumulator_version);
+            self.inner.schedule_withdraws(event).await;
+        }
+    }
+
+    async fn process_settlement_task(
+        self: Arc<Self>,
+        mut settlement_receiver: UnboundedReceiver<BalanceSettlement>,
+        init_accumulator_version: SequenceNumber,
+    ) {
+        let mut expected_version = init_accumulator_version.next();
+        let mut pending_settlements = BTreeMap::new();
+        while let Some(settlement) = settlement_receiver.recv().await {
+            pending_settlements.insert(settlement.accumulator_version, settlement);
+            while let Some(settlement) = pending_settlements.remove(&expected_version) {
+                expected_version = settlement.accumulator_version.next();
+                self.inner.settle_balances(settlement).await;
+            }
+        }
+    }
+}

--- a/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/tests.rs
+++ b/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/tests.rs
@@ -1,0 +1,454 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::execution_scheduler::balance_withdraw_scheduler::{
+    balance_read::MockBalanceRead, scheduler::BalanceWithdrawScheduler, BalanceSettlement,
+    ScheduleResult, TxBalanceWithdraw,
+};
+use rand::{seq::SliceRandom, Rng};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
+use sui_types::{
+    base_types::{ObjectID, SequenceNumber},
+    digests::TransactionDigest,
+};
+#[cfg(test)]
+use tokio::sync::oneshot;
+
+#[derive(Clone)]
+struct TestScheduler {
+    mock_read: Arc<MockBalanceRead>,
+    scheduler: Arc<BalanceWithdrawScheduler>,
+}
+
+impl TestScheduler {
+    fn new(init_version: SequenceNumber, init_balances: BTreeMap<ObjectID, u64>) -> Self {
+        let mock_read = Arc::new(MockBalanceRead::new(init_version, init_balances));
+        let scheduler = BalanceWithdrawScheduler::new(mock_read.clone(), init_version);
+        Self {
+            mock_read,
+            scheduler,
+        }
+    }
+
+    fn settle_balance_changes(&self, version: SequenceNumber, changes: BTreeMap<ObjectID, i128>) {
+        self.mock_read
+            .settle_balance_changes(version, changes.clone());
+        self.scheduler.settle_balances(BalanceSettlement {
+            accumulator_version: version,
+            balance_changes: changes,
+        });
+    }
+}
+
+#[cfg(test)]
+async fn wait_until(receiver: oneshot::Receiver<ScheduleResult>, until: ScheduleResult) {
+    use std::time::Duration;
+
+    use tokio::time::timeout;
+
+    timeout(Duration::from_secs(3), async {
+        assert_eq!(receiver.await.unwrap(), until);
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn test_basic_sufficient_balance() {
+    let init_version = SequenceNumber::from_u64(0);
+    let account = ObjectID::random();
+    let test = TestScheduler::new(init_version, BTreeMap::from([(account, 100)]));
+
+    let reservations = BTreeMap::from([(account, 50)]);
+    let withdraw = TxBalanceWithdraw {
+        tx_digest: TransactionDigest::random(),
+        reservations,
+    };
+
+    let receivers = test
+        .scheduler
+        .schedule_withdraws(init_version, vec![withdraw]);
+    for (_, receiver) in receivers {
+        wait_until(receiver, ScheduleResult::SufficientBalance).await;
+    }
+}
+
+#[tokio::test]
+async fn test_basic_insufficient_balance() {
+    let init_version = SequenceNumber::from_u64(0);
+    let account = ObjectID::random();
+    let test = TestScheduler::new(init_version, BTreeMap::from([(account, 100)]));
+
+    let reservations = BTreeMap::from([(account, 150)]);
+    let withdraw = TxBalanceWithdraw {
+        tx_digest: TransactionDigest::random(),
+        reservations,
+    };
+
+    let receivers = test
+        .scheduler
+        .schedule_withdraws(init_version, vec![withdraw]);
+    for (_, receiver) in receivers {
+        wait_until(receiver, ScheduleResult::InsufficientBalance).await;
+    }
+}
+
+#[tokio::test]
+async fn test_already_scheduled() {
+    let init_version = SequenceNumber::from_u64(0);
+    let account = ObjectID::random();
+    let test = TestScheduler::new(init_version, BTreeMap::from([(account, 100)]));
+
+    let reservations = BTreeMap::from([(account, 50)]);
+    let withdraw = TxBalanceWithdraw {
+        tx_digest: TransactionDigest::random(),
+        reservations,
+    };
+
+    let receivers = test
+        .scheduler
+        .schedule_withdraws(init_version, vec![withdraw.clone()]);
+    for (_, receiver) in receivers {
+        wait_until(receiver, ScheduleResult::SufficientBalance).await;
+    }
+
+    let receivers = test
+        .scheduler
+        .schedule_withdraws(init_version, vec![withdraw]);
+    for (_, receiver) in receivers {
+        wait_until(receiver, ScheduleResult::AlreadyScheduled).await;
+    }
+}
+
+#[tokio::test]
+async fn test_basic_settlement() {
+    let init_version = SequenceNumber::from_u64(0);
+    let account = ObjectID::random();
+    let test = TestScheduler::new(init_version, BTreeMap::from([(account, 100)]));
+
+    let reservations = BTreeMap::from([(account, 50)]);
+    let withdraw = TxBalanceWithdraw {
+        tx_digest: TransactionDigest::random(),
+        reservations,
+    };
+
+    let receivers = test
+        .scheduler
+        .schedule_withdraws(init_version, vec![withdraw.clone()]);
+    for (_, receiver) in receivers {
+        wait_until(receiver, ScheduleResult::SufficientBalance).await;
+    }
+
+    let next_version = init_version.next();
+    test.settle_balance_changes(next_version, BTreeMap::from([(account, -50i128)]));
+
+    let receivers = test
+        .scheduler
+        .schedule_withdraws(next_version, vec![withdraw]);
+    for (_, receiver) in receivers {
+        wait_until(receiver, ScheduleResult::SufficientBalance).await;
+    }
+}
+
+#[tokio::test]
+async fn test_out_of_order_settlements() {
+    let v0 = SequenceNumber::from_u64(0);
+    let account = ObjectID::random();
+    let test = TestScheduler::new(v0, BTreeMap::from([(account, 100)]));
+
+    let v1 = v0.next();
+    let v2 = v1.next();
+
+    test.settle_balance_changes(v2, BTreeMap::from([(account, -80i128)]));
+    test.settle_balance_changes(v1, BTreeMap::from([(account, -20i128)]));
+
+    let withdraw1 = TxBalanceWithdraw {
+        tx_digest: TransactionDigest::random(),
+        reservations: BTreeMap::from([(account, 50)]),
+    };
+    let mut receivers = test
+        .scheduler
+        .schedule_withdraws(v0, vec![withdraw1.clone()]);
+    wait_until(
+        receivers.remove(&withdraw1.tx_digest).unwrap(),
+        ScheduleResult::SufficientBalance,
+    )
+    .await;
+
+    let withdraw2 = TxBalanceWithdraw {
+        tx_digest: TransactionDigest::random(),
+        reservations: BTreeMap::from([(account, 80)]),
+    };
+    let mut receivers = test
+        .scheduler
+        .schedule_withdraws(v1, vec![withdraw2.clone()]);
+    wait_until(
+        receivers.remove(&withdraw2.tx_digest).unwrap(),
+        ScheduleResult::SufficientBalance,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_multi_accounts() {
+    let init_version = SequenceNumber::from_u64(0);
+    let account1 = ObjectID::random();
+    let account2 = ObjectID::random();
+    let test = TestScheduler::new(
+        init_version,
+        BTreeMap::from([(account1, 100), (account2, 100)]),
+    );
+
+    let reservations1 = BTreeMap::from([(account1, 50), (account2, 50)]);
+    let withdraw1 = TxBalanceWithdraw {
+        tx_digest: TransactionDigest::random(),
+        reservations: reservations1,
+    };
+    let reservations2 = BTreeMap::from([(account1, 50), (account2, 60)]);
+    let withdraw2 = TxBalanceWithdraw {
+        tx_digest: TransactionDigest::random(),
+        reservations: reservations2,
+    };
+    let reservations3 = BTreeMap::from([(account1, 50), (account2, 50)]);
+    let withdraw3 = TxBalanceWithdraw {
+        tx_digest: TransactionDigest::random(),
+        reservations: reservations3,
+    };
+
+    let mut receivers = test.scheduler.schedule_withdraws(
+        init_version,
+        vec![withdraw1.clone(), withdraw2.clone(), withdraw3.clone()],
+    );
+    wait_until(
+        receivers.remove(&withdraw1.tx_digest).unwrap(),
+        ScheduleResult::SufficientBalance,
+    )
+    .await;
+    wait_until(
+        receivers.remove(&withdraw2.tx_digest).unwrap(),
+        ScheduleResult::InsufficientBalance,
+    )
+    .await;
+    wait_until(
+        receivers.remove(&withdraw3.tx_digest).unwrap(),
+        ScheduleResult::SufficientBalance,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_multi_settlements() {
+    let init_version = SequenceNumber::from_u64(0);
+    let account = ObjectID::random();
+    let test = TestScheduler::new(init_version, BTreeMap::from([(account, 100)]));
+
+    let reservations = BTreeMap::from([(account, 50)]);
+    let withdraw = TxBalanceWithdraw {
+        tx_digest: TransactionDigest::random(),
+        reservations,
+    };
+
+    let mut receivers = test
+        .scheduler
+        .schedule_withdraws(init_version, vec![withdraw.clone()]);
+    wait_until(
+        receivers.remove(&withdraw.tx_digest).unwrap(),
+        ScheduleResult::SufficientBalance,
+    )
+    .await;
+
+    let next_version = init_version.next();
+    test.settle_balance_changes(next_version, BTreeMap::from([(account, -50i128)]));
+
+    let mut receivers = test
+        .scheduler
+        .schedule_withdraws(next_version, vec![withdraw.clone()]);
+    wait_until(
+        receivers.remove(&withdraw.tx_digest).unwrap(),
+        ScheduleResult::SufficientBalance,
+    )
+    .await;
+
+    let next_version = next_version.next();
+    test.settle_balance_changes(next_version, BTreeMap::from([(account, -50i128)]));
+
+    let mut receivers = test
+        .scheduler
+        .schedule_withdraws(next_version, vec![withdraw.clone()]);
+    wait_until(
+        receivers.remove(&withdraw.tx_digest).unwrap(),
+        ScheduleResult::InsufficientBalance,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_settlement_far_ahead_of_schedule() {
+    let v0 = SequenceNumber::from_u64(0);
+    let account = ObjectID::random();
+    let test = TestScheduler::new(v0, BTreeMap::from([(account, 100)]));
+    let v1 = v0.next();
+    let v2 = v1.next();
+    let v3 = v2.next();
+
+    // From v0 to v1, we reserve 100, but does not withdraw anything.
+    test.settle_balance_changes(v1, BTreeMap::from([]));
+
+    // From v1 to v2, we reserve 100, and withdraw 50.
+    test.settle_balance_changes(v2, BTreeMap::from([(account, -50i128)]));
+
+    // From v2 to v3, we reserve 50, and withdraw 50.
+    test.settle_balance_changes(v3, BTreeMap::from([(account, -50i128)]));
+
+    let withdraw = TxBalanceWithdraw {
+        tx_digest: TransactionDigest::random(),
+        reservations: BTreeMap::from([(account, 100)]),
+    };
+    let mut receivers = test
+        .scheduler
+        .schedule_withdraws(v0, vec![withdraw.clone()]);
+    wait_until(
+        receivers.remove(&withdraw.tx_digest).unwrap(),
+        ScheduleResult::SufficientBalance,
+    )
+    .await;
+
+    let mut receivers = test
+        .scheduler
+        .schedule_withdraws(v1, vec![withdraw.clone()]);
+    wait_until(
+        receivers.remove(&withdraw.tx_digest).unwrap(),
+        ScheduleResult::SufficientBalance,
+    )
+    .await;
+
+    let withdraw = TxBalanceWithdraw {
+        tx_digest: TransactionDigest::random(),
+        reservations: BTreeMap::from([(account, 50)]),
+    };
+
+    let mut receivers = test
+        .scheduler
+        .schedule_withdraws(v2, vec![withdraw.clone()]);
+    wait_until(
+        receivers.remove(&withdraw.tx_digest).unwrap(),
+        ScheduleResult::SufficientBalance,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn stress_test() {
+    let num_accounts = 100;
+    let num_transactions = 10000;
+
+    let mut version = SequenceNumber::from_u64(0);
+    let accounts = (0..num_accounts)
+        .map(|_| ObjectID::random())
+        .collect::<Vec<_>>();
+    let mut rng = rand::thread_rng();
+    let init_balances = accounts
+        .iter()
+        .filter_map(|account_id| {
+            if rng.gen_bool(0.7) {
+                Some((*account_id, rng.gen_range(0..10)))
+            } else {
+                None
+            }
+        })
+        .collect::<BTreeMap<_, _>>();
+    let test = TestScheduler::new(version, init_balances.clone());
+
+    let mut withdraws = Vec::new();
+    let mut expected_results = BTreeMap::new();
+    let mut settlements = Vec::new();
+    let mut balances = init_balances;
+    let mut cur_reservations = Vec::new();
+
+    for idx in 0..num_transactions {
+        let num_accounts = rng.gen_range(1..3);
+        let account_ids = accounts
+            .choose_multiple(&mut rng, num_accounts)
+            .cloned()
+            .collect::<Vec<_>>();
+        let reservations = account_ids
+            .iter()
+            .map(|account_id| (*account_id, rng.gen_range(0..10)))
+            .collect::<BTreeMap<_, _>>();
+        cur_reservations.push(TxBalanceWithdraw {
+            tx_digest: TransactionDigest::random(),
+            reservations,
+        });
+        if rng.gen_bool(0.2) || idx == num_transactions - 1 {
+            let mut accumulated_reservations: BTreeMap<ObjectID, u64> = BTreeMap::new();
+            let mut balance_changes: BTreeMap<ObjectID, i128> = BTreeMap::new();
+            for reservation in &cur_reservations {
+                let mut success = true;
+                for (account_id, amount) in &reservation.reservations {
+                    if *amount
+                        + accumulated_reservations
+                            .get(account_id)
+                            .copied()
+                            .unwrap_or_default()
+                        > balances.get(account_id).copied().unwrap_or_default()
+                    {
+                        success = false;
+                        break;
+                    }
+                }
+                if success {
+                    for (account_id, amount) in &reservation.reservations {
+                        *accumulated_reservations.entry(*account_id).or_default() += *amount;
+                    }
+                    expected_results
+                        .insert(reservation.tx_digest, ScheduleResult::SufficientBalance);
+                    for (account_id, amount) in &reservation.reservations {
+                        *balance_changes.entry(*account_id).or_default() +=
+                            -(rng.gen_range(0..=*amount) as i128);
+                    }
+                } else {
+                    expected_results
+                        .insert(reservation.tx_digest, ScheduleResult::InsufficientBalance);
+                }
+            }
+            let num_deposits = rng.gen_range(0..5);
+            for _ in 0..num_deposits {
+                let account_id = accounts.choose(&mut rng).unwrap();
+                let amount = rng.gen_range(0..10) as i128;
+                *balance_changes.entry(*account_id).or_default() += amount;
+            }
+            for (account_id, amount) in &balance_changes {
+                let existing = balances.entry(*account_id).or_default();
+                *existing = (*existing as i128 + *amount) as u64;
+            }
+            withdraws.push((version, std::mem::take(&mut cur_reservations)));
+            version = version.next();
+            settlements.push((version, balance_changes));
+        }
+    }
+
+    // Start a separate thread to run all settlements on the scheduler.
+    let test_clone = test.clone();
+    let settle_task = tokio::spawn(async move {
+        for (version, balance_changes) in settlements {
+            test_clone.settle_balance_changes(version, balance_changes);
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    });
+
+    // Run all withdraws on the scheduler.
+    let mut all_receivers = BTreeMap::new();
+    for (version, withdraws) in withdraws {
+        let receivers = test.scheduler.schedule_withdraws(version, withdraws);
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        all_receivers.extend(receivers);
+    }
+
+    // Wait for the settle task to finish.
+    settle_task.await.unwrap();
+
+    // Wait for all receivers to be processed.
+    for (tx_digest, receiver) in all_receivers {
+        wait_until(receiver, expected_results[&tx_digest]).await;
+    }
+}

--- a/crates/sui-core/src/execution_scheduler/mod.rs
+++ b/crates/sui-core/src/execution_scheduler/mod.rs
@@ -23,6 +23,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use tokio::time::Instant;
 use transaction_manager::TransactionManager;
 
+mod balance_withdraw_scheduler;
 pub(crate) mod execution_scheduler_impl;
 mod overload_tracker;
 pub(crate) mod transaction_manager;


### PR DESCRIPTION
## Description 

This PR implements a naive balance withdraw scheduler, that always wait for the previous accumulator version to be settled before scheduling the next set of withdraws.
It is meant to serve a few purposes:
1. Set up the interface so we can all see how the system should interact with it.
2. Allow us to make progress in testing the rest of the system
3. We can use this naive implementation to test a more optimistic implementation.

The scheduler exposes 2 APIs:
1. schedule_withdraws. This will be called from ConsensusHandler, on every batch of consensus commits, providing the list of withdraws as well as the version of the accumulator root object they will be reading from. This will immediately return a list of notify receivers, which will be carried into the ExecutionScheduler. It will use these receivers to wait for the withdraws to be reserved first, and then go on with the normal object dependency flow in the scheduler, eventually ready for execution. Note that since we use the balance withdraw scheduler to schedule withdraw reservations, we no longer need to include the accumulator root object in the object dependency when it waits for all input objects to be ready.
2. settle_balance_changes. This will be called either in authority state or writeback cache, as soon as we finish executing a settlement transaction and write the output to the writeback cache, we will call this function to notify the scheduler that a new accumulator version is available with a list of balance settlements.

The interaction with above is relatively straightforward in a naive scheduler implementation.
However with an optimistic version, we will need to make sure that during execution, a transaction is able to read an earlier version of the accumulator root object without causing any data inconsistencies.

## Test plan 

Added unit tests and stress tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
