### PR TITLE
[TD] Use TransactionDriver to submit 50% of benchmark workload in simtests

### DIFF
--- a/crates/sui-core/src/transaction_driver/mod.rs
+++ b/crates/sui-core/src/transaction_driver/mod.rs
@@ -178,6 +178,29 @@ where
     }
 }
 
+// Chooses the percentage of transactions to be driven by TransactionDriver.
+pub fn choose_transaction_driver_percentage() -> u8 {
+    // Currently, TD cannot work in non-test environments.
+    if std::env::var(sui_types::digests::SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE_ENV_VAR_NAME).is_ok() {
+        return 0;
+    }
+
+    if let Ok(v) = std::env::var("TRANSACTION_DRIVER") {
+        if let Ok(tx_driver_percentage) = v.parse::<u8>() {
+            if tx_driver_percentage > 0 && tx_driver_percentage <= 100 {
+                return tx_driver_percentage;
+            }
+        }
+    }
+
+    // Default to 50% in simtests.
+    if cfg!(msim) {
+        return 50;
+    }
+
+    0
+}
+
 // Inner state of TransactionDriver.
 struct State {
     tasks: JoinSet<()>,

--- a/crates/sui-types/src/digests.rs
+++ b/crates/sui-types/src/digests.rs
@@ -165,7 +165,8 @@ pub static TESTNET_CHAIN_IDENTIFIER: OnceCell<ChainIdentifier> = OnceCell::new()
 
 /// For testing purposes or bootstrapping regenesis chain configuration, you can set
 /// this environment variable to force protocol config to use a specific Chain.
-const SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE_ENV_VAR_NAME: &str = "SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE";
+pub const SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE_ENV_VAR_NAME: &str =
+    "SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE";
 
 static SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE: Lazy<Option<Chain>> = Lazy::new(|| {
     if let Ok(s) = env::var(SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE_ENV_VAR_NAME) {


### PR DESCRIPTION
## Description 

Enable exercising TD in simtests.

Also, retries `ObjectNotFound` and `DependentPackageNotFound` errors in QD. Because fastpath execution results go to fastpath cache when using TD, making sure QD retrying these errors allow QD and TD to operate on the same objects.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
