### PR TITLE
graphql-alt: Checkpoint.validatorSignatures

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/validatorSignatures.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/validatorSignatures.move
@@ -1,0 +1,43 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --simulator
+
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# advance-clock --duration-ns 321000000
+
+//# create-checkpoint
+
+//# run-graphql
+{ # Fetch each checkpoint individually, and then in a multi-get
+  c0: checkpoint(sequenceNumber: 0) { ...Cp }
+  c1: checkpoint(sequenceNumber: 1) { ...Cp }
+  c2: checkpoint(sequenceNumber: 2) { ...Cp }
+  multiGetCheckpoints(keys: [0, 1, 2]) { ...Cp }
+}
+
+fragment Cp on Checkpoint {
+  sequenceNumber
+  validatorSignatures
+}
+
+//# run-graphql
+{ # Fetch a non-existent checkpoint
+  checkpoint(sequenceNumber: 4) {
+    sequenceNumber
+    validatorSignatures
+  }
+}
+
+//# run-graphql
+{ # Multi-get a mix of existing and non-existing checkpoints
+  multiGetCheckpoints(keys: [2, 100, 0, 200]) {
+    sequenceNumber
+    validatorSignatures
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/validatorSignatures.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/validatorSignatures.snap
@@ -1,0 +1,83 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 8 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-8:
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 10:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, line 14:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 5, lines 16-27:
+//# run-graphql
+Response: {
+  "data": {
+    "c0": {
+      "sequenceNumber": 0,
+      "validatorSignatures": "sqTHHfkSR11Z+F1hT87Kq6omvXa6VgddqwTlq7kkS20vBM0XEMQsqq+YjSLf31fZ"
+    },
+    "c1": {
+      "sequenceNumber": 1,
+      "validatorSignatures": "itarOBS1SwEd1S2WVAcgGLbglRaQRp/qKy7jluHoXs0b5RVzcs/xqPikk3qD786T"
+    },
+    "c2": {
+      "sequenceNumber": 2,
+      "validatorSignatures": "hfQTGy0w/9ZkXDTUcMkiSXFpuPG5+4P/RUo6pJxNOLp7Mkv6sf8BY6iX8fta3iLk"
+    },
+    "multiGetCheckpoints": [
+      {
+        "sequenceNumber": 0,
+        "validatorSignatures": "sqTHHfkSR11Z+F1hT87Kq6omvXa6VgddqwTlq7kkS20vBM0XEMQsqq+YjSLf31fZ"
+      },
+      {
+        "sequenceNumber": 1,
+        "validatorSignatures": "itarOBS1SwEd1S2WVAcgGLbglRaQRp/qKy7jluHoXs0b5RVzcs/xqPikk3qD786T"
+      },
+      {
+        "sequenceNumber": 2,
+        "validatorSignatures": "hfQTGy0w/9ZkXDTUcMkiSXFpuPG5+4P/RUo6pJxNOLp7Mkv6sf8BY6iX8fta3iLk"
+      }
+    ]
+  }
+}
+
+task 6, lines 29-35:
+//# run-graphql
+Response: {
+  "data": {
+    "checkpoint": null
+  }
+}
+
+task 7, lines 37-43:
+//# run-graphql
+Response: {
+  "data": {
+    "multiGetCheckpoints": [
+      {
+        "sequenceNumber": 2,
+        "validatorSignatures": "hfQTGy0w/9ZkXDTUcMkiSXFpuPG5+4P/RUo6pJxNOLp7Mkv6sf8BY6iX8fta3iLk"
+      },
+      null,
+      {
+        "sequenceNumber": 0,
+        "validatorSignatures": "sqTHHfkSR11Z+F1hT87Kq6omvXa6VgddqwTlq7kkS20vBM0XEMQsqq+YjSLf31fZ"
+      },
+      null
+    ]
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -48,6 +48,10 @@ type Checkpoint {
 	The timestamp at which the checkpoint is agreed to have happened according to consensus. Transactions that access time in this checkpoint will observe this timestamp.
 	"""
 	timestamp: DateTime
+	"""
+	This is an aggregation of signatures from a quorum of validators for the checkpoint proposal.
+	"""
+	validatorSignatures: Base64
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/api/types/checkpoint.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/checkpoint.rs
@@ -3,6 +3,7 @@
 
 use anyhow::Context as _;
 use async_graphql::{Context, Object};
+
 use sui_indexer_alt_reader::kv_loader::KvLoader;
 use sui_types::{
     crypto::AuthorityStrongQuorumSignInfo,
@@ -13,7 +14,7 @@ use sui_types::{
 use crate::{
     api::{
         query::Query,
-        scalars::{date_time::DateTime, uint53::UInt53},
+        scalars::{base64::Base64, date_time::DateTime, uint53::UInt53},
     },
     error::RpcError,
     scope::Scope,
@@ -105,6 +106,14 @@ impl CheckpointContents {
         };
 
         Ok(Some(DateTime::from_ms(summary.timestamp_ms as i64)?))
+    }
+
+    /// This is an aggregation of signatures from a quorum of validators for the checkpoint proposal.
+    async fn validator_signatures(&self) -> Result<Option<Base64>, RpcError> {
+        let Some((_, _, authority)) = &self.contents else {
+            return Ok(None);
+        };
+        Ok(Some(Base64::from(authority.signature.as_ref())))
     }
 }
 

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -52,6 +52,10 @@ type Checkpoint {
 	The timestamp at which the checkpoint is agreed to have happened according to consensus. Transactions that access time in this checkpoint will observe this timestamp.
 	"""
 	timestamp: DateTime
+	"""
+	This is an aggregation of signatures from a quorum of validators for the checkpoint proposal.
+	"""
+	validatorSignatures: Base64
 }
 
 """


### PR DESCRIPTION
## Description 

Added support for `Checkpoint.validatorSignature`

## Test plan 

E2E tests:

`cargo nextest run -p sui-indexer-alt-e2e-tests  -- graphql/checkpoints`

Schema tests:
`cargo nextest run -p sui-indexer-alt-graphql -- schema`
`cargo nextest run -p sui-indexer-alt-graphql --features staging -- schema`

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
