### PR TITLE
[move][utils] Add runtime visitor to match annotated visitor

### DIFF
--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -2292,6 +2292,7 @@ dependencies = [
  "ethnum",
  "hex",
  "indexmap 2.8.0",
+ "insta",
  "leb128",
  "move-proc-macros",
  "num",

--- a/external-crates/move/crates/move-core-types/Cargo.toml
+++ b/external-crates/move/crates/move-core-types/Cargo.toml
@@ -38,6 +38,7 @@ proptest-derive.workspace = true
 regex.workspace = true
 serde_json.workspace = true
 arbitrary = { workspace = true, features = ["derive_arbitrary"] }
+insta.workspace = true
 
 [features]
 default = []

--- a/external-crates/move/crates/move-core-types/src/lib.rs
+++ b/external-crates/move/crates/move-core-types/src/lib.rs
@@ -20,6 +20,7 @@ pub mod parsing;
 pub mod proptest_types;
 pub mod resolver;
 pub mod runtime_value;
+pub mod runtime_visitor;
 pub mod u256;
 #[cfg(test)]
 mod unit_tests;

--- a/external-crates/move/crates/move-core-types/src/runtime_visitor.rs
+++ b/external-crates/move/crates/move-core-types/src/runtime_visitor.rs
@@ -1,0 +1,781 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::{Cursor, Read};
+
+use crate::{
+    VARIANT_TAG_MAX_VALUE,
+    account_address::AccountAddress,
+    runtime_value::{MoveEnumLayout, MoveStructLayout, MoveTypeLayout},
+    u256::U256,
+};
+
+/// Visitors can be used for building values out of a serialized Move struct or value.
+pub trait Visitor<'b, 'l> {
+    type Value;
+
+    /// Visitors can return any error as long as it can represent an error from the visitor itself.
+    /// The easiest way to achieve this is to use `thiserror`:
+    ///
+    /// ```rust,no_doc
+    /// #[derive(thiserror::Error)]
+    /// enum Error {
+    ///     #[error(transparent)]
+    ///     Visitor(#[from] runtime_visitor::Error)
+    ///
+    ///     // Custom error variants ...
+    /// }
+    /// ```
+    type Error: From<Error>;
+
+    fn visit_u8(
+        &mut self,
+        driver: &ValueDriver<'_, 'b, 'l>,
+        value: u8,
+    ) -> Result<Self::Value, Self::Error>;
+
+    fn visit_u16(
+        &mut self,
+        driver: &ValueDriver<'_, 'b, 'l>,
+        value: u16,
+    ) -> Result<Self::Value, Self::Error>;
+
+    fn visit_u32(
+        &mut self,
+        driver: &ValueDriver<'_, 'b, 'l>,
+        value: u32,
+    ) -> Result<Self::Value, Self::Error>;
+
+    fn visit_u64(
+        &mut self,
+        driver: &ValueDriver<'_, 'b, 'l>,
+        value: u64,
+    ) -> Result<Self::Value, Self::Error>;
+
+    fn visit_u128(
+        &mut self,
+        driver: &ValueDriver<'_, 'b, 'l>,
+        value: u128,
+    ) -> Result<Self::Value, Self::Error>;
+
+    fn visit_u256(
+        &mut self,
+        driver: &ValueDriver<'_, 'b, 'l>,
+        value: U256,
+    ) -> Result<Self::Value, Self::Error>;
+
+    fn visit_bool(
+        &mut self,
+        driver: &ValueDriver<'_, 'b, 'l>,
+        value: bool,
+    ) -> Result<Self::Value, Self::Error>;
+
+    fn visit_address(
+        &mut self,
+        driver: &ValueDriver<'_, 'b, 'l>,
+        value: AccountAddress,
+    ) -> Result<Self::Value, Self::Error>;
+
+    fn visit_signer(
+        &mut self,
+        driver: &ValueDriver<'_, 'b, 'l>,
+        value: AccountAddress,
+    ) -> Result<Self::Value, Self::Error>;
+
+    fn visit_vector(
+        &mut self,
+        driver: &mut VecDriver<'_, 'b, 'l>,
+    ) -> Result<Self::Value, Self::Error>;
+
+    fn visit_struct(
+        &mut self,
+        driver: &mut StructDriver<'_, 'b, 'l>,
+    ) -> Result<Self::Value, Self::Error>;
+
+    fn visit_variant(
+        &mut self,
+        driver: &mut VariantDriver<'_, 'b, 'l>,
+    ) -> Result<Self::Value, Self::Error>;
+}
+
+/// A traversal is a special kind of visitor that doesn't return any values. The trait comes with
+/// default implementations for every variant that do nothing, allowing an implementor to focus on
+/// only the cases they care about.
+///
+/// Note that the default implementation for structs and vectors recurse down into their elements. A
+/// traversal that doesn't want to look inside structs and vectors needs to provide a custom
+/// implementation with an empty body:
+///
+/// ```rust,no_run
+/// fn traverse_vector(&mut self, _: &mut VecDriver) -> Result<(), Self::Error> {
+///     Ok(())
+/// }
+/// ```
+pub trait Traversal<'b, 'l> {
+    type Error: From<Error>;
+
+    fn traverse_u8(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        _value: u8,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn traverse_u16(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        _value: u16,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn traverse_u32(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        _value: u32,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn traverse_u64(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        _value: u64,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn traverse_u128(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        _value: u128,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn traverse_u256(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        _value: U256,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn traverse_bool(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        _value: bool,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn traverse_address(
+        &mut self,
+        _: &ValueDriver<'_, 'b, 'l>,
+        _: AccountAddress,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn traverse_signer(
+        &mut self,
+        _: &ValueDriver<'_, 'b, 'l>,
+        _: AccountAddress,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn traverse_vector(&mut self, driver: &mut VecDriver<'_, 'b, 'l>) -> Result<(), Self::Error> {
+        while driver.next_element(self)?.is_some() {}
+        Ok(())
+    }
+
+    fn traverse_struct(
+        &mut self,
+        driver: &mut StructDriver<'_, 'b, 'l>,
+    ) -> Result<(), Self::Error> {
+        while driver.next_field(self)?.is_some() {}
+        Ok(())
+    }
+
+    fn traverse_variant(
+        &mut self,
+        driver: &mut VariantDriver<'_, 'b, 'l>,
+    ) -> Result<(), Self::Error> {
+        while driver.next_field(self)?.is_some() {}
+        Ok(())
+    }
+}
+
+/// Default implementation converting any traversal into a visitor.
+impl<'b, 'l, T: Traversal<'b, 'l> + ?Sized> Visitor<'b, 'l> for T {
+    type Value = ();
+    type Error = T::Error;
+
+    fn visit_u8(
+        &mut self,
+        driver: &ValueDriver<'_, 'b, 'l>,
+        value: u8,
+    ) -> Result<Self::Value, Self::Error> {
+        self.traverse_u8(driver, value)
+    }
+
+    fn visit_u16(
+        &mut self,
+        driver: &ValueDriver<'_, 'b, 'l>,
+        value: u16,
+    ) -> Result<Self::Value, Self::Error> {
+        self.traverse_u16(driver, value)
+    }
+
+    fn visit_u32(
+        &mut self,
+        driver: &ValueDriver<'_, 'b, 'l>,
+        value: u32,
+    ) -> Result<Self::Value, Self::Error> {
+        self.traverse_u32(driver, value)
+    }
+
+    fn visit_u64(
+        &mut self,
+        driver: &ValueDriver<'_, 'b, 'l>,
+        value: u64,
+    ) -> Result<Self::Value, Self::Error> {
+        self.traverse_u64(driver, value)
+    }
+
+    fn visit_u128(
+        &mut self,
+        driver: &ValueDriver<'_, 'b, 'l>,
+        value: u128,
+    ) -> Result<Self::Value, Self::Error> {
+        self.traverse_u128(driver, value)
+    }
+
+    fn visit_u256(
+        &mut self,
+        driver: &ValueDriver<'_, 'b, 'l>,
+        value: U256,
+    ) -> Result<Self::Value, Self::Error> {
+        self.traverse_u256(driver, value)
+    }
+
+    fn visit_bool(
+        &mut self,
+        driver: &ValueDriver<'_, 'b, 'l>,
+        value: bool,
+    ) -> Result<Self::Value, Self::Error> {
+        self.traverse_bool(driver, value)
+    }
+
+    fn visit_address(
+        &mut self,
+        driver: &ValueDriver<'_, 'b, 'l>,
+        value: AccountAddress,
+    ) -> Result<Self::Value, Self::Error> {
+        self.traverse_address(driver, value)
+    }
+
+    fn visit_signer(
+        &mut self,
+        driver: &ValueDriver<'_, 'b, 'l>,
+        value: AccountAddress,
+    ) -> Result<Self::Value, Self::Error> {
+        self.traverse_signer(driver, value)
+    }
+
+    fn visit_vector(
+        &mut self,
+        driver: &mut VecDriver<'_, 'b, 'l>,
+    ) -> Result<Self::Value, Self::Error> {
+        self.traverse_vector(driver)
+    }
+
+    fn visit_struct(
+        &mut self,
+        driver: &mut StructDriver<'_, 'b, 'l>,
+    ) -> Result<Self::Value, Self::Error> {
+        self.traverse_struct(driver)
+    }
+
+    fn visit_variant(
+        &mut self,
+        driver: &mut VariantDriver<'_, 'b, 'l>,
+    ) -> Result<Self::Value, Self::Error> {
+        self.traverse_variant(driver)
+    }
+}
+
+/// Exposes information about the byte stream that the value being visited came from, namely the
+/// bytes themselves, and the offset at which the value starts. Also exposes the layout of the
+/// value being visited.
+pub struct ValueDriver<'c, 'b, 'l> {
+    bytes: &'c mut Cursor<&'b [u8]>,
+    layout: Option<&'l MoveTypeLayout>,
+    start: usize,
+}
+
+/// Exposes information about a vector being visited (the element layout) to a visitor
+/// implementation, and allows that visitor to progress the traversal (by visiting or skipping
+/// elements).
+pub struct VecDriver<'c, 'b, 'l> {
+    inner: ValueDriver<'c, 'b, 'l>,
+    layout: &'l MoveTypeLayout,
+    len: u64,
+    off: u64,
+}
+
+/// Exposes information about a struct being visited (its layout, details about the next field to be
+/// visited) to a visitor implementation, and allows that visitor to progress the traversal (by
+/// visiting or skipping fields).
+pub struct StructDriver<'c, 'b, 'l> {
+    inner: ValueDriver<'c, 'b, 'l>,
+    layout: &'l MoveStructLayout,
+    off: u64,
+}
+
+/// Exposes information about a variant being visited (its layout, details about the next field to
+/// be visited, and the variant's tag) to a visitor implementation, and allows that visitor
+/// to progress the traversal (by visiting or skipping fields).
+pub struct VariantDriver<'c, 'b, 'l> {
+    inner: ValueDriver<'c, 'b, 'l>,
+    layout: &'l MoveEnumLayout,
+    tag: u16,
+    variant_layout: &'l [MoveTypeLayout],
+    off: u64,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("unexpected end of input")]
+    UnexpectedEof,
+
+    #[error("unexpected byte: {0}")]
+    UnexpectedByte(u8),
+
+    #[error("trailing {0} byte(s) at the end of input")]
+    TrailingBytes(usize),
+
+    #[error("invalid variant tag: {0}")]
+    UnexpectedVariantTag(usize),
+
+    #[error("no layout available for value")]
+    NoValueLayout,
+}
+
+/// The null traversal implements `Traversal` and `Visitor` but without doing anything (does not
+/// return a value, and does not modify any state). This is useful for skipping over parts of the
+/// value structure.
+pub struct NullTraversal;
+
+impl Traversal<'_, '_> for NullTraversal {
+    type Error = Error;
+}
+
+impl<'c, 'b, 'l> ValueDriver<'c, 'b, 'l> {
+    pub(crate) fn new(bytes: &'c mut Cursor<&'b [u8]>, layout: Option<&'l MoveTypeLayout>) -> Self {
+        let start = bytes.position() as usize;
+        Self {
+            bytes,
+            layout,
+            start,
+        }
+    }
+
+    /// The offset at which the value being visited starts in the byte stream.
+    pub fn start(&self) -> usize {
+        self.start
+    }
+
+    /// The current position in the byte stream.
+    pub fn position(&self) -> usize {
+        self.bytes.position() as usize
+    }
+
+    /// All the bytes in the byte stream (including the ones that have been read).
+    pub fn bytes(&self) -> &'b [u8] {
+        self.bytes.get_ref()
+    }
+    ///
+    /// The bytes that haven't been consumed by the visitor yet.
+    pub fn remaining_bytes(&self) -> &'b [u8] {
+        &self.bytes.get_ref()[self.position()..]
+    }
+
+    /// Type layout for the value being visited. May produce an error if a layout was not supplied
+    /// when the driver was created (which should only happen if the driver was created for
+    /// visiting a struct specifically).
+    pub fn layout(&self) -> Result<&'l MoveTypeLayout, Error> {
+        self.layout.ok_or(Error::NoValueLayout)
+    }
+
+    fn read_exact<const N: usize>(&mut self) -> Result<[u8; N], Error> {
+        let mut buf = [0u8; N];
+        self.bytes
+            .read_exact(&mut buf)
+            .map_err(|_| Error::UnexpectedEof)?;
+        Ok(buf)
+    }
+
+    fn read_leb128(&mut self) -> Result<u64, Error> {
+        leb128::read::unsigned(self.bytes).map_err(|_| Error::UnexpectedEof)
+    }
+}
+
+#[allow(clippy::len_without_is_empty)]
+impl<'c, 'b, 'l> VecDriver<'c, 'b, 'l> {
+    fn new(inner: ValueDriver<'c, 'b, 'l>, layout: &'l MoveTypeLayout, len: u64) -> Self {
+        Self {
+            inner,
+            layout,
+            len,
+            off: 0,
+        }
+    }
+
+    /// The offset at which the value being visited starts in the byte stream.
+    pub fn start(&self) -> usize {
+        self.inner.start()
+    }
+
+    /// The current position in the byte stream.
+    pub fn position(&self) -> usize {
+        self.inner.position()
+    }
+
+    /// All the bytes in the byte stream (including the ones that have been read).
+    pub fn bytes(&self) -> &'b [u8] {
+        self.inner.bytes()
+    }
+
+    /// The bytes that haven't been consumed by the visitor yet.
+    pub fn remaining_bytes(&self) -> &'b [u8] {
+        self.inner.remaining_bytes()
+    }
+
+    /// Type layout for the vector's inner type.
+    pub fn element_layout(&self) -> &'l MoveTypeLayout {
+        self.layout
+    }
+
+    /// The number of elements in this vector that have been visited so far.
+    pub fn off(&self) -> u64 {
+        self.off
+    }
+
+    /// The number of elements in this vector.
+    pub fn len(&self) -> u64 {
+        self.len
+    }
+
+    /// Returns whether or not there are more elements to visit in this vector.
+    pub fn has_element(&self) -> bool {
+        self.off < self.len
+    }
+
+    /// Visit the next element in the vector. The driver accepts a visitor to use for this element,
+    /// allowing the visitor to be changed on recursive calls or even between elements in the same
+    /// vector.
+    ///
+    /// Returns `Ok(None)` if there are no more elements in the vector, `Ok(v)` if there was an
+    /// element and it was successfully visited (where `v` is the value returned by the visitor) or
+    /// an error if there was an underlying deserialization error, or an error during visitation.
+    pub fn next_element<V: Visitor<'b, 'l> + ?Sized>(
+        &mut self,
+        visitor: &mut V,
+    ) -> Result<Option<V::Value>, V::Error> {
+        Ok(if self.off >= self.len {
+            None
+        } else {
+            let res = visit_value(self.inner.bytes, self.layout, visitor)?;
+            self.off += 1;
+            Some(res)
+        })
+    }
+
+    /// Skip the next element in this vector. Returns whether there was an element to skip or not on
+    /// success, or an error if there was an underlying deserialization error.
+    pub fn skip_element(&mut self) -> Result<bool, Error> {
+        self.next_element(&mut NullTraversal).map(|v| v.is_some())
+    }
+}
+
+impl<'c, 'b, 'l> StructDriver<'c, 'b, 'l> {
+    fn new(inner: ValueDriver<'c, 'b, 'l>, layout: &'l MoveStructLayout) -> Self {
+        Self {
+            inner,
+            layout,
+            off: 0,
+        }
+    }
+
+    /// The offset at which the value being visited starts in the byte stream.
+    pub fn start(&self) -> usize {
+        self.inner.start()
+    }
+
+    /// The current position in the byte stream.
+    pub fn position(&self) -> usize {
+        self.inner.position()
+    }
+
+    /// All the bytes in the byte stream (including the ones that have been read).
+    pub fn bytes(&self) -> &'b [u8] {
+        self.inner.bytes()
+    }
+
+    /// The bytes that haven't been consumed by the visitor yet.
+    pub fn remaining_bytes(&self) -> &'b [u8] {
+        self.inner.remaining_bytes()
+    }
+
+    /// The layout of the struct being visited.
+    pub fn struct_layout(&self) -> &'l MoveStructLayout {
+        self.layout
+    }
+
+    /// The number of fields in this struct that have been visited so far.
+    pub fn off(&self) -> u64 {
+        self.off
+    }
+
+    /// The layout of the next field to be visited (if there is one), or `None` otherwise.
+    pub fn peek_field(&self) -> Option<&'l MoveTypeLayout> {
+        self.layout.fields().get(self.off as usize)
+    }
+
+    /// Visit the next field in the struct. The driver accepts a visitor to use for this field,
+    /// allowing the visitor to be changed on recursive calls or even between fields in the same
+    /// struct.
+    ///
+    /// Returns `Ok(None)` if there are no more fields in the struct, `Ok((f, v))` if there was an
+    /// field and it was successfully visited (where `v` is the value returned by the visitor, and
+    /// `f` is the layout of the field that was visited) or an error if there was an underlying
+    /// deserialization error, or an error during visitation.
+    pub fn next_field<V: Visitor<'b, 'l> + ?Sized>(
+        &mut self,
+        visitor: &mut V,
+    ) -> Result<Option<(&'l MoveTypeLayout, V::Value)>, V::Error> {
+        let Some(field_layout) = self.peek_field() else {
+            return Ok(None);
+        };
+
+        let res = visit_value(self.inner.bytes, field_layout, visitor)?;
+        self.off += 1;
+        Ok(Some((field_layout, res)))
+    }
+
+    /// Skip the next field. Returns the layout of the field that was visited if there was one, or
+    /// `None` if there was none. Can return an error if there was a deserialization error.
+    pub fn skip_field(&mut self) -> Result<Option<&'l MoveTypeLayout>, Error> {
+        self.next_field(&mut NullTraversal)
+            .map(|res| res.map(|(f, _)| f))
+    }
+}
+
+impl<'c, 'b, 'l> VariantDriver<'c, 'b, 'l> {
+    fn new(
+        inner: ValueDriver<'c, 'b, 'l>,
+        layout: &'l MoveEnumLayout,
+        variant_layout: &'l [MoveTypeLayout],
+        tag: u16,
+    ) -> Self {
+        Self {
+            inner,
+            layout,
+            tag,
+            variant_layout,
+            off: 0,
+        }
+    }
+
+    /// The offset at which the value being visited starts in the byte stream.
+    pub fn start(&self) -> usize {
+        self.inner.start()
+    }
+
+    /// The current position in the byte stream.
+    pub fn position(&self) -> usize {
+        self.inner.position()
+    }
+
+    /// All the bytes in the byte stream (including the ones that have been read).
+    pub fn bytes(&self) -> &'b [u8] {
+        self.inner.bytes()
+    }
+
+    /// The bytes that haven't been consumed by the visitor yet.
+    pub fn remaining_bytes(&self) -> &'b [u8] {
+        self.inner.remaining_bytes()
+    }
+
+    /// The layout of the enum being visited.
+    pub fn enum_layout(&self) -> &'l MoveEnumLayout {
+        self.layout
+    }
+
+    /// The layout of the variant being visited.
+    pub fn variant_layout(&self) -> &'l [MoveTypeLayout] {
+        self.variant_layout
+    }
+
+    /// The tag of the variant being visited.
+    pub fn tag(&self) -> u16 {
+        self.tag
+    }
+
+    /// The number of elements in this vector that have been visited so far.
+    pub fn off(&self) -> u64 {
+        self.off
+    }
+
+    /// The layout of the next field to be visited (if there is one), or `None` otherwise.
+    pub fn peek_field(&self) -> Option<&'l MoveTypeLayout> {
+        self.variant_layout.get(self.off as usize)
+    }
+
+    /// Visit the next field in the variant. The driver accepts a visitor to use for this field,
+    /// allowing the visitor to be changed on recursive calls or even between fields in the same
+    /// variant.
+    ///
+    /// Returns `Ok(None)` if there are no more fields in the variant, `Ok((f, v))` if there was an
+    /// field and it was successfully visited (where `v` is the value returned by the visitor, and
+    /// `f` is the layout of the field that was visited) or an error if there was an underlying
+    /// deserialization error, or an error during visitation.
+    pub fn next_field<V: Visitor<'b, 'l> + ?Sized>(
+        &mut self,
+        visitor: &mut V,
+    ) -> Result<Option<(&'l MoveTypeLayout, V::Value)>, V::Error> {
+        let Some(field_layout) = self.peek_field() else {
+            return Ok(None);
+        };
+
+        let res = visit_value(self.inner.bytes, field_layout, visitor)?;
+        self.off += 1;
+        Ok(Some((field_layout, res)))
+    }
+
+    /// Skip the next field. Returns the layout of the field that was visited if there was one, or
+    /// `None` if there was none. Can return an error if there was a deserialization error.
+    pub fn skip_field(&mut self) -> Result<Option<&'l MoveTypeLayout>, Error> {
+        self.next_field(&mut NullTraversal)
+            .map(|res| res.map(|(f, _)| f))
+    }
+}
+
+/// Visit a serialized Move value with the provided `layout`, held in `bytes`, using the provided
+/// visitor to build a value out of it. See `runtime_value::MoveValue::visit_deserialize` for
+/// details.
+pub(crate) fn visit_value<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
+    bytes: &'c mut Cursor<&'b [u8]>,
+    layout: &'l MoveTypeLayout,
+    visitor: &mut V,
+) -> Result<V::Value, V::Error> {
+    use MoveTypeLayout as L;
+
+    let mut driver = ValueDriver::new(bytes, Some(layout));
+    match layout {
+        L::Bool => match driver.read_exact()? {
+            [0] => visitor.visit_bool(&driver, false),
+            [1] => visitor.visit_bool(&driver, true),
+            [b] => Err(Error::UnexpectedByte(b).into()),
+        },
+
+        L::U8 => {
+            let v = u8::from_le_bytes(driver.read_exact()?);
+            visitor.visit_u8(&driver, v)
+        }
+
+        L::U16 => {
+            let v = u16::from_le_bytes(driver.read_exact()?);
+            visitor.visit_u16(&driver, v)
+        }
+
+        L::U32 => {
+            let v = u32::from_le_bytes(driver.read_exact()?);
+            visitor.visit_u32(&driver, v)
+        }
+
+        L::U64 => {
+            let v = u64::from_le_bytes(driver.read_exact()?);
+            visitor.visit_u64(&driver, v)
+        }
+
+        L::U128 => {
+            let v = u128::from_le_bytes(driver.read_exact()?);
+            visitor.visit_u128(&driver, v)
+        }
+
+        L::U256 => {
+            let v = U256::from_le_bytes(&driver.read_exact()?);
+            visitor.visit_u256(&driver, v)
+        }
+
+        L::Address => {
+            let v = AccountAddress::new(driver.read_exact()?);
+            visitor.visit_address(&driver, v)
+        }
+
+        L::Signer => {
+            let v = AccountAddress::new(driver.read_exact()?);
+            visitor.visit_signer(&driver, v)
+        }
+
+        L::Vector(l) => visit_vector(driver, l.as_ref(), visitor),
+        L::Struct(l) => visit_struct(driver, l, visitor),
+        L::Enum(e) => visit_variant(driver, e, visitor),
+    }
+}
+
+/// Like `visit_value` but specialized to visiting a vector (where the `bytes` is known to be a
+/// serialized move vector), and the layout is the vector's element's layout.
+fn visit_vector<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
+    mut inner: ValueDriver<'c, 'b, 'l>,
+    layout: &'l MoveTypeLayout,
+    visitor: &mut V,
+) -> Result<V::Value, V::Error> {
+    let len = inner.read_leb128()?;
+    let mut driver = VecDriver::new(inner, layout, len);
+    let res = visitor.visit_vector(&mut driver)?;
+    while driver.skip_element()? {}
+    Ok(res)
+}
+
+/// Like `visit_value` but specialized to visiting a struct (where the `bytes` is known to be a
+/// serialized move struct), and the layout is a struct layout.
+pub(crate) fn visit_struct<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
+    inner: ValueDriver<'c, 'b, 'l>,
+    layout: &'l MoveStructLayout,
+    visitor: &mut V,
+) -> Result<V::Value, V::Error> {
+    let mut driver = StructDriver::new(inner, layout);
+    let res = visitor.visit_struct(&mut driver)?;
+    while driver.skip_field()?.is_some() {}
+    Ok(res)
+}
+
+/// Like `visit_struct` but specialized to visiting a variant (where the `bytes` is known to be a
+/// serialized move variant), and the layout is an enum layout.
+fn visit_variant<'c, 'b, 'l, V: Visitor<'b, 'l> + ?Sized>(
+    mut inner: ValueDriver<'c, 'b, 'l>,
+    layout: &'l MoveEnumLayout,
+    visitor: &mut V,
+) -> Result<V::Value, V::Error> {
+    // Since variants are bounded at 127, we can read the tag as a single byte.
+    // When we add true ULEB encoding for enum variants switch to this:
+    // let tag = inner.read_leb128()?;
+    let [tag] = inner.read_exact()?;
+    if tag > VARIANT_TAG_MAX_VALUE as u8 {
+        return Err(Error::UnexpectedVariantTag(tag as usize).into());
+    }
+    let variant_layout = layout
+        .0
+        .get(tag as usize)
+        .ok_or(Error::UnexpectedVariantTag(tag as usize))?;
+
+    let mut driver = VariantDriver::new(inner, layout, variant_layout, tag as u16);
+    let res = visitor.visit_variant(&mut driver)?;
+    while driver.skip_field()?.is_some() {}
+    Ok(res)
+}

--- a/external-crates/move/crates/move-core-types/src/unit_tests/annotated_visitor_test.rs
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/annotated_visitor_test.rs
@@ -1,8 +1,6 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{fmt::Write, str::FromStr};
-
 use crate::{
     VARIANT_TAG_MAX_VALUE,
     account_address::AccountAddress,
@@ -18,6 +16,7 @@ use crate::{
     language_storage::StructTag,
     u256::U256,
 };
+use std::{fmt::Write, str::FromStr};
 
 #[derive(Default)]
 pub(crate) struct CountingTraversal(usize);
@@ -544,41 +543,13 @@ fn nested_datatype_visit() {
     let from_struct =
         MoveStruct::visit_deserialize(&bytes, struct_layout, &mut struct_visitor).unwrap();
 
-    let expected_output = r#"
-[0] struct 0x0::foo::Bar {
-    inner: struct 0x0::baz::Qux {
-        f: u64,
-        g: vector<u32>,
-    },
-    last: enum 0x0::foo::Baz {
-        e {
-            h: u64,
-        },
-    },
-}
-[1] struct 0x0::baz::Qux {
-    f: u64,
-    g: vector<u32>,
-}
-[2] 7: u64
-[2] vector<u32>
-[3] 1: u32
-[3] 2: u32
-[3] 3: u32
-[1] enum 0x0::foo::Baz {
-    e {
-        h: u64,
-    },
-}
-[2] 4: u64"#;
-
     // This is a little strange -- even though we are deserializing a struct, we still get a value.
     // This is because the return type comes from the visitor, not the deserializer.
     assert_eq!(value, from_value);
     assert_eq!(value, from_struct);
 
-    assert_eq!(value_visitor.output, expected_output);
-    assert_eq!(struct_visitor.output, expected_output);
+    assert_eq!(value_visitor.output, struct_visitor.output);
+    insta::assert_snapshot!(value_visitor.output);
 }
 
 #[test]
@@ -1022,36 +993,8 @@ fn byte_offset_test() {
     let mut struct_visitor = ByteOffsetVisitor::default();
     MoveStruct::visit_deserialize(&bytes, struct_layout, &mut struct_visitor).unwrap();
 
-    let expected_output = r#"
-[  0 ..   0] struct 0x0::foo::Bar {
-    inner: struct 0x0::baz::Qux {
-        f: u64,
-        g: vector<u32>,
-    },
-    last: enum 0x0::foo::Baz {
-        e {
-            h: u64,
-        },
-    },
-}
-[  0 ..   0] struct 0x0::baz::Qux {
-    f: u64,
-    g: vector<u32>,
-}
-[  0 ..   8] 7: u64
-[  8 ..   9] vector<u32>
-[  9 ..  13] 1: u32
-[ 13 ..  17] 2: u32
-[ 17 ..  21] 3: u32
-[ 21 ..  22] enum 0x0::foo::Baz {
-    e {
-        h: u64,
-    },
-}
-[ 22 ..  30] 4: u64"#;
-
-    assert_eq!(value_visitor.0, expected_output);
-    assert_eq!(struct_visitor.0, expected_output);
+    assert_eq!(value_visitor.0, struct_visitor.0);
+    insta::assert_snapshot!(value_visitor.0);
 }
 
 /// Create a struct value for test purposes.

--- a/external-crates/move/crates/move-core-types/src/unit_tests/extractor_test.rs
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/extractor_test.rs
@@ -8,7 +8,7 @@ use crate::{
     annotated_extractor::{Element as E, Extractor},
     annotated_value::{MoveTypeLayout, MoveValue},
     language_storage::TypeTag,
-    unit_tests::visitor_test::{
+    unit_tests::annotated_visitor_test::{
         PrintVisitor, enum_layout_, serialize, struct_layout_, struct_value_, variant_value_,
     },
 };

--- a/external-crates/move/crates/move-core-types/src/unit_tests/mod.rs
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/mod.rs
@@ -2,9 +2,10 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+mod annotated_visitor_test;
 mod extractor_test;
 mod identifier_test;
 mod language_storage_test;
 mod parsing_test;
+mod runtime_visitor_test;
 mod value_test;
-mod visitor_test;

--- a/external-crates/move/crates/move-core-types/src/unit_tests/runtime_visitor_test.rs
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/runtime_visitor_test.rs
@@ -1,0 +1,959 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt::Write;
+
+use crate::{
+    VARIANT_COUNT_MAX, VARIANT_TAG_MAX_VALUE,
+    account_address::AccountAddress,
+    runtime_value::{
+        MoveEnumLayout, MoveStruct, MoveStructLayout, MoveTypeLayout, MoveValue, MoveVariant,
+    },
+    runtime_visitor::{
+        self, NullTraversal, StructDriver, Traversal, ValueDriver, VariantDriver, VecDriver,
+        Visitor,
+    },
+    u256::U256,
+};
+
+#[derive(Default)]
+pub(crate) struct CountingTraversal(usize);
+
+#[derive(Default)]
+pub(crate) struct PrintVisitor {
+    depth: usize,
+    pub output: String,
+}
+
+impl<'b, 'l> Traversal<'b, 'l> for CountingTraversal {
+    type Error = runtime_visitor::Error;
+
+    fn traverse_u8(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        _value: u8,
+    ) -> Result<(), Self::Error> {
+        self.0 += 1;
+        Ok(())
+    }
+
+    fn traverse_u16(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        _value: u16,
+    ) -> Result<(), Self::Error> {
+        self.0 += 1;
+        Ok(())
+    }
+
+    fn traverse_u32(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        _value: u32,
+    ) -> Result<(), Self::Error> {
+        self.0 += 1;
+        Ok(())
+    }
+
+    fn traverse_u64(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        _value: u64,
+    ) -> Result<(), Self::Error> {
+        self.0 += 1;
+        Ok(())
+    }
+
+    fn traverse_u128(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        _value: u128,
+    ) -> Result<(), Self::Error> {
+        self.0 += 1;
+        Ok(())
+    }
+
+    fn traverse_u256(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        _value: U256,
+    ) -> Result<(), Self::Error> {
+        self.0 += 1;
+        Ok(())
+    }
+
+    fn traverse_bool(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        _value: bool,
+    ) -> Result<(), Self::Error> {
+        self.0 += 1;
+        Ok(())
+    }
+
+    fn traverse_address(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        _value: AccountAddress,
+    ) -> Result<(), Self::Error> {
+        self.0 += 1;
+        Ok(())
+    }
+
+    fn traverse_signer(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        _value: AccountAddress,
+    ) -> Result<(), Self::Error> {
+        self.0 += 1;
+        Ok(())
+    }
+
+    fn traverse_vector(&mut self, driver: &mut VecDriver<'_, 'b, 'l>) -> Result<(), Self::Error> {
+        self.0 += 1;
+        while driver.next_element(self)?.is_some() {}
+        Ok(())
+    }
+
+    fn traverse_struct(
+        &mut self,
+        driver: &mut StructDriver<'_, 'b, 'l>,
+    ) -> Result<(), Self::Error> {
+        self.0 += 1;
+        while driver.next_field(self)?.is_some() {}
+        Ok(())
+    }
+
+    fn traverse_variant(
+        &mut self,
+        driver: &mut VariantDriver<'_, 'b, 'l>,
+    ) -> Result<(), Self::Error> {
+        self.0 += 1;
+        while driver.next_field(self)?.is_some() {}
+        Ok(())
+    }
+}
+
+impl<'b, 'l> Visitor<'b, 'l> for PrintVisitor {
+    type Value = MoveValue;
+    type Error = runtime_visitor::Error;
+
+    fn visit_u8(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        value: u8,
+    ) -> Result<Self::Value, Self::Error> {
+        write!(self.output, "\n[{}] {value}: u8", self.depth).unwrap();
+        Ok(MoveValue::U8(value))
+    }
+
+    fn visit_u16(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        value: u16,
+    ) -> Result<Self::Value, Self::Error> {
+        write!(self.output, "\n[{}] {value}: u16", self.depth).unwrap();
+        Ok(MoveValue::U16(value))
+    }
+
+    fn visit_u32(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        value: u32,
+    ) -> Result<Self::Value, Self::Error> {
+        write!(self.output, "\n[{}] {value}: u32", self.depth).unwrap();
+        Ok(MoveValue::U32(value))
+    }
+
+    fn visit_u64(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        value: u64,
+    ) -> Result<Self::Value, Self::Error> {
+        write!(self.output, "\n[{}] {value}: u64", self.depth).unwrap();
+        Ok(MoveValue::U64(value))
+    }
+
+    fn visit_u128(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        value: u128,
+    ) -> Result<Self::Value, Self::Error> {
+        write!(self.output, "\n[{}] {value}: u128", self.depth).unwrap();
+        Ok(MoveValue::U128(value))
+    }
+
+    fn visit_u256(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        value: U256,
+    ) -> Result<Self::Value, Self::Error> {
+        write!(self.output, "\n[{}] {value}: u256", self.depth).unwrap();
+        Ok(MoveValue::U256(value))
+    }
+
+    fn visit_bool(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        value: bool,
+    ) -> Result<Self::Value, Self::Error> {
+        write!(self.output, "\n[{}] {value}: bool", self.depth).unwrap();
+        Ok(MoveValue::Bool(value))
+    }
+
+    fn visit_address(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        value: AccountAddress,
+    ) -> Result<Self::Value, Self::Error> {
+        write!(self.output, "\n[{}] {value}: address", self.depth).unwrap();
+        Ok(MoveValue::Address(value))
+    }
+
+    fn visit_signer(
+        &mut self,
+        _driver: &ValueDriver<'_, 'b, 'l>,
+        value: AccountAddress,
+    ) -> Result<Self::Value, Self::Error> {
+        write!(self.output, "\n[{}] {value}: signer", self.depth).unwrap();
+        Ok(MoveValue::Signer(value))
+    }
+
+    fn visit_vector(
+        &mut self,
+        driver: &mut VecDriver<'_, 'b, 'l>,
+    ) -> Result<Self::Value, Self::Error> {
+        let layout = driver.element_layout();
+        write!(self.output, "\n[{}] vector<{layout:#}>", self.depth).unwrap();
+
+        let mut elems = vec![];
+        let mut elem_visitor = Self {
+            depth: self.depth + 1,
+            output: std::mem::take(&mut self.output),
+        };
+
+        while let Some(elem) = driver.next_element(&mut elem_visitor)? {
+            elems.push(elem)
+        }
+
+        self.output = elem_visitor.output;
+        Ok(MoveValue::Vector(elems))
+    }
+
+    fn visit_struct(
+        &mut self,
+        driver: &mut StructDriver<'_, 'b, 'l>,
+    ) -> Result<Self::Value, Self::Error> {
+        let layout = driver.struct_layout();
+        write!(self.output, "\n[{}] {layout:#}", self.depth).unwrap();
+
+        let mut fields = vec![];
+        let mut field_visitor = Self {
+            depth: self.depth + 1,
+            output: std::mem::take(&mut self.output),
+        };
+
+        while let Some((_, value)) = driver.next_field(&mut field_visitor)? {
+            fields.push(value);
+        }
+
+        self.output = field_visitor.output;
+        Ok(MoveValue::Struct(MoveStruct(fields)))
+    }
+
+    fn visit_variant(
+        &mut self,
+        driver: &mut VariantDriver<'_, 'b, 'l>,
+    ) -> Result<Self::Value, Self::Error> {
+        let layout = driver.enum_layout();
+        write!(self.output, "\n[{}] {layout:#}", self.depth).unwrap();
+
+        let mut fields = vec![];
+        let mut field_visitor = Self {
+            depth: self.depth + 1,
+            output: std::mem::take(&mut self.output),
+        };
+
+        while let Some((_, value)) = driver.next_field(&mut field_visitor)? {
+            fields.push(value);
+        }
+
+        self.output = field_visitor.output;
+        Ok(MoveValue::Variant(MoveVariant {
+            tag: driver.tag(),
+            fields,
+        }))
+    }
+}
+
+#[test]
+fn traversal() {
+    use MoveTypeLayout as T;
+    use MoveValue as V;
+
+    let type_layout = struct_layout_(vec![
+        T::U8,
+        T::U16,
+        T::U32,
+        T::U64,
+        T::U128,
+        T::U256,
+        T::Bool,
+        T::Address,
+        T::Signer,
+        T::Vector(Box::new(T::U8)),
+        struct_layout_(vec![T::U8]),
+        enum_layout_(vec![vec![T::U8]]),
+    ]);
+
+    let T::Struct(struct_layout) = &type_layout else {
+        panic!("Not a struct layout");
+    };
+
+    let value = struct_value_(vec![
+        V::U8(1),
+        V::U16(2),
+        V::U32(3),
+        V::U64(4),
+        V::U128(5),
+        V::U256(6u32.into()),
+        V::Bool(true),
+        V::Address(AccountAddress::ZERO),
+        V::Signer(AccountAddress::ZERO),
+        V::Vector(vec![V::U8(7), V::U8(8), V::U8(9)]),
+        struct_value_(vec![V::U8(10)]),
+        variant_value_(0, vec![V::U8(11)]),
+    ]);
+
+    let bytes = serialize(value);
+
+    let mut value_traversal = CountingTraversal::default();
+    MoveValue::visit_deserialize(&bytes, &type_layout, &mut value_traversal).unwrap();
+
+    let mut struct_traversal = CountingTraversal::default();
+    MoveStruct::visit_deserialize(&bytes, struct_layout, &mut struct_traversal).unwrap();
+
+    assert_eq!(18, value_traversal.0);
+    assert_eq!(18, struct_traversal.0);
+}
+
+#[test]
+fn max_variant() {
+    let variants = (0..VARIANT_COUNT_MAX)
+        .map(|_| vec![MoveTypeLayout::U8])
+        .collect();
+    let layout = enum_layout_(variants);
+
+    let value = variant_value_(VARIANT_TAG_MAX_VALUE as u16, vec![MoveValue::U8(42)]);
+    let bytes = serialize(value);
+    let mut val_traversal = CountingTraversal::default();
+    MoveValue::simple_deserialize(&bytes, &layout).unwrap();
+    MoveValue::visit_deserialize(&bytes, &layout, &mut val_traversal).unwrap();
+}
+
+#[test]
+fn unexpected_eof() {
+    use MoveTypeLayout as T;
+    use MoveValue as V;
+
+    let type_layout = struct_layout_(vec![T::U64]);
+    let value = struct_value_(vec![V::U64(42)]);
+
+    let T::Struct(struct_layout) = &type_layout else {
+        panic!("Not a struct layout");
+    };
+
+    let mut bytes = serialize(value);
+
+    // Oops, dropped a byte
+    bytes.pop();
+
+    assert_eq!(
+        "unexpected end of input",
+        MoveValue::visit_deserialize(&bytes, &type_layout, &mut NullTraversal)
+            .unwrap_err()
+            .to_string(),
+    );
+
+    assert_eq!(
+        "unexpected end of input",
+        MoveStruct::visit_deserialize(&bytes, struct_layout, &mut NullTraversal)
+            .unwrap_err()
+            .to_string(),
+    );
+}
+
+#[test]
+fn no_enum_tag() {
+    use MoveTypeLayout as T;
+    use MoveValue as V;
+    let layout = enum_layout_(vec![vec![T::U8]]);
+    let value = variant_value_(0, vec![V::U8(42)]);
+    let mut bytes = serialize(value);
+
+    // drop tag
+    bytes.remove(0);
+
+    assert_eq!(
+        "invalid variant tag: 42",
+        MoveValue::visit_deserialize(&bytes, &layout, &mut NullTraversal)
+            .unwrap_err()
+            .to_string(),
+    );
+}
+
+#[test]
+fn out_of_range_enum_tag() {
+    use MoveTypeLayout as T;
+    use MoveValue as V;
+    let layout = enum_layout_(vec![vec![T::U8]]);
+    let value = variant_value_(0, vec![V::U8(42)]);
+    let mut bytes = serialize(value);
+
+    // Invalid tag value
+    bytes[0] = VARIANT_TAG_MAX_VALUE as u8 + 1;
+
+    assert_eq!(
+        "invalid variant tag: 127",
+        MoveValue::visit_deserialize(&bytes, &layout, &mut NullTraversal)
+            .unwrap_err()
+            .to_string(),
+    );
+}
+
+#[test]
+fn invalid_variant_tag() {
+    use MoveTypeLayout as T;
+    use MoveValue as V;
+    let layout = enum_layout_(vec![vec![T::U8]]);
+    let value = variant_value_(0, vec![V::U8(42)]);
+    let mut bytes = serialize(value);
+
+    // tag for variant that doesn't exist
+    bytes[0] = 1;
+
+    assert_eq!(
+        "invalid variant tag: 1",
+        MoveValue::visit_deserialize(&bytes, &layout, &mut NullTraversal)
+            .unwrap_err()
+            .to_string(),
+    );
+}
+
+#[test]
+fn bad_bool_byte() {
+    use MoveTypeLayout as T;
+    assert_eq!(
+        "unexpected byte: 42",
+        MoveValue::visit_deserialize(&[42], &T::Bool, &mut NullTraversal)
+            .unwrap_err()
+            .to_string(),
+    );
+}
+
+#[test]
+fn bad_vector_length() {
+    use MoveTypeLayout as T;
+    use MoveValue as V;
+
+    let layout = T::Vector(Box::new(T::U8));
+    let value = V::Vector(vec![V::U8(1), V::U8(2), V::U8(3)]);
+
+    let mut bytes = serialize(value);
+
+    // Oops, dropped a byte
+    bytes.pop();
+
+    assert_eq!(
+        "unexpected end of input",
+        MoveValue::visit_deserialize(&bytes, &layout, &mut NullTraversal)
+            .unwrap_err()
+            .to_string(),
+    );
+}
+
+#[test]
+fn trailing_bytes() {
+    use MoveTypeLayout as T;
+    assert_eq!(
+        "trailing 1 byte(s) at the end of input",
+        MoveValue::visit_deserialize(&[42, 42], &T::U8, &mut NullTraversal)
+            .unwrap_err()
+            .to_string(),
+    );
+}
+
+#[test]
+fn nested_datatype_visit() {
+    use MoveTypeLayout as T;
+    use MoveValue as V;
+
+    let type_layout = struct_layout_(vec![
+        struct_layout_(vec![T::U64, T::Vector(Box::new(T::U32))]),
+        enum_layout_(vec![vec![T::U64]]),
+    ]);
+
+    let T::Struct(struct_layout) = &type_layout else {
+        panic!("Not a struct layout");
+    };
+
+    let value = struct_value_(vec![
+        struct_value_(vec![
+            V::U64(7),
+            V::Vector(vec![V::U32(1), V::U32(2), V::U32(3)]),
+        ]),
+        variant_value_(0, vec![V::U64(4)]),
+    ]);
+
+    let bytes = serialize(value.clone());
+
+    let mut value_visitor = PrintVisitor::default();
+    let from_value =
+        MoveValue::visit_deserialize(&bytes, &type_layout, &mut value_visitor).unwrap();
+
+    let mut struct_visitor = PrintVisitor::default();
+    let from_struct =
+        MoveStruct::visit_deserialize(&bytes, struct_layout, &mut struct_visitor).unwrap();
+
+    // This is a little strange -- even though we are deserializing a struct, we still get a value.
+    // This is because the return type comes from the visitor, not the deserializer.
+    assert_eq!(value, from_value);
+    assert_eq!(value, from_struct);
+
+    assert_eq!(value_visitor.output, struct_visitor.output);
+    insta::assert_snapshot!(value_visitor.output);
+}
+
+#[test]
+fn peek_field_test() {
+    use MoveTypeLayout as T;
+    use MoveValue as V;
+
+    struct PeekU64Visitor<'f> {
+        fields: &'f [u64],
+    }
+
+    impl<'b, 'l> Visitor<'b, 'l> for PeekU64Visitor<'_> {
+        type Value = Option<u64>;
+        type Error = runtime_visitor::Error;
+
+        fn visit_u64(
+            &mut self,
+            _driver: &ValueDriver<'_, 'b, 'l>,
+            value: u64,
+        ) -> Result<Self::Value, Self::Error> {
+            Ok(self.fields.is_empty().then_some(value))
+        }
+
+        fn visit_struct(
+            &mut self,
+            driver: &mut StructDriver<'_, 'b, 'l>,
+        ) -> Result<Self::Value, Self::Error> {
+            let [field, fields @ ..] = self.fields else {
+                return Ok(None);
+            };
+
+            while driver.peek_field().is_some() {
+                if driver.off() == *field {
+                    return driver
+                        .next_field(&mut Self { fields })
+                        .map(|value| value.and_then(|(_, v)| v));
+                } else {
+                    driver.skip_field()?;
+                }
+            }
+
+            Ok(None)
+        }
+
+        fn visit_variant(
+            &mut self,
+            driver: &mut VariantDriver<'_, 'b, 'l>,
+        ) -> Result<Self::Value, Self::Error> {
+            let [field, fields @ ..] = self.fields else {
+                return Ok(None);
+            };
+
+            while driver.peek_field().is_some() {
+                if driver.off() == *field {
+                    return driver
+                        .next_field(&mut Self { fields })
+                        .map(|value| value.and_then(|(_, v)| v));
+                } else {
+                    driver.skip_field()?;
+                }
+            }
+
+            Ok(None)
+        }
+
+        // === Empty/default cases ===
+
+        fn visit_u8(
+            &mut self,
+            _: &ValueDriver<'_, 'b, 'l>,
+            _: u8,
+        ) -> Result<Self::Value, Self::Error> {
+            Ok(None)
+        }
+
+        fn visit_u16(
+            &mut self,
+            _: &ValueDriver<'_, 'b, 'l>,
+            _: u16,
+        ) -> Result<Self::Value, Self::Error> {
+            Ok(None)
+        }
+
+        fn visit_u32(
+            &mut self,
+            _: &ValueDriver<'_, 'b, 'l>,
+            _: u32,
+        ) -> Result<Self::Value, Self::Error> {
+            Ok(None)
+        }
+
+        fn visit_u128(
+            &mut self,
+            _: &ValueDriver<'_, 'b, 'l>,
+            _: u128,
+        ) -> Result<Self::Value, Self::Error> {
+            Ok(None)
+        }
+
+        fn visit_u256(
+            &mut self,
+            _: &ValueDriver<'_, 'b, 'l>,
+            _: U256,
+        ) -> Result<Self::Value, Self::Error> {
+            Ok(None)
+        }
+
+        fn visit_bool(
+            &mut self,
+            _: &ValueDriver<'_, 'b, 'l>,
+            _: bool,
+        ) -> Result<Self::Value, Self::Error> {
+            Ok(None)
+        }
+
+        fn visit_address(
+            &mut self,
+            _: &ValueDriver<'_, 'b, 'l>,
+            _: AccountAddress,
+        ) -> Result<Self::Value, Self::Error> {
+            Ok(None)
+        }
+
+        fn visit_signer(
+            &mut self,
+            _: &ValueDriver<'_, 'b, 'l>,
+            _: AccountAddress,
+        ) -> Result<Self::Value, Self::Error> {
+            Ok(None)
+        }
+
+        /// Field specifier doesn't support vectors, so we know we won't find the field we want
+        /// under here.
+        fn visit_vector(
+            &mut self,
+            _: &mut VecDriver<'_, 'b, 'l>,
+        ) -> Result<Self::Value, Self::Error> {
+            Ok(None)
+        }
+    }
+
+    let type_layout = struct_layout_(vec![
+        T::U64,
+        T::U32,
+        T::Vector(Box::new(T::U64)),
+        struct_layout_(vec![T::U64]),
+        enum_layout_(vec![vec![T::U64]]),
+    ]);
+
+    let T::Struct(struct_layout) = &type_layout else {
+        panic!("Not a struct layout");
+    };
+
+    let value = struct_value_(vec![
+        V::U64(42),
+        V::U32(43),
+        V::Vector(vec![V::U64(44)]),
+        struct_value_(vec![V::U64(45)]),
+        variant_value_(0, vec![V::U64(46)]),
+    ]);
+
+    let bytes = serialize(value);
+
+    let visit_value = |fields| {
+        MoveValue::visit_deserialize(&bytes, &type_layout, &mut PeekU64Visitor { fields }).unwrap()
+    };
+
+    let visit_struct = |fields| {
+        MoveStruct::visit_deserialize(&bytes, struct_layout, &mut PeekU64Visitor { fields })
+            .unwrap()
+    };
+
+    assert_eq!(visit_value(&[0]), Some(42));
+    assert_eq!(visit_value(&[1]), None);
+    assert_eq!(visit_value(&[2]), None);
+    assert_eq!(visit_value(&[3, 0]), Some(45));
+    assert_eq!(visit_value(&[4, 0]), Some(46));
+
+    assert_eq!(visit_struct(&[0]), Some(42));
+    assert_eq!(visit_struct(&[1]), None);
+    assert_eq!(visit_struct(&[2]), None);
+    assert_eq!(visit_struct(&[3, 0]), Some(45));
+    assert_eq!(visit_struct(&[4, 0]), Some(46));
+}
+
+#[test]
+fn byte_offset_test() {
+    use MoveTypeLayout as T;
+    use MoveValue as V;
+
+    #[derive(Default)]
+    struct ByteOffsetVisitor(String);
+
+    impl<'b, 'l> Traversal<'b, 'l> for ByteOffsetVisitor {
+        type Error = runtime_visitor::Error;
+
+        fn traverse_u8(
+            &mut self,
+            driver: &ValueDriver<'_, 'b, 'l>,
+            value: u8,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] {value}: u8",
+                driver.start(),
+                driver.position()
+            )
+            .unwrap();
+            Ok(())
+        }
+
+        fn traverse_u16(
+            &mut self,
+            driver: &ValueDriver<'_, 'b, 'l>,
+            value: u16,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] {value}: u16",
+                driver.start(),
+                driver.position()
+            )
+            .unwrap();
+            Ok(())
+        }
+
+        fn traverse_u32(
+            &mut self,
+            driver: &ValueDriver<'_, 'b, 'l>,
+            value: u32,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] {value}: u32",
+                driver.start(),
+                driver.position()
+            )
+            .unwrap();
+            Ok(())
+        }
+
+        fn traverse_u64(
+            &mut self,
+            driver: &ValueDriver<'_, 'b, 'l>,
+            value: u64,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] {value}: u64",
+                driver.start(),
+                driver.position()
+            )
+            .unwrap();
+            Ok(())
+        }
+
+        fn traverse_u128(
+            &mut self,
+            driver: &ValueDriver<'_, 'b, 'l>,
+            value: u128,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] {value}: u128",
+                driver.start(),
+                driver.position()
+            )
+            .unwrap();
+            Ok(())
+        }
+
+        fn traverse_u256(
+            &mut self,
+            driver: &ValueDriver<'_, 'b, 'l>,
+            value: U256,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] {value}: u256",
+                driver.start(),
+                driver.position()
+            )
+            .unwrap();
+            Ok(())
+        }
+
+        fn traverse_bool(
+            &mut self,
+            driver: &ValueDriver<'_, 'b, 'l>,
+            value: bool,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] {value}: bool",
+                driver.start(),
+                driver.position()
+            )
+            .unwrap();
+            Ok(())
+        }
+
+        fn traverse_address(
+            &mut self,
+            driver: &ValueDriver<'_, 'b, 'l>,
+            value: AccountAddress,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] {}: address",
+                driver.start(),
+                driver.position(),
+                value.to_canonical_display(/* with_prefix */ true),
+            )
+            .unwrap();
+            Ok(())
+        }
+
+        fn traverse_signer(
+            &mut self,
+            driver: &ValueDriver<'_, 'b, 'l>,
+            value: AccountAddress,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] {}: address",
+                driver.start(),
+                driver.position(),
+                value.to_canonical_display(/* with_prefix */ true),
+            )
+            .unwrap();
+            Ok(())
+        }
+
+        fn traverse_vector(
+            &mut self,
+            driver: &mut VecDriver<'_, 'b, 'l>,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] vector<{:#}>",
+                driver.start(),
+                driver.position(),
+                driver.element_layout(),
+            )
+            .unwrap();
+            while driver.next_element(self)?.is_some() {}
+            Ok(())
+        }
+
+        fn traverse_struct(
+            &mut self,
+            driver: &mut StructDriver<'_, 'b, 'l>,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] {:#}",
+                driver.start(),
+                driver.position(),
+                driver.struct_layout(),
+            )
+            .unwrap();
+
+            while let Some((_, ())) = driver.next_field(self)? {}
+            Ok(())
+        }
+
+        fn traverse_variant(
+            &mut self,
+            driver: &mut VariantDriver<'_, 'b, 'l>,
+        ) -> Result<(), Self::Error> {
+            write!(
+                &mut self.0,
+                "\n[{:>3} .. {:>3}] {:#}",
+                driver.start(),
+                driver.position(),
+                driver.enum_layout(),
+            )
+            .unwrap();
+
+            while let Some((_, ())) = driver.next_field(self)? {}
+            Ok(())
+        }
+    }
+
+    let type_layout = struct_layout_(vec![
+        struct_layout_(vec![T::U64, T::Vector(Box::new(T::U32))]),
+        enum_layout_(vec![vec![T::U64]]),
+    ]);
+
+    let T::Struct(struct_layout) = &type_layout else {
+        panic!("Not a struct layout");
+    };
+
+    let bytes = serialize(struct_value_(vec![
+        struct_value_(vec![
+            V::U64(7),
+            V::Vector(vec![V::U32(1), V::U32(2), V::U32(3)]),
+        ]),
+        variant_value_(0, vec![V::U64(4)]),
+    ]));
+
+    let mut value_visitor = ByteOffsetVisitor::default();
+    MoveValue::visit_deserialize(&bytes, &type_layout, &mut value_visitor).unwrap();
+
+    let mut struct_visitor = ByteOffsetVisitor::default();
+    MoveStruct::visit_deserialize(&bytes, struct_layout, &mut struct_visitor).unwrap();
+
+    assert_eq!(value_visitor.0, struct_visitor.0);
+    insta::assert_snapshot!(value_visitor.0);
+}
+
+/// Create a struct value for test purposes.
+pub(crate) fn struct_value_(fields: Vec<MoveValue>) -> MoveValue {
+    MoveValue::Struct(MoveStruct::new(fields))
+}
+
+/// Create a struct layout for test purposes.
+pub(crate) fn struct_layout_(fields: Vec<MoveTypeLayout>) -> MoveTypeLayout {
+    MoveTypeLayout::Struct(Box::new(MoveStructLayout(Box::new(fields))))
+}
+
+/// Create a variant value for test purposes.
+pub(crate) fn variant_value_(tag: u16, fields: Vec<MoveValue>) -> MoveValue {
+    MoveValue::Variant(MoveVariant { tag, fields })
+}
+
+/// Create an enum layout for test purposes.
+pub(crate) fn enum_layout_(variants: Vec<Vec<MoveTypeLayout>>) -> MoveTypeLayout {
+    MoveTypeLayout::Enum(Box::new(MoveEnumLayout(Box::new(variants))))
+}
+
+/// BCS encode Move value.
+pub(crate) fn serialize(value: MoveValue) -> Vec<u8> {
+    value.simple_serialize().unwrap()
+}

--- a/external-crates/move/crates/move-core-types/src/unit_tests/snapshots/move_core_types__unit_tests__annotated_visitor_test__byte_offset_test.snap
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/snapshots/move_core_types__unit_tests__annotated_visitor_test__byte_offset_test.snap
@@ -1,0 +1,30 @@
+---
+source: crates/move-core-types/src/unit_tests/annotated_visitor_test.rs
+expression: value_visitor.0
+---
+[  0 ..   0] struct 0x0::foo::Bar {
+    inner: struct 0x0::baz::Qux {
+        f: u64,
+        g: vector<u32>,
+    },
+    last: enum 0x0::foo::Baz {
+        e {
+            h: u64,
+        },
+    },
+}
+[  0 ..   0] struct 0x0::baz::Qux {
+    f: u64,
+    g: vector<u32>,
+}
+[  0 ..   8] 7: u64
+[  8 ..   9] vector<u32>
+[  9 ..  13] 1: u32
+[ 13 ..  17] 2: u32
+[ 17 ..  21] 3: u32
+[ 21 ..  22] enum 0x0::foo::Baz {
+    e {
+        h: u64,
+    },
+}
+[ 22 ..  30] 4: u64

--- a/external-crates/move/crates/move-core-types/src/unit_tests/snapshots/move_core_types__unit_tests__annotated_visitor_test__nested_datatype_visit.snap
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/snapshots/move_core_types__unit_tests__annotated_visitor_test__nested_datatype_visit.snap
@@ -1,0 +1,30 @@
+---
+source: crates/move-core-types/src/unit_tests/annotated_visitor_test.rs
+expression: value_visitor.output
+---
+[0] struct 0x0::foo::Bar {
+    inner: struct 0x0::baz::Qux {
+        f: u64,
+        g: vector<u32>,
+    },
+    last: enum 0x0::foo::Baz {
+        e {
+            h: u64,
+        },
+    },
+}
+[1] struct 0x0::baz::Qux {
+    f: u64,
+    g: vector<u32>,
+}
+[2] 7: u64
+[2] vector<u32>
+[3] 1: u32
+[3] 2: u32
+[3] 3: u32
+[1] enum 0x0::foo::Baz {
+    e {
+        h: u64,
+    },
+}
+[2] 4: u64

--- a/external-crates/move/crates/move-core-types/src/unit_tests/snapshots/move_core_types__unit_tests__runtime_visitor_test__byte_offset_test.snap
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/snapshots/move_core_types__unit_tests__runtime_visitor_test__byte_offset_test.snap
@@ -1,0 +1,22 @@
+---
+source: crates/move-core-types/src/unit_tests/runtime_visitor_test.rs
+expression: value_visitor.0
+---
+[  0 ..   0] struct {
+    0: struct {
+        0: u64,
+        1: vector<u32>,
+    },
+    1: enum variant_tag: 0 { 0: u64,  } ,
+}
+[  0 ..   0] struct {
+    0: u64,
+    1: vector<u32>,
+}
+[  0 ..   8] 7: u64
+[  8 ..   9] vector<u32>
+[  9 ..  13] 1: u32
+[ 13 ..  17] 2: u32
+[ 17 ..  21] 3: u32
+[ 21 ..  22] enum variant_tag: 0 { 0: u64,  } 
+[ 22 ..  30] 4: u64

--- a/external-crates/move/crates/move-core-types/src/unit_tests/snapshots/move_core_types__unit_tests__runtime_visitor_test__nested_datatype_visit.snap
+++ b/external-crates/move/crates/move-core-types/src/unit_tests/snapshots/move_core_types__unit_tests__runtime_visitor_test__nested_datatype_visit.snap
@@ -1,0 +1,22 @@
+---
+source: crates/move-core-types/src/unit_tests/runtime_visitor_test.rs
+expression: value_visitor.output
+---
+[0] struct {
+    0: struct {
+        0: u64,
+        1: vector<u32>,
+    },
+    1: enum variant_tag: 0 { 0: u64,  } ,
+}
+[1] struct {
+    0: u64,
+    1: vector<u32>,
+}
+[2] 7: u64
+[2] vector<u32>
+[3] 1: u32
+[3] 2: u32
+[3] 3: u32
+[1] enum variant_tag: 0 { 0: u64,  } 
+[2] 4: u64


### PR DESCRIPTION
## Description 

Adds a runtime value visitor to match the annotated value visitor and traversal that already exists. Not used anywhere yet, but a good utility to have (/nice to have the feature parity).

## Test plan 

Added new tests + CI
