### PR TITLE
[indexer-alt-framework] Improve test coverage for reader_watermark

### DIFF
--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/committer.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/committer.rs
@@ -515,6 +515,7 @@ mod tests {
             connection_failure: Arc::new(Mutex::new(ConnectionFailure {
                 connection_failure_attempts: 1,
                 connection_delay_ms: 1_000, // Long connection delay for testing state between retry
+                ..Default::default()
             })),
             ..Default::default()
         };

--- a/crates/sui-indexer-alt-framework/src/testing/mock_store.rs
+++ b/crates/sui-indexer-alt-framework/src/testing/mock_store.rs
@@ -30,6 +30,8 @@ pub struct ConnectionFailure {
     pub connection_failure_attempts: usize,
     /// Delay in milliseconds for each connection attempt (applied even when connection fails)
     pub connection_delay_ms: u64,
+    /// Counter for tracking total connection attempts
+    pub connection_attempts: usize,
 }
 
 /// A mock store for testing. It maintains a map of checkpoint sequence numbers to transaction
@@ -169,19 +171,19 @@ impl Store for MockStore {
     type Connection<'c> = MockConnection<'c>;
 
     async fn connect(&self) -> anyhow::Result<Self::Connection<'_>> {
-        // Check for connection failure simulation
-        let should_fail = {
+        // Check for connection failure simulation and increment attempts counter
+        let (should_fail, delay_ms) = {
             let mut failure = self.connection_failure.lock().unwrap();
-            if failure.connection_failure_attempts > 0 {
+            failure.connection_attempts += 1;
+
+            let should_fail = if failure.connection_failure_attempts > 0 {
                 failure.connection_failure_attempts -= 1;
                 true
             } else {
                 false
-            }
-        };
-        let delay_ms = {
-            let failure = self.connection_failure.lock().unwrap();
-            failure.connection_delay_ms
+            };
+
+            (should_fail, failure.connection_delay_ms)
         };
 
         if delay_ms > 0 {
@@ -209,5 +211,24 @@ impl MockStore {
     /// Helper to get the current watermark state for testing
     pub fn get_watermark(&self) -> MockWatermark {
         self.watermarks.lock().unwrap().clone()
+    }
+
+    /// Helper to get the number of connection attempts for testing
+    pub fn get_connection_attempts(&self) -> usize {
+        self.connection_failure.lock().unwrap().connection_attempts
+    }
+
+    /// Helper to wait for a specific number of connection attempts with timeout
+    pub async fn wait_for_connection_attempts(&self, expected: usize, timeout: Duration) {
+        tokio::time::timeout(timeout, async {
+            loop {
+                if self.get_connection_attempts() >= expected {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
     }
 }


### PR DESCRIPTION
## Description 

Improve test coverage for concurrent/reader_watermark.rs

Test coverage includes:

* Basic watermark update
* Watermark no update with smaller reader_lo
* DB connection failure
* DB set_reader_watermark falure

## Test plan 

How did you test the new or updated feature?

```
cargo test -p sui-indexer-alt-framework  reader_watermark  --lib
```

---

## Stack

- #22359
- #22366
- #22393
- #22397 
- #22400 

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:


