### PR TITLE
Setup devx-indexers-and-rpcs team in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,8 +12,9 @@ CHANGELOG.md
 /crates/sui-framework/src/natives/ @dariorussi
 
 # GraphQL RPC working group
-/crates/sui-graphql-rpc/ @amnn @wlmyng @stefan-mysten @emmazzz
-/crates/sui-graphql-e2e-tests/ @amnn @wlmyng @stefan-mysten @emmazzz
+/crates/sui-graphql* @MystenLabs/devx-indexers-and-rpcs
+/crates/sui-indexer* @MystenLabs/devx-indexers-and-rpcs
+/crates/sui-pg-db @MystenLabs/devx-indexers-and-rpcs
 
 # Consensus working group
 /consensus/ @MystenLabs/consensus

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,9 +12,13 @@ CHANGELOG.md
 /crates/sui-framework/src/natives/ @dariorussi
 
 # GraphQL RPC working group
+/crates/sui-default-config @MystenLabs/devx-indexers-and-rpcs
+/crates/sui-display @MystenLabs/devx-indexers-and-rpcs
+/crates/sui-field-count* @MystenLabs/devx-indexers-and-rpcs
 /crates/sui-graphql* @MystenLabs/devx-indexers-and-rpcs
 /crates/sui-indexer* @MystenLabs/devx-indexers-and-rpcs
 /crates/sui-pg-db @MystenLabs/devx-indexers-and-rpcs
+/crates/sui-sql-macro @MystenLabs/devx-indexers-and-rpcs
 
 # Consensus working group
 /consensus/ @MystenLabs/consensus


### PR DESCRIPTION
## Description 

This adds the newly created `devx-indexers-and-rpcs` team to the crates the team owns in CODEOWNERS.

## Test plan 

The `devx-indexers-and-rpcs` team needs permissions set up before this is merged. The permissions can be verified by being able to add the team as a reviewer to this PR.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
