### PR TITLE
[static ptb] Switch TxContext to a Location 

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/size_limits/deleted_id_limits_tests@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/deleted_id_limits_tests@v2.snap
@@ -22,7 +22,7 @@ gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 9
 task 4, lines 39-41:
 //# run Test::M1::delete_n_ids --args 2048 --gas-budget 100000000000000
 mutated: object(0,0)
-gas summary: computation_cost: 16000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 14000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 5, lines 42-44:
 //# run Test::M1::delete_n_ids --args 2049 --gas-budget 100000000000000

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/new_id_limits_tests@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/new_id_limits_tests@v2.snap
@@ -22,7 +22,7 @@ gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 9
 task 4, lines 40-42:
 //# run Test::M1::create_n_ids --args 2048 --gas-budget 100000000000000
 mutated: object(0,0)
-gas summary: computation_cost: 16000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 14000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 5, lines 43-45:
 //# run Test::M1::create_n_ids --args 2049 --gas-budget 100000000000000

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/object_runtime_limits@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/object_runtime_limits@v2.snap
@@ -22,7 +22,7 @@ task 3, line 30:
 //# run a::m::add_n_items --sender A --args 1000 --gas-budget 1000000000000 --summarize
 created: 2000
 mutated: 1
-gas summary: computation_cost: 212000000, storage_cost: 2691388000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 201000000, storage_cost: 2691388000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4, line 32:
 //# run a::m::add_n_items --sender A --args 1025 --gas-budget 1000000000000

--- a/crates/sui-adapter-transactional-tests/tests/size_limits/transfered_id_limits_tests@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/size_limits/transfered_id_limits_tests@v2.snap
@@ -25,7 +25,7 @@ task 4, lines 39-41:
 //# run Test::M1::transfer_n_ids --args 2048 --gas-budget 100000000000000 --summarize
 created: 2048
 mutated: 1
-gas summary: computation_cost: 33000000, storage_cost: 2522485600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 18000000, storage_cost: 2522485600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 5, lines 42-44:
 //# run Test::M1::transfer_n_ids --args 2049 --gas-budget 100000000000000

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -1133,6 +1133,15 @@ impl TxContext {
         }
     }
 
+    pub fn type_() -> StructTag {
+        StructTag {
+            address: SUI_FRAMEWORK_ADDRESS,
+            module: TX_CONTEXT_MODULE_NAME.to_owned(),
+            name: TX_CONTEXT_STRUCT_NAME.to_owned(),
+            type_params: vec![],
+        }
+    }
+
     pub fn epoch(&self) -> EpochId {
         self.epoch
     }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/ast.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/ast.rs
@@ -115,7 +115,6 @@ pub struct LoadedFunction {
     pub name: Identifier,
     pub type_arguments: Vec<Type>,
     pub signature: LoadedFunctionInstantiation,
-    pub tx_context: TxContextKind,
     pub linkage: RootedLinkage,
     pub instruction_length: CodeOffset,
     pub definition_index: FunctionDefinitionIndex,

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/ast.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/ast.rs
@@ -89,6 +89,7 @@ pub struct MoveCall {
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum Location {
+    TxContext,
     GasCoin,
     Input(u16),
     Result(u16, u16),
@@ -183,6 +184,7 @@ impl TryFrom<Type> for VectorSpecialization {
 impl fmt::Display for Location {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Location::TxContext => write!(f, "TxContext"),
             Location::GasCoin => write!(f, "GasCoin"),
             Location::Input(idx) => write!(f, "Input({idx})"),
             Location::Result(result_idx, nested_idx) => {

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/drop_safety.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/drop_safety.rs
@@ -92,6 +92,7 @@ mod verify {
     struct Value;
 
     struct Context {
+        tx_context: Option<Value>,
         gas_coin: Option<Value>,
         inputs: Vec<Option<Value>>,
         results: Vec<Vec<Option<Value>>>,
@@ -101,6 +102,7 @@ mod verify {
         fn new(ast: &T::Transaction) -> Result<Self, ExecutionError> {
             let inputs = ast.inputs.iter().map(|_| Some(Value)).collect();
             Ok(Self {
+                tx_context: Some(Value),
                 gas_coin: Some(Value),
                 inputs,
                 results: Vec::with_capacity(ast.commands.len()),
@@ -109,6 +111,7 @@ mod verify {
 
         fn location(&mut self, l: T::Location) -> &mut Option<Value> {
             match l {
+                T::Location::TxContext => &mut self.tx_context,
                 T::Location::GasCoin => &mut self.gas_coin,
                 T::Location::Input(i) => &mut self.inputs[i as usize],
                 T::Location::Result(i, j) => &mut self.results[i as usize][j as usize],
@@ -129,6 +132,7 @@ mod verify {
         }
 
         let Context {
+            tx_context,
             gas_coin,
             inputs,
             results,
@@ -143,6 +147,7 @@ mod verify {
                 drop_value_opt((i, j), vopt, ty)?;
             }
         }
+        assert_invariant!(tx_context.is_some(), "tx_context should never be moved");
         Ok(())
     }
 

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/input_arguments.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/input_arguments.rs
@@ -277,7 +277,7 @@ fn check_obj_by_mut_ref(
     location: &T::Location,
 ) -> Result<(), ExecutionError> {
     match location {
-        T::Location::GasCoin | T::Location::Result(_, _) => Ok(()),
+        T::Location::GasCoin | T::Location::Result(_, _) | T::Location::TxContext => Ok(()),
         T::Location::Input(idx) => match &context.inputs[*idx as usize] {
             None
             | Some(ObjectUsage {
@@ -302,7 +302,7 @@ fn check_by_value(
     location: &T::Location,
 ) -> Result<(), ExecutionError> {
     match location {
-        T::Location::GasCoin | T::Location::Result(_, _) => Ok(()),
+        T::Location::TxContext | T::Location::GasCoin | T::Location::Result(_, _) => Ok(()),
         T::Location::Input(idx) => match &context.inputs[*idx as usize] {
             None
             | Some(ObjectUsage {
@@ -343,6 +343,6 @@ fn check_gas_by_value_loc(idx: u16, location: &T::Location) -> Result<(), Execut
             CommandArgumentError::InvalidGasCoinUsage,
             idx as usize,
         )),
-        T::Location::Input(_) | T::Location::Result(_, _) => Ok(()),
+        T::Location::TxContext | T::Location::Input(_) | T::Location::Result(_, _) => Ok(()),
     }
 }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/move_functions.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/move_functions.rs
@@ -61,6 +61,7 @@ impl Context {
 
     fn is_loc_dirty(&self, location: T::Location) -> bool {
         match location {
+            T::Location::TxContext => false, // TxContext is never dirty
             T::Location::GasCoin => self.gas_coin.is_dirty(),
             T::Location::Input(i) => self.inputs[i as usize].is_dirty(),
             T::Location::Result(i, j) => self.results[i as usize][j as usize].is_dirty(),
@@ -80,6 +81,7 @@ impl Context {
 
     fn mark_loc_dirty(&mut self, location: T::Location) {
         match location {
+            T::Location::TxContext => (), // TxContext is never dirty, so nothing to do
             T::Location::GasCoin => self.gas_coin = IsDirty::Fixed { is_dirty: true },
             T::Location::Input(i) => match &mut self.inputs[i as usize] {
                 // if it needs to be dirtied, it will first be marked as fixed


### PR DESCRIPTION
## Description 

- There were a few spots where TxContext was special cased as a parameter at the end
- Now TxContext is a location that is borrowed like anything else

## Test plan 

- Updated tests... though I'm surprised they changed

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
