### PR TITLE
indexer-alt: context for metrics address binding

### DIFF
--- a/crates/sui-indexer-alt-metrics/src/lib.rs
+++ b/crates/sui-indexer-alt-metrics/src/lib.rs
@@ -3,6 +3,7 @@
 
 use std::net::SocketAddr;
 
+use anyhow::Context;
 use axum::{http::StatusCode, routing::get, Extension, Router};
 use prometheus::{Registry, TextEncoder};
 use tokio::{net::TcpListener, task::JoinHandle};
@@ -53,7 +54,10 @@ impl MetricsService {
             cancel,
         } = self;
 
-        let listener = TcpListener::bind(&self.addr).await?;
+        let listener = TcpListener::bind(&self.addr)
+            .await
+            .with_context(|| format!("Failed to bind metrics at {addr}"))?;
+
         let app = Router::new()
             .route("/metrics", get(metrics))
             .layer(Extension(registry));


### PR DESCRIPTION
## Description

Add a context message on the error we get when failing to bind a metrics address. This can fail if the address is already in use, and it's useful to know what we were binding at the time.

## Test plan

Manually tested (run two instances of the indexer).

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
