### PR TITLE
Fix end of epoch stored observation bug on simtest for all protocol versions before 88

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -824,10 +824,10 @@ mod test {
     }
 
     async fn test_protocol_upgrade_compatibility_impl() {
-        // Override record_time_estimate_processed for protocol version 87 in tests
-        // it is currently set to true in 87 in mainnet only
+        // Override record_time_estimate_processed for protocol versions before 88 in tests
+        // to correct for known issue that appeared on mainnet.
         let _guard = ProtocolConfig::apply_overrides_for_testing(|version, mut config| {
-            if version.as_u64() == 87 {
+            if version.as_u64() <= 87 {
                 config.set_record_time_estimate_processed_for_testing(true);
             }
             config


### PR DESCRIPTION


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
