### PR TITLE
[indexer-alt-framework] Implement integration tests for pipeline/concurrent

### DIFF
--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
@@ -28,11 +28,6 @@ mod committer;
 mod pruner;
 mod reader_watermark;
 
-/// The maximum number of watermarks that can show up in a single batch. This limit exists to deal
-/// with pipelines that produce no data for a majority of checkpoints -- the size of these
-/// pipeline's batches will be dominated by watermark updates.
-const MAX_WATERMARK_UPDATES: usize = 10_000;
-
 /// Handlers implement the logic for a given indexing pipeline: How to process checkpoint data (by
 /// implementing [Processor]) into rows for their table, and how to write those rows to the database.
 ///
@@ -61,6 +56,11 @@ pub trait Handler: Processor<Value: FieldCount> {
 
     /// If there are more than this many rows pending, the committer applies backpressure.
     const MAX_PENDING_ROWS: usize = 5000;
+
+    /// The maximum number of watermarks that can show up in a single batch.
+    /// This limit exists to deal with pipelines that produce no data for a majority of
+    /// checkpoints -- the size of these pipeline's batches will be dominated by watermark updates.
+    const MAX_WATERMARK_UPDATES: usize = 10_000;
 
     /// Take a chunk of values and commit them to the database, returning the number of rows
     /// affected.
@@ -148,7 +148,8 @@ impl<H: Handler> BatchedRows<H> {
     /// The batch is full if it has more than enough values to write to the database, or more than
     /// enough watermarks to update.
     fn is_full(&self) -> bool {
-        self.values.len() >= max_chunk_rows::<H>() || self.watermark.len() >= MAX_WATERMARK_UPDATES
+        self.values.len() >= max_chunk_rows::<H>()
+            || self.watermark.len() >= H::MAX_WATERMARK_UPDATES
     }
 }
 
@@ -280,5 +281,628 @@ const fn max_chunk_rows<H: Handler>() -> usize {
         i16::MAX as usize
     } else {
         i16::MAX as usize / H::Value::FIELD_COUNT
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use async_trait::async_trait;
+    use prometheus::Registry;
+    use tokio::{sync::mpsc, time::timeout};
+    use tokio_util::sync::CancellationToken;
+
+    use crate::{
+        metrics::IndexerMetrics,
+        pipeline::Processor,
+        store::CommitterWatermark,
+        testing::mock_store::MockStore,
+        types::{
+            full_checkpoint_content::CheckpointData,
+            test_checkpoint_data_builder::TestCheckpointDataBuilder,
+        },
+        FieldCount,
+    };
+
+    use super::*;
+
+    const TEST_TIMEOUT: Duration = Duration::from_secs(60);
+    const TEST_CHECKPOINT_BUFFER_SIZE: usize = 3; // Critical for back-pressure testing calculations
+
+    #[derive(Clone, Debug, FieldCount)]
+    struct TestValue {
+        checkpoint: u64,
+        data: u64,
+    }
+
+    struct DataPipeline;
+
+    impl Processor for DataPipeline {
+        const NAME: &'static str = "test_handler";
+        const FANOUT: usize = 2;
+        type Value = TestValue;
+
+        fn process(&self, checkpoint: &Arc<CheckpointData>) -> anyhow::Result<Vec<Self::Value>> {
+            let cp_num = checkpoint.checkpoint_summary.sequence_number;
+
+            // Every checkpoint will come with 2 processed values
+            Ok(vec![
+                TestValue {
+                    checkpoint: cp_num,
+                    data: cp_num * 10 + 1,
+                },
+                TestValue {
+                    checkpoint: cp_num,
+                    data: cp_num * 10 + 2,
+                },
+            ])
+        }
+    }
+
+    #[async_trait]
+    impl Handler for DataPipeline {
+        type Store = MockStore;
+        const MIN_EAGER_ROWS: usize = 1000; // High value to disable eager batching
+        const MAX_PENDING_ROWS: usize = 4; // Small value to trigger back pressure quickly
+        const MAX_WATERMARK_UPDATES: usize = 1; // Each batch will have 1 checkpoint for an ease of testing.
+
+        async fn commit<'a>(
+            values: &[Self::Value],
+            conn: &mut crate::testing::mock_store::MockConnection<'a>,
+        ) -> anyhow::Result<usize> {
+            // Group values by checkpoint
+            let mut grouped: std::collections::HashMap<u64, Vec<u64>> =
+                std::collections::HashMap::new();
+            for value in values {
+                grouped
+                    .entry(value.checkpoint)
+                    .or_default()
+                    .push(value.data);
+            }
+
+            // Commit all data at once
+            conn.0.commit_data(grouped).await
+        }
+
+        async fn prune<'a>(
+            &self,
+            from: u64,
+            to_exclusive: u64,
+            conn: &mut crate::testing::mock_store::MockConnection<'a>,
+        ) -> anyhow::Result<usize> {
+            conn.0.prune_data(from, to_exclusive)
+        }
+    }
+
+    struct TestSetup {
+        store: MockStore,
+        checkpoint_tx: mpsc::Sender<Arc<CheckpointData>>,
+        pipeline_handle: JoinHandle<()>,
+        cancel: CancellationToken,
+    }
+
+    impl TestSetup {
+        async fn new(
+            config: ConcurrentConfig,
+            store: MockStore,
+            initial_watermark: Option<CommitterWatermark>,
+        ) -> Self {
+            let (checkpoint_tx, checkpoint_rx) = mpsc::channel(TEST_CHECKPOINT_BUFFER_SIZE);
+            let metrics = IndexerMetrics::new(&Registry::default());
+            let cancel = CancellationToken::new();
+
+            let skip_watermark = false;
+            let pipeline_handle = pipeline(
+                DataPipeline,
+                initial_watermark,
+                config,
+                skip_watermark,
+                store.clone(),
+                checkpoint_rx,
+                metrics,
+                cancel.clone(),
+            );
+
+            Self {
+                store,
+                checkpoint_tx,
+                pipeline_handle,
+                cancel,
+            }
+        }
+
+        async fn send_checkpoint(&self, checkpoint: u64) -> anyhow::Result<()> {
+            let checkpoint = Arc::new(
+                TestCheckpointDataBuilder::new(checkpoint)
+                    .with_epoch(1)
+                    .with_network_total_transactions(checkpoint * 2)
+                    .with_timestamp_ms(1000000000 + checkpoint * 1000)
+                    .build_checkpoint(),
+            );
+            self.checkpoint_tx.send(checkpoint).await?;
+            Ok(())
+        }
+
+        async fn shutdown(self) {
+            drop(self.checkpoint_tx);
+            self.cancel.cancel();
+            let _ = self.pipeline_handle.await;
+        }
+
+        async fn send_checkpoint_with_timeout(
+            &self,
+            checkpoint: u64,
+            timeout_duration: Duration,
+        ) -> anyhow::Result<()> {
+            timeout(timeout_duration, self.send_checkpoint(checkpoint)).await?
+        }
+
+        async fn send_checkpoint_expect_timeout(
+            &self,
+            checkpoint: u64,
+            timeout_duration: Duration,
+        ) {
+            timeout(timeout_duration, self.send_checkpoint(checkpoint))
+                .await
+                .unwrap_err(); // Panics if send succeeds
+        }
+    }
+
+    #[tokio::test]
+    async fn test_e2e_pipeline() {
+        let config = ConcurrentConfig {
+            pruner: Some(PrunerConfig {
+                interval_ms: 5_000, // Long interval to test states before pruning
+                delay_ms: 100,      // Short delay for faster tests
+                retention: 3,       // Keep only 3 checkpoints
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let store = MockStore::default();
+        let setup = TestSetup::new(config, store, None).await;
+
+        // Send initial checkpoints
+        for i in 0..3 {
+            setup
+                .send_checkpoint_with_timeout(i, Duration::from_millis(200))
+                .await
+                .unwrap();
+        }
+
+        // Verify all initial data is available (before any pruning)
+        for i in 0..3 {
+            let data = setup.store.wait_for_data(i, TEST_TIMEOUT).await;
+            assert_eq!(data, vec![i * 10 + 1, i * 10 + 2]);
+        }
+
+        // Add more checkpoints to trigger pruning
+        for i in 3..6 {
+            setup
+                .send_checkpoint_with_timeout(i, Duration::from_millis(200))
+                .await
+                .unwrap();
+        }
+
+        // Verify data is still available BEFORE pruning kicks in
+        // With long pruning interval (5s), we can safely verify data without race conditions
+        for i in 0..6 {
+            let data = setup.store.wait_for_data(i, Duration::from_secs(1)).await;
+            assert_eq!(data, vec![i * 10 + 1, i * 10 + 2]);
+        }
+
+        // Wait for pruning to occur (5s + delay + processing time)
+        tokio::time::sleep(Duration::from_millis(5_200)).await;
+
+        // Verify pruning has occurred
+        {
+            let data = setup.store.data.lock().unwrap();
+
+            // Verify recent checkpoints are still available
+            assert!(data.contains_key(&3));
+            assert!(data.contains_key(&4));
+            assert!(data.contains_key(&5));
+
+            // Verify old checkpoints are pruned
+            assert!(!data.contains_key(&0));
+            assert!(!data.contains_key(&1));
+            assert!(!data.contains_key(&2));
+        };
+
+        setup.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_e2e_pipeline_without_pruning() {
+        let config = ConcurrentConfig {
+            pruner: None,
+            ..Default::default()
+        };
+        let store = MockStore::default();
+        let setup = TestSetup::new(config, store, None).await;
+
+        // Send several checkpoints
+        for i in 0..10 {
+            setup
+                .send_checkpoint_with_timeout(i, Duration::from_millis(200))
+                .await
+                .unwrap();
+        }
+
+        // Wait for all data to be processed and committed
+        let watermark = setup.store.wait_for_watermark(9, TEST_TIMEOUT).await;
+
+        // Verify ALL data was processed correctly (no pruning)
+        for i in 0..10 {
+            let data = setup.store.wait_for_data(i, Duration::from_secs(1)).await;
+            assert_eq!(data, vec![i * 10 + 1, i * 10 + 2]);
+        }
+
+        // Verify watermark progression
+        assert_eq!(watermark.checkpoint_hi_inclusive, 9);
+        assert_eq!(watermark.tx_hi, 18); // 9 * 2
+        assert_eq!(watermark.timestamp_ms_hi_inclusive, 1000009000); // 1000000000 + 9 * 1000
+
+        // Verify no data was pruned - all 10 checkpoints should still exist
+        let total_checkpoints = {
+            let data = setup.store.data.lock().unwrap();
+            data.len()
+        };
+        assert_eq!(total_checkpoints, 10);
+
+        setup.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_out_of_order_processing() {
+        let config = ConcurrentConfig::default();
+        let store = MockStore::default();
+        let setup = TestSetup::new(config, store, None).await;
+
+        // Send checkpoints out of order
+        let checkpoints = vec![2, 0, 4, 1, 3];
+        for cp in checkpoints {
+            setup
+                .send_checkpoint_with_timeout(cp, Duration::from_millis(200))
+                .await
+                .unwrap();
+        }
+
+        // Wait for all data to be processed
+        let _watermark = setup
+            .store
+            .wait_for_watermark(4, Duration::from_secs(5))
+            .await;
+
+        // Verify all checkpoints were processed correctly despite out-of-order arrival
+        for i in 0..5 {
+            let data = setup.store.wait_for_data(i, Duration::from_secs(1)).await;
+            assert_eq!(data, vec![i * 10 + 1, i * 10 + 2]);
+        }
+
+        setup.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_watermark_progression_with_gaps() {
+        let config = ConcurrentConfig::default();
+        let store = MockStore::default();
+        let setup = TestSetup::new(config, store, None).await;
+
+        // Send checkpoints with a gap (0, 1, 3, 4) - missing checkpoint 2
+        for cp in [0, 1, 3, 4] {
+            setup
+                .send_checkpoint_with_timeout(cp, Duration::from_millis(200))
+                .await
+                .unwrap();
+        }
+
+        // Wait for processing
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        // Watermark should only progress to 1 (can't progress past the gap)
+        let watermark = setup.store.get_watermark();
+        assert_eq!(watermark.checkpoint_hi_inclusive, 1);
+
+        // Now send the missing checkpoint 2
+        setup
+            .send_checkpoint_with_timeout(2, Duration::from_millis(200))
+            .await
+            .unwrap();
+
+        // Now watermark should progress to 4
+        let watermark = setup.store.wait_for_watermark(4, TEST_TIMEOUT).await;
+        assert_eq!(watermark.checkpoint_hi_inclusive, 4);
+
+        setup.shutdown().await;
+    }
+
+    // ==================== BACK-PRESSURE TESTING ====================
+
+    #[tokio::test]
+    async fn test_back_pressure_collector_max_pending_rows() {
+        // Pipeline Diagram - Collector Back Pressure via MAX_PENDING_ROWS:
+        //
+        // ┌────────────┐    ┌────────────┐    ┌────────────┐    ┌────────────┐
+        // │ Checkpoint │ ─► │ Processor  │ ─► │ Collector  │ ─► │ Committer  │
+        // │   Input    │    │ (FANOUT=2) │    │            │    │            │
+        // └────────────┘    └────────────┘    └[BOTTLENECK]┘    └────────────┘
+        //                │                 │                 │
+        //              [●●●]           [●●●●●●●]         [●●●●●●]
+        //            buffer: 3         buffer: 7         buffer: 6
+        //
+        // BOTTLENECK: Collector stops accepting when pending rows ≥ MAX_PENDING_ROWS (4)
+
+        let config = ConcurrentConfig {
+            committer: CommitterConfig {
+                collect_interval_ms: 5_000, // Long interval to prevent timer-driven collection
+                write_concurrency: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let store = MockStore::default();
+        let setup = TestSetup::new(config, store, None).await;
+
+        // Wait for initial setup
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Pipeline capacity analysis with collector back pressure:
+        // Configuration: MAX_PENDING_ROWS=4, FANOUT=2, PIPELINE_BUFFER=5
+        //
+        // Channel and task breakdown:
+        // - Checkpoint->Processor channel: 3 slots (TEST_CHECKPOINT_BUFFER_SIZE)
+        // - Processor tasks: 2 tasks (FANOUT=2)
+        // - Processor->Collector channel: 7 slots (FANOUT=2 + PIPELINE_BUFFER=5)
+        // - Collector pending: 2 checkpoints × 2 values = 4 values (hits MAX_PENDING_ROWS=4)
+        //
+        // Total capacity: 3 + 2 + 7 + 2 = 14 checkpoints
+
+        // Fill pipeline to capacity - these should all succeed
+        for i in 0..14 {
+            setup
+                .send_checkpoint_with_timeout(i, Duration::from_millis(200))
+                .await
+                .unwrap();
+        }
+
+        // Checkpoint 14 should block due to MAX_PENDING_ROWS back pressure
+        setup
+            .send_checkpoint_expect_timeout(14, Duration::from_millis(200))
+            .await;
+
+        // Allow pipeline to drain by sending the blocked checkpoint with longer timeout
+        setup
+            .send_checkpoint_with_timeout(14, TEST_TIMEOUT)
+            .await
+            .unwrap();
+
+        // Verify data was processed correctly
+        let data = setup.store.wait_for_data(0, TEST_TIMEOUT).await;
+        assert_eq!(data, vec![1, 2]);
+
+        setup.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_back_pressure_committer_slow_commits() {
+        // Pipeline Diagram - Committer Back Pressure via Slow Database Commits:
+        //
+        // ┌────────────┐    ┌────────────┐    ┌────────────┐    ┌────────────┐
+        // │ Checkpoint │ ─► │ Processor  │ ─► │ Collector  │ ─► │ Committer  │
+        // │   Input    │    │ (FANOUT=2) │    │            │    │🐌 10s Delay│
+        // └────────────┘    └────────────┘    └────────────┘    └[BOTTLENECK]┘
+        //                │                 │                 │
+        //              [●●●]           [●●●●●●●]         [●●●●●●]
+        //            buffer: 3         buffer: 7         buffer: 6
+        //
+        // BOTTLENECK: Committer with 10s delay blocks entire pipeline
+
+        let config = ConcurrentConfig {
+            committer: CommitterConfig {
+                write_concurrency: 1, // Single committer for deterministic blocking
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let store = MockStore::default().with_commit_delay(10_000); // 10 seconds delay
+        let setup = TestSetup::new(config, store, None).await;
+
+        // Pipeline capacity analysis with slow commits:
+        // Configuration: FANOUT=2, write_concurrency=1, PIPELINE_BUFFER=5
+        //
+        // Channel and task breakdown:
+        // - Checkpoint->Processor channel: 3 slots (TEST_CHECKPOINT_BUFFER_SIZE)
+        // - Processor tasks: 2 tasks (FANOUT=2)
+        // - Processor->Collector channel: 7 slots (FANOUT=2 + PIPELINE_BUFFER=5)
+        // - Collector->Committer channel: 6 slots (write_concurrency=1 + PIPELINE_BUFFER=5)
+        // - Committer task: 1 task (blocked by slow commit)
+        //
+        // Total theoretical capacity: 3 + 2 + 7 + 6 + 1 = 19 checkpoints
+
+        // Fill pipeline to theoretical capacity - these should all succeed
+        for i in 0..19 {
+            setup
+                .send_checkpoint_with_timeout(i, Duration::from_millis(100))
+                .await
+                .unwrap();
+        }
+
+        // Find the actual back pressure point
+        // Due to non-determinism in collector's tokio::select!, the collector may consume
+        // up to 2 checkpoints (filling MAX_PENDING_ROWS=4) before applying back pressure.
+        // This means back pressure occurs somewhere in range 19-21.
+        let mut back_pressure_checkpoint = None;
+        for checkpoint in 19..22 {
+            if setup
+                .send_checkpoint_with_timeout(checkpoint, Duration::from_millis(100))
+                .await
+                .is_err()
+            {
+                back_pressure_checkpoint = Some(checkpoint);
+                break;
+            }
+        }
+        assert!(
+            back_pressure_checkpoint.is_some(),
+            "Back pressure should occur between checkpoints 19-21"
+        );
+
+        // Verify that some data has been processed (pipeline is working)
+        setup.store.wait_for_any_data(TEST_TIMEOUT).await;
+
+        // Allow pipeline to drain by sending the blocked checkpoint with longer timeout
+        setup
+            .send_checkpoint_with_timeout(back_pressure_checkpoint.unwrap(), TEST_TIMEOUT)
+            .await
+            .unwrap();
+
+        setup.shutdown().await;
+    }
+
+    // ==================== FAILURE TESTING ====================
+
+    #[tokio::test]
+    async fn test_commit_failure_retry() {
+        let config = ConcurrentConfig::default();
+        let store = MockStore::default().with_commit_failures(2); // Fail 2 times, then succeed
+        let setup = TestSetup::new(config, store, None).await;
+
+        // Send a checkpoint
+        setup
+            .send_checkpoint_with_timeout(0, Duration::from_millis(200))
+            .await
+            .unwrap();
+
+        // Should eventually succeed despite initial commit failures
+        let _watermark = setup.store.wait_for_watermark(0, TEST_TIMEOUT).await;
+
+        // Verify data was eventually committed
+        let data = setup.store.wait_for_data(0, Duration::from_secs(1)).await;
+        assert_eq!(data, vec![1, 2]);
+
+        setup.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_prune_failure_retry() {
+        let config = ConcurrentConfig {
+            pruner: Some(PrunerConfig {
+                interval_ms: 2000, // 2 seconds interval for testing
+                delay_ms: 100,     // Short delay
+                retention: 2,      // Keep only 2 checkpoints
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        // Configure prune failures for range [0, 2) - fail twice then succeed
+        let store = MockStore::default().with_prune_failures(0, 2, 1);
+        let setup = TestSetup::new(config, store, None).await;
+
+        // Send enough checkpoints to trigger pruning
+        for i in 0..4 {
+            setup
+                .send_checkpoint_with_timeout(i, Duration::from_millis(200))
+                .await
+                .unwrap();
+        }
+
+        // Verify data is still available BEFORE pruning kicks in
+        // With long pruning interval (5s), we can safely verify data without race conditions
+        for i in 0..4 {
+            let data = setup.store.wait_for_data(i, Duration::from_secs(1)).await;
+            assert_eq!(data, vec![i * 10 + 1, i * 10 + 2]);
+        }
+
+        // Wait for first pruning attempt (should fail) and verify no data has been pruned
+        setup
+            .store
+            .wait_for_prune_attempts(0, 2, 1, TEST_TIMEOUT)
+            .await;
+        {
+            let data = setup.store.data.lock().unwrap();
+            for i in 0..4 {
+                assert!(data.contains_key(&i));
+            }
+        };
+
+        // Wait for second pruning attempt (should succeed)
+        setup
+            .store
+            .wait_for_prune_attempts(0, 2, 2, TEST_TIMEOUT)
+            .await;
+        {
+            let data = setup.store.data.lock().unwrap();
+            // Verify recent checkpoints are still available
+            assert!(data.contains_key(&2));
+            assert!(data.contains_key(&3));
+
+            // Verify old checkpoints are pruned
+            assert!(!data.contains_key(&0));
+            assert!(!data.contains_key(&1));
+        };
+
+        setup.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_reader_watermark_failure_retry() {
+        let config = ConcurrentConfig {
+            pruner: Some(PrunerConfig {
+                interval_ms: 100, // Fast interval for testing
+                delay_ms: 100,    // Short delay
+                retention: 3,     // Keep 3 checkpoints
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        // Configure reader watermark failures - fail 2 times then succeed
+        let store = MockStore::default().with_reader_watermark_failures(2);
+        let setup = TestSetup::new(config, store, None).await;
+
+        // Send checkpoints to trigger reader watermark updates
+        for i in 0..6 {
+            setup
+                .send_checkpoint_with_timeout(i, Duration::from_millis(200))
+                .await
+                .unwrap();
+        }
+
+        // Wait for processing to complete
+        let _watermark = setup.store.wait_for_watermark(5, TEST_TIMEOUT).await;
+
+        // Wait for reader watermark task to attempt updates (with failures and retries)
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        // Verify that reader watermark was eventually updated despite failures
+        let watermark = setup.store.get_watermark();
+        assert_eq!(watermark.reader_lo, 3);
+
+        setup.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_database_connection_failure_retry() {
+        let config = ConcurrentConfig::default();
+        let store = MockStore::default().with_connection_failures(2); // Fail 2 times, then succeed
+        let setup = TestSetup::new(config, store, None).await;
+
+        // Send a checkpoint
+        setup
+            .send_checkpoint_with_timeout(0, Duration::from_millis(200))
+            .await
+            .unwrap();
+
+        // Should eventually succeed despite initial failures
+        let _watermark = setup.store.wait_for_watermark(0, TEST_TIMEOUT).await;
+
+        // Verify data was eventually committed
+        let data = setup.store.wait_for_data(0, TEST_TIMEOUT).await;
+        assert_eq!(data, vec![1, 2]);
+
+        setup.shutdown().await;
     }
 }

--- a/crates/sui-indexer-alt-framework/src/testing/mock_store.rs
+++ b/crates/sui-indexer-alt-framework/src/testing/mock_store.rs
@@ -10,6 +10,8 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
+use dashmap::DashMap;
+
 use anyhow::ensure;
 use async_trait::async_trait;
 use scoped_futures::ScopedBoxFuture;
@@ -41,9 +43,9 @@ pub struct ConnectionFailure {
     pub connection_attempts: usize,
 }
 
-/// Configuration for simulating transaction failures in tests
+/// Configuration for simulating failures in tests
 #[derive(Default)]
-pub struct TransactionFailures {
+pub struct Failures {
     /// Number of failures to simulate before allowing success
     pub failures: usize,
     /// Counter for tracking total transaction attempts
@@ -62,16 +64,19 @@ pub struct MockStore {
     /// Each entry is the checkpoint number that was processed
     pub sequential_checkpoint_data: Arc<Mutex<Vec<u64>>>,
     /// Controls pruning failure simulation for testing retry behavior.
-    /// Maps from [from_checkpoint, to_checkpoint_exclusive) to number of remaining failure attempts.
-    /// When a prune operation is attempted on a range, if there are remaining failures,
-    /// the operation will fail and the counter will be decremented.
-    pub prune_failure_attempts: Arc<Mutex<HashMap<(u64, u64), usize>>>,
+    /// Maps from [from_checkpoint, to_checkpoint_exclusive) to Failures struct.
+    /// Thread-safe for concurrent access during pruning operations.
+    pub prune_failure_attempts: Arc<DashMap<(u64, u64), Failures>>,
     /// Configuration for simulating connection failures in tests
     pub connection_failure: Arc<Mutex<ConnectionFailure>>,
     /// Number of remaining failures for set_reader_watermark operation
     pub set_reader_watermark_failure_attempts: Arc<Mutex<usize>>,
     /// Configuration for simulating transaction failures in tests
-    pub transaction_failures: Arc<TransactionFailures>,
+    pub transaction_failures: Arc<Failures>,
+    /// Configuration for simulating commit failures in tests
+    pub commit_failures: Arc<Failures>,
+    /// Delay in milliseconds for each transaction commit
+    pub commit_delay_ms: u64,
 }
 
 #[derive(Clone)]
@@ -232,6 +237,63 @@ impl TransactionalStore for MockStore {
 }
 
 impl MockStore {
+    /// Commits data to the mock store, handling delays and simulated failures
+    pub async fn commit_data(
+        &self,
+        values: std::collections::HashMap<u64, Vec<u64>>,
+    ) -> anyhow::Result<usize> {
+        // Apply commit delay if configured
+        if self.commit_delay_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(self.commit_delay_ms)).await;
+        }
+
+        // Check for commit failure simulation
+        let prev = self
+            .commit_failures
+            .attempts
+            .fetch_add(1, Ordering::Relaxed);
+        ensure!(
+            prev >= self.commit_failures.failures,
+            "Transaction failed, remaining failures: {}",
+            self.commit_failures.failures - prev
+        );
+
+        // Store the data
+        let mut total_count = 0;
+        {
+            let mut data = self.data.lock().unwrap();
+            for (checkpoint, checkpoint_values) in values {
+                total_count += checkpoint_values.len();
+                data.entry(checkpoint)
+                    .or_default()
+                    .extend(checkpoint_values);
+            }
+        }
+
+        Ok(total_count)
+    }
+
+    /// Prunes data for the given checkpoints, handling failure simulation
+    pub fn prune_data(&self, from: u64, to_exclusive: u64) -> anyhow::Result<usize> {
+        let should_fail = self
+            .prune_failure_attempts
+            .get(&(from, to_exclusive))
+            .is_some_and(|f| f.attempts.fetch_add(1, Ordering::Relaxed) < f.failures);
+
+        ensure!(!should_fail, "Pruning failed");
+
+        // Remove the data
+        let mut data = self.data.lock().unwrap();
+        let mut pruned_count = 0;
+        for checkpoint in from..to_exclusive {
+            if data.remove(&checkpoint).is_some() {
+                pruned_count += 1;
+            }
+        }
+
+        Ok(pruned_count)
+    }
+
     /// Helper to configure connection failure simulation
     pub fn with_connection_failures(self, attempts: usize) -> Self {
         self.connection_failure
@@ -243,14 +305,47 @@ impl MockStore {
 
     /// Helper to configure transaction failure simulation
     pub fn with_transaction_failures(mut self, failures: usize) -> Self {
-        self.transaction_failures = Arc::new(TransactionFailures {
+        self.transaction_failures = Arc::new(Failures {
             failures,
             attempts: AtomicUsize::new(0),
         });
         self
     }
 
-    /// Get the sequential checkpoint data for testing.
+    /// Create a new MockStore with commit delay
+    pub fn with_commit_delay(mut self, delay_ms: u64) -> Self {
+        self.commit_delay_ms = delay_ms;
+        self
+    }
+
+    /// Helper to configure reader watermark failure simulation
+    pub fn with_reader_watermark_failures(self, attempts: usize) -> Self {
+        *self.set_reader_watermark_failure_attempts.lock().unwrap() = attempts;
+        self
+    }
+
+    /// Helper to configure prune failure simulation for a specific range
+    pub fn with_prune_failures(self, from: u64, to_exclusive: u64, failures: usize) -> Self {
+        self.prune_failure_attempts.insert(
+            (from, to_exclusive),
+            Failures {
+                failures,
+                attempts: AtomicUsize::new(0),
+            },
+        );
+        self
+    }
+
+    /// Helper to configure commit failure simulation
+    pub fn with_commit_failures(mut self, failures: usize) -> Self {
+        self.commit_failures = Arc::new(Failures {
+            failures,
+            attempts: AtomicUsize::new(0),
+        });
+        self
+    }
+
+    /// Get the sequential checkpoint data
     pub fn get_sequential_data(&self) -> Vec<u64> {
         self.sequential_checkpoint_data.lock().unwrap().clone()
     }
@@ -277,5 +372,80 @@ impl MockStore {
         })
         .await
         .unwrap();
+    }
+
+    /// Helper to get the number of prune attempts for a specific range
+    pub fn prune_attempts(&self, from: u64, to_exclusive: u64) -> usize {
+        self.prune_failure_attempts
+            .get(&(from, to_exclusive))
+            .map(|failures| failures.attempts.load(Ordering::Relaxed))
+            .unwrap_or(0)
+    }
+
+    /// Helper to wait for a specific number of prune attempts with timeout
+    pub async fn wait_for_prune_attempts(
+        &self,
+        from: u64,
+        to_exclusive: u64,
+        expected: usize,
+        timeout: Duration,
+    ) {
+        tokio::time::timeout(timeout, async {
+            loop {
+                if self.prune_attempts(from, to_exclusive) >= expected {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+
+    /// Wait for any data to be processed and stored, panicking if timeout is reached
+    pub async fn wait_for_any_data(&self, timeout_duration: Duration) {
+        let start = std::time::Instant::now();
+        while start.elapsed() < timeout_duration {
+            {
+                let data = self.data.lock().unwrap();
+                if !data.is_empty() {
+                    return;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        panic!("Timeout waiting for any data to be processed - pipeline may be stuck");
+    }
+
+    /// Wait for data from a specific checkpoint, panicking if timeout is reached
+    pub async fn wait_for_data(&self, checkpoint: u64, timeout_duration: Duration) -> Vec<u64> {
+        let start = std::time::Instant::now();
+        while start.elapsed() < timeout_duration {
+            {
+                let data = self.data.lock().unwrap();
+                if let Some(values) = data.get(&checkpoint) {
+                    return values.clone();
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        panic!("Timeout waiting for data for checkpoint {}", checkpoint);
+    }
+
+    /// Wait for watermark to reach the expected checkpoint, returning the watermark when reached
+    pub async fn wait_for_watermark(
+        &self,
+        checkpoint: u64,
+        timeout_duration: Duration,
+    ) -> MockWatermark {
+        let start = std::time::Instant::now();
+        while start.elapsed() < timeout_duration {
+            let watermark = self.get_watermark();
+            if watermark.checkpoint_hi_inclusive >= checkpoint {
+                return watermark;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        panic!("Timeout waiting for watermark to reach {}", checkpoint);
     }
 }


### PR DESCRIPTION
## Description 

Improve integration tests coverage for pipeline/concurrent in mod.rs

Test coverage includes:

* Basic functionality with pruning
* Basic functionality without pruning
* Back Pressure testing
* Failure testing

Within this PR, I also do 2 small refactorings:

1. Move `MAX_WATERMARK_UPDATES` to Handler so that we could override it in testings
2. Update `prune_failure_attempts` within MockStore to thread-safe DashMap for cleaner testing

This is the final PR to finalize the testing coverage for Indexer Alt Framework ([DVX-420](https://linear.app/mysten-labs/issue/DVX-420/testing-support))

## Test plan 

How did you test the new or updated feature?

```
cargo test -p sui-indexer-alt-framework  concurrent  --lib
```

---

## Stack

- #22359
- #22366
- #22393
- #22397 
- #22400 
- #22407

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
