### PR TITLE
Observe and commit to "indirect" state.

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -105,8 +105,9 @@ use crate::checkpoints::{
     PendingCheckpointInfo, PendingCheckpointV2, PendingCheckpointV2Contents,
 };
 use crate::consensus_handler::{
-    ConsensusCommitInfo, SequencedConsensusTransaction, SequencedConsensusTransactionKey,
-    SequencedConsensusTransactionKind, VerifiedSequencedConsensusTransaction,
+    ConsensusCommitInfo, IndirectStateObserver, SequencedConsensusTransaction,
+    SequencedConsensusTransactionKey, SequencedConsensusTransactionKind,
+    VerifiedSequencedConsensusTransaction,
 };
 use crate::epoch::epoch_metrics::EpochMetrics;
 use crate::epoch::randomness::{
@@ -2201,7 +2202,7 @@ impl AuthorityPerEpochStore {
 
     fn should_defer(
         &self,
-        execution_time_estimator: Option<&ExecutionTimeEstimator>,
+        tx_cost: Option<u64>,
         cert: &VerifiedExecutableTransaction,
         commit_info: &ConsensusCommitInfo,
         dkg_failed: bool,
@@ -2229,7 +2230,7 @@ impl AuthorityPerEpochStore {
         // Defer transaction if it uses shared objects that are congested.
         if let Some((deferral_key, congested_objects)) = shared_object_congestion_tracker
             .should_defer_due_to_object_congestion(
-                execution_time_estimator,
+                tx_cost,
                 cert,
                 previously_deferred_tx_digests,
                 commit_info,
@@ -3029,6 +3030,7 @@ impl AuthorityPerEpochStore {
         checkpoint_service: &Arc<C>,
         cache_reader: &dyn ObjectCacheRead,
         consensus_commit_info: &ConsensusCommitInfo,
+        indirect_state_observer: IndirectStateObserver,
         authority_metrics: &Arc<AuthorityMetrics>,
     ) -> SuiResult<(Vec<Schedulable>, AssignedTxAndVersions)> {
         // Split transactions into different types for processing.
@@ -3274,6 +3276,7 @@ impl AuthorityPerEpochStore {
                 checkpoint_service,
                 cache_reader,
                 consensus_commit_info,
+                indirect_state_observer,
                 &mut roots,
                 &mut randomness_roots,
                 shared_object_congestion_tracker,
@@ -3445,6 +3448,7 @@ impl AuthorityPerEpochStore {
         output: &mut ConsensusCommitOutput,
         transactions: &mut VecDeque<Schedulable<VerifiedExecutableTransaction>>,
         consensus_commit_info: &ConsensusCommitInfo,
+        indirect_state_observer: IndirectStateObserver,
         cancelled_txns: &BTreeMap<TransactionDigest, CancelConsensusCertificateReason>,
     ) -> SuiResult<Option<TransactionKey>> {
         {
@@ -3488,6 +3492,7 @@ impl AuthorityPerEpochStore {
             self.protocol_config(),
             version_assignment,
             consensus_commit_info,
+            indirect_state_observer,
         );
         let consensus_commit_prologue_root = match self.process_consensus_system_transaction(&transaction) {
             ConsensusCertificateResult::SuiTransaction(processed_tx) => {
@@ -3567,6 +3572,7 @@ impl AuthorityPerEpochStore {
                 Some(Duration::from_millis(80)),
                 skip_consensus_commit_prologue_in_test,
             ),
+            IndirectStateObserver::new(),
             authority_metrics,
         )
         .await
@@ -3626,6 +3632,7 @@ impl AuthorityPerEpochStore {
         checkpoint_service: &Arc<C>,
         cache_reader: &dyn ObjectCacheRead,
         consensus_commit_info: &ConsensusCommitInfo,
+        mut indirect_state_observer: IndirectStateObserver,
         non_randomness_roots: &mut BTreeSet<TransactionKey>,
         randomness_roots: &mut BTreeSet<TransactionKey>,
         mut shared_object_congestion_tracker: SharedObjectCongestionTracker,
@@ -3707,6 +3714,7 @@ impl AuthorityPerEpochStore {
                     tx,
                     checkpoint_service,
                     consensus_commit_info,
+                    &mut indirect_state_observer,
                     &previously_deferred_tx_digests,
                     randomness_manager.as_deref_mut(),
                     dkg_failed,
@@ -3827,6 +3835,7 @@ impl AuthorityPerEpochStore {
             output,
             &mut verified_non_randomness_certificates,
             consensus_commit_info,
+            indirect_state_observer,
             &cancelled_txns,
         )?;
 
@@ -3966,6 +3975,7 @@ impl AuthorityPerEpochStore {
         transaction: &VerifiedSequencedConsensusTransaction,
         checkpoint_service: &Arc<C>,
         commit_info: &ConsensusCommitInfo,
+        indirect_state_observer: &mut IndirectStateObserver,
         previously_deferred_tx_digests: &HashMap<TransactionDigest, DeferralKey>,
         mut randomness_manager: Option<&mut RandomnessManager>,
         dkg_failed: bool,
@@ -4006,6 +4016,7 @@ impl AuthorityPerEpochStore {
                     transaction,
                     certificate_author,
                     commit_info,
+                    indirect_state_observer,
                     tracking_id,
                     previously_deferred_tx_digests,
                     dkg_failed,
@@ -4201,6 +4212,7 @@ impl AuthorityPerEpochStore {
                     transaction,
                     certificate_author,
                     commit_info,
+                    indirect_state_observer,
                     tracking_id,
                     previously_deferred_tx_digests,
                     dkg_failed,
@@ -4238,6 +4250,7 @@ impl AuthorityPerEpochStore {
         transaction: VerifiedExecutableTransaction,
         block_author: &AuthorityPublicKeyBytes,
         commit_info: &ConsensusCommitInfo,
+        indirect_state_observer: &mut IndirectStateObserver,
         tracking_id: u64,
         previously_deferred_tx_digests: &HashMap<TransactionDigest, DeferralKey>,
         dkg_failed: bool,
@@ -4277,8 +4290,14 @@ impl AuthorityPerEpochStore {
             return Ok(ConsensusCertificateResult::Ignored);
         }
 
-        let deferral_info = self.should_defer(
+        let tx_cost = shared_object_congestion_tracker.get_tx_cost(
             execution_time_estimator,
+            &transaction,
+            indirect_state_observer,
+        );
+
+        let deferral_info = self.should_defer(
+            tx_cost,
             &transaction,
             commit_info,
             dkg_failed,
@@ -4344,8 +4363,7 @@ impl AuthorityPerEpochStore {
         }
 
         // This certificate will be scheduled. Update object execution cost.
-        shared_object_congestion_tracker
-            .bump_object_execution_cost(execution_time_estimator, &transaction);
+        shared_object_congestion_tracker.bump_object_execution_cost(tx_cost, &transaction);
 
         Ok(ConsensusCertificateResult::SuiTransaction(transaction))
     }

--- a/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
+++ b/crates/sui-core/src/authority/shared_object_congestion_tracker.rs
@@ -3,7 +3,7 @@
 
 use super::execution_time_estimator::ExecutionTimeEstimator;
 use crate::authority::transaction_deferral::DeferralKey;
-use crate::consensus_handler::ConsensusCommitInfo;
+use crate::consensus_handler::{ConsensusCommitInfo, IndirectStateObserver};
 use mysten_common::fatal;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -218,8 +218,9 @@ impl SharedObjectCongestionTracker {
         &self,
         execution_time_estimator: Option<&ExecutionTimeEstimator>,
         cert: &VerifiedExecutableTransaction,
+        indirect_state_observer: &mut IndirectStateObserver,
     ) -> Option<u64> {
-        match &self.params.mode {
+        let tx_cost = match &self.params.mode {
             PerObjectCongestionControlMode::None => None,
             PerObjectCongestionControlMode::TotalGasBudget => Some(cert.gas_budget()),
             PerObjectCongestionControlMode::TotalTxCount => Some(1),
@@ -243,20 +244,22 @@ impl SharedObjectCongestionTracker {
 
                 Some(estimate_us)
             }
-        }
+        };
+        indirect_state_observer.observe_indirect_state(&tx_cost);
+        tx_cost
     }
 
     // Given a transaction, returns the deferral key and the congested objects if the transaction should be deferred.
     pub fn should_defer_due_to_object_congestion(
         &self,
-        execution_time_estimator: Option<&ExecutionTimeEstimator>,
+        tx_cost: Option<u64>,
         cert: &VerifiedExecutableTransaction,
         previously_deferred_tx_digests: &HashMap<TransactionDigest, DeferralKey>,
         commit_info: &ConsensusCommitInfo,
     ) -> Option<(DeferralKey, Vec<ObjectID>)> {
         let commit_round = commit_info.round;
 
-        let tx_cost = self.get_tx_cost(execution_time_estimator, cert)?;
+        let tx_cost = tx_cost?;
 
         let shared_input_objects: Vec<_> = cert.shared_input_objects().collect();
         if shared_input_objects.is_empty() {
@@ -316,7 +319,7 @@ impl SharedObjectCongestionTracker {
     // This is called when `cert` is scheduled for execution.
     pub fn bump_object_execution_cost(
         &mut self,
-        execution_time_estimator: Option<&ExecutionTimeEstimator>,
+        tx_cost: Option<u64>,
         cert: &VerifiedExecutableTransaction,
     ) {
         let shared_input_objects: Vec<_> = cert.shared_input_objects().collect();
@@ -324,7 +327,7 @@ impl SharedObjectCongestionTracker {
             return;
         }
 
-        let Some(tx_cost) = self.get_tx_cost(execution_time_estimator, cert) else {
+        let Some(tx_cost) = tx_cost else {
             return;
         };
 
@@ -665,7 +668,11 @@ mod object_cost_tests {
             let tx = build_transaction(&[(shared_obj_0, *mutable)], tx_gas_budget);
             if let Some((_, congested_objects)) = shared_object_congestion_tracker
                 .should_defer_due_to_object_congestion(
-                    Some(&execution_time_estimator),
+                    shared_object_congestion_tracker.get_tx_cost(
+                        Some(&execution_time_estimator),
+                        &tx,
+                        &mut IndirectStateObserver::new(),
+                    ),
                     &tx,
                     &HashMap::new(),
                     &ConsensusCommitInfo::new_for_congestion_test(
@@ -689,7 +696,11 @@ mod object_cost_tests {
             let tx = build_transaction(&[(shared_obj_1, *mutable)], tx_gas_budget);
             assert!(shared_object_congestion_tracker
                 .should_defer_due_to_object_congestion(
-                    Some(&execution_time_estimator),
+                    shared_object_congestion_tracker.get_tx_cost(
+                        Some(&execution_time_estimator),
+                        &tx,
+                        &mut IndirectStateObserver::new(),
+                    ),
                     &tx,
                     &HashMap::new(),
                     &ConsensusCommitInfo::new_for_congestion_test(
@@ -710,7 +721,11 @@ mod object_cost_tests {
                 );
                 if let Some((_, congested_objects)) = shared_object_congestion_tracker
                     .should_defer_due_to_object_congestion(
-                        Some(&execution_time_estimator),
+                        shared_object_congestion_tracker.get_tx_cost(
+                            Some(&execution_time_estimator),
+                            &tx,
+                            &mut IndirectStateObserver::new(),
+                        ),
                         &tx,
                         &HashMap::new(),
                         &ConsensusCommitInfo::new_for_congestion_test(
@@ -781,7 +796,11 @@ mod object_cost_tests {
             },
             _,
         )) = shared_object_congestion_tracker.should_defer_due_to_object_congestion(
-            Some(&execution_time_estimator),
+            shared_object_congestion_tracker.get_tx_cost(
+                Some(&execution_time_estimator),
+                &tx,
+                &mut IndirectStateObserver::new(),
+            ),
             &tx,
             &previously_deferred_tx_digests,
             &ConsensusCommitInfo::new_for_congestion_test(
@@ -812,7 +831,11 @@ mod object_cost_tests {
             },
             _,
         )) = shared_object_congestion_tracker.should_defer_due_to_object_congestion(
-            Some(&execution_time_estimator),
+            shared_object_congestion_tracker.get_tx_cost(
+                Some(&execution_time_estimator),
+                &tx,
+                &mut IndirectStateObserver::new(),
+            ),
             &tx,
             &previously_deferred_tx_digests,
             &ConsensusCommitInfo::new_for_congestion_test(
@@ -844,7 +867,11 @@ mod object_cost_tests {
             },
             _,
         )) = shared_object_congestion_tracker.should_defer_due_to_object_congestion(
-            Some(&execution_time_estimator),
+            shared_object_congestion_tracker.get_tx_cost(
+                Some(&execution_time_estimator),
+                &tx,
+                &mut IndirectStateObserver::new(),
+            ),
             &tx,
             &previously_deferred_tx_digests,
             &ConsensusCommitInfo::new_for_congestion_test(
@@ -971,7 +998,11 @@ mod object_cost_tests {
             let tx = build_transaction(&[(shared_obj_0, *mutable)], tx_gas_budget);
             if let Some((_, congested_objects)) = shared_object_congestion_tracker
                 .should_defer_due_to_object_congestion(
-                    Some(&execution_time_estimator),
+                    shared_object_congestion_tracker.get_tx_cost(
+                        Some(&execution_time_estimator),
+                        &tx,
+                        &mut IndirectStateObserver::new(),
+                    ),
                     &tx,
                     &HashMap::new(),
                     &ConsensusCommitInfo::new_for_congestion_test(
@@ -993,7 +1024,11 @@ mod object_cost_tests {
             let tx = build_transaction(&[(shared_obj_1, *mutable)], tx_gas_budget);
             assert!(shared_object_congestion_tracker
                 .should_defer_due_to_object_congestion(
-                    Some(&execution_time_estimator),
+                    shared_object_congestion_tracker.get_tx_cost(
+                        Some(&execution_time_estimator),
+                        &tx,
+                        &mut IndirectStateObserver::new(),
+                    ),
                     &tx,
                     &HashMap::new(),
                     &ConsensusCommitInfo::new_for_congestion_test(
@@ -1014,7 +1049,11 @@ mod object_cost_tests {
                 );
                 if let Some((_, congested_objects)) = shared_object_congestion_tracker
                     .should_defer_due_to_object_congestion(
-                        Some(&execution_time_estimator),
+                        shared_object_congestion_tracker.get_tx_cost(
+                            Some(&execution_time_estimator),
+                            &tx,
+                            &mut IndirectStateObserver::new(),
+                        ),
                         &tx,
                         &HashMap::new(),
                         &ConsensusCommitInfo::new_for_congestion_test(
@@ -1164,7 +1203,11 @@ mod object_cost_tests {
             let tx = build_transaction(&[(shared_obj_0, *mutable)], tx_gas_budget);
             if let Some((_, congested_objects)) = shared_object_congestion_tracker
                 .should_defer_due_to_object_congestion(
-                    Some(&execution_time_estimator),
+                    shared_object_congestion_tracker.get_tx_cost(
+                        Some(&execution_time_estimator),
+                        &tx,
+                        &mut IndirectStateObserver::new(),
+                    ),
                     &tx,
                     &HashMap::new(),
                     &ConsensusCommitInfo::new_for_congestion_test(
@@ -1187,7 +1230,11 @@ mod object_cost_tests {
             let tx = build_transaction(&[(shared_obj_1, *mutable)], tx_gas_budget);
             assert!(shared_object_congestion_tracker
                 .should_defer_due_to_object_congestion(
-                    Some(&execution_time_estimator),
+                    shared_object_congestion_tracker.get_tx_cost(
+                        Some(&execution_time_estimator),
+                        &tx,
+                        &mut IndirectStateObserver::new(),
+                    ),
                     &tx,
                     &HashMap::new(),
                     &ConsensusCommitInfo::new_for_congestion_test(
@@ -1208,7 +1255,11 @@ mod object_cost_tests {
                 );
                 if let Some((_, congested_objects)) = shared_object_congestion_tracker
                     .should_defer_due_to_object_congestion(
-                        Some(&execution_time_estimator),
+                        shared_object_congestion_tracker.get_tx_cost(
+                            Some(&execution_time_estimator),
+                            &tx,
+                            &mut IndirectStateObserver::new(),
+                        ),
                         &tx,
                         &HashMap::new(),
                         &ConsensusCommitInfo::new_for_congestion_test(
@@ -1270,8 +1321,14 @@ mod object_cost_tests {
 
         // Read two objects should not change the object execution cost.
         let cert = build_transaction(&[(object_id_0, false), (object_id_1, false)], 10);
-        shared_object_congestion_tracker
-            .bump_object_execution_cost(Some(&execution_time_estimator), &cert);
+        shared_object_congestion_tracker.bump_object_execution_cost(
+            shared_object_congestion_tracker.get_tx_cost(
+                Some(&execution_time_estimator),
+                &cert,
+                &mut IndirectStateObserver::new(),
+            ),
+            &cert,
+        );
         assert_eq!(
             shared_object_congestion_tracker,
             SharedObjectCongestionTracker::new(
@@ -1289,8 +1346,14 @@ mod object_cost_tests {
 
         // Write to object 0 should only bump object 0's execution cost. The start cost should be object 1's cost.
         let cert = build_transaction(&[(object_id_0, true), (object_id_1, false)], 10);
-        shared_object_congestion_tracker
-            .bump_object_execution_cost(Some(&execution_time_estimator), &cert);
+        shared_object_congestion_tracker.bump_object_execution_cost(
+            shared_object_congestion_tracker.get_tx_cost(
+                Some(&execution_time_estimator),
+                &cert,
+                &mut IndirectStateObserver::new(),
+            ),
+            &cert,
+        );
         let expected_object_0_cost = match mode {
             PerObjectCongestionControlMode::None => unreachable!(),
             PerObjectCongestionControlMode::TotalGasBudget => 20,
@@ -1332,8 +1395,14 @@ mod object_cost_tests {
             PerObjectCongestionControlMode::TotalGasBudgetWithCap => 17, // 3 objects, 1 command
             PerObjectCongestionControlMode::ExecutionTimeEstimate(_) => 2_010,
         };
-        shared_object_congestion_tracker
-            .bump_object_execution_cost(Some(&execution_time_estimator), &cert);
+        shared_object_congestion_tracker.bump_object_execution_cost(
+            shared_object_congestion_tracker.get_tx_cost(
+                Some(&execution_time_estimator),
+                &cert,
+                &mut IndirectStateObserver::new(),
+            ),
+            &cert,
+        );
         assert_eq!(
             shared_object_congestion_tracker,
             SharedObjectCongestionTracker::new(
@@ -1374,8 +1443,14 @@ mod object_cost_tests {
             // previous cost 2_010 + (unknown-command default of 1000 * 7 commands)
             PerObjectCongestionControlMode::ExecutionTimeEstimate(_) => 9_010,
         };
-        shared_object_congestion_tracker
-            .bump_object_execution_cost(Some(&execution_time_estimator), &cert);
+        shared_object_congestion_tracker.bump_object_execution_cost(
+            shared_object_congestion_tracker.get_tx_cost(
+                Some(&execution_time_estimator),
+                &cert,
+                &mut IndirectStateObserver::new(),
+            ),
+            &cert,
+        );
         assert_eq!(
             shared_object_congestion_tracker,
             SharedObjectCongestionTracker::new(
@@ -1501,8 +1576,14 @@ mod object_cost_tests {
         // Simulate a tx on object 0 that exceeds the budget.
         for mutable in [true, false].iter() {
             let tx = build_transaction(&[(shared_obj_0, *mutable)], tx_gas_budget);
-            shared_object_congestion_tracker
-                .bump_object_execution_cost(Some(&execution_time_estimator), &tx);
+            shared_object_congestion_tracker.bump_object_execution_cost(
+                shared_object_congestion_tracker.get_tx_cost(
+                    Some(&execution_time_estimator),
+                    &tx,
+                    &mut IndirectStateObserver::new(),
+                ),
+                &tx,
+            );
         }
 
         // Verify that accumulated_debts reports the debt for object 0.
@@ -1584,9 +1665,14 @@ mod object_cost_tests {
 
         // Verify that the transaction is allowed to execute.
         // 2000 gas budget would exceed overage limit of 1000 but is capped to 200 by the absolute cap.
+        let tx_cost = shared_object_congestion_tracker.get_tx_cost(
+            Some(&execution_time_estimator),
+            &tx,
+            &mut IndirectStateObserver::new(),
+        );
         assert!(shared_object_congestion_tracker
             .should_defer_due_to_object_congestion(
-                Some(&execution_time_estimator),
+                tx_cost,
                 &tx,
                 &HashMap::new(),
                 &ConsensusCommitInfo::new_for_congestion_test(0, 0, Duration::ZERO),
@@ -1594,8 +1680,7 @@ mod object_cost_tests {
             .is_none());
 
         // Verify max cost after bumping is limited by the absolute cap.
-        shared_object_congestion_tracker
-            .bump_object_execution_cost(Some(&execution_time_estimator), &tx);
+        shared_object_congestion_tracker.bump_object_execution_cost(tx_cost, &tx);
         assert_eq!(300, shared_object_congestion_tracker.max_cost());
 
         // Verify accumulated debts still uses the per-commit budget to decrement.

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -138,6 +138,7 @@ mod additional_consensus_state {
     use std::marker::PhantomData;
 
     use fastcrypto::hash::HashFunction as _;
+    use sui_types::crypto::DefaultHash;
 
     use super::*;
     /// AdditionalConsensusState tracks any in-memory state that is retained by ConsensusHandler
@@ -207,7 +208,7 @@ mod additional_consensus_state {
 
         /// Get the digest of the current state.
         fn digest(&self) -> AdditionalConsensusStateDigest {
-            let mut hash = sui_types::crypto::DefaultHash::new();
+            let mut hash = DefaultHash::new();
             bcs::serialize_into(&mut hash, self).unwrap();
             AdditionalConsensusStateDigest::new(hash.finalize().into())
         }
@@ -336,6 +337,7 @@ mod additional_consensus_state {
                 Vec<(ConsensusObjectSequenceKey, SequenceNumber)>,
             )>,
             commit_info: &ConsensusCommitInfo,
+            indirect_state_observer: IndirectStateObserver,
         ) -> VerifiedExecutableTransaction {
             let version_assignments = if protocol_config
                 .record_consensus_determined_version_assignments_in_prologue_v2()
@@ -365,10 +367,18 @@ mod additional_consensus_state {
             };
 
             if protocol_config.record_additional_state_digest_in_prologue() {
+                let additional_state_digest =
+                    if protocol_config.additional_consensus_digest_indirect_state() {
+                        let d1 = commit_info.additional_state_digest();
+                        indirect_state_observer.fold_with(d1)
+                    } else {
+                        commit_info.additional_state_digest()
+                    };
+
                 self.consensus_commit_prologue_v4_transaction(
                     epoch,
                     version_assignments.unwrap(),
-                    commit_info.additional_state_digest(),
+                    additional_state_digest,
                 )
             } else if let Some(version_assignments) = version_assignments {
                 self.consensus_commit_prologue_v3_transaction(epoch, version_assignments)
@@ -377,6 +387,34 @@ mod additional_consensus_state {
             } else {
                 self.consensus_commit_prologue_transaction(epoch)
             }
+        }
+    }
+
+    #[derive(Default)]
+    pub struct IndirectStateObserver {
+        hash: DefaultHash,
+    }
+
+    impl IndirectStateObserver {
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        pub fn observe_indirect_state<T: Serialize>(&mut self, state: &T) {
+            bcs::serialize_into(&mut self.hash, state).unwrap();
+        }
+
+        pub fn fold_with(
+            self,
+            d1: AdditionalConsensusStateDigest,
+        ) -> AdditionalConsensusStateDigest {
+            let hash = self.hash.finalize();
+            let d2 = AdditionalConsensusStateDigest::new(hash.into());
+
+            let mut hasher = DefaultHash::new();
+            bcs::serialize_into(&mut hasher, &d1).unwrap();
+            bcs::serialize_into(&mut hasher, &d2).unwrap();
+            AdditionalConsensusStateDigest::new(hasher.finalize().into())
         }
     }
 
@@ -461,7 +499,7 @@ mod additional_consensus_state {
     }
 }
 use additional_consensus_state::AdditionalConsensusState;
-pub(crate) use additional_consensus_state::ConsensusCommitInfo;
+pub(crate) use additional_consensus_state::{ConsensusCommitInfo, IndirectStateObserver};
 
 pub struct ConsensusHandler<C> {
     /// A store created for each epoch. ConsensusHandler is recreated each epoch, with the
@@ -834,6 +872,8 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             }
         }
 
+        let indirect_state_observer = IndirectStateObserver::new();
+
         let (executable_transactions, assigned_versions) = self
             .epoch_store
             .process_consensus_transactions_and_commit_boundary(
@@ -842,6 +882,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 &self.checkpoint_service,
                 self.cache_reader.as_ref(),
                 &commit_info,
+                indirect_state_observer,
                 &self.metrics,
             )
             .await

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -731,6 +731,10 @@ struct FeatureFlags {
     // If true, record the time estimate processed in the consensus commit prologue.
     #[serde(skip_serializing_if = "is_false")]
     record_time_estimate_processed: bool,
+
+    // If true, include indirect state in the additional consensus digest.
+    #[serde(skip_serializing_if = "is_false")]
+    additional_consensus_digest_indirect_state: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -2084,6 +2088,11 @@ impl ProtocolConfig {
 
     pub fn record_time_estimate_processed(&self) -> bool {
         self.feature_flags.record_time_estimate_processed
+    }
+
+    pub fn additional_consensus_digest_indirect_state(&self) -> bool {
+        self.feature_flags
+            .additional_consensus_digest_indirect_state
     }
 }
 
@@ -3783,6 +3792,7 @@ impl ProtocolConfig {
                 }
                 88 => {
                     cfg.feature_flags.record_time_estimate_processed = true;
+                    cfg.feature_flags.additional_consensus_digest_indirect_state = true;
                     cfg.tx_context_rgp_cost_base = Some(30);
                 }
                 // Use this template when making changes:


### PR DESCRIPTION
Indirect state is any state we inspect and make a decision on while
processing a commit, which could diverge unintentionally due to code
changes.

The contents of a commit are already committed to, but any non-trivial
derivation of that information (for instance, reading from persistent
state that was constructed while processing previous commits) is not,
prior to this change.

This means that divergences in state can hide until they cross some
threshold, which means both that we are less likely to catch the issue
in tests, and also that a fork may happen long after that state has
diverged, rather than immediately, which makes the fork much harder to
repair.
