### PR TITLE
[static ptb] Add memory safety invariant checks

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_no_inputs.move
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_no_inputs.move
@@ -1,0 +1,53 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests returning a reference without any inputs
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m {
+
+    public struct Pair has copy, drop, store{
+        x: u64,
+        y: u64,
+    }
+
+    public fun pair_mut(): &mut Pair { abort 0 }
+    public fun box_mut(): (&mut Pair, &mut Pair) { abort 1 }
+
+    public fun increment(p: &mut Pair) {
+        p.x = p.x + 1;
+        p.y = p.y + 1;
+    }
+
+    public fun swap_x(p1: &mut Pair, p2: &mut Pair) {
+        let tmp = p1.x;
+        p1.x = p2.x;
+        p2.x = tmp;
+    }
+}
+
+
+//# programmable --dev-inspect
+// This should be allowed and should abort
+//> 0: test::m::pair_mut();
+//> test::m::increment(Result(0));
+
+//# programmable --dev-inspect
+// This should be allowed and should abort
+//> 0: test::m::box_mut();
+//> test::m::increment(NestedResult(0,0));
+//> test::m::increment(NestedResult(0,1));
+//> test::m::increment(NestedResult(0,0));
+//> test::m::swap_x(NestedResult(0,0), NestedResult(0,1));
+
+//# programmable --dev-inspect
+// This should be rejected by the borrow checker (in static PTBs)
+//> 0: test::m::pair_mut();
+//> test::m::swap_x(Result(0), Result(0));
+
+//# programmable --dev-inspect
+// This should be rejected by the borrow checker (in static PTBs)
+//> 0: test::m::box_mut();
+//> test::m::swap_x(NestedResult(0,0), NestedResult(0,0));

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_no_inputs.snap
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_no_inputs.snap
@@ -1,0 +1,48 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 8-29:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 5137600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 32-35:
+//# programmable --dev-inspect
+// This should be allowed and should abort
+//> 0: test::m::pair_mut();
+//> test::m::increment(Result(0));
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("pair_mut") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("pair_mut") }, 0) in command 0
+
+task 3, lines 37-43:
+//# programmable --dev-inspect
+// This should be allowed and should abort
+//> 0: test::m::box_mut();
+//> test::m::increment(NestedResult(0,0));
+//> test::m::increment(NestedResult(0,1));
+//> test::m::increment(NestedResult(0,0));
+//> test::m::swap_x(NestedResult(0,0), NestedResult(0,1));
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("box_mut") }, 1) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("box_mut") }, 1) in command 0
+
+task 4, lines 45-48:
+//# programmable --dev-inspect
+// This should be rejected by the borrow checker (in static PTBs)
+//> 0: test::m::pair_mut();
+//> test::m::swap_x(Result(0), Result(0));
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("pair_mut") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("pair_mut") }, 0) in command 0
+
+task 5, lines 50-53:
+//# programmable --dev-inspect
+// This should be rejected by the borrow checker (in static PTBs)
+//> 0: test::m::box_mut();
+//> test::m::swap_x(NestedResult(0,0), NestedResult(0,0));
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("box_mut") }, 1) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("box_mut") }, 1) in command 0

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_no_inputs@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_no_inputs@v2.snap
@@ -1,0 +1,48 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 8-29:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 5137600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 32-35:
+//# programmable --dev-inspect
+// This should be allowed and should abort
+//> 0: test::m::pair_mut();
+//> test::m::increment(Result(0));
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("pair_mut") }, 0) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("pair_mut") }, 0) in command 0
+
+task 3, lines 37-43:
+//# programmable --dev-inspect
+// This should be allowed and should abort
+//> 0: test::m::box_mut();
+//> test::m::increment(NestedResult(0,0));
+//> test::m::increment(NestedResult(0,1));
+//> test::m::increment(NestedResult(0,0));
+//> test::m::swap_x(NestedResult(0,0), NestedResult(0,1));
+Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("box_mut") }, 1) in command 0
+Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("box_mut") }, 1) in command 0
+
+task 4, lines 45-48:
+//# programmable --dev-inspect
+// This should be rejected by the borrow checker (in static PTBs)
+//> 0: test::m::pair_mut();
+//> test::m::swap_x(Result(0), Result(0));
+Error: Transaction Effects Status: CommandArgumentError { arg_idx: 1, kind: InvalidValueUsage } in command 1
+Execution Error: CommandArgumentError { arg_idx: 1, kind: InvalidValueUsage } in command 1
+
+task 5, lines 50-53:
+//# programmable --dev-inspect
+// This should be rejected by the borrow checker (in static PTBs)
+//> 0: test::m::box_mut();
+//> test::m::swap_x(NestedResult(0,0), NestedResult(0,0));
+Error: Transaction Effects Status: CommandArgumentError { arg_idx: 1, kind: InvalidValueUsage } in command 1
+Execution Error: CommandArgumentError { arg_idx: 1, kind: InvalidValueUsage } in command 1

--- a/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_no_copy.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_no_copy.move
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests invalid unused values without copy
+
+//# init --addresses test=0x0 --accounts A
+
+//# publish
+module test::m1 {
+    public struct HotPotato {}
+    public fun hot_potato(): HotPotato {
+        HotPotato {}
+    }
+    public fun borrow_and_drop(_: HotPotato, _: &HotPotato) { abort 0 }
+}
+
+//# programmable --sender A
+// unconsumed copyable value
+//> 0: test::m1::hot_potato();
+//> test::m1::borrow_and_drop(Result(0), Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_no_copy.snap
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_no_copy.snap
@@ -1,0 +1,21 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 3 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 8-16:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 4392800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 18-21:
+//# programmable --sender A
+// unconsumed copyable value
+//> 0: test::m1::hot_potato();
+//> test::m1::borrow_and_drop(Result(0), Result(0));
+Error: Transaction Effects Status: Invalid command argument at 1. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: InvalidValueUsage }, source: None, command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_no_copy@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_no_copy@v2.snap
@@ -6,13 +6,13 @@ processed 3 tasks
 init:
 A: object(0,0)
 
-task 1, lines 8-16:
+task 1, lines 8-15:
 //# publish
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 4392800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 4423200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 18-21:
+task 2, lines 17-20:
 //# programmable --sender A
 // unconsumed copyable value
 //> 0: test::m1::hot_potato();

--- a/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_no_copy@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_no_copy@v2.snap
@@ -1,0 +1,21 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 3 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 8-16:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 4392800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 18-21:
+//# programmable --sender A
+// unconsumed copyable value
+//> 0: test::m1::hot_potato();
+//> test::m1::borrow_and_drop(Result(0), Result(0));
+Error: Transaction Effects Status: Invalid command argument at 1. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: InvalidValueUsage }, source: None, command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_valid.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_valid.move
@@ -23,6 +23,9 @@ module test::m1 {
     public fun copyable(): Copyable { Copyable {} }
     public fun borrow(_: &Copyable) {}
     public fun copy_(c: Copyable) { let Copyable {} = c; }
+    public fun borrow_and_copy(_: &Copyable, c: Copyable) {
+        let Copyable {} = c;
+    }
 
     public fun num_mut(_: &u64) {}
 }
@@ -49,3 +52,7 @@ module test::m1 {
 // unused pure that was cast
 //# programmable --sender A --inputs 0
 //> test::m1::num_mut(Input(0))
+
+//# programmable --sender A
+//> 0: test::m1::copyable();
+//> test::m1::borrow_and_copy(Result(0), Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_valid.snap
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_valid.snap
@@ -6,13 +6,13 @@ processed 6 tasks
 init:
 A: object(0,0)
 
-task 1, lines 8-30:
+task 1, lines 8-33:
 //# publish
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 7242800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 7546800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 31-35:
+task 2, lines 34-38:
 //# programmable --sender A --inputs @A
 //> 0: test::m1::r();
 //> TransferObjects([Result(0)], Input(0))
@@ -21,7 +21,7 @@ created: object(2,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2204000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, lines 36-41:
+task 3, lines 39-44:
 //# programmable --sender A --inputs object(2,0) 0 vector[@0,@0]
 //> 0: test::m1::droppable();
 //> 1: test::m1::droppable();
@@ -30,7 +30,7 @@ task 3, lines 36-41:
 mutated: object(0,0), object(2,0)
 gas summary: computation_cost: 1000000, storage_cost: 2204000,  storage_rebate: 2181960, non_refundable_storage_fee: 22040
 
-task 4, lines 42-49:
+task 4, lines 45-52:
 //# programmable --sender A
 //> 0: test::m1::copyable();
 //> 1: test::m1::borrow(Result(0));
@@ -41,7 +41,7 @@ task 4, lines 42-49:
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 5, lines 50-51:
+task 5, lines 53-54:
 //# programmable --sender A --inputs 0
 //> test::m1::num_mut(Input(0))
 mutated: object(0,0)

--- a/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_valid.snap
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_valid.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 6 tasks
+processed 7 tasks
 
 init:
 A: object(0,0)
@@ -44,5 +44,12 @@ gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 9
 task 5, lines 53-54:
 //# programmable --sender A --inputs 0
 //> test::m1::num_mut(Input(0))
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 56-58:
+//# programmable --sender A
+//> 0: test::m1::copyable();
+//> test::m1::borrow_and_copy(Result(0), Result(0));
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_valid@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_valid@v2.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 6 tasks
+processed 7 tasks
 
 init:
 A: object(0,0)
@@ -46,3 +46,10 @@ task 5, lines 53-54:
 //> test::m1::num_mut(Input(0))
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 56-58:
+//# programmable --sender A
+//> 0: test::m1::copyable();
+//> test::m1::borrow_and_copy(Result(0), Result(0));
+Error: Transaction Effects Status: Unused result without the drop ability. Command result 0, return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: UnusedValueWithoutDrop { result_idx: 0, secondary_idx: 0 }, source: Some("The value has copy, but not drop. Its last usage must be by-value so it can be taken."), command: None } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_valid@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/unused_values_valid@v2.snap
@@ -6,13 +6,13 @@ processed 6 tasks
 init:
 A: object(0,0)
 
-task 1, lines 8-30:
+task 1, lines 8-33:
 //# publish
 created: object(1,0)
 mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 7242800,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 7546800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 31-35:
+task 2, lines 34-38:
 //# programmable --sender A --inputs @A
 //> 0: test::m1::r();
 //> TransferObjects([Result(0)], Input(0))
@@ -21,7 +21,7 @@ created: object(2,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 2204000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, lines 36-41:
+task 3, lines 39-44:
 //# programmable --sender A --inputs object(2,0) 0 vector[@0,@0]
 //> 0: test::m1::droppable();
 //> 1: test::m1::droppable();
@@ -30,7 +30,7 @@ task 3, lines 36-41:
 mutated: object(0,0), object(2,0)
 gas summary: computation_cost: 1000000, storage_cost: 2204000,  storage_rebate: 2181960, non_refundable_storage_fee: 22040
 
-task 4, lines 42-49:
+task 4, lines 45-52:
 //# programmable --sender A
 //> 0: test::m1::copyable();
 //> 1: test::m1::borrow(Result(0));
@@ -41,7 +41,7 @@ task 4, lines 42-49:
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 5, lines 50-51:
+task 5, lines 53-54:
 //# programmable --sender A --inputs 0
 //> test::m1::num_mut(Input(0))
 mutated: object(0,0)

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/ast.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/ast.rs
@@ -106,7 +106,7 @@ pub struct MoveCall {
     pub arguments: Vec<Argument>,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub enum Location {
     TxContext,
     GasCoin,

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/memory_safety.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/memory_safety.rs
@@ -1,0 +1,415 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    sp,
+    static_programmable_transactions::{env::Env, typing::ast as T},
+};
+use indexmap::IndexSet;
+use std::rc::Rc;
+use sui_types::error::ExecutionError;
+
+/// We more or less have a new sym counter for each reference we make
+/// We do not include the `Rc` in this type itself to make it clear where we are relying on the
+/// Rc's reference counting for correctness
+type AbstractLocation = u64;
+type AbstractLocationCounter = u64;
+
+struct AbstractReference {
+    /// the roots this locations borrows from
+    borrows_from: IndexSet<Rc<AbstractLocation>>,
+    /// The root location of the reference, extensions borrow from this `root` and all locations
+    /// this reference borrows from
+    root: Rc<AbstractLocation>,
+}
+
+enum Value {
+    NonRef,
+    Ref {
+        is_mut: bool,
+        data: Rc<AbstractReference>,
+    },
+}
+
+struct Location {
+    // Much like a reference, this tracks used to track if the location is borrowed
+    // However, this is not used if the value is a reference (since you cannot borrow a reference)
+    root: Rc<AbstractLocation>,
+    value: Option<Value>,
+}
+
+struct Context {
+    counter: AbstractLocationCounter,
+    tx_context: Location,
+    gas: Location,
+    inputs: Vec<Location>,
+    results: Vec<Vec<Location>>,
+}
+
+impl AbstractReference {
+    fn new(
+        counter: &mut AbstractLocationCounter,
+        borrows_from: IndexSet<Rc<AbstractLocation>>,
+    ) -> Self {
+        let abs = *counter;
+        *counter += 1;
+        Self {
+            root: Rc::new(abs),
+            borrows_from,
+        }
+    }
+
+    fn has_extensions(&self) -> bool {
+        Rc::strong_count(&self.root) > 1
+    }
+}
+
+impl Value {
+    fn copy(&self) -> Value {
+        match self {
+            Value::NonRef => Value::NonRef,
+            Value::Ref { is_mut, data } => Value::Ref {
+                is_mut: *is_mut,
+                data: data.clone(),
+            },
+        }
+    }
+
+    fn freeze(&mut self) -> anyhow::Result<Value> {
+        let copied = self.copy();
+        match copied {
+            Value::NonRef => {
+                anyhow::bail!("Cannot freeze a non-reference value")
+            }
+            Value::Ref { is_mut, data } => {
+                anyhow::ensure!(is_mut, "Cannot freeze an immutable reference");
+                Ok(Value::Ref {
+                    is_mut: false,
+                    data,
+                })
+            }
+        }
+    }
+}
+
+impl Location {
+    fn non_ref(counter: &mut AbstractLocationCounter) -> Self {
+        let abs = *counter;
+        *counter += 1;
+        Self {
+            root: Rc::new(abs),
+            value: Some(Value::NonRef),
+        }
+    }
+
+    /// returns true if the location is borrowed.
+    /// It does not check if the reference (if present) is borrowed.
+    fn is_borrowed(&self) -> anyhow::Result<bool> {
+        let location_is_borrowed = Rc::strong_count(&self.root) > 1;
+        match &self.value {
+            None => {
+                anyhow::ensure!(
+                    !location_is_borrowed,
+                    "A location without a value should not be borrowed"
+                );
+                Ok(false)
+            }
+            Some(Value::Ref { .. }) => {
+                anyhow::ensure!(
+                    !location_is_borrowed,
+                    "A reference value's location should not be borrowed"
+                );
+                Ok(false)
+            }
+            Some(Value::NonRef) => Ok(location_is_borrowed),
+        }
+    }
+
+    fn copy_value(&self) -> anyhow::Result<Value> {
+        let Some(value) = self.value.as_ref() else {
+            anyhow::bail!("Use of invalid memory location")
+        };
+        Ok(value.copy())
+    }
+
+    fn take(&mut self) -> anyhow::Result<Value> {
+        let Some(value) = self.value.take() else {
+            anyhow::bail!("Use of invalid memory location")
+        };
+        // we have to check this after moving the value to ensure we are not considering
+        // whether a reference stored here is borrowed
+        if self.is_borrowed()? {
+            anyhow::bail!("Cannot move borrowed value")
+        }
+        Ok(value)
+    }
+
+    fn use_(&mut self, usage: &T::Usage) -> anyhow::Result<Value> {
+        match usage {
+            T::Usage::Move(_) => self.take(),
+            T::Usage::Copy { borrowed, .. } => {
+                let Some(borrowed) = borrowed.get().copied() else {
+                    anyhow::bail!("`borrowed` was not set for location usage")
+                };
+                anyhow::ensure!(
+                    self.is_borrowed()? == borrowed,
+                    "Value borrowed status does not match usage marked borrowed status"
+                );
+                self.copy_value()
+            }
+        }
+    }
+
+    fn borrow(
+        &mut self,
+        counter: &mut AbstractLocationCounter,
+        is_mut: bool,
+    ) -> anyhow::Result<Value> {
+        match &self.value {
+            None => {
+                anyhow::bail!("Borrow of invalid memory location")
+            }
+            Some(Value::Ref { .. }) => {
+                anyhow::bail!("Cannot borrow a reference")
+            }
+            Some(Value::NonRef) => {
+                // a new reference that borrows from this location
+                let borrows_from = IndexSet::from([self.root.clone()]);
+                Ok(Value::Ref {
+                    is_mut,
+                    data: Rc::new(AbstractReference::new(counter, borrows_from)),
+                })
+            }
+        }
+    }
+}
+
+impl Context {
+    fn new(txn: &T::Transaction) -> Self {
+        let mut counter = 0;
+        let inputs = txn
+            .inputs
+            .iter()
+            .map(|_| Location::non_ref(&mut counter))
+            .collect();
+        Self {
+            counter,
+            tx_context: Location::non_ref(&mut counter),
+            gas: Location::non_ref(&mut counter),
+            inputs,
+            results: vec![],
+        }
+    }
+
+    fn add_result_values(&mut self, results: impl IntoIterator<Item = Value>) {
+        let counter = &mut self.counter;
+        self.results.push(
+            results
+                .into_iter()
+                .map(|v| Location {
+                    root: Rc::new(*counter),
+                    value: Some(v),
+                })
+                .collect(),
+        );
+    }
+
+    fn add_results(&mut self, results: &[T::Type]) {
+        self.add_result_values(results.iter().map(|t| {
+            debug_assert!(!matches!(t, T::Type::Reference(_, _)));
+            Value::NonRef
+        }));
+    }
+
+    fn location(
+        &mut self,
+        loc: T::Location,
+    ) -> anyhow::Result<(&mut AbstractLocationCounter, &mut Location)> {
+        let location = match loc {
+            T::Location::TxContext => &mut self.tx_context,
+            T::Location::GasCoin => &mut self.gas,
+            T::Location::Input(i) => self
+                .inputs
+                .get_mut(i as usize)
+                .ok_or_else(|| anyhow::anyhow!("Input index out of bounds {i}"))?,
+            T::Location::Result(i, j) => self
+                .results
+                .get_mut(i as usize)
+                .and_then(|r| r.get_mut(j as usize))
+                .ok_or_else(|| anyhow::anyhow!("Result index out of bounds ({i},{j})"))?,
+        };
+        Ok((&mut self.counter, location))
+    }
+
+    fn argument(&mut self, sp!(_, (arg, _)): &T::Argument) -> anyhow::Result<Value> {
+        let (counter, location) = self.location(arg.location())?;
+        let value = match arg {
+            T::Argument__::Use(usage) => location.use_(usage)?,
+            T::Argument__::Freeze(usage) => location.use_(usage)?.freeze()?,
+            T::Argument__::Borrow(is_mut, _) => location.borrow(counter, *is_mut)?,
+            T::Argument__::Read(usage) => {
+                location.use_(usage)?;
+                Value::NonRef
+            }
+        };
+        Ok(value)
+    }
+
+    fn arguments(&mut self, args: &[T::Argument]) -> anyhow::Result<Vec<Value>> {
+        args.iter()
+            .map(|arg| self.argument(arg))
+            .collect::<anyhow::Result<Vec<_>>>()
+    }
+}
+
+/// Verifies memory safety of a transaction. This is a re-implementation of `verify::memory_safety`
+/// using an alternative approach given the newness of the Regex based borrow graph in that
+/// implementation.
+/// This approach uses `Rc`s to track the borrowing of memory locations in the PTB. This only works
+/// given the limited construction of references and their usage. If more direct aliasing and
+/// extensions were possible, this implementation would not be expressive enough. In other words,
+/// this implementation assumes that all extensions are the result of a "call" (a ".*" extension in
+/// the regex based implementation).
+/// Checks the following
+/// - Values are not used after being moved
+/// - Reference safety is upheld (no dangling references)
+pub fn verify(_env: &Env, txn: &T::Transaction) -> Result<(), ExecutionError> {
+    verify_(txn).map_err(|e| make_invariant_violation!("{}. Transaction {:?}", e, txn))
+}
+
+fn verify_(txn: &T::Transaction) -> anyhow::Result<()> {
+    let mut context = Context::new(txn);
+    let T::Transaction {
+        inputs: _,
+        commands,
+    } = txn;
+    for (c, result_tys) in commands {
+        command(&mut context, c, result_tys)?;
+    }
+    Ok(())
+}
+
+fn command(
+    context: &mut Context,
+    sp!(_, command): &T::Command,
+    result_tys: &[T::Type],
+) -> anyhow::Result<()> {
+    match command {
+        T::Command_::MoveCall(move_call) => {
+            let T::MoveCall {
+                function,
+                arguments,
+            } = &**move_call;
+            let arg_values = context.arguments(arguments)?;
+            call(context, &function.signature, arg_values)?;
+        }
+        T::Command_::TransferObjects(objs, recipient) => {
+            context.arguments(objs)?;
+            context.argument(recipient)?;
+            context.add_results(result_tys);
+        }
+        T::Command_::SplitCoins(_, coin, amounts) => {
+            context.arguments(amounts)?;
+            context.argument(coin)?;
+            context.add_results(result_tys);
+        }
+        T::Command_::MergeCoins(_, target, coins) => {
+            context.arguments(coins)?;
+            let target_value = context.argument(target)?;
+            write_ref(target_value)?;
+        }
+        T::Command_::MakeMoveVec(_, arguments) => {
+            context.arguments(arguments)?;
+            context.add_results(result_tys);
+        }
+        T::Command_::Publish(_, _, _) => context.add_results(result_tys),
+        T::Command_::Upgrade(_, _, _, ticket, _) => {
+            context.argument(ticket)?;
+            context.add_results(result_tys);
+        }
+    }
+
+    Ok(())
+}
+
+fn write_ref(value: Value) -> anyhow::Result<()> {
+    match value {
+        Value::NonRef => {
+            anyhow::bail!("Cannot write to a non-reference value");
+        }
+
+        Value::Ref { is_mut: false, .. } => {
+            anyhow::bail!("Cannot write to an immutable reference");
+        }
+        Value::Ref { is_mut: true, data } => {
+            anyhow::ensure!(
+                !data.has_extensions(),
+                "Cannot write to a mutable reference that has extensions"
+            );
+            Ok(())
+        }
+    }
+}
+
+fn call(
+    context: &mut Context,
+    signature: &T::LoadedFunctionInstantiation,
+    arguments: Vec<Value>,
+) -> anyhow::Result<()> {
+    let return_ = &signature.return_;
+    let mut all_locations: IndexSet<Rc<AbstractLocation>> = IndexSet::new();
+    let mut imm_locations: IndexSet<Rc<AbstractLocation>> = IndexSet::new();
+    let mut mut_locations: IndexSet<Rc<AbstractLocation>> = IndexSet::new();
+    for arg in arguments {
+        match arg {
+            Value::NonRef => (),
+            Value::Ref { is_mut: true, data } => {
+                anyhow::ensure!(
+                    !data.has_extensions(),
+                    "Cannot transfer a mutable ref with extensions"
+                );
+                all_locations.extend(data.borrows_from.iter().cloned());
+                // mutable borrows must be unique going into a call
+                for loc in &data.borrows_from {
+                    let was_new = mut_locations.insert(loc.clone());
+                    // if not new, then the location was already passed to the call
+                    anyhow::ensure!(was_new, "Double mutable borrow");
+                }
+            }
+            Value::Ref {
+                is_mut: false,
+                data,
+            } => {
+                all_locations.extend(data.borrows_from.iter().cloned());
+                imm_locations.extend(data.borrows_from.iter().cloned());
+            }
+        }
+    }
+    for mut_loc in &mut_locations {
+        anyhow::ensure!(
+            !imm_locations.contains(mut_loc),
+            "Mutable and immutable borrows cannot overlap"
+        );
+    }
+    let counter = &mut context.counter;
+    let result_values = return_
+        .iter()
+        .map(|ty| {
+            match ty {
+                T::Type::Reference(/* is mut */ true, _) => Value::Ref {
+                    is_mut: true,
+                    data: Rc::new(AbstractReference::new(counter, mut_locations.clone())),
+                },
+                // technically the immutable references could borrow from each other, but it does
+                // not matter in practice since we cannot write to them or their extensions
+                T::Type::Reference(/* is mut */ false, _) => Value::Ref {
+                    is_mut: true,
+                    data: Rc::new(AbstractReference::new(counter, all_locations.clone())),
+                },
+                _ => Value::NonRef,
+            }
+        })
+        .collect::<Vec<_>>();
+    context.add_result_values(result_values);
+    Ok(())
+}

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/mod.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/invariant_checks/mod.rs
@@ -8,6 +8,7 @@ use crate::{
 use sui_types::error::ExecutionError;
 
 pub mod defining_ids_in_types;
+pub mod memory_safety;
 pub mod type_check;
 
 pub fn transaction<Mode: ExecutionMode>(
@@ -16,6 +17,7 @@ pub fn transaction<Mode: ExecutionMode>(
 ) -> Result<(), ExecutionError> {
     defining_ids_in_types::verify(env, tt)?;
     type_check::verify::<Mode>(env, tt)?;
+    memory_safety::verify(env, tt)?;
     // Add in other invariants checks here as needed/desired.
     Ok(())
 }


### PR DESCRIPTION
## Description 

- Add a memory safety invariant check based on the delta domain set based borrow checker

## Test plan 

- A few new tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
