### PR TITLE
Fix download formal snapshot stuck on single connection

### DIFF
--- a/crates/sui-data-ingestion-core/src/reader.rs
+++ b/crates/sui-data-ingestion-core/src/reader.rs
@@ -148,13 +148,14 @@ impl CheckpointReader {
         checkpoint_number: CheckpointSequenceNumber,
     ) -> Result<(Arc<CheckpointData>, usize)> {
         let mut backoff = backoff::ExponentialBackoff::default();
-        backoff.max_elapsed_time = Some(Duration::from_secs(60));
+        let max_elapsed_time = Duration::from_secs(60);
+        backoff.max_elapsed_time = Some(max_elapsed_time);
         backoff.initial_interval = Duration::from_millis(100);
         backoff.current_interval = backoff.initial_interval;
         backoff.multiplier = 1.0;
         loop {
             match tokio::time::timeout(
-                backoff.max_elapsed_time.unwrap(),
+                max_elapsed_time,
                 Self::remote_fetch_checkpoint_internal(store, checkpoint_number),
             )
             .await


### PR DESCRIPTION
## Description 

Hello Sui team.

I'm downloading the formal snapshot, notably with `--all-checkpoints`, but this never succeeds. The download progress gets stuck after 200k-1M checkpoints are downloaded. I tried this for 3-4 times and it can stuck on download any random single object for 20+ hours. I also tried to adjust the parallel parameters from 4 to 8192 but no luck.

I can confirm by `bmon` that when the downloading is not stuck, the download speed is roughly 950Mbps and that's exactly the bandwidth our ISP provides and I got ~1k checkpoints per seconds. However, when it gets stuck, the download throughput is dropped to 50-100Kbps and no new checkpoint can be downloaded due to this slow connection (and original backoff mechanism will always wait), where I suspect some sort of QoS is applied by our ISP in this case. But restarting the download everything works well again. I also wrote a few lines PoC to confirm this and thus have this PR.

To overcome such QoS, I do think we should have a better backoff mechanism. To be specific, as this PR proposes, we should also actively do retry immediately if a connection exceeds `backoff.max_elapsed_time`, in addition to doing retry only after passively getting connection errors. This ensures that one slow connection won't ruin the whole downloading experience.

This fixes my issues and the downloading progress is going very well. I will continue to monitor my downloading progress in case my fix is not correct.

Let me know what you think.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
