### PR TITLE
Add workflows to test with mainnet protocol config

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -235,6 +235,33 @@ jobs:
         run: |
           scripts/simtest/stress-new-tests.sh
 
+  simtest-mainnet:
+    needs: diff
+    if: needs.diff.outputs.isRust == 'true' || needs.diff.outputs.isSolidity == 'true'
+    timeout-minutes: 45
+    runs-on: [ ubuntu-ghcloud ]
+    env:
+      MSIM_WATCHDOG_TIMEOUT_MS: 300000
+      SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE: mainnet
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # Pin v4.1.1
+        with:
+          ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
+      - uses: taiki-e/install-action@nextest
+      - uses: taiki-e/install-action@protoc
+      - name: Add postgres to PATH
+        run: echo "/usr/lib/postgresql/14/bin" >> $GITHUB_PATH
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 256
+      - name: cargo simtest
+        run: |
+          MSIM_TEST_SEED="$(printf "%lu\n" 0x$(git rev-parse HEAD | cut -c1-16))" scripts/simtest/cargo-simtest simtest --no-fail-fast
+      - name: check new tests for flakiness
+        run: |
+          scripts/simtest/stress-new-tests.sh
+
   # This job ensures that Move unit tests are run if there are changes
   # to Move code but not Rust code (If there are Rust changes, they
   # will be run as part of a larger test suite).

--- a/.github/workflows/simulator-nightly.yml
+++ b/.github/workflows/simulator-nightly.yml
@@ -6,6 +6,7 @@ concurrency:
 on:
   schedule:
     - cron: '0 9 * * *' # equivalent to 1am PST
+    - cron: '0 21 * * *' # equivalent to 1pm PST
   workflow_dispatch:
     inputs:
       sui_ref:
@@ -18,6 +19,11 @@ on:
         type: string
         required: false
         default: "30"
+      protocol_config_override:
+        description: "Protocol config override"
+        type: string
+        required: false
+        default: ""
 
 env:
   SUI_REF: "${{ github.event.inputs.sui_ref || 'main' }}"
@@ -76,6 +82,24 @@ jobs:
       - name: Install simtest
         run: |
           tsh -i ${{ steps.auth.outputs.identity-file }} ssh ubuntu@simtest-01 "source ~/.bashrc && source ~/.cargo/env && cd ~/sui && ./scripts/simtest/install.sh"
+
+      - name: Set protocol config override based on trigger
+        # This step determines which protocol config override to use.
+        # It checks if the trigger was a manual dispatch or a specific schedule.
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            if [[ -n "${{ github.event.inputs.protocol_config_override }}" ]]; then
+              echo "Testing with protocol config override: ${{ github.event.inputs.protocol_config_override }}"
+              echo "SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE=${{ github.event.inputs.protocol_config_override }}" >> $GITHUB_ENV
+            else
+              echo "Testing latest protocol config for dispatched run"
+            fi
+          elif [[ "${{ github.event.schedule }}" == "0 21 * * *" ]]; then
+            echo "Testing mainnet protocol config"
+            echo "SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE=mainnet" >> $GITHUB_ENV
+          else
+            echo "Testing latest protocol config"
+          fi
 
       # Run simulator tests
       - name: Run simtest

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -108,6 +108,9 @@ mod test {
 
     #[sim_test(config = "test_config()")]
     async fn test_testnet_config() {
+        if sui_simulator::has_mainnet_protocol_config_override() {
+            return;
+        }
         chain_config_smoke_test(Chain::Testnet).await;
     }
 
@@ -707,6 +710,10 @@ mod test {
 
     #[sim_test(config = "test_config()")]
     async fn test_simulated_load_mysticeti_fastpath() {
+        if sui_simulator::has_mainnet_protocol_config_override() {
+            return;
+        }
+
         unsafe {
             std::env::set_var("TRANSACTION_DRIVER", "100");
         }

--- a/crates/sui-core/src/unit_tests/transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_tests.rs
@@ -637,6 +637,10 @@ async fn test_zklogin_transfer_with_large_address_seed() {
 
 #[sim_test]
 async fn zklogin_test_caching_scenarios() {
+    if sui_simulator::has_mainnet_protocol_config_override() {
+        return;
+    }
+
     telemetry_subscribers::init_for_testing();
     let (
         object_ids,
@@ -656,7 +660,7 @@ async fn zklogin_test_caching_scenarios() {
     let res = client
         .handle_transaction(transfer_transaction, Some(socket_addr))
         .await;
-    assert!(res.is_ok());
+    assert!(res.is_ok(), "{}", res.unwrap_err());
 
     assert_eq!(
         epoch_store

--- a/crates/sui-e2e-tests/tests/multisig_tests.rs
+++ b/crates/sui-e2e-tests/tests/multisig_tests.rs
@@ -426,6 +426,10 @@ async fn test_multisig_e2e() {
 
 #[sim_test]
 async fn test_multisig_with_zklogin_scenerios() {
+    if sui_simulator::has_mainnet_protocol_config_override() {
+        return;
+    }
+
     let test_cluster = TestClusterBuilder::new()
         // Use a long epoch duration such that it won't change epoch on its own.
         .with_epoch_duration_ms(10000000)
@@ -959,6 +963,10 @@ async fn test_max_epoch_too_large_fail_zklogin_in_multisig() {
 
 #[sim_test]
 async fn test_random_zklogin_in_multisig() {
+    if sui_simulator::has_mainnet_protocol_config_override() {
+        return;
+    }
+
     let test_vectors =
         &load_test_vectors("../sui-types/src/unit_tests/zklogin_test_vectors.json")[1..11];
     let test_cluster = TestClusterBuilder::new()

--- a/crates/sui-e2e-tests/tests/party_objects_tests.rs
+++ b/crates/sui-e2e-tests/tests/party_objects_tests.rs
@@ -18,6 +18,10 @@ use tracing::info;
 /// Delete a party object as the object owner.
 #[sim_test]
 async fn party_object_deletion() {
+    if sui_simulator::has_mainnet_protocol_config_override() {
+        return;
+    }
+
     telemetry_subscribers::init_for_testing();
     let test_cluster = TestClusterBuilder::new().build().await;
 
@@ -56,6 +60,10 @@ async fn party_object_deletion() {
 
 #[sim_test]
 async fn party_object_deletion_multiple_times() {
+    if sui_simulator::has_mainnet_protocol_config_override() {
+        return;
+    }
+
     telemetry_subscribers::init_for_testing();
 
     let num_deletions = 20;
@@ -128,6 +136,10 @@ async fn party_object_deletion_multiple_times() {
 
 #[sim_test]
 async fn party_object_deletion_multiple_times_cert_racing() {
+    if sui_simulator::has_mainnet_protocol_config_override() {
+        return;
+    }
+
     telemetry_subscribers::init_for_testing();
 
     let num_deletions = 10;
@@ -201,6 +213,10 @@ async fn party_object_deletion_multiple_times_cert_racing() {
 /// Transfer a party object as the object owner.
 #[sim_test]
 async fn party_object_transfer() {
+    if sui_simulator::has_mainnet_protocol_config_override() {
+        return;
+    }
+
     telemetry_subscribers::init_for_testing();
     let test_cluster = TestClusterBuilder::new().build().await;
 
@@ -249,6 +265,10 @@ async fn party_object_transfer() {
 
 #[sim_test]
 async fn party_object_transfer_multiple_times() {
+    if sui_simulator::has_mainnet_protocol_config_override() {
+        return;
+    }
+
     telemetry_subscribers::init_for_testing();
 
     let num_transfers = 20;
@@ -329,6 +349,10 @@ async fn party_object_transfer_multiple_times() {
 /// 4. Execute the remaining two.
 #[sim_test]
 async fn party_object_transfer_multi_certs() {
+    if sui_simulator::has_mainnet_protocol_config_override() {
+        return;
+    }
+
     telemetry_subscribers::init_for_testing();
 
     // cause random delay just before tx is executed (to explore all orders)
@@ -457,6 +481,10 @@ async fn party_object_transfer_multi_certs() {
 /// Use a party object immutably.
 #[sim_test]
 async fn party_object_read() {
+    if sui_simulator::has_mainnet_protocol_config_override() {
+        return;
+    }
+
     telemetry_subscribers::init_for_testing();
 
     // Create a test cluster with enough gas coins for the below.
@@ -617,6 +645,10 @@ async fn party_object_grpc() {
     use sui_rpc::proto::sui::rpc::v2beta2::GetObjectRequest;
     use sui_rpc::proto::sui::rpc::v2beta2::ListOwnedObjectsRequest;
 
+    if sui_simulator::has_mainnet_protocol_config_override() {
+        return;
+    }
+
     let test_cluster = TestClusterBuilder::new().build().await;
 
     let (package, object) =
@@ -764,6 +796,10 @@ async fn party_coin_grpc() {
     use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
     use sui_types::transaction::{CallArg, ObjectArg, TransactionData};
     use sui_types::Identifier;
+
+    if sui_simulator::has_mainnet_protocol_config_override() {
+        return;
+    }
 
     let cluster = TestClusterBuilder::new().build().await;
     let channel = tonic::transport::Channel::from_shared(cluster.rpc_url().to_owned())
@@ -928,6 +964,10 @@ async fn party_coin_grpc() {
 /// indexes
 #[sim_test]
 async fn party_object_jsonrpc() {
+    if sui_simulator::has_mainnet_protocol_config_override() {
+        return;
+    }
+
     let test_cluster = TestClusterBuilder::new().build().await;
 
     let (package, object) =

--- a/crates/sui-e2e-tests/tests/passkey_e2e_tests.rs
+++ b/crates/sui-e2e-tests/tests/passkey_e2e_tests.rs
@@ -230,6 +230,9 @@ fn make_good_passkey_tx(response: PasskeyResponse<TransactionData>) -> Transacti
 #[sim_test]
 async fn test_passkey_feature_deny() {
     use sui_protocol_config::ProtocolConfig;
+    if sui_simulator::has_mainnet_protocol_config_override() {
+        return;
+    }
     let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
         config.set_passkey_auth_for_testing(false);
         config
@@ -248,6 +251,9 @@ async fn test_passkey_feature_deny() {
 
 #[sim_test]
 async fn test_passkey_authenticator_verifies() {
+    if sui_simulator::has_mainnet_protocol_config_override() {
+        return;
+    }
     let test_cluster = TestClusterBuilder::new().build().await;
     let response = create_credential_and_sign_test_tx(&test_cluster, None, false, false).await;
     let tx = make_good_passkey_tx(response);
@@ -257,6 +263,9 @@ async fn test_passkey_authenticator_verifies() {
 
 #[sim_test]
 async fn test_passkey_fails_mismatched_challenge() {
+    if sui_simulator::has_mainnet_protocol_config_override() {
+        return;
+    }
     let test_cluster = TestClusterBuilder::new().build().await;
 
     // Tweak intent in challenge that is sent to passkey.
@@ -302,6 +311,9 @@ async fn test_passkey_fails_mismatched_challenge() {
 
 #[sim_test]
 async fn test_passkey_fails_to_verify_sig() {
+    if sui_simulator::has_mainnet_protocol_config_override() {
+        return;
+    }
     let test_cluster = TestClusterBuilder::new().build().await;
     let response = create_credential_and_sign_test_tx(&test_cluster, None, false, false).await;
     let mut modified_sig = response.user_sig_bytes.clone();
@@ -331,6 +343,9 @@ async fn test_passkey_fails_to_verify_sig() {
 
 #[sim_test]
 async fn test_passkey_fails_wrong_author() {
+    if sui_simulator::has_mainnet_protocol_config_override() {
+        return;
+    }
     let test_cluster = TestClusterBuilder::new().build().await;
     // Modify sender that receives gas and construct test txn.
     let response =

--- a/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
@@ -234,6 +234,9 @@ async fn test_passive_reconfig_mainnet_smoke_test() {
 
 #[sim_test]
 async fn test_passive_reconfig_testnet_smoke_test() {
+    if sui_simulator::has_mainnet_protocol_config_override() {
+        return;
+    }
     do_test_passive_reconfig(Some(Chain::Testnet)).await;
 }
 

--- a/crates/sui-e2e-tests/tests/rpc/v2beta2/signature_verification_service.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2beta2/signature_verification_service.rs
@@ -16,6 +16,10 @@ use test_cluster::TestClusterBuilder;
 
 #[sim_test]
 async fn test_verify_signature_zklogin() -> Result<(), anyhow::Error> {
+    if sui_simulator::has_mainnet_protocol_config_override() {
+        return Ok(());
+    }
+
     let test_cluster = TestClusterBuilder::new()
         .with_epoch_duration_ms(10000)
         .with_default_jwks()

--- a/crates/sui-e2e-tests/tests/zklogin_tests.rs
+++ b/crates/sui-e2e-tests/tests/zklogin_tests.rs
@@ -118,6 +118,10 @@ async fn test_legacy_zklogin_address_accept() {
 
 #[sim_test]
 async fn zklogin_end_to_end_test() {
+    if sui_simulator::has_mainnet_protocol_config_override() {
+        return;
+    }
+
     let test_cluster = TestClusterBuilder::new()
         .with_epoch_duration_ms(15000)
         .with_default_jwks()

--- a/crates/sui-json-rpc-tests/tests/rpc_server_tests.rs
+++ b/crates/sui-json-rpc-tests/tests/rpc_server_tests.rs
@@ -993,6 +993,10 @@ async fn test_staking_multiple_coins() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_zklogin_verify() -> Result<(), anyhow::Error> {
+    if sui_simulator::has_mainnet_protocol_config_override() {
+        return Ok(());
+    }
+
     let test_cluster = TestClusterBuilder::new()
         .with_epoch_duration_ms(15000)
         .with_default_jwks()

--- a/crates/sui-sdk/tests/tests.rs
+++ b/crates/sui-sdk/tests/tests.rs
@@ -70,6 +70,10 @@ async fn test_verify_personal_message_signature() {
 async fn test_verify_signature_zklogin() {
     use test_cluster::TestClusterBuilder;
 
+    if sui_simulator::has_mainnet_protocol_config_override() {
+        return;
+    }
+
     let message = b"hello";
     let personal_message = PersonalMessage {
         message: message.to_vec(),

--- a/crates/sui-simulator/src/lib.rs
+++ b/crates/sui-simulator/src/lib.rs
@@ -149,6 +149,12 @@ pub fn current_simnode_id() -> msim::task::NodeId {
     msim::runtime::NodeHandle::current().id()
 }
 
+pub fn has_mainnet_protocol_config_override() -> bool {
+    use sui_types::{digests::ChainIdentifier, supported_protocol_versions::Chain};
+
+    ChainIdentifier::default().chain() == Chain::Mainnet
+}
+
 #[cfg(msim)]
 pub mod random {
     use super::*;

--- a/crates/sui-types/src/digests.rs
+++ b/crates/sui-types/src/digests.rs
@@ -1105,12 +1105,20 @@ impl fmt::Debug for AdditionalConsensusStateDigest {
     }
 }
 
+#[cfg(test)]
 mod test {
-    #[allow(unused_imports)]
-    use crate::digests::ChainIdentifier;
+    use crate::digests::{ChainIdentifier, SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE};
+
+    fn has_env_override() -> bool {
+        SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE.is_some()
+    }
+
     // check that the chain id returns mainnet
     #[test]
     fn test_chain_id_mainnet() {
+        if has_env_override() {
+            return;
+        }
         let chain_id = ChainIdentifier::from_chain_short_id(&String::from("35834a8a"));
         assert_eq!(
             chain_id.unwrap().chain(),
@@ -1120,6 +1128,9 @@ mod test {
 
     #[test]
     fn test_chain_id_testnet() {
+        if has_env_override() {
+            return;
+        }
         let chain_id = ChainIdentifier::from_chain_short_id(&String::from("4c78adac"));
         assert_eq!(
             chain_id.unwrap().chain(),
@@ -1129,6 +1140,9 @@ mod test {
 
     #[test]
     fn test_chain_id_unknown() {
+        if has_env_override() {
+            return;
+        }
         let chain_id = ChainIdentifier::from_chain_short_id(&String::from("unknown"));
         assert_eq!(chain_id, None);
     }


### PR DESCRIPTION
## Description 

It is common to have a feature enabled in simtests and optionally testnet, but not mainnet. A feature can be in this state for months. But mainnet protocol config is only tested in a few upgrade related tests. It is important to make sure changes do not accidentally break the `mainnet` protocol while passing tests with the latest protocol config via features enabled in dev environments.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
