### PR TITLE
[TD] add common components to retry submission and getting full effects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13732,6 +13732,7 @@ dependencies = [
  "test-fuzz",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-retry",
  "tokio-stream",
  "tracing",
  "twox-hash",
@@ -17322,6 +17323,17 @@ dependencies = [
  "tokio-postgres",
  "tokio-rustls 0.26.2",
  "x509-certificate",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.5",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/sui-core/Cargo.toml
+++ b/crates/sui-core/Cargo.toml
@@ -58,6 +58,7 @@ tap.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
+tokio-retry.workspace = true
 tokio-stream.workspace = true
 tracing.workspace = true
 twox-hash.workspace = true

--- a/crates/sui-core/src/lib.rs
+++ b/crates/sui-core/src/lib.rs
@@ -37,6 +37,7 @@ pub mod rpc_index;
 pub mod safe_client;
 mod scoring_decision;
 mod stake_aggregator;
+mod status_aggregator;
 pub mod storage;
 pub mod streamer;
 pub mod subscription_handler;

--- a/crates/sui-core/src/status_aggregator.rs
+++ b/crates/sui-core/src/status_aggregator.rs
@@ -1,0 +1,124 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::BTreeMap, sync::Arc};
+
+use mysten_common::debug_fatal;
+use sui_types::{
+    base_types::AuthorityName,
+    committee::{Committee, StakeUnit},
+};
+
+/// Aggregates various types of statuses from different authorities,
+/// and the total stake of authorities that have inserted statuses.
+/// Only keeps the latest status for each authority.
+pub(crate) struct StatusAggregator<T> {
+    committee: Arc<Committee>,
+    total_votes: StakeUnit,
+    statuses: BTreeMap<AuthorityName, T>,
+}
+
+impl<T> StatusAggregator<T> {
+    pub(crate) fn new(committee: Arc<Committee>) -> Self {
+        Self {
+            committee,
+            total_votes: 0,
+            statuses: BTreeMap::new(),
+        }
+    }
+
+    /// Returns true if the status is inserted the first time for the authority.
+    pub(crate) fn insert(&mut self, authority: AuthorityName, status: T) -> bool {
+        let Some(index) = self.committee.authority_index(&authority) else {
+            debug_fatal!("Authority {} not found in committee", authority);
+            return false;
+        };
+        if self.statuses.insert(authority, status).is_some() {
+            return false;
+        }
+        self.total_votes += self.committee.stake_by_index(index).unwrap();
+        true
+    }
+
+    /// Returns the total stake of authorities that have inserted statuses.
+    pub(crate) fn total_votes(&self) -> StakeUnit {
+        self.total_votes
+    }
+
+    /// Returns the status of each authority.
+    pub(crate) fn statuses(&self) -> &BTreeMap<AuthorityName, T> {
+        &self.statuses
+    }
+
+    pub(crate) fn reached_validity_threshold(&self) -> bool {
+        self.total_votes >= self.committee.validity_threshold()
+    }
+
+    pub(crate) fn reached_quorum_threshold(&self) -> bool {
+        self.total_votes >= self.committee.quorum_threshold()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_insert() {
+        let (committee, _) = Committee::new_simple_test_committee();
+        let authorities: Vec<_> = committee.names().copied().collect();
+        let stake_per_authority = committee.stake_by_index(0).unwrap();
+        let mut aggregator = StatusAggregator::<&str>::new(Arc::new(committee));
+
+        // Insert a status for authority 0.
+        let initial_status = "initial";
+        assert!(aggregator.insert(authorities[0], initial_status));
+        assert_eq!(aggregator.total_votes(), stake_per_authority);
+        assert_eq!(
+            aggregator.statuses().get(&authorities[0]),
+            Some(&initial_status)
+        );
+
+        // Insert the same status for authority 0 again.
+        assert!(!aggregator.insert(authorities[0], initial_status));
+        assert_eq!(aggregator.total_votes(), stake_per_authority);
+
+        // Insert a different status for authority 0.
+        let different_status = "different";
+        assert!(!aggregator.insert(authorities[0], different_status));
+        assert_eq!(aggregator.total_votes(), stake_per_authority);
+        assert_eq!(
+            aggregator.statuses().get(&authorities[0]),
+            Some(&different_status)
+        );
+
+        // Does not reach validity threshold or quorum threshold.
+        assert!(!aggregator.reached_validity_threshold());
+        assert!(!aggregator.reached_quorum_threshold());
+
+        // Insert a new status for authority 1.
+        let new_status = "new";
+        assert!(aggregator.insert(authorities[1], new_status));
+        assert_eq!(aggregator.total_votes(), 2 * stake_per_authority);
+        assert_eq!(
+            aggregator.statuses().get(&authorities[1]),
+            Some(&new_status)
+        );
+
+        // Reaches validity threshold but not quorum threshold.
+        assert!(aggregator.reached_validity_threshold());
+        assert!(!aggregator.reached_quorum_threshold());
+
+        // Insert a new status for authority 2.
+        assert!(aggregator.insert(authorities[2], new_status));
+        assert_eq!(aggregator.total_votes(), 3 * stake_per_authority);
+        assert_eq!(
+            aggregator.statuses().get(&authorities[2]),
+            Some(&new_status)
+        );
+
+        // Reaches validity and quorum thresholds.
+        assert!(aggregator.reached_validity_threshold());
+        assert!(aggregator.reached_quorum_threshold());
+    }
+}

--- a/crates/sui-core/src/transaction_driver/effects_certifier.rs
+++ b/crates/sui-core/src/transaction_driver/effects_certifier.rs
@@ -1,13 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use futures::{join, stream::FuturesUnordered, StreamExt as _};
-use mysten_common::debug_fatal;
-use rand::{seq::SliceRandom as _, Rng as _};
+use itertools::Itertools as _;
+use rand::Rng as _;
 use sui_types::{
-    base_types::ConciseableName,
+    base_types::{AuthorityName, ConciseableName},
+    committee::EpochId,
     digests::{TransactionDigest, TransactionEffectsDigest},
     effects::TransactionEffectsAPI as _,
     messages_consensus::ConsensusPosition,
@@ -20,15 +21,17 @@ use tracing::instrument;
 use crate::{
     authority_aggregator::AuthorityAggregator,
     authority_client::AuthorityAPI,
-    stake_aggregator::{InsertResult, StakeAggregator},
+    safe_client::SafeClient,
+    status_aggregator::StatusAggregator,
     transaction_driver::{
-        error::TransactionDriverError, metrics::TransactionDriverMetrics, ExecutedData,
-        QuorumTransactionResponse, SubmitTransactionOptions, SubmitTxResponse,
-        WaitForEffectsRequest, WaitForEffectsResponse,
+        error::TransactionDriverError, metrics::TransactionDriverMetrics,
+        transaction_retrier::TransactionRetrier, ExecutedData, QuorumTransactionResponse,
+        RejectReason, SubmitTransactionOptions, SubmitTxResponse, WaitForEffectsRequest,
+        WaitForEffectsResponse,
     },
 };
 
-const WAIT_FOR_EFFECTS_TIMEOUT: Duration = Duration::from_secs(2);
+const WAIT_FOR_EFFECTS_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub(crate) struct EffectsCertifier {
     metrics: Arc<TransactionDriverMetrics>,
@@ -39,11 +42,14 @@ impl EffectsCertifier {
         Self { metrics }
     }
 
+    // TODO(fastpath): this should return an aggregated error from effects certification or
+    // retries to get full effects.
     #[instrument(level = "trace", skip_all, fields(tx_digest = ?tx_digest))]
     pub(crate) async fn get_certified_finalized_effects<A>(
         &self,
         authority_aggregator: &Arc<AuthorityAggregator<A>>,
         tx_digest: &TransactionDigest,
+        mut current_target: AuthorityName,
         submit_txn_resp: SubmitTxResponse,
         options: &SubmitTransactionOptions,
     ) -> Result<QuorumTransactionResponse, TransactionDriverError>
@@ -65,30 +71,36 @@ impl EffectsCertifier {
                 None => (None, None),
             },
         };
+
+        // List of peers to try getting full effects from.
+        let mut retrier = TransactionRetrier::new(authority_aggregator);
+
         let (acknowledgments_result, mut full_effects_result) = join!(
-            self.wait_for_acknowledgments_with_retry(
+            self.wait_for_acknowledgments(
                 authority_aggregator,
                 tx_digest,
                 consensus_position,
                 options,
             ),
-            async move {
+            async {
+                // No need to send a full effects request if it is already provided.
                 if let Some(full_effects) = full_effects {
                     return Ok(full_effects);
                 }
-                self.get_full_effects_with_retry(
-                    authority_aggregator,
-                    tx_digest,
-                    consensus_position,
-                    options,
-                )
-                .await
+                let (name, client) = retrier.next_target()?;
+                current_target = name;
+                self.get_full_effects(client, tx_digest, consensus_position, options)
+                    .await
             },
         );
 
+        // If certification of transaction effects failed, it should be the error from this function,
+        // instead of failure to get individual full effects.
         let certified_digest = acknowledgments_result?;
 
-        // Retry until full effects digest matches the certified digest.
+        // Retry until there is a valid full effects that matches the certified digest.
+        // This loop terminates when there are enough (f+1) non-retriable errors when getting full effects,
+        // or all feasible targets returned errors or timed out.
         // TODO(fastpath): send backup requests to get full effects before timeout or failure.
         loop {
             match full_effects_result {
@@ -100,7 +112,7 @@ impl EffectsCertifier {
                             certified_digest
                         );
                     } else {
-                        return Ok(self.get_effects_response(
+                        return Ok(self.get_quorum_transaction_response(
                             effects_digest,
                             executed_data,
                             tx_digest,
@@ -109,22 +121,24 @@ impl EffectsCertifier {
                 }
                 Err(e) => {
                     tracing::warn!("Failed to get full effects: {e}");
+                    retrier.add_error(current_target, e)?;
                 }
             };
+
+            tokio::task::yield_now().await;
+
+            // Retry getting full effects.
+            let (name, client) = retrier.next_target()?;
+            current_target = name;
             full_effects_result = self
-                .get_full_effects_with_retry(
-                    authority_aggregator,
-                    tx_digest,
-                    consensus_position,
-                    options,
-                )
+                .get_full_effects(client, tx_digest, consensus_position, options)
                 .await;
         }
     }
 
-    async fn get_full_effects_with_retry<A>(
+    async fn get_full_effects<A>(
         &self,
-        authority_aggregator: &Arc<AuthorityAggregator<A>>,
+        client: Arc<SafeClient<A>>,
         tx_digest: &TransactionDigest,
         consensus_position: Option<ConsensusPosition>,
         options: &SubmitTransactionOptions,
@@ -132,94 +146,48 @@ impl EffectsCertifier {
     where
         A: AuthorityAPI + Send + Sync + 'static + Clone,
     {
-        let mut attempts = 0;
-        // TODO(fastpath): Remove MAX_ATTEMPTS. Retry until unretriable error.
-        const MAX_ATTEMPTS: usize = 10;
-        let clients = authority_aggregator
-            .authority_clients
-            .iter()
-            .collect::<Vec<_>>();
-
         let raw_request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
             transaction_digest: *tx_digest,
             consensus_position,
             include_details: true,
         })
-        .map_err(TransactionDriverError::SerializationError)?;
+        .unwrap();
 
-        // TODO(fastpath): only retry transient (RPC) errors. aggregate permanent errors on a higher level.
-        loop {
-            attempts += 1;
-            // TODO(fastpath): pick target with performance metrics.
-            let (name, client) = clients.choose(&mut rand::thread_rng()).unwrap();
-
-            match timeout(
-                WAIT_FOR_EFFECTS_TIMEOUT,
-                client.wait_for_effects(raw_request.clone(), options.forwarded_client_addr),
-            )
-            .await
-            {
-                Ok(Ok(response)) => match response {
-                    WaitForEffectsResponse::Executed {
-                        effects_digest,
-                        details,
-                    } => {
-                        // All error cases are retryable until max attempt due to the chance
-                        // of the status being returned from a byzantine validator.
-                        if let Some(details) = details {
-                            return Ok((effects_digest, details));
-                        } else {
-                            if attempts >= MAX_ATTEMPTS {
-                                return Err(TransactionDriverError::ExecutionDataNotFound(
-                                    tx_digest.to_string(),
-                                ));
-                            }
-                            tracing::debug!("Execution data not found, retrying...");
-                        }
+        match timeout(
+            WAIT_FOR_EFFECTS_TIMEOUT,
+            client.wait_for_effects(raw_request.clone(), options.forwarded_client_addr),
+        )
+        .await
+        {
+            Ok(Ok(response)) => match response {
+                WaitForEffectsResponse::Executed {
+                    effects_digest,
+                    details,
+                } => {
+                    // All error cases are retriable until max attempt due to the chance
+                    // of the status being returned from a byzantine validator.
+                    if let Some(details) = details {
+                        Ok((effects_digest, details))
+                    } else {
+                        tracing::debug!("Execution data not found, retrying...");
+                        Err(TransactionDriverError::ExecutionDataNotFound(
+                            tx_digest.to_string(),
+                        ))
                     }
-                    WaitForEffectsResponse::Rejected { ref reason } => {
-                        if attempts >= MAX_ATTEMPTS {
-                            return Err(TransactionDriverError::TransactionRejected(
-                                reason.to_string(),
-                            ));
-                        }
-                        tracing::debug!("Transaction rejected, retrying... Reason: {}", reason);
-                    }
-                    WaitForEffectsResponse::Expired { epoch, round } => {
-                        if attempts >= MAX_ATTEMPTS {
-                            return Err(TransactionDriverError::TransactionStatusExpired);
-                        }
-                        tracing::debug!(
-                            "Transaction status expired at epoch {}, round {}, retrying...",
-                            epoch,
-                            round.unwrap_or(0),
-                        );
-                    }
-                },
-                Ok(Err(e)) => {
-                    if attempts >= MAX_ATTEMPTS {
-                        return Err(TransactionDriverError::RpcFailure(
-                            name.concise().to_string(),
-                            e.to_string(),
-                        ));
-                    }
-                    tracing::debug!(
-                        "Full effects request failed from {}: {}, retrying...",
-                        name.concise(),
-                        e
-                    );
                 }
-                Err(_) => {
-                    if attempts >= MAX_ATTEMPTS {
-                        return Err(TransactionDriverError::TimeoutGettingFullEffects);
-                    }
-                    tracing::debug!("Full effects request timed out, retrying...");
-                }
-            }
+                WaitForEffectsResponse::Rejected { ref reason } => Err(
+                    TransactionDriverError::TransactionRejectedAtValidator(reason.to_string()),
+                ),
+                WaitForEffectsResponse::Expired { epoch, round } => Err(
+                    TransactionDriverError::TransactionStatusExpired(epoch, round.unwrap_or(0)),
+                ),
+            },
+            Ok(Err(e)) => Err(TransactionDriverError::ValidatorInternalError(e)),
+            Err(_) => Err(TransactionDriverError::TimedOutGettingFullEffectsAtValidator),
         }
     }
 
-    async fn wait_for_acknowledgments_with_retry<A>(
+    async fn wait_for_acknowledgments<A>(
         &self,
         authority_aggregator: &Arc<AuthorityAggregator<A>>,
         tx_digest: &TransactionDigest,
@@ -239,7 +207,7 @@ impl EffectsCertifier {
             consensus_position,
             include_details: false,
         })
-        .map_err(TransactionDriverError::SerializationError)?;
+        .unwrap();
 
         // Create futures for all validators (digest-only requests)
         let mut futures = FuturesUnordered::new();
@@ -248,7 +216,7 @@ impl EffectsCertifier {
             let name = *name;
             let raw_request = raw_request.clone();
             let future = async move {
-                // Keep retrying transient errors until cancellation.
+                // TODO(fastpath): add a timeout for the loop.
                 loop {
                     let result = timeout(
                         WAIT_FOR_EFFECTS_TIMEOUT,
@@ -274,14 +242,12 @@ impl EffectsCertifier {
             futures.push(future);
         }
 
-        let mut effects_digest_aggregators: HashMap<
+        let mut effects_digest_aggregators: BTreeMap<
             TransactionEffectsDigest,
-            StakeAggregator<(), true>,
-        > = HashMap::new();
-        let mut rejected_aggregator = StakeAggregator::<(), true>::new(committee.clone());
-        let mut expired_aggregator = StakeAggregator::<(), true>::new(committee.clone());
-        let mut rejected_errors = Vec::new();
-        let mut expired_errors = Vec::new();
+            StatusAggregator<()>,
+        > = BTreeMap::new();
+        let mut rejected_aggregator = StatusAggregator::<RejectReason>::new(committee.clone());
+        let mut expired_aggregator = StatusAggregator::<(EpochId, u32)>::new(committee.clone());
 
         // Every validator returns at most one WaitForEffectsResponse.
         while let Some((name, response)) = futures.next().await {
@@ -292,59 +258,35 @@ impl EffectsCertifier {
                 } => {
                     let aggregator = effects_digest_aggregators
                         .entry(effects_digest)
-                        .or_insert_with(|| StakeAggregator::<(), true>::new(committee.clone()));
-
-                    match aggregator.insert_generic(name, ()) {
-                        InsertResult::QuorumReached(_) => {
-                            let quorum_weight = aggregator.total_votes();
-                            for (other_digest, other_aggregator) in effects_digest_aggregators {
-                                if other_digest != effects_digest
-                                    && other_aggregator.total_votes() > 0
-                                {
-                                    tracing::warn!(
-                                        "Effects digest inconsistency detected: quorum digest {effects_digest:?} (weight {quorum_weight}), other digest {other_digest:?} (weight {})",
-                                        other_aggregator.total_votes()
-                                    );
-                                    self.metrics.effects_digest_mismatches.inc();
-                                }
+                        .or_insert_with(|| StatusAggregator::<()>::new(committee.clone()));
+                    aggregator.insert(name, ());
+                    if aggregator.reached_quorum_threshold() {
+                        let quorum_weight = aggregator.total_votes();
+                        for (other_digest, other_aggregator) in effects_digest_aggregators {
+                            if other_digest != effects_digest && other_aggregator.total_votes() > 0
+                            {
+                                tracing::warn!(
+                                    "Effects digest inconsistency detected: quorum digest {effects_digest:?} (weight {quorum_weight}), other digest {other_digest:?} (weight {})",
+                                    other_aggregator.total_votes()
+                                );
+                                self.metrics.effects_digest_mismatches.inc();
                             }
-                            return Ok(effects_digest);
                         }
-                        InsertResult::NotEnoughVotes { .. } => {}
-                        InsertResult::Failed { error } => {
-                            debug_fatal!(
-                                "Failed to insert vote for digest {}: {:?}",
-                                effects_digest,
-                                error
-                            );
-                        }
+                        return Ok(effects_digest);
                     }
                 }
                 WaitForEffectsResponse::Rejected { reason } => {
-                    rejected_errors.push(format!("{}: {}", name.concise(), reason));
+                    rejected_aggregator.insert(name, reason);
                     self.metrics.rejection_acks.inc();
-                    if let InsertResult::Failed { error } =
-                        rejected_aggregator.insert_generic(name, ())
-                    {
-                        debug_fatal!("Failed to insert rejection vote: {:?}", error);
-                    }
                 }
                 WaitForEffectsResponse::Expired { epoch, round } => {
-                    expired_errors.push(format!(
-                        "{} at epoch {}, round {}",
-                        name.concise(),
-                        epoch,
-                        round.unwrap_or(0),
-                    ));
+                    expired_aggregator.insert(name, (epoch, round.unwrap_or(0)));
                     self.metrics.expiration_acks.inc();
-                    if let InsertResult::Failed { error } =
-                        expired_aggregator.insert_generic(name, ())
-                    {
-                        debug_fatal!("Failed to insert expiration vote: {:?}", error);
-                    }
                 }
             };
 
+            // Adding vote up between different StatusAggregators without de-duplication is ok,
+            // because each authority only returns one response.
             let executed_weight: u64 = effects_digest_aggregators
                 .values()
                 .map(|agg| agg.total_votes())
@@ -353,34 +295,37 @@ impl EffectsCertifier {
             let expired_weight = expired_aggregator.total_votes();
             let total_weight = executed_weight + rejected_weight + expired_weight;
 
+            // Quorum threshold is used here to gather as many responses as possible for summary,
+            // while making sure the loop can exit with f malicious peers.
             if total_weight >= committee.quorum_threshold() {
-                // Abort as early as possible because there is no guarantee that another response will be received.
-                if rejected_weight + expired_weight >= committee.validity_threshold() {
-                    return Err(TransactionDriverError::TransactionRejectedOrExpired(
-                        rejected_errors.join(", "),
-                        expired_errors.join(", "),
-                    ));
-                }
-                // Check if quorum can still be reached with remaining responses.
-                let remaining_weight = committee.total_votes().saturating_sub(total_weight);
-                let quorum_feasible = effects_digest_aggregators.values().any(|agg| {
-                    agg.total_votes() + remaining_weight >= committee.quorum_threshold()
-                });
-                if !quorum_feasible {
-                    break;
-                }
-            } else {
-                // Abort less eagerly for clearer error message.
-                // More responses are available when the network is live.
+                // TransactionRejected status may or may not be retriable.
                 if rejected_weight >= committee.validity_threshold() {
                     return Err(TransactionDriverError::TransactionRejected(
-                        rejected_errors.join(", "),
+                        rejected_weight,
+                        rejected_aggregator
+                            .statuses()
+                            .iter()
+                            .map(|(n, s)| format!("{}: {:?}", n.concise(), s))
+                            .join(", "),
+                    ));
+                }
+                // TransactionRejectedOrExpired status is always retriable.
+                if rejected_weight + expired_weight >= committee.validity_threshold() {
+                    return Err(TransactionDriverError::TransactionRejectedOrExpired(
+                        rejected_weight,
+                        expired_weight,
+                        rejected_aggregator
+                            .statuses()
+                            .iter()
+                            .map(|(n, s)| format!("{}: {:?}", n.concise(), s))
+                            .join(", "),
                     ));
                 }
             }
         }
 
-        // No quorum is reached or can be reached for any effects digest.
+        // At this point, no effects digest has reached quorum. But there is not a validity threshold
+        // of failed responses either.
         let executed_weight: u64 = effects_digest_aggregators
             .values()
             .map(|agg| agg.total_votes())
@@ -399,7 +344,7 @@ impl EffectsCertifier {
     }
 
     /// Creates the final full response.
-    fn get_effects_response(
+    fn get_quorum_transaction_response(
         &self,
         effects_digest: TransactionEffectsDigest,
         executed_data: Box<ExecutedData>,

--- a/crates/sui-core/src/transaction_driver/error.rs
+++ b/crates/sui-core/src/transaction_driver/error.rs
@@ -2,33 +2,38 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
-use sui_types::error::SuiError;
+use sui_types::{committee::EpochId, error::SuiError};
 use thiserror::Error;
 
 /// Client facing errors regarding transaction submission via Transaction Driver.
 /// Every invariant needs detailed content to instruct client handling.
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Error, Hash)]
 pub enum TransactionDriverError {
-    #[error("Serialization error: {0}")]
-    SerializationError(SuiError),
-    #[error("Deserialization error: {0}")]
-    DeserializationError(SuiError),
+    // Errors against individual validators.
     #[error("Transaction timed out getting consensus position")]
-    TimeoutSubmittingTransaction,
-    #[error("Transaction timed out while acknowledging effects")]
-    TimeoutAcknowledgingEffects,
+    TimedOutSubmittingTransaction,
     #[error("Transaction timed out while getting full effects")]
-    TimeoutGettingFullEffects,
-    #[error("Failed to call validator {0}: {1}")]
-    RpcFailure(String, String),
+    TimedOutGettingFullEffectsAtValidator,
     #[error("Failed to find execution data: {0}")]
     ExecutionDataNotFound(String),
-    #[error("Transaction rejected with reason: {0}")]
-    TransactionRejected(String),
-    #[error("Transaction status expired at peer validator")]
-    TransactionStatusExpired,
-    #[error("Transaction rejected with reason: {0} & expired with reason: {1}")]
-    TransactionRejectedOrExpired(String, String),
+    #[error("Transaction rejected at peer validator")]
+    TransactionRejectedAtValidator(String),
+    #[error("Transaction status expired at peer validator, currently at epoch {0} round {1}")]
+    TransactionStatusExpired(EpochId, u32),
+    #[error("Validator internal error: {0}")]
+    ValidatorInternalError(SuiError),
+
+    // TODO(fastpath): after proper error aggregation, there errors should not exist.
+    #[error("No more targets to retry")]
+    NoMoreTargets,
+    #[error("Transaction driver failed after retries. See logs for details.")]
+    TransactionDriverFailure,
+
+    // TODO(fastpath): Move these aggregated errors to a different status.
+    #[error("Transaction rejected with stake {0} & reasons: {1}")]
+    TransactionRejected(u64, String),
+    #[error("Transaction rejected with stake {0} and expired with stake {1}, reasons: {2}")]
+    TransactionRejectedOrExpired(u64, u64, String),
     #[error("Forked execution results: total_responses_weight {total_responses_weight}, executed_weight {executed_weight}, rejected_weight {rejected_weight}, expired_weight {expired_weight}, Errors: {errors:?}")]
     ForkedExecution {
         total_responses_weight: u64,

--- a/crates/sui-core/src/transaction_driver/transaction_retrier.rs
+++ b/crates/sui-core/src/transaction_driver/transaction_retrier.rs
@@ -1,0 +1,158 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use itertools::Itertools as _;
+use rand::seq::SliceRandom as _;
+use sui_types::base_types::{AuthorityName, ConciseableName as _};
+
+use crate::{
+    authority_aggregator::AuthorityAggregator, safe_client::SafeClient,
+    status_aggregator::StatusAggregator, transaction_driver::error::TransactionDriverError,
+};
+
+/// Provides the next target validator to retry operations,
+/// and gathers the errors along with the operations.
+///
+/// In TransactionDriver, submitting a transaction and getting full effects follow the same pattern:
+/// 1. Retry against all validators until the operation succeeds.
+/// 2. If non‑retriable errors from a quorum of validators are returned, the operation should fail permanently.
+///
+/// This component helps to manager this retry pattern.
+pub(crate) struct TransactionRetrier<A: Clone> {
+    remaining_clients: Vec<(AuthorityName, Arc<SafeClient<A>>)>,
+    non_retriable_errors_aggregator: StatusAggregator<TransactionDriverError>,
+}
+
+impl<A: Clone> TransactionRetrier<A> {
+    pub(crate) fn new(auth_agg: &Arc<AuthorityAggregator<A>>) -> Self {
+        // TODO(fastpath): select and order targets based on performance metrics.
+        let mut remaining_clients = auth_agg
+            .authority_clients
+            .iter()
+            .map(|(name, client)| (*name, client.clone()))
+            .collect::<Vec<_>>();
+        remaining_clients.shuffle(&mut rand::thread_rng());
+        let non_retriable_errors_aggregator =
+            StatusAggregator::<TransactionDriverError>::new(auth_agg.committee.clone());
+        Self {
+            remaining_clients,
+            non_retriable_errors_aggregator,
+        }
+    }
+
+    // Selects the next target validator to attempt an operation.
+    pub(crate) fn next_target(
+        &mut self,
+    ) -> Result<(AuthorityName, Arc<SafeClient<A>>), TransactionDriverError> {
+        let Some((name, client)) = self.remaining_clients.pop() else {
+            // TODO(fastpath): aggregated saves errors.
+            return Err(TransactionDriverError::NoMoreTargets);
+        };
+        Ok((name, client))
+    }
+
+    // Adds an error associated with the operation against the authority.
+    // Returns an error if there are enough non-retriable errors to reject the transaction.
+    // TODO(fastpath): return an aggregated error.
+    pub(crate) fn add_error(
+        &mut self,
+        name: AuthorityName,
+        error: TransactionDriverError,
+    ) -> Result<(), TransactionDriverError> {
+        // TODO(fastpath): check if the error is non-retriable.
+        self.non_retriable_errors_aggregator.insert(name, error);
+
+        // Ensuring there is at least one non-retriable error from a honest validator
+        // is enough to reject the transaction, same as the logic in EffectsCertifier.
+        if self
+            .non_retriable_errors_aggregator
+            .reached_validity_threshold()
+        {
+            Err(TransactionDriverError::TransactionRejected(
+                self.non_retriable_errors_aggregator.total_votes(),
+                self.non_retriable_errors_aggregator
+                    .statuses()
+                    .iter()
+                    .map(|(n, s)| format!("{}: {:?}", n.concise(), s))
+                    .join(", "),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, sync::Mutex, time::Duration};
+
+    use fastcrypto::traits::KeyPair as _;
+    use sui_types::{
+        committee::Committee,
+        crypto::{get_key_pair, AuthorityKeyPair},
+    };
+
+    use crate::{
+        authority_aggregator::{AuthorityAggregatorBuilder, TimeoutConfig},
+        test_authority_clients::MockAuthorityApi,
+    };
+
+    use super::*;
+
+    fn get_authority_aggregator(committee_size: usize) -> AuthorityAggregator<MockAuthorityApi> {
+        let count = Arc::new(Mutex::new(0));
+        let mut authorities = BTreeMap::new();
+        let mut clients = BTreeMap::new();
+        for _ in 0..committee_size {
+            let (_, sec): (_, AuthorityKeyPair) = get_key_pair();
+            let name: AuthorityName = sec.public().into();
+            authorities.insert(name, 1);
+            clients.insert(
+                name,
+                MockAuthorityApi::new(Duration::from_millis(100), count.clone()),
+            );
+        }
+
+        let (committee, _keypairs) = Committee::new_simple_test_committee_of_size(committee_size);
+        let timeouts_config = TimeoutConfig {
+            serial_authority_request_interval: Duration::from_millis(50),
+            ..Default::default()
+        };
+        AuthorityAggregatorBuilder::from_committee(committee)
+            .with_timeouts_config(timeouts_config)
+            .build_custom_clients(clients)
+    }
+
+    #[tokio::test]
+    async fn test_next_target() {
+        let auth_agg = Arc::new(get_authority_aggregator(4));
+        let mut retrier = TransactionRetrier::new(&auth_agg);
+
+        for _ in 0..4 {
+            retrier.next_target().unwrap();
+        }
+        assert!(retrier.next_target().is_err());
+    }
+
+    #[tokio::test]
+    async fn test_add_error() {
+        let auth_agg = Arc::new(get_authority_aggregator(4));
+        let authorities: Vec<_> = auth_agg.committee.names().copied().collect();
+        let mut retrier = TransactionRetrier::new(&auth_agg);
+
+        // 25% stake.
+        retrier
+            .add_error(authorities[0], TransactionDriverError::NoMoreTargets)
+            .unwrap();
+        // 50% stake, above validity threshold.
+        retrier
+            .add_error(authorities[1], TransactionDriverError::NoMoreTargets)
+            .unwrap_err();
+        // 75% stake, above validity threshold.
+        retrier
+            .add_error(authorities[2], TransactionDriverError::NoMoreTargets)
+            .unwrap_err();
+    }
+}

--- a/crates/sui-core/src/transaction_driver/transaction_submitter.rs
+++ b/crates/sui-core/src/transaction_driver/transaction_submitter.rs
@@ -3,12 +3,10 @@
 
 use std::{sync::Arc, time::Duration};
 
-use rand::{seq::SliceRandom as _, Rng as _};
 use sui_types::{
-    base_types::ConciseableName, crypto::AuthorityPublicKeyBytes, digests::TransactionDigest,
-    messages_grpc::RawSubmitTxRequest,
+    base_types::AuthorityName, digests::TransactionDigest, messages_grpc::RawSubmitTxRequest,
 };
-use tokio::time::{sleep, timeout};
+use tokio::time::timeout;
 use tracing::instrument;
 
 use crate::{
@@ -16,8 +14,8 @@ use crate::{
     authority_client::AuthorityAPI,
     safe_client::SafeClient,
     transaction_driver::{
-        error::TransactionDriverError, SubmitTransactionOptions, SubmitTxResponse,
-        TransactionDriverMetrics,
+        error::TransactionDriverError, transaction_retrier::TransactionRetrier,
+        SubmitTransactionOptions, SubmitTxResponse, TransactionDriverMetrics,
     },
 };
 
@@ -32,6 +30,7 @@ impl TransactionSubmitter {
         Self { metrics }
     }
 
+    // TODO(fastpath): this should return an aggregated error from submission retries.
     #[instrument(level = "trace", skip_all, fields(tx_digest = ?tx_digest))]
     pub(crate) async fn submit_transaction<A>(
         &self,
@@ -39,50 +38,36 @@ impl TransactionSubmitter {
         tx_digest: &TransactionDigest,
         raw_request: RawSubmitTxRequest,
         options: &SubmitTransactionOptions,
-    ) -> Result<SubmitTxResponse, TransactionDriverError>
+    ) -> Result<(AuthorityName, SubmitTxResponse), TransactionDriverError>
     where
         A: AuthorityAPI + Send + Sync + 'static + Clone,
     {
-        let mut attempts = 0;
+        let mut retrier = TransactionRetrier::new(authority_aggregator);
+        // This loop terminates when there are enough (f+1) non-retriable errors when submitting the transaction,
+        // or all feasible targets returned errors or timed out.
         loop {
-            let mut clients = authority_aggregator
-                .authority_clients
-                .iter()
-                .collect::<Vec<_>>();
-            clients.shuffle(&mut rand::thread_rng());
-
-            for (name, client) in clients {
-                attempts += 1;
-                // TODO(fastpath): iterate over a list of good performing validators.
-                match self
-                    .submit_transaction_once(name, client, &raw_request, options)
-                    .await
-                {
-                    Ok(resp) => {
-                        self.metrics.submit_transaction_success.inc();
-                        return Ok(resp);
-                    }
-                    Err(e) => {
-                        self.metrics.submit_transaction_error.inc();
-                        // TODO(fastpath): Retry until f+1 permanent failures.
-                        tracing::warn!(
-                            "Failed to submit transaction {tx_digest} (attempt {attempts}): {e}",
-                        );
-                    }
-                };
-                tokio::task::yield_now().await;
-            }
-
-            let delay_ms = rand::thread_rng().gen_range(1000..2000);
-            sleep(Duration::from_millis(delay_ms)).await;
+            let (name, client) = retrier.next_target()?;
+            match self
+                .submit_transaction_once(client, &raw_request, options)
+                .await
+            {
+                Ok(resp) => {
+                    self.metrics.submit_transaction_success.inc();
+                    return Ok((name, resp));
+                }
+                Err(e) => {
+                    self.metrics.submit_transaction_error.inc();
+                    retrier.add_error(name, e)?;
+                }
+            };
+            tokio::task::yield_now().await;
         }
     }
 
     #[instrument(level = "trace", skip_all)]
     async fn submit_transaction_once<A>(
         &self,
-        name: &AuthorityPublicKeyBytes,
-        client: &Arc<SafeClient<A>>,
+        client: Arc<SafeClient<A>>,
         raw_request: &RawSubmitTxRequest,
         options: &SubmitTransactionOptions,
     ) -> Result<SubmitTxResponse, TransactionDriverError>
@@ -94,10 +79,8 @@ impl TransactionSubmitter {
             client.submit_transaction(raw_request.clone(), options.forwarded_client_addr),
         )
         .await
-        .map_err(|_| TransactionDriverError::TimeoutSubmittingTransaction)?
-        .map_err(|e| {
-            TransactionDriverError::RpcFailure(name.concise().to_string(), e.to_string())
-        })?;
+        .map_err(|_| TransactionDriverError::TimedOutSubmittingTransaction)?
+        .map_err(TransactionDriverError::ValidatorInternalError)?;
         Ok(resp)
     }
 }


### PR DESCRIPTION
## Description 

Transactions submission and full effects query follow the same pattern:
1. Retries against each validator (may change to parallel requests during retries).
2. The process succeeds when one validator returns a good response.
3. After getting back f+1 permanent failures, the whole operation should abort.

Components are added to abstract the pattern for retries and calling into error categorization.

## Test plan 

CI
PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
