### PR TITLE
[graphql-alt] Update advance-clock to assign transaction digests

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/gas_input.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/gas_input.move
@@ -38,6 +38,11 @@ module test::simple {
 
 //# create-checkpoint
 
+// Test system transaction created by advance-clock
+//# advance-clock --duration-ns 1000000
+
+//# create-checkpoint
+
 //# run-graphql
 { # Test basic single gas payment transaction
   basicTransaction: transaction(digest: "@{digest_2}") {
@@ -113,6 +118,29 @@ module test::simple {
           hasNextPage
           hasPreviousPage
           startCursor
+        }
+        nodes {
+          address
+          version
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{ # Test system transaction GasInput (should be null for system transactions)
+  systemTransaction: transaction(digest: "@{digest_6}") {
+    gasInput {
+      gasSponsor {
+        address
+      }
+      gasPrice
+      gasBudget
+      gasPayment {
+        pageInfo {
+          hasNextPage
+          hasPreviousPage
         }
         nodes {
           address

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/gas_input.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/gas_input.move
@@ -129,7 +129,7 @@ module test::simple {
 }
 
 //# run-graphql
-{ # Test system transaction GasInput (should be null for system transactions)
+{ # Test system transaction GasInput
   systemTransaction: transaction(digest: "@{digest_6}") {
     gasInput {
       gasSponsor {

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/gas_input.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/gas_input.snap
@@ -158,9 +158,7 @@ Response: {
   "data": {
     "systemTransaction": {
       "gasInput": {
-        "gasSponsor": {
-          "address": "0x0000000000000000000000000000000000000000000000000000000000000000"
-        },
+        "gasSponsor": null,
         "gasPrice": "1",
         "gasBudget": "0",
         "gasPayment": {
@@ -168,12 +166,7 @@ Response: {
             "hasNextPage": false,
             "hasPreviousPage": false
           },
-          "nodes": [
-            {
-              "address": "0x0000000000000000000000000000000000000000000000000000000000000000",
-              "version": 0
-            }
-          ]
+          "nodes": []
         }
       }
     }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/gas_input.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/gas_input.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 10 tasks
+processed 13 tasks
 
 init:
 A: object(0,0)
@@ -36,11 +36,15 @@ mutated: object(1,0), object(3,0)
 deleted: object(3,1)
 gas summary: computation_cost: 1000000, storage_cost: 2340800,  storage_rebate: 3295512, non_refundable_storage_fee: 33288
 
-task 5, line 39:
+task 5, lines 39-41:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 6, lines 41-62:
+task 7, line 44:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 8, lines 46-67:
 //# run-graphql
 Response: {
   "data": {
@@ -68,7 +72,7 @@ Response: {
   }
 }
 
-task 7, lines 64-85:
+task 9, lines 69-90:
 //# run-graphql
 Response: {
   "data": {
@@ -100,7 +104,7 @@ Response: {
   }
 }
 
-task 8, lines 88-105:
+task 10, lines 93-110:
 //# run-graphql
 Response: {
   "data": {
@@ -124,7 +128,7 @@ Response: {
   }
 }
 
-task 9, lines 107-124:
+task 11, lines 112-129:
 //# run-graphql
 Response: {
   "data": {
@@ -140,6 +144,34 @@ Response: {
             {
               "address": "0xd36321d7785495cfdf1e73d5c088b789410123f49d711320a624324c44641527",
               "version": 4
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+
+task 12, lines 131-152:
+//# run-graphql
+Response: {
+  "data": {
+    "systemTransaction": {
+      "gasInput": {
+        "gasSponsor": {
+          "address": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "gasPrice": "1",
+        "gasBudget": "0",
+        "gasPayment": {
+          "pageInfo": {
+            "hasNextPage": false,
+            "hasPreviousPage": false
+          },
+          "nodes": [
+            {
+              "address": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "version": 0
             }
           ]
         }

--- a/crates/sui-indexer-alt-graphql/src/api/types/gas_input.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/gas_input.rs
@@ -5,10 +5,7 @@ use async_graphql::{
     connection::{Connection, CursorType, Edge},
     *,
 };
-use sui_types::{
-    base_types::{ObjectID, SuiAddress},
-    transaction::GasData,
-};
+use sui_types::{base_types::SuiAddress, transaction::GasData};
 
 use crate::{
     api::scalars::{big_int::BigInt, cursor::JsonCursor},
@@ -40,11 +37,8 @@ type CGasPayment = JsonCursor<usize>;
 impl GasInput {
     /// Address of the owner of the gas object(s) used.
     async fn gas_sponsor(&self) -> Option<Address> {
-        if self.native.owner == SuiAddress::ZERO {
-            None
-        } else {
-            Some(Address::with_address(self.scope.clone(), self.native.owner))
-        }
+        (self.native.owner != SuiAddress::ZERO)
+            .then(|| Address::with_address(self.scope.clone(), self.native.owner))
     }
 
     /// An unsigned integer specifying the number of native tokens per gas unit this transaction will pay (in MIST).
@@ -66,24 +60,21 @@ impl GasInput {
         last: Option<u64>,
         before: Option<CGasPayment>,
     ) -> Result<Option<Connection<String, Object>>, RpcError> {
+        // Return empty connection for system transactions.
+        if self.native.owner == SuiAddress::ZERO {
+            return Ok(Some(Connection::new(false, false)));
+        }
+
         let pagination: &PaginationConfig = ctx.data()?;
         let limits = pagination.limits("GasInput", "gasPayment");
         let page = Page::from_params(limits, first, after, last, before)?;
 
-        // Filter out payments with zero object ID (sentinel values for system transactions)
-        let filtered_payments: Vec<_> = self
-            .native
-            .payment
-            .iter()
-            .filter(|(id, _, _)| *id != ObjectID::ZERO)
-            .collect();
-
-        let cursors = page.paginate_indices(filtered_payments.len());
+        let cursors = page.paginate_indices(self.native.payment.len());
         let mut conn = Connection::new(cursors.has_previous_page, cursors.has_next_page);
         for edge in cursors.edges {
-            let (id, version, digest) = filtered_payments[*edge.cursor];
-            let address = Address::with_address(self.scope.clone(), (*id).into());
-            let object = Object::with_ref(address, *version, *digest);
+            let (id, version, digest) = self.native.payment[*edge.cursor];
+            let address = Address::with_address(self.scope.clone(), id.into());
+            let object = Object::with_ref(address, version, digest);
 
             conn.edges
                 .push(Edge::new(edge.cursor.encode_cursor(), object));

--- a/crates/sui-indexer-alt-graphql/src/api/types/gas_input.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/gas_input.rs
@@ -5,7 +5,10 @@ use async_graphql::{
     connection::{Connection, CursorType, Edge},
     *,
 };
-use sui_types::transaction::GasData;
+use sui_types::{
+    base_types::{ObjectID, SuiAddress},
+    transaction::GasData,
+};
 
 use crate::{
     api::scalars::{big_int::BigInt, cursor::JsonCursor},
@@ -37,7 +40,11 @@ type CGasPayment = JsonCursor<usize>;
 impl GasInput {
     /// Address of the owner of the gas object(s) used.
     async fn gas_sponsor(&self) -> Option<Address> {
-        Some(Address::with_address(self.scope.clone(), self.native.owner))
+        if self.native.owner == SuiAddress::ZERO {
+            None
+        } else {
+            Some(Address::with_address(self.scope.clone(), self.native.owner))
+        }
     }
 
     /// An unsigned integer specifying the number of native tokens per gas unit this transaction will pay (in MIST).
@@ -63,12 +70,20 @@ impl GasInput {
         let limits = pagination.limits("GasInput", "gasPayment");
         let page = Page::from_params(limits, first, after, last, before)?;
 
-        let cursors = page.paginate_indices(self.native.payment.len());
+        // Filter out payments with zero object ID (sentinel values for system transactions)
+        let filtered_payments: Vec<_> = self
+            .native
+            .payment
+            .iter()
+            .filter(|(id, _, _)| *id != ObjectID::ZERO)
+            .collect();
+
+        let cursors = page.paginate_indices(filtered_payments.len());
         let mut conn = Connection::new(cursors.has_previous_page, cursors.has_next_page);
         for edge in cursors.edges {
-            let (id, version, digest) = self.native.payment[*edge.cursor];
-            let address = Address::with_address(self.scope.clone(), id.into());
-            let object = Object::with_ref(address, version, digest);
+            let (id, version, digest) = filtered_payments[*edge.cursor];
+            let address = Address::with_address(self.scope.clone(), (*id).into());
+            let object = Object::with_ref(address, *version, *digest);
 
             conn.edges
                 .push(Edge::new(edge.cursor.encode_cursor(), object));


### PR DESCRIPTION
## Description 

Following discussion on PR #22652, this PR does following things:

1. Update advance-clock to assign transaction digests
2. Adding a test to gas_input on how it will behaving with a system transaction.

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-graphql
cargo nextest run -p sui-indexer-alt-reader
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

---

## Stack
- #22652 

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
