### PR TITLE
Add sui-tool command to display consensus commits from DB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16269,6 +16269,7 @@ dependencies = [
  "clap",
  "colored",
  "comfy-table",
+ "consensus-core",
  "eyre",
  "fastcrypto",
  "futures",

--- a/consensus/core/src/commit.rs
+++ b/consensus/core/src/commit.rs
@@ -56,7 +56,7 @@ pub(crate) type WaveNumber = u32;
 /// sequence of Commits.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[enum_dispatch(CommitAPI)]
-pub(crate) enum Commit {
+pub enum Commit {
     V1(CommitV1),
 }
 
@@ -86,7 +86,7 @@ impl Commit {
 
 /// Accessors to Commit info.
 #[enum_dispatch]
-pub(crate) trait CommitAPI {
+pub trait CommitAPI {
     fn round(&self) -> Round;
     fn index(&self) -> CommitIndex;
     fn previous_digest(&self) -> CommitDigest;
@@ -98,7 +98,7 @@ pub(crate) trait CommitAPI {
 /// Specifies one consensus commit.
 /// It is stored on disk, so it does not contain blocks which are stored individually.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
-pub(crate) struct CommitV1 {
+pub struct CommitV1 {
     /// Index of the commit.
     /// First commit after genesis has an index of 1, then every next commit has an index incremented by 1.
     index: CommitIndex,
@@ -146,7 +146,7 @@ impl CommitAPI for CommitV1 {
 ///
 /// Note: clone() is relatively cheap with the underlying data refcounted.
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) struct TrustedCommit {
+pub struct TrustedCommit {
     inner: Arc<Commit>,
 
     // Cached digest and serialized value, to avoid re-computing these values.
@@ -576,43 +576,43 @@ impl Display for DecidedLeader {
 /// and potentially restoring from an earlier state.
 // TODO: version this struct.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct CommitInfo {
+pub struct CommitInfo {
     pub(crate) committed_rounds: Vec<Round>,
     pub(crate) reputation_scores: ReputationScores,
 }
 
-/// CommitRange stores a range of CommitIndex. The range contains the start (inclusive)
+/// `CommitRange` stores a range of `CommitIndex`. The range contains the start (inclusive)
 /// and end (inclusive) commit indices and can be ordered for use as the key of a table.
 ///
-/// NOTE: using Range<CommitIndex> for internal representation for backward compatibility.
-/// The external semantics of CommitRange is closer to RangeInclusive<CommitIndex>.
+/// NOTE: using `Range<CommitIndex>` for internal representation for backward compatibility.
+/// The external semantics of `CommitRange` is closer to `RangeInclusive<CommitIndex>`.
 #[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct CommitRange(Range<CommitIndex>);
+pub struct CommitRange(Range<CommitIndex>);
 
 impl CommitRange {
-    pub(crate) fn new(range: RangeInclusive<CommitIndex>) -> Self {
+    pub fn new(range: RangeInclusive<CommitIndex>) -> Self {
         // When end is CommitIndex::MAX, the range can be considered as unbounded
         // so it is ok to saturate at the end.
         Self(*range.start()..(*range.end()).saturating_add(1))
     }
 
     // Inclusive
-    pub(crate) fn start(&self) -> CommitIndex {
+    pub fn start(&self) -> CommitIndex {
         self.0.start
     }
 
     // Inclusive
-    pub(crate) fn end(&self) -> CommitIndex {
+    pub fn end(&self) -> CommitIndex {
         self.0.end.saturating_sub(1)
     }
 
-    pub(crate) fn extend_to(&mut self, other: CommitIndex) {
+    pub fn extend_to(&mut self, other: CommitIndex) {
         let new_end = other.saturating_add(1);
         assert!(self.0.end <= new_end);
         self.0 = self.0.start..new_end;
     }
 
-    pub(crate) fn size(&self) -> usize {
+    pub fn size(&self) -> usize {
         self.0
             .end
             .checked_sub(self.0.start)
@@ -620,12 +620,12 @@ impl CommitRange {
     }
 
     /// Check whether the two ranges have the same size.
-    pub(crate) fn is_equal_size(&self, other: &Self) -> bool {
+    pub fn is_equal_size(&self, other: &Self) -> bool {
         self.size() == other.size()
     }
 
     /// Check if the provided range is sequentially after this range.
-    pub(crate) fn is_next_range(&self, other: &Self) -> bool {
+    pub fn is_next_range(&self, other: &Self) -> bool {
         self.0.end == other.0.start
     }
 }

--- a/consensus/core/src/error.rs
+++ b/consensus/core/src/error.rs
@@ -12,7 +12,7 @@ use crate::commit::{Commit, CommitIndex};
 
 /// Errors that can occur when processing blocks, reading from storage, or encountering shutdown.
 #[derive(Clone, Debug, Error, IntoStaticStr)]
-pub(crate) enum ConsensusError {
+pub enum ConsensusError {
     #[error("Error deserializing block: {0}")]
     MalformedBlock(bcs::Error),
 

--- a/consensus/core/src/lib.rs
+++ b/consensus/core/src/lib.rs
@@ -31,7 +31,7 @@ mod proposed_block_handler;
 mod round_prober;
 mod round_tracker;
 mod stake_aggregator;
-mod storage;
+pub mod storage;
 mod subscriber;
 mod synchronizer;
 mod threshold_clock;
@@ -58,7 +58,7 @@ pub use block::{BlockAPI, CertifiedBlock, CertifiedBlocksOutput};
 
 /// Exported API for testing.
 pub use block::{TestBlock, Transaction, VerifiedBlock};
-pub use commit::{CommitDigest, CommitIndex, CommitRef, CommittedSubDag};
+pub use commit::{CommitAPI, CommitDigest, CommitIndex, CommitRange, CommitRef, CommittedSubDag};
 pub use commit_consumer::{CommitConsumer, CommitConsumerMonitor};
 pub use context::Clock;
 pub use network::{

--- a/consensus/core/src/storage/mod.rs
+++ b/consensus/core/src/storage/mod.rs
@@ -3,7 +3,7 @@
 
 #[cfg(test)]
 pub(crate) mod mem_store;
-pub(crate) mod rocksdb_store;
+pub mod rocksdb_store;
 
 #[cfg(test)]
 mod store_tests;
@@ -19,7 +19,7 @@ use crate::{
 };
 
 /// A common interface for consensus storage.
-pub(crate) trait Store: Send + Sync {
+pub trait Store: Send + Sync {
     /// Writes blocks, consensus commits and other data to store atomically.
     fn write(&self, write_batch: WriteBatch) -> ConsensusResult<()>;
 
@@ -61,14 +61,14 @@ pub(crate) trait Store: Send + Sync {
 
 /// Represents data to be written to the store together atomically.
 #[derive(Debug, Default)]
-pub(crate) struct WriteBatch {
-    pub(crate) blocks: Vec<VerifiedBlock>,
-    pub(crate) commits: Vec<TrustedCommit>,
-    pub(crate) commit_info: Vec<(CommitRef, CommitInfo)>,
+pub struct WriteBatch {
+    pub blocks: Vec<VerifiedBlock>,
+    pub commits: Vec<TrustedCommit>,
+    pub commit_info: Vec<(CommitRef, CommitInfo)>,
 }
 
 impl WriteBatch {
-    pub(crate) fn new(
+    pub fn new(
         blocks: Vec<VerifiedBlock>,
         commits: Vec<TrustedCommit>,
         commit_info: Vec<(CommitRef, CommitInfo)>,
@@ -83,19 +83,19 @@ impl WriteBatch {
     // Test setters.
 
     #[cfg(test)]
-    pub(crate) fn blocks(mut self, blocks: Vec<VerifiedBlock>) -> Self {
+    pub fn blocks(mut self, blocks: Vec<VerifiedBlock>) -> Self {
         self.blocks = blocks;
         self
     }
 
     #[cfg(test)]
-    pub(crate) fn commits(mut self, commits: Vec<TrustedCommit>) -> Self {
+    pub fn commits(mut self, commits: Vec<TrustedCommit>) -> Self {
         self.commits = commits;
         self
     }
 
     #[cfg(test)]
-    pub(crate) fn commit_info(mut self, commit_info: Vec<(CommitRef, CommitInfo)>) -> Self {
+    pub fn commit_info(mut self, commit_info: Vec<(CommitRef, CommitInfo)>) -> Self {
         self.commit_info = commit_info;
         self
     }

--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -27,7 +27,7 @@ use crate::{
 /// Persistent storage with RocksDB.
 #[derive(DBMapUtils)]
 #[cfg_attr(tidehunter, tidehunter)]
-pub(crate) struct RocksDBStore {
+pub struct RocksDBStore {
     /// Stores SignedBlock by refs.
     blocks: DBMap<(Round, AuthorityIndex, BlockDigest), Bytes>,
     /// A secondary index that orders refs first by authors.
@@ -51,7 +51,7 @@ impl RocksDBStore {
 
     /// Creates a new instance of RocksDB storage.
     #[cfg(not(tidehunter))]
-    pub(crate) fn new(path: &str) -> Self {
+    pub fn new(path: &str) -> Self {
         // Consensus data has high write throughput (all transactions) and is rarely read
         // (only during recovery and when helping peers catch up).
         let db_options = default_db_options().optimize_db_for_write_throughput(2);
@@ -83,7 +83,7 @@ impl RocksDBStore {
     }
 
     #[cfg(tidehunter)]
-    pub(crate) fn new(path: &str) -> Self {
+    pub fn new(path: &str) -> Self {
         tracing::warn!("Consensus store using tidehunter");
         use typed_store::tidehunter_util::{KeyIndexing, KeySpaceConfig, KeyType, ThConfig};
         const MUTEXES: usize = 1024;

--- a/crates/sui-tool/Cargo.toml
+++ b/crates/sui-tool/Cargo.toml
@@ -28,6 +28,7 @@ tracing.workspace = true
 prometheus.workspace = true
 object_store.workspace = true
 indicatif.workspace = true
+consensus-core.workspace = true
 
 anemo-cli.workspace = true
 anemo.workspace = true


### PR DESCRIPTION
Makes needed types from consensus crates public.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
