### PR TITLE
[sui-replay-2] Produce artifacts as result of replay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13160,6 +13160,7 @@ dependencies = [
  "sui-package-management",
  "sui-protocol-config",
  "sui-replay",
+ "sui-replay-2",
  "sui-sdk",
  "sui-simulator",
  "sui-source-validation",
@@ -15673,16 +15674,20 @@ dependencies = [
  "prometheus",
  "reqwest 0.12.9",
  "serde",
+ "serde_json",
  "similar",
  "sui-execution",
  "sui-framework",
+ "sui-json-rpc-types",
  "sui-move-build",
  "sui-package-management",
  "sui-types",
+ "tabled",
  "telemetry-subscribers",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "zstd 0.12.3+zstd.1.5.2",
 ]
 
 [[package]]

--- a/crates/sui-replay-2/Cargo.toml
+++ b/crates/sui-replay-2/Cargo.toml
@@ -39,6 +39,10 @@ telemetry-subscribers.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
+sui-json-rpc-types.workspace = true
+serde_json.workspace = true
+zstd.workspace = true
+tabled.workspace = true
 
 [build-dependencies]
 cynic-codegen.workspace = true

--- a/crates/sui-replay-2/src/artifacts.rs
+++ b/crates/sui-replay-2/src/artifacts.rs
@@ -1,0 +1,264 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use move_trace_format::format::{MoveTrace, MoveTraceReader};
+use sui_types::{effects::TransactionEffects, gas::GasUsageReport};
+
+pub const ARTIFACTS_ENCODING_EXT: &str = "json";
+pub const ARTIFACTS_ENCODING_COMPRESSION_EXT: &str = "json.zst";
+
+pub const ARTIFACTS: [Artifact; 4] = [
+    Artifact::Trace,
+    Artifact::TransactionEffects,
+    Artifact::TransactionGasReport,
+    Artifact::ForkedTransactionEffects,
+];
+
+/// The types of artifacts that the replay tool knows about and may output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Artifact {
+    Trace,
+    TransactionEffects,
+    TransactionGasReport,
+    ForkedTransactionEffects,
+}
+
+/// Encoding types for artifacts that may be output by the replay tool.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EncodingType {
+    Json,
+    JsonCompressed,
+}
+
+/// Manages artifacts produced by the replay tool. An `ArtifactManager` is always with respect to a
+/// given base path (e.g., the output replay directory for a specific transaction).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArtifactManager<'a> {
+    pub base_path: &'a Path,
+    pub overrides_allowed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArtifactMember<'a, 'b> {
+    manager: &'a ArtifactManager<'b>,
+    artifact_type: Artifact,
+    artifact_path: PathBuf,
+}
+
+impl EncodingType {
+    /// Returns the file extension associated with the encoding type.
+    pub const fn ext(&self) -> &str {
+        match self {
+            EncodingType::Json => ARTIFACTS_ENCODING_EXT,
+            EncodingType::JsonCompressed => ARTIFACTS_ENCODING_COMPRESSION_EXT,
+        }
+    }
+}
+
+impl<'b> ArtifactManager<'b> {
+    /// Creates a new `ArtifactManager` with the given base path and whether overrides are allowed.
+    pub fn new(base_path: &'b Path, overrides_allowed: bool) -> anyhow::Result<Self> {
+        std::fs::create_dir_all(base_path).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to create base path for replay artifacts at {}: {e}",
+                base_path.display()
+            )
+        })?;
+        Ok(ArtifactManager {
+            base_path,
+            overrides_allowed,
+        })
+    }
+
+    /// Create an `ArtifactManager` for this artifact type, rooted at the given `base_path`.
+    pub fn member<'a>(&'a self, artifact: Artifact) -> ArtifactMember<'a, 'b> {
+        ArtifactMember {
+            artifact_path: self.base_path.join(artifact.as_file()),
+            manager: self,
+            artifact_type: artifact,
+        }
+    }
+}
+
+impl Artifact {
+    /// Returns the string representation of the artifact type.
+    pub const fn as_str(&self) -> &str {
+        match self {
+            Artifact::Trace => "trace",
+            Artifact::TransactionEffects => "transaction_effects",
+            Artifact::ForkedTransactionEffects => "forked_transaction_effects",
+            Artifact::TransactionGasReport => "transaction_gas_report",
+        }
+    }
+
+    /// Encoding type for each artifact.
+    pub fn encoding_type(&self) -> EncodingType {
+        match self {
+            Artifact::Trace => EncodingType::JsonCompressed,
+            Artifact::ForkedTransactionEffects
+            | Artifact::TransactionEffects
+            | Artifact::TransactionGasReport => EncodingType::Json,
+        }
+    }
+
+    /// Returns the file for the artifact, including its encoding type. The returned `PathBuf` is
+    /// not rooted.
+    pub fn as_file(&self) -> PathBuf {
+        PathBuf::from(format!("{}.{}", self.as_str(), self.encoding_type().ext()))
+    }
+}
+
+/// Deserialization methods for `ArtifactManager`.
+impl ArtifactMember<'_, '_> {
+    pub fn exists(&self) -> bool {
+        self.artifact_path.exists()
+    }
+
+    /// Deserialize the artifact into json. This should always succeed if the artifact exists and
+    /// is well-formed.
+    pub fn get_json(&self) -> anyhow::Result<serde_json::Value> {
+        let file_content = std::fs::read(&self.artifact_path)?;
+        let contents = match self.artifact_type.encoding_type() {
+            EncodingType::Json => file_content,
+            EncodingType::JsonCompressed => {
+                let mut buf = Vec::new();
+                zstd::bulk::decompress_to_buffer(&file_content, &mut buf)?;
+                buf
+            }
+        };
+        Ok(serde_json::from_slice(&contents)?)
+    }
+
+    /// Try to get the trace reader if the artifact type is a trace.
+    /// If the artifact type is not `Trace` `None` is returned.
+    pub fn try_get_trace(&self) -> Option<anyhow::Result<MoveTraceReader<std::fs::File>>> {
+        if self.artifact_type == Artifact::Trace {
+            Some(
+                std::fs::File::open(&self.artifact_path)
+                    .and_then(MoveTraceReader::new)
+                    .map_err(|e| {
+                        anyhow::anyhow!(
+                            "Failed to open trace file {}: {e}",
+                            self.artifact_path.display()
+                        )
+                    }),
+            )
+        } else {
+            None
+        }
+    }
+
+    /// Try to get the transaction effects if the artifact type is `TransactionEffects`.
+    /// If the artifact type is not `TransactionEffects` `None` is returned.
+    pub fn try_get_transaction_effects(&self) -> Option<anyhow::Result<TransactionEffects>> {
+        if matches!(
+            self.artifact_type,
+            Artifact::TransactionEffects | Artifact::ForkedTransactionEffects
+        ) {
+            Some(self.get_json().and_then(|json| {
+                serde_json::from_value::<TransactionEffects>(json).map_err(|e| {
+                    anyhow::anyhow!(
+                        "Failed to deserialize transaction effects from {}: {e}",
+                        self.artifact_path.display()
+                    )
+                })
+            }))
+        } else {
+            None
+        }
+    }
+
+    /// Try to get the GasUsageReport if the artifact type is `TransactionGasReport`.
+    /// If the artifact type is not `TransactionGasReport` `None` is returned.
+    pub fn try_get_gas_report(&self) -> Option<anyhow::Result<GasUsageReport>> {
+        if self.artifact_type == Artifact::TransactionGasReport {
+            Some(self.get_json().and_then(|json| {
+                serde_json::from_value::<GasUsageReport>(json).map_err(|e| {
+                    anyhow::anyhow!(
+                        "Failed to deserialize gas usage report from {}: {e}",
+                        self.artifact_path.display()
+                    )
+                })
+            }))
+        } else {
+            None
+        }
+    }
+}
+
+/// Serialization methods for `ArtifactManager`.
+impl ArtifactMember<'_, '_> {
+    pub fn serialize_move_trace(&self, trace: MoveTrace) -> Option<anyhow::Result<()>> {
+        if self.artifact_type != Artifact::Trace {
+            return None;
+        }
+
+        if !self.manager.overrides_allowed && self.artifact_path.exists() {
+            return Some(Err(anyhow::anyhow!(
+                "Trace file already exists at {}",
+                self.artifact_path.display()
+            )));
+        }
+
+        Some(
+            std::fs::write(&self.artifact_path, trace.into_compressed_json_bytes()).map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to write trace to {}: {e}",
+                    self.artifact_path.display()
+                )
+            }),
+        )
+    }
+
+    pub fn serialize_artifact(&self, data: &impl serde::Serialize) -> Option<anyhow::Result<()>> {
+        if self.artifact_type == Artifact::Trace {
+            return None;
+        }
+
+        if !self.manager.overrides_allowed && self.artifact_path.exists() {
+            return Some(Err(anyhow::anyhow!(
+                "File for {} already exists at {}",
+                self.artifact_type.as_str(),
+                self.artifact_path.display()
+            )));
+        }
+        let mut file = match std::fs::File::create(&self.artifact_path).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to create file {}: {e}",
+                self.artifact_path.display()
+            )
+        }) {
+            Ok(file) => file,
+            Err(e) => return Some(Err(e)),
+        };
+
+        Some(match self.artifact_type.encoding_type() {
+            EncodingType::Json => serde_json::to_writer(file, &data)
+                .map_err(|e| anyhow::anyhow!("Failed to write JSON: {e}")),
+            EncodingType::JsonCompressed => {
+                let mut buf = Vec::new();
+                let mut compressed_buf = Vec::new();
+                if let Err(e) = serde_json::to_writer(&mut buf, &data)
+                    .map_err(|e| anyhow::anyhow!("Failed to write JSON: {e}"))
+                {
+                    return Some(Err(e));
+                }
+                zstd::bulk::compress_to_buffer(&buf, &mut compressed_buf, 0)
+                    .map_err(|e| anyhow::anyhow!("Failed to compress JSON: {e}"))
+                    .and_then(|_| {
+                        file.write_all(&buf).map_err(|e| {
+                            anyhow::anyhow!(
+                                "Failed to write compressed JSON to {}: {e}",
+                                self.artifact_path.display()
+                            )
+                        })
+                    })
+            }
+        })
+    }
+}

--- a/crates/sui-replay-2/src/displays/gas_report.rs
+++ b/crates/sui-replay-2/src/displays/gas_report.rs
@@ -1,0 +1,68 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::displays::Pretty;
+use std::fmt::{Display, Formatter};
+use sui_types::gas::GasUsageReport;
+use tabled::{
+    builder::Builder as TableBuilder,
+    settings::{style::HorizontalLine, Style as TableStyle},
+};
+
+impl Display for Pretty<'_, GasUsageReport> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let Pretty(gas_report) = self;
+        display_info(f, gas_report)?;
+        per_object_storage_table(f, gas_report)?;
+        Ok(())
+    }
+}
+
+fn per_object_storage_table(f: &mut Formatter, gas_report: &GasUsageReport) -> std::fmt::Result {
+    let mut builder = TableBuilder::default();
+    builder.push_record(vec!["Object ID", "Bytes", "Old Rebate", "New Rebate"]);
+    for (object_id, per_obj_storage) in &gas_report.per_object_storage {
+        builder.push_record(vec![
+            object_id.to_string(),
+            per_obj_storage.new_size.to_string(),
+            per_obj_storage.storage_rebate.to_string(),
+            per_obj_storage.storage_cost.to_string(),
+        ]);
+    }
+    let mut table = builder.build();
+
+    table.with(TableStyle::rounded().horizontals([HorizontalLine::new(
+        1,
+        TableStyle::modern().get_horizontal(),
+    )]));
+    write!(f, "\n{}\n", table)
+}
+
+fn display_info(f: &mut Formatter<'_>, gas_report: &GasUsageReport) -> std::fmt::Result {
+    let mut builder = TableBuilder::default();
+    macro_rules! record {
+        ($($msg:expr),+) => {
+            builder.push_record(vec![$($msg.to_string()),+]);
+        };
+    }
+    record!("Gas Info");
+
+    record!("Computation Cost", gas_report.cost_summary.computation_cost);
+    record!("Storage Cost", gas_report.cost_summary.storage_cost);
+    record!("Storage Rebate", gas_report.cost_summary.storage_rebate);
+    record!(
+        "Non-Refundable Storage Fee",
+        gas_report.cost_summary.non_refundable_storage_fee
+    );
+    record!("Gas Used", gas_report.gas_used);
+    record!("Gas Budget", gas_report.gas_budget);
+    record!("Gas Price", gas_report.gas_price);
+    record!("Reference Gas Price", gas_report.reference_gas_price);
+    record!("Storage Gas Price", gas_report.storage_gas_price);
+    record!("Rebate Rate", gas_report.rebate_rate);
+
+    let mut table = builder.build();
+    table.with(TableStyle::rounded());
+
+    write!(f, "\n{}\n", table)
+}

--- a/crates/sui-replay-2/src/displays/mod.rs
+++ b/crates/sui-replay-2/src/displays/mod.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+mod gas_report;
+
+pub struct Pretty<'a, T>(pub &'a T);

--- a/crates/sui-replay-2/src/lib.rs
+++ b/crates/sui-replay-2/src/lib.rs
@@ -1,19 +1,27 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::artifacts::ArtifactManager;
 use crate::build::BuildCmdConfig;
+use crate::data_store::DataStore;
+use crate::replay_txn::replay_transaction;
+use anyhow::{anyhow, bail};
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 use std::str::FromStr;
 use sui_types::supported_protocol_versions::Chain;
 
+pub mod artifacts;
 pub mod build;
 pub mod data_store;
+pub mod displays;
 pub mod execution;
 pub mod gql_queries;
 pub mod replay_interface;
 pub mod replay_txn;
 pub mod tracing;
+
+const DEFAULT_OUTPUT_DIR: &str = ".replay";
 
 /// Arguments to the replay tool.
 /// It allows to replay a single transaction by digest or
@@ -55,15 +63,18 @@ pub struct ReplayConfig {
     /// RPC of the fullnode used to replay the transaction.
     #[arg(long, short, default_value = "mainnet")]
     pub node: Node,
+    /// Provide a directory to collect tracing. Or defaults to `<cur_dir>/.replay/<digest>`
+    #[arg(long = "trace", default_value = "false")]
+    pub trace: bool,
+    /// Terminate a batch replay early if an error occurs when replaying one of the transactions.
+    #[arg(long, default_value = "false")]
+    pub terminate_early: bool,
+    /// The output directory for the replay artifacts. Defaults `<cur_dir>/.replay/<digest>`.
+    #[arg(long, short)]
+    pub output_dir: Option<PathBuf>,
     /// Show transaction effects.
     #[arg(long, short, default_value = "false")]
     pub show_effects: bool,
-    /// Verify transaction execution matches what was executed on chain.
-    #[arg(long, short, default_value = "false")]
-    pub verify: bool,
-    /// Provide a directory to collect tracing. Or defaults to `<cur_dir>/.replay/<digest>`
-    #[arg(long = "trace", default_value = None)]
-    pub trace: Option<Option<PathBuf>>,
 }
 
 /// Enum around rpc gql endpoints.
@@ -99,4 +110,74 @@ impl FromStr for Node {
             _ => Ok(Node::Custom(s.to_string())),
         }
     }
+}
+
+pub fn handle_replay_config(config: ReplayConfig, version: &str) -> anyhow::Result<PathBuf> {
+    let ReplayConfig {
+        node,
+        digest,
+        digests_path,
+        trace,
+        mut terminate_early,
+        output_dir,
+        show_effects: _,
+    } = config;
+
+    let output_root_dir = if let Some(dir) = output_dir {
+        dir
+    } else {
+        // Default output directory is `<cur_dir>/.replay/<digest>`
+        let current_dir =
+            std::env::current_dir().map_err(|e| anyhow!("Failed to get current directory: {e}"))?;
+        current_dir.join(DEFAULT_OUTPUT_DIR)
+    };
+
+    // If a file is specified it is read and the digest ignored.
+    // Once we decide on the options we want this is likely to change.
+    let digests = if let Some(digests_path) = digests_path {
+        // read digests from file
+        std::fs::read_to_string(digests_path.clone())
+            .map_err(|e| {
+                anyhow!(
+                    "Failed to read digests file {}: {e}",
+                    digests_path.display(),
+                )
+            })?
+            .lines()
+            .map(|s| s.trim().to_string())
+            .collect::<Vec<_>>()
+    } else if let Some(tx_digest) = digest {
+        // terminate early if a single digest is provided this way we get proper error messages from
+        terminate_early = true;
+        // single digest provided
+        vec![tx_digest]
+    } else {
+        bail!("either --digest or --digests-path must be provided");
+    };
+
+    ::tracing::debug!("Binary version: {version}");
+
+    // `DataStore` implements `TransactionStore`, `EpochStore` and `ObjectStore`
+    let data_store = DataStore::new(node, version)
+        .map_err(|e| anyhow!("Failed to create data store: {:?}", e))?;
+
+    // load and replay transactions
+    for tx_digest in digests {
+        let tx_dir = output_root_dir.join(&tx_digest);
+        let artifact_manager = ArtifactManager::new(&tx_dir, true /* overrides_allowed */)?;
+        match replay_transaction(&artifact_manager, &tx_digest, &data_store, trace) {
+            Err(e) if terminate_early => {
+                ::tracing::error!("Error while replaying transaction {}: {:?}", tx_digest, e);
+                bail!("Replay terminated due to error: {}", e);
+            }
+            Err(e) => {
+                ::tracing::error!("Failed to replay transaction {}: {:?}", tx_digest, e);
+            }
+            Ok(_) => {
+                ::tracing::info!("Successfully replayed transaction {}", tx_digest);
+            }
+        }
+    }
+
+    Ok(output_root_dir)
 }

--- a/crates/sui-replay-2/src/main.rs
+++ b/crates/sui-replay-2/src/main.rs
@@ -1,22 +1,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::anyhow;
-use anyhow::bail;
 use clap::*;
 use core::panic;
-use move_trace_format::format::MoveTraceBuilder;
 use similar::{ChangeTag, TextDiff};
-use std::path::PathBuf;
-use sui_replay_2::build::handle_build_command;
+use sui_json_rpc_types::SuiTransactionBlockEffects;
 use sui_replay_2::{
-    data_store::DataStore,
-    execution::execute_transaction_to_effects,
-    replay_txn::ReplayTransaction,
-    tracing::{get_trace_output_path, save_trace_output},
-    Commands, Config, ReplayConfig,
+    artifacts::{Artifact, ArtifactManager},
+    build::handle_build_command,
+    displays::Pretty,
+    handle_replay_config, Commands, Config,
 };
-use sui_types::{effects::TransactionEffects, gas::SuiGasStatus};
+use sui_types::effects::TransactionEffects;
 use tracing::debug;
 
 // Define the `GIT_REVISION` and `VERSION` consts
@@ -36,138 +31,59 @@ fn main() -> anyhow::Result<()> {
         }
         None => {
             // Default to replay behavior when no subcommand is specified
-            handle_replay_command(config.replay)?;
+            let tx_digest = config.replay.digest.clone();
+            let show_effects = config.replay.show_effects;
+
+            let output_root = handle_replay_config(config.replay, VERSION)?;
+
+            if let Some(digest) = tx_digest {
+                let output_dir = output_root.join(&digest);
+                let manager = ArtifactManager::new(&output_dir, false)?;
+                if manager.member(Artifact::ForkedTransactionEffects).exists() {
+                    println!("*** Transaction {digest} forked");
+                    let forked_effects = manager
+                        .member(Artifact::ForkedTransactionEffects)
+                        .try_get_transaction_effects()
+                        .transpose()?
+                        .unwrap();
+                    let expected_effects = manager
+                        .member(Artifact::TransactionEffects)
+                        .try_get_transaction_effects()
+                        .transpose()?
+                        .unwrap();
+                    println!(
+                        "*** Forked Transaction Effects for {digest}\n{}",
+                        diff_effects(&expected_effects, &forked_effects)
+                    );
+                } else if show_effects {
+                    let tx_effects = manager
+                        .member(Artifact::TransactionEffects)
+                        .try_get_transaction_effects()
+                        .transpose()?
+                        .unwrap();
+                    println!(
+                        "*** Transaction Effects for {digest}\n{}",
+                        SuiTransactionBlockEffects::try_from(tx_effects.clone())
+                            .map_err(|e| anyhow::anyhow!("Failed to convert effects: {e}"))?
+                    );
+                    manager
+                        .member(Artifact::TransactionGasReport)
+                        .try_get_gas_report()
+                        .transpose()?
+                        .map(|report| {
+                            println!(
+                                "*** Transaction Gas Report for {digest}\n{}",
+                                Pretty(&report)
+                            );
+                        })
+                        .unwrap_or_else(|| {
+                            println!("*** No gas report available for transaction {digest}");
+                        });
+                }
+            }
         }
     }
-
     Ok(())
-}
-
-fn handle_replay_command(config: ReplayConfig) -> anyhow::Result<()> {
-    let ReplayConfig {
-        node,
-        digest,
-        digests_path,
-        show_effects,
-        verify,
-        trace,
-    } = config;
-
-    // If a file is specified it is read and the digest ignored.
-    // Once we decide on the options we want this is likely to change.
-    let digests = if let Some(digests_path) = digests_path {
-        // read digests from file
-        std::fs::read_to_string(digests_path.clone())
-            .map_err(|e| {
-                anyhow!(
-                    "Failed to read digests file {}: {e}",
-                    digests_path.display(),
-                )
-            })?
-            .lines()
-            .map(|s| s.trim().to_string())
-            .collect::<Vec<_>>()
-    } else if let Some(tx_digest) = digest {
-        // single digest provided
-        vec![tx_digest]
-    } else {
-        bail!("either --digest or --digests-path must be provided");
-    };
-
-    debug!("Binary version: {VERSION}");
-
-    // `DataStore` implements `TransactionStore`, `EpochStore` and `ObjectStore`
-    let data_store = DataStore::new(node, VERSION)
-        .map_err(|e| anyhow!("Failed to create data store: {:?}", e))?;
-
-    // load and replay transactions
-    for tx_digest in digests {
-        replay_transaction(&tx_digest, &data_store, trace.clone(), show_effects, verify);
-    }
-
-    Ok(())
-}
-
-//
-// Run a single transaction and print results to stdout
-//
-fn replay_transaction(
-    tx_digest: &str,
-    data_store: &DataStore,
-    trace: Option<Option<PathBuf>>,
-    show_effects: bool,
-    verify: bool,
-) {
-    // load a `ReplayTranaction`
-    let replay_txn = match ReplayTransaction::load(tx_digest, data_store, data_store, data_store) {
-        Ok(replay_txn) => replay_txn,
-        Err(e) => {
-            println!("** TRANSACTION {} failed to load -> {:?}", tx_digest, e);
-            return;
-        }
-    };
-
-    // replay the transaction
-    let mut trace_builder_opt = trace.clone().map(|_| MoveTraceBuilder::new());
-    let (result, context_and_effects) = match execute_transaction_to_effects(
-        replay_txn,
-        data_store,
-        data_store,
-        &mut trace_builder_opt,
-    ) {
-        Ok((result, context_and_effects)) => (result, context_and_effects),
-        Err(e) => {
-            println!("** TRANSACTION {} failed to execute -> {:?}", tx_digest, e);
-            return;
-        }
-    };
-
-    // TODO: make tracing better abstracted? different tracers?
-    if let Some(trace_builder) = trace_builder_opt {
-        let _ = get_trace_output_path(trace.unwrap())
-            .and_then(|output_path| save_trace_output(&output_path, tx_digest, trace_builder, &context_and_effects))
-            .map_err(|e| {
-                println!(
-                    "WARNING (skipping tracing): transaction {} failed to build a trace output path -> {:?}",
-                    tx_digest, e
-                );
-                e
-            });
-    };
-
-    // print results
-    println!("** TRANSACTION {} -> {:?}", tx_digest, result);
-    if show_effects {
-        print_txn_effects(
-            &context_and_effects.execution_effects,
-            &context_and_effects.gas_status,
-        );
-    }
-    if verify {
-        verify_txn(
-            &context_and_effects.expected_effects,
-            &context_and_effects.execution_effects,
-        );
-    }
-}
-
-//
-// After command printing of requested results
-//
-
-fn print_txn_effects(effects: &TransactionEffects, gas_status: &SuiGasStatus) {
-    println!("*** TRANSACTION EFFECTS -> {:?}", effects);
-    println!("*** TRANSACTION GAS STATUS -> {:?}", gas_status);
-}
-
-fn verify_txn(expected_effects: &TransactionEffects, effects: &TransactionEffects) {
-    println!("*** VERIFYING TRANSACTION EFFECTS");
-    if effects != expected_effects {
-        println!("**** FORKING: TRANSACTION EFFECTS DO NOT MATCH");
-        println!("{}", diff_effects(expected_effects, effects));
-    } else {
-        println!("**** SUCCESS: TRANSACTION EFFECTS MATCH");
-    }
 }
 
 /// Utility to diff `TransactionEffect` in a human readable format

--- a/crates/sui-replay-2/src/replay_txn.rs
+++ b/crates/sui-replay-2/src/replay_txn.rs
@@ -11,12 +11,15 @@
 //! in this module and saved in the `ReplayTransaction` instance.
 
 use crate::{
-    execution::ReplayExecutor,
+    artifacts::{Artifact, ArtifactManager},
+    data_store::DataStore,
+    execution::{execute_transaction_to_effects, ReplayExecutor},
     replay_interface::{EpochStore, ObjectKey, ObjectStore, TransactionStore, VersionQuery},
+    tracing::save_trace_output,
 };
-use anyhow::Context;
+use anyhow::{anyhow, bail, Context};
+use move_trace_format::format::MoveTraceBuilder;
 use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
-use sui_types::transaction::{InputObjectKind, ObjectReadResult, ObjectReadResultKind};
 use sui_types::{base_types::SequenceNumber, TypeTag};
 use sui_types::{
     base_types::{ObjectID, SuiAddress},
@@ -27,6 +30,10 @@ use sui_types::{
         CallArg, Command, GasData, InputObjects, ObjectArg, TransactionData, TransactionDataAPI,
         TransactionKind,
     },
+};
+use sui_types::{
+    gas::SuiGasStatusAPI,
+    transaction::{InputObjectKind, ObjectReadResult, ObjectReadResultKind},
 };
 use tracing::{debug, trace};
 
@@ -43,6 +50,93 @@ pub struct ReplayTransaction {
     pub executor: ReplayExecutor,
     // Objects and packages used by the transaction
     pub object_cache: BTreeMap<ObjectID, BTreeMap<ObjectVersion, Object>>,
+}
+
+//
+// Run a single transaction and print results to stdout
+//
+pub(crate) fn replay_transaction(
+    artifact_manager: &ArtifactManager<'_>,
+    tx_digest: &str,
+    data_store: &DataStore,
+    trace: bool,
+) -> anyhow::Result<()> {
+    // load a `ReplayTranaction`
+    let replay_txn = match ReplayTransaction::load(tx_digest, data_store, data_store, data_store) {
+        Ok(replay_txn) => replay_txn,
+        Err(e) => {
+            bail!("Failed to load transaction {}: {:?}", tx_digest, e);
+        }
+    };
+
+    // replay the transaction
+    let mut trace_builder_opt = trace.then(MoveTraceBuilder::new);
+
+    let (result, context_and_effects) =
+        execute_transaction_to_effects(replay_txn, data_store, data_store, &mut trace_builder_opt)?;
+
+    // TODO: make tracing better abstracted? different tracers?
+    if let Some(trace_builder) = trace_builder_opt {
+        save_trace_output(artifact_manager, trace_builder, &context_and_effects).map_err(|e| {
+            anyhow!(
+                "transaction {} failed to build a trace output path -> {:?}",
+                tx_digest,
+                e
+            )
+        })?;
+    }
+
+    // Save results
+    tracing::info!(
+        "Executed transaction {}: {:?}. Saving artifacts under {}",
+        tx_digest,
+        result,
+        artifact_manager.base_path.display()
+    );
+
+    artifact_manager
+        .member(Artifact::TransactionEffects)
+        .serialize_artifact(&context_and_effects.execution_effects)
+        .transpose()?
+        .unwrap();
+
+    artifact_manager
+        .member(Artifact::TransactionGasReport)
+        .serialize_artifact(&context_and_effects.gas_status.gas_usage_report())
+        .transpose()?
+        .unwrap();
+
+    verify_txn_and_save_forked_effects(
+        artifact_manager,
+        &context_and_effects.expected_effects,
+        &context_and_effects.execution_effects,
+    )?;
+
+    Ok(())
+}
+
+fn verify_txn_and_save_forked_effects(
+    artifact_manager: &ArtifactManager<'_>,
+    expected_effects: &TransactionEffects,
+    effects: &TransactionEffects,
+) -> anyhow::Result<()> {
+    if effects != expected_effects {
+        tracing::error!(
+            "Transaction effects do not match expected effects for transaction {}. Saving to ",
+            effects.transaction_digest()
+        );
+        artifact_manager
+            .member(Artifact::ForkedTransactionEffects)
+            .serialize_artifact(effects)
+            .transpose()?
+            .unwrap();
+        bail!(
+            "Transaction effects do not match expected effects for transaction {}",
+            effects.transaction_digest()
+        );
+    } else {
+        Ok(())
+    }
 }
 
 impl ReplayTransaction {

--- a/crates/sui-replay-2/src/tracing.rs
+++ b/crates/sui-replay-2/src/tracing.rs
@@ -4,7 +4,10 @@
 //! Tracing utilities.
 //! Mostly deals with directory/file saving and what gets saved in the trace output.
 
-use crate::execution::TxnContextAndEffects;
+use crate::{
+    artifacts::{Artifact, ArtifactManager},
+    execution::TxnContextAndEffects,
+};
 use anyhow::Context;
 use move_binary_format::CompiledModule;
 use move_bytecode_source_map::utils::serialize_to_json_string;
@@ -12,81 +15,28 @@ use move_command_line_common::files::MOVE_BYTECODE_EXTENSION;
 use move_disassembler::disassembler::Disassembler;
 use move_ir_types::location::Spanned;
 use move_trace_format::format::MoveTraceBuilder;
-use std::{
-    env, fs,
-    path::{Path, PathBuf},
-};
+use std::fs;
 use sui_types::object::Data;
 
-const DEFAULT_TRACE_OUTPUT_DIR: &str = ".replay";
-const TRACE_FILE_NAME: &str = "trace.json.zst";
 const BCODE_DIR: &str = "bytecode";
 const SOURCE_DIR: &str = "source";
-
-/// Gets the path to store trace output (either the default one './replay' or user-specified).
-/// Upon success, the path will exist in the file system.
-pub fn get_trace_output_path(trace_execution: Option<PathBuf>) -> Result<PathBuf, anyhow::Error> {
-    match trace_execution {
-        Some(path) => {
-            if !path.exists() {
-                return Err(anyhow::anyhow!(format!(
-                    "User-specified path to store trace output does not exist: {:?}",
-                    path
-                )));
-            }
-            if !path.is_dir() {
-                return Err(anyhow::anyhow!(format!(
-                    "User-specified path to store trace output is not a directory: {:?}",
-                    path
-                )));
-            }
-            Ok(path)
-        }
-        None => {
-            let current_dir = env::current_dir().context("Failed to get current directory")?;
-            let path = current_dir.join(DEFAULT_TRACE_OUTPUT_DIR);
-            if path.exists() && path.is_file() {
-                return Err(anyhow::anyhow!(
-                    format!(
-                        "Default path to store trace output already exists and is a file, not a directory: {:?}",
-                        path
-                    )
-                ));
-            }
-            fs::create_dir_all(&path).context("Failed to create default trace output directory")?;
-            Ok(path)
-        }
-    }
-}
 
 /// Saves the trace and additional metadata needed to analyze the trace
 /// to a subderectory named after the transaction digest.
 pub fn save_trace_output(
-    output_path: &Path,
-    digest: &str,
+    artifact_manager: &ArtifactManager<'_>,
     trace_builder: MoveTraceBuilder,
     context_and_effects: &TxnContextAndEffects,
 ) -> Result<(), anyhow::Error> {
-    let txn_output_path = output_path.join(digest);
-    if txn_output_path.exists() {
-        return Err(anyhow::anyhow!(
-            "Trace output directory for transaction {} already exists: {:?}",
-            digest,
-            txn_output_path,
-        ));
-    }
-    fs::create_dir_all(&txn_output_path).context(format!(
-        "Failed to create trace output directory for transaction {}",
-        digest,
-    ))?;
     let trace = trace_builder.into_trace();
-    let json = trace.into_compressed_json_bytes();
-    let trace_file_path = txn_output_path.join(TRACE_FILE_NAME);
-    fs::write(&trace_file_path, json).context(format!(
-        "Failed to write trace output to {:?}",
-        trace_file_path,
-    ))?;
-    let bcode_dir = txn_output_path.join(BCODE_DIR);
+    let trace_member = artifact_manager.member(Artifact::Trace);
+    trace_member
+        .serialize_move_trace(trace)
+        .transpose()?
+        .unwrap();
+
+    // TODO: have this use the artifact manager as well.
+    let bcode_dir = artifact_manager.base_path.join(BCODE_DIR);
     fs::create_dir(&bcode_dir).context(format!(
         "Failed to create bytecode output directory '{:?}'",
         bcode_dir,
@@ -161,7 +111,7 @@ pub fn save_trace_output(
     }
     // create empty sources directory as a known placeholder for the users
     // to put optional source files there
-    let src_dir = txn_output_path.join(SOURCE_DIR);
+    let src_dir = artifact_manager.base_path.join(SOURCE_DIR);
     fs::create_dir(&src_dir).context(format!(
         "Failed to create source output directory '{:?}'",
         src_dir,

--- a/crates/sui-types/src/gas.rs
+++ b/crates/sui-types/src/gas.rs
@@ -3,10 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use checked::*;
+use serde::{Deserialize, Serialize};
+
+use crate::{base_types::ObjectID, gas_model::gas_v2::PerObjectStorage};
 
 #[sui_macros::with_checked_arithmetic]
 pub mod checked {
 
+    use crate::gas::GasUsageReport;
     use crate::gas_model::gas_predicates::gas_price_too_high;
     use crate::{
         effects::{TransactionEffects, TransactionEffectsAPI},
@@ -48,6 +52,7 @@ pub mod checked {
         ) -> u64;
         fn charge_storage_and_rebate(&mut self) -> Result<(), ExecutionError>;
         fn adjust_computation_on_out_of_gas(&mut self);
+        fn gas_usage_report(&self) -> GasUsageReport;
     }
 
     /// Version aware enum for gas status.
@@ -282,4 +287,16 @@ pub mod checked {
             })
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GasUsageReport {
+    pub cost_summary: GasCostSummary,
+    pub gas_used: u64,
+    pub gas_budget: u64,
+    pub gas_price: u64,
+    pub reference_gas_price: u64,
+    pub storage_gas_price: u64,
+    pub rebate_rate: u64,
+    pub per_object_storage: Vec<(ObjectID, PerObjectStorage)>,
 }

--- a/crates/sui-types/src/gas_model/gas_v2.rs
+++ b/crates/sui-types/src/gas_model/gas_v2.rs
@@ -7,7 +7,7 @@ pub use checked::*;
 #[sui_macros::with_checked_arithmetic]
 mod checked {
     use crate::error::{UserInputError, UserInputResult};
-    use crate::gas::{self, GasCostSummary, SuiGasStatusAPI};
+    use crate::gas::{self, GasCostSummary, GasUsageReport, SuiGasStatusAPI};
     use crate::gas_model::gas_predicates::{cost_table_for_version, txn_base_cost_as_multiplier};
     use crate::gas_model::units_types::CostTable;
     use crate::transaction::ObjectReadResult;
@@ -17,6 +17,7 @@ mod checked {
         ObjectID,
     };
     use move_core_types::vm_status::StatusCode;
+    use serde::{Deserialize, Serialize};
     use sui_protocol_config::*;
 
     /// A bucket defines a range of units that will be priced the same.
@@ -144,7 +145,7 @@ mod checked {
         }
     }
 
-    #[derive(Debug)]
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct PerObjectStorage {
         /// storage_cost is the total storage gas to charge. This is computed
         /// at the end of execution while determining storage charges.
@@ -516,6 +517,19 @@ mod checked {
         fn adjust_computation_on_out_of_gas(&mut self) {
             self.per_object_storage = Vec::new();
             self.computation_cost = self.gas_budget;
+        }
+
+        fn gas_usage_report(&self) -> GasUsageReport {
+            GasUsageReport {
+                cost_summary: self.summary(),
+                gas_used: self.gas_used(),
+                gas_price: self.gas_price(),
+                reference_gas_price: self.reference_gas_price(),
+                per_object_storage: self.per_object_storage().clone(),
+                gas_budget: self.gas_budget(),
+                storage_gas_price: self.storage_gas_price,
+                rebate_rate: self.rebate_rate,
+            }
         }
     }
 }


### PR DESCRIPTION
## Description 

Does a bunch of cleanup and moving some things around in preparation for incorporating it into the the main Sui CLI.

One of the main things is the addition of `Artifacts` these are on-disk data that are the result of replay. The `ArtifactManager` is a way to easily deal with these artifacts (finding them, reading them, writing to them etc.) and more artifact types I'm sure will be added over time. 

Existing artifacts (i.e., for the debugger) locations are not changed. 

## Test plan 

Ran some replays locally.

## TODO

Need to incorporate the saving the bytecode files and source maps out via the artifact manager.