### PR TITLE
[rpc-alt] retry kv and tx_digest read operations

### DIFF
--- a/crates/sui-indexer-alt-jsonrpc/src/api/transactions/error.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/transactions/error.rs
@@ -14,8 +14,8 @@ pub(super) enum Error {
     #[error("Pagination issue: {0}")]
     Pagination(#[from] crate::paginate::Error),
 
-    #[error("Balance changes for transaction {0} have been pruned")]
-    PrunedBalanceChanges(TransactionDigest),
+    #[error("Balance changes for transaction {0} are either pruned or not yet available")]
+    BalanceChangesNotFound(TransactionDigest),
 
     #[error(
         "Transaction {0} affected object {} pruned at version {2}",

--- a/crates/sui-indexer-alt-jsonrpc/src/api/transactions/filter.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/transactions/filter.rs
@@ -399,12 +399,12 @@ async fn from_sequence_numbers(
 
     // Get digests from the table and retry any of the digests that are not found.
     let config = &ctx.config().transactions;
-    let retries = config.tx_digest_retry_count;
+    let retries = config.tx_retry_count;
     let mut retry_interval =
-        tokio::time::interval(Duration::from_millis(config.tx_digest_retry_interval_ms));
+        tokio::time::interval(Duration::from_millis(config.tx_retry_interval_ms));
     let mut keys: Vec<_> = rows.iter().map(|&seq| TxDigestKey(seq as u64)).collect();
     let mut digests: HashMap<TxDigestKey, StoredTxDigest> = HashMap::new();
-    for _ in 0..retries {
+    for _ in 0..=retries {
         retry_interval.tick().await;
 
         digests.extend(

--- a/crates/sui-indexer-alt-jsonrpc/src/api/transactions/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/transactions/mod.rs
@@ -103,9 +103,33 @@ impl QueryTransactionsApiServer for QueryTransactions {
 
         let options = query.options.unwrap_or_default();
 
-        let tx_futures = digests
-            .iter()
-            .map(|d| response::transaction(ctx, *d, &options));
+        let tx_futures = digests.iter().map(|d| {
+            let options = options.clone();
+            async move {
+                let mut tx = response::transaction(ctx, *d, &options).await;
+
+                let config = &ctx.config().transactions;
+                let mut interval = tokio::time::interval(std::time::Duration::from_millis(
+                    config.tx_digest_retry_interval_ms,
+                ));
+
+                for _ in 0..config.tx_digest_retry_count {
+                    // Retry only if the error is an invalid params error, which can only be due to
+                    // the transaction not being found in the kv store or tx balance changes table.
+                    if let Err(RpcError::InvalidParams(_)) = tx {
+                        interval.tick().await;
+                        tx = response::transaction(ctx, *d, &options).await;
+                        ctx.metrics()
+                            .read_retries
+                            .with_label_values(&["kv_tx"])
+                            .inc();
+                    } else {
+                        break;
+                    }
+                }
+                tx
+            }
+        });
 
         let data = future::join_all(tx_futures)
             .await

--- a/crates/sui-indexer-alt-jsonrpc/src/api/transactions/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/transactions/mod.rs
@@ -104,24 +104,26 @@ impl QueryTransactionsApiServer for QueryTransactions {
         let options = query.options.unwrap_or_default();
 
         let tx_futures = digests.iter().map(|d| {
-            let options = options.clone();
-            async move {
+            async {
                 let mut tx = response::transaction(ctx, *d, &options).await;
 
                 let config = &ctx.config().transactions;
                 let mut interval = tokio::time::interval(std::time::Duration::from_millis(
-                    config.tx_digest_retry_interval_ms,
+                    config.tx_retry_interval_ms,
                 ));
 
-                for _ in 0..config.tx_digest_retry_count {
+                for _ in 0..config.tx_retry_count {
                     // Retry only if the error is an invalid params error, which can only be due to
                     // the transaction not being found in the kv store or tx balance changes table.
-                    if let Err(RpcError::InvalidParams(_)) = tx {
+                    if let Err(RpcError::InvalidParams(
+                        _e @ (Error::BalanceChangesNotFound(_) | Error::NotFound(_)),
+                    )) = tx
+                    {
                         interval.tick().await;
                         tx = response::transaction(ctx, *d, &options).await;
                         ctx.metrics()
                             .read_retries
-                            .with_label_values(&["kv_tx"])
+                            .with_label_values(&["tx_response"])
                             .inc();
                     } else {
                         break;

--- a/crates/sui-indexer-alt-jsonrpc/src/api/transactions/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/transactions/response.rs
@@ -60,7 +60,7 @@ pub(super) async fn transaction(
         .transpose()
         .context("Failed to fetch balance changes from store")?
     {
-        Some(None) => return Err(invalid_params(Error::PrunedBalanceChanges(digest))),
+        Some(None) => return Err(invalid_params(Error::BalanceChangesNotFound(digest))),
         Some(changes) => changes,
         None => None,
     };

--- a/crates/sui-indexer-alt-jsonrpc/src/config.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/config.rs
@@ -143,6 +143,13 @@ pub struct TransactionsConfig {
 
     /// The interval between tx_digest retry attempts in milliseconds.
     pub tx_digest_retry_interval_ms: u64,
+
+    /// The number of times to retry a kv get operation to the transaction table. Retry is needed when a transaction
+    /// is not yet found in the kv store due to the kv being behind the pg table's checkpoint watermark.
+    pub kv_retry_count: usize,
+
+    /// The interval between kv retry attempts in milliseconds.
+    pub kv_retry_interval_ms: u64,
 }
 
 #[DefaultConfig]
@@ -152,6 +159,8 @@ pub struct TransactionsLayer {
     pub max_page_size: Option<usize>,
     pub tx_digest_retry_count: Option<usize>,
     pub tx_digest_retry_interval_ms: Option<u64>,
+    pub kv_retry_count: Option<usize>,
+    pub kv_retry_interval_ms: Option<u64>,
 
     #[serde(flatten)]
     pub extra: toml::Table,
@@ -296,6 +305,10 @@ impl TransactionsLayer {
             tx_digest_retry_interval_ms: self
                 .tx_digest_retry_interval_ms
                 .unwrap_or(base.tx_digest_retry_interval_ms),
+            kv_retry_count: self.kv_retry_count.unwrap_or(base.kv_retry_count),
+            kv_retry_interval_ms: self
+                .kv_retry_interval_ms
+                .unwrap_or(base.kv_retry_interval_ms),
         }
     }
 }
@@ -406,6 +419,8 @@ impl Default for TransactionsConfig {
             max_page_size: 100,
             tx_digest_retry_count: 5,
             tx_digest_retry_interval_ms: 100,
+            kv_retry_count: 5,
+            kv_retry_interval_ms: 100,
         }
     }
 }
@@ -481,6 +496,8 @@ impl From<TransactionsConfig> for TransactionsLayer {
             max_page_size: Some(config.max_page_size),
             tx_digest_retry_count: Some(config.tx_digest_retry_count),
             tx_digest_retry_interval_ms: Some(config.tx_digest_retry_interval_ms),
+            kv_retry_count: Some(config.kv_retry_count),
+            kv_retry_interval_ms: Some(config.kv_retry_interval_ms),
             extra: Default::default(),
         }
     }

--- a/crates/sui-indexer-alt-jsonrpc/src/data.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data.rs
@@ -32,9 +32,9 @@ pub(crate) async fn load_live(
     // Read from kv store and retry if the object is not found.
     let mut object = None;
     let config = &ctx.config().objects;
-    let mut interval = tokio::time::interval(Duration::from_millis(config.kv_retry_interval_ms));
+    let mut interval = tokio::time::interval(Duration::from_millis(config.obj_retry_interval_ms));
 
-    for _ in 0..config.kv_retry_count {
+    for _ in 0..=config.obj_retry_count {
         interval.tick().await;
 
         object = ctx

--- a/crates/sui-indexer-alt-jsonrpc/src/metrics/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/metrics/mod.rs
@@ -29,6 +29,7 @@ pub struct RpcMetrics {
     pub requests_failed: IntCounterVec,
 
     pub owned_objects_filter_scans: Histogram,
+    pub read_retries: IntCounterVec,
 }
 
 impl RpcMetrics {
@@ -72,6 +73,14 @@ impl RpcMetrics {
                 "Number of pages of owned objects scanned in response to compound owned object filters",
                 PAGE_SCAN_BUCKETS.to_vec(),
                 registry,
+            )
+            .unwrap(),
+
+            read_retries: register_int_counter_vec_with_registry!(
+                "read_retries",
+                "Number of retries for reads from Bigtable or Postgres tables",
+                &["table"],
+                registry
             )
             .unwrap(),
         })


### PR DESCRIPTION
## Description 

From traffic shadowing we see that internal errors can arise due to kv objects and tx_digests table being behind other objects/tx tables. This PR aims to resolve these internal errors by retrying the reads.

## Test plan 

tested with a local jsonrpc server

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
