### PR TITLE
Add snapshot tests to ExecutionTimeObserver

### DIFF
--- a/crates/sui-core/src/authority/execution_time_estimator.rs
+++ b/crates/sui-core/src/authority/execution_time_estimator.rs
@@ -8,6 +8,8 @@ use std::{
     time::Duration,
 };
 
+use serde::{Deserialize, Serialize};
+
 use super::authority_per_epoch_store::AuthorityPerEpochStore;
 use super::weighted_moving_average::WeightedMovingAverage;
 use crate::consensus_adapter::SubmitToConsensus;
@@ -508,7 +510,7 @@ pub struct ExecutionTimeEstimator {
     consensus_observations: HashMap<ExecutionTimeObservationKey, ConsensusObservations>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConsensusObservations {
     observations: Vec<(u64 /* generation */, Option<Duration>)>, // keyed by authority index
     stake_weighted_median: Option<Duration>,                     // cached value
@@ -1702,5 +1704,148 @@ mod tests {
             estimator.get_estimate(&multi_command_tx),
             Duration::from_millis(510)
         );
+    }
+
+    // Add imports for snapshot tests
+    #[cfg(test)]
+    use {
+        rand::{Rng, SeedableRng},
+        sui_protocol_config::ProtocolVersion,
+    };
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    struct ExecutionTimeObserverSnapshot {
+        protocol_version: u64,
+        consensus_observations: Vec<(ExecutionTimeObservationKey, ConsensusObservations)>,
+    }
+
+    // Generates deterministic test inputs for process_observation_from_consensus
+    fn generate_test_inputs(
+        protocol_version: u64,
+        num_validators: usize,
+    ) -> Vec<(AuthorityIndex, u64, ExecutionTimeObservationKey, Duration)> {
+        // Use protocol version as seed for deterministic results
+        let mut rng = rand::rngs::StdRng::seed_from_u64(protocol_version);
+
+        let observation_keys = vec![
+            ExecutionTimeObservationKey::MoveEntryPoint {
+                package: ObjectID::from_hex_literal("0x1").unwrap(),
+                module: "coin".to_string(),
+                function: "transfer".to_string(),
+                type_arguments: vec![],
+            },
+            ExecutionTimeObservationKey::MoveEntryPoint {
+                package: ObjectID::from_hex_literal("0x2").unwrap(),
+                module: "nft".to_string(),
+                function: "mint".to_string(),
+                type_arguments: vec![],
+            },
+            ExecutionTimeObservationKey::TransferObjects,
+            ExecutionTimeObservationKey::SplitCoins,
+            ExecutionTimeObservationKey::MergeCoins,
+            ExecutionTimeObservationKey::MakeMoveVec,
+            ExecutionTimeObservationKey::Upgrade,
+        ];
+
+        let mut inputs = Vec::new();
+        let target_samples = 25; // Target 20-30 samples
+
+        // Generate multiple observations per key from different authorities over time
+        for _ in 0..target_samples {
+            let key = observation_keys[rng.gen_range(0..observation_keys.len())].clone();
+            let authority_index =
+                AuthorityIndex::try_from(rng.gen_range(0..num_validators)).unwrap();
+
+            // Generate generations that simulate observations over time
+            // Use a realistic range where newer generations might replace older ones
+            let generation = rng.gen_range(1..=10);
+
+            // Generate duration based on the key type and add some variance
+            let base_duration = match &key {
+                ExecutionTimeObservationKey::MoveEntryPoint { .. } => rng.gen_range(50..=500),
+                ExecutionTimeObservationKey::TransferObjects => rng.gen_range(10..=100),
+                ExecutionTimeObservationKey::SplitCoins => rng.gen_range(20..=80),
+                ExecutionTimeObservationKey::MergeCoins => rng.gen_range(15..=70),
+                ExecutionTimeObservationKey::MakeMoveVec => rng.gen_range(5..=30),
+                ExecutionTimeObservationKey::Upgrade => rng.gen_range(100..=1000),
+                ExecutionTimeObservationKey::Publish => rng.gen_range(200..=2000),
+            };
+
+            let duration = Duration::from_millis(base_duration);
+
+            inputs.push((authority_index, generation, key, duration));
+        }
+
+        inputs
+    }
+
+    // Safeguard against forking because of changes to the execution time estimator.
+    //
+    // Within an epoch, each estimator must reach the same conclusion about the observations and
+    // stake_weighted_median from the observations shared by other validators, as this is used
+    // for transaction ordering.
+    //
+    // Therefore; any change in the calculation of the observations or stake_weighted_median
+    // not accompanied by a protocol version change may fork.
+    //
+    // This test uses snapshots of computed stake weighted median at particular protocol versions
+    // to attempt to regressions that might fork.
+    #[test]
+    fn snapshot_tests() {
+        println!("\n============================================================================");
+        println!("!                                                                          !");
+        println!("! IMPORTANT: never update snapshots from this test. only add new versions! !");
+        println!("!                                                                          !");
+        println!("============================================================================\n");
+
+        let max_version = ProtocolVersion::MAX.as_u64();
+
+        // Test the last 10 protocol versions to focus on recent behavior
+        let test_versions: Vec<u64> = (max_version.saturating_sub(9)..=max_version).collect();
+
+        for version in test_versions {
+            // Create a test committee with 4 validators
+            let (committee, _) = Committee::new_simple_test_committee_of_size(4);
+            let committee = Arc::new(committee);
+
+            // Generate deterministic test inputs for this version
+            let test_inputs = generate_test_inputs(version, committee.num_members());
+
+            // Create a fresh estimator
+            let mut estimator = ExecutionTimeEstimator::new(
+                committee.clone(),
+                ExecutionTimeEstimateParams::default(),
+                std::iter::empty(), // No initial observations
+            );
+
+            // Process observations by calling process_observation_from_consensus
+            for (source, generation, observation_key, duration) in test_inputs {
+                estimator.process_observation_from_consensus(
+                    source,
+                    generation,
+                    observation_key,
+                    duration,
+                    false, // Don't skip update so stake_weighted_median is calculated
+                );
+            }
+
+            // Get the final state after processing all observations
+            let mut final_observations = estimator.get_observations();
+
+            // Sort observations by their string representation for deterministic snapshots
+            final_observations.sort_by(|a, b| a.0.to_string().cmp(&b.0.to_string()));
+
+            // Create snapshot data
+            let snapshot_data = ExecutionTimeObserverSnapshot {
+                protocol_version: version,
+                consensus_observations: final_observations.clone(),
+            };
+
+            // Generate snapshot using insta
+            insta::assert_yaml_snapshot!(
+                format!("execution_time_observer_v{}", version),
+                snapshot_data
+            );
+        }
     }
 }

--- a/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v79.snap
+++ b/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v79.snap
@@ -1,0 +1,121 @@
+---
+source: crates/sui-core/src/authority/execution_time_estimator.rs
+expression: snapshot_data
+---
+protocol_version: 79
+consensus_observations:
+  - - MakeMoveVec
+    - observations:
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 10
+          - secs: 0
+            nanos: 18000000
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 18000000
+  - - MergeCoins
+    - observations:
+        - - 10
+          - secs: 0
+            nanos: 18000000
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 9
+          - secs: 0
+            nanos: 43000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 43000000
+  - - SplitCoins
+    - observations:
+        - - 9
+          - secs: 0
+            nanos: 57000000
+        - - 0
+          - ~
+        - - 6
+          - secs: 0
+            nanos: 62000000
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 62000000
+  - - TransferObjects
+    - observations:
+        - - 3
+          - secs: 0
+            nanos: 10000000
+        - - 8
+          - secs: 0
+            nanos: 29000000
+        - - 5
+          - secs: 0
+            nanos: 48000000
+        - - 1
+          - secs: 0
+            nanos: 56000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 48000000
+  - - Upgrade
+    - observations:
+        - - 8
+          - secs: 0
+            nanos: 513000000
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 2
+          - secs: 0
+            nanos: 651000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 651000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000001"
+        module: coin
+        function: transfer
+        type_arguments: []
+    - observations:
+        - - 7
+          - secs: 0
+            nanos: 317000000
+        - - 7
+          - secs: 0
+            nanos: 218000000
+        - - 0
+          - ~
+        - - 9
+          - secs: 0
+            nanos: 464000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 317000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000002"
+        module: nft
+        function: mint
+        type_arguments: []
+    - observations:
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 3
+          - secs: 0
+            nanos: 495000000
+        - - 3
+          - secs: 0
+            nanos: 272000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 495000000

--- a/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v80.snap
+++ b/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v80.snap
@@ -1,0 +1,109 @@
+---
+source: crates/sui-core/src/authority/execution_time_estimator.rs
+expression: snapshot_data
+---
+protocol_version: 80
+consensus_observations:
+  - - MakeMoveVec
+    - observations:
+        - - 5
+          - secs: 0
+            nanos: 13000000
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 7
+          - secs: 0
+            nanos: 16000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 16000000
+  - - MergeCoins
+    - observations:
+        - - 3
+          - secs: 0
+            nanos: 50000000
+        - - 4
+          - secs: 0
+            nanos: 42000000
+        - - 3
+          - secs: 0
+            nanos: 22000000
+        - - 10
+          - secs: 0
+            nanos: 27000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 42000000
+  - - SplitCoins
+    - observations:
+        - - 1
+          - secs: 0
+            nanos: 47000000
+        - - 1
+          - secs: 0
+            nanos: 61000000
+        - - 0
+          - ~
+        - - 10
+          - secs: 0
+            nanos: 42000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 47000000
+  - - TransferObjects
+    - observations:
+        - - 10
+          - secs: 0
+            nanos: 91000000
+        - - 0
+          - ~
+        - - 5
+          - secs: 0
+            nanos: 44000000
+        - - 8
+          - secs: 0
+            nanos: 62000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 62000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000001"
+        module: coin
+        function: transfer
+        type_arguments: []
+    - observations:
+        - - 1
+          - secs: 0
+            nanos: 358000000
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 3
+          - secs: 0
+            nanos: 407000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 407000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000002"
+        module: nft
+        function: mint
+        type_arguments: []
+    - observations:
+        - - 9
+          - secs: 0
+            nanos: 70000000
+        - - 0
+          - ~
+        - - 10
+          - secs: 0
+            nanos: 491000000
+        - - 8
+          - secs: 0
+            nanos: 359000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 359000000

--- a/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v81.snap
+++ b/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v81.snap
@@ -1,0 +1,122 @@
+---
+source: crates/sui-core/src/authority/execution_time_estimator.rs
+expression: snapshot_data
+---
+protocol_version: 81
+consensus_observations:
+  - - MakeMoveVec
+    - observations:
+        - - 9
+          - secs: 0
+            nanos: 6000000
+        - - 0
+          - ~
+        - - 6
+          - secs: 0
+            nanos: 19000000
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 19000000
+  - - MergeCoins
+    - observations:
+        - - 0
+          - ~
+        - - 10
+          - secs: 0
+            nanos: 41000000
+        - - 10
+          - secs: 0
+            nanos: 46000000
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 46000000
+  - - SplitCoins
+    - observations:
+        - - 2
+          - secs: 0
+            nanos: 51000000
+        - - 0
+          - ~
+        - - 6
+          - secs: 0
+            nanos: 32000000
+        - - 2
+          - secs: 0
+            nanos: 57000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 51000000
+  - - TransferObjects
+    - observations:
+        - - 5
+          - secs: 0
+            nanos: 34000000
+        - - 9
+          - secs: 0
+            nanos: 89000000
+        - - 8
+          - secs: 0
+            nanos: 10000000
+        - - 3
+          - secs: 0
+            nanos: 90000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 89000000
+  - - Upgrade
+    - observations:
+        - - 4
+          - secs: 0
+            nanos: 722000000
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 5
+          - secs: 0
+            nanos: 624000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 722000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000001"
+        module: coin
+        function: transfer
+        type_arguments: []
+    - observations:
+        - - 3
+          - secs: 0
+            nanos: 99000000
+        - - 5
+          - secs: 0
+            nanos: 158000000
+        - - 7
+          - secs: 0
+            nanos: 252000000
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 158000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000002"
+        module: nft
+        function: mint
+        type_arguments: []
+    - observations:
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 9
+          - secs: 0
+            nanos: 489000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 489000000

--- a/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v82.snap
+++ b/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v82.snap
@@ -1,0 +1,121 @@
+---
+source: crates/sui-core/src/authority/execution_time_estimator.rs
+expression: snapshot_data
+---
+protocol_version: 82
+consensus_observations:
+  - - MakeMoveVec
+    - observations:
+        - - 0
+          - ~
+        - - 5
+          - secs: 0
+            nanos: 30000000
+        - - 0
+          - ~
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 30000000
+  - - MergeCoins
+    - observations:
+        - - 10
+          - secs: 0
+            nanos: 32000000
+        - - 0
+          - ~
+        - - 4
+          - secs: 0
+            nanos: 28000000
+        - - 9
+          - secs: 0
+            nanos: 26000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 28000000
+  - - SplitCoins
+    - observations:
+        - - 0
+          - ~
+        - - 9
+          - secs: 0
+            nanos: 39000000
+        - - 0
+          - ~
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 39000000
+  - - TransferObjects
+    - observations:
+        - - 8
+          - secs: 0
+            nanos: 84000000
+        - - 6
+          - secs: 0
+            nanos: 80000000
+        - - 0
+          - ~
+        - - 3
+          - secs: 0
+            nanos: 43000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 80000000
+  - - Upgrade
+    - observations:
+        - - 5
+          - secs: 0
+            nanos: 916000000
+        - - 0
+          - ~
+        - - 5
+          - secs: 0
+            nanos: 629000000
+        - - 7
+          - secs: 0
+            nanos: 981000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 916000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000001"
+        module: coin
+        function: transfer
+        type_arguments: []
+    - observations:
+        - - 8
+          - secs: 0
+            nanos: 133000000
+        - - 9
+          - secs: 0
+            nanos: 358000000
+        - - 0
+          - ~
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 358000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000002"
+        module: nft
+        function: mint
+        type_arguments: []
+    - observations:
+        - - 4
+          - secs: 0
+            nanos: 234000000
+        - - 6
+          - secs: 0
+            nanos: 234000000
+        - - 2
+          - secs: 0
+            nanos: 206000000
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 234000000

--- a/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v83.snap
+++ b/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v83.snap
@@ -1,0 +1,118 @@
+---
+source: crates/sui-core/src/authority/execution_time_estimator.rs
+expression: snapshot_data
+---
+protocol_version: 83
+consensus_observations:
+  - - MakeMoveVec
+    - observations:
+        - - 0
+          - ~
+        - - 4
+          - secs: 0
+            nanos: 28000000
+        - - 0
+          - ~
+        - - 9
+          - secs: 0
+            nanos: 21000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 28000000
+  - - MergeCoins
+    - observations:
+        - - 7
+          - secs: 0
+            nanos: 30000000
+        - - 0
+          - ~
+        - - 9
+          - secs: 0
+            nanos: 19000000
+        - - 5
+          - secs: 0
+            nanos: 54000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 30000000
+  - - SplitCoins
+    - observations:
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 8
+          - secs: 0
+            nanos: 49000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 49000000
+  - - TransferObjects
+    - observations:
+        - - 9
+          - secs: 0
+            nanos: 53000000
+        - - 6
+          - secs: 0
+            nanos: 12000000
+        - - 0
+          - ~
+        - - 10
+          - secs: 0
+            nanos: 55000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 53000000
+  - - Upgrade
+    - observations:
+        - - 2
+          - secs: 0
+            nanos: 498000000
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 8
+          - secs: 0
+            nanos: 109000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 498000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000001"
+        module: coin
+        function: transfer
+        type_arguments: []
+    - observations:
+        - - 0
+          - ~
+        - - 9
+          - secs: 0
+            nanos: 245000000
+        - - 0
+          - ~
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 245000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000002"
+        module: nft
+        function: mint
+        type_arguments: []
+    - observations:
+        - - 4
+          - secs: 0
+            nanos: 382000000
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 382000000

--- a/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v84.snap
+++ b/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v84.snap
@@ -1,0 +1,123 @@
+---
+source: crates/sui-core/src/authority/execution_time_estimator.rs
+expression: snapshot_data
+---
+protocol_version: 84
+consensus_observations:
+  - - MakeMoveVec
+    - observations:
+        - - 6
+          - secs: 0
+            nanos: 15000000
+        - - 3
+          - secs: 0
+            nanos: 19000000
+        - - 3
+          - secs: 0
+            nanos: 30000000
+        - - 4
+          - secs: 0
+            nanos: 28000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 28000000
+  - - MergeCoins
+    - observations:
+        - - 8
+          - secs: 0
+            nanos: 18000000
+        - - 3
+          - secs: 0
+            nanos: 53000000
+        - - 0
+          - ~
+        - - 5
+          - secs: 0
+            nanos: 44000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 44000000
+  - - SplitCoins
+    - observations:
+        - - 0
+          - ~
+        - - 9
+          - secs: 0
+            nanos: 43000000
+        - - 7
+          - secs: 0
+            nanos: 43000000
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 43000000
+  - - TransferObjects
+    - observations:
+        - - 8
+          - secs: 0
+            nanos: 44000000
+        - - 10
+          - secs: 0
+            nanos: 35000000
+        - - 6
+          - secs: 0
+            nanos: 10000000
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 35000000
+  - - Upgrade
+    - observations:
+        - - 3
+          - secs: 0
+            nanos: 341000000
+        - - 0
+          - ~
+        - - 6
+          - secs: 0
+            nanos: 968000000
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 968000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000001"
+        module: coin
+        function: transfer
+        type_arguments: []
+    - observations:
+        - - 6
+          - secs: 0
+            nanos: 65000000
+        - - 0
+          - ~
+        - - 5
+          - secs: 0
+            nanos: 196000000
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 196000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000002"
+        module: nft
+        function: mint
+        type_arguments: []
+    - observations:
+        - - 0
+          - ~
+        - - 1
+          - secs: 0
+            nanos: 321000000
+        - - 0
+          - ~
+        - - 9
+          - secs: 0
+            nanos: 427000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 427000000

--- a/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v85.snap
+++ b/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v85.snap
@@ -1,0 +1,122 @@
+---
+source: crates/sui-core/src/authority/execution_time_estimator.rs
+expression: snapshot_data
+---
+protocol_version: 85
+consensus_observations:
+  - - MakeMoveVec
+    - observations:
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 10
+          - secs: 0
+            nanos: 25000000
+        - - 8
+          - secs: 0
+            nanos: 17000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 25000000
+  - - MergeCoins
+    - observations:
+        - - 0
+          - ~
+        - - 9
+          - secs: 0
+            nanos: 30000000
+        - - 0
+          - ~
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 30000000
+  - - SplitCoins
+    - observations:
+        - - 4
+          - secs: 0
+            nanos: 21000000
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 6
+          - secs: 0
+            nanos: 76000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 76000000
+  - - TransferObjects
+    - observations:
+        - - 4
+          - secs: 0
+            nanos: 71000000
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 10
+          - secs: 0
+            nanos: 57000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 71000000
+  - - Upgrade
+    - observations:
+        - - 10
+          - secs: 0
+            nanos: 441000000
+        - - 0
+          - ~
+        - - 1
+          - secs: 0
+            nanos: 838000000
+        - - 2
+          - secs: 0
+            nanos: 207000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 441000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000001"
+        module: coin
+        function: transfer
+        type_arguments: []
+    - observations:
+        - - 5
+          - secs: 0
+            nanos: 193000000
+        - - 1
+          - secs: 0
+            nanos: 357000000
+        - - 3
+          - secs: 0
+            nanos: 66000000
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 193000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000002"
+        module: nft
+        function: mint
+        type_arguments: []
+    - observations:
+        - - 7
+          - secs: 0
+            nanos: 169000000
+        - - 1
+          - secs: 0
+            nanos: 315000000
+        - - 6
+          - secs: 0
+            nanos: 270000000
+        - - 9
+          - secs: 0
+            nanos: 393000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 315000000

--- a/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v86.snap
+++ b/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v86.snap
@@ -1,0 +1,123 @@
+---
+source: crates/sui-core/src/authority/execution_time_estimator.rs
+expression: snapshot_data
+---
+protocol_version: 86
+consensus_observations:
+  - - MakeMoveVec
+    - observations:
+        - - 9
+          - secs: 0
+            nanos: 30000000
+        - - 5
+          - secs: 0
+            nanos: 30000000
+        - - 0
+          - ~
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 30000000
+  - - MergeCoins
+    - observations:
+        - - 5
+          - secs: 0
+            nanos: 68000000
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 3
+          - secs: 0
+            nanos: 65000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 68000000
+  - - SplitCoins
+    - observations:
+        - - 7
+          - secs: 0
+            nanos: 52000000
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 5
+          - secs: 0
+            nanos: 29000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 52000000
+  - - TransferObjects
+    - observations:
+        - - 7
+          - secs: 0
+            nanos: 16000000
+        - - 8
+          - secs: 0
+            nanos: 27000000
+        - - 6
+          - secs: 0
+            nanos: 60000000
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 27000000
+  - - Upgrade
+    - observations:
+        - - 3
+          - secs: 0
+            nanos: 759000000
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 759000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000001"
+        module: coin
+        function: transfer
+        type_arguments: []
+    - observations:
+        - - 6
+          - secs: 0
+            nanos: 272000000
+        - - 10
+          - secs: 0
+            nanos: 293000000
+        - - 2
+          - secs: 0
+            nanos: 245000000
+        - - 2
+          - secs: 0
+            nanos: 397000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 293000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000002"
+        module: nft
+        function: mint
+        type_arguments: []
+    - observations:
+        - - 10
+          - secs: 0
+            nanos: 208000000
+        - - 1
+          - secs: 0
+            nanos: 395000000
+        - - 4
+          - secs: 0
+            nanos: 52000000
+        - - 7
+          - secs: 0
+            nanos: 450000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 395000000

--- a/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v87.snap
+++ b/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v87.snap
@@ -1,0 +1,125 @@
+---
+source: crates/sui-core/src/authority/execution_time_estimator.rs
+expression: snapshot_data
+---
+protocol_version: 87
+consensus_observations:
+  - - MakeMoveVec
+    - observations:
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 6
+          - secs: 0
+            nanos: 21000000
+        - - 7
+          - secs: 0
+            nanos: 22000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 22000000
+  - - MergeCoins
+    - observations:
+        - - 5
+          - secs: 0
+            nanos: 43000000
+        - - 0
+          - ~
+        - - 9
+          - secs: 0
+            nanos: 61000000
+        - - 1
+          - secs: 0
+            nanos: 31000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 43000000
+  - - SplitCoins
+    - observations:
+        - - 10
+          - secs: 0
+            nanos: 29000000
+        - - 8
+          - secs: 0
+            nanos: 28000000
+        - - 10
+          - secs: 0
+            nanos: 50000000
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 29000000
+  - - TransferObjects
+    - observations:
+        - - 4
+          - secs: 0
+            nanos: 13000000
+        - - 3
+          - secs: 0
+            nanos: 28000000
+        - - 9
+          - secs: 0
+            nanos: 39000000
+        - - 10
+          - secs: 0
+            nanos: 80000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 39000000
+  - - Upgrade
+    - observations:
+        - - 8
+          - secs: 0
+            nanos: 458000000
+        - - 0
+          - ~
+        - - 5
+          - secs: 0
+            nanos: 158000000
+        - - 3
+          - secs: 0
+            nanos: 671000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 458000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000001"
+        module: coin
+        function: transfer
+        type_arguments: []
+    - observations:
+        - - 0
+          - ~
+        - - 9
+          - secs: 0
+            nanos: 363000000
+        - - 0
+          - ~
+        - - 3
+          - secs: 0
+            nanos: 451000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 451000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000002"
+        module: nft
+        function: mint
+        type_arguments: []
+    - observations:
+        - - 0
+          - ~
+        - - 9
+          - secs: 0
+            nanos: 371000000
+        - - 8
+          - secs: 0
+            nanos: 331000000
+        - - 3
+          - secs: 0
+            nanos: 154000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 331000000

--- a/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v88.snap
+++ b/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v88.snap
@@ -1,0 +1,122 @@
+---
+source: crates/sui-core/src/authority/execution_time_estimator.rs
+expression: snapshot_data
+---
+protocol_version: 88
+consensus_observations:
+  - - MakeMoveVec
+    - observations:
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 3
+          - secs: 0
+            nanos: 17000000
+        - - 10
+          - secs: 0
+            nanos: 28000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 28000000
+  - - MergeCoins
+    - observations:
+        - - 0
+          - ~
+        - - 5
+          - secs: 0
+            nanos: 39000000
+        - - 7
+          - secs: 0
+            nanos: 20000000
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 39000000
+  - - SplitCoins
+    - observations:
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 3
+          - secs: 0
+            nanos: 35000000
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 35000000
+  - - TransferObjects
+    - observations:
+        - - 8
+          - secs: 0
+            nanos: 100000000
+        - - 0
+          - ~
+        - - 9
+          - secs: 0
+            nanos: 10000000
+        - - 7
+          - secs: 0
+            nanos: 31000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 31000000
+  - - Upgrade
+    - observations:
+        - - 6
+          - secs: 0
+            nanos: 188000000
+        - - 0
+          - ~
+        - - 6
+          - secs: 0
+            nanos: 198000000
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 198000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000001"
+        module: coin
+        function: transfer
+        type_arguments: []
+    - observations:
+        - - 8
+          - secs: 0
+            nanos: 442000000
+        - - 4
+          - secs: 0
+            nanos: 367000000
+        - - 5
+          - secs: 0
+            nanos: 110000000
+        - - 10
+          - secs: 0
+            nanos: 188000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 367000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000002"
+        module: nft
+        function: mint
+        type_arguments: []
+    - observations:
+        - - 6
+          - secs: 0
+            nanos: 177000000
+        - - 1
+          - secs: 0
+            nanos: 162000000
+        - - 5
+          - secs: 0
+            nanos: 126000000
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 162000000


### PR DESCRIPTION
## Description 

Add snapshot tests to ExecutionTimeObserver to detect regressions to observer calculations within the same protocol version.

## Test plan 

Test only change

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
