### PR TITLE
[traffic controller] show dry run status via metric

### DIFF
--- a/crates/sui-core/src/traffic_controller/metrics.rs
+++ b/crates/sui-core/src/traffic_controller/metrics.rs
@@ -28,6 +28,7 @@ pub struct TrafficControllerMetrics {
     pub error_client_threshold: IntGauge,
     pub spam_proxied_client_threshold: IntGauge,
     pub error_proxied_client_threshold: IntGauge,
+    pub dry_run_enabled: IntGauge,
 }
 
 impl TrafficControllerMetrics {
@@ -154,6 +155,12 @@ impl TrafficControllerMetrics {
             error_proxied_client_threshold: register_int_gauge_with_registry!(
                 "error_proxied_client_threshold",
                 "Error proxied client threshold",
+                registry
+            )
+            .unwrap(),
+            dry_run_enabled: register_int_gauge_with_registry!(
+                "dry_run_enabled",
+                "If 1, dry run mode is enabled and traffic will not be blocked",
                 registry
             )
             .unwrap(),

--- a/crates/sui-core/src/traffic_controller/mod.rs
+++ b/crates/sui-core/src/traffic_controller/mod.rs
@@ -83,6 +83,7 @@ impl TrafficController {
         metrics: TrafficControllerMetrics,
         fw_config: Option<RemoteFirewallConfig>,
     ) -> Self {
+        metrics.dry_run_enabled.set(policy_config.dry_run as i64);
         match policy_config.allow_list {
             Some(allow_list) => {
                 let allowlist = allow_list


### PR DESCRIPTION
## Description 

add a metric so we can discern if any validators have dry run disabled

Fine to only update the metric in `init()` right now. I'll update https://github.com/MystenLabs/sui/pull/20887 to keep the metric correctly synced

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
