### PR TITLE
[move][cleanup] Cleanup tag bounding constant names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15510,6 +15510,7 @@ dependencies = [
  "clap",
  "fastcrypto",
  "insta",
+ "move-core-types",
  "move-vm-config",
  "schemars",
  "serde",

--- a/crates/sui-protocol-config/Cargo.toml
+++ b/crates/sui-protocol-config/Cargo.toml
@@ -19,6 +19,7 @@ clap.workspace = true
 move-vm-config.workspace = true
 serde-env.workspace = true
 fastcrypto = { workspace = true }
+move-core-types.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -243,6 +243,7 @@ const MAX_PROTOCOL_VERSION: u64 = 86;
 // Version 84: Limit number of stored execution time observations between epochs.
 // Version 85: Enable party transfer in devnet.
 // Version 86: Use type tags in the object runtime and adapter instead of `Type`s.
+//             Make variant count limit explicit in protocol config.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -3729,6 +3730,7 @@ impl ProtocolConfig {
                 }
                 86 => {
                     cfg.feature_flags.type_tags_in_object_runtime = true;
+                    cfg.max_move_enum_variants = Some(move_core_types::VARIANT_COUNT_MAX);
 
                     // Set a stake_weighted_median_threshold for congestion control.
                     cfg.feature_flags.per_object_congestion_control_mode =

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_86.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_86.snap
@@ -156,6 +156,7 @@ max_event_emit_size_total: 65536000
 max_move_vector_len: 262144
 max_move_identifier_len: 128
 max_move_value_depth: 128
+max_move_enum_variants: 127
 max_back_edges_per_function: 10000
 max_back_edges_per_module: 10000
 max_verifier_meter_ticks_per_function: 16000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_86.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_86.snap
@@ -158,6 +158,7 @@ max_event_emit_size_total: 65536000
 max_move_vector_len: 262144
 max_move_identifier_len: 128
 max_move_value_depth: 128
+max_move_enum_variants: 127
 max_back_edges_per_function: 10000
 max_back_edges_per_module: 10000
 max_verifier_meter_ticks_per_function: 16000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_86.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_86.snap
@@ -164,6 +164,7 @@ max_event_emit_size_total: 65536000
 max_move_vector_len: 262144
 max_move_identifier_len: 128
 max_move_value_depth: 128
+max_move_enum_variants: 127
 max_back_edges_per_function: 10000
 max_back_edges_per_module: 10000
 max_verifier_meter_ticks_per_function: 16000000

--- a/external-crates/move/crates/move-binary-format/src/deserializer.rs
+++ b/external-crates/move/crates/move-binary-format/src/deserializer.rs
@@ -276,7 +276,7 @@ fn load_field_count(cursor: &mut VersionedCursor) -> BinaryLoaderResult<u64> {
 }
 
 fn load_variant_tag(cursor: &mut VersionedCursor) -> BinaryLoaderResult<u16> {
-    read_uleb_internal(cursor, VARIANT_COUNT_MAX)
+    read_uleb_internal(cursor, VARIANT_TAG_MAX_VALUE)
 }
 
 fn load_variant_count(cursor: &mut VersionedCursor) -> BinaryLoaderResult<u64> {

--- a/external-crates/move/crates/move-binary-format/src/file_format_common.rs
+++ b/external-crates/move/crates/move-binary-format/src/file_format_common.rs
@@ -170,6 +170,8 @@ pub const VARIANT_COUNT_MAX: u64 = {
     MVT::VARIANT_COUNT_MAX
 };
 
+pub const VARIANT_TAG_MAX_VALUE: u64 = VARIANT_COUNT_MAX - 1;
+
 #[allow(clippy::assertions_on_constants)]
 pub const JUMP_TABLE_INDEX_MAX: u64 = {
     assert!(

--- a/external-crates/move/crates/move-binary-format/src/proptest_types/functions.rs
+++ b/external-crates/move/crates/move-binary-format/src/proptest_types/functions.rs
@@ -15,7 +15,7 @@ use crate::{
         VariantInstantiationHandleIndex, VariantJumpTable, VariantJumpTableIndex, Visibility,
     },
     file_format_common::{
-        VARIANT_COUNT_MAX, VARIANT_HANDLE_INDEX_MAX, VARIANT_INSTANTIATION_HANDLE_INDEX_MAX,
+        VARIANT_HANDLE_INDEX_MAX, VARIANT_INSTANTIATION_HANDLE_INDEX_MAX, VARIANT_TAG_MAX_VALUE,
     },
     internals::ModuleIndex,
     proptest_types::{
@@ -956,7 +956,7 @@ impl BytecodeGen {
             }
             BytecodeGen::PackVariant(idx, tag) => {
                 let enum_defs_len = state.enum_defs.len();
-                if tag as u64 >= VARIANT_COUNT_MAX || enum_defs_len == 0 {
+                if tag as u64 > VARIANT_TAG_MAX_VALUE || enum_defs_len == 0 {
                     return None;
                 }
                 let ed_idx = idx.index(enum_defs_len);
@@ -986,7 +986,7 @@ impl BytecodeGen {
             }
             BytecodeGen::UnpackVariant(idx, tag) => {
                 let enum_defs_len = state.enum_defs.len();
-                if tag as u64 >= VARIANT_COUNT_MAX || enum_defs_len == 0 {
+                if tag as u64 > VARIANT_TAG_MAX_VALUE || enum_defs_len == 0 {
                     return None;
                 }
                 let ed_idx = idx.index(enum_defs_len);
@@ -1017,7 +1017,7 @@ impl BytecodeGen {
             }
             BytecodeGen::UnpackVariantImmRef(idx, tag) => {
                 let enum_defs_len = state.enum_defs.len();
-                if tag as u64 >= VARIANT_COUNT_MAX || enum_defs_len == 0 {
+                if tag as u64 > VARIANT_TAG_MAX_VALUE || enum_defs_len == 0 {
                     return None;
                 }
                 let ed_idx = idx.index(enum_defs_len);
@@ -1048,7 +1048,7 @@ impl BytecodeGen {
             }
             BytecodeGen::UnpackVariantMutRef(idx, tag) => {
                 let enum_defs_len = state.enum_defs.len();
-                if tag as u64 >= VARIANT_COUNT_MAX || enum_defs_len == 0 {
+                if tag as u64 > VARIANT_TAG_MAX_VALUE || enum_defs_len == 0 {
                     return None;
                 }
                 let ed_idx = idx.index(enum_defs_len);

--- a/external-crates/move/crates/move-binary-format/src/serializer.rs
+++ b/external-crates/move/crates/move-binary-format/src/serializer.rs
@@ -148,7 +148,7 @@ fn serialize_variant_count(binary: &mut BinaryData, len: usize) -> Result<()> {
 }
 
 fn serialize_variant_tag(binary: &mut BinaryData, tag: u16) -> Result<()> {
-    write_as_uleb128(binary, tag as u64, VARIANT_COUNT_MAX)
+    write_as_uleb128(binary, tag as u64, VARIANT_TAG_MAX_VALUE)
 }
 
 fn serialize_field_offset(binary: &mut BinaryData, offset: u16) -> Result<()> {

--- a/external-crates/move/crates/move-core-types/src/annotated_value.rs
+++ b/external-crates/move/crates/move-core-types/src/annotated_value.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    VARIANT_COUNT_MAX,
+    VARIANT_TAG_MAX_VALUE,
     account_address::AccountAddress,
     annotated_visitor::{Error as VError, ValueDriver, Visitor, visit_struct, visit_value},
     identifier::Identifier,
@@ -482,7 +482,7 @@ impl<'d> serde::de::Visitor<'d> for DecoratedEnumFieldVisitor<'_> {
         A: serde::de::SeqAccess<'d>,
     {
         let tag = match seq.next_element_seed(&MoveTypeLayout::U8)? {
-            Some(MoveValue::U8(tag)) if tag as u64 <= VARIANT_COUNT_MAX => tag as u16,
+            Some(MoveValue::U8(tag)) if tag as u64 <= VARIANT_TAG_MAX_VALUE => tag as u16,
             Some(MoveValue::U8(tag)) => return Err(A::Error::invalid_length(tag as usize, &self)),
             Some(val) => {
                 return Err(A::Error::invalid_type(

--- a/external-crates/move/crates/move-core-types/src/annotated_visitor.rs
+++ b/external-crates/move/crates/move-core-types/src/annotated_visitor.rs
@@ -4,7 +4,7 @@
 use std::io::{Cursor, Read};
 
 use crate::{
-    VARIANT_COUNT_MAX,
+    VARIANT_TAG_MAX_VALUE,
     account_address::AccountAddress,
     annotated_value::{MoveEnumLayout, MoveFieldLayout, MoveStructLayout, MoveTypeLayout},
     identifier::IdentStr,
@@ -775,7 +775,7 @@ fn visit_variant<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
     // When we add true ULEB encoding for enum variants switch to this:
     // let tag = inner.read_leb128()?;
     let [tag] = inner.read_exact()?;
-    if tag >= VARIANT_COUNT_MAX as u8 {
+    if tag > VARIANT_TAG_MAX_VALUE as u8 {
         return Err(Error::UnexpectedVariantTag(tag as usize).into());
     }
     let variant_layout = layout

--- a/external-crates/move/crates/move-core-types/src/lib.rs
+++ b/external-crates/move/crates/move-core-types/src/lib.rs
@@ -27,6 +27,9 @@ pub mod vm_status;
 
 pub const VARIANT_COUNT_MAX: u64 = 127;
 
+// Tags are zero-indexed so the max tag value is one less than the max variant count.
+pub const VARIANT_TAG_MAX_VALUE: u64 = VARIANT_COUNT_MAX - 1;
+
 pub(crate) fn fmt_list<T: fmt::Display>(
     f: &mut fmt::Formatter<'_>,
     begin: &str,

--- a/external-crates/move/crates/move-core-types/src/runtime_value.rs
+++ b/external-crates/move/crates/move-core-types/src/runtime_value.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    VARIANT_COUNT_MAX, account_address::AccountAddress, annotated_value as A, fmt_list, u256,
+    VARIANT_TAG_MAX_VALUE, account_address::AccountAddress, annotated_value as A, fmt_list, u256,
 };
 use anyhow::{Result as AResult, anyhow};
 use move_proc_macros::test_variant_order;
@@ -370,7 +370,7 @@ impl<'d> serde::de::Visitor<'d> for EnumFieldVisitor<'_> {
         A: serde::de::SeqAccess<'d>,
     {
         let tag = match seq.next_element_seed(&MoveTypeLayout::U8)? {
-            Some(MoveValue::U8(tag)) if tag as u64 <= VARIANT_COUNT_MAX => tag as u16,
+            Some(MoveValue::U8(tag)) if tag as u64 <= VARIANT_TAG_MAX_VALUE => tag as u16,
             Some(MoveValue::U8(tag)) => return Err(A::Error::invalid_length(tag as usize, &self)),
             Some(val) => {
                 return Err(A::Error::invalid_type(
@@ -447,10 +447,10 @@ impl serde::Serialize for MoveVariant {
     // in uleb encoding and we don't actually need to uleb encode it, but we can at a later date if
     // we want/need to.
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let tag = if self.tag as u64 > VARIANT_COUNT_MAX {
+        let tag = if self.tag as u64 > VARIANT_TAG_MAX_VALUE {
             return Err(serde::ser::Error::custom(format!(
                 "Variant tag {} is greater than the maximum allowed value of {}",
-                self.tag, VARIANT_COUNT_MAX
+                self.tag, VARIANT_TAG_MAX_VALUE
             )));
         } else {
             self.tag as u8

--- a/external-crates/move/crates/move-core-types/src/unit_tests/visitor_test.rs
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/visitor_test.rs
@@ -4,7 +4,7 @@
 use std::{fmt::Write, str::FromStr};
 
 use crate::{
-    VARIANT_COUNT_MAX,
+    VARIANT_TAG_MAX_VALUE,
     account_address::AccountAddress,
     annotated_value::{
         MoveEnumLayout, MoveFieldLayout, MoveStruct, MoveStructLayout, MoveTypeLayout, MoveValue,
@@ -416,10 +416,10 @@ fn out_of_range_enum_tag() {
     let mut bytes = serialize(value);
 
     // Invalid tag value
-    bytes[0] = VARIANT_COUNT_MAX as u8 + 1;
+    bytes[0] = VARIANT_TAG_MAX_VALUE as u8 + 1;
 
     assert_eq!(
-        "invalid variant tag: 128",
+        "invalid variant tag: 127",
         MoveValue::visit_deserialize(&bytes, &layout, &mut NullTraversal)
             .unwrap_err()
             .to_string(),

--- a/external-crates/move/crates/move-vm-types/src/values/values_impl.rs
+++ b/external-crates/move/crates/move-vm-types/src/values/values_impl.rs
@@ -10,9 +10,8 @@ use move_binary_format::{
     errors::*,
     file_format::{Constant, SignatureToken, VariantTag},
 };
-use move_core_types::annotated_value as A;
+use move_core_types::{VARIANT_TAG_MAX_VALUE, annotated_value as A};
 use move_core_types::{
-    VARIANT_COUNT_MAX,
     account_address::AccountAddress,
     effects::Op,
     gas_algebra::AbstractMemorySize,
@@ -3444,10 +3443,10 @@ impl serde::Serialize for Container {
             }
             Container::Variant(r) => {
                 let (tag, values) = &*r.borrow();
-                let tag = if *tag as u64 > VARIANT_COUNT_MAX {
+                let tag = if *tag as u64 > VARIANT_TAG_MAX_VALUE {
                     return Err(serde::ser::Error::custom(format!(
                         "Variant tag {} is greater than the maximum allowed value of {}",
-                        tag, VARIANT_COUNT_MAX
+                        tag, VARIANT_TAG_MAX_VALUE
                     )));
                 } else {
                     *tag as u8
@@ -3602,10 +3601,10 @@ impl serde::Serialize for AnnotatedValue<'_, '_, MoveStructLayout, Vec<ValueImpl
 impl serde::Serialize for AnnotatedValue<'_, '_, MoveEnumLayout, (VariantTag, Vec<ValueImpl>)> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let (tag, values) = &self.val;
-        let tag = if *tag as u64 > VARIANT_COUNT_MAX {
+        let tag = if *tag as u64 > VARIANT_TAG_MAX_VALUE {
             return Err(serde::ser::Error::custom(format!(
                 "Variant tag {} is greater than the maximum allowed value of {}",
-                tag, VARIANT_COUNT_MAX
+                tag, VARIANT_TAG_MAX_VALUE
             )));
         } else {
             *tag as u8
@@ -3814,7 +3813,7 @@ impl<'d> serde::de::Visitor<'d> for EnumFieldVisitor<'_> {
         A: serde::de::SeqAccess<'d>,
     {
         let tag = match seq.next_element_seed(&MoveTypeLayout::U8)? {
-            Some(MoveValue::U8(tag)) if tag as u64 <= VARIANT_COUNT_MAX => tag as u16,
+            Some(MoveValue::U8(tag)) if tag as u64 <= VARIANT_TAG_MAX_VALUE => tag as u16,
             Some(MoveValue::U8(tag)) => return Err(A::Error::invalid_length(tag as usize, &self)),
             Some(val) => {
                 return Err(A::Error::invalid_type(


### PR DESCRIPTION
## Description 

Cleanup the naming and usage of the constant names and do a bit of cleanup/administrivia around variant bounds. 

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [X] Protocol: Adds an existing hardcoded bound to the protocol config for clarity.
