### PR TITLE
[traffic controller] fix race condition in blocklist metric dec() call

### DIFF
--- a/crates/sui-core/src/traffic_controller/mod.rs
+++ b/crates/sui-core/src/traffic_controller/mod.rs
@@ -417,9 +417,8 @@ impl TrafficController {
                 _ => (true, false),
             }
         };
-        if should_remove {
+        if should_remove && blocklist.remove(client).is_some() {
             blocklist_len_gauge.dec();
-            blocklist.remove(client);
         }
         !should_block
     }


### PR DESCRIPTION
## Description 

the blocklist len metric often reports as being a negative number, which shouldn't be possible. This fixes a possible race condition where the same IP is triggering `check_and_clear_blocklist` in parallel, causing the blocklist to be decremented multiple times when only a single IP is being removed. 

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
