### PR TITLE
[TD] certify effects when the transaction has already finalized

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -72,7 +72,7 @@ use crate::{
     execution_scheduler::SchedulingSource,
     mysticeti_adapter::LazyMysticetiClient,
     transaction_driver::{
-        ExecutedData, RejectReason, WaitForEffectsRequest, WaitForEffectsResponse,
+        ExecutedData, RejectReason, SubmitTxResponse, WaitForEffectsRequest, WaitForEffectsResponse,
     },
     transaction_outputs::TransactionOutputs,
 };
@@ -604,9 +604,8 @@ impl ValidatorService {
             // Only submitting a single tx so we should get back a single consensus position
             let consensus_position = resp.remove(0);
 
-            let submit_transaction_response = RawSubmitTxResponse {
-                consensus_position: consensus_position.into_raw()?,
-            };
+            let submit_transaction_response =
+                SubmitTxResponse::Submitted { consensus_position }.try_into()?;
 
             Ok((
                 tonic::Response::new(submit_transaction_response),

--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -8,7 +8,9 @@ use std::{
     time::Duration,
 };
 
-use crate::{authority::AuthorityState, authority_client::AuthorityAPI};
+use crate::{
+    authority::AuthorityState, authority_client::AuthorityAPI, transaction_driver::SubmitTxResponse,
+};
 use crate::{
     authority::{test_authority_builder::TestAuthorityBuilder, ExecutionEnv},
     execution_scheduler::ExecutionSchedulerAPI,
@@ -111,9 +113,7 @@ impl AuthorityAPI for LocalAuthorityClient {
             index: 0,
         };
 
-        Ok(RawSubmitTxResponse {
-            consensus_position: consensus_position.into_raw()?,
-        })
+        SubmitTxResponse::Submitted { consensus_position }.try_into()
     }
 
     async fn handle_transaction(

--- a/crates/sui-core/src/transaction_driver/effects_certifier.rs
+++ b/crates/sui-core/src/transaction_driver/effects_certifier.rs
@@ -60,6 +60,8 @@ impl EffectsCertifier {
                 details,
             } => match details {
                 Some(details) => (None, Some((effects_digest, details))),
+                // Details should always be set in correct responses.
+                // But if it is not set, continuing to get full effects and certify the digest are still correct.
                 None => (None, None),
             },
         };

--- a/crates/sui-core/src/transaction_driver/effects_certifier.rs
+++ b/crates/sui-core/src/transaction_driver/effects_certifier.rs
@@ -8,8 +8,8 @@ use mysten_common::debug_fatal;
 use rand::{seq::SliceRandom as _, Rng as _};
 use sui_types::{
     base_types::ConciseableName,
-    committee::EpochId,
     digests::{TransactionDigest, TransactionEffectsDigest},
+    effects::TransactionEffectsAPI as _,
     messages_consensus::ConsensusPosition,
     messages_grpc::RawWaitForEffectsRequest,
     quorum_driver_types::{EffectsFinalityInfo, FinalizedEffects},
@@ -22,10 +22,10 @@ use crate::{
     authority_client::AuthorityAPI,
     stake_aggregator::{InsertResult, StakeAggregator},
     transaction_driver::{
-        error::TransactionDriverError, metrics::TransactionDriverMetrics,
-        QuorumTransactionResponse, SubmitTransactionOptions,
+        error::TransactionDriverError, metrics::TransactionDriverMetrics, ExecutedData,
+        QuorumTransactionResponse, SubmitTransactionOptions, SubmitTxResponse,
+        WaitForEffectsRequest, WaitForEffectsResponse,
     },
-    transaction_driver::{ExecutedData, WaitForEffectsRequest, WaitForEffectsResponse},
 };
 
 const WAIT_FOR_EFFECTS_TIMEOUT: Duration = Duration::from_secs(2);
@@ -44,12 +44,25 @@ impl EffectsCertifier {
         &self,
         authority_aggregator: &Arc<AuthorityAggregator<A>>,
         tx_digest: &TransactionDigest,
-        consensus_position: ConsensusPosition,
+        submit_txn_resp: SubmitTxResponse,
         options: &SubmitTransactionOptions,
     ) -> Result<QuorumTransactionResponse, TransactionDriverError>
     where
         A: AuthorityAPI + Send + Sync + 'static + Clone,
     {
+        // When consensus position is provided, wait for finalized and fastpath outputs at the validators' side.
+        // Otherwise, only wait for finalized effects.
+        // Skip the first attempt to get full effects if it is already provided.
+        let (consensus_position, full_effects) = match submit_txn_resp {
+            SubmitTxResponse::Submitted { consensus_position } => (Some(consensus_position), None),
+            SubmitTxResponse::Executed {
+                effects_digest,
+                details,
+            } => match details {
+                Some(details) => (None, Some((effects_digest, details))),
+                None => (None, None),
+            },
+        };
         let (acknowledgments_result, mut full_effects_result) = join!(
             self.wait_for_acknowledgments_with_retry(
                 authority_aggregator,
@@ -57,13 +70,20 @@ impl EffectsCertifier {
                 consensus_position,
                 options,
             ),
-            self.get_full_effects_with_retry(
-                authority_aggregator,
-                tx_digest,
-                consensus_position,
-                options,
-            ),
+            async move {
+                if let Some(full_effects) = full_effects {
+                    return Ok(full_effects);
+                }
+                self.get_full_effects_with_retry(
+                    authority_aggregator,
+                    tx_digest,
+                    consensus_position,
+                    options,
+                )
+                .await
+            },
         );
+
         let certified_digest = acknowledgments_result?;
 
         // Retry until full effects digest matches the certified digest.
@@ -81,7 +101,6 @@ impl EffectsCertifier {
                         return Ok(self.get_effects_response(
                             effects_digest,
                             executed_data,
-                            consensus_position.epoch,
                             tx_digest,
                         ));
                     }
@@ -105,9 +124,9 @@ impl EffectsCertifier {
         &self,
         authority_aggregator: &Arc<AuthorityAggregator<A>>,
         tx_digest: &TransactionDigest,
-        consensus_position: ConsensusPosition,
+        consensus_position: Option<ConsensusPosition>,
         options: &SubmitTransactionOptions,
-    ) -> Result<(TransactionEffectsDigest, ExecutedData), TransactionDriverError>
+    ) -> Result<(TransactionEffectsDigest, Box<ExecutedData>), TransactionDriverError>
     where
         A: AuthorityAPI + Send + Sync + 'static + Clone,
     {
@@ -146,7 +165,7 @@ impl EffectsCertifier {
                         // All error cases are retryable until max attempt due to the chance
                         // of the status being returned from a byzantine validator.
                         if let Some(details) = details {
-                            return Ok((effects_digest, *details));
+                            return Ok((effects_digest, details));
                         } else {
                             if attempts >= MAX_ATTEMPTS {
                                 return Err(TransactionDriverError::ExecutionDataNotFound(
@@ -202,7 +221,7 @@ impl EffectsCertifier {
         &self,
         authority_aggregator: &Arc<AuthorityAggregator<A>>,
         tx_digest: &TransactionDigest,
-        consensus_position: ConsensusPosition,
+        consensus_position: Option<ConsensusPosition>,
         options: &SubmitTransactionOptions,
     ) -> Result<TransactionEffectsDigest, TransactionDriverError>
     where
@@ -381,14 +400,14 @@ impl EffectsCertifier {
     fn get_effects_response(
         &self,
         effects_digest: TransactionEffectsDigest,
-        executed_data: ExecutedData,
-        epoch: EpochId,
+        executed_data: Box<ExecutedData>,
         tx_digest: &TransactionDigest,
     ) -> QuorumTransactionResponse {
         self.metrics.executed_transactions.inc();
 
         tracing::debug!("Transaction {tx_digest} executed with effects digest: {effects_digest}",);
 
+        let epoch = executed_data.effects.executed_epoch();
         let details = FinalizedEffects {
             effects: executed_data.effects,
             finality_info: EffectsFinalityInfo::QuorumExecuted(epoch),

--- a/crates/sui-core/src/transaction_driver/message_types.rs
+++ b/crates/sui-core/src/transaction_driver/message_types.rs
@@ -41,6 +41,8 @@ pub enum SubmitTxResponse {
     },
     Executed {
         effects_digest: TransactionEffectsDigest,
+        // Response should always include details for executed transactions.
+        // TODO(fastpath): validate this field is always present and return an error during deserialization.
         details: Option<Box<ExecutedData>>,
     },
 }
@@ -104,9 +106,10 @@ pub struct QuorumTransactionResponse {
 
 pub(crate) struct WaitForEffectsRequest {
     pub transaction_digest: TransactionDigest,
-    /// If provided, wait for the consensus position to execute and wait for fastpath outputs of the transaction,
-    /// in addition to waiting for finalized effects.
-    /// If not provided, only wait for finalized effects.
+    /// If consensus position is provided, waits in the server handler for the transaction in it to execute,
+    /// either in fastpath outputs or finalized.
+    /// If it is not provided, only waits for finalized effects of the transaction in the server handler,
+    /// but not for fastpath outputs.
     pub consensus_position: Option<ConsensusPosition>,
     /// Whether to include details of the effects,
     /// including the effects content, events, input objects, and output objects.

--- a/crates/sui-core/src/transaction_driver/message_types.rs
+++ b/crates/sui-core/src/transaction_driver/message_types.rs
@@ -10,8 +10,8 @@ use sui_types::{
     messages_consensus::ConsensusPosition,
     messages_grpc::{
         RawExecutedData, RawExecutedStatus, RawExpiredStatus, RawRejectReason, RawRejectedStatus,
-        RawSubmitTxRequest, RawValidatorTransactionStatus, RawWaitForEffectsRequest,
-        RawWaitForEffectsResponse,
+        RawSubmitTxRequest, RawSubmitTxResponse, RawValidatorSubmitStatus,
+        RawValidatorTransactionStatus, RawWaitForEffectsRequest, RawWaitForEffectsResponse,
     },
     object::Object,
     quorum_driver_types::FinalizedEffects,
@@ -32,6 +32,72 @@ impl SubmitTxRequest {
                 })?
                 .into(),
         })
+    }
+}
+
+pub enum SubmitTxResponse {
+    Submitted {
+        consensus_position: ConsensusPosition,
+    },
+    Executed {
+        effects_digest: TransactionEffectsDigest,
+        details: Option<Box<ExecutedData>>,
+    },
+    Rejected {
+        // The rejection reason when processing the transaction before submitting to consensus.
+        reason: RejectReason,
+    },
+}
+
+impl TryFrom<RawSubmitTxResponse> for SubmitTxResponse {
+    type Error = SuiError;
+
+    fn try_from(value: RawSubmitTxResponse) -> Result<Self, Self::Error> {
+        match value.inner {
+            Some(RawValidatorSubmitStatus::Submitted(consensus_position)) => Ok(Self::Submitted {
+                consensus_position: consensus_position.as_ref().try_into()?,
+            }),
+            Some(RawValidatorSubmitStatus::Executed(executed)) => {
+                let (effects_digest, details) = try_from_raw_executed_status(executed)?;
+                Ok(Self::Executed {
+                    effects_digest,
+                    details,
+                })
+            }
+            Some(RawValidatorSubmitStatus::Rejected(rejected)) => {
+                let reason = try_from_raw_rejected_status(rejected)?;
+                Ok(Self::Rejected { reason })
+            }
+            None => Err(SuiError::GrpcMessageDeserializeError {
+                type_info: "RawSubmitTxResponse.inner".to_string(),
+                error: "RawSubmitTxResponse.inner is None".to_string(),
+            }),
+        }
+    }
+}
+
+impl TryFrom<SubmitTxResponse> for RawSubmitTxResponse {
+    type Error = SuiError;
+
+    fn try_from(value: SubmitTxResponse) -> Result<Self, Self::Error> {
+        let inner = match value {
+            SubmitTxResponse::Submitted { consensus_position } => {
+                let consensus_position = consensus_position.into_raw()?;
+                RawValidatorSubmitStatus::Submitted(consensus_position)
+            }
+            SubmitTxResponse::Executed {
+                effects_digest,
+                details,
+            } => {
+                let raw_executed = try_from_response_executed(effects_digest, details)?;
+                RawValidatorSubmitStatus::Executed(raw_executed)
+            }
+            SubmitTxResponse::Rejected { reason } => {
+                let raw_rejected = try_from_response_rejected(reason)?;
+                RawValidatorSubmitStatus::Rejected(raw_rejected)
+            }
+        };
+        Ok(RawSubmitTxResponse { inner: Some(inner) })
     }
 }
 
@@ -139,81 +205,14 @@ impl TryFrom<RawWaitForEffectsResponse> for WaitForEffectsResponse {
     fn try_from(value: RawWaitForEffectsResponse) -> Result<Self, Self::Error> {
         match value.inner {
             Some(RawValidatorTransactionStatus::Executed(executed)) => {
-                let effects_digest = bcs::from_bytes(&executed.effects_digest).map_err(|err| {
-                    SuiError::GrpcMessageDeserializeError {
-                        type_info: "RawWaitForEffectsResponse.effects_digest".to_string(),
-                        error: err.to_string(),
-                    }
-                })?;
-                let details = if let Some(details) = executed.details {
-                    let effects = bcs::from_bytes(&details.effects).map_err(|err| {
-                        SuiError::GrpcMessageDeserializeError {
-                            type_info: "RawWaitForEffectsResponse.details.effects".to_string(),
-                            error: err.to_string(),
-                        }
-                    })?;
-                    let events = if let Some(events) = details.events {
-                        Some(bcs::from_bytes(&events).map_err(|err| {
-                            SuiError::GrpcMessageDeserializeError {
-                                type_info: "RawWaitForEffectsResponse.details.events".to_string(),
-                                error: err.to_string(),
-                            }
-                        })?)
-                    } else {
-                        None
-                    };
-                    let mut input_objects = Vec::with_capacity(details.input_objects.len());
-                    for object in details.input_objects {
-                        input_objects.push(bcs::from_bytes(&object).map_err(|err| {
-                            SuiError::GrpcMessageDeserializeError {
-                                type_info: "RawWaitForEffectsResponse.input_objects".to_string(),
-                                error: err.to_string(),
-                            }
-                        })?);
-                    }
-                    let mut output_objects = Vec::with_capacity(details.output_objects.len());
-                    for object in details.output_objects {
-                        output_objects.push(bcs::from_bytes(&object).map_err(|err| {
-                            SuiError::GrpcMessageDeserializeError {
-                                type_info: "RawWaitForEffectsResponse.output_objects".to_string(),
-                                error: err.to_string(),
-                            }
-                        })?);
-                    }
-                    Some(Box::new(ExecutedData {
-                        effects,
-                        events,
-                        input_objects,
-                        output_objects,
-                    }))
-                } else {
-                    None
-                };
+                let (effects_digest, details) = try_from_raw_executed_status(executed)?;
                 Ok(Self::Executed {
                     effects_digest,
                     details,
                 })
             }
             Some(RawValidatorTransactionStatus::Rejected(rejected)) => {
-                let raw_reason = RawRejectReason::try_from(rejected.reason).map_err(|err| {
-                    SuiError::GrpcMessageDeserializeError {
-                        type_info: "RawWaitForEffectsResponse.rejected.reason".to_string(),
-                        error: err.to_string(),
-                    }
-                })?;
-                let reason = match raw_reason {
-                    RawRejectReason::None => RejectReason::None,
-                    RawRejectReason::LockConflict => {
-                        RejectReason::LockConflict(rejected.message.unwrap_or_default())
-                    }
-                    RawRejectReason::PackageVerification => {
-                        RejectReason::PackageVerification(rejected.message.unwrap_or_default())
-                    }
-                    RawRejectReason::Overload => {
-                        RejectReason::Overload(rejected.message.unwrap_or_default())
-                    }
-                    RawRejectReason::CoinDenyList => RejectReason::CoinDenyList,
-                };
+                let reason = try_from_raw_rejected_status(rejected)?;
                 Ok(Self::Rejected { reason })
             }
             Some(RawValidatorTransactionStatus::Expired(expired)) => Ok(Self::Expired {
@@ -228,6 +227,83 @@ impl TryFrom<RawWaitForEffectsResponse> for WaitForEffectsResponse {
     }
 }
 
+fn try_from_raw_executed_status(
+    executed: RawExecutedStatus,
+) -> Result<(TransactionEffectsDigest, Option<Box<ExecutedData>>), SuiError> {
+    let effects_digest = bcs::from_bytes(&executed.effects_digest).map_err(|err| {
+        SuiError::GrpcMessageDeserializeError {
+            type_info: "RawWaitForEffectsResponse.effects_digest".to_string(),
+            error: err.to_string(),
+        }
+    })?;
+    let details = if let Some(details) = executed.details {
+        let effects = bcs::from_bytes(&details.effects).map_err(|err| {
+            SuiError::GrpcMessageDeserializeError {
+                type_info: "RawWaitForEffectsResponse.details.effects".to_string(),
+                error: err.to_string(),
+            }
+        })?;
+        let events = if let Some(events) = details.events {
+            Some(
+                bcs::from_bytes(&events).map_err(|err| SuiError::GrpcMessageDeserializeError {
+                    type_info: "RawWaitForEffectsResponse.details.events".to_string(),
+                    error: err.to_string(),
+                })?,
+            )
+        } else {
+            None
+        };
+        let mut input_objects = Vec::with_capacity(details.input_objects.len());
+        for object in details.input_objects {
+            input_objects.push(bcs::from_bytes(&object).map_err(|err| {
+                SuiError::GrpcMessageDeserializeError {
+                    type_info: "RawWaitForEffectsResponse.input_objects".to_string(),
+                    error: err.to_string(),
+                }
+            })?);
+        }
+        let mut output_objects = Vec::with_capacity(details.output_objects.len());
+        for object in details.output_objects {
+            output_objects.push(bcs::from_bytes(&object).map_err(|err| {
+                SuiError::GrpcMessageDeserializeError {
+                    type_info: "RawWaitForEffectsResponse.output_objects".to_string(),
+                    error: err.to_string(),
+                }
+            })?);
+        }
+        Some(Box::new(ExecutedData {
+            effects,
+            events,
+            input_objects,
+            output_objects,
+        }))
+    } else {
+        None
+    };
+    Ok((effects_digest, details))
+}
+
+fn try_from_raw_rejected_status(rejected: RawRejectedStatus) -> Result<RejectReason, SuiError> {
+    let raw_reason = RawRejectReason::try_from(rejected.reason).map_err(|err| {
+        SuiError::GrpcMessageDeserializeError {
+            type_info: "RawWaitForEffectsResponse.rejected.reason".to_string(),
+            error: err.to_string(),
+        }
+    })?;
+    let reason = match raw_reason {
+        RawRejectReason::None => RejectReason::None,
+        RawRejectReason::LockConflict => {
+            RejectReason::LockConflict(rejected.message.unwrap_or_default())
+        }
+        RawRejectReason::PackageVerification => {
+            RejectReason::PackageVerification(rejected.message.unwrap_or_default())
+        }
+        RawRejectReason::Overload => RejectReason::Overload(rejected.message.unwrap_or_default()),
+        RawRejectReason::CoinDenyList => RejectReason::CoinDenyList,
+    };
+    Ok(reason)
+}
+
 impl TryFrom<WaitForEffectsRequest> for RawWaitForEffectsRequest {
     type Error = SuiError;
 
@@ -238,12 +314,7 @@ impl TryFrom<WaitForEffectsRequest> for RawWaitForEffectsRequest {
                 error: err.to_string(),
             })?
             .into();
-        let consensus_position = bcs::to_bytes(&value.consensus_position)
-            .map_err(|err| SuiError::GrpcMessageSerializeError {
-                type_info: "RawWaitForEffectsRequest.consensus_position".to_string(),
-                error: err.to_string(),
-            })?
-            .into();
+        let consensus_position = value.consensus_position.into_raw()?;
         Ok(Self {
             consensus_position,
             transaction_digest,
@@ -261,86 +332,12 @@ impl TryFrom<WaitForEffectsResponse> for RawWaitForEffectsResponse {
                 effects_digest,
                 details,
             } => {
-                let effects_digest = bcs::to_bytes(&effects_digest)
-                    .map_err(|err| SuiError::GrpcMessageSerializeError {
-                        type_info: "RawWaitForEffectsResponse.effects_digest".to_string(),
-                        error: err.to_string(),
-                    })?
-                    .into();
-                let details = if let Some(details) = details {
-                    let effects = bcs::to_bytes(&details.effects)
-                        .map_err(|err| SuiError::GrpcMessageSerializeError {
-                            type_info: "RawWaitForEffectsResponse.details.effects".to_string(),
-                            error: err.to_string(),
-                        })?
-                        .into();
-                    let events = if let Some(events) = &details.events {
-                        Some(
-                            bcs::to_bytes(events)
-                                .map_err(|err| SuiError::GrpcMessageSerializeError {
-                                    type_info: "RawWaitForEffectsResponse.details.events"
-                                        .to_string(),
-                                    error: err.to_string(),
-                                })?
-                                .into(),
-                        )
-                    } else {
-                        None
-                    };
-                    let mut input_objects = Vec::with_capacity(details.input_objects.len());
-                    for object in details.input_objects {
-                        input_objects.push(
-                            bcs::to_bytes(&object)
-                                .map_err(|err| SuiError::GrpcMessageSerializeError {
-                                    type_info: "RawWaitForEffectsResponse.input_objects"
-                                        .to_string(),
-                                    error: err.to_string(),
-                                })?
-                                .into(),
-                        );
-                    }
-                    let mut output_objects = Vec::with_capacity(details.output_objects.len());
-                    for object in details.output_objects {
-                        output_objects.push(
-                            bcs::to_bytes(&object)
-                                .map_err(|err| SuiError::GrpcMessageSerializeError {
-                                    type_info: "RawWaitForEffectsResponse.output_objects"
-                                        .to_string(),
-                                    error: err.to_string(),
-                                })?
-                                .into(),
-                        );
-                    }
-                    Some(RawExecutedData {
-                        effects,
-                        events,
-                        input_objects,
-                        output_objects,
-                    })
-                } else {
-                    None
-                };
-                RawValidatorTransactionStatus::Executed(RawExecutedStatus {
-                    effects_digest,
-                    details,
-                })
+                let raw_executed = try_from_response_executed(effects_digest, details)?;
+                RawValidatorTransactionStatus::Executed(raw_executed)
             }
             WaitForEffectsResponse::Rejected { reason } => {
-                let (reason, message) = match reason {
-                    RejectReason::None => (RawRejectReason::None, None),
-                    RejectReason::LockConflict(message) => {
-                        (RawRejectReason::LockConflict, Some(message))
-                    }
-                    RejectReason::PackageVerification(message) => {
-                        (RawRejectReason::PackageVerification, Some(message))
-                    }
-                    RejectReason::Overload(message) => (RawRejectReason::Overload, Some(message)),
-                    RejectReason::CoinDenyList => (RawRejectReason::CoinDenyList, None),
-                };
-                RawValidatorTransactionStatus::Rejected(RawRejectedStatus {
-                    reason: reason as i32,
-                    message,
-                })
+                let raw_rejected = try_from_response_rejected(reason)?;
+                RawValidatorTransactionStatus::Rejected(raw_rejected)
             }
             WaitForEffectsResponse::Expired { epoch, round } => {
                 RawValidatorTransactionStatus::Expired(RawExpiredStatus { epoch, round })
@@ -348,4 +345,86 @@ impl TryFrom<WaitForEffectsResponse> for RawWaitForEffectsResponse {
         };
         Ok(RawWaitForEffectsResponse { inner: Some(inner) })
     }
+}
+
+fn try_from_response_executed(
+    effects_digest: TransactionEffectsDigest,
+    details: Option<Box<ExecutedData>>,
+) -> Result<RawExecutedStatus, SuiError> {
+    let effects_digest = bcs::to_bytes(&effects_digest)
+        .map_err(|err| SuiError::GrpcMessageSerializeError {
+            type_info: "RawWaitForEffectsResponse.effects_digest".to_string(),
+            error: err.to_string(),
+        })?
+        .into();
+    let details = if let Some(details) = details {
+        let effects = bcs::to_bytes(&details.effects)
+            .map_err(|err| SuiError::GrpcMessageSerializeError {
+                type_info: "RawWaitForEffectsResponse.details.effects".to_string(),
+                error: err.to_string(),
+            })?
+            .into();
+        let events = if let Some(events) = &details.events {
+            Some(
+                bcs::to_bytes(events)
+                    .map_err(|err| SuiError::GrpcMessageSerializeError {
+                        type_info: "RawWaitForEffectsResponse.details.events".to_string(),
+                        error: err.to_string(),
+                    })?
+                    .into(),
+            )
+        } else {
+            None
+        };
+        let mut input_objects = Vec::with_capacity(details.input_objects.len());
+        for object in details.input_objects {
+            input_objects.push(
+                bcs::to_bytes(&object)
+                    .map_err(|err| SuiError::GrpcMessageSerializeError {
+                        type_info: "RawWaitForEffectsResponse.input_objects".to_string(),
+                        error: err.to_string(),
+                    })?
+                    .into(),
+            );
+        }
+        let mut output_objects = Vec::with_capacity(details.output_objects.len());
+        for object in details.output_objects {
+            output_objects.push(
+                bcs::to_bytes(&object)
+                    .map_err(|err| SuiError::GrpcMessageSerializeError {
+                        type_info: "RawWaitForEffectsResponse.output_objects".to_string(),
+                        error: err.to_string(),
+                    })?
+                    .into(),
+            );
+        }
+        Some(RawExecutedData {
+            effects,
+            events,
+            input_objects,
+            output_objects,
+        })
+    } else {
+        None
+    };
+    Ok(RawExecutedStatus {
+        effects_digest,
+        details,
+    })
+}
+
+fn try_from_response_rejected(reason: RejectReason) -> Result<RawRejectedStatus, SuiError> {
+    let (reason, message) = match reason {
+        RejectReason::None => (RawRejectReason::None, None),
+        RejectReason::LockConflict(message) => (RawRejectReason::LockConflict, Some(message)),
+        RejectReason::PackageVerification(message) => {
+            (RawRejectReason::PackageVerification, Some(message))
+        }
+        RejectReason::Overload(message) => (RawRejectReason::Overload, Some(message)),
+        RejectReason::CoinDenyList => (RawRejectReason::CoinDenyList, None),
+    };
+    Ok(RawRejectedStatus {
+        reason: reason.into(),
+        message,
+    })
 }

--- a/crates/sui-core/src/transaction_driver/mod.rs
+++ b/crates/sui-core/src/transaction_driver/mod.rs
@@ -122,10 +122,15 @@ where
         let auth_agg = self.authority_aggregator.load();
 
         // Get consensus position using TransactionSubmitter
-        let consensus_position = self
+        let submit_txn_resp = self
             .submitter
             .submit_transaction(&auth_agg, tx_digest, raw_request, options)
             .await?;
+
+        let consensus_position = match submit_txn_resp {
+            SubmitTxResponse::Submitted { consensus_position } => consensus_position,
+            _ => todo!(),
+        };
 
         // Wait for quorum effects using EffectsCertifier
         self.certifier

--- a/crates/sui-core/src/transaction_driver/mod.rs
+++ b/crates/sui-core/src/transaction_driver/mod.rs
@@ -127,14 +127,9 @@ where
             .submit_transaction(&auth_agg, tx_digest, raw_request, options)
             .await?;
 
-        let consensus_position = match submit_txn_resp {
-            SubmitTxResponse::Submitted { consensus_position } => consensus_position,
-            _ => todo!(),
-        };
-
         // Wait for quorum effects using EffectsCertifier
         self.certifier
-            .get_certified_finalized_effects(&auth_agg, tx_digest, consensus_position, options)
+            .get_certified_finalized_effects(&auth_agg, tx_digest, submit_txn_resp, options)
             .await
     }
 

--- a/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
+++ b/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
@@ -10,6 +10,7 @@ use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::{ObjectRef, SuiAddress, TransactionDigest};
 use sui_types::committee::EpochId;
 use sui_types::crypto::{get_account_key_pair, AccountKeyPair};
+use sui_types::effects::TransactionEffectsAPI as _;
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
 use sui_types::message_envelope::Message;
 use sui_types::messages_consensus::ConsensusPosition;
@@ -86,7 +87,7 @@ impl TestContext {
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_wait_for_effects_position_mismatch() {
     // This test exercise the path where if the position of the transaction
     // triggered the execution differs from the position in the request,
@@ -106,13 +107,6 @@ async fn test_wait_for_effects_position_mismatch() {
         index: TransactionIndex::MIN + 1,
     };
 
-    let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
-        transaction_digest: tx_digest,
-        consensus_position: Some(tx_position1),
-        include_details: true,
-    })
-    .unwrap();
-
     let state_clone = test_context.state.clone();
     tokio::spawn(async move {
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -121,13 +115,20 @@ async fn test_wait_for_effects_position_mismatch() {
         state_clone
             .try_execute_immediately(
                 &transaction,
-                ExecutionEnv::new().with_scheduling_source(SchedulingSource::NonFastPath),
+                ExecutionEnv::new().with_scheduling_source(SchedulingSource::MysticetiFastPath),
                 &epoch_store,
             )
             .await
             .unwrap()
             .0
     });
+
+    let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
+        transaction_digest: tx_digest,
+        consensus_position: Some(tx_position1),
+        include_details: true,
+    })
+    .unwrap();
 
     let response = test_context.client.wait_for_effects(request, None).await;
 
@@ -179,7 +180,7 @@ async fn test_wait_for_effects_post_commit_rejected() {
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_wait_for_effects_epoch_mismatch() {
     // This test exercises the path where the epoch of the request does not match the epoch
     // of the authority.
@@ -204,7 +205,7 @@ async fn test_wait_for_effects_epoch_mismatch() {
     assert!(response.is_err());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn test_wait_for_effects_timeout() {
     // This test exercises the path where the transaction is never executed.
     // The request will timeout.
@@ -272,8 +273,83 @@ async fn test_wait_for_effects_quorum_rejected() {
     }
 }
 
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_wait_for_effects_fastpath_certified_only() {
+    // This test exercises the path where the transaction is only fastpath certified.
+    // Waiting on effects acknowledgement should still succeed with consensus position.
+    // But it should timeout without consensus position.
+    let test_context = TestContext::new().await;
+
+    let transaction = test_context.build_test_transaction();
+    let tx_digest = *transaction.digest();
+    let tx_position = ConsensusPosition {
+        epoch: EpochId::MIN,
+        block: BlockRef::MIN,
+        index: TransactionIndex::MIN,
+    };
+
+    let state_clone = test_context.state.clone();
+    let exec_handle = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let epoch_store = state_clone.epoch_store_for_testing();
+        epoch_store.set_consensus_tx_status(tx_position, ConsensusTxStatus::FastpathCertified);
+        state_clone
+            .try_execute_immediately(
+                &transaction,
+                ExecutionEnv::new().with_scheduling_source(SchedulingSource::MysticetiFastPath),
+                &epoch_store,
+            )
+            .await
+            .unwrap()
+            .0
+    });
+
+    // -------- First, test getting effects acknowledgement with consensus position. --------
+
+    let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
+        transaction_digest: tx_digest,
+        consensus_position: Some(tx_position),
+        // Also test the case where details are not requested.
+        include_details: false,
+    })
+    .unwrap();
+
+    let response = test_context
+        .client
+        .wait_for_effects(request, None)
+        .await
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    let exec_effects = exec_handle.await.unwrap();
+    match response {
+        WaitForEffectsResponse::Executed {
+            details,
+            effects_digest,
+        } => {
+            assert!(details.is_none());
+            assert_eq!(effects_digest, exec_effects.digest());
+        }
+        _ => panic!("Expected Executed response"),
+    }
+
+    // -------- Then, test getting effects acknowledgement without consensus position. --------
+
+    let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
+        transaction_digest: tx_digest,
+        consensus_position: None,
+        include_details: true,
+    })
+    .unwrap();
+
+    let response = test_context.client.wait_for_effects(request, None).await;
+
+    assert!(response.is_err());
+}
+
 #[tokio::test]
-async fn test_wait_for_effects_fastpath_certified() {
+async fn test_wait_for_effects_fastpath_certified_then_executed() {
     // This test exercises the path where the transaction is first fastpath certified,
     // then executed right away.
     let test_context = TestContext::new().await;
@@ -335,8 +411,9 @@ async fn test_wait_for_effects_fastpath_certified() {
 #[tokio::test]
 async fn test_wait_for_effects_finalized() {
     telemetry_subscribers::init_for_testing();
-    // This test exercises the path where the transaction is first fastpath certified,
-    // then finalized, and then executed.
+    // This test exercises the path where after the transaction has been executed,
+    // it is possible to get acknowledgement of the execution with consensus position.
+    // And it is possible to get the full effects without consensus position.
     let test_context = TestContext::new().await;
 
     let transaction = test_context.build_test_transaction();
@@ -346,14 +423,6 @@ async fn test_wait_for_effects_finalized() {
         block: BlockRef::MIN,
         index: TransactionIndex::MIN,
     };
-
-    let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
-        transaction_digest: tx_digest,
-        consensus_position: Some(tx_position),
-        // Also test the case where details are not requested.
-        include_details: false,
-    })
-    .unwrap();
 
     let state_clone = test_context.state.clone();
     let exec_handle = tokio::spawn(async move {
@@ -374,6 +443,16 @@ async fn test_wait_for_effects_finalized() {
             .0
     });
 
+    // -------- First, test getting effects acknowledgement with consensus position. --------
+
+    let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
+        transaction_digest: tx_digest,
+        consensus_position: Some(tx_position),
+        // Also test the case where details are not requested.
+        include_details: false,
+    })
+    .unwrap();
+
     let response = test_context
         .client
         .wait_for_effects(request, None)
@@ -390,6 +469,36 @@ async fn test_wait_for_effects_finalized() {
         } => {
             assert!(details.is_none());
             assert_eq!(effects_digest, exec_effects.digest());
+        }
+        _ => panic!("Expected Executed response"),
+    }
+
+    // -------- Then, test getting full effects without consensus position. --------
+
+    let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
+        transaction_digest: tx_digest,
+        consensus_position: None,
+        include_details: true,
+    })
+    .unwrap();
+
+    let response = test_context
+        .client
+        .wait_for_effects(request, None)
+        .await
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    match response {
+        WaitForEffectsResponse::Executed {
+            details,
+            effects_digest,
+        } => {
+            let details = details.unwrap();
+            assert_eq!(effects_digest, exec_effects.digest());
+            assert_eq!(effects_digest, details.effects.digest());
+            assert_eq!(tx_digest, *details.effects.transaction_digest());
         }
         _ => panic!("Expected Executed response"),
     }

--- a/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
+++ b/crates/sui-core/src/unit_tests/wait_for_effects_tests.rs
@@ -108,7 +108,7 @@ async fn test_wait_for_effects_position_mismatch() {
 
     let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
         transaction_digest: tx_digest,
-        consensus_position: tx_position1,
+        consensus_position: Some(tx_position1),
         include_details: true,
     })
     .unwrap();
@@ -148,7 +148,7 @@ async fn test_wait_for_effects_post_commit_rejected() {
 
     let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
         transaction_digest: tx_digest,
-        consensus_position: tx_position,
+        consensus_position: Some(tx_position),
         include_details: true,
     })
     .unwrap();
@@ -194,7 +194,7 @@ async fn test_wait_for_effects_epoch_mismatch() {
 
     let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
         transaction_digest: tx_digest,
-        consensus_position: tx_position,
+        consensus_position: Some(tx_position),
         include_details: true,
     })
     .unwrap();
@@ -219,7 +219,7 @@ async fn test_wait_for_effects_timeout() {
 
     let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
         transaction_digest: tx_digest,
-        consensus_position: tx_position,
+        consensus_position: Some(tx_position),
         include_details: true,
     })
     .unwrap();
@@ -244,7 +244,7 @@ async fn test_wait_for_effects_quorum_rejected() {
 
     let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
         transaction_digest: tx_digest,
-        consensus_position: tx_position,
+        consensus_position: Some(tx_position),
         include_details: true,
     })
     .unwrap();
@@ -288,7 +288,7 @@ async fn test_wait_for_effects_fastpath_certified() {
 
     let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
         transaction_digest: tx_digest,
-        consensus_position: tx_position,
+        consensus_position: Some(tx_position),
         // Also test the case where details are not requested.
         include_details: false,
     })
@@ -349,7 +349,7 @@ async fn test_wait_for_effects_finalized() {
 
     let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
         transaction_digest: tx_digest,
-        consensus_position: tx_position,
+        consensus_position: Some(tx_position),
         // Also test the case where details are not requested.
         include_details: false,
     })
@@ -409,7 +409,7 @@ async fn test_wait_for_effects_expired() {
 
     let request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
         transaction_digest: tx_digest,
-        consensus_position: tx_position,
+        consensus_position: Some(tx_position),
         include_details: true,
     })
     .unwrap();

--- a/crates/sui-types/src/messages_grpc.rs
+++ b/crates/sui-types/src/messages_grpc.rs
@@ -6,7 +6,6 @@ use crate::crypto::{AuthoritySignInfo, AuthorityStrongQuorumSignInfo};
 use crate::effects::{
     SignedTransactionEffects, TransactionEvents, VerifiedSignedTransactionEffects,
 };
-use crate::messages_consensus::ConsensusPosition;
 use crate::object::Object;
 use crate::transaction::{CertifiedTransaction, SenderSignedData, SignedTransaction};
 use bytes::Bytes;
@@ -230,13 +229,23 @@ pub struct RawSubmitTxRequest {
 #[derive(Clone, prost::Message)]
 pub struct RawSubmitTxResponse {
     // Serialized Consensus Position
-    #[prost(bytes = "bytes", tag = "1")]
-    pub consensus_position: Bytes,
+    #[prost(oneof = "RawValidatorSubmitStatus", tags = "1, 2, 3")]
+    pub inner: Option<RawValidatorSubmitStatus>,
 }
 
-#[derive(Clone, Debug)]
-pub struct SubmitTxResponse {
-    pub consensus_position: ConsensusPosition,
+#[derive(Clone, prost::Oneof)]
+pub enum RawValidatorSubmitStatus {
+    // Serialized Consensus Position.
+    #[prost(bytes = "bytes", tag = "1")]
+    Submitted(Bytes),
+
+    // Transaction has already been executed (finalized).
+    #[prost(message, tag = "2")]
+    Executed(RawExecutedStatus),
+
+    // Transaction is rejected without consensus submission.
+    #[prost(message, tag = "3")]
+    Rejected(RawRejectedStatus),
 }
 
 #[derive(Clone, prost::Message)]

--- a/crates/sui-types/src/messages_grpc.rs
+++ b/crates/sui-types/src/messages_grpc.rs
@@ -242,19 +242,18 @@ pub enum RawValidatorSubmitStatus {
     // Transaction has already been executed (finalized).
     #[prost(message, tag = "2")]
     Executed(RawExecutedStatus),
-
-    // Transaction is rejected without consensus submission.
-    #[prost(message, tag = "3")]
-    Rejected(RawRejectedStatus),
 }
 
 #[derive(Clone, prost::Message)]
 pub struct RawWaitForEffectsRequest {
     #[prost(bytes = "bytes", tag = "1")]
-    pub consensus_position: Bytes,
-
-    #[prost(bytes = "bytes", tag = "2")]
     pub transaction_digest: Bytes,
+
+    /// If provided, wait for the consensus position to execute and wait for fastpath outputs of the transaction,
+    /// in addition to waiting for finalized effects.
+    /// If not provided, only wait for finalized effects.
+    #[prost(bytes = "bytes", optional, tag = "2")]
+    pub consensus_position: Option<Bytes>,
 
     /// Whether to include details of the effects,
     /// including the effects content, events, input objects, and output objects.


### PR DESCRIPTION
## Description 

During transaction submission, if it is found that the transaction already has finalized effects, the full effects will be returned instead of consensus position.
Then effects certifier and authority handler will proceed assuming the transaction has finalized.

## Test plan 

CI
