### PR TITLE
[Consensus] disable the recovery of the transaction certifier & refactor commit consumer recovery

### DIFF
--- a/consensus/core/src/authority_node.rs
+++ b/consensus/core/src/authority_node.rs
@@ -198,12 +198,13 @@ where
         );
         let own_hostname = committee.authority(own_index).hostname.clone();
         info!(
-            "Starting consensus authority {} {}, {:?}, epoch start timestamp {}, boot counter {}",
+            "Starting consensus authority {} {}, {:?}, epoch start timestamp {}, boot counter {}, last processed commit index {}",
             own_index,
             own_hostname,
             protocol_config.version,
             epoch_start_timestamp_ms,
-            boot_counter
+            boot_counter,
+            commit_consumer.last_processed_commit_index
         );
         info!(
             "Consensus authorities: {}",

--- a/consensus/core/src/commit_observer.rs
+++ b/consensus/core/src/commit_observer.rs
@@ -1,11 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{sync::Arc, time::Duration};
+use std::{sync::Arc, thread, time::Duration};
 
 use parking_lot::RwLock;
 use tokio::time::Instant;
-use tracing::{debug, info};
+use tracing::info;
 
 use crate::{
     block::{BlockAPI, VerifiedBlock},
@@ -143,58 +143,114 @@ impl CommitObserver {
             let last_commit_index = last_commit.index();
             assert!(last_commit_index >= last_processed_commit_index);
             if last_commit_index == last_processed_commit_index {
-                debug!("Nothing to recover for commit observer as commit index {last_commit_index} = {last_processed_commit_index} last processed index");
+                info!("Nothing to recover for commit observer as commit index {last_commit_index} = {last_processed_commit_index} last processed index");
                 return;
             }
-        };
-
-        // We should not send the last processed commit again, so start from last_processed_commit_index+1
-        let unsent_commits = self
-            .store
-            .scan_commits(((last_processed_commit_index + 1)..=CommitIndex::MAX).into())
-            .expect("Scanning commits should not fail");
-
-        // Buffered unsent commits in DAG state which is required to contain them when they are flushed
-        // by CommitFinalizer.
-        self.dag_state
-            .write()
-            .recover_commits_to_write(unsent_commits.clone());
-
-        info!("Recovering commit observer after index {last_processed_commit_index} with last commit {} and {} unsent commits", last_commit.map(|c|c.index()).unwrap_or_default(), unsent_commits.len());
-
-        // Resend all the committed subdags to the consensus output channel
-        // for all the commits above the last processed index.
-        let mut last_sent_commit_index = last_processed_commit_index;
-        let num_unsent_commits = unsent_commits.len();
-        for (index, commit) in unsent_commits.into_iter().enumerate() {
-            // Commit index must be continuous.
-            assert_eq!(commit.index(), last_sent_commit_index + 1);
-
-            // On recovery leader schedule will be updated with the current scores
-            // and the scores will be passed along with the last commit sent to
-            // sui so that the current scores are available for submission.
-            let reputation_scores = if index == num_unsent_commits - 1 {
-                self.leader_schedule
-                    .leader_swap_table
-                    .read()
-                    .reputation_scores_desc
-                    .clone()
-            } else {
-                vec![]
-            };
-
-            info!("Sending commit {} during recovery", commit.index());
-            let committed_sub_dag =
-                load_committed_subdag_from_store(self.store.as_ref(), commit, reputation_scores);
-            // committed_sub_dag has the `local` field set to true, and will be treated as from
-            // local committer. This is fine even if the commit is originally from commit sync,
-            // because only finalized commits are persisted and can be recovered.
-            self.commit_finalizer_handle
-                .send(committed_sub_dag)
-                .unwrap();
-
-            last_sent_commit_index += 1;
+        } else {
+            assert!(
+                last_processed_commit_index == 0,
+                "Last processed commit index should be 0 if last commit is not found"
+            );
+            info!("Nothing to recover for commit observer as last processed index and commit index == 0");
+            return;
         }
+
+        let last_commit_index = last_commit.unwrap().index();
+
+        info!(
+            "Recovering commit observer in the range [{}..={last_commit_index}]",
+            last_processed_commit_index + 1
+        );
+
+        // To avoid scanning too many commits at once and load in memory, we limit the batch size to 1000 and iterate over.
+        const COMMIT_RECOVERY_BATCH_SIZE: u32 = if cfg!(test) { 3 } else { 250 };
+
+        let mut last_sent_commit_index = last_processed_commit_index;
+
+        // Make sure that there is no pending commits to be written to the store.
+        self.dag_state.read().ensure_commits_to_write_is_empty();
+
+        for start_index in (last_processed_commit_index + 1..=last_commit_index)
+            .step_by(COMMIT_RECOVERY_BATCH_SIZE as usize)
+        {
+            let end_index = start_index
+                .saturating_add(COMMIT_RECOVERY_BATCH_SIZE - 1)
+                .min(last_commit_index);
+
+            let unsent_commits = self
+                .store
+                .scan_commits((start_index..=end_index).into())
+                .expect("Scanning commits should not fail");
+
+            // If there are no unsent commits, then break, there is nothing more to recover.
+            if unsent_commits.is_empty() {
+                break;
+            }
+
+            // Buffered unsent commits in DAG state which is required to contain them when they are flushed
+            // by CommitFinalizer.
+            self.dag_state
+                .write()
+                .recover_commits_to_write(unsent_commits.clone());
+
+            info!(
+                "Recovered {} unsent commits in range [{start_index}..={end_index}]",
+                unsent_commits.len()
+            );
+
+            // Resend all the committed subdags to the consensus output channel
+            // for all the commits above the last processed index.
+            for commit in unsent_commits.into_iter() {
+                // Commit index must be continuous.
+                last_sent_commit_index += 1;
+                assert_eq!(commit.index(), last_sent_commit_index);
+
+                // On recovery leader schedule will be updated with the current scores
+                // and the scores will be passed along with the last commit of this recovered batchsent to
+                // sui so that the current scores are available for submission.
+                let reputation_scores = if commit.index() == last_commit_index {
+                    self.leader_schedule
+                        .leader_swap_table
+                        .read()
+                        .reputation_scores_desc
+                        .clone()
+                } else {
+                    vec![]
+                };
+
+                let committed_sub_dag = load_committed_subdag_from_store(
+                    self.store.as_ref(),
+                    commit,
+                    reputation_scores,
+                );
+                // committed_sub_dag has the `local` field set to true, and will be treated as from
+                // local committer. This is fine even if the commit is originally from commit sync,
+                // because only finalized commits are persisted and can be recovered.
+                self.commit_finalizer_handle
+                    .send(committed_sub_dag)
+                    .unwrap();
+
+                self.context
+                    .metrics
+                    .node_metrics
+                    .commit_observer_last_recovered_commit_index
+                    .set(last_sent_commit_index as i64);
+            }
+
+            // If we have reached the last commit, then break, there is nothing more to recover.
+            if end_index == last_commit_index {
+                break;
+            }
+
+            // Sleep to avoid overwhelming the disk I/O.
+            thread::sleep(Duration::from_millis(100));
+        }
+
+        assert_eq!(
+            last_sent_commit_index, last_commit_index,
+            "We should have sent all commits up to the last commit {}",
+            last_commit_index
+        );
 
         info!(
             "Commit observer recovery completed, took {:?}",

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -898,8 +898,14 @@ impl DagState {
 
     /// Recovers commits to write from storage, at startup.
     pub(crate) fn recover_commits_to_write(&mut self, commits: Vec<TrustedCommit>) {
-        assert!(self.commits_to_write.is_empty());
         self.commits_to_write.extend(commits);
+    }
+
+    pub(crate) fn ensure_commits_to_write_is_empty(&self) {
+        assert!(
+            self.commits_to_write.is_empty(),
+            "Commits to write should be empty"
+        );
     }
 
     pub(crate) fn add_commit_info(&mut self, reputation_scores: ReputationScores) {

--- a/consensus/core/src/metrics.rs
+++ b/consensus/core/src/metrics.rs
@@ -118,6 +118,7 @@ pub(crate) struct NodeMetrics {
     pub(crate) blocks_per_commit_count: Histogram,
     pub(crate) blocks_pruned_on_commit: IntCounterVec,
     pub(crate) broadcaster_rtt_estimate_ms: IntGaugeVec,
+    pub(crate) commit_observer_last_recovered_commit_index: IntGauge,
     pub(crate) core_add_blocks_batch_size: Histogram,
     pub(crate) core_check_block_refs_batch_size: Histogram,
     pub(crate) core_lock_dequeued: IntCounter,
@@ -327,6 +328,11 @@ impl NodeMetrics {
                 "broadcaster_rtt_estimate_ms",
                 "Estimated RTT latency per peer authority, for block sending in Broadcaster",
                 &["peer"],
+                registry,
+            ).unwrap(),
+            commit_observer_last_recovered_commit_index: register_int_gauge_with_registry!(
+                "commit_observer_last_recovered_commit_index",
+                "The last commit index recovered by the commit observer",
                 registry,
             ).unwrap(),
             core_add_blocks_batch_size: register_histogram_with_registry!(


### PR DESCRIPTION
## Description 

* Do not attempt to recover on the transaction certifier when mysticeti fast path is disabled
* Refactor commit consumer so commits are recovered in batches. This ensures we do the recovery gracefully and do not attempt to load all the data at once in memory resulting in OOM under stress conditions (ex authority quarantining commits for long period)

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
