### PR TITLE
Remove aggressive debug_fatal()

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1188,7 +1188,7 @@ impl CheckpointBuilder {
                     if msg.contains("change epoch tx has already been executed via state sync") {
                         info!("change epoch tx has already been executed via state sync. Checkpoint builder will be shut down briefly");
                     } else {
-                        error!("Error while making checkpoint, will retry in 1s: {}", msg);
+                        debug_fatal!("Error while making checkpoint, will retry in 1s: {}", msg);
                     }
 
                     tokio::time::sleep(Duration::from_secs(1)).await;


### PR DESCRIPTION
The checkpoint builder error can trigger harmlessly during shutdown at the end of the epoch, so we are getting spurious test failures