### PR TITLE
Serialize transaction status change notifications

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -1181,7 +1181,7 @@ impl ValidatorService {
                             if status == ConsensusTxStatus::Rejected {
                                 return Ok(WaitForEffectsResponse::Rejected { reason: RejectReason::None });
                             }
-                            assert!(matches!(status, ConsensusTxStatus::Finalized));
+                            assert_eq!(status, ConsensusTxStatus::Finalized);
                             // Update the current status so that notify_read_transaction_status will no
                             // longer be triggered again after the transaction is finalized.
                             cur_status = status;


### PR DESCRIPTION
## Description 

Otherwise, it is possible for a thread to read out / get notified about `Finalized` first, then receive a notification on `FastpathCertified`.

## Test plan 

PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
