### PR TITLE
[static-ptbs] Unify old an new execution entry point APIs

### DIFF
--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
@@ -90,6 +90,7 @@ mod checked {
         metrics: Arc<LimitsMetrics>,
         vm: &MoveVM,
         state_view: &mut dyn ExecutionState,
+        _package_store: &dyn BackingPackageStore,
         tx_context: Rc<RefCell<TxContext>>,
         gas_charger: &mut GasCharger,
         pt: ProgrammableTransaction,

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/mod.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/mod.rs
@@ -38,10 +38,10 @@ pub fn better_todo_<T>(s: String) -> T {
 
 pub fn execute<Mode: ExecutionMode>(
     protocol_config: &ProtocolConfig,
+    metrics: Arc<LimitsMetrics>,
     vm: &MoveVM,
     state_view: &mut dyn ExecutionState,
     package_store: &dyn BackingPackageStore,
-    metrics: Arc<LimitsMetrics>,
     tx_context: Rc<RefCell<TxContext>>,
     gas_charger: &mut GasCharger,
     txn: ProgrammableTransaction,


### PR DESCRIPTION
## Description 

Unify the PTB execution entrypoint API between the old and new PTB runtimes. This should make the switchover and testing easier.

## Test plan 

👁️ 👁️ 

