### PR TITLE
[move, cli] adds .trace and .coverage to gitignore

### DIFF
--- a/crates/sui/tests/snapshots/shell_tests__sui_move_new_tests__gitignore_exists.sh.snap
+++ b/crates/sui/tests/snapshots/shell_tests__sui_move_new_tests__gitignore_exists.sh.snap
@@ -18,5 +18,7 @@ exit_code: 0
 ----- stdout -----
 existing_ignore
 build/*
+.trace
+.coverage*
 
 ----- stderr -----

--- a/crates/sui/tests/snapshots/shell_tests__sui_move_new_tests__gitignore_has_build.sh.snap
+++ b/crates/sui/tests/snapshots/shell_tests__sui_move_new_tests__gitignore_has_build.sh.snap
@@ -23,6 +23,8 @@ exit_code: 0
 ----- stdout -----
 ignore1
 build/*
+.trace
+.coverage*
 ignore2
 
 ==== files in example/ ====

--- a/crates/sui/tests/snapshots/shell_tests__sui_move_new_tests__gitignore_has_build.sh.snap
+++ b/crates/sui/tests/snapshots/shell_tests__sui_move_new_tests__gitignore_has_build.sh.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/sui/tests/shell_tests.rs
-description: tests/shell_tests/new_tests/gitignore_has_build.sh
+description: tests/shell_tests/sui_move_new_tests/gitignore_has_build.sh
 ---
 ----- script -----
 # Copyright (c) Mysten Labs, Inc.
@@ -23,9 +23,10 @@ exit_code: 0
 ----- stdout -----
 ignore1
 build/*
+ignore2
+build/*
 .trace
 .coverage*
-ignore2
 
 ==== files in example/ ====
 .gitignore

--- a/external-crates/move/crates/move-cli/src/base/new.rs
+++ b/external-crates/move/crates/move-cli/src/base/new.rs
@@ -55,7 +55,7 @@ impl New {
 
     /// add `build/*` to `{path}/.gitignore` if it doesn't already have it
     fn write_gitignore(&self, path: &Path) -> anyhow::Result<()> {
-        let gitignore_entry = "build/*";
+        let gitignore_entry = "build/*\n.trace\n.coverage*";
 
         let mut file = std::fs::OpenOptions::new()
             .create(true)

--- a/external-crates/move/crates/move-cli/tests/build_tests/new_clobber/gitignore_exists/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/new_clobber/gitignore_exists/args.exp
@@ -2,6 +2,8 @@ Command `new -p package example`:
 External Command `cat package/.gitignore`:
 existing_ignore
 build/*
+.trace
+.coverage*
 External Command `ls -A package`:
 .gitignore
 Move.toml

--- a/external-crates/move/crates/move-cli/tests/build_tests/new_simple/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/new_simple/args.exp
@@ -37,6 +37,8 @@ edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
 
 External Command `cat P1/.gitignore`:
 build/*
+.trace
+.coverage*
 Command `new P2 -p other_dir`:
 External Command `cat other_dir/Move.toml`:
 [package]
@@ -76,3 +78,5 @@ edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
 
 External Command `cat other_dir/.gitignore`:
 build/*
+.trace
+.coverage*


### PR DESCRIPTION
## Description 

Extends default `.gitignore`

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
