### PR TITLE
[state sync] allow passing remote store options to the archive fallback

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -757,6 +757,7 @@ impl NodeConfig {
             .first()
             .map(|config| ArchiveReaderConfig {
                 ingestion_url: config.ingestion_url.clone(),
+                remote_store_options: config.remote_store_options.clone(),
                 download_concurrency: NonZeroUsize::new(config.concurrency)
                     .unwrap_or(NonZeroUsize::new(5).unwrap()),
                 remote_store_config: ObjectStoreConfig::default(),
@@ -1112,6 +1113,7 @@ pub struct ArchiveReaderConfig {
     pub remote_store_config: ObjectStoreConfig,
     pub download_concurrency: NonZeroUsize,
     pub ingestion_url: Option<String>,
+    pub remote_store_options: Vec<(String, String)>,
 }
 
 #[derive(Default, Debug, Clone, Deserialize, Serialize)]
@@ -1122,6 +1124,8 @@ pub struct StateArchiveConfig {
     pub concurrency: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ingestion_url: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    remote_store_options: Vec<(String, String)>,
 }
 
 #[derive(Default, Debug, Clone, Deserialize, Serialize)]

--- a/crates/sui-data-ingestion-core/src/lib.rs
+++ b/crates/sui-data-ingestion-core/src/lib.rs
@@ -15,7 +15,10 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
-pub use executor::{setup_single_workflow, IndexerExecutor, MAX_CHECKPOINTS_IN_PROGRESS};
+pub use executor::{
+    setup_single_workflow, setup_single_workflow_with_options, IndexerExecutor,
+    MAX_CHECKPOINTS_IN_PROGRESS,
+};
 pub use metrics::DataIngestionMetrics;
 pub use progress_store::{
     ExecutorProgress, FileProgressStore, ProgressStore, ShimIndexerProgressStore, ShimProgressStore,

--- a/crates/sui-network/src/state_sync/tests.rs
+++ b/crates/sui-network/src/state_sync/tests.rs
@@ -290,6 +290,7 @@ async fn test_state_sync_using_archive() -> anyhow::Result<()> {
         remote_store_config: ObjectStoreConfig::default(),
         download_concurrency: NonZeroUsize::new(1).unwrap(),
         ingestion_url: Some(format!("file://{}", temp_dir.display())),
+        remote_store_options: vec![],
     };
     // Build and connect two nodes where Node 1 will be given access to an archive store
     // Node 2 will prune older checkpoints, so Node 1 is forced to backfill from the archive


### PR DESCRIPTION
## Description 

will be used for `requester pays` feature

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
