### PR TITLE
[consensus] add metrics to measure per-round delays when receiving blocks

### DIFF
--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -7,6 +7,7 @@ use std::{
     ops::Bound::{Excluded, Included, Unbounded},
     panic,
     sync::Arc,
+    time::{Duration},
     vec,
 };
 
@@ -332,7 +333,18 @@ impl DagState {
         self.recent_blocks
             .insert(block_ref, BlockInfo::new(block.clone()));
         self.recent_refs_by_authority[block_ref.author].insert(block_ref);
-        self.threshold_clock.add_block(block_ref);
+        if self.threshold_clock.add_block(block_ref) {
+            let quorum_delay_ms = self
+                .context
+                .clock
+                .timestamp_utc_ms()
+                .saturating_sub(self.get_last_proposed_block().timestamp_ms());
+            self.context
+                .metrics
+                .node_metrics
+                .quorum_receive_latency
+                .observe(Duration::from_millis(quorum_delay_ms).as_secs_f64());
+        }
         self.highest_accepted_round = max(self.highest_accepted_round, block.round());
         self.context
             .metrics

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -333,18 +333,24 @@ impl DagState {
         self.recent_blocks
             .insert(block_ref, BlockInfo::new(block.clone()));
         self.recent_refs_by_authority[block_ref.author].insert(block_ref);
+
         if self.threshold_clock.add_block(block_ref) {
-            let quorum_delay_ms = self
-                .context
-                .clock
-                .timestamp_utc_ms()
-                .saturating_sub(self.get_last_proposed_block().timestamp_ms());
-            self.context
-                .metrics
-                .node_metrics
-                .quorum_receive_latency
-                .observe(Duration::from_millis(quorum_delay_ms).as_secs_f64());
+            // Do not measure quorum delay when no local block is proposed in the round.
+            let last_proposed_block = self.get_last_proposed_block();
+            if last_proposed_block.round() == block_ref.round {
+                let quorum_delay_ms = self
+                    .context
+                    .clock
+                    .timestamp_utc_ms()
+                    .saturating_sub(self.get_last_proposed_block().timestamp_ms());
+                self.context
+                    .metrics
+                    .node_metrics
+                    .quorum_receive_latency
+                    .observe(Duration::from_millis(quorum_delay_ms).as_secs_f64());
+            }
         }
+
         self.highest_accepted_round = max(self.highest_accepted_round, block.round());
         self.context
             .metrics

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -7,7 +7,7 @@ use std::{
     ops::Bound::{Excluded, Included, Unbounded},
     panic,
     sync::Arc,
-    time::{Duration},
+    time::Duration,
     vec,
 };
 

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -165,6 +165,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) missing_blocks_after_fetch_total: IntCounter,
     pub(crate) num_of_bad_nodes: IntGauge,
     pub(crate) quorum_receive_latency: Histogram,
+    pub(crate) block_receive_delay: IntCounterVec,
     pub(crate) reputation_scores: IntGaugeVec,
     pub(crate) scope_processing_time: HistogramVec,
     pub(crate) sub_dags_per_commit_count: Histogram,
@@ -592,6 +593,12 @@ impl NodeMetrics {
                 "quorum_receive_latency",
                 "The time it took to receive a new round quorum of blocks",
                 registry
+            ).unwrap(),
+            block_receive_delay: register_int_counter_vec_with_registry!(
+                "block_receive_delay",
+                "Total delay from the start of the round to receiving the block, in milliseconds per authority",
+                &["authority"],
+                registry,
             ).unwrap(),
             reputation_scores: register_int_gauge_vec_with_registry!(
                 "reputation_scores",

--- a/consensus/core/src/transaction_certifier.rs
+++ b/consensus/core/src/transaction_certifier.rs
@@ -342,15 +342,6 @@ impl CertifierState {
             }
         }
 
-        if !certified_blocks.is_empty() {
-            self.context
-                .metrics
-                .node_metrics
-                .certifier_output_blocks
-                .with_label_values(&["proposed"])
-                .inc_by(certified_blocks.len() as u64);
-        }
-
         certified_blocks
     }
 
@@ -412,6 +403,15 @@ impl CertifierState {
                     certified_blocks.push(certified_block);
                 }
             }
+        }
+
+        if !certified_blocks.is_empty() {
+            self.context
+                .metrics
+                .node_metrics
+                .certifier_output_blocks
+                .with_label_values(&["proposed"])
+                .inc_by(certified_blocks.len() as u64);
         }
 
         certified_blocks


### PR DESCRIPTION
## Description 

Add metrics to help investigate delays between rounds.

Fix counting `consensus_certifier_output_blocks`.

## Test plan 


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
