### PR TITLE
[indexer-alt-framework] Update slow_future_monitor

### DIFF
--- a/crates/sui-indexer-alt-framework/src/ingestion/slow_future_monitor.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/slow_future_monitor.rs
@@ -1,74 +1,47 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use pin_project_lite::pin_project;
-use std::{
-    future::Future,
-    pin::Pin,
-    task::{Context, Poll},
-    time::Duration,
-};
-use tokio::time::Instant;
+use std::{future::Future, time::Duration};
+use tokio::time::sleep;
 
-// We need pin_project to safely poll the inner future from our Future implementation
-pin_project! {
-    /// A Future wrapper that calls a callback when the wrapped future takes too long,
-    /// but continues execution without canceling the future. The callback is guaranteed
-    /// to be called once if the threshold is exceeded.
-    pub(crate) struct SlowFutureMonitor<F, C> {
-        #[pin] inner: F,
-        on_threshold_exceeded: Option<C>,
-        threshold: Duration,
-        start_time: Instant,
-    }
-}
-
-impl<F, C> Future for SlowFutureMonitor<F, C>
-where
-    F: Future,
-    C: FnOnce(),
-{
-    type Output = F::Output;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.project();
-
-        // Check if we should call the callback (only once)
-        let elapsed = this.start_time.elapsed();
-        if elapsed >= *this.threshold {
-            if let Some(callback) = this.on_threshold_exceeded.take() {
-                callback();
-            }
-        }
-
-        // Poll the inner future
-        this.inner.poll(cx)
-    }
-}
-
-/// Helper function to wrap a future with slow future monitoring
-pub(crate) fn with_slow_future_monitor<F, C>(
+/// Wraps a future with slow/stuck detection using tokio::select!
+///
+/// This implementation races the future against a timer. If the timer expires first,
+/// the callback is executed (exactly once) but the future continues to run.
+/// This approach can detect stuck futures that never wake their waker.
+pub(crate) async fn with_slow_future_monitor<F, C>(
     future: F,
     threshold: Duration,
     callback: C,
-) -> SlowFutureMonitor<F, C>
+) -> F::Output
 where
     F: Future,
     C: FnOnce(),
 {
-    SlowFutureMonitor {
-        inner: future,
-        on_threshold_exceeded: Some(callback),
-        threshold,
-        start_time: Instant::now(),
+    // The select! macro needs to poll the future, which requires it to be pinned
+    tokio::pin!(future);
+
+    tokio::select! {
+        result = &mut future => {
+            // Future completed before timeout
+            return result;
+        }
+        _ = sleep(threshold) => {
+            // Timeout elapsed - fire the warning
+            callback();
+        }
     }
+
+    // If we get here, the timeout fired but the future is still running
+    // Continue waiting for the future to complete
+    future.await
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::{Arc, Mutex};
-    use tokio::time::{sleep, Duration};
+    use tokio::time::{sleep, timeout, Duration};
 
     // Helper to create a counter that can be shared across async boundaries
     fn new_counter() -> (Arc<Mutex<usize>>, impl Fn() + Send + 'static) {
@@ -90,74 +63,52 @@ mod tests {
     async fn test_callback_called_once_when_threshold_exceeded() {
         let (counter, increment_counter) = new_counter();
 
-        let monitored_future = with_slow_future_monitor(
-            sleep(Duration::from_millis(200)),
+        let result = with_slow_future_monitor(
+            async {
+                sleep(Duration::from_millis(200)).await;
+                42 // Return a value to verify completion
+            },
             Duration::from_millis(100),
             increment_counter,
-        );
+        )
+        .await;
 
-        monitored_future.await;
         assert_eq!(get_count(&counter), 1);
+        assert_eq!(result, 42);
     }
 
     #[tokio::test]
     async fn test_callback_not_called_when_threshold_not_exceeded() {
         let (counter, increment_counter) = new_counter();
 
-        let monitored_future = with_slow_future_monitor(
-            sleep(Duration::from_millis(50)),
+        let result = with_slow_future_monitor(
+            async {
+                sleep(Duration::from_millis(50)).await;
+                42 // Return a value to verify completion
+            },
             Duration::from_millis(200),
             increment_counter,
-        );
+        )
+        .await;
 
-        monitored_future.await;
         assert_eq!(get_count(&counter), 0);
-    }
-
-    #[tokio::test]
-    async fn test_future_returns_correct_value() {
-        // Create a future that returns a specific value
-        let value_future = async { 1512 };
-        let threshold = Duration::from_millis(100);
-
-        let monitored_future = with_slow_future_monitor(value_future, threshold, || {
-            // Callback doesn't matter for this test
-        });
-
-        // Wait for the future to complete and check the return value
-        let result = monitored_future.await;
-        assert_eq!(result, 1512);
-    }
-
-    #[tokio::test]
-    async fn test_zero_threshold() {
-        let (counter, increment_counter) = new_counter();
-
-        let monitored_future = with_slow_future_monitor(
-            async { "done" },
-            Duration::from_millis(0),
-            increment_counter,
-        );
-
-        let result = monitored_future.await;
-        assert_eq!(get_count(&counter), 1);
-        assert_eq!(result, "done");
+        assert_eq!(result, 42);
     }
 
     #[tokio::test]
     async fn test_error_propagation() {
         let (counter, increment_counter) = new_counter();
 
-        let monitored_future = with_slow_future_monitor(
+        let result: Result<i32, &str> = with_slow_future_monitor(
             async {
                 sleep(Duration::from_millis(150)).await;
                 Err("Something went wrong")
             },
             Duration::from_millis(100),
             increment_counter,
-        );
+        )
+        .await;
 
-        let result: Result<i32, &str> = monitored_future.await;
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), "Something went wrong");
         assert_eq!(get_count(&counter), 1);
@@ -167,18 +118,49 @@ mod tests {
     async fn test_error_propagation_without_callback() {
         let (counter, increment_counter) = new_counter();
 
-        let monitored_future = with_slow_future_monitor(
+        let result: Result<i32, &str> = with_slow_future_monitor(
             async {
                 sleep(Duration::from_millis(50)).await;
                 Err("Quick error")
             },
             Duration::from_millis(200),
             increment_counter,
-        );
+        )
+        .await;
 
-        let result: Result<i32, &str> = monitored_future.await;
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), "Quick error");
         assert_eq!(get_count(&counter), 0);
+    }
+
+    #[tokio::test]
+    async fn test_stuck_future_detection() {
+        use std::future::Future;
+        use std::pin::Pin;
+        use std::task::{Context, Poll};
+
+        // A future that returns Pending but never wakes the waker
+        struct StuckFuture;
+        impl Future for StuckFuture {
+            type Output = ();
+            fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+                Poll::Pending
+            }
+        }
+
+        let (counter, increment_counter) = new_counter();
+
+        // Even though StuckFuture never wakes, our monitor will detect it!
+        let monitored =
+            with_slow_future_monitor(StuckFuture, Duration::from_millis(200), increment_counter);
+
+        // Use a timeout to prevent the test from hanging
+        match timeout(Duration::from_secs(2), monitored).await {
+            Ok(_) => panic!("Stuck future should not complete"),
+            Err(_) => {
+                // The outer timeout fired, but our callback should have fired first
+                assert_eq!(get_count(&counter), 1);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description 

The original `SlowFutureMonitor` implementation could not detect futures that get "stuck" (never wake their waker). It only checked elapsed time during poll() calls, but if a future returns Poll::Pending without scheduling a wake, it will never be polled again, and the warning callback would never fire.

**Solution**
Replaced the polling-based approach with a tokio::select!-based implementation that races the monitored future against a timer:

```
tokio::select! {
    result = &mut future => return result,  // Future completed first
    _ = sleep(threshold) => callback(),     // Timer expired - fire warning
}
```

## Test plan 

How did you test the new or updated feature?

```
cargo test -p sui-indexer-alt-framework  remote_client  --lib
```

---

## Stack
- #22516

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
