### PR TITLE
[examples] Remove unnecessary prompts

### DIFF
--- a/examples/move/token/sources/gems.move
+++ b/examples/move/token/sources/gems.move
@@ -51,7 +51,6 @@ module examples::gem {
     const LARGE_BUNDLE: u64 = 1_000_000_000_000;
     const LARGE_AMOUNT: u64 = 100_000;
 
-    #[allow(lint(coin_field))]
     /// Gems can be purchased through the `Store`.
     public struct GemStore has key {
         id: UID,


### PR DESCRIPTION
## Description 

It is `Balance<SUI>`, so `#[allow(lint(coin_field))]` is not needed
