### PR TITLE
[move][move-compiler][typing] Use `join` for match arm typing

### DIFF
--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/abc_match_ref_invalid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/abc_match_ref_invalid.move
@@ -6,7 +6,7 @@ module 0x42::m {
         C(T)
     }
 
-    fun t0(abc: &ABC): u64 {
+    fun t0(abc: &ABC<u64>): u64 {
         match (abc) {
             ABC::C(x) => x,
             ABC::A(x) => x,

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/abc_match_ref_invalid.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/abc_match_ref_invalid.snap
@@ -5,33 +5,15 @@ info:
   edition: 2024.alpha
   lint: false
 ---
-error[E03008]: too few type arguments
-  ┌─ tests/move_2024/matching/abc_match_ref_invalid.move:9:18
-  │
-9 │     fun t0(abc: &ABC): u64 {
-  │                  ^^^ Invalid instantiation of '0x42::m::ABC'. Expected 1 type argument(s) but got 0
-
 error[E04007]: incompatible types
-   ┌─ tests/move_2024/matching/abc_match_ref_invalid.move:10:9
+   ┌─ tests/move_2024/matching/abc_match_ref_invalid.move:10:21
    │  
- 9 │       fun t0(abc: &ABC): u64 {
-   │                          --- Expected: 'u64'
-10 │ ╭         match (abc) {
+10 │           match (abc) {
+   │ ╭─────────────────────^
 11 │ │             ABC::C(x) => x,
-   │ │             --------- Given: '&_'
 12 │ │             ABC::A(x) => x,
+   │ │                    - Found: '&u64'. It is not compatible with the other type.
 13 │ │             ABC::B => 1,
+   │ │                       - Found: integer. It is not compatible with the other type.
 14 │ │         }
-   │ ╰─────────^ Invalid return expression
-
-error[E04007]: incompatible types
-   ┌─ tests/move_2024/matching/abc_match_ref_invalid.move:13:23
-   │
-11 │             ABC::C(x) => x,
-   │             --------- Expected: '&_'
-12 │             ABC::A(x) => x,
-13 │             ABC::B => 1,
-   │                       ^
-   │                       │
-   │                       Invalid right-hand side expression
-   │                       Given: integer
+   │ ╰─────────^ invalid match arm

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/match_arm_promotion.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/match_arm_promotion.move
@@ -1,0 +1,8 @@
+module a::m;
+
+fun test(x: &u64, y: &mut u64): &u64 {
+    match (true) {
+        true => x,
+        false => y,
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/match_arm_promotion.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/match_arm_promotion.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/matching/struct_match_mut_invalid.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/matching/struct_match_mut_invalid.snap
@@ -8,18 +8,16 @@ info:
 error[E04003]: built-in operation not supported
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:33:21
    │
- 6 │     public struct NBase has copy, drop { t: u64 }
-   │                                             --- Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
-   ·
+32 │            NBase { mut t } => {
+   │                        - Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 33 │                 t = t + 1;
    │                     ^ Invalid argument to '+'
 
 error[E04007]: incompatible types
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:33:23
    │
- 6 │     public struct NBase has copy, drop { t: u64 }
-   │                                             --- Found: '&u64'. It is not compatible with the other type.
-   ·
+32 │            NBase { mut t } => {
+   │                        - Found: '&u64'. It is not compatible with the other type.
 33 │                 t = t + 1;
    │                       ^ - Found: integer. It is not compatible with the other type.
    │                       │  
@@ -28,27 +26,24 @@ error[E04007]: incompatible types
 error[E04003]: built-in operation not supported
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:33:25
    │
- 6 │     public struct NBase has copy, drop { t: u64 }
-   │                                             --- Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
-   ·
+32 │            NBase { mut t } => {
+   │                        - Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 33 │                 t = t + 1;
    │                         ^ Invalid argument to '+'
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:42:21
    │
- 6 │     public struct NBase has copy, drop { t: u64 }
-   │                                             --- Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
-   ·
+41 │            NBase { t: mut x } => {
+   │                           - Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 42 │                 x = x + 1;
    │                     ^ Invalid argument to '+'
 
 error[E04007]: incompatible types
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:42:23
    │
- 6 │     public struct NBase has copy, drop { t: u64 }
-   │                                             --- Found: '&u64'. It is not compatible with the other type.
-   ·
+41 │            NBase { t: mut x } => {
+   │                           - Found: '&u64'. It is not compatible with the other type.
 42 │                 x = x + 1;
    │                       ^ - Found: integer. It is not compatible with the other type.
    │                       │  
@@ -57,27 +52,24 @@ error[E04007]: incompatible types
 error[E04003]: built-in operation not supported
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:42:25
    │
- 6 │     public struct NBase has copy, drop { t: u64 }
-   │                                             --- Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
-   ·
+41 │            NBase { t: mut x } => {
+   │                           - Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 42 │                 x = x + 1;
    │                         ^ Invalid argument to '+'
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:51:20
    │
- 8 │     public struct PBase(u64) has copy, drop;
-   │                         --- Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
-   ·
+50 │            PBase(mut x) => {
+   │                      - Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 51 │                x = x + 1;
    │                    ^ Invalid argument to '+'
 
 error[E04007]: incompatible types
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:51:22
    │
- 8 │     public struct PBase(u64) has copy, drop;
-   │                         --- Found: '&u64'. It is not compatible with the other type.
-   ·
+50 │            PBase(mut x) => {
+   │                      - Found: '&u64'. It is not compatible with the other type.
 51 │                x = x + 1;
    │                      ^ - Found: integer. It is not compatible with the other type.
    │                      │  
@@ -86,27 +78,24 @@ error[E04007]: incompatible types
 error[E04003]: built-in operation not supported
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:51:24
    │
- 8 │     public struct PBase(u64) has copy, drop;
-   │                         --- Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
-   ·
+50 │            PBase(mut x) => {
+   │                      - Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 51 │                x = x + 1;
    │                        ^ Invalid argument to '+'
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:60:21
    │
- 6 │     public struct NBase has copy, drop { t: u64 }
-   │                                             --- Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
-   ·
+59 │            NPoly { t : NBase { mut t } } => {
+   │                                    - Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 60 │                 t = t + 1;
    │                     ^ Invalid argument to '+'
 
 error[E04007]: incompatible types
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:60:23
    │
- 6 │     public struct NBase has copy, drop { t: u64 }
-   │                                             --- Found: '&u64'. It is not compatible with the other type.
-   ·
+59 │            NPoly { t : NBase { mut t } } => {
+   │                                    - Found: '&u64'. It is not compatible with the other type.
 60 │                 t = t + 1;
    │                       ^ - Found: integer. It is not compatible with the other type.
    │                       │  
@@ -115,27 +104,24 @@ error[E04007]: incompatible types
 error[E04003]: built-in operation not supported
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:60:25
    │
- 6 │     public struct NBase has copy, drop { t: u64 }
-   │                                             --- Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
-   ·
+59 │            NPoly { t : NBase { mut t } } => {
+   │                                    - Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 60 │                 t = t + 1;
    │                         ^ Invalid argument to '+'
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:69:21
    │
- 6 │     public struct NBase has copy, drop { t: u64 }
-   │                                             --- Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
-   ·
+68 │            NPoly { t : NBase { t: mut x } } => {
+   │                                       - Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 69 │                 x = x + 1;
    │                     ^ Invalid argument to '+'
 
 error[E04007]: incompatible types
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:69:23
    │
- 6 │     public struct NBase has copy, drop { t: u64 }
-   │                                             --- Found: '&u64'. It is not compatible with the other type.
-   ·
+68 │            NPoly { t : NBase { t: mut x } } => {
+   │                                       - Found: '&u64'. It is not compatible with the other type.
 69 │                 x = x + 1;
    │                       ^ - Found: integer. It is not compatible with the other type.
    │                       │  
@@ -144,27 +130,24 @@ error[E04007]: incompatible types
 error[E04003]: built-in operation not supported
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:69:25
    │
- 6 │     public struct NBase has copy, drop { t: u64 }
-   │                                             --- Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
-   ·
+68 │            NPoly { t : NBase { t: mut x } } => {
+   │                                       - Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 69 │                 x = x + 1;
    │                         ^ Invalid argument to '+'
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:78:21
    │
- 8 │     public struct PBase(u64) has copy, drop;
-   │                         --- Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
-   ·
+77 │            NPoly { t : PBase(mut x) } => {
+   │                                  - Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 78 │                 x = x + 1;
    │                     ^ Invalid argument to '+'
 
 error[E04007]: incompatible types
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:78:23
    │
- 8 │     public struct PBase(u64) has copy, drop;
-   │                         --- Found: '&u64'. It is not compatible with the other type.
-   ·
+77 │            NPoly { t : PBase(mut x) } => {
+   │                                  - Found: '&u64'. It is not compatible with the other type.
 78 │                 x = x + 1;
    │                       ^ - Found: integer. It is not compatible with the other type.
    │                       │  
@@ -173,27 +156,24 @@ error[E04007]: incompatible types
 error[E04003]: built-in operation not supported
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:78:25
    │
- 8 │     public struct PBase(u64) has copy, drop;
-   │                         --- Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
-   ·
+77 │            NPoly { t : PBase(mut x) } => {
+   │                                  - Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 78 │                 x = x + 1;
    │                         ^ Invalid argument to '+'
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:87:21
    │
- 6 │     public struct NBase has copy, drop { t: u64 }
-   │                                             --- Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
-   ·
+86 │            PPoly(NBase { t: mut x }) => {
+   │                                 - Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 87 │                 x = x + 1;
    │                     ^ Invalid argument to '+'
 
 error[E04007]: incompatible types
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:87:23
    │
- 6 │     public struct NBase has copy, drop { t: u64 }
-   │                                             --- Found: '&u64'. It is not compatible with the other type.
-   ·
+86 │            PPoly(NBase { t: mut x }) => {
+   │                                 - Found: '&u64'. It is not compatible with the other type.
 87 │                 x = x + 1;
    │                       ^ - Found: integer. It is not compatible with the other type.
    │                       │  
@@ -202,27 +182,24 @@ error[E04007]: incompatible types
 error[E04003]: built-in operation not supported
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:87:25
    │
- 6 │     public struct NBase has copy, drop { t: u64 }
-   │                                             --- Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
-   ·
+86 │            PPoly(NBase { t: mut x }) => {
+   │                                 - Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 87 │                 x = x + 1;
    │                         ^ Invalid argument to '+'
 
 error[E04003]: built-in operation not supported
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:96:21
    │
- 8 │     public struct PBase(u64) has copy, drop;
-   │                         --- Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
-   ·
+95 │            PPoly(PBase(mut x)) => {
+   │                            - Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 96 │                 x = x + 1;
    │                     ^ Invalid argument to '+'
 
 error[E04007]: incompatible types
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:96:23
    │
- 8 │     public struct PBase(u64) has copy, drop;
-   │                         --- Found: '&u64'. It is not compatible with the other type.
-   ·
+95 │            PPoly(PBase(mut x)) => {
+   │                            - Found: '&u64'. It is not compatible with the other type.
 96 │                 x = x + 1;
    │                       ^ - Found: integer. It is not compatible with the other type.
    │                       │  
@@ -231,8 +208,7 @@ error[E04007]: incompatible types
 error[E04003]: built-in operation not supported
    ┌─ tests/move_2024/matching/struct_match_mut_invalid.move:96:25
    │
- 8 │     public struct PBase(u64) has copy, drop;
-   │                         --- Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
-   ·
+95 │            PPoly(PBase(mut x)) => {
+   │                            - Found: '&u64'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 96 │                 x = x + 1;
    │                         ^ Invalid argument to '+'


### PR DESCRIPTION
## Description 

Makes match arms join, which they should have always done.

Also does a small bit of location cleanup for typing of bindings to improve those errors just a touch.

## Test plan 

New tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
