### PR TITLE
Revert "Insert missing tx keys at start up (#22545)"

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1632,17 +1632,6 @@ impl AuthorityPerEpochStore {
         Ok(())
     }
 
-    pub fn insert_tx_key_only_for_recovery(
-        &self,
-        tx_key: &TransactionKey,
-        tx_digest: &TransactionDigest,
-    ) -> SuiResult {
-        let tables = self.tables()?;
-        tables.transaction_key_to_digest.insert(tx_key, tx_digest)?;
-        self.executed_digests_notify_read.notify(tx_key, tx_digest);
-        Ok(())
-    }
-
     pub(crate) fn remove_shared_version_assignments(
         &self,
         keys: impl IntoIterator<Item = TransactionKey>,


### PR DESCRIPTION
This reverts commit d4c0059ff5e066819631ef25fc59ff519efe6134.

The fix in that commit is no longer necessary now that we have recovered from the testnet incident
