### PR TITLE
[stdlib] `option::extract_or` and `vector::find_indices`

### DIFF
--- a/crates/sui-framework/packages/move-stdlib/sources/option.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/option.move
@@ -225,6 +225,13 @@ public macro fun is_some_and<$T>($o: &Option<$T>, $f: |&$T| -> bool): bool {
     o.is_some() && $f(o.borrow())
 }
 
+/// Extract the value inside `Option<T>` if it holds one, or `default` otherwise.
+/// Similar to `destroy_or`, but can be performed on a mutable reference to the option.
+public macro fun extract_or<$T>($o: &mut Option<$T>, $default: $T): $T {
+    let o = $o;
+    if (o.is_some()) o.destroy_some() else $default
+}
+
 /// Destroy `Option<T>` and return the value inside if it holds one, or `default` otherwise.
 /// Equivalent to Rust's `t.unwrap_or(default)`.
 ///

--- a/crates/sui-framework/packages/move-stdlib/sources/vector.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/vector.move
@@ -247,6 +247,16 @@ public macro fun find_index<$T>($v: &vector<$T>, $f: |&$T| -> bool): Option<u64>
     }
 }
 
+
+/// Finds all indices of elements in the vector `v` that satisfy the predicate `f`.
+/// Returns a vector of indices.
+public macro fun find_indices<$T>($v: &vector<$T>, $f: |&$T| -> bool): vector<u64> {
+    let v = $v;
+    let mut indices = vector[];
+    v.length().do!(|i| if ($f(&v[i])) indices.push_back(i));
+    indices
+}
+
 /// Count how many elements in the vector `v` satisfy the predicate `f`.
 public macro fun count<$T>($v: &vector<$T>, $f: |&$T| -> bool): u64 {
     let v = $v;

--- a/crates/sui-framework/packages/move-stdlib/tests/option_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/option_tests.move
@@ -289,3 +289,14 @@ fun destroy_or_no_drop() {
     let NoDrop {} = some;
     let NoDrop {} = none;
 }
+
+#[test]
+fun extract_or() {
+    let mut none = option::none<u64>();
+    assert!(option::extract_or(&mut none, 10) == 10);
+    assert!(none.is_none());
+
+    let mut some = option::some(5);
+    assert!(option::extract_or(&mut some, 10) == 5);
+    assert!(some.is_none());
+}

--- a/crates/sui-framework/packages/move-stdlib/tests/vector_tests.move
+++ b/crates/sui-framework/packages/move-stdlib/tests/vector_tests.move
@@ -710,6 +710,21 @@ fun find_index_macro() {
 }
 
 #[test]
+fun find_indices_macro() {
+    let e = vector<u8>[];
+    assert!(e.find_indices!(|e| *e == 0) == vector[]);
+    assert!(e.find_indices!(|_| true) == vector[]);
+
+    let r = vector[0, 10, 100, 1_000];
+    assert!(r.find_indices!(|e| *e == 100) == vector[2]);
+    assert!(r.find_indices!(|e| *e == 10_000) == vector[]);
+
+    let v = vector[Droppable {}, Droppable {}];
+    let idx = v.find_indices!(|e| e == Droppable{});
+    assert!(idx == vector[0, 1]);
+}
+
+#[test]
 fun fold_macro() {
     let e = vector<u8>[];
     assert!(e.fold!(0, |acc, e| acc + e) == 0);


### PR DESCRIPTION
## Description 

Adds two macros:
- `option::extract_or`
- `vector::find_indices` (replaces #20957)

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
