### PR TITLE
[bug fix] use the epoch state for latest epoch in simulator txn test

### DIFF
--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -34,7 +34,7 @@ use sui_types::storage::{ObjectStore, ReadStore, RpcStateReader};
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemState;
 use sui_types::transaction::EndOfEpochTransactionKind;
 use sui_types::{
-    base_types::SuiAddress,
+    base_types::{EpochId, SuiAddress},
     committee::Committee,
     effects::TransactionEffects,
     error::ExecutionError,
@@ -498,6 +498,10 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
 
     fn get_latest_checkpoint(&self) -> sui_types::storage::error::Result<VerifiedCheckpoint> {
         Ok(self.store().get_highest_checkpint().unwrap())
+    }
+
+    fn get_latest_epoch_id(&self) -> sui_types::storage::error::Result<EpochId> {
+        Ok(self.epoch_state.epoch())
     }
 
     fn get_highest_verified_checkpoint(

--- a/crates/sui-graphql-e2e-tests/tests/stable/call/simple.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/call/simple.snap
@@ -76,7 +76,7 @@ CheckpointSummary { epoch: 0, seq: 4, content_digest: D3oWLCcqoa1D15gxzvMaDemNNY
 
 task 9, line 41:
 //# advance-epoch 6
-Epoch advanced: 5
+Epoch advanced: 6
 
 task 10, line 43:
 //# view-checkpoint
@@ -147,7 +147,7 @@ CheckpointSummary { epoch: 6, seq: 11, content_digest: D3oWLCcqoa1D15gxzvMaDemNN
 
 task 17, lines 72-75:
 //# advance-epoch
-Epoch advanced: 6
+Epoch advanced: 7
 
 task 18, lines 77-92:
 //# run-graphql

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/epochs/checkpoints.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/epochs/checkpoints.snap
@@ -16,7 +16,7 @@ Checkpoint created: 2
 
 task 3, line 17:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 4, lines 19-36:
 //# run-graphql
@@ -66,7 +66,7 @@ Checkpoint created: 6
 
 task 8, line 44:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 9, line 46:
 //# create-checkpoint

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/epochs/transaction_blocks.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/epochs/transaction_blocks.snap
@@ -28,7 +28,7 @@ Checkpoint created: 2
 
 task 5, line 43:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 6, lines 45-61:
 //# run-graphql
@@ -103,7 +103,7 @@ Checkpoint created: 6
 
 task 13, line 75:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 14, line 77:
 //# run Test::M1::create --args 0 @A --sender A
@@ -137,11 +137,11 @@ Checkpoint created: 10
 
 task 20, line 89:
 //# advance-epoch
-Epoch advanced: 2
+Epoch advanced: 3
 
 task 21, line 91:
 //# advance-epoch
-Epoch advanced: 3
+Epoch advanced: 4
 
 task 22, lines 93-157:
 //# run-graphql --cursors {"t":3,"i":false,"c":4} {"t":7,"i":false,"c":8} {"t":11,"i":false,"c":12}

--- a/crates/sui-graphql-e2e-tests/tests/stable/consistency/staked_sui.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/consistency/staked_sui.snap
@@ -40,7 +40,7 @@ Checkpoint created: 1
 
 task 5, line 28:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 6, lines 30-32:
 //# programmable --sender C --inputs 10000000000 @C
@@ -64,7 +64,7 @@ Checkpoint created: 3
 
 task 9, line 38:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 10, line 40:
 //# view-object 3,1

--- a/crates/sui-graphql-e2e-tests/tests/stable/datetime/datetime.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/datetime/datetime.snap
@@ -33,7 +33,7 @@ Checkpoint created: 7
 
 task 15, line 41:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 16, lines 43-45:
 //# create-checkpoint
@@ -45,7 +45,7 @@ Checkpoint created: 10
 
 task 20, line 53:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 21, lines 55-66:
 //# run-graphql

--- a/crates/sui-graphql-e2e-tests/tests/stable/epoch/epoch.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/epoch/epoch.snap
@@ -12,7 +12,7 @@ Checkpoint created: 1
 
 task 2, line 10:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 3, lines 12-14:
 //# programmable --sender C --inputs 10000000000 @C
@@ -36,7 +36,7 @@ Checkpoint created: 3
 
 task 6, lines 21-23:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 7, lines 24-28:
 //# programmable --sender C --inputs 10000000000 @C
@@ -53,7 +53,7 @@ Checkpoint created: 5
 
 task 9, lines 31-32:
 //# advance-epoch
-Epoch advanced: 2
+Epoch advanced: 3
 
 task 10, lines 33-62:
 //# run-graphql

--- a/crates/sui-graphql-e2e-tests/tests/stable/epoch/epoch_start_to_end.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/epoch/epoch_start_to_end.snap
@@ -12,7 +12,7 @@ Checkpoint created: 1
 
 task 2, line 8:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 3, lines 10-12:
 //# programmable --sender C --inputs 10000000000 @C
@@ -109,7 +109,7 @@ Checkpoint created: 4
 
 task 9, line 76:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 10, line 78:
 //# create-checkpoint

--- a/crates/sui-graphql-e2e-tests/tests/stable/epoch/pagination.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/epoch/pagination.snap
@@ -8,27 +8,27 @@ C: object(0,0)
 
 task 1, line 6:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 2, line 8:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 3, line 10:
 //# advance-epoch
-Epoch advanced: 2
+Epoch advanced: 3
 
 task 4, line 12:
 //# advance-epoch
-Epoch advanced: 3
+Epoch advanced: 4
 
 task 5, line 14:
 //# advance-epoch
-Epoch advanced: 4
+Epoch advanced: 5
 
 task 6, line 16:
 //# advance-epoch
-Epoch advanced: 5
+Epoch advanced: 6
 
 task 7, lines 18-29:
 //# run-graphql 

--- a/crates/sui-graphql-e2e-tests/tests/stable/epoch/system_state.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/epoch/system_state.snap
@@ -12,7 +12,7 @@ Checkpoint created: 1
 
 task 2, line 12:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 3, lines 14-16:
 //# programmable --sender C --inputs 10000000000 @C
@@ -36,7 +36,7 @@ Checkpoint created: 3
 
 task 6, line 22:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 7, line 24:
 //# create-checkpoint
@@ -44,7 +44,7 @@ Checkpoint created: 5
 
 task 8, line 26:
 //# advance-epoch
-Epoch advanced: 2
+Epoch advanced: 3
 
 task 9, lines 28-30:
 //# programmable --sender C --inputs 10000000000 @C
@@ -60,7 +60,7 @@ Checkpoint created: 7
 
 task 11, line 34:
 //# advance-epoch
-Epoch advanced: 3
+Epoch advanced: 4
 
 task 12, line 36:
 //# run 0x3::sui_system::request_withdraw_stake --args object(0x5) object(4,0) --sender C
@@ -76,7 +76,7 @@ Checkpoint created: 9
 
 task 14, line 40:
 //# advance-epoch
-Epoch advanced: 4
+Epoch advanced: 5
 
 task 15, lines 42-44:
 //# programmable --sender C --inputs 10000000000 @C
@@ -92,7 +92,7 @@ Checkpoint created: 11
 
 task 17, line 48:
 //# advance-epoch
-Epoch advanced: 5
+Epoch advanced: 6
 
 task 18, lines 50-60:
 //# run-graphql

--- a/crates/sui-graphql-e2e-tests/tests/stable/objects/filter_by_type.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/objects/filter_by_type.snap
@@ -12,7 +12,7 @@ Checkpoint created: 1
 
 task 2, line 9:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 3, lines 11-13:
 //# programmable --sender C --inputs 10000000000 @C
@@ -36,7 +36,7 @@ Checkpoint created: 3
 
 task 6, line 20:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 7, lines 22-37:
 //# run-graphql

--- a/crates/sui-graphql-e2e-tests/tests/stable/objects/full_objects_history.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/objects/full_objects_history.snap
@@ -21,7 +21,7 @@ Checkpoint created: 1
 
 task 4, line 29:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 5, line 31:
 //# run Test::M1::mutate --args object(2,0) 1
@@ -54,7 +54,7 @@ Response: {
 
 task 9, line 49:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 10, lines 51-53:
 //# create-checkpoint

--- a/crates/sui-graphql-e2e-tests/tests/stable/objects/staked_sui.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/objects/staked_sui.snap
@@ -54,7 +54,7 @@ Checkpoint created: 1
 
 task 5, line 41:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 6, lines 43-69:
 //# run-graphql

--- a/crates/sui-graphql-e2e-tests/tests/stable/prune/events.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/prune/events.snap
@@ -30,7 +30,7 @@ Checkpoint created: 1
 
 task 5, line 45:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 6, line 47:
 //# run Test::M1::emit_a --sender A --args object(2,0) 1

--- a/crates/sui-graphql-e2e-tests/tests/stable/prune/prune.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/prune/prune.snap
@@ -21,7 +21,7 @@ Checkpoint created: 1
 
 task 4, line 31:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 5, line 33:
 //# run Test::M1::create --args 1 @A
@@ -35,7 +35,7 @@ Checkpoint created: 3
 
 task 7, line 37:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 8, line 39:
 //# run Test::M1::create --args 2 @A
@@ -49,7 +49,7 @@ Checkpoint created: 5
 
 task 10, line 43:
 //# advance-epoch
-Epoch advanced: 2
+Epoch advanced: 3
 
 task 11, lines 45-58:
 //# run-graphql --wait-for-checkpoint-pruned 4

--- a/crates/sui-graphql-e2e-tests/tests/stable/prune/transactions.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/prune/transactions.snap
@@ -24,7 +24,7 @@ Checkpoint created: 1
 
 task 4, line 31:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 5, line 33:
 //# run Test::M1::create --sender A --args 1 @A
@@ -38,7 +38,7 @@ Checkpoint created: 3
 
 task 7, line 37:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 8, line 39:
 //# run Test::M1::create --sender A --args 2 @A
@@ -52,7 +52,7 @@ Checkpoint created: 5
 
 task 10, line 43:
 //# advance-epoch
-Epoch advanced: 2
+Epoch advanced: 3
 
 task 11, line 45:
 //# run Test::M1::create --sender A --args 3 @A

--- a/crates/sui-graphql-e2e-tests/tests/stable/transaction_block_effects/balance_changes.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transaction_block_effects/balance_changes.snap
@@ -30,7 +30,7 @@ Checkpoint created: 1
 
 task 4, line 19:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 5, lines 21-45:
 //# run-graphql

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/random.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/random.snap
@@ -9,7 +9,7 @@ Checkpoint created: 1
 
 task 2, line 8:
 //# advance-epoch --create-random-state
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 3, lines 10-46:
 //# run-graphql
@@ -83,7 +83,7 @@ Response: {
           "kind": {
             "__typename": "RandomnessStateUpdateTransaction",
             "epoch": {
-              "epochId": 0
+              "epochId": 1
             },
             "randomnessRound": 0,
             "randomBytes": "SGVsbG8gU3Vp",

--- a/crates/sui-graphql-e2e-tests/tests/stable/transactions/system.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/transactions/system.snap
@@ -1559,7 +1559,7 @@ Response: {
 
 task 6, line 187:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 7, lines 189-276:
 //# run-graphql

--- a/crates/sui-graphql-e2e-tests/tests/stable/validator/validator.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/validator/validator.snap
@@ -8,7 +8,7 @@ A: object(0,0)
 
 task 1, line 8:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 2, line 10:
 //# create-checkpoint
@@ -50,7 +50,7 @@ Checkpoint created: 3
 
 task 9, line 49:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 10, lines 51-63:
 //# run-graphql
@@ -167,7 +167,7 @@ Checkpoint created: 5
 
 task 27, lines 97-99:
 //# advance-epoch
-Epoch advanced: 2
+Epoch advanced: 3
 
 task 28, lines 101-118:
 //# run-graphql

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/epoch.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/epoch.snap
@@ -12,7 +12,7 @@ Checkpoint created: 1
 
 task 2, line 8:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 3, line 10:
 //# create-checkpoint
@@ -24,7 +24,7 @@ Checkpoint created: 4
 
 task 5, line 14:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 6, line 16:
 //# create-checkpoint

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/coin_deny_list.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/coin_deny_list.snap
@@ -8,7 +8,7 @@ A: object(0,0)
 
 task 1, line 6:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 2, lines 8-49:
 //# publish --sender A
@@ -30,7 +30,7 @@ Checkpoint created: 2
 
 task 5, line 56:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 6, line 58:
 //# create-checkpoint

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
@@ -8,15 +8,15 @@ A: object(0,0)
 
 task 2, line 8:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 4, line 12:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 5, line 14:
 //# advance-epoch
-Epoch advanced: 2
+Epoch advanced: 3
 
 task 6, lines 16-33:
 //# run-graphql

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/system_packages.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/system_packages.snap
@@ -8,7 +8,7 @@ A: object(0,0)
 
 task 1, line 6:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 2, lines 8-25:
 //# run-graphql

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/checkpoints/get_checkpoint.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/checkpoints/get_checkpoint.snap
@@ -32,7 +32,7 @@ Checkpoint created: 2
 
 task 6, line 20:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 7, lines 22-24:
 //# programmable --inputs 42 @A

--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/governance/system_state.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc/governance/system_state.snap
@@ -198,7 +198,7 @@ Response: {
 
 task 6, line 26:
 //# advance-epoch
-Epoch advanced: 0
+Epoch advanced: 1
 
 task 7, lines 28-32:
 //# run-jsonrpc
@@ -391,7 +391,7 @@ Response: {
 
 task 11, line 45:
 //# advance-epoch
-Epoch advanced: 1
+Epoch advanced: 2
 
 task 12, lines 47-51:
 //# run-jsonrpc


### PR DESCRIPTION
## Description 

Before this PR, the `ReadStore:: get_latest_epoch_id` implementation for `Simulacrum` would use the default impl and return the epoch of the latest checkpoint instead of the latest epoch according to epoch state. This would result in `get_latest_epoch_id` returning the previous epoch number when the epoch change just happened and a new checkpoint hasn't been created yet.

## Test plan 

Existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
