### PR TITLE
Fix incorrect log message for download errors

### DIFF
--- a/crates/anemo-benchmark/src/main.rs
+++ b/crates/anemo-benchmark/src/main.rs
@@ -197,7 +197,7 @@ async fn main() {
                 download_requests += 1;
                 if let Some(error) = error {
                     download_errors += 1;
-                    println!("upload error on peer {peer_id}: {:?}", error);
+                    println!("download error on peer {peer_id}: {:?}", error);
                 } else {
                     download_bytes += args.size_down as usize;
                 }


### PR DESCRIPTION
Correct the log message in the download error handler to display "download error" instead of "upload error" for better clarity during benchmarking.