### PR TITLE
[mfp] Add effects certifier

### DIFF
--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -344,7 +344,7 @@ impl LocalValidatorAggregatorProxy {
     async fn submit_transaction_block(&self, tx: Transaction) -> anyhow::Result<ExecutionEffects> {
         let response = self
             .td
-            .submit_transaction(
+            .drive_transaction(
                 SubmitTxRequest {
                     transaction: tx.clone(),
                 },

--- a/crates/sui-core/src/transaction_driver/effects_certifier.rs
+++ b/crates/sui-core/src/transaction_driver/effects_certifier.rs
@@ -307,7 +307,7 @@ impl EffectsCertifier {
                     }
                 }
                 WaitForEffectsResponse::Expired(round) => {
-                    expired_errors.push(format!("{}: expired at round {}", name.concise(), round));
+                    expired_errors.push(format!("{}: {}", name.concise(), round));
                     self.metrics.expiration_acks.inc();
                     if let InsertResult::Failed { error } =
                         expired_aggregator.insert_generic(name, ())

--- a/crates/sui-core/src/transaction_driver/effects_certifier.rs
+++ b/crates/sui-core/src/transaction_driver/effects_certifier.rs
@@ -1,0 +1,392 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
+use rand::seq::SliceRandom as _;
+use sui_types::{
+    base_types::ConciseableName,
+    committee::EpochId,
+    digests::TransactionEffectsDigest,
+    messages_consensus::ConsensusPosition,
+    messages_grpc::RawWaitForEffectsRequest,
+    quorum_driver_types::{EffectsFinalityInfo, FinalizedEffects},
+    transaction::Transaction,
+};
+use tokio::time::timeout;
+use tracing::instrument;
+
+use crate::{
+    authority_aggregator::AuthorityAggregator,
+    authority_client::AuthorityAPI,
+    stake_aggregator::{InsertResult, StakeAggregator},
+    transaction_driver::{
+        error::TransactionDriverError, metrics::TransactionDriverMetrics,
+        QuorumSubmitTransactionResponse, SubmitTransactionOptions,
+    },
+    wait_for_effects_request::{ExecutedData, WaitForEffectsRequest, WaitForEffectsResponse},
+};
+
+pub struct EffectsCertifier {
+    metrics: Arc<TransactionDriverMetrics>,
+}
+
+impl EffectsCertifier {
+    pub fn new(metrics: Arc<TransactionDriverMetrics>) -> Self {
+        Self { metrics }
+    }
+
+    #[instrument(level = "trace", skip_all, fields(tx_digest = ?transaction.digest()))]
+    pub async fn wait_for_quorum_effects<A>(
+        &self,
+        authority_aggregator: &Arc<AuthorityAggregator<A>>,
+        transaction: &Transaction,
+        consensus_position: ConsensusPosition,
+        epoch: EpochId,
+        options: &SubmitTransactionOptions,
+    ) -> Result<QuorumSubmitTransactionResponse, TransactionDriverError>
+    where
+        A: AuthorityAPI + Send + Sync + 'static + Clone,
+    {
+        // Run full effects request and acknowledgments concurrently
+        let (full_effects_result, acknowledgments_result) = tokio::join!(
+            self.get_full_effects_with_retry(
+                authority_aggregator,
+                transaction,
+                consensus_position,
+                epoch,
+                options
+            ),
+            self.wait_for_acknowledgments_with_retry(
+                authority_aggregator,
+                transaction,
+                consensus_position,
+                epoch,
+                options
+            )
+        );
+
+        match full_effects_result {
+            Ok((effects_digest, executed_data)) => {
+                let details = FinalizedEffects {
+                    effects: executed_data.effects,
+                    finality_info: EffectsFinalityInfo::QuorumExecuted(epoch),
+                };
+
+                match acknowledgments_result {
+                    Ok(confirmed_digest) => {
+                        if effects_digest == confirmed_digest {
+                            self.metrics.executed_transactions.inc();
+
+                            tracing::info!(
+                                "Transaction {} executed with effects digest: {}",
+                                transaction.digest(),
+                                effects_digest
+                            );
+
+                            Ok(QuorumSubmitTransactionResponse {
+                                effects: details,
+                                events: executed_data.events,
+                                input_objects: if !executed_data.input_objects.is_empty() {
+                                    Some(executed_data.input_objects)
+                                } else {
+                                    None
+                                },
+                                output_objects: if !executed_data.output_objects.is_empty() {
+                                    Some(executed_data.output_objects)
+                                } else {
+                                    None
+                                },
+                                auxiliary_data: None,
+                            })
+                        } else {
+                            Err(TransactionDriverError::EffectsDigestMismatch {
+                                quorum_expected: effects_digest.to_string(),
+                                actual: confirmed_digest.to_string(),
+                            })
+                        }
+                    }
+                    Err(e) => Err(e),
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn get_full_effects_with_retry<A>(
+        &self,
+        authority_aggregator: &Arc<AuthorityAggregator<A>>,
+        transaction: &Transaction,
+        consensus_position: ConsensusPosition,
+        epoch: EpochId,
+        options: &SubmitTransactionOptions,
+    ) -> Result<(TransactionEffectsDigest, ExecutedData), TransactionDriverError>
+    where
+        A: AuthorityAPI + Send + Sync + 'static + Clone,
+    {
+        let mut attempts = 0;
+        const MAX_ATTEMPTS: usize = 10;
+        let clients = authority_aggregator
+            .authority_clients
+            .iter()
+            .collect::<Vec<_>>();
+
+        loop {
+            attempts += 1;
+            let (name, client) = clients.choose(&mut rand::thread_rng()).unwrap();
+
+            let raw_request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
+                epoch,
+                transaction_digest: *transaction.digest(),
+                transaction_position: consensus_position,
+                include_details: true,
+            })
+            .map_err(TransactionDriverError::SerializationError)?;
+
+            match timeout(
+                Duration::from_secs(2),
+                client.wait_for_effects(raw_request, options.forwarded_client_addr),
+            )
+            .await
+            {
+                Ok(Ok(response)) => match response {
+                    WaitForEffectsResponse::Executed {
+                        effects_digest,
+                        details,
+                    } => {
+                        if let Some(details) = details {
+                            return Ok((effects_digest, *details));
+                        } else {
+                            return Err(TransactionDriverError::ExecutionDataNotFound(
+                                transaction.digest().to_string(),
+                            ));
+                        }
+                    }
+                    WaitForEffectsResponse::Rejected { ref reason } => {
+                        if attempts >= MAX_ATTEMPTS {
+                            return Err(TransactionDriverError::TransactionRejected(
+                                reason.to_string(),
+                            ));
+                        }
+                        tracing::warn!("Transaction rejected, retrying... Reason: {}", reason);
+                    }
+                    WaitForEffectsResponse::Expired(round) => {
+                        if attempts >= MAX_ATTEMPTS {
+                            return Err(TransactionDriverError::TransactionExpired(
+                                round.to_string(),
+                            ));
+                        }
+                        tracing::warn!("Transaction expired at round {}, retrying...", round);
+                    }
+                },
+                Ok(Err(e)) => {
+                    if attempts >= MAX_ATTEMPTS {
+                        return Err(TransactionDriverError::RpcFailure(
+                            name.concise().to_string(),
+                            e.to_string(),
+                        ));
+                    }
+                    tracing::warn!(
+                        "Full effects request failed from {}: {}, retrying...",
+                        name.concise(),
+                        e
+                    );
+                }
+                Err(_) => {
+                    if attempts >= MAX_ATTEMPTS {
+                        return Err(TransactionDriverError::TimeoutGettingFullEffects);
+                    }
+                    tracing::warn!("Full effects request timed out, retrying...");
+                }
+            }
+        }
+    }
+
+    async fn wait_for_acknowledgments_with_retry<A>(
+        &self,
+        authority_aggregator: &Arc<AuthorityAggregator<A>>,
+        transaction: &Transaction,
+        consensus_position: ConsensusPosition,
+        epoch: EpochId,
+        options: &SubmitTransactionOptions,
+    ) -> Result<TransactionEffectsDigest, TransactionDriverError>
+    where
+        A: AuthorityAPI + Send + Sync + 'static + Clone,
+    {
+        let clients = authority_aggregator
+            .authority_clients
+            .iter()
+            .collect::<Vec<_>>();
+        let committee = authority_aggregator.committee.clone();
+
+        // Create futures for all validators (digest-only requests)
+        let mut futures = Vec::new();
+        for (name, client) in clients {
+            let client_clone = client.clone();
+            let name_clone = *name;
+            let transaction_digest = *transaction.digest();
+
+            let future = async move {
+                let raw_request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
+                    epoch,
+                    transaction_digest,
+                    transaction_position: consensus_position,
+                    include_details: false,
+                })
+                .map_err(TransactionDriverError::SerializationError)?;
+
+                match timeout(
+                    Duration::from_secs(2),
+                    client_clone.wait_for_effects(raw_request, options.forwarded_client_addr),
+                )
+                .await
+                {
+                    Ok(Ok(response)) => Ok((name_clone, response)),
+                    Ok(Err(e)) => Err(TransactionDriverError::RpcFailure(
+                        name_clone.concise().to_string(),
+                        e.to_string(),
+                    )),
+                    Err(_) => Err(TransactionDriverError::TimeoutWaitingForEffects),
+                }
+            };
+
+            futures.push(future);
+        }
+
+        // Use StakeAggregator to track quorum for each effects digest
+        let mut effects_digest_aggregators: HashMap<
+            TransactionEffectsDigest,
+            StakeAggregator<(), true>,
+        > = HashMap::new();
+        let mut rejected_aggregator = StakeAggregator::<(), true>::new(committee.clone());
+        let mut expired_aggregator = StakeAggregator::<(), true>::new(committee.clone());
+        let mut rejected_errors = Vec::new();
+        let mut expired_errors = Vec::new();
+        let mut errors = Vec::new();
+
+        let mut futures = FuturesUnordered::from_iter(futures);
+
+        while let Some(result) = futures.next().await {
+            match result {
+                Ok((name, response)) => {
+                    match response {
+                        WaitForEffectsResponse::Executed {
+                            effects_digest,
+                            details: _,
+                        } => {
+                            // Get or create aggregator for this digest
+                            let aggregator = effects_digest_aggregators
+                                .entry(effects_digest)
+                                .or_insert_with(|| {
+                                    StakeAggregator::<(), true>::new(committee.clone())
+                                });
+
+                            match aggregator.insert_generic(name, ()) {
+                                InsertResult::QuorumReached(_) => {
+                                    // Found quorum for this digest, check for inconsistencies
+                                    let quorum_weight = aggregator.total_votes();
+                                    let inconsistencies: Vec<_> = effects_digest_aggregators
+                                        .iter()
+                                        .filter_map(|(other_digest, other_aggregator)| {
+                                            if other_digest != &effects_digest
+                                                && other_aggregator.total_votes() > 0
+                                            {
+                                                Some((
+                                                    *other_digest,
+                                                    other_aggregator.total_votes(),
+                                                ))
+                                            } else {
+                                                None
+                                            }
+                                        })
+                                        .collect();
+
+                                    for (other_digest, other_weight) in inconsistencies {
+                                        tracing::warn!(
+                                            "Effects digest inconsistency detected: quorum digest {:?} (weight {}), other digest {:?} (weight {})",
+                                            effects_digest,
+                                            quorum_weight,
+                                            other_digest,
+                                            other_weight
+                                        );
+                                        self.metrics.effects_digest_mismatches.inc();
+                                    }
+                                    return Ok(effects_digest);
+                                }
+                                InsertResult::NotEnoughVotes { .. } => {}
+                                InsertResult::Failed { error } => {
+                                    tracing::warn!(
+                                        "Failed to insert vote for digest {}: {:?}",
+                                        effects_digest,
+                                        error
+                                    );
+                                }
+                            }
+                        }
+                        WaitForEffectsResponse::Rejected { reason } => {
+                            rejected_errors.push(format!("{}: {}", name.concise(), reason));
+
+                            match rejected_aggregator.insert_generic(name, ()) {
+                                InsertResult::QuorumReached(_) => {
+                                    self.metrics.rejected_transactions.inc();
+
+                                    return Err(TransactionDriverError::TransactionRejected(
+                                        format!("Quorum rejected: {}", rejected_errors.join(", ")),
+                                    ));
+                                }
+                                InsertResult::NotEnoughVotes { .. } => {}
+                                InsertResult::Failed { error } => {
+                                    tracing::warn!("Failed to insert rejection vote: {:?}", error);
+                                }
+                            }
+                        }
+                        WaitForEffectsResponse::Expired(round) => {
+                            expired_errors.push(format!(
+                                "{}: expired at round {}",
+                                name.concise(),
+                                round
+                            ));
+
+                            match expired_aggregator.insert_generic(name, ()) {
+                                InsertResult::QuorumReached(_) => {
+                                    self.metrics.expired_transactions.inc();
+
+                                    return Err(TransactionDriverError::TransactionExpired(
+                                        format!("Quorum expired: {}", expired_errors.join(", ")),
+                                    ));
+                                }
+                                InsertResult::NotEnoughVotes { .. } => {}
+                                InsertResult::Failed { error } => {
+                                    tracing::warn!("Failed to insert expiration vote: {:?}", error);
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    // TODO(fastpath): Categorize retryable errors and push to retry queue, store premanent failures. Exit on f+1 errors
+                    errors.push(e);
+                }
+            }
+        }
+
+        // If we get here, we didn't reach quorum for any digest
+        let executed_weight: u64 = effects_digest_aggregators
+            .values()
+            .map(|agg| agg.total_votes())
+            .sum();
+        let rejected_weight = rejected_aggregator.total_votes();
+        let expired_weight = expired_aggregator.total_votes();
+
+        Err(TransactionDriverError::InsufficientResponses {
+            total_responses_weight: executed_weight + rejected_weight + expired_weight,
+            executed_weight,
+            rejected_weight,
+            expired_weight,
+            // TODO(fastpath): Aggregate and summarize errors
+            errors: errors.into_iter().map(|e| e.to_string()).collect(),
+        })
+    }
+}

--- a/crates/sui-core/src/transaction_driver/error.rs
+++ b/crates/sui-core/src/transaction_driver/error.rs
@@ -15,8 +15,8 @@ pub enum TransactionDriverError {
     DeserializationError(SuiError),
     #[error("Transaction timed out getting consensus position")]
     TimeoutSubmittingTransaction,
-    #[error("Transaction timed out while waiting for effects")]
-    TimeoutWaitingForEffects,
+    #[error("Transaction timed out while acknowledging effects")]
+    TimeoutAcknowledgingEffects,
     #[error("Transaction timed out while getting full effects")]
     TimeoutGettingFullEffects,
     #[error("Failed to call validator {0}: {1}")]

--- a/crates/sui-core/src/transaction_driver/error.rs
+++ b/crates/sui-core/src/transaction_driver/error.rs
@@ -15,10 +15,10 @@ pub enum TransactionDriverError {
     DeserializationError(SuiError),
     #[error("Transaction timed out getting consensus position")]
     TimeoutSubmittingTransaction,
-    #[error("Transaction timed out before getting wait for effects response")]
+    #[error("Transaction timed out while waiting for effects")]
     TimeoutWaitingForEffects,
-    #[error("Transaction timed out before reaching finality")]
-    TimeoutBeforeFinality,
+    #[error("Transaction timed out while getting full effects")]
+    TimeoutGettingFullEffects,
     #[error("Failed to call validator {0}: {1}")]
     RpcFailure(String, String),
     #[error("Failed to find execution data: {0}")]
@@ -27,4 +27,17 @@ pub enum TransactionDriverError {
     TransactionRejected(String),
     #[error("Transaction expired at round: {0}")]
     TransactionExpired(String),
+    #[error("Insufficient responses from quorum: total_responses_weight {total_responses_weight}, executed_weight {executed_weight}, executed_weight {executed_weight}. Errors: {errors:?}")]
+    InsufficientResponses {
+        total_responses_weight: u64,
+        executed_weight: u64,
+        rejected_weight: u64,
+        expired_weight: u64,
+        errors: Vec<String>,
+    },
+    #[error("Effects digest mismatch: quorum_expected {quorum_expected}, got {actual}")]
+    EffectsDigestMismatch {
+        quorum_expected: String,
+        actual: String,
+    },
 }

--- a/crates/sui-core/src/transaction_driver/error.rs
+++ b/crates/sui-core/src/transaction_driver/error.rs
@@ -28,9 +28,9 @@ pub enum TransactionDriverError {
     #[error("Transaction expired at round: {0}")]
     TransactionExpired(String),
     #[error("Transaction rejected with reason: {0} & expired with reason: {1}")]
-    TransactionRejectedAndExpired(String, String),
-    #[error("Insufficient responses from quorum: total_responses_weight {total_responses_weight}, executed_weight {executed_weight}, executed_weight {executed_weight}. Errors: {errors:?}")]
-    InsufficientResponses {
+    TransactionRejectedOrExpired(String, String),
+    #[error("Forked execution results: total_responses_weight {total_responses_weight}, executed_weight {executed_weight}, executed_weight {executed_weight}. Errors: {errors:?}")]
+    ForkedExecution {
         total_responses_weight: u64,
         executed_weight: u64,
         rejected_weight: u64,

--- a/crates/sui-core/src/transaction_driver/error.rs
+++ b/crates/sui-core/src/transaction_driver/error.rs
@@ -27,6 +27,8 @@ pub enum TransactionDriverError {
     TransactionRejected(String),
     #[error("Transaction expired at round: {0}")]
     TransactionExpired(String),
+    #[error("Transaction rejected with reason: {0} & expired with reason: {1}")]
+    TransactionRejectedAndExpired(String, String),
     #[error("Insufficient responses from quorum: total_responses_weight {total_responses_weight}, executed_weight {executed_weight}, executed_weight {executed_weight}. Errors: {errors:?}")]
     InsufficientResponses {
         total_responses_weight: u64,

--- a/crates/sui-core/src/transaction_driver/error.rs
+++ b/crates/sui-core/src/transaction_driver/error.rs
@@ -29,17 +29,12 @@ pub enum TransactionDriverError {
     TransactionExpired(String),
     #[error("Transaction rejected with reason: {0} & expired with reason: {1}")]
     TransactionRejectedOrExpired(String, String),
-    #[error("Forked execution results: total_responses_weight {total_responses_weight}, executed_weight {executed_weight}, executed_weight {executed_weight}. Errors: {errors:?}")]
+    #[error("Forked execution results: total_responses_weight {total_responses_weight}, executed_weight {executed_weight}, rejected_weight {rejected_weight}, expired_weight {expired_weight}, Errors: {errors:?}")]
     ForkedExecution {
         total_responses_weight: u64,
         executed_weight: u64,
         rejected_weight: u64,
         expired_weight: u64,
         errors: Vec<String>,
-    },
-    #[error("Effects digest mismatch: quorum_expected {quorum_expected}, got {actual}")]
-    EffectsDigestMismatch {
-        quorum_expected: String,
-        actual: String,
     },
 }

--- a/crates/sui-core/src/transaction_driver/message_types.rs
+++ b/crates/sui-core/src/transaction_driver/message_types.rs
@@ -26,7 +26,7 @@ impl SubmitTxRequest {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct QuorumSubmitTransactionResponse {
+pub struct QuorumTransactionResponse {
     // TODO(fastpath): Stop using QD types
     pub effects: FinalizedEffects,
 

--- a/crates/sui-core/src/transaction_driver/metrics.rs
+++ b/crates/sui-core/src/transaction_driver/metrics.rs
@@ -50,19 +50,19 @@ impl TransactionDriverMetrics {
             .unwrap(),
             executed_transactions: register_int_counter_with_registry!(
                 "transaction_driver_executed_transactions",
-                "Number of transactions executed by the transaction driver",
+                "Number of transactions executed observed by the transaction driver",
                 registry,
             )
             .unwrap(),
             rejected_transactions: register_int_counter_with_registry!(
                 "transaction_driver_rejected_transactions",
-                "Number of transactions rejected by the transaction driver",
+                "Number of transactions rejected observed by the transaction driver",
                 registry,
             )
             .unwrap(),
             expired_transactions: register_int_counter_with_registry!(
                 "transaction_driver_expired_transactions",
-                "Number of transactions expired by the transaction driver",
+                "Number of transactions expired observed by the transaction driver",
                 registry,
             )
             .unwrap(),

--- a/crates/sui-core/src/transaction_driver/metrics.rs
+++ b/crates/sui-core/src/transaction_driver/metrics.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use prometheus::{register_histogram_vec_with_registry, HistogramVec, Registry};
+use prometheus::{
+    register_histogram_vec_with_registry, register_int_counter_with_registry, HistogramVec,
+    IntCounter, Registry,
+};
 
 const FINALITY_LATENCY_SEC_BUCKETS: &[f64] = &[
     0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85,
@@ -14,6 +17,12 @@ const FINALITY_LATENCY_SEC_BUCKETS: &[f64] = &[
 #[derive(Clone)]
 pub struct TransactionDriverMetrics {
     pub(crate) settlement_finality_latency: HistogramVec,
+    pub(crate) submit_transaction_success: IntCounter,
+    pub(crate) submit_transaction_error: IntCounter,
+    pub(crate) executed_transactions: IntCounter,
+    pub(crate) rejected_transactions: IntCounter,
+    pub(crate) expired_transactions: IntCounter,
+    pub(crate) effects_digest_mismatches: IntCounter,
 }
 
 impl TransactionDriverMetrics {
@@ -24,6 +33,42 @@ impl TransactionDriverMetrics {
                 "Settlement finality latency observed from transaction driver",
                 &["tx_type"],
                 FINALITY_LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            submit_transaction_success: register_int_counter_with_registry!(
+                "transaction_driver_submit_transaction_success",
+                "Number of transactions successfully submitted",
+                registry,
+            )
+            .unwrap(),
+            submit_transaction_error: register_int_counter_with_registry!(
+                "transaction_driver_submit_transaction_error",
+                "Number of transactions unsuccessfully submitted",
+                registry,
+            )
+            .unwrap(),
+            executed_transactions: register_int_counter_with_registry!(
+                "transaction_driver_executed_transactions",
+                "Number of transactions executed by the transaction driver",
+                registry,
+            )
+            .unwrap(),
+            rejected_transactions: register_int_counter_with_registry!(
+                "transaction_driver_rejected_transactions",
+                "Number of transactions rejected by the transaction driver",
+                registry,
+            )
+            .unwrap(),
+            expired_transactions: register_int_counter_with_registry!(
+                "transaction_driver_expired_transactions",
+                "Number of transactions expired by the transaction driver",
+                registry,
+            )
+            .unwrap(),
+            effects_digest_mismatches: register_int_counter_with_registry!(
+                "transaction_driver_effects_digest_mismatches",
+                "Number of effects digest mismatches detected by the transaction driver",
                 registry,
             )
             .unwrap(),

--- a/crates/sui-core/src/transaction_driver/metrics.rs
+++ b/crates/sui-core/src/transaction_driver/metrics.rs
@@ -20,8 +20,8 @@ pub struct TransactionDriverMetrics {
     pub(crate) submit_transaction_success: IntCounter,
     pub(crate) submit_transaction_error: IntCounter,
     pub(crate) executed_transactions: IntCounter,
-    pub(crate) rejected_transactions: IntCounter,
-    pub(crate) expired_transactions: IntCounter,
+    pub(crate) rejection_acks: IntCounter,
+    pub(crate) expiration_acks: IntCounter,
     pub(crate) effects_digest_mismatches: IntCounter,
 }
 
@@ -54,15 +54,15 @@ impl TransactionDriverMetrics {
                 registry,
             )
             .unwrap(),
-            rejected_transactions: register_int_counter_with_registry!(
-                "transaction_driver_rejected_transactions",
-                "Number of transactions rejected observed by the transaction driver",
+            rejection_acks: register_int_counter_with_registry!(
+                "transaction_driver_rejected_acks",
+                "Number of rejection acknowledgments observed by the transaction driver",
                 registry,
             )
             .unwrap(),
-            expired_transactions: register_int_counter_with_registry!(
-                "transaction_driver_expired_transactions",
-                "Number of transactions expired observed by the transaction driver",
+            expiration_acks: register_int_counter_with_registry!(
+                "transaction_driver_expiration_acks",
+                "Number of expiration acknowledgments observed by the transaction driver",
                 registry,
             )
             .unwrap(),

--- a/crates/sui-core/src/transaction_driver/mod.rs
+++ b/crates/sui-core/src/transaction_driver/mod.rs
@@ -1,40 +1,30 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+mod effects_certifier;
 mod error;
 mod message_types;
 mod metrics;
+mod transaction_submitter;
 
-use std::{
-    net::SocketAddr,
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{net::SocketAddr, sync::Arc, time::Instant};
 
 use arc_swap::ArcSwap;
+pub use effects_certifier::*;
 pub use error::*;
 pub use message_types::*;
 pub use metrics::*;
 use mysten_metrics::{monitored_future, TX_TYPE_SHARED_OBJ_TX, TX_TYPE_SINGLE_WRITER_TX};
 use parking_lot::Mutex;
-use rand::seq::SliceRandom as _;
-use sui_types::{
-    base_types::ConciseableName,
-    committee::EpochId,
-    messages_grpc::RawWaitForEffectsRequest,
-    quorum_driver_types::{EffectsFinalityInfo, FinalizedEffects},
-};
-use tokio::{
-    task::JoinSet,
-    time::{sleep, timeout},
-};
-use tracing::{debug, instrument};
+use sui_types::{committee::EpochId, messages_grpc::RawSubmitTxRequest, transaction::Transaction};
+use tokio::task::JoinSet;
+use tracing::instrument;
+pub use transaction_submitter::*;
 
 use crate::{
     authority_aggregator::AuthorityAggregator,
     authority_client::AuthorityAPI,
     quorum_driver::{reconfig_observer::ReconfigObserver, AuthorityAggregatorUpdatable},
-    wait_for_effects_request::{WaitForEffectsRequest, WaitForEffectsResponse},
 };
 
 /// Options for submitting a transaction.
@@ -49,6 +39,8 @@ pub struct TransactionDriver<A: Clone> {
     authority_aggregator: ArcSwap<AuthorityAggregator<A>>,
     state: Mutex<State>,
     metrics: Arc<TransactionDriverMetrics>,
+    submitter: TransactionSubmitter,
+    certifier: EffectsCertifier,
 }
 
 impl<A> TransactionDriver<A>
@@ -63,23 +55,38 @@ where
         let driver = Arc::new(Self {
             authority_aggregator: ArcSwap::new(authority_aggregator),
             state: Mutex::new(State::new()),
-            metrics,
+            metrics: metrics.clone(),
+            submitter: TransactionSubmitter::new(metrics.clone()),
+            certifier: EffectsCertifier::new(metrics),
         });
         driver.enable_reconfig(reconfig_observer);
         driver
     }
 
     #[instrument(level = "trace", skip_all, fields(tx_digest = ?request.transaction.digest()))]
-    pub async fn submit_transaction(
+    pub async fn drive_transaction(
         &self,
         request: SubmitTxRequest,
         options: SubmitTransactionOptions,
     ) -> Result<QuorumSubmitTransactionResponse, TransactionDriverError> {
         let tx_digest = request.transaction.digest();
         let is_single_writer_tx = !request.transaction.is_consensus_tx();
+        let transaction = request.transaction.clone();
+        let raw_request = request
+            .into_raw()
+            .map_err(TransactionDriverError::SerializationError)?;
         let timer = Instant::now();
+
+        let mut attempts = 0;
+        const MAX_ATTEMPTS: usize = 10;
+
         loop {
-            match self.submit_transaction_once(&request, &options).await {
+            attempts += 1;
+            // TODO(fastpath): Check local state before submitting transaction
+            match self
+                .drive_transaction_once(&transaction, raw_request.clone(), &options)
+                .await
+            {
                 Ok(resp) => {
                     let settlement_finality_latency = timer.elapsed().as_secs_f64();
                     self.metrics
@@ -93,109 +100,42 @@ where
                     return Ok(resp);
                 }
                 Err(e) => {
-                    tracing::warn!("Failed to submit transaction {tx_digest}: {}", e);
-                    sleep(Duration::from_secs(1)).await;
+                    // TODO: Continue to retry only if error is retryable
+                    if attempts >= MAX_ATTEMPTS {
+                        return Err(e);
+                    }
+                    tracing::warn!(
+                        "Failed to submit transaction {tx_digest} (attempt {}/{}): {}",
+                        attempts,
+                        MAX_ATTEMPTS,
+                        e
+                    );
                 }
             }
         }
     }
 
-    #[instrument(level = "trace", skip_all, fields(tx_digest = ?request.transaction.digest()))]
-    async fn submit_transaction_once(
+    #[instrument(level = "trace", skip_all, fields(tx_digest = ?transaction.digest()))]
+    async fn drive_transaction_once(
         &self,
-        request: &SubmitTxRequest,
+        transaction: &Transaction,
+        raw_request: RawSubmitTxRequest,
         options: &SubmitTransactionOptions,
     ) -> Result<QuorumSubmitTransactionResponse, TransactionDriverError> {
-        // Store the epoch number; we read it from the votes and use it later to create the certificate.
         let auth_agg = self.authority_aggregator.load();
         let committee = auth_agg.committee.clone();
         let epoch = committee.epoch();
-        let transaction = request.transaction.clone();
-        let raw_request = request
-            .into_raw()
-            .map_err(TransactionDriverError::SerializationError)?;
 
-        // TODO(fastpath): Use validator performance metrics to choose who to submit with
-        // Send the transaction to a random validator.
-        let clients = auth_agg.authority_clients.iter().collect::<Vec<_>>();
-        let (name, client) = clients.choose(&mut rand::thread_rng()).unwrap();
+        // Get consensus position using TransactionSubmitter
+        let consensus_position = self
+            .submitter
+            .submit_transaction(&auth_agg, transaction, raw_request, options)
+            .await?;
 
-        let consensus_position = timeout(
-            Duration::from_secs(2),
-            client.submit_transaction(raw_request, options.forwarded_client_addr),
-        )
-        .await
-        .map_err(|_| TransactionDriverError::TimeoutSubmittingTransaction)?
-        .map_err(|e| {
-            TransactionDriverError::RpcFailure(name.concise().to_string(), e.to_string())
-        })?;
-
-        debug!(
-            "Transaction {} submitted to consensus at position: {consensus_position:?}",
-            transaction.digest()
-        );
-
-        let response = match timeout(
-            // TODO(fastpath): This will be removed when we change this to wait for effects from a quorum
-            Duration::from_secs(20),
-            client.wait_for_effects(
-                RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
-                    epoch,
-                    transaction_digest: *transaction.digest(),
-                    transaction_position: consensus_position,
-                    include_details: true,
-                })
-                .map_err(TransactionDriverError::SerializationError)?,
-                options.forwarded_client_addr,
-            ),
-        )
-        .await
-        {
-            Ok(Ok(response)) => response,
-            Ok(Err(e)) => {
-                return Err(TransactionDriverError::RpcFailure(
-                    name.concise().to_string(),
-                    e.to_string(),
-                ));
-            }
-            Err(_) => {
-                return Err(TransactionDriverError::TimeoutWaitingForEffects);
-            }
-        };
-
-        match response {
-            WaitForEffectsResponse::Executed {
-                details,
-                effects_digest: _,
-            } => {
-                if let Some(details) = details {
-                    return Ok(QuorumSubmitTransactionResponse {
-                        effects: FinalizedEffects {
-                            effects: details.effects,
-                            finality_info: EffectsFinalityInfo::QuorumExecuted(epoch),
-                        },
-                        events: details.events,
-                        input_objects: Some(details.input_objects),
-                        output_objects: Some(details.output_objects),
-                        auxiliary_data: None,
-                    });
-                } else {
-                    return Err(TransactionDriverError::ExecutionDataNotFound(
-                        transaction.digest().to_string(),
-                    ));
-                }
-            }
-            WaitForEffectsResponse::Rejected { reason } => {
-                return Err(TransactionDriverError::TransactionRejected(
-                    reason.to_string(),
-                ));
-            }
-            WaitForEffectsResponse::Expired(round) => {
-                return Err(TransactionDriverError::TransactionExpired(
-                    round.to_string(),
-                ));
-            }
-        };
+        // Wait for quorum effects using EffectsCertifier
+        self.certifier
+            .wait_for_quorum_effects(&auth_agg, transaction, consensus_position, epoch, options)
+            .await
     }
 
     fn enable_reconfig(

--- a/crates/sui-core/src/transaction_driver/transaction_submitter.rs
+++ b/crates/sui-core/src/transaction_driver/transaction_submitter.rs
@@ -21,17 +21,17 @@ use crate::{
 
 const SUBMIT_TRANSACTION_TIMEOUT: Duration = Duration::from_secs(2);
 
-pub struct TransactionSubmitter {
+pub(crate) struct TransactionSubmitter {
     metrics: Arc<TransactionDriverMetrics>,
 }
 
 impl TransactionSubmitter {
-    pub fn new(metrics: Arc<TransactionDriverMetrics>) -> Self {
+    pub(crate) fn new(metrics: Arc<TransactionDriverMetrics>) -> Self {
         Self { metrics }
     }
 
     #[instrument(level = "trace", skip_all, fields(tx_digest = ?tx_digest))]
-    pub async fn submit_transaction<A>(
+    pub(crate) async fn submit_transaction<A>(
         &self,
         authority_aggregator: &Arc<AuthorityAggregator<A>>,
         tx_digest: &TransactionDigest,
@@ -42,7 +42,7 @@ impl TransactionSubmitter {
         A: AuthorityAPI + Send + Sync + 'static + Clone,
     {
         let mut attempts = 0;
-        // TODO(fastpath): Retry until f+1 permanent failures
+        // TODO(fastpath): Remove MAX_ATTEMPTS. Retry until f+1 permanent failures or cancellation.
         const MAX_ATTEMPTS: usize = 10;
 
         loop {

--- a/crates/sui-core/src/transaction_driver/transaction_submitter.rs
+++ b/crates/sui-core/src/transaction_driver/transaction_submitter.rs
@@ -1,0 +1,105 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{sync::Arc, time::Duration};
+
+use rand::seq::SliceRandom as _;
+use sui_types::{
+    base_types::ConciseableName, messages_consensus::ConsensusPosition,
+    messages_grpc::RawSubmitTxRequest, transaction::Transaction,
+};
+use tokio::time::timeout;
+use tracing::{debug, instrument};
+
+use crate::{
+    authority_aggregator::AuthorityAggregator,
+    authority_client::AuthorityAPI,
+    transaction_driver::{
+        error::TransactionDriverError, SubmitTransactionOptions, TransactionDriverMetrics,
+    },
+};
+
+pub struct TransactionSubmitter {
+    metrics: Arc<TransactionDriverMetrics>,
+}
+
+impl TransactionSubmitter {
+    pub fn new(metrics: Arc<TransactionDriverMetrics>) -> Self {
+        Self { metrics }
+    }
+
+    #[instrument(level = "trace", skip_all, fields(tx_digest = ?transaction.digest()))]
+    pub async fn submit_transaction<A>(
+        &self,
+        authority_aggregator: &Arc<AuthorityAggregator<A>>,
+        transaction: &Transaction,
+        raw_request: RawSubmitTxRequest,
+        options: &SubmitTransactionOptions,
+    ) -> Result<ConsensusPosition, TransactionDriverError>
+    where
+        A: AuthorityAPI + Send + Sync + 'static + Clone,
+    {
+        let mut attempts = 0;
+        // TODO(fastpath): Retry until f+1 permanent failures
+        const MAX_ATTEMPTS: usize = 10;
+
+        loop {
+            attempts += 1;
+            match self
+                .submit_transaction_once(authority_aggregator, &raw_request, options)
+                .await
+            {
+                Ok(consensus_position) => {
+                    debug!(
+                        "Transaction {} submitted to consensus at position: {consensus_position:?}",
+                        transaction.digest()
+                    );
+                    self.metrics.submit_transaction_error.inc();
+                    return Ok(consensus_position);
+                }
+                Err(e) => {
+                    self.metrics.submit_transaction_success.inc();
+                    if attempts >= MAX_ATTEMPTS {
+                        return Err(e);
+                    }
+                    tracing::warn!(
+                        "Failed to submit transaction {} (attempt {}/{}): {}",
+                        transaction.digest(),
+                        attempts,
+                        MAX_ATTEMPTS,
+                        e
+                    );
+                }
+            }
+        }
+    }
+
+    #[instrument(level = "trace", skip_all)]
+    async fn submit_transaction_once<A>(
+        &self,
+        authority_aggregator: &Arc<AuthorityAggregator<A>>,
+        raw_request: &RawSubmitTxRequest,
+        options: &SubmitTransactionOptions,
+    ) -> Result<ConsensusPosition, TransactionDriverError>
+    where
+        A: AuthorityAPI + Send + Sync + 'static + Clone,
+    {
+        let clients = authority_aggregator
+            .authority_clients
+            .iter()
+            .collect::<Vec<_>>();
+        let (name, client) = clients.choose(&mut rand::thread_rng()).unwrap();
+
+        let consensus_position = timeout(
+            Duration::from_secs(2),
+            client.submit_transaction(raw_request.clone(), options.forwarded_client_addr),
+        )
+        .await
+        .map_err(|_| TransactionDriverError::TimeoutSubmittingTransaction)?
+        .map_err(|e| {
+            TransactionDriverError::RpcFailure(name.concise().to_string(), e.to_string())
+        })?;
+
+        Ok(consensus_position)
+    }
+}

--- a/crates/sui-core/src/transaction_driver/transaction_submitter.rs
+++ b/crates/sui-core/src/transaction_driver/transaction_submitter.rs
@@ -5,8 +5,8 @@ use std::{sync::Arc, time::Duration};
 
 use rand::seq::SliceRandom as _;
 use sui_types::{
-    base_types::ConciseableName, messages_consensus::ConsensusPosition,
-    messages_grpc::RawSubmitTxRequest, transaction::Transaction,
+    base_types::ConciseableName, digests::TransactionDigest, messages_consensus::ConsensusPosition,
+    messages_grpc::RawSubmitTxRequest,
 };
 use tokio::time::timeout;
 use tracing::{debug, instrument};
@@ -19,6 +19,8 @@ use crate::{
     },
 };
 
+const SUBMIT_TRANSACTION_TIMEOUT: Duration = Duration::from_secs(2);
+
 pub struct TransactionSubmitter {
     metrics: Arc<TransactionDriverMetrics>,
 }
@@ -28,11 +30,11 @@ impl TransactionSubmitter {
         Self { metrics }
     }
 
-    #[instrument(level = "trace", skip_all, fields(tx_digest = ?transaction.digest()))]
+    #[instrument(level = "trace", skip_all, fields(tx_digest = ?tx_digest))]
     pub async fn submit_transaction<A>(
         &self,
         authority_aggregator: &Arc<AuthorityAggregator<A>>,
-        transaction: &Transaction,
+        tx_digest: &TransactionDigest,
         raw_request: RawSubmitTxRequest,
         options: &SubmitTransactionOptions,
     ) -> Result<ConsensusPosition, TransactionDriverError>
@@ -51,23 +53,18 @@ impl TransactionSubmitter {
             {
                 Ok(consensus_position) => {
                     debug!(
-                        "Transaction {} submitted to consensus at position: {consensus_position:?}",
-                        transaction.digest()
+                        "Transaction {tx_digest} submitted to consensus at position: {consensus_position:?}",
                     );
-                    self.metrics.submit_transaction_error.inc();
+                    self.metrics.submit_transaction_success.inc();
                     return Ok(consensus_position);
                 }
                 Err(e) => {
-                    self.metrics.submit_transaction_success.inc();
+                    self.metrics.submit_transaction_error.inc();
                     if attempts >= MAX_ATTEMPTS {
                         return Err(e);
                     }
                     tracing::warn!(
-                        "Failed to submit transaction {} (attempt {}/{}): {}",
-                        transaction.digest(),
-                        attempts,
-                        MAX_ATTEMPTS,
-                        e
+                        "Failed to submit transaction {tx_digest} (attempt {attempts}/{MAX_ATTEMPTS}): {e}",
                     );
                 }
             }
@@ -91,7 +88,7 @@ impl TransactionSubmitter {
         let (name, client) = clients.choose(&mut rand::thread_rng()).unwrap();
 
         let consensus_position = timeout(
-            Duration::from_secs(2),
+            SUBMIT_TRANSACTION_TIMEOUT,
             client.submit_transaction(raw_request.clone(), options.forwarded_client_addr),
         )
         .await


### PR DESCRIPTION
## Description 

`EffectsCertifier` will concurrently wait for full effects from one validator and acks for quorum of effects digest from all validators. Once `ErrorCategorizer` component is added we will modify `EffectsCertifier` & `TransactionSubmitter` to use this and retry more intelligently

