### PR TITLE
[cli] Fix keytool export to  show alias

### DIFF
--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -670,11 +670,13 @@ impl KeyToolCommand {
             KeyToolCommand::Export { key_identity } => {
                 let address = get_identity_address_from_keystore(key_identity, keystore)?;
                 let skp = keystore.get_key(&address)?;
+                let mut key = Key::from(skp);
+                key.alias = keystore.get_alias_by_address(&key.sui_address).ok();
                 let key = ExportedKey {
                     exported_private_key: skp
                         .encode()
                         .map_err(|_| anyhow!("Cannot decode keypair"))?,
-                    key: Key::from(skp),
+                    key,
                 };
                 CommandOutput::Export(key)
             }


### PR DESCRIPTION
## Description 
Make the  `sui keytool export` to show the `alias` field correctly.

## Test plan 

`sui keytool export --key-identity temp-user`

**Before**
```
sui keytool export --key-identity temp-user
╭────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────╮
│ exportedPrivateKey │  suiprivkey1qzs65v9kxhhaxm9wxr25d28r2e2kn5d3dtax7wd6v27znmtk59r4275rjfq                    │
│ key                │ ╭─────────────────┬──────────────────────────────────────────────────────────────────────╮ │
│                    │ │ alias           │                                                                      │ │
│                    │ │ suiAddress      │  0x9161de6c0d4e6d7d72c4b96208978e71b1e066c8decbadc0fb2f091b3ceb29b9  │ │
│                    │ │ publicBase64Key │  ABRY5Ux8iRBzZ+3K0D8v7r301bT8oXb6Qc63vbqFxRnh                        │ │
│                    │ │ keyScheme       │  ed25519                                                             │ │
│                    │ │ flag            │  0                                                                   │ │
│                    │ │ peerId          │  1458e54c7c89107367edcad03f2feebdf4d5b4fca176fa41ceb7bdba85c519e1    │ │
│                    │ ╰─────────────────┴──────────────────────────────────────────────────────────────────────╯ │
╰────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────╯
```

**After**
```
╭────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────╮
│ exportedPrivateKey │  suiprivkey1qzs65v9kxhhaxm9wxr25d28r2e2kn5d3dtax7wd6v27znmtk59r4275rjfq                    │
│ key                │ ╭─────────────────┬──────────────────────────────────────────────────────────────────────╮ │
│                    │ │ alias           │  temp-user                                                           │ │
│                    │ │ suiAddress      │  0x9161de6c0d4e6d7d72c4b96208978e71b1e066c8decbadc0fb2f091b3ceb29b9  │ │
│                    │ │ publicBase64Key │  ABRY5Ux8iRBzZ+3K0D8v7r301bT8oXb6Qc63vbqFxRnh                        │ │
│                    │ │ keyScheme       │  ed25519                                                             │ │
│                    │ │ flag            │  0                                                                   │ │
│                    │ │ peerId          │  1458e54c7c89107367edcad03f2feebdf4d5b4fca176fa41ceb7bdba85c519e1    │ │
│                    │ ╰─────────────────┴──────────────────────────────────────────────────────────────────────╯ │
╰────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────╯
```
---

## Release notes


- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI:  `sui keytool export` to show the `alias` field correctly.
- [ ] Rust SDK:
