### PR TITLE
[static ptb] Refactor Pure values into separate locals

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut.move
@@ -1,0 +1,52 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests that pure arguments have distinct values/locals per type usage
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    use std::string::{Self, String};
+    use std::ascii;
+
+    public fun modify_u8(s: &mut u8) {
+        assert!(*s == 0);
+        *s = 1;
+    }
+    public fun assert_u8(s: u8) {
+        assert!(s == 1);
+    }
+
+    public fun modify_ascii(s: &mut ascii::String) {
+        assert!(s.is_empty());
+        s.append(ascii::string(b"ascii"));
+    }
+    public fun assert_ascii(s: ascii::String) {
+        assert!(s.as_bytes() == b"ascii");
+    }
+
+    public fun modify_string(s: &mut String) {
+        assert!(s.is_empty());
+        s.append(string::utf8(b"utf8"));
+    }
+    public fun assert_string(s: String) {
+        assert!(s.as_bytes() == b"utf8");
+    }
+}
+
+// In statically checked PTBs, tests that each type usage gets its own value/locals
+// Originally, this will fail for changing types
+//# programmable --inputs 0u8
+//> test::m1::modify_u8(Input(0));
+//> test::m1::modify_ascii(Input(0));
+//> test::m1::modify_string(Input(0));
+//> test::m1::assert_u8(Input(0));
+//> test::m1::assert_ascii(Input(0));
+//> test::m1::assert_string(Input(0));
+
+// Tests that locals of the same type are distinct even if they are the same value+type
+// This should abort
+//# programmable --inputs 0u8 0u8
+//> test::m1::modify_u8(Input(0));
+//> test::m1::assert_string(Input(1));

--- a/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut.move
@@ -10,6 +10,10 @@ module test::m1 {
     use std::string::{Self, String};
     use std::ascii;
 
+    public fun borrow_mut<T>(x: &mut T): &mut T {
+        x
+    }
+
     public fun modify_u8(s: &mut u8) {
         assert!(*s == 0);
         *s = 1;
@@ -50,3 +54,16 @@ module test::m1 {
 //# programmable --inputs 0u8 0u8
 //> test::m1::modify_u8(Input(0));
 //> test::m1::assert_string(Input(1));
+
+// In statically checked PTBs, tests that each type can be borrowed mutably separately
+//# programmable --inputs 0u8 --dev-inspect
+//> 0: test::m1::borrow_mut<u8>(Input(0));
+//> 1: test::m1::borrow_mut<std::ascii::String>(Input(0));
+//> test::m1::modify_ascii(Result(1));
+//> test::m1::modify_u8(Result(0));
+
+//# programmable --inputs 0u8 --dev-inspect
+//> 0: test::m1::borrow_mut<u8>(Input(0));
+//> 1: test::m1::borrow_mut<std::ascii::String>(Input(0));
+//> test::m1::modify_u8(Result(0));
+//> test::m1::modify_ascii(Result(1));

--- a/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut.snap
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut.snap
@@ -1,18 +1,18 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 4 tasks
+processed 6 tasks
 
 init:
 A: object(0,0)
 
-task 1, lines 8-39:
+task 1, lines 8-43:
 //# publish
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 7273200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 7508800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 40-49:
+task 2, lines 44-53:
 //# programmable --inputs 0u8
 //> test::m1::modify_u8(Input(0));
 //> test::m1::modify_ascii(Input(0));
@@ -25,9 +25,28 @@ task 2, lines 40-49:
 Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(1) } }
 
-task 3, lines 50-52:
+task 3, lines 54-58:
 //# programmable --inputs 0u8 0u8
 //> test::m1::modify_u8(Input(0));
 //> test::m1::assert_string(Input(1));
-Error: Transaction Effects Status: Move Runtime Abort. Location: test::m1::assert_string (function index 5) at offset 11, Abort Code: 13906834311782334463
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m1") }, function: 5, instruction: 11, function_name: Some("assert_string") }, 13906834311782334463), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834311782334463), message: Some("test::m1::assert_string at offset 11"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m1") }), indices: [], offsets: [(FunctionDefinitionIndex(5), 11)] }), command: Some(1) } }
+// In statically checked PTBs, tests that each type can be borrowed mutably separately
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::m1::assert_string (function index 6) at offset 11, Abort Code: 13906834324667236351
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m1") }, function: 6, instruction: 11, function_name: Some("assert_string") }, 13906834324667236351), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834324667236351), message: Some("test::m1::assert_string at offset 11"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m1") }), indices: [], offsets: [(FunctionDefinitionIndex(6), 11)] }), command: Some(1) } }
+
+task 4, lines 59-63:
+//# programmable --inputs 0u8 --dev-inspect
+//> 0: test::m1::borrow_mut<u8>(Input(0));
+//> 1: test::m1::borrow_mut<std::ascii::String>(Input(0));
+//> test::m1::modify_ascii(Result(1));
+//> test::m1::modify_u8(Result(0));
+Error: Transaction Effects Status: CommandArgumentError { arg_idx: 0, kind: TypeMismatch } in command 1
+Execution Error: CommandArgumentError { arg_idx: 0, kind: TypeMismatch } in command 1
+
+task 5, lines 65-69:
+//# programmable --inputs 0u8 --dev-inspect
+//> 0: test::m1::borrow_mut<u8>(Input(0));
+//> 1: test::m1::borrow_mut<std::ascii::String>(Input(0));
+//> test::m1::modify_u8(Result(0));
+//> test::m1::modify_ascii(Result(1));
+Error: Transaction Effects Status: CommandArgumentError { arg_idx: 0, kind: TypeMismatch } in command 1
+Execution Error: CommandArgumentError { arg_idx: 0, kind: TypeMismatch } in command 1

--- a/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut.snap
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut.snap
@@ -1,0 +1,33 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 8-39:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7273200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 40-49:
+//# programmable --inputs 0u8
+//> test::m1::modify_u8(Input(0));
+//> test::m1::modify_ascii(Input(0));
+//> test::m1::modify_string(Input(0));
+//> test::m1::assert_u8(Input(0));
+//> test::m1::assert_ascii(Input(0));
+//> test::m1::assert_string(Input(0));
+// Tests that locals of the same type are distinct even if they are the same value+type
+// This should abort
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(1) } }
+
+task 3, lines 50-52:
+//# programmable --inputs 0u8 0u8
+//> test::m1::modify_u8(Input(0));
+//> test::m1::assert_string(Input(1));
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::m1::assert_string (function index 5) at offset 11, Abort Code: 13906834311782334463
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m1") }, function: 5, instruction: 11, function_name: Some("assert_string") }, 13906834311782334463), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834311782334463), message: Some("test::m1::assert_string at offset 11"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m1") }), indices: [], offsets: [(FunctionDefinitionIndex(5), 11)] }), command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut@v2.snap
@@ -1,18 +1,18 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 4 tasks
+processed 6 tasks
 
 init:
 A: object(0,0)
 
-task 1, lines 8-39:
+task 1, lines 8-43:
 //# publish
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 7273200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 7508800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 40-49:
+task 2, lines 44-53:
 //# programmable --inputs 0u8
 //> test::m1::modify_u8(Input(0));
 //> test::m1::modify_ascii(Input(0));
@@ -25,9 +25,28 @@ task 2, lines 40-49:
 mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 3, lines 50-52:
+task 3, lines 54-58:
 //# programmable --inputs 0u8 0u8
 //> test::m1::modify_u8(Input(0));
 //> test::m1::assert_string(Input(1));
-Error: Transaction Effects Status: Move Runtime Abort. Location: test::m1::assert_string (function index 5) at offset 11, Abort Code: 13906834311782334463
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m1") }, function: 5, instruction: 11, function_name: Some("assert_string") }, 13906834311782334463), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834311782334463), message: Some("test::m1::assert_string at offset 11"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m1") }), indices: [], offsets: [(FunctionDefinitionIndex(5), 11)] }), command: Some(1) } }
+// In statically checked PTBs, tests that each type can be borrowed mutably separately
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::m1::assert_string (function index 6) at offset 11, Abort Code: 13906834324667236351
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m1") }, function: 6, instruction: 11, function_name: Some("assert_string") }, 13906834324667236351), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834324667236351), message: Some("test::m1::assert_string at offset 11"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m1") }), indices: [], offsets: [(FunctionDefinitionIndex(6), 11)] }), command: Some(1) } }
+
+task 4, lines 59-63:
+//# programmable --inputs 0u8 --dev-inspect
+//> 0: test::m1::borrow_mut<u8>(Input(0));
+//> 1: test::m1::borrow_mut<std::ascii::String>(Input(0));
+//> test::m1::modify_ascii(Result(1));
+//> test::m1::modify_u8(Result(0));
+mutated: object(_)
+gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 5, lines 65-69:
+//# programmable --inputs 0u8 --dev-inspect
+//> 0: test::m1::borrow_mut<u8>(Input(0));
+//> 1: test::m1::borrow_mut<std::ascii::String>(Input(0));
+//> test::m1::modify_u8(Result(0));
+//> test::m1::modify_ascii(Result(1));
+mutated: object(_)
+gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0

--- a/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut@v2.snap
@@ -1,0 +1,33 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 8-39:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 7273200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 40-49:
+//# programmable --inputs 0u8
+//> test::m1::modify_u8(Input(0));
+//> test::m1::modify_ascii(Input(0));
+//> test::m1::modify_string(Input(0));
+//> test::m1::assert_u8(Input(0));
+//> test::m1::assert_ascii(Input(0));
+//> test::m1::assert_string(Input(0));
+// Tests that locals of the same type are distinct even if they are the same value+type
+// This should abort
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 50-52:
+//# programmable --inputs 0u8 0u8
+//> test::m1::modify_u8(Input(0));
+//> test::m1::assert_string(Input(1));
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::m1::assert_string (function index 5) at offset 11, Abort Code: 13906834311782334463
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m1") }, function: 5, instruction: 11, function_name: Some("assert_string") }, 13906834311782334463), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834311782334463), message: Some("test::m1::assert_string at offset 11"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m1") }), indices: [], offsets: [(FunctionDefinitionIndex(5), 11)] }), command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_type_change.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_type_change.move
@@ -29,7 +29,7 @@ module test::m1 {
 //> 0: test::m1::ascii_(Input(0));
 //> 1: test::m1::string(Input(0));
 //> 2: test::m1::fix<std::ascii::String>(Input(0));
-// now will fail as Input(0) if always a String
+// In original PTB execution, now will fail as Input(0) if always a String
 //> 3: test::m1::string(Input(0));
 
 //# programmable --inputs @A
@@ -37,7 +37,7 @@ module test::m1 {
 //> 0: test::m1::addr(Input(0));
 //> 1: test::m1::id(Input(0));
 //> 2: test::m1::fix<sui::object::ID>(Input(0));
-// now will fail as Input(0) if always an ID
+// In original PTB execution, now will fail as Input(0) if always an ID
 //> 3: test::m1::addr(Input(0));
 
 //# programmable --inputs vector[0u64]
@@ -45,7 +45,7 @@ module test::m1 {
 //> 0: test::m1::vec<u64>(Input(0));
 //> 1: test::m1::opt<u64>(Input(0));
 //> 2: test::m1::fix<vector<u64>>(Input(0));
-// now will fail as Input(0) if always a vector
+// In original PTB execution, now will fail as Input(0) if always a vector
 //> 3: test::m1::opt<u64>(Input(0));
 
 //# programmable --inputs vector[]
@@ -53,5 +53,5 @@ module test::m1 {
 //> 0: test::m1::vec<u64>(Input(0));
 //> 1: test::m1::opt<u64>(Input(0));
 //> 2: test::m1::fix<std::option::Option<u64>>(Input(0));
-// now will fail as Input(0) if always an Option
+// In original PTB execution, now will fail as Input(0) if always an Option
 //> 3: test::m1::vec<u64>(Input(0));

--- a/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_type_change.snap
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_type_change.snap
@@ -17,7 +17,7 @@ task 2, lines 27-33:
 //> 0: test::m1::ascii_(Input(0));
 //> 1: test::m1::string(Input(0));
 //> 2: test::m1::fix<std::ascii::String>(Input(0));
-// now will fail as Input(0) if always a String
+// In original PTB execution, now will fail as Input(0) if always a String
 //> 3: test::m1::string(Input(0));
 Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(3) } }
@@ -27,7 +27,7 @@ task 3, lines 35-41:
 //> 0: test::m1::addr(Input(0));
 //> 1: test::m1::id(Input(0));
 //> 2: test::m1::fix<sui::object::ID>(Input(0));
-// now will fail as Input(0) if always an ID
+// In original PTB execution, now will fail as Input(0) if always an ID
 //> 3: test::m1::addr(Input(0));
 Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(3) } }
@@ -37,7 +37,7 @@ task 4, lines 43-49:
 //> 0: test::m1::vec<u64>(Input(0));
 //> 1: test::m1::opt<u64>(Input(0));
 //> 2: test::m1::fix<vector<u64>>(Input(0));
-// now will fail as Input(0) if always a vector
+// In original PTB execution, now will fail as Input(0) if always a vector
 //> 3: test::m1::opt<u64>(Input(0));
 Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(3) } }
@@ -47,7 +47,7 @@ task 5, lines 51-57:
 //> 0: test::m1::vec<u64>(Input(0));
 //> 1: test::m1::opt<u64>(Input(0));
 //> 2: test::m1::fix<std::option::Option<u64>>(Input(0));
-// now will fail as Input(0) if always an Option
+// In original PTB execution, now will fail as Input(0) if always an Option
 //> 3: test::m1::vec<u64>(Input(0));
 Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(3) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_type_change@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_type_change@v2.snap
@@ -17,37 +17,37 @@ task 2, lines 27-33:
 //> 0: test::m1::ascii_(Input(0));
 //> 1: test::m1::string(Input(0));
 //> 2: test::m1::fix<std::ascii::String>(Input(0));
-// now will fail as Input(0) if always a String
+// In original PTB execution, now will fail as Input(0) if always a String
 //> 3: test::m1::string(Input(0));
-Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(3) } }
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 3, lines 35-41:
 //# programmable --inputs @A
 //> 0: test::m1::addr(Input(0));
 //> 1: test::m1::id(Input(0));
 //> 2: test::m1::fix<sui::object::ID>(Input(0));
-// now will fail as Input(0) if always an ID
+// In original PTB execution, now will fail as Input(0) if always an ID
 //> 3: test::m1::addr(Input(0));
-Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(3) } }
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4, lines 43-49:
 //# programmable --inputs vector[0u64]
 //> 0: test::m1::vec<u64>(Input(0));
 //> 1: test::m1::opt<u64>(Input(0));
 //> 2: test::m1::fix<vector<u64>>(Input(0));
-// now will fail as Input(0) if always a vector
+// In original PTB execution, now will fail as Input(0) if always a vector
 //> 3: test::m1::opt<u64>(Input(0));
-Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(3) } }
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 5, lines 51-57:
 //# programmable --inputs vector[]
 //> 0: test::m1::vec<u64>(Input(0));
 //> 1: test::m1::opt<u64>(Input(0));
 //> 2: test::m1::fix<std::option::Option<u64>>(Input(0));
-// now will fail as Input(0) if always an Option
+// In original PTB execution, now will fail as Input(0) if always an Option
 //> 3: test::m1::vec<u64>(Input(0));
-Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(3) } }
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/pt_receive_type_fixing.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/pt_receive_type_fixing.move
@@ -63,6 +63,7 @@ module tto::M1 {
 
 //# programmable --inputs object(2,0) receiving(2,1)
 //> 0: tto::M1::pass_through_a(Input(1));
+// Now treated as Receiving<B> in the new PTB execution
 //> tto::M1::receiver(Input(0), Result(0));
 
 //# programmable --inputs object(2,0) receiving(2,1)

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/pt_receive_type_fixing.snap
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/pt_receive_type_fixing.snap
@@ -46,21 +46,22 @@ task 5, lines 60-62:
 mutated: object(0,0), object(2,0), object(2,1)
 gas summary: computation_cost: 1000000, storage_cost: 3420000,  storage_rebate: 3385800, non_refundable_storage_fee: 34200
 
-task 6, lines 64-66:
+task 6, lines 64-67:
 //# programmable --inputs object(2,0) receiving(2,1)
 //> 0: tto::M1::pass_through_a(Input(1));
+// Now treated as Receiving<B> in the new PTB execution
 //> tto::M1::receiver(Input(0), Result(0));
 Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: None, command: Some(1) } }
 
-task 7, lines 68-70:
+task 7, lines 69-71:
 //# programmable --inputs object(2,0) receiving(2,1)
 //> 0: tto::M1::pass_through_mut_ref_a(Input(1));
 //> tto::M1::receiver(Input(0), Input(1));
 Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: None, command: Some(1) } }
 
-task 8, lines 72-76:
+task 8, lines 73-77:
 //# programmable --inputs object(2,0) receiving(2,1)
 //> 0: tto::M1::pass_through_ref_a(Input(1));
 //> tto::M1::receiver(Input(0), Input(1));
@@ -68,14 +69,14 @@ task 8, lines 72-76:
 Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: None, command: Some(1) } }
 
-task 9, lines 77-79:
+task 9, lines 78-80:
 //# programmable --inputs object(2,0) receiving(2,1)
 //> 0: MakeMoveVec<sui::transfer::Receiving<tto::M1::A>>([Input(1)]);
 //> 1: tto::M1::unpacker_b(Result(0));
 Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(1) } }
 
-task 10, lines 81-86:
+task 10, lines 82-87:
 //# programmable --inputs object(2,0) receiving(2,1)
 //> 0: MakeMoveVec<sui::transfer::Receiving<tto::M1::A>>([Input(1)]);
 //> 1: tto::M1::unpacker_a(Result(0));
@@ -84,7 +85,7 @@ task 10, lines 81-86:
 Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: None, command: Some(2) } }
 
-task 11, lines 87-92:
+task 11, lines 88-93:
 //# programmable --inputs object(2,0) receiving(2,1)
 //> 0: MakeMoveVec<sui::transfer::Receiving<tto::M1::A>>([Input(1)]);
 //> 1: tto::M1::unpacker_generic<tto::M1::A>(Result(0));
@@ -93,7 +94,7 @@ task 11, lines 87-92:
 Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: None, command: Some(2) } }
 
-task 12, lines 93-95:
+task 12, lines 94-96:
 //# programmable --inputs object(2,0) receiving(2,1)
 //> 0: MakeMoveVec<sui::transfer::Receiving<tto::M1::A>>([Input(1)]);
 //> 1: tto::M1::unpacker_generic<tto::M1::B>(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/pt_receive_type_fixing@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/pt_receive_type_fixing@v2.snap
@@ -46,21 +46,22 @@ task 5, lines 60-62:
 mutated: object(0,0), object(2,0), object(2,1)
 gas summary: computation_cost: 1000000, storage_cost: 3420000,  storage_rebate: 3385800, non_refundable_storage_fee: 34200
 
-task 6, lines 64-66:
+task 6, lines 64-67:
 //# programmable --inputs object(2,0) receiving(2,1)
 //> 0: tto::M1::pass_through_a(Input(1));
+// Now treated as Receiving<B> in the new PTB execution
 //> tto::M1::receiver(Input(0), Result(0));
 Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: None, command: Some(1) } }
 
-task 7, lines 68-70:
+task 7, lines 69-71:
 //# programmable --inputs object(2,0) receiving(2,1)
 //> 0: tto::M1::pass_through_mut_ref_a(Input(1));
 //> tto::M1::receiver(Input(0), Input(1));
-Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: None, command: Some(1) } }
+Error: Transaction Effects Status: Move Runtime Abort. Location: sui::transfer::receive_impl (function index 15) at offset 0, Abort Code: 3
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("transfer") }, function: 15, instruction: 0, function_name: Some("receive_impl") }, 3), source: Some(VMError { major_status: ABORTED, sub_status: Some(3), message: None, exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("transfer") }), indices: [], offsets: [(FunctionDefinitionIndex(15), 0)] }), command: Some(1) } }
 
-task 8, lines 72-76:
+task 8, lines 73-77:
 //# programmable --inputs object(2,0) receiving(2,1)
 //> 0: tto::M1::pass_through_ref_a(Input(1));
 //> tto::M1::receiver(Input(0), Input(1));
@@ -68,14 +69,14 @@ task 8, lines 72-76:
 Error: Transaction Effects Status: Move Runtime Abort. Location: sui::transfer::receive_impl (function index 15) at offset 0, Abort Code: 3
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("transfer") }, function: 15, instruction: 0, function_name: Some("receive_impl") }, 3), source: Some(VMError { major_status: ABORTED, sub_status: Some(3), message: None, exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("transfer") }), indices: [], offsets: [(FunctionDefinitionIndex(15), 0)] }), command: Some(1) } }
 
-task 9, lines 77-79:
+task 9, lines 78-80:
 //# programmable --inputs object(2,0) receiving(2,1)
 //> 0: MakeMoveVec<sui::transfer::Receiving<tto::M1::A>>([Input(1)]);
 //> 1: tto::M1::unpacker_b(Result(0));
 Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: TypeMismatch }, source: None, command: Some(1) } }
 
-task 10, lines 81-86:
+task 10, lines 82-87:
 //# programmable --inputs object(2,0) receiving(2,1)
 //> 0: MakeMoveVec<sui::transfer::Receiving<tto::M1::A>>([Input(1)]);
 //> 1: tto::M1::unpacker_a(Result(0));
@@ -84,7 +85,7 @@ task 10, lines 81-86:
 Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: None, command: Some(2) } }
 
-task 11, lines 87-92:
+task 11, lines 88-93:
 //# programmable --inputs object(2,0) receiving(2,1)
 //> 0: MakeMoveVec<sui::transfer::Receiving<tto::M1::A>>([Input(1)]);
 //> 1: tto::M1::unpacker_generic<tto::M1::A>(Result(0));
@@ -93,7 +94,7 @@ task 11, lines 87-92:
 Error: Transaction Effects Status: Invalid command argument at 1. The type of the value does not match the expected type
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: TypeMismatch }, source: None, command: Some(2) } }
 
-task 12, lines 93-95:
+task 12, lines 94-96:
 //# programmable --inputs object(2,0) receiving(2,1)
 //> 0: MakeMoveVec<sui::transfer::Receiving<tto::M1::A>>([Input(1)]);
 //> 1: tto::M1::unpacker_generic<tto::M1::B>(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/pt_receive_type_separation.move
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/pt_receive_type_separation.move
@@ -1,0 +1,93 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests that reach receiving usage by type has a different logical value/local in PTB execution
+
+//# init --addresses tto=0x0
+
+//# publish
+module tto::m1 {
+    use sui::transfer::Receiving;
+
+    public struct A has key, store {
+        id: UID,
+    }
+
+    public struct B has key, store {
+        id: UID,
+    }
+
+    public struct C has key, store {
+        id: UID,
+    }
+
+    public fun start(ctx: &mut TxContext) {
+        let a = A { id: object::new(ctx) };
+        let a_address = object::id_address(&a);
+        transfer::public_transfer(a, tx_context::sender(ctx));
+        transfer::public_transfer(B { id: object::new(ctx) }, a_address);
+        transfer::public_transfer(B { id: object::new(ctx) }, a_address);
+    }
+
+    public fun id<T: key>(x: Receiving<T>): Receiving<T> {
+        x
+    }
+
+    public fun borrow_mut<T: key>(x: &mut Receiving<T>): &mut Receiving<T> {
+        x
+    }
+
+    public fun receive(parent: &mut A, x: Receiving<B>) {
+        let b = transfer::receive(&mut parent.id, x);
+        transfer::public_transfer(b, @tto);
+    }
+
+    public fun take_all(parent: &mut A, a: Receiving<A>, b: Receiving<B>, c: Receiving<C>) {
+        assert!(transfer::receiving_object_id(&a) == transfer::receiving_object_id(&b));
+        assert!(transfer::receiving_object_id(&b) == transfer::receiving_object_id(&c));
+        receive(parent, b);
+    }
+
+    public fun take_two_b(parent: &mut A, b1: Receiving<B>, b2: Receiving<B>, ) {
+        receive(parent, b1);
+        receive(parent, b2);
+    }
+
+}
+
+//# run tto::m1::start
+
+//# view-object 2,0
+
+//# view-object 2,1
+
+//# view-object 2,2
+
+// Can use receiving multiple times with different types
+//# programmable --inputs receiving(2,1) --dev-inspect
+//> 0: tto::m1::borrow_mut<tto::m1::A>(Input(0));
+//> tto::m1::id<tto::m1::B>(Input(0));
+//> tto::m1::id<tto::m1::C>(Input(0));
+//> tto::m1::borrow_mut<tto::m1::A>(Result(0));
+
+// But we cannot use them multiple times (by value) with the same type
+//# programmable --inputs receiving(2,1)
+//> tto::m1::id<tto::m1::A>(Input(0));
+//> tto::m1::id<tto::m1::B>(Input(0));
+//> tto::m1::id<tto::m1::C>(Input(0));
+//> tto::m1::id<tto::m1::A>(Input(0));
+
+// And can receive one of them
+//# programmable --inputs object(2,0) receiving(2,1)
+//> tto::m1::id<tto::m1::A>(Input(1));
+//> 1: tto::m1::id<tto::m1::B>(Input(1));
+//> tto::m1::id<tto::m1::C>(Input(1));
+//> tto::m1::receive(Input(0), Result(1));
+
+// Cannot double take the same receiving input twice at the same type
+//# programmable --inputs object(2,0) receiving(2,2)
+//> tto::m1::take_two_b(Input(0), Input(1), Input(1))
+
+// But can use receiving multiple times with different types all at once
+//# programmable --inputs object(2,0) receiving(2,2)
+//> tto::m1::take_all(Input(0), Input(1), Input(1), Input(1))

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/pt_receive_type_separation.snap
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/pt_receive_type_separation.snap
@@ -1,0 +1,95 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 11 tasks
+
+task 1, lines 8-56:
+//# publish
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 9180800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 58:
+//# run tto::m1::start
+created: object(2,0), object(2,1), object(2,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 4636000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, line 60:
+//# view-object 2,0
+Owner: Account Address ( _ )
+Version: 3
+Contents: tto::m1::A {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+}
+
+task 4, line 62:
+//# view-object 2,1
+Owner: Account Address ( fake(2,0) )
+Version: 3
+Contents: tto::m1::B {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,1),
+        },
+    },
+}
+
+task 5, lines 64-66:
+//# view-object 2,2
+Owner: Account Address ( fake(2,0) )
+Version: 3
+Contents: tto::m1::B {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,2),
+        },
+    },
+}
+
+task 6, lines 67-73:
+//# programmable --inputs receiving(2,1) --dev-inspect
+//> 0: tto::m1::borrow_mut<tto::m1::A>(Input(0));
+//> tto::m1::id<tto::m1::B>(Input(0));
+//> tto::m1::id<tto::m1::C>(Input(0));
+//> tto::m1::borrow_mut<tto::m1::A>(Result(0));
+// But we cannot use them multiple times (by value) with the same type
+Error: Transaction Effects Status: CommandArgumentError { arg_idx: 0, kind: TypeMismatch } in command 1
+Execution Error: CommandArgumentError { arg_idx: 0, kind: TypeMismatch } in command 1
+
+task 7, lines 74-80:
+//# programmable --inputs receiving(2,1)
+//> tto::m1::id<tto::m1::A>(Input(0));
+//> tto::m1::id<tto::m1::B>(Input(0));
+//> tto::m1::id<tto::m1::C>(Input(0));
+//> tto::m1::id<tto::m1::A>(Input(0));
+// And can receive one of them
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidValueUsage }, source: None, command: Some(1) } }
+
+task 8, lines 81-87:
+//# programmable --inputs object(2,0) receiving(2,1)
+//> tto::m1::id<tto::m1::A>(Input(1));
+//> 1: tto::m1::id<tto::m1::B>(Input(1));
+//> tto::m1::id<tto::m1::C>(Input(1));
+//> tto::m1::receive(Input(0), Result(1));
+// Cannot double take the same receiving input twice at the same type
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidValueUsage }, source: None, command: Some(1) } }
+
+task 9, lines 88-91:
+//# programmable --inputs object(2,0) receiving(2,2)
+//> tto::m1::take_two_b(Input(0), Input(1), Input(1))
+// But can use receiving multiple times with different types all at once
+Error: Transaction Effects Status: Invalid command argument at 2. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 2, kind: InvalidValueUsage }, source: None, command: Some(0) } }
+
+task 10, lines 92-93:
+//# programmable --inputs object(2,0) receiving(2,2)
+//> tto::m1::take_all(Input(0), Input(1), Input(1), Input(1))
+Error: Transaction Effects Status: Invalid command argument at 2. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 2, kind: InvalidValueUsage }, source: None, command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/receive_object/pt_receive_type_separation@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/receive_object/pt_receive_type_separation@v2.snap
@@ -1,0 +1,95 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 11 tasks
+
+task 1, lines 8-56:
+//# publish
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 9180800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 58:
+//# run tto::m1::start
+created: object(2,0), object(2,1), object(2,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 4636000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, line 60:
+//# view-object 2,0
+Owner: Account Address ( _ )
+Version: 3
+Contents: tto::m1::A {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,0),
+        },
+    },
+}
+
+task 4, line 62:
+//# view-object 2,1
+Owner: Account Address ( fake(2,0) )
+Version: 3
+Contents: tto::m1::B {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,1),
+        },
+    },
+}
+
+task 5, lines 64-66:
+//# view-object 2,2
+Owner: Account Address ( fake(2,0) )
+Version: 3
+Contents: tto::m1::B {
+    id: sui::object::UID {
+        id: sui::object::ID {
+            bytes: fake(2,2),
+        },
+    },
+}
+
+task 6, lines 67-73:
+//# programmable --inputs receiving(2,1) --dev-inspect
+//> 0: tto::m1::borrow_mut<tto::m1::A>(Input(0));
+//> tto::m1::id<tto::m1::B>(Input(0));
+//> tto::m1::id<tto::m1::C>(Input(0));
+//> tto::m1::borrow_mut<tto::m1::A>(Result(0));
+// But we cannot use them multiple times (by value) with the same type
+mutated: object(_)
+gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 7, lines 74-80:
+//# programmable --inputs receiving(2,1)
+//> tto::m1::id<tto::m1::A>(Input(0));
+//> tto::m1::id<tto::m1::B>(Input(0));
+//> tto::m1::id<tto::m1::C>(Input(0));
+//> tto::m1::id<tto::m1::A>(Input(0));
+// And can receive one of them
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: InvalidValueUsage }, source: None, command: Some(3) } }
+
+task 8, lines 81-87:
+//# programmable --inputs object(2,0) receiving(2,1)
+//> tto::m1::id<tto::m1::A>(Input(1));
+//> 1: tto::m1::id<tto::m1::B>(Input(1));
+//> tto::m1::id<tto::m1::C>(Input(1));
+//> tto::m1::receive(Input(0), Result(1));
+// Cannot double take the same receiving input twice at the same type
+mutated: object(0,0), object(2,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 3420000,  storage_rebate: 3385800, non_refundable_storage_fee: 34200
+
+task 9, lines 88-91:
+//# programmable --inputs object(2,0) receiving(2,2)
+//> tto::m1::take_two_b(Input(0), Input(1), Input(1))
+// But can use receiving multiple times with different types all at once
+Error: Transaction Effects Status: Invalid command argument at 2. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 2, kind: InvalidValueUsage }, source: None, command: Some(0) } }
+
+task 10, lines 92-93:
+//# programmable --inputs object(2,0) receiving(2,2)
+//> tto::m1::take_all(Input(0), Input(1), Input(1), Input(1))
+mutated: object(0,0), object(2,0), object(2,2)
+gas summary: computation_cost: 1000000, storage_cost: 3420000,  storage_rebate: 3385800, non_refundable_storage_fee: 34200

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
@@ -1028,7 +1028,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas> Context<'env, 'pc, 'vm, 'state, 'li
                 self.locations.pure_input_metadata[i as usize].original_input_index,
             ),
             T::Location::ReceivingInput(i) => TxArgument::Input(
-                self.locations.pure_input_metadata[i as usize].original_input_index,
+                self.locations.receiving_input_metadata[i as usize].original_input_index,
             ),
         };
         Ok(Some((arg, bytes, tag)))

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
@@ -10,14 +10,12 @@ use crate::{
     programmable_transactions as legacy_ptb, sp,
     static_programmable_transactions::{
         env::Env,
-        execution::values::{
-            ByteValue, InitialInput, InputObjectMetadata, InputValue, Inputs, Local, Locals, Value,
-        },
+        execution::values::{Local, Locals, Value},
         linkage::resolved_linkage::{ResolvedLinkage, RootedLinkage},
         typing::ast::{self as T, Type},
     },
 };
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use move_binary_format::{
     CompiledModule,
     errors::{Location, PartialVMError, VMResult},
@@ -46,7 +44,7 @@ use sui_move_natives::object_runtime::{
 };
 use sui_types::{
     TypeTag,
-    base_types::{MoveObjectType, ObjectID, TxContext},
+    base_types::{MoveObjectType, ObjectID, SequenceNumber, TxContext},
     error::{ExecutionError, ExecutionErrorKind},
     execution::ExecutionResults,
     execution_config_utils::to_binary_config,
@@ -95,20 +93,54 @@ macro_rules! charge_gas {
 #[derive(Debug)]
 pub struct CtxValue(Value);
 
-enum LocationValue<'a> {
-    Loaded(Local<'a>),
-    InputBytes(&'a mut Inputs, u16, Type),
+#[derive(Clone, Debug)]
+pub struct InputObjectMetadata {
+    pub id: ObjectID,
+    pub is_mutable_input: bool,
+    pub owner: Owner,
+    pub version: SequenceNumber,
+    pub type_: Type,
 }
 
 #[derive(Copy, Clone)]
 enum UsageKind {
     Move,
     Copy,
-    Borrow(/* mut */ bool),
+    Borrow,
 }
 
-// Type alias used to document borrowing the `imm_ref_temps` field
-type TempLocals = Vec<Locals>;
+// Locals and metadata for all `Location`s. Separated from `Context` for lifetime reasons.
+struct Locations {
+    // A single local for holding the TxContext
+    tx_context_value: Locals,
+    /// The runtime value for the Gas coin, None if no gas coin is provided
+    gas: Option<(InputObjectMetadata, Locals)>,
+    /// The runtime value for the input objects args
+    input_object_metadata: Vec<(/* original input index */ u16, InputObjectMetadata)>,
+    object_inputs: Locals,
+    pure_input_bytes: IndexSet<Vec<u8>>,
+    pure_input_metadata: Vec<T::PureInput>,
+    pure_inputs: Locals,
+    receiving_input_metadata: Vec<T::ReceivingInput>,
+    receiving_inputs: Locals,
+    /// The results of a given command. For most commands, the inner vector will have length 1.
+    /// It will only not be 1 for Move calls with multiple return values.
+    /// Inner values are None if taken/moved by-value
+    results: Vec<Locals>,
+}
+
+enum ResolvedLocation<'a> {
+    Local(Local<'a>),
+    Pure {
+        bytes: &'a [u8],
+        metadata: &'a T::PureInput,
+        local: Local<'a>,
+    },
+    Receiving {
+        metadata: &'a T::ReceivingInput,
+        local: Local<'a>,
+    },
+}
 
 /// Maintains all runtime state specific to programmable transactions
 pub struct Context<'env, 'pc, 'vm, 'state, 'linkage, 'gas> {
@@ -124,19 +156,54 @@ pub struct Context<'env, 'pc, 'vm, 'state, 'linkage, 'gas> {
     /// User events are claimed after each Move call
     user_events: Vec<(ModuleId, StructTag, Vec<u8>)>,
     // runtime data
-    // A single local for holding the TxContext
-    tx_context_value: Locals,
-    /// The runtime value for the Gas coin, None if no gas coin is provided
-    gas: Option<Inputs>,
-    /// The runtime value for the inputs/call args
-    inputs: Inputs,
-    /// The results of a given command. For most commands, the inner vector will have length 1.
-    /// It will only not be 1 for Move calls with multiple return values.
-    /// Inner values are None if taken/moved by-value
-    results: Vec<Locals>,
-    // used by by-ref Pure inputs without fixed types. We must create one-off references to these
-    // values, which will be dropped at the end of the transaction.
-    imm_ref_temps: TempLocals,
+    locations: Locations,
+}
+
+impl Locations {
+    /// NOTE! This does not charge gas and should not be used directly. It is exposed for
+    /// dev-inspect
+    fn resolve<'a>(
+        &'a mut self,
+        location: T::Location,
+    ) -> Result<ResolvedLocation<'a>, ExecutionError> {
+        Ok(match location {
+            T::Location::TxContext => ResolvedLocation::Local(self.tx_context_value.local(0)?),
+            T::Location::GasCoin => {
+                let (_, gas_locals) = unwrap!(self.gas.as_mut(), "Gas coin not provided");
+                ResolvedLocation::Local(gas_locals.local(0)?)
+            }
+            T::Location::ObjectInput(i) => {
+                ResolvedLocation::Local(self.object_inputs.local(i as u16)?)
+            }
+            T::Location::Result(i, j) => {
+                let result = unwrap!(self.results.get_mut(i as usize), "bounds already verified");
+                ResolvedLocation::Local(result.local(j)?)
+            }
+            T::Location::PureInput(i) => {
+                let local = self.pure_inputs.local(i as u16)?;
+                let metadata = &self.pure_input_metadata[i as usize];
+                let bytes = self
+                    .pure_input_bytes
+                    .get_index(metadata.byte_index)
+                    .ok_or_else(|| {
+                        make_invariant_violation!(
+                            "Pure input {} bytes out of bounds at index {}",
+                            metadata.original_input_index,
+                            metadata.byte_index,
+                        )
+                    })?;
+                ResolvedLocation::Pure {
+                    bytes,
+                    metadata,
+                    local,
+                }
+            }
+            T::Location::ReceivingInput(i) => ResolvedLocation::Receiving {
+                metadata: &self.receiving_input_metadata[i as usize],
+                local: self.receiving_inputs.local(i as u16)?,
+            },
+        })
+    }
 }
 
 impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas> Context<'env, 'pc, 'vm, 'state, 'linkage, 'gas> {
@@ -146,17 +213,25 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas> Context<'env, 'pc, 'vm, 'state, 'li
         metrics: Arc<LimitsMetrics>,
         tx_context: Rc<RefCell<TxContext>>,
         gas_charger: &'gas mut GasCharger,
-        inputs: T::Inputs,
+        pure_input_bytes: IndexSet<Vec<u8>>,
+        object_inputs: Vec<T::ObjectInput>,
+        pure_input_metadata: Vec<T::PureInput>,
+        receiving_input_metadata: Vec<T::ReceivingInput>,
     ) -> Result<Self, ExecutionError>
     where
         'pc: 'state,
     {
         let mut input_object_map = BTreeMap::new();
-        let inputs = inputs
-            .into_iter()
-            .map(|(arg, ty)| load_input_arg(gas_charger, env, &mut input_object_map, arg, ty))
-            .collect::<Result<Vec<_>, ExecutionError>>()?;
-        let inputs = Inputs::new(inputs)?;
+        let mut input_object_metadata = Vec::with_capacity(object_inputs.len());
+        let mut object_values = Vec::with_capacity(object_inputs.len());
+        for object_input in object_inputs {
+            let (i, m, v) = load_object_arg(gas_charger, env, &mut input_object_map, object_input)?;
+            input_object_metadata.push((i, m));
+            object_values.push(v);
+        }
+        let object_inputs = Locals::new(object_values)?;
+        let pure_inputs = Locals::new_invalid(pure_input_metadata.len())?;
+        let receiving_inputs = Locals::new_invalid(receiving_input_metadata.len())?;
         let gas = match gas_charger.gas_coin() {
             Some(gas_coin) => {
                 let ty = env.gas_coin_type()?;
@@ -168,15 +243,13 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas> Context<'env, 'pc, 'vm, 'state, 'li
                     true,
                     ty,
                 )?;
-                let mut gas_locals = Inputs::new([InitialInput::Object(gas_metadata, gas_value)])?;
-                let InputValue::Loaded(gas_local) = gas_locals.get(0)? else {
-                    invariant_violation!("Gas coin should be loaded, not bytes");
-                };
+                let mut gas_locals = Locals::new([gas_value])?;
+                let gas_local = gas_locals.local(0)?;
                 let gas_ref = gas_local.borrow()?;
                 // We have already checked that the gas balance is enough to cover the gas budget
                 let max_gas_in_balance = gas_charger.gas_budget();
                 gas_ref.coin_ref_subtract_balance(max_gas_in_balance)?;
-                Some(gas_locals)
+                Some((gas_metadata, gas_locals))
             }
             None => None,
         };
@@ -197,32 +270,46 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas> Context<'env, 'pc, 'vm, 'state, 'li
             tx_context,
             gas_charger,
             user_events: vec![],
-            tx_context_value,
-            gas,
-            inputs,
-            results: vec![],
-            imm_ref_temps: vec![],
+            locations: Locations {
+                tx_context_value,
+                gas,
+                input_object_metadata,
+                object_inputs,
+                pure_input_bytes,
+                pure_input_metadata,
+                pure_inputs,
+                receiving_input_metadata,
+                receiving_inputs,
+                results: vec![],
+            },
         })
     }
 
     pub fn finish<Mode: ExecutionMode>(mut self) -> Result<ExecutionResults, ExecutionError> {
         assert_invariant!(
-            !self.tx_context_value.local(0)?.is_invalid()?,
+            !self.locations.tx_context_value.local(0)?.is_invalid()?,
             "tx context value should be present"
         );
-        let gas = std::mem::take(&mut self.gas);
-        let inputs = std::mem::replace(&mut self.inputs, Inputs::new([])?);
+        let gas = std::mem::take(&mut self.locations.gas);
+        let object_input_metadata = std::mem::take(&mut self.locations.input_object_metadata);
+        let mut object_inputs =
+            std::mem::replace(&mut self.locations.object_inputs, Locals::new_invalid(0)?);
         let mut loaded_runtime_objects = BTreeMap::new();
         let mut by_value_shared_objects = BTreeSet::new();
         let mut consensus_owner_objects = BTreeMap::new();
-        let gas_object = gas
-            .map(|g| g.into_objects())
-            .transpose()?
-            .unwrap_or_default();
-        debug_assert!(gas_object.len() <= 1);
-        let gas_id_opt = gas_object.first().map(|(o, _)| o.id);
-        let input_objects = inputs.into_objects()?;
-        for (metadata, value) in input_objects.into_iter().chain(gas_object) {
+        let gas = gas
+            .map(|(m, mut g)| Result::<_, ExecutionError>::Ok((m, g.local(0)?.move_if_valid()?)))
+            .transpose()?;
+        let gas_id_opt = gas.as_ref().map(|(m, _)| m.id);
+        let object_inputs = object_input_metadata
+            .into_iter()
+            .enumerate()
+            .map(|(i, (_, m))| {
+                let v_opt = object_inputs.local(i as u16)?.move_if_valid()?;
+                Ok((m, v_opt))
+            })
+            .collect::<Result<Vec<_>, ExecutionError>>()?;
+        for (metadata, value_opt) in object_inputs.into_iter().chain(gas) {
             let InputObjectMetadata {
                 id,
                 is_mutable_input,
@@ -241,7 +328,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas> Context<'env, 'pc, 'vm, 'state, 'li
                     is_modified: true,
                 },
             );
-            if let Some(object) = value {
+            if let Some(object) = value_opt {
                 self.transfer_object_(
                     owner,
                     type_,
@@ -297,7 +384,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas> Context<'env, 'pc, 'vm, 'state, 'li
             let abilities = ty.abilities();
             let has_public_transfer = abilities.has_store();
             let Some(bytes) = value.serialize() else {
-                invariant_violation!("Failed to deserialize already serialized Move value");
+                invariant_violation!("Failed to serialize already deserialized Move value");
             };
             // safe because has_public_transfer has been determined by the abilities
             let move_object = unsafe {
@@ -416,125 +503,62 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas> Context<'env, 'pc, 'vm, 'state, 'li
     // Arguments and Values
     //
 
-    /// NOTE! This does not charge gas and should not be used directly. It is exposed for
-    /// dev-inspect
-    fn location_value<'a>(
-        &'a mut self,
-        location: T::Location,
-        ty: Type,
-    ) -> Result<
-        (
-            &'a mut TempLocals,
-            &'a mut GasCharger,
-            &'env Env<'pc, 'vm, 'state, 'linkage>,
-            LocationValue<'a>,
-        ),
-        ExecutionError,
-    > {
-        let v = match location {
-            T::Location::TxContext => {
-                let tx_context_local = self.tx_context_value.local(0)?;
-                LocationValue::Loaded(tx_context_local)
-            }
-            T::Location::GasCoin => {
-                let gas_locals = unwrap!(self.gas.as_mut(), "Gas coin not provided");
-                let InputValue::Loaded(gas_local) = gas_locals.get(0)? else {
-                    // TODO maybe give a better error here
-                    invariant_violation!("Gas coin could not be loaded");
-                };
-                LocationValue::Loaded(gas_local)
-            }
-            T::Location::Result(i, j) => {
-                let result = unwrap!(self.results.get_mut(i as usize), "bounds already verified");
-                let v = result.local(j)?;
-                LocationValue::Loaded(v)
-            }
-            T::Location::Input(i) => {
-                let is_bytes = self.inputs.is_bytes(i);
-                if is_bytes {
-                    LocationValue::InputBytes(&mut self.inputs, i, ty)
-                } else {
-                    let InputValue::Loaded(v) = self.inputs.get(i)? else {
-                        invariant_violation!("Expected local");
-                    };
-                    LocationValue::Loaded(v)
-                }
-            }
-        };
-        Ok((&mut self.imm_ref_temps, self.gas_charger, self.env, v))
-    }
-
     fn location(
         &mut self,
         usage: UsageKind,
         location: T::Location,
-        ty: Type,
     ) -> Result<Value, ExecutionError> {
-        let (imm_ref_temps, gas_charger, env, lv) = self.location_value(location, ty)?;
-        let mut local = match lv {
-            LocationValue::Loaded(v) => v,
-            LocationValue::InputBytes(inputs, i, ty) => {
-                let bytes = match inputs.get(i)? {
-                    InputValue::Bytes(v) => v,
-                    InputValue::Loaded(_) => invariant_violation!("Expected bytes"),
-                };
-                let value = load_byte_value(gas_charger, env, bytes, ty)?;
-                match usage {
-                    UsageKind::Borrow(true) => {
-                        // "fix" the BCS bytes to a given value
-                        inputs.fix(i, value)?;
-                        match inputs.get(i)? {
-                            InputValue::Loaded(v) => v,
-                            InputValue::Bytes(_) => invariant_violation!("Expected fixed value"),
-                        }
-                    }
-                    UsageKind::Borrow(false) => {
-                        // in the case that we need a reference but it is not "fixed", we must
-                        // create a temporary local to borrow
-                        imm_ref_temps.push(Locals::new(vec![value])?);
-                        let local = imm_ref_temps.last_mut().unwrap();
-                        local.local(0)?
-                    }
-                    UsageKind::Move | UsageKind::Copy => {
-                        // return a fresh copy of the value
-                        // Move should only happen for dev-inspect or `Receiving`
-                        return Ok(value);
-                    }
+        let resolved = self.locations.resolve(location)?;
+        let mut local = match resolved {
+            ResolvedLocation::Local(l) => l,
+            ResolvedLocation::Pure {
+                bytes,
+                metadata,
+                mut local,
+            } => {
+                if local.is_invalid()? {
+                    let v = load_pure_value(self.gas_charger, self.env, bytes, metadata)?;
+                    local.store(v)?;
                 }
+                local
+            }
+            ResolvedLocation::Receiving {
+                metadata,
+                mut local,
+            } => {
+                if local.is_invalid()? {
+                    let v = load_receiving_value(self.gas_charger, self.env, metadata)?;
+                    local.store(v)?;
+                }
+                local
             }
         };
         Ok(match usage {
             UsageKind::Move => local.move_()?,
             UsageKind::Copy => {
                 let value = local.copy()?;
-                charge_gas_!(gas_charger, env, charge_copy_loc, &value)?;
+                charge_gas_!(self.gas_charger, self.env, charge_copy_loc, &value)?;
                 value
             }
-            UsageKind::Borrow(_) => local.borrow()?,
+            UsageKind::Borrow => local.borrow()?,
         })
     }
 
-    fn location_usage(&mut self, usage: T::Usage, ty: Type) -> Result<Value, ExecutionError> {
+    fn location_usage(&mut self, usage: T::Usage) -> Result<Value, ExecutionError> {
         match usage {
-            T::Usage::Move(location) => self.location(UsageKind::Move, location, ty),
-            T::Usage::Copy { location, .. } => self.location(UsageKind::Copy, location, ty),
+            T::Usage::Move(location) => self.location(UsageKind::Move, location),
+            T::Usage::Copy { location, .. } => self.location(UsageKind::Copy, location),
         }
     }
 
-    fn argument_value(&mut self, sp!(_, (arg_, ty)): T::Argument) -> Result<Value, ExecutionError> {
+    fn argument_value(&mut self, sp!(_, (arg_, _)): T::Argument) -> Result<Value, ExecutionError> {
         match arg_ {
-            T::Argument__::Use(usage) => self.location_usage(usage, ty),
+            T::Argument__::Use(usage) => self.location_usage(usage),
             // freeze is a no-op for references since the value does not track mutability
-            T::Argument__::Freeze(usage) => self.location_usage(usage, ty),
-            T::Argument__::Borrow(is_mut, location) => {
-                let ty = match ty {
-                    Type::Reference(_, inner) => (*inner).clone(),
-                    _ => invariant_violation!("Expected reference type"),
-                };
-                self.location(UsageKind::Borrow(is_mut), location, ty)
-            }
+            T::Argument__::Freeze(usage) => self.location_usage(usage),
+            T::Argument__::Borrow(_, location) => self.location(UsageKind::Borrow, location),
             T::Argument__::Read(usage) => {
-                let reference = self.location_usage(usage, ty)?;
+                let reference = self.location_usage(usage)?;
                 charge_gas!(self, charge_read_ref, &reference)?;
                 reference.read_ref()
             }
@@ -558,7 +582,8 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas> Context<'env, 'pc, 'vm, 'state, 'li
     }
 
     pub fn result(&mut self, result: Vec<CtxValue>) -> Result<(), ExecutionError> {
-        self.results
+        self.locations
+            .results
             .push(Locals::new(result.into_iter().map(|v| v.0))?);
         Ok(())
     }
@@ -967,16 +992,15 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas> Context<'env, 'pc, 'vm, 'state, 'li
             invariant_violation!("unable to generate type tag from type")
         };
         let location = arg.location();
-        let (_, _, _, lv) = self.location_value(location, ty)?;
-        let local = match lv {
-            LocationValue::Loaded(v) => {
-                if v.is_invalid()? {
-                    return Ok(None);
-                }
-                v
-            }
-            LocationValue::InputBytes(_, _, _) => return Ok(None),
+        let resolved = self.locations.resolve(location)?;
+        let local = match resolved {
+            ResolvedLocation::Local(local)
+            | ResolvedLocation::Pure { local, .. }
+            | ResolvedLocation::Receiving { local, .. } => local,
         };
+        if local.is_invalid()? {
+            return Ok(None);
+        }
         // copy the value from the local
         let value = local.copy()?;
         let value = match arg {
@@ -1001,8 +1025,16 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas> Context<'env, 'pc, 'vm, 'state, 'li
         let arg = match location {
             T::Location::TxContext => return Ok(None),
             T::Location::GasCoin => TxArgument::GasCoin,
-            T::Location::Input(i) => TxArgument::Input(i),
             T::Location::Result(i, j) => TxArgument::NestedResult(i, j),
+            T::Location::ObjectInput(i) => {
+                TxArgument::Input(self.locations.input_object_metadata[i as usize].0)
+            }
+            T::Location::PureInput(i) => TxArgument::Input(
+                self.locations.pure_input_metadata[i as usize].original_input_index,
+            ),
+            T::Location::ReceivingInput(i) => TxArgument::Input(
+                self.locations.pure_input_metadata[i as usize].original_input_index,
+            ),
         };
         Ok(Some((arg, bytes, tag)))
     }
@@ -1077,38 +1109,24 @@ impl CtxValue {
     }
 }
 
-fn load_input_arg(
-    meter: &mut GasCharger,
-    env: &Env,
-    input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
-    arg: T::InputArg,
-    ty: T::InputType,
-) -> Result<InitialInput, ExecutionError> {
-    Ok(match arg {
-        T::InputArg::Pure(bytes) => InitialInput::Bytes(ByteValue::Pure(bytes)),
-        T::InputArg::Receiving((id, version, _)) => {
-            InitialInput::Bytes(ByteValue::Receiving { id, version })
-        }
-        T::InputArg::Object(arg) => {
-            let T::InputType::Fixed(ty) = ty else {
-                invariant_violation!("Expected fixed type for object arg");
-            };
-            let (object_metadata, value) = load_object_arg(meter, env, input_object_map, arg, ty)?;
-            InitialInput::Object(object_metadata, value)
-        }
-    })
-}
-
 fn load_object_arg(
     meter: &mut GasCharger,
     env: &Env,
     input_object_map: &mut BTreeMap<ObjectID, object_runtime::InputObject>,
-    arg: T::ObjectArg,
-    ty: T::Type,
-) -> Result<(InputObjectMetadata, Value), ExecutionError> {
-    let id = arg.id();
-    let is_mutable_input = arg.is_mutable();
-    load_object_arg_impl(meter, env, input_object_map, id, is_mutable_input, ty)
+    input: T::ObjectInput,
+) -> Result<
+    (
+        /* original input index */ u16,
+        InputObjectMetadata,
+        Value,
+    ),
+    ExecutionError,
+> {
+    let id = input.arg.id();
+    let is_mutable_input = input.arg.is_mutable();
+    let (metadata, value) =
+        load_object_arg_impl(meter, env, input_object_map, id, is_mutable_input, input.ty)?;
+    Ok((input.original_input_index, metadata, value))
 }
 
 fn load_object_arg_impl(
@@ -1156,16 +1174,25 @@ fn load_object_arg_impl(
     Ok((object_metadata, v))
 }
 
-fn load_byte_value(
+fn load_pure_value(
     meter: &mut GasCharger,
     env: &Env,
-    value: &ByteValue,
-    ty: Type,
+    bytes: &[u8],
+    metadata: &T::PureInput,
 ) -> Result<Value, ExecutionError> {
-    let loaded = match value {
-        ByteValue::Pure(bytes) => Value::deserialize(env, bytes, ty)?,
-        ByteValue::Receiving { id, version } => Value::receiving(*id, *version),
-    };
+    let loaded = Value::deserialize(env, bytes, metadata.ty.clone())?;
+    // ByteValue::Receiving { id, version } => Value::receiving(*id, *version),
+    charge_gas_!(meter, env, charge_copy_loc, &loaded)?;
+    Ok(loaded)
+}
+
+fn load_receiving_value(
+    meter: &mut GasCharger,
+    env: &Env,
+    metadata: &T::ReceivingInput,
+) -> Result<Value, ExecutionError> {
+    let (id, version, _) = metadata.object_ref;
+    let loaded = Value::receiving(id, version);
     charge_gas_!(meter, env, charge_copy_loc, &loaded)?;
     Ok(loaded)
 }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
@@ -162,25 +162,20 @@ pub struct Context<'env, 'pc, 'vm, 'state, 'linkage, 'gas> {
 impl Locations {
     /// NOTE! This does not charge gas and should not be used directly. It is exposed for
     /// dev-inspect
-    fn resolve<'a>(
-        &'a mut self,
-        location: T::Location,
-    ) -> Result<ResolvedLocation<'a>, ExecutionError> {
+    fn resolve(&mut self, location: T::Location) -> Result<ResolvedLocation, ExecutionError> {
         Ok(match location {
             T::Location::TxContext => ResolvedLocation::Local(self.tx_context_value.local(0)?),
             T::Location::GasCoin => {
                 let (_, gas_locals) = unwrap!(self.gas.as_mut(), "Gas coin not provided");
                 ResolvedLocation::Local(gas_locals.local(0)?)
             }
-            T::Location::ObjectInput(i) => {
-                ResolvedLocation::Local(self.object_inputs.local(i as u16)?)
-            }
+            T::Location::ObjectInput(i) => ResolvedLocation::Local(self.object_inputs.local(i)?),
             T::Location::Result(i, j) => {
                 let result = unwrap!(self.results.get_mut(i as usize), "bounds already verified");
                 ResolvedLocation::Local(result.local(j)?)
             }
             T::Location::PureInput(i) => {
-                let local = self.pure_inputs.local(i as u16)?;
+                let local = self.pure_inputs.local(i)?;
                 let metadata = &self.pure_input_metadata[i as usize];
                 let bytes = self
                     .pure_input_bytes
@@ -200,7 +195,7 @@ impl Locations {
             }
             T::Location::ReceivingInput(i) => ResolvedLocation::Receiving {
                 metadata: &self.receiving_input_metadata[i as usize],
-                local: self.receiving_inputs.local(i as u16)?,
+                local: self.receiving_inputs.local(i)?,
             },
         })
     }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/interpreter.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/interpreter.rs
@@ -66,8 +66,23 @@ pub fn execute_inner<'env, 'pc, 'vm, 'state, 'linkage, Mode: ExecutionMode>(
 where
     'pc: 'state,
 {
-    let T::Transaction { inputs, commands } = ast;
-    let mut context = Context::new(env, metrics, tx_context, gas_charger, inputs)?;
+    let T::Transaction {
+        bytes,
+        objects,
+        pure,
+        receiving,
+        commands,
+    } = ast;
+    let mut context = Context::new(
+        env,
+        metrics,
+        tx_context,
+        gas_charger,
+        bytes,
+        objects,
+        pure,
+        receiving,
+    )?;
     let mut mode_results = Mode::empty_results();
     for (sp!(idx, command), tys) in commands {
         let start = Instant::now();

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/ast.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/ast.rs
@@ -49,7 +49,7 @@ pub enum ObjectArg {
     },
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Type {
     Bool,
     U8,
@@ -65,13 +65,13 @@ pub enum Type {
     Reference(/* is mut */ bool, Rc<Type>),
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Vector {
     pub abilities: AbilitySet,
     pub element_type: Type,
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Datatype {
     pub abilities: AbilitySet,
     pub module: ModuleId,

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/ast.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/ast.rs
@@ -32,6 +32,7 @@ pub type Inputs = Vec<(InputArg, InputType)>;
 pub type Commands = Vec<Command>;
 
 #[derive(Debug)]
+#[cfg_attr(debug_assertions, derive(Clone))]
 pub enum InputArg {
     Pure(Vec<u8>),
     Receiving(ObjectRef),
@@ -39,6 +40,7 @@ pub enum InputArg {
 }
 
 #[derive(Debug)]
+#[cfg_attr(debug_assertions, derive(Clone))]
 pub enum ObjectArg {
     ImmObject(ObjectRef),
     OwnedObject(ObjectRef),

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/ast.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/ast.rs
@@ -6,11 +6,8 @@ use crate::static_programmable_transactions::{
 };
 use indexmap::IndexSet;
 use move_vm_types::values::VectorSpecialization;
-use std::{cell::OnceCell, collections::BTreeMap, fmt};
-use sui_types::{
-    base_types::{ObjectID, ObjectRef},
-    transfer::Receiving,
-};
+use std::cell::OnceCell;
+use sui_types::base_types::{ObjectID, ObjectRef};
 
 //**************************************************************************************************
 // AST Nodes

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/ast.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/ast.rs
@@ -110,6 +110,7 @@ pub enum Location {
     GasCoin,
     ObjectInput(u16),
     PureInput(u16),
+    ReceivingInput(u16),
     Result(u16, u16),
 }
 

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/ast.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/ast.rs
@@ -26,9 +26,14 @@ pub struct Transaction {
     pub commands: Commands,
 }
 
+/// The original index into the `input` vector of the transaction, before the inputs were split
+/// into their respective categories (objects, pure, or receiving).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct InputIndex(pub u16);
+
 #[derive(Debug)]
 pub struct ObjectInput {
-    pub original_input_index: u16,
+    pub original_input_index: InputIndex,
     pub arg: ObjectArg,
     pub ty: Type,
 }
@@ -37,7 +42,7 @@ pub type ByteIndex = usize;
 
 #[derive(Debug)]
 pub struct PureInput {
-    pub original_input_index: u16,
+    pub original_input_index: InputIndex,
     // A index into `byte` table of BCS bytes
     pub byte_index: ByteIndex,
     // the type that the BCS bytes will be deserialized into
@@ -48,7 +53,7 @@ pub struct PureInput {
 
 #[derive(Debug)]
 pub struct ReceivingInput {
-    pub original_input_index: u16,
+    pub original_input_index: InputIndex,
     pub object_ref: ObjectRef,
     pub ty: Type,
     // Information about where this constraint came from

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/ast.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/ast.rs
@@ -4,9 +4,13 @@
 use crate::static_programmable_transactions::{
     linkage::resolved_linkage::ResolvedLinkage, loading::ast as L, spanned::Spanned,
 };
+use indexmap::IndexSet;
 use move_vm_types::values::VectorSpecialization;
 use std::{cell::OnceCell, collections::BTreeMap, fmt};
-use sui_types::base_types::ObjectID;
+use sui_types::{
+    base_types::{ObjectID, ObjectRef},
+    transfer::Receiving,
+};
 
 //**************************************************************************************************
 // AST Nodes
@@ -14,29 +18,51 @@ use sui_types::base_types::ObjectID;
 
 #[derive(Debug)]
 pub struct Transaction {
-    pub inputs: Inputs,
+    /// Gathered BCS bytes from Pure inputs
+    pub bytes: IndexSet<Vec<u8>>,
+    // All input objects
+    pub objects: Vec<ObjectInput>,
+    /// All pure inputs
+    pub pure: Vec<PureInput>,
+    /// All receiving inputs
+    pub receiving: Vec<ReceivingInput>,
     pub commands: Commands,
 }
 
-pub type Inputs = Vec<(InputArg, InputType)>;
+#[derive(Debug)]
+pub struct ObjectInput {
+    pub original_input_index: u16,
+    pub arg: ObjectArg,
+    pub ty: Type,
+}
+
+pub type ByteIndex = usize;
+
+#[derive(Debug)]
+pub struct PureInput {
+    pub original_input_index: u16,
+    // A index into `byte` table of BCS bytes
+    pub byte_index: ByteIndex,
+    // the type that the BCS bytes will be deserialized into
+    pub ty: Type,
+    // Information about where this constraint came from
+    pub constraint: BytesConstraint,
+}
+
+#[derive(Debug)]
+pub struct ReceivingInput {
+    pub original_input_index: u16,
+    pub object_ref: ObjectRef,
+    pub ty: Type,
+    // Information about where this constraint came from
+    pub constraint: BytesConstraint,
+}
 
 pub type Commands = Vec<(Command, ResultType)>;
-
-pub type InputArg = L::InputArg;
 
 pub type ObjectArg = L::ObjectArg;
 
 pub type Type = L::Type;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BytesUsage {
-    /// The bytes are copied
-    Copied,
-    /// The bytes are immutably borrowed, which means they are created once and then dropped
-    ByImmRef,
-    /// The bytes are mutably borrowed, which "fixes" the type
-    ByMutRef,
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// Information for a given constraint for input bytes
@@ -45,17 +71,8 @@ pub struct BytesConstraint {
     pub command: u16,
     /// The argument in that command
     pub argument: u16,
-    /// The type of usage for this bytes constraint
-    pub usage: BytesUsage,
 }
 
-#[derive(Debug)]
-pub enum InputType {
-    /// A series of BCS bytes, and all types that this must satisfy
-    Bytes(BTreeMap<Type, BytesConstraint>),
-    /// A fixed type--the type is known and "fixed" at input
-    Fixed(Type),
-}
 pub type ResultType = Vec<Type>;
 
 pub type Command = Spanned<Command_>;
@@ -91,7 +108,8 @@ pub struct MoveCall {
 pub enum Location {
     TxContext,
     GasCoin,
-    Input(u16),
+    ObjectInput(u16),
+    PureInput(u16),
     Result(u16, u16),
 }
 
@@ -184,18 +202,5 @@ impl TryFrom<Type> for VectorSpecialization {
             Type::Signer | Type::Vector(_) | Type::Datatype(_) => VectorSpecialization::Container,
             Type::Reference(_, _) => return Err("unexpected reference in vector specialization"),
         })
-    }
-}
-
-impl fmt::Display for Location {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Location::TxContext => write!(f, "TxContext"),
-            Location::GasCoin => write!(f, "GasCoin"),
-            Location::Input(idx) => write!(f, "Input({idx})"),
-            Location::Result(result_idx, nested_idx) => {
-                write!(f, "Result({result_idx}, {nested_idx})")
-            }
-        }
     }
 }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/defining_ids_in_types.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/defining_ids_in_types.rs
@@ -13,12 +13,15 @@ pub fn verify(env: &env::Env, tt: &T::Transaction) -> Result<(), ExecutionError>
     let check_arg = |sp!(_, (_, ty)): &Spanned<_>| ensure_type_defining_id_based(env, ty);
 
     // Verify all types in inputs are defining-id based.
-    tt.inputs
+    tt.objects
         .iter()
-        .try_for_each(|(_, input_type)| match input_type {
-            T::InputType::Bytes(tys) => tys.keys().try_for_each(check_type),
-            T::InputType::Fixed(ty) => check_type(ty),
-        })?;
+        .try_for_each(|object_input| check_type(&object_input.ty))?;
+    tt.pure
+        .iter()
+        .try_for_each(|pure_input| check_type(&pure_input.ty))?;
+    tt.receiving
+        .iter()
+        .try_for_each(|receiving_input| check_type(&receiving_input.ty))?;
 
     // Verify all types in commands are defining-id based.
     tt.commands

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/type_check.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/type_check.rs
@@ -314,7 +314,7 @@ fn usage(env: &Env, context: &Context, u: &T::Usage) -> anyhow::Result<T::Type> 
     }
 }
 
-fn location<'a>(env: &Env, context: &Context<'a>, l: T::Location) -> anyhow::Result<T::Type> {
+fn location(env: &Env, context: &Context, l: T::Location) -> anyhow::Result<T::Type> {
     Ok(match l {
         T::Location::TxContext => env.tx_context_type()?,
         T::Location::GasCoin => env.gas_coin_type()?,

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/type_check.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/type_check.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, rc::Rc};
+use std::rc::Rc;
 
 use crate::{
     execution_mode::ExecutionMode,
@@ -15,16 +15,18 @@ use crate::{
 use sui_types::{coin::RESOLVED_COIN_STRUCT, error::ExecutionError};
 
 struct Context<'txn> {
-    inputs: Vec<&'txn T::InputType>,
-    usable_inputs: Vec<bool>,
+    objects: Vec<&'txn T::Type>,
+    pure: Vec<&'txn T::Type>,
+    receiving: Vec<&'txn T::Type>,
     result_types: Vec<&'txn [T::Type]>,
 }
 
 impl<'txn> Context<'txn> {
     fn new(txn: &'txn T::Transaction) -> Self {
         Self {
-            inputs: txn.inputs.iter().map(|(_, ty)| ty).collect(),
-            usable_inputs: vec![false; txn.inputs.len()], // set later
+            objects: txn.objects.iter().map(|o| &o.ty).collect(),
+            pure: txn.pure.iter().map(|p| &p.ty).collect(),
+            receiving: txn.receiving.iter().map(|r| &r.ty).collect(),
             result_types: txn.commands.iter().map(|(_, ty)| ty.as_slice()).collect(),
         }
     }
@@ -35,10 +37,22 @@ pub fn verify<Mode: ExecutionMode>(env: &Env, txn: &T::Transaction) -> Result<()
 }
 
 fn verify_<Mode: ExecutionMode>(env: &Env, txn: &T::Transaction) -> anyhow::Result<()> {
-    let mut context = Context::new(txn);
-    let T::Transaction { inputs, commands } = txn;
-    for (idx, (i, ty)) in inputs.iter().enumerate() {
-        input::<Mode>(&mut context, idx, i, ty)?;
+    let context = Context::new(txn);
+    let T::Transaction {
+        bytes: _,
+        objects,
+        pure,
+        receiving,
+        commands,
+    } = txn;
+    for obj in objects {
+        object_input(obj)?;
+    }
+    for p in pure {
+        pure_input::<Mode>(p)?;
+    }
+    for r in receiving {
+        receiving_input(r)?;
     }
     for (c, result_tys) in commands {
         command::<Mode>(env, &context, c, result_tys)?;
@@ -46,47 +60,26 @@ fn verify_<Mode: ExecutionMode>(env: &Env, txn: &T::Transaction) -> anyhow::Resu
     Ok(())
 }
 
-fn input<Mode: ExecutionMode>(
-    context: &mut Context,
-    idx: usize,
-    arg: &T::InputArg,
-    ty: &T::InputType,
-) -> anyhow::Result<()> {
-    match arg {
-        T::InputArg::Pure(_) => {
-            let T::InputType::Bytes(tys) = ty else {
-                anyhow::bail!("pure should not have a fixed type",);
-            };
-            if !Mode::allow_arbitrary_values() {
-                for ty in tys.keys() {
-                    anyhow::ensure!(
-                        input_arguments::is_valid_pure_type(ty)?,
-                        "pure type must be valid"
-                    );
-                }
-            }
-            context.usable_inputs[idx] = !tys.is_empty();
-        }
-        T::InputArg::Receiving(_) => {
-            let T::InputType::Bytes(tys) = ty else {
-                anyhow::bail!("receiving should not have a fixed type",);
-            };
-            for ty in tys.keys() {
-                anyhow::ensure!(
-                    input_arguments::is_valid_receiving(ty),
-                    "receiving type must be valid"
-                );
-            }
-            context.usable_inputs[idx] = !tys.is_empty();
-        }
-        T::InputArg::Object(_) => {
-            let T::InputType::Fixed(ty) = ty else {
-                anyhow::bail!("object should not have a bytes type",);
-            };
-            anyhow::ensure!(ty.abilities().has_key(), "object type must have key");
-            context.usable_inputs[idx] = true
-        }
+fn object_input(obj: &T::ObjectInput) -> anyhow::Result<()> {
+    anyhow::ensure!(obj.ty.abilities().has_key(), "object type must have key");
+    Ok(())
+}
+
+fn pure_input<Mode: ExecutionMode>(p: &T::PureInput) -> anyhow::Result<()> {
+    if !Mode::allow_arbitrary_values() {
+        anyhow::ensure!(
+            input_arguments::is_valid_pure_type(&p.ty)?,
+            "pure type must be valid"
+        );
     }
+    Ok(())
+}
+
+fn receiving_input(r: &T::ReceivingInput) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        input_arguments::is_valid_receiving(&r.ty),
+        "receiving type must be valid"
+    );
     Ok(())
 }
 
@@ -252,7 +245,6 @@ fn argument(
     sp!(_, (arg__, ty)): &T::Argument,
     param: &T::Type,
 ) -> anyhow::Result<()> {
-    let t;
     anyhow::ensure!(
         ty == param,
         "argument type mismatch. Expected {param:?}, got {ty:?}"
@@ -260,35 +252,25 @@ fn argument(
     let (actual, expected) = match arg__ {
         T::Argument__::Use(u) => (usage(env, context, u)?, param),
         T::Argument__::Read(u) => {
-            let actual = usage(env, context, u)?;
-            t = match actual {
-                LocationType::Fixed(T::Type::Reference(_, inner)) => (*inner).clone(),
-                LocationType::Bytes(_) => {
-                    anyhow::bail!("should never ReadRef a non-reference location")
-                }
-                LocationType::Fixed(ty) => {
+            let actual = match usage(env, context, u)? {
+                T::Type::Reference(_, inner) => (*inner).clone(),
+                _ => {
                     anyhow::bail!("should never ReadRef a non-reference type, got {ty:?}");
                 }
             };
-            (LocationType::Fixed(t), param)
+            (actual, param)
         }
         T::Argument__::Freeze(u) => {
-            let actual = usage(env, context, u)?;
-            t = match actual {
-                LocationType::Fixed(T::Type::Reference(true, inner)) => {
-                    T::Type::Reference(false, inner.clone())
-                }
-                LocationType::Bytes(_) => {
-                    anyhow::bail!("should never FreezeRef a non-reference location")
-                }
-                LocationType::Fixed(T::Type::Reference(false, _)) => {
+            let actual = match usage(env, context, u)? {
+                T::Type::Reference(true, inner) => T::Type::Reference(false, inner.clone()),
+                T::Type::Reference(false, _) => {
                     anyhow::bail!("should never FreezeRef an immutable reference")
                 }
-                LocationType::Fixed(ty) => {
+                ty => {
                     anyhow::bail!("should never Freeze a non-reference type, got {ty:?}");
                 }
             };
-            (LocationType::Fixed(t), param)
+            (actual, param)
         }
         T::Argument__::Borrow(is_mut, l) => {
             let T::Type::Reference(param_mut, expected) = param else {
@@ -303,20 +285,10 @@ fn argument(
         }
     };
     // check actual == expected
-    match actual {
-        LocationType::Bytes(constraints) => {
-            anyhow::ensure!(
-                constraints.contains_key(expected),
-                "Bytes are not constrained for expected type {expected:?}"
-            );
-        }
-        LocationType::Fixed(actual_ty) => {
-            anyhow::ensure!(
-                &actual_ty == expected,
-                "argument type mismatch. Expected {expected:?}, got {actual_ty:?}"
-            );
-        }
-    }
+    anyhow::ensure!(
+        &actual == expected,
+        "argument type mismatch. Expected {expected:?}, got {actual:?}"
+    );
     // check copy usage
     match arg__ {
         T::Argument__::Use(T::Usage::Copy { .. }) | T::Argument__::Read(_) => {
@@ -332,7 +304,7 @@ fn argument(
     Ok(())
 }
 
-fn usage<'a>(env: &Env, context: &Context<'a>, u: &T::Usage) -> anyhow::Result<LocationType<'a>> {
+fn usage(env: &Env, context: &Context, u: &T::Usage) -> anyhow::Result<T::Type> {
     match u {
         T::Usage::Move(l)
         | T::Usage::Copy {
@@ -342,46 +314,33 @@ fn usage<'a>(env: &Env, context: &Context<'a>, u: &T::Usage) -> anyhow::Result<L
     }
 }
 
-enum LocationType<'a> {
-    Bytes(&'a BTreeMap<T::Type, T::BytesConstraint>),
-    Fixed(T::Type),
-}
-
-fn location<'a>(
-    env: &Env,
-    context: &Context<'a>,
-    l: T::Location,
-) -> anyhow::Result<LocationType<'a>> {
-    Ok(LocationType::Fixed(match l {
+fn location<'a>(env: &Env, context: &Context<'a>, l: T::Location) -> anyhow::Result<T::Type> {
+    Ok(match l {
         T::Location::TxContext => env.tx_context_type()?,
         T::Location::GasCoin => env.gas_coin_type()?,
-        T::Location::Input(i) => {
-            let usable = context.usable_inputs.get(i as usize).ok_or_else(|| {
-                anyhow::anyhow!(
-                    "input {i} out of bounds for inputs of length {}",
-                    context.inputs.len()
-                )
-            })?;
-            anyhow::ensure!(
-                *usable,
-                "input {i} is not usable as it does not have constrained Pure bytes"
-            );
-            let input_ty = context.inputs.get(i as usize).ok_or_else(|| {
-                anyhow::anyhow!(
-                    "input {i} out of bounds for inputs of length {}",
-                    context.inputs.len()
-                )
-            })?;
-            match input_ty {
-                T::InputType::Bytes(constraints) => return Ok(LocationType::Bytes(constraints)),
-                T::InputType::Fixed(t) => t.clone(),
-            }
-        }
+        T::Location::ObjectInput(i) => context
+            .objects
+            .get(i as usize)
+            .copied()
+            .ok_or_else(|| anyhow::anyhow!("object input {i} out of bounds"))?
+            .clone(),
+        T::Location::PureInput(i) => context
+            .pure
+            .get(i as usize)
+            .copied()
+            .ok_or_else(|| anyhow::anyhow!("pure input {i} out of bounds"))?
+            .clone(),
+        T::Location::ReceivingInput(i) => context
+            .receiving
+            .get(i as usize)
+            .copied()
+            .ok_or_else(|| anyhow::anyhow!("receiving input {i} out of bounds"))?
+            .clone(),
         T::Location::Result(i, j) => context
             .result_types
             .get(i as usize)
             .and_then(|v| v.get(j as usize))
             .ok_or_else(|| anyhow::anyhow!("result ({i}, {j}) out of bounds",))?
             .clone(),
-    }))
+    })
 }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/translate.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/translate.rs
@@ -546,7 +546,7 @@ fn argument_(
             };
             debug_assert!(expected_ty.abilities().has_copy());
             // unused since the type is fixed
-            check_type(&*a, b)?;
+            check_type(&a, b)?;
             if needs_freeze {
                 T::Argument__::Freeze(T::Usage::new_copy(location))
             } else {
@@ -554,7 +554,7 @@ fn argument_(
             }
         }
         (Type::Reference(_, a), b) => {
-            check_type(&*a, b)?;
+            check_type(&a, b)?;
             if !b.abilities().has_copy() {
                 // TODO this should be a different error for missing copy
                 return Err(CommandArgumentError::TypeMismatch.into());

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/translate.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/translate.rs
@@ -6,14 +6,13 @@ use crate::{
     execution_mode::ExecutionMode,
     programmable_transactions::context::EitherError,
     static_programmable_transactions::{
-        loading::ast::{self as L, InputArg, Type},
+        loading::ast::{self as L, Type},
         spanned::sp,
-        typing::ast::{BytesConstraint, BytesUsage},
+        typing::ast::BytesConstraint,
     },
 };
 use indexmap::{IndexMap, IndexSet};
-use serde_json::value::Index;
-use std::{collections::BTreeMap, rc::Rc};
+use std::rc::Rc;
 use sui_types::{
     base_types::{ObjectRef, TxContextKind},
     coin::RESOLVED_COIN_STRUCT,
@@ -21,6 +20,7 @@ use sui_types::{
     execution_status::CommandArgumentError,
 };
 
+#[derive(Debug, Clone, Copy)]
 enum SplatLocation {
     TxContext,
     GasCoin,
@@ -116,28 +116,97 @@ impl Context {
         match location {
             SplatLocation::GasCoin => None,
             SplatLocation::TxContext => None,
-            SplatLocation::Input(i) => self.input_resolution.get(i as usize).copied(),
+            SplatLocation::Input(i) => Some(self.input_resolution[i as usize]),
             SplatLocation::Result(_, _) => None, // results are not inputs
         }
     }
 
-    fn location_type<'context>(
-        &'context mut self,
+    // Get the fixed type of a location. Returns `None` for Pure and Receiving inputs,
+    fn fixed_type(
+        &mut self,
         env: &Env,
-        location: T::Location,
-    ) -> Result<LocationType<'context>, ExecutionError> {
-        Ok(match location {
-            T::Location::GasCoin => LocationType::Fixed(env.gas_coin_type()?),
-            T::Location::Input(i) => match &mut self.inputs[i as usize].1 {
-                t @ InputType::Bytes => {
-                    LocationType::Bytes(t, self.gathered_input_types.get_mut(&i).unwrap())
+        location: SplatLocation,
+    ) -> Result<Option<(T::Location, Type)>, ExecutionError> {
+        Ok(Some(match location {
+            SplatLocation::TxContext => (T::Location::TxContext, env.tx_context_type()?),
+            SplatLocation::GasCoin => (T::Location::GasCoin, env.gas_coin_type()?),
+            SplatLocation::Result(i, j) => (
+                T::Location::Result(i, j),
+                self.results[i as usize][j as usize].clone(),
+            ),
+            SplatLocation::Input(i) => match &self.input_resolution[i as usize] {
+                InputKind::Object => {
+                    let Some((object_index, _, object_input)) = self.objects.get_full(&i) else {
+                        invariant_violation!("Unbound object input {i}")
+                    };
+                    (
+                        T::Location::ObjectInput(object_index as u16),
+                        object_input.ty.clone(),
+                    )
                 }
-                InputType::Fixed(t) => LocationType::Fixed(t.clone()),
+                InputKind::Pure | InputKind::Receiving => return Ok(None),
             },
-            T::Location::Result(i, j) => {
-                LocationType::Fixed(self.results[i as usize][j as usize].clone())
-            }
-            T::Location::TxContext => LocationType::Fixed(env.tx_context_type()?),
+        }))
+    }
+
+    fn resolve_location(
+        &mut self,
+        env: &Env,
+        location: SplatLocation,
+        expected_ty: &Type,
+        bytes_constraint: BytesConstraint,
+    ) -> Result<(T::Location, Type), ExecutionError> {
+        Ok(match location {
+            SplatLocation::TxContext | SplatLocation::GasCoin | SplatLocation::Result(_, _) => self
+                .fixed_type(env, location)?
+                .ok_or_else(|| make_invariant_violation!("Expected fixed type for {location:?}"))?,
+            SplatLocation::Input(i) => match &self.input_resolution[i as usize] {
+                InputKind::Object => self.fixed_type(env, location)?.ok_or_else(|| {
+                    make_invariant_violation!("Expected fixed type for {location:?}")
+                })?,
+                InputKind::Pure => {
+                    let ty = match expected_ty {
+                        Type::Reference(_, inner) => (**inner).clone(),
+                        ty => ty.clone(),
+                    };
+                    let k = (i, ty.clone());
+                    if !self.pure.contains_key(&k) {
+                        let Some(byte_index) = self.bytes_idx_remapping.get(&i).copied() else {
+                            invariant_violation!("Unbound pure input {i}");
+                        };
+                        let pure = T::PureInput {
+                            original_input_index: i,
+                            byte_index,
+                            ty: ty.clone(),
+                            constraint: bytes_constraint,
+                        };
+                        self.pure.insert(k.clone(), pure);
+                    }
+                    let byte_index = self.pure.get_index_of(&k).unwrap();
+                    (T::Location::PureInput(byte_index as u16), ty)
+                }
+                InputKind::Receiving => {
+                    let ty = match expected_ty {
+                        Type::Reference(_, inner) => (**inner).clone(),
+                        ty => ty.clone(),
+                    };
+                    let k = (i, ty.clone());
+                    if !self.receiving.contains_key(&k) {
+                        let Some(object_ref) = self.receiving_refs.get(&i).copied() else {
+                            invariant_violation!("Unbound receiving input {i}");
+                        };
+                        let receiving = T::ReceivingInput {
+                            original_input_index: i,
+                            object_ref,
+                            ty: ty.clone(),
+                            constraint: bytes_constraint,
+                        };
+                        self.receiving.insert(k.clone(), receiving);
+                    }
+                    let byte_index = self.receiving.get_index_of(&k).unwrap();
+                    (T::Location::ReceivingInput(byte_index as u16), ty)
+                }
+            },
         })
     }
 }
@@ -358,9 +427,9 @@ fn one_location(
     context: &mut Context,
     command_arg_idx: usize,
     arg: L::Argument,
-) -> Result<T::Location, ExecutionError> {
+) -> Result<SplatLocation, ExecutionError> {
     let locs = locations(context, command_arg_idx, vec![arg])?;
-    let Ok([loc]): Result<[T::Location; 1], _> = locs.try_into() else {
+    let Ok([loc]): Result<[SplatLocation; 1], _> = locs.try_into() else {
         return Err(command_argument_error(
             CommandArgumentError::InvalidArgumentArity,
             command_arg_idx,
@@ -379,11 +448,11 @@ where
 {
     fn splat_arg(
         context: &mut Context,
-        res: &mut Vec<T::Location>,
+        res: &mut Vec<SplatLocation>,
         arg: L::Argument,
     ) -> Result<(), EitherError> {
         match arg {
-            L::Argument::GasCoin => res.push(T::Location::GasCoin),
+            L::Argument::GasCoin => res.push(SplatLocation::GasCoin),
             L::Argument::Input(i) => {
                 if i as usize >= context.input_resolution.len() {
                     return Err(CommandArgumentError::IndexOutOfBounds { idx: i }.into());
@@ -473,7 +542,8 @@ fn argument_(
         command: current_command,
         argument: command_arg_idx as u16,
     };
-    let actual_ty: Type = context.resolve_location(env, location, expected_ty, bytes_constraint)?;
+    let (location, actual_ty): (T::Location, Type) =
+        context.resolve_location(env, location, expected_ty, bytes_constraint)?;
     Ok(match (actual_ty, expected_ty) {
         // Reference location types
         (Type::Reference(a_is_mut, a), Type::Reference(b_is_mut, b)) => {
@@ -487,12 +557,7 @@ fn argument_(
             };
             debug_assert!(expected_ty.abilities().has_copy());
             // unused since the type is fixed
-            let unused_constraint = BytesConstraint {
-                command: current_command,
-                argument: command_arg_idx as u16,
-                usage: BytesUsage::Copied,
-            };
-            check_type(unused_constraint, LocationType::Fixed((*a).clone()), b)?;
+            check_type(&*a, b)?;
             if needs_freeze {
                 T::Argument__::Freeze(T::Usage::new_copy(location))
             } else {
@@ -500,13 +565,7 @@ fn argument_(
             }
         }
         (Type::Reference(_, a), b) => {
-            // unused since the type is fixed
-            let unused_constraint = BytesConstraint {
-                command: current_command,
-                argument: command_arg_idx as u16,
-                usage: BytesUsage::Copied,
-            };
-            check_type(unused_constraint, LocationType::Fixed((*a).clone()), b)?;
+            check_type(&*a, b)?;
             if !b.abilities().has_copy() {
                 // TODO this should be a different error for missing copy
                 return Err(CommandArgumentError::TypeMismatch.into());
@@ -516,26 +575,11 @@ fn argument_(
 
         // Non reference location types
         (actual_ty, Type::Reference(is_mut, inner)) => {
-            let usage = if *is_mut {
-                BytesUsage::ByMutRef
-            } else {
-                BytesUsage::ByImmRef
-            };
-            let constraint = BytesConstraint {
-                command: current_command,
-                argument: command_arg_idx as u16,
-                usage,
-            };
-            check_type_impl(constraint, actual_ty, inner)?;
+            check_type(&actual_ty, inner)?;
             T::Argument__::Borrow(/* mut */ *is_mut, location)
         }
         (actual_ty, _) => {
-            let constraint = BytesConstraint {
-                command: current_command,
-                argument: command_arg_idx as u16,
-                usage: BytesUsage::Copied,
-            };
-            check_type(constraint, actual_ty, expected_ty)?;
+            check_type(&actual_ty, expected_ty)?;
             T::Argument__::Use(if expected_ty.abilities().has_copy() {
                 T::Usage::new_copy(location)
             } else {
@@ -545,38 +589,11 @@ fn argument_(
     })
 }
 
-fn check_type(
-    // not used if the type is fixed
-    constraint: BytesConstraint,
-    actual_ty: LocationType,
-    expected_ty: &Type,
-) -> Result<(), CommandArgumentError> {
-    debug_assert!(matches!(constraint.usage, BytesUsage::Copied));
-    check_type_impl(constraint, actual_ty, expected_ty)
-}
-
-fn check_type_impl(
-    // not used if the type is fixed
-    constraint: BytesConstraint,
-    mut actual_ty: LocationType,
-    expected_ty: &Type,
-) -> Result<(), CommandArgumentError> {
-    match &mut actual_ty {
-        LocationType::Fixed(actual_ty) | LocationType::Bytes(InputType::Fixed(actual_ty), _) => {
-            if actual_ty == expected_ty {
-                Ok(())
-            } else {
-                Err(CommandArgumentError::TypeMismatch)
-            }
-        }
-        LocationType::Bytes(ty, types) => {
-            if matches!(&constraint.usage, BytesUsage::ByMutRef) {
-                **ty = InputType::Fixed(expected_ty.clone());
-            }
-            types.entry(expected_ty.clone()).or_insert(constraint);
-            // validity of pure types is checked elsewhere
-            Ok(())
-        }
+fn check_type(actual_ty: &Type, expected_ty: &Type) -> Result<(), CommandArgumentError> {
+    if actual_ty == expected_ty {
+        Ok(())
+    } else {
+        Err(CommandArgumentError::TypeMismatch)
     }
 }
 
@@ -584,7 +601,7 @@ fn constrained_arguments<P: FnMut(&Type) -> Result<bool, ExecutionError>>(
     env: &Env,
     context: &mut Context,
     start_idx: usize,
-    locations: Vec<T::Location>,
+    locations: Vec<SplatLocation>,
     mut is_valid: P,
     err_case: CommandArgumentError,
 ) -> Result<Vec<T::Argument>, ExecutionError> {
@@ -602,7 +619,7 @@ fn constrained_argument<P: FnMut(&Type) -> Result<bool, ExecutionError>>(
     env: &Env,
     context: &mut Context,
     command_arg_idx: usize,
-    location: T::Location,
+    location: SplatLocation,
     mut is_valid: P,
     err_case: CommandArgumentError,
 ) -> Result<T::Argument, ExecutionError> {
@@ -620,7 +637,7 @@ fn constrained_argument_<P: FnMut(&Type) -> Result<bool, ExecutionError>>(
     env: &Env,
     context: &mut Context,
     command_arg_idx: usize,
-    location: T::Location,
+    location: SplatLocation,
     is_valid: &mut P,
     err_case: CommandArgumentError,
 ) -> Result<T::Argument, ExecutionError> {
@@ -632,11 +649,11 @@ fn constrained_argument_<P: FnMut(&Type) -> Result<bool, ExecutionError>>(
 fn constrained_argument__<P: FnMut(&Type) -> Result<bool, ExecutionError>>(
     env: &Env,
     context: &mut Context,
-    location: T::Location,
+    location: SplatLocation,
     is_valid: &mut P,
     err_case: CommandArgumentError,
 ) -> Result<T::Argument_, EitherError> {
-    if let Some(ty) = constrained_type(env, context, location, is_valid)? {
+    if let Some((location, ty)) = constrained_type(env, context, location, is_valid)? {
         if ty.abilities().has_copy() {
             Ok((T::Argument__::new_copy(location), ty))
         } else {
@@ -650,20 +667,24 @@ fn constrained_argument__<P: FnMut(&Type) -> Result<bool, ExecutionError>>(
 fn constrained_type<'a, P: FnMut(&Type) -> Result<bool, ExecutionError>>(
     env: &'a Env,
     context: &'a mut Context,
-    location: T::Location,
+    location: SplatLocation,
     mut is_valid: P,
-) -> Result<Option<Type>, ExecutionError> {
-    let LocationType::Fixed(ty) = context.location_type(env, location)? else {
+) -> Result<Option<(T::Location, Type)>, ExecutionError> {
+    let Some((location, ty)) = context.fixed_type(env, location)? else {
         return Ok(None);
     };
-    Ok(if is_valid(&ty)? { Some(ty) } else { None })
+    Ok(if is_valid(&ty)? {
+        Some((location, ty))
+    } else {
+        None
+    })
 }
 
 fn coin_mut_ref_argument(
     env: &Env,
     context: &mut Context,
     command_arg_idx: usize,
-    location: T::Location,
+    location: SplatLocation,
 ) -> Result<T::Argument, ExecutionError> {
     let arg_ = coin_mut_ref_argument_(env, context, location)
         .map_err(|e| e.into_execution_error(command_arg_idx))?;
@@ -673,29 +694,27 @@ fn coin_mut_ref_argument(
 fn coin_mut_ref_argument_(
     env: &Env,
     context: &mut Context,
-    location: T::Location,
+    location: SplatLocation,
 ) -> Result<T::Argument_, EitherError> {
-    let actual_ty = context.location_type(env, location)?;
-
+    let Some((location, actual_ty)) = context.fixed_type(env, location)? else {
+        // TODO we do not currently bytes in any mode as that would require additional type
+        // inference not currently supported
+        return Err(CommandArgumentError::TypeMismatch.into());
+    };
     Ok(match &actual_ty {
-        LocationType::Fixed(Type::Reference(is_mut, ty)) if *is_mut => {
+        Type::Reference(is_mut, ty) if *is_mut => {
             check_coin_type(ty)?;
             (
                 T::Argument__::new_copy(location),
                 Type::Reference(*is_mut, ty.clone()),
             )
         }
-        LocationType::Fixed(ty) => {
+        ty => {
             check_coin_type(ty)?;
             (
                 T::Argument__::Borrow(/* mut */ true, location),
                 Type::Reference(true, Rc::new(ty.clone())),
             )
-        }
-        LocationType::Bytes(_, _) => {
-            // TODO we do not currently bytes in any mode as that would require additional type
-            // inference not currently supported
-            return Err(CommandArgumentError::TypeMismatch.into());
         }
     })
 }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/input_arguments.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/input_arguments.rs
@@ -71,7 +71,7 @@ pub fn verify<Mode: ExecutionMode>(_env: &Env, txn: &T::Transaction) -> Result<(
         check_pure_input::<Mode>(bytes, pure)?;
     }
     for receiving in receiving {
-        check_receving_input::<Mode>(receiving)?;
+        check_receving_input(receiving)?;
     }
     let context = &mut Context::new(txn);
     for (c, _t) in commands {
@@ -176,9 +176,7 @@ fn primitive_serialization_layout(
     })
 }
 
-fn check_receving_input<Mode: ExecutionMode>(
-    receiving: &T::ReceivingInput,
-) -> Result<(), ExecutionError> {
+fn check_receving_input(receiving: &T::ReceivingInput) -> Result<(), ExecutionError> {
     let T::ReceivingInput {
         original_input_index: _,
         object_ref: _,
@@ -186,7 +184,7 @@ fn check_receving_input<Mode: ExecutionMode>(
         constraint,
     } = receiving;
     let BytesConstraint { command, argument } = constraint;
-    check_receiving(*argument, &ty).map_err(|e| e.with_command_index(*command as usize))
+    check_receiving(*argument, ty).map_err(|e| e.with_command_index(*command as usize))
 }
 
 fn check_receiving(command_arg_idx: u16, constraint: &Type) -> Result<(), ExecutionError> {

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/input_arguments.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/input_arguments.rs
@@ -96,7 +96,9 @@ fn check_pure_input<Mode: ExecutionMode>(
     } = pure;
     let Some(bcs_bytes) = bytes.get_index(*byte_index) else {
         invariant_violation!(
-            "Unbound byte index {byte_index} for pure input at index {original_input_index}"
+            "Unbound byte index {} for pure input at index {}",
+            byte_index,
+            original_input_index.0
         );
     };
     let BytesConstraint { command, argument } = constraint;

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/input_arguments.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/input_arguments.rs
@@ -8,9 +8,10 @@ use crate::{
     static_programmable_transactions::{
         env::Env,
         loading::ast::Type,
-        typing::ast::{self as T, BytesConstraint, BytesUsage, InputArg, ObjectArg},
+        typing::ast::{self as T, BytesConstraint, ObjectArg},
     },
 };
+use indexmap::IndexSet;
 use sui_types::{
     base_types::{RESOLVED_ASCII_STR, RESOLVED_STD_OPTION, RESOLVED_UTF8_STR},
     error::{ExecutionError, ExecutionErrorKind, command_argument_error},
@@ -25,32 +26,30 @@ struct ObjectUsage {
 }
 
 struct Context {
-    inputs: Vec<Option<ObjectUsage>>,
+    objects: Vec<ObjectUsage>,
 }
 
 impl Context {
-    fn new(inputs: &T::Inputs) -> Self {
-        let inputs = inputs
+    fn new(txn: &T::Transaction) -> Self {
+        let objects = txn
+            .objects
             .iter()
-            .map(|(arg, _)| {
-                Some(match arg {
-                    InputArg::Pure(_) | InputArg::Receiving(_) => return None,
-                    InputArg::Object(ObjectArg::ImmObject(_)) => ObjectUsage {
-                        allow_by_value: false,
-                        allow_by_mut_ref: false,
-                    },
-                    InputArg::Object(ObjectArg::OwnedObject(_)) => ObjectUsage {
-                        allow_by_value: true,
-                        allow_by_mut_ref: true,
-                    },
-                    InputArg::Object(ObjectArg::SharedObject { mutable, .. }) => ObjectUsage {
-                        allow_by_value: *mutable,
-                        allow_by_mut_ref: *mutable,
-                    },
-                })
+            .map(|object_input| match &object_input.arg {
+                ObjectArg::ImmObject(_) => ObjectUsage {
+                    allow_by_value: false,
+                    allow_by_mut_ref: false,
+                },
+                ObjectArg::OwnedObject(_) => ObjectUsage {
+                    allow_by_value: true,
+                    allow_by_mut_ref: true,
+                },
+                ObjectArg::SharedObject { mutable, .. } => ObjectUsage {
+                    allow_by_value: *mutable,
+                    allow_by_mut_ref: *mutable,
+                },
             })
             .collect();
-        Self { inputs }
+        Self { objects }
     }
 }
 
@@ -61,24 +60,20 @@ impl Context {
 /// 2. That any `Object` arguments are used validly. This means mutable references are taken only
 ///    on mutable objects. And that the gas coin is only taken by value in transfer objects
 pub fn verify<Mode: ExecutionMode>(_env: &Env, txn: &T::Transaction) -> Result<(), ExecutionError> {
-    let T::Transaction { inputs, commands } = txn;
-    for (arg, ty) in inputs {
-        match ty {
-            T::InputType::Bytes(constraints) => {
-                for (constraint, constraint_info) in constraints {
-                    let BytesConstraint {
-                        command,
-                        argument,
-                        usage,
-                    } = *constraint_info;
-                    check_constraint::<Mode>(argument, arg, constraint, usage)
-                        .map_err(|e| e.with_command_index(command as usize))?;
-                }
-            }
-            T::InputType::Fixed(_) => (),
-        }
+    let T::Transaction {
+        bytes,
+        objects: _,
+        pure,
+        receiving,
+        commands,
+    } = txn;
+    for pure in pure {
+        check_pure_input::<Mode>(bytes, pure)?;
     }
-    let context = &mut Context::new(inputs);
+    for receiving in receiving {
+        check_receving_input::<Mode>(receiving)?;
+    }
+    let context = &mut Context::new(txn);
     for (c, _t) in commands {
         command(context, c).map_err(|e| e.with_command_index(c.idx as usize))?;
     }
@@ -89,30 +84,30 @@ pub fn verify<Mode: ExecutionMode>(_env: &Env, txn: &T::Transaction) -> Result<(
 // Pure bytes
 //**************************************************************************************************
 
-fn check_constraint<Mode: ExecutionMode>(
-    command_arg_idx: u16,
-    arg: &InputArg,
-    constraint: &Type,
-    usage: BytesUsage,
+fn check_pure_input<Mode: ExecutionMode>(
+    bytes: &IndexSet<Vec<u8>>,
+    pure: &T::PureInput,
 ) -> Result<(), ExecutionError> {
-    match arg {
-        InputArg::Pure(bytes) => {
-            check_pure_bytes::<Mode>(command_arg_idx, bytes, constraint, usage)
-        }
-        InputArg::Receiving(_) => check_receiving(command_arg_idx, constraint),
-        InputArg::Object(
-            ObjectArg::ImmObject(_) | ObjectArg::OwnedObject(_) | ObjectArg::SharedObject { .. },
-        ) => {
-            invariant_violation!("Object inputs should be Fixed")
-        }
-    }
+    let T::PureInput {
+        original_input_index,
+        byte_index,
+        ty,
+        constraint,
+    } = pure;
+    let Some(bcs_bytes) = bytes.get_index(*byte_index) else {
+        invariant_violation!(
+            "Unbound byte index {byte_index} for pure input at index {original_input_index}"
+        );
+    };
+    let BytesConstraint { command, argument } = constraint;
+    check_pure_bytes::<Mode>(*argument, bcs_bytes, ty)
+        .map_err(|e| e.with_command_index(*command as usize))
 }
 
 fn check_pure_bytes<Mode: ExecutionMode>(
     command_arg_idx: u16,
     bytes: &[u8],
     constraint: &Type,
-    usage: BytesUsage,
 ) -> Result<(), ExecutionError> {
     assert_invariant!(
         !matches!(constraint, Type::Reference(_, _)),
@@ -133,18 +128,6 @@ fn check_pure_bytes<Mode: ExecutionMode>(
             msg,
         ));
     };
-    match usage {
-        BytesUsage::Copied => assert_invariant!(
-            constraint.abilities().has_copy(),
-            "non-fixed bytes used by-value should be copyable. For type {constraint:?}"
-        ),
-        BytesUsage::ByImmRef => assert_invariant!(
-            constraint.abilities().has_drop(),
-            "non-fixed bytes used by-immutable-ref should be droppable since they will be \
-            deserialized, borrowed, but ultimately dropped. For type {constraint:?}"
-        ),
-        BytesUsage::ByMutRef => (),
-    }
     bcs_argument_validate(bytes, command_arg_idx, layout)?;
     Ok(())
 }
@@ -191,6 +174,19 @@ fn primitive_serialization_layout(
             }
         }
     })
+}
+
+fn check_receving_input<Mode: ExecutionMode>(
+    receiving: &T::ReceivingInput,
+) -> Result<(), ExecutionError> {
+    let T::ReceivingInput {
+        original_input_index: _,
+        object_ref: _,
+        ty,
+        constraint,
+    } = receiving;
+    let BytesConstraint { command, argument } = constraint;
+    check_receiving(*argument, &ty).map_err(|e| e.with_command_index(*command as usize))
 }
 
 fn check_receiving(command_arg_idx: u16, constraint: &Type) -> Result<(), ExecutionError> {
@@ -291,21 +287,21 @@ fn check_obj_by_mut_ref(
     location: &T::Location,
 ) -> Result<(), ExecutionError> {
     match location {
-        T::Location::GasCoin | T::Location::Result(_, _) | T::Location::TxContext => Ok(()),
-        T::Location::Input(idx) => match &context.inputs[*idx as usize] {
-            None
-            | Some(ObjectUsage {
-                allow_by_mut_ref: true,
-                ..
-            }) => Ok(()),
-            Some(ObjectUsage {
-                allow_by_mut_ref: false,
-                ..
-            }) => Err(command_argument_error(
-                CommandArgumentError::InvalidObjectByMutRef,
-                arg_idx as usize,
-            )),
-        },
+        T::Location::PureInput(_)
+        | T::Location::ReceivingInput(_)
+        | T::Location::TxContext
+        | T::Location::GasCoin
+        | T::Location::Result(_, _) => Ok(()),
+        T::Location::ObjectInput(idx) => {
+            if !context.objects[*idx as usize].allow_by_mut_ref {
+                Err(command_argument_error(
+                    CommandArgumentError::InvalidObjectByMutRef,
+                    arg_idx as usize,
+                ))
+            } else {
+                Ok(())
+            }
+        }
     }
 }
 
@@ -316,21 +312,21 @@ fn check_by_value(
     location: &T::Location,
 ) -> Result<(), ExecutionError> {
     match location {
-        T::Location::TxContext | T::Location::GasCoin | T::Location::Result(_, _) => Ok(()),
-        T::Location::Input(idx) => match &context.inputs[*idx as usize] {
-            None
-            | Some(ObjectUsage {
-                allow_by_value: true,
-                ..
-            }) => Ok(()),
-            Some(ObjectUsage {
-                allow_by_value: false,
-                ..
-            }) => Err(command_argument_error(
-                CommandArgumentError::InvalidObjectByValue,
-                arg_idx as usize,
-            )),
-        },
+        T::Location::GasCoin
+        | T::Location::Result(_, _)
+        | T::Location::TxContext
+        | T::Location::PureInput(_)
+        | T::Location::ReceivingInput(_) => Ok(()),
+        T::Location::ObjectInput(idx) => {
+            if !context.objects[*idx as usize].allow_by_value {
+                Err(command_argument_error(
+                    CommandArgumentError::InvalidObjectByValue,
+                    arg_idx as usize,
+                ))
+            } else {
+                Ok(())
+            }
+        }
     }
 }
 
@@ -359,6 +355,10 @@ fn check_gas_by_value_loc(idx: u16, location: &T::Location) -> Result<(), Execut
             CommandArgumentError::InvalidGasCoinUsage,
             idx as usize,
         )),
-        T::Location::TxContext | T::Location::Input(_) | T::Location::Result(_, _) => Ok(()),
+        T::Location::TxContext
+        | T::Location::ObjectInput(_)
+        | T::Location::PureInput(_)
+        | T::Location::ReceivingInput(_)
+        | T::Location::Result(_, _) => Ok(()),
     }
 }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/move_functions.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/move_functions.rs
@@ -3,7 +3,6 @@
 
 use crate::execution_mode::ExecutionMode;
 use crate::programmable_transactions::execution::check_private_generics;
-use crate::static_programmable_transactions::typing::ast::InputArg;
 use crate::static_programmable_transactions::{env::Env, loading::ast::Type, typing::ast as T};
 use move_binary_format::{CompiledModule, file_format::Visibility};
 use sui_types::{
@@ -13,58 +12,39 @@ use sui_types::{
 
 struct Context {
     gas_coin: IsDirty,
-    inputs: Vec<IsDirty>,
+    objects: Vec<IsDirty>,
+    pure: Vec<IsDirty>,
+    receiving: Vec<IsDirty>,
     results: Vec<Vec<IsDirty>>,
 }
 
 /// Is dirty for entry verifier rules
-#[derive(Copy, Clone)]
-enum IsDirty {
-    /// BCS input is not yet fixed
-    NotFixed,
-    Fixed {
-        is_dirty: bool,
-    },
-}
+type IsDirty = bool;
 
 impl Context {
-    fn new(inputs: &T::Inputs) -> Self {
-        let inputs = inputs
-            .iter()
-            .map(|(arg, _)| match arg {
-                InputArg::Pure(_) => IsDirty::NotFixed,
-                InputArg::Receiving(_) | InputArg::Object(_) => IsDirty::Fixed { is_dirty: false },
-            })
-            .collect();
+    fn new(txn: &T::Transaction) -> Self {
         Self {
-            gas_coin: IsDirty::Fixed { is_dirty: false },
-            inputs,
+            gas_coin: false,
+            objects: txn.objects.iter().map(|_| false).collect(),
+            pure: txn.pure.iter().map(|_| false).collect(),
+            receiving: txn.receiving.iter().map(|_| false).collect(),
             results: vec![],
         }
     }
 
     // check if dirty, and mark it as fixed if mutably borrowing a pure input
-    fn is_dirty(&mut self, arg: &T::Argument) -> bool {
-        match &arg.value.0 {
-            T::Argument__::Borrow(/* mut */ true, T::Location::Input(i)) => {
-                match &mut self.inputs[*i as usize] {
-                    input @ IsDirty::NotFixed => {
-                        *input = IsDirty::Fixed { is_dirty: false };
-                        false
-                    }
-                    IsDirty::Fixed { is_dirty } => *is_dirty,
-                }
-            }
-            _ => self.is_loc_dirty(arg.value.0.location()),
-        }
+    fn is_dirty(&self, arg: &T::Argument) -> bool {
+        self.is_loc_dirty(arg.value.0.location())
     }
 
     fn is_loc_dirty(&self, location: T::Location) -> bool {
         match location {
             T::Location::TxContext => false, // TxContext is never dirty
-            T::Location::GasCoin => self.gas_coin.is_dirty(),
-            T::Location::Input(i) => self.inputs[i as usize].is_dirty(),
-            T::Location::Result(i, j) => self.results[i as usize][j as usize].is_dirty(),
+            T::Location::GasCoin => self.gas_coin,
+            T::Location::ObjectInput(i) => self.objects[i as usize],
+            T::Location::PureInput(i) => self.pure[i as usize],
+            T::Location::ReceivingInput(i) => self.receiving[i as usize],
+            T::Location::Result(i, j) => self.results[i as usize][j as usize],
         }
     }
 
@@ -83,24 +63,11 @@ impl Context {
     fn mark_loc_dirty(&mut self, location: T::Location) {
         match location {
             T::Location::TxContext => (), // TxContext is never dirty, so nothing to do
-            T::Location::GasCoin => self.gas_coin = IsDirty::Fixed { is_dirty: true },
-            T::Location::Input(i) => match &mut self.inputs[i as usize] {
-                // if it needs to be dirtied, it will first be marked as fixed
-                IsDirty::NotFixed => (),
-                IsDirty::Fixed { is_dirty } => *is_dirty = true,
-            },
-            T::Location::Result(i, j) => {
-                self.results[i as usize][j as usize] = IsDirty::Fixed { is_dirty: true }
-            }
-        }
-    }
-}
-
-impl IsDirty {
-    fn is_dirty(self) -> bool {
-        match self {
-            IsDirty::NotFixed => false,
-            IsDirty::Fixed { is_dirty } => is_dirty,
+            T::Location::GasCoin => self.gas_coin = true,
+            T::Location::ObjectInput(i) => self.objects[i as usize] = true,
+            T::Location::PureInput(i) => self.pure[i as usize] = true,
+            T::Location::ReceivingInput(i) => self.receiving[i as usize] = true,
+            T::Location::Result(i, j) => self.results[i as usize][j as usize] = true,
         }
     }
 }
@@ -113,9 +80,8 @@ impl IsDirty {
 /// - no references returned from move calls
 ///    - Can be disabled under certain execution modes
 pub fn verify<Mode: ExecutionMode>(env: &Env, txn: &T::Transaction) -> Result<(), ExecutionError> {
-    let T::Transaction { inputs, commands } = txn;
-    let mut context = Context::new(inputs);
-    for (c, result) in commands {
+    let mut context = Context::new(txn);
+    for (c, result) in &txn.commands {
         let result_dirties = command::<Mode>(env, &mut context, c, result)
             .map_err(|e| e.with_command_index(c.idx as usize))?;
         assert_invariant!(
@@ -147,7 +113,7 @@ fn command<Mode: ExecutionMode>(
             if is_dirty {
                 context.mark_dirty(coin);
             }
-            vec![IsDirty::Fixed { is_dirty }; result.len()]
+            vec![is_dirty; result.len()]
         }
         T::Command_::MergeCoins(_, target, coins) => {
             let is_dirty = arguments(env, context, coins);
@@ -160,19 +126,16 @@ fn command<Mode: ExecutionMode>(
         T::Command_::MakeMoveVec(_, args) => {
             let is_dirty = arguments(env, context, args);
             debug_assert_eq!(result.len(), 1);
-            vec![IsDirty::Fixed { is_dirty }]
+            vec![is_dirty]
         }
         T::Command_::Publish(_, _, _) => {
             debug_assert_eq!(Mode::packages_are_predefined(), result.is_empty());
             debug_assert_eq!(!Mode::packages_are_predefined(), result.len() == 1);
-            result
-                .iter()
-                .map(|_| IsDirty::Fixed { is_dirty: false })
-                .collect::<Vec<_>>()
+            result.iter().map(|_| false).collect::<Vec<_>>()
         }
         T::Command_::Upgrade(_, _, _, ticket, _) => {
             debug_assert_eq!(result.len(), 1);
-            let result = vec![IsDirty::Fixed { is_dirty: false }];
+            let result = vec![false];
             argument(env, context, ticket);
             result
         }
@@ -219,7 +182,7 @@ fn move_call<Mode: ExecutionMode>(
             context.mark_dirty(arg);
         }
     }
-    Ok(vec![IsDirty::Fixed { is_dirty: true }; result.len()])
+    Ok(vec![true; result.len()])
 }
 
 fn check_signature<Mode: ExecutionMode>(


### PR DESCRIPTION
## Description 

- Each pure value now gets a separate local per input, per type 
- This greatly reduces the complexity in type checking, verification, and runtime value tracking (no more input metadata. no more temporary locals)

## Test plan 

- A few new tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
