### PR TITLE
[trace-view] Fixed a problem related to using incorrect pkg IDs

### DIFF
--- a/crates/sui-replay-2/src/tracing.rs
+++ b/crates/sui-replay-2/src/tracing.rs
@@ -83,11 +83,14 @@ pub fn save_trace_output(
                     "Failed to create disassembler for module {:?} in package {}",
                     mod_name, &pkg_addr,
                 ))?;
-            let (disassemble_string, bcode_map) =
+            let (disassemble_string, mut bcode_map) =
                 d.disassemble_with_source_map().context(format!(
                     "Failed to disassemble module {:?} in package {}",
                     mod_name, &pkg_addr,
                 ))?;
+            // need version ID here (for potentially upgraded package) rather than original ID (for the original
+            // version of the package), otherwise we won't be able to distinguish map content based on their module IDs
+            bcode_map.module_name.0 = pkg.id().into();
             let bcode_map_json = serialize_to_json_string(&bcode_map).context(format!(
                 "Failed to serialize bytecode source map for module {:?} in package {}",
                 mod_name, &pkg_addr,


### PR DESCRIPTION
## Description 

This PR fixes a problem with replay and trace-debugging transactions that include calls into upgraded packages. The problem was related to modules being represented as belonging to the original package rather than the defining (upgraded) package. This was manifested in two places:
- `OpenFrame` event in the trace
- debug info

The result of the former was that a function that did not exist in the original package could not be found during trace debugging as the debugger, seeing module name and original package ID, would look for this function in debug info representing a module from the original package, where this function indeed does not exist.

The result of the latter was that debug info (key-ed in the debugger on the module name and package ID) for different versions of the module could not be distinguished in the debugger as all these debug info-s would contain original package ID

## Test plan 

Tested that upgraded packages are handled correctly, In particular, mainnet transaction with the following digest can now be trace-debugged correctly: `8jfAyyiQZG895NtjBjnb3eEjiwQtSwXi3FYHMGuJJZr6
