### PR TITLE
[pkg-alt] added implicit-deps field to manifest

### DIFF
--- a/external-crates/move/crates/move-package-alt/src/compatibility/legacy_parser.rs
+++ b/external-crates/move/crates/move-package-alt/src/compatibility/legacy_parser.rs
@@ -11,9 +11,9 @@ use crate::{
     errors::FileHandle,
     package::{EnvironmentName, layout::SourcePackageLayout, paths::PackagePath},
     schema::{
-        DefaultDependency, ExternalDependency, LocalDepInfo, ManifestDependencyInfo,
-        ManifestGitDependency, OnChainDepInfo, OriginalID, PackageMetadata, PackageName,
-        PublishAddresses, PublishedID,
+        DefaultDependency, ExternalDependency, ImplicitDepMode, LocalDepInfo,
+        ManifestDependencyInfo, ManifestGitDependency, OnChainDepInfo, OriginalID, PackageMetadata,
+        PackageName, PublishAddresses, PublishedID,
     },
 };
 use anyhow::{Context, Result, anyhow, bail, format_err};
@@ -251,6 +251,7 @@ fn parse_source_manifest(
                 metadata: PackageMetadata {
                     name: new_name,
                     edition,
+                    implicit_deps: ImplicitDepMode::Legacy,
                 },
                 deps: dependencies,
                 legacy_data: LegacyData {

--- a/external-crates/move/crates/move-package-alt/src/dependency/dependency_set.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/dependency_set.rs
@@ -35,7 +35,7 @@ impl<T> DependencySet<T> {
     ///
     /// ```
     /// use move_package_alt::dependency::DependencySet;
-    /// use move_package_alt::package::{EnvironmentName, PackageName};
+    /// use move_package_alt::schema::{EnvironmentName, PackageName};
     /// let mut example = DependencySet::new();
     /// assert!(example.is_empty());
     ///

--- a/external-crates/move/crates/move-package-alt/tests/data/basic/Move@parsed.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/basic/Move@parsed.snap
@@ -10,6 +10,7 @@ ParsedManifest {
             ),
         },
         edition: "2025",
+        implicit_deps: Enabled,
     },
     environments: {
         Spanned {

--- a/external-crates/move/crates/move-package-alt/tests/data/basic_external_resolver/Move@parsed.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/basic_external_resolver/Move@parsed.snap
@@ -10,6 +10,7 @@ ParsedManifest {
             ),
         },
         edition: "2025",
+        implicit_deps: Enabled,
     },
     environments: {
         Spanned {

--- a/external-crates/move/crates/move-package-alt/tests/data/basic_implicit_deps/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/basic_implicit_deps/Move.toml
@@ -3,7 +3,6 @@ name = "example"
 edition = "2025"
 license = "Apache-2.0"
 authors = ["Move Team"]
-implicit-deps = true
 
 [environments]
 mainnet = "35834a8a"

--- a/external-crates/move/crates/move-package-alt/tests/data/basic_implicit_deps/Move@parsed.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/basic_implicit_deps/Move@parsed.snap
@@ -10,19 +10,20 @@ ParsedManifest {
             ),
         },
         edition: "2025",
+        implicit_deps: Enabled,
     },
     environments: {
         Spanned {
-            span: 128..135,
+            span: 107..114,
             value: "mainnet",
         }: Spanned {
-            span: 138..148,
+            span: 117..127,
             value: "35834a8a",
         },
     },
     dependencies: {
         Spanned {
-            span: 165..168,
+            span: 144..147,
             value: Identifier(
                 "Sui",
             ),

--- a/external-crates/move/crates/move-package-alt/tests/data/basic_no_dep_override_git/Move@parsed.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/basic_no_dep_override_git/Move@parsed.snap
@@ -10,6 +10,7 @@ ParsedManifest {
             ),
         },
         edition: "2025",
+        implicit_deps: Enabled,
     },
     environments: {
         Spanned {

--- a/external-crates/move/crates/move-package-alt/tests/data/basic_with_bar/Move@parsed.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/basic_with_bar/Move@parsed.snap
@@ -10,6 +10,7 @@ ParsedManifest {
             ),
         },
         edition: "2025",
+        implicit_deps: Enabled,
     },
     environments: {
         Spanned {

--- a/external-crates/move/crates/move-package-alt/tests/data/basic_with_bar/bar/Move.toml
+++ b/external-crates/move/crates/move-package-alt/tests/data/basic_with_bar/bar/Move.toml
@@ -3,7 +3,6 @@ name = "bar"
 edition = "2025"
 authors = ["Move Team"]
 license = "Apache-2.0"
-implicit-deps = true
 
 [environments]
 mainnet = "35834a8a"

--- a/external-crates/move/crates/move-package-alt/tests/data/basic_with_bar/bar/Move@parsed.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/basic_with_bar/bar/Move@parsed.snap
@@ -10,19 +10,20 @@ ParsedManifest {
             ),
         },
         edition: "2025",
+        implicit_deps: Enabled,
     },
     environments: {
         Spanned {
-            span: 124..131,
+            span: 103..110,
             value: "mainnet",
         }: Spanned {
-            span: 134..144,
+            span: 113..123,
             value: "35834a8a",
         },
     },
     dependencies: {
         Spanned {
-            span: 161..164,
+            span: 140..143,
             value: Identifier(
                 "Sui",
             ),

--- a/external-crates/move/crates/move-package-alt/tests/data/flavor_global_storage/Move@parsed.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/flavor_global_storage/Move@parsed.snap
@@ -10,6 +10,7 @@ ParsedManifest {
             ),
         },
         edition: "2025",
+        implicit_deps: Enabled,
     },
     environments: {
         Spanned {

--- a/external-crates/move/crates/move-package-alt/tests/data/flavor_sui/Move@parsed.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/flavor_sui/Move@parsed.snap
@@ -10,6 +10,7 @@ ParsedManifest {
             ),
         },
         edition: "2025",
+        implicit_deps: Enabled,
     },
     environments: {
         Spanned {

--- a/external-crates/move/crates/move-package-alt/tests/data/flavor_unknown/Move@parsed.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/flavor_unknown/Move@parsed.snap
@@ -10,6 +10,7 @@ ParsedManifest {
             ),
         },
         edition: "2025",
+        implicit_deps: Enabled,
     },
     environments: {
         Spanned {

--- a/external-crates/move/crates/move-package-alt/tests/data/invalid_author/Move@parsed.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/invalid_author/Move@parsed.snap
@@ -10,6 +10,7 @@ ParsedManifest {
             ),
         },
         edition: "2025",
+        implicit_deps: Enabled,
     },
     environments: {
         Spanned {

--- a/external-crates/move/crates/move-package-alt/tests/data/invalid_authors/Move@parsed.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/invalid_authors/Move@parsed.snap
@@ -10,6 +10,7 @@ ParsedManifest {
             ),
         },
         edition: "2025",
+        implicit_deps: Enabled,
     },
     environments: {
         Spanned {

--- a/external-crates/move/crates/move-package-alt/tests/data/non_identifier_address_name_in_subst/Move@parsed.snap
+++ b/external-crates/move/crates/move-package-alt/tests/data/non_identifier_address_name_in_subst/Move@parsed.snap
@@ -8,3 +8,4 @@ error: Error while loading `"tests/data/non_identifier_address_name_in_subst/Mov
   │                                  ^^^
   │
   = Invalid identifier '©'
+


### PR DESCRIPTION
## Description

This adds the `implicit-deps` field to the manifest format. There are 4 modes: enabled and disabled are clear. Legacy is only used for legacy packages - for those, implicit deps are enabled unless any of them are present. Finally, I added a "testing" mode as a way for us to do implicit deps differently in the monorepo for our internal tests (this is something that has been a headache with our existing implicit deps).

## Test plan 

I added unit tests. In principle these could be integration tests, but my goal is to start migrating those back so I'm trying out the unit test format.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
