### PR TITLE
[cherrypick][rpc-alt] retry kv and tx_digest read operations (#22586)

### DIFF
--- a/crates/sui-indexer-alt-jsonrpc/src/api/transactions/error.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/transactions/error.rs
@@ -14,8 +14,8 @@ pub(super) enum Error {
     #[error("Pagination issue: {0}")]
     Pagination(#[from] crate::paginate::Error),
 
-    #[error("Balance changes for transaction {0} have been pruned")]
-    PrunedBalanceChanges(TransactionDigest),
+    #[error("Balance changes for transaction {0} are either pruned or not yet available")]
+    BalanceChangesNotFound(TransactionDigest),
 
     #[error(
         "Transaction {0} affected object {} pruned at version {2}",

--- a/crates/sui-indexer-alt-jsonrpc/src/api/transactions/filter.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/transactions/filter.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{collections::HashMap, time::Duration};
+
 use anyhow::Context as _;
 use diesel::{
     expression::{
@@ -19,6 +21,7 @@ use sui_indexer_alt_reader::tx_digests::TxDigestKey;
 use sui_indexer_alt_schema::schema::{
     tx_affected_addresses, tx_affected_objects, tx_calls, tx_digests,
 };
+use sui_indexer_alt_schema::transactions::StoredTxDigest;
 use sui_json_rpc_types::{Page as PageResponse, SuiTransactionBlockResponseOptions};
 use sui_sql_macro::sql;
 use sui_types::{
@@ -394,11 +397,33 @@ async fn from_sequence_numbers(
         .transpose()
         .context("Failed to encode next cursor")?;
 
-    let digests = ctx
-        .pg_loader()
-        .load_many(rows.iter().map(|&seq| TxDigestKey(seq as u64)))
-        .await
-        .context("Failed to load transaction digests")?;
+    // Get digests from the table and retry any of the digests that are not found.
+    let config = &ctx.config().transactions;
+    let retries = config.tx_retry_count;
+    let mut retry_interval =
+        tokio::time::interval(Duration::from_millis(config.tx_retry_interval_ms));
+    let mut keys: Vec<_> = rows.iter().map(|&seq| TxDigestKey(seq as u64)).collect();
+    let mut digests: HashMap<TxDigestKey, StoredTxDigest> = HashMap::new();
+    for _ in 0..=retries {
+        retry_interval.tick().await;
+
+        digests.extend(
+            ctx.pg_loader()
+                .load_many(keys.clone())
+                .await
+                .context("Failed to load transaction digests")?,
+        );
+
+        // Only retry the keys that are not found.
+        keys.retain(|key| !digests.contains_key(key));
+        if keys.is_empty() {
+            break;
+        }
+        ctx.metrics()
+            .read_retries
+            .with_label_values(&["tx_digest"])
+            .inc();
+    }
 
     let mut data = Vec::with_capacity(rows.len());
     for seq in rows {

--- a/crates/sui-indexer-alt-jsonrpc/src/api/transactions/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/transactions/mod.rs
@@ -103,9 +103,35 @@ impl QueryTransactionsApiServer for QueryTransactions {
 
         let options = query.options.unwrap_or_default();
 
-        let tx_futures = digests
-            .iter()
-            .map(|d| response::transaction(ctx, *d, &options));
+        let tx_futures = digests.iter().map(|d| {
+            async {
+                let mut tx = response::transaction(ctx, *d, &options).await;
+
+                let config = &ctx.config().transactions;
+                let mut interval = tokio::time::interval(std::time::Duration::from_millis(
+                    config.tx_retry_interval_ms,
+                ));
+
+                for _ in 0..config.tx_retry_count {
+                    // Retry only if the error is an invalid params error, which can only be due to
+                    // the transaction not being found in the kv store or tx balance changes table.
+                    if let Err(RpcError::InvalidParams(
+                        _e @ (Error::BalanceChangesNotFound(_) | Error::NotFound(_)),
+                    )) = tx
+                    {
+                        interval.tick().await;
+                        tx = response::transaction(ctx, *d, &options).await;
+                        ctx.metrics()
+                            .read_retries
+                            .with_label_values(&["tx_response"])
+                            .inc();
+                    } else {
+                        break;
+                    }
+                }
+                tx
+            }
+        });
 
         let data = future::join_all(tx_futures)
             .await

--- a/crates/sui-indexer-alt-jsonrpc/src/api/transactions/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/transactions/response.rs
@@ -60,7 +60,7 @@ pub(super) async fn transaction(
         .transpose()
         .context("Failed to fetch balance changes from store")?
     {
-        Some(None) => return Err(invalid_params(Error::PrunedBalanceChanges(digest))),
+        Some(None) => return Err(invalid_params(Error::BalanceChangesNotFound(digest))),
         Some(changes) => changes,
         None => None,
     };

--- a/crates/sui-indexer-alt-jsonrpc/src/config.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/config.rs
@@ -81,6 +81,13 @@ pub struct ObjectsConfig {
     /// The number of owned objects to fetch in one go when fulfilling a compound owned object
     /// filter.
     pub filter_scan_size: usize,
+
+    /// The number of times to retry a kv get operation. Retry is needed when a version of the object
+    /// is not yet found in the kv store due to the kv being behind the pg table's checkpoint watermark.
+    pub obj_retry_count: usize,
+
+    /// The interval between kv retry attempts in milliseconds.
+    pub obj_retry_interval_ms: u64,
 }
 
 #[DefaultConfig]
@@ -94,6 +101,8 @@ pub struct ObjectsLayer {
     pub max_filter_depth: Option<usize>,
     pub max_type_filters: Option<usize>,
     pub filter_scan_size: Option<usize>,
+    pub obj_retry_count: Option<usize>,
+    pub obj_retry_interval_ms: Option<u64>,
 
     #[serde(flatten)]
     pub extra: toml::Table,
@@ -127,6 +136,13 @@ pub struct TransactionsConfig {
     /// The largest acceptable page size when querying transactions. Requesting a page larger than
     /// this is a user error.
     pub max_page_size: usize,
+
+    /// The number of times to retry a read from kv or pg transaction tables. Retry is needed when a tx digest
+    /// is not yet found in the table due to it being behind other transaction table's checkpoint watermark.
+    pub tx_retry_count: usize,
+
+    /// The interval between tx_digest retry attempts in milliseconds.
+    pub tx_retry_interval_ms: u64,
 }
 
 #[DefaultConfig]
@@ -134,6 +150,8 @@ pub struct TransactionsConfig {
 pub struct TransactionsLayer {
     pub default_page_size: Option<usize>,
     pub max_page_size: Option<usize>,
+    pub tx_retry_count: Option<usize>,
+    pub tx_retry_interval_ms: Option<u64>,
 
     #[serde(flatten)]
     pub extra: toml::Table,
@@ -248,6 +266,10 @@ impl ObjectsLayer {
             max_filter_depth: self.max_filter_depth.unwrap_or(base.max_filter_depth),
             max_type_filters: self.max_type_filters.unwrap_or(base.max_type_filters),
             filter_scan_size: self.filter_scan_size.unwrap_or(base.filter_scan_size),
+            obj_retry_count: self.obj_retry_count.unwrap_or(base.obj_retry_count),
+            obj_retry_interval_ms: self
+                .obj_retry_interval_ms
+                .unwrap_or(base.obj_retry_interval_ms),
         }
     }
 }
@@ -268,6 +290,10 @@ impl TransactionsLayer {
         TransactionsConfig {
             default_page_size: self.default_page_size.unwrap_or(base.default_page_size),
             max_page_size: self.max_page_size.unwrap_or(base.max_page_size),
+            tx_retry_count: self.tx_retry_count.unwrap_or(base.tx_retry_count),
+            tx_retry_interval_ms: self
+                .tx_retry_interval_ms
+                .unwrap_or(base.tx_retry_interval_ms),
         }
     }
 }
@@ -356,6 +382,8 @@ impl Default for ObjectsConfig {
             max_filter_depth: 3,
             max_type_filters: 10,
             filter_scan_size: 200,
+            obj_retry_count: 5,
+            obj_retry_interval_ms: 100,
         }
     }
 }
@@ -374,6 +402,8 @@ impl Default for TransactionsConfig {
         Self {
             default_page_size: 50,
             max_page_size: 100,
+            tx_retry_count: 5,
+            tx_retry_interval_ms: 100,
         }
     }
 }
@@ -425,6 +455,8 @@ impl From<ObjectsConfig> for ObjectsLayer {
             max_filter_depth: Some(config.max_filter_depth),
             max_type_filters: Some(config.max_type_filters),
             filter_scan_size: Some(config.filter_scan_size),
+            obj_retry_count: Some(config.obj_retry_count),
+            obj_retry_interval_ms: Some(config.obj_retry_interval_ms),
             extra: Default::default(),
         }
     }
@@ -445,6 +477,8 @@ impl From<TransactionsConfig> for TransactionsLayer {
         Self {
             default_page_size: Some(config.default_page_size),
             max_page_size: Some(config.max_page_size),
+            tx_retry_count: Some(config.tx_retry_count),
+            tx_retry_interval_ms: Some(config.tx_retry_interval_ms),
             extra: Default::default(),
         }
     }

--- a/crates/sui-indexer-alt-jsonrpc/src/metrics/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/metrics/mod.rs
@@ -29,6 +29,7 @@ pub struct RpcMetrics {
     pub requests_failed: IntCounterVec,
 
     pub owned_objects_filter_scans: Histogram,
+    pub read_retries: IntCounterVec,
 }
 
 impl RpcMetrics {
@@ -72,6 +73,14 @@ impl RpcMetrics {
                 "Number of pages of owned objects scanned in response to compound owned object filters",
                 PAGE_SCAN_BUCKETS.to_vec(),
                 registry,
+            )
+            .unwrap(),
+
+            read_retries: register_int_counter_vec_with_registry!(
+                "read_retries",
+                "Number of retries for reads from Bigtable or Postgres tables",
+                &["table"],
+                registry
             )
             .unwrap(),
         })


### PR DESCRIPTION
## Description 

From traffic shadowing we see that internal errors can arise due to kv objects and tx_digests table being behind other objects/tx tables. This PR aims to resolve these internal errors by retrying the reads.

## Test plan 

tested with a local jsonrpc server

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
