### PR TITLE
chore: remove leftover suins-toolkit docs

### DIFF
--- a/sdk/suins-toolkit/README.md
+++ b/sdk/suins-toolkit/README.md
@@ -1,2 +1,0 @@
-`@mysten/suins-toolkit` has moved to
-https://github.com/MystenLabs/ts-sdks/tree/main/packages/suins-toolkit


### PR DESCRIPTION
## Description 

The suins-toolkit codebase was fully removed in [#148](https://github.com/MystenLabs/ts-sdks/pull/148).  
This PR remove the leftover README file in the suins-toolkit directory, as the documentation is no longer relevant.

