### PR TITLE
[move reference] Fix code errors

### DIFF
--- a/external-crates/move/documentation/book/src/abort-and-assert.md
+++ b/external-crates/move/documentation/book/src/abort-and-assert.md
@@ -44,7 +44,7 @@ that all numbers in the vector are less than the specified `bound`. And aborts o
 ```move=
 use std::vector;
 fun check_vec(v: &vector<u64>, bound: u64) {
-    let i = 0;
+    let mut i = 0;
     let n = vector::length(v);
     while (i < n) {
         let cur = *vector::borrow(v, i);
@@ -87,7 +87,7 @@ and
 ```move=
 use std::vector;
 fun check_vec(v: &vector<u64>, bound: u64) {
-    let i = 0;
+    let mut i = 0;
     let n = vector::length(v);
     while (i < n) {
         let cur = *vector::borrow(v, i);
@@ -107,7 +107,7 @@ assert!(true, 1 / 0)
 Will not result in an arithmetic error, it is equivalent to
 
 ```move
-if (true) () else (1 / 0)
+if (true) () else abort (1 / 0)
 ```
 
 So the arithmetic expression is never evaluated!


### PR DESCRIPTION
## Description 

1. Cannot execute `i = i + 1` without `mut`
2. `if (true) () else (1 / 0)` is wrong because the two branches return different types. According to the context of the article, this should demonstrate `if (condition) () else abort code`, so this should be changed to `if (true) () else abort (1 / 0)`
