### PR TITLE
kv store: enable extra stats on bigtable

### DIFF
--- a/crates/sui-kvstore/src/bigtable/metrics.rs
+++ b/crates/sui-kvstore/src/bigtable/metrics.rs
@@ -18,6 +18,9 @@ pub(crate) struct KvMetrics {
     pub kv_scan_not_found: IntCounterVec,
     pub kv_scan_error: IntCounterVec,
     pub kv_scan_latency_ms: HistogramVec,
+    pub kv_bt_chunk_latency_ms: HistogramVec,
+    pub kv_bt_chunk_rows_returned_count: IntCounterVec,
+    pub kv_bt_chunk_rows_seen_count: IntCounterVec,
 }
 
 impl KvMetrics {
@@ -102,6 +105,30 @@ impl KvMetrics {
                 prometheus::exponential_buckets(1.0, 1.6, 24)
                     .unwrap()
                     .to_vec(),
+                registry,
+            )
+            .unwrap(),
+            kv_bt_chunk_latency_ms: register_histogram_vec_with_registry!(
+                "kv_bt_chunk_latency_ms",
+                "Reported BigTable latency for a single chunk",
+                &["client", "table"],
+                prometheus::exponential_buckets(1.0, 1.6, 24)
+                    .unwrap()
+                    .to_vec(),
+                registry,
+            )
+            .unwrap(),
+            kv_bt_chunk_rows_returned_count: register_int_counter_vec_with_registry!(
+                "kv_bt_chunk_rows_returned_count",
+                "Reported BigTable rows returned count for a single chunk",
+                &["client", "table"],
+                registry,
+            )
+            .unwrap(),
+            kv_bt_chunk_rows_seen_count: register_int_counter_vec_with_registry!(
+                "kv_bt_chunk_rows_seen_count",
+                "Reported BigTable rows seen count for a single chunk",
+                &["client", "table"],
                 registry,
             )
             .unwrap(),


### PR DESCRIPTION
## Description 

enables extra bigtable stats on gRPC level

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
