### PR TITLE
[package-alt] Call rename-from in main workflow

### DIFF
--- a/external-crates/move/crates/move-package-alt/src/errors/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/errors/mod.rs
@@ -22,6 +22,7 @@ use thiserror::Error;
 use crate::dependency::ResolverError;
 use crate::git::GitError;
 use crate::graph::LinkageError;
+use crate::graph::RenameError;
 use crate::package::manifest::ManifestError;
 use crate::package::paths::PackagePathError;
 
@@ -63,6 +64,9 @@ pub enum PackageError {
 
     #[error(transparent)]
     Linkage(#[from] LinkageError),
+
+    #[error(transparent)]
+    RenameFrom(#[from] RenameError),
 }
 
 impl PackageError {

--- a/external-crates/move/crates/move-package-alt/src/graph/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/mod.rs
@@ -8,6 +8,7 @@ mod rename_from;
 mod to_lockfile;
 
 pub use linkage::LinkageError;
+pub use rename_from::RenameError;
 
 use std::sync::Arc;
 

--- a/external-crates/move/crates/move-package-alt/src/test_utils/graph_builder.rs
+++ b/external-crates/move/crates/move-package-alt/src/test_utils/graph_builder.rs
@@ -392,8 +392,12 @@ impl DepSpec {
 }
 
 impl Scenario {
+    pub fn path_for(&self, package: impl AsRef<str>) -> PackagePath {
+        PackagePath::new(self.project.root().join(package.as_ref())).unwrap()
+    }
+
     pub async fn graph_for(&self, package: impl AsRef<str>) -> PackageGraph<Vanilla> {
-        let path = PackagePath::new(self.project.root().join(package.as_ref())).unwrap();
+        let path = self.path_for(package);
 
         PackageGraph::<Vanilla>::load_from_manifests(&path, &vanilla::default_environment())
             .await


### PR DESCRIPTION
## Description 

This adds a call to the rename-from check to the root package loading.

## PR stack

#22767 Call rename-from in main workflow
#22763 Rename-from test implementation
#22766 Linkage bug fixes

## Test plan 

Added a unit test to root package.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
