### PR TITLE
pick(22535) graphql: fix graphiql dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,7 +903,7 @@ dependencies = [
 [[package]]
 name = "async-graphql"
 version = "7.0.1"
-source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18#3fa614a54b4bda9efc9cad6f11579a328bfe35d0"
+source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18-graphiql-4#accb23623380994ae8a02218858e23eb6ec66187"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
@@ -942,7 +942,7 @@ dependencies = [
 [[package]]
 name = "async-graphql-axum"
 version = "7.0.1"
-source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18#3fa614a54b4bda9efc9cad6f11579a328bfe35d0"
+source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18-graphiql-4#accb23623380994ae8a02218858e23eb6ec66187"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -959,7 +959,7 @@ dependencies = [
 [[package]]
 name = "async-graphql-derive"
 version = "7.0.1"
-source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18#3fa614a54b4bda9efc9cad6f11579a328bfe35d0"
+source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18-graphiql-4#accb23623380994ae8a02218858e23eb6ec66187"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
@@ -975,7 +975,7 @@ dependencies = [
 [[package]]
 name = "async-graphql-parser"
 version = "7.0.1"
-source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18#3fa614a54b4bda9efc9cad6f11579a328bfe35d0"
+source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18-graphiql-4#accb23623380994ae8a02218858e23eb6ec66187"
 dependencies = [
  "async-graphql-value",
  "pest",
@@ -986,7 +986,7 @@ dependencies = [
 [[package]]
 name = "async-graphql-value"
 version = "7.0.1"
-source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18#3fa614a54b4bda9efc9cad6f11579a328bfe35d0"
+source = "git+https://github.com/amnn/async-graphql?branch=v7.0.1-react-18-graphiql-4#accb23623380994ae8a02218858e23eb6ec66187"
 dependencies = [
  "bytes",
  "indexmap 2.8.0",
@@ -5734,9 +5734,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "4.3.7"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c3372087601b532857d332f5957cbae686da52bb7810bf038c3e3c3cc2fa0d"
+checksum = "faa67bab9ff362228eb3d00bd024a4965d8231bbb7921167f0cfa66c6626b225"
 dependencies = [
  "log",
  "pest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -776,6 +776,6 @@ sui-execution = { path = "sui-execution" }
 # move-bytecode-verifier = { path = "external-crates/move/move-bytecode-verifier" }
 
 [patch.crates-io]
-async-graphql = { git = "https://github.com/amnn/async-graphql", branch = "v7.0.1-react-18" }
-async-graphql-axum = { git = "https://github.com/amnn/async-graphql", branch = "v7.0.1-react-18" }
-async-graphql-value = { git = "https://github.com/amnn/async-graphql", branch = "v7.0.1-react-18" }
+async-graphql = { git = "https://github.com/amnn/async-graphql", branch = "v7.0.1-react-18-graphiql-4" }
+async-graphql-axum = { git = "https://github.com/amnn/async-graphql", branch = "v7.0.1-react-18-graphiql-4" }
+async-graphql-value = { git = "https://github.com/amnn/async-graphql", branch = "v7.0.1-react-18-graphiql-4" }


### PR DESCRIPTION
## Description

GraphiQL is currently not working because of an issue with `unpkg` knowing that `graphiql` `5.0.0` has been released but not having the resources for it.

The fix is to cherry-pick some upstream changes to `async-graphql` that pins the version of GraphiQL to use.

## Test plan

Run the GraphQL service locally -- previously the UI would not load, and after this change it does.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
