### PR TITLE
[mfp] Add validator performance monitor

### DIFF
--- a/crates/mysten-common/src/decay_moving_average.rs
+++ b/crates/mysten-common/src/decay_moving_average.rs
@@ -1,0 +1,97 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// A moving average that decays over time so that the average value
+/// skews towards the newer values over time.
+///
+/// The decay factor is a value between 0 and 1 that determines how much of the previous value
+/// is kept when updating the average.
+///
+/// A decay factor of 0 means that the average is completely replaced with the new value every time,
+/// and a decay factor of 1 means that the average never changes (keeps the old value).
+///
+/// ## Choosing Decay Factors for Different Behaviors
+///
+/// **Lower decay factor (closer to 0.0):**
+/// - Adapts quickly to new values, making the average more responsive to recent changes
+/// - Outliers are "forgotten" faster, providing better tolerance to temporary spikes or anomalies
+/// - Useful for tracking recent trends where you want to react quickly to changes
+/// - Example: `0.1` - heavily weights recent values, good for responsive latency tracking
+///
+/// **Higher decay factor (closer to 1.0):**
+/// - Changes slowly and retains more historical information
+/// - Outliers have a longer-lasting impact on the average, making them more visible
+/// - Provides more stable tracking that's less sensitive to temporary fluctuations
+/// - Example: `0.9` - heavily weights historical values, good for stable baseline tracking
+///
+/// When using this to track moving average of latency, it is important that
+/// there should be a cap on the maximum value that can be stored.
+#[derive(Debug, Clone)]
+pub struct DecayMovingAverage {
+    value: f64,
+    decay_factor: f64,
+}
+
+impl DecayMovingAverage {
+    /// Create a new DecayMovingAverage with an initial value and decay factor.
+    ///
+    /// # Arguments
+    /// * `init_value` - The initial value for the moving average
+    /// * `decay_factor` - A value between 0.0 and 1.0 that controls how much historical data is retained.
+    ///   Lower values (e.g., 0.1) make the average more responsive to recent values and better at
+    ///   forgetting outliers. Higher values (e.g., 0.9) make the average more stable but outliers
+    ///   will have a longer-lasting impact.
+    pub fn new(init_value: f64, decay_factor: f64) -> Self {
+        assert!(
+            decay_factor > 0.0 && decay_factor < 1.0,
+            "Decay factor must be between 0 and 1"
+        );
+        Self {
+            value: init_value,
+            decay_factor,
+        }
+    }
+
+    /// Update the moving average with a new value.
+    ///
+    /// The new value is weighted by (1 - decay_factor), and the previous value
+    /// is weighted by decay_factor, so that the average value skews towards
+    /// the newer values over time.
+    pub fn update_moving_average(&mut self, value: f64) {
+        self.value = self.value * self.decay_factor + value * (1.0 - self.decay_factor);
+    }
+
+    /// Override the moving average with a new value, bypassing the decay calculation.
+    ///
+    /// Unlike `update_moving_average()`, this method immediately sets the average to the new value
+    /// rather than blending it with the previous value using the decay factor.
+    ///
+    /// This is particularly useful for implementing patterns like "decay moving max":
+    /// - Track the maximum value seen recently, but let it decay over time if no new maxima occur
+    /// - When a new maximum is encountered, immediately jump to that value using `override_moving_average()`
+    /// - For regular updates below the maximum, use `update_moving_average()` to let the value decay naturally
+    ///
+    /// # Example: Decay Moving Max
+    /// ```
+    /// fn update_moving_max(new_value: f64) {
+    ///     use mysten_common::decay_moving_average::DecayMovingAverage;
+    ///     let mut decay_max = DecayMovingAverage::new(0.0, 0.9);
+    ///
+    ///     // New maximum encountered - immediately jump to it
+    ///     if new_value > decay_max.get() {
+    ///         decay_max.override_moving_average(new_value);
+    ///     } else {
+    ///         // Let the maximum decay naturally toward the current value
+    ///         decay_max.update_moving_average(new_value);
+    ///     }
+    /// }
+    /// ```
+    pub fn override_moving_average(&mut self, value: f64) {
+        self.value = value;
+    }
+
+    /// Get the current value of the moving average.
+    pub fn get(&self) -> f64 {
+        self.value
+    }
+}

--- a/crates/mysten-common/src/lib.rs
+++ b/crates/mysten-common/src/lib.rs
@@ -4,6 +4,7 @@
 use once_cell::sync::Lazy;
 use tracing::warn;
 
+pub mod decay_moving_average;
 pub mod logging;
 pub mod random;
 pub mod random_util;

--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -21,6 +21,7 @@ use sui_core::{
         choose_transaction_driver_percentage, SubmitTransactionOptions, SubmitTxRequest,
         TransactionDriver, TransactionDriverMetrics,
     },
+    validator_client_monitor::ValidatorClientMetrics,
 };
 use sui_json_rpc_types::{
     SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery, SuiTransactionBlockEffects,
@@ -341,7 +342,16 @@ impl LocalValidatorAggregatorProxy {
                 .with_reconfig_observer(reconfig_observer.clone());
         let qd_handler = qd_handler_builder.start();
         let qd = qd_handler.clone_quorum_driver();
-        let td = TransactionDriver::new(aggregator, reconfig_observer, transaction_driver_metrics);
+        let client_metrics = Arc::new(ValidatorClientMetrics::new(&Registry::new()));
+
+        // For benchmark, pass None to use default validator client monitor config
+        let td = TransactionDriver::new(
+            aggregator,
+            reconfig_observer,
+            transaction_driver_metrics,
+            None,
+            client_metrics,
+        );
         Self {
             _qd_handler: qd_handler,
             qd,

--- a/crates/sui-config/src/lib.rs
+++ b/crates/sui-config/src/lib.rs
@@ -19,6 +19,7 @@ pub mod object_storage_config;
 pub mod p2p;
 pub mod rpc_config;
 pub mod transaction_deny_config;
+pub mod validator_client_monitor_config;
 pub mod verifier_signing_config;
 
 pub use node::{ConsensusConfig, ExecutionCacheConfig, NodeConfig};

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -5,6 +5,7 @@ use crate::genesis;
 use crate::object_storage_config::ObjectStoreConfig;
 use crate::p2p::P2pConfig;
 use crate::transaction_deny_config::TransactionDenyConfig;
+use crate::validator_client_monitor_config::ValidatorClientMonitorConfig;
 use crate::verifier_signing_config::VerifierSigningConfig;
 use crate::Config;
 use anyhow::Result;
@@ -211,6 +212,11 @@ pub struct NodeConfig {
     /// override this value on production networks will result in an error.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub chain_override_for_testing: Option<Chain>,
+
+    /// Configuration for validator client monitoring from the client perspective.
+    /// When enabled, tracks client-observed performance metrics for validators.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub validator_client_monitor_config: Option<ValidatorClientMonitorConfig>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/crates/sui-config/src/validator_client_monitor_config.rs
+++ b/crates/sui-config/src/validator_client_monitor_config.rs
@@ -1,0 +1,234 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Configuration for the Validator Client Monitor
+//!
+//! The Validator Client Monitor tracks client-observed performance metrics for validators
+//! in the Sui network. It runs from the perspective of a fullnode and monitors:
+//! - Transaction submission latency
+//! - Effects retrieval latency
+//! - Health check response times
+//! - Success/failure rates
+//!
+//! # Tuning Guide
+//!
+//! ## Monitoring Metrics
+//!
+//! The following Prometheus metrics can help tune the configuration:
+//!
+//! - `validator_client_observed_latency` - Histogram of operation latencies per validator
+//! - `validator_client_operation_success_total` - Counter of successful operations
+//! - `validator_client_operation_failure_total` - Counter of failed operations
+//! - `validator_client_observed_score` - Current score for each validator (0-1)
+//! - `validator_client_consecutive_failures` - Current consecutive failure count
+//! - `validator_client_selections_total` - How often each validator is selected
+//!
+//! ## Configuration Parameters
+//!
+//! ### Health Check Settings
+//!
+//! - `health_check_interval`: How often to probe validator health
+//!   - Default: 10s
+//!   - Decrease for more responsive failure detection (higher overhead)
+//!   - Increase to reduce network traffic
+//!   - Monitor `validator_client_operation_success_total{operation="health_check"}` to see probe frequency
+//!
+//! - `health_check_timeout`: Maximum time to wait for health check response
+//!   - Default: 2s
+//!   - Should be less than `health_check_interval`
+//!   - Set based on p99 of `validator_client_observed_latency{operation="health_check"}`
+//!
+//! ### Failure Handling
+//!
+//! - `max_consecutive_failures`: Failures before temporary exclusion
+//!   - Default: 5
+//!   - Lower values = faster exclusion of problematic validators
+//!   - Higher values = more tolerance for transient issues
+//!   - Monitor `validator_client_consecutive_failures` to see failure patterns
+//!
+//! - `failure_cooldown`: How long to exclude failed validators
+//!   - Default: 30s
+//!   - Should be several times the `health_check_interval`
+//!   - Too short = thrashing between exclusion/inclusion
+//!   - Too long = reduced validator pool during transient issues
+//!
+//! ### Score Weights
+//!
+//! Scores combine reliability and latency metrics. Adjust weights based on priorities:
+//!
+//! - `reliability`: Weight for success rate (0-1)
+//!   - Default: 0.6
+//!   - Increase if consistency is critical
+//!   - Decrease if latency is more important than occasional failures
+//!
+//! - `latency`: Weight for latency scores
+//!   - Default: 0.4
+//!   - Increase for latency-sensitive applications
+//!   - Individual operation weights can be tuned separately
+//!
+//! # Example Configurations
+//!
+//! ## Low Latency Priority
+//! ```yaml
+//! validator-client-monitor-config:
+//!   health-check-interval: 5s
+//!   health-check-timeout: 1s
+//!   max-consecutive-failures: 3
+//!   failure-cooldown: 20s
+//!   score-weights:
+//!     latency: 0.7
+//!     reliability: 0.3
+//!     effects-latency-weight: 0.6  # Effects queries are critical
+//! ```
+//!
+//! ## High Reliability Priority
+//! ```yaml
+//! validator-client-monitor-config:
+//!   health-check-interval: 15s
+//!   max-consecutive-failures: 10  # Very tolerant
+//!   failure-cooldown: 60s
+//!   score-weights:
+//!     latency: 0.2
+//!     reliability: 0.8
+//! ```
+
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+/// Configuration for validator client monitoring from the client perspective
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ValidatorClientMonitorConfig {
+    /// How often to perform health checks on validators.
+    ///
+    /// Lower values provide faster failure detection but increase network overhead.
+    /// This should be balanced against the `failure_cooldown` period.
+    #[serde(default = "default_health_check_interval")]
+    pub health_check_interval: Duration,
+
+    /// Timeout for health check requests.
+    ///
+    /// Should be less than `health_check_interval` to avoid overlapping checks.
+    /// Set based on network latency characteristics - typically 2-3x p99 latency.
+    #[serde(default = "default_health_check_timeout")]
+    pub health_check_timeout: Duration,
+
+    /// Weight configuration for score calculation.
+    ///
+    /// Determines how different factors contribute to validator selection.
+    #[serde(default)]
+    pub score_weights: ScoreWeights,
+
+    /// Cooldown period after failures before considering a validator again.
+    ///
+    /// Should be long enough to allow transient issues to resolve,
+    /// but short enough to quickly recover capacity when issues are fixed.
+    #[serde(default = "default_failure_cooldown")]
+    pub failure_cooldown: Duration,
+
+    /// Maximum number of consecutive failures before temporary exclusion.
+    ///
+    /// Lower values are more aggressive about excluding problematic validators.
+    /// Higher values are more tolerant of intermittent issues.
+    #[serde(default = "default_max_consecutive_failures")]
+    pub max_consecutive_failures: u32,
+}
+
+/// Weights for different factors in score calculation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ScoreWeights {
+    /// Weight for latency (lower is better).
+    ///
+    /// This is the overall weight for all latency scores combined.
+    /// Individual operation latencies are weighted separately below.
+    #[serde(default = "default_latency_weight")]
+    pub latency: f64,
+
+    /// Weight for success rate.
+    ///
+    /// Higher values prioritize reliability over performance.
+    #[serde(default = "default_reliability_weight")]
+    pub reliability: f64,
+
+    /// Weight for submit transaction latency.
+    ///
+    /// Controls importance of transaction submission speed.
+    #[serde(default = "default_submit_latency_weight")]
+    pub submit_latency_weight: f64,
+
+    /// Weight for effects retrieval latency.
+    ///
+    /// Controls importance of effects query speed.
+    /// Often the most critical operation for application responsiveness.
+    #[serde(default = "default_effects_latency_weight")]
+    pub effects_latency_weight: f64,
+
+    /// Weight for health check latency.
+    ///
+    /// Usually less critical than actual operations.
+    #[serde(default = "default_health_check_latency_weight")]
+    pub health_check_latency_weight: f64,
+}
+
+impl Default for ValidatorClientMonitorConfig {
+    fn default() -> Self {
+        Self {
+            health_check_interval: default_health_check_interval(),
+            health_check_timeout: default_health_check_timeout(),
+            score_weights: ScoreWeights::default(),
+            failure_cooldown: default_failure_cooldown(),
+            max_consecutive_failures: default_max_consecutive_failures(),
+        }
+    }
+}
+
+impl Default for ScoreWeights {
+    fn default() -> Self {
+        Self {
+            latency: default_latency_weight(),
+            reliability: default_reliability_weight(),
+            submit_latency_weight: default_submit_latency_weight(),
+            effects_latency_weight: default_effects_latency_weight(),
+            health_check_latency_weight: default_health_check_latency_weight(),
+        }
+    }
+}
+
+// Default value functions
+
+fn default_health_check_interval() -> Duration {
+    Duration::from_secs(10)
+}
+
+fn default_health_check_timeout() -> Duration {
+    Duration::from_secs(2)
+}
+
+fn default_failure_cooldown() -> Duration {
+    Duration::from_secs(30)
+}
+
+fn default_max_consecutive_failures() -> u32 {
+    100
+}
+
+fn default_latency_weight() -> f64 {
+    0.4
+}
+
+fn default_reliability_weight() -> f64 {
+    0.6
+}
+
+fn default_submit_latency_weight() -> f64 {
+    0.3
+}
+
+fn default_effects_latency_weight() -> f64 {
+    0.5
+}
+
+fn default_health_check_latency_weight() -> f64 {
+    0.2
+}

--- a/crates/sui-core/src/authority/consensus_tx_status_cache.rs
+++ b/crates/sui-core/src/authority/consensus_tx_status_cache.rs
@@ -172,6 +172,10 @@ impl ConsensusTxStatusCache {
         let _ = self.last_committed_leader_round_tx.send(Some(leader_round));
     }
 
+    pub fn get_last_committed_leader_round(&self) -> Option<u32> {
+        *self.last_committed_leader_round_rx.borrow()
+    }
+
     /// Returns true if the position is too far ahead of the last committed round.
     pub fn check_position_too_ahead(&self, position: &ConsensusPosition) -> SuiResult<()> {
         if let Some(last_committed_leader_round) = *self.last_committed_leader_round_rx.borrow() {

--- a/crates/sui-core/src/authority_client.rs
+++ b/crates/sui-core/src/authority_client.rs
@@ -108,6 +108,12 @@ pub trait AuthorityAPI {
         &self,
         request: SystemStateRequest,
     ) -> Result<SuiSystemState, SuiError>;
+
+    /// Get validator health metrics (for latency measurement)
+    async fn validator_health(
+        &self,
+        request: sui_types::messages_grpc::RawValidatorHealthRequest,
+    ) -> Result<sui_types::messages_grpc::RawValidatorHealthResponse, SuiError>;
 }
 
 #[derive(Clone)]
@@ -314,6 +320,17 @@ impl AuthorityAPI for NetworkAuthorityClient {
     ) -> Result<SuiSystemState, SuiError> {
         self.client()?
             .get_system_state_object(request)
+            .await
+            .map(tonic::Response::into_inner)
+            .map_err(Into::into)
+    }
+
+    async fn validator_health(
+        &self,
+        request: sui_types::messages_grpc::RawValidatorHealthRequest,
+    ) -> Result<sui_types::messages_grpc::RawValidatorHealthResponse, SuiError> {
+        self.client()?
+            .validator_health(request)
             .await
             .map(tonic::Response::into_inner)
             .map_err(Into::into)

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -335,6 +335,11 @@ impl ConsensusAdapter {
         self.consensus_throughput_profiler.store(Some(profiler))
     }
 
+    /// Get the current number of in-flight transactions
+    pub fn num_inflight_transactions(&self) -> u64 {
+        self.num_inflight_transactions.load(Ordering::Relaxed)
+    }
+
     pub fn submit_recovered(self: &Arc<Self>, epoch_store: &Arc<AuthorityPerEpochStore>) {
         // Currently narwhal worker might lose transactions on restart, so we need to resend them
         // todo - get_all_pending_consensus_transactions is called twice when

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -47,6 +47,7 @@ pub mod transaction_driver;
 mod transaction_input_loader;
 pub mod transaction_orchestrator;
 mod transaction_outputs;
+pub mod validator_client_monitor;
 pub mod validator_tx_finalizer;
 pub mod verify_indexes;
 

--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -695,4 +695,30 @@ where
             .handle_system_state_object(SystemStateRequest { _unused: false })
             .await
     }
+
+    /// Handle validator health check requests (for latency measurement)
+    #[instrument(level = "trace", skip_all, fields(authority = ?self.address.concise()))]
+    pub async fn validator_health(
+        &self,
+        request: sui_types::messages_grpc::ValidatorHealthRequest,
+    ) -> Result<sui_types::messages_grpc::ValidatorHealthResponse, SuiError> {
+        // Convert typed request to raw for gRPC
+        let raw_request = request.try_into().map_err(|e| {
+            sui_types::error::SuiError::GrpcMessageSerializeError {
+                type_info: "ValidatorHealthRequest".to_string(),
+                error: format!("Failed to convert to raw request: {}", e),
+            }
+        })?;
+
+        // Call the raw gRPC interface
+        let raw_response = self.authority_client.validator_health(raw_request).await?;
+
+        // Convert raw response back to typed
+        raw_response.try_into().map_err(|e| {
+            sui_types::error::SuiError::GrpcMessageDeserializeError {
+                type_info: "RawValidatorHealthResponse".to_string(),
+                error: format!("Failed to convert from raw response: {}", e),
+            }
+        })
+    }
 }

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -237,6 +237,25 @@ impl AuthorityAPI for LocalAuthorityClient {
     ) -> Result<SuiSystemState, SuiError> {
         self.state.get_sui_system_state_object_for_testing()
     }
+
+    async fn validator_health(
+        &self,
+        _request: sui_types::messages_grpc::RawValidatorHealthRequest,
+    ) -> Result<sui_types::messages_grpc::RawValidatorHealthResponse, SuiError> {
+        let typed_response = sui_types::messages_grpc::ValidatorHealthResponse {
+            num_inflight_consensus_transactions: 0,
+            num_inflight_execution_transactions: 0,
+            last_committed_leader_round: 1000,
+            last_locally_built_checkpoint: 500,
+        };
+
+        typed_response.try_into().map_err(|e| {
+            sui_types::error::SuiError::GrpcMessageSerializeError {
+                type_info: "ValidatorHealthResponse".to_string(),
+                error: format!("Failed to convert to raw response: {}", e),
+            }
+        })
+    }
 }
 
 impl LocalAuthorityClient {
@@ -334,6 +353,7 @@ impl LocalAuthorityClient {
     }
 }
 
+// TODO: The way we are passing in and using delay and count is really ugly code. Please fix it.
 #[derive(Clone)]
 pub struct MockAuthorityApi {
     delay: Duration,
@@ -457,6 +477,25 @@ impl AuthorityAPI for MockAuthorityApi {
     ) -> Result<SuiSystemState, SuiError> {
         unimplemented!();
     }
+
+    async fn validator_health(
+        &self,
+        _request: sui_types::messages_grpc::RawValidatorHealthRequest,
+    ) -> Result<sui_types::messages_grpc::RawValidatorHealthResponse, SuiError> {
+        let typed_response = sui_types::messages_grpc::ValidatorHealthResponse {
+            num_inflight_consensus_transactions: 0,
+            num_inflight_execution_transactions: 0,
+            last_committed_leader_round: 1000,
+            last_locally_built_checkpoint: 500,
+        };
+
+        typed_response.try_into().map_err(|e| {
+            sui_types::error::SuiError::GrpcMessageSerializeError {
+                type_info: "ValidatorHealthResponse".to_string(),
+                error: format!("Failed to convert to raw response: {}", e),
+            }
+        })
+    }
 }
 
 #[derive(Clone)]
@@ -556,6 +595,13 @@ impl AuthorityAPI for HandleTransactionTestAuthorityClient {
         &self,
         _request: SystemStateRequest,
     ) -> Result<SuiSystemState, SuiError> {
+        unimplemented!()
+    }
+
+    async fn validator_health(
+        &self,
+        _request: sui_types::messages_grpc::RawValidatorHealthRequest,
+    ) -> Result<sui_types::messages_grpc::RawValidatorHealthResponse, SuiError> {
         unimplemented!()
     }
 }

--- a/crates/sui-core/src/transaction_driver/metrics.rs
+++ b/crates/sui-core/src/transaction_driver/metrics.rs
@@ -36,6 +36,7 @@ pub struct TransactionDriverMetrics {
     pub(crate) certified_effects_ack_latency: Histogram,
     pub(crate) certified_effects_ack_attempts: IntCounter,
     pub(crate) certified_effects_ack_successes: IntCounter,
+    pub(crate) validator_selections: IntCounterVec,
 }
 
 impl TransactionDriverMetrics {
@@ -133,6 +134,13 @@ impl TransactionDriverMetrics {
             certified_effects_ack_successes: register_int_counter_with_registry!(
                 "transaction_driver_certified_effects_ack_successes",
                 "Number of successful certified effects acknowledgments",
+                registry,
+            )
+            .unwrap(),
+            validator_selections: register_int_counter_vec_with_registry!(
+                "transaction_driver_validator_selections",
+                "Number of times each validator was selected for transaction submission",
+                &["validator"],
                 registry,
             )
             .unwrap(),

--- a/crates/sui-core/src/transaction_driver/mod.rs
+++ b/crates/sui-core/src/transaction_driver/mod.rs
@@ -35,7 +35,9 @@ use crate::{
     authority_aggregator::AuthorityAggregator,
     authority_client::AuthorityAPI,
     quorum_driver::{reconfig_observer::ReconfigObserver, AuthorityAggregatorUpdatable},
+    validator_client_monitor::{ValidatorClientMetrics, ValidatorClientMonitor},
 };
+use sui_config::NodeConfig;
 
 /// Options for submitting a transaction.
 #[derive(Clone, Default, Debug)]
@@ -46,11 +48,12 @@ pub struct SubmitTransactionOptions {
 }
 
 pub struct TransactionDriver<A: Clone> {
-    authority_aggregator: ArcSwap<AuthorityAggregator<A>>,
+    authority_aggregator: Arc<ArcSwap<AuthorityAggregator<A>>>,
     state: Mutex<State>,
     metrics: Arc<TransactionDriverMetrics>,
     submitter: TransactionSubmitter,
     certifier: EffectsCertifier,
+    client_monitor: Arc<ValidatorClientMonitor<A>>,
 }
 
 impl<A> TransactionDriver<A>
@@ -61,14 +64,27 @@ where
         authority_aggregator: Arc<AuthorityAggregator<A>>,
         reconfig_observer: Arc<dyn ReconfigObserver<A> + Sync + Send>,
         metrics: Arc<TransactionDriverMetrics>,
+        node_config: Option<&NodeConfig>,
+        client_metrics: Arc<ValidatorClientMetrics>,
     ) -> Arc<Self> {
+        let shared_swap = Arc::new(ArcSwap::new(authority_aggregator));
+
+        // Extract validator client monitor config from NodeConfig or use default
+        let monitor_config = node_config
+            .and_then(|nc| nc.validator_client_monitor_config.clone())
+            .unwrap_or_default();
+        let client_monitor =
+            ValidatorClientMonitor::new(monitor_config, client_metrics, shared_swap.clone());
+
         let driver = Arc::new(Self {
-            authority_aggregator: ArcSwap::new(authority_aggregator),
+            authority_aggregator: shared_swap,
             state: Mutex::new(State::new()),
             metrics: metrics.clone(),
             submitter: TransactionSubmitter::new(metrics.clone()),
             certifier: EffectsCertifier::new(metrics),
+            client_monitor,
         });
+
         driver.enable_reconfig(reconfig_observer);
         driver
     }
@@ -84,10 +100,10 @@ where
         let raw_request = request.into_raw().unwrap();
         let timer = Instant::now();
 
-        // Track total transactions submitted
         self.metrics.total_transactions_submitted.inc();
 
         const MAX_RETRY_DELAY: Duration = Duration::from_secs(10);
+        // Exponential backoff with jitter to prevent thundering herd on retries
         let mut backoff = ExponentialBackoff::from_millis(100)
             .max_delay(MAX_RETRY_DELAY)
             .map(jitter);
@@ -146,15 +162,27 @@ where
     ) -> Result<QuorumTransactionResponse, TransactionDriverError> {
         let auth_agg = self.authority_aggregator.load();
 
-        // Get consensus position using TransactionSubmitter
         let (name, submit_txn_resp) = self
             .submitter
-            .submit_transaction(&auth_agg, tx_digest, raw_request, options)
+            .submit_transaction(
+                &auth_agg,
+                &self.client_monitor,
+                tx_digest,
+                raw_request,
+                options,
+            )
             .await?;
 
         // Wait for quorum effects using EffectsCertifier
         self.certifier
-            .get_certified_finalized_effects(&auth_agg, tx_digest, name, submit_txn_resp, options)
+            .get_certified_finalized_effects(
+                &auth_agg,
+                &self.client_monitor,
+                tx_digest,
+                name,
+                submit_txn_resp,
+                options,
+            )
             .await
     }
 
@@ -187,6 +215,7 @@ where
             "Transaction Driver updating AuthorityAggregator with committee {}",
             new_authorities.committee
         );
+
         self.authority_aggregator.store(new_authorities);
     }
 }

--- a/crates/sui-core/src/transaction_driver/unit_tests/effects_certifier_tests.rs
+++ b/crates/sui-core/src/transaction_driver/unit_tests/effects_certifier_tests.rs
@@ -13,6 +13,7 @@ use crate::{
         metrics::TransactionDriverMetrics,
         SubmitTransactionOptions,
     },
+    validator_client_monitor::ValidatorClientMonitor,
 };
 use async_trait::async_trait;
 use consensus_types::block::BlockRef;
@@ -190,6 +191,13 @@ impl AuthorityAPI for MockAuthority {
     ) -> Result<SuiSystemState, SuiError> {
         unimplemented!()
     }
+
+    async fn validator_health(
+        &self,
+        _request: sui_types::messages_grpc::RawValidatorHealthRequest,
+    ) -> Result<sui_types::messages_grpc::RawValidatorHealthResponse, SuiError> {
+        unimplemented!()
+    }
 }
 
 fn create_test_authority_aggregator() -> AuthorityAggregator<MockAuthority> {
@@ -225,6 +233,9 @@ fn create_test_executed_data() -> ExecutedData {
 async fn test_successful_certified_effects() {
     telemetry_subscribers::init_for_testing();
     let authority_aggregator = Arc::new(create_test_authority_aggregator());
+    let client_monitor = Arc::new(ValidatorClientMonitor::new_for_test(
+        authority_aggregator.clone(),
+    ));
     let metrics = Arc::new(TransactionDriverMetrics::new_for_tests());
     let certifier = EffectsCertifier::new(metrics);
 
@@ -267,6 +278,7 @@ async fn test_successful_certified_effects() {
     let result = certifier
         .get_certified_finalized_effects(
             &authority_aggregator,
+            &client_monitor,
             &tx_digest,
             *name,
             submit_tx_resp,
@@ -302,6 +314,7 @@ async fn test_successful_certified_effects() {
     let result = certifier
         .get_certified_finalized_effects(
             &authority_aggregator,
+            &client_monitor,
             &tx_digest,
             *name,
             submit_tx_resp,
@@ -323,6 +336,9 @@ async fn test_successful_certified_effects() {
 async fn test_transaction_rejected_non_retriable() {
     telemetry_subscribers::init_for_testing();
     let authority_aggregator = Arc::new(create_test_authority_aggregator());
+    let client_monitor = Arc::new(ValidatorClientMonitor::new_for_test(
+        authority_aggregator.clone(),
+    ));
     let metrics = Arc::new(TransactionDriverMetrics::new_for_tests());
     let certifier = EffectsCertifier::new(metrics);
 
@@ -360,6 +376,7 @@ async fn test_transaction_rejected_non_retriable() {
     let result = certifier
         .get_certified_finalized_effects(
             &authority_aggregator,
+            &client_monitor,
             &tx_digest,
             *name,
             SubmitTxResponse::Submitted { consensus_position },
@@ -384,6 +401,9 @@ async fn test_transaction_rejected_non_retriable() {
 async fn test_transaction_rejected_retriable() {
     telemetry_subscribers::init_for_testing();
     let authority_aggregator = Arc::new(create_test_authority_aggregator());
+    let client_monitor = Arc::new(ValidatorClientMonitor::new_for_test(
+        authority_aggregator.clone(),
+    ));
     let metrics = Arc::new(TransactionDriverMetrics::new_for_tests());
     let certifier = EffectsCertifier::new(metrics);
 
@@ -420,6 +440,7 @@ async fn test_transaction_rejected_retriable() {
     let result = certifier
         .get_certified_finalized_effects(
             &authority_aggregator,
+            &client_monitor,
             &tx_digest,
             *name,
             SubmitTxResponse::Submitted { consensus_position },
@@ -446,6 +467,9 @@ async fn test_transaction_rejected_retriable() {
 async fn test_transaction_expired() {
     telemetry_subscribers::init_for_testing();
     let authority_aggregator = Arc::new(create_test_authority_aggregator());
+    let client_monitor = Arc::new(ValidatorClientMonitor::new_for_test(
+        authority_aggregator.clone(),
+    ));
     let metrics = Arc::new(TransactionDriverMetrics::new_for_tests());
     let certifier = EffectsCertifier::new(metrics);
 
@@ -478,6 +502,7 @@ async fn test_transaction_expired() {
     let result = certifier
         .get_certified_finalized_effects(
             &authority_aggregator,
+            &client_monitor,
             &tx_digest,
             *name,
             SubmitTxResponse::Submitted { consensus_position },
@@ -504,6 +529,9 @@ async fn test_transaction_expired() {
 async fn test_mixed_rejected_and_expired() {
     telemetry_subscribers::init_for_testing();
     let authority_aggregator = Arc::new(create_test_authority_aggregator());
+    let client_monitor = Arc::new(ValidatorClientMonitor::new_for_test(
+        authority_aggregator.clone(),
+    ));
     let metrics = Arc::new(TransactionDriverMetrics::new_for_tests());
     let certifier = EffectsCertifier::new(metrics);
 
@@ -556,6 +584,7 @@ async fn test_mixed_rejected_and_expired() {
     let result = certifier
         .get_certified_finalized_effects(
             &authority_aggregator,
+            &client_monitor,
             &tx_digest,
             *name,
             SubmitTxResponse::Submitted { consensus_position },
@@ -595,6 +624,7 @@ async fn test_mixed_rejected_and_expired() {
     let result = certifier
         .get_certified_finalized_effects(
             &authority_aggregator,
+            &client_monitor,
             &tx_digest,
             *name,
             SubmitTxResponse::Submitted { consensus_position },
@@ -621,6 +651,9 @@ async fn test_mixed_rejected_and_expired() {
 async fn test_forked_execution() {
     telemetry_subscribers::init_for_testing();
     let authority_aggregator = Arc::new(create_test_authority_aggregator());
+    let client_monitor = Arc::new(ValidatorClientMonitor::new_for_test(
+        authority_aggregator.clone(),
+    ));
     let metrics = Arc::new(TransactionDriverMetrics::new_for_tests());
     let certifier = EffectsCertifier::new(metrics);
 
@@ -672,6 +705,7 @@ async fn test_forked_execution() {
     let result = certifier
         .get_certified_finalized_effects(
             &authority_aggregator,
+            &client_monitor,
             &tx_digest,
             *name,
             SubmitTxResponse::Submitted { consensus_position },
@@ -700,6 +734,9 @@ async fn test_forked_execution() {
 async fn test_full_effects_retry_loop() {
     telemetry_subscribers::init_for_testing();
     let authority_aggregator = Arc::new(create_test_authority_aggregator());
+    let client_monitor = Arc::new(ValidatorClientMonitor::new_for_test(
+        authority_aggregator.clone(),
+    ));
     let metrics = Arc::new(TransactionDriverMetrics::new_for_tests());
     let certifier = EffectsCertifier::new(metrics);
 
@@ -760,6 +797,7 @@ async fn test_full_effects_retry_loop() {
     let result = certifier
         .get_certified_finalized_effects(
             &authority_aggregator,
+            &client_monitor,
             &tx_digest,
             *name,
             SubmitTxResponse::Submitted { consensus_position },
@@ -782,6 +820,9 @@ async fn test_full_effects_retry_loop() {
 async fn test_full_effects_digest_mismatch() {
     telemetry_subscribers::init_for_testing();
     let authority_aggregator = Arc::new(create_test_authority_aggregator());
+    let client_monitor = Arc::new(ValidatorClientMonitor::new_for_test(
+        authority_aggregator.clone(),
+    ));
     let metrics = Arc::new(TransactionDriverMetrics::new_for_tests());
     let certifier = EffectsCertifier::new(metrics);
 
@@ -839,6 +880,7 @@ async fn test_full_effects_digest_mismatch() {
     let result = certifier
         .get_certified_finalized_effects(
             &authority_aggregator,
+            &client_monitor,
             &tx_digest,
             *name,
             SubmitTxResponse::Submitted { consensus_position },
@@ -861,6 +903,9 @@ async fn test_full_effects_digest_mismatch() {
 async fn test_request_retrier_exhaustion() {
     telemetry_subscribers::init_for_testing();
     let authority_aggregator = Arc::new(create_test_authority_aggregator());
+    let client_monitor = Arc::new(ValidatorClientMonitor::new_for_test(
+        authority_aggregator.clone(),
+    ));
     let metrics = Arc::new(TransactionDriverMetrics::new_for_tests());
     let certifier = EffectsCertifier::new(metrics);
 
@@ -908,6 +953,7 @@ async fn test_request_retrier_exhaustion() {
     let result = certifier
         .get_certified_finalized_effects(
             &authority_aggregator,
+            &client_monitor,
             &tx_digest,
             *name,
             SubmitTxResponse::Submitted { consensus_position },

--- a/crates/sui-core/src/validator_client_monitor/metrics.rs
+++ b/crates/sui-core/src/validator_client_monitor/metrics.rs
@@ -1,0 +1,93 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use prometheus::{
+    register_gauge_vec_with_registry, register_histogram_vec_with_registry,
+    register_int_counter_vec_with_registry, register_int_gauge_vec_with_registry, GaugeVec,
+    HistogramVec, IntCounterVec, IntGaugeVec, Registry,
+};
+
+const LATENCY_SEC_BUCKETS: &[f64] = &[
+    0.001, 0.005, 0.01, 0.015, 0.02, 0.025, 0.03, 0.04, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+];
+
+#[derive(Clone)]
+pub struct ValidatorClientMetrics {
+    /// Latency of operations per validator
+    pub observed_latency: HistogramVec,
+
+    /// Success count per validator and operation type
+    pub operation_success: IntCounterVec,
+
+    /// Failure count per validator and operation type
+    pub operation_failure: IntCounterVec,
+
+    /// Current performance score per validator
+    pub performance_score: GaugeVec,
+
+    /// Consecutive failures per validator
+    pub consecutive_failures: IntGaugeVec,
+
+    /// Time since last successful operation per validator
+    pub time_since_last_success: GaugeVec,
+}
+
+impl ValidatorClientMetrics {
+    pub fn new(registry: &Registry) -> Self {
+        Self {
+            observed_latency: register_histogram_vec_with_registry!(
+                "validator_client_observed_latency",
+                "Client-observed latency of operations per validator",
+                &["validator", "operation_type"],
+                LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+
+            operation_success: register_int_counter_vec_with_registry!(
+                "validator_client_operation_success_total",
+                "Total successful operations observed by client per validator",
+                &["validator", "operation_type"],
+                registry,
+            )
+            .unwrap(),
+
+            operation_failure: register_int_counter_vec_with_registry!(
+                "validator_client_operation_failure_total",
+                "Total failed operations observed by client per validator",
+                &["validator", "operation_type"],
+                registry,
+            )
+            .unwrap(),
+
+            performance_score: register_gauge_vec_with_registry!(
+                "validator_client_observed_score",
+                "Current client-observed score per validator",
+                &["validator"],
+                registry,
+            )
+            .unwrap(),
+
+            consecutive_failures: register_int_gauge_vec_with_registry!(
+                "validator_client_consecutive_failures",
+                "Current consecutive failures observed by client per validator",
+                &["validator"],
+                registry,
+            )
+            .unwrap(),
+
+            time_since_last_success: register_gauge_vec_with_registry!(
+                "validator_client_time_since_last_success",
+                "Time in seconds since last successful client interaction",
+                &["validator"],
+                registry,
+            )
+            .unwrap(),
+        }
+    }
+
+    pub fn new_for_tests() -> Self {
+        let registry = Registry::new();
+        Self::new(&registry)
+    }
+}

--- a/crates/sui-core/src/validator_client_monitor/mod.rs
+++ b/crates/sui-core/src/validator_client_monitor/mod.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+mod metrics;
+mod monitor;
+mod stats;
+
+#[cfg(test)]
+mod tests;
+
+pub use metrics::ValidatorClientMetrics;
+pub use monitor::ValidatorClientMonitor;
+use strum::EnumIter;
+use sui_types::base_types::AuthorityName;
+
+use std::time::Duration;
+
+/// Operation types for validator performance tracking
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumIter)]
+pub enum OperationType {
+    Submit,
+    Effects,
+    HealthCheck,
+}
+
+/// Feedback from TransactionDriver operations
+#[derive(Debug, Clone)]
+pub struct OperationFeedback {
+    /// The unique authority name (public key)
+    pub authority_name: AuthorityName,
+    /// The human-readable display name for the validator
+    pub display_name: String,
+    /// The operation type
+    pub operation: OperationType,
+    /// Result of the operation: Ok(latency) if successful, Err(()) if failed
+    pub result: Result<Duration, ()>,
+}

--- a/crates/sui-core/src/validator_client_monitor/monitor.rs
+++ b/crates/sui-core/src/validator_client_monitor/monitor.rs
@@ -1,0 +1,284 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::authority_aggregator::AuthorityAggregator;
+use crate::authority_client::AuthorityAPI;
+use crate::validator_client_monitor::stats::ClientObservedStats;
+use crate::validator_client_monitor::{
+    metrics::ValidatorClientMetrics, OperationFeedback, OperationType,
+};
+use arc_swap::ArcSwap;
+use parking_lot::RwLock;
+use rand::seq::SliceRandom;
+use std::collections::HashMap;
+use std::{sync::Arc, time::Instant};
+use sui_config::validator_client_monitor_config::ValidatorClientMonitorConfig;
+use sui_types::committee::Committee;
+use sui_types::{
+    base_types::{AuthorityName, ConciseableName},
+    messages_grpc::ValidatorHealthRequest,
+};
+use tokio::{
+    task::JoinSet,
+    time::{interval, timeout},
+};
+use tracing::{debug, info, warn};
+
+/// Monitors validator interactions from the client's perspective.
+///
+/// This component:
+/// - Collects client-side metrics from TransactionDriver operations
+/// - Runs periodic health checks on all validators from the client
+/// - Maintains client-observed statistics for reliability and latency
+/// - Provides intelligent validator selection based on client-observed performance
+/// - Handles epoch changes by cleaning up stale validator data
+///
+/// The monitor runs a background task for health checks and uses
+/// exponential moving averages to smooth client-side measurements.
+pub struct ValidatorClientMonitor<A: Clone> {
+    config: ValidatorClientMonitorConfig,
+    metrics: Arc<ValidatorClientMetrics>,
+    client_stats: RwLock<ClientObservedStats>,
+    authority_aggregator: Arc<ArcSwap<AuthorityAggregator<A>>>,
+    cached_scores: RwLock<Option<HashMap<AuthorityName, f64>>>,
+}
+
+impl<A> ValidatorClientMonitor<A>
+where
+    A: AuthorityAPI + Send + Sync + 'static + Clone,
+{
+    pub fn new(
+        config: ValidatorClientMonitorConfig,
+        metrics: Arc<ValidatorClientMetrics>,
+        authority_aggregator: Arc<ArcSwap<AuthorityAggregator<A>>>,
+    ) -> Arc<Self> {
+        info!(
+            "Validator client monitor starting with config: {:?}",
+            config
+        );
+
+        let monitor = Arc::new(Self {
+            config: config.clone(),
+            metrics,
+            client_stats: RwLock::new(ClientObservedStats::new(config)),
+            authority_aggregator,
+            cached_scores: RwLock::new(None),
+        });
+
+        let monitor_clone = monitor.clone();
+        tokio::spawn(async move {
+            monitor_clone.run_health_checks().await;
+        });
+
+        monitor
+    }
+
+    #[cfg(test)]
+    pub fn new_for_test(authority_aggregator: Arc<AuthorityAggregator<A>>) -> Arc<Self> {
+        use prometheus::Registry;
+
+        Self::new(
+            ValidatorClientMonitorConfig::default(),
+            Arc::new(ValidatorClientMetrics::new(&Registry::default())),
+            Arc::new(ArcSwap::new(authority_aggregator)),
+        )
+    }
+
+    /// Background task that runs periodic health checks on all validators.
+    ///
+    /// Sends health check requests to all validators in parallel and records
+    /// the results (success/failure and latency). Timeouts are treated as
+    /// failures without recording latency to avoid polluting latency statistics.
+    async fn run_health_checks(self: Arc<Self>) {
+        let mut interval = interval(self.config.health_check_interval);
+
+        loop {
+            interval.tick().await;
+
+            let authority_agg = self.authority_aggregator.load();
+
+            let current_validators: Vec<_> = authority_agg.committee.names().cloned().collect();
+            self.client_stats
+                .write()
+                .retain_validators(&current_validators);
+
+            let mut tasks = JoinSet::new();
+
+            for (name, safe_client) in authority_agg.authority_clients.iter() {
+                let name = *name;
+                let display_name = authority_agg.get_display_name(&name);
+                let client = safe_client.clone();
+                let timeout_duration = self.config.health_check_timeout;
+                let monitor = self.clone();
+
+                tasks.spawn(async move {
+                    let start = Instant::now();
+                    match timeout(
+                        timeout_duration,
+                        client.validator_health(ValidatorHealthRequest {}),
+                    )
+                    .await
+                    {
+                        // TODO: Actually use the response details.
+                        Ok(Ok(_response)) => {
+                            let latency = start.elapsed();
+                            monitor.record_interaction_result(OperationFeedback {
+                                authority_name: name,
+                                display_name: display_name.clone(),
+                                operation: OperationType::HealthCheck,
+                                result: Ok(latency),
+                            });
+                        }
+                        Ok(Err(_)) => {
+                            let _latency = start.elapsed();
+                            monitor.record_interaction_result(OperationFeedback {
+                                authority_name: name,
+                                display_name: display_name.clone(),
+                                operation: OperationType::HealthCheck,
+                                result: Err(()),
+                            });
+                        }
+                        Err(_) => {
+                            monitor.record_interaction_result(OperationFeedback {
+                                authority_name: name,
+                                display_name,
+                                operation: OperationType::HealthCheck,
+                                result: Err(()),
+                            });
+                        }
+                    }
+                });
+            }
+
+            while let Some(result) = tasks.join_next().await {
+                if let Err(e) = result {
+                    warn!("Health check task failed: {}", e);
+                }
+            }
+
+            self.update_cached_scores();
+        }
+    }
+}
+
+impl<A: Clone> ValidatorClientMonitor<A> {
+    /// Calculate and cache scores for all validators.
+    ///
+    /// This method is called periodically after health checks complete to update
+    /// the cached validator scores.
+    fn update_cached_scores(&self) {
+        let authority_agg = self.authority_aggregator.load();
+        let committee = &authority_agg.committee;
+
+        let score_map = self
+            .client_stats
+            .read()
+            .get_all_validator_stats(committee, &authority_agg.validator_display_names);
+
+        for (validator, score) in score_map.iter() {
+            debug!("Validator {}: score {}", validator, score);
+            self.metrics
+                .performance_score
+                .with_label_values(&[&validator.concise().to_string()])
+                .set(*score);
+        }
+
+        *self.cached_scores.write() = Some(score_map);
+    }
+
+    /// Record client-observed interaction result with a validator.
+    ///
+    /// Records operation results including success/failure status and latency
+    /// from the client's perspective. Updates both Prometheus metrics and
+    /// internal client statistics. This is the primary interface for the
+    /// TransactionDriver to report client-observed validator interactions.
+    /// TODO: Consider adding a byzantine flag to the feedback.
+    pub fn record_interaction_result(&self, feedback: OperationFeedback) {
+        let operation_str = match feedback.operation {
+            OperationType::Submit => "submit",
+            OperationType::Effects => "effects",
+            OperationType::HealthCheck => "health_check",
+        };
+
+        match feedback.result {
+            Ok(latency) => {
+                self.metrics
+                    .observed_latency
+                    .with_label_values(&[&feedback.display_name, operation_str])
+                    .observe(latency.as_secs_f64());
+                self.metrics
+                    .operation_success
+                    .with_label_values(&[&feedback.display_name, operation_str])
+                    .inc();
+            }
+            Err(()) => {
+                self.metrics
+                    .operation_failure
+                    .with_label_values(&[&feedback.display_name, operation_str])
+                    .inc();
+            }
+        }
+
+        let mut client_stats = self.client_stats.write();
+        client_stats.record_interaction_result(feedback, &self.metrics);
+    }
+
+    /// Select validators based on client-observed performance with shuffled top k.
+    ///
+    /// We need to pass the current committee here because it is possible
+    /// that the fullnode is in the middle of a committee change when this
+    /// is called, and we need to maintain an invariant that the selected
+    /// validators are always in the committee passed in.
+    ///
+    /// We shuffle the top k validators to avoid the same validator being selected
+    /// too many times in a row and getting overloaded.
+    ///
+    /// Returns a vector containing:
+    /// 1. The top `k` validators by score (shuffled)
+    /// 2. The remaining validators ordered by score (not shuffled)
+    pub fn select_shuffled_preferred_validators(
+        &self,
+        committee: &Committee,
+        k: usize,
+        // TODO: Pass in the operation type so that we can select validators based on the operation type.
+    ) -> Vec<AuthorityName> {
+        let mut rng = rand::thread_rng();
+
+        let Some(cached_scores) = self.cached_scores.read().clone() else {
+            let mut validators: Vec<_> = committee.names().cloned().collect();
+            validators.shuffle(&mut rng);
+            return validators;
+        };
+
+        // Since the cached scores are updated periodically, it is possible that it was ran on
+        // an out-of-date committee.
+        let mut validator_with_scores: Vec<_> = committee
+            .names()
+            .map(|v| (*v, cached_scores.get(v).copied().unwrap_or(0.0)))
+            .collect();
+        validator_with_scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+
+        let k = k.min(validator_with_scores.len());
+        validator_with_scores[..k].shuffle(&mut rng);
+
+        validator_with_scores.into_iter().map(|(v, _)| v).collect()
+    }
+
+    #[cfg(test)]
+    pub fn force_update_cached_scores(&self) {
+        self.update_cached_scores();
+    }
+
+    #[cfg(test)]
+    pub fn get_client_stats_len(&self) -> usize {
+        self.client_stats.read().validator_stats.len()
+    }
+
+    #[cfg(test)]
+    pub fn has_validator_stats(&self, validator: &AuthorityName) -> bool {
+        self.client_stats
+            .read()
+            .validator_stats
+            .contains_key(validator)
+    }
+}

--- a/crates/sui-core/src/validator_client_monitor/stats.rs
+++ b/crates/sui-core/src/validator_client_monitor/stats.rs
@@ -1,0 +1,287 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::validator_client_monitor::{OperationFeedback, OperationType, ValidatorClientMetrics};
+use mysten_common::decay_moving_average::DecayMovingAverage;
+use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet};
+use std::time::{Duration, Instant};
+use strum::IntoEnumIterator;
+use sui_config::validator_client_monitor_config::ValidatorClientMonitorConfig;
+use sui_types::base_types::AuthorityName;
+use sui_types::committee::Committee;
+use tracing::debug;
+
+// TODO: A few optimization to consider:
+// 1. There may be times when the entire network is unstable, and in that case
+//    we may not want to punish validators when they have errors.
+// 2. Some reports are more critical than others. For example, a health check
+//    report is more critical than a submit report in terms of failures status.
+
+/// Decay factor for reliability EMA - lower values give more weight to recent observations
+const RELIABILITY_DECAY_FACTOR: f64 = 0.5;
+/// Decay factor for latency EMA - higher values smooth out spikes better
+const LATENCY_DECAY_FACTOR: f64 = 0.9;
+/// Decay factor for max latency - higher values keep max stable over time
+const MAX_LATENCY_DECAY_FACTOR: f64 = 0.99;
+
+/// Complete client-observed statistics for validator interactions.
+///
+/// This struct maintains client-side metrics for all validators in the network,
+/// including reliability scores, latency measurements, and failure tracking
+/// as observed from the client's perspective. It uses exponential moving averages (EMA)
+/// to smooth out transient spikes while still responding to sustained changes.
+#[derive(Debug, Clone)]
+pub struct ClientObservedStats {
+    /// Per-validator statistics mapping authority names to their client-observed metrics
+    pub validator_stats: HashMap<AuthorityName, ValidatorClientStats>,
+    /// Global statistics used for normalization and comparison
+    pub global_stats: GlobalStats,
+    /// Configuration parameters for scoring and exclusion policies
+    pub config: ValidatorClientMonitorConfig,
+}
+
+/// Client-observed stats for a single validator.
+///
+/// Tracks reliability, latency, and failure patterns for a specific validator
+/// as observed from the client's perspective. Uses exponential moving averages
+/// to smooth measurements while maintaining responsiveness to changes.
+#[derive(Debug, Clone)]
+pub struct ValidatorClientStats {
+    /// Exponential moving average of success rate (0.0 to 1.0)
+    pub reliability: DecayMovingAverage,
+    /// EMA latencies for each operation type (Submit, Effects, HealthCheck)
+    pub average_latencies: HashMap<OperationType, DecayMovingAverage>,
+    /// Counter for consecutive failures - resets on success
+    pub consecutive_failures: u32,
+    /// Time when validator was temporarily excluded due to failures.
+    /// Validators are excluded when consecutive_failures >= max_consecutive_failures
+    pub exclusion_time: Option<Instant>,
+}
+
+impl ValidatorClientStats {
+    pub fn new(init_reliability: f64) -> Self {
+        Self {
+            reliability: DecayMovingAverage::new(init_reliability, RELIABILITY_DECAY_FACTOR),
+            average_latencies: HashMap::new(),
+            consecutive_failures: 0,
+            exclusion_time: None,
+        }
+    }
+
+    pub fn update_average_latency(&mut self, operation: OperationType, new_latency: Duration) {
+        match self.average_latencies.entry(operation) {
+            Entry::Occupied(mut entry) => {
+                entry
+                    .get_mut()
+                    .update_moving_average(new_latency.as_secs_f64());
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(DecayMovingAverage::new(
+                    new_latency.as_secs_f64(),
+                    LATENCY_DECAY_FACTOR,
+                ));
+            }
+        }
+    }
+}
+
+/// Global statistics across all validators.
+///
+/// Used to track network-wide performance metrics that serve as baselines
+/// for scoring individual validators. Currently tracks maximum latencies
+/// for normalization purposes.
+#[derive(Debug, Clone, Default)]
+pub struct GlobalStats {
+    /// Maximum observed latencies for each operation type across all validators.
+    /// Used to normalize individual validator latencies in score calculations.
+    pub max_latencies: HashMap<OperationType, DecayMovingAverage>,
+}
+
+impl ClientObservedStats {
+    pub fn new(config: ValidatorClientMonitorConfig) -> Self {
+        Self {
+            validator_stats: HashMap::new(),
+            global_stats: GlobalStats::default(),
+            config,
+        }
+    }
+
+    /// Record client-observed interaction result with a validator.
+    ///
+    /// Updates reliability scores, latency measurements, and failure counts
+    /// based on client observations. Automatically excludes validators that
+    /// exceed the maximum consecutive failure threshold.
+    pub fn record_interaction_result(
+        &mut self,
+        feedback: OperationFeedback,
+        metrics: &ValidatorClientMetrics,
+    ) {
+        let validator_stats = self
+            .validator_stats
+            .entry(feedback.authority_name)
+            .or_insert_with(|| ValidatorClientStats::new(1.0));
+
+        match feedback.result {
+            Ok(latency) => {
+                validator_stats.reliability.update_moving_average(1.0);
+                validator_stats.consecutive_failures = 0;
+                validator_stats.update_average_latency(feedback.operation, latency);
+            }
+            Err(()) => {
+                validator_stats.reliability.update_moving_average(0.0);
+                validator_stats.consecutive_failures += 1;
+
+                // Exclude validator temporarily after too many consecutive failures
+                if validator_stats.consecutive_failures >= self.config.max_consecutive_failures {
+                    validator_stats.exclusion_time = Some(Instant::now());
+                }
+            }
+        }
+
+        metrics
+            .consecutive_failures
+            .with_label_values(&[&feedback.display_name])
+            .set(validator_stats.consecutive_failures as i64);
+
+        if let Ok(latency) = feedback.result {
+            self.update_global_stats(feedback.operation, latency);
+        }
+    }
+
+    /// Update global maximum latency statistics.
+    ///
+    /// For max latencies, we use a special update strategy:
+    /// - If the new latency is higher than the current max, we immediately update to it
+    /// - Otherwise, we apply decay to gradually lower the max over time
+    ///
+    /// This ensures we always capture peak latencies while still allowing the max to decrease
+    /// when network conditions improve to reduce the impact of outliers.
+    pub fn update_global_stats(&mut self, operation: OperationType, latency: Duration) {
+        let latency_secs = latency.as_secs_f64();
+
+        match self.global_stats.max_latencies.entry(operation) {
+            Entry::Occupied(mut entry) => {
+                let current_max = entry.get().get();
+                if latency_secs > current_max {
+                    // New latency is higher - immediately update to this value
+                    entry.get_mut().override_moving_average(latency_secs);
+                } else {
+                    // New latency is lower - apply decay to gradually reduce max
+                    entry.get_mut().update_moving_average(latency_secs);
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(DecayMovingAverage::new(
+                    latency_secs,
+                    MAX_LATENCY_DECAY_FACTOR,
+                ));
+            }
+        }
+    }
+
+    /// Get validator scores for all validators in the committee.
+    ///
+    /// Returns a map of all tracked validators to their scores.
+    /// Score is 0 if the validator is excluded or has no stats.
+    pub fn get_all_validator_stats(
+        &self,
+        committee: &Committee,
+        _display_names: &HashMap<AuthorityName, String>,
+    ) -> HashMap<AuthorityName, f64> {
+        committee
+            .names()
+            .map(|validator| {
+                let score = if let Some(stats) = self.validator_stats.get(validator) {
+                    let is_excluded = if let Some(exclusion_time) = stats.exclusion_time {
+                        exclusion_time.elapsed() < self.config.failure_cooldown
+                    } else {
+                        false
+                    };
+                    if is_excluded {
+                        0.0
+                    } else {
+                        self.calculate_client_score(stats, &self.global_stats)
+                    }
+                } else {
+                    0.0
+                };
+                (*validator, score)
+            })
+            .collect()
+    }
+
+    /// Calculate client-observed score for a single validator.
+    ///
+    /// The score combines reliability and latency metrics as observed by the client,
+    /// weighted according to configuration.
+    ///
+    /// If a validator is missing local stats for an operation type, we use a
+    /// conservative default (assuming they are at the global maximum latency)
+    /// to ensure fairness while still allowing them to be scored.
+    ///
+    /// Score calculation:
+    /// 1. Latency scores are normalized against global maximums
+    /// 2. Each operation type has its own weight
+    /// 3. Final score = (weighted_latency_score * latency_weight) + (reliability * reliability_weight)
+    fn calculate_client_score(
+        &self,
+        stats: &ValidatorClientStats,
+        global_stats: &GlobalStats,
+    ) -> f64 {
+        let mut latency_score = 0.0;
+        let mut total_weight = 0.0;
+
+        for op in OperationType::iter() {
+            let latency_weight = match op {
+                OperationType::Submit => self.config.score_weights.submit_latency_weight,
+                OperationType::Effects => self.config.score_weights.effects_latency_weight,
+                OperationType::HealthCheck => self.config.score_weights.health_check_latency_weight,
+            };
+
+            // Skip if global stats are missing for this operation
+            let Some(max_latency) = global_stats.max_latencies.get(&op).map(|ma| ma.get()) else {
+                continue;
+            };
+
+            // If validator has local stats, use them; otherwise assume max latency (conservative)
+            let latency = stats
+                .average_latencies
+                .get(&op)
+                .map(|ma| ma.get())
+                .unwrap_or(max_latency);
+
+            // Lower latency ratios are better (inverted for scoring)
+            let latency_ratio = (latency / max_latency).min(1.0);
+            latency_score += (1.0 - latency_ratio) * latency_weight;
+            total_weight += latency_weight;
+        }
+
+        let latency_score = if total_weight == 0.0 {
+            0.0
+        } else {
+            // Normalize latency score by total weight
+            latency_score / total_weight
+        };
+
+        let reliability_score = stats.reliability.get();
+        latency_score * self.config.score_weights.latency
+            + reliability_score * self.config.score_weights.reliability
+    }
+
+    /// Retain only the specified validators, removing any others.
+    ///
+    /// Called periodically during health checks to clean up statistics for validators
+    /// that are no longer in the active set. This prevents memory leaks and
+    /// ensures scores are only calculated for current validators.
+    pub fn retain_validators(&mut self, current_validators: &[AuthorityName]) {
+        let cur_len = self.validator_stats.len();
+        let validator_set: HashSet<_> = current_validators.iter().collect();
+        self.validator_stats
+            .retain(|validator, _| validator_set.contains(validator));
+        let removed_count = cur_len - self.validator_stats.len();
+        if removed_count > 0 {
+            debug!("Removed {} stale validator data", removed_count);
+        }
+    }
+}

--- a/crates/sui-core/src/validator_client_monitor/tests.rs
+++ b/crates/sui-core/src/validator_client_monitor/tests.rs
@@ -1,0 +1,1026 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use crate::validator_client_monitor::stats::{ClientObservedStats, ValidatorClientStats};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use sui_config::validator_client_monitor_config::{ScoreWeights, ValidatorClientMonitorConfig};
+use sui_types::base_types::{AuthorityName, ConciseableName};
+use sui_types::committee::Committee;
+use sui_types::crypto::{get_key_pair, AuthorityKeyPair, KeypairTraits};
+use tokio::time::sleep;
+
+mod client_stats_tests {
+
+    use super::*;
+    use crate::validator_client_monitor::metrics::ValidatorClientMetrics;
+    use prometheus::Registry;
+
+    /// Helper to create test validator names
+    fn create_test_validator_names(n: usize) -> Vec<AuthorityName> {
+        (0..n)
+            .map(|_| {
+                let (_, key_pair): (_, AuthorityKeyPair) = get_key_pair();
+                key_pair.public().into()
+            })
+            .collect()
+    }
+
+    /// Helper to create test metrics
+    fn create_test_metrics() -> ValidatorClientMetrics {
+        ValidatorClientMetrics::new(&Registry::default())
+    }
+
+    #[tokio::test]
+    async fn test_client_stats_record_success() {
+        let config = ValidatorClientMonitorConfig::default();
+        let mut stats = ClientObservedStats::new(config);
+        let metrics = create_test_metrics();
+
+        let validators = create_test_validator_names(1);
+        let validator = validators[0];
+
+        // Record successful operation
+        let feedback = OperationFeedback {
+            authority_name: validator,
+            display_name: validator.concise().to_string(),
+            operation: OperationType::Submit,
+            result: Ok(Duration::from_millis(100)),
+        };
+
+        stats.record_interaction_result(feedback, &metrics);
+
+        // Check validator stats were created and updated
+        let validator_stats = stats.validator_stats.get(&validator).unwrap();
+        assert_eq!(validator_stats.consecutive_failures, 0);
+        assert!(validator_stats.exclusion_time.is_none());
+        assert_eq!(validator_stats.reliability.get(), 1.0);
+
+        // Check latency was recorded
+        let submit_latency = validator_stats
+            .average_latencies
+            .get(&OperationType::Submit)
+            .unwrap();
+        assert_eq!(submit_latency.get(), 0.1); // 100ms = 0.1s
+    }
+
+    #[tokio::test]
+    async fn test_client_stats_record_failure() {
+        let config = ValidatorClientMonitorConfig {
+            max_consecutive_failures: 3,
+            ..Default::default()
+        };
+        let mut stats = ClientObservedStats::new(config);
+        let metrics = create_test_metrics();
+
+        let validators = create_test_validator_names(1);
+        let validator = validators[0];
+
+        // Record multiple failures
+        for i in 0..3 {
+            let feedback = OperationFeedback {
+                authority_name: validator,
+                display_name: validator.concise().to_string(),
+                operation: OperationType::Submit,
+                result: Err(()),
+            };
+            stats.record_interaction_result(feedback, &metrics);
+
+            let validator_stats = stats.validator_stats.get(&validator).unwrap();
+            assert_eq!(validator_stats.consecutive_failures, i + 1);
+
+            // Should be excluded after 3rd failure
+            if i == 2 {
+                assert!(validator_stats.exclusion_time.is_some());
+            } else {
+                assert!(validator_stats.exclusion_time.is_none());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_client_stats_calculate_scores() {
+        let config = ValidatorClientMonitorConfig::default();
+        let mut stats = ClientObservedStats::new(config);
+        let metrics = create_test_metrics();
+
+        // Create two validators with different performance
+        let validators = create_test_validator_names(2);
+        let validator1 = validators[0];
+        let validator2 = validators[1];
+
+        // Validator 1: good performance
+        for op in [
+            OperationType::Submit,
+            OperationType::Effects,
+            OperationType::HealthCheck,
+        ] {
+            stats.record_interaction_result(
+                OperationFeedback {
+                    authority_name: validator1,
+                    display_name: validator1.concise().to_string(),
+                    operation: op,
+                    result: Ok(Duration::from_millis(50)),
+                },
+                &metrics,
+            );
+        }
+
+        // Validator 2: worse performance
+        for op in [
+            OperationType::Submit,
+            OperationType::Effects,
+            OperationType::HealthCheck,
+        ] {
+            stats.record_interaction_result(
+                OperationFeedback {
+                    authority_name: validator2,
+                    display_name: validator2.concise().to_string(),
+                    operation: op,
+                    result: Ok(Duration::from_millis(200)),
+                },
+                &metrics,
+            );
+        }
+
+        // Add one failure for validator2
+        stats.record_interaction_result(
+            OperationFeedback {
+                authority_name: validator2,
+                display_name: validator2.concise().to_string(),
+                operation: OperationType::Submit,
+                result: Err(()),
+            },
+            &metrics,
+        );
+
+        // Create a committee with both validators
+        let committee = Committee::new_for_testing_with_normalized_voting_power(
+            0,
+            vec![(validator1, 1), (validator2, 1)].into_iter().collect(),
+        );
+
+        // Create display names map for testing
+        let display_names: HashMap<AuthorityName, String> = validators
+            .iter()
+            .map(|v| (*v, v.concise().to_string()))
+            .collect();
+        let all_stats = stats.get_all_validator_stats(&committee, &display_names);
+        assert_eq!(all_stats.len(), 2);
+
+        // Validator 1 should have higher score
+        let score1 = *all_stats.get(&validator1).unwrap();
+        let score2 = *all_stats.get(&validator2).unwrap();
+        assert!(score1 > score2);
+    }
+
+    #[tokio::test]
+    async fn test_client_stats_exclusion() {
+        let config = ValidatorClientMonitorConfig {
+            max_consecutive_failures: 2,
+            failure_cooldown: Duration::from_millis(100),
+            ..Default::default()
+        };
+        let mut stats = ClientObservedStats::new(config);
+        let metrics = create_test_metrics();
+
+        let validators = create_test_validator_names(1);
+        let validator = validators[0];
+
+        // Initialize with all operation types
+        for op in [
+            OperationType::Submit,
+            OperationType::Effects,
+            OperationType::HealthCheck,
+        ] {
+            stats.record_interaction_result(
+                OperationFeedback {
+                    authority_name: validator,
+                    display_name: validator.concise().to_string(),
+                    operation: op,
+                    result: Ok(Duration::from_millis(50)),
+                },
+                &metrics,
+            );
+        }
+
+        // Cause exclusion
+        for _ in 0..2 {
+            stats.record_interaction_result(
+                OperationFeedback {
+                    authority_name: validator,
+                    display_name: validator.concise().to_string(),
+                    operation: OperationType::Submit,
+                    result: Err(()),
+                },
+                &metrics,
+            );
+        }
+
+        // Create a committee with the validator
+        let committee = Committee::new_for_testing_with_normalized_voting_power(
+            0,
+            vec![(validator, 1)].into_iter().collect(),
+        );
+
+        // Should be excluded (score 0)
+        // Create display names map for testing
+        let display_names: HashMap<AuthorityName, String> = validators
+            .iter()
+            .map(|v| (*v, v.concise().to_string()))
+            .collect();
+        let all_stats = stats.get_all_validator_stats(&committee, &display_names);
+        let score = *all_stats.get(&validator).unwrap();
+        assert_eq!(score, 0.0);
+
+        // Wait for cooldown
+        sleep(Duration::from_millis(150)).await;
+
+        // Should be included again (score > 0)
+        // Create display names map for testing
+        let display_names: HashMap<AuthorityName, String> = validators
+            .iter()
+            .map(|v| (*v, v.concise().to_string()))
+            .collect();
+        let all_stats = stats.get_all_validator_stats(&committee, &display_names);
+        let score = *all_stats.get(&validator).unwrap();
+        assert!(score > 0.0);
+    }
+
+    #[tokio::test]
+    async fn test_client_stats_refresh_validator_set() {
+        let config = ValidatorClientMonitorConfig::default();
+        let mut stats = ClientObservedStats::new(config);
+
+        // Add stats for 3 validators
+        let validators = create_test_validator_names(3);
+
+        let metrics = create_test_metrics();
+        for validator in &validators {
+            stats.record_interaction_result(
+                OperationFeedback {
+                    authority_name: *validator,
+                    display_name: validator.concise().to_string(),
+                    operation: OperationType::Submit,
+                    result: Ok(Duration::from_millis(100)),
+                },
+                &metrics,
+            );
+        }
+
+        assert_eq!(stats.validator_stats.len(), 3);
+
+        // Refresh with only first 2 validators
+        let remaining_validators: Vec<_> = validators.iter().take(2).cloned().collect();
+        stats.retain_validators(&remaining_validators);
+
+        assert_eq!(stats.validator_stats.len(), 2);
+        assert!(stats.validator_stats.contains_key(&validators[0]));
+        assert!(stats.validator_stats.contains_key(&validators[1]));
+        assert!(!stats.validator_stats.contains_key(&validators[2]));
+    }
+
+    #[tokio::test]
+    async fn test_validator_stats_update_latency() {
+        let mut stats = ValidatorClientStats::new(1.0);
+
+        // First update creates the entry
+        stats.update_average_latency(OperationType::Submit, Duration::from_millis(100));
+        assert_eq!(stats.average_latencies.len(), 1);
+        assert_eq!(
+            stats
+                .average_latencies
+                .get(&OperationType::Submit)
+                .unwrap()
+                .get(),
+            0.1
+        );
+
+        // Second update uses EMA
+        stats.update_average_latency(OperationType::Submit, Duration::from_millis(200));
+        let latency = stats
+            .average_latencies
+            .get(&OperationType::Submit)
+            .unwrap()
+            .get();
+        // With decay factor 0.9, new value = 0.1 * 0.9 + 0.2 * (1 - 0.9) = 0.09 + 0.02 = 0.11
+        assert!((latency - 0.11).abs() < 0.001);
+    }
+
+    #[tokio::test]
+    async fn test_global_stats_update() {
+        let config = ValidatorClientMonitorConfig::default();
+        let mut stats = ClientObservedStats::new(config);
+
+        // First update sets initial value
+        stats.update_global_stats(OperationType::Submit, Duration::from_millis(100));
+        let max_latency = stats
+            .global_stats
+            .max_latencies
+            .get(&OperationType::Submit)
+            .unwrap();
+        assert_eq!(max_latency.get(), 0.1); // 100ms = 0.1s
+
+        // Update with higher latency - should immediately jump to new max
+        stats.update_global_stats(OperationType::Submit, Duration::from_millis(300));
+        let max_latency = stats
+            .global_stats
+            .max_latencies
+            .get(&OperationType::Submit)
+            .unwrap();
+        assert_eq!(max_latency.get(), 0.3); // 300ms = 0.3s
+
+        // Update with lower latency - should apply decay
+        stats.update_global_stats(OperationType::Submit, Duration::from_millis(100));
+        let max_latency = stats
+            .global_stats
+            .max_latencies
+            .get(&OperationType::Submit)
+            .unwrap();
+        // With decay factor 0.99: 0.3 * 0.99 + 0.1 * (1 - 0.99) = 0.297 + 0.001 = 0.298
+        assert!((max_latency.get() - 0.298).abs() < 0.001);
+
+        // Another lower update to verify continued decay
+        stats.update_global_stats(OperationType::Submit, Duration::from_millis(50));
+        let max_latency = stats
+            .global_stats
+            .max_latencies
+            .get(&OperationType::Submit)
+            .unwrap();
+        // With decay factor 0.99: 0.298 * 0.99 + 0.05 * (1 - 0.99) = 0.29502 + 0.0005 = 0.29552
+        assert!((max_latency.get() - 0.29552).abs() < 0.001);
+
+        // Update with higher latency again - should jump to new max
+        stats.update_global_stats(OperationType::Submit, Duration::from_millis(500));
+        let max_latency = stats
+            .global_stats
+            .max_latencies
+            .get(&OperationType::Submit)
+            .unwrap();
+        assert_eq!(max_latency.get(), 0.5); // 500ms = 0.5s
+    }
+
+    #[tokio::test]
+    async fn test_score_calculation_with_missing_operations() {
+        let config = ValidatorClientMonitorConfig::default();
+        let mut stats = ClientObservedStats::new(config);
+        let metrics = create_test_metrics();
+
+        let validators = create_test_validator_names(1);
+        let validator = validators[0];
+
+        // Only record Submit operation, missing Effects and HealthCheck
+        stats.record_interaction_result(
+            OperationFeedback {
+                authority_name: validator,
+                display_name: validator.concise().to_string(),
+                operation: OperationType::Submit,
+                result: Ok(Duration::from_millis(100)),
+            },
+            &metrics,
+        );
+
+        // Create a committee with the validator
+        let committee = Committee::new_for_testing_with_normalized_voting_power(
+            0,
+            vec![(validator, 1)].into_iter().collect(),
+        );
+
+        // Create display names map for testing
+        let display_names: HashMap<AuthorityName, String> = validators
+            .iter()
+            .map(|v| (*v, v.concise().to_string()))
+            .collect();
+        let all_stats = stats.get_all_validator_stats(&committee, &display_names);
+        // Should have a partial score even with only one operation type
+        let score = *all_stats.get(&validator).unwrap();
+        assert!(score > 0.0);
+    }
+
+    #[tokio::test]
+    async fn test_reliability_decay() {
+        let config = ValidatorClientMonitorConfig::default();
+        let mut stats = ClientObservedStats::new(config);
+        let metrics = create_test_metrics();
+
+        let validators = create_test_validator_names(1);
+        let validator = validators[0];
+
+        // Start with success
+        stats.record_interaction_result(
+            OperationFeedback {
+                authority_name: validator,
+                display_name: validator.concise().to_string(),
+                operation: OperationType::Submit,
+                result: Ok(Duration::from_millis(100)),
+            },
+            &metrics,
+        );
+
+        let initial_reliability = stats
+            .validator_stats
+            .get(&validator)
+            .unwrap()
+            .reliability
+            .get();
+        assert_eq!(initial_reliability, 1.0);
+
+        // Add failure
+        stats.record_interaction_result(
+            OperationFeedback {
+                authority_name: validator,
+                display_name: validator.concise().to_string(),
+                operation: OperationType::Submit,
+                result: Err(()),
+            },
+            &metrics,
+        );
+
+        let new_reliability = stats
+            .validator_stats
+            .get(&validator)
+            .unwrap()
+            .reliability
+            .get();
+        // With decay factor 0.5: 1.0 * 0.5 + 0.0 * 0.5 = 0.5
+        assert_eq!(new_reliability, 0.5);
+    }
+
+    #[tokio::test]
+    async fn test_global_max_latency_with_multiple_validators() {
+        let config = ValidatorClientMonitorConfig::default();
+        let mut stats = ClientObservedStats::new(config);
+        let metrics = create_test_metrics();
+
+        let validators = create_test_validator_names(3);
+
+        // Validator 1: 100ms latency
+        stats.record_interaction_result(
+            OperationFeedback {
+                authority_name: validators[0],
+                display_name: validators[0].concise().to_string(),
+                operation: OperationType::Submit,
+                result: Ok(Duration::from_millis(100)),
+            },
+            &metrics,
+        );
+
+        // Check global max is 100ms
+        let max_latency = stats
+            .global_stats
+            .max_latencies
+            .get(&OperationType::Submit)
+            .unwrap();
+        assert_eq!(max_latency.get(), 0.1);
+
+        // Validator 2: 50ms latency (lower, should apply decay)
+        stats.record_interaction_result(
+            OperationFeedback {
+                authority_name: validators[1],
+                display_name: validators[1].concise().to_string(),
+                operation: OperationType::Submit,
+                result: Ok(Duration::from_millis(50)),
+            },
+            &metrics,
+        );
+
+        // Max should decay towards 50ms
+        let max_latency = stats
+            .global_stats
+            .max_latencies
+            .get(&OperationType::Submit)
+            .unwrap();
+        // 0.1 * 0.99 + 0.05 * (1 - 0.99) = 0.099 + 0.0005 = 0.0995
+        assert!((max_latency.get() - 0.0995).abs() < 0.001);
+
+        // Validator 3: 200ms latency (higher, should immediately become new max)
+        stats.record_interaction_result(
+            OperationFeedback {
+                authority_name: validators[2],
+                display_name: validators[2].concise().to_string(),
+                operation: OperationType::Submit,
+                result: Ok(Duration::from_millis(200)),
+            },
+            &metrics,
+        );
+
+        // Max should jump to 200ms
+        let max_latency = stats
+            .global_stats
+            .max_latencies
+            .get(&OperationType::Submit)
+            .unwrap();
+        assert_eq!(max_latency.get(), 0.2);
+    }
+
+    #[tokio::test]
+    async fn test_decay_factor_differences() {
+        let config = ValidatorClientMonitorConfig::default();
+        let mut stats = ClientObservedStats::new(config);
+        let metrics = create_test_metrics();
+
+        let validator = create_test_validator_names(1)[0];
+
+        // Initial values for both validator latency and global max
+        stats.record_interaction_result(
+            OperationFeedback {
+                authority_name: validator,
+                display_name: validator.concise().to_string(),
+                operation: OperationType::Submit,
+                result: Ok(Duration::from_millis(100)),
+            },
+            &metrics,
+        );
+
+        // Both should start at 100ms
+        let validator_latency = stats
+            .validator_stats
+            .get(&validator)
+            .unwrap()
+            .average_latencies
+            .get(&OperationType::Submit)
+            .unwrap()
+            .get();
+        assert_eq!(validator_latency, 0.1);
+
+        let max_latency = stats
+            .global_stats
+            .max_latencies
+            .get(&OperationType::Submit)
+            .unwrap()
+            .get();
+        assert_eq!(max_latency, 0.1);
+
+        // Update with lower value (50ms)
+        stats.record_interaction_result(
+            OperationFeedback {
+                authority_name: validator,
+                display_name: validator.concise().to_string(),
+                operation: OperationType::Submit,
+                result: Ok(Duration::from_millis(50)),
+            },
+            &metrics,
+        );
+
+        // Validator latency should decay faster (factor 0.1)
+        let validator_latency = stats
+            .validator_stats
+            .get(&validator)
+            .unwrap()
+            .average_latencies
+            .get(&OperationType::Submit)
+            .unwrap()
+            .get();
+        // old * decay + new * (1-decay) = 0.1 * 0.9 + 0.05 * (1 - 0.9) = 0.09 + 0.005 = 0.095
+        assert!((validator_latency - 0.095).abs() < 0.001);
+
+        // Max latency should decay slower (factor 0.01)
+        let max_latency = stats
+            .global_stats
+            .max_latencies
+            .get(&OperationType::Submit)
+            .unwrap()
+            .get();
+        // Since new value (0.05) is less than current (0.1), we apply decay
+        // old * decay + new * (1-decay) = 0.1 * 0.99 + 0.05 * (1 - 0.99) = 0.099 + 0.0005 = 0.0995
+        assert!((max_latency - 0.0995).abs() < 0.001);
+
+        // Since max decays slower, it should be closer to the original value than validator average
+        // validator_latency = 0.055, max_latency = 0.0505
+        // Actually validator average went lower, so this assertion was wrong
+        // Let's just verify both decayed correctly
+    }
+
+    #[tokio::test]
+    async fn test_different_operation_weights() {
+        let config = ValidatorClientMonitorConfig {
+            score_weights: ScoreWeights {
+                submit_latency_weight: 0.1,
+                effects_latency_weight: 0.8,
+                health_check_latency_weight: 0.1,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut stats = ClientObservedStats::new(config);
+        let metrics = create_test_metrics();
+
+        let validators = create_test_validator_names(2);
+        let validator1 = validators[0];
+        let validator2 = validators[1];
+
+        // Validator 1: fast effects, slow others
+        for op in [
+            OperationType::Submit,
+            OperationType::Effects,
+            OperationType::HealthCheck,
+        ] {
+            let latency = if op == OperationType::Effects {
+                50
+            } else {
+                200
+            };
+            stats.record_interaction_result(
+                OperationFeedback {
+                    authority_name: validator1,
+                    display_name: validator1.concise().to_string(),
+                    operation: op,
+                    result: Ok(Duration::from_millis(latency)),
+                },
+                &metrics,
+            );
+        }
+
+        // Validator 2: slow effects, fast others
+        for op in [
+            OperationType::Submit,
+            OperationType::Effects,
+            OperationType::HealthCheck,
+        ] {
+            let latency = if op == OperationType::Effects {
+                200
+            } else {
+                50
+            };
+            stats.record_interaction_result(
+                OperationFeedback {
+                    authority_name: validator2,
+                    display_name: validator2.concise().to_string(),
+                    operation: op,
+                    result: Ok(Duration::from_millis(latency)),
+                },
+                &metrics,
+            );
+        }
+
+        // Create a committee with both validators
+        let committee = Committee::new_for_testing_with_normalized_voting_power(
+            0,
+            vec![(validator1, 1), (validator2, 1)].into_iter().collect(),
+        );
+
+        // Create display names map for testing
+        let display_names: HashMap<AuthorityName, String> = validators
+            .iter()
+            .map(|v| (*v, v.concise().to_string()))
+            .collect();
+        let all_stats = stats.get_all_validator_stats(&committee, &display_names);
+        // Validator 1 should have higher score due to fast effects (high weight)
+        let score1 = *all_stats.get(&validator1).unwrap();
+        let score2 = *all_stats.get(&validator2).unwrap();
+        assert!(score1 > score2);
+    }
+}
+
+#[cfg(test)]
+mod client_monitor_tests {
+    use crate::{
+        authority_aggregator::{AuthorityAggregator, AuthorityAggregatorBuilder},
+        test_authority_clients::MockAuthorityApi,
+    };
+
+    use super::*;
+    use std::collections::HashSet;
+
+    fn get_authority_aggregator(
+        committee_size: usize,
+    ) -> Arc<AuthorityAggregator<MockAuthorityApi>> {
+        Arc::new(
+            AuthorityAggregatorBuilder::from_committee_size(committee_size)
+                .build_mock_authority_aggregator(),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_validator_selection_top_k_basic() {
+        let auth_agg = get_authority_aggregator(4);
+        let monitor = ValidatorClientMonitor::new_for_test(auth_agg.clone());
+
+        let committee = auth_agg.committee.clone();
+        let validators = committee.names().cloned().collect::<Vec<_>>();
+
+        // Record different performance for each validator
+        for (i, validator) in validators.iter().enumerate() {
+            for op in [
+                OperationType::Submit,
+                OperationType::Effects,
+                OperationType::HealthCheck,
+            ] {
+                monitor.record_interaction_result(OperationFeedback {
+                    authority_name: *validator,
+                    display_name: auth_agg.get_display_name(validator),
+                    operation: op,
+                    result: Ok(Duration::from_millis((i as u64 + 1) * 50)),
+                });
+            }
+        }
+
+        // Force update cached scores (in production this happens in the health check loop)
+        monitor.force_update_cached_scores();
+
+        // Select validators with k=2
+        let selected = monitor.select_shuffled_preferred_validators(&committee, 2);
+        assert_eq!(selected.len(), 4); // Should return all 4 validators from committee
+
+        // The first 2 positions should contain the best two validators (but shuffled)
+        let top_2_positions: HashSet<_> = selected.iter().take(2).cloned().collect();
+        assert!(top_2_positions.contains(&validators[0])); // Best performer
+        assert!(top_2_positions.contains(&validators[1])); // Second best
+
+        // The third position should be validator[2] (third best)
+        assert_eq!(selected[2], validators[2]);
+
+        // The fourth position should be validator[3] (no stats recorded)
+        assert_eq!(selected[3], validators[3]);
+    }
+
+    #[tokio::test]
+    async fn test_validator_selection_with_failures() {
+        let auth_agg = get_authority_aggregator(5);
+        let monitor = ValidatorClientMonitor::new_for_test(auth_agg.clone());
+
+        let committee = auth_agg.committee.clone();
+        let validators = committee.names().cloned().collect::<Vec<_>>();
+
+        // Record different performance for each validator
+        for (i, validator) in validators.iter().enumerate() {
+            for op in [
+                OperationType::Submit,
+                OperationType::Effects,
+                OperationType::HealthCheck,
+            ] {
+                monitor.record_interaction_result(OperationFeedback {
+                    authority_name: *validator,
+                    display_name: auth_agg.get_display_name(validator),
+                    operation: op,
+                    result: if i < 2 {
+                        Ok(Duration::from_millis((i as u64 + 1) * 50))
+                    } else {
+                        Err(())
+                    }, // First 2 validators succeed, others fail
+                });
+            }
+        }
+
+        // Force update cached scores (in production this happens in the health check loop)
+        monitor.force_update_cached_scores();
+
+        // Select validators with k=3
+        let selected = monitor.select_shuffled_preferred_validators(&committee, 3);
+
+        // Should return all 5 validators
+        assert_eq!(selected.len(), 5);
+
+        // The first 3 positions should contain:
+        // - validators[0] and validators[1] (successful, better latency)
+        // - One of the failed validators (shuffled in top k)
+        let top_3_positions: HashSet<_> = selected.iter().take(3).cloned().collect();
+        assert!(top_3_positions.contains(&validators[0])); // Best performer with success
+        assert!(top_3_positions.contains(&validators[1])); // Second best with success
+
+        // Remaining positions should have the failed validators in score order
+        // Since they all have 0 reliability, they'll be ordered by latency
+    }
+
+    #[tokio::test]
+    async fn test_validator_selection_empty_committee() {
+        let auth_agg = get_authority_aggregator(2);
+        let monitor = ValidatorClientMonitor::new_for_test(auth_agg.clone());
+
+        let committee = auth_agg.committee.clone();
+        let validators = committee.names().cloned().collect::<Vec<_>>();
+
+        // Create a different committee that doesn't include our tracked validators
+        let other_validators: Vec<AuthorityName> = (0..3)
+            .map(|_| {
+                let (_, key_pair): (_, AuthorityKeyPair) = get_key_pair();
+                key_pair.public().into()
+            })
+            .collect();
+
+        let other_committee = Committee::new_for_testing_with_normalized_voting_power(
+            0,
+            other_validators.iter().map(|v| (*v, 1)).collect(),
+        );
+
+        // Record performance for our original validators (not in committee)
+        for validator in &validators {
+            for op in [
+                OperationType::Submit,
+                OperationType::Effects,
+                OperationType::HealthCheck,
+            ] {
+                monitor.record_interaction_result(OperationFeedback {
+                    authority_name: *validator,
+                    display_name: auth_agg.get_display_name(validator),
+                    operation: op,
+                    result: Ok(Duration::from_millis(100)),
+                });
+            }
+        }
+
+        // Force update cached scores (in production this happens in the health check loop)
+        monitor.force_update_cached_scores();
+
+        // Should still select validators from the provided committee
+        let selected = monitor.select_shuffled_preferred_validators(&other_committee, 2);
+        assert_eq!(selected.len(), 3); // Should return all 3 validators from other_committee
+        for validator in &selected {
+            assert!(other_committee.authority_exists(validator));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_validator_selection_more_k_than_validators() {
+        let auth_agg = get_authority_aggregator(2);
+        let monitor = ValidatorClientMonitor::new_for_test(auth_agg.clone());
+
+        let committee = auth_agg.committee.clone();
+        let validators = committee.names().cloned().collect::<Vec<_>>();
+
+        // Record performance for validators
+        for validator in &validators {
+            for op in [
+                OperationType::Submit,
+                OperationType::Effects,
+                OperationType::HealthCheck,
+            ] {
+                monitor.record_interaction_result(OperationFeedback {
+                    authority_name: *validator,
+                    display_name: auth_agg.get_display_name(validator),
+                    operation: op,
+                    result: Ok(Duration::from_millis(100)),
+                });
+            }
+        }
+
+        // Force update cached scores (in production this happens in the health check loop)
+        monitor.force_update_cached_scores();
+
+        // Request more validators than available
+        let selected = monitor.select_shuffled_preferred_validators(&committee, 5);
+        // Should return all available validators
+        assert_eq!(selected.len(), 2);
+        assert!(selected.contains(&validators[0]));
+        assert!(selected.contains(&validators[1]));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_stats_cleanup_on_authority_aggregator_change() {
+        use arc_swap::ArcSwap;
+        use prometheus::Registry;
+        use tokio::time::{sleep, timeout};
+
+        // Create initial committee with 3 validators
+        let initial_auth_agg = get_authority_aggregator(3);
+        let initial_validators: Vec<_> = initial_auth_agg.committee.names().cloned().collect();
+
+        // Create monitor with shorter health check interval for testing
+        let config = ValidatorClientMonitorConfig {
+            health_check_interval: Duration::from_millis(50),
+            ..Default::default()
+        };
+
+        let metrics = Arc::new(ValidatorClientMetrics::new(&Registry::default()));
+        let auth_agg_swap = Arc::new(ArcSwap::new(initial_auth_agg.clone()));
+        let monitor = ValidatorClientMonitor::new(config, metrics, auth_agg_swap.clone());
+
+        // Record stats for all initial validators
+        for validator in &initial_validators {
+            monitor.record_interaction_result(OperationFeedback {
+                authority_name: *validator,
+                display_name: initial_auth_agg.get_display_name(validator),
+                operation: OperationType::Submit,
+                result: Ok(Duration::from_millis(100)),
+            });
+        }
+
+        // Verify initial stats exist
+        assert_eq!(monitor.get_client_stats_len(), 3);
+        for validator in &initial_validators {
+            assert!(monitor.has_validator_stats(validator));
+        }
+
+        // Create new committee with only 2 of the original validators
+        let new_auth_agg = Arc::new(
+            AuthorityAggregatorBuilder::from_committee(
+                Committee::new_for_testing_with_normalized_voting_power(
+                    0, // Same epoch
+                    initial_validators.iter().take(2).map(|v| (*v, 1)).collect(),
+                ),
+            )
+            .build_mock_authority_aggregator(),
+        );
+
+        // Update the authority aggregator
+        auth_agg_swap.store(new_auth_agg.clone());
+
+        // Wait for at least one health check cycle to complete
+        // The monitor should clean up stats for validators not in the new committee
+        let check_result = timeout(Duration::from_secs(2), async {
+            loop {
+                sleep(Duration::from_millis(100)).await;
+                if monitor.get_client_stats_len() == 2 {
+                    break;
+                }
+            }
+        })
+        .await;
+
+        assert!(
+            check_result.is_ok(),
+            "Stats cleanup did not happen within timeout"
+        );
+
+        // Verify cleanup happened correctly
+        assert_eq!(monitor.get_client_stats_len(), 2);
+        assert!(monitor.has_validator_stats(&initial_validators[0]));
+        assert!(monitor.has_validator_stats(&initial_validators[1]));
+        assert!(!monitor.has_validator_stats(&initial_validators[2]));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_new_validators_added_after_committee_change() {
+        use arc_swap::ArcSwap;
+        use prometheus::Registry;
+        use tokio::time::{sleep, timeout};
+
+        // Create initial committee with 2 validators
+        let initial_auth_agg = get_authority_aggregator(2);
+        let initial_validators: Vec<_> = initial_auth_agg.committee.names().cloned().collect();
+
+        // Create monitor with shorter health check interval for testing
+        let config = ValidatorClientMonitorConfig {
+            health_check_interval: Duration::from_millis(50),
+            ..Default::default()
+        };
+
+        let metrics = Arc::new(ValidatorClientMetrics::new(&Registry::default()));
+        let auth_agg_swap = Arc::new(ArcSwap::new(initial_auth_agg.clone()));
+        let monitor = ValidatorClientMonitor::new(config, metrics, auth_agg_swap.clone());
+
+        // Record stats for initial validators
+        for validator in &initial_validators {
+            monitor.record_interaction_result(OperationFeedback {
+                authority_name: *validator,
+                display_name: initial_auth_agg.get_display_name(validator),
+                operation: OperationType::HealthCheck,
+                result: Ok(Duration::from_millis(100)),
+            });
+        }
+
+        // Create new validator that will be added
+        let (_, new_key_pair): (_, AuthorityKeyPair) = get_key_pair();
+        let new_validator: AuthorityName = new_key_pair.public().into();
+
+        // Create new committee with all 3 validators (2 old + 1 new)
+        let mut new_committee_members = initial_validators
+            .iter()
+            .map(|v| (*v, 1))
+            .collect::<Vec<_>>();
+        new_committee_members.push((new_validator, 1));
+
+        let new_committee = Committee::new_for_testing_with_normalized_voting_power(
+            0, // Same epoch
+            new_committee_members.into_iter().collect(),
+        );
+
+        // Create new authority aggregator
+        let new_auth_agg = Arc::new(
+            AuthorityAggregatorBuilder::from_committee(new_committee)
+                .build_mock_authority_aggregator(),
+        );
+
+        // Update the authority aggregator
+        auth_agg_swap.store(new_auth_agg.clone());
+
+        // Wait for health check to run and record stats for new validator
+        let check_result = timeout(Duration::from_secs(2), async {
+            loop {
+                sleep(Duration::from_millis(100)).await;
+                // Check if we have stats for all 3 validators including the new one
+                if monitor.get_client_stats_len() == 3
+                    && monitor.has_validator_stats(&new_validator)
+                {
+                    break;
+                }
+            }
+        })
+        .await;
+
+        assert!(
+            check_result.is_ok(),
+            "New validator stats were not added within timeout"
+        );
+
+        // Verify all validators have stats
+        assert_eq!(monitor.get_client_stats_len(), 3);
+        for validator in &initial_validators {
+            assert!(monitor.has_validator_stats(validator));
+        }
+        assert!(monitor.has_validator_stats(&new_validator));
+    }
+}

--- a/crates/sui-core/src/validator_tx_finalizer.rs
+++ b/crates/sui-core/src/validator_tx_finalizer.rs
@@ -443,6 +443,25 @@ mod tests {
         ) -> Result<SuiSystemState, SuiError> {
             unimplemented!()
         }
+
+        async fn validator_health(
+            &self,
+            _request: sui_types::messages_grpc::RawValidatorHealthRequest,
+        ) -> Result<sui_types::messages_grpc::RawValidatorHealthResponse, SuiError> {
+            let typed_response = sui_types::messages_grpc::ValidatorHealthResponse {
+                num_inflight_consensus_transactions: 0,
+                num_inflight_execution_transactions: 0,
+                last_committed_leader_round: 1000,
+                last_locally_built_checkpoint: 500,
+            };
+
+            typed_response.try_into().map_err(|e| {
+                sui_types::error::SuiError::GrpcMessageSerializeError {
+                    type_info: "ValidatorHealthResponse".to_string(),
+                    error: format!("Failed to convert to raw response: {}", e),
+                }
+            })
+        }
     }
 
     #[sim_test]

--- a/crates/sui-network/build.rs
+++ b/crates/sui-network/build.rs
@@ -132,6 +132,15 @@ fn main() -> Result<()> {
                 .codec_path(codec_path)
                 .build(),
         )
+        .method(
+            Method::builder()
+                .name("validator_health")
+                .route_name("ValidatorHealth")
+                .input_type("sui_types::messages_grpc::RawValidatorHealthRequest")
+                .output_type("sui_types::messages_grpc::RawValidatorHealthResponse")
+                .codec_path(prost_codec_path)
+                .build(),
+        )
         .build();
 
     Builder::new()

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -796,6 +796,7 @@ impl SuiNode {
                 end_of_epoch_receiver,
                 &config.db_path(),
                 &prometheus_registry,
+                &config,
             )))
         } else {
             None

--- a/crates/sui-swarm-config/src/node_config_builder.rs
+++ b/crates/sui-swarm-config/src/node_config_builder.rs
@@ -253,6 +253,7 @@ impl ValidatorConfigBuilder {
             enable_db_write_stall: None,
             execution_time_observer_config: self.execution_time_observer_config,
             chain_override_for_testing: self.chain_override,
+            validator_client_monitor_config: None,
         }
     }
 
@@ -560,6 +561,7 @@ impl FullnodeConfigBuilder {
             enable_db_write_stall: None,
             execution_time_observer_config: None,
             chain_override_for_testing: self.chain_override,
+            validator_client_monitor_config: None,
         }
     }
 }


### PR DESCRIPTION
## Description 

Summary

  This PR introduces a Validator Performance Monitor that tracks client-side observations of validator performance metrics.
  The monitor runs from the perspective of a fullnode and provides intelligent validator selection based on real-time
  performance data.

  Key Features

  - Client-side performance tracking: Monitors transaction submission latency, effects retrieval latency, and health check
  response times from the client's perspective
  - Exponential moving averages: Uses decay-based moving averages to smooth measurements and prioritize recent performance
  data
  - Automatic epoch handling: Cleans up stale validator data during epoch transitions
  - Configurable health checks: Periodic background health checks with customizable intervals and timeouts

  Implementation Details

  Core Components

  1. ValidatorClientMonitor (crates/sui-core/src/validator_client_monitor/):
    - Main monitoring component that tracks client-observed metrics
    - Runs background health checks on all validators
    - Provides intelligent validator selection based on performance
  2. DecayMovingAverage (crates/mysten-common/src/decay_moving_average.rs):
    - Utility for tracking smoothed performance metrics
    - Configurable decay factor to weight recent observations
  3. Configuration (crates/sui-config/src/validator_client_monitor_config.rs):
    - Extensive configuration options for tuning monitor behavior
    - Supports different selection strategies and performance thresholds

  Integration Points

  - TransactionDriver: Updated to use the monitor for validator selection when configured
  - Metrics: Comprehensive Prometheus metrics for monitoring validator performance

  Configuration

  The monitor can be enabled via node configuration:

  validator_client_monitor_config:
    enable_health_checks: true
    health_check_interval_seconds: 30
    max_consecutive_failures: 3
    exclusion_duration_seconds: 60

Metrics

  New Prometheus metrics added:
  - validator_client_operation_latency: Operation latency histogram
  - validator_client_operation_success: Success counter
  - validator_client_operation_failure: Failure counter
  - validator_client_health_status: Current health status gauge
  - validator_client_performance_score: Current performance score gauge

## Test plan 

  - Comprehensive unit tests added in crates/sui-core/src/validator_client_monitor/tests.rs
  - Tests cover validator selection, failure handling, epoch transitions, and metric tracking

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
