### PR TITLE
[state sync] [cp] support path to creds in remote store options (#22572)

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -1124,8 +1124,12 @@ pub struct StateArchiveConfig {
     pub concurrency: usize,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ingestion_url: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    remote_store_options: Vec<(String, String)>,
+    #[serde(
+        skip_serializing_if = "Vec::is_empty",
+        default,
+        deserialize_with = "deserialize_remote_store_options"
+    )]
+    pub remote_store_options: Vec<(String, String)>,
 }
 
 #[derive(Default, Debug, Clone, Deserialize, Serialize)]
@@ -1459,6 +1463,42 @@ pub struct StateDebugDumpConfig {
     pub dump_file_directory: Option<PathBuf>,
 }
 
+fn read_credential_from_path_or_literal(value: &str) -> Result<String, std::io::Error> {
+    let path = Path::new(value);
+    if path.exists() && path.is_file() {
+        std::fs::read_to_string(path).map(|content| content.trim().to_string())
+    } else {
+        Ok(value.to_string())
+    }
+}
+
+// Custom deserializer for remote store options that supports file paths or literal values
+fn deserialize_remote_store_options<'de, D>(
+    deserializer: D,
+) -> Result<Vec<(String, String)>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error;
+
+    let raw_options: Vec<(String, String)> = Vec::deserialize(deserializer)?;
+    let mut processed_options = Vec::new();
+
+    for (key, value) in raw_options {
+        match read_credential_from_path_or_literal(&value) {
+            Ok(processed_value) => processed_options.push((key, processed_value)),
+            Err(e) => {
+                return Err(D::Error::custom(format!(
+                    "Failed to read credential for key '{}': {}",
+                    key, e
+                )))
+            }
+        }
+    }
+
+    Ok(processed_options)
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
@@ -1468,7 +1508,7 @@ mod tests {
     use sui_keys::keypair_file::{write_authority_keypair_to_file, write_keypair_to_file};
     use sui_types::crypto::{get_key_pair_from_rng, AuthorityKeyPair, NetworkKeyPair, SuiKeyPair};
 
-    use super::Genesis;
+    use super::{Genesis, StateArchiveConfig};
     use crate::NodeConfig;
 
     #[test]
@@ -1531,6 +1571,79 @@ mod tests {
             template.worker_key_pair().public(),
             worker_key_pair.public()
         );
+    }
+
+    #[test]
+    fn test_remote_store_options_file_path_support() {
+        // Create temporary credential files
+        let temp_dir = std::env::temp_dir();
+        let access_key_file = temp_dir.join("test_access_key");
+        let secret_key_file = temp_dir.join("test_secret_key");
+
+        std::fs::write(&access_key_file, "test_access_key_value").unwrap();
+        std::fs::write(&secret_key_file, "test_secret_key_value\n").unwrap();
+
+        let yaml_config = format!(
+            r#"
+object-store-config: null
+concurrency: 5
+ingestion-url: "https://example.com"
+remote-store-options:
+  - ["aws_access_key_id", "{}"]
+  - ["aws_secret_access_key", "{}"]
+  - ["literal_key", "literal_value"]
+"#,
+            access_key_file.to_string_lossy(),
+            secret_key_file.to_string_lossy()
+        );
+
+        let config: StateArchiveConfig = serde_yaml::from_str(&yaml_config).unwrap();
+
+        // Verify that file paths were resolved and literal values preserved
+        assert_eq!(config.remote_store_options.len(), 3);
+
+        let access_key_option = config
+            .remote_store_options
+            .iter()
+            .find(|(key, _)| key == "aws_access_key_id")
+            .unwrap();
+        assert_eq!(access_key_option.1, "test_access_key_value");
+
+        let secret_key_option = config
+            .remote_store_options
+            .iter()
+            .find(|(key, _)| key == "aws_secret_access_key")
+            .unwrap();
+        assert_eq!(secret_key_option.1, "test_secret_key_value");
+
+        let literal_option = config
+            .remote_store_options
+            .iter()
+            .find(|(key, _)| key == "literal_key")
+            .unwrap();
+        assert_eq!(literal_option.1, "literal_value");
+
+        // Clean up
+        std::fs::remove_file(&access_key_file).ok();
+        std::fs::remove_file(&secret_key_file).ok();
+    }
+
+    #[test]
+    fn test_remote_store_options_literal_values_only() {
+        let yaml_config = r#"
+object-store-config: null
+concurrency: 5
+ingestion-url: "https://example.com"
+remote-store-options:
+  - ["aws_access_key_id", "literal_access_key"]
+  - ["aws_secret_access_key", "literal_secret_key"]
+"#;
+
+        let config: StateArchiveConfig = serde_yaml::from_str(yaml_config).unwrap();
+
+        assert_eq!(config.remote_store_options.len(), 2);
+        assert_eq!(config.remote_store_options[0].1, "literal_access_key");
+        assert_eq!(config.remote_store_options[1].1, "literal_secret_key");
     }
 }
 

--- a/docs/content/guides/operator/archives.mdx
+++ b/docs/content/guides/operator/archives.mdx
@@ -18,9 +18,12 @@ To enable your node to fallback to an archive in case of lag, add this to your f
 
 ```yaml
 state-archive-read-config:
-  - ingestion-url: "https://checkpoints.mainnet.sui.io"
+  - ingestion-url: "https://s3.us-west-2.amazonaws.com/mysten-mainnet-checkpoints"
     # How many objects to read ahead when catching up
     concurrency: 5
+    remote-store-options:
+      - ["aws_access_key_id", <YOUR_AWS_ACCESS_KEY_ID|PATH_TO_AWS_ACCESS_KEY>]
+      - ["aws_secret_access_key", <AWS_SECRET_ACCESS_KEY|PATH_TO_AWS_SECRET_ACCESS_KEY>]
 ```
 
 </TabItem>


### PR DESCRIPTION
support path based remote store options

unit tests

cp #22572

---

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [x] Nodes (Validators and Full nodes): support path based remote-store options for fullnode state sync fallback
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
