### PR TITLE
[move-package] speedup clones with `--filter=tree:0`

### DIFF
--- a/external-crates/move/crates/move-package/src/resolution/dependency_cache.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_cache.rs
@@ -89,10 +89,14 @@ impl DependencyCache {
                         git_url,
                     )?;
                     // If the cached folder does not exist, download and clone accordingly
-                    if let Ok(mut output) = Command::new("git")
-                        .args([OsStr::new("clone"), os_git_url, git_path.as_os_str()])
-                        .stdin(Stdio::null())
-                        .spawn()
+                    if let Ok(mut output) = dbg!(Command::new("git").args([
+                        OsStr::new("clone"),
+                        OsStr::new("--filter=tree:0"),
+                        os_git_url,
+                        git_path.as_os_str(),
+                    ]))
+                    .stdin(Stdio::null())
+                    .spawn()
                     {
                         output.wait().map_err(|_| {
                             anyhow::anyhow!(


### PR DESCRIPTION
## Description 

This attempts to speedup initial clones of git repos in the Move package manager by cloning with `--filter=tree:0`. This will clone `HEAD` + commit information sufficient for checking out other branches or revisions, but data for other branches and revisions will be checked out lazily. See [here](https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone) for an explanation of the options available.

There is probably more that can be done here, but it feels like this might be a good first (easy step) as I found this decreased initial build times by half.

Adding @bmwill as he is the resident git-master and will be able to tell me if I'm jousting at windmills here and this won't work at all...

## Test plan 

CI + tested locally and noticed on average build times of about half (so a fresh clone + build on an empty package using the Sui framework was ~54s now is ~21s on my machine).  

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: Improved initial clones times for Move packages that are git dependencies. 
- [ ] Rust SDK:
