### PR TITLE
[consensus] flush all pending commits

### DIFF
--- a/consensus/core/src/commit_finalizer.rs
+++ b/consensus/core/src/commit_finalizer.rs
@@ -115,12 +115,12 @@ impl CommitFinalizer {
             } else {
                 vec![committed_sub_dag]
             };
-            if let Some(commit) = finalized_commits.last() {
+            if !finalized_commits.is_empty() {
                 // Commits and committed blocks must be persisted to storage before sending them to Sui
                 // to execute their finalized transactions.
                 // Commit metadata and uncommitted blocks can be persisted more lazily because they are recoverable.
                 // But for simplicity, all unpersisted commits and blocks are flushed to storage.
-                self.dag_state.write().flush(commit.commit_ref.index);
+                self.dag_state.write().flush();
             }
             for commit in finalized_commits {
                 if let Err(e) = self.commit_sender.send(commit) {

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -34,7 +34,6 @@ use crate::{
     block_manager::BlockManager,
     commit::{
         CertifiedCommit, CertifiedCommits, CommitAPI, CommittedSubDag, DecidedLeader, Decision,
-        GENESIS_COMMIT_INDEX,
     },
     commit_observer::CommitObserver,
     context::Context,
@@ -701,9 +700,7 @@ impl Core {
         }
 
         // Ensure the new block and its ancestors are persisted, before broadcasting it.
-        // Commits cannot be persisted before being finalized. It is ok for the block to contain
-        // votes for unpersisted commits.
-        self.dag_state.write().flush(GENESIS_COMMIT_INDEX);
+        self.dag_state.write().flush();
 
         // Now acknowledge the transactions for their inclusion to block
         ack_transactions(verified_block.reference());

--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -1600,7 +1600,7 @@ mod test {
         }
 
         // Flush the DAG state to storage.
-        dag_state.write().flush_all_in_test();
+        dag_state.write().flush();
 
         // There were no commits prior to the core starting up but there was completed
         // rounds up to and including round 4. So we should commit leaders in round 1 & 2
@@ -1740,7 +1740,7 @@ mod test {
         core.try_commit(vec![]).ok();
 
         // Flush the DAG state to storage.
-        core.dag_state.write().flush_all_in_test();
+        core.dag_state.write().flush();
 
         // There were no commits prior to the core starting up but there was completed
         // rounds up to round 4. So we should commit leaders in round 1 & 2 as soon
@@ -1863,7 +1863,7 @@ mod test {
         assert!(core.try_propose(true).unwrap().is_none());
 
         // Flush the DAG state to storage.
-        dag_state.write().flush_all_in_test();
+        dag_state.write().flush();
 
         // Check no commits have been persisted to dag_state & store
         let last_commit = store.read_last_commit().unwrap();
@@ -1929,7 +1929,7 @@ mod test {
         assert_eq!(transaction_vote.rejects, vec![1, 4]);
 
         // Flush the DAG state to storage.
-        dag_state.write().flush_all_in_test();
+        dag_state.write().flush();
 
         // Check no commits have been persisted to dag_state & store
         let last_commit = store.read_last_commit().unwrap();
@@ -2020,7 +2020,7 @@ mod test {
         .await;
 
         // Flush the DAG state to storage.
-        dag_state.write().flush_all_in_test();
+        dag_state.write().flush();
 
         // Check no commits have been persisted to dag_state or store.
         let last_commit = store.read_last_commit().unwrap();
@@ -2053,7 +2053,7 @@ mod test {
         );
 
         // Flush the DAG state to storage.
-        dag_state.write().flush_all_in_test();
+        dag_state.write().flush();
 
         let last_commit = store
             .read_last_commit()
@@ -2180,7 +2180,7 @@ mod test {
         .await;
 
         // Flush the DAG state to storage.
-        dag_state.write().flush_all_in_test();
+        dag_state.write().flush();
 
         // Check no commits have been persisted to dag_state or store.
         let last_commit = store.read_last_commit().unwrap();
@@ -2421,7 +2421,7 @@ mod test {
             assert_eq!(core_fixture.core.last_proposed_round(), 4);
 
             // Flush the DAG state to storage.
-            core_fixture.dag_state.write().flush_all_in_test();
+            core_fixture.dag_state.write().flush();
 
             // Check commits have been persisted to store
             let last_commit = core_fixture
@@ -3254,7 +3254,7 @@ mod test {
 
         for core_fixture in cores {
             // Flush the DAG state to storage.
-            core_fixture.dag_state.write().flush_all_in_test();
+            core_fixture.dag_state.write().flush();
 
             // Check commits have been persisted to store
             let last_commit = core_fixture
@@ -3449,7 +3449,7 @@ mod test {
         assert_eq!(committed_sub_dags.len(), 4);
 
         // Flush the DAG state to storage.
-        core.dag_state.write().flush_all_in_test();
+        core.dag_state.write().flush();
 
         println!("Case 1. Provide no certified commits. No commit should happen.");
 
@@ -3480,7 +3480,7 @@ mod test {
             .expect("Should not fail");
 
         // Flush the DAG state to storage.
-        core.dag_state.write().flush_all_in_test();
+        core.dag_state.write().flush();
 
         let commits = store.scan_commits((6..=10).into()).unwrap();
 
@@ -3740,7 +3740,7 @@ mod test {
             };
 
             // Flush the DAG state to storage.
-            core_fixture.dag_state.write().flush_all_in_test();
+            core_fixture.dag_state.write().flush();
 
             // Check commits have been persisted to store
             let last_commit = core_fixture
@@ -3875,7 +3875,7 @@ mod test {
 
         for core_fixture in cores {
             // Flush the DAG state to storage.
-            core_fixture.dag_state.write().flush_all_in_test();
+            core_fixture.dag_state.write().flush();
             // Check commits have been persisted to store
             let last_commit = core_fixture
                 .store
@@ -3969,7 +3969,7 @@ mod test {
         }
 
         // Flush the DAG state to storage.
-        core_fixture.dag_state.write().flush_all_in_test();
+        core_fixture.dag_state.write().flush();
 
         // Check commits have been persisted to store
         let last_commit = core_fixture

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -998,19 +998,26 @@ impl DagState {
         commit_round.saturating_sub(self.context.protocol_config.gc_depth())
     }
 
+    /// Flushes unpersisted blocks, commits and commit info to storage.
+    ///
+    /// REQUIRED: when buffering a block, all of its ancestors and the latest commit which sets the GC round
+    /// must also be buffered.
+    /// REQUIRED: when buffering a commit, all of its included blocks and the previous commits must also be buffered.
+    /// REQUIRED: when flushing, all of the buffered blocks and commits must be flushed together to ensure consistency.
+    ///
     /// After each flush, DagState becomes persisted in storage and it expected to recover
     /// all internal states from storage after restarts.
-    pub(crate) fn flush(&mut self, finalized_commit_index: CommitIndex) {
-        self.flush_internal(finalized_commit_index, /* ensure_exists */ true);
+    pub(crate) fn flush(&mut self) {
+        self.flush_internal();
     }
 
     /// Flush all buffered commits to storage.
     #[cfg(test)]
     pub(crate) fn flush_all_in_test(&mut self) {
-        self.flush_internal(CommitIndex::MAX, /* ensure_exists */ false);
+        self.flush_internal();
     }
 
-    fn flush_internal(&mut self, finalized_commit_index: CommitIndex, ensure_exists: bool) {
+    fn flush_internal(&mut self) {
         let _s = self
             .context
             .metrics
@@ -1018,61 +1025,39 @@ impl DagState {
             .scope_processing_time
             .with_label_values(&["DagState::flush"])
             .start_timer();
+
         // Flush buffered data to storage.
-        let blocks = std::mem::take(&mut self.blocks_to_write);
-
-        let unfinalized_commits = self.commits_to_write.split_off(
-            self.commits_to_write
-                .iter()
-                .position(|c| c.index() > finalized_commit_index) // Find first element NOT satisfying condition
-                .unwrap_or(self.commits_to_write.len()), // If all satisfy, split_off at len
-        );
-        let finalized_commits = std::mem::replace(&mut self.commits_to_write, unfinalized_commits);
-        if ensure_exists && finalized_commit_index != GENESIS_COMMIT_INDEX {
-            assert!(
-                !finalized_commits.is_empty(),
-                "No commit is found (<= {}). Remaining buffered commits: {:?}",
-                finalized_commit_index,
-                self.commits_to_write
-            );
-            assert_eq!(
-                finalized_commits.last().unwrap().index(),
-                finalized_commit_index,
-                "Finalized commit not found. Finalized commits: {:?}, Buffered commits: {:?}",
-                finalized_commits,
-                self.commits_to_write
-            );
-        }
-
-        let unfinalized_commit_info = self.commit_info_to_write.split_off(
-            self.commit_info_to_write
-                .iter()
-                .position(|(c, _)| c.index > finalized_commit_index) // Find first element NOT satisfying condition
-                .unwrap_or(self.commit_info_to_write.len()), // If all satisfy, split_off at len
-        );
-        let finalized_commit_info =
-            std::mem::replace(&mut self.commit_info_to_write, unfinalized_commit_info);
-
-        if blocks.is_empty() && finalized_commits.is_empty() {
+        let pending_blocks = std::mem::take(&mut self.blocks_to_write);
+        let pending_commits = std::mem::take(&mut self.commits_to_write);
+        let pending_commit_info = std::mem::take(&mut self.commit_info_to_write);
+        if pending_blocks.is_empty() && pending_commits.is_empty() && pending_commit_info.is_empty()
+        {
             return;
         }
+
         debug!(
-            "Flushing {} blocks ({}), {} finalized commits ({}) and {} commit infos ({}) to storage.",
-            blocks.len(),
-            blocks.iter().map(|b| b.reference().to_string()).join(","),
-            finalized_commits.len(),
-            finalized_commits.iter().map(|c| c.reference().to_string()).join(","),
-            finalized_commit_info.len(),
-            finalized_commit_info
+            "Flushing {} blocks ({}), {} commits ({}) and {} commit infos ({}) to storage.",
+            pending_blocks.len(),
+            pending_blocks
+                .iter()
+                .map(|b| b.reference().to_string())
+                .join(","),
+            pending_commits.len(),
+            pending_commits
+                .iter()
+                .map(|c| c.reference().to_string())
+                .join(","),
+            pending_commit_info.len(),
+            pending_commit_info
                 .iter()
                 .map(|(commit_ref, _)| commit_ref.to_string())
                 .join(","),
         );
         self.store
             .write(WriteBatch::new(
-                blocks,
-                finalized_commits,
-                finalized_commit_info,
+                pending_blocks,
+                pending_commits,
+                pending_commit_info,
             ))
             .unwrap_or_else(|e| panic!("Failed to write to storage: {:?}", e));
         self.context
@@ -1777,7 +1762,7 @@ mod test {
             vec![],
         ));
         // Flush the DAG state to storage.
-        dag_state.flush(1);
+        dag_state.flush();
 
         // Ensure that gc round has been updated
         assert_eq!(dag_state.gc_round(), 3, "GC round should be 3");
@@ -1908,18 +1893,18 @@ mod test {
         // Note that the commit of round 8 is missing because where authority 0 is the leader but produced no block.
         // So commit 8 has leader round 9.
         const PERSISTED_BLOCK_ROUNDS: u32 = 12;
-        const NUM_FINALIZED_COMMITS: usize = 8;
-        const LAST_FINALIZED_COMMIT_ROUND: Round = 9;
-        const LAST_FINALIZED_COMMIT_INDEX: CommitIndex = 8;
+        const NUM_PERSISTED_COMMITS: usize = 8;
+        const LAST_PERSISTED_COMMIT_ROUND: Round = 9;
+        const LAST_PERSISTED_COMMIT_INDEX: CommitIndex = 8;
         dag_state.accept_blocks(dag_builder.blocks(1..=PERSISTED_BLOCK_ROUNDS));
         let mut finalized_commits = vec![];
-        for commit in commits.iter().take(NUM_FINALIZED_COMMITS).cloned() {
+        for commit in commits.iter().take(NUM_PERSISTED_COMMITS).cloned() {
             finalized_commits.push(commit.clone());
             dag_state.add_commit(commit);
         }
         let last_finalized_commit = finalized_commits.last().unwrap();
-        assert_eq!(last_finalized_commit.round(), LAST_FINALIZED_COMMIT_ROUND);
-        assert_eq!(last_finalized_commit.index(), LAST_FINALIZED_COMMIT_INDEX);
+        assert_eq!(last_finalized_commit.round(), LAST_PERSISTED_COMMIT_ROUND);
+        assert_eq!(last_finalized_commit.index(), LAST_PERSISTED_COMMIT_INDEX);
 
         // Collect finalized blocks.
         let finalized_blocks = finalized_commits
@@ -1927,33 +1912,28 @@ mod test {
             .flat_map(|commit| commit.blocks())
             .collect::<BTreeSet<_>>();
 
-        // Add one more commit to the dag state that will not be flushed.
-        assert_eq!(commits[NUM_FINALIZED_COMMITS].round(), 10);
-        dag_state.add_commit(commits[NUM_FINALIZED_COMMITS].clone());
+        // Flush commits from the dag state
+        dag_state.flush();
 
-        // Flush finalized commits from the dag state
-        dag_state.flush(LAST_FINALIZED_COMMIT_INDEX);
-
-        // Verify the store has blocks up to round 12, and commits up to index 7.
-        // The additional commit at round 10 should not be flushed.
+        // Verify the store has blocks up to round 12, and commits up to index 8.
         let store_blocks = store
             .scan_blocks_by_author(AuthorityIndex::new_for_test(1), 1)
             .unwrap();
         assert_eq!(store_blocks.last().unwrap().round(), PERSISTED_BLOCK_ROUNDS);
         let store_commits = store.scan_commits((0..=CommitIndex::MAX).into()).unwrap();
-        assert_eq!(store_commits.len(), NUM_FINALIZED_COMMITS);
+        assert_eq!(store_commits.len(), NUM_PERSISTED_COMMITS);
         assert_eq!(
             store_commits.last().unwrap().index(),
-            LAST_FINALIZED_COMMIT_INDEX
+            LAST_PERSISTED_COMMIT_INDEX
         );
         assert_eq!(
             store_commits.last().unwrap().round(),
-            LAST_FINALIZED_COMMIT_ROUND
+            LAST_PERSISTED_COMMIT_ROUND
         );
 
         // Add the rest of the blocks and commits to the dag state
         dag_state.accept_blocks(dag_builder.blocks(PERSISTED_BLOCK_ROUNDS + 1..=NUM_ROUNDS));
-        for commit in commits.iter().skip(NUM_FINALIZED_COMMITS + 1).cloned() {
+        for commit in commits.iter().skip(NUM_PERSISTED_COMMITS).cloned() {
             dag_state.add_commit(commit);
         }
 
@@ -2006,8 +1986,8 @@ mod test {
         assert!(retrieved_blocks.is_empty());
 
         // Recovered last commit index and round should be 8 and 9.
-        assert_eq!(dag_state.last_commit_index(), LAST_FINALIZED_COMMIT_INDEX);
-        assert_eq!(dag_state.last_commit_round(), LAST_FINALIZED_COMMIT_ROUND);
+        assert_eq!(dag_state.last_commit_index(), LAST_PERSISTED_COMMIT_INDEX);
+        assert_eq!(dag_state.last_commit_round(), LAST_PERSISTED_COMMIT_ROUND);
 
         // The last_commit_rounds of the finalized commits should have been recovered.
         let expected_last_committed_rounds = vec![5, 9, 8, 8];
@@ -2016,7 +1996,7 @@ mod test {
             expected_last_committed_rounds
         );
         // Unscored subdags will be recovered based on the flushed commits and no commit info.
-        assert_eq!(dag_state.scoring_subdags_count(), NUM_FINALIZED_COMMITS);
+        assert_eq!(dag_state.scoring_subdags_count(), NUM_PERSISTED_COMMITS);
 
         // Ensure that cached blocks exist only for specific rounds per authority
         for (authority_index, _) in context.committee.authorities() {
@@ -2345,7 +2325,7 @@ mod test {
         //
         // When GC is enabled then we'll keep all the blocks that are > gc_round (2) and for those who don't have blocks > gc_round, we'll keep
         // all their highest round blocks for CACHED_ROUNDS.
-        dag_state.flush(GENESIS_COMMIT_INDEX);
+        dag_state.flush();
 
         // AND we request before round 3
         let end_round = 3;
@@ -2432,7 +2412,7 @@ mod test {
         ));
 
         // Flush the store so we update the evict rounds
-        dag_state.flush(1);
+        dag_state.flush();
 
         // THEN the method should panic, as some authorities have already evicted rounds <= round 2
         dag_state.get_last_cached_block_per_authority(2);

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -1008,16 +1008,6 @@ impl DagState {
     /// After each flush, DagState becomes persisted in storage and it expected to recover
     /// all internal states from storage after restarts.
     pub(crate) fn flush(&mut self) {
-        self.flush_internal();
-    }
-
-    /// Flush all buffered commits to storage.
-    #[cfg(test)]
-    pub(crate) fn flush_all_in_test(&mut self) {
-        self.flush_internal();
-    }
-
-    fn flush_internal(&mut self) {
         let _s = self
             .context
             .metrics


### PR DESCRIPTION
## Description 

It is unnecessary to restrict commit flushing to finalized commits only. Sui / execution replays consensus from last processed commit, and replaying commits rerun the transaction finalization logic. Also it is incorrect to flush blocks without flushing the commit that sets the GC round at the time. The GC round determines which ancestors of a block must exist, so it should be flushed together with the ancestors before persisting a block.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
