### PR TITLE
Rename contains_shared_object to is_consensus_tx

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -4230,7 +4230,7 @@ impl AuthorityPerEpochStore {
         }
 
         // If needed we can support owned object system transactions as well...
-        assert!(system_transaction.contains_shared_object());
+        assert!(system_transaction.is_consensus_tx());
         ConsensusCertificateResult::SuiTransaction(system_transaction.clone())
     }
 
@@ -4345,10 +4345,8 @@ impl AuthorityPerEpochStore {
         }
 
         // This certificate will be scheduled. Update object execution cost.
-        if transaction.contains_shared_object() {
-            shared_object_congestion_tracker
-                .bump_object_execution_cost(execution_time_estimator, &transaction);
-        }
+        shared_object_congestion_tracker
+            .bump_object_execution_cost(execution_time_estimator, &transaction);
 
         Ok(ConsensusCertificateResult::SuiTransaction(transaction))
     }

--- a/crates/sui-core/src/mock_consensus.rs
+++ b/crates/sui-core/src/mock_consensus.rs
@@ -88,7 +88,7 @@ impl MockConsensusClient {
             };
             match &tx.kind {
                 ConsensusTransactionKind::CertifiedTransaction(tx) => {
-                    if tx.contains_shared_object() {
+                    if tx.is_consensus_tx() {
                         validator.execution_scheduler().enqueue(
                             vec![(
                                 VerifiedExecutableTransaction::new_from_certificate(
@@ -102,7 +102,7 @@ impl MockConsensusClient {
                     }
                 }
                 ConsensusTransactionKind::UserTransaction(tx) => {
-                    if tx.contains_shared_object() {
+                    if tx.is_consensus_tx() {
                         validator.execution_scheduler().enqueue(
                             vec![(
                                 VerifiedExecutableTransaction::new_from_consensus(

--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -596,7 +596,7 @@ where
         } = task;
         let transaction = &request.transaction;
         let tx_digest = *transaction.digest();
-        let is_single_writer_tx = !transaction.contains_shared_object();
+        let is_single_writer_tx = !transaction.is_consensus_tx();
 
         let timer = Instant::now();
         let (tx_cert, newly_formed) = match tx_cert {

--- a/crates/sui-core/src/transaction_driver/mod.rs
+++ b/crates/sui-core/src/transaction_driver/mod.rs
@@ -76,7 +76,7 @@ where
         options: SubmitTransactionOptions,
     ) -> Result<QuorumSubmitTransactionResponse, TransactionDriverError> {
         let tx_digest = request.transaction.digest();
-        let is_single_writer_tx = !request.transaction.contains_shared_object();
+        let is_single_writer_tx = !request.transaction.is_consensus_tx();
         let timer = Instant::now();
         loop {
             match self.submit_transaction_once(&request, &options).await {

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -236,7 +236,7 @@ where
         let tx_digest = *transaction.digest();
         debug!(?tx_digest, "TO Received transaction execution request.");
 
-        let (_e2e_latency_timer, _txn_finality_timer) = if transaction.contains_shared_object() {
+        let (_e2e_latency_timer, _txn_finality_timer) = if transaction.is_consensus_tx() {
             (
                 self.metrics.request_latency_shared_obj.start_timer(),
                 self.metrics
@@ -354,7 +354,7 @@ where
                 in_flight.dec();
             });
 
-        let _guard = if transaction.contains_shared_object() {
+        let _guard = if transaction.is_consensus_tx() {
             metrics.local_execution_latency_shared_obj.start_timer()
         } else {
             metrics.local_execution_latency_single_writer.start_timer()
@@ -446,7 +446,7 @@ where
         &'_ self,
         transaction: &VerifiedTransaction,
     ) -> (impl Drop, &'_ GenericCounter<AtomicU64>) {
-        let (in_flight, good_response) = if transaction.contains_shared_object() {
+        let (in_flight, good_response) = if transaction.is_consensus_tx() {
             self.metrics.total_req_received_shared_object.inc();
             (
                 self.metrics.req_in_flight_shared_object.clone(),

--- a/crates/sui-core/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_tests.rs
@@ -550,7 +550,7 @@ async fn do_transaction_test_impl(
             err_check(&err);
 
             // Additionally, if the tx contains access to shared objects, check if Soft Bundle handler returns the same error.
-            if ct.contains_shared_object() {
+            if ct.is_consensus_tx() {
                 epoch_store.clear_signature_cache();
                 let err = client
                     .handle_soft_bundle_certificates_v3(

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1571,9 +1571,7 @@ impl SuiNode {
             match tx.kind {
                 // Shared object txns cannot be re-executed at this point, because we must wait for
                 // consensus replay to assign shared object versions.
-                ConsensusTransactionKind::CertifiedTransaction(tx)
-                    if !tx.contains_shared_object() =>
-                {
+                ConsensusTransactionKind::CertifiedTransaction(tx) if !tx.is_consensus_tx() => {
                     let tx = *tx;
                     // new_unchecked is safe because we never submit a transaction to consensus
                     // without verifying it

--- a/crates/sui-single-node-benchmark/src/benchmark_context.rs
+++ b/crates/sui-single-node-benchmark/src/benchmark_context.rs
@@ -293,8 +293,8 @@ impl BenchmarkContext {
             transactions.len()
         );
 
-        let has_shared_object = transactions.iter().any(|tx| tx.contains_shared_object());
-        if has_shared_object {
+        let is_consensus_tx = transactions.iter().any(|tx| tx.is_consensus_tx());
+        if is_consensus_tx {
             // With shared objects, we must execute each transaction in order.
             for transaction in transactions {
                 let key = transaction.key();
@@ -487,9 +487,9 @@ impl BenchmarkContext {
         transactions: Vec<CertifiedTransaction>,
         assigned_versions: AssignedTxAndVersions,
     ) -> Vec<TransactionEffects> {
-        let has_shared_object = transactions.iter().any(|tx| tx.contains_shared_object());
+        let is_consensus_tx = transactions.iter().any(|tx| tx.is_consensus_tx());
         let assigned_versions = assigned_versions.into_map();
-        if has_shared_object {
+        if is_consensus_tx {
             // With shared objects, we must execute each transaction in order.
             let mut effects = Vec::new();
             for transaction in transactions {

--- a/crates/sui-single-node-benchmark/src/single_node.rs
+++ b/crates/sui-single-node-benchmark/src/single_node.rs
@@ -169,7 +169,7 @@ impl SingleValidator {
             }
             Component::WithTxManager => {
                 let cert = VerifiedCertificate::new_unchecked(cert);
-                if cert.contains_shared_object() {
+                if cert.is_consensus_tx() {
                     // For shared objects transactions, `execute_certificate` won't enqueue it because
                     // it expects consensus to do so. However we don't have consensus, hence the manual enqueue.
                     self.get_validator().execution_scheduler().enqueue(

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -46,7 +46,6 @@ use sui_types::storage::ReadStore;
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
 use sui_types::sui_system_state::SuiSystemStateTrait;
 use sui_types::transaction::Transaction;
-use sui_types::transaction::TransactionDataAPI;
 use sui_types::transaction::TransactionKind;
 use sui_types::transaction::{InputObjects, TransactionData};
 use test_adapter::{SuiTestAdapter, PRE_COMPILED};
@@ -155,16 +154,12 @@ impl TransactionalAdapter for ValidatorWithFullnode {
         &mut self,
         transaction: Transaction,
     ) -> anyhow::Result<(TransactionEffects, Option<ExecutionError>)> {
-        let with_shared = transaction
-            .data()
-            .intent_message()
-            .value
-            .contains_shared_object();
+        let is_consensus_tx = transaction.is_consensus_tx();
         let (_, effects, execution_error) = send_and_confirm_transaction_with_execution_error(
             &self.validator,
             Some(&self.fullnode),
             transaction,
-            with_shared,
+            is_consensus_tx,
             false,
         )
         .await?;

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -85,7 +85,7 @@ use sui_types::{
     crypto::{get_key_pair_from_rng, AccountKeyPair},
     event::Event,
     object::{self, Object},
-    transaction::{Transaction, TransactionData, TransactionDataAPI, VerifiedTransaction},
+    transaction::{Transaction, TransactionData, VerifiedTransaction},
     MOVE_STDLIB_ADDRESS, SUI_CLOCK_OBJECT_ID, SUI_FRAMEWORK_ADDRESS, SUI_SYSTEM_STATE_OBJECT_ID,
 };
 use sui_types::{execution_status::ExecutionStatus, transaction::TransactionKind};
@@ -1674,11 +1674,7 @@ impl SuiTestAdapter {
     }
 
     async fn execute_txn(&mut self, transaction: Transaction) -> anyhow::Result<TxnSummary> {
-        let with_shared = transaction
-            .data()
-            .intent_message()
-            .value
-            .contains_shared_object();
+        let is_consensus_tx = transaction.is_consensus_tx();
         let (effects, error_opt) = self.executor.execute_txn(transaction).await?;
         let digest = effects.transaction_digest();
 
@@ -1767,7 +1763,7 @@ impl SuiTestAdapter {
                 })
             }
             ExecutionStatus::Failure { error, command } => {
-                let execution_msg = if with_shared {
+                let execution_msg = if is_consensus_tx {
                     format!("Debug of error: {error:?} at command {command:?}")
                 } else {
                     format!("Execution Error: {}", error_opt.unwrap())

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -1312,10 +1312,6 @@ impl TransactionKind {
         Some((e.computation_charge + e.storage_charge, e.storage_rebate))
     }
 
-    pub fn contains_shared_object(&self) -> bool {
-        self.shared_input_objects().next().is_some()
-    }
-
     /// Returns an iterator of all shared input objects used by this transaction.
     /// It covers both Call and ChangeEpoch transaction kind, because both makes Move calls.
     pub fn shared_input_objects(&self) -> impl Iterator<Item = SharedInputObject> + '_ {
@@ -2116,8 +2112,6 @@ pub trait TransactionDataAPI {
 
     fn expiration(&self) -> &TransactionExpiration;
 
-    fn contains_shared_object(&self) -> bool;
-
     fn shared_input_objects(&self) -> Vec<SharedInputObject>;
 
     fn move_calls(&self) -> Vec<(&ObjectID, &str, &str)>;
@@ -2201,10 +2195,6 @@ impl TransactionDataAPI for TransactionDataV1 {
 
     fn expiration(&self) -> &TransactionExpiration {
         &self.expiration
-    }
-
-    fn contains_shared_object(&self) -> bool {
-        self.kind.shared_input_objects().next().is_some()
     }
 
     fn shared_input_objects(&self) -> Vec<SharedInputObject> {
@@ -2602,7 +2592,8 @@ impl<S> Envelope<SenderSignedData, S> {
         self.data().intent_message().value.gas()
     }
 
-    pub fn contains_shared_object(&self) -> bool {
+    pub fn is_consensus_tx(&self) -> bool {
+        // TODO(address-balances): Once we support withdrawls, add the check here.
         self.shared_input_objects().next().is_some()
     }
 

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -1023,7 +1023,7 @@ fn verify_sender_signature_correctly_with_flag() {
 #[test]
 fn test_change_epoch_transaction() {
     let tx = VerifiedTransaction::new_change_epoch(1, ProtocolVersion::MIN, 0, 0, 0, 0, 0, vec![]);
-    assert!(tx.contains_shared_object());
+    assert!(tx.is_consensus_tx());
     assert_eq!(
         tx.shared_input_objects().next().unwrap(),
         SharedInputObject::SUI_SYSTEM_OBJ
@@ -1043,7 +1043,7 @@ fn test_change_epoch_transaction() {
 #[test]
 fn test_consensus_commit_prologue_transaction() {
     let tx = VerifiedTransaction::new_consensus_commit_prologue(0, 0, 42);
-    assert!(tx.contains_shared_object());
+    assert!(tx.is_consensus_tx());
     assert_eq!(
         tx.shared_input_objects().next().unwrap(),
         SharedInputObject {
@@ -1072,7 +1072,7 @@ fn test_consensus_commit_prologue_v2_transaction() {
         42,
         ConsensusCommitDigest::default(),
     );
-    assert!(tx.contains_shared_object());
+    assert!(tx.is_consensus_tx());
     assert_eq!(
         tx.shared_input_objects().next().unwrap(),
         SharedInputObject {
@@ -1102,7 +1102,7 @@ fn test_consensus_commit_prologue_v3_transaction() {
         ConsensusCommitDigest::default(),
         ConsensusDeterminedVersionAssignments::empty_for_testing(),
     );
-    assert!(tx.contains_shared_object());
+    assert!(tx.is_consensus_tx());
     assert_eq!(
         tx.shared_input_objects().next().unwrap(),
         SharedInputObject {


### PR DESCRIPTION
## Description 

We will no longer be able to simply use shared objects to determine whether a transaction is a consensus transaction, due to withdraws.
Removing this interface to make it less error prone.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
