### PR TITLE
graphql-alt: Checkpoint.contentDigest

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/content_digest.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/content_digest.move
@@ -1,0 +1,58 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --simulator
+
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs object(1,0) 1
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+
+//# programmable --sender A --inputs object(1,0) 2
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+
+//# create-checkpoint
+
+//# advance-clock --duration-ns 321000000
+
+//# create-checkpoint
+
+
+//# run-graphql
+{ # Fetch each checkpoint individually, and then in a multi-get
+  c0: checkpoint(sequenceNumber: 0) { ...Cp }
+  c1: checkpoint(sequenceNumber: 1) { ...Cp }
+  c2: checkpoint(sequenceNumber: 2) { ...Cp }
+  c3: checkpoint(sequenceNumber: 3) { ...Cp }
+  multiGetCheckpoints(keys: [0, 1, 2, 3]) { ...Cp }
+}
+
+fragment Cp on Checkpoint {
+  sequenceNumber
+  digest
+  contentDigest
+}
+
+//# run-graphql
+{ # Fetch a non-existent checkpoint
+  checkpoint(sequenceNumber: 4) {
+    sequenceNumber
+    digest
+    contentDigest
+  }
+}
+
+//# run-graphql
+{ # Multi-get a mix of existing and non-existing checkpoints
+  multiGetCheckpoints(keys: [2, 100, 0, 200]) {
+    sequenceNumber
+    digest
+    contentDigest
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/content_digest.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/content_digest.snap
@@ -1,0 +1,119 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 11 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-8:
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 10:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 12-14:
+//# programmable --sender A --inputs object(1,0) 1
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+mutated: object(0,0), object(1,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 4, lines 16-18:
+//# programmable --sender A --inputs object(1,0) 2
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+mutated: object(0,0), object(1,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 5, line 20:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 7, line 24:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 8, lines 27-40:
+//# run-graphql
+Response: {
+  "data": {
+    "c0": {
+      "sequenceNumber": 0,
+      "digest": "EznTSQyzQqRf8tuPhLWZDdhny9jgA7Rw81nWB486rW8C",
+      "contentDigest": "AgQ37j8wCNoA7Hw7B8WDwTe6d1x23HpD5Q398FREE68b"
+    },
+    "c1": {
+      "sequenceNumber": 1,
+      "digest": "6KC42LBjuKZP3F9Nfmdz8nC3nvXtMYsX8cEDeMQBkE6P",
+      "contentDigest": "6WqRHqMjbG8x3DTRLyqCicLU3m9k69zwR3SVzZRZPHbq"
+    },
+    "c2": {
+      "sequenceNumber": 2,
+      "digest": "2HqixJnQgrp9A74ddZLxNFaJfUeqCci5hUws5pUN7d1R",
+      "contentDigest": "6GDrFGtQ8QrMiqPKBD8CLNWpRVBCBig4SvkLzxHJrXzj"
+    },
+    "c3": {
+      "sequenceNumber": 3,
+      "digest": "5MPMJ8CDUt35cXKebu3AbzQNg8sLXNtX5nhggxZSnDpj",
+      "contentDigest": "HQWfdryyKCGZsp3ypii6WRqco3uUYeGCSTkfgUagjC9s"
+    },
+    "multiGetCheckpoints": [
+      {
+        "sequenceNumber": 0,
+        "digest": "EznTSQyzQqRf8tuPhLWZDdhny9jgA7Rw81nWB486rW8C",
+        "contentDigest": "AgQ37j8wCNoA7Hw7B8WDwTe6d1x23HpD5Q398FREE68b"
+      },
+      {
+        "sequenceNumber": 1,
+        "digest": "6KC42LBjuKZP3F9Nfmdz8nC3nvXtMYsX8cEDeMQBkE6P",
+        "contentDigest": "6WqRHqMjbG8x3DTRLyqCicLU3m9k69zwR3SVzZRZPHbq"
+      },
+      {
+        "sequenceNumber": 2,
+        "digest": "2HqixJnQgrp9A74ddZLxNFaJfUeqCci5hUws5pUN7d1R",
+        "contentDigest": "6GDrFGtQ8QrMiqPKBD8CLNWpRVBCBig4SvkLzxHJrXzj"
+      },
+      {
+        "sequenceNumber": 3,
+        "digest": "5MPMJ8CDUt35cXKebu3AbzQNg8sLXNtX5nhggxZSnDpj",
+        "contentDigest": "HQWfdryyKCGZsp3ypii6WRqco3uUYeGCSTkfgUagjC9s"
+      }
+    ]
+  }
+}
+
+task 9, lines 42-49:
+//# run-graphql
+Response: {
+  "data": {
+    "checkpoint": null
+  }
+}
+
+task 10, lines 51-58:
+//# run-graphql
+Response: {
+  "data": {
+    "multiGetCheckpoints": [
+      {
+        "sequenceNumber": 2,
+        "digest": "2HqixJnQgrp9A74ddZLxNFaJfUeqCci5hUws5pUN7d1R",
+        "contentDigest": "6GDrFGtQ8QrMiqPKBD8CLNWpRVBCBig4SvkLzxHJrXzj"
+      },
+      null,
+      {
+        "sequenceNumber": 0,
+        "digest": "EznTSQyzQqRf8tuPhLWZDdhny9jgA7Rw81nWB486rW8C",
+        "contentDigest": "AgQ37j8wCNoA7Hw7B8WDwTe6d1x23HpD5Q398FREE68b"
+      },
+      null
+    ]
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -33,6 +33,10 @@ type Checkpoint {
 	"""
 	digest: String
 	"""
+	A 32-byte hash that uniquely identifies the checkpoint's content, encoded in Base58.
+	"""
+	contentDigest: String
+	"""
 	The epoch that this checkpoint is part of.
 	"""
 	epoch: Epoch

--- a/crates/sui-indexer-alt-graphql/src/api/types/checkpoint.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/checkpoint.rs
@@ -73,6 +73,14 @@ impl CheckpointContents {
         Ok(Some(summary.digest().base58_encode()))
     }
 
+    /// A 32-byte hash that uniquely identifies the checkpoint's content, encoded in Base58.
+    async fn content_digest(&self) -> Result<Option<String>, RpcError> {
+        let Some((summary, _, _)) = &self.contents else {
+            return Ok(None);
+        };
+        Ok(Some(summary.content_digest.base58_encode()))
+    }
+
     /// The epoch that this checkpoint is part of.
     async fn epoch(&self) -> Option<Epoch> {
         let (summary, _, _) = self.contents.as_ref()?;

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -37,6 +37,10 @@ type Checkpoint {
 	"""
 	digest: String
 	"""
+	A 32-byte hash that uniquely identifies the checkpoint's content, encoded in Base58.
+	"""
+	contentDigest: String
+	"""
 	The epoch that this checkpoint is part of.
 	"""
 	epoch: Epoch

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -37,6 +37,10 @@ type Checkpoint {
 	"""
 	digest: String
 	"""
+	A 32-byte hash that uniquely identifies the checkpoint's content, encoded in Base58.
+	"""
+	contentDigest: String
+	"""
 	The epoch that this checkpoint is part of.
 	"""
 	epoch: Epoch

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -33,6 +33,10 @@ type Checkpoint {
 	"""
 	digest: String
 	"""
+	A 32-byte hash that uniquely identifies the checkpoint's content, encoded in Base58.
+	"""
+	contentDigest: String
+	"""
 	The epoch that this checkpoint is part of.
 	"""
 	epoch: Epoch


### PR DESCRIPTION
## Description 

Added support for `Checkpoint.contentDigest`

## Test plan 

E2E tests:

`cargo nextest run -p sui-indexer-alt-e2e-tests  -- graphql/checkpoints`

Schema tests:
`cargo nextest run -p sui-indexer-alt-graphql -- schema`
`cargo nextest run -p sui-indexer-alt-graphql --features staging -- schema`

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [x] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
