### PR TITLE
[indexer-alt] Implement fluent Args API Builder with last-write-win semantics

### DIFF
--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -31,7 +31,7 @@ mod slow_future_monitor;
 #[cfg(test)]
 mod test_utils;
 
-#[derive(clap::Args, Clone, Debug)]
+#[derive(clap::Args, Clone, Debug, Default)]
 #[group(required = true)]
 pub struct ClientArgs {
     /// Remote Store to fetch checkpoints from.


### PR DESCRIPTION
## Description 

Extends `IndexerClusterBuilder` with individual fluent API methods for `IndexerArgs`, `ClientArgs`, and `MetricsArgs` components, implementing "Last Write Wins" semantics as described in [Approach 2](https://www.notion.so/mystenlabs/IndexerClusterBuilder-Improvement-Options-22b6d9dcb4e9800d8da4c91170f668a2?source=copy_link#22d6d9dcb4e9800e8fd1f548c3773dd1) from my design doc.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
