### PR TITLE
[graphql-alt] Support status for TransactionEffects

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/status.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/status.move
@@ -21,20 +21,14 @@ module test::failed_module {
 
 //# run-graphql
 { # Test status field on successful transaction effects
-  successTransaction: transaction(digest: "@{digest_2}") {
-    digest
-    effects {
-      status
-    }
+  successTransaction: transactionEffects(digest: "@{digest_2}") {
+    status
   }
 } 
 
 //# run-graphql
 { # Test status field on failed transaction
-  failedTransaction: transaction(digest: "@{digest_3}") {
-    digest
-    effects {
-      status
-    }
+  failedTransaction: transactionEffects(digest: "@{digest_3}") {
+    status
   }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/status.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/status.move
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --addresses test=0x0 --simulator
+
+//# publish
+module test::failed_module {
+    /// Function that always aborts, creating a failed transaction
+    public entry fun always_fails() {
+        abort 42
+    }
+}
+
+//# programmable --sender A --inputs 100 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# run test::failed_module::always_fails --sender A
+
+//# create-checkpoint
+
+//# run-graphql
+{ # Test status field on successful transaction effects
+  successTransaction: transaction(digest: "@{digest_2}") {
+    digest
+    effects {
+      status
+    }
+  }
+} 
+
+//# run-graphql
+{ # Test status field on failed transaction
+  failedTransaction: transaction(digest: "@{digest_3}") {
+    digest
+    effects {
+      status
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/status.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/status.snap
@@ -1,0 +1,56 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-12:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 3693600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 14-16:
+//# programmable --sender A --inputs 100 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 18:
+//# run test::failed_module::always_fails --sender A
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::failed_module::always_fails (function index 0) at offset 1, Abort Code: 42
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("failed_module") }, function: 0, instruction: 1, function_name: Some("always_fails") }, 42), source: Some(VMError { major_status: ABORTED, sub_status: Some(42), message: Some("test::failed_module::always_fails at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("failed_module") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 1)] }), command: Some(0) } }
+
+task 4, line 20:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, lines 22-30:
+//# run-graphql
+Response: {
+  "data": {
+    "successTransaction": {
+      "digest": "8oTvMSFKtR2oBsj6a3X8PokBiuT2Ykhzkar8WKmEyMnP",
+      "effects": {
+        "status": "SUCCESS"
+      }
+    }
+  }
+}
+
+task 6, lines 32-40:
+//# run-graphql
+Response: {
+  "data": {
+    "failedTransaction": {
+      "digest": "7xyrMFpP933Sm7S6nbvAzNqnxddT19XqmLSs3iyUHKKk",
+      "effects": {
+        "status": "FAILURE"
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/status.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/status.snap
@@ -29,28 +29,22 @@ task 4, line 20:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 5, lines 22-30:
+task 5, lines 22-27:
 //# run-graphql
 Response: {
   "data": {
     "successTransaction": {
-      "digest": "8oTvMSFKtR2oBsj6a3X8PokBiuT2Ykhzkar8WKmEyMnP",
-      "effects": {
-        "status": "SUCCESS"
-      }
+      "status": "SUCCESS"
     }
   }
 }
 
-task 6, lines 32-40:
+task 6, lines 29-34:
 //# run-graphql
 Response: {
   "data": {
     "failedTransaction": {
-      "digest": "7xyrMFpP933Sm7S6nbvAzNqnxddT19XqmLSs3iyUHKKk",
-      "effects": {
-        "status": "FAILURE"
-      }
+      "status": "FAILURE"
     }
   }
 }

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -119,6 +119,20 @@ type Epoch {
 }
 
 """
+The execution status of this transaction: success or failure.
+"""
+enum ExecutionStatus {
+	"""
+	The transaction was successfully executed.
+	"""
+	SUCCESS
+	"""
+	The transaction could not be executed.
+	"""
+	FAILURE
+}
+
+"""
 A boolean protocol configuration.
 """
 type FeatureFlag {
@@ -808,6 +822,10 @@ type TransactionEffects {
 	The checkpoint this transaction was finalized in.
 	"""
 	checkpoint: Checkpoint
+	"""
+	Whether the transaction executed successfully or not.
+	"""
+	status: ExecutionStatus
 	"""
 	The Base64-encoded BCS serialization of these effects, as `TransactionEffects`.
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -123,6 +123,20 @@ type Epoch {
 }
 
 """
+The execution status of this transaction: success or failure.
+"""
+enum ExecutionStatus {
+	"""
+	The transaction was successfully executed.
+	"""
+	SUCCESS
+	"""
+	The transaction could not be executed.
+	"""
+	FAILURE
+}
+
+"""
 A boolean protocol configuration.
 """
 type FeatureFlag {
@@ -812,6 +826,10 @@ type TransactionEffects {
 	The checkpoint this transaction was finalized in.
 	"""
 	checkpoint: Checkpoint
+	"""
+	Whether the transaction executed successfully or not.
+	"""
+	status: ExecutionStatus
 	"""
 	The Base64-encoded BCS serialization of these effects, as `TransactionEffects`.
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -123,6 +123,20 @@ type Epoch {
 }
 
 """
+The execution status of this transaction: success or failure.
+"""
+enum ExecutionStatus {
+	"""
+	The transaction was successfully executed.
+	"""
+	SUCCESS
+	"""
+	The transaction could not be executed.
+	"""
+	FAILURE
+}
+
+"""
 A boolean protocol configuration.
 """
 type FeatureFlag {
@@ -812,6 +826,10 @@ type TransactionEffects {
 	The checkpoint this transaction was finalized in.
 	"""
 	checkpoint: Checkpoint
+	"""
+	Whether the transaction executed successfully or not.
+	"""
+	status: ExecutionStatus
 	"""
 	The Base64-encoded BCS serialization of these effects, as `TransactionEffects`.
 	"""

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -119,6 +119,20 @@ type Epoch {
 }
 
 """
+The execution status of this transaction: success or failure.
+"""
+enum ExecutionStatus {
+	"""
+	The transaction was successfully executed.
+	"""
+	SUCCESS
+	"""
+	The transaction could not be executed.
+	"""
+	FAILURE
+}
+
+"""
 A boolean protocol configuration.
 """
 type FeatureFlag {
@@ -808,6 +822,10 @@ type TransactionEffects {
 	The checkpoint this transaction was finalized in.
 	"""
 	checkpoint: Checkpoint
+	"""
+	Whether the transaction executed successfully or not.
+	"""
+	status: ExecutionStatus
 	"""
 	The Base64-encoded BCS serialization of these effects, as `TransactionEffects`.
 	"""


### PR DESCRIPTION
## Description 

Implement `status` field support for `TransactionEffects` type.

Reference: Based on legacy implementation in sui/crates/sui-graphql-rpc/src/types /transaction_block_effects.rs

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-graphql
cargo nextest run -p sui-indexer-alt-reader
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
