### PR TITLE
[cli] Add replay2 to Sui CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13179,6 +13179,7 @@ dependencies = [
  "sui-package-management",
  "sui-protocol-config",
  "sui-replay",
+ "sui-replay-2",
  "sui-sdk",
  "sui-simulator",
  "sui-source-validation",

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -76,6 +76,7 @@ move-binary-format.workspace = true
 move-bytecode-source-map.workspace = true
 mysten-common.workspace = true
 test-cluster.workspace = true
+sui-replay-2.workspace = true
 
 fastcrypto.workspace = true
 fastcrypto-zkp.workspace = true


### PR DESCRIPTION
## Description 

Switch over replay support in the Sui CLI to use the new replay2 transaction replayer.

Currently a draft, but please leave comments! 

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: Updates to the transaction `replay-transaction` and `replay-batch` client subcommands to use the new transaction replay infrastructure. 
- [ ] Rust SDK:
