### PR TITLE
Enable Party objects in testnet

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -245,6 +245,7 @@ const MAX_PROTOCOL_VERSION: u64 = 86;
 // Version 86: Use type tags in the object runtime and adapter instead of `Type`s.
 //             Make variant count limit explicit in protocol config.
 //             Enable epoch stable sequence number in effects for unsequenced config reads.
+//             Enable party transfer in testnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -3765,6 +3766,11 @@ impl ProtocolConfig {
                         );
                     cfg.feature_flags
                         .include_epoch_stable_sequence_number_in_effects = true;
+
+                    // Enable party transfer for testnet.
+                    if chain != Chain::Mainnet {
+                        cfg.feature_flags.enable_party_transfer = true;
+                    }
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_86.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_86.snap
@@ -96,6 +96,7 @@ feature_flags:
   enforce_checkpoint_timestamp_monotonicity: true
   max_ptb_value_size_v2: true
   resolve_type_input_ids_to_defining_id: true
+  enable_party_transfer: true
   allow_unbounded_system_objects: true
   type_tags_in_object_runtime: true
   include_epoch_stable_sequence_number_in_effects: true


### PR DESCRIPTION


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [x] Protocol: enables Party objects (and associated `party_transfer` functions) in testnet
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
