### PR TITLE
Move the sponsor to a set/unset api

### DIFF
--- a/crates/sui-framework/packages/sui-framework/sources/test/test_scenario.move
+++ b/crates/sui-framework/packages/sui-framework/sources/test/test_scenario.move
@@ -190,8 +190,14 @@ public fun set_gas_budget(mut builder: TxContextBuilder, gas_budget: u64): TxCon
 }
 
 /// Set the sponsor for the `TxContextBuilder`.
-public fun set_sponsor(mut builder: TxContextBuilder, sponsor: Option<address>): TxContextBuilder {
-    builder.sponsor = sponsor;
+public fun set_sponsor(mut builder: TxContextBuilder, sponsor: address): TxContextBuilder {
+    builder.sponsor = option::some(sponsor);
+    builder
+}
+
+/// Set the sponsor for the `TxContextBuilder` to `option::none()`.
+public fun unset_sponsor(mut builder: TxContextBuilder): TxContextBuilder {
+    builder.sponsor = option::none();
     builder
 }
 

--- a/crates/sui-framework/packages/sui-framework/tests/test_scenario_tests.move
+++ b/crates/sui-framework/packages/sui-framework/tests/test_scenario_tests.move
@@ -1186,7 +1186,7 @@ fun test_tx_context() {
     // add sponsor and change few values
     let ctx_builder = scenario
         .ctx_builder()
-        .set_sponsor(option::some(@0xD))
+        .set_sponsor(@0xD)
         .set_ids_created(5)
         .set_gas_price(800)
         .set_epoch_timestamp(1_000_000_100);
@@ -1200,6 +1200,12 @@ fun test_tx_context() {
     assert_eq!(ctx.gas_price(), 800);
     assert_eq!(ctx.gas_budget(), 100_000);
     assert_eq!(ctx.ids_created(), 5);
+
+    // unset sponsor
+    let ctx_builder = scenario.ctx_builder().unset_sponsor();
+    scenario.next_with_context(ctx_builder);
+    let ctx = scenario.ctx();
+    assert!(ctx.sponsor().is_none());
 
     scenario.end();
 }


### PR DESCRIPTION
## Description 

the `sponsor` field in `TxContextBuilder` is an option like `rgp` but did not have a set/unset API.
Originally I did not care to do that too because the sponsor is truly an `option` whereas the `rgp` is an `option` just to mean set it or ignore it.
For consistency a `set/unset` API seems more proper, not sure what others think, so this is the PR in case we want it. I'll cherry pick tomorrow if accepted it

## Test plan 

changed the tests to use the set/unset API

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
