### PR TITLE
[cli] sui keys interface rework

### DIFF
--- a/crates/sui-benchmark/src/util.rs
+++ b/crates/sui-benchmark/src/util.rs
@@ -25,7 +25,7 @@ pub fn get_ed25519_keypair_from_keystore(
     requested_address: &SuiAddress,
 ) -> Result<AccountKeyPair> {
     let keystore = FileBasedKeystore::new(&keystore_path)?;
-    match keystore.get_key(requested_address) {
+    match keystore.export(requested_address) {
         Ok(SuiKeyPair::Ed25519(kp)) => Ok(kp.copy()),
         other => Err(anyhow::anyhow!("Invalid key type: {:?}", other)),
     }

--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -366,7 +366,7 @@ pub fn new_wallet_context_from_cluster(
     let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path).unwrap());
     let address: SuiAddress = key_pair.public().into();
     keystore
-        .add_key(None, SuiKeyPair::Ed25519(key_pair))
+        .import(None, SuiKeyPair::Ed25519(key_pair))
         .unwrap();
     SuiClientConfig {
         keystore,

--- a/crates/sui-e2e-tests/tests/full_node_tests.rs
+++ b/crates/sui-e2e-tests/tests/full_node_tests.rs
@@ -159,17 +159,12 @@ async fn test_sponsored_transaction() -> Result<(), anyhow::Error> {
     let tx = to_sender_signed_transaction_with_multi_signers(
         tx_data,
         vec![
+            test_cluster.wallet.config.keystore.export(&sender).unwrap(),
             test_cluster
                 .wallet
                 .config
                 .keystore
-                .get_key(&sender)
-                .unwrap(),
-            test_cluster
-                .wallet
-                .config
-                .keystore
-                .get_key(&sponsor)
+                .export(&sponsor)
                 .unwrap(),
         ],
     );
@@ -834,11 +829,11 @@ async fn test_execute_tx_with_serialized_signature() -> Result<(), anyhow::Error
     context
         .config
         .keystore
-        .add_key(None, SuiKeyPair::Secp256k1(get_key_pair().1))?;
+        .import(None, SuiKeyPair::Secp256k1(get_key_pair().1))?;
     context
         .config
         .keystore
-        .add_key(None, SuiKeyPair::Ed25519(get_key_pair().1))?;
+        .import(None, SuiKeyPair::Ed25519(get_key_pair().1))?;
 
     let jsonrpc_client = &test_cluster.fullnode_handle.rpc_client;
 
@@ -1172,7 +1167,7 @@ async fn test_pass_back_no_object() -> Result<(), anyhow::Error> {
     )
     .unwrap();
     let tx =
-        to_sender_signed_transaction(tx_data, context.config.keystore.get_key(&sender).unwrap());
+        to_sender_signed_transaction(tx_data, context.config.keystore.export(&sender).unwrap());
 
     let digest = *tx.digest();
     let _res = transaction_orchestrator

--- a/crates/sui-keys/src/key_identity.rs
+++ b/crates/sui-keys/src/key_identity.rs
@@ -41,27 +41,3 @@ impl Display for KeyIdentity {
         write!(f, "{}", v)
     }
 }
-
-// Get the SuiAddress corresponding to this key identity.
-// If no string is provided, then the current active address is returned.
-// TODO wallet method
-// pub fn get_identity_address(
-//     input: Option<KeyIdentity>,
-//     ctx: &mut WalletContext,
-// ) -> Result<SuiAddress, Error> {
-//     if let Some(addr) = input {
-//         get_identity_address_from_keystore(addr, &ctx.config.keystore)
-//     } else {
-//         Ok(ctx.active_address()?)
-//     }
-// }
-
-// pub fn get_identity_address_from_keystore(
-//     input: KeyIdentity,
-//     keystore: &Keystore,
-// ) -> Result<SuiAddress, Error> {
-//     match input {
-//         KeyIdentity::Address(x) => Ok(x),
-//         KeyIdentity::Alias(x) => Ok(*keystore.get_address_by_alias(x)?),
-//     }
-// }

--- a/crates/sui-keys/src/key_identity.rs
+++ b/crates/sui-keys/src/key_identity.rs
@@ -3,16 +3,13 @@
 
 use std::{fmt::Display, str::FromStr};
 
-use anyhow::Error;
 use serde::Serialize;
-use sui_keys::keystore::{AccountKeystore, Keystore};
-use sui_sdk::wallet_context::WalletContext;
 use sui_types::base_types::SuiAddress;
 
 /// An address or an alias associated with a key in the wallet
 /// This is used to distinguish between an address or an alias,
 /// enabling a user to use an alias for any command that requires an address.
-#[derive(Serialize, Clone)]
+#[derive(Debug, Serialize, Clone)]
 pub enum KeyIdentity {
     Address(SuiAddress),
     Alias(String),
@@ -29,6 +26,12 @@ impl FromStr for KeyIdentity {
     }
 }
 
+impl From<SuiAddress> for KeyIdentity {
+    fn from(addr: SuiAddress) -> Self {
+        KeyIdentity::Address(addr)
+    }
+}
+
 impl Display for KeyIdentity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let v = match self {
@@ -39,25 +42,26 @@ impl Display for KeyIdentity {
     }
 }
 
-/// Get the SuiAddress corresponding to this key identity.
-/// If no string is provided, then the current active address is returned.
-pub fn get_identity_address(
-    input: Option<KeyIdentity>,
-    ctx: &mut WalletContext,
-) -> Result<SuiAddress, Error> {
-    if let Some(addr) = input {
-        get_identity_address_from_keystore(addr, &ctx.config.keystore)
-    } else {
-        Ok(ctx.active_address()?)
-    }
-}
+// Get the SuiAddress corresponding to this key identity.
+// If no string is provided, then the current active address is returned.
+// TODO wallet method
+// pub fn get_identity_address(
+//     input: Option<KeyIdentity>,
+//     ctx: &mut WalletContext,
+// ) -> Result<SuiAddress, Error> {
+//     if let Some(addr) = input {
+//         get_identity_address_from_keystore(addr, &ctx.config.keystore)
+//     } else {
+//         Ok(ctx.active_address()?)
+//     }
+// }
 
-pub fn get_identity_address_from_keystore(
-    input: KeyIdentity,
-    keystore: &Keystore,
-) -> Result<SuiAddress, Error> {
-    match input {
-        KeyIdentity::Address(x) => Ok(x),
-        KeyIdentity::Alias(x) => Ok(*keystore.get_address_by_alias(x)?),
-    }
-}
+// pub fn get_identity_address_from_keystore(
+//     input: KeyIdentity,
+//     keystore: &Keystore,
+// ) -> Result<SuiAddress, Error> {
+//     match input {
+//         KeyIdentity::Address(x) => Ok(x),
+//         KeyIdentity::Alias(x) => Ok(*keystore.get_address_by_alias(x)?),
+//     }
+// }

--- a/crates/sui-keys/src/keystore.rs
+++ b/crates/sui-keys/src/keystore.rs
@@ -69,6 +69,10 @@ pub trait AccountKeystore: Send + Sync {
     fn aliases_mut(&mut self) -> Vec<&mut Alias>;
 
     fn get_alias(&self, address: &SuiAddress) -> Result<String, anyhow::Error>;
+    /// Check if an alias exists by its name
+    fn alias_exists(&self, alias: &str) -> bool {
+        self.aliases().iter().any(|a| a.alias == alias)
+    }
 
     /// Get alias of address
     fn get_by_identity(&self, key_identity: KeyIdentity) -> Result<SuiAddress, anyhow::Error> {
@@ -262,7 +266,8 @@ impl AccountKeystore for FileBasedKeystore {
     /// If no alias has been passed, it will generate a new alias.
     fn create_alias(&self, alias: Option<String>) -> Result<String, anyhow::Error> {
         match alias {
-            Some(a) if self.aliases.values().any(|x| x.alias == a) => {
+            Some(a) if self.alias_exists(&a) => {
+                //} aliases.values().any(|x| x.alias == a) => {
                 bail!("Alias {a} already exists. Please choose another alias.")
             }
             Some(a) => validate_alias(&a),
@@ -540,7 +545,7 @@ impl AccountKeystore for InMemKeystore {
     /// If no alias has been passed, it will generate a new alias.
     fn create_alias(&self, alias: Option<String>) -> Result<String, anyhow::Error> {
         match alias {
-            Some(a) if self.aliases.values().any(|x| x.alias == a) => {
+            Some(a) if self.alias_exists(&a) => {
                 bail!("Alias {a} already exists. Please choose another alias.")
             }
             Some(a) => validate_alias(&a),

--- a/crates/sui-keys/src/keystore.rs
+++ b/crates/sui-keys/src/keystore.rs
@@ -46,7 +46,7 @@ pub trait AccountKeystore: Send + Sync {
     }
 
     fn import(&mut self, alias: Option<String>, keypair: SuiKeyPair) -> Result<(), anyhow::Error>;
-    fn remove(&mut self, address: impl Into<SuiAddress>) -> Result<(), anyhow::Error>;
+    fn remove(&mut self, address: SuiAddress) -> Result<(), anyhow::Error>;
     fn entries(&self) -> Vec<PublicKey>;
     fn export(&self, address: &SuiAddress) -> Result<&SuiKeyPair, anyhow::Error>;
 
@@ -71,10 +71,7 @@ pub trait AccountKeystore: Send + Sync {
     fn get_alias(&self, address: &SuiAddress) -> Result<String, anyhow::Error>;
 
     /// Get alias of address
-    fn get_by_identity(
-        &self,
-        key_identity: impl Into<KeyIdentity>,
-    ) -> Result<SuiAddress, anyhow::Error> {
+    fn get_by_identity(&self, key_identity: KeyIdentity) -> Result<SuiAddress, anyhow::Error> {
         let key_identity = key_identity.into();
         match key_identity {
             KeyIdentity::Address(addr) => Ok(addr),
@@ -234,7 +231,7 @@ impl AccountKeystore for FileBasedKeystore {
         Ok(())
     }
 
-    fn remove(&mut self, address: impl Into<SuiAddress>) -> Result<(), anyhow::Error> {
+    fn remove(&mut self, address: SuiAddress) -> Result<(), anyhow::Error> {
         let address: SuiAddress = address.into();
         self.aliases.remove(&address);
         self.keys.remove(&address);
@@ -503,7 +500,7 @@ impl AccountKeystore for InMemKeystore {
         Ok(())
     }
 
-    fn remove(&mut self, address: impl Into<SuiAddress>) -> Result<(), anyhow::Error> {
+    fn remove(&mut self, address: SuiAddress) -> Result<(), anyhow::Error> {
         let address: SuiAddress = address.into();
         self.aliases.remove(&address);
         self.keys.remove(&address);

--- a/crates/sui-keys/src/lib.rs
+++ b/crates/sui-keys/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod key_derive;
+pub mod key_identity;
 pub mod keypair_file;
 pub mod keystore;
 pub mod random_names;

--- a/crates/sui-rosetta/src/main.rs
+++ b/crates/sui-rosetta/src/main.rs
@@ -244,10 +244,10 @@ fn test_read_keystore() {
     let path = temp_dir.path().join("sui.keystore");
     let mut ks = Keystore::from(FileBasedKeystore::new(&path).unwrap());
     let key1 = ks
-        .generate_and_add_new_key(SignatureScheme::ED25519, None, None, None)
+        .generate(SignatureScheme::ED25519, None, None, None)
         .unwrap();
     let key2 = ks
-        .generate_and_add_new_key(SignatureScheme::Secp256k1, None, None, None)
+        .generate(SignatureScheme::Secp256k1, None, None, None)
         .unwrap();
 
     let accounts = read_prefunded_account(&path).unwrap();

--- a/crates/sui-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-rosetta/tests/end_to_end_tests.rs
@@ -102,7 +102,7 @@ async fn test_get_staked_sui() {
         )
         .await
         .unwrap();
-    let tx = to_sender_signed_transaction(delegation_tx, keystore.get_key(&address).unwrap());
+    let tx = to_sender_signed_transaction(delegation_tx, keystore.export(&address).unwrap());
     client
         .quorum_driver_api()
         .execute_transaction_block(

--- a/crates/sui-rosetta/tests/gas_budget_tests.rs
+++ b/crates/sui-rosetta/tests/gas_budget_tests.rs
@@ -132,7 +132,7 @@ async fn pay_with_gas_budget(budget: u64) -> TransactionIdentifierResponseResult
     let bytes = Hex::decode(&signing_payload.hex_bytes).unwrap();
     let signer = signing_payload.account_identifier.address;
     let signature = keystore.sign_hashed(&signer, &bytes).unwrap();
-    let public_key = keystore.get_key(&signer).unwrap().public();
+    let public_key = keystore.export(&signer).unwrap().public();
 
     let combine: ConstructionCombineResponse = rosetta_client
         .call(

--- a/crates/sui-rosetta/tests/rosetta_client.rs
+++ b/crates/sui-rosetta/tests/rosetta_client.rs
@@ -154,7 +154,7 @@ impl RosettaClient {
         let bytes = Hex::decode(&signing_payload.hex_bytes).unwrap();
         let signer = signing_payload.account_identifier.address;
         let signature = keystore.sign_hashed(&signer, &bytes).unwrap();
-        let public_key = keystore.get_key(&signer).unwrap().public();
+        let public_key = keystore.export(&signer).unwrap().public();
         let combine: ConstructionCombineResponse = self
             .call(
                 RosettaEndpoint::Combine,

--- a/crates/sui-rpc-loadgen/src/main.rs
+++ b/crates/sui-rpc-loadgen/src/main.rs
@@ -141,7 +141,7 @@ fn get_keypair() -> Result<SignerInfo> {
     let keystore_path = get_sui_config_directory().join("sui.keystore");
     let keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
     let active_address = keystore.addresses().pop().unwrap();
-    let keypair: &SuiKeyPair = keystore.get_key(&active_address)?;
+    let keypair: &SuiKeyPair = keystore.export(&active_address)?;
     println!("using address {active_address} for signing");
     Ok(SignerInfo::new(keypair.encode_base64()))
 }

--- a/crates/sui-sdk/examples/utils.rs
+++ b/crates/sui-sdk/examples/utils.rs
@@ -299,13 +299,11 @@ pub fn retrieve_wallet() -> Result<WalletContext, anyhow::Error> {
     let default_active_address = if let Some(address) = keystore.addresses().first() {
         *address
     } else {
-        keystore
-            .generate_and_add_new_key(ED25519, None, None, None)?
-            .0
+        keystore.generate(ED25519, None, None, None)?.0
     };
 
     if keystore.addresses().len() < 2 {
-        keystore.generate_and_add_new_key(ED25519, None, None, None)?;
+        keystore.generate(ED25519, None, None, None)?;
     }
 
     client_config.active_address = Some(default_active_address);

--- a/crates/sui-sdk/src/wallet_context.rs
+++ b/crates/sui-sdk/src/wallet_context.rs
@@ -78,7 +78,7 @@ impl WalletContext {
         input: Option<KeyIdentity>,
     ) -> Result<SuiAddress, anyhow::Error> {
         if let Some(key_identity) = input {
-            Ok(self.config.keystore.get_by_identity(key_identity)?.into())
+            Ok(self.config.keystore.get_by_identity(key_identity)?)
         } else {
             self.active_address()
         }

--- a/crates/sui-sdk/src/wallet_context.rs
+++ b/crates/sui-sdk/src/wallet_context.rs
@@ -14,6 +14,7 @@ use sui_json_rpc_types::{
     SuiObjectData, SuiObjectDataFilter, SuiObjectDataOptions, SuiObjectResponse,
     SuiObjectResponseQuery, SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
 };
+use sui_keys::key_identity::KeyIdentity;
 use sui_keys::keystore::AccountKeystore;
 use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
 use sui_types::crypto::SuiKeyPair;
@@ -72,6 +73,17 @@ impl WalletContext {
         self.env_override.clone()
     }
 
+    pub fn get_identity_address(
+        &mut self,
+        input: Option<KeyIdentity>,
+    ) -> Result<SuiAddress, anyhow::Error> {
+        if let Some(key_identity) = input {
+            Ok(self.config.keystore.get_by_identity(key_identity)?.into())
+        } else {
+            self.active_address()
+        }
+    }
+
     pub async fn get_client(&self) -> Result<SuiClient, anyhow::Error> {
         let read = self.client.read().await;
 
@@ -102,7 +114,7 @@ impl WalletContext {
 
     // TODO: Ger rid of mut
     pub fn active_address(&mut self) -> Result<SuiAddress, anyhow::Error> {
-        if self.config.keystore.addresses().is_empty() {
+        if self.config.keystore.entries().is_empty() {
             return Err(anyhow!(
                 "No managed addresses. Create new address with `new-address` command."
             ));
@@ -326,7 +338,7 @@ impl WalletContext {
 
     /// Add an account
     pub fn add_account(&mut self, alias: Option<String>, keypair: SuiKeyPair) {
-        self.config.keystore.add_key(alias, keypair).unwrap();
+        self.config.keystore.import(alias, keypair).unwrap();
     }
 
     /// Sign a transaction with a key currently managed by the WalletContext

--- a/crates/sui-sdk/tests/tests.rs
+++ b/crates/sui-sdk/tests/tests.rs
@@ -23,7 +23,7 @@ fn mnemonic_test() {
     let keystore_path = temp_dir.path().join("sui.keystore");
     let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path).unwrap());
     let (address, phrase, scheme) = keystore
-        .generate_and_add_new_key(SignatureScheme::ED25519, None, None, None)
+        .generate(SignatureScheme::ED25519, None, None, None)
         .unwrap();
 
     let keystore_path_2 = temp_dir.path().join("sui2.keystore");

--- a/crates/sui/src/lib.rs
+++ b/crates/sui/src/lib.rs
@@ -10,7 +10,6 @@ pub mod displays;
 pub mod fire_drill;
 pub mod genesis_ceremony;
 pub mod genesis_inspector;
-pub mod key_identity;
 pub mod keytool;
 pub mod mvr_resolver;
 pub mod sui_commands;

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -1026,7 +1026,7 @@ async fn start(
             let keystore_path = config_dir.join(SUI_KEYSTORE_FILENAME);
             let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path).unwrap());
             let address: SuiAddress = kp.public().into();
-            keystore.add_key(None, SuiKeyPair::Ed25519(kp)).unwrap();
+            keystore.import(None, SuiKeyPair::Ed25519(kp)).unwrap();
             SuiClientConfig {
                 keystore,
                 envs: vec![SuiEnv {
@@ -1160,7 +1160,7 @@ async fn genesis(
                 let path = sui_config_dir.join(SUI_BENCHMARK_GENESIS_GAS_KEYSTORE_FILENAME);
                 let mut keystore = FileBasedKeystore::new(&path)?;
                 for gas_key in GenesisConfig::benchmark_gas_keys(ips.len()) {
-                    keystore.add_key(None, gas_key)?;
+                    keystore.import(None, gas_key)?;
                 }
                 keystore.save()?;
 
@@ -1214,7 +1214,7 @@ async fn genesis(
 
     let mut keystore = FileBasedKeystore::new(&keystore_path)?;
     for key in &network_config.account_keys {
-        keystore.add_key(None, SuiKeyPair::Ed25519(key.copy()))?;
+        keystore.import(None, SuiKeyPair::Ed25519(key.copy()))?;
     }
     let active_address = keystore.addresses().pop();
 
@@ -1422,9 +1422,8 @@ async fn prompt_if_no_config(
                     Err(e) => return Err(anyhow!("{e}")),
                 }
             };
-            let (new_address, phrase, scheme) =
-                keystore.generate_and_add_new_key(key_scheme, None, None, None)?;
-            let alias = keystore.get_alias_by_address(&new_address)?;
+            let (new_address, phrase, scheme) = keystore.generate(key_scheme, None, None, None)?;
+            let alias = keystore.get_alias(&new_address)?;
             println!(
                 "Generated new keypair and alias for address with scheme {:?} [{alias}: {new_address}]",
                 scheme.to_string()

--- a/crates/sui/src/unit_tests/keytool_tests.rs
+++ b/crates/sui/src/unit_tests/keytool_tests.rs
@@ -3,7 +3,6 @@
 
 use std::str::FromStr;
 
-use crate::key_identity::KeyIdentity;
 use crate::keytool::read_authority_keypair_from_file;
 use crate::keytool::read_keypair_from_file;
 use crate::keytool::CommandOutput;
@@ -20,6 +19,7 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 use shared_crypto::intent::Intent;
 use shared_crypto::intent::IntentScope;
+use sui_keys::key_identity::KeyIdentity;
 use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, InMemKeystore, Keystore};
 use sui_types::base_types::ObjectDigest;
 use sui_types::base_types::ObjectID;
@@ -50,7 +50,7 @@ async fn test_addresses_command() -> Result<(), anyhow::Error> {
 
     // Add another 3 Secp256k1 KeyPairs
     for _ in 0..3 {
-        keystore.add_key(None, SuiKeyPair::Secp256k1(get_key_pair().1))?;
+        keystore.import(None, SuiKeyPair::Secp256k1(get_key_pair().1))?;
     }
 
     // List all addresses with flag
@@ -67,10 +67,10 @@ async fn test_addresses_command() -> Result<(), anyhow::Error> {
 async fn test_flag_in_signature_and_keypair() -> Result<(), anyhow::Error> {
     let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(0));
 
-    keystore.add_key(None, SuiKeyPair::Secp256k1(get_key_pair().1))?;
-    keystore.add_key(None, SuiKeyPair::Ed25519(get_key_pair().1))?;
+    keystore.import(None, SuiKeyPair::Secp256k1(get_key_pair().1))?;
+    keystore.import(None, SuiKeyPair::Ed25519(get_key_pair().1))?;
 
-    for pk in keystore.keys() {
+    for pk in keystore.entries() {
         let pk1 = pk.clone();
         let sig = keystore.sign_secure(&(&pk).into(), b"hello", Intent::sui_transaction())?;
         match sig {
@@ -516,7 +516,7 @@ async fn test_sign_command() -> Result<(), anyhow::Error> {
     let mut keystore = Keystore::from(InMemKeystore::new_insecure_for_tests(1));
     let binding = keystore.addresses();
     let sender = binding.first().unwrap();
-    let alias = keystore.get_alias_by_address(sender).unwrap();
+    let alias = keystore.get_alias(sender).unwrap();
 
     // Create a dummy TransactionData
     let gas = (

--- a/crates/sui/src/validator_commands.rs
+++ b/crates/sui/src/validator_commands.rs
@@ -285,7 +285,7 @@ impl SuiValidatorCommand {
             } => {
                 let dir = std::env::current_dir()?;
                 let protocol_key_file_name = dir.join("protocol.key");
-                let account_key = match context.config.keystore.get_key(&sui_address)? {
+                let account_key = match context.config.keystore.export(&sui_address)? {
                     SuiKeyPair::Ed25519(account_key) => SuiKeyPair::Ed25519(account_key.copy()),
                     _ => panic!(
                         "Other account key types supported yet, please use Ed25519 keys for now."

--- a/crates/sui/src/zklogin_commands_util.rs
+++ b/crates/sui/src/zklogin_commands_util.rs
@@ -110,7 +110,7 @@ pub async fn perform_zk_login_test_tx(
     )?;
 
     let sender = if test_multisig {
-        keystore.add_key(None, skp1)?;
+        keystore.import(None, skp1)?;
         println!("Use multisig address as sender");
         SuiAddress::from(&multisig_pk)
     } else {

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -1295,7 +1295,7 @@ impl TestClusterBuilder {
         swarm.config().save(network_path)?;
         let mut keystore = Keystore::from(FileBasedKeystore::new(&keystore_path)?);
         for key in &swarm.config().account_keys {
-            keystore.add_key(None, SuiKeyPair::Ed25519(key.copy()))?;
+            keystore.import(None, SuiKeyPair::Ed25519(key.copy()))?;
         }
 
         let active_address = keystore.addresses().first().cloned();


### PR DESCRIPTION
## Description 

"key" now implied in function names, "export" and "import" used to be more inline with wallet terminology and disambiguate between "generate" and "import".
- add_key -> import
- get_key -> export
- remove_key -> remove
- get_key -> export
- keys -> entries

pushed the identity module into sui-keys, KeyIdentity helper function into wallet context
- get_alias_by_address -> get_alias
- get_address_by_alias -> replaced via get_by_identity
- alias_names -> now a test helper outside of trait

## Test plan 

Good coverage exists with unit tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
