### PR TITLE
[move-ide] A fix to displaying diagnostics for dependencies

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
   "publisher": "mysten",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "preview": true,
   "repository": {
     "url": "https://github.com/MystenLabs/sui.git",

--- a/external-crates/move/crates/move-analyzer/src/symbols/mod.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols/mod.rs
@@ -198,6 +198,7 @@ pub fn compute_symbols(
     let deps_hash = compiled_pkg_info.deps_hash.clone();
     let edition = compiled_pkg_info.edition;
     let compiler_info = compiled_pkg_info.compiler_info.clone();
+    let lsp_diags = compiled_pkg_info.lsp_diags.clone();
     let file_hashes = compiled_pkg_info
         .mapped_files
         .file_name_mapping()
@@ -246,6 +247,7 @@ pub fn compute_symbols(
                     file_hashes: Arc::new(file_hashes),
                     edition,
                     compiler_info,
+                    lsp_diags,
                 },
             );
         }


### PR DESCRIPTION
## Description 

This PR fixes a problem related to displaying diagnostics whose main message location is in one of the files that belong to dependent packages.

Prior to this PR, we reset diagnostics for a package being currently symbolicated, and display any diagnostics for this package that are a result of compilation during symbolication (which may be none). The resetting is necessary to make sure that any compilation-related fixes that might have happened in the past are reflected in the diagnostics being displayed.

This typically works pretty well but there is a scenario when it doesn't. There may be a situation when the current package has a build error that manifests itself in a file that belongs to one of the dependent packages rather than in a file that belongs to a package being symbolicated. In, particular, this happens with macro-related problesm.

In the following code, a semicolon inside the macro is placed incorrectly making the returned type incorrect. 
```move
module macro_diag::macro_diag;

public fun repro(): bool {
    let vec = vector[1, 2, 3];
    vec.any!(|item| {
        item == 2;
    })
}
```
This results in a diagnostic whose main message location is in `vector.move`:

![image](https://github.com/user-attachments/assets/4416ff2b-b450-4dec-8d77-3b4185dd23fd)

However, when we click on the message to go to `vector.move` file, we will open another (dependent package) which will be symbolicated. This package happens to have no build errors so its diagnostics will be reset and the error from the original user package will disappear (no red squiggly).

This PR fixes this problem by layering deduplicated diagnostics from other packages onto the reset diagnostics of the current package (if any).

You can see the behavior before this PR here:

https://github.com/user-attachments/assets/28c5d40f-8b2f-4b0f-98b8-045067276d93

And you can see the behavior after this PR here:

https://github.com/user-attachments/assets/3fd29696-6155-44a4-a856-f252f0d4205b






## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
