### PR TITLE
enable passkey mainnet

### DIFF
--- a/crates/sui-e2e-tests/tests/passkey_e2e_tests.rs
+++ b/crates/sui-e2e-tests/tests/passkey_e2e_tests.rs
@@ -324,7 +324,32 @@ async fn test_passkey_fails_to_verify_sig() {
     }
     let sig = GenericSignature::PasskeyAuthenticator(
         PasskeyAuthenticator::new_for_testing(
-            response.authenticator_data,
+            response.authenticator_data.clone(),
+            response.client_data_json.clone(),
+            Signature::from_bytes(&modified_sig).unwrap(),
+        )
+        .unwrap(),
+    );
+    let tx = Transaction::from_generic_sig_data(response.intent_msg.value.clone(), vec![sig]);
+    let res = execute_tx(tx, &test_cluster).await;
+    let err = res.unwrap_err();
+    assert_eq!(
+        err,
+        SuiError::InvalidSignature {
+            error: "Fails to verify".to_string()
+        }
+    );
+
+    // mangles authenticator data fails to verify
+    let mut mangled_authenticator_data = response.authenticator_data.clone();
+    if mangled_authenticator_data[1] == 0x00 {
+        mangled_authenticator_data[1] = 0x01;
+    } else {
+        mangled_authenticator_data[1] = 0x00;
+    }
+    let sig = GenericSignature::PasskeyAuthenticator(
+        PasskeyAuthenticator::new_for_testing(
+            mangled_authenticator_data,
             response.client_data_json,
             Signature::from_bytes(&modified_sig).unwrap(),
         )

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -251,6 +251,7 @@ const MAX_PROTOCOL_VERSION: u64 = 89;
 //             Ignore execution time observations after validator stops accepting certs.
 // Version 89: Standard library improvements.
 //             Enable `debug_fatal` on Move invariant violations.
+//             Enable passkey and passkey inside multisig for mainnet. 
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -3859,14 +3860,14 @@ impl ProtocolConfig {
                                 default_none_duration_for_new_keys: true,
                             },
                         );
-                    cfg.feature_flags.accept_passkey_in_multisig = true;
-                    cfg.feature_flags.passkey_auth = true;
                 }
                 89 => {
                     // 100x RGP
                     cfg.max_gas_price_rgp_factor_for_aborted_transactions = Some(100);
                     cfg.feature_flags.debug_fatal_on_move_invariant_violation = true;
                     cfg.feature_flags.additional_consensus_digest_indirect_state = true;
+                    cfg.feature_flags.accept_passkey_in_multisig = true;
+                    cfg.feature_flags.passkey_auth = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -251,7 +251,7 @@ const MAX_PROTOCOL_VERSION: u64 = 89;
 //             Ignore execution time observations after validator stops accepting certs.
 // Version 89: Standard library improvements.
 //             Enable `debug_fatal` on Move invariant violations.
-//             Enable passkey and passkey inside multisig for mainnet. 
+//             Enable passkey and passkey inside multisig for mainnet.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -3859,6 +3859,8 @@ impl ProtocolConfig {
                                 default_none_duration_for_new_keys: true,
                             },
                         );
+                    cfg.feature_flags.accept_passkey_in_multisig = true;
+                    cfg.feature_flags.passkey_auth = true;
                 }
                 89 => {
                     // 100x RGP

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_88.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_88.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+snapshot_kind: text
 ---
 version: 88
 feature_flags:
@@ -39,6 +40,7 @@ feature_flags:
   verify_legacy_zklogin_address: true
   recompute_has_public_transfer_in_execution: true
   accept_zklogin_in_multisig: true
+  accept_passkey_in_multisig: true
   include_consensus_digest_in_prologue: true
   hardened_otw_check: true
   allow_receiving_object_id: true
@@ -71,6 +73,7 @@ feature_flags:
   mysticeti_num_leaders_per_round: 1
   soft_bundle: true
   enable_coin_deny_list_v2: true
+  passkey_auth: true
   rethrow_serialization_type_layout_errors: true
   consensus_distributed_vote_scoring_strategy: true
   consensus_round_prober: true

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_88.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_88.snap
@@ -40,7 +40,6 @@ feature_flags:
   verify_legacy_zklogin_address: true
   recompute_has_public_transfer_in_execution: true
   accept_zklogin_in_multisig: true
-  accept_passkey_in_multisig: true
   include_consensus_digest_in_prologue: true
   hardened_otw_check: true
   allow_receiving_object_id: true
@@ -73,7 +72,6 @@ feature_flags:
   mysticeti_num_leaders_per_round: 1
   soft_bundle: true
   enable_coin_deny_list_v2: true
-  passkey_auth: true
   rethrow_serialization_type_layout_errors: true
   consensus_distributed_vote_scoring_strategy: true
   consensus_round_prober: true

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_89.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_89.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+snapshot_kind: text
 ---
 version: 89
 feature_flags:
@@ -39,6 +40,7 @@ feature_flags:
   verify_legacy_zklogin_address: true
   recompute_has_public_transfer_in_execution: true
   accept_zklogin_in_multisig: true
+  accept_passkey_in_multisig: true
   include_consensus_digest_in_prologue: true
   hardened_otw_check: true
   allow_receiving_object_id: true
@@ -71,6 +73,7 @@ feature_flags:
   mysticeti_num_leaders_per_round: 1
   soft_bundle: true
   enable_coin_deny_list_v2: true
+  passkey_auth: true
   rethrow_serialization_type_layout_errors: true
   consensus_distributed_vote_scoring_strategy: true
   consensus_round_prober: true

--- a/crates/sui-types/src/passkey_authenticator.rs
+++ b/crates/sui-types/src/passkey_authenticator.rs
@@ -196,6 +196,7 @@ impl PasskeyAuthenticator {
         bytes.extend_from_slice(self.signature.as_ref());
         bytes.extend_from_slice(self.pk.as_ref());
 
+        // Safe to unwrap because signature and pk are serialized from valid struct.
         Signature::Secp256r1SuiSignature(Secp256r1SuiSignature::from_bytes(&bytes).unwrap())
     }
 }

--- a/crates/sui-types/src/passkey_authenticator.rs
+++ b/crates/sui-types/src/passkey_authenticator.rs
@@ -64,7 +64,7 @@ pub struct PasskeyAuthenticator {
     bytes: OnceCell<Vec<u8>>,
 }
 
-/// An raw passkey authenticator struct used during deserialization. Can be converted to [struct PasskeyAuthenticator].
+/// A raw passkey authenticator struct used during deserialization. Can be converted to [struct PasskeyAuthenticator].
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RawPasskeyAuthenticator {
     pub authenticator_data: Vec<u8>,
@@ -96,7 +96,7 @@ impl TryFrom<RawPasskeyAuthenticator> for PasskeyAuthenticator {
             })?
             .try_into()
             .map_err(|_| SuiError::InvalidSignature {
-                error: "Invalid encoded challenge".to_string(),
+                error: "Invalid size for challenge".to_string(),
             })?;
 
         if raw.user_signature.scheme() != SignatureScheme::Secp256r1 {
@@ -155,12 +155,13 @@ impl Serialize for PasskeyAuthenticator {
             authenticator_data: self.authenticator_data.clone(),
             client_data_json: self.client_data_json.clone(),
             user_signature: Signature::Secp256r1SuiSignature(
-                Secp256r1SuiSignature::from_bytes(&bytes).unwrap(),
+                Secp256r1SuiSignature::from_bytes(&bytes).unwrap(), // ok to unwrap since the bytes are constructed as valid above.
             ),
         };
         raw.serialize(serializer)
     }
 }
+
 impl PasskeyAuthenticator {
     /// A constructor for [struct PasskeyAuthenticator] with custom
     /// defined fields. Used for testing.
@@ -238,6 +239,13 @@ impl AuthenticatorTrait for PasskeyAuthenticator {
     where
         T: Serialize,
     {
+        // Check if author is derived from the public key.
+        if author != SuiAddress::from(&self.get_pk()?) {
+            return Err(SuiError::InvalidSignature {
+                error: "Invalid author".to_string(),
+            });
+        };
+
         // Check the intent and signing is consisted from what's parsed from client_data_json.challenge
         if self.challenge != to_signing_message(intent_msg) {
             return Err(SuiError::InvalidSignature {
@@ -249,13 +257,6 @@ impl AuthenticatorTrait for PasskeyAuthenticator {
         let mut message = self.authenticator_data.clone();
         let client_data_hash = Sha256::digest(self.client_data_json.as_bytes()).digest;
         message.extend_from_slice(&client_data_hash);
-
-        // Check if author is derived from the public key.
-        if author != SuiAddress::from(&self.get_pk()?) {
-            return Err(SuiError::InvalidSignature {
-                error: "Invalid author".to_string(),
-            });
-        };
 
         // Verify the signature against pk and message.
         self.pk

--- a/crates/sui-types/src/unit_tests/passkey_authenticator_test.rs
+++ b/crates/sui-types/src/unit_tests/passkey_authenticator_test.rs
@@ -15,6 +15,8 @@ use crate::{
     signature_verification::VerifiedDigestCache,
     transaction::{TransactionData, TEST_ONLY_GAS_UNIT_FOR_TRANSFER},
 };
+use fastcrypto::encoding::Base64;
+use fastcrypto::encoding::Encoding;
 use fastcrypto::hash::HashFunction;
 use fastcrypto::rsa::{Base64UrlUnpadded, Encoding as _};
 use fastcrypto::traits::ToFromBytes;
@@ -33,6 +35,7 @@ use passkey_types::{
     Bytes, Passkey,
 };
 use shared_crypto::intent::{Intent, IntentMessage};
+use std::str::FromStr;
 use url::Url;
 
 /// Helper struct to initialize passkey client.
@@ -296,8 +299,8 @@ async fn test_passkey_fails_invalid_json() {
         Base64UrlUnpadded::encode_string(&[0; CORRECT_LEN])
     );
     let raw_3 = RawPasskeyAuthenticator {
-        authenticator_data: response.authenticator_data,
-        client_data_json: client_data_json_correct,
+        authenticator_data: response.authenticator_data.clone(),
+        client_data_json: client_data_json_correct.clone(),
         user_signature: Signature::from_bytes(&response.user_sig_bytes).unwrap(),
     };
     let res_3: Result<PasskeyAuthenticator, SuiError> = raw_3.try_into();
@@ -346,56 +349,20 @@ async fn test_passkey_fails_wrong_client_data_type() {
     );
 }
 
-// #[tokio::test]
-// async fn test_passkey_fails_not_normalized_signature() {
-//     // crafts a particular not normalized signature, fails to verify. this is produced from typescript client https://github.com/joyqvq/sui-webauthn-poc/tree/joy/tx-example
-//     let tx_data: TransactionData = bcs::from_bytes(&Base64::decode("AAAAAHaTZLc0GGZ6RNYAqPC8LWZV7xHO+54zf71arV1MwFUtAcDum6pkbPZZN/iYq0zJpOxiV2wrZAnVU0bnNpOjombGAgAAAAAAAAAgAIiQFrz1abd2rNdo76dQS026yMAS1noA7FiGsggyt9V2k2S3NBhmekTWAKjwvC1mVe8RzvueM3+9Wq1dTMBVLegDAAAAAAAAgIQeAAAAAAAA").unwrap()).unwrap();
-//     let response = PasskeyResponse::<TransactionData> {
-//         user_sig_bytes: Hex::decode("02bbd02ace0bad3b32eb3a891dc5c85e56274f52695d24db41b247ec694d1531d6fe1a5bec11a8063d1eb0512e7971bfd23395c2cb8862f73049d0f78fd204c6d602276d5f3a22f3e698cdd2272a63da8bfdd9344de73312c7f7f9eca21bfc304f2e").unwrap(),
-//         authenticator_data: Hex::decode("49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97631d00000000").unwrap(),
-//         client_data_json: r#"{"type":"webauthn.get","challenge":"AAAAZgUD1inhS1l9qUfZePaivu6IbIo_SxCGmYcfTwrmcFU","origin":"http://localhost:5173","crossOrigin":false}"#.to_string(),
-//         intent_msg: IntentMessage::new(Intent::sui_transaction(), tx_data),
-//         sender: SuiAddress::from_str("0x769364b73418667a44d600a8f0bc2d6655ef11cefb9e337fbd5aad5d4cc0552d").unwrap()
-//     };
-//     let sig = GenericSignature::PasskeyAuthenticator(
-//         PasskeyAuthenticator::new_for_testing(
-//             response.authenticator_data,
-//             response.client_data_json,
-//             Signature::from_bytes(&response.user_sig_bytes).unwrap(),
-//         )
-//         .unwrap(),
-//     );
-
-//     let res = sig.verify_authenticator(
-//         &response.intent_msg,
-//         response.sender,
-//         0,
-//         &Default::default(),
-//         Arc::new(VerifiedDigestCache::new_empty()),
-//     );
-//     let err = res.unwrap_err();
-//     assert_eq!(
-//         err,
-//         SuiError::InvalidSignature {
-//             error: "Fails to verify".to_string()
-//         }
-//     );
-// }
-
-// #[tokio::test]
-// async fn test_real_passkey_output() {
-//     // response from a real passkey authenticator created in iCloud, from typescript client: https://github.com/joyqvq/sui-webauthn-poc/tree/joy/tx-example
-//     let address =
-//         SuiAddress::from_str("0xac8564f638fbf673fc92eb85b5abe5f7c29bdaa60a4a10329868fbe6c551dda2")
-//             .unwrap();
-//     let sig = GenericSignature::from_bytes(&Base64::decode("BiVJlg3liA6MaHQ0Fw9kdmBbj+SuuaKGMseZXPO6gx2XYx0AAAAAigF7InR5cGUiOiJ3ZWJhdXRobi5nZXQiLCJjaGFsbGVuZ2UiOiJBQUFBdF9taklCMXZiVnBZTTZXVjZZX29peDZKOGFOXzlzYjhTS0ZidWtCZmlRdyIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3Q6NTE3MyIsImNyb3NzT3JpZ2luIjpmYWxzZX1iApjskL9Xyfopyg9Av7MSrcchSpfWqAYoJ+qfSId4gNmoQ1YNgj2alDpRIbq9kthmyGY25+k24FrW114PEoy5C+8DPRcOCTtACi3ZywtZ4UILhwV+Suh79rWtbKqDqhBQwxM=").unwrap()).unwrap();
-//     let tx_data: TransactionData = bcs::from_bytes(&Base64::decode("AAAAAKyFZPY4+/Zz/JLrhbWr5ffCm9qmCkoQMpho++bFUd2iAUwOMmeNHuxq2hS4PvO1uivs9exQGefW2wNQAt7tRkkdAgAAAAAAAAAgCsJHAaWbb8oUlZsGdsyW3Atf3d51wBEr9HLkrBF0/UushWT2OPv2c/yS64W1q+X3wpvapgpKEDKYaPvmxVHdougDAAAAAAAAgIQeAAAAAAAA").unwrap()).unwrap();
-//     let res = sig.verify_authenticator(
-//         &IntentMessage::new(Intent::sui_transaction(), tx_data),
-//         address,
-//         0,
-//         &Default::default(),
-//         Arc::new(VerifiedDigestCache::new_empty()),
-//     );
-//     assert!(res.is_ok());
-// }
+#[tokio::test]
+async fn test_real_passkey_output() {
+    // response from a real passkey authenticator created in iCloud, from typescript client: https://passkey-example.vercel.app/ (repo: https://github.com/MystenLabs/passkey-example)
+    let address =
+        SuiAddress::from_str("0x9c0c00e929f08431583dad0e9409b5afb20cdbae0043fa5577f2577dbe88a0db")
+            .unwrap();
+    let sig = GenericSignature::from_bytes(&Base64::decode("BiUL6eJ3+l0jTWmL4buH5lE8Vxe1+ge6xSU0oczBPpmt+h0AAAAAkwF7InR5cGUiOiJ3ZWJhdXRobi5nZXQiLCJjaGFsbGVuZ2UiOiJ5TzEtb3VBczFBRUsyOWd0X1dJTGM4ZndDdlFjMkhEQmEwX2dTU3RpU1FzIiwib3JpZ2luIjoiaHR0cHM6Ly9wYXNza2V5LWV4YW1wbGUudmVyY2VsLmFwcCIsImNyb3NzT3JpZ2luIjpmYWxzZX1iAu0JsgVDVgBZQJhsl9MUZmUfUkNTh1qCg0zNWFrXfTx3NKuakm8Wqaa3qnfo+s9K2KvfYp8jT8BazhK7bi9YSmsCATpOyeWH387SdhY7+172wODmilJnXx5QcaUnR+3QlEM=").unwrap()).unwrap();
+    let tx_data: TransactionData = bcs::from_bytes(&Base64::decode("AAAAAJwMAOkp8IQxWD2tDpQJta+yDNuuAEP6VXfyV32+iKDbARrKzR59iiRcEIbBEBlB283cnWUBeUeKCiMa3UKM6NURNRHQFAAAAAAgVLos3IwH9g4OHDSWiKyUZCvixybPtnDQIeML1f+ErGOcDADpKfCEMVg9rQ6UCbWvsgzbrgBD+lV38ld9voig2+gDAAAAAAAAgIQeAAAAAAAA").unwrap()).unwrap();
+    let res = sig.verify_authenticator(
+        &IntentMessage::new(Intent::sui_transaction(), tx_data),
+        address,
+        0,
+        &Default::default(),
+        Arc::new(VerifiedDigestCache::new_empty()),
+    );
+    assert!(res.is_ok());
+}


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [x] Protocol: Enable passkey and passkey inside multisig for mainnet in protocol version 89. 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
