### PR TITLE
[move][easy] Filter out macro-locations when computing source coverage

### DIFF
--- a/external-crates/move/crates/move-coverage/src/source_coverage.rs
+++ b/external-crates/move/crates/move-coverage/src/source_coverage.rs
@@ -257,6 +257,15 @@ fn merge_spans(cov: FunctionSourceCoverage) -> Vec<Span> {
         .uncovered_locations
         .iter()
         .filter_map(|loc| {
+            // TODO(macros/debug info): We filter out locations that do not match the file hash of
+            // the function here-- locations that are not in the same file as the function.
+            // These are the product of macro expansion.
+            //
+            // Once we have more rich debug info that captures the original "reference" location of
+            // the macro we should be able to include these locations as well by using the
+            // "referent location". But for now in order to avoid confusion and avoid referencing
+            // locations as "in the file" when they are not, we filter out any locations that don't
+            // match the file hash of the function we are currently processing.
             (loc.file_hash() == cov.fn_file_hash).then_some(Span::new(loc.start(), loc.end()))
         })
         .collect();


### PR DESCRIPTION
## Description 

Expanded macros pull in source locations from other files. This can lead to errors when computing source coverage (spans that refer to locations outside of the current file). 

When computing the coverage map for a file, we remove any locations not located within that file (i.e., locations from macro expansion). Sadly this means that we lose some level of coverage information about the macro call, but hopefully in the future with some nicer locations we can improve this. But for now, this at least stops it from erroring out completely. 

## Test plan 

CI + tested it on a local repro.

