### PR TITLE
chore: fix ci failure because of the removal of an empty line

### DIFF
--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_61.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_61.snap
@@ -325,3 +325,4 @@ checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
 bridge_should_try_to_finalize_committee: true
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
+

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_61.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_61.snap
@@ -335,3 +335,4 @@ checkpoint_summary_version_specific_data: 1
 max_soft_bundle_size: 5
 bridge_should_try_to_finalize_committee: true
 max_accumulated_txn_cost_per_object_in_mysticeti_commit: 10
+


### PR DESCRIPTION
## Description 

CI run (Checking protocol compatibility) fails due to a recent change in [this commit](https://github.com/MystenLabs/sui/commit/7ccbb5c62e0a083d80c0c64cde31dc2599946ef0)

adding back the deleted empty line

## Test plan 

ran https://github.com/MystenLabs/sui-operations/actions/runs/15747972002 against my fix branch and it works

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
