### PR TITLE
[examples] Remove unnecessary prompts

### DIFF
--- a/examples/move/random/random_nft/sources/example.move
+++ b/examples/move/random/random_nft/sources/example.move
@@ -28,7 +28,6 @@ public struct MintingCapability has key {
     id: UID,
 }
 
-#[allow(unused_function)]
 fun init(ctx: &mut TxContext) {
     transfer::transfer(
         MintingCapability { id: object::new(ctx) },


### PR DESCRIPTION
## Description 

It seems that there is no need to add `#[allow(unused_function)]` before the `init` function
