### PR TITLE
Connect ExecutionScheduler and balance withdraw scheduler

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -820,6 +820,14 @@ impl AuthorityMetrics {
 ///
 pub type StableSyncAuthoritySigner = Pin<Arc<dyn Signer<AuthoritySignature> + Send + Sync>>;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BalanceWithdrawEnv {
+    NoWithdraw,
+    SufficientBalance,
+    // TODO(address-balances): Add information on the address and type?
+    InsufficientBalance,
+}
+
 /// Execution env contains the "environment" for the transaction to be executed in, that is,
 /// all the information necessary for execution that is not specified by the transaction itself.
 #[derive(Debug, Clone)]
@@ -831,6 +839,8 @@ pub struct ExecutionEnv {
     pub expected_effects_digest: Option<TransactionEffectsDigest>,
     /// The source of the scheduling of the transaction.
     pub scheduling_source: SchedulingSource,
+    /// Information regarding the balance withdraw of the transaction.
+    pub withdraw_env: BalanceWithdrawEnv,
 }
 
 impl Default for ExecutionEnv {
@@ -839,6 +849,7 @@ impl Default for ExecutionEnv {
             assigned_versions: Default::default(),
             expected_effects_digest: None,
             scheduling_source: SchedulingSource::NonFastPath,
+            withdraw_env: BalanceWithdrawEnv::NoWithdraw,
         }
     }
 }
@@ -867,6 +878,16 @@ impl ExecutionEnv {
             // scheduling source cannot be fast path if assigned versions are set
             self.scheduling_source = SchedulingSource::NonFastPath;
         }
+        self
+    }
+
+    pub fn with_sufficient_balance(mut self) -> Self {
+        self.withdraw_env = BalanceWithdrawEnv::SufficientBalance;
+        self
+    }
+
+    pub fn with_insufficient_balance(mut self) -> Self {
+        self.withdraw_env = BalanceWithdrawEnv::InsufficientBalance;
         self
     }
 }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -821,7 +821,7 @@ impl AuthorityMetrics {
 pub type StableSyncAuthoritySigner = Pin<Arc<dyn Signer<AuthoritySignature> + Send + Sync>>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum BalanceWithdrawEnv {
+pub enum BalanceWithdrawStatus {
     NoWithdraw,
     SufficientBalance,
     // TODO(address-balances): Add information on the address and type?
@@ -840,7 +840,7 @@ pub struct ExecutionEnv {
     /// The source of the scheduling of the transaction.
     pub scheduling_source: SchedulingSource,
     /// Information regarding the balance withdraw of the transaction.
-    pub withdraw_env: BalanceWithdrawEnv,
+    pub withdraw_env: BalanceWithdrawStatus,
 }
 
 impl Default for ExecutionEnv {
@@ -849,7 +849,7 @@ impl Default for ExecutionEnv {
             assigned_versions: Default::default(),
             expected_effects_digest: None,
             scheduling_source: SchedulingSource::NonFastPath,
-            withdraw_env: BalanceWithdrawEnv::NoWithdraw,
+            withdraw_env: BalanceWithdrawStatus::NoWithdraw,
         }
     }
 }
@@ -882,12 +882,12 @@ impl ExecutionEnv {
     }
 
     pub fn with_sufficient_balance(mut self) -> Self {
-        self.withdraw_env = BalanceWithdrawEnv::SufficientBalance;
+        self.withdraw_env = BalanceWithdrawStatus::SufficientBalance;
         self
     }
 
     pub fn with_insufficient_balance(mut self) -> Self {
-        self.withdraw_env = BalanceWithdrawEnv::InsufficientBalance;
+        self.withdraw_env = BalanceWithdrawStatus::InsufficientBalance;
         self
     }
 }

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -839,8 +839,8 @@ pub struct ExecutionEnv {
     pub expected_effects_digest: Option<TransactionEffectsDigest>,
     /// The source of the scheduling of the transaction.
     pub scheduling_source: SchedulingSource,
-    /// Information regarding the balance withdraw of the transaction.
-    pub withdraw_env: BalanceWithdrawStatus,
+    /// Status of the balance withdraw scheduling of the transaction.
+    pub withdraw_status: BalanceWithdrawStatus,
 }
 
 impl Default for ExecutionEnv {
@@ -849,7 +849,7 @@ impl Default for ExecutionEnv {
             assigned_versions: Default::default(),
             expected_effects_digest: None,
             scheduling_source: SchedulingSource::NonFastPath,
-            withdraw_env: BalanceWithdrawStatus::NoWithdraw,
+            withdraw_status: BalanceWithdrawStatus::NoWithdraw,
         }
     }
 }
@@ -882,12 +882,12 @@ impl ExecutionEnv {
     }
 
     pub fn with_sufficient_balance(mut self) -> Self {
-        self.withdraw_env = BalanceWithdrawStatus::SufficientBalance;
+        self.withdraw_status = BalanceWithdrawStatus::SufficientBalance;
         self
     }
 
     pub fn with_insufficient_balance(mut self) -> Self {
-        self.withdraw_env = BalanceWithdrawStatus::InsufficientBalance;
+        self.withdraw_status = BalanceWithdrawStatus::InsufficientBalance;
         self
     }
 }

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -2752,7 +2752,7 @@ impl AuthorityPerEpochStore {
     fn process_user_signatures<'a>(&self, certificates: impl Iterator<Item = &'a Schedulable>) {
         let sigs: Vec<_> = certificates
             .filter_map(|s| match s {
-                Schedulable::Transaction(certificate) => {
+                Schedulable::Transaction(certificate) | Schedulable::Withdraw(certificate, _) => {
                     Some((*certificate.digest(), certificate.tx_signatures().to_vec()))
                 }
                 Schedulable::RandomnessStateUpdate(_, _) => None,

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -924,6 +924,7 @@ impl TransactionManagerSender {
                             .with_assigned_versions(
                                 assigned_versions.get(&key).cloned().unwrap_or_default(),
                             ),
+                        // TODO(address-balances) Add the accumulator version for each transaction.
                     )
                 })
                 .collect();

--- a/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/balance_read.rs
+++ b/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/balance_read.rs
@@ -7,11 +7,13 @@ use std::sync::Arc;
 
 #[cfg(test)]
 use parking_lot::RwLock;
-use sui_types::base_types::{ObjectID, SequenceNumber};
+use sui_types::{
+    accumulator_root::get_balance_from_account_for_testing,
+    base_types::{ObjectID, SequenceNumber},
+};
 
 use crate::execution_cache::ObjectCacheRead;
 
-#[allow(dead_code)]
 pub(crate) trait AccountBalanceRead: Send + Sync {
     fn get_account_balance(
         &self,
@@ -29,10 +31,7 @@ impl AccountBalanceRead for Arc<dyn ObjectCacheRead> {
         accumulator_version: SequenceNumber,
     ) -> u64 {
         self.find_object_lt_or_eq_version(*account_id, accumulator_version)
-            .map(|_obj| {
-                // TODO: Get the balance from the object.
-                0
-            })
+            .map(|obj| get_balance_from_account_for_testing(&obj))
             .unwrap_or_default()
     }
 }

--- a/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/e2e_tests.rs
+++ b/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/e2e_tests.rs
@@ -30,7 +30,7 @@ use crate::execution_scheduler::balance_withdraw_scheduler::BalanceSettlement;
 use crate::{
     authority::{
         shared_object_version_manager::Schedulable, test_authority_builder::TestAuthorityBuilder,
-        AuthorityState, BalanceWithdrawEnv, ExecutionEnv,
+        AuthorityState, BalanceWithdrawStatus, ExecutionEnv,
     },
     execution_scheduler::{
         ExecutionScheduler, ExecutionSchedulerAPI, ExecutionSchedulerWrapper, PendingCertificate,
@@ -157,7 +157,7 @@ impl TestEnv {
             .ok()?
     }
 
-    async fn expect_withdraw_results(&mut self, expected_results: Vec<BalanceWithdrawEnv>) {
+    async fn expect_withdraw_results(&mut self, expected_results: Vec<BalanceWithdrawStatus>) {
         for expected_result in expected_results {
             let cert = self.receive_certificate().await.unwrap();
             assert_eq!(cert.execution_env.withdraw_env, expected_result);
@@ -206,9 +206,9 @@ async fn test_withdraw_schedule_e2e() {
     test_env.enqueue_transactions(transactions);
     test_env
         .expect_withdraw_results(vec![
-            BalanceWithdrawEnv::SufficientBalance,
-            BalanceWithdrawEnv::SufficientBalance,
-            BalanceWithdrawEnv::InsufficientBalance,
+            BalanceWithdrawStatus::SufficientBalance,
+            BalanceWithdrawStatus::SufficientBalance,
+            BalanceWithdrawStatus::InsufficientBalance,
         ])
         .await;
 
@@ -221,8 +221,8 @@ async fn test_withdraw_schedule_e2e() {
 
     test_env
         .expect_withdraw_results(vec![
-            BalanceWithdrawEnv::SufficientBalance,
-            BalanceWithdrawEnv::InsufficientBalance,
+            BalanceWithdrawStatus::SufficientBalance,
+            BalanceWithdrawStatus::InsufficientBalance,
         ])
         .await;
 
@@ -233,6 +233,6 @@ async fn test_withdraw_schedule_e2e() {
     test_env.enqueue_transactions(transactions);
 
     test_env
-        .expect_withdraw_results(vec![BalanceWithdrawEnv::InsufficientBalance])
+        .expect_withdraw_results(vec![BalanceWithdrawStatus::InsufficientBalance])
         .await;
 }

--- a/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/e2e_tests.rs
+++ b/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/e2e_tests.rs
@@ -160,7 +160,7 @@ impl TestEnv {
     async fn expect_withdraw_results(&mut self, expected_results: Vec<BalanceWithdrawStatus>) {
         for expected_result in expected_results {
             let cert = self.receive_certificate().await.unwrap();
-            assert_eq!(cert.execution_env.withdraw_env, expected_result);
+            assert_eq!(cert.execution_env.withdraw_status, expected_result);
         }
     }
 

--- a/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/e2e_tests.rs
+++ b/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/e2e_tests.rs
@@ -1,0 +1,238 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use move_core_types::language_storage::TypeTag;
+use sui_protocol_config::ProtocolConfig;
+use sui_test_transaction_builder::TestTransactionBuilder;
+use sui_types::accumulator_root::update_account_balance_for_testing;
+use sui_types::base_types::ObjectID;
+use sui_types::transaction::WithdrawTypeParam;
+use sui_types::type_input::TypeInput;
+use sui_types::SUI_ACCUMULATOR_ROOT_OBJECT_ID;
+use sui_types::{
+    accumulator_root::create_account_for_testing,
+    base_types::{SequenceNumber, SuiAddress},
+    crypto::{get_account_key_pair, AccountKeyPair},
+    executable_transaction::VerifiedExecutableTransaction,
+    gas_coin::GAS,
+    object::Object,
+    programmable_transaction_builder::ProgrammableTransactionBuilder,
+    transaction::BalanceWithdrawArg,
+};
+use tokio::sync::mpsc::{self, unbounded_channel};
+use tokio::time::timeout;
+
+use crate::execution_scheduler::balance_withdraw_scheduler::BalanceSettlement;
+use crate::{
+    authority::{
+        shared_object_version_manager::Schedulable, test_authority_builder::TestAuthorityBuilder,
+        AuthorityState, BalanceWithdrawEnv, ExecutionEnv,
+    },
+    execution_scheduler::{
+        ExecutionScheduler, ExecutionSchedulerAPI, ExecutionSchedulerWrapper, PendingCertificate,
+    },
+};
+
+struct TestEnv {
+    sender: SuiAddress,
+    sender_key: AccountKeyPair,
+    gas_object: Object,
+    account_objects: Vec<ObjectID>,
+    rx_ready_certificates: mpsc::UnboundedReceiver<PendingCertificate>,
+    scheduler: Arc<ExecutionSchedulerWrapper>,
+    state: Arc<AuthorityState>,
+}
+
+#[allow(clippy::disallowed_methods)]
+async fn create_test_env(init_balances: BTreeMap<TypeTag, u64>) -> TestEnv {
+    let (tx_ready_certificates, rx_ready_certificates) = unbounded_channel();
+    let (sender, sender_key) = get_account_key_pair();
+    let gas_object = Object::with_owner_for_testing(sender);
+    let mut starting_objects: Vec<_> = init_balances
+        .into_iter()
+        .map(|(type_tag, balance)| {
+            create_account_for_testing(
+                sender,
+                WithdrawTypeParam::Balance(TypeInput::from(type_tag)),
+                balance,
+            )
+        })
+        .collect();
+    let account_objects = starting_objects.iter().map(|o| o.id()).collect();
+    starting_objects.push(gas_object.clone());
+    let mut protocol_config = ProtocolConfig::get_for_max_version_UNSAFE();
+    protocol_config.set_enable_accumulators_for_testing(true);
+    let state = TestAuthorityBuilder::new()
+        .with_protocol_config(protocol_config)
+        .with_starting_objects(&starting_objects)
+        .build()
+        .await;
+    let scheduler = Arc::new(ExecutionSchedulerWrapper::ExecutionScheduler(
+        ExecutionScheduler::new(
+            state.get_object_cache_reader().clone(),
+            state.get_transaction_cache_reader().clone(),
+            tx_ready_certificates,
+            true,
+            state.metrics.clone(),
+        ),
+    ));
+    TestEnv {
+        sender,
+        sender_key,
+        gas_object,
+        account_objects,
+        rx_ready_certificates,
+        scheduler,
+        state,
+    }
+}
+
+impl TestEnv {
+    fn create_transactions(&self, amounts: Vec<Option<u64>>) -> Vec<VerifiedExecutableTransaction> {
+        amounts
+            .into_iter()
+            .enumerate()
+            .map(|(idx, amount)| {
+                let withdraw = if let Some(amount) = amount {
+                    BalanceWithdrawArg::new_with_amount(amount, GAS::type_tag().into())
+                } else {
+                    BalanceWithdrawArg::new_with_entire_balance(GAS::type_tag().into())
+                };
+                let mut ptb = ProgrammableTransactionBuilder::new();
+                ptb.balance_withdraw(withdraw).unwrap();
+                let tx_data = TestTransactionBuilder::new(
+                    self.sender,
+                    self.gas_object.compute_object_reference(),
+                    // Use a unique index to make the transaction digests unique.
+                    idx as u64 + 1,
+                )
+                .programmable(ptb.finish())
+                .build();
+                VerifiedExecutableTransaction::new_for_testing(tx_data, &self.sender_key)
+            })
+            .collect()
+    }
+
+    fn get_accumulator_object(&self) -> Object {
+        self.state
+            .get_object_cache_reader()
+            .get_object(&SUI_ACCUMULATOR_ROOT_OBJECT_ID)
+            .unwrap()
+    }
+
+    fn get_accumulator_version(&self) -> SequenceNumber {
+        self.get_accumulator_object().version()
+    }
+
+    fn enqueue_transactions(&self, transactions: Vec<VerifiedExecutableTransaction>) {
+        self.enqueue_transactions_with_version(transactions, self.get_accumulator_version())
+    }
+
+    fn enqueue_transactions_with_version(
+        &self,
+        transactions: Vec<VerifiedExecutableTransaction>,
+        version: SequenceNumber,
+    ) {
+        self.scheduler.enqueue(
+            transactions
+                .iter()
+                .map(|tx| {
+                    (
+                        Schedulable::Withdraw(tx.clone(), version),
+                        ExecutionEnv::default(),
+                    )
+                })
+                .collect(),
+            &self.state.epoch_store_for_testing(),
+        );
+    }
+
+    async fn receive_certificate(&mut self) -> Option<PendingCertificate> {
+        timeout(Duration::from_secs(1), self.rx_ready_certificates.recv())
+            .await
+            .ok()?
+    }
+
+    async fn expect_withdraw_results(&mut self, expected_results: Vec<BalanceWithdrawEnv>) {
+        for expected_result in expected_results {
+            let cert = self.receive_certificate().await.unwrap();
+            assert_eq!(cert.execution_env.withdraw_env, expected_result);
+        }
+    }
+
+    fn settle_balances(&mut self, balance_changes: BTreeMap<ObjectID, i128>) {
+        let mut accumulator_object = self.get_accumulator_object();
+        let accumulator_version = accumulator_object.version().next();
+        self.scheduler.settle_balances(BalanceSettlement {
+            accumulator_version,
+            balance_changes: balance_changes.clone(),
+        });
+        for (object_id, balance_change) in balance_changes {
+            let mut account_object = self
+                .state
+                .get_object_cache_reader()
+                .get_object(&object_id)
+                .unwrap();
+            update_account_balance_for_testing(&mut account_object, balance_change);
+            account_object
+                .data
+                .try_as_move_mut()
+                .unwrap()
+                .increment_version_to(accumulator_version);
+            self.state
+                .get_cache_writer()
+                .write_object_entry_for_test(account_object);
+        }
+        accumulator_object
+            .data
+            .try_as_move_mut()
+            .unwrap()
+            .increment_version_to(accumulator_version);
+        self.state
+            .get_cache_writer()
+            .write_object_entry_for_test(accumulator_object);
+    }
+}
+
+#[tokio::test]
+async fn test_withdraw_schedule_e2e() {
+    telemetry_subscribers::init_for_testing();
+    let mut test_env = create_test_env(BTreeMap::from([(GAS::type_tag(), 1000)])).await;
+    let transactions: Vec<_> = test_env.create_transactions(vec![Some(400), Some(600), Some(1)]);
+    test_env.enqueue_transactions(transactions);
+    test_env
+        .expect_withdraw_results(vec![
+            BalanceWithdrawEnv::SufficientBalance,
+            BalanceWithdrawEnv::SufficientBalance,
+            BalanceWithdrawEnv::InsufficientBalance,
+        ])
+        .await;
+
+    let transactions: Vec<_> = test_env.create_transactions(vec![Some(500), Some(500)]);
+    let next_version = test_env.get_accumulator_version().next();
+    test_env.enqueue_transactions_with_version(transactions, next_version);
+    assert!(test_env.receive_certificate().await.is_none());
+
+    test_env.settle_balances(BTreeMap::from([(test_env.account_objects[0], -500)]));
+
+    test_env
+        .expect_withdraw_results(vec![
+            BalanceWithdrawEnv::SufficientBalance,
+            BalanceWithdrawEnv::InsufficientBalance,
+        ])
+        .await;
+
+    test_env.settle_balances(BTreeMap::from([(test_env.account_objects[0], -500)]));
+
+    let transactions = test_env.create_transactions(vec![None]);
+
+    test_env.enqueue_transactions(transactions);
+
+    test_env
+        .expect_withdraw_results(vec![BalanceWithdrawEnv::InsufficientBalance])
+        .await;
+}

--- a/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/mod.rs
+++ b/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/mod.rs
@@ -18,9 +18,9 @@ mod tests;
 #[cfg(test)]
 mod e2e_tests;
 
-/// The result of scheduling the withdraw reservations for a transaction.
+/// The status of scheduling the withdraw reservations for a transaction.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub(crate) enum ScheduleResult {
+pub(crate) enum ScheduleStatus {
     /// We know for sure that the withdraw reservations in this transactions all have enough balance.
     /// This transaction can be executed normally as soon as its object dependencies are ready.
     SufficientBalance,
@@ -32,6 +32,13 @@ pub(crate) enum ScheduleResult {
     /// The caller should stop the scheduling of this transaction.
     /// This is to avoid scheduling the same transaction multiple times.
     AlreadyScheduled,
+}
+
+/// The result of scheduling the withdraw reservations for a transaction.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct ScheduleResult {
+    pub tx_digest: TransactionDigest,
+    pub status: ScheduleStatus,
 }
 
 /// Details regarding a balance settlement, generated when a settlement transaction has been executed

--- a/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/mod.rs
+++ b/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/mod.rs
@@ -15,8 +15,10 @@ pub(crate) mod scheduler;
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
+mod e2e_tests;
+
 /// The result of scheduling the withdraw reservations for a transaction.
-#[allow(dead_code)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub(crate) enum ScheduleResult {
     /// We know for sure that the withdraw reservations in this transactions all have enough balance.
@@ -34,18 +36,19 @@ pub(crate) enum ScheduleResult {
 
 /// Details regarding a balance settlement, generated when a settlement transaction has been executed
 /// and committed to the writeback cache.
-#[allow(dead_code)]
-pub(crate) struct BalanceSettlement {
+pub struct BalanceSettlement {
     /// The accumulator version at which the settlement was committed.
     /// i.e. the root accumulator object is now at this version after the settlement.
     pub accumulator_version: SequenceNumber,
     /// The balance changes for each account object ID.
+    /// This is currently unused because the naive scheduler
+    /// always load the latest balance during scheduling.
+    #[allow(unused)]
     pub balance_changes: BTreeMap<ObjectID, i128>,
 }
 
 /// Details regarding all balance withdraw reservations in a transaction.
-#[allow(dead_code)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct TxBalanceWithdraw {
     pub tx_digest: TransactionDigest,
     pub reservations: BTreeMap<ObjectID, Reservation>,

--- a/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/naive_scheduler.rs
+++ b/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/naive_scheduler.rs
@@ -10,7 +10,7 @@ use tracing::debug;
 use crate::execution_scheduler::balance_withdraw_scheduler::{
     balance_read::AccountBalanceRead,
     scheduler::{BalanceWithdrawSchedulerTrait, WithdrawReservations},
-    BalanceSettlement, ScheduleResult,
+    BalanceSettlement, ScheduleResult, ScheduleStatus,
 };
 
 /// A naive implementation of the balance withdraw scheduler that does not attempt to optimize the scheduling.
@@ -110,9 +110,15 @@ impl BalanceWithdrawSchedulerTrait for NaiveBalanceWithdrawScheduler {
                         }
                     }
                 }
-                let _ = sender.send(ScheduleResult::SufficientBalance);
+                let _ = sender.send(ScheduleResult {
+                    tx_digest: withdraw.tx_digest,
+                    status: ScheduleStatus::SufficientBalance,
+                });
             } else {
-                let _ = sender.send(ScheduleResult::InsufficientBalance);
+                let _ = sender.send(ScheduleResult {
+                    tx_digest: withdraw.tx_digest,
+                    status: ScheduleStatus::InsufficientBalance,
+                });
             }
         }
     }

--- a/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/naive_scheduler.rs
+++ b/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/naive_scheduler.rs
@@ -5,6 +5,7 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use sui_types::{base_types::SequenceNumber, transaction::Reservation};
 use tokio::sync::watch;
+use tracing::debug;
 
 use crate::execution_scheduler::balance_withdraw_scheduler::{
     balance_read::AccountBalanceRead,
@@ -17,7 +18,6 @@ use crate::execution_scheduler::balance_withdraw_scheduler::{
 /// and then check if the balance is sufficient.
 /// This implementation is simple and easy to understand, but it is not efficient.
 /// It is only used to unblock further development of the balance withdraw scheduler.
-#[allow(dead_code)]
 pub(crate) struct NaiveBalanceWithdrawScheduler {
     balance_read: Arc<dyn AccountBalanceRead>,
     last_settled_version_sender: watch::Sender<SequenceNumber>,
@@ -26,7 +26,6 @@ pub(crate) struct NaiveBalanceWithdrawScheduler {
 }
 
 impl NaiveBalanceWithdrawScheduler {
-    #[allow(dead_code)]
     pub fn new(
         balance_read: Arc<dyn AccountBalanceRead>,
         last_settled_accumulator_version: SequenceNumber,
@@ -46,6 +45,10 @@ impl BalanceWithdrawSchedulerTrait for NaiveBalanceWithdrawScheduler {
     async fn schedule_withdraws(&self, withdraws: WithdrawReservations) {
         let mut receiver = self.last_settled_version_sender.subscribe();
         while *receiver.borrow_and_update() < withdraws.accumulator_version {
+            debug!(
+                "Waiting for accumulator version {:?} to be settled",
+                withdraws.accumulator_version
+            );
             if receiver.changed().await.is_err() {
                 return;
             }
@@ -66,10 +69,15 @@ impl BalanceWithdrawSchedulerTrait for NaiveBalanceWithdrawScheduler {
                     self.balance_read
                         .get_account_balance(object_id, withdraws.accumulator_version)
                 });
+                debug!("Starting balance for {:?}: {:?}", object_id, entry);
 
                 match reservation {
                     Reservation::MaxAmountU64(amount) => {
                         if *entry < *amount {
+                            debug!(
+                                "Insufficient balance for {:?}. Requested: {:?}, Available: {:?}",
+                                object_id, amount, entry
+                            );
                             success = false;
                             break;
                         }
@@ -78,6 +86,7 @@ impl BalanceWithdrawSchedulerTrait for NaiveBalanceWithdrawScheduler {
                         // When we want to reserve the entire balance,
                         // we still need to ensure that the entire balance is not already reserved.
                         if *entry == 0 {
+                            debug!("No more balance available for {:?}", object_id);
                             success = false;
                             break;
                         }
@@ -85,6 +94,7 @@ impl BalanceWithdrawSchedulerTrait for NaiveBalanceWithdrawScheduler {
                 }
             }
             if success {
+                debug!("Successfully reserved all withdraws for {:?}", withdraw);
                 for (object_id, reservation) in withdraw.reservations {
                     // unwrap safe because we always initialize each account in the above loop.
                     let balance = cur_balances.get_mut(&object_id).unwrap();
@@ -108,6 +118,10 @@ impl BalanceWithdrawSchedulerTrait for NaiveBalanceWithdrawScheduler {
     }
 
     async fn settle_balances(&self, settlement: BalanceSettlement) {
+        debug!(
+            "Settling balances for version {:?}",
+            settlement.accumulator_version
+        );
         let _ = self
             .last_settled_version_sender
             .send(settlement.accumulator_version);

--- a/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/scheduler.rs
+++ b/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/scheduler.rs
@@ -10,22 +10,20 @@ use crate::execution_scheduler::balance_withdraw_scheduler::{
 use mysten_metrics::monitored_mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use sui_types::{base_types::SequenceNumber, digests::TransactionDigest};
 use tokio::sync::oneshot;
+use tracing::debug;
 
-#[allow(dead_code)]
 #[async_trait::async_trait]
 pub(crate) trait BalanceWithdrawSchedulerTrait: Send + Sync {
     async fn schedule_withdraws(&self, withdraws: WithdrawReservations);
     async fn settle_balances(&self, settlement: BalanceSettlement);
 }
 
-#[allow(dead_code)]
 pub(crate) struct WithdrawReservations {
     pub accumulator_version: SequenceNumber,
     pub withdraws: Vec<TxBalanceWithdraw>,
     pub senders: Vec<oneshot::Sender<ScheduleResult>>,
 }
 
-#[allow(dead_code)]
 #[derive(Clone)]
 pub(crate) struct BalanceWithdrawScheduler {
     inner: Arc<dyn BalanceWithdrawSchedulerTrait>,
@@ -35,7 +33,6 @@ pub(crate) struct BalanceWithdrawScheduler {
 }
 
 impl WithdrawReservations {
-    #[allow(dead_code)]
     pub fn new(
         accumulator_version: SequenceNumber,
         withdraws: Vec<TxBalanceWithdraw>,
@@ -62,12 +59,11 @@ impl WithdrawReservations {
 }
 
 impl BalanceWithdrawScheduler {
-    #[allow(dead_code)]
     pub fn new(
         balance_read: Arc<dyn AccountBalanceRead>,
-        init_accumulator_version: SequenceNumber,
+        starting_accumulator_version: SequenceNumber,
     ) -> Arc<Self> {
-        let inner = NaiveBalanceWithdrawScheduler::new(balance_read, init_accumulator_version);
+        let inner = NaiveBalanceWithdrawScheduler::new(balance_read, starting_accumulator_version);
         let (withdraw_sender, withdraw_receiver) =
             unbounded_channel("withdraw_scheduler_withdraws");
         let (settlement_sender, settlement_receiver) =
@@ -81,7 +77,7 @@ impl BalanceWithdrawScheduler {
         tokio::spawn(
             scheduler
                 .clone()
-                .process_settlement_task(settlement_receiver, init_accumulator_version),
+                .process_settlement_task(settlement_receiver, starting_accumulator_version),
         );
         scheduler
     }
@@ -92,12 +88,15 @@ impl BalanceWithdrawScheduler {
     /// It must be called sequentially in order to correctly schedule withdraws.
     /// It is OK to call this function multiple times for the same accumulator version (which will happen between
     /// the calls to the function by ConsensusHandler and the CheckpointExecutor).
-    #[allow(dead_code)]
     pub fn schedule_withdraws(
         &self,
         accumulator_version: SequenceNumber,
         withdraws: Vec<TxBalanceWithdraw>,
     ) -> BTreeMap<TransactionDigest, oneshot::Receiver<ScheduleResult>> {
+        debug!(
+            "schedule_withdraws: {:?}, {:?}",
+            accumulator_version, withdraws
+        );
         let (reservations, receivers) = WithdrawReservations::new(accumulator_version, withdraws);
         if let Err(err) = self.withdraw_sender.send(reservations) {
             tracing::error!("Failed to send withdraw reservations: {:?}", err);
@@ -109,7 +108,6 @@ impl BalanceWithdrawScheduler {
     /// in the writeback cache.
     /// It is OK to call this function out of order, as the implementation will handle the out of order calls.
     /// It must be called once for each version of the accumulator root object.
-    #[allow(dead_code)]
     pub fn settle_balances(&self, settlement: BalanceSettlement) {
         if let Err(err) = self.settlement_sender.send(settlement) {
             tracing::error!("Failed to send balance settlement: {:?}", err);
@@ -141,11 +139,15 @@ impl BalanceWithdrawScheduler {
     async fn process_settlement_task(
         self: Arc<Self>,
         mut settlement_receiver: UnboundedReceiver<BalanceSettlement>,
-        init_accumulator_version: SequenceNumber,
+        starting_accumulator_version: SequenceNumber,
     ) {
-        let mut expected_version = init_accumulator_version.next();
+        let mut expected_version = starting_accumulator_version.next();
         let mut pending_settlements = BTreeMap::new();
         while let Some(settlement) = settlement_receiver.recv().await {
+            debug!(
+                "process_settlement_task received version: {:?}, expected version: {:?}",
+                settlement.accumulator_version, expected_version
+            );
             pending_settlements.insert(settlement.accumulator_version, settlement);
             while let Some(settlement) = pending_settlements.remove(&expected_version) {
                 expected_version = settlement.accumulator_version.next();

--- a/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/tests.rs
+++ b/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/tests.rs
@@ -1,10 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::execution_scheduler::balance_withdraw_scheduler::ScheduleResult;
 use crate::execution_scheduler::balance_withdraw_scheduler::{
     balance_read::MockBalanceRead, scheduler::BalanceWithdrawScheduler, BalanceSettlement,
-    ScheduleResult, TxBalanceWithdraw,
+    ScheduleStatus, TxBalanceWithdraw,
 };
+use futures::stream::{FuturesUnordered, StreamExt};
 use rand::{seq::SliceRandom, Rng};
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
 use sui_types::{
@@ -12,8 +14,8 @@ use sui_types::{
     digests::TransactionDigest,
     transaction::Reservation,
 };
-#[cfg(test)]
 use tokio::sync::oneshot;
+use tokio::time::timeout;
 
 #[derive(Clone)]
 struct TestScheduler {
@@ -41,14 +43,17 @@ impl TestScheduler {
     }
 }
 
-#[cfg(test)]
-async fn wait_until(receiver: oneshot::Receiver<ScheduleResult>, until: ScheduleResult) {
-    use std::time::Duration;
-
-    use tokio::time::timeout;
-
+async fn wait_for_results(
+    mut receivers: FuturesUnordered<oneshot::Receiver<ScheduleResult>>,
+    expected_results: BTreeMap<TransactionDigest, ScheduleStatus>,
+) {
     timeout(Duration::from_secs(3), async {
-        assert_eq!(receiver.await.unwrap(), until);
+        let mut results = BTreeMap::new();
+        while let Some(result) = receivers.next().await {
+            let result = result.unwrap();
+            results.insert(result.tx_digest, result.status);
+        }
+        assert_eq!(results, expected_results);
     })
     .await
     .unwrap();
@@ -67,10 +72,12 @@ async fn test_basic_sufficient_balance() {
 
     let receivers = test
         .scheduler
-        .schedule_withdraws(init_version, vec![withdraw]);
-    for (_, receiver) in receivers {
-        wait_until(receiver, ScheduleResult::SufficientBalance).await;
-    }
+        .schedule_withdraws(init_version, vec![withdraw.clone()]);
+    wait_for_results(
+        receivers,
+        BTreeMap::from([(withdraw.tx_digest, ScheduleStatus::SufficientBalance)]),
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -86,10 +93,12 @@ async fn test_basic_insufficient_balance() {
 
     let receivers = test
         .scheduler
-        .schedule_withdraws(init_version, vec![withdraw]);
-    for (_, receiver) in receivers {
-        wait_until(receiver, ScheduleResult::InsufficientBalance).await;
-    }
+        .schedule_withdraws(init_version, vec![withdraw.clone()]);
+    wait_for_results(
+        receivers,
+        BTreeMap::from([(withdraw.tx_digest, ScheduleStatus::InsufficientBalance)]),
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -106,16 +115,20 @@ async fn test_already_scheduled() {
     let receivers = test
         .scheduler
         .schedule_withdraws(init_version, vec![withdraw.clone()]);
-    for (_, receiver) in receivers {
-        wait_until(receiver, ScheduleResult::SufficientBalance).await;
-    }
+    wait_for_results(
+        receivers,
+        BTreeMap::from([(withdraw.tx_digest, ScheduleStatus::SufficientBalance)]),
+    )
+    .await;
 
     let receivers = test
         .scheduler
-        .schedule_withdraws(init_version, vec![withdraw]);
-    for (_, receiver) in receivers {
-        wait_until(receiver, ScheduleResult::AlreadyScheduled).await;
-    }
+        .schedule_withdraws(init_version, vec![withdraw.clone()]);
+    wait_for_results(
+        receivers,
+        BTreeMap::from([(withdraw.tx_digest, ScheduleStatus::AlreadyScheduled)]),
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -132,19 +145,23 @@ async fn test_basic_settlement() {
     let receivers = test
         .scheduler
         .schedule_withdraws(init_version, vec![withdraw.clone()]);
-    for (_, receiver) in receivers {
-        wait_until(receiver, ScheduleResult::SufficientBalance).await;
-    }
+    wait_for_results(
+        receivers,
+        BTreeMap::from([(withdraw.tx_digest, ScheduleStatus::SufficientBalance)]),
+    )
+    .await;
 
     let next_version = init_version.next();
     test.settle_balance_changes(next_version, BTreeMap::from([(account, -50i128)]));
 
     let receivers = test
         .scheduler
-        .schedule_withdraws(next_version, vec![withdraw]);
-    for (_, receiver) in receivers {
-        wait_until(receiver, ScheduleResult::SufficientBalance).await;
-    }
+        .schedule_withdraws(next_version, vec![withdraw.clone()]);
+    wait_for_results(
+        receivers,
+        BTreeMap::from([(withdraw.tx_digest, ScheduleStatus::SufficientBalance)]),
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -163,12 +180,12 @@ async fn test_out_of_order_settlements() {
         tx_digest: TransactionDigest::random(),
         reservations: BTreeMap::from([(account, Reservation::MaxAmountU64(50))]),
     };
-    let mut receivers = test
+    let receivers = test
         .scheduler
         .schedule_withdraws(v0, vec![withdraw1.clone()]);
-    wait_until(
-        receivers.remove(&withdraw1.tx_digest).unwrap(),
-        ScheduleResult::SufficientBalance,
+    wait_for_results(
+        receivers,
+        BTreeMap::from([(withdraw1.tx_digest, ScheduleStatus::SufficientBalance)]),
     )
     .await;
 
@@ -176,12 +193,12 @@ async fn test_out_of_order_settlements() {
         tx_digest: TransactionDigest::random(),
         reservations: BTreeMap::from([(account, Reservation::MaxAmountU64(80))]),
     };
-    let mut receivers = test
+    let receivers = test
         .scheduler
         .schedule_withdraws(v1, vec![withdraw2.clone()]);
-    wait_until(
-        receivers.remove(&withdraw2.tx_digest).unwrap(),
-        ScheduleResult::SufficientBalance,
+    wait_for_results(
+        receivers,
+        BTreeMap::from([(withdraw2.tx_digest, ScheduleStatus::SufficientBalance)]),
     )
     .await;
 }
@@ -221,23 +238,17 @@ async fn test_multi_accounts() {
         reservations: reservations3,
     };
 
-    let mut receivers = test.scheduler.schedule_withdraws(
+    let receivers = test.scheduler.schedule_withdraws(
         init_version,
         vec![withdraw1.clone(), withdraw2.clone(), withdraw3.clone()],
     );
-    wait_until(
-        receivers.remove(&withdraw1.tx_digest).unwrap(),
-        ScheduleResult::SufficientBalance,
-    )
-    .await;
-    wait_until(
-        receivers.remove(&withdraw2.tx_digest).unwrap(),
-        ScheduleResult::InsufficientBalance,
-    )
-    .await;
-    wait_until(
-        receivers.remove(&withdraw3.tx_digest).unwrap(),
-        ScheduleResult::SufficientBalance,
+    wait_for_results(
+        receivers,
+        BTreeMap::from([
+            (withdraw1.tx_digest, ScheduleStatus::SufficientBalance),
+            (withdraw2.tx_digest, ScheduleStatus::InsufficientBalance),
+            (withdraw3.tx_digest, ScheduleStatus::SufficientBalance),
+        ]),
     )
     .await;
 }
@@ -253,36 +264,36 @@ async fn test_multi_settlements() {
         reservations: BTreeMap::from([(account, Reservation::MaxAmountU64(50))]),
     };
 
-    let mut receivers = test
+    let receivers = test
         .scheduler
         .schedule_withdraws(init_version, vec![withdraw.clone()]);
-    wait_until(
-        receivers.remove(&withdraw.tx_digest).unwrap(),
-        ScheduleResult::SufficientBalance,
+    wait_for_results(
+        receivers,
+        BTreeMap::from([(withdraw.tx_digest, ScheduleStatus::SufficientBalance)]),
     )
     .await;
 
     let next_version = init_version.next();
     test.settle_balance_changes(next_version, BTreeMap::from([(account, -50i128)]));
 
-    let mut receivers = test
+    let receivers = test
         .scheduler
         .schedule_withdraws(next_version, vec![withdraw.clone()]);
-    wait_until(
-        receivers.remove(&withdraw.tx_digest).unwrap(),
-        ScheduleResult::SufficientBalance,
+    wait_for_results(
+        receivers,
+        BTreeMap::from([(withdraw.tx_digest, ScheduleStatus::SufficientBalance)]),
     )
     .await;
 
     let next_version = next_version.next();
     test.settle_balance_changes(next_version, BTreeMap::from([(account, -50i128)]));
 
-    let mut receivers = test
+    let receivers = test
         .scheduler
         .schedule_withdraws(next_version, vec![withdraw.clone()]);
-    wait_until(
-        receivers.remove(&withdraw.tx_digest).unwrap(),
-        ScheduleResult::InsufficientBalance,
+    wait_for_results(
+        receivers,
+        BTreeMap::from([(withdraw.tx_digest, ScheduleStatus::InsufficientBalance)]),
     )
     .await;
 }
@@ -309,21 +320,21 @@ async fn test_settlement_far_ahead_of_schedule() {
         tx_digest: TransactionDigest::random(),
         reservations: BTreeMap::from([(account, Reservation::MaxAmountU64(100))]),
     };
-    let mut receivers = test
+    let receivers = test
         .scheduler
         .schedule_withdraws(v0, vec![withdraw.clone()]);
-    wait_until(
-        receivers.remove(&withdraw.tx_digest).unwrap(),
-        ScheduleResult::SufficientBalance,
+    wait_for_results(
+        receivers,
+        BTreeMap::from([(withdraw.tx_digest, ScheduleStatus::SufficientBalance)]),
     )
     .await;
 
-    let mut receivers = test
+    let receivers = test
         .scheduler
         .schedule_withdraws(v1, vec![withdraw.clone()]);
-    wait_until(
-        receivers.remove(&withdraw.tx_digest).unwrap(),
-        ScheduleResult::SufficientBalance,
+    wait_for_results(
+        receivers,
+        BTreeMap::from([(withdraw.tx_digest, ScheduleStatus::SufficientBalance)]),
     )
     .await;
 
@@ -332,12 +343,12 @@ async fn test_settlement_far_ahead_of_schedule() {
         reservations: BTreeMap::from([(account, Reservation::MaxAmountU64(50))]),
     };
 
-    let mut receivers = test
+    let receivers = test
         .scheduler
         .schedule_withdraws(v2, vec![withdraw.clone()]);
-    wait_until(
-        receivers.remove(&withdraw.tx_digest).unwrap(),
-        ScheduleResult::SufficientBalance,
+    wait_for_results(
+        receivers,
+        BTreeMap::from([(withdraw.tx_digest, ScheduleStatus::SufficientBalance)]),
     )
     .await;
 }
@@ -364,7 +375,7 @@ async fn test_withdraw_entire_balance() {
         },
     ];
 
-    let mut receivers1 = test
+    let receivers1 = test
         .scheduler
         .schedule_withdraws(init_version, withdraws1.clone());
 
@@ -383,41 +394,29 @@ async fn test_withdraw_entire_balance() {
         },
     ];
 
-    let mut receivers2 = test
+    let receivers2 = test
         .scheduler
         .schedule_withdraws(next_version, withdraws2.clone());
 
     test.settle_balance_changes(next_version, BTreeMap::new());
 
-    wait_until(
-        receivers1.remove(&withdraws1[0].tx_digest).unwrap(),
-        ScheduleResult::SufficientBalance,
-    )
-    .await;
-    wait_until(
-        receivers1.remove(&withdraws1[1].tx_digest).unwrap(),
-        ScheduleResult::InsufficientBalance,
-    )
-    .await;
-    wait_until(
-        receivers1.remove(&withdraws1[2].tx_digest).unwrap(),
-        ScheduleResult::InsufficientBalance,
+    wait_for_results(
+        receivers1,
+        BTreeMap::from([
+            (withdraws1[0].tx_digest, ScheduleStatus::SufficientBalance),
+            (withdraws1[1].tx_digest, ScheduleStatus::InsufficientBalance),
+            (withdraws1[2].tx_digest, ScheduleStatus::InsufficientBalance),
+        ]),
     )
     .await;
 
-    wait_until(
-        receivers2.remove(&withdraws2[0].tx_digest).unwrap(),
-        ScheduleResult::SufficientBalance,
-    )
-    .await;
-    wait_until(
-        receivers2.remove(&withdraws2[1].tx_digest).unwrap(),
-        ScheduleResult::InsufficientBalance,
-    )
-    .await;
-    wait_until(
-        receivers2.remove(&withdraws2[2].tx_digest).unwrap(),
-        ScheduleResult::InsufficientBalance,
+    wait_for_results(
+        receivers2,
+        BTreeMap::from([
+            (withdraws2[0].tx_digest, ScheduleStatus::SufficientBalance),
+            (withdraws2[1].tx_digest, ScheduleStatus::InsufficientBalance),
+            (withdraws2[2].tx_digest, ScheduleStatus::InsufficientBalance),
+        ]),
     )
     .await;
 }
@@ -504,7 +503,7 @@ async fn stress_test() {
                 }
             });
 
-            let mut all_receivers = BTreeMap::new();
+            let mut all_receivers = FuturesUnordered::new();
             for (version, withdraws) in withdraws {
                 let receivers = test.scheduler.schedule_withdraws(version, withdraws);
                 tokio::time::sleep(Duration::from_millis(5)).await;
@@ -514,8 +513,9 @@ async fn stress_test() {
             settle_task.await.unwrap();
 
             let mut results = BTreeMap::new();
-            for (tx_digest, receiver) in all_receivers {
-                results.insert(tx_digest, receiver.await.unwrap());
+            while let Some(result) = all_receivers.next().await {
+                let result = result.unwrap();
+                results.insert(result.tx_digest, result.status);
             }
             results
         });

--- a/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
+++ b/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
@@ -280,12 +280,14 @@ impl ExecutionScheduler {
                                 "Balance withdraw scheduling result: Insufficient balance"
                             );
                             let (cert, env) = cert_map.remove(&tx_digest).expect("cert must exist");
+                            let env = env.with_insufficient_balance();
                             scheduler.enqueue_transactions(vec![(cert, env)], &epoch_store);
                         }
                         ScheduleStatus::SufficientBalance => {
                             let tx_digest = result.tx_digest;
                             debug!(?tx_digest, "Balance withdraw scheduling result: Success");
                             let (cert, env) = cert_map.remove(&tx_digest).expect("cert must exist");
+                            let env = env.with_sufficient_balance();
                             scheduler.enqueue_transactions(vec![(cert, env)], &epoch_store);
                         }
                         ScheduleStatus::AlreadyScheduled => {

--- a/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
+++ b/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
@@ -88,10 +88,12 @@ impl ExecutionScheduler {
         let balance_withdraw_scheduler = if balance_accumulator_enabled {
             let starting_accumulator_version = object_cache_read
                 .get_object(&SUI_ACCUMULATOR_ROOT_OBJECT_ID)
-                .map(|obj| obj.version());
-            starting_accumulator_version.map(|version| {
-                BalanceWithdrawScheduler::new(Arc::new(object_cache_read.clone()), version)
-            })
+                .expect("Accumulator root object must be present if balance accumulator is enabled")
+                .version();
+            Some(BalanceWithdrawScheduler::new(
+                Arc::new(object_cache_read.clone()),
+                starting_accumulator_version,
+            ))
         } else {
             None
         };

--- a/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
+++ b/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
@@ -7,24 +7,32 @@ use crate::{
         shared_object_version_manager::Schedulable, AuthorityMetrics, ExecutionEnv,
     },
     execution_cache::{ObjectCacheRead, TransactionCacheRead},
-    execution_scheduler::{ExecutingGuard, PendingCertificateStats},
+    execution_scheduler::{
+        balance_withdraw_scheduler::{
+            scheduler::BalanceWithdrawScheduler, BalanceSettlement, ScheduleResult,
+            TxBalanceWithdraw,
+        },
+        ExecutingGuard, PendingCertificateStats,
+    },
 };
+use mysten_common::debug_fatal;
 use mysten_metrics::spawn_monitored_task;
 use std::{
-    collections::{BTreeSet, HashSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     sync::Arc,
 };
 use sui_config::node::AuthorityOverloadConfig;
 use sui_types::{
-    base_types::FullObjectID,
+    base_types::{FullObjectID, SequenceNumber},
     error::SuiResult,
     executable_transaction::VerifiedExecutableTransaction,
     storage::InputKey,
-    transaction::{SenderSignedData, TransactionDataAPI},
+    transaction::{SenderSignedData, TransactionDataAPI, TransactionKey},
+    SUI_ACCUMULATOR_ROOT_OBJECT_ID,
 };
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::time::Instant;
-use tracing::{debug, warn};
+use tracing::{debug, error};
 
 use super::{overload_tracker::OverloadTracker, ExecutionSchedulerAPI, PendingCertificate};
 
@@ -34,6 +42,7 @@ pub struct ExecutionScheduler {
     transaction_cache_read: Arc<dyn TransactionCacheRead>,
     overload_tracker: Arc<OverloadTracker>,
     tx_ready_certificates: UnboundedSender<PendingCertificate>,
+    balance_withdraw_scheduler: Option<Arc<BalanceWithdrawScheduler>>,
     metrics: Arc<AuthorityMetrics>,
 }
 
@@ -72,14 +81,26 @@ impl ExecutionScheduler {
         object_cache_read: Arc<dyn ObjectCacheRead>,
         transaction_cache_read: Arc<dyn TransactionCacheRead>,
         tx_ready_certificates: UnboundedSender<PendingCertificate>,
+        balance_accumulator_enabled: bool,
         metrics: Arc<AuthorityMetrics>,
     ) -> Self {
         tracing::info!("Creating new ExecutionScheduler");
+        let balance_withdraw_scheduler = if balance_accumulator_enabled {
+            let starting_accumulator_version = object_cache_read
+                .get_object(&SUI_ACCUMULATOR_ROOT_OBJECT_ID)
+                .map(|obj| obj.version());
+            starting_accumulator_version.map(|version| {
+                BalanceWithdrawScheduler::new(Arc::new(object_cache_read.clone()), version)
+            })
+        } else {
+            None
+        };
         Self {
             object_cache_read,
             transaction_cache_read,
             overload_tracker: Arc::new(OverloadTracker::new()),
             tx_ready_certificates,
+            balance_withdraw_scheduler,
             metrics,
         }
     }
@@ -91,6 +112,9 @@ impl ExecutionScheduler {
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) {
         let enqueue_time = Instant::now();
+        let tx_digest = cert.digest();
+        let digests = [*tx_digest];
+
         let tx_data = cert.transaction_data();
         let input_object_kinds = tx_data
             .input_objects()
@@ -121,11 +145,9 @@ impl ExecutionScheduler {
         .concat();
 
         let epoch = epoch_store.epoch();
-        let digest = cert.digest();
-        let digests = [*digest];
-        debug!(?digest, "Scheduled transaction in execution scheduler");
+        debug!(?tx_digest, "Scheduled transaction in execution scheduler");
         tracing::trace!(
-            ?digests,
+            ?tx_digest,
             "Waiting for input objects: {:?}",
             input_and_receiving_keys
         );
@@ -146,7 +168,7 @@ impl ExecutionScheduler {
                 .transaction_manager_num_enqueued_certificates
                 .with_label_values(&["ready"])
                 .inc();
-            debug!(?digest, "Input objects already available");
+            debug!(?tx_digest, "Input objects already available");
             self.send_transaction_for_execution(&cert, execution_env, enqueue_time);
             return;
         }
@@ -163,7 +185,7 @@ impl ExecutionScheduler {
                     self.metrics
                         .transaction_manager_transaction_queue_age_s
                         .observe(enqueue_time.elapsed().as_secs_f64());
-                    debug!(?digest, "Input objects available");
+                    debug!(?tx_digest, "Input objects available");
                     // TODO: Eventually we could fold execution_driver into the scheduler.
                     self.send_transaction_for_execution(
                         &cert,
@@ -172,7 +194,7 @@ impl ExecutionScheduler {
                     );
                 }
             _ = self.transaction_cache_read.notify_read_executed_effects_digests(&digests) => {
-                debug!(?digests, "Transaction already executed");
+                debug!(?tx_digest, "Transaction already executed");
             }
         };
     }
@@ -199,6 +221,107 @@ impl ExecutionScheduler {
         };
         let _ = self.tx_ready_certificates.send(pending_cert);
     }
+
+    fn schedule_balance_withdraws(
+        &self,
+        certs: Vec<(VerifiedExecutableTransaction, SequenceNumber, ExecutionEnv)>,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) {
+        if certs.is_empty() {
+            return;
+        }
+        let scheduler = self
+            .balance_withdraw_scheduler
+            .as_ref()
+            .expect("Balance withdraw scheduler must be enabled if there are withdraws");
+        let mut withdraws = BTreeMap::new();
+        let mut prev_version = None;
+        for (cert, version, _) in &certs {
+            let tx_withdraws = cert
+                .transaction_data()
+                .process_balance_withdraws()
+                .expect("Balance withdraws should have already been checked");
+            assert!(!tx_withdraws.is_empty());
+            if let Some(prev_version) = prev_version {
+                // Transactions must be in order.
+                assert!(prev_version <= *version);
+            }
+            prev_version = Some(*version);
+            let tx_digest = *cert.digest();
+            withdraws
+                .entry(*version)
+                .or_insert(Vec::new())
+                .push(TxBalanceWithdraw {
+                    tx_digest,
+                    reservations: tx_withdraws,
+                });
+        }
+        let mut receivers = BTreeMap::new();
+        for (version, tx_withdraws) in withdraws {
+            receivers.extend(scheduler.schedule_withdraws(version, tx_withdraws));
+        }
+        let scheduler = self.clone();
+        let epoch_store = epoch_store.clone();
+        spawn_monitored_task!(epoch_store.clone().within_alive_epoch(async move {
+            for (cert, _, env) in certs {
+                let tx_digest = *cert.digest();
+                let receiver = receivers.remove(&tx_digest).expect("receiver must exist");
+                let result = receiver.await;
+                match result {
+                    Ok(ScheduleResult::InsufficientBalance) => {
+                        debug!(
+                            ?tx_digest,
+                            "Balance withdraw scheduling result: Insufficient balance"
+                        );
+                        let env = env.with_insufficient_balance();
+                        scheduler.enqueue_transactions(vec![(cert, env)], &epoch_store);
+                    }
+                    Ok(ScheduleResult::SufficientBalance) => {
+                        debug!(?tx_digest, "Balance withdraw scheduling result: Success");
+                        let env = env.with_sufficient_balance();
+                        scheduler.enqueue_transactions(vec![(cert, env)], &epoch_store);
+                    }
+                    Ok(ScheduleResult::AlreadyScheduled) => {
+                        debug!(?tx_digest, "Withdraw already scheduled or executed");
+                    }
+                    Err(e) => {
+                        error!(?tx_digest, "Withdraw scheduler stopped: {:?}", e);
+                    }
+                }
+            }
+        }));
+    }
+
+    fn schedule_tx_keys(
+        &self,
+        tx_with_keys: Vec<(TransactionKey, ExecutionEnv)>,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) {
+        if tx_with_keys.is_empty() {
+            return;
+        }
+
+        let scheduler = self.clone();
+        let epoch_store = epoch_store.clone();
+        spawn_monitored_task!(epoch_store.clone().within_alive_epoch(async move {
+            let tx_keys: Vec<_> = tx_with_keys.iter().map(|(key, _)| key).cloned().collect();
+            let digests = epoch_store
+                .notify_read_tx_key_to_digest(&tx_keys)
+                .await
+                .expect("db error");
+            let transactions = scheduler
+                .transaction_cache_read
+                .multi_get_transaction_blocks(&digests)
+                .into_iter()
+                .map(|tx| {
+                    let tx = tx.expect("tx must exist").as_ref().clone();
+                    VerifiedExecutableTransaction::new_system(tx, epoch_store.epoch())
+                })
+                .zip(tx_with_keys.into_iter().map(|(_, env)| env))
+                .collect::<Vec<_>>();
+            scheduler.enqueue_transactions(transactions, &epoch_store);
+        }));
+    }
 }
 
 impl ExecutionSchedulerAPI for ExecutionScheduler {
@@ -208,47 +331,27 @@ impl ExecutionSchedulerAPI for ExecutionScheduler {
         epoch_store: &Arc<AuthorityPerEpochStore>,
     ) {
         // schedule all transactions immediately
-        let mut txns = Vec::with_capacity(certs.len());
-        let mut rest = Vec::new();
+        let mut ordinary_txns = Vec::with_capacity(certs.len());
+        let mut tx_with_keys = Vec::new();
+        let mut tx_with_withdraws = Vec::new();
 
         for (schedulable, env) in certs {
-            if let Schedulable::Transaction(tx) = schedulable {
-                txns.push((tx, env));
-            } else {
-                rest.push((schedulable, env));
+            match schedulable {
+                Schedulable::Transaction(tx) => {
+                    ordinary_txns.push((tx, env));
+                }
+                s @ Schedulable::RandomnessStateUpdate(..) => {
+                    tx_with_keys.push((s.key(), env));
+                }
+                Schedulable::Withdraw(tx, version) => {
+                    tx_with_withdraws.push((tx, version, env));
+                }
             }
         }
 
-        self.enqueue_transactions(txns, epoch_store);
-
-        if rest.is_empty() {
-            return;
-        }
-
-        let rest_keys = rest
-            .iter()
-            .map(|(schedulable, _)| schedulable.key())
-            .collect::<Vec<_>>();
-
-        let scheduler = self.clone();
-        let epoch_store = epoch_store.clone();
-        spawn_monitored_task!(epoch_store.clone().within_alive_epoch(async move {
-            let rest_digests = epoch_store
-                .notify_read_tx_key_to_digest(&rest_keys)
-                .await
-                .expect("db error");
-            let rest_transactions = scheduler
-                .transaction_cache_read
-                .multi_get_transaction_blocks(&rest_digests)
-                .into_iter()
-                .map(|tx| {
-                    let tx = tx.expect("tx must exist").as_ref().clone();
-                    VerifiedExecutableTransaction::new_system(tx, epoch_store.epoch())
-                })
-                .zip(rest.into_iter().map(|(_, env)| env))
-                .collect::<Vec<_>>();
-            scheduler.enqueue_transactions(rest_transactions, &epoch_store);
-        }));
+        self.enqueue_transactions(ordinary_txns, epoch_store);
+        self.schedule_tx_keys(tx_with_keys, epoch_store);
+        self.schedule_balance_withdraws(tx_with_withdraws, epoch_store);
     }
 
     fn enqueue_transactions(
@@ -263,8 +366,8 @@ impl ExecutionSchedulerAPI for ExecutionScheduler {
                 if cert.0.epoch() == epoch_store.epoch() {
                     Some(cert)
                 } else {
-                    warn!(
-                        "Ignoring enqueued certificate from wrong epoch. Expected={} Certificate={:?}",
+                    debug_fatal!(
+                        "We should never enqueue certificate from wrong epoch. Expected={} Certificate={:?}",
                         epoch_store.epoch(),
                         cert.0.epoch(),
                     );
@@ -306,6 +409,13 @@ impl ExecutionSchedulerAPI for ExecutionScheduler {
             .transaction_manager_num_enqueued_certificates
             .with_label_values(&["already_executed"])
             .inc_by(already_executed_certs_num);
+    }
+
+    fn settle_balances(&self, settlement: BalanceSettlement) {
+        self.balance_withdraw_scheduler
+            .as_ref()
+            .expect("Balance withdraw scheduler must be enabled if there are settlements")
+            .settle_balances(settlement);
     }
 
     fn check_execution_overload(
@@ -381,6 +491,7 @@ mod test {
                 state.get_object_cache_reader().clone(),
                 state.get_transaction_cache_reader().clone(),
                 tx_ready_certificates,
+                false,
                 state.metrics.clone(),
             ));
 

--- a/crates/sui-core/src/execution_scheduler/mod.rs
+++ b/crates/sui-core/src/execution_scheduler/mod.rs
@@ -4,7 +4,6 @@
 use crate::{
     authority::{
         authority_per_epoch_store::AuthorityPerEpochStore,
-        epoch_start_configuration::EpochStartConfigTrait,
         shared_object_version_manager::Schedulable, AuthorityMetrics, ExecutionEnv,
     },
     execution_cache::{ObjectCacheRead, TransactionCacheRead},
@@ -131,11 +130,7 @@ impl ExecutionSchedulerWrapper {
             chain != Chain::Mainnet
         };
         if enable_execution_scheduler {
-            let enable_accumulators = epoch_store.protocol_config().enable_accumulators()
-                && epoch_store
-                    .epoch_start_config()
-                    .accumulator_root_obj_initial_shared_version()
-                    .is_some();
+            let enable_accumulators = epoch_store.accumulators_enabled();
             Self::ExecutionScheduler(ExecutionScheduler::new(
                 object_cache_read,
                 transaction_cache_read,

--- a/crates/sui-core/src/execution_scheduler/mod.rs
+++ b/crates/sui-core/src/execution_scheduler/mod.rs
@@ -4,6 +4,7 @@
 use crate::{
     authority::{
         authority_per_epoch_store::AuthorityPerEpochStore,
+        epoch_start_configuration::EpochStartConfigTrait,
         shared_object_version_manager::Schedulable, AuthorityMetrics, ExecutionEnv,
     },
     execution_cache::{ObjectCacheRead, TransactionCacheRead},
@@ -130,11 +131,16 @@ impl ExecutionSchedulerWrapper {
             chain != Chain::Mainnet
         };
         if enable_execution_scheduler {
+            let enable_accumulators = epoch_store.protocol_config().enable_accumulators()
+                && epoch_store
+                    .epoch_start_config()
+                    .accumulator_root_obj_initial_shared_version()
+                    .is_some();
             Self::ExecutionScheduler(ExecutionScheduler::new(
                 object_cache_read,
                 transaction_cache_read,
                 tx_ready_certificates,
-                epoch_store.protocol_config().enable_accumulators(),
+                enable_accumulators,
                 metrics,
             ))
         } else {

--- a/crates/sui-core/src/execution_scheduler/mod.rs
+++ b/crates/sui-core/src/execution_scheduler/mod.rs
@@ -7,6 +7,7 @@ use crate::{
         shared_object_version_manager::Schedulable, AuthorityMetrics, ExecutionEnv,
     },
     execution_cache::{ObjectCacheRead, TransactionCacheRead},
+    execution_scheduler::balance_withdraw_scheduler::BalanceSettlement,
 };
 use enum_dispatch::enum_dispatch;
 use execution_scheduler_impl::ExecutionScheduler;
@@ -77,6 +78,8 @@ pub trait ExecutionSchedulerAPI {
         epoch_store: &Arc<AuthorityPerEpochStore>,
     );
 
+    fn settle_balances(&self, settlement: BalanceSettlement);
+
     fn check_execution_overload(
         &self,
         overload_config: &AuthorityOverloadConfig,
@@ -131,6 +134,7 @@ impl ExecutionSchedulerWrapper {
                 object_cache_read,
                 transaction_cache_read,
                 tx_ready_certificates,
+                epoch_store.protocol_config().enable_accumulators(),
                 metrics,
             ))
         } else {

--- a/crates/sui-core/src/execution_scheduler/transaction_manager.rs
+++ b/crates/sui-core/src/execution_scheduler/transaction_manager.rs
@@ -32,6 +32,7 @@ use crate::{
         shared_object_version_manager::Schedulable,
     },
     execution_cache::ObjectCacheRead,
+    execution_scheduler::balance_withdraw_scheduler::BalanceSettlement,
 };
 use crate::{
     authority::{AuthorityMetrics, ExecutionEnv},
@@ -732,6 +733,10 @@ impl ExecutionSchedulerAPI for TransactionManager {
             .set(inner.pending_certificates.len() as i64);
 
         inner.maybe_reserve_capacity();
+    }
+
+    fn settle_balances(&self, _: BalanceSettlement) {
+        unimplemented!("balance withdraw scheduler not implemented for TransactionManager");
     }
 
     fn check_execution_overload(

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -3962,6 +3962,10 @@ impl ProtocolConfig {
             allowed_tx_digests,
         });
     }
+
+    pub fn set_enable_accumulators_for_testing(&mut self, val: bool) {
+        self.feature_flags.enable_accumulators = val;
+    }
 }
 
 type OverrideFn = dyn Fn(ProtocolVersion, ProtocolConfig) -> ProtocolConfig + Send;

--- a/crates/sui-types/src/accumulator_root.rs
+++ b/crates/sui-types/src/accumulator_root.rs
@@ -6,7 +6,8 @@ use crate::{
     base_types::{ObjectID, SequenceNumber, SuiAddress},
     dynamic_field::{derive_dynamic_field_id, DOFWrapper},
     error::SuiResult,
-    object::Owner,
+    gas_coin::GasCoin,
+    object::{Object, Owner},
     storage::ObjectStore,
     transaction::WithdrawTypeParam,
     MoveTypeTagTrait, SUI_ACCUMULATOR_ROOT_OBJECT_ID, SUI_FRAMEWORK_PACKAGE_ID,
@@ -78,4 +79,31 @@ pub fn derive_balance_account_object_id(
         &bcs::to_bytes(&key)?,
     )
     .map_err(|e| e.into())
+}
+
+/// Given an account object, return the balance of the account.
+/// This is a temporary function for testing.
+pub fn get_balance_from_account_for_testing(account_object: &Object) -> u64 {
+    // TODO(address-balances): Implement this properly.
+    GasCoin::try_from(account_object).unwrap().value()
+}
+
+pub fn update_account_balance_for_testing(account_object: &mut Object, balance_change: i128) {
+    let new_balance = get_balance_from_account_for_testing(account_object) as i128 + balance_change;
+    account_object
+        .data
+        .try_as_move_mut()
+        .unwrap()
+        .set_coin_value_unsafe(new_balance as u64);
+}
+
+/// Create an account object for testing.
+/// This is a temporary function for testing.
+pub fn create_account_for_testing(
+    owner: SuiAddress,
+    type_param: WithdrawTypeParam,
+    balance: u64,
+) -> Object {
+    let account_object_id = derive_balance_account_object_id(owner, type_param).unwrap();
+    Object::with_id_owner_gas_for_testing(account_object_id, owner, balance)
 }

--- a/crates/sui-types/src/executable_transaction.rs
+++ b/crates/sui-types/src/executable_transaction.rs
@@ -1,11 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::crypto::AccountKeyPair;
 use crate::messages_checkpoint::CheckpointSequenceNumber;
+use crate::utils::to_sender_signed_transaction;
 use crate::{committee::EpochId, crypto::AuthorityStrongQuorumSignInfo};
 
 use crate::message_envelope::{Envelope, TrustedEnvelope, VerifiedEnvelope};
-use crate::transaction::{SenderSignedData, TransactionDataAPI};
+use crate::transaction::{
+    SenderSignedData, TransactionData, TransactionDataAPI, VerifiedTransaction,
+};
 use serde::{Deserialize, Serialize};
 
 /// CertificateProof is a proof that a transaction certs existed at a given epoch and hence can be executed.
@@ -65,5 +69,10 @@ pub type TrustedExecutableTransaction = TrustedEnvelope<SenderSignedData, Certif
 impl VerifiedExecutableTransaction {
     pub fn gas_budget(&self) -> u64 {
         self.data().transaction_data().gas_budget()
+    }
+
+    pub fn new_for_testing(tx_data: TransactionData, keypair: &AccountKeyPair) -> Self {
+        let tx = to_sender_signed_transaction(tx_data, keypair);
+        Self::new_from_quorum_execution(VerifiedTransaction::new_unchecked(tx), 0)
     }
 }


### PR DESCRIPTION
## Description 

This PR connects the ExecutionScheduler and balance withdraw scheduler.
We add a new variant to `Schedulable` that represents a transaction with withdraw reservations.
Such a transaction will not get scheduled immediately, instead, similar to randomness update transactions, it will wait until its withdraw is scheduled. The scheduling result is passed as part of the ExecutionEnv which then can be used by authority (not included in this PR). 

## Test plan 

Added end-to-end scheduling test.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
