### PR TITLE
[move][move-compiler][typing] Extend var typing constraints in type inference

### DIFF
--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -1337,23 +1337,6 @@ impl VarConstraint {
     }
 }
 
-pub fn join_var_constraints(
-    lhs: Option<VarConstraint>,
-    rhs: Option<VarConstraint>,
-) -> Result<Option<VarConstraint>, TypingError> {
-    match (&lhs, &rhs) {
-        (None, None) => Ok(None),
-        (Some(_), None) => Ok(lhs),
-        (None, Some(_)) => Ok(rhs),
-        (Some(lhs_inner), Some(rhs_inner)) => {
-            // This will eventually do actual join work and possibly return an error
-            match (lhs_inner, rhs_inner) {
-                (VarConstraint::Num(_), VarConstraint::Num(_)) => Ok(rhs),
-            }
-        }
-    }
-}
-
 impl ast_debug::AstDebug for Subst {
     fn ast_debug(&self, w: &mut ast_debug::AstWriter) {
         let Subst {
@@ -3083,6 +3066,23 @@ fn join_impl_types(
         tys.push(t)
     }
     Ok((subst, tys))
+}
+
+pub fn join_var_constraints(
+    lhs: Option<VarConstraint>,
+    rhs: Option<VarConstraint>,
+) -> Result<Option<VarConstraint>, TypingError> {
+    match (&lhs, &rhs) {
+        (None, None) => Ok(None),
+        (Some(_), None) => Ok(lhs),
+        (None, Some(_)) => Ok(rhs),
+        (Some(lhs_inner), Some(rhs_inner)) => {
+            // This will eventually do actual join work and possibly return an error
+            match (lhs_inner, rhs_inner) {
+                (VarConstraint::Num(_), VarConstraint::Num(_)) => Ok(rhs),
+            }
+        }
+    }
 }
 
 fn join_tvar(

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -1270,18 +1270,28 @@ impl TVarCounter {
 #[derive(Clone, Debug)]
 pub struct Subst {
     tvars: HashMap<TVar, Type>,
-    num_vars: HashMap<TVar, Loc>,
+    var_constraints: HashMap<TVar, VarConstraint>,
+}
+
+#[derive(Clone, Debug)]
+// This will eventually hold constraints like `Void` and `String` as well
+pub enum VarConstraint {
+    Num(Loc),
 }
 
 impl Subst {
     pub fn empty() -> Self {
         Self {
             tvars: HashMap::new(),
-            num_vars: HashMap::new(),
+            var_constraints: HashMap::new(),
         }
     }
 
     pub fn insert(&mut self, tvar: TVar, bt: Type) {
+        self.tvars.insert(tvar, bt);
+    }
+
+    pub fn insert_with_constraint(&mut self, tvar: TVar, bt: Type) {
         self.tvars.insert(tvar, bt);
     }
 
@@ -1291,26 +1301,65 @@ impl Subst {
 
     pub fn new_num_var(&mut self, counter: &mut TVarCounter, loc: Loc) -> TVar {
         let tvar = counter.next();
-        assert!(self.num_vars.insert(tvar, loc).is_none());
+        assert!(
+            self.var_constraints
+                .insert(tvar, VarConstraint::Num(loc))
+                .is_none()
+        );
         tvar
     }
 
-    pub fn set_num_var(&mut self, tvar: TVar, loc: Loc) {
-        self.num_vars.entry(tvar).or_insert(loc);
-        if let Some(sp!(_, Type_::Var(next))) = self.get(tvar) {
-            let next = *next;
-            self.set_num_var(next, loc)
+    pub fn set_constraint_opt(&mut self, tvar: TVar, constraint_opt: Option<VarConstraint>) {
+        if let Some(constraint) = constraint_opt {
+            assert!(self.var_constraints.insert(tvar, constraint).is_none());
         }
     }
 
-    pub fn is_num_var(&self, tvar: TVar) -> bool {
-        self.num_vars.contains_key(&tvar)
+    pub fn is_num_var(&self, tvar: &TVar) -> bool {
+        self.var_constraints
+            .get(tvar)
+            .map(|constraint| constraint.is_num_var())
+            .unwrap_or(false)
+    }
+}
+
+impl VarConstraint {
+    pub fn is_num_var(&self) -> bool {
+        match self {
+            VarConstraint::Num(_) => true,
+        }
+    }
+
+    pub fn loc(&self) -> Loc {
+        match self {
+            VarConstraint::Num(loc) => *loc,
+        }
+    }
+}
+
+pub fn join_var_constraints(
+    lhs: Option<VarConstraint>,
+    rhs: Option<VarConstraint>,
+) -> Result<Option<VarConstraint>, TypingError> {
+    match (&lhs, &rhs) {
+        (None, None) => Ok(None),
+        (Some(_), None) => Ok(lhs),
+        (None, Some(_)) => Ok(rhs),
+        (Some(lhs_inner), Some(rhs_inner)) => {
+            // This will eventually do actual join work and possibly return an error
+            match (lhs_inner, rhs_inner) {
+                (VarConstraint::Num(_), VarConstraint::Num(_)) => Ok(rhs),
+            }
+        }
     }
 }
 
 impl ast_debug::AstDebug for Subst {
     fn ast_debug(&self, w: &mut ast_debug::AstWriter) {
-        let Subst { tvars, num_vars } = self;
+        let Subst {
+            tvars,
+            var_constraints,
+        } = self;
 
         w.write("tvars:");
         w.indent(4, |w| {
@@ -1324,7 +1373,7 @@ impl ast_debug::AstDebug for Subst {
         });
         w.write("num_vars:");
         w.indent(4, |w| {
-            let mut num_vars = num_vars.keys().collect::<Vec<_>>();
+            let mut num_vars = var_constraints.keys().collect::<Vec<_>>();
             num_vars.sort();
             for tvar in num_vars {
                 w.writeln(format!("{:?}", tvar))
@@ -1363,8 +1412,8 @@ fn error_format_impl_(b_: &Type_, subst: &Subst, nested: bool) -> String {
             match subst.get(last_id) {
                 Some(sp!(_, Var(_))) => unreachable!(),
                 Some(t) => error_format_nested(t, subst),
-                None if nested && subst.is_num_var(last_id) => "{integer}".to_string(),
-                None if subst.is_num_var(last_id) => return "integer".to_string(),
+                None if nested && subst.is_num_var(&last_id) => "{integer}".to_string(),
+                None if subst.is_num_var(&last_id) => return "integer".to_string(),
                 None => "_".to_string(),
             }
         }
@@ -2177,20 +2226,28 @@ pub fn check_call_arity<S: std::fmt::Display, F: Fn() -> S>(
 
 pub fn solve_constraints(context: &mut Context) {
     use BuiltinTypeName_ as BT;
-    let num_vars = context.subst.num_vars.clone();
+
+    let var_constraints = context.subst.var_constraints.clone();
     let mut subst = std::mem::replace(&mut context.subst, Subst::empty());
-    for (num_var, loc) in num_vars {
-        let tvar = sp(loc, Type_::Var(num_var));
-        match unfold_type(&subst, tvar.clone()).value {
-            Type_::UnresolvedError | Type_::Anything => {
-                let next_subst = join(&mut context.tvar_counter, subst, &Type_::u64(loc), &tvar)
-                    .unwrap()
-                    .0;
-                subst = next_subst;
+
+    for (var, constraint) in var_constraints.into_iter() {
+        match constraint {
+            VarConstraint::Num(loc) => {
+                let tvar = sp(loc, Type_::Var(var));
+                match unfold_type(&subst, tvar.clone()).value {
+                    Type_::UnresolvedError | Type_::Anything => {
+                        let next_subst =
+                            join(&mut context.tvar_counter, subst, &Type_::u64(loc), &tvar)
+                                .unwrap()
+                                .0;
+                        subst = next_subst;
+                    }
+                    _ => (),
+                }
             }
-            _ => (),
         }
     }
+
     context.subst = subst;
 
     let constraints = std::mem::take(&mut context.constraints);
@@ -3050,15 +3107,13 @@ fn join_tvar(
     };
 
     let new_tvar = counter.next();
-    let num_loc_1 = subst.num_vars.get(&last_id1);
-    let num_loc_2 = subst.num_vars.get(&last_id2);
-    match (num_loc_1, num_loc_2) {
-        (_, Some(nloc)) | (Some(nloc), _) => {
-            let nloc = *nloc;
-            subst.set_num_var(new_tvar, nloc);
-        }
-        _ => (),
-    }
+
+    // join constraints
+    let constraints_1 = subst.var_constraints.get(&last_id1).cloned();
+    let constraints_2 = subst.var_constraints.get(&last_id2).cloned();
+    let new_constraint_opt = join_var_constraints(constraints_1, constraints_2)?;
+    subst.set_constraint_opt(new_tvar, new_constraint_opt);
+
     subst.insert(last_id1, sp(loc1, Var(new_tvar)));
     subst.insert(last_id2, sp(loc2, Var(new_tvar)));
 
@@ -3122,7 +3177,7 @@ fn join_bind_tvar(subst: &mut Subst, loc: Loc, tvar: TVar, ty: Type) -> Result<b
     }
 
     // check not necessary for soundness but improves error message structure
-    if !check_num_tvar(subst, loc, tvar, &ty) {
+    if !check_num_tvar(subst, loc, &tvar, &ty) {
         return Ok(false);
     }
 
@@ -3139,7 +3194,7 @@ fn join_bind_tvar(subst: &mut Subst, loc: Loc, tvar: TVar, ty: Type) -> Result<b
     Ok(true)
 }
 
-fn check_num_tvar(subst: &Subst, _loc: Loc, tvar: TVar, ty: &Type) -> bool {
+fn check_num_tvar(subst: &Subst, _loc: Loc, tvar: &TVar, ty: &Type) -> bool {
     !subst.is_num_var(tvar) || check_num_tvar_(subst, ty)
 }
 
@@ -3153,7 +3208,7 @@ fn check_num_tvar_(subst: &Subst, ty: &Type) -> bool {
             let last_tvar = forward_tvar(subst, *v);
             match subst.get(last_tvar) {
                 Some(sp!(_, Var(_))) => unreachable!(),
-                None => subst.is_num_var(last_tvar),
+                None => subst.is_num_var(&last_tvar),
                 Some(t) => check_num_tvar_(subst, t),
             }
         }

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -1270,7 +1270,7 @@ impl TVarCounter {
 #[derive(Clone, Debug)]
 pub struct Subst {
     tvars: HashMap<TVar, Type>,
-    var_constraints: HashMap<TVar, VarConstraint>,
+    tvar_constraints: HashMap<TVar, VarConstraint>,
 }
 
 #[derive(Clone, Debug)]
@@ -1283,7 +1283,7 @@ impl Subst {
     pub fn empty() -> Self {
         Self {
             tvars: HashMap::new(),
-            var_constraints: HashMap::new(),
+            tvar_constraints: HashMap::new(),
         }
     }
 
@@ -1302,7 +1302,7 @@ impl Subst {
     pub fn new_num_var(&mut self, counter: &mut TVarCounter, loc: Loc) -> TVar {
         let tvar = counter.next();
         assert!(
-            self.var_constraints
+            self.tvar_constraints
                 .insert(tvar, VarConstraint::Num(loc))
                 .is_none()
         );
@@ -1311,12 +1311,12 @@ impl Subst {
 
     pub fn set_constraint_opt(&mut self, tvar: TVar, constraint_opt: Option<VarConstraint>) {
         if let Some(constraint) = constraint_opt {
-            assert!(self.var_constraints.insert(tvar, constraint).is_none());
+            assert!(self.tvar_constraints.insert(tvar, constraint).is_none());
         }
     }
 
     pub fn is_num_var(&self, tvar: &TVar) -> bool {
-        self.var_constraints
+        self.tvar_constraints
             .get(tvar)
             .map(|constraint| constraint.is_num_var())
             .unwrap_or(false)
@@ -1341,7 +1341,7 @@ impl ast_debug::AstDebug for Subst {
     fn ast_debug(&self, w: &mut ast_debug::AstWriter) {
         let Subst {
             tvars,
-            var_constraints,
+            tvar_constraints: var_constraints,
         } = self;
 
         w.write("tvars:");
@@ -2210,7 +2210,7 @@ pub fn check_call_arity<S: std::fmt::Display, F: Fn() -> S>(
 pub fn solve_constraints(context: &mut Context) {
     use BuiltinTypeName_ as BT;
 
-    let var_constraints = context.subst.var_constraints.clone();
+    let var_constraints = context.subst.tvar_constraints.clone();
     let mut subst = std::mem::replace(&mut context.subst, Subst::empty());
 
     for (var, constraint) in var_constraints.into_iter() {
@@ -3104,8 +3104,8 @@ fn join_tvar(
     let new_tvar = counter.next();
 
     // join constraints
-    let constraints_1 = subst.var_constraints.get(&last_id1).cloned();
-    let constraints_2 = subst.var_constraints.get(&last_id2).cloned();
+    let constraints_1 = subst.tvar_constraints.get(&last_id1).cloned();
+    let constraints_2 = subst.tvar_constraints.get(&last_id2).cloned();
     let new_constraint_opt = join_var_constraints(constraints_1, constraints_2)?;
     subst.set_constraint_opt(new_tvar, new_constraint_opt);
 

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -3073,15 +3073,10 @@ pub fn join_var_constraints(
     rhs: Option<VarConstraint>,
 ) -> Result<Option<VarConstraint>, TypingError> {
     match (&lhs, &rhs) {
+        (Some(VarConstraint::Num(_)), Some(VarConstraint::Num(_))) => Ok(rhs),
+        (Some(VarConstraint::Num(_)), None) => Ok(lhs),
+        (None, Some(VarConstraint::Num(_))) => Ok(rhs),
         (None, None) => Ok(None),
-        (Some(_), None) => Ok(lhs),
-        (None, Some(_)) => Ok(rhs),
-        (Some(lhs_inner), Some(rhs_inner)) => {
-            // This will eventually do actual join work and possibly return an error
-            match (lhs_inner, rhs_inner) {
-                (VarConstraint::Num(_), VarConstraint::Num(_)) => Ok(rhs),
-            }
-        }
     }
 }
 

--- a/external-crates/move/crates/move-compiler/src/typing/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/translate.rs
@@ -2953,7 +2953,7 @@ fn resolve_field(context: &mut Context, loc: Loc, ty: Type, field: &Field) -> Ty
             ));
             context.error_type(loc)
         }
-        sp!(tloc, Var(i)) if !context.subst.is_num_var(i) => {
+        sp!(tloc, Var(i)) if !context.subst.is_num_var(&i) => {
             context.add_diag(diag!(
                 TypeSafety::UninferredType,
                 (loc, msg()),


### PR DESCRIPTION
## Description 

This generalizes type variable constraints in the compiler, toward #22593

## Test plan 

Tests all still pass

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
