### PR TITLE
[execution] protocol gate adding additional configs to unchanged shared objects

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -3967,6 +3967,10 @@ impl ProtocolConfig {
             allowed_tx_digests,
         });
     }
+    pub fn set_include_epoch_stable_sequence_number_in_effects_for_testing(&mut self, val: bool) {
+        self.feature_flags
+            .include_epoch_stable_sequence_number_in_effects = val;
+    }
 }
 
 type OverrideFn = dyn Fn(ProtocolVersion, ProtocolConfig) -> ProtocolConfig + Send;

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -1096,9 +1096,14 @@ impl Storage for TemporaryStore<'_> {
     }
 
     fn save_unsequenced_config_accesses(&mut self, accessed_config_objects: BTreeSet<ObjectID>) {
-        self.loaded_per_epoch_config_objects
-            .write()
-            .extend(accessed_config_objects);
+        if self
+            .protocol_config
+            .include_epoch_stable_sequence_number_in_effects()
+        {
+            self.loaded_per_epoch_config_objects
+                .write()
+                .extend(accessed_config_objects);
+        }
     }
 }
 


### PR DESCRIPTION
## Description 

Fixes an issue where we were adding in additional config objects accessed without protocol gating it.

## Test plan 

CI + added new tests

