### PR TITLE
[kv grpc] migrate to v2beta2

### DIFF
--- a/crates/sui-kv-rpc/src/lib.rs
+++ b/crates/sui-kv-rpc/src/lib.rs
@@ -3,11 +3,11 @@
 
 use prometheus::Registry;
 use sui_kvstore::{BigTableClient, KeyValueStoreReader};
-use sui_rpc_api::proto::rpc::v2beta::{
+use sui_rpc::proto::sui::rpc::v2beta2::{
     ledger_service_server::LedgerService, BatchGetObjectsRequest, BatchGetObjectsResponse,
-    BatchGetTransactionsRequest, BatchGetTransactionsResponse, Checkpoint, Epoch,
-    ExecutedTransaction, GetCheckpointRequest, GetEpochRequest, GetObjectRequest,
-    GetServiceInfoRequest, GetServiceInfoResponse, GetTransactionRequest, Object,
+    BatchGetTransactionsRequest, BatchGetTransactionsResponse, GetCheckpointRequest,
+    GetCheckpointResponse, GetEpochRequest, GetEpochResponse, GetObjectRequest, GetObjectResponse,
+    GetServiceInfoRequest, GetServiceInfoResponse, GetTransactionRequest, GetTransactionResponse,
 };
 use sui_rpc_api::proto::timestamp_ms_to_proto;
 use sui_rpc_api::{CheckpointNotFoundError, RpcError, ServerVersion};
@@ -76,7 +76,7 @@ impl LedgerService for KvRpcServer {
     async fn get_object(
         &self,
         request: tonic::Request<GetObjectRequest>,
-    ) -> Result<tonic::Response<Object>, tonic::Status> {
+    ) -> Result<tonic::Response<GetObjectResponse>, tonic::Status> {
         get_object::get_object(self.client.clone(), request.into_inner())
             .await
             .map(tonic::Response::new)
@@ -96,7 +96,7 @@ impl LedgerService for KvRpcServer {
     async fn get_transaction(
         &self,
         request: tonic::Request<GetTransactionRequest>,
-    ) -> Result<tonic::Response<ExecutedTransaction>, tonic::Status> {
+    ) -> Result<tonic::Response<GetTransactionResponse>, tonic::Status> {
         get_transaction::get_transaction(self.client.clone(), request.into_inner())
             .await
             .map(tonic::Response::new)
@@ -116,7 +116,7 @@ impl LedgerService for KvRpcServer {
     async fn get_checkpoint(
         &self,
         request: tonic::Request<GetCheckpointRequest>,
-    ) -> Result<tonic::Response<Checkpoint>, tonic::Status> {
+    ) -> Result<tonic::Response<GetCheckpointResponse>, tonic::Status> {
         get_checkpoint::get_checkpoint(self.client.clone(), request.into_inner())
             .await
             .map(tonic::Response::new)
@@ -126,7 +126,7 @@ impl LedgerService for KvRpcServer {
     async fn get_epoch(
         &self,
         request: tonic::Request<GetEpochRequest>,
-    ) -> Result<tonic::Response<Epoch>, tonic::Status> {
+    ) -> Result<tonic::Response<GetEpochResponse>, tonic::Status> {
         get_epoch::get_epoch(
             self.client.clone(),
             request.into_inner(),
@@ -154,6 +154,6 @@ async fn get_service_info(
         timestamp: Some(timestamp_ms_to_proto(checkpoint.timestamp_ms)),
         lowest_available_checkpoint: Some(0),
         lowest_available_checkpoint_objects: Some(0),
-        server_version: server_version.as_ref().map(ToString::to_string),
+        server: server_version.as_ref().map(ToString::to_string),
     })
 }

--- a/crates/sui-kv-rpc/src/main.rs
+++ b/crates/sui-kv-rpc/src/main.rs
@@ -9,7 +9,7 @@ use mysten_network::callback::CallbackLayer;
 use prometheus::Registry;
 use std::sync::Arc;
 use sui_kv_rpc::KvRpcServer;
-use sui_rpc_api::proto::rpc::v2beta::ledger_service_server::LedgerServiceServer;
+use sui_rpc::proto::sui::rpc::v2beta2::ledger_service_server::LedgerServiceServer;
 use sui_rpc_api::{RpcMetrics, RpcMetricsMakeCallbackHandler, ServerVersion};
 use telemetry_subscribers::TelemetryConfig;
 use tonic::transport::{Identity, Server, ServerTlsConfig};

--- a/crates/sui-rpc-api/src/error.rs
+++ b/crates/sui-rpc-api/src/error.rs
@@ -37,7 +37,7 @@ impl RpcError {
         }
     }
 
-    pub(crate) fn into_status_proto(self) -> crate::proto::google::rpc::Status {
+    pub fn into_status_proto(self) -> crate::proto::google::rpc::Status {
         crate::proto::google::rpc::Status {
             code: self.code.into(),
             message: self.message.unwrap_or_default(),

--- a/crates/sui-rpc-api/src/grpc/v2beta2/ledger_service/get_epoch.rs
+++ b/crates/sui-rpc-api/src/grpc/v2beta2/ledger_service/get_epoch.rs
@@ -5,6 +5,7 @@ use crate::ErrorReason;
 use crate::Result;
 use crate::RpcService;
 use prost_types::FieldMask;
+use sui_protocol_config::ProtocolConfigValue;
 use sui_rpc::field::FieldMaskTree;
 use sui_rpc::field::FieldMaskUtil;
 use sui_rpc::merge::Merge;
@@ -168,12 +169,13 @@ fn get_protocol_config(
     version: u64,
     chain: sui_protocol_config::Chain,
 ) -> Result<ProtocolConfig, ProtocolVersionNotFoundError> {
-    use sui_protocol_config::ProtocolConfigValue;
-
     let config =
         sui_protocol_config::ProtocolConfig::get_for_version_if_supported(version.into(), chain)
             .ok_or_else(|| ProtocolVersionNotFoundError::new(version))?;
+    Ok(protocol_config_to_proto(config))
+}
 
+pub fn protocol_config_to_proto(config: sui_protocol_config::ProtocolConfig) -> ProtocolConfig {
     let protocol_version = config.version.as_u64();
     let attributes = config
         .attr_map()
@@ -191,10 +193,9 @@ fn get_protocol_config(
         })
         .collect();
     let feature_flags = config.feature_map().into_iter().collect();
-
-    Ok(ProtocolConfig {
+    ProtocolConfig {
         protocol_version: Some(protocol_version),
         feature_flags,
         attributes,
-    })
+    }
 }

--- a/crates/sui-rpc-api/src/grpc/v2beta2/ledger_service/mod.rs
+++ b/crates/sui-rpc-api/src/grpc/v2beta2/ledger_service/mod.rs
@@ -23,6 +23,7 @@ mod get_epoch;
 mod get_object;
 mod get_service_info;
 mod get_transaction;
+pub use get_epoch::protocol_config_to_proto;
 
 #[tonic::async_trait]
 impl LedgerService for RpcService {

--- a/crates/sui-rpc-api/src/grpc/v2beta2/mod.rs
+++ b/crates/sui-rpc-api/src/grpc/v2beta2/mod.rs
@@ -7,6 +7,7 @@ mod move_package_service;
 mod signature_verification_service;
 mod subscription_service;
 mod transaction_execution_service;
+pub use ledger_service::protocol_config_to_proto;
 
 fn render_json(
     service: &crate::RpcService,

--- a/crates/sui-rpc-api/src/lib.rs
+++ b/crates/sui-rpc-api/src/lib.rs
@@ -21,6 +21,7 @@ mod service;
 pub mod subscription;
 
 pub use crate::grpc::v2beta::ledger_service;
+pub use crate::grpc::v2beta2::protocol_config_to_proto;
 pub use client::Client;
 pub use config::Config;
 pub use error::{


### PR DESCRIPTION
## Description 

migrate KV service to v2beta2

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
