### PR TITLE
[cli/summaries] Use local framework dependencies when generating summaries in tests

### DIFF
--- a/crates/sui/tests/shell_tests.rs
+++ b/crates/sui/tests/shell_tests.rs
@@ -101,7 +101,6 @@ fn get_sui_bin_path() -> String {
 fn get_sui_package_dir() -> PathBuf {
     let mut path = PathBuf::from(std::env!("CARGO_MANIFEST_DIR"));
     path.push("../sui-framework/packages");
-    println!("SRC FRAMEWORK PATH: {}", path.display());
     path
 }
 

--- a/crates/sui/tests/shell_tests.rs
+++ b/crates/sui/tests/shell_tests.rs
@@ -4,7 +4,7 @@
 use fs_extra::dir::CopyOptions;
 use insta_cmd::get_cargo_bin;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use sui_config::SUI_CLIENT_CONFIG;
 use test_cluster::TestClusterBuilder;
@@ -40,7 +40,14 @@ async fn test_shell_snapshot(path: &Path) -> datatest_stable::Result<()> {
     let tmpdir = tempfile::tempdir()?;
     let sandbox = tmpdir.path();
 
+    let sui_package_dir_src = get_sui_package_dir();
+
     fs_extra::dir::copy(srcdir, sandbox, &CopyOptions::new().content_only(true))?;
+    fs_extra::dir::copy(
+        sui_package_dir_src,
+        sandbox,
+        &CopyOptions::new().content_only(true),
+    )?;
 
     // set up command
     let mut shell = Command::new("bash");
@@ -88,6 +95,14 @@ fn get_sui_bin_path() -> String {
         .to_str()
         .expect("directory name is valid UTF-8")
         .to_owned()
+}
+
+/// Return the package dir for the Sui framework packages which may be used in some shell tests.
+fn get_sui_package_dir() -> PathBuf {
+    let mut path = PathBuf::from(std::env!("CARGO_MANIFEST_DIR"));
+    path.push("../sui-framework/packages");
+    println!("SRC FRAMEWORK PATH: {}", path.display());
+    path
 }
 
 #[cfg(not(msim))]

--- a/crates/sui/tests/shell_tests/summaries/data/move_package/Move.toml
+++ b/crates/sui/tests/shell_tests/summaries/data/move_package/Move.toml
@@ -2,5 +2,8 @@
 name = "move_package"
 edition = "2024"
 
+[dependencies]
+Sui = { local = "../../sui-framework" }
+
 [addresses]
 move_package = "0x0"

--- a/crates/sui/tests/shell_tests/summaries/data/overlapping_summaries/Move.toml
+++ b/crates/sui/tests/shell_tests/summaries/data/overlapping_summaries/Move.toml
@@ -7,6 +7,7 @@ edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
 [dependencies]
 child_pkg = { local = "./child_pkg" }
 other_child = { local = "./other_child" }
+Sui = { local = "../../sui-framework" }
 
 # For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
 # Revision can be a branch, a tag, and a commit hash.

--- a/crates/sui/tests/shell_tests/summaries/data/overlapping_summaries/child_pkg/Move.toml
+++ b/crates/sui/tests/shell_tests/summaries/data/overlapping_summaries/child_pkg/Move.toml
@@ -5,6 +5,7 @@ edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
 # authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 
 [dependencies]
+Sui = { local = "../../../sui-framework" }
 
 # For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
 # Revision can be a branch, a tag, and a commit hash.

--- a/crates/sui/tests/shell_tests/summaries/data/overlapping_summaries/other_child/Move.toml
+++ b/crates/sui/tests/shell_tests/summaries/data/overlapping_summaries/other_child/Move.toml
@@ -5,6 +5,7 @@ edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
 # authors = ["..."]      # e.g., ["Joe Smith (joesmith@noemail.com)", "John Snow (johnsnow@noemail.com)"]
 
 [dependencies]
+Sui = { local = "../../../sui-framework" }
 
 # For remote import, use the `{ git = "...", subdir = "...", rev = "..." }`.
 # Revision can be a branch, a tag, and a commit hash.

--- a/crates/sui/tests/shell_tests/summaries/data/pkg_with_hardcoded_addr/Move.toml
+++ b/crates/sui/tests/shell_tests/summaries/data/pkg_with_hardcoded_addr/Move.toml
@@ -2,5 +2,8 @@
 name = "summaries"
 edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
 
+[dependencies]
+Sui = { local = "../../sui-framework" }
+
 [addresses]
 summary_pkg = "0xc0ffee"

--- a/crates/sui/tests/snapshots/shell_tests__summaries__summarize_json.sh.snap
+++ b/crates/sui/tests/snapshots/shell_tests__summaries__summarize_json.sh.snap
@@ -24,21 +24,18 @@ cat data/move_package/package_summaries/address_mapping.json
 success: true
 exit_code: 0
 ----- stdout -----
-INCLUDING DEPENDENCY Bridge
-INCLUDING DEPENDENCY SuiSystem
 INCLUDING DEPENDENCY Sui
 INCLUDING DEPENDENCY MoveStdlib
 BUILDING move_package
 
 Summary generation successful. Summaries stored in 'package_summaries'
 address_mapping.json
-bridge
 move_package
 root_package_metadata.json
 std
 sui
-sui_system
 move_package.json
+accumulator.json
 address.json
 authenticator_state.json
 bag.json
@@ -116,10 +113,9 @@ uq64_64.json
 vector.json
 {}
 {
-  "bridge": "0x000000000000000000000000000000000000000000000000000000000000000b",
   "move_package": "0x0000000000000000000000000000000000000000000000000000000000000000",
   "std": "0x0000000000000000000000000000000000000000000000000000000000000001",
-  "sui": "0x0000000000000000000000000000000000000000000000000000000000000002",
-  "sui_system": "0x0000000000000000000000000000000000000000000000000000000000000003"
+  "sui": "0x0000000000000000000000000000000000000000000000000000000000000002"
 }
 ----- stderr -----
+[note] Dependencies on Bridge, MoveStdlib, Sui, and SuiSystem are automatically added, but this feature is disabled for your package because you have explicitly included dependencies on Sui. Consider removing these dependencies from Move.toml.

--- a/crates/sui/tests/snapshots/shell_tests__summaries__summarize_yaml.sh.snap
+++ b/crates/sui/tests/snapshots/shell_tests__summaries__summarize_yaml.sh.snap
@@ -22,21 +22,18 @@ cat data/move_package/package_summaries/address_mapping.yaml
 success: true
 exit_code: 0
 ----- stdout -----
-INCLUDING DEPENDENCY Bridge
-INCLUDING DEPENDENCY SuiSystem
 INCLUDING DEPENDENCY Sui
 INCLUDING DEPENDENCY MoveStdlib
 BUILDING move_package
 
 Summary generation successful. Summaries stored in 'package_summaries'
 address_mapping.yaml
-bridge
 move_package
 root_package_metadata.yaml
 std
 sui
-sui_system
 move_package.yaml
+accumulator.yaml
 address.yaml
 authenticator_state.yaml
 bag.yaml
@@ -115,10 +112,9 @@ vector.yaml
 ---
 {}
 ---
-bridge: "0x000000000000000000000000000000000000000000000000000000000000000b"
 move_package: "0x0000000000000000000000000000000000000000000000000000000000000000"
 std: "0x0000000000000000000000000000000000000000000000000000000000000001"
 sui: "0x0000000000000000000000000000000000000000000000000000000000000002"
-sui_system: "0x0000000000000000000000000000000000000000000000000000000000000003"
 
 ----- stderr -----
+[note] Dependencies on Bridge, MoveStdlib, Sui, and SuiSystem are automatically added, but this feature is disabled for your package because you have explicitly included dependencies on Sui. Consider removing these dependencies from Move.toml.

--- a/crates/sui/tests/snapshots/shell_tests__summaries__summary_address_remapping.sh.snap
+++ b/crates/sui/tests/snapshots/shell_tests__summaries__summary_address_remapping.sh.snap
@@ -20,22 +20,18 @@ exit_code: 0
 ----- stdout -----
 INCLUDING DEPENDENCY child_pkg
 INCLUDING DEPENDENCY other_child
-INCLUDING DEPENDENCY Bridge
-INCLUDING DEPENDENCY SuiSystem
 INCLUDING DEPENDENCY Sui
 INCLUDING DEPENDENCY MoveStdlib
 BUILDING overlapping_summaries
 
 Summary generation successful. Summaries stored in 'package_summaries'
 address_mapping.json
-bridge
 child_pkg
 other_child
 overlapping_summaries
 root_package_metadata.json
 std
 sui
-sui_system
 {
   "id": {
     "address": "child_pkg",
@@ -205,12 +201,11 @@ sui_system
   },
   "enums": {}
 }{
-  "bridge": "0x000000000000000000000000000000000000000000000000000000000000000b",
   "child_pkg": "0x0000000000000000000000000000000000000000000000000000000000000000",
   "other_child": "0x000000000000000000000000000000000000000000000000000000000000000c",
   "overlapping_summaries": "0x0000000000000000000000000000000000000000000000000000000000000000",
   "std": "0x0000000000000000000000000000000000000000000000000000000000000001",
-  "sui": "0x0000000000000000000000000000000000000000000000000000000000000002",
-  "sui_system": "0x0000000000000000000000000000000000000000000000000000000000000003"
+  "sui": "0x0000000000000000000000000000000000000000000000000000000000000002"
 }
 ----- stderr -----
+[note] Dependencies on Bridge, MoveStdlib, Sui, and SuiSystem are automatically added, but this feature is disabled for your package because you have explicitly included dependencies on Sui. Consider removing these dependencies from Move.toml.

--- a/crates/sui/tests/snapshots/shell_tests__summaries__summary_hardcoded_addr.sh.snap
+++ b/crates/sui/tests/snapshots/shell_tests__summaries__summary_hardcoded_addr.sh.snap
@@ -18,19 +18,15 @@ cat data/pkg_with_hardcoded_addr/package_summaries/address_mapping.json
 success: true
 exit_code: 0
 ----- stdout -----
-INCLUDING DEPENDENCY Bridge
-INCLUDING DEPENDENCY SuiSystem
 INCLUDING DEPENDENCY Sui
 INCLUDING DEPENDENCY MoveStdlib
 BUILDING summaries
 
 Summary generation successful. Summaries stored in 'package_summaries'
 address_mapping.json
-bridge
 root_package_metadata.json
 std
 sui
-sui_system
 summary_pkg
 {
   "id": {
@@ -286,10 +282,9 @@ summary_pkg
   },
   "enums": {}
 }{
-  "bridge": "0x000000000000000000000000000000000000000000000000000000000000000b",
   "std": "0x0000000000000000000000000000000000000000000000000000000000000001",
   "sui": "0x0000000000000000000000000000000000000000000000000000000000000002",
-  "sui_system": "0x0000000000000000000000000000000000000000000000000000000000000003",
   "summary_pkg": "0x0000000000000000000000000000000000000000000000000000000000c0ffee"
 }
 ----- stderr -----
+[note] Dependencies on Bridge, MoveStdlib, Sui, and SuiSystem are automatically added, but this feature is disabled for your package because you have explicitly included dependencies on Sui. Consider removing these dependencies from Move.toml.


### PR DESCRIPTION
## Description 

Switch to using a local dependency of the sui-framework when generating package summaries to keep it in-line with other local references of the sui-framework in the repo.

## Test plan 

Updated tests + CI

