### PR TITLE
[move][move-compiler][typing] Use `join` for break typing

### DIFF
--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -1090,6 +1090,11 @@ impl<'env, 'outer> Context<'env, 'outer> {
         }
     }
 
+    // pass in a location for a better error location
+    pub fn update_named_block_type(&mut self, name: BlockLabel, ty: Type) {
+        self.named_block_map.insert(name, ty);
+    }
+
     pub fn named_block_type_opt(&self, name: BlockLabel) -> Option<Type> {
         self.named_block_map.get(&name).cloned()
     }

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -1405,6 +1405,18 @@ fn join<T: ToString, F: FnOnce() -> T>(
     }
 }
 
+fn join_named_block_type<T: ToString, F: FnOnce() -> T>(
+    context: &mut Context,
+    name: BlockLabel,
+    loc: Loc,
+    msg: F,
+    exp_type: Type,
+) {
+    let block_ty = context.named_block_type(name, loc);
+    let loop_ty = join(context, loc, msg, exp_type, block_ty);
+    context.update_named_block_type(name, loop_ty);
+}
+
 fn invariant_no_report(
     context: &mut Context,
     pre_lhs: Type,
@@ -1745,11 +1757,13 @@ fn exp(context: &mut Context, ne: Box<N::Exp>) -> Box<T::Exp> {
                 eb.ty.clone(),
                 Type_::bool(bloc),
             );
-            let (_has_break, ty, body) = loop_body(context, eloc, name, false, nloop);
+            let (_has_break, ty, body) =
+                loop_body(context, eloc, name, /* while_loop */ true, nloop);
             (sp(eloc, ty.value), TE::While(name, eb, body))
         }
         NE::Loop(name, nloop) => {
-            let (has_break, ty, body) = loop_body(context, eloc, name, true, nloop);
+            let (has_break, ty, body) =
+                loop_body(context, eloc, name, /* while_loop */ false, nloop);
             let eloop = TE::Loop {
                 name,
                 has_break,
@@ -1834,13 +1848,12 @@ fn exp(context: &mut Context, ne: Box<N::Exp>) -> Box<T::Exp> {
         }
         NE::Give(usage, name, rhs) => {
             let break_rhs = exp(context, rhs);
-            let loop_ty = context.named_block_type(name, eloc);
-            subtype(
+            join_named_block_type(
                 context,
+                name,
                 eloc,
                 || format!("Invalid {usage}"),
                 break_rhs.ty.clone(),
-                loop_ty,
             );
             (sp(eloc, Type_::Anything), TE::Give(name, break_rhs))
         }
@@ -2171,11 +2184,11 @@ fn loop_body(
     context: &mut Context,
     eloc: Loc,
     name: BlockLabel,
-    is_loop: bool,
+    while_loop: bool,
     nloop: Box<N::Exp>,
 ) -> (bool, Type, Box<T::Exp>) {
     // set while break to ()
-    if !is_loop {
+    if while_loop {
         let while_loop_type = context.named_block_type(name, eloc);
         // while loop breaks must break with unit
         subtype(

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/lambda_return_mismatched.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/lambda_return_mismatched.snap
@@ -9,55 +9,49 @@ error[E04007]: incompatible types
   ┌─ tests/move_2024/typing/lambda_return_mismatched.move:9:23
   │
 8 │             if (cond) return 0;
-  │                       -------- Expected: integer
+  │                       -------- Found: integer. It is not compatible with the other type.
 9 │             if (cond) return false;
   │                       ^^^^^^^^^^^^
   │                       │      │
-  │                       │      Given: 'bool'
+  │                       │      Found: 'bool'. It is not compatible with the other type.
   │                       Invalid return
-
-error[E04007]: incompatible types
-   ┌─ tests/move_2024/typing/lambda_return_mismatched.move:10:13
-   │
- 8 │             if (cond) return 0;
-   │                       -------- Expected: integer
- 9 │             if (cond) return false;
-10 │             return @0
-   │             ^^^^^^^^^
-   │             │      │
-   │             │      Given: 'address'
-   │             Invalid return
 
 error[E04007]: incompatible types
    ┌─ tests/move_2024/typing/lambda_return_mismatched.move:15:13
    │
 13 │             if (cond) return &0;
-   │                              -- Expected: '&{integer}'
+   │                              -- Found: '&{integer}'. It is not compatible with the other type.
 14 │             if (cond) return &mut 0;
 15 │             return 0
    │             ^^^^^^^^
    │             │      │
-   │             │      Given: integer
+   │             │      Found: integer. It is not compatible with the other type.
    │             Invalid return
 
 error[E04007]: incompatible types
    ┌─ tests/move_2024/typing/lambda_return_mismatched.move:19:23
    │
 18 │             if (cond) return (&0, vector[0]);
-   │                                          - Expected: integer
+   │                                          - Found: integer. It is not compatible with the other type.
 19 │             if (cond) return (&mut 0, vector[false]);
    │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │                       │                      │
-   │                       │                      Given: 'bool'
+   │                       │                      Found: 'bool'. It is not compatible with the other type.
    │                       Invalid return
+
+error[E04010]: cannot infer type
+   ┌─ tests/move_2024/typing/lambda_return_mismatched.move:20:25
+   │
+20 │             return (&0, vector[])
+   │                         ^^^^^^^^ Could not infer this type. Try adding an annotation
 
 error[E04007]: incompatible types
    ┌─ tests/move_2024/typing/lambda_return_mismatched.move:24:23
    │
 23 │             if (cond) return (&0, vector[0]);
-   │                              --------------- Expected expression list of length 2: '(&{integer}, vector<{integer}>)'
+   │                              --------------- Found expression list of length 2: '(&{integer}, vector<{integer}>)'. It is not compatible with the other type of length 3.
 24 │             if (cond) return (&0, vector[0], 1);
    │                       ^^^^^^^^^^^^^^^^^^^^^^^^^
    │                       │      │
-   │                       │      Given expression list of length 3: '(&{integer}, vector<{integer}>, {integer})'
+   │                       │      Found expression list of length 3: '(&{integer}, vector<{integer}>, {integer})'. It is not compatible with the other type of length 2.
    │                       Invalid return

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_invalid_0.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_invalid_0.move
@@ -1,0 +1,8 @@
+module a::m;
+
+fun test(): u64 {
+    loop {
+        break 0u8
+    };
+    0u64
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_invalid_0.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_invalid_0.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_invalid_1.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_invalid_1.move
@@ -1,0 +1,8 @@
+module a::m;
+
+fun test(): u64 {
+    let x: u64 = loop {
+        break 0u8
+    };
+    x
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_invalid_1.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_invalid_1.snap
@@ -1,0 +1,17 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+error[E04007]: incompatible types
+  ┌─ tests/move_2024/typing/loop_break_invalid_1.move:4:12
+  │
+4 │     let x: u64 = loop {
+  │            ^^^
+  │            │
+  │            Invalid type annotation
+  │            Expected: 'u64'
+5 │         break 0u8
+  │               --- Given: 'u8'

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_invalid_2.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_invalid_2.move
@@ -1,0 +1,8 @@
+module a::m;
+
+fun test(): u64 {
+    let x = loop {
+        break 0u8
+    };
+    x
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_invalid_2.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_invalid_2.snap
@@ -1,0 +1,18 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+error[E04007]: incompatible types
+  ┌─ tests/move_2024/typing/loop_break_invalid_2.move:7:5
+  │
+3 │ fun test(): u64 {
+  │             --- Expected: 'u64'
+4 │     let x = loop {
+5 │         break 0u8
+  │               --- Given: 'u8'
+6 │     };
+7 │     x
+  │     ^ Invalid return expression

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_ref.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_ref.move
@@ -1,0 +1,8 @@
+module a::m;
+
+fun test(a: &mut u64): &u64 {
+    let x = loop {
+        break a
+    };
+    x
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_ref.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_ref.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_ref_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_ref_invalid.move
@@ -1,0 +1,8 @@
+module a::m;
+
+fun test(a: &u64): &mut u64 {
+    let x = loop {
+        break a
+    };
+    x
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_ref_invalid.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_ref_invalid.snap
@@ -1,0 +1,17 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+error[E04006]: invalid subtype
+  ┌─ tests/move_2024/typing/loop_break_ref_invalid.move:7:5
+  │
+3 │ fun test(a: &u64): &mut u64 {
+  │             ----   -------- Expected: '&mut u64'
+  │             │       
+  │             Given: '&u64'
+  ·
+7 │     x
+  │     ^ Invalid return expression

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_ref_invalid_1.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_ref_invalid_1.move
@@ -1,0 +1,7 @@
+module a::m;
+
+fun test(a: &u64): &mut u64 {
+    loop {
+        break a
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_ref_invalid_1.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_ref_invalid_1.snap
@@ -1,0 +1,18 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+error[E04006]: invalid subtype
+  ┌─ tests/move_2024/typing/loop_break_ref_invalid_1.move:4:5
+  │  
+3 │   fun test(a: &u64): &mut u64 {
+  │               ----   -------- Expected: '&mut u64'
+  │               │       
+  │               Given: '&u64'
+4 │ ╭     loop {
+5 │ │         break a
+6 │ │     }
+  │ ╰─────^ Invalid return expression

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_ref_invalid_2.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_ref_invalid_2.move
@@ -1,0 +1,8 @@
+module a::m;
+
+fun test(a: &u64): &mut u64 {
+    let b = a;
+    loop {
+        break b
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_ref_invalid_2.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/loop_break_ref_invalid_2.snap
@@ -1,0 +1,19 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+error[E04006]: invalid subtype
+  ┌─ tests/move_2024/typing/loop_break_ref_invalid_2.move:5:5
+  │  
+3 │   fun test(a: &u64): &mut u64 {
+  │               ----   -------- Expected: '&mut u64'
+  │               │       
+  │               Given: '&u64'
+4 │       let b = a;
+5 │ ╭     loop {
+6 │ │         break b
+7 │ │     }
+  │ ╰─────^ Invalid return expression

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/break_with_value_invalid.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/break_with_value_invalid.snap
@@ -40,25 +40,14 @@ error[E04007]: incompatible types
    │ ╰─────────^ Incompatible branches
 
 error[E04007]: incompatible types
-   ┌─ tests/move_check/typing/break_with_value_invalid.move:19:9
-   │
-18 │     fun t3(cond: bool): bool {
-   │                         ---- Expected: 'bool'
-19 │         while (cond) { break true } 
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   │         │
-   │         Invalid return expression
-   │         Given: '()'
-
-error[E04007]: incompatible types
    ┌─ tests/move_check/typing/break_with_value_invalid.move:19:24
    │
 19 │         while (cond) { break true } 
    │         ---------------^^^^^^^^^^--
    │         │              │     │
-   │         │              │     Given: 'bool'
+   │         │              │     Found: 'bool'. It is not compatible with the other type.
    │         │              Invalid break
-   │         Expected: '()'
+   │         Found: '()'. It is not compatible with the other type.
 
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/break_with_value_invalid.move:23:24
@@ -66,9 +55,9 @@ error[E04007]: incompatible types
 23 │         while (cond) { break true }; 
    │         ---------------^^^^^^^^^^--
    │         │              │     │
-   │         │              │     Given: 'bool'
+   │         │              │     Found: 'bool'. It is not compatible with the other type.
    │         │              Invalid break
-   │         Expected: '()'
+   │         Found: '()'. It is not compatible with the other type.
 
 error[E04007]: incompatible types
    ┌─ tests/move_check/typing/break_with_value_invalid.move:23:36


### PR DESCRIPTION
## Description 

This fixes a small bug where we were using `subtype` instead of `join` for break return types.

## Test plan 

New tests plus tests updated.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
