### PR TITLE
[move][move-compiler][typing] Add lambda annotation to named block instead of sequence

### DIFF
--- a/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/macro_expand.rs
@@ -1079,10 +1079,7 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
                 unreachable!()
             };
             let body_loc = lambda_body.loc;
-            let annot_body = all_result_ty.into_iter().fold(lambda_body, |body, ty| {
-                Box::new(sp(body_loc, N::Exp_::Annotate(body, ty)))
-            });
-            let labeled_seq = VecDeque::from([sp(body_loc, N::SequenceItem_::Seq(annot_body))]);
+            let labeled_seq = VecDeque::from([sp(body_loc, N::SequenceItem_::Seq(lambda_body))]);
             let labeled_body_ = N::Exp_::Block(N::Block {
                 name: Some(return_label),
                 // mark lambda expansion for recursive macro check
@@ -1090,6 +1087,9 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
                 seq: (N::UseFuns::new(use_fun_color), labeled_seq),
             });
             let labeled_body = Box::new(sp(body_loc, labeled_body_));
+            let annot_body = all_result_ty.into_iter().fold(labeled_body, |body, ty| {
+                Box::new(sp(body_loc, N::Exp_::Annotate(body, ty)))
+            });
             // pad args with errors
             let args = args.into_iter().chain(std::iter::repeat_with(|| {
                 sp(argloc, N::Exp_::UnresolvedError)
@@ -1109,7 +1109,7 @@ fn exp(context: &mut Context, sp!(eloc, e_): &mut N::Exp) {
                     sp(param_loc, N::SequenceItem_::Bind(lvs, annot_arg))
                 })
                 .collect();
-            result.push_back(sp(body_loc, N::SequenceItem_::Seq(labeled_body)));
+            result.push_back(sp(body_loc, N::SequenceItem_::Seq(annot_body)));
 
             let block = N::Exp_::Block(N::Block {
                 name: None,

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/lambda_annotated_return_type_invalid.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/lambda_annotated_return_type_invalid.snap
@@ -10,8 +10,8 @@ error[E04007]: incompatible types
    │
 13 │         call!(|| -> X { 0 }).foo();
    │         ^^^^^^^^^^^^^^^^^^^^
-   │         │           │   │
-   │         │           │   Given: integer
+   │         │           │ │
+   │         │           │ Given: integer
    │         │           Expected: 'a::m::X'
    │         Invalid type annotation
 
@@ -20,7 +20,7 @@ error[E04006]: invalid subtype
    │
 14 │         call!(|| -> &mut u64 { &0 });
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   │         │           │          │
-   │         │           │          Given: '&{integer}'
+   │         │           │        │
+   │         │           │        Given: '&{integer}'
    │         │           Expected: '&mut u64'
    │         Invalid type annotation

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/lambda_return_invalid_conditional.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/lambda_return_invalid_conditional.snap
@@ -19,11 +19,11 @@ error[E04007]: incompatible types
   ┌─ tests/move_2024/typing/lambda_return_invalid_conditional.move:8:18
   │
 8 │         call!(|| { if (cond) 1 else return &0 });
-  │         ---------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
-  │         │        │                         │
-  │         │        │                         Found: '&{integer}'. It is not compatible with the other type.
-  │         │        Invalid lambda return
-  │         Found: integer. It is not compatible with the other type.
+  │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │                  │           │             │
+  │                  │           │             Found: '&{integer}'. It is not compatible with the other type.
+  │                  │           Found: integer. It is not compatible with the other type.
+  │                  Invalid lambda return
 
 error[E04007]: incompatible types
   ┌─ tests/move_2024/typing/lambda_return_invalid_conditional.move:9:18
@@ -39,11 +39,11 @@ error[E04007]: incompatible types
    ┌─ tests/move_2024/typing/lambda_return_invalid_conditional.move:10:18
    │
 10 │         call!(|| { if (cond) 1 else return &0 });
-   │         ---------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
-   │         │        │                         │
-   │         │        │                         Found: '&{integer}'. It is not compatible with the other type.
-   │         │        Invalid lambda return
-   │         Found: integer. It is not compatible with the other type.
+   │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │                  │           │             │
+   │                  │           │             Found: '&{integer}'. It is not compatible with the other type.
+   │                  │           Found: integer. It is not compatible with the other type.
+   │                  Invalid lambda return
 
 error[E04007]: incompatible types
    ┌─ tests/move_2024/typing/lambda_return_invalid_conditional.move:11:18

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/lambda_return_invalid_simple.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/lambda_return_invalid_simple.snap
@@ -6,31 +6,28 @@ info:
   lint: false
 ---
 error[E04007]: incompatible types
-  ┌─ tests/move_2024/typing/lambda_return_invalid_simple.move:8:23
+  ┌─ tests/move_2024/typing/lambda_return_invalid_simple.move:8:15
   │
 8 │         call!<u64>(|| return &0);
-  │               ---     ^^^^^^^^^
-  │               │       │      │
-  │               │       │      Found: '&{integer}'. It is not compatible with the other type.
-  │               │       Invalid lambda return
-  │               Found: 'u64'. It is not compatible with the other type.
+  │               ^^^     --------- Given: '&{integer}'
+  │               │        
+  │               Invalid type annotation
+  │               Expected: 'u64'
 
 error[E04007]: incompatible types
-  ┌─ tests/move_2024/typing/lambda_return_invalid_simple.move:9:24
+  ┌─ tests/move_2024/typing/lambda_return_invalid_simple.move:9:15
   │
 9 │         call!<&u64>(|| return 0);
-  │               ----     ^^^^^^^^
-  │               │        │
-  │               │        Invalid lambda return
-  │               │        Found: integer. It is not compatible with the other type.
-  │               Found: '&u64'. It is not compatible with the other type.
+  │               ^^^^     -------- Given: integer
+  │               │         
+  │               Invalid type annotation
+  │               Expected: '&u64'
 
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/typing/lambda_return_invalid_simple.move:10:30
+   ┌─ tests/move_2024/typing/lambda_return_invalid_simple.move:10:15
    │
 10 │         call!<(&u64, u8)>(|| return (&0, 1, 3));
-   │               ----------     ^^^^^^^^^^^^^^^^^
-   │               │              │      │
-   │               │              │      Found expression list of length 3: '(&{integer}, {integer}, {integer})'. It is not compatible with the other type of length 2.
-   │               │              Invalid lambda return
-   │               Found expression list of length 2: '(&u64, u8)'. It is not compatible with the other type of length 3.
+   │               ^^^^^^^^^^     ----------------- Given expression list of length 3: '(&{integer}, {integer}, {integer})'
+   │               │               
+   │               Invalid type annotation
+   │               Expected expression list of length 2: '(&u64, u8)'

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/lambda_subtyping_usage_respects_annotations.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/lambda_subtyping_usage_respects_annotations.snap
@@ -8,14 +8,13 @@ info:
 error[E04006]: invalid subtype
    ┌─ tests/move_2024/typing/lambda_subtyping_usage_respects_annotations.move:15:10
    │
+14 │     macro fun return_imm($f: || -> &u64) {
+   │                                    ---- Given: '&u64'
 15 │         *$f() = 0;
    │          ^^^^
    │          │
    │          Invalid mutation. Expected a mutable reference
    │          Expected: '&mut _'
-   ·
-24 │         return_imm!(|| &mut x);
-   │                        ------ Given: '&u64'
 
 error[E04006]: invalid subtype
    ┌─ tests/move_2024/typing/lambda_subtyping_usage_respects_annotations.move:20:24

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/simple_lambda_return.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/simple_lambda_return.move
@@ -1,0 +1,14 @@
+module a::m;
+
+macro fun call<$T>($f: || -> $T): $T {
+    $f()
+}
+
+#[allow(dead_code)]
+fun commands(cond: bool) {
+    call!(|| {
+        if (cond) return false;
+        if (cond) return false;
+        return true
+    });
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/simple_lambda_return.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/simple_lambda_return.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/simple_lambda_return_annot.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/simple_lambda_return_annot.move
@@ -1,0 +1,14 @@
+module a::m;
+
+macro fun call($f: || -> bool): bool {
+    $f()
+}
+
+#[allow(dead_code)]
+fun commands(cond: bool) {
+    call!(|| {
+        if (cond) return false;
+        if (cond) return false;
+        (return true: u8)
+    });
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/simple_lambda_return_annot.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/simple_lambda_return_annot.snap
@@ -1,0 +1,19 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+error[E04007]: incompatible types
+   ┌─ tests/move_2024/typing/simple_lambda_return_annot.move:9:14
+   │  
+ 9 │       call!(|| {
+   │ ╭──────────────^
+10 │ │         if (cond) return false;
+   │ │                          ----- Found: 'bool'. It is not compatible with the other type.
+11 │ │         if (cond) return false;
+12 │ │         (return true: u8)
+   │ │                       -- Found: 'u8'. It is not compatible with the other type.
+13 │ │     });
+   │ ╰─────^ Invalid lambda return

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/type_hole_macro_lambda_with_annotaitons.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/type_hole_macro_lambda_with_annotaitons.snap
@@ -15,7 +15,7 @@ error[E04007]: incompatible types
    │                                     Expected: 'u64'
    ·
 20 │         applyu64!(|_: _| -> _ { 0u8 });
-   │                                 --- Given: 'u8'
+   │                               ------- Given: 'u8'
 
 error[E04007]: incompatible types
    ┌─ tests/move_2024/typing/type_hole_macro_lambda_with_annotaitons.move:6:37
@@ -27,7 +27,7 @@ error[E04007]: incompatible types
    │                                     Expected: 'u64'
    ·
 21 │         applyu64!(|_: _| -> _ { b"hello" });
-   │                                 -------- Given: 'vector<u8>'
+   │                               ------------ Given: 'vector<u8>'
 
 error[E04007]: incompatible types
    ┌─ tests/move_2024/typing/type_hole_macro_lambda_with_annotaitons.move:10:46


### PR DESCRIPTION
## Description 

This moves lambda annotations to the named block instead of the interior sequence.

## Test plan 

A few tests updated and added

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
