### PR TITLE
Make `replace` in `TxContext` Move "variadic"

### DIFF
--- a/sui-execution/latest/sui-move-natives/src/tx_context.rs
+++ b/sui-execution/latest/sui-move-natives/src/tx_context.rs
@@ -400,7 +400,8 @@ pub fn replace(
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(ty_args.is_empty());
-    debug_assert!(args.len() == 9);
+    let args_len = args.len();
+    debug_assert!(args_len == 8 || args_len == 9);
 
     // use the `TxContextReplaceCostParams` for the cost of this function
     let tx_context_replace_cost_params: TxContextReplaceCostParams = context
@@ -413,16 +414,20 @@ pub fn replace(
         tx_context_replace_cost_params.tx_context_replace_cost_base
     );
 
+    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
     let mut sponsor: Vec<AccountAddress> = pop_arg!(args, Vec<AccountAddress>);
     let gas_budget: u64 = pop_arg!(args, u64);
     let gas_price: u64 = pop_arg!(args, u64);
-    let rgp: u64 = pop_arg!(args, u64);
+    let rgp: u64 = if args_len == 9 {
+        pop_arg!(args, u64)
+    } else {
+        transaction_context.rgp()
+    };
     let ids_created: u64 = pop_arg!(args, u64);
     let epoch_timestamp_ms: u64 = pop_arg!(args, u64);
     let epoch: u64 = pop_arg!(args, u64);
     let tx_hash: Vec<u8> = pop_arg!(args, Vec<u8>);
     let sender: AccountAddress = pop_arg!(args, AccountAddress);
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
     transaction_context.replace(
         sender,
         tx_hash,


### PR DESCRIPTION
## Description 

`TxContext::replace` was changed in the number of args from 8 to 9. We thought that was ok given implicit deps and the test only function.
It turns out that because of the release schedule and the multiple versions of the CLI that can be used having both version work would be ideal, maybe necessary.
This PR makes the native work both when 8 or 9 args are provided. Basically the native works for both the old and the new version of the framework

## Test plan 

Tested manually on the cli run that fails

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
