### PR TITLE
simulate execution time to trigger congestion control in test - alt

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -823,6 +823,15 @@ mod test {
     }
 
     async fn test_protocol_upgrade_compatibility_impl() {
+        // Override record_time_estimate_processed for protocol version 87 in tests
+        // it is currently set to true in 87 in mainnet only
+        let _guard = ProtocolConfig::apply_overrides_for_testing(|version, mut config| {
+            if version.as_u64() == 87 {
+                config.set_record_time_estimate_processed_for_testing(true);
+            }
+            config
+        });
+
         let max_ver = ProtocolVersion::MAX.as_u64();
         let manifest = sui_framework_snapshot::load_bytecode_snapshot_manifest();
 
@@ -857,7 +866,7 @@ mod test {
                 info!("Targeting protocol version: {version}");
                 test_cluster.wait_for_all_nodes_upgrade_to(version).await;
                 info!("All nodes are at protocol version: {version}");
-                // Let all nodes run for a few epochs at this version.
+                // Let all nodes run for a few epochs at this version
                 tokio::time::sleep(Duration::from_secs(30)).await;
                 if version == max_ver {
                     break;

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -3980,6 +3980,10 @@ impl ProtocolConfig {
         self.feature_flags.enable_ptb_execution_v2 = val;
     }
 
+    pub fn set_record_time_estimate_processed_for_testing(&mut self, val: bool) {
+        self.feature_flags.record_time_estimate_processed = val;
+    }
+
     pub fn push_aliased_addresses_for_testing(
         &mut self,
         original: [u8; 32],


### PR DESCRIPTION
Simulate execution time to trigger congestion control in test environments

## Description 

As described. Test-only, no impact to production.

## Test plan 

Antithesis + SIM testing


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
