### PR TITLE
[fastpath] do not notify when there is no transaction status update

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -1151,7 +1151,7 @@ impl ValidatorService {
                 ConsensusTxStatus::FastpathCertified | ConsensusTxStatus::Finalized => status,
             },
             NotifyReadConsensusTxStatusResult::Expired(round) => {
-                return Ok(WaitForEffectsResponse::Expired(round));
+                return Ok(WaitForEffectsResponse::Expired(round.into()));
             }
         };
         // Now that we know the transaction position is accepted by consensus,
@@ -1180,7 +1180,7 @@ impl ValidatorService {
                             continue;
                         }
                         NotifyReadConsensusTxStatusResult::Expired(round) => {
-                            return Ok(WaitForEffectsResponse::Expired(round));
+                            return Ok(WaitForEffectsResponse::Expired(round.into()));
                         }
                     }
                 },

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -579,7 +579,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
         if let Some(consensus_tx_status_cache) = self.epoch_store.consensus_tx_status_cache.as_ref()
         {
             consensus_tx_status_cache
-                .update_last_committed_leader_round(last_committed_round)
+                .update_last_committed_leader_round(last_committed_round as u32)
                 .await;
         }
 

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -715,8 +715,8 @@ pub enum SuiError {
         "Validator consensus rounds are lagging behind. last committed leader round: {last_committed_round:?}, requested round: {round:?}"
     )]
     ValidatorConsensusLagging {
-        round: u64,
-        last_committed_round: u64,
+        round: u32,
+        last_committed_round: u32,
     },
 }
 

--- a/crates/sui-types/src/messages_consensus.rs
+++ b/crates/sui-types/src/messages_consensus.rs
@@ -40,7 +40,7 @@ pub type TransactionIndex = u16;
 pub type TimestampMs = u64;
 
 /// The position of a transaction in consensus.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct ConsensusPosition {
     // Block containing a transaction.
     pub block: BlockRef,


### PR DESCRIPTION
## Description 

Return early from `set_transaction_status()` when a status update to `FastpathCertified` is ignored, instead of continuing to notify.

Also, remove per-transaction tracking in status cache. And use `u32` for Round in Sui unless for legacy compatibility. Consensus already uses u32 for Round.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
