### PR TITLE
graphql-alt: Checkpoint.networkTotalTransactions, Checkpoint.rollingGasSummary, Checkpoint.summaryBcs, Checkpoint.contentBcs

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/checkpoint_bcs.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/checkpoint_bcs.move
@@ -1,0 +1,61 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --simulator
+
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs object(1,0) 1
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+
+//# programmable --sender A --inputs object(1,0) 2
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+
+//# create-checkpoint
+
+//# advance-clock --duration-ns 321000000
+
+//# create-checkpoint
+
+
+//# run-graphql
+{ # Fetch each checkpoint individually, and then in a multi-get
+  c0: checkpoint(sequenceNumber: 0) { ...Cp }
+  c1: checkpoint(sequenceNumber: 1) { ...Cp }
+  c2: checkpoint(sequenceNumber: 2) { ...Cp }
+  c3: checkpoint(sequenceNumber: 3) { ...Cp }
+  multiGetCheckpoints(keys: [0, 1, 2, 3]) { ...Cp }
+}
+
+fragment Cp on Checkpoint {
+  sequenceNumber
+  digest
+  summaryBcs
+  contentBcs
+}
+
+//# run-graphql
+{ # Fetch a non-existent checkpoint
+  checkpoint(sequenceNumber: 4) {
+    sequenceNumber
+    digest
+    summaryBcs
+    contentBcs
+  }
+}
+
+//# run-graphql
+{ # Multi-get a mix of existing and non-existing checkpoints
+  multiGetCheckpoints(keys: [2, 100, 0, 200]) {
+    sequenceNumber
+    digest
+    summaryBcs
+    contentBcs
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/checkpoint_bcs.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/checkpoint_bcs.snap
@@ -1,0 +1,129 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 11 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-8:
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 10:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 12-14:
+//# programmable --sender A --inputs object(1,0) 1
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+mutated: object(0,0), object(1,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 4, lines 16-18:
+//# programmable --sender A --inputs object(1,0) 2
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+mutated: object(0,0), object(1,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 5, line 20:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 7, line 24:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 8, lines 27-41:
+//# run-graphql
+Response: {
+  "data": {
+    "c0": {
+      "sequenceNumber": 0,
+      "digest": "EznTSQyzQqRf8tuPhLWZDdhny9jgA7Rw81nWB486rW8C",
+      "summaryBcs": "AAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAII/Q4Z5+qdJKUDyzNYkuLiwR01x7Y/3tCE0YTmrFpwFEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAA==",
+      "contentBcs": "AAEgIWDMbaVHvFW7i0Ui8x2OI/4gF+maumAYbO23tQoH9xogiyn+aqWBXKl0VAbMsD+elKCWE021VdzI1bOrkhv+KboBAA=="
+    },
+    "c1": {
+      "sequenceNumber": 1,
+      "digest": "6KC42LBjuKZP3F9Nfmdz8nC3nvXtMYsX8cEDeMQBkE6P",
+      "summaryBcs": "AAAAAAAAAAABAAAAAAAAAAIAAAAAAAAAIFHvBoDXUXQZlB5hdm06OL3S9Gmfs5bQ9xB5kRzXF88UASDP9W7oPLPDw+Uqki7RqRI2vyM0QFeSc91NeRy1tRl7zUBCDwAAAAAAwCYeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAA==",
+      "contentBcs": "AAEgjBxd57wb5tluI7Ueto4FmG/q+paWNHz62u2u8j6AnBUgRvut9H4eEz0mz5lFOIN2q2Tt//zCJMirMptQB4MTDeIBAWEA9TS9Lcr1ukH4MtLpLk5SW6DoOsE/AN5Q7DNZZVmaYcgL4uCRCwUB7oCFK4q79P05vNMz0baKxJ3iW1rmdmYQBn9RRjrrdtiNybdeY3JQsiDEnPW3ln2/F8H5+nxZSgko"
+    },
+    "c2": {
+      "sequenceNumber": 2,
+      "digest": "2HqixJnQgrp9A74ddZLxNFaJfUeqCci5hUws5pUN7d1R",
+      "summaryBcs": "AAAAAAAAAAACAAAAAAAAAAQAAAAAAAAAIE4wrN29KdUdkVqjJvp8KXSTGMHUFoKTwi3IbBKuBZxEASBO82LIKYn7tw9t9ZHmFGV7FH7ne2EZZBgjCgbSE/wIRMDGLQAAAAAAQHRaAAAAAAAgszsAAAAAAGCaAAAAAAAAAAAAAAAAAAAAAAIAAA==",
+      "contentBcs": "AAIgcwtWw5nt1Yp17lbrFbdiyLmF5+uAJ6TZ0dWwQQquv4IgTcBtBTiXcnIKwyMUVPl4zEZ/EId0ziLPOyvXtYH9MrggRnW8HNjY0btS7NU+TmivkevFabCxIjZIAJyqO/iQxy0ghcg/yGfr85tX66T8EPRfNAbd7iSs07LsapyEA6yFsVwCAWEA6EEXlYP2LHgWTerSIjGtbjDeFfvrO5HWXzO7YIeNeD6eKgawmxCslr4DdFG/qnxDobl62iX/syD/WLZ68YpOCn9RRjrrdtiNybdeY3JQsiDEnPW3ln2/F8H5+nxZSgkoAWEAQoZV9oG7KfDNPtRbJ4AGlMotZ7bMYZJGX0wZuzjzw2cuIqJQvUY3z/3G1SOWFXPo2ZrT7tiXtb4gW7+FLt+zDX9RRjrrdtiNybdeY3JQsiDEnPW3ln2/F8H5+nxZSgko"
+    },
+    "c3": {
+      "sequenceNumber": 3,
+      "digest": "5MPMJ8CDUt35cXKebu3AbzQNg8sLXNtX5nhggxZSnDpj",
+      "summaryBcs": "AAAAAAAAAAADAAAAAAAAAAUAAAAAAAAAIPPA5J2n/GXiDNc3BDPZ5R2ELDz7FjYIUax0C0nu1apuASATLBJPcHdnaF/uUwa4cIqwq1cHEaA1DYutE/WiSRkaCMDGLQAAAAAAQHRaAAAAAAAgszsAAAAAAGCaAAAAAAAAQQEAAAAAAAAAAAIAAA==",
+      "contentBcs": "AAEgD3ACDl8vpFB3ECpvuesWXiAaqYtvv+lttTo/309jYxAgIXkBn9nUOW1PgI7FXpZOilExi9XDRx8XyRdnBmcLLDIBAWEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "multiGetCheckpoints": [
+      {
+        "sequenceNumber": 0,
+        "digest": "EznTSQyzQqRf8tuPhLWZDdhny9jgA7Rw81nWB486rW8C",
+        "summaryBcs": "AAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAII/Q4Z5+qdJKUDyzNYkuLiwR01x7Y/3tCE0YTmrFpwFEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAA==",
+        "contentBcs": "AAEgIWDMbaVHvFW7i0Ui8x2OI/4gF+maumAYbO23tQoH9xogiyn+aqWBXKl0VAbMsD+elKCWE021VdzI1bOrkhv+KboBAA=="
+      },
+      {
+        "sequenceNumber": 1,
+        "digest": "6KC42LBjuKZP3F9Nfmdz8nC3nvXtMYsX8cEDeMQBkE6P",
+        "summaryBcs": "AAAAAAAAAAABAAAAAAAAAAIAAAAAAAAAIFHvBoDXUXQZlB5hdm06OL3S9Gmfs5bQ9xB5kRzXF88UASDP9W7oPLPDw+Uqki7RqRI2vyM0QFeSc91NeRy1tRl7zUBCDwAAAAAAwCYeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAA==",
+        "contentBcs": "AAEgjBxd57wb5tluI7Ueto4FmG/q+paWNHz62u2u8j6AnBUgRvut9H4eEz0mz5lFOIN2q2Tt//zCJMirMptQB4MTDeIBAWEA9TS9Lcr1ukH4MtLpLk5SW6DoOsE/AN5Q7DNZZVmaYcgL4uCRCwUB7oCFK4q79P05vNMz0baKxJ3iW1rmdmYQBn9RRjrrdtiNybdeY3JQsiDEnPW3ln2/F8H5+nxZSgko"
+      },
+      {
+        "sequenceNumber": 2,
+        "digest": "2HqixJnQgrp9A74ddZLxNFaJfUeqCci5hUws5pUN7d1R",
+        "summaryBcs": "AAAAAAAAAAACAAAAAAAAAAQAAAAAAAAAIE4wrN29KdUdkVqjJvp8KXSTGMHUFoKTwi3IbBKuBZxEASBO82LIKYn7tw9t9ZHmFGV7FH7ne2EZZBgjCgbSE/wIRMDGLQAAAAAAQHRaAAAAAAAgszsAAAAAAGCaAAAAAAAAAAAAAAAAAAAAAAIAAA==",
+        "contentBcs": "AAIgcwtWw5nt1Yp17lbrFbdiyLmF5+uAJ6TZ0dWwQQquv4IgTcBtBTiXcnIKwyMUVPl4zEZ/EId0ziLPOyvXtYH9MrggRnW8HNjY0btS7NU+TmivkevFabCxIjZIAJyqO/iQxy0ghcg/yGfr85tX66T8EPRfNAbd7iSs07LsapyEA6yFsVwCAWEA6EEXlYP2LHgWTerSIjGtbjDeFfvrO5HWXzO7YIeNeD6eKgawmxCslr4DdFG/qnxDobl62iX/syD/WLZ68YpOCn9RRjrrdtiNybdeY3JQsiDEnPW3ln2/F8H5+nxZSgkoAWEAQoZV9oG7KfDNPtRbJ4AGlMotZ7bMYZJGX0wZuzjzw2cuIqJQvUY3z/3G1SOWFXPo2ZrT7tiXtb4gW7+FLt+zDX9RRjrrdtiNybdeY3JQsiDEnPW3ln2/F8H5+nxZSgko"
+      },
+      {
+        "sequenceNumber": 3,
+        "digest": "5MPMJ8CDUt35cXKebu3AbzQNg8sLXNtX5nhggxZSnDpj",
+        "summaryBcs": "AAAAAAAAAAADAAAAAAAAAAUAAAAAAAAAIPPA5J2n/GXiDNc3BDPZ5R2ELDz7FjYIUax0C0nu1apuASATLBJPcHdnaF/uUwa4cIqwq1cHEaA1DYutE/WiSRkaCMDGLQAAAAAAQHRaAAAAAAAgszsAAAAAAGCaAAAAAAAAQQEAAAAAAAAAAAIAAA==",
+        "contentBcs": "AAEgD3ACDl8vpFB3ECpvuesWXiAaqYtvv+lttTo/309jYxAgIXkBn9nUOW1PgI7FXpZOilExi9XDRx8XyRdnBmcLLDIBAWEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      }
+    ]
+  }
+}
+
+task 9, lines 43-51:
+//# run-graphql
+Response: {
+  "data": {
+    "checkpoint": null
+  }
+}
+
+task 10, lines 53-61:
+//# run-graphql
+Response: {
+  "data": {
+    "multiGetCheckpoints": [
+      {
+        "sequenceNumber": 2,
+        "digest": "2HqixJnQgrp9A74ddZLxNFaJfUeqCci5hUws5pUN7d1R",
+        "summaryBcs": "AAAAAAAAAAACAAAAAAAAAAQAAAAAAAAAIE4wrN29KdUdkVqjJvp8KXSTGMHUFoKTwi3IbBKuBZxEASBO82LIKYn7tw9t9ZHmFGV7FH7ne2EZZBgjCgbSE/wIRMDGLQAAAAAAQHRaAAAAAAAgszsAAAAAAGCaAAAAAAAAAAAAAAAAAAAAAAIAAA==",
+        "contentBcs": "AAIgcwtWw5nt1Yp17lbrFbdiyLmF5+uAJ6TZ0dWwQQquv4IgTcBtBTiXcnIKwyMUVPl4zEZ/EId0ziLPOyvXtYH9MrggRnW8HNjY0btS7NU+TmivkevFabCxIjZIAJyqO/iQxy0ghcg/yGfr85tX66T8EPRfNAbd7iSs07LsapyEA6yFsVwCAWEA6EEXlYP2LHgWTerSIjGtbjDeFfvrO5HWXzO7YIeNeD6eKgawmxCslr4DdFG/qnxDobl62iX/syD/WLZ68YpOCn9RRjrrdtiNybdeY3JQsiDEnPW3ln2/F8H5+nxZSgkoAWEAQoZV9oG7KfDNPtRbJ4AGlMotZ7bMYZJGX0wZuzjzw2cuIqJQvUY3z/3G1SOWFXPo2ZrT7tiXtb4gW7+FLt+zDX9RRjrrdtiNybdeY3JQsiDEnPW3ln2/F8H5+nxZSgko"
+      },
+      null,
+      {
+        "sequenceNumber": 0,
+        "digest": "EznTSQyzQqRf8tuPhLWZDdhny9jgA7Rw81nWB486rW8C",
+        "summaryBcs": "AAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAII/Q4Z5+qdJKUDyzNYkuLiwR01x7Y/3tCE0YTmrFpwFEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAA==",
+        "contentBcs": "AAEgIWDMbaVHvFW7i0Ui8x2OI/4gF+maumAYbO23tQoH9xogiyn+aqWBXKl0VAbMsD+elKCWE021VdzI1bOrkhv+KboBAA=="
+      },
+      null
+    ]
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/network_total_transactions.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/network_total_transactions.move
@@ -1,0 +1,67 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --simulator
+
+//# run-graphql
+{ # Check Checkpoint: 0, it should have network_total_transactions of 1
+  c0: checkpoint(sequenceNumber: 0) { networkTotalTransactions }
+}
+
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+
+//# create-checkpoint
+
+//# run-graphql
+{ # Check Checkpoint: 1, it should have network_total_transactions of 2
+  c1: checkpoint(sequenceNumber: 1) { networkTotalTransactions }
+}
+
+//# create-checkpoint
+
+//# run-graphql
+{ # Check Checkpoint: 2, it should have network_total_transactions of 2
+  c2: checkpoint(sequenceNumber: 2) { networkTotalTransactions }
+}
+
+//# programmable --sender A --inputs 44 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender B --inputs 43 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# run-graphql
+{ # Check Checkpoint: 3, it should have network_total_transactions of 4
+  c3: checkpoint(sequenceNumber: 3) { networkTotalTransactions }
+}
+
+//# run-graphql
+{ # Check Checkpoint: 4, non-existent 
+  c4: checkpoint(sequenceNumber: 4) { networkTotalTransactions }
+}
+
+//# run-graphql
+{ # Fetch each checkpoints in a multi-get
+  multiGetCheckpoints(keys: [0, 1, 2, 3]) { ...Cp }
+}
+
+fragment Cp on Checkpoint {
+  sequenceNumber
+  networkTotalTransactions
+}
+
+
+//# run-graphql
+{ # Multi-get a mix of existing and non-existing checkpoints
+  multiGetCheckpoints(keys: [2, 100, 0, 200]) {
+    sequenceNumber
+    networkTotalTransactions
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/network_total_transactions.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/network_total_transactions.snap
@@ -1,0 +1,135 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 14 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-9:
+//# run-graphql
+Response: {
+  "data": {
+    "c0": {
+      "networkTotalTransactions": 1
+    }
+  }
+}
+
+task 2, lines 11-13:
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 16:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 18-21:
+//# run-graphql
+Response: {
+  "data": {
+    "c1": {
+      "networkTotalTransactions": 2
+    }
+  }
+}
+
+task 5, line 23:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 6, lines 25-28:
+//# run-graphql
+Response: {
+  "data": {
+    "c2": {
+      "networkTotalTransactions": 2
+    }
+  }
+}
+
+task 7, lines 30-32:
+//# programmable --sender A --inputs 44 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(7,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 8, lines 34-36:
+//# programmable --sender B --inputs 43 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(8,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 9, line 38:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 10, lines 40-43:
+//# run-graphql
+Response: {
+  "data": {
+    "c3": {
+      "networkTotalTransactions": 4
+    }
+  }
+}
+
+task 11, lines 45-48:
+//# run-graphql
+Response: {
+  "data": {
+    "c4": null
+  }
+}
+
+task 12, lines 50-58:
+//# run-graphql
+Response: {
+  "data": {
+    "multiGetCheckpoints": [
+      {
+        "sequenceNumber": 0,
+        "networkTotalTransactions": 1
+      },
+      {
+        "sequenceNumber": 1,
+        "networkTotalTransactions": 2
+      },
+      {
+        "sequenceNumber": 2,
+        "networkTotalTransactions": 2
+      },
+      {
+        "sequenceNumber": 3,
+        "networkTotalTransactions": 4
+      }
+    ]
+  }
+}
+
+task 13, lines 61-67:
+//# run-graphql
+Response: {
+  "data": {
+    "multiGetCheckpoints": [
+      {
+        "sequenceNumber": 2,
+        "networkTotalTransactions": 2
+      },
+      null,
+      {
+        "sequenceNumber": 0,
+        "networkTotalTransactions": 1
+      },
+      null
+    ]
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/rolling_gas_summary.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/rolling_gas_summary.move
@@ -1,0 +1,81 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --simulator
+
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# programmable --sender A --inputs object(1,0) 1
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+
+//# programmable --sender A --inputs object(1,0) 2
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# advance-clock --duration-ns 321000000
+
+//# create-checkpoint
+
+//# run-graphql
+{ # Fetch each checkpoint individually, and then in a multi-get
+  c0: checkpoint(sequenceNumber: 0) { ...Cp }
+  c1: checkpoint(sequenceNumber: 1) { ...Cp }
+  c2: checkpoint(sequenceNumber: 2) { ...Cp }
+  c3: checkpoint(sequenceNumber: 3) { ...Cp }
+  c4: checkpoint(sequenceNumber: 4) { ...Cp }
+  c5: checkpoint(sequenceNumber: 5) { ...Cp }
+  # Fetch a non-existent checkpoint c6
+  c6: checkpoint(sequenceNumber: 6) { ...Cp }
+  # Multi-get a mix of existing and non-existing checkpoints
+  multiGetCheckpoints(keys: [0, 1, 2, 3, 4, 5, 6]) { ...Cp }
+}
+
+fragment Cp on Checkpoint {
+  sequenceNumber
+  epoch { epochId }
+  rollingGasSummary { 
+    computationCost,
+    storageCost, 
+    storageRebate, 
+    nonRefundableStorageFee
+  }
+}
+
+//# run-graphql
+{ # Fetch partial fields on rollingGasSummary with non-zero values
+  c4: checkpoint(sequenceNumber: 4) { ...Cp }
+  c5: checkpoint(sequenceNumber: 5) { ...Cp }
+}
+
+fragment Cp on Checkpoint {
+  sequenceNumber
+  epoch { epochId }
+  rollingGasSummary { 
+    computationCost,
+    storageCost
+  }
+}
+
+
+//# run-graphql
+{ # Multi-get a mix of existing and non-existing checkpoints and partial fields
+  multiGetCheckpoints(keys: [2, 100, 0, 5, 200]) {
+    sequenceNumber
+    epoch { epochId }
+    rollingGasSummary { 
+      computationCost,
+      storageCost, 
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/rolling_gas_summary.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/rolling_gas_summary.snap
@@ -1,0 +1,272 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 13 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-8:
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 10:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, line 12:
+//# advance-epoch
+Epoch advanced: 1
+
+task 4, lines 14-16:
+//# programmable --sender A --inputs object(1,0) 1
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+mutated: object(0,0), object(1,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 5, lines 18-20:
+//# programmable --sender A --inputs object(1,0) 2
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+mutated: object(0,0), object(1,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 6, line 22:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 7, line 24:
+//# advance-epoch
+Epoch advanced: 2
+
+task 9, line 28:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 10, lines 30-53:
+//# run-graphql
+Response: {
+  "data": {
+    "c0": {
+      "sequenceNumber": 0,
+      "epoch": {
+        "epochId": 0
+      },
+      "rollingGasSummary": {
+        "computationCost": 0,
+        "storageCost": 0,
+        "storageRebate": 0,
+        "nonRefundableStorageFee": 0
+      }
+    },
+    "c1": {
+      "sequenceNumber": 1,
+      "epoch": {
+        "epochId": 0
+      },
+      "rollingGasSummary": {
+        "computationCost": 1000000,
+        "storageCost": 1976000,
+        "storageRebate": 0,
+        "nonRefundableStorageFee": 0
+      }
+    },
+    "c2": {
+      "sequenceNumber": 2,
+      "epoch": {
+        "epochId": 0
+      },
+      "rollingGasSummary": {
+        "computationCost": 1000000,
+        "storageCost": 1976000,
+        "storageRebate": 0,
+        "nonRefundableStorageFee": 0
+      }
+    },
+    "c3": {
+      "sequenceNumber": 3,
+      "epoch": {
+        "epochId": 1
+      },
+      "rollingGasSummary": {
+        "computationCost": 2000000,
+        "storageCost": 3952000,
+        "storageRebate": 3912480,
+        "nonRefundableStorageFee": 39520
+      }
+    },
+    "c4": {
+      "sequenceNumber": 4,
+      "epoch": {
+        "epochId": 1
+      },
+      "rollingGasSummary": {
+        "computationCost": 2000000,
+        "storageCost": 3952000,
+        "storageRebate": 3912480,
+        "nonRefundableStorageFee": 39520
+      }
+    },
+    "c5": {
+      "sequenceNumber": 5,
+      "epoch": {
+        "epochId": 2
+      },
+      "rollingGasSummary": {
+        "computationCost": 0,
+        "storageCost": 0,
+        "storageRebate": 0,
+        "nonRefundableStorageFee": 0
+      }
+    },
+    "c6": null,
+    "multiGetCheckpoints": [
+      {
+        "sequenceNumber": 0,
+        "epoch": {
+          "epochId": 0
+        },
+        "rollingGasSummary": {
+          "computationCost": 0,
+          "storageCost": 0,
+          "storageRebate": 0,
+          "nonRefundableStorageFee": 0
+        }
+      },
+      {
+        "sequenceNumber": 1,
+        "epoch": {
+          "epochId": 0
+        },
+        "rollingGasSummary": {
+          "computationCost": 1000000,
+          "storageCost": 1976000,
+          "storageRebate": 0,
+          "nonRefundableStorageFee": 0
+        }
+      },
+      {
+        "sequenceNumber": 2,
+        "epoch": {
+          "epochId": 0
+        },
+        "rollingGasSummary": {
+          "computationCost": 1000000,
+          "storageCost": 1976000,
+          "storageRebate": 0,
+          "nonRefundableStorageFee": 0
+        }
+      },
+      {
+        "sequenceNumber": 3,
+        "epoch": {
+          "epochId": 1
+        },
+        "rollingGasSummary": {
+          "computationCost": 2000000,
+          "storageCost": 3952000,
+          "storageRebate": 3912480,
+          "nonRefundableStorageFee": 39520
+        }
+      },
+      {
+        "sequenceNumber": 4,
+        "epoch": {
+          "epochId": 1
+        },
+        "rollingGasSummary": {
+          "computationCost": 2000000,
+          "storageCost": 3952000,
+          "storageRebate": 3912480,
+          "nonRefundableStorageFee": 39520
+        }
+      },
+      {
+        "sequenceNumber": 5,
+        "epoch": {
+          "epochId": 2
+        },
+        "rollingGasSummary": {
+          "computationCost": 0,
+          "storageCost": 0,
+          "storageRebate": 0,
+          "nonRefundableStorageFee": 0
+        }
+      },
+      null
+    ]
+  }
+}
+
+task 11, lines 55-68:
+//# run-graphql
+Response: {
+  "data": {
+    "c4": {
+      "sequenceNumber": 4,
+      "epoch": {
+        "epochId": 1
+      },
+      "rollingGasSummary": {
+        "computationCost": 2000000,
+        "storageCost": 3952000
+      }
+    },
+    "c5": {
+      "sequenceNumber": 5,
+      "epoch": {
+        "epochId": 2
+      },
+      "rollingGasSummary": {
+        "computationCost": 0,
+        "storageCost": 0
+      }
+    }
+  }
+}
+
+task 12, lines 71-81:
+//# run-graphql
+Response: {
+  "data": {
+    "multiGetCheckpoints": [
+      {
+        "sequenceNumber": 2,
+        "epoch": {
+          "epochId": 0
+        },
+        "rollingGasSummary": {
+          "computationCost": 1000000,
+          "storageCost": 1976000
+        }
+      },
+      null,
+      {
+        "sequenceNumber": 0,
+        "epoch": {
+          "epochId": 0
+        },
+        "rollingGasSummary": {
+          "computationCost": 0,
+          "storageCost": 0
+        }
+      },
+      {
+        "sequenceNumber": 5,
+        "epoch": {
+          "epochId": 2
+        },
+        "rollingGasSummary": {
+          "computationCost": 0,
+          "storageCost": 0
+        }
+      },
+      null
+    ]
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -53,6 +53,14 @@ type Checkpoint {
 	"""
 	rollingGasSummary: GasCostSummary
 	"""
+	The Base64 serialized BCS bytes of this checkpoint's summary.
+	"""
+	summaryBcs: Base64
+	"""
+	The Base64 serialized BCS bytes of this checkpoint's contents.
+	"""
+	contentBcs: Base64
+	"""
 	The timestamp at which the checkpoint is agreed to have happened according to consensus. Transactions that access time in this checkpoint will observe this timestamp.
 	"""
 	timestamp: DateTime

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -49,6 +49,10 @@ type Checkpoint {
 	"""
 	previousCheckpointDigest: String
 	"""
+	The computation cost, storage cost, storage rebate, and non-refundable storage fee accumulated during this epoch, up to and including this checkpoint. These values increase monotonically across checkpoints in the same epoch, and reset on epoch boundaries.
+	"""
+	rollingGasSummary: GasCostSummary
+	"""
 	The timestamp at which the checkpoint is agreed to have happened according to consensus. Transactions that access time in this checkpoint will observe this timestamp.
 	"""
 	timestamp: DateTime
@@ -158,6 +162,32 @@ type FeatureFlag {
 	value: Boolean!
 }
 
+
+"""
+Summary of charges from transactions.
+
+Storage is charged in three parts -- `storage_cost`, `-storage_rebate`, and `non_refundable_storage_fee` -- independently of `computation_cost`.
+
+The overall cost of a transaction, deducted from its gas coins, is its `computation_cost + storage_cost - storage_rebate`. `non_refundable_storage_fee` is collected from objects being mutated or deleted and accumulated by the system in storage funds, the remaining storage costs of previous object versions are what become the `storage_rebate`. The ratio between `non_refundable_storage_fee` and `storage_rebate` is set by the protocol.
+"""
+type GasCostSummary {
+	"""
+	The sum cost of computation/execution
+	"""
+	computationCost: UInt53
+	"""
+	Cost for storage at the time the transaction is executed, calculated as the size of the objects being mutated in bytes multiplied by a storage cost per byte (part of the protocol).
+	"""
+	storageCost: UInt53
+	"""
+	Amount the user gets back from the storage cost of the previous versions of objects being mutated or deleted.
+	"""
+	storageRebate: UInt53
+	"""
+	Amount that is retained by the system in the storage fund from the cost of the previous versions of objects being mutated or deleted.
+	"""
+	nonRefundableStorageFee: UInt53
+}
 
 type GasInput {
 	"""

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -41,6 +41,10 @@ type Checkpoint {
 	"""
 	epoch: Epoch
 	"""
+	The total number of transactions in the network by the end of this checkpoint.
+	"""
+	networkTotalTransactions: UInt53
+	"""
 	The digest of the previous checkpoint's summary.
 	"""
 	previousCheckpointDigest: String

--- a/crates/sui-indexer-alt-graphql/src/api/types/checkpoint.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/checkpoint.rs
@@ -13,7 +13,7 @@ use sui_types::{
 use crate::{
     api::{
         query::Query,
-        scalars::{date_time::DateTime, uint53::UInt53},
+        scalars::{base64::Base64, date_time::DateTime, uint53::UInt53},
     },
     error::RpcError,
     scope::Scope,
@@ -110,6 +110,26 @@ impl CheckpointContents {
         Some(GasCostSummary::from(
             summary.epoch_rolling_gas_cost_summary.clone(),
         ))
+    }
+
+    /// The Base64 serialized BCS bytes of this checkpoint's summary.
+    async fn summary_bcs(&self) -> Result<Option<Base64>, RpcError> {
+        let Some((summary, _, _)) = &self.contents else {
+            return Ok(None);
+        };
+        Ok(Some(Base64::from(
+            bcs::to_bytes(summary).context("Failed to serialize checkpoint summary")?,
+        )))
+    }
+
+    /// The Base64 serialized BCS bytes of this checkpoint's contents.
+    async fn content_bcs(&self) -> Result<Option<Base64>, RpcError> {
+        let Some((_, content, _)) = &self.contents else {
+            return Ok(None);
+        };
+        Ok(Some(Base64::from(
+            bcs::to_bytes(content).context("Failed to serialize checkpoint content")?,
+        )))
     }
 
     /// The timestamp at which the checkpoint is agreed to have happened according to consensus. Transactions that access time in this checkpoint will observe this timestamp.

--- a/crates/sui-indexer-alt-graphql/src/api/types/checkpoint.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/checkpoint.rs
@@ -87,6 +87,12 @@ impl CheckpointContents {
         Some(Epoch::with_id(self.scope.clone(), summary.epoch))
     }
 
+    /// The total number of transactions in the network by the end of this checkpoint.
+    async fn network_total_transactions(&self) -> Option<UInt53> {
+        let (summary, _, _) = self.contents.as_ref()?;
+        Some(summary.network_total_transactions.into())
+    }
+
     /// The digest of the previous checkpoint's summary.
     async fn previous_checkpoint_digest(&self) -> Result<Option<String>, RpcError> {
         let Some((summary, _, _)) = &self.contents else {

--- a/crates/sui-indexer-alt-graphql/src/api/types/checkpoint.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/checkpoint.rs
@@ -19,7 +19,7 @@ use crate::{
     scope::Scope,
 };
 
-use super::epoch::Epoch;
+use super::{epoch::Epoch, gas::GasCostSummary};
 
 pub(crate) struct Checkpoint {
     pub(crate) sequence_number: u64,
@@ -102,6 +102,14 @@ impl CheckpointContents {
             .previous_digest
             .as_ref()
             .map(|digest| digest.base58_encode()))
+    }
+
+    /// The computation cost, storage cost, storage rebate, and non-refundable storage fee accumulated during this epoch, up to and including this checkpoint. These values increase monotonically across checkpoints in the same epoch, and reset on epoch boundaries.
+    async fn rolling_gas_summary(&self) -> Option<GasCostSummary> {
+        let (summary, _, _) = self.contents.as_ref()?;
+        Some(GasCostSummary::from(
+            summary.epoch_rolling_gas_cost_summary.clone(),
+        ))
     }
 
     /// The timestamp at which the checkpoint is agreed to have happened according to consensus. Transactions that access time in this checkpoint will observe this timestamp.

--- a/crates/sui-indexer-alt-graphql/src/api/types/gas.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/gas.rs
@@ -1,0 +1,42 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::Object;
+use sui_types::gas::GasCostSummary as NativeGasCostSummary;
+
+use crate::api::scalars::uint53::UInt53;
+
+pub(crate) struct GasCostSummary {
+    native: NativeGasCostSummary,
+}
+
+/// Summary of charges from transactions.
+///
+/// Storage is charged in three parts -- `storage_cost`, `-storage_rebate`, and `non_refundable_storage_fee` -- independently of `computation_cost`.
+///
+/// The overall cost of a transaction, deducted from its gas coins, is its `computation_cost + storage_cost - storage_rebate`. `non_refundable_storage_fee` is collected from objects being mutated or deleted and accumulated by the system in storage funds, the remaining storage costs of previous object versions are what become the `storage_rebate`. The ratio between `non_refundable_storage_fee` and `storage_rebate` is set by the protocol.
+#[Object]
+impl GasCostSummary {
+    /// The sum cost of computation/execution
+    async fn computation_cost(&self) -> Option<UInt53> {
+        Some(self.native.computation_cost.into())
+    }
+    /// Cost for storage at the time the transaction is executed, calculated as the size of the objects being mutated in bytes multiplied by a storage cost per byte (part of the protocol).
+    async fn storage_cost(&self) -> Option<UInt53> {
+        Some(self.native.storage_cost.into())
+    }
+    /// Amount the user gets back from the storage cost of the previous versions of objects being mutated or deleted.
+    async fn storage_rebate(&self) -> Option<UInt53> {
+        Some(self.native.storage_rebate.into())
+    }
+    /// Amount that is retained by the system in the storage fund from the cost of the previous versions of objects being mutated or deleted.
+    async fn non_refundable_storage_fee(&self) -> Option<UInt53> {
+        Some(self.native.non_refundable_storage_fee.into())
+    }
+}
+
+impl From<NativeGasCostSummary> for GasCostSummary {
+    fn from(native: NativeGasCostSummary) -> Self {
+        Self { native }
+    }
+}

--- a/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
@@ -4,6 +4,8 @@
 pub(crate) mod address;
 pub(crate) mod checkpoint;
 pub(crate) mod epoch;
+
+pub(crate) mod gas;
 pub(crate) mod gas_input;
 pub(crate) mod move_package;
 pub(crate) mod object;

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -57,6 +57,14 @@ type Checkpoint {
 	"""
 	rollingGasSummary: GasCostSummary
 	"""
+	The Base64 serialized BCS bytes of this checkpoint's summary.
+	"""
+	summaryBcs: Base64
+	"""
+	The Base64 serialized BCS bytes of this checkpoint's contents.
+	"""
+	contentBcs: Base64
+	"""
 	The timestamp at which the checkpoint is agreed to have happened according to consensus. Transactions that access time in this checkpoint will observe this timestamp.
 	"""
 	timestamp: DateTime

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -53,6 +53,10 @@ type Checkpoint {
 	"""
 	previousCheckpointDigest: String
 	"""
+	The computation cost, storage cost, storage rebate, and non-refundable storage fee accumulated during this epoch, up to and including this checkpoint. These values increase monotonically across checkpoints in the same epoch, and reset on epoch boundaries.
+	"""
+	rollingGasSummary: GasCostSummary
+	"""
 	The timestamp at which the checkpoint is agreed to have happened according to consensus. Transactions that access time in this checkpoint will observe this timestamp.
 	"""
 	timestamp: DateTime
@@ -162,6 +166,32 @@ type FeatureFlag {
 	value: Boolean!
 }
 
+
+"""
+Summary of charges from transactions.
+
+Storage is charged in three parts -- `storage_cost`, `-storage_rebate`, and `non_refundable_storage_fee` -- independently of `computation_cost`.
+
+The overall cost of a transaction, deducted from its gas coins, is its `computation_cost + storage_cost - storage_rebate`. `non_refundable_storage_fee` is collected from objects being mutated or deleted and accumulated by the system in storage funds, the remaining storage costs of previous object versions are what become the `storage_rebate`. The ratio between `non_refundable_storage_fee` and `storage_rebate` is set by the protocol.
+"""
+type GasCostSummary {
+	"""
+	The sum cost of computation/execution
+	"""
+	computationCost: UInt53
+	"""
+	Cost for storage at the time the transaction is executed, calculated as the size of the objects being mutated in bytes multiplied by a storage cost per byte (part of the protocol).
+	"""
+	storageCost: UInt53
+	"""
+	Amount the user gets back from the storage cost of the previous versions of objects being mutated or deleted.
+	"""
+	storageRebate: UInt53
+	"""
+	Amount that is retained by the system in the storage fund from the cost of the previous versions of objects being mutated or deleted.
+	"""
+	nonRefundableStorageFee: UInt53
+}
 
 type GasInput {
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -45,6 +45,10 @@ type Checkpoint {
 	"""
 	epoch: Epoch
 	"""
+	The total number of transactions in the network by the end of this checkpoint.
+	"""
+	networkTotalTransactions: UInt53
+	"""
 	The digest of the previous checkpoint's summary.
 	"""
 	previousCheckpointDigest: String

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -57,6 +57,14 @@ type Checkpoint {
 	"""
 	rollingGasSummary: GasCostSummary
 	"""
+	The Base64 serialized BCS bytes of this checkpoint's summary.
+	"""
+	summaryBcs: Base64
+	"""
+	The Base64 serialized BCS bytes of this checkpoint's contents.
+	"""
+	contentBcs: Base64
+	"""
 	The timestamp at which the checkpoint is agreed to have happened according to consensus. Transactions that access time in this checkpoint will observe this timestamp.
 	"""
 	timestamp: DateTime

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -53,6 +53,10 @@ type Checkpoint {
 	"""
 	previousCheckpointDigest: String
 	"""
+	The computation cost, storage cost, storage rebate, and non-refundable storage fee accumulated during this epoch, up to and including this checkpoint. These values increase monotonically across checkpoints in the same epoch, and reset on epoch boundaries.
+	"""
+	rollingGasSummary: GasCostSummary
+	"""
 	The timestamp at which the checkpoint is agreed to have happened according to consensus. Transactions that access time in this checkpoint will observe this timestamp.
 	"""
 	timestamp: DateTime
@@ -162,6 +166,32 @@ type FeatureFlag {
 	value: Boolean!
 }
 
+
+"""
+Summary of charges from transactions.
+
+Storage is charged in three parts -- `storage_cost`, `-storage_rebate`, and `non_refundable_storage_fee` -- independently of `computation_cost`.
+
+The overall cost of a transaction, deducted from its gas coins, is its `computation_cost + storage_cost - storage_rebate`. `non_refundable_storage_fee` is collected from objects being mutated or deleted and accumulated by the system in storage funds, the remaining storage costs of previous object versions are what become the `storage_rebate`. The ratio between `non_refundable_storage_fee` and `storage_rebate` is set by the protocol.
+"""
+type GasCostSummary {
+	"""
+	The sum cost of computation/execution
+	"""
+	computationCost: UInt53
+	"""
+	Cost for storage at the time the transaction is executed, calculated as the size of the objects being mutated in bytes multiplied by a storage cost per byte (part of the protocol).
+	"""
+	storageCost: UInt53
+	"""
+	Amount the user gets back from the storage cost of the previous versions of objects being mutated or deleted.
+	"""
+	storageRebate: UInt53
+	"""
+	Amount that is retained by the system in the storage fund from the cost of the previous versions of objects being mutated or deleted.
+	"""
+	nonRefundableStorageFee: UInt53
+}
 
 type GasInput {
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -45,6 +45,10 @@ type Checkpoint {
 	"""
 	epoch: Epoch
 	"""
+	The total number of transactions in the network by the end of this checkpoint.
+	"""
+	networkTotalTransactions: UInt53
+	"""
 	The digest of the previous checkpoint's summary.
 	"""
 	previousCheckpointDigest: String

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -53,6 +53,14 @@ type Checkpoint {
 	"""
 	rollingGasSummary: GasCostSummary
 	"""
+	The Base64 serialized BCS bytes of this checkpoint's summary.
+	"""
+	summaryBcs: Base64
+	"""
+	The Base64 serialized BCS bytes of this checkpoint's contents.
+	"""
+	contentBcs: Base64
+	"""
 	The timestamp at which the checkpoint is agreed to have happened according to consensus. Transactions that access time in this checkpoint will observe this timestamp.
 	"""
 	timestamp: DateTime

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -49,6 +49,10 @@ type Checkpoint {
 	"""
 	previousCheckpointDigest: String
 	"""
+	The computation cost, storage cost, storage rebate, and non-refundable storage fee accumulated during this epoch, up to and including this checkpoint. These values increase monotonically across checkpoints in the same epoch, and reset on epoch boundaries.
+	"""
+	rollingGasSummary: GasCostSummary
+	"""
 	The timestamp at which the checkpoint is agreed to have happened according to consensus. Transactions that access time in this checkpoint will observe this timestamp.
 	"""
 	timestamp: DateTime
@@ -158,6 +162,32 @@ type FeatureFlag {
 	value: Boolean!
 }
 
+
+"""
+Summary of charges from transactions.
+
+Storage is charged in three parts -- `storage_cost`, `-storage_rebate`, and `non_refundable_storage_fee` -- independently of `computation_cost`.
+
+The overall cost of a transaction, deducted from its gas coins, is its `computation_cost + storage_cost - storage_rebate`. `non_refundable_storage_fee` is collected from objects being mutated or deleted and accumulated by the system in storage funds, the remaining storage costs of previous object versions are what become the `storage_rebate`. The ratio between `non_refundable_storage_fee` and `storage_rebate` is set by the protocol.
+"""
+type GasCostSummary {
+	"""
+	The sum cost of computation/execution
+	"""
+	computationCost: UInt53
+	"""
+	Cost for storage at the time the transaction is executed, calculated as the size of the objects being mutated in bytes multiplied by a storage cost per byte (part of the protocol).
+	"""
+	storageCost: UInt53
+	"""
+	Amount the user gets back from the storage cost of the previous versions of objects being mutated or deleted.
+	"""
+	storageRebate: UInt53
+	"""
+	Amount that is retained by the system in the storage fund from the cost of the previous versions of objects being mutated or deleted.
+	"""
+	nonRefundableStorageFee: UInt53
+}
 
 type GasInput {
 	"""

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -41,6 +41,10 @@ type Checkpoint {
 	"""
 	epoch: Epoch
 	"""
+	The total number of transactions in the network by the end of this checkpoint.
+	"""
+	networkTotalTransactions: UInt53
+	"""
 	The digest of the previous checkpoint's summary.
 	"""
 	previousCheckpointDigest: String


### PR DESCRIPTION
Description
Added support for:
`Checkpoint.networkTotalTransactions` 
`Checkpoint.rollingGasSummary` 
`Checkpoint.summaryBcs` 
`Checkpoint.contentBcs`

Test plan

E2E tests:
`cargo nextest run -p sui-indexer-alt-e2e-tests  -- graphql/checkpoints`

Schema tests:
`cargo nextest run -p sui-indexer-alt-graphql -- schema`
`cargo nextest run -p sui-indexer-alt-graphql --features staging -- schema`

Stack:
https://github.com/MystenLabs/sui/pull/22651 
https://github.com/MystenLabs/sui/pull/22686 
https://github.com/MystenLabs/sui/pull/22688 
https://github.com/MystenLabs/sui/pull/22690 👈
https://github.com/MystenLabs/sui/pull/22691
https://github.com/MystenLabs/sui/pull/22708


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
