### PR TITLE
[static-ptbs] Add ability to serialize values without needing layouts

### DIFF
--- a/external-crates/move/crates/move-stdlib-natives/src/bcs.rs
+++ b/external-crates/move/crates/move-stdlib-natives/src/bcs.rs
@@ -68,7 +68,7 @@ fn native_to_bytes(
     };
     // serialize value
     let val = ref_to_val.read_ref()?;
-    let serialized_value = match val.simple_serialize(&layout) {
+    let serialized_value = match val.typed_serialize(&layout) {
         Some(serialized_value) => serialized_value,
         None => {
             // If we run out of gas when charging for failure, we don't want the `OUT_OF_GAS` error

--- a/external-crates/move/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/runtime.rs
@@ -281,7 +281,7 @@ impl VMRuntime {
             })?
         };
 
-        let bytes = value.simple_serialize(&layout).ok_or_else(|| {
+        let bytes = value.typed_serialize(&layout).ok_or_else(|| {
             PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
                 .with_message("failed to serialize return values".to_string())
         })?;

--- a/external-crates/move/crates/move-vm-types/Cargo.toml
+++ b/external-crates/move/crates/move-vm-types/Cargo.toml
@@ -22,6 +22,7 @@ move-vm-profiler.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
+move-core-types = { workspace = true, features = ["fuzzing"] }
 
 [features]
 default = []

--- a/external-crates/move/crates/move-vm-types/src/values/mod.rs
+++ b/external-crates/move/crates/move-vm-types/src/values/mod.rs
@@ -7,7 +7,7 @@ pub mod values_impl;
 #[cfg(test)]
 mod value_tests;
 
-#[cfg(all(test, feature = "fuzzing"))]
+#[cfg(any(test, feature = "fuzzing"))]
 mod value_prop_tests;
 
 pub use values_impl::*;

--- a/external-crates/move/crates/move-vm-types/src/values/value_prop_tests.rs
+++ b/external-crates/move/crates/move-vm-types/src/values/value_prop_tests.rs
@@ -9,7 +9,10 @@ use proptest::prelude::*;
 proptest! {
     #[test]
     fn serializer_round_trip((layout, value) in layout_and_value_strategy()) {
-        let blob = value.simple_serialize(&layout).expect("must serialize");
+        let typed_blob = value.typed_serialize(&layout).expect("must serialize");
+        let blob = value.serialize().expect("must serialize");
+        assert_eq!(typed_blob, blob);
+
         let value_deserialized = Value::simple_deserialize(&blob, &layout).expect("must deserialize");
         assert!(value.equals(&value_deserialized).unwrap());
 

--- a/external-crates/move/crates/move-vm-types/src/values/value_tests.rs
+++ b/external-crates/move/crates/move-vm-types/src/values/value_tests.rs
@@ -4,7 +4,7 @@
 
 use crate::{loaded_data::runtime_types::Type, values::*, views::*};
 use move_binary_format::errors::*;
-use move_core_types::{account_address::AccountAddress, u256::U256};
+use move_core_types::{account_address::AccountAddress, runtime_value, u256::U256};
 
 #[test]
 fn locals() -> PartialVMResult<()> {
@@ -230,4 +230,24 @@ fn test_vm_value_vector_u64_casting() {
 #[test]
 fn assert_sizes() {
     assert_eq!(size_of::<Value>(), 16);
+}
+
+#[test]
+fn signer_equivalence() -> PartialVMResult<()> {
+    let addr = AccountAddress::TWO;
+    let signer = Value::signer(addr);
+
+    assert_eq!(
+        signer.serialize(),
+        signer.typed_serialize(&runtime_value::MoveTypeLayout::Signer)
+    );
+
+    assert_eq!(
+        signer.serialize(),
+        signer.typed_serialize(&runtime_value::MoveTypeLayout::Struct(Box::new(
+            runtime_value::MoveStructLayout(Box::new(vec![runtime_value::MoveTypeLayout::Address]))
+        )))
+    );
+
+    Ok(())
 }

--- a/external-crates/move/crates/move-vm-types/src/values/values_impl.rs
+++ b/external-crates/move/crates/move-vm-types/src/values/values_impl.rs
@@ -3380,12 +3380,103 @@ impl Value {
         bcs::from_bytes_seed(SeedWrapper { layout }, blob).ok()
     }
 
-    pub fn simple_serialize(&self, layout: &MoveTypeLayout) -> Option<Vec<u8>> {
+    pub fn typed_serialize(&self, layout: &MoveTypeLayout) -> Option<Vec<u8>> {
         bcs::to_bytes(&AnnotatedValue {
             layout,
             val: &self.0,
         })
         .ok()
+    }
+
+    pub fn serialize(&self) -> Option<Vec<u8>> {
+        bcs::to_bytes(&self.0).ok()
+    }
+}
+
+impl serde::Serialize for ValueImpl {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            ValueImpl::U8(u) => serializer.serialize_u8(*u),
+            ValueImpl::U16(u) => serializer.serialize_u16(*u),
+            ValueImpl::U32(u) => serializer.serialize_u32(*u),
+            ValueImpl::U64(u) => serializer.serialize_u64(*u),
+            ValueImpl::U128(u) => serializer.serialize_u128(**u),
+            ValueImpl::U256(u) => u.serialize(serializer),
+            ValueImpl::Bool(b) => serializer.serialize_bool(*b),
+            ValueImpl::Address(a) => a.serialize(serializer),
+            ValueImpl::Container(container) => container.serialize(serializer),
+            v @ (ValueImpl::ContainerRef(_) | ValueImpl::IndexedRef(_) | ValueImpl::Invalid) => {
+                Err(invariant_violation::<S>(format!(
+                    "cannot serialize value {:?}",
+                    v
+                )))
+            }
+        }
+    }
+}
+
+impl serde::Serialize for Container {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Container::VecU8(r) => r.borrow().serialize(serializer),
+            Container::VecU16(r) => r.borrow().serialize(serializer),
+            Container::VecU32(r) => r.borrow().serialize(serializer),
+            Container::VecU64(r) => r.borrow().serialize(serializer),
+            Container::VecU128(r) => r.borrow().serialize(serializer),
+            Container::VecU256(r) => r.borrow().serialize(serializer),
+            Container::VecBool(r) => r.borrow().serialize(serializer),
+            Container::VecAddress(r) => r.borrow().serialize(serializer),
+            Container::Vec(r) => {
+                let v = r.borrow();
+                let mut s = serializer.serialize_seq(Some(v.len()))?;
+                for v in v.iter() {
+                    s.serialize_element(v)?;
+                }
+                s.end()
+            }
+            Container::Struct(r) => {
+                let v = r.borrow();
+                let mut t = serializer.serialize_tuple(v.len())?;
+                for val in v.iter() {
+                    t.serialize_element(&val)?;
+                }
+                t.end()
+            }
+            Container::Variant(r) => {
+                let (tag, values) = &*r.borrow();
+                let tag = if *tag as u64 > VARIANT_COUNT_MAX {
+                    return Err(serde::ser::Error::custom(format!(
+                        "Variant tag {} is greater than the maximum allowed value of {}",
+                        tag, VARIANT_COUNT_MAX
+                    )));
+                } else {
+                    *tag as u8
+                };
+
+                struct VariantsSerializer<'a>(&'a [ValueImpl]);
+                impl<'a> serde::Serialize for VariantsSerializer<'a> {
+                    fn serialize<S: serde::Serializer>(
+                        &self,
+                        serializer: S,
+                    ) -> Result<S::Ok, S::Error> {
+                        let mut t = serializer.serialize_tuple(self.0.len())?;
+                        for val in self.0.iter() {
+                            t.serialize_element(val)?;
+                        }
+                        t.end()
+                    }
+                }
+
+                let mut t = serializer.serialize_tuple(2)?;
+                t.serialize_element(&tag)?;
+                t.serialize_element(&VariantsSerializer(values))?;
+                t.end()
+            }
+            Container::Locals(_) => Err(invariant_violation::<S>(format!(
+                "Tried to serialize a locals container {:?}",
+                self
+            ))),
+        }
     }
 }
 
@@ -4101,12 +4192,12 @@ impl GlobalValue {
  *   Random generation of values that fit into a given layout.
  *
  **************************************************************************************/
-#[cfg(feature = "fuzzing")]
+#[cfg(any(test, feature = "fuzzing"))]
 pub mod prop {
     use super::*;
     use proptest::{collection::vec, prelude::*};
 
-    pub fn value_strategy_with_layout(layout: &MoveTypeLayout) -> impl Strategy<Value = Value> {
+    pub fn value_strategy_with_layout(layout: MoveTypeLayout) -> impl Strategy<Value = Value> {
         use MoveTypeLayout as L;
 
         match layout {
@@ -4120,7 +4211,7 @@ pub mod prop {
             L::Address => any::<AccountAddress>().prop_map(Value::address).boxed(),
             L::Signer => any::<AccountAddress>().prop_map(Value::signer).boxed(),
 
-            L::Vector(layout) => match &**layout {
+            L::Vector(layout) => match *layout {
                 L::U8 => vec(any::<u8>(), 0..10)
                     .prop_map(|vals| {
                         Value(ValueImpl::Container(Container::VecU8(Rc::new(
@@ -4187,15 +4278,15 @@ pub mod prop {
             },
 
             L::Struct(struct_layout) => struct_layout
-                .fields()
-                .iter()
+                .into_fields()
+                .into_iter()
                 .map(value_strategy_with_layout)
                 .collect::<Vec<_>>()
                 .prop_map(move |vals| Value::struct_(Struct::pack(vals)))
                 .boxed(),
 
             L::Enum(enum_layout) => {
-                let enum_layouts = (**enum_layout)
+                let enum_layouts = enum_layout
                     .clone()
                     .0
                     .into_iter()
@@ -4204,7 +4295,7 @@ pub mod prop {
                 proptest::sample::select(enum_layouts)
                     .prop_flat_map(move |(tag, layout)| {
                         layout
-                            .iter()
+                            .into_iter()
                             .map(value_strategy_with_layout)
                             .collect::<Vec<_>>()
                             .prop_map(move |v| Value::variant(Variant::pack(tag as u16, v)))
@@ -4240,7 +4331,7 @@ pub mod prop {
 
     pub fn layout_and_value_strategy() -> impl Strategy<Value = (MoveTypeLayout, Value)> {
         layout_strategy().no_shrink().prop_flat_map(|layout| {
-            let value_strategy = value_strategy_with_layout(&layout);
+            let value_strategy = value_strategy_with_layout(layout.clone());
             (Just(layout), value_strategy)
         })
     }

--- a/external-crates/move/crates/move-vm-types/src/values/values_impl.rs
+++ b/external-crates/move/crates/move-vm-types/src/values/values_impl.rs
@@ -3454,7 +3454,7 @@ impl serde::Serialize for Container {
                 };
 
                 struct VariantsSerializer<'a>(&'a [ValueImpl]);
-                impl<'a> serde::Serialize for VariantsSerializer<'a> {
+                impl serde::Serialize for VariantsSerializer<'_> {
                     fn serialize<S: serde::Serializer>(
                         &self,
                         serializer: S,

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -358,7 +358,7 @@ mod checked {
                         .get_runtime()
                         .type_to_type_layout(&ty)
                         .map_err(|e| self.convert_vm_error(e))?;
-                    let Some(bytes) = value.simple_serialize(&layout) else {
+                    let Some(bytes) = value.typed_serialize(&layout) else {
                         invariant_violation!("Failed to deserialize already serialized Move value");
                     };
                     Ok((module_id.clone(), tag, bytes))
@@ -918,7 +918,7 @@ mod checked {
                         protocol_config.resolve_abort_locations_to_package_id(),
                     )
                 })?;
-                let Some(bytes) = value.simple_serialize(&layout) else {
+                let Some(bytes) = value.typed_serialize(&layout) else {
                     invariant_violation!("Failed to deserialize already serialized Move value");
                 };
                 // safe because has_public_transfer has been determined by the abilities

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
@@ -280,8 +280,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas> Context<'env, 'pc, 'vm, 'state, 'li
             };
             let abilities = ty.abilities();
             let has_public_transfer = abilities.has_store();
-            let layout = env.runtime_layout(&ty)?;
-            let Some(bytes) = value.simple_serialize(&layout) else {
+            let Some(bytes) = value.serialize() else {
                 invariant_violation!("Failed to deserialize already serialized Move value");
             };
             // safe because has_public_transfer has been determined by the abilities
@@ -379,23 +378,8 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas> Context<'env, 'pc, 'vm, 'state, 'li
         let new_events = events
             .into_iter()
             .map(|(tag, value)| {
-                let ty = self
-                    .env
-                    .vm
-                    .get_runtime()
-                    .try_load_cached_type(&TypeTag::Struct(Box::new(tag.clone())))
-                    .map_err(|e| self.env.convert_vm_error(e))?
-                    .ok_or_else(|| {
-                        make_invariant_violation!("Failed to load type for event tag: {}", tag)
-                    })?;
-                let layout = self
-                    .env
-                    .vm
-                    .get_runtime()
-                    .type_to_type_layout(&ty)
-                    .map_err(|e| self.env.convert_vm_error(e))?;
-                let Some(bytes) = value.simple_serialize(&layout) else {
-                    invariant_violation!("Failed to deserialize already serialized Move value");
+                let Some(bytes) = value.serialize() else {
+                    invariant_violation!("Failed to serialize Move event");
                 };
                 Ok((module_id.clone(), tag, bytes))
             })
@@ -623,7 +607,6 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas> Context<'env, 'pc, 'vm, 'state, 'li
         let Ok(tag): Result<TypeTag, _> = ty.clone().try_into() else {
             invariant_violation!("unable to generate type tag from type")
         };
-        let layout = self.env.runtime_layout(&ty)?;
         let (_, _, lv) = self.location_value(location, ty)?;
         let local = match lv {
             LocationValue::Loaded(v) => {
@@ -634,7 +617,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas> Context<'env, 'pc, 'vm, 'state, 'li
             }
             LocationValue::InputBytes(_, _, _) => return Ok(None),
         };
-        let Some(bytes) = local.copy()?.serialize(&layout) else {
+        let Some(bytes) = local.copy()?.serialize() else {
             invariant_violation!("Failed to serialize Move value");
         };
         let arg = match location {
@@ -666,7 +649,6 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas> Context<'env, 'pc, 'vm, 'state, 'li
         result: &Value,
         ty: Type,
     ) -> Result<(Vec<u8>, TypeTag), ExecutionError> {
-        let layout = self.env.runtime_layout(&ty)?;
         let inner_value;
         let (v, ty) = match ty {
             Type::Reference(_, inner) => {
@@ -675,7 +657,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas> Context<'env, 'pc, 'vm, 'state, 'li
             }
             _ => (result, ty),
         };
-        let Some(bytes) = v.serialize(&layout) else {
+        let Some(bytes) = v.serialize() else {
             invariant_violation!("Failed to serialize Move value");
         };
         let Ok(tag): Result<TypeTag, _> = ty.try_into() else {

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/values.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/values.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 
 use crate::static_programmable_transactions::{env::Env, typing::ast::Type};
 use move_binary_format::errors::PartialVMError;
-use move_core_types::{account_address::AccountAddress, runtime_value};
+use move_core_types::account_address::AccountAddress;
 use move_vm_types::{
     values::{
         self, Locals as VMLocals, Struct, VMValueCast, Value as VMValue, VectorSpecialization,
@@ -241,8 +241,8 @@ impl Value {
         Ok(Value(value))
     }
 
-    pub fn serialize(&self, layout: &runtime_value::MoveTypeLayout) -> Option<Vec<u8>> {
-        self.0.simple_serialize(layout)
+    pub fn serialize(&self) -> Option<Vec<u8>> {
+        self.0.serialize()
     }
 }
 

--- a/sui-execution/latest/sui-move-natives/src/dynamic_field.rs
+++ b/sui-execution/latest/sui-move-natives/src/dynamic_field.rs
@@ -131,7 +131,7 @@ pub fn hash_type_and_key(
         Ok(Some(layout)) => layout,
         _ => return Ok(NativeResult::err(cost, E_BCS_SERIALIZATION_FAILURE)),
     };
-    let Some(k_bytes) = k.simple_serialize(&k_layout) else {
+    let Some(k_bytes) = k.typed_serialize(&k_layout) else {
         return Ok(NativeResult::err(cost, E_BCS_SERIALIZATION_FAILURE));
     };
     let Ok(id) = derive_dynamic_field_id(parent, &k_tag, &k_bytes) else {

--- a/sui-execution/latest/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/latest/sui-move-natives/src/test_scenario.rs
@@ -660,7 +660,7 @@ pub fn allocate_receiving_ticket_for_object(
     }
 
     let obj_value = inventories.objects.remove(&id).unwrap();
-    let Some(bytes) = obj_value.simple_serialize(&layout) else {
+    let Some(bytes) = obj_value.typed_serialize(&layout) else {
         return Ok(NativeResult::err(
             context.gas_used(),
             E_UNABLE_TO_ALLOCATE_RECEIVING_TICKET,
@@ -1015,7 +1015,7 @@ fn find_all_wrapped_objects<'a, 'i>(
             continue;
         };
 
-        let blob = value.borrow().simple_serialize(&layout).unwrap();
+        let blob = value.borrow().typed_serialize(&layout).unwrap();
         MoveValue::visit_deserialize(
             &blob,
             &annotated_layout,


### PR DESCRIPTION
## Description 

We don't need a type layout when serializing a Move value in order to produce valid serialized bytes.

This adds this function, renames the existing `simple_serialize` to `typed_serialize`, and updates the usage of the the `typed_serialize` function in the new static ptbs to use the serialization function that does not require the type layout.

## Test plan 

Added an additional test for one interesting case, re-enabled values-impl proptests and in this we ensure that the serialized bytes for values are the same whether using `typed_serialize` or `serialize`. 

