### PR TITLE
Improve postgres error output, add debugging instructions

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/README.md
+++ b/crates/sui-indexer-alt-e2e-tests/README.md
@@ -1,0 +1,23 @@
+### Debugging transactional tests in RustRover
+
+1. Add new `Cargo` run configuration
+2. 1. Command to run all tests 
+      ```
+      test -p sui-indexer-alt-e2e-tests --test transactional_tests
+      ```
+   2. Command to run single test (replace `graphql/epochs/query.move` with the test you want to run)
+      ```
+      test -p sui-indexer-alt-e2e-tests --test transactional_tests graphql/epochs/query.move
+      ```
+   3. Note: debugging is not supported for nextest (https://youtrack.jetbrains.com/issue/RUST-12459)
+3. To prevent `error: invalid value 'json' for '--format <pretty|terse|json>'` or `error: unexpected argument '-Z' found`, uncheck 
+   
+   ```
+   RustRover -> Settings -> Advanced Settings -> Show test results in the Test tool window
+   ```
+   
+   (https://youtrack.jetbrains.com/issue/RUST-7891/Cargo-test-bench-something-fails-with-unexpected-argument#focus=Comments-27-8478362.0-0)
+4. To prevent `FATAL:  postmaster became multithreaded during startup` in homebrew postgres15 server logs, 
+   set `Environment Variables` to `LC_ALL=en_US.UTF-8`.
+
+   (https://github.com/Homebrew/homebrew-core/issues/124215#issuecomment-1445300937)

--- a/crates/sui-pg-db/src/temp.rs
+++ b/crates/sui-pg-db/src/temp.rs
@@ -6,6 +6,7 @@ use anyhow::Context;
 use anyhow::Result;
 use std::fmt::Debug;
 use std::fs::OpenOptions;
+use std::process::ExitStatus;
 use std::{
     path::{Path, PathBuf},
     process::{Child, Command},
@@ -45,11 +46,26 @@ struct PostgresProcess {
 
 #[derive(Debug)]
 enum HealthCheckError {
-    NotRunning(String),
+    NotRunning(Option<ExitStatus>),
     NotReady,
     #[allow(unused)]
     Unknown(String),
 }
+
+impl std::fmt::Display for HealthCheckError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HealthCheckError::NotRunning(Some(status)) => {
+                write!(f, "Not running - exit status: {}", status)
+            }
+            HealthCheckError::NotRunning(None) => write!(f, "Not running - no exit status"),
+            HealthCheckError::NotReady => write!(f, "Not ready"),
+            HealthCheckError::Unknown(msg) => write!(f, "Unknown error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for HealthCheckError {}
 
 impl TempDb {
     /// Create and start a new temporary postgres database.
@@ -118,10 +134,12 @@ impl LocalDatabase {
     fn start(&mut self) -> Result<()> {
         if self.process.is_none() {
             self.process = Some(PostgresProcess::start(self.dir.clone(), self.port)?);
-            self.wait_till_ready().map_err(|e| {
-                let dir = self.dir.clone().into_os_string().into_string();
-                // may need to add breakpoint/sleep to prevent temp dir from being deleted
-                anyhow!("unable to start postgres: {e:?} check dir {dir:?} for logs")
+            self.wait_till_ready().with_context(|| {
+                format!(
+                    // may need to add breakpoint/sleep to prevent temp dir from being deleted
+                    "Unable to start postgres, check dir {} for logs",
+                    self.dir.display(),
+                )
             })?;
         }
 
@@ -132,7 +150,7 @@ impl LocalDatabase {
         if let Some(p) = &mut self.process {
             match p.inner.try_wait() {
                 // This would mean the child process has crashed
-                Ok(Some(status)) => Err(HealthCheckError::NotRunning(status.to_string())),
+                Ok(Some(status)) => Err(HealthCheckError::NotRunning(Some(status))),
 
                 // This is the case where the process is still running
                 Ok(None) => pg_isready(self.port),
@@ -141,9 +159,7 @@ impl LocalDatabase {
                 Err(e) => Err(HealthCheckError::Unknown(e.to_string())),
             }
         } else {
-            Err(HealthCheckError::NotRunning(
-                "no postgres process".to_owned(),
-            ))
+            Err(HealthCheckError::NotRunning(None))
         }
     }
 
@@ -152,18 +168,8 @@ impl LocalDatabase {
 
         while start.elapsed() < Duration::from_secs(10) {
             match self.health_check() {
-                Ok(()) => return Ok(()),
                 Err(HealthCheckError::NotReady) => {}
-                Err(HealthCheckError::NotRunning(status)) => {
-                    return Err(HealthCheckError::NotRunning(format!(
-                        "not running error - status: {status:?}"
-                    )))
-                }
-                Err(HealthCheckError::Unknown(msg)) => {
-                    return Err(HealthCheckError::Unknown(format!(
-                        "unknown error - message: {msg}"
-                    )))
-                }
+                result => return result,
             }
 
             std::thread::sleep(Duration::from_millis(50));


### PR DESCRIPTION
## Description 

Improve the error output to include additional details (exit code, message, log dir) in output when postgres fails to start.
Example output:
```
Failed to create off-chain cluster: Failed to create database

Caused by:
    0: Unable to start postgres, check dir /var/folders/5d/ppmp0h310tnbrgf8xn1vrpnw0000gn/T/.tmpZReFSd for logs
    1: Not running - exit status: exit status: 1

Stack backtrace:
   0: std::backtrace_rs::backtrace::libunwind::trace
             at /rustc/4eb161250e340c8f48f66e2b929ef4a5bed7c181/library/std/src/../../backtrace/src/backtrace/libunwind.rs:116:5
...
```

Add instructions for running transactional tests in the RustRover debugger.

## Test plan 

Ran `test -p sui-indexer-alt-e2e-tests --test transactional_tests graphql/epochs/query.move` and was able to set breakpoints.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
