### PR TITLE
[mfp] treat WaitForEffects requests for past epoch consensus positions as expired.

### DIFF
--- a/consensus/core/src/transaction.rs
+++ b/consensus/core/src/transaction.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::{collections::BTreeMap, sync::Arc};
 
+use consensus_config::Epoch;
 use consensus_types::block::{BlockRef, Round, TransactionIndex};
 use mysten_common::debug_fatal;
 use mysten_metrics::monitored_mpsc::{channel, Receiver, Sender};
@@ -220,6 +221,7 @@ impl TransactionConsumer {
 
 #[derive(Clone)]
 pub struct TransactionClient {
+    context: Arc<Context>,
     sender: Sender<TransactionsGuard>,
     max_transaction_size: u64,
     max_transactions_in_block_bytes: u64,
@@ -255,9 +257,15 @@ impl TransactionClient {
                 max_transactions_in_block_count: context
                     .protocol_config
                     .max_num_transactions_in_block(),
+                context: context.clone(),
             },
             receiver,
         )
+    }
+
+    /// Returns the current epoch of this client.
+    pub fn epoch(&self) -> Epoch {
+        self.context.committee.epoch()
     }
 
     /// Submits a list of transactions to be sequenced. The method returns when all the transactions have been successfully included

--- a/crates/sui-benchmark/src/benchmark_setup.rs
+++ b/crates/sui-benchmark/src/benchmark_setup.rs
@@ -131,8 +131,9 @@ impl Env {
         // Wait for the embedded reconfig observer.
         sleep(Duration::from_secs(5)).await;
         let (genesis, primary_gas) = genesis_recv.await.unwrap();
-        let proxy: Arc<dyn ValidatorProxy + Send + Sync> =
-            Arc::new(LocalValidatorAggregatorProxy::from_genesis(&genesis, registry, None).await);
+        let proxy: Arc<dyn ValidatorProxy + Send + Sync> = Arc::new(
+            LocalValidatorAggregatorProxy::from_genesis(&genesis, registry, None, None).await,
+        );
         Ok(BenchmarkSetup {
             server_handle: join_handle,
             shutdown_notifier: shutdown_sender,
@@ -194,6 +195,7 @@ impl Env {
                     genesis,
                     registry,
                     reconfig_fullnode_rpc_url.map(|x| &**x),
+                    None,
                 )
                 .await,
             )]

--- a/crates/sui-benchmark/src/workloads/adversarial.rs
+++ b/crates/sui-benchmark/src/workloads/adversarial.rs
@@ -557,6 +557,10 @@ impl Workload<dyn Payload> for AdversarialWorkload {
             .map(|b| Box::<dyn Payload>::from(Box::new(b)))
             .collect()
     }
+
+    fn name(&self) -> &str {
+        "Adversarial"
+    }
 }
 
 struct AdversarialPayloadArgs {

--- a/crates/sui-benchmark/src/workloads/batch_payment.rs
+++ b/crates/sui-benchmark/src/workloads/batch_payment.rs
@@ -274,4 +274,8 @@ impl Workload<dyn Payload> for BatchPaymentWorkload {
             .map(|b| Box::<dyn Payload>::from(b))
             .collect()
     }
+
+    fn name(&self) -> &str {
+        "BatchPayment"
+    }
 }

--- a/crates/sui-benchmark/src/workloads/delegation.rs
+++ b/crates/sui-benchmark/src/workloads/delegation.rs
@@ -192,4 +192,8 @@ impl Workload<dyn Payload> for DelegationWorkload {
             .map(|b| Box::<dyn Payload>::from(b))
             .collect()
     }
+
+    fn name(&self) -> &str {
+        "Delegation"
+    }
 }

--- a/crates/sui-benchmark/src/workloads/expected_failure.rs
+++ b/crates/sui-benchmark/src/workloads/expected_failure.rs
@@ -263,4 +263,8 @@ impl Workload<dyn Payload> for ExpectedFailureWorkload {
             .map(|b| Box::<dyn Payload>::from(b))
             .collect()
     }
+
+    fn name(&self) -> &str {
+        "ExpectedFailure"
+    }
 }

--- a/crates/sui-benchmark/src/workloads/party.rs
+++ b/crates/sui-benchmark/src/workloads/party.rs
@@ -358,4 +358,8 @@ impl Workload<dyn Payload> for PartyWorkload {
             .map(|b| Box::<dyn Payload>::from(Box::new(b)))
             .collect()
     }
+
+    fn name(&self) -> &str {
+        "Party"
+    }
 }

--- a/crates/sui-benchmark/src/workloads/randomized_transaction.rs
+++ b/crates/sui-benchmark/src/workloads/randomized_transaction.rs
@@ -530,4 +530,8 @@ impl Workload<dyn Payload> for RandomizedTransactionWorkload {
             .map(|b| Box::<dyn Payload>::from(b))
             .collect()
     }
+
+    fn name(&self) -> &str {
+        "RandomizedTransaction"
+    }
 }

--- a/crates/sui-benchmark/src/workloads/randomness.rs
+++ b/crates/sui-benchmark/src/workloads/randomness.rs
@@ -215,4 +215,8 @@ impl Workload<dyn Payload> for RandomnessWorkload {
             .collect();
         payloads
     }
+
+    fn name(&self) -> &str {
+        "Randomness"
+    }
 }

--- a/crates/sui-benchmark/src/workloads/shared_counter.rs
+++ b/crates/sui-benchmark/src/workloads/shared_counter.rs
@@ -273,4 +273,8 @@ impl Workload<dyn Payload> for SharedCounterWorkload {
             .collect();
         payloads
     }
+
+    fn name(&self) -> &str {
+        "SharedCounter"
+    }
 }

--- a/crates/sui-benchmark/src/workloads/shared_object_deletion.rs
+++ b/crates/sui-benchmark/src/workloads/shared_object_deletion.rs
@@ -280,6 +280,7 @@ impl Workload<dyn Payload> for SharedCounterDeletionWorkload {
         }
         self.counters = join_all(futures).await;
     }
+
     async fn make_test_payloads(
         &self,
         _proxy: Arc<dyn ValidatorProxy + Sync + Send>,
@@ -315,5 +316,9 @@ impl Workload<dyn Payload> for SharedCounterDeletionWorkload {
             .map(|b| Box::<dyn Payload>::from(b))
             .collect();
         payloads
+    }
+
+    fn name(&self) -> &str {
+        "SharedObjectDeletion"
     }
 }

--- a/crates/sui-benchmark/src/workloads/slow.rs
+++ b/crates/sui-benchmark/src/workloads/slow.rs
@@ -261,4 +261,8 @@ impl Workload<dyn Payload> for SlowWorkload {
             .map(|b| Box::<dyn Payload>::from(Box::new(b)))
             .collect()
     }
+
+    fn name(&self) -> &str {
+        "Slow"
+    }
 }

--- a/crates/sui-benchmark/src/workloads/transfer_object.rs
+++ b/crates/sui-benchmark/src/workloads/transfer_object.rs
@@ -249,4 +249,8 @@ impl Workload<dyn Payload> for TransferObjectWorkload {
             .map(|b| Box::<dyn Payload>::from(b))
             .collect()
     }
+
+    fn name(&self) -> &str {
+        "TransferObject"
+    }
 }

--- a/crates/sui-benchmark/src/workloads/workload.rs
+++ b/crates/sui-benchmark/src/workloads/workload.rs
@@ -115,4 +115,5 @@ pub trait Workload<T: Payload + ?Sized>: Send + Sync + std::fmt::Debug {
         proxy: Arc<dyn ValidatorProxy + Sync + Send>,
         system_state_observer: Arc<SystemStateObserver>,
     ) -> Vec<Box<T>>;
+    fn name(&self) -> &str;
 }

--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -125,6 +125,8 @@ mod test {
             .with_submit_delay_step_override_millis(3000)
             .with_num_unpruned_validators(1)
             .with_chain_override(chain)
+            // Disable TransactionDriver in chain configide override tests.
+            .transaction_driver_percentage(0)
             .build()
             .await
             .into();
@@ -854,6 +856,8 @@ mod test {
                 )
                 .with_objects(init_framework.into_iter().map(|p| p.genesis_object()))
                 .with_stake_subsidy_start_epoch(10)
+                // Disable TransactionDriver in upgrade compatibility tests.
+                .transaction_driver_percentage(0)
                 .build()
                 .await,
         );
@@ -1139,8 +1143,15 @@ mod test {
         let primary_coin = (primary_gas, sender, ed25519_keypair.clone());
 
         let registry = prometheus::Registry::new();
-        let proxy: Arc<dyn ValidatorProxy + Send + Sync> =
-            Arc::new(LocalValidatorAggregatorProxy::from_genesis(&genesis, &registry, None).await);
+        let proxy: Arc<dyn ValidatorProxy + Send + Sync> = Arc::new(
+            LocalValidatorAggregatorProxy::from_genesis(
+                &genesis,
+                &registry,
+                None,
+                test_cluster.transaction_driver_percentage(),
+            )
+            .await,
+        );
 
         let bank = BenchmarkBank::new(proxy.clone(), primary_coin);
         let system_state_observer = {

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -1135,7 +1135,7 @@ impl ValidatorService {
                 // if response from this validator is desired.
                 let response = WaitForEffectsResponse::Expired {
                     epoch: local_epoch,
-                    round: 0,
+                    round: None,
                 };
                 return Ok(response);
             }
@@ -1179,7 +1179,7 @@ impl ValidatorService {
             NotifyReadConsensusTxStatusResult::Expired(round) => {
                 return Ok(WaitForEffectsResponse::Expired {
                     epoch: epoch_store.epoch(),
-                    round,
+                    round: Some(round),
                 });
             }
         };
@@ -1211,7 +1211,7 @@ impl ValidatorService {
                         NotifyReadConsensusTxStatusResult::Expired(round) => {
                             return Ok(WaitForEffectsResponse::Expired {
                                 epoch: epoch_store.epoch(),
-                                round,
+                                round: Some(round),
                             });
                         }
                     }

--- a/crates/sui-core/src/mock_consensus.rs
+++ b/crates/sui-core/src/mock_consensus.rs
@@ -11,6 +11,7 @@ use consensus_types::block::BlockRef;
 use prometheus::Registry;
 use std::sync::{Arc, Weak};
 use std::time::Duration;
+use sui_types::committee::EpochId;
 use sui_types::error::{SuiError, SuiResult};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::messages_consensus::{
@@ -134,6 +135,7 @@ impl MockConsensusClient {
         // TODO(fastpath): Add some way to simulate consensus positions across blocks
         Ok((
             vec![ConsensusPosition {
+                epoch: EpochId::MIN,
                 block: BlockRef::MIN,
                 index: 0,
             }],

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -18,6 +18,7 @@ use consensus_types::block::BlockRef;
 use mysten_metrics::spawn_monitored_task;
 use sui_config::genesis::Genesis;
 use sui_types::{
+    committee::EpochId,
     crypto::AuthorityKeyPair,
     error::SuiError,
     executable_transaction::VerifiedExecutableTransaction,
@@ -105,6 +106,7 @@ impl AuthorityAPI for LocalAuthorityClient {
         // dummy consensus position
         // TODO(fastpath): Return the actual consensus position
         let consensus_position = ConsensusPosition {
+            epoch: EpochId::MIN,
             block: BlockRef::MIN,
             index: 0,
         };

--- a/crates/sui-core/src/transaction_driver/effects_certifier.rs
+++ b/crates/sui-core/src/transaction_driver/effects_certifier.rs
@@ -166,14 +166,12 @@ impl EffectsCertifier {
                     }
                     WaitForEffectsResponse::Expired { epoch, round } => {
                         if attempts >= MAX_ATTEMPTS {
-                            return Err(TransactionDriverError::TransactionExpired(
-                                round.to_string(),
-                            ));
+                            return Err(TransactionDriverError::TransactionStatusExpired);
                         }
                         tracing::debug!(
-                            "Transaction expired at epoch {}, round {}, retrying...",
+                            "Transaction status expired at epoch {}, round {}, retrying...",
                             epoch,
-                            round
+                            round.unwrap_or(0),
                         );
                     }
                 },
@@ -315,7 +313,7 @@ impl EffectsCertifier {
                         "{} at epoch {}, round {}",
                         name.concise(),
                         epoch,
-                        round,
+                        round.unwrap_or(0),
                     ));
                     self.metrics.expiration_acks.inc();
                     if let InsertResult::Failed { error } =

--- a/crates/sui-core/src/transaction_driver/effects_certifier.rs
+++ b/crates/sui-core/src/transaction_driver/effects_certifier.rs
@@ -45,7 +45,6 @@ impl EffectsCertifier {
         authority_aggregator: &Arc<AuthorityAggregator<A>>,
         tx_digest: &TransactionDigest,
         consensus_position: ConsensusPosition,
-        epoch: EpochId,
         options: &SubmitTransactionOptions,
     ) -> Result<QuorumTransactionResponse, TransactionDriverError>
     where
@@ -56,14 +55,12 @@ impl EffectsCertifier {
                 authority_aggregator,
                 tx_digest,
                 consensus_position,
-                epoch,
                 options,
             ),
             self.get_full_effects_with_retry(
                 authority_aggregator,
                 tx_digest,
                 consensus_position,
-                epoch,
                 options,
             ),
         );
@@ -84,7 +81,7 @@ impl EffectsCertifier {
                         return Ok(self.get_effects_response(
                             effects_digest,
                             executed_data,
-                            epoch,
+                            consensus_position.epoch,
                             tx_digest,
                         ));
                     }
@@ -98,7 +95,6 @@ impl EffectsCertifier {
                     authority_aggregator,
                     tx_digest,
                     consensus_position,
-                    epoch,
                     options,
                 )
                 .await;
@@ -110,7 +106,6 @@ impl EffectsCertifier {
         authority_aggregator: &Arc<AuthorityAggregator<A>>,
         tx_digest: &TransactionDigest,
         consensus_position: ConsensusPosition,
-        epoch: EpochId,
         options: &SubmitTransactionOptions,
     ) -> Result<(TransactionEffectsDigest, ExecutedData), TransactionDriverError>
     where
@@ -125,9 +120,8 @@ impl EffectsCertifier {
             .collect::<Vec<_>>();
 
         let raw_request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
-            epoch,
             transaction_digest: *tx_digest,
-            transaction_position: consensus_position,
+            consensus_position,
             include_details: true,
         })
         .map_err(TransactionDriverError::SerializationError)?;
@@ -211,7 +205,6 @@ impl EffectsCertifier {
         authority_aggregator: &Arc<AuthorityAggregator<A>>,
         tx_digest: &TransactionDigest,
         consensus_position: ConsensusPosition,
-        epoch: EpochId,
         options: &SubmitTransactionOptions,
     ) -> Result<TransactionEffectsDigest, TransactionDriverError>
     where
@@ -223,9 +216,8 @@ impl EffectsCertifier {
             .collect::<Vec<_>>();
         let committee = authority_aggregator.committee.clone();
         let raw_request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
-            epoch,
             transaction_digest: *tx_digest,
-            transaction_position: consensus_position,
+            consensus_position,
             include_details: false,
         })
         .map_err(TransactionDriverError::SerializationError)?;

--- a/crates/sui-core/src/transaction_driver/effects_certifier.rs
+++ b/crates/sui-core/src/transaction_driver/effects_certifier.rs
@@ -176,7 +176,11 @@ impl EffectsCertifier {
                                 round.to_string(),
                             ));
                         }
-                        tracing::debug!("Transaction expired at epoch {}, round {}, retrying...", epoch, round);
+                        tracing::debug!(
+                            "Transaction expired at epoch {}, round {}, retrying...",
+                            epoch,
+                            round
+                        );
                     }
                 },
                 Ok(Err(e)) => {
@@ -245,10 +249,7 @@ impl EffectsCertifier {
                             return (name, response);
                         }
                         Ok(Err(e)) => {
-                            tracing::trace!(
-                                "Wait for effects acknowledgement: error: {:?}",
-                                e
-                            );
+                            tracing::trace!("Wait for effects acknowledgement: error: {:?}", e);
                         }
                         Err(_) => {
                             tracing::trace!("Wait for effects acknowledgement: timeout");

--- a/crates/sui-core/src/transaction_driver/error.rs
+++ b/crates/sui-core/src/transaction_driver/error.rs
@@ -25,8 +25,8 @@ pub enum TransactionDriverError {
     ExecutionDataNotFound(String),
     #[error("Transaction rejected with reason: {0}")]
     TransactionRejected(String),
-    #[error("Transaction expired at round: {0}")]
-    TransactionExpired(String),
+    #[error("Transaction status expired at peer validator")]
+    TransactionStatusExpired,
     #[error("Transaction rejected with reason: {0} & expired with reason: {1}")]
     TransactionRejectedOrExpired(String, String),
     #[error("Forked execution results: total_responses_weight {total_responses_weight}, executed_weight {executed_weight}, rejected_weight {rejected_weight}, expired_weight {expired_weight}, Errors: {errors:?}")]

--- a/crates/sui-core/src/transaction_driver/mod.rs
+++ b/crates/sui-core/src/transaction_driver/mod.rs
@@ -81,9 +81,6 @@ where
         let timer = Instant::now();
 
         let mut attempts = 0;
-        // TODO(fastpath): Remove MAX_ATTEMPTS. Retry until unretriable error.
-        const MAX_ATTEMPTS: usize = 10;
-
         loop {
             attempts += 1;
             // TODO(fastpath): Check local state before submitting transaction
@@ -104,13 +101,10 @@ where
                     return Ok(resp);
                 }
                 Err(e) => {
-                    if attempts >= MAX_ATTEMPTS {
-                        return Err(e);
-                    }
+                    // TODO(fastpath): Break when the error is unretriable.
                     tracing::warn!(
-                        "Failed to submit transaction {tx_digest} (attempt {}/{}): {}",
+                        "Failed to submit transaction {tx_digest} (attempt {}): {}",
                         attempts,
-                        MAX_ATTEMPTS,
                         e
                     );
                 }

--- a/crates/sui-core/src/transaction_driver/mod.rs
+++ b/crates/sui-core/src/transaction_driver/mod.rs
@@ -103,7 +103,7 @@ where
                 Err(e) => {
                     // TODO(fastpath): Break when the error is unretriable.
                     tracing::warn!(
-                        "Failed to submit transaction {tx_digest} (attempt {}): {}",
+                        "Failed to finalize transaction {tx_digest} (attempt {}): {}",
                         attempts,
                         e
                     );
@@ -120,8 +120,6 @@ where
         options: &SubmitTransactionOptions,
     ) -> Result<QuorumTransactionResponse, TransactionDriverError> {
         let auth_agg = self.authority_aggregator.load();
-        let committee = auth_agg.committee.clone();
-        let epoch = committee.epoch();
 
         // Get consensus position using TransactionSubmitter
         let consensus_position = self
@@ -131,13 +129,7 @@ where
 
         // Wait for quorum effects using EffectsCertifier
         self.certifier
-            .get_certified_finalized_effects(
-                &auth_agg,
-                tx_digest,
-                consensus_position,
-                epoch,
-                options,
-            )
+            .get_certified_finalized_effects(&auth_agg, tx_digest, consensus_position, options)
             .await
     }
 

--- a/crates/sui-core/src/transaction_driver/transaction_submitter.rs
+++ b/crates/sui-core/src/transaction_driver/transaction_submitter.rs
@@ -3,17 +3,18 @@
 
 use std::{sync::Arc, time::Duration};
 
-use rand::seq::SliceRandom as _;
+use rand::{seq::SliceRandom as _, Rng as _};
 use sui_types::{
-    base_types::ConciseableName, digests::TransactionDigest, messages_consensus::ConsensusPosition,
-    messages_grpc::RawSubmitTxRequest,
+    base_types::ConciseableName, crypto::AuthorityPublicKeyBytes, digests::TransactionDigest,
+    messages_consensus::ConsensusPosition, messages_grpc::RawSubmitTxRequest,
 };
-use tokio::time::timeout;
+use tokio::time::{sleep, timeout};
 use tracing::{debug, instrument};
 
 use crate::{
     authority_aggregator::AuthorityAggregator,
     authority_client::AuthorityAPI,
+    safe_client::SafeClient,
     transaction_driver::{
         error::TransactionDriverError, SubmitTransactionOptions, TransactionDriverMetrics,
     },
@@ -42,51 +43,54 @@ impl TransactionSubmitter {
         A: AuthorityAPI + Send + Sync + 'static + Clone,
     {
         let mut attempts = 0;
-        // TODO(fastpath): Remove MAX_ATTEMPTS. Retry until f+1 permanent failures or cancellation.
-        const MAX_ATTEMPTS: usize = 10;
-
         loop {
-            attempts += 1;
-            match self
-                .submit_transaction_once(authority_aggregator, &raw_request, options)
-                .await
-            {
-                Ok(consensus_position) => {
-                    debug!(
-                        "Transaction {tx_digest} submitted to consensus at position: {consensus_position:?}",
-                    );
-                    self.metrics.submit_transaction_success.inc();
-                    return Ok(consensus_position);
-                }
-                Err(e) => {
-                    self.metrics.submit_transaction_error.inc();
-                    if attempts >= MAX_ATTEMPTS {
-                        return Err(e);
+            let mut clients = authority_aggregator
+                .authority_clients
+                .iter()
+                .collect::<Vec<_>>();
+            clients.shuffle(&mut rand::thread_rng());
+
+            for (name, client) in clients {
+                attempts += 1;
+                // TODO(fastpath): iterate over a list of good performing validators.
+                match self
+                    .submit_transaction_once(name, client, &raw_request, options)
+                    .await
+                {
+                    Ok(consensus_position) => {
+                        debug!(
+                            "Transaction {tx_digest} submitted to consensus at position: {consensus_position:?}",
+                        );
+                        self.metrics.submit_transaction_success.inc();
+                        return Ok(consensus_position);
                     }
-                    tracing::warn!(
-                        "Failed to submit transaction {tx_digest} (attempt {attempts}/{MAX_ATTEMPTS}): {e}",
-                    );
+                    Err(e) => {
+                        self.metrics.submit_transaction_error.inc();
+                        // TODO(fastpath): Retry until f+1 permanent failures.
+                        tracing::warn!(
+                            "Failed to submit transaction {tx_digest} (attempt {attempts}): {e}",
+                        );
+                    }
                 }
+                tokio::task::yield_now().await;
             }
+
+            let delay_ms = rand::thread_rng().gen_range(1000..2000);
+            sleep(Duration::from_millis(delay_ms)).await;
         }
     }
 
     #[instrument(level = "trace", skip_all)]
     async fn submit_transaction_once<A>(
         &self,
-        authority_aggregator: &Arc<AuthorityAggregator<A>>,
+        name: &AuthorityPublicKeyBytes,
+        client: &Arc<SafeClient<A>>,
         raw_request: &RawSubmitTxRequest,
         options: &SubmitTransactionOptions,
     ) -> Result<ConsensusPosition, TransactionDriverError>
     where
         A: AuthorityAPI + Send + Sync + 'static + Clone,
     {
-        let clients = authority_aggregator
-            .authority_clients
-            .iter()
-            .collect::<Vec<_>>();
-        let (name, client) = clients.choose(&mut rand::thread_rng()).unwrap();
-
         let consensus_position = timeout(
             SUBMIT_TRANSACTION_TIMEOUT,
             client.submit_transaction(raw_request.clone(), options.forwarded_client_addr),
@@ -96,7 +100,6 @@ impl TransactionSubmitter {
         .map_err(|e| {
             TransactionDriverError::RpcFailure(name.concise().to_string(), e.to_string())
         })?;
-
         Ok(consensus_position)
     }
 }

--- a/crates/sui-core/src/transaction_driver/transaction_submitter.rs
+++ b/crates/sui-core/src/transaction_driver/transaction_submitter.rs
@@ -20,7 +20,7 @@ use crate::{
     },
 };
 
-const SUBMIT_TRANSACTION_TIMEOUT: Duration = Duration::from_secs(2);
+const SUBMIT_TRANSACTION_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub(crate) struct TransactionSubmitter {
     metrics: Arc<TransactionDriverMetrics>,

--- a/crates/sui-core/src/unit_tests/consensus_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_tests.rs
@@ -288,6 +288,7 @@ pub fn make_consensus_adapter_for_test(
             let mut consensus_positions = Vec::new();
             for index in 0..num_transactions {
                 consensus_positions.push(ConsensusPosition {
+                    epoch: epoch_store.epoch(),
                     index: index as u16,
                     block: BlockRef::MIN,
                 });

--- a/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
+++ b/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
@@ -445,5 +445,5 @@ async fn test_wait_for_effects_expired() {
         .try_into()
         .unwrap();
 
-    assert!(matches!(response, WaitForEffectsResponse::Expired(_)));
+    assert!(matches!(response, WaitForEffectsResponse::Expired{..}));
 }

--- a/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
+++ b/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
@@ -445,5 +445,5 @@ async fn test_wait_for_effects_expired() {
         .try_into()
         .unwrap();
 
-    assert!(matches!(response, WaitForEffectsResponse::Expired{..}));
+    assert!(matches!(response, WaitForEffectsResponse::Expired { .. }));
 }

--- a/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
+++ b/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
@@ -8,6 +8,7 @@ use consensus_types::block::{BlockRef, TransactionIndex};
 use fastcrypto::traits::KeyPair;
 use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::{ObjectRef, SuiAddress, TransactionDigest};
+use sui_types::committee::EpochId;
 use sui_types::crypto::{get_account_key_pair, AccountKeyPair};
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::message_envelope::Message;
@@ -97,18 +98,19 @@ async fn test_wait_for_effects_position_mismatch() {
     let transaction = test_context.build_test_transaction();
     let tx_digest = *transaction.digest();
     let tx_position1 = ConsensusPosition {
+        epoch: EpochId::MIN,
         block: BlockRef::MIN,
         index: TransactionIndex::MIN,
     };
     let tx_position2 = ConsensusPosition {
+        epoch: EpochId::MIN,
         block: BlockRef::MIN,
         index: TransactionIndex::MIN + 1,
     };
 
     let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
-        epoch: 0,
         transaction_digest: tx_digest,
-        transaction_position: tx_position1,
+        consensus_position: tx_position1,
         include_details: true,
     })
     .unwrap();
@@ -141,14 +143,14 @@ async fn test_wait_for_effects_post_commit_rejected() {
     let transaction = test_context.build_test_transaction();
     let tx_digest = *transaction.digest();
     let tx_position = ConsensusPosition {
+        epoch: EpochId::MIN,
         block: BlockRef::MIN,
         index: TransactionIndex::MIN,
     };
 
     let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
-        epoch: 0,
         transaction_digest: tx_digest,
-        transaction_position: tx_position,
+        consensus_position: tx_position,
         include_details: true,
     })
     .unwrap();
@@ -187,14 +189,14 @@ async fn test_wait_for_effects_epoch_mismatch() {
 
     let tx_digest = TransactionDigest::random();
     let tx_position = ConsensusPosition {
+        epoch: EpochId::MIN,
         block: BlockRef::MIN,
         index: TransactionIndex::MIN,
     };
 
     let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
-        epoch: 1,
         transaction_digest: tx_digest,
-        transaction_position: tx_position,
+        consensus_position: tx_position,
         include_details: true,
     })
     .unwrap();
@@ -212,14 +214,14 @@ async fn test_wait_for_effects_timeout() {
 
     let tx_digest = TransactionDigest::random();
     let tx_position = ConsensusPosition {
+        epoch: EpochId::MIN,
         block: BlockRef::MIN,
         index: TransactionIndex::MIN,
     };
 
     let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
-        epoch: 0,
         transaction_digest: tx_digest,
-        transaction_position: tx_position,
+        consensus_position: tx_position,
         include_details: true,
     })
     .unwrap();
@@ -237,14 +239,14 @@ async fn test_wait_for_effects_quorum_rejected() {
     let transaction = test_context.build_test_transaction();
     let tx_digest = *transaction.digest();
     let tx_position = ConsensusPosition {
+        epoch: EpochId::MIN,
         block: BlockRef::MIN,
         index: TransactionIndex::MIN,
     };
 
     let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
-        epoch: 0,
         transaction_digest: tx_digest,
-        transaction_position: tx_position,
+        consensus_position: tx_position,
         include_details: true,
     })
     .unwrap();
@@ -281,14 +283,14 @@ async fn test_wait_for_effects_fastpath_certified() {
     let transaction = test_context.build_test_transaction();
     let tx_digest = *transaction.digest();
     let tx_position = ConsensusPosition {
+        epoch: EpochId::MIN,
         block: BlockRef::MIN,
         index: TransactionIndex::MIN,
     };
 
     let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
-        epoch: 0,
         transaction_digest: tx_digest,
-        transaction_position: tx_position,
+        consensus_position: tx_position,
         // Also test the case where details are not requested.
         include_details: false,
     })
@@ -342,14 +344,14 @@ async fn test_wait_for_effects_finalized() {
     let transaction = test_context.build_test_transaction();
     let tx_digest = *transaction.digest();
     let tx_position = ConsensusPosition {
+        epoch: EpochId::MIN,
         block: BlockRef::MIN,
         index: TransactionIndex::MIN,
     };
 
     let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
-        epoch: 0,
         transaction_digest: tx_digest,
-        transaction_position: tx_position,
+        consensus_position: tx_position,
         // Also test the case where details are not requested.
         include_details: false,
     })
@@ -402,14 +404,14 @@ async fn test_wait_for_effects_expired() {
     let transaction = test_context.build_test_transaction();
     let tx_digest = *transaction.digest();
     let tx_position = ConsensusPosition {
+        epoch: EpochId::MIN,
         block: BlockRef::MIN,
         index: TransactionIndex::MIN,
     };
 
     let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
-        epoch: 0,
         transaction_digest: tx_digest,
-        transaction_position: tx_position,
+        consensus_position: tx_position,
         include_details: true,
     })
     .unwrap();

--- a/crates/sui-core/src/wait_for_effects_request.rs
+++ b/crates/sui-core/src/wait_for_effects_request.rs
@@ -66,10 +66,11 @@ pub enum WaitForEffectsResponse {
         // The rejection reason known locally.
         reason: RejectReason,
     },
-    // The transaction position is expired at the committed round.
+    // The transaction position is expired, with the local epoch and committed round.
+    // When round is None, the expiration is due to lagging epoch in the request.
     Expired {
         epoch: u64,
-        round: u32,
+        round: Option<u32>,
     },
 }
 

--- a/crates/sui-core/src/wait_for_effects_request.rs
+++ b/crates/sui-core/src/wait_for_effects_request.rs
@@ -6,9 +6,10 @@ use sui_types::{
     digests::{TransactionDigest, TransactionEffectsDigest},
     effects::{TransactionEffects, TransactionEvents},
     error::SuiError,
-    messages_consensus::{ConsensusPosition},
+    messages_consensus::ConsensusPosition,
     messages_grpc::{
-        RawExecutedData, RawExecutedStatus, RawExpiredStatus, RawRejectReason, RawRejectedStatus, RawValidatorTransactionStatus, RawWaitForEffectsRequest, RawWaitForEffectsResponse
+        RawExecutedData, RawExecutedStatus, RawExpiredStatus, RawRejectReason, RawRejectedStatus,
+        RawValidatorTransactionStatus, RawWaitForEffectsRequest, RawWaitForEffectsResponse,
     },
     object::Object,
 };

--- a/crates/sui-core/src/wait_for_effects_request.rs
+++ b/crates/sui-core/src/wait_for_effects_request.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use sui_types::{
-    committee::EpochId,
     digests::{TransactionDigest, TransactionEffectsDigest},
     effects::{TransactionEffects, TransactionEvents},
     error::SuiError,
@@ -15,9 +14,8 @@ use sui_types::{
 };
 
 pub(crate) struct WaitForEffectsRequest {
-    pub epoch: EpochId,
+    pub consensus_position: ConsensusPosition,
     pub transaction_digest: TransactionDigest,
-    pub transaction_position: ConsensusPosition,
     /// Whether to include details of the effects,
     /// including the effects content, events, input objects, and output objects.
     pub include_details: bool,
@@ -70,7 +68,7 @@ pub enum WaitForEffectsResponse {
     },
     // The transaction position is expired at the committed round.
     Expired {
-        epoch: u32,
+        epoch: u64,
         round: u32,
     },
 }
@@ -85,16 +83,15 @@ impl TryFrom<RawWaitForEffectsRequest> for WaitForEffectsRequest {
                 error: err.to_string(),
             }
         })?;
-        let transaction_position = bcs::from_bytes(&value.transaction_position).map_err(|err| {
+        let consensus_position = bcs::from_bytes(&value.consensus_position).map_err(|err| {
             SuiError::GrpcMessageDeserializeError {
-                type_info: "RawWaitForEffectsRequest.transaction_position".to_string(),
+                type_info: "RawWaitForEffectsRequest.consensus_position".to_string(),
                 error: err.to_string(),
             }
         })?;
         Ok(Self {
-            epoch: value.epoch,
+            consensus_position,
             transaction_digest,
-            transaction_position,
             include_details: value.include_details,
         })
     }
@@ -205,16 +202,15 @@ impl TryFrom<WaitForEffectsRequest> for RawWaitForEffectsRequest {
                 error: err.to_string(),
             })?
             .into();
-        let transaction_position = bcs::to_bytes(&value.transaction_position)
+        let consensus_position = bcs::to_bytes(&value.consensus_position)
             .map_err(|err| SuiError::GrpcMessageSerializeError {
-                type_info: "RawWaitForEffectsRequest.transaction_position".to_string(),
+                type_info: "RawWaitForEffectsRequest.consensus_position".to_string(),
                 error: err.to_string(),
             })?
             .into();
         Ok(Self {
-            epoch: value.epoch,
+            consensus_position,
             transaction_digest,
-            transaction_position,
             include_details: value.include_details,
         })
     }

--- a/crates/sui-types/src/messages_consensus.rs
+++ b/crates/sui-types/src/messages_consensus.rs
@@ -3,6 +3,7 @@
 
 use crate::base_types::{AuthorityName, ConsensusObjectSequenceKey, ObjectRef, TransactionDigest};
 use crate::base_types::{ConciseableName, ObjectID, SequenceNumber};
+use crate::committee::EpochId;
 use crate::digests::{AdditionalConsensusStateDigest, ConsensusCommitDigest};
 use crate::error::SuiError;
 use crate::execution::ExecutionTimeObservationKey;
@@ -39,8 +40,10 @@ pub type Round = u64;
 pub type TimestampMs = u64;
 
 /// The position of a transaction in consensus.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct ConsensusPosition {
+    // Epoch of the consensus instance.
+    pub epoch: EpochId,
     // Block containing a transaction.
     pub block: BlockRef,
     // Index of the transaction in the block.
@@ -66,6 +69,18 @@ impl TryFrom<&[u8]> for ConsensusPosition {
             type_info: "ConsensusPosition".to_string(),
             error: e.to_string(),
         })
+    }
+}
+
+impl std::fmt::Display for ConsensusPosition {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "P(E{}, {}, {})", self.epoch, self.block, self.index)
+    }
+}
+
+impl std::fmt::Debug for ConsensusPosition {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "P(E{}, {:?}, {})", self.epoch, self.block, self.index)
     }
 }
 

--- a/crates/sui-types/src/messages_grpc.rs
+++ b/crates/sui-types/src/messages_grpc.rs
@@ -322,8 +322,8 @@ pub struct RawExpiredStatus {
     #[prost(uint64, tag = "1")]
     pub epoch: u64,
     // Validator's current round. 0 if it is not yet checked.
-    #[prost(uint32, tag = "2")]
-    pub round: u32,
+    #[prost(uint32, optional, tag = "2")]
+    pub round: Option<u32>,
 }
 
 impl From<HandleCertificateResponseV3> for HandleCertificateResponseV2 {

--- a/crates/sui-types/src/messages_grpc.rs
+++ b/crates/sui-types/src/messages_grpc.rs
@@ -241,18 +241,15 @@ pub struct SubmitTxResponse {
 
 #[derive(Clone, prost::Message)]
 pub struct RawWaitForEffectsRequest {
-    #[prost(uint64, tag = "1")]
-    pub epoch: u64,
+    #[prost(bytes = "bytes", tag = "1")]
+    pub consensus_position: Bytes,
 
     #[prost(bytes = "bytes", tag = "2")]
-    pub transaction_position: Bytes,
-
-    #[prost(bytes = "bytes", tag = "3")]
     pub transaction_digest: Bytes,
 
     /// Whether to include details of the effects,
     /// including the effects content, events, input objects, and output objects.
-    #[prost(bool, tag = "4")]
+    #[prost(bool, tag = "3")]
     pub include_details: bool,
 }
 
@@ -322,8 +319,8 @@ pub enum RawRejectReason {
 #[derive(Clone, prost::Message)]
 pub struct RawExpiredStatus {
     // Validator's current epoch.
-    #[prost(uint32, tag = "1")]
-    pub epoch: u32,
+    #[prost(uint64, tag = "1")]
+    pub epoch: u64,
     // Validator's current round. 0 if it is not yet checked.
     #[prost(uint32, tag = "2")]
     pub round: u32,

--- a/crates/sui-types/src/messages_grpc.rs
+++ b/crates/sui-types/src/messages_grpc.rs
@@ -6,7 +6,7 @@ use crate::crypto::{AuthoritySignInfo, AuthorityStrongQuorumSignInfo};
 use crate::effects::{
     SignedTransactionEffects, TransactionEvents, VerifiedSignedTransactionEffects,
 };
-use crate::messages_consensus::{ConsensusPosition, Round};
+use crate::messages_consensus::ConsensusPosition;
 use crate::object::Object;
 use crate::transaction::{CertifiedTransaction, SenderSignedData, SignedTransaction};
 use bytes::Bytes;
@@ -245,10 +245,10 @@ pub struct RawWaitForEffectsRequest {
     pub epoch: u64,
 
     #[prost(bytes = "bytes", tag = "2")]
-    pub transaction_digest: Bytes,
+    pub transaction_position: Bytes,
 
     #[prost(bytes = "bytes", tag = "3")]
-    pub transaction_position: Bytes,
+    pub transaction_digest: Bytes,
 
     /// Whether to include details of the effects,
     /// including the effects content, events, input objects, and output objects.
@@ -272,8 +272,8 @@ pub enum RawValidatorTransactionStatus {
     Executed(RawExecutedStatus),
     #[prost(message, tag = "2")]
     Rejected(RawRejectedStatus),
-    #[prost(uint64, tag = "3")]
-    Expired(Round),
+    #[prost(message, tag = "3")]
+    Expired(RawExpiredStatus),
 }
 
 #[derive(Clone, prost::Message)]
@@ -317,6 +317,16 @@ pub enum RawRejectReason {
     Overload = 3,
     // Rejected due to coin deny list.
     CoinDenyList = 4,
+}
+
+#[derive(Clone, prost::Message)]
+pub struct RawExpiredStatus {
+    // Validator's current epoch.
+    #[prost(uint32, tag = "1")]
+    pub epoch: u32,
+    // Validator's current round. 0 if it is not yet checked.
+    #[prost(uint32, tag = "2")]
+    pub round: u32,
 }
 
 impl From<HandleCertificateResponseV3> for HandleCertificateResponseV2 {

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -93,6 +93,7 @@ pub struct TestCluster {
     pub wallet: WalletContext,
     pub fullnode_handle: FullNodeHandle,
     indexer_handle: Option<test_indexer_handle::IndexerHandle>,
+    transaction_driver_percentage: Option<u8>,
 }
 
 impl TestCluster {
@@ -156,6 +157,10 @@ impl TestCluster {
         self.fullnode_handle
             .sui_node
             .with(|node| node.state().epoch_store_for_testing().committee().clone())
+    }
+
+    pub fn transaction_driver_percentage(&self) -> Option<u8> {
+        self.transaction_driver_percentage
     }
 
     /// Convenience method to start a new fullnode in the test cluster.
@@ -850,6 +855,8 @@ pub struct TestClusterBuilder {
     indexer_backed_rpc: bool,
 
     chain_override: Option<Chain>,
+
+    transaction_driver_percentage: Option<u8>,
 }
 
 impl TestClusterBuilder {
@@ -884,6 +891,7 @@ impl TestClusterBuilder {
                 true,
             ),
             indexer_backed_rpc: false,
+            transaction_driver_percentage: None,
         }
     }
 
@@ -1106,6 +1114,13 @@ impl TestClusterBuilder {
         self
     }
 
+    /// Percentage of transactions going through TransactionDriver, instead of QuorumDriver.
+    /// Can be overridden by setting the TRANSACTION_DRIVER environment variable.
+    pub fn transaction_driver_percentage(mut self, percent: u8) -> Self {
+        self.transaction_driver_percentage = Some(percent);
+        self
+    }
+
     pub async fn build(mut self) -> TestCluster {
         // All test clusters receive a continuous stream of random JWKs.
         // If we later use zklogin authenticated transactions in tests we will need to supply
@@ -1193,11 +1208,14 @@ impl TestClusterBuilder {
         let wallet_conf = swarm.dir().join(SUI_CLIENT_CONFIG);
         let wallet = WalletContext::new(&wallet_conf).unwrap();
 
+        let transaction_driver_percentage = self.transaction_driver_percentage;
+
         TestCluster {
             swarm,
             wallet,
             fullnode_handle,
             indexer_handle,
+            transaction_driver_percentage,
         }
     }
 


### PR DESCRIPTION
## Description 

When the environment changes epoch frequently, WaitForEffects can fail because the consensus position is from past epoch. Transaction submission should be retried in this case.

Additional fixes:
- Disable TD for envs where MFP is disabled.
- Retry indefinitely in the top level of TransactionDriver.

## Test plan 

`TRANSACTION_DRIVER=100 cargo simtest --test simtest`
Before: 12 passed
After: 14 passed. Remaining failures are different from before.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
