### PR TITLE
graphql-alt: Add Epoch.totalGasFees

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.move
@@ -31,6 +31,7 @@ fragment E on Epoch {
   startTimestamp
   endTimestamp
   totalCheckpoints
+  totalGasFees
 }
 
 //# run-graphql
@@ -52,4 +53,5 @@ fragment E on Epoch {
   startTimestamp
   endTimestamp
   totalCheckpoints
+  totalGasFees
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
@@ -18,7 +18,7 @@ task 5, line 14:
 //# advance-epoch
 Epoch advanced: 3
 
-task 6, lines 16-34:
+task 6, lines 16-35:
 //# run-graphql
 Response: {
   "data": {
@@ -27,34 +27,38 @@ Response: {
       "referenceGasPrice": "1000",
       "startTimestamp": "1970-01-01T00:00:00.444Z",
       "endTimestamp": "1970-01-01T00:00:00.444Z",
-      "totalCheckpoints": 1
+      "totalCheckpoints": 1,
+      "totalGasFees": "0"
     },
     "e0": {
       "epochId": 0,
       "referenceGasPrice": "1000",
       "startTimestamp": "1970-01-01T00:00:00Z",
       "endTimestamp": "1970-01-01T00:00:00.123Z",
-      "totalCheckpoints": 2
+      "totalCheckpoints": 2,
+      "totalGasFees": "0"
     },
     "e1": {
       "epochId": 1,
       "referenceGasPrice": "1000",
       "startTimestamp": "1970-01-01T00:00:00.123Z",
       "endTimestamp": "1970-01-01T00:00:00.444Z",
-      "totalCheckpoints": 1
+      "totalCheckpoints": 1,
+      "totalGasFees": "0"
     },
     "e2": {
       "epochId": 2,
       "referenceGasPrice": "1000",
       "startTimestamp": "1970-01-01T00:00:00.444Z",
       "endTimestamp": "1970-01-01T00:00:00.444Z",
-      "totalCheckpoints": 1
+      "totalCheckpoints": 1,
+      "totalGasFees": "0"
     },
     "e3": null
   }
 }
 
-task 7, lines 36-55:
+task 7, lines 37-57:
 //# run-graphql
 Response: {
   "data": {
@@ -65,21 +69,24 @@ Response: {
           "referenceGasPrice": "1000",
           "startTimestamp": "1970-01-01T00:00:00.123Z",
           "endTimestamp": "1970-01-01T00:00:00.444Z",
-          "totalCheckpoints": 1
+          "totalCheckpoints": 1,
+          "totalGasFees": "0"
         },
         "e0": {
           "epochId": 0,
           "referenceGasPrice": "1000",
           "startTimestamp": "1970-01-01T00:00:00Z",
           "endTimestamp": "1970-01-01T00:00:00.123Z",
-          "totalCheckpoints": 2
+          "totalCheckpoints": 2,
+          "totalGasFees": "0"
         },
         "e1": {
           "epochId": 1,
           "referenceGasPrice": "1000",
           "startTimestamp": "1970-01-01T00:00:00.123Z",
           "endTimestamp": "1970-01-01T00:00:00.444Z",
-          "totalCheckpoints": 1
+          "totalCheckpoints": 1,
+          "totalGasFees": "0"
         },
         "e2": null
       }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalGasFees/totalGasFees.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalGasFees/totalGasFees.move
@@ -12,6 +12,7 @@
 
 //# programmable --sender A --inputs 42 @B
 //> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
 
 //# run-graphql
 { # no gas fees after SplitCoins before epoch has end

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalGasFees/totalGasFees.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalGasFees/totalGasFees.move
@@ -1,0 +1,30 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --simulator
+
+//# run-graphql
+{ # no gas fees initially
+  e0: epoch(epochId: 0) {
+    totalGasFees
+  }
+}
+
+//# programmable --sender A --inputs 42 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+
+//# run-graphql
+{ # no gas fees after SplitCoins before epoch has end
+  e0: epoch(epochId: 0) {
+    totalGasFees
+  }
+}
+
+//# advance-epoch
+
+//# run-graphql
+{ # gas fees after epoch has end
+  e0: epoch(epochId: 0) {
+    totalGasFees
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalGasFees/totalGasFees.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalGasFees/totalGasFees.snap
@@ -16,13 +16,15 @@ Response: {
   }
 }
 
-task 2, lines 13-14:
+task 2, lines 13-15:
 //# programmable --sender A --inputs 42 @B
 //> 0: SplitCoins(Gas, [Input(0)]);
-Error: Transaction Effects Status: Unused result without the drop ability. Command result 0, return value 0
-Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: UnusedValueWithoutDrop { result_idx: 0, secondary_idx: 0 }, source: None, command: None } }
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, lines 16-21:
+task 3, lines 17-22:
 //# run-graphql
 Response: {
   "data": {
@@ -32,11 +34,11 @@ Response: {
   }
 }
 
-task 4, line 23:
+task 4, line 24:
 //# advance-epoch
 Epoch advanced: 1
 
-task 5, lines 25-30:
+task 5, lines 26-31:
 //# run-graphql
 Response: {
   "data": {

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalGasFees/totalGasFees.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalGasFees/totalGasFees.snap
@@ -1,0 +1,47 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-11:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "totalGasFees": null
+    }
+  }
+}
+
+task 2, lines 13-14:
+//# programmable --sender A --inputs 42 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+Error: Transaction Effects Status: Unused result without the drop ability. Command result 0, return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: UnusedValueWithoutDrop { result_idx: 0, secondary_idx: 0 }, source: None, command: None } }
+
+task 3, lines 16-21:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "totalGasFees": null
+    }
+  }
+}
+
+task 4, line 23:
+//# advance-epoch
+Epoch advanced: 1
+
+task 5, lines 25-30:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "totalGasFees": "1000000"
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -116,6 +116,10 @@ type Epoch {
 	The total number of checkpoints in this epoch.
 	"""
 	totalCheckpoints: UInt53
+	"""
+	The total amount of gas fees (in MIST) that were paid in this epoch.
+	"""
+	totalGasFees: BigInt
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
@@ -155,13 +155,11 @@ impl Epoch {
 
     /// The total amount of gas fees (in MIST) that were paid in this epoch.
     async fn total_gas_fees(&self, ctx: &Context<'_>) -> Result<Option<BigInt>, RpcError> {
-        let result = self
-            .end(ctx)
-            .await?
-            .as_ref()
-            .and_then(|last| last.total_gas_fees)
-            .map(BigInt::from);
-        Ok(result)
+        let Some(StoredEpochEnd { total_gas_fees, .. }) = self.end(ctx).await? else {
+            return Ok(None);
+        };
+
+        Ok(total_gas_fees.map(BigInt::from))
     }
 }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
@@ -160,7 +160,7 @@ impl Epoch {
             .await?
             .as_ref()
             .and_then(|last| last.total_gas_fees)
-            .map(|fees| BigInt::from(fees));
+            .map(BigInt::from);
         Ok(result)
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
@@ -152,6 +152,17 @@ impl Epoch {
 
         Ok(Some(UInt53::from(hi - lo)))
     }
+
+    /// The total amount of gas fees (in MIST) that were paid in this epoch.
+    async fn total_gas_fees(&self, ctx: &Context<'_>) -> Result<Option<BigInt>, RpcError> {
+        let result = self
+            .end(ctx)
+            .await?
+            .as_ref()
+            .and_then(|last| last.total_gas_fees)
+            .map(|fees| BigInt::from(fees));
+        Ok(result)
+    }
 }
 
 impl Epoch {

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -120,6 +120,10 @@ type Epoch {
 	The total number of checkpoints in this epoch.
 	"""
 	totalCheckpoints: UInt53
+	"""
+	The total amount of gas fees (in MIST) that were paid in this epoch.
+	"""
+	totalGasFees: BigInt
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -120,6 +120,10 @@ type Epoch {
 	The total number of checkpoints in this epoch.
 	"""
 	totalCheckpoints: UInt53
+	"""
+	The total amount of gas fees (in MIST) that were paid in this epoch.
+	"""
+	totalGasFees: BigInt
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -116,6 +116,10 @@ type Epoch {
 	The total number of checkpoints in this epoch.
 	"""
 	totalCheckpoints: UInt53
+	"""
+	The total amount of gas fees (in MIST) that were paid in this epoch.
+	"""
+	totalGasFees: BigInt
 }
 
 """


### PR DESCRIPTION
## Description 

Implements `Epoch.totalGasFees` based on
https://github.com/MystenLabs/sui/blob/4275c1a55988d28b638be8720aebdf1e7da3b06b/crates/sui-graphql-rpc/src/types/epoch.rs#L149-L151

## Test plan 

1. Added totalCheckpoints to the `query.move` snapshot test.
2. Added new `totalGasFees.move` test file.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
