### PR TITLE
[docs][ci] Action to support protobuf doc creation

### DIFF
--- a/.github/workflows/docs-protobuf.yml
+++ b/.github/workflows/docs-protobuf.yml
@@ -17,13 +17,13 @@ jobs:
 
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
           ref: main
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version: '1.21'
 
@@ -60,7 +60,7 @@ jobs:
 
       - name: Create PR with updated docs
         if: steps.git-diff.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: update generated documentation.json"


### PR DESCRIPTION
Adds an action that triggers on a merged PR that includes changes to the .proto files. Auto-gens a subsequent PR that updates the JSON file that is processed by a component on docs site. Only opens PR if the JSON file has changed...which should always be true, but just in case.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
