### PR TITLE
[examples] Remove unnecessary prompts

### DIFF
--- a/examples/vesting/sources/backloaded.move
+++ b/examples/vesting/sources/backloaded.move
@@ -12,7 +12,6 @@
 /// Functionality:
 /// - Defines a backloaded vesting schedule.
 /// ===========================================================================================
-#[allow(unused_const)]
 module vesting::backloaded;
 
 use sui::clock::Clock;

--- a/examples/vesting/sources/cliff.move
+++ b/examples/vesting/sources/cliff.move
@@ -10,7 +10,6 @@
 /// Functionality:
 /// - Defines a cliff vesting schedule.
 /// ===========================================================================================
-#[allow(unused_const)]
 module vesting::cliff;
 
 use sui::balance::Balance;

--- a/examples/vesting/sources/hybrid.move
+++ b/examples/vesting/sources/hybrid.move
@@ -10,7 +10,6 @@
 /// Functionality:
 /// - Defines a hybrid vesting schedule.
 /// ===========================================================================================
-#[allow(unused_const)]
 module vesting::hybrid;
 
 use sui::clock::Clock;

--- a/examples/vesting/sources/linear.move
+++ b/examples/vesting/sources/linear.move
@@ -9,7 +9,6 @@
 /// Functionality:
 /// - Defines a linear vesting schedule.
 /// ===========================================================================================
-#[allow(unused_const)]
 module vesting::linear;
 
 use sui::balance::Balance;


### PR DESCRIPTION
## Description 

It seems that all `const` are used, so there is no need to add `#[allow(unused_const)]`