### PR TITLE
[TD] wait for fastpath input objects before signing and submission

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -71,6 +71,7 @@ use sui_types::layout_resolver::into_struct_layout;
 use sui_types::layout_resolver::LayoutResolver;
 use sui_types::messages_consensus::{AuthorityCapabilitiesV1, AuthorityCapabilitiesV2};
 use sui_types::object::bounded_visitor::BoundedVisitor;
+use sui_types::storage::InputKey;
 use sui_types::traffic_control::{
     PolicyConfig, RemoteFirewallConfig, TrafficControlReconfigParams,
 };
@@ -81,6 +82,7 @@ use tokio::sync::mpsc::unbounded_channel;
 use tokio::sync::RwLock;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
+use tokio::time::timeout;
 use tracing::trace;
 use tracing::{debug, error, info, instrument, warn};
 
@@ -1135,7 +1137,31 @@ impl AuthorityState {
             .start_timer();
         self.metrics.tx_orders.inc();
 
-        let signed = self.handle_transaction_impl(transaction, true, epoch_store);
+        // timeout in tests can be reduced to exercise error paths, if QD retry gets fixed.
+        if epoch_store.protocol_config().mysticeti_fastpath()
+            && !self
+                .wait_for_fastpath_input_objects(
+                    &transaction,
+                    epoch_store.epoch(),
+                    Duration::from_secs(10),
+                )
+                .await?
+        {
+            debug!("fastpath input objects are still unavailable after waiting");
+            // Proceed with input checks to generate a proper error.
+        }
+
+        self.handle_sign_transaction(epoch_store, transaction).await
+    }
+
+    /// Signs a transaction. Exposed for testing.
+    pub async fn handle_sign_transaction(
+        &self,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+        transaction: VerifiedTransaction,
+    ) -> SuiResult<HandleTransactionResponse> {
+        let tx_digest = *transaction.digest();
+        let signed = self.handle_transaction_impl(transaction, /* sign */ true, epoch_store);
         match signed {
             Ok(Some(s)) => {
                 if self.is_validator(epoch_store) {
@@ -1271,6 +1297,53 @@ impl AuthorityState {
             .transaction_overload_sources
             .with_label_values(&[source])
             .inc();
+    }
+
+    /// Waits for fastpath (owned) input objects to become available until the specified max_wait timeout.
+    /// Returns true if all fastpath input objects are available, false otherwise.
+    pub(crate) async fn wait_for_fastpath_input_objects(
+        &self,
+        transaction: &VerifiedTransaction,
+        epoch: EpochId,
+        max_wait: Duration,
+    ) -> SuiResult<bool> {
+        let txn_data = transaction.data().transaction_data();
+        let fastpath_input_objects = txn_data
+            .input_objects()?
+            .iter()
+            .filter_map(|o| match o {
+                InputObjectKind::ImmOrOwnedMoveObject(object_ref) => {
+                    Some(InputKey::VersionedObject {
+                        id: FullObjectID::new(object_ref.0, None),
+                        version: object_ref.1,
+                    })
+                }
+                InputObjectKind::MovePackage(package_id) => {
+                    Some(InputKey::Package { id: *package_id })
+                }
+                InputObjectKind::SharedMoveObject { .. } => None,
+            })
+            .collect::<Vec<_>>();
+        if fastpath_input_objects.is_empty() {
+            return Ok(true);
+        }
+        // It is ok to not check receiving objects, unless it turns out to be a common failure.
+        let receiving_keys = HashSet::new();
+        match timeout(
+            max_wait,
+            self.get_object_cache_reader().notify_read_input_objects(
+                &fastpath_input_objects,
+                &receiving_keys,
+                epoch,
+            ),
+        )
+        .await
+        {
+            Ok(()) => Ok(true),
+            // Maybe return an error for unavailable input objects,
+            // and allow the caller to skip the rest of input checks?
+            Err(_) => Ok(false),
+        }
     }
 
     /// Wait for a certificate to be executed.

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -66,7 +66,7 @@ use crate::{
     authority::{
         authority_per_epoch_store::AuthorityPerEpochStore,
         consensus_tx_status_cache::NotifyReadConsensusTxStatusResult,
-        shared_object_version_manager::Schedulable, ExecutionEnv,
+        shared_object_version_manager::Schedulable, ExecutionEnv, WAIT_FOR_FASTPATH_INPUT_TIMEOUT,
     },
     checkpoints::CheckpointStore,
     execution_scheduler::SchedulingSource,
@@ -599,12 +599,12 @@ impl ValidatorService {
             }
         }
 
-        // Use shorter wait timeout in tests to exercise server-side error paths and
+        // Use shorter wait timeout in simtests to exercise server-side error paths and
         // client-side retry logic.
-        let wait_for_fastpath_input_objects_timeout = if cfg!(debug_assertions) {
-            Duration::from_millis(1)
+        let wait_for_fastpath_input_objects_timeout = if cfg!(msim) {
+            Duration::from_millis(100)
         } else {
-            Duration::from_secs(10)
+            WAIT_FOR_FASTPATH_INPUT_TIMEOUT
         };
         if !state
             .wait_for_fastpath_input_objects(

--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -244,7 +244,7 @@ pub trait ObjectCacheRead: Send + Sync {
         &self,
         keys: &[InputKey],
         receiving_objects: &HashSet<InputKey>,
-        epoch: &EpochId,
+        epoch: EpochId,
     ) -> Vec<bool> {
         let mut results = vec![false; keys.len()];
         let non_canceled_keys = keys.iter().enumerate().filter(|(idx, key)| {
@@ -288,22 +288,22 @@ pub trait ObjectCacheRead: Send + Sync {
                     .get_object(&id.id())
                     .map(|obj| obj.version() >= **version)
                     .unwrap_or(false)
-                    || self.fastpath_stream_ended_at_version_or_after(id.id(), **version, *epoch);
+                    || self.fastpath_stream_ended_at_version_or_after(id.id(), **version, epoch);
                 results[*idx] = is_available;
             } else {
                 // If the object is an already-removed consensus object, mark it as available if the
                 // version for that object is in the marker table.
                 let is_consensus_stream_ended = self
-                    .get_consensus_stream_end_tx_digest(FullObjectKey::new(**id, **version), *epoch)
+                    .get_consensus_stream_end_tx_digest(FullObjectKey::new(**id, **version), epoch)
                     .is_some();
                 results[*idx] = is_consensus_stream_ended;
             }
         }
 
         package_object_keys.into_iter().for_each(|(idx, id)| {
-            // unwrap is safe since this only errors when the object is not a package,
-            // which is impossible if we have a certificate for execution.
-            results[idx] = self.get_package_object(id).unwrap().is_some();
+            // get_package_object() only errors when the object is not a package, so returning false on error.
+            // Error is possible when this gets called on uncertified transactions.
+            results[idx] = self.get_package_object(id).is_ok_and(|p| p.is_some());
         });
 
         results
@@ -411,7 +411,7 @@ pub trait ObjectCacheRead: Send + Sync {
         &'a self,
         input_and_receiving_keys: &'a [InputKey],
         receiving_keys: &'a HashSet<InputKey>,
-        epoch: &'a EpochId,
+        epoch: EpochId,
     ) -> BoxFuture<'a, ()>;
 }
 

--- a/crates/sui-core/src/execution_cache/unit_tests/notify_read_input_objects_tests.rs
+++ b/crates/sui-core/src/execution_cache/unit_tests/notify_read_input_objects_tests.rs
@@ -40,7 +40,7 @@ async fn test_immediate_return_canceled_shared() {
         version: SequenceNumber::CANCELLED_READ,
     };
     let receiving_keys = HashSet::new();
-    let epoch = &0;
+    let epoch = 0;
 
     // Should return immediately since canceled shared objects are always available
     cache
@@ -84,7 +84,7 @@ async fn test_immediate_return_cached_object() {
         version,
     }];
     let receiving_keys = HashSet::new();
-    let epoch = &0;
+    let epoch = 0;
 
     // Should return immediately since object is in cache
     cache
@@ -101,7 +101,7 @@ async fn test_immediate_return_cached_package() {
         id: SUI_FRAMEWORK_PACKAGE_ID,
     }];
     let receiving_keys = HashSet::new();
-    let epoch = &0;
+    let epoch = 0;
 
     // Should return immediately since system package is available by default.
     cache
@@ -133,7 +133,7 @@ async fn test_immediate_return_consensus_stream_ended() {
 
     // Should return immediately since object is marked as consensus stream ended
     cache
-        .notify_read_input_objects(&input_keys, &receiving_keys, &epoch)
+        .notify_read_input_objects(&input_keys, &receiving_keys, epoch)
         .now_or_never()
         .unwrap();
 }
@@ -150,7 +150,7 @@ async fn test_wait_for_object() {
         version,
     }];
     let receiving_keys = HashSet::new();
-    let epoch = &0;
+    let epoch = 0;
 
     let result = timeout(
         Duration::from_secs(3),
@@ -224,7 +224,7 @@ async fn test_wait_for_package() {
 
     let input_keys = vec![InputKey::Package { id: package_id }];
     let receiving_keys = HashSet::new();
-    let epoch = &0;
+    let epoch = 0;
 
     // Start notification future
     let notification = cache.notify_read_input_objects(&input_keys, &receiving_keys, epoch);
@@ -248,7 +248,7 @@ async fn test_wait_for_consensus_stream_end() {
 
     let object_id = ObjectID::random();
     let version = SequenceNumber::from(1);
-    let epoch = &0;
+    let epoch = 0;
 
     let input_keys = vec![InputKey::VersionedObject {
         id: FullObjectID::new(object_id, Some(version)),
@@ -265,7 +265,7 @@ async fn test_wait_for_consensus_stream_end() {
         async move {
             tokio::time::sleep(Duration::from_millis(100)).await;
             cache.write_marker_value(
-                *epoch,
+                epoch,
                 FullObjectKey::new(FullObjectID::new(object_id, Some(version)), version),
                 MarkerValue::ConsensusStreamEnded(TransactionDigest::random()),
             );
@@ -298,7 +298,7 @@ async fn test_receiving_object_higher_version() {
     }];
     let mut receiving_keys = HashSet::new();
     receiving_keys.insert(input_keys[0]);
-    let epoch = &0;
+    let epoch = 0;
 
     // Should return immediately since a higher version exists for receiving object
     cache

--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -1845,10 +1845,10 @@ impl ObjectCacheRead for WritebackCache {
         &'a self,
         input_and_receiving_keys: &'a [InputKey],
         receiving_keys: &'a HashSet<InputKey>,
-        epoch: &'a EpochId,
+        epoch: EpochId,
     ) -> BoxFuture<'a, ()> {
         self.object_notify_read
-            .read(input_and_receiving_keys, |keys| {
+            .read(input_and_receiving_keys, move |keys| {
                 self.multi_input_objects_available(keys, receiving_keys, epoch)
                     .into_iter()
                     .map(|available| if available { Some(()) } else { None })

--- a/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
+++ b/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
@@ -183,7 +183,7 @@ impl ExecutionScheduler {
             .inc();
         tokio::select! {
             _ = self.object_cache_read
-                .notify_read_input_objects(&missing_input_keys, &receiving_object_keys, &epoch)
+                .notify_read_input_objects(&missing_input_keys, &receiving_object_keys, epoch)
                 => {
                     self.metrics
                         .transaction_manager_transaction_queue_age_s

--- a/crates/sui-core/src/execution_scheduler/transaction_manager.rs
+++ b/crates/sui-core/src/execution_scheduler/transaction_manager.rs
@@ -578,7 +578,7 @@ impl ExecutionSchedulerAPI for TransactionManager {
             .multi_input_objects_available(
                 &input_object_cache_misses,
                 &receiving_objects,
-                &epoch_store.epoch(),
+                epoch_store.epoch(),
             )
             .into_iter()
             .zip(input_object_cache_misses);

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -36,6 +36,7 @@ use crate::global_state_hasher::GlobalStateHasher;
 
 const WAIT_FOR_TX_TIMEOUT: Duration = Duration::from_secs(15);
 
+// TODO(fastpath): switch to use MFP flow.
 pub async fn send_and_confirm_transaction(
     authority: &AuthorityState,
     fullnode: Option<&AuthorityState>,
@@ -46,7 +47,7 @@ pub async fn send_and_confirm_transaction(
     transaction.validity_check(&epoch_store.tx_validity_check_context())?;
     let transaction = epoch_store.verify_transaction(transaction)?;
     let response = authority
-        .handle_transaction(&epoch_store, transaction.clone())
+        .handle_sign_transaction(&epoch_store, transaction.clone())
         .await?;
     let vote = response.status.into_signed_for_testing();
 


### PR DESCRIPTION
## Description 

After fastpath transaction executes through Mysticeti fastpath, input objects are not immediately available for locking. This adds a wait on the input objects to become available before running the signing / voting logic.

## Test plan 

CI
PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
