### PR TITLE
graphql-alt: Add Epoch.totalStakeRewards

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.move
@@ -32,6 +32,7 @@ fragment E on Epoch {
   endTimestamp
   totalCheckpoints
   totalGasFees
+  totalStakeRewards
 }
 
 //# run-graphql
@@ -54,4 +55,5 @@ fragment E on Epoch {
   endTimestamp
   totalCheckpoints
   totalGasFees
+  totalStakeRewards
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
@@ -18,7 +18,7 @@ task 5, line 14:
 //# advance-epoch
 Epoch advanced: 3
 
-task 6, lines 16-35:
+task 6, lines 16-36:
 //# run-graphql
 Response: {
   "data": {
@@ -28,7 +28,8 @@ Response: {
       "startTimestamp": "1970-01-01T00:00:00.444Z",
       "endTimestamp": "1970-01-01T00:00:00.444Z",
       "totalCheckpoints": 1,
-      "totalGasFees": "0"
+      "totalGasFees": "0",
+      "totalStakeRewards": "0"
     },
     "e0": {
       "epochId": 0,
@@ -36,7 +37,8 @@ Response: {
       "startTimestamp": "1970-01-01T00:00:00Z",
       "endTimestamp": "1970-01-01T00:00:00.123Z",
       "totalCheckpoints": 2,
-      "totalGasFees": "0"
+      "totalGasFees": "0",
+      "totalStakeRewards": "0"
     },
     "e1": {
       "epochId": 1,
@@ -44,7 +46,8 @@ Response: {
       "startTimestamp": "1970-01-01T00:00:00.123Z",
       "endTimestamp": "1970-01-01T00:00:00.444Z",
       "totalCheckpoints": 1,
-      "totalGasFees": "0"
+      "totalGasFees": "0",
+      "totalStakeRewards": "0"
     },
     "e2": {
       "epochId": 2,
@@ -52,13 +55,14 @@ Response: {
       "startTimestamp": "1970-01-01T00:00:00.444Z",
       "endTimestamp": "1970-01-01T00:00:00.444Z",
       "totalCheckpoints": 1,
-      "totalGasFees": "0"
+      "totalGasFees": "0",
+      "totalStakeRewards": "0"
     },
     "e3": null
   }
 }
 
-task 7, lines 37-57:
+task 7, lines 38-59:
 //# run-graphql
 Response: {
   "data": {
@@ -70,7 +74,8 @@ Response: {
           "startTimestamp": "1970-01-01T00:00:00.123Z",
           "endTimestamp": "1970-01-01T00:00:00.444Z",
           "totalCheckpoints": 1,
-          "totalGasFees": "0"
+          "totalGasFees": "0",
+          "totalStakeRewards": "0"
         },
         "e0": {
           "epochId": 0,
@@ -78,7 +83,8 @@ Response: {
           "startTimestamp": "1970-01-01T00:00:00Z",
           "endTimestamp": "1970-01-01T00:00:00.123Z",
           "totalCheckpoints": 2,
-          "totalGasFees": "0"
+          "totalGasFees": "0",
+          "totalStakeRewards": "0"
         },
         "e1": {
           "epochId": 1,
@@ -86,7 +92,8 @@ Response: {
           "startTimestamp": "1970-01-01T00:00:00.123Z",
           "endTimestamp": "1970-01-01T00:00:00.444Z",
           "totalCheckpoints": 1,
-          "totalGasFees": "0"
+          "totalGasFees": "0",
+          "totalStakeRewards": "0"
         },
         "e2": null
       }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalStakeRewards/totalStakeRewards.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalStakeRewards/totalStakeRewards.move
@@ -1,0 +1,31 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --simulator
+
+//# run-graphql
+{ # no stake rewards initially
+  e0: epoch(epochId: 0) {
+    totalStakeRewards
+  }
+}
+
+//# programmable --sender A --inputs 42 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# run-graphql
+{ # no stake rewards after SplitCoins before epoch has end
+  e0: epoch(epochId: 0) {
+    totalStakeRewards
+  }
+}
+
+//# advance-epoch
+
+//# run-graphql
+{ # stake rewards after epoch has end
+  e0: epoch(epochId: 0) {
+    totalStakeRewards
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalStakeRewards/totalStakeRewards.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalStakeRewards/totalStakeRewards.snap
@@ -1,0 +1,49 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-11:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "totalStakeRewards": null
+    }
+  }
+}
+
+task 2, lines 13-15:
+//# programmable --sender A --inputs 42 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 17-22:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "totalStakeRewards": null
+    }
+  }
+}
+
+task 4, line 24:
+//# advance-epoch
+Epoch advanced: 1
+
+task 5, lines 26-31:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "totalStakeRewards": "1000000"
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -120,6 +120,10 @@ type Epoch {
 	The total amount of gas fees (in MIST) that were paid in this epoch.
 	"""
 	totalGasFees: BigInt
+	"""
+	The total MIST rewarded as stake.
+	"""
+	totalStakeRewards: BigInt
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -117,11 +117,11 @@ type Epoch {
 	"""
 	totalCheckpoints: UInt53
 	"""
-	The total amount of gas fees (in MIST) that were paid in this epoch.
+	The total amount of gas fees (in MIST) that were paid in this epoch (or `null` if the epoch has not finished yet).
 	"""
 	totalGasFees: BigInt
 	"""
-	The total MIST rewarded as stake.
+	The total MIST rewarded as stake (or `null` if the epoch has not finished yet).
 	"""
 	totalStakeRewards: BigInt
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
@@ -153,7 +153,7 @@ impl Epoch {
         Ok(Some(UInt53::from(hi - lo)))
     }
 
-    /// The total amount of gas fees (in MIST) that were paid in this epoch.
+    /// The total amount of gas fees (in MIST) that were paid in this epoch (or `null` if the epoch has not finished yet).
     async fn total_gas_fees(&self, ctx: &Context<'_>) -> Result<Option<BigInt>, RpcError> {
         let Some(StoredEpochEnd { total_gas_fees, .. }) = self.end(ctx).await? else {
             return Ok(None);
@@ -162,7 +162,7 @@ impl Epoch {
         Ok(total_gas_fees.map(BigInt::from))
     }
 
-    /// The total MIST rewarded as stake.
+    /// The total MIST rewarded as stake (or `null` if the epoch has not finished yet).
     async fn total_stake_rewards(&self, ctx: &Context<'_>) -> Result<Option<BigInt>, RpcError> {
         let Some(StoredEpochEnd {
             total_stake_rewards_distributed,

--- a/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
@@ -161,6 +161,19 @@ impl Epoch {
 
         Ok(total_gas_fees.map(BigInt::from))
     }
+
+    /// The total MIST rewarded as stake.
+    async fn total_stake_rewards(&self, ctx: &Context<'_>) -> Result<Option<BigInt>, RpcError> {
+        let Some(StoredEpochEnd {
+            total_stake_rewards_distributed,
+            ..
+        }) = self.end(ctx).await?
+        else {
+            return Ok(None);
+        };
+
+        Ok(total_stake_rewards_distributed.map(BigInt::from))
+    }
 }
 
 impl Epoch {

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -121,11 +121,11 @@ type Epoch {
 	"""
 	totalCheckpoints: UInt53
 	"""
-	The total amount of gas fees (in MIST) that were paid in this epoch.
+	The total amount of gas fees (in MIST) that were paid in this epoch (or `null` if the epoch has not finished yet).
 	"""
 	totalGasFees: BigInt
 	"""
-	The total MIST rewarded as stake.
+	The total MIST rewarded as stake (or `null` if the epoch has not finished yet).
 	"""
 	totalStakeRewards: BigInt
 }

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -124,6 +124,10 @@ type Epoch {
 	The total amount of gas fees (in MIST) that were paid in this epoch.
 	"""
 	totalGasFees: BigInt
+	"""
+	The total MIST rewarded as stake.
+	"""
+	totalStakeRewards: BigInt
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -121,11 +121,11 @@ type Epoch {
 	"""
 	totalCheckpoints: UInt53
 	"""
-	The total amount of gas fees (in MIST) that were paid in this epoch.
+	The total amount of gas fees (in MIST) that were paid in this epoch (or `null` if the epoch has not finished yet).
 	"""
 	totalGasFees: BigInt
 	"""
-	The total MIST rewarded as stake.
+	The total MIST rewarded as stake (or `null` if the epoch has not finished yet).
 	"""
 	totalStakeRewards: BigInt
 }

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -124,6 +124,10 @@ type Epoch {
 	The total amount of gas fees (in MIST) that were paid in this epoch.
 	"""
 	totalGasFees: BigInt
+	"""
+	The total MIST rewarded as stake.
+	"""
+	totalStakeRewards: BigInt
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -120,6 +120,10 @@ type Epoch {
 	The total amount of gas fees (in MIST) that were paid in this epoch.
 	"""
 	totalGasFees: BigInt
+	"""
+	The total MIST rewarded as stake.
+	"""
+	totalStakeRewards: BigInt
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -117,11 +117,11 @@ type Epoch {
 	"""
 	totalCheckpoints: UInt53
 	"""
-	The total amount of gas fees (in MIST) that were paid in this epoch.
+	The total amount of gas fees (in MIST) that were paid in this epoch (or `null` if the epoch has not finished yet).
 	"""
 	totalGasFees: BigInt
 	"""
-	The total MIST rewarded as stake.
+	The total MIST rewarded as stake (or `null` if the epoch has not finished yet).
 	"""
 	totalStakeRewards: BigInt
 }


### PR DESCRIPTION
## Description 

Implements `Epoch.totalStakeRewards` based on
https://github.com/MystenLabs/sui/blob/4275c1a55988d28b638be8720aebdf1e7da3b06b/crates/sui-graphql-rpc/src/types/epoch.rs#L154-L158

## Test plan 

1. Added `totalStakeRewards` to the `query.move` snapshot test.
2. Added new `totalStakeRewards.move` test file.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
