### PR TITLE
[Bridge Indexer] - added optional config to run eth only indexer

### DIFF
--- a/crates/sui-bridge-indexer/src/config.rs
+++ b/crates/sui-bridge-indexer/src/config.rs
@@ -25,6 +25,9 @@ pub struct IndexerConfig {
     pub eth_sui_bridge_contract_address: String,
 
     pub metric_port: u16,
+
+    #[serde(default)]
+    pub eth_only: bool,
 }
 
 impl sui_config::Config for IndexerConfig {}

--- a/crates/sui-bridge-indexer/src/main.rs
+++ b/crates/sui-bridge-indexer/src/main.rs
@@ -117,8 +117,11 @@ async fn main() -> Result<()> {
     .await?;
     tasks.push(spawn_logged_monitored_task!(eth_sync_indexer.start()));
 
-    let indexer = create_sui_indexer(pool, indexer_meterics, ingestion_metrics, &config).await?;
-    tasks.push(spawn_logged_monitored_task!(indexer.start()));
+    if !config.eth_only {
+        let indexer =
+            create_sui_indexer(pool, indexer_meterics, ingestion_metrics, &config).await?;
+        tasks.push(spawn_logged_monitored_task!(indexer.start()));
+    }
 
     let sui_bridge_client =
         Arc::new(SuiBridgeClient::new(&config.sui_rpc_url, bridge_metrics.clone()).await?);

--- a/crates/sui-bridge-indexer/tests/indexer_tests.rs
+++ b/crates/sui-bridge-indexer/tests/indexer_tests.rs
@@ -166,6 +166,7 @@ async fn setup_bridge_env(with_eth_env: bool) -> (IndexerConfig, BridgeTestClust
         eth_bridge_genesis_block: 0,
         eth_sui_bridge_contract_address: bridge_test_cluster.sui_bridge_address(),
         metric_port: 9001,
+        eth_only: false,
     };
 
     (config, bridge_test_cluster, db)


### PR DESCRIPTION
## Description 

added optional config to run eth only indexer, in preparation to split out Sui indexing using indexer-alt framework

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
