### PR TITLE
[indexer-alt-framework] Improve test coverage for concurrent/committer

### DIFF
--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -393,3 +393,6 @@ impl<T: TransactionalStore> Indexer<T> {
         Ok(())
     }
 }
+
+#[cfg(test)]
+pub mod testing;

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/committer.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/committer.rs
@@ -1,7 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::atomic::{AtomicUsize, Ordering},
+    sync::Arc,
+    time::Duration,
+};
 
 use backoff::ExponentialBackoff;
 use tokio::{sync::mpsc, task::JoinHandle};
@@ -212,4 +216,357 @@ pub(super) fn committer<H: Handler + 'static>(
             }
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashMap,
+        sync::{Arc, Mutex},
+    };
+
+    use async_trait::async_trait;
+    use sui_types::full_checkpoint_content::CheckpointData;
+    use tokio::sync::mpsc;
+    use tokio_util::sync::CancellationToken;
+
+    use crate::{
+        metrics::IndexerMetrics,
+        pipeline::{
+            concurrent::{BatchedRows, Handler},
+            Processor, WatermarkPart,
+        },
+        store::CommitterWatermark,
+        testing::mock_store::*,
+        FieldCount,
+    };
+
+    use super::*;
+
+    #[derive(Clone, FieldCount)]
+    pub struct StoredData {
+        pub cp_sequence_number: u64,
+        pub tx_sequence_numbers: Vec<u64>,
+        /// Tracks remaining commit failures for testing retry logic.
+        /// The committer spawns concurrent tasks that call H::commit,
+        /// so this needs to be thread-safe (hence Arc<AtomicUsize>).
+        pub commit_failure_remaining: Arc<AtomicUsize>,
+        pub commit_delay_ms: u64,
+    }
+
+    impl Default for StoredData {
+        fn default() -> Self {
+            Self {
+                cp_sequence_number: 0,
+                tx_sequence_numbers: Vec::new(),
+                commit_failure_remaining: Arc::new(AtomicUsize::new(0)),
+                commit_delay_ms: 0,
+            }
+        }
+    }
+
+    pub struct DataPipeline;
+
+    impl Processor for DataPipeline {
+        const NAME: &'static str = "data";
+
+        type Value = StoredData;
+
+        fn process(&self, _checkpoint: &Arc<CheckpointData>) -> anyhow::Result<Vec<Self::Value>> {
+            Ok(vec![])
+        }
+    }
+
+    #[async_trait]
+    impl Handler for DataPipeline {
+        type Store = MockStore;
+
+        async fn commit<'a>(
+            values: &[StoredData],
+            conn: &mut MockConnection<'a>,
+        ) -> anyhow::Result<usize> {
+            for value in values {
+                // If there's a delay, sleep for that duration
+                if value.commit_delay_ms > 0 {
+                    tokio::time::sleep(Duration::from_millis(value.commit_delay_ms)).await;
+                }
+
+                // If there are remaining failures, fail the commit and decrement the counter
+                {
+                    let remaining = value
+                        .commit_failure_remaining
+                        .fetch_sub(1, Ordering::SeqCst);
+                    if remaining > 0 {
+                        return Err(anyhow::anyhow!(
+                            "Commit failed, remaining failures: {}",
+                            remaining - 1
+                        ));
+                    }
+                }
+
+                // Lock, insert, and immediately drop the lock
+                {
+                    let mut data = conn.0.data.lock().unwrap();
+                    data.insert(value.cp_sequence_number, value.tx_sequence_numbers.clone());
+                }
+            }
+            Ok(values.len())
+        }
+    }
+
+    struct TestSetup {
+        store: MockStore,
+        batch_tx: mpsc::Sender<BatchedRows<DataPipeline>>,
+        watermark_rx: mpsc::Receiver<Vec<WatermarkPart>>,
+        committer_handle: JoinHandle<()>,
+    }
+
+    /// Creates and spawns a committer task with the provided mock store, along with
+    /// all necessary channels and configuration. The committer runs in the background
+    /// and can be interacted with through the returned channels.
+    async fn setup_test(store: MockStore) -> TestSetup {
+        let config = CommitterConfig::default();
+        let metrics = IndexerMetrics::new(&Default::default());
+        let cancel = CancellationToken::new();
+
+        let (batch_tx, batch_rx) = mpsc::channel::<BatchedRows<DataPipeline>>(10);
+        let (watermark_tx, watermark_rx) = mpsc::channel(10);
+
+        let store_clone = store.clone();
+        let committer_handle = tokio::spawn(async move {
+            let _ = committer(
+                config,
+                false,
+                batch_rx,
+                watermark_tx,
+                store_clone,
+                metrics,
+                cancel,
+            )
+            .await;
+        });
+
+        TestSetup {
+            store,
+            batch_tx,
+            watermark_rx,
+            committer_handle,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_batch_processing() {
+        let store = MockStore {
+            watermarks: Arc::new(Mutex::new(MockWatermark::default())),
+            ..Default::default()
+        };
+        let mut setup = setup_test(store).await;
+
+        // Send batches
+        let batch1 = BatchedRows {
+            values: vec![
+                StoredData {
+                    cp_sequence_number: 1,
+                    tx_sequence_numbers: vec![1, 2, 3],
+                    ..Default::default()
+                },
+                StoredData {
+                    cp_sequence_number: 2,
+                    tx_sequence_numbers: vec![4, 5, 6],
+                    ..Default::default()
+                },
+            ],
+            watermark: vec![
+                WatermarkPart {
+                    watermark: CommitterWatermark {
+                        epoch_hi_inclusive: 0,
+                        checkpoint_hi_inclusive: 1,
+                        tx_hi: 3,
+                        timestamp_ms_hi_inclusive: 1000,
+                    },
+                    batch_rows: 1,
+                    total_rows: 1, // Total rows from checkpoint 1
+                },
+                WatermarkPart {
+                    watermark: CommitterWatermark {
+                        epoch_hi_inclusive: 0,
+                        checkpoint_hi_inclusive: 2,
+                        tx_hi: 6,
+                        timestamp_ms_hi_inclusive: 2000,
+                    },
+                    batch_rows: 1,
+                    total_rows: 1, // Total rows from checkpoint 2
+                },
+            ],
+        };
+
+        let batch2 = BatchedRows {
+            values: vec![StoredData {
+                cp_sequence_number: 3,
+                tx_sequence_numbers: vec![7, 8, 9],
+                ..Default::default()
+            }],
+            watermark: vec![WatermarkPart {
+                watermark: CommitterWatermark {
+                    epoch_hi_inclusive: 0,
+                    checkpoint_hi_inclusive: 3,
+                    tx_hi: 9,
+                    timestamp_ms_hi_inclusive: 3000,
+                },
+                batch_rows: 1,
+                total_rows: 1, // Total rows from checkpoint 3
+            }],
+        };
+
+        setup.batch_tx.send(batch1).await.unwrap();
+        setup.batch_tx.send(batch2).await.unwrap();
+
+        // Verify watermarks. Blocking until committer has processed.
+        let watermark1 = setup.watermark_rx.recv().await.unwrap();
+        let watermark2 = setup.watermark_rx.recv().await.unwrap();
+        assert_eq!(watermark1.len(), 2);
+        assert_eq!(watermark2.len(), 1);
+
+        // Verify data was committed
+        {
+            let data: std::sync::MutexGuard<'_, HashMap<u64, Vec<u64>>> =
+                setup.store.data.lock().unwrap();
+            assert_eq!(data.len(), 3);
+            assert_eq!(data.get(&1).unwrap(), &vec![1, 2, 3]);
+            assert_eq!(data.get(&2).unwrap(), &vec![4, 5, 6]);
+            assert_eq!(data.get(&3).unwrap(), &vec![7, 8, 9]);
+        }
+
+        // Clean up
+        drop(setup.batch_tx);
+        let _ = setup.committer_handle.await;
+    }
+
+    #[tokio::test]
+    async fn test_commit_with_retries_for_commit_failure() {
+        // Create a batch with a single item that will fail once before succeeding
+        let store = MockStore {
+            watermarks: Arc::new(Mutex::new(MockWatermark::default())),
+            ..Default::default()
+        };
+        let mut setup = setup_test(store).await;
+
+        let batch = BatchedRows {
+            values: vec![StoredData {
+                cp_sequence_number: 1,
+                tx_sequence_numbers: vec![1, 2, 3],
+                commit_failure_remaining: Arc::new(AtomicUsize::new(1)),
+                commit_delay_ms: 1_000, // Long commit delay for testing state between retry
+            }],
+            watermark: vec![WatermarkPart {
+                watermark: CommitterWatermark {
+                    epoch_hi_inclusive: 0,
+                    checkpoint_hi_inclusive: 1,
+                    tx_hi: 3,
+                    timestamp_ms_hi_inclusive: 1000,
+                },
+                batch_rows: 1,
+                total_rows: 1,
+            }],
+        };
+
+        // Send the batch
+        setup.batch_tx.send(batch).await.unwrap();
+
+        // Wait for the first attempt to fail and before the retry succeeds
+        tokio::time::sleep(Duration::from_millis(1_500)).await;
+
+        // Verify state before retry succeeds
+        {
+            let data = setup.store.data.lock().unwrap();
+            assert!(
+                data.is_empty(),
+                "Data should not be committed before retry succeeds"
+            );
+        }
+        assert!(
+            setup.watermark_rx.try_recv().is_err(),
+            "No watermark should be received before retry succeeds"
+        );
+
+        // Wait for the retry to succeed
+        tokio::time::sleep(Duration::from_millis(1_500)).await;
+
+        // Verify state after retry succeeds
+        {
+            let data = setup.store.data.lock().unwrap();
+            assert_eq!(data.get(&1).unwrap(), &vec![1, 2, 3]);
+        }
+        let watermark = setup.watermark_rx.recv().await.unwrap();
+        assert_eq!(watermark.len(), 1);
+
+        // Clean up
+        drop(setup.batch_tx);
+        let _ = setup.committer_handle.await;
+    }
+
+    #[tokio::test]
+    async fn test_commit_with_retries_for_connection_failure() {
+        // Create a batch with a single item
+        let store = MockStore {
+            connection_failure: Arc::new(Mutex::new(ConnectionFailure {
+                connection_failure_attempts: 1,
+                connection_delay_ms: 1_000, // Long connection delay for testing state between retry
+            })),
+            ..Default::default()
+        };
+        let mut setup = setup_test(store).await;
+
+        let batch = BatchedRows {
+            values: vec![StoredData {
+                cp_sequence_number: 1,
+                tx_sequence_numbers: vec![1, 2, 3],
+                ..Default::default()
+            }],
+            watermark: vec![WatermarkPart {
+                watermark: CommitterWatermark {
+                    epoch_hi_inclusive: 0,
+                    checkpoint_hi_inclusive: 1,
+                    tx_hi: 3,
+                    timestamp_ms_hi_inclusive: 1000,
+                },
+                batch_rows: 1,
+                total_rows: 1,
+            }],
+        };
+
+        // Send the batch
+        setup.batch_tx.send(batch).await.unwrap();
+
+        // Wait for the first attempt to fail and before the retry succeeds
+        tokio::time::sleep(Duration::from_millis(1_500)).await;
+
+        // Verify state before retry succeeds
+        {
+            let data = setup.store.data.lock().unwrap();
+            assert!(
+                data.is_empty(),
+                "Data should not be committed before retry succeeds"
+            );
+        }
+        assert!(
+            setup.watermark_rx.try_recv().is_err(),
+            "No watermark should be received before retry succeeds"
+        );
+
+        // Wait for the retry to succeed
+        tokio::time::sleep(Duration::from_millis(1_500)).await;
+
+        // Verify state after retry succeeds
+        {
+            let data = setup.store.data.lock().unwrap();
+            assert_eq!(data.get(&1).unwrap(), &vec![1, 2, 3]);
+        }
+        let watermark = setup.watermark_rx.recv().await.unwrap();
+        assert_eq!(watermark.len(), 1);
+
+        // Clean up
+        drop(setup.batch_tx);
+        let _ = setup.committer_handle.await;
+    }
 }

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
@@ -344,137 +344,24 @@ async fn prune_task_impl<H: Handler + Send + Sync + 'static>(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-    use std::sync::{Arc, Mutex};
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use std::sync::Arc;
+    use std::{
+        collections::HashMap,
+        sync::Mutex,
+        time::{SystemTime, UNIX_EPOCH},
+    };
 
     use async_trait::async_trait;
     use prometheus::Registry;
-    use sui_indexer_alt_framework_store_traits::{
-        CommitterWatermark, PrunerWatermark, ReaderWatermark, Store,
-    };
     use sui_types::full_checkpoint_content::CheckpointData;
+    use tokio::time::Duration;
+    use tokio_util::sync::CancellationToken;
 
-    use crate::{pipeline::Processor, store::Connection, FieldCount};
+    use crate::{metrics::IndexerMetrics, pipeline::Processor, testing::mock_store::*, FieldCount};
 
     use super::*;
 
-    #[derive(Clone, Default)]
-    pub struct MockWatermark {
-        epoch_hi_inclusive: u64,
-        checkpoint_hi_inclusive: u64,
-        tx_hi: u64,
-        timestamp_ms_hi_inclusive: u64,
-        reader_lo: u64,
-        pruner_timestamp: u64,
-        pruner_hi: u64,
-    }
-
-    #[derive(Clone)]
-    pub struct MockStore {
-        pub watermarks: Arc<Mutex<MockWatermark>>,
-        /// Map of checkpoint sequence number to list of transaction sequence numbers.
-        pub data: Arc<Mutex<HashMap<u64, Vec<u64>>>>,
-        /// Map of [from, to) -> remaining failure count before success
-        pub remaining_failures: Arc<Mutex<HashMap<(u64, u64), usize>>>,
-    }
-
-    #[derive(Clone)]
-    pub struct MockConnection<'c>(pub &'c MockStore);
-
-    #[async_trait]
-    impl Connection for MockConnection<'_> {
-        async fn committer_watermark(
-            &mut self,
-            _pipeline: &'static str,
-        ) -> Result<Option<CommitterWatermark>, anyhow::Error> {
-            let watermarks = self.0.watermarks.lock().unwrap();
-            Ok(Some(CommitterWatermark {
-                epoch_hi_inclusive: watermarks.epoch_hi_inclusive,
-                checkpoint_hi_inclusive: watermarks.checkpoint_hi_inclusive,
-                tx_hi: watermarks.tx_hi,
-                timestamp_ms_hi_inclusive: watermarks.timestamp_ms_hi_inclusive,
-            }))
-        }
-
-        async fn reader_watermark(
-            &mut self,
-            _pipeline: &'static str,
-        ) -> Result<Option<ReaderWatermark>, anyhow::Error> {
-            let watermarks = self.0.watermarks.lock().unwrap();
-            Ok(Some(ReaderWatermark {
-                checkpoint_hi_inclusive: watermarks.checkpoint_hi_inclusive,
-                reader_lo: watermarks.reader_lo,
-            }))
-        }
-
-        async fn pruner_watermark(
-            &mut self,
-            _pipeline: &'static str,
-            delay: Duration,
-        ) -> Result<Option<PrunerWatermark>, anyhow::Error> {
-            let watermarks = self.0.watermarks.lock().unwrap();
-            let elapsed_ms = watermarks.pruner_timestamp as i64
-                - SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap()
-                    .as_millis() as i64;
-            let wait_for_ms = delay.as_millis() as i64 + elapsed_ms;
-            Ok(Some(PrunerWatermark {
-                pruner_hi: watermarks.pruner_hi,
-                reader_lo: watermarks.reader_lo,
-                wait_for_ms,
-            }))
-        }
-
-        async fn set_committer_watermark(
-            &mut self,
-            _pipeline: &'static str,
-            watermark: CommitterWatermark,
-        ) -> anyhow::Result<bool> {
-            let mut watermarks = self.0.watermarks.lock().unwrap();
-            watermarks.epoch_hi_inclusive = watermark.epoch_hi_inclusive;
-            watermarks.checkpoint_hi_inclusive = watermark.checkpoint_hi_inclusive;
-            watermarks.tx_hi = watermark.tx_hi;
-            watermarks.timestamp_ms_hi_inclusive = watermark.timestamp_ms_hi_inclusive;
-            Ok(true)
-        }
-
-        async fn set_reader_watermark(
-            &mut self,
-            _pipeline: &'static str,
-            reader_lo: u64,
-        ) -> anyhow::Result<bool> {
-            let mut watermarks = self.0.watermarks.lock().unwrap();
-            watermarks.reader_lo = reader_lo;
-            watermarks.pruner_timestamp = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_millis() as u64;
-            Ok(true)
-        }
-
-        async fn set_pruner_watermark(
-            &mut self,
-            _pipeline: &'static str,
-            pruner_hi: u64,
-        ) -> anyhow::Result<bool> {
-            let mut watermarks = self.0.watermarks.lock().unwrap();
-            watermarks.pruner_hi = pruner_hi;
-            Ok(true)
-        }
-    }
-
-    #[async_trait]
-    impl Store for MockStore {
-        type Connection<'c> = MockConnection<'c>;
-
-        async fn connect<'c>(&'c self) -> Result<Self::Connection<'c>, anyhow::Error> {
-            Ok(MockConnection(self))
-        }
-    }
-
-    #[derive(FieldCount)]
+    #[derive(Clone, FieldCount)]
     pub struct StoredData {}
 
     pub struct DataPipeline;
@@ -508,7 +395,7 @@ mod tests {
         ) -> anyhow::Result<usize> {
             let should_fail = conn
                 .0
-                .remaining_failures
+                .prune_failure_attempts
                 .lock()
                 .unwrap()
                 .get_mut(&(from, to_exclusive))
@@ -687,7 +574,7 @@ mod tests {
         let store = MockStore {
             watermarks: Arc::new(Mutex::new(watermark)),
             data: Arc::new(Mutex::new(test_data.clone())),
-            remaining_failures: Arc::new(Mutex::new(HashMap::new())),
+            ..Default::default()
         };
 
         // Start the pruner
@@ -783,7 +670,7 @@ mod tests {
         let store = MockStore {
             watermarks: Arc::new(Mutex::new(watermark)),
             data: Arc::new(Mutex::new(test_data.clone())),
-            remaining_failures: Arc::new(Mutex::new(HashMap::new())),
+            ..Default::default()
         };
 
         // Start the pruner
@@ -865,12 +752,13 @@ mod tests {
         };
 
         // Configure failing behavior: range [1,2) should fail once before succeeding
-        let mut remaining_failures = HashMap::new();
-        remaining_failures.insert((1, 2), 1);
+        let mut prune_failure_attempts = HashMap::new();
+        prune_failure_attempts.insert((1, 2), 1);
         let store = MockStore {
             watermarks: Arc::new(Mutex::new(watermark)),
             data: Arc::new(Mutex::new(test_data.clone())),
-            remaining_failures: Arc::new(Mutex::new(remaining_failures)),
+            prune_failure_attempts: Arc::new(Mutex::new(prune_failure_attempts)),
+            ..Default::default()
         };
 
         // Start the pruner

--- a/crates/sui-indexer-alt-framework/src/testing/mock_store.rs
+++ b/crates/sui-indexer-alt-framework/src/testing/mock_store.rs
@@ -1,0 +1,179 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use async_trait::async_trait;
+use tokio::time::Duration;
+
+use crate::store::{CommitterWatermark, Connection, PrunerWatermark, ReaderWatermark, Store};
+
+#[derive(Default)]
+pub struct MockWatermark {
+    pub epoch_hi_inclusive: u64,
+    pub checkpoint_hi_inclusive: u64,
+    pub tx_hi: u64,
+    pub timestamp_ms_hi_inclusive: u64,
+    pub reader_lo: u64,
+    pub pruner_timestamp: u64,
+    pub pruner_hi: u64,
+}
+
+/// Configuration for simulating connection failures in tests
+#[derive(Default)]
+pub struct ConnectionFailure {
+    /// Number of failures before connection succeeds
+    pub connection_failure_attempts: usize,
+    /// Delay in milliseconds for each connection attempt (applied even when connection fails)
+    pub connection_delay_ms: u64,
+}
+
+/// A mock store for testing. It maintains a map of checkpoint sequence numbers to transaction
+/// sequence numbers, and a watermark that can be used to test the watermark task.
+#[derive(Clone)]
+pub struct MockStore {
+    /// Tracks various watermark states (committer, reader, pruner)
+    pub watermarks: Arc<Mutex<MockWatermark>>,
+    /// Stores the actual data, mapping checkpoint sequence numbers to transaction sequence numbers
+    pub data: Arc<Mutex<HashMap<u64, Vec<u64>>>>,
+    /// Controls pruning failure simulation for testing retry behavior.
+    /// Maps from [from_checkpoint, to_checkpoint_exclusive) to number of remaining failure attempts.
+    /// When a prune operation is attempted on a range, if there are remaining failures,
+    /// the operation will fail and the counter will be decremented.
+    pub prune_failure_attempts: Arc<Mutex<HashMap<(u64, u64), usize>>>,
+    /// Configuration for simulating connection failures in tests
+    pub connection_failure: Arc<Mutex<ConnectionFailure>>,
+}
+
+impl Default for MockStore {
+    fn default() -> Self {
+        Self {
+            watermarks: Arc::new(Mutex::new(MockWatermark::default())),
+            data: Arc::new(Mutex::new(HashMap::new())),
+            prune_failure_attempts: Arc::new(Mutex::new(HashMap::new())),
+            connection_failure: Arc::new(Mutex::new(ConnectionFailure::default())),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct MockConnection<'c>(pub &'c MockStore);
+
+#[async_trait]
+impl Connection for MockConnection<'_> {
+    async fn committer_watermark(
+        &mut self,
+        _pipeline: &'static str,
+    ) -> Result<Option<CommitterWatermark>, anyhow::Error> {
+        let watermarks = self.0.watermarks.lock().unwrap();
+        Ok(Some(CommitterWatermark {
+            epoch_hi_inclusive: watermarks.epoch_hi_inclusive,
+            checkpoint_hi_inclusive: watermarks.checkpoint_hi_inclusive,
+            tx_hi: watermarks.tx_hi,
+            timestamp_ms_hi_inclusive: watermarks.timestamp_ms_hi_inclusive,
+        }))
+    }
+
+    async fn reader_watermark(
+        &mut self,
+        _pipeline: &'static str,
+    ) -> Result<Option<ReaderWatermark>, anyhow::Error> {
+        let watermarks = self.0.watermarks.lock().unwrap();
+        Ok(Some(ReaderWatermark {
+            checkpoint_hi_inclusive: watermarks.checkpoint_hi_inclusive,
+            reader_lo: watermarks.reader_lo,
+        }))
+    }
+
+    async fn pruner_watermark(
+        &mut self,
+        _pipeline: &'static str,
+        delay: Duration,
+    ) -> Result<Option<PrunerWatermark>, anyhow::Error> {
+        let watermarks = self.0.watermarks.lock().unwrap();
+        let elapsed_ms = watermarks.pruner_timestamp as i64
+            - SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as i64;
+        let wait_for_ms = delay.as_millis() as i64 + elapsed_ms;
+        Ok(Some(PrunerWatermark {
+            pruner_hi: watermarks.pruner_hi,
+            reader_lo: watermarks.reader_lo,
+            wait_for_ms,
+        }))
+    }
+
+    async fn set_committer_watermark(
+        &mut self,
+        _pipeline: &'static str,
+        watermark: CommitterWatermark,
+    ) -> anyhow::Result<bool> {
+        let mut watermarks = self.0.watermarks.lock().unwrap();
+        watermarks.epoch_hi_inclusive = watermark.epoch_hi_inclusive;
+        watermarks.checkpoint_hi_inclusive = watermark.checkpoint_hi_inclusive;
+        watermarks.tx_hi = watermark.tx_hi;
+        watermarks.timestamp_ms_hi_inclusive = watermark.timestamp_ms_hi_inclusive;
+        Ok(true)
+    }
+
+    async fn set_reader_watermark(
+        &mut self,
+        _pipeline: &'static str,
+        reader_lo: u64,
+    ) -> anyhow::Result<bool> {
+        let mut watermarks = self.0.watermarks.lock().unwrap();
+        watermarks.reader_lo = reader_lo;
+        watermarks.pruner_timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        Ok(true)
+    }
+
+    async fn set_pruner_watermark(
+        &mut self,
+        _pipeline: &'static str,
+        pruner_hi: u64,
+    ) -> anyhow::Result<bool> {
+        let mut watermarks = self.0.watermarks.lock().unwrap();
+        watermarks.pruner_hi = pruner_hi;
+        Ok(true)
+    }
+}
+
+#[async_trait]
+impl Store for MockStore {
+    type Connection<'c> = MockConnection<'c>;
+
+    async fn connect(&self) -> anyhow::Result<Self::Connection<'_>> {
+        // Check for connection failure simulation
+        let should_fail = {
+            let mut failure = self.connection_failure.lock().unwrap();
+            if failure.connection_failure_attempts > 0 {
+                failure.connection_failure_attempts -= 1;
+                true
+            } else {
+                false
+            }
+        };
+        let delay_ms = {
+            let failure = self.connection_failure.lock().unwrap();
+            failure.connection_delay_ms
+        };
+
+        if delay_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+        }
+
+        if should_fail {
+            return Err(anyhow::anyhow!("Connection failed"));
+        }
+
+        Ok(MockConnection(self))
+    }
+}

--- a/crates/sui-indexer-alt-framework/src/testing/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/testing/mod.rs
@@ -1,0 +1,4 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod mock_store;


### PR DESCRIPTION
## Description 

Improve test coverage for concurrent/committers.rs

Test coverage includes:
* Commit received BatchRows
* Commit with exponential backoff for failed commit
* Commit with exponential backoff for failed DB connection

Also, I refactored the `MockStore` and `MockConnection` logic, moving it from `pruner.rs` to `mock_store.rs` to make it reusable by other files.

## Test plan 

How did you test the new or updated feature?

```
cargo test -p sui-indexer-alt-framework  committer  --lib
```

## Stack

- #22359
- #22366
- #22393

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:




