### PR TITLE
Only spawn metric task if reporting is enabled

### DIFF
--- a/crates/sui-analytics-indexer/src/analytics_processor.rs
+++ b/crates/sui-analytics-indexer/src/analytics_processor.rs
@@ -144,13 +144,16 @@ impl<S: Serialize + ParquetSchema + Send + Sync + 'static> AnalyticsProcessor<S>
             name.clone(),
         ));
         let (max_checkpoint_sender, max_checkpoint_receiver) = oneshot::channel::<()>();
-        tokio::spawn(Self::setup_max_checkpoint_metrics_updates(
-            max_checkpoint_reader,
-            task_context.metrics.clone(),
-            max_checkpoint_receiver,
-            name,
-        ));
-
+        if task_context.config.report_bq_max_table_checkpoint
+            || task_context.config.report_sf_max_table_checkpoint
+        {
+            tokio::spawn(Self::setup_max_checkpoint_metrics_updates(
+                max_checkpoint_reader,
+                task_context.metrics.clone(),
+                max_checkpoint_receiver,
+                name,
+            ));
+        }
         let state = State {
             current_epoch: 0,
             current_checkpoint_range: next_checkpoint_seq_num..next_checkpoint_seq_num,


### PR DESCRIPTION
## Description

This morning Michael and I shut off the pipes for the legacy stack, which caused me to get a few lag alerts. Currently we can "disable" this metric, but we still emit a -1 value when it is disabled. I am changing this behavior to just completely not emit the metric instead, which will silence the alerts.
