### PR TITLE
Kubernetes Benchmark Issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6663,28 +6663,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
-name = "jemalloc-ctl"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1891c671f3db85d8ea8525dd43ab147f9977041911d24a03e5a36187a7bfde9"
-dependencies = [
- "jemalloc-sys",
- "libc",
- "paste",
-]
-
-[[package]]
-name = "jemalloc-sys"
-version = "0.5.2+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134163979b6eed9564c98637b710b40979939ba351f59952708234ea11b5f3f8"
-dependencies = [
- "cc",
- "fs_extra",
- "libc",
-]
-
-[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7217,6 +7195,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "lz4-sys",
+ "tikv-jemalloc-sys",
  "zstd-sys",
 ]
 
@@ -13134,7 +13113,6 @@ dependencies = [
  "inquire",
  "insta",
  "insta-cmd",
- "jemalloc-ctl",
  "json_to_table",
  "miette",
  "move-analyzer",
@@ -13196,6 +13174,7 @@ dependencies = [
  "tempfile",
  "test-cluster",
  "thiserror 1.0.69",
+ "tikv-jemalloc-ctl",
  "tokio",
  "toml 0.7.4",
  "tower 0.5.2",
@@ -15133,7 +15112,6 @@ dependencies = [
  "colored",
  "futures",
  "insta",
- "jemalloc-ctl",
  "jsonrpsee",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -15160,6 +15138,7 @@ dependencies = [
  "sui-types",
  "telemetry-subscribers",
  "tempfile",
+ "tikv-jemalloc-ctl",
  "tokio",
  "tracing",
  "walkdir",
@@ -15383,6 +15362,7 @@ dependencies = [
  "sui-types",
  "tap",
  "telemetry-subscribers",
+ "tikv-jemallocator",
  "tokio",
  "tower 0.5.2",
  "tower-http",
@@ -17168,6 +17148,37 @@ dependencies = [
  "serde",
  "smallvec",
  "tokio",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619bfed27d807b54f7f776b9430d4f8060e66ee138a28632ca898584d462c31c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -404,7 +404,8 @@ insta-cmd = "0.6.0"
 integer-encoding = "3.0.1"
 ipnetwork = "0.20.0"
 itertools = "0.13.0"
-jemalloc-ctl = "^0.5"
+tikv-jemalloc-ctl = "^0.5"
+tikv-jemallocator = "^0.5"
 jsonrpsee = { version = "0.24.9", features = [
   "server",
   "macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -405,7 +405,7 @@ integer-encoding = "3.0.1"
 ipnetwork = "0.20.0"
 itertools = "0.13.0"
 tikv-jemalloc-ctl = "^0.5"
-tikv-jemallocator = "^0.5"
+tikv-jemallocator = { version = "^0.5", features = ["profiling", "disable_initial_exec_tls"] }
 jsonrpsee = { version = "0.24.9", features = [
   "server",
   "macros",

--- a/crates/sui-move/Cargo.toml
+++ b/crates/sui-move/Cargo.toml
@@ -40,7 +40,7 @@ sui-package-management.workspace = true
 better_any = "0.1.1"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemalloc-ctl.workspace = true
+tikv-jemalloc-ctl.workspace = true
 
 [dev-dependencies]
 futures.workspace = true
@@ -56,7 +56,7 @@ mysten-metrics.workspace = true
 sui-macros.workspace = true
 
 [package.metadata.cargo-udeps.ignore]
-normal = ["jemalloc-ctl"]
+normal = ["tikv-jemalloc-ctl"]
 
 [lints]
 workspace = true

--- a/crates/sui-node/Cargo.toml
+++ b/crates/sui-node/Cargo.toml
@@ -61,5 +61,8 @@ move-vm-profiler.workspace = true
 sui-http.workspace = true
 sui-metrics-push-client.workspace = true
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator.workspace = true
+
 [target.'cfg(msim)'.dependencies]
 sui-simulator.workspace = true

--- a/crates/sui-node/Cargo.toml
+++ b/crates/sui-node/Cargo.toml
@@ -62,7 +62,11 @@ sui-http.workspace = true
 sui-metrics-push-client.workspace = true
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator.workspace = true
+tikv-jemallocator = { workspace = true, optional = true, features = ["profiling", "disable_initial_exec_tls"] }
 
 [target.'cfg(msim)'.dependencies]
 sui-simulator.workspace = true
+
+[features]
+default = ["jemalloc"]
+jemalloc = ["tikv-jemallocator"]

--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -43,6 +43,10 @@ struct Args {
     run_with_range_checkpoint: Option<CheckpointSequenceNumber>,
 }
 
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static JEMALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 fn main() {
     antithesis_sdk::antithesis_init();
 

--- a/crates/sui-node/src/main.rs
+++ b/crates/sui-node/src/main.rs
@@ -43,7 +43,7 @@ struct Args {
     run_with_range_checkpoint: Option<CheckpointSequenceNumber>,
 }
 
-#[cfg(not(target_env = "msvc"))]
+#[cfg(all(not(target_env = "msvc"), feature = "jemalloc"))]
 #[global_allocator]
 static JEMALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -103,7 +103,7 @@ move-cli.workspace = true
 move-symbol-pool.workspace = true
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemalloc-ctl.workspace = true
+tikv-jemalloc-ctl.workspace = true
 
 [dev-dependencies]
 prometheus.workspace = true
@@ -125,7 +125,7 @@ serde_json.workspace = true
 msim.workspace = true
 
 [package.metadata.cargo-udeps.ignore]
-normal = ["jemalloc-ctl"]
+normal = ["tikv-jemalloc-ctl"]
 
 [[example]]
 name = "generate-genesis-checkpoint"

--- a/crates/typed-store/Cargo.toml
+++ b/crates/typed-store/Cargo.toml
@@ -37,6 +37,9 @@ mysten-metrics.workspace = true
 [target.'cfg(not(windows))'.dependencies]
 tidehunter = {git = "https://github.com/andll/tidehunter.git", rev = "dd686f055375aa8fa2145618301bdfd5170a2a6b", version = "0.1.0", optional = true}
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+rocksdb = { version = "0.22.0", default-features = false, features = ["jemalloc"] }
+
 [dev-dependencies]
 tempfile.workspace = true
 once_cell.workspace = true

--- a/docker/sui-node-deterministic/Dockerfile
+++ b/docker/sui-node-deterministic/Dockerfile
@@ -9,6 +9,7 @@ FROM stagex/core-clang@sha256:abf6d2868bc441b5910ef28f38123c6053391521948b33eaf6
 FROM stagex/core-llvm@sha256:bc1c6d67aa73a96dd92f5def7e2701de78b0639d0c815d69110fbb9b3b3e85fe AS llvm
 FROM stagex/core-lld@sha256:a5cb61edc071d404cd33cb0b5c7113a334cb90ca203cb40fe6cafd3559b6daa5 AS lld
 FROM stagex/core-libffi@sha256:9acd18e59ca11fa727670725e69a976d96f85a00704dea6ad07870bff2bd4e8b AS libffi
+FROM stagex/core-make@sha256:a47d8f67f8fd74905f724fdc5f0d18e29df96391751754947bdeaba9bef8f7d8 AS make
 
 FROM pallet-rust AS build
 ARG PROFILE
@@ -20,6 +21,7 @@ COPY --from=clang . /
 COPY --from=llvm . /
 COPY --from=lld . /
 COPY --from=libffi . /
+COPY --from=make . /
 
 ENV RUST_BACKTRACE=1
 ENV RUSTFLAGS="-C codegen-units=1"

--- a/docker/sui-node/Dockerfile
+++ b/docker/sui-node/Dockerfile
@@ -20,8 +20,7 @@ RUN cargo build --profile ${PROFILE} --bin sui-node
 # Production Image
 FROM debian:bullseye-slim AS runtime
 # Use jemalloc as memory allocator
-RUN apt-get update && apt-get install -y libjemalloc-dev ca-certificates curl
-ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libjemalloc.so
+RUN apt-get update && apt-get install -y ca-certificates curl
 ARG PROFILE=release
 WORKDIR "$WORKDIR/sui"
 # Both bench and release profiles copy from release dir


### PR DESCRIPTION
## Description 

Fix issue with segfault when running sui-node in kubernetes.
Update tikv-jemallocator features to enable profiling
Remove extra jemalloc LD_PRELOAD'ed into container now that jemalloc is statically linked in rust buildd 

## Test plan 

* run benchmark against commit in sui-operations `pulumi up -s benchmark-mainnet`
* run asymptotic run `./scripts/run-antithesis-tests -t 0.25 -d testing_jemalloc` [initial-run](https://github.com/MystenLabs/sui-operations/actions/runs/16042081694)

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
