### PR TITLE
Test-only: congestion control - use 1st checkpoint digest as seed

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -4530,6 +4530,22 @@ impl AuthorityPerEpochStore {
             .map(|s| s.summary))
     }
 
+    pub(crate) fn get_lowest_non_genesis_checkpoint_summary(
+        &self,
+    ) -> SuiResult<Option<CheckpointSummary>> {
+        for result in self
+            .tables()?
+            .builder_checkpoint_summary_v2
+            .safe_iter_with_bounds(None, None)
+        {
+            let (seq, bcs) = result?;
+            if seq > 0 {
+                return Ok(Some(bcs.summary));
+            }
+        }
+        Ok(None)
+    }
+
     pub fn builder_included_transactions_in_checkpoint<'a>(
         &self,
         digests: impl Iterator<Item = &'a TransactionDigest>,


### PR DESCRIPTION
## Description 

Use the digest of the 1st checkpoint created after genesis as the seed for the RNG, in Antithesis tests only. This will ensure that during Antithesis test runs, each command type will have a consistent latency measurement across validators ranging from 100-600ms, and all validators will agree on this latency measurement. For SIM tests, and in the Genesis checkpoint, fall back on a thread-local random seed.

## Test plan 

How did you test the new or updated feature?
https://mystenlabs.antithesis.com/report/YKuEzJthuhTJf1Yjnb5APWPz/sMZdf2Rme4X6Y4MUXtWHYLACtG8q595NpPKUr-qNo7k.html?auth=v2.public.eyJzY29wZSI6eyJSZXBvcnRTY29wZVYxIjp7ImFzc2V0Ijoic01aZGYyUm1lNFg2WTRNVVh0V0hZTEFDdEc4cTU5NU5wUEtVci1xTm83ay5odG1sIiwicmVwb3J0X2lkIjoiWUt1RXpKdGh1aFRKZjFZam5iNUFQV1B6In19LCJuYmYiOiIyMDI1LTA3LTE1VDE2OjI3OjExLjQwODAzMTk5NFoifVAS5DHVJ9oAMbUG6NUpxwjd-nekuD1R8uXdofZp_cBUfqeuPp4hBubGfCez3nYCZBHoY-_9Y5_Aai2whdUPdAk

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
