### PR TITLE
[indexer-alt-framework] Implement slow operation warnings to remote checkpoint fetching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14535,6 +14535,7 @@ dependencies = [
  "diesel-async",
  "diesel_migrations",
  "futures",
+ "pin-project-lite",
  "prometheus",
  "rand 0.8.5",
  "reqwest 0.12.9",

--- a/crates/sui-indexer-alt-framework/Cargo.toml
+++ b/crates/sui-indexer-alt-framework/Cargo.toml
@@ -18,6 +18,7 @@ diesel = { workspace = true, features = ["chrono"] }
 diesel-async = { workspace = true, features = ["bb8", "postgres", "async-connection-wrapper"] }
 diesel_migrations.workspace = true
 futures.workspace = true
+pin-project-lite.workspace = true
 prometheus.workspace = true
 reqwest.workspace = true
 scoped-futures.workspace = true

--- a/crates/sui-indexer-alt-framework/src/ingestion/client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/client.rs
@@ -12,11 +12,12 @@ use sui_rpc_api::client::AuthInterceptor;
 use sui_rpc_api::Client;
 use sui_storage::blob::Blob;
 use tokio_util::bytes::Bytes;
-use tracing::debug;
+use tracing::{debug, warn};
 use url::Url;
 
 use crate::ingestion::local_client::LocalIngestionClient;
 use crate::ingestion::remote_client::RemoteIngestionClient;
+use crate::ingestion::slow_future_monitor::with_slow_future_monitor;
 use crate::ingestion::Error as IngestionError;
 use crate::ingestion::Result as IngestionResult;
 use crate::metrics::CheckpointLagMetricReporter;
@@ -25,6 +26,13 @@ use crate::types::full_checkpoint_content::CheckpointData;
 
 /// Wait at most this long between retries for transient errors.
 const MAX_TRANSIENT_RETRY_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Threshold for logging warnings about slow HTTP operations during checkpoint fetching.
+///
+/// Operations that take longer than this duration will trigger a warning log, but will
+/// continue executing without being canceled. This helps identify network issues or
+/// slow remote stores without interrupting the ingestion process.
+const SLOW_OPERATION_WARNING_THRESHOLD: Duration = Duration::from_secs(60);
 
 #[async_trait::async_trait]
 pub(crate) trait IngestionClientTrait: Send + Sync {
@@ -136,7 +144,20 @@ impl IngestionClient {
         let request = move || {
             let client = client.clone();
             async move {
-                let fetch_data = client.fetch(checkpoint).await.map_err(|err| match err {
+                let fetch_data = with_slow_future_monitor(
+                    client.fetch(checkpoint),
+                    SLOW_OPERATION_WARNING_THRESHOLD,
+                    /* on_threshold_exceeded =*/
+                    || {
+                        warn!(
+                            checkpoint,
+                            threshold_ms = SLOW_OPERATION_WARNING_THRESHOLD.as_millis(),
+                            "Slow checkpoint fetch operation detected"
+                        );
+                    },
+                )
+                .await
+                .map_err(|err| match err {
                     FetchError::NotFound => BE::permanent(IngestionError::NotFound(checkpoint)),
                     FetchError::Transient { reason, error } => self.metrics.inc_retry(
                         checkpoint,

--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -27,6 +27,7 @@ mod local_client;
 mod regulator;
 mod remote_client;
 mod rpc_client;
+mod slow_future_monitor;
 #[cfg(test)]
 mod test_utils;
 

--- a/crates/sui-indexer-alt-framework/src/ingestion/remote_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/remote_client.rs
@@ -2,19 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::ingestion::client::{FetchData, FetchError, FetchResult, IngestionClientTrait};
-use crate::ingestion::slow_future_monitor::with_slow_future_monitor;
 use crate::ingestion::Result as IngestionResult;
 use reqwest::{Client, StatusCode};
-use std::time::Duration;
-use tracing::{debug, error, warn};
+use tracing::{debug, error};
 use url::Url;
-
-/// Threshold for logging warnings about slow HTTP operations during checkpoint fetching.
-///
-/// Operations that take longer than this duration will trigger a warning log, but will
-/// continue executing without being canceled. This helps identify network issues or
-/// slow remote stores without interrupting the ingestion process.
-const SLOW_OPERATION_WARNING_THRESHOLD: Duration = Duration::from_secs(60);
 
 #[derive(thiserror::Error, Debug, Eq, PartialEq)]
 pub enum HttpError {
@@ -58,23 +49,15 @@ impl IngestionClientTrait for RemoteIngestionClient {
             .join(&format!("/{checkpoint}.chk"))
             .expect("Unexpected invalid URL");
 
-        let response = with_slow_future_monitor(
-            self.client.get(url).send(),
-            SLOW_OPERATION_WARNING_THRESHOLD,
-            /* on_threshold_exceeded =*/
-            || {
-                warn!(
-                    checkpoint,
-                    threshold_ms = SLOW_OPERATION_WARNING_THRESHOLD.as_millis(),
-                    "Slow checkpoint fetch operation detected"
-                );
-            },
-        )
-        .await
-        .map_err(|e| FetchError::Transient {
-            reason: "request",
-            error: e.into(),
-        })?;
+        let response = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| FetchError::Transient {
+                reason: "request",
+                error: e.into(),
+            })?;
 
         match response.status() {
             code if code.is_success() => {

--- a/crates/sui-indexer-alt-framework/src/ingestion/slow_future_monitor.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/slow_future_monitor.rs
@@ -13,7 +13,8 @@ use tokio::time::Instant;
 // We need pin_project to safely poll the inner future from our Future implementation
 pin_project! {
     /// A Future wrapper that calls a callback when the wrapped future takes too long,
-    /// but continues execution without canceling the future.
+    /// but continues execution without canceling the future. The callback is guaranteed
+    /// to be called once if the threshold is exceeded.
     pub(crate) struct SlowFutureMonitor<F, C> {
         #[pin] inner: F,
         on_threshold_exceeded: Option<C>,
@@ -33,12 +34,10 @@ where
         let this = self.project();
 
         // Check if we should call the callback (only once)
-        if this.on_threshold_exceeded.is_some() {
-            let elapsed = this.start_time.elapsed();
-            if elapsed >= *this.threshold {
-                if let Some(callback) = this.on_threshold_exceeded.take() {
-                    callback();
-                }
+        let elapsed = this.start_time.elapsed();
+        if elapsed >= *this.threshold {
+            if let Some(callback) = this.on_threshold_exceeded.take() {
+                callback();
             }
         }
 
@@ -62,5 +61,124 @@ where
         on_threshold_exceeded: Some(callback),
         threshold,
         start_time: Instant::now(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use tokio::time::{sleep, Duration};
+
+    // Helper to create a counter that can be shared across async boundaries
+    fn new_counter() -> (Arc<Mutex<usize>>, impl Fn() + Send + 'static) {
+        let counter = Arc::new(Mutex::new(0));
+        let counter_clone = counter.clone();
+        let increment_counter = move || {
+            let mut count = counter_clone.lock().unwrap();
+            *count += 1;
+        };
+        (counter, increment_counter)
+    }
+
+    // Helper to get counter value
+    fn get_count(counter: &Arc<Mutex<usize>>) -> usize {
+        *counter.lock().unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_callback_called_once_when_threshold_exceeded() {
+        let (counter, increment_counter) = new_counter();
+
+        let monitored_future = with_slow_future_monitor(
+            sleep(Duration::from_millis(200)),
+            Duration::from_millis(100),
+            increment_counter,
+        );
+
+        monitored_future.await;
+        assert_eq!(get_count(&counter), 1);
+    }
+
+    #[tokio::test]
+    async fn test_callback_not_called_when_threshold_not_exceeded() {
+        let (counter, increment_counter) = new_counter();
+
+        let monitored_future = with_slow_future_monitor(
+            sleep(Duration::from_millis(50)),
+            Duration::from_millis(200),
+            increment_counter,
+        );
+
+        monitored_future.await;
+        assert_eq!(get_count(&counter), 0);
+    }
+
+    #[tokio::test]
+    async fn test_future_returns_correct_value() {
+        // Create a future that returns a specific value
+        let value_future = async { 1512 };
+        let threshold = Duration::from_millis(100);
+
+        let monitored_future = with_slow_future_monitor(value_future, threshold, || {
+            // Callback doesn't matter for this test
+        });
+
+        // Wait for the future to complete and check the return value
+        let result = monitored_future.await;
+        assert_eq!(result, 1512);
+    }
+
+    #[tokio::test]
+    async fn test_zero_threshold() {
+        let (counter, increment_counter) = new_counter();
+
+        let monitored_future = with_slow_future_monitor(
+            async { "done" },
+            Duration::from_millis(0),
+            increment_counter,
+        );
+
+        let result = monitored_future.await;
+        assert_eq!(get_count(&counter), 1);
+        assert_eq!(result, "done");
+    }
+
+    #[tokio::test]
+    async fn test_error_propagation() {
+        let (counter, increment_counter) = new_counter();
+
+        let monitored_future = with_slow_future_monitor(
+            async {
+                sleep(Duration::from_millis(150)).await;
+                Err("Something went wrong")
+            },
+            Duration::from_millis(100),
+            increment_counter,
+        );
+
+        let result: Result<i32, &str> = monitored_future.await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "Something went wrong");
+        assert_eq!(get_count(&counter), 1);
+    }
+
+    #[tokio::test]
+    async fn test_error_propagation_without_callback() {
+        let (counter, increment_counter) = new_counter();
+
+        let monitored_future = with_slow_future_monitor(
+            async {
+                sleep(Duration::from_millis(50)).await;
+                Err("Quick error")
+            },
+            Duration::from_millis(200),
+            increment_counter,
+        );
+
+        let result: Result<i32, &str> = monitored_future.await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "Quick error");
+        assert_eq!(get_count(&counter), 0);
     }
 }

--- a/crates/sui-indexer-alt-framework/src/ingestion/slow_future_monitor.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/slow_future_monitor.rs
@@ -1,0 +1,66 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use pin_project_lite::pin_project;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+use tokio::time::Instant;
+
+// We need pin_project to safely poll the inner future from our Future implementation
+pin_project! {
+    /// A Future wrapper that calls a callback when the wrapped future takes too long,
+    /// but continues execution without canceling the future.
+    pub(crate) struct SlowFutureMonitor<F, C> {
+        #[pin] inner: F,
+        on_threshold_exceeded: Option<C>,
+        threshold: Duration,
+        start_time: Instant,
+    }
+}
+
+impl<F, C> Future for SlowFutureMonitor<F, C>
+where
+    F: Future,
+    C: FnOnce(),
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        // Check if we should call the callback (only once)
+        if this.on_threshold_exceeded.is_some() {
+            let elapsed = this.start_time.elapsed();
+            if elapsed >= *this.threshold {
+                if let Some(callback) = this.on_threshold_exceeded.take() {
+                    callback();
+                }
+            }
+        }
+
+        // Poll the inner future
+        this.inner.poll(cx)
+    }
+}
+
+/// Helper function to wrap a future with slow future monitoring
+pub(crate) fn with_slow_future_monitor<F, C>(
+    future: F,
+    threshold: Duration,
+    callback: C,
+) -> SlowFutureMonitor<F, C>
+where
+    F: Future,
+    C: FnOnce(),
+{
+    SlowFutureMonitor {
+        inner: future,
+        on_threshold_exceeded: Some(callback),
+        threshold,
+        start_time: Instant::now(),
+    }
+}


### PR DESCRIPTION
## Description 

From the bug where the MVR Indexer was stalling ([Linear](https://linear.app/mysten-labs/issue/DVX-1198/mvr-indexer-pipeline-stopped-committing-watermark)), one potential culprit for the stall was that remote checkpoint fetching was somehow taking forever. However, there's currently no way to confirm this hypothesis, so this PR adds warnings when remote checkpoint fetching takes too long while still allowing the fetching to run until successful.

SlowFutureMonitor's implementation is based on the same idea of [`crates/sui-indexer-alt-jsonrpc/src/timeout.rs`](https://github.com/MystenLabs/sui/blob/cfef00b4e656d99d2450bc2505fb37902f65cdee/crates/sui-indexer-alt-jsonrpc/src/timeout.rs), but for monitoring rather than cancellation.

## Test plan 

How did you test the new or updated feature?

```
cargo test -p sui-indexer-alt-framework  remote_client  --lib
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
