### PR TITLE
[rust-sdk] Cherry pick to adds custom header support in the SuiClientBuilder struct

### DIFF
--- a/crates/sui-sdk/src/error.rs
+++ b/crates/sui-sdk/src/error.rs
@@ -35,4 +35,6 @@ pub enum Error {
     InsufficientFund { address: SuiAddress, amount: u128 },
     #[error("Invalid signature")]
     InvalidSignature,
+    #[error("Invalid Header key-value pair: {0}")]
+    CustomHeadersError(String),
 }


### PR DESCRIPTION
…(#22595)

## Description 

- Creates a new `CustomHeadersError` Error for `SuiRpcResult`.
- Adds support for custom user defined headers in the `SuiClientBuilder`.

## Test plan 

Tested the initialization locally with the new Enoki RPC apikey protected RPC.
```rust
let mut headers = std::collections::HashMap::new();
    let api_key = String::from("apikey");
    let value = String::from("<a key here>");
    headers.insert(api_key, value);
    let sui_custom_headers = SuiClientBuilder::default()
        .custom_headers(headers)
        .build("https://enoki-rpc.mystenlabs.com/")
        .await?;

    let balanced = sui_custom_headers
        .coin_read_api()
        .get_all_balances(
            SuiAddress::from_str(
                "an address here",
            )
            .unwrap(),
        )
        .await
        .unwrap();
```
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [x] Rust SDK: Adds support for custom user defined headers in the `SuiClientBuilder`. Custom headers can be defined through the
`SuiClientBuilder::custom_headers` function and should be added right before building.