### PR TITLE
Insert tx keys after execution, add assertion to detect that they are missing when they shouldn't be

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13748,6 +13748,7 @@ dependencies = [
  "object_store",
  "once_cell",
  "parking_lot 0.12.3",
+ "pin-project-lite",
  "pprof",
  "pretty_assertions",
  "prometheus",

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -450,6 +450,7 @@ mod test {
             }
         });
         register_fail_point_async("consensus-delay", || delay_failpoint(10..20, 0.001));
+        register_fail_point_async("randomness-delay", || delay_failpoint(10..1000, 0.5));
 
         test_simulated_load(test_cluster, 120).await;
     }

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -39,6 +39,7 @@ num_cpus.workspace = true
 object_store.workspace = true
 once_cell.workspace = true
 parking_lot.workspace = true
+pin-project-lite.workspace = true
 prometheus.workspace = true
 rand.workspace = true
 roaring.workspace = true


### PR DESCRIPTION
The fix for this bug is very simple (the 4 new lines in authority.rs) - everything else in this PR is to facilitate reproducing the issue in tests.
