### PR TITLE
graphql-alt: Add Epoch.totalCheckpoints

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/endTimestamp/endTimestamp_end_epoch_checkpoint.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/endTimestamp/endTimestamp_end_epoch_checkpoint.move
@@ -1,0 +1,18 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --simulator
+
+//# advance-epoch
+
+//# run-graphql
+{
+  checkpoint(sequenceNumber: 1) {
+    query {
+      epoch(epochId: 0) {
+        startTimestamp
+        endTimestamp
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/endTimestamp/endTimestamp_end_epoch_checkpoint.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/endTimestamp/endTimestamp_end_epoch_checkpoint.snap
@@ -1,0 +1,26 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 3 tasks
+
+init:
+A: object(0,0)
+
+task 1, line 6:
+//# advance-epoch
+Epoch advanced: 1
+
+task 2, lines 8-18:
+//# run-graphql
+Response: {
+  "data": {
+    "checkpoint": {
+      "query": {
+        "epoch": {
+          "startTimestamp": "1970-01-01T00:00:00Z",
+          "endTimestamp": "1970-01-01T00:00:00Z"
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.move
@@ -30,6 +30,7 @@ fragment E on Epoch {
   referenceGasPrice
   startTimestamp
   endTimestamp
+  totalCheckpoints
 }
 
 //# run-graphql
@@ -50,4 +51,5 @@ fragment E on Epoch {
   referenceGasPrice
   startTimestamp
   endTimestamp
+  totalCheckpoints
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
@@ -18,7 +18,7 @@ task 5, line 14:
 //# advance-epoch
 Epoch advanced: 3
 
-task 6, lines 16-33:
+task 6, lines 16-34:
 //# run-graphql
 Response: {
   "data": {
@@ -26,31 +26,35 @@ Response: {
       "epochId": 2,
       "referenceGasPrice": "1000",
       "startTimestamp": "1970-01-01T00:00:00.444Z",
-      "endTimestamp": null
+      "endTimestamp": null,
+      "totalCheckpoints": 0
     },
     "e0": {
       "epochId": 0,
       "referenceGasPrice": "1000",
       "startTimestamp": "1970-01-01T00:00:00Z",
-      "endTimestamp": "1970-01-01T00:00:00.123Z"
+      "endTimestamp": "1970-01-01T00:00:00.123Z",
+      "totalCheckpoints": 2
     },
     "e1": {
       "epochId": 1,
       "referenceGasPrice": "1000",
       "startTimestamp": "1970-01-01T00:00:00.123Z",
-      "endTimestamp": "1970-01-01T00:00:00.444Z"
+      "endTimestamp": "1970-01-01T00:00:00.444Z",
+      "totalCheckpoints": 1
     },
     "e2": {
       "epochId": 2,
       "referenceGasPrice": "1000",
       "startTimestamp": "1970-01-01T00:00:00.444Z",
-      "endTimestamp": null
+      "endTimestamp": null,
+      "totalCheckpoints": 0
     },
     "e3": null
   }
 }
 
-task 7, lines 35-53:
+task 7, lines 36-55:
 //# run-graphql
 Response: {
   "data": {
@@ -60,19 +64,22 @@ Response: {
           "epochId": 1,
           "referenceGasPrice": "1000",
           "startTimestamp": "1970-01-01T00:00:00.123Z",
-          "endTimestamp": null
+          "endTimestamp": null,
+          "totalCheckpoints": 1
         },
         "e0": {
           "epochId": 0,
           "referenceGasPrice": "1000",
           "startTimestamp": "1970-01-01T00:00:00Z",
-          "endTimestamp": "1970-01-01T00:00:00.123Z"
+          "endTimestamp": "1970-01-01T00:00:00.123Z",
+          "totalCheckpoints": 2
         },
         "e1": {
           "epochId": 1,
           "referenceGasPrice": "1000",
           "startTimestamp": "1970-01-01T00:00:00.123Z",
-          "endTimestamp": null
+          "endTimestamp": null,
+          "totalCheckpoints": 1
         },
         "e2": null
       }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
@@ -26,7 +26,7 @@ Response: {
       "epochId": 2,
       "referenceGasPrice": "1000",
       "startTimestamp": "1970-01-01T00:00:00.444Z",
-      "endTimestamp": null,
+      "endTimestamp": "1970-01-01T00:00:00.444Z",
       "totalCheckpoints": 1
     },
     "e0": {
@@ -47,7 +47,7 @@ Response: {
       "epochId": 2,
       "referenceGasPrice": "1000",
       "startTimestamp": "1970-01-01T00:00:00.444Z",
-      "endTimestamp": null,
+      "endTimestamp": "1970-01-01T00:00:00.444Z",
       "totalCheckpoints": 1
     },
     "e3": null
@@ -64,7 +64,7 @@ Response: {
           "epochId": 1,
           "referenceGasPrice": "1000",
           "startTimestamp": "1970-01-01T00:00:00.123Z",
-          "endTimestamp": null,
+          "endTimestamp": "1970-01-01T00:00:00.444Z",
           "totalCheckpoints": 1
         },
         "e0": {
@@ -78,7 +78,7 @@ Response: {
           "epochId": 1,
           "referenceGasPrice": "1000",
           "startTimestamp": "1970-01-01T00:00:00.123Z",
-          "endTimestamp": null,
+          "endTimestamp": "1970-01-01T00:00:00.444Z",
           "totalCheckpoints": 1
         },
         "e2": null

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
@@ -27,7 +27,7 @@ Response: {
       "referenceGasPrice": "1000",
       "startTimestamp": "1970-01-01T00:00:00.444Z",
       "endTimestamp": null,
-      "totalCheckpoints": null
+      "totalCheckpoints": 1
     },
     "e0": {
       "epochId": 0,
@@ -48,7 +48,7 @@ Response: {
       "referenceGasPrice": "1000",
       "startTimestamp": "1970-01-01T00:00:00.444Z",
       "endTimestamp": null,
-      "totalCheckpoints": null
+      "totalCheckpoints": 1
     },
     "e3": null
   }
@@ -65,7 +65,7 @@ Response: {
           "referenceGasPrice": "1000",
           "startTimestamp": "1970-01-01T00:00:00.123Z",
           "endTimestamp": null,
-          "totalCheckpoints": null
+          "totalCheckpoints": 1
         },
         "e0": {
           "epochId": 0,
@@ -79,7 +79,7 @@ Response: {
           "referenceGasPrice": "1000",
           "startTimestamp": "1970-01-01T00:00:00.123Z",
           "endTimestamp": null,
-          "totalCheckpoints": null
+          "totalCheckpoints": 1
         },
         "e2": null
       }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
@@ -65,7 +65,7 @@ Response: {
           "referenceGasPrice": "1000",
           "startTimestamp": "1970-01-01T00:00:00.123Z",
           "endTimestamp": null,
-          "totalCheckpoints": 1
+          "totalCheckpoints": 0
         },
         "e0": {
           "epochId": 0,
@@ -79,7 +79,7 @@ Response: {
           "referenceGasPrice": "1000",
           "startTimestamp": "1970-01-01T00:00:00.123Z",
           "endTimestamp": null,
-          "totalCheckpoints": 1
+          "totalCheckpoints": 0
         },
         "e2": null
       }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
@@ -27,7 +27,7 @@ Response: {
       "referenceGasPrice": "1000",
       "startTimestamp": "1970-01-01T00:00:00.444Z",
       "endTimestamp": null,
-      "totalCheckpoints": 0
+      "totalCheckpoints": null
     },
     "e0": {
       "epochId": 0,
@@ -48,7 +48,7 @@ Response: {
       "referenceGasPrice": "1000",
       "startTimestamp": "1970-01-01T00:00:00.444Z",
       "endTimestamp": null,
-      "totalCheckpoints": 0
+      "totalCheckpoints": null
     },
     "e3": null
   }
@@ -65,7 +65,7 @@ Response: {
           "referenceGasPrice": "1000",
           "startTimestamp": "1970-01-01T00:00:00.123Z",
           "endTimestamp": null,
-          "totalCheckpoints": 0
+          "totalCheckpoints": null
         },
         "e0": {
           "epochId": 0,
@@ -79,7 +79,7 @@ Response: {
           "referenceGasPrice": "1000",
           "startTimestamp": "1970-01-01T00:00:00.123Z",
           "endTimestamp": null,
-          "totalCheckpoints": 0
+          "totalCheckpoints": null
         },
         "e2": null
       }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalCheckpoints/totalCheckpoints_empty_epoch.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalCheckpoints/totalCheckpoints_empty_epoch.move
@@ -1,0 +1,41 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --simulator
+
+//# run-graphql
+{ # genesis epoch
+  e0: epoch(epochId: 0) { ...E }
+  e1: epoch(epochId: 1) { ...E }
+  e2: epoch(epochId: 2) { ...E }
+}
+
+fragment E on Epoch {
+  totalCheckpoints
+}
+
+//# advance-epoch
+
+//# run-graphql
+{ # epochs without middle epoch
+  e0: epoch(epochId: 0) { ...E }
+  e1: epoch(epochId: 1) { ...E }
+  e2: epoch(epochId: 2) { ...E }
+}
+
+fragment E on Epoch {
+  totalCheckpoints
+}
+
+//# advance-epoch
+
+//# run-graphql
+{ # epochs with middle epoch
+  e0: epoch(epochId: 0) { ...E }
+  e1: epoch(epochId: 1) { ...E }
+  e2: epoch(epochId: 2) { ...E }
+}
+
+fragment E on Epoch {
+  totalCheckpoints
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalCheckpoints/totalCheckpoints_empty_epoch.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalCheckpoints/totalCheckpoints_empty_epoch.snap
@@ -1,0 +1,53 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-15:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "totalCheckpoints": 1
+    },
+    "e1": null,
+    "e2": null
+  }
+}
+
+task 2, line 17:
+//# advance-epoch
+Epoch advanced: 1
+
+task 3, lines 19-28:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "totalCheckpoints": 2
+    },
+    "e1": null,
+    "e2": null
+  }
+}
+
+task 4, line 30:
+//# advance-epoch
+Epoch advanced: 2
+
+task 5, lines 32-41:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "totalCheckpoints": 2
+    },
+    "e1": {
+      "totalCheckpoints": 1
+    },
+    "e2": null
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalCheckpoints/totalCheckpoints_with_checkpoint.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalCheckpoints/totalCheckpoints_with_checkpoint.move
@@ -1,0 +1,47 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --simulator
+
+//# create-checkpoint
+
+//# run-graphql
+{ # genesis epoch
+  e0: epoch(epochId: 0) { ...E }
+  e1: epoch(epochId: 1) { ...E }
+  e2: epoch(epochId: 2) { ...E }
+}
+
+fragment E on Epoch {
+  totalCheckpoints
+}
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# run-graphql
+{ # epochs without middle epoch
+  e0: epoch(epochId: 0) { ...E }
+  e1: epoch(epochId: 1) { ...E }
+  e2: epoch(epochId: 2) { ...E }
+}
+
+fragment E on Epoch {
+  totalCheckpoints
+}
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# run-graphql
+{ # epochs with middle epoch
+  e0: epoch(epochId: 0) { ...E }
+  e1: epoch(epochId: 1) { ...E }
+  e2: epoch(epochId: 2) { ...E }
+}
+
+fragment E on Epoch {
+  totalCheckpoints
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalCheckpoints/totalCheckpoints_with_checkpoint.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalCheckpoints/totalCheckpoints_with_checkpoint.snap
@@ -1,0 +1,69 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 9 tasks
+
+init:
+A: object(0,0)
+
+task 1, line 6:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 2, lines 8-17:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "totalCheckpoints": 2
+    },
+    "e1": null,
+    "e2": null
+  }
+}
+
+task 3, line 19:
+//# advance-epoch
+Epoch advanced: 1
+
+task 4, line 21:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 5, lines 23-32:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "totalCheckpoints": 3
+    },
+    "e1": {
+      "totalCheckpoints": 1
+    },
+    "e2": null
+  }
+}
+
+task 6, line 34:
+//# advance-epoch
+Epoch advanced: 2
+
+task 7, line 36:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 8, lines 38-47:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "totalCheckpoints": 3
+    },
+    "e1": {
+      "totalCheckpoints": 2
+    },
+    "e2": {
+      "totalCheckpoints": 1
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -108,6 +108,10 @@ type Epoch {
 	The timestamp associated with the last checkpoint in the epoch (or `null` if the epoch has not finished yet).
 	"""
 	endTimestamp: DateTime
+	"""
+	The total number of checkpoints in this epoch.
+	"""
+	totalCheckpoints: UInt53
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
@@ -78,8 +78,8 @@ impl Epoch {
             None => return Ok(None),
         };
         let last = match end {
-            Some(last) => last.cp_hi as u64,          // exclusive
-            None => scope.checkpoint_viewed_at() + 1, // inclusive
+            Some(last) => last.cp_hi as u64,
+            None => scope.checkpoint_viewed_at_exclusive_bound(),
         };
         Ok(Some(UInt53::from(last - first)))
     }
@@ -271,7 +271,9 @@ impl EpochEnd {
             .context("Failed to fetch epoch end information")?;
 
         let end = match stored {
-            Some(end) if end.cp_hi as u64 <= scope.checkpoint_viewed_at() => Some(Arc::new(end)),
+            Some(end) if end.cp_hi as u64 <= scope.checkpoint_viewed_at_exclusive_bound() => {
+                Some(Arc::new(end))
+            }
             _ => None,
         };
         Ok(Self {

--- a/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
@@ -17,7 +17,6 @@ use super::{
     object::{self, Object},
     protocol_configs::ProtocolConfigs,
 };
-use crate::task::watermark::Watermarks;
 use crate::{
     api::scalars::{big_int::BigInt, date_time::DateTime, uint53::UInt53},
     error::RpcError,
@@ -72,10 +71,7 @@ impl Epoch {
     async fn total_checkpoints(&self, ctx: &Context<'_>) -> Result<Option<UInt53>, RpcError> {
         let last = match &self.end(ctx).await?.contents {
             Some(last) => last.cp_hi as u64,
-            None => {
-                let watermark: &Arc<Watermarks> = ctx.data()?;
-                watermark.high_watermark().checkpoint()
-            }
+            None => self.start.scope.checkpoint_viewed_at(),
         };
         let first = match &self.start.contents {
             Some(first) => first.cp_lo as u64,

--- a/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
@@ -78,7 +78,7 @@ impl Epoch {
             None => return Ok(None),
         };
         let last = match end {
-            Some(last) => last.cp_hi as u64, // exclusive
+            Some(last) => last.cp_hi as u64,          // exclusive
             None => scope.checkpoint_viewed_at() + 1, // inclusive
         };
         Ok(Some(UInt53::from(last - first)))
@@ -104,7 +104,7 @@ impl EpochStart {
             SUI_DENY_LIST_OBJECT_ID.into(),
             (contents.cp_lo as u64).saturating_sub(1).into(),
         )
-            .await
+        .await
     }
 
     /// The epoch's corresponding protocol configuration, including the feature flags and the configuration options.
@@ -160,7 +160,7 @@ impl EpochStart {
                 page,
                 contents.cp_lo as u64,
             )
-                .await?,
+            .await?,
         ))
     }
 }
@@ -238,7 +238,7 @@ impl EpochStart {
             let cp = self.scope.checkpoint_viewed_at();
             pg_loader.load_one(CheckpointBoundedEpochStartKey(cp)).await
         }
-            .context("Failed to fetch epoch start information")?;
+        .context("Failed to fetch epoch start information")?;
 
         let Some(stored) = load else {
             return Ok(self.clone());
@@ -272,7 +272,7 @@ impl EpochEnd {
 
         let end = match stored {
             Some(end) if end.cp_hi as u64 <= scope.checkpoint_viewed_at() => Some(Arc::new(end)),
-            _ => None
+            _ => None,
         };
         Ok(Self {
             scope,

--- a/crates/sui-indexer-alt-graphql/src/scope.rs
+++ b/crates/sui-indexer-alt-graphql/src/scope.rs
@@ -38,7 +38,13 @@ impl Scope {
         })
     }
 
+    // inclusive upper bound on data visible to request
     pub(crate) fn checkpoint_viewed_at(&self) -> u64 {
         self.checkpoint_viewed_at
+    }
+
+    // exclusive upper bound on data visible to request
+    pub(crate) fn checkpoint_viewed_at_exclusive_bound(&self) -> u64 {
+        self.checkpoint_viewed_at + 1
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -112,6 +112,10 @@ type Epoch {
 	The timestamp associated with the last checkpoint in the epoch (or `null` if the epoch has not finished yet).
 	"""
 	endTimestamp: DateTime
+	"""
+	The total number of checkpoints in this epoch.
+	"""
+	totalCheckpoints: UInt53
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -112,6 +112,10 @@ type Epoch {
 	The timestamp associated with the last checkpoint in the epoch (or `null` if the epoch has not finished yet).
 	"""
 	endTimestamp: DateTime
+	"""
+	The total number of checkpoints in this epoch.
+	"""
+	totalCheckpoints: UInt53
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -108,6 +108,10 @@ type Epoch {
 	The timestamp associated with the last checkpoint in the epoch (or `null` if the epoch has not finished yet).
 	"""
 	endTimestamp: DateTime
+	"""
+	The total number of checkpoints in this epoch.
+	"""
+	totalCheckpoints: UInt53
 }
 
 """


### PR DESCRIPTION
## Description 

1. Implements `Epoch.totalCheckpoints` based on https://github.com/MystenLabs/sui/blob/4275c1a55988d28b638be8720aebdf1e7da3b06b/crates/sui-graphql-rpc/src/types/epoch.rs#L125-L137
2. Fixes a bug with epoch end bounds

## Test plan 

1. Added `totalCheckpoints` to the `query.move` snapshot test.
2. Added new tests for `totalCheckpoints` and `startTimestamp`/`endTimestamp`.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
