### PR TITLE
[move-ide] Version check fix

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/package-lock.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "move",
-  "version": "1.0.13",
+  "version": "1.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "move",
-      "version": "1.0.13",
+      "version": "1.0.23",
       "license": "Apache-2.0",
       "dependencies": {
         "command-exists": "^1.2.9",

--- a/external-crates/move/crates/move-analyzer/editors/code/src/context.ts
+++ b/external-crates/move/crates/move-analyzer/editors/code/src/context.ts
@@ -19,7 +19,10 @@ function version(path: string, args?: readonly string[]): string | null {
     const versionString = childProcess.spawnSync(
         path, args, { encoding: 'utf8' },
     );
-    return versionString.stdout;
+    // Need the null check as despite stdout in TS technically being only
+    // of type String, it can actually also be undefined
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    return versionString.stdout ?? null;
 }
 
 function semanticVersion(versionString: string | null): semver.SemVer | null {

--- a/external-crates/move/crates/move-analyzer/editors/code/src/context.ts
+++ b/external-crates/move/crates/move-analyzer/editors/code/src/context.ts
@@ -20,7 +20,7 @@ function version(path: string, args?: readonly string[]): string | null {
         path, args, { encoding: 'utf8' },
     );
     // Need the null check as despite stdout in TS technically being only
-    // of type String, it can actually also be undefined
+    // of type `string`, it can actually also be undefined
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     return versionString.stdout ?? null;
 }


### PR DESCRIPTION
## Description 

What the subject says. The function could actually return `undefined` (instead of just `string` or `null`) which would cause the extension startup to fail if one of the versions was not available during installation

## Test plan 

Tested manually
