### PR TITLE
[move][move-compiler][typing] Divergent type constraint

### DIFF
--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -1084,7 +1084,8 @@ impl<'env, 'outer> Context<'env, 'outer> {
         if let Some(ty) = self.named_block_map.get(&name) {
             ty.clone()
         } else {
-            let new_type = make_tvar(self, loc);
+            // A named block may diverge
+            let new_type = make_divergent_tvar(self, loc);
             self.named_block_map.insert(name, new_type.clone());
             new_type
         }
@@ -1271,6 +1272,7 @@ impl TVarCounter {
 pub struct Subst {
     tvars: HashMap<TVar, Type>,
     num_vars: HashMap<TVar, Loc>,
+    divergent_vars: HashMap<TVar, Loc>,
 }
 
 impl Subst {
@@ -1278,6 +1280,7 @@ impl Subst {
         Self {
             tvars: HashMap::new(),
             num_vars: HashMap::new(),
+            divergent_vars: HashMap::new(),
         }
     }
 
@@ -1306,11 +1309,31 @@ impl Subst {
     pub fn is_num_var(&self, tvar: TVar) -> bool {
         self.num_vars.contains_key(&tvar)
     }
+
+    pub fn new_divergent_var(&mut self, counter: &mut TVarCounter, loc: Loc) -> TVar {
+        let tvar = counter.next();
+        assert!(self.divergent_vars.insert(tvar, loc).is_none());
+        tvar
+    }
+
+    pub fn set_divergent_var(&mut self, tvar: TVar, loc: Loc) {
+        // No need to recur down setting divergence, as it is only applied if it is a new variable
+        // or it is the join of two that are both divergent.
+        self.divergent_vars.entry(tvar).or_insert(loc);
+    }
+
+    pub fn is_divergent_var(&self, tvar: TVar) -> bool {
+        self.divergent_vars.contains_key(&tvar)
+    }
 }
 
 impl ast_debug::AstDebug for Subst {
     fn ast_debug(&self, w: &mut ast_debug::AstWriter) {
-        let Subst { tvars, num_vars } = self;
+        let Subst {
+            tvars,
+            num_vars,
+            divergent_vars,
+        } = self;
 
         w.write("tvars:");
         w.indent(4, |w| {
@@ -1327,6 +1350,14 @@ impl ast_debug::AstDebug for Subst {
             let mut num_vars = num_vars.keys().collect::<Vec<_>>();
             num_vars.sort();
             for tvar in num_vars {
+                w.writeln(format!("{:?}", tvar))
+            }
+        });
+        w.write("divergent_vars:");
+        w.indent(4, |w| {
+            let mut divergent_vars = divergent_vars.keys().collect::<Vec<_>>();
+            divergent_vars.sort();
+            for tvar in divergent_vars {
                 w.writeln(format!("{:?}", tvar))
             }
         })
@@ -1505,6 +1536,13 @@ fn debug_abilities_info(context: &mut Context, ty: &Type) -> (Option<Loc>, Abili
         }
         T::Fun(_, _) => (None, AbilitySet::functions(loc), vec![]),
     }
+}
+
+pub fn make_divergent_tvar(context: &mut Context, loc: Loc) -> Type {
+    let tvar = context
+        .subst
+        .new_divergent_var(&mut context.tvar_counter, loc);
+    sp(loc, Type_::Var(tvar))
 }
 
 pub fn make_num_tvar(context: &mut Context, loc: Loc) -> Type {
@@ -2177,8 +2215,10 @@ pub fn check_call_arity<S: std::fmt::Display, F: Fn() -> S>(
 
 pub fn solve_constraints(context: &mut Context) {
     use BuiltinTypeName_ as BT;
-    let num_vars = context.subst.num_vars.clone();
+
     let mut subst = std::mem::replace(&mut context.subst, Subst::empty());
+
+    let num_vars = subst.num_vars.clone();
     for (num_var, loc) in num_vars {
         let tvar = sp(loc, Type_::Var(num_var));
         match unfold_type(&subst, tvar.clone()).value {
@@ -2191,6 +2231,16 @@ pub fn solve_constraints(context: &mut Context) {
             _ => (),
         }
     }
+
+    let divergent_vars = subst.divergent_vars.clone();
+    for (divergent_var, loc) in divergent_vars {
+        let last_tvar = forward_tvar(&subst, divergent_var);
+        if subst.get(last_tvar).is_none() {
+            join_bind_tvar(&mut subst, loc, last_tvar, sp(loc, Type_::Unit))
+                .expect("ICE failed handling unbound divergent type");
+        }
+    }
+
     context.subst = subst;
 
     let constraints = std::mem::take(&mut context.constraints);
@@ -3059,6 +3109,12 @@ fn join_tvar(
         }
         _ => (),
     }
+    let divergent_loc_1 = subst.divergent_vars.get(&last_id1);
+    let divergent_loc_2 = subst.divergent_vars.get(&last_id2);
+    if let (Some(_), Some(nloc)) = (divergent_loc_1, divergent_loc_2) {
+        let nloc = *nloc;
+        subst.set_divergent_var(new_tvar, nloc);
+    }
     subst.insert(last_id1, sp(loc1, Var(new_tvar)));
     subst.insert(last_id2, sp(loc2, Var(new_tvar)));
 
@@ -3099,25 +3155,17 @@ fn join_bind_tvar(subst: &mut Subst, loc: Loc, tvar: TVar, ty: Type) -> Result<b
         "ICE join_bind_tvar called on bound tvar"
     );
 
-    fn used_tvars(used: &mut BTreeMap<TVar, Loc>, sp!(loc, t_): &Type) {
+    fn occurs_check(target_tvar: &TVar, sp!(_, t_): &Type) -> bool {
         use Type_ as T;
         match t_ {
-            T::Var(v) => {
-                used.insert(*v, *loc);
-            }
-            T::Ref(_, inner) => used_tvars(used, inner),
-            T::Apply(_, _, inners) => inners
-                .iter()
-                .rev()
-                .for_each(|inner| used_tvars(used, inner)),
+            T::Var(v) => v == target_tvar,
+            T::Ref(_, inner) => occurs_check(target_tvar, inner),
+            T::Apply(_, _, inners) => inners.iter().any(|inner| occurs_check(target_tvar, inner)),
             T::Fun(inner_args, inner_ret) => {
-                inner_args
-                    .iter()
-                    .rev()
-                    .for_each(|inner| used_tvars(used, inner));
-                used_tvars(used, inner_ret)
+                inner_args.iter().any(|arg| occurs_check(target_tvar, arg))
+                    || occurs_check(target_tvar, inner_ret)
             }
-            T::Unit | T::Param(_) | T::Anything | T::UnresolvedError => (),
+            T::Unit | T::Param(_) | T::Anything | T::UnresolvedError => false,
         }
     }
 
@@ -3126,9 +3174,7 @@ fn join_bind_tvar(subst: &mut Subst, loc: Loc, tvar: TVar, ty: Type) -> Result<b
         return Ok(false);
     }
 
-    let used = &mut BTreeMap::new();
-    used_tvars(used, &ty);
-    if let Some(_rec_loc) = used.get(&tvar) {
+    if occurs_check(&tvar, &ty) {
         return Err(TypingError::RecursiveType(loc));
     }
 

--- a/external-crates/move/crates/move-compiler/src/typing/expand.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/expand.rs
@@ -65,10 +65,7 @@ pub fn type_(context: &mut Context, ty: &mut Type) {
             debug_print!(context.debug().type_elaboration, ("resolved" => replacement));
             let replacement = match replacement {
                 sp!(loc, Var(_)) => {
-                    let diag = ice!((
-                        ty.loc,
-                        "ICE unfold_type_base failed to expand type inf. var"
-                    ));
+                    let diag = ice!((ty.loc, "ICE unfold_type failed to expand type inf. var"));
                     context.add_diag(diag);
                     sp(loc, UnresolvedError)
                 }

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -1836,14 +1836,14 @@ fn exp(context: &mut Context, ne: Box<N::Exp>) -> Box<T::Exp> {
             let eret = exp(context, nret);
             let ret_ty = context.return_type.clone().unwrap();
             subtype(context, eloc, || "Invalid return", eret.ty.clone(), ret_ty);
-            (sp(eloc, Type_::Anything), TE::Return(eret))
+            (core::make_divergent_tvar(context, eloc), TE::Return(eret))
         }
         NE::Abort(ncode) => {
             let mut ecode = exp(context, ncode);
             let code_ty = Type_::u64(eloc);
             annotated_error_const(context, &mut ecode, "abort");
             subtype(context, eloc, || "Invalid abort", ecode.ty.clone(), code_ty);
-            (sp(eloc, Type_::Anything), TE::Abort(ecode))
+            (core::make_divergent_tvar(context, eloc), TE::Abort(ecode))
         }
         NE::Give(usage, name, rhs) => {
             let break_rhs = exp(context, rhs);
@@ -1854,9 +1854,12 @@ fn exp(context: &mut Context, ne: Box<N::Exp>) -> Box<T::Exp> {
                 || format!("Invalid {usage}"),
                 break_rhs.ty.clone(),
             );
-            (sp(eloc, Type_::Anything), TE::Give(name, break_rhs))
+            (
+                core::make_divergent_tvar(context, eloc),
+                TE::Give(name, break_rhs),
+            )
         }
-        NE::Continue(name) => (sp(eloc, Type_::Anything), TE::Continue(name)),
+        NE::Continue(name) => (core::make_divergent_tvar(context, eloc), TE::Continue(name)),
 
         NE::Dereference(nref) => {
             let eref = exp(context, nref);
@@ -2230,9 +2233,10 @@ fn match_arms(
         .into_iter()
         .map(|narm| match_arm(context, subject_type, narm, ref_mut))
         .collect::<Vec<_>>();
+    // Start with a divergent tvar in case all of the arms diverge
     let result_type = arms
         .iter()
-        .fold(core::make_tvar(context, *arms_loc), |ty, arm| {
+        .fold(core::make_divergent_tvar(context, *arms_loc), |ty, arm| {
             join(
                 context,
                 *arms_loc,
@@ -4745,7 +4749,8 @@ fn convert_macro_arg_to_block(context: &mut Context, sp!(loc, ne_): N::Exp) -> N
                     .iter()
                     .map(|(sp!(loc, _), _)| core::make_tvar(context, *loc))
                     .collect::<Vec<_>>();
-                let res_ty = core::make_tvar(context, lambda.body.loc);
+                // The return may be divergent
+                let res_ty = core::make_divergent_tvar(context, lambda.body.loc);
                 let tfun = sp(loc, Type_::Fun(param_tys.clone(), Box::new(res_ty.clone())));
                 for annot in extra_annotations {
                     let annot_loc = annot.loc;

--- a/external-crates/move/crates/move-compiler/tests/linter/move_2024/unneeded_return_branch.snap
+++ b/external-crates/move/crates/move-compiler/tests/linter/move_2024/unneeded_return_branch.snap
@@ -5,6 +5,14 @@ info:
   edition: 2024.alpha
   lint: true
 ---
+warning[W09005]: dead or unreachable code
+  ┌─ tests/linter/move_2024/unneeded_return_branch.move:5:5
+  │
+5 │     if (cond) { return 5 } else { abort ZERO }
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Any code after this expression will not be reached
+  │
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
 warning[Lint W04004]: unneeded return
   ┌─ tests/linter/move_2024/unneeded_return_branch.move:5:17
   │
@@ -12,6 +20,14 @@ warning[Lint W04004]: unneeded return
   │                 ^^^^^^^^ Remove unnecessary 'return', the expression is already in a 'return' position
   │
   = This warning can be suppressed with '#[allow(lint(unneeded_return))]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[W09005]: dead or unreachable code
+  ┌─ tests/linter/move_2024/unneeded_return_branch.move:9:5
+  │
+9 │     if (cond) { return 5 } else { return 0 }
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Any code after this expression will not be reached
+  │
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
 
 warning[Lint W04004]: unneeded return
   ┌─ tests/linter/move_2024/unneeded_return_branch.move:9:17

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/dead_code_block_match_return.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/dead_code_block_match_return.move
@@ -1,0 +1,13 @@
+module a::m;
+
+fun test(): bool {
+    let result = 'a: {
+        match (0u8) {
+            255 => return 'a true,
+            0 => return 'a false,
+            _ => return 'a false,
+        };
+        true
+    };
+    result
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/dead_code_block_match_return.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/dead_code_block_match_return.snap
@@ -1,0 +1,21 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_2024/hlir/dead_code_block_match_return.move:5:21
+   │  
+ 5 │           match (0u8) {
+   │ ╭─────────────────────^
+ 6 │ │             255 => return 'a true,
+ 7 │ │             0 => return 'a false,
+ 8 │ │             _ => return 'a false,
+ 9 │ │         };
+   │ ╰─────────^ Any code after this expression will not be reached
+10 │           true
+   │           ---- Unreachable code. This statement (and any following statements) will not be executed.
+   │  
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/dead_code_block_match_return_valid.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/dead_code_block_match_return_valid.move
@@ -1,0 +1,12 @@
+module a::m;
+
+fun test(): bool {
+    let result = 'a: {
+        match (0u8) {
+            255 => return 'a true,
+            0 => return 'a false,
+            _ => return 'a false,
+        }
+    };
+    result
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/dead_code_block_match_return_valid.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/dead_code_block_match_return_valid.snap
@@ -1,0 +1,19 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+warning[W09005]: dead or unreachable code
+  ┌─ tests/move_2024/hlir/dead_code_block_match_return_valid.move:5:21
+  │  
+5 │           match (0u8) {
+  │ ╭─────────────────────^
+6 │ │             255 => return 'a true,
+7 │ │             0 => return 'a false,
+8 │ │             _ => return 'a false,
+9 │ │         }
+  │ ╰─────────^ Expected a value. Any code surrounding or after this expression will not be reached
+  │  
+  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/dead_code_match_return_0.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/dead_code_match_return_0.move
@@ -1,0 +1,9 @@
+module a::m;
+
+fun test(): bool {
+    match (0u8) {
+        255 => return true,
+        0 => return false,
+        _ => return false,
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/dead_code_match_return_0.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/dead_code_match_return_0.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/dead_code_match_return_1.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/dead_code_match_return_1.move
@@ -1,0 +1,9 @@
+module a::m;
+
+fun test(): bool {
+    match (0u8) {
+        255 => return true,
+        0 => return false,
+        _ => return false,
+    }
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/hlir/dead_code_match_return_1.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/hlir/dead_code_match_return_1.snap
@@ -1,0 +1,8 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/control_exp_autocomplete.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/control_exp_autocomplete.snap
@@ -5,10 +5,6 @@ info:
   edition: 2024.alpha
   lint: false
 ---
-error[E04010]: cannot infer type
- = Compiler Error -- no location information for error:
-     Could not infer this type. Try adding an annotation
-
 warning[W10007]: issue with attribute value
   ┌─ tests/move_2024/ide_mode/control_exp_autocomplete.move:3:9
   │

--- a/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/control_exp_autocomplete@ide.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/ide_mode/control_exp_autocomplete@ide.snap
@@ -9,10 +9,6 @@ note[I15004]: IDE missing match arms
  = Compiler Error -- no location information for error:
      Missing arms: '_'
 
-error[E04010]: cannot infer type
- = Compiler Error -- no location information for error:
-     Could not infer this type. Try adding an annotation
-
 error[E04007]: incompatible types
    ┌─ tests/move_2024/ide_mode/control_exp_autocomplete.move:15:13
    │

--- a/external-crates/move/crates/move-compiler/tests/move_2024/naming/macro_parameter_assignment.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/naming/macro_parameter_assignment.snap
@@ -25,6 +25,14 @@ error[E02010]: invalid name
   │
   = 'macro' parameters start with '$' to indicate that their arguments are not evaluated before the macro is expanded, meaning the entire expression is substituted. This is different from regular function parameters that are evaluated before the function is called.
 
+error[E04005]: expected a single type
+  ┌─ tests/move_2024/naming/macro_parameter_assignment.move:3:9
+  │
+3 │         f = abort 0;
+  │         ^   ------- Expected a single type, but found expression list type: '()'
+  │         │    
+  │         Invalid type for local
+
 error[E04029]: invalid function call
   ┌─ tests/move_2024/naming/macro_parameter_assignment.move:5:9
   │

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/cast_invalid.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/cast_invalid.snap
@@ -32,6 +32,15 @@ error[E01015]: ambiguous 'as'
 6 │         loop {} as u32;
   │         ^^^^^^^ Potentially ambiguous 'as'. Add parentheses to disambiguate
 
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_2024/parser/cast_invalid.move:6:9
+  │
+6 │         loop {} as u32;
+  │         ^^^^^^^
+  │         │
+  │         Invalid argument to 'as'
+  │         Found: '()'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
+
 error[E01015]: ambiguous 'as'
   ┌─ tests/move_2024/parser/cast_invalid.move:7:9
   │
@@ -50,17 +59,44 @@ error[E01015]: ambiguous 'as'
 9 │         return as u32;
   │         ^^^^^^ Potentially ambiguous 'as'. Add parentheses to disambiguate
 
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_2024/parser/cast_invalid.move:9:9
+  │
+9 │         return as u32;
+  │         ^^^^^^
+  │         │
+  │         Invalid argument to 'as'
+  │         Found: '()'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
+
 error[E01015]: ambiguous 'as'
    ┌─ tests/move_2024/parser/cast_invalid.move:11:13
    │
 11 │             break as u32;
    │             ^^^^^ Potentially ambiguous 'as'. Add parentheses to disambiguate
 
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_2024/parser/cast_invalid.move:11:13
+   │
+11 │             break as u32;
+   │             ^^^^^
+   │             │
+   │             Invalid argument to 'as'
+   │             Found: '()'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
+
 error[E01015]: ambiguous 'as'
    ┌─ tests/move_2024/parser/cast_invalid.move:12:13
    │
 12 │             continue as u32;
    │             ^^^^^^^^ Potentially ambiguous 'as'. Add parentheses to disambiguate
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_2024/parser/cast_invalid.move:12:13
+   │
+12 │             continue as u32;
+   │             ^^^^^^^^
+   │             │
+   │             Invalid argument to 'as'
+   │             Found: '()'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 
 error[E01015]: ambiguous 'as'
    ┌─ tests/move_2024/parser/cast_invalid.move:14:9

--- a/external-crates/move/crates/move-compiler/tests/move_2024/parser/cast_invalid_made_valid.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/parser/cast_invalid_made_valid.snap
@@ -5,4 +5,56 @@ info:
   edition: 2024.alpha
   lint: false
 ---
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_2024/parser/cast_invalid_made_valid.move:11:10
+   │
+11 │         (return) as u32;
+   │          ^^^^^^
+   │          │
+   │          Invalid argument to 'as'
+   │          Found: '()'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
 
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_2024/parser/cast_invalid_made_valid.move:12:10
+   │
+12 │         (return as u32);
+   │          ^^^^^^
+   │          │
+   │          Invalid argument to 'as'
+   │          Found: '()'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_2024/parser/cast_invalid_made_valid.move:14:14
+   │
+14 │             (break) as u32;
+   │              ^^^^^
+   │              │
+   │              Invalid argument to 'as'
+   │              Found: '()'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_2024/parser/cast_invalid_made_valid.move:15:14
+   │
+15 │             (break as u32);
+   │              ^^^^^
+   │              │
+   │              Invalid argument to 'as'
+   │              Found: '()'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_2024/parser/cast_invalid_made_valid.move:16:14
+   │
+16 │             (continue) as u32;
+   │              ^^^^^^^^
+   │              │
+   │              Invalid argument to 'as'
+   │              Found: '()'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
+
+error[E04003]: built-in operation not supported
+   ┌─ tests/move_2024/parser/cast_invalid_made_valid.move:17:14
+   │
+17 │             (continue as u32);
+   │              ^^^^^^^^
+   │              │
+   │              Invalid argument to 'as'
+   │              Found: '()'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/match_loop_return.move
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/match_loop_return.move
@@ -1,0 +1,15 @@
+module a::m;
+
+fun test(): bool {
+    let values = 'search: {
+        vector[1,2,3u8].destroy!(|v| {
+            match (v) {
+                255 => return 'search false,
+                0 => return 'search true,
+                _ => return 'search true,
+            }
+        });
+        true
+    };
+    values
+}

--- a/external-crates/move/crates/move-compiler/tests/move_2024/typing/match_loop_return.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/typing/match_loop_return.snap
@@ -1,0 +1,29 @@
+---
+source: crates/move-compiler/tests/move_check_testsuite.rs
+info:
+  flavor: core
+  edition: 2024.alpha
+  lint: false
+---
+warning[W09005]: dead or unreachable code
+   ┌─ tests/move_2024/typing/match_loop_return.move:6:23
+   │  
+ 6 │               match (v) {
+   │ ╭───────────────────────^
+ 7 │ │                 255 => return 'search false,
+ 8 │ │                 0 => return 'search true,
+ 9 │ │                 _ => return 'search true,
+10 │ │             }
+   │ ╰─────────────^ Expected a value. Any code surrounding or after this expression will not be reached
+   │  
+   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+
+warning[W09012]: unused 'mut' modifiers
+   ┌─ /Users/cgswords/sui-main/external-crates/move/crates/move-stdlib/sources/macros.move:88:13
+   │
+88 │     let mut i = $start;
+   │         --- ^ The variable 'i' is never used mutably
+   │         │    
+   │         Consider removing the 'mut' declaration here
+   │
+   = This warning can be suppressed with '#[allow(unused_let_mut)]' applied to the 'module' or module member ('const', 'fun', or 'struct')

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/return_in_binop.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/return_in_binop.snap
@@ -5,10 +5,20 @@ info:
   edition: legacy
   lint: false
 ---
-warning[W09005]: dead or unreachable code
+error[E04003]: built-in operation not supported
   ┌─ tests/move_check/parser/return_in_binop.move:3:9
   │
 3 │         return >> 0;
-  │         ^^^^^^ Expected a value. Any code surrounding or after this expression will not be reached
+  │         ^^^^^^
+  │         │
+  │         Invalid argument to '>>'
+  │         Found: '()'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'
+
+error[E04003]: built-in operation not supported
+  ┌─ tests/move_check/parser/return_in_binop.move:4:9
   │
-  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+4 │         return << 0;
+  │         ^^^^^^
+  │         │
+  │         Invalid argument to '<<'
+  │         Found: '()'. But expected: 'u8', 'u16', 'u32', 'u64', 'u128', 'u256'

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/borrow_divergent.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/borrow_divergent.snap
@@ -5,26 +5,29 @@ info:
   edition: legacy
   lint: false
 ---
-warning[W09005]: dead or unreachable code
-  ┌─ tests/move_check/typing/borrow_divergent.move:4:13
+error[E04004]: expected a single non-reference type
+  ┌─ tests/move_check/typing/borrow_divergent.move:4:12
   │
 4 │            &break;
-  │             ^^^^^ Expected a value. Any code surrounding or after this expression will not be reached
-  │
-  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  │            ^^^^^^
+  │            ││
+  │            │Expected a single non-reference type, but found: '()'
+  │            Invalid borrow
 
-warning[W09005]: dead or unreachable code
-  ┌─ tests/move_check/typing/borrow_divergent.move:9:12
+error[E04004]: expected a single non-reference type
+  ┌─ tests/move_check/typing/borrow_divergent.move:9:9
   │
 9 │         &{ return };
-  │            ^^^^^^ Expected a value. Any code surrounding or after this expression will not be reached
-  │
-  = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+  │         ^^^^^^^^^^^
+  │         │  │
+  │         │  Expected a single non-reference type, but found: '()'
+  │         Invalid borrow
 
-warning[W09005]: dead or unreachable code
-   ┌─ tests/move_check/typing/borrow_divergent.move:13:11
+error[E04004]: expected a single non-reference type
+   ┌─ tests/move_check/typing/borrow_divergent.move:13:9
    │
 13 │         &(if (cond) return else return);
-   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expected a value. Any code surrounding or after this expression will not be reached
-   │
-   = This warning can be suppressed with '#[allow(dead_code)]' applied to the 'module' or module member ('const', 'fun', or 'struct')
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │         │           │
+   │         │           Expected a single non-reference type, but found: '()'
+   │         Invalid borrow

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/exp_list_resource_drop.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/exp_list_resource_drop.snap
@@ -31,12 +31,15 @@ error[E05001]: ability constraint not satisfied
 9 │         (0, S{ }, Box { f: abort 0 });
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   │         │   │
-  │         │   The type '(u64, 0x8675309::M::S, 0x8675309::M::Box<_>)' can have the ability 'drop' but the type argument '0x8675309::M::S' does not have the required ability 'drop'
+  │         │   The type '(u64, 0x8675309::M::S, 0x8675309::M::Box<()>)' can have the ability 'drop' but the type argument '0x8675309::M::S' does not have the required ability 'drop'
   │         Cannot ignore values without the 'drop' ability. The value must be used
-  │         The type '(u64, 0x8675309::M::S, 0x8675309::M::Box<_>)' does not have the ability 'drop'
+  │         The type '(u64, 0x8675309::M::S, 0x8675309::M::Box<()>)' does not have the ability 'drop'
 
-error[E04010]: cannot infer type
+error[E04004]: expected a single non-reference type
   ┌─ tests/move_check/typing/exp_list_resource_drop.move:9:19
   │
 9 │         (0, S{ }, Box { f: abort 0 });
-  │                   ^^^^^^^^^^^^^^^^^^ Could not infer this type. Try adding an annotation
+  │                   ^^^^^^^^^^^^^^^^^^
+  │                   │        │
+  │                   │        Expected a single non-reference type, but found: '()'
+  │                   Invalid type argument


### PR DESCRIPTION
## Description 

This adds a divergent type constraint and sets unground divergent types to unit during constraint sovling.

## Test plan 

New tests and test revisions

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
