### PR TITLE
Add withdraw reservation to Transaction

### DIFF
--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -702,6 +702,7 @@ impl From<CallArg> for BenchMoveCallArg {
                 }
             },
             CallArg::BalanceWithdraw(_) => {
+                // TODO(address-balances): Support BalanceWithdraw in benchmarks.
                 todo!("BalanceWithdraw is not supported for benchmarks")
             }
         }

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -701,6 +701,9 @@ impl From<CallArg> for BenchMoveCallArg {
                     unimplemented!("Receiving is not supported for benchmarks")
                 }
             },
+            CallArg::BalanceWithdraw(_) => {
+                todo!("BalanceWithdraw is not supported for benchmarks")
+            }
         }
     }
 }

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -71,8 +71,8 @@ use sui_types::sui_system_state::{self, SuiSystemState};
 use sui_types::transaction::{
     AuthenticatorStateUpdate, CallArg, CertifiedTransaction, InputObjectKind, ObjectArg,
     ProgrammableTransaction, SenderSignedData, StoredExecutionTimeObservations, Transaction,
-    TransactionData, TransactionDataAPI, TransactionKey, TransactionKind, VerifiedCertificate,
-    VerifiedSignedTransaction, VerifiedTransaction,
+    TransactionData, TransactionDataAPI, TransactionKey, TransactionKind, TxValidityCheckContext,
+    VerifiedCertificate, VerifiedSignedTransaction, VerifiedTransaction,
 };
 use tap::TapOptional;
 use tokio::sync::{mpsc, OnceCell};
@@ -1359,6 +1359,16 @@ impl AuthorityPerEpochStore {
 
     pub fn epoch(&self) -> EpochId {
         self.committee.epoch
+    }
+
+    pub fn tx_validity_check_context(&self) -> TxValidityCheckContext {
+        TxValidityCheckContext {
+            config: &self.protocol_config,
+            epoch: self.epoch(),
+            accumulator_object_init_shared_version: self
+                .epoch_start_configuration
+                .accumulator_root_obj_initial_shared_version(),
+        }
     }
 
     pub fn get_state_hash_for_checkpoint(

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -53,7 +53,7 @@ pub async fn certify_transaction(
     // Make the initial request
     let epoch_store = authority.load_epoch_store_one_call_per_task();
     // TODO: Move this check to a more appropriate place.
-    transaction.validity_check(epoch_store.protocol_config(), epoch_store.epoch())?;
+    transaction.validity_check(&epoch_store.tx_validity_check_context())?;
     let transaction = epoch_store.verify_transaction(transaction).unwrap();
 
     let response = authority

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -165,7 +165,7 @@ impl SuiTxValidator {
     ) -> SuiResult<()> {
         // Currently validity_check() and verify_transaction() are not required to be consistent across validators,
         // so they do not run in validate_transactions(). They can run there once we confirm it is safe.
-        tx.validity_check(epoch_store.protocol_config(), epoch_store.epoch())?;
+        tx.validity_check(&epoch_store.tx_validity_check_context())?;
 
         self.authority_state.check_system_overload(
             &*self.consensus_overload_checker,

--- a/crates/sui-core/src/generate_format.rs
+++ b/crates/sui-core/src/generate_format.rs
@@ -33,7 +33,8 @@ use sui_types::messages_grpc::ObjectInfoRequestKind;
 use sui_types::move_package::TypeOrigin;
 use sui_types::object::Object;
 use sui_types::transaction::{
-    GenesisObject, SenderSignedData, StoredExecutionTimeObservations, TransactionData,
+    GenesisObject, Reservation, SenderSignedData, StoredExecutionTimeObservations, TransactionData,
+    WithdrawFrom,
 };
 use sui_types::type_input::{StructInput, TypeInput};
 use sui_types::{
@@ -199,6 +200,8 @@ fn get_registry() -> Result<Registry> {
     tracer
         .trace_type::<ExecutionFailureStatus>(&samples)
         .unwrap();
+    tracer.trace_type::<Reservation>(&samples).unwrap();
+    tracer.trace_type::<WithdrawFrom>(&samples).unwrap();
     tracer.trace_type::<CallArg>(&samples).unwrap();
     tracer.trace_type::<ObjectArg>(&samples).unwrap();
     tracer.trace_type::<Data>(&samples).unwrap();

--- a/crates/sui-core/src/generate_format.rs
+++ b/crates/sui-core/src/generate_format.rs
@@ -34,7 +34,7 @@ use sui_types::move_package::TypeOrigin;
 use sui_types::object::Object;
 use sui_types::transaction::{
     GenesisObject, Reservation, SenderSignedData, StoredExecutionTimeObservations, TransactionData,
-    WithdrawFrom,
+    WithdrawFrom, WithdrawTypeParam,
 };
 use sui_types::type_input::{StructInput, TypeInput};
 use sui_types::{
@@ -202,6 +202,7 @@ fn get_registry() -> Result<Registry> {
         .unwrap();
     tracer.trace_type::<Reservation>(&samples).unwrap();
     tracer.trace_type::<WithdrawFrom>(&samples).unwrap();
+    tracer.trace_type::<WithdrawTypeParam>(&samples).unwrap();
     tracer.trace_type::<CallArg>(&samples).unwrap();
     tracer.trace_type::<ObjectArg>(&samples).unwrap();
     tracer.trace_type::<Data>(&samples).unwrap();

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -43,7 +43,7 @@ pub async fn send_and_confirm_transaction(
 ) -> Result<(CertifiedTransaction, SignedTransactionEffects), SuiError> {
     // Make the initial request
     let epoch_store = authority.load_epoch_store_one_call_per_task();
-    transaction.validity_check(epoch_store.protocol_config(), epoch_store.epoch())?;
+    transaction.validity_check(&epoch_store.tx_validity_check_context())?;
     let transaction = epoch_store.verify_transaction(transaction)?;
     let response = authority
         .handle_transaction(&epoch_store, transaction.clone())

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -1360,7 +1360,7 @@ WithdrawFrom:
     0:
       Sender:
         NEWTYPE:
-          TYPENAME: TypeTag
+          TYPENAME: TypeInput
 ZkLoginAuthenticatorAsBytes:
   NEWTYPESTRUCT:
     SEQ: U8

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -83,6 +83,12 @@ AuthorityQuorumSignInfo:
           CONTENT: U8
           SIZE: 48
     - signers_map: BYTES
+BalanceWithdrawArg:
+  STRUCT:
+    - reservation:
+        TYPENAME: Reservation
+    - withdraw_from:
+        TYPENAME: WithdrawFrom
 CallArg:
   ENUM:
     0:
@@ -93,6 +99,10 @@ CallArg:
       Object:
         NEWTYPE:
           TYPENAME: ObjectArg
+    2:
+      BalanceWithdraw:
+        NEWTYPE:
+          TYPENAME: BalanceWithdrawArg
 ChainIdentifier:
   NEWTYPESTRUCT:
     TYPENAME: CheckpointDigest
@@ -972,6 +982,13 @@ RandomnessStateUpdate:
         SEQ: U8
     - randomness_obj_initial_shared_version:
         TYPENAME: SequenceNumber
+Reservation:
+  ENUM:
+    0:
+      EntireBalance: UNIT
+    1:
+      MaxAmount:
+        NEWTYPE: U64
 SenderSignedData:
   NEWTYPESTRUCT:
     SEQ:
@@ -1338,6 +1355,12 @@ UpgradeInfo:
         TYPENAME: ObjectID
     - upgraded_version:
         TYPENAME: SequenceNumber
+WithdrawFrom:
+  ENUM:
+    0:
+      Sender:
+        NEWTYPE:
+          TYPENAME: TypeTag
 ZkLoginAuthenticatorAsBytes:
   NEWTYPESTRUCT:
     SEQ: U8

--- a/crates/sui-core/tests/staged/sui.yaml
+++ b/crates/sui-core/tests/staged/sui.yaml
@@ -87,6 +87,8 @@ BalanceWithdrawArg:
   STRUCT:
     - reservation:
         TYPENAME: Reservation
+    - type_param:
+        TYPENAME: WithdrawTypeParam
     - withdraw_from:
         TYPENAME: WithdrawFrom
 CallArg:
@@ -987,7 +989,7 @@ Reservation:
     0:
       EntireBalance: UNIT
     1:
-      MaxAmount:
+      MaxAmountU64:
         NEWTYPE: U64
 SenderSignedData:
   NEWTYPESTRUCT:
@@ -1358,7 +1360,11 @@ UpgradeInfo:
 WithdrawFrom:
   ENUM:
     0:
-      Sender:
+      Sender: UNIT
+WithdrawTypeParam:
+  ENUM:
+    0:
+      Balance:
         NEWTYPE:
           TYPENAME: TypeInput
 ZkLoginAuthenticatorAsBytes:

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
@@ -449,6 +449,7 @@ impl TransactionInput {
                 },
             }),
 
+            // TODO(address-balances): Add support for balance withdraws.
             N::BalanceWithdraw(_) => todo!("BalanceWithdraw is not supported for GraphQL"),
         }
     }

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
@@ -448,6 +448,8 @@ impl TransactionInput {
                     checkpoint_viewed_at,
                 },
             }),
+
+            N::BalanceWithdraw(_) => todo!("BalanceWithdraw is not supported for GraphQL"),
         }
     }
 }

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -2271,6 +2271,9 @@ impl SuiCallArg {
                     digest,
                 })
             }
+            CallArg::BalanceWithdraw(_) => {
+                todo!("Balance withdraws not yet supported in json rpc types")
+            }
         })
     }
 

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -2272,6 +2272,7 @@ impl SuiCallArg {
                 })
             }
             CallArg::BalanceWithdraw(_) => {
+                // TODO(address-balances): Add support for balance withdraws.
                 todo!("Balance withdraws not yet supported in json rpc types")
             }
         })

--- a/crates/sui-replay/src/displays/transaction_displays.rs
+++ b/crates/sui-replay/src/displays/transaction_displays.rs
@@ -80,7 +80,7 @@ impl Display for Pretty<'_, FullPTB> {
                     CallArg::BalanceWithdraw(r) => {
                         builder.push_record(vec![format!(
                             "{i:<3} Balance Withdraw reservation from {:?} and max amount {:?}",
-                            r.withdraw_from, r.max_amount
+                            r.withdraw_from, r.reservation
                         )]);
                     }
                 };

--- a/crates/sui-replay/src/displays/transaction_displays.rs
+++ b/crates/sui-replay/src/displays/transaction_displays.rs
@@ -77,6 +77,12 @@ impl Display for Pretty<'_, FullPTB> {
                     CallArg::Object(ObjectArg::Receiving(o)) => {
                         builder.push_record(vec![format!("{i:<3} Receiving Object  ID: {}", o.0)]);
                     }
+                    CallArg::BalanceWithdraw(r) => {
+                        builder.push_record(vec![format!(
+                            "{i:<3} Balance Withdraw reservation from {:?} and max amount {:?}",
+                            r.withdraw_from, r.max_amount
+                        )]);
+                    }
                 };
             }
 

--- a/crates/sui-types/src/accumulator_root.rs
+++ b/crates/sui-types/src/accumulator_root.rs
@@ -2,10 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    base_types::SequenceNumber, error::SuiResult, object::Owner, storage::ObjectStore,
-    SUI_ACCUMULATOR_ROOT_OBJECT_ID,
+    base_types::{ObjectID, SequenceNumber, SuiAddress},
+    dynamic_field::{derive_dynamic_field_id, DOFWrapper},
+    error::SuiResult,
+    object::Owner,
+    storage::ObjectStore,
+    MoveTypeTagTrait, SUI_ACCUMULATOR_ROOT_OBJECT_ID, SUI_FRAMEWORK_PACKAGE_ID,
 };
-use move_core_types::{ident_str, identifier::IdentStr};
+use move_core_types::{
+    ident_str,
+    identifier::IdentStr,
+    language_storage::{StructTag, TypeTag},
+};
+use serde::{Deserialize, Serialize};
 
 pub const ACCUMULATOR_ROOT_MODULE: &IdentStr = ident_str!("accumulator");
 pub const ACCUMULATOR_ROOT_CREATE_FUNC: &IdentStr = ident_str!("create");
@@ -21,4 +30,44 @@ pub fn get_accumulator_root_obj_initial_shared_version(
             } => initial_shared_version,
             _ => unreachable!("Accumulator root object must be shared"),
         }))
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct AccumulatorKey {
+    owner: SuiAddress,
+    type_tag: TypeTag,
+}
+
+impl AccumulatorKey {
+    pub fn type_() -> StructTag {
+        StructTag {
+            address: SUI_FRAMEWORK_PACKAGE_ID.into(),
+            module: ACCUMULATOR_ROOT_MODULE.to_owned(),
+            name: ident_str!("AccumulatorKey").to_owned(),
+            type_params: vec![],
+        }
+    }
+}
+
+impl MoveTypeTagTrait for AccumulatorKey {
+    fn get_type_tag() -> TypeTag {
+        TypeTag::Struct(Box::new(Self::type_()))
+    }
+}
+
+// TODO: This may not be the actual way of organizing balance accounts.
+// Fix it when we have the Move code.
+pub fn derive_balance_account_object_id(
+    owner: SuiAddress,
+    type_tag: TypeTag,
+) -> anyhow::Result<ObjectID> {
+    let key = DOFWrapper {
+        name: AccumulatorKey { owner, type_tag },
+    };
+    derive_dynamic_field_id(
+        SUI_ACCUMULATOR_ROOT_OBJECT_ID,
+        &AccumulatorKey::get_type_tag(),
+        &bcs::to_bytes(&key)?,
+    )
+    .map_err(|e| e.into())
 }

--- a/crates/sui-types/src/accumulator_root.rs
+++ b/crates/sui-types/src/accumulator_root.rs
@@ -7,6 +7,7 @@ use crate::{
     error::SuiResult,
     object::Owner,
     storage::ObjectStore,
+    type_input::TypeInput,
     MoveTypeTagTrait, SUI_ACCUMULATOR_ROOT_OBJECT_ID, SUI_FRAMEWORK_PACKAGE_ID,
 };
 use move_core_types::{
@@ -59,10 +60,13 @@ impl MoveTypeTagTrait for AccumulatorKey {
 // Fix it when we have the Move code.
 pub fn derive_balance_account_object_id(
     owner: SuiAddress,
-    type_tag: TypeTag,
+    balance_type: TypeInput,
 ) -> anyhow::Result<ObjectID> {
     let key = DOFWrapper {
-        name: AccumulatorKey { owner, type_tag },
+        name: AccumulatorKey {
+            owner,
+            type_tag: balance_type.to_type_tag()?,
+        },
     };
     derive_dynamic_field_id(
         SUI_ACCUMULATOR_ROOT_OBJECT_ID,

--- a/crates/sui-types/src/accumulator_root.rs
+++ b/crates/sui-types/src/accumulator_root.rs
@@ -33,10 +33,13 @@ pub fn get_accumulator_root_obj_initial_shared_version(
         }))
 }
 
+/// Rust type for the Move type AccumulatorKey used to derive the dynamic field id for the
+/// balance account object.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 struct AccumulatorKey {
     owner: SuiAddress,
-    type_tag: TypeTag,
+    /// Raw bytes of the balance type name string.
+    type_tag: Vec<u8>,
 }
 
 impl AccumulatorKey {
@@ -56,8 +59,6 @@ impl MoveTypeTagTrait for AccumulatorKey {
     }
 }
 
-// TODO(address-balances): This may not be the actual way of organizing balance accounts.
-// Fix it when we have the Move code.
 pub fn derive_balance_account_object_id(
     owner: SuiAddress,
     balance_type: TypeInput,
@@ -65,7 +66,7 @@ pub fn derive_balance_account_object_id(
     let key = DOFWrapper {
         name: AccumulatorKey {
             owner,
-            type_tag: balance_type.to_type_tag()?,
+            type_tag: balance_type.to_canonical_string(false).into_bytes(),
         },
     };
     derive_dynamic_field_id(

--- a/crates/sui-types/src/accumulator_root.rs
+++ b/crates/sui-types/src/accumulator_root.rs
@@ -55,7 +55,7 @@ impl MoveTypeTagTrait for AccumulatorKey {
     }
 }
 
-// TODO: This may not be the actual way of organizing balance accounts.
+// TODO(address-balances): This may not be the actual way of organizing balance accounts.
 // Fix it when we have the Move code.
 pub fn derive_balance_account_object_id(
     owner: SuiAddress,

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -297,6 +297,9 @@ pub enum UserInputError {
 
     #[error("Object used as owned is not owned")]
     NotOwnedObjectError,
+
+    #[error("Invalid withdraw reservation: {error}")]
+    InvalidWithdrawReservation { error: String },
 }
 
 #[derive(

--- a/crates/sui-types/src/executable_transaction.rs
+++ b/crates/sui-types/src/executable_transaction.rs
@@ -5,8 +5,7 @@ use crate::messages_checkpoint::CheckpointSequenceNumber;
 use crate::{committee::EpochId, crypto::AuthorityStrongQuorumSignInfo};
 
 use crate::message_envelope::{Envelope, TrustedEnvelope, VerifiedEnvelope};
-use crate::transaction::SenderSignedData;
-use crate::transaction::TransactionDataAPI;
+use crate::transaction::{SenderSignedData, TransactionDataAPI};
 use serde::{Deserialize, Serialize};
 
 /// CertificateProof is a proof that a transaction certs existed at a given epoch and hence can be executed.

--- a/crates/sui-types/src/programmable_transaction_builder.rs
+++ b/crates/sui-types/src/programmable_transaction_builder.rs
@@ -75,6 +75,9 @@ impl ProgrammableTransactionBuilder {
             let old_obj_arg = match old_value {
                 CallArg::Pure(_) => anyhow::bail!("invariant violation! object has pure argument"),
                 CallArg::Object(arg) => arg,
+                CallArg::BalanceWithdraw(_) => {
+                    anyhow::bail!("invariant violation! object has balance withdraw argument")
+                }
             };
             match (old_obj_arg, obj_arg) {
                 (
@@ -121,6 +124,9 @@ impl ProgrammableTransactionBuilder {
         match call_arg {
             CallArg::Pure(bytes) => Ok(self.pure_bytes(bytes, /* force separate */ false)),
             CallArg::Object(obj) => self.obj(obj),
+            CallArg::BalanceWithdraw(_) => {
+                todo!("Convert balance withdraw reservation to argument")
+            }
         }
     }
 

--- a/crates/sui-types/src/programmable_transaction_builder.rs
+++ b/crates/sui-types/src/programmable_transaction_builder.rs
@@ -125,6 +125,7 @@ impl ProgrammableTransactionBuilder {
             CallArg::Pure(bytes) => Ok(self.pure_bytes(bytes, /* force separate */ false)),
             CallArg::Object(obj) => self.obj(obj),
             CallArg::BalanceWithdraw(_) => {
+                // TODO(address-balances): Add support for balance withdraws.
                 todo!("Convert balance withdraw reservation to argument")
             }
         }

--- a/crates/sui-types/src/programmable_transaction_builder.rs
+++ b/crates/sui-types/src/programmable_transaction_builder.rs
@@ -12,7 +12,9 @@ use serde::Serialize;
 use crate::{
     base_types::{FullObjectID, FullObjectRef, ObjectID, ObjectRef, SuiAddress},
     move_package::PACKAGE_MODULE_NAME,
-    transaction::{Argument, CallArg, Command, ObjectArg, ProgrammableTransaction},
+    transaction::{
+        Argument, BalanceWithdrawArg, CallArg, Command, ObjectArg, ProgrammableTransaction,
+    },
     SUI_FRAMEWORK_PACKAGE_ID,
 };
 
@@ -25,6 +27,7 @@ enum BuilderArg {
     Object(ObjectID),
     Pure(Vec<u8>),
     ForcedNonUniquePure(usize),
+    BalanceWithdraw(usize),
 }
 
 #[derive(Default)]
@@ -120,14 +123,19 @@ impl ProgrammableTransactionBuilder {
         Ok(Argument::Input(i as u16))
     }
 
+    pub fn balance_withdraw(&mut self, arg: BalanceWithdrawArg) -> anyhow::Result<Argument> {
+        let (i, _) = self.inputs.insert_full(
+            BuilderArg::BalanceWithdraw(self.inputs.len()),
+            CallArg::BalanceWithdraw(arg),
+        );
+        Ok(Argument::Input(i as u16))
+    }
+
     pub fn input(&mut self, call_arg: CallArg) -> anyhow::Result<Argument> {
         match call_arg {
             CallArg::Pure(bytes) => Ok(self.pure_bytes(bytes, /* force separate */ false)),
             CallArg::Object(obj) => self.obj(obj),
-            CallArg::BalanceWithdraw(_) => {
-                // TODO(address-balances): Add support for balance withdraws.
-                todo!("Convert balance withdraw reservation to argument")
-            }
+            CallArg::BalanceWithdraw(arg) => self.balance_withdraw(arg),
         }
     }
 

--- a/crates/sui-types/src/sui_sdk_types_conversions.rs
+++ b/crates/sui-types/src/sui_sdk_types_conversions.rs
@@ -1149,6 +1149,9 @@ impl From<crate::transaction::CallArg> for Input {
                     ObjectReference::new(id.into(), version.value(), digest.into()),
                 ),
             },
+            crate::transaction::CallArg::BalanceWithdraw(_) => {
+                todo!("Convert balance withdraw reservation to sdk Input")
+            }
         }
     }
 }

--- a/crates/sui-types/src/sui_sdk_types_conversions.rs
+++ b/crates/sui-types/src/sui_sdk_types_conversions.rs
@@ -1150,6 +1150,7 @@ impl From<crate::transaction::CallArg> for Input {
                 ),
             },
             crate::transaction::CallArg::BalanceWithdraw(_) => {
+                // TODO(address-balances): Add support for balance withdraws.
                 todo!("Convert balance withdraw reservation to sdk Input")
             }
         }

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -140,26 +140,25 @@ pub struct BalanceWithdrawArg {
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub enum WithdrawFrom {
     /// Withdraw from the sender of the transaction, with balance type T as T in Balance<T>.
-    // TODO(address-balances): Use TypeInput instead of TypeTag.
     // TODO(address-balances): Consider hoisting the type tag to BalanceWithdrawArg.
-    Sender(TypeTag),
+    Sender(TypeInput),
     // TODO(address-balances): Add more options here, such as Sponsor, or even multi-party withdraws.
 }
 
 impl BalanceWithdrawArg {
     #[allow(unused)]
-    pub fn new_with_amount(amount: u64, type_tag: TypeTag) -> Self {
+    pub fn new_with_amount(amount: u64, balance_type: TypeInput) -> Self {
         Self {
             reservation: Reservation::MaxAmount(amount),
-            withdraw_from: WithdrawFrom::Sender(type_tag),
+            withdraw_from: WithdrawFrom::Sender(balance_type),
         }
     }
 
     #[allow(unused)]
-    pub fn new_with_entire_balance(type_tag: TypeTag) -> Self {
+    pub fn new_with_entire_balance(balance_type: TypeInput) -> Self {
         Self {
             reservation: Reservation::EntireBalance,
-            withdraw_from: WithdrawFrom::Sender(type_tag),
+            withdraw_from: WithdrawFrom::Sender(balance_type),
         }
     }
 }
@@ -2316,12 +2315,10 @@ impl TransactionDataAPI for TransactionDataV1 {
                     });
                 }
             }
-            let WithdrawFrom::Sender(type_tag) = withdraw.withdraw_from;
-            let account_id =
-                derive_balance_account_object_id(self.sender(), type_tag).map_err(|e| {
-                    UserInputError::InvalidWithdrawReservation {
-                        error: e.to_string(),
-                    }
+            let WithdrawFrom::Sender(balance_type) = withdraw.withdraw_from;
+            let account_id = derive_balance_account_object_id(self.sender(), balance_type)
+                .map_err(|e| UserInputError::InvalidWithdrawReservation {
+                    error: e.to_string(),
                 })?;
             let entry = withdraw_map
                 .entry(account_id)

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -142,6 +142,24 @@ pub enum WithdrawFrom {
     // TODO(address-balances): Add more options here, such as Sponsor, or even multi-party withdraws.
 }
 
+impl BalanceWithdrawArg {
+    #[allow(unused)]
+    pub fn new_with_amount(amount: u64, type_tag: TypeTag) -> Self {
+        Self {
+            reservation: Reservation::MaxAmount(amount),
+            withdraw_from: WithdrawFrom::Sender(type_tag),
+        }
+    }
+
+    #[allow(unused)]
+    pub fn new_with_entire_balance(type_tag: TypeTag) -> Self {
+        Self {
+            reservation: Reservation::EntireBalance,
+            withdraw_from: WithdrawFrom::Sender(type_tag),
+        }
+    }
+}
+
 fn type_input_validity_check(
     tag: &TypeInput,
     config: &ProtocolConfig,

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -2287,6 +2287,13 @@ impl TransactionDataAPI for TransactionDataV1 {
 
         let mut withdraw_map = BTreeMap::new();
         for withdraw in withdraws {
+            if let Reservation::MaxAmount(amount) = &withdraw.reservation {
+                if *amount == 0 {
+                    return Err(UserInputError::InvalidWithdrawReservation {
+                        error: "Balance withdraw reservation amount must be non-zero".to_string(),
+                    });
+                }
+            }
             let WithdrawFrom::Sender(type_tag) = withdraw.withdraw_from;
             let account_id =
                 derive_balance_account_object_id(self.sender(), type_tag).map_err(|e| {

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -140,14 +140,13 @@ pub struct BalanceWithdrawArg {
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub enum WithdrawFrom {
-    /// Withdraw from the sender of the transaction, with balance type T as T in Balance<T>.
+    /// Withdraw from the sender of the transaction, with balance type T as T in `Balance<T>`.
     // TODO(address-balances): Consider hoisting the type tag to BalanceWithdrawArg.
     Sender(TypeInput),
     // TODO(address-balances): Add more options here, such as Sponsor, or even multi-party withdraws.
 }
 
 impl BalanceWithdrawArg {
-    #[allow(unused)]
     pub fn new_with_amount(amount: u64, balance_type: TypeInput) -> Self {
         Self {
             reservation: Reservation::MaxAmount(amount),
@@ -155,7 +154,6 @@ impl BalanceWithdrawArg {
         }
     }
 
-    #[allow(unused)]
     pub fn new_with_entire_balance(balance_type: TypeInput) -> Self {
         Self {
             reservation: Reservation::EntireBalance,

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -137,6 +137,7 @@ pub struct BalanceWithdrawArg {
 pub enum WithdrawFrom {
     /// Withdraw from the sender of the transaction, with balance type T as T in Balance<T>.
     // TODO(address-balances): Use TypeInput instead of TypeTag.
+    // TODO(address-balances): Consider hoisting the type tag to BalanceWithdrawArg.
     Sender(TypeTag),
     // TODO(address-balances): Add more options here, such as Sponsor, or even multi-party withdraws.
 }

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -77,6 +77,10 @@ const BLOCKED_MOVE_FUNCTIONS: [(ObjectID, &str, &str); 0] = [];
 #[path = "unit_tests/messages_tests.rs"]
 mod messages_tests;
 
+#[cfg(test)]
+#[path = "unit_tests/balance_withdraw_tests.rs"]
+mod balance_withdraw_tests;
+
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub enum CallArg {
     // contains no structs or objects
@@ -2331,13 +2335,10 @@ impl TransactionDataAPI for TransactionDataV1 {
                     )?;
                     *entry = Reservation::MaxAmount(new_amount);
                 }
-                (Reservation::MaxAmount(_), Reservation::EntireBalance)
-                | (Reservation::EntireBalance, Reservation::MaxAmount(_)) => {
-                    *entry = Reservation::EntireBalance;
-                }
-                (Reservation::EntireBalance, Reservation::EntireBalance) => {
+                _ => {
                     return Err(UserInputError::InvalidWithdrawReservation {
-                        error: "Cannot reserve entire balance twice on the same account"
+                        error: "If there exists a reservation that reserves the entire balance,
+                        no further reservation can be made on the same account."
                             .to_string(),
                     });
                 }

--- a/crates/sui-types/src/unit_tests/balance_withdraw_tests.rs
+++ b/crates/sui-types/src/unit_tests/balance_withdraw_tests.rs
@@ -8,7 +8,7 @@ use crate::{
     base_types::{random_object_ref, SuiAddress},
     gas_coin::GAS,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
-    transaction::{BalanceWithdrawArg, TransactionData, TransactionDataAPI},
+    transaction::{BalanceWithdrawArg, TransactionData, TransactionDataAPI, WithdrawTypeParam},
     type_input::TypeInput,
 };
 
@@ -22,8 +22,11 @@ fn test_withdraw_max_amount() {
         TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
     assert!(tx.has_balance_withdraws());
     let withdraws = tx.balance_withdraws().unwrap();
-    let account_id =
-        derive_balance_account_object_id(sender, TypeInput::from(GAS::type_tag())).unwrap();
+    let account_id = derive_balance_account_object_id(
+        sender,
+        WithdrawTypeParam::Balance(GAS::type_tag().into()),
+    )
+    .unwrap();
     assert_eq!(withdraws, BTreeMap::from([(account_id, arg.reservation)]));
 }
 
@@ -37,8 +40,11 @@ fn test_withdraw_entire_balance() {
         TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
     assert!(tx.has_balance_withdraws());
     let withdraws = tx.balance_withdraws().unwrap();
-    let account_id =
-        derive_balance_account_object_id(sender, TypeInput::from(GAS::type_tag())).unwrap();
+    let account_id = derive_balance_account_object_id(
+        sender,
+        WithdrawTypeParam::Balance(GAS::type_tag().into()),
+    )
+    .unwrap();
     assert_eq!(withdraws, BTreeMap::from([(account_id, arg.reservation)]));
 }
 
@@ -54,9 +60,14 @@ fn test_multiple_withdraws() {
         TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
     assert!(tx.has_balance_withdraws());
     let withdraws = tx.balance_withdraws().unwrap();
-    let account_id1 =
-        derive_balance_account_object_id(sender, TypeInput::from(GAS::type_tag())).unwrap();
-    let account_id2 = derive_balance_account_object_id(sender, TypeInput::Bool).unwrap();
+    let account_id1 = derive_balance_account_object_id(
+        sender,
+        WithdrawTypeParam::Balance(GAS::type_tag().into()),
+    )
+    .unwrap();
+    let account_id2 =
+        derive_balance_account_object_id(sender, WithdrawTypeParam::Balance(TypeInput::Bool))
+            .unwrap();
     assert_eq!(
         withdraws,
         BTreeMap::from([
@@ -114,9 +125,14 @@ fn test_withdraw_entire_balance_multiple_times_different_types() {
     let tx =
         TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
     let withdraws = tx.balance_withdraws().unwrap();
-    let account_id1 =
-        derive_balance_account_object_id(sender, TypeInput::from(GAS::type_tag())).unwrap();
-    let account_id2 = derive_balance_account_object_id(sender, TypeInput::Bool).unwrap();
+    let account_id1 = derive_balance_account_object_id(
+        sender,
+        WithdrawTypeParam::Balance(GAS::type_tag().into()),
+    )
+    .unwrap();
+    let account_id2 =
+        derive_balance_account_object_id(sender, WithdrawTypeParam::Balance(TypeInput::Bool))
+            .unwrap();
     assert_eq!(
         withdraws,
         BTreeMap::from([

--- a/crates/sui-types/src/unit_tests/balance_withdraw_tests.rs
+++ b/crates/sui-types/src/unit_tests/balance_withdraw_tests.rs
@@ -3,19 +3,18 @@
 
 use std::collections::BTreeMap;
 
-use move_core_types::language_storage::TypeTag;
-
 use crate::{
     accumulator_root::derive_balance_account_object_id,
     base_types::{random_object_ref, SuiAddress},
     gas_coin::GAS,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     transaction::{BalanceWithdrawArg, TransactionData, TransactionDataAPI},
+    type_input::TypeInput,
 };
 
 #[test]
 fn test_withdraw_max_amount() {
-    let arg = BalanceWithdrawArg::new_with_amount(100, GAS::type_tag());
+    let arg = BalanceWithdrawArg::new_with_amount(100, TypeInput::from(GAS::type_tag()));
     let mut ptb = ProgrammableTransactionBuilder::new();
     ptb.balance_withdraw(arg.clone()).unwrap();
     let sender = SuiAddress::random_for_testing_only();
@@ -23,13 +22,14 @@ fn test_withdraw_max_amount() {
         TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
     assert!(tx.has_balance_withdraws());
     let withdraws = tx.balance_withdraws().unwrap();
-    let account_id = derive_balance_account_object_id(sender, GAS::type_tag()).unwrap();
+    let account_id =
+        derive_balance_account_object_id(sender, TypeInput::from(GAS::type_tag())).unwrap();
     assert_eq!(withdraws, BTreeMap::from([(account_id, arg.reservation)]));
 }
 
 #[test]
 fn test_withdraw_entire_balance() {
-    let arg = BalanceWithdrawArg::new_with_entire_balance(GAS::type_tag());
+    let arg = BalanceWithdrawArg::new_with_entire_balance(TypeInput::from(GAS::type_tag()));
     let mut ptb = ProgrammableTransactionBuilder::new();
     ptb.balance_withdraw(arg.clone()).unwrap();
     let sender = SuiAddress::random_for_testing_only();
@@ -37,14 +37,15 @@ fn test_withdraw_entire_balance() {
         TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
     assert!(tx.has_balance_withdraws());
     let withdraws = tx.balance_withdraws().unwrap();
-    let account_id = derive_balance_account_object_id(sender, GAS::type_tag()).unwrap();
+    let account_id =
+        derive_balance_account_object_id(sender, TypeInput::from(GAS::type_tag())).unwrap();
     assert_eq!(withdraws, BTreeMap::from([(account_id, arg.reservation)]));
 }
 
 #[test]
 fn test_multiple_withdraws() {
-    let arg1 = BalanceWithdrawArg::new_with_amount(100, GAS::type_tag());
-    let arg2 = BalanceWithdrawArg::new_with_entire_balance(TypeTag::Bool);
+    let arg1 = BalanceWithdrawArg::new_with_amount(100, TypeInput::from(GAS::type_tag()));
+    let arg2 = BalanceWithdrawArg::new_with_entire_balance(TypeInput::Bool);
     let mut ptb = ProgrammableTransactionBuilder::new();
     ptb.balance_withdraw(arg1.clone()).unwrap();
     ptb.balance_withdraw(arg2.clone()).unwrap();
@@ -53,8 +54,9 @@ fn test_multiple_withdraws() {
         TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
     assert!(tx.has_balance_withdraws());
     let withdraws = tx.balance_withdraws().unwrap();
-    let account_id1 = derive_balance_account_object_id(sender, GAS::type_tag()).unwrap();
-    let account_id2 = derive_balance_account_object_id(sender, TypeTag::Bool).unwrap();
+    let account_id1 =
+        derive_balance_account_object_id(sender, TypeInput::from(GAS::type_tag())).unwrap();
+    let account_id2 = derive_balance_account_object_id(sender, TypeInput::Bool).unwrap();
     assert_eq!(
         withdraws,
         BTreeMap::from([
@@ -66,7 +68,7 @@ fn test_multiple_withdraws() {
 
 #[test]
 fn test_withdraw_zero_amount() {
-    let arg = BalanceWithdrawArg::new_with_amount(0, GAS::type_tag());
+    let arg = BalanceWithdrawArg::new_with_amount(0, TypeInput::from(GAS::type_tag()));
     let mut ptb = ProgrammableTransactionBuilder::new();
     ptb.balance_withdraw(arg.clone()).unwrap();
     let sender = SuiAddress::random_for_testing_only();
@@ -77,8 +79,8 @@ fn test_withdraw_zero_amount() {
 
 #[test]
 fn test_withdraw_entire_balance_multiple_times() {
-    let arg1 = BalanceWithdrawArg::new_with_entire_balance(GAS::type_tag());
-    let arg2 = BalanceWithdrawArg::new_with_entire_balance(GAS::type_tag());
+    let arg1 = BalanceWithdrawArg::new_with_entire_balance(TypeInput::from(GAS::type_tag()));
+    let arg2 = BalanceWithdrawArg::new_with_entire_balance(TypeInput::from(GAS::type_tag()));
     let mut ptb = ProgrammableTransactionBuilder::new();
     ptb.balance_withdraw(arg1.clone()).unwrap();
     ptb.balance_withdraw(arg2.clone()).unwrap();
@@ -90,8 +92,8 @@ fn test_withdraw_entire_balance_multiple_times() {
 
 #[test]
 fn test_withdraw_amount_and_entire_balance() {
-    let arg1 = BalanceWithdrawArg::new_with_amount(100, GAS::type_tag());
-    let arg2 = BalanceWithdrawArg::new_with_entire_balance(GAS::type_tag());
+    let arg1 = BalanceWithdrawArg::new_with_amount(100, TypeInput::from(GAS::type_tag()));
+    let arg2 = BalanceWithdrawArg::new_with_entire_balance(TypeInput::from(GAS::type_tag()));
     let mut ptb = ProgrammableTransactionBuilder::new();
     ptb.balance_withdraw(arg1.clone()).unwrap();
     ptb.balance_withdraw(arg2.clone()).unwrap();
@@ -103,8 +105,8 @@ fn test_withdraw_amount_and_entire_balance() {
 
 #[test]
 fn test_withdraw_entire_balance_multiple_times_different_types() {
-    let arg1 = BalanceWithdrawArg::new_with_entire_balance(GAS::type_tag());
-    let arg2 = BalanceWithdrawArg::new_with_entire_balance(TypeTag::Bool);
+    let arg1 = BalanceWithdrawArg::new_with_entire_balance(TypeInput::from(GAS::type_tag()));
+    let arg2 = BalanceWithdrawArg::new_with_entire_balance(TypeInput::Bool);
     let mut ptb = ProgrammableTransactionBuilder::new();
     ptb.balance_withdraw(arg1.clone()).unwrap();
     ptb.balance_withdraw(arg2.clone()).unwrap();
@@ -112,8 +114,9 @@ fn test_withdraw_entire_balance_multiple_times_different_types() {
     let tx =
         TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
     let withdraws = tx.balance_withdraws().unwrap();
-    let account_id1 = derive_balance_account_object_id(sender, GAS::type_tag()).unwrap();
-    let account_id2 = derive_balance_account_object_id(sender, TypeTag::Bool).unwrap();
+    let account_id1 =
+        derive_balance_account_object_id(sender, TypeInput::from(GAS::type_tag())).unwrap();
+    let account_id2 = derive_balance_account_object_id(sender, TypeInput::Bool).unwrap();
     assert_eq!(
         withdraws,
         BTreeMap::from([
@@ -127,8 +130,11 @@ fn test_withdraw_entire_balance_multiple_times_different_types() {
 fn test_withdraw_too_many_withdraws() {
     let mut ptb = ProgrammableTransactionBuilder::new();
     for _ in 0..11 {
-        ptb.balance_withdraw(BalanceWithdrawArg::new_with_amount(100, GAS::type_tag()))
-            .unwrap();
+        ptb.balance_withdraw(BalanceWithdrawArg::new_with_amount(
+            100,
+            TypeInput::from(GAS::type_tag()),
+        ))
+        .unwrap();
     }
     let sender = SuiAddress::random_for_testing_only();
     let tx =

--- a/crates/sui-types/src/unit_tests/balance_withdraw_tests.rs
+++ b/crates/sui-types/src/unit_tests/balance_withdraw_tests.rs
@@ -21,7 +21,7 @@ fn test_withdraw_max_amount() {
     let tx =
         TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
     assert!(tx.has_balance_withdraws());
-    let withdraws = tx.balance_withdraws().unwrap();
+    let withdraws = tx.process_balance_withdraws().unwrap();
     let account_id = derive_balance_account_object_id(
         sender,
         WithdrawTypeParam::Balance(GAS::type_tag().into()),
@@ -39,7 +39,7 @@ fn test_withdraw_entire_balance() {
     let tx =
         TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
     assert!(tx.has_balance_withdraws());
-    let withdraws = tx.balance_withdraws().unwrap();
+    let withdraws = tx.process_balance_withdraws().unwrap();
     let account_id = derive_balance_account_object_id(
         sender,
         WithdrawTypeParam::Balance(GAS::type_tag().into()),
@@ -59,7 +59,7 @@ fn test_multiple_withdraws() {
     let tx =
         TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
     assert!(tx.has_balance_withdraws());
-    let withdraws = tx.balance_withdraws().unwrap();
+    let withdraws = tx.process_balance_withdraws().unwrap();
     let account_id1 = derive_balance_account_object_id(
         sender,
         WithdrawTypeParam::Balance(GAS::type_tag().into()),
@@ -85,7 +85,7 @@ fn test_withdraw_zero_amount() {
     let sender = SuiAddress::random_for_testing_only();
     let tx =
         TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
-    assert!(tx.balance_withdraws().is_err());
+    assert!(tx.process_balance_withdraws().is_err());
 }
 
 #[test]
@@ -98,7 +98,7 @@ fn test_withdraw_entire_balance_multiple_times() {
     let sender = SuiAddress::random_for_testing_only();
     let tx =
         TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
-    assert!(tx.balance_withdraws().is_err());
+    assert!(tx.process_balance_withdraws().is_err());
 }
 
 #[test]
@@ -111,7 +111,7 @@ fn test_withdraw_amount_and_entire_balance() {
     let sender = SuiAddress::random_for_testing_only();
     let tx =
         TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
-    assert!(tx.balance_withdraws().is_err());
+    assert!(tx.process_balance_withdraws().is_err());
 }
 
 #[test]
@@ -124,7 +124,7 @@ fn test_withdraw_entire_balance_multiple_times_different_types() {
     let sender = SuiAddress::random_for_testing_only();
     let tx =
         TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
-    let withdraws = tx.balance_withdraws().unwrap();
+    let withdraws = tx.process_balance_withdraws().unwrap();
     let account_id1 = derive_balance_account_object_id(
         sender,
         WithdrawTypeParam::Balance(GAS::type_tag().into()),
@@ -155,5 +155,5 @@ fn test_withdraw_too_many_withdraws() {
     let sender = SuiAddress::random_for_testing_only();
     let tx =
         TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
-    assert!(tx.balance_withdraws().is_err());
+    assert!(tx.process_balance_withdraws().is_err());
 }

--- a/crates/sui-types/src/unit_tests/balance_withdraw_tests.rs
+++ b/crates/sui-types/src/unit_tests/balance_withdraw_tests.rs
@@ -1,0 +1,137 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+
+use move_core_types::language_storage::TypeTag;
+
+use crate::{
+    accumulator_root::derive_balance_account_object_id,
+    base_types::{random_object_ref, SuiAddress},
+    gas_coin::GAS,
+    programmable_transaction_builder::ProgrammableTransactionBuilder,
+    transaction::{BalanceWithdrawArg, TransactionData, TransactionDataAPI},
+};
+
+#[test]
+fn test_withdraw_max_amount() {
+    let arg = BalanceWithdrawArg::new_with_amount(100, GAS::type_tag());
+    let mut ptb = ProgrammableTransactionBuilder::new();
+    ptb.balance_withdraw(arg.clone()).unwrap();
+    let sender = SuiAddress::random_for_testing_only();
+    let tx =
+        TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
+    assert!(tx.has_balance_withdraws());
+    let withdraws = tx.balance_withdraws().unwrap();
+    let account_id = derive_balance_account_object_id(sender, GAS::type_tag()).unwrap();
+    assert_eq!(withdraws, BTreeMap::from([(account_id, arg.reservation)]));
+}
+
+#[test]
+fn test_withdraw_entire_balance() {
+    let arg = BalanceWithdrawArg::new_with_entire_balance(GAS::type_tag());
+    let mut ptb = ProgrammableTransactionBuilder::new();
+    ptb.balance_withdraw(arg.clone()).unwrap();
+    let sender = SuiAddress::random_for_testing_only();
+    let tx =
+        TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
+    assert!(tx.has_balance_withdraws());
+    let withdraws = tx.balance_withdraws().unwrap();
+    let account_id = derive_balance_account_object_id(sender, GAS::type_tag()).unwrap();
+    assert_eq!(withdraws, BTreeMap::from([(account_id, arg.reservation)]));
+}
+
+#[test]
+fn test_multiple_withdraws() {
+    let arg1 = BalanceWithdrawArg::new_with_amount(100, GAS::type_tag());
+    let arg2 = BalanceWithdrawArg::new_with_entire_balance(TypeTag::Bool);
+    let mut ptb = ProgrammableTransactionBuilder::new();
+    ptb.balance_withdraw(arg1.clone()).unwrap();
+    ptb.balance_withdraw(arg2.clone()).unwrap();
+    let sender = SuiAddress::random_for_testing_only();
+    let tx =
+        TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
+    assert!(tx.has_balance_withdraws());
+    let withdraws = tx.balance_withdraws().unwrap();
+    let account_id1 = derive_balance_account_object_id(sender, GAS::type_tag()).unwrap();
+    let account_id2 = derive_balance_account_object_id(sender, TypeTag::Bool).unwrap();
+    assert_eq!(
+        withdraws,
+        BTreeMap::from([
+            (account_id1, arg1.reservation),
+            (account_id2, arg2.reservation)
+        ])
+    );
+}
+
+#[test]
+fn test_withdraw_zero_amount() {
+    let arg = BalanceWithdrawArg::new_with_amount(0, GAS::type_tag());
+    let mut ptb = ProgrammableTransactionBuilder::new();
+    ptb.balance_withdraw(arg.clone()).unwrap();
+    let sender = SuiAddress::random_for_testing_only();
+    let tx =
+        TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
+    assert!(tx.balance_withdraws().is_err());
+}
+
+#[test]
+fn test_withdraw_entire_balance_multiple_times() {
+    let arg1 = BalanceWithdrawArg::new_with_entire_balance(GAS::type_tag());
+    let arg2 = BalanceWithdrawArg::new_with_entire_balance(GAS::type_tag());
+    let mut ptb = ProgrammableTransactionBuilder::new();
+    ptb.balance_withdraw(arg1.clone()).unwrap();
+    ptb.balance_withdraw(arg2.clone()).unwrap();
+    let sender = SuiAddress::random_for_testing_only();
+    let tx =
+        TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
+    assert!(tx.balance_withdraws().is_err());
+}
+
+#[test]
+fn test_withdraw_amount_and_entire_balance() {
+    let arg1 = BalanceWithdrawArg::new_with_amount(100, GAS::type_tag());
+    let arg2 = BalanceWithdrawArg::new_with_entire_balance(GAS::type_tag());
+    let mut ptb = ProgrammableTransactionBuilder::new();
+    ptb.balance_withdraw(arg1.clone()).unwrap();
+    ptb.balance_withdraw(arg2.clone()).unwrap();
+    let sender = SuiAddress::random_for_testing_only();
+    let tx =
+        TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
+    assert!(tx.balance_withdraws().is_err());
+}
+
+#[test]
+fn test_withdraw_entire_balance_multiple_times_different_types() {
+    let arg1 = BalanceWithdrawArg::new_with_entire_balance(GAS::type_tag());
+    let arg2 = BalanceWithdrawArg::new_with_entire_balance(TypeTag::Bool);
+    let mut ptb = ProgrammableTransactionBuilder::new();
+    ptb.balance_withdraw(arg1.clone()).unwrap();
+    ptb.balance_withdraw(arg2.clone()).unwrap();
+    let sender = SuiAddress::random_for_testing_only();
+    let tx =
+        TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
+    let withdraws = tx.balance_withdraws().unwrap();
+    let account_id1 = derive_balance_account_object_id(sender, GAS::type_tag()).unwrap();
+    let account_id2 = derive_balance_account_object_id(sender, TypeTag::Bool).unwrap();
+    assert_eq!(
+        withdraws,
+        BTreeMap::from([
+            (account_id1, arg1.reservation),
+            (account_id2, arg2.reservation)
+        ])
+    );
+}
+
+#[test]
+fn test_withdraw_too_many_withdraws() {
+    let mut ptb = ProgrammableTransactionBuilder::new();
+    for _ in 0..11 {
+        ptb.balance_withdraw(BalanceWithdrawArg::new_with_amount(100, GAS::type_tag()))
+            .unwrap();
+    }
+    let sender = SuiAddress::random_for_testing_only();
+    let tx =
+        TransactionData::new_programmable(sender, vec![random_object_ref()], ptb.finish(), 1, 1);
+    assert!(tx.balance_withdraws().is_err());
+}

--- a/crates/sui/tests/ptb_files_tests.rs
+++ b/crates/sui/tests/ptb_files_tests.rs
@@ -111,6 +111,7 @@ fn stable_call_arg_display(ca: &CallArg) -> String {
             }
             ObjectArg::Receiving(_) => "Receiving".to_string(),
         },
+        CallArg::BalanceWithdraw(_) => "BalanceWithdraw".to_string(),
     }
 }
 

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -1634,6 +1634,9 @@ mod checked {
                 input_object_map,
                 obj_arg,
             )?,
+            CallArg::BalanceWithdraw(_) => {
+                todo!("Load balance withdraw call arg")
+            }
         })
     }
 

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -1635,6 +1635,7 @@ mod checked {
                 obj_arg,
             )?,
             CallArg::BalanceWithdraw(_) => {
+                // TODO(address-balances): Add support for balance withdraws.
                 todo!("Load balance withdraw call arg")
             }
         })

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/translate.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/translate.rs
@@ -73,6 +73,7 @@ fn input(env: &Env, arg: CallArg) -> Result<(L::InputArg, L::InputType), Executi
             )
         }
         CallArg::BalanceWithdraw(_) => {
+            // TODO(address-balances): Add support for balance withdraws.
             todo!("Load balance withdraw call arg")
         }
     })

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/translate.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/translate.rs
@@ -47,7 +47,7 @@ fn input(env: &Env, arg: CallArg) -> Result<(L::InputArg, L::InputType), Executi
                 Owner::ObjectOwner(_)
                 | Owner::Shared { .. }
                 | Owner::ConsensusAddressOwner { .. } => {
-                    invariant_violation!("Unepected owner for ImmOrOwnedObject: {:?}", obj.owner);
+                    invariant_violation!("Unexpected owner for ImmOrOwnedObject: {:?}", obj.owner);
                 }
             };
             (L::InputArg::Object(arg), L::InputType::Fixed(ty))
@@ -71,6 +71,9 @@ fn input(env: &Env, arg: CallArg) -> Result<(L::InputArg, L::InputType), Executi
                 }),
                 L::InputType::Fixed(ty),
             )
+        }
+        CallArg::BalanceWithdraw(_) => {
+            todo!("Load balance withdraw call arg")
         }
     })
 }

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
@@ -1235,6 +1235,7 @@ mod checked {
             CallArg::Object(obj_arg) => {
                 load_object_arg(vm, state_view, session, input_object_map, obj_arg)?
             }
+            CallArg::BalanceWithdraw(_) => unreachable!("Impossible to hit BalanceWithdraw in v0"),
         })
     }
 

--- a/sui-execution/v1/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v1/sui-adapter/src/programmable_transactions/context.rs
@@ -1230,6 +1230,9 @@ mod checked {
                 input_object_map,
                 obj_arg,
             )?,
+            CallArg::BalanceWithdraw(_) => {
+                unreachable!("Impossible to hit BalanceWithdraw in v1")
+            }
         })
     }
 

--- a/sui-execution/v2/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v2/sui-adapter/src/programmable_transactions/context.rs
@@ -1287,6 +1287,9 @@ mod checked {
                 input_object_map,
                 obj_arg,
             )?,
+            CallArg::BalanceWithdraw(_) => {
+                unreachable!("Impossible to hit BalanceWithdraw in v2")
+            }
         })
     }
 


### PR DESCRIPTION
## Description 

Add a new CallArg to represent balance withdraw reservation.
This is not necessarily the final form. Adding it to support e2e testing and development.
Since this is all gated behind a protocol config, no transactions with withdraw reservation can be committed on-chain right now.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
