### PR TITLE
[graphql-alt] Support Expiration for Transaction

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/expiration.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/expiration.move
@@ -1,0 +1,34 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --simulator
+
+//# programmable --sender A --inputs 42 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 44 @B --expiration 10
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# run-graphql
+{ # Null expiration
+  transaction(digest: "@{digest_1}") {
+    expiration {
+      epochId
+    }
+  }
+}
+
+//# run-graphql
+{ # Non-Null expiration
+  transaction(digest: "@{digest_2}") {
+    expiration {
+      epochId
+      startTimestamp
+      endTimestamp
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/expiration.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/expiration.snap
@@ -1,0 +1,51 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-8:
+//# programmable --sender A --inputs 42 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 10-12:
+//# programmable --sender A --inputs 44 @B --expiration 10
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, line 14:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 16-23:
+//# run-graphql
+Response: {
+  "data": {
+    "transaction": {
+      "expiration": null
+    }
+  }
+}
+
+task 5, lines 25-34:
+//# run-graphql
+Response: {
+  "data": {
+    "transaction": {
+      "expiration": {
+        "epochId": 10,
+        "startTimestamp": null,
+        "endTimestamp": null
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -757,6 +757,10 @@ type Transaction {
 	"""
 	effects: TransactionEffects
 	"""
+	This field is set by senders of a transaction block. It is an epoch reference that sets a deadline after which validators will no longer consider the transaction valid. By default, there is no deadline for when a transaction must execute.
+	"""
+	expiration: Epoch
+	"""
 	The gas input field provides information on what objects were used as gas as well as the owner of the gas object(s) and information on the gas price and budget.
 	"""
 	gasInput: GasInput

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -761,6 +761,10 @@ type Transaction {
 	"""
 	effects: TransactionEffects
 	"""
+	This field is set by senders of a transaction block. It is an epoch reference that sets a deadline after which validators will no longer consider the transaction valid. By default, there is no deadline for when a transaction must execute.
+	"""
+	expiration: Epoch
+	"""
 	The gas input field provides information on what objects were used as gas as well as the owner of the gas object(s) and information on the gas price and budget.
 	"""
 	gasInput: GasInput

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -761,6 +761,10 @@ type Transaction {
 	"""
 	effects: TransactionEffects
 	"""
+	This field is set by senders of a transaction block. It is an epoch reference that sets a deadline after which validators will no longer consider the transaction valid. By default, there is no deadline for when a transaction must execute.
+	"""
+	expiration: Epoch
+	"""
 	The gas input field provides information on what objects were used as gas as well as the owner of the gas object(s) and information on the gas price and budget.
 	"""
 	gasInput: GasInput

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -757,6 +757,10 @@ type Transaction {
 	"""
 	effects: TransactionEffects
 	"""
+	This field is set by senders of a transaction block. It is an epoch reference that sets a deadline after which validators will no longer consider the transaction valid. By default, there is no deadline for when a transaction must execute.
+	"""
+	expiration: Epoch
+	"""
 	The gas input field provides information on what objects were used as gas as well as the owner of the gas object(s) and information on the gas price and budget.
 	"""
 	gasInput: GasInput

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -128,6 +128,8 @@ pub struct ProgrammableTransactionCommand {
     pub dev_inspect: bool,
     #[clap(long = "dry-run")]
     pub dry_run: bool,
+    #[clap(long = "expiration")]
+    pub expiration: Option<u64>,
     #[clap(
         long = "inputs",
         value_parser = ParsedValue::<SuiExtraValueArgs>::parse,

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -93,7 +93,7 @@ use sui_types::{execution_status::ExecutionStatus, transaction::TransactionKind}
 use sui_types::{gas::GasCostSummary, object::GAS_VALUE_FOR_TESTING};
 use sui_types::{
     move_package::MovePackage,
-    transaction::{Argument, CallArg},
+    transaction::{Argument, CallArg, TransactionDataAPI, TransactionExpiration},
 };
 use sui_types::{
     programmable_transaction_builder::ProgrammableTransactionBuilder, SUI_FRAMEWORK_PACKAGE_ID,
@@ -880,6 +880,7 @@ impl MoveTestAdapter<'_> for SuiTestAdapter {
                 gas_payment,
                 dev_inspect,
                 dry_run,
+                expiration,
                 inputs,
             }) => {
                 if dev_inspect && self.is_simulator() {
@@ -929,37 +930,46 @@ impl MoveTestAdapter<'_> for SuiTestAdapter {
                 let summary = if !dev_inspect && !dry_run {
                     let gas_budget = gas_budget.unwrap_or(DEFAULT_GAS_BUDGET);
                     let gas_price = gas_price.unwrap_or(self.gas_price);
+                    let expiration = expiration
+                        .map(TransactionExpiration::Epoch)
+                        .unwrap_or(TransactionExpiration::None);
                     let transaction = self.sign_sponsor_txn(
                         sender,
                         sponsor,
                         gas_payment.unwrap_or_default(),
                         |sender, sponsor, gas| {
-                            TransactionData::new_programmable_allow_sponsor(
+                            let mut tx_data = TransactionData::new_programmable_allow_sponsor(
                                 sender,
                                 gas,
                                 ProgrammableTransaction { inputs, commands },
                                 gas_budget,
                                 gas_price,
                                 sponsor,
-                            )
+                            );
+                            *tx_data.expiration_mut_for_testing() = expiration;
+                            tx_data
                         },
                     );
                     self.execute_txn(transaction).await?
                 } else if dry_run {
                     let gas_budget = gas_budget.unwrap_or(DEFAULT_GAS_BUDGET);
                     let gas_price = gas_price.unwrap_or(self.gas_price);
+                    let expiration = expiration
+                        .map(TransactionExpiration::Epoch)
+                        .unwrap_or(TransactionExpiration::None);
                     let sender = self.get_sender(sender);
                     let sponsor = sponsor.map_or(sender, |a| self.get_sender(Some(a)));
 
                     let payments = self.get_payments(sponsor, gas_payment.unwrap_or_default());
 
-                    let transaction = TransactionData::new_programmable(
+                    let mut transaction = TransactionData::new_programmable(
                         sender.address,
                         payments,
                         ProgrammableTransaction { inputs, commands },
                         gas_budget,
                         gas_price,
                     );
+                    *transaction.expiration_mut_for_testing() = expiration;
                     self.dry_run(transaction).await?
                 } else {
                     assert!(


### PR DESCRIPTION
## Description 

Implement expiration field support for `Transaction` type.

Within this PR, I also added support for `expiration` for ProgrammableTransactionCommand, which allows us to implementation snapshot test for `Transaction.expiration`

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-graphql
cargo nextest run -p sui-indexer-alt-reader
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
