### PR TITLE
[pkg-alt] simpler package / compilation interface

### DIFF
--- a/external-crates/move/crates/move-package-alt-compilation/src/build_plan.rs
+++ b/external-crates/move/crates/move-package-alt-compilation/src/build_plan.rs
@@ -68,15 +68,12 @@ impl<F: MoveFlavor> BuildPlan<F> {
         )
             -> anyhow::Result<(MappedFiles, Vec<AnnotatedCompiledUnit>)>,
     ) -> PackageResult<CompiledPackage> {
-        let project_root = self.root_pkg.package_path().clone();
-        let project_root = project_root.path();
         let program_info_hook = SaveHook::new([SaveFlag::TypingInfo]);
         let compiled = build_all::<W, F>(
             writer,
             self.compiler_vfs_root.clone(),
-            project_root,
             self.root_pkg,
-            &self.build_config.clone(),
+            &self.build_config,
             |compiler| {
                 let compiler = compiler.add_save_hook(&program_info_hook);
                 compiler_driver(compiler)

--- a/external-crates/move/crates/move-package-alt-compilation/src/build_plan.rs
+++ b/external-crates/move/crates/move-package-alt-compilation/src/build_plan.rs
@@ -15,38 +15,19 @@ use move_compiler::{
     compiled_unit::AnnotatedCompiledUnit,
     shared::{SaveFlag, SaveHook, files::MappedFiles},
 };
-use move_package_alt::{
-    errors::PackageResult,
-    flavor::MoveFlavor,
-    graph::PackageGraph,
-    package::RootPackage,
-    schema::{Environment, PackageName},
-};
+use move_package_alt::{errors::PackageResult, flavor::MoveFlavor, package::RootPackage};
 
 #[derive(Debug)]
 pub struct BuildPlan<F: MoveFlavor> {
     root_pkg: RootPackage<F>,
-    _env: Environment,
-    _sorted_deps: Vec<PackageName>,
-    _package_graph: PackageGraph<F>,
     compiler_vfs_root: Option<VfsPath>,
     build_config: BuildConfig,
 }
 
 impl<F: MoveFlavor> BuildPlan<F> {
-    pub fn create(
-        root_pkg: RootPackage<F>,
-        build_config: &BuildConfig,
-        env: &Environment,
-    ) -> PackageResult<Self> {
-        let _package_graph = root_pkg.package_graph().clone();
-        let _sorted_deps = root_pkg.package_graph().sorted_deps();
-
+    pub fn create(root_pkg: RootPackage<F>, build_config: &BuildConfig) -> PackageResult<Self> {
         Ok(Self {
             root_pkg,
-            _env: env.clone(),
-            _sorted_deps,
-            _package_graph,
             build_config: build_config.clone(),
             compiler_vfs_root: None,
         })
@@ -89,14 +70,12 @@ impl<F: MoveFlavor> BuildPlan<F> {
     ) -> PackageResult<CompiledPackage> {
         let project_root = self.root_pkg.package_path().clone();
         let project_root = project_root.path();
-        let package_name = self.root_pkg.name().clone();
         let program_info_hook = SaveHook::new([SaveFlag::TypingInfo]);
         let compiled = build_all::<W, F>(
             writer,
             self.compiler_vfs_root.clone(),
             project_root,
             self.root_pkg,
-            package_name,
             &self.build_config.clone(),
             |compiler| {
                 let compiler = compiler.add_save_hook(&program_info_hook);

--- a/external-crates/move/crates/move-package-alt-compilation/src/compiled_package.rs
+++ b/external-crates/move/crates/move-package-alt-compilation/src/compiled_package.rs
@@ -5,7 +5,6 @@
 use move_package_alt::{
     flavor::MoveFlavor,
     package::{RootPackage, paths::PackagePath},
-    schema::PackageName,
 };
 
 use colored::Colorize;
@@ -18,8 +17,6 @@ use crate::layout::CompiledPackageLayout;
 
 use move_package_alt::schema::PublishedID;
 
-use move_core_types::account_address::AccountAddress;
-
 use anyhow::{Result, anyhow};
 use move_binary_format::CompiledModule;
 use move_bytecode_utils::Modules;
@@ -28,7 +25,7 @@ use move_compiler::{
     Compiler, Flags,
     compiled_unit::{AnnotatedCompiledUnit, CompiledUnit},
     diagnostics::{Diagnostics, report_warnings, warning_filters::WarningFiltersBuilder},
-    editions::Flavor,
+    editions::{Edition, Flavor},
     linters::{self, LINT_WARNING_PREFIX},
     shared::{
         PackageConfig, PackagePaths, SaveFlag, SaveHook,
@@ -45,8 +42,8 @@ use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
     io::Write,
     path::{Path, PathBuf},
+    str::FromStr,
 };
-use tracing::debug;
 use vfs::VfsPath;
 
 /// References file for documentation generation
@@ -441,11 +438,11 @@ pub fn build_all<W: Write, F: MoveFlavor>(
     vfs_root: Option<VfsPath>,
     project_root: &Path,
     root_pkg: RootPackage<F>,
-    package_name: PackageName,
     build_config: &BuildConfig,
     compiler_driver: impl FnOnce(Compiler) -> Result<(MappedFiles, Vec<AnnotatedCompiledUnit>)>,
 ) -> Result<CompiledPackage> {
     let program_info_hook = SaveHook::new([SaveFlag::TypingInfo]);
+    let package_name = Symbol::from(root_pkg.name().as_str());
     let (file_map, all_compiled_units) =
         build_for_driver(w, vfs_root, build_config, root_pkg, |compiler| {
             let compiler = compiler.add_save_hook(&program_info_hook);
@@ -550,6 +547,7 @@ pub fn build_all<W: Write, F: MoveFlavor>(
     Ok(compiled_package)
 }
 
+#[allow(unreachable_code)] // TODO
 pub(crate) fn build_for_driver<W: Write, T, F: MoveFlavor>(
     w: &mut W,
     vfs_root: Option<VfsPath>,
@@ -557,90 +555,44 @@ pub(crate) fn build_for_driver<W: Write, T, F: MoveFlavor>(
     root_pkg: RootPackage<F>,
     compiler_driver: impl FnOnce(Compiler) -> Result<T>,
 ) -> Result<T> {
-    let deps = root_pkg.dependencies();
+    let packages = root_pkg.packages();
 
-    // TODO: this should go away up to see below
-    let names = BTreeMap::from([
-        ("Sui", "sui"),
-        ("SuiSystem", "sui_system"),
-        ("MoveStdlib", "std"),
-    ]);
+    let mut package_paths: Vec<PackagePaths> = vec![];
 
-    let mut named_address_map: BTreeMap<Symbol, NumericalAddress> = BTreeMap::new();
+    for pkg in packages {
+        let name: Symbol = pkg.name().as_str().into();
 
-    for node in &deps {
-        println!("Node {:?}", node);
-        let addr = &node
-            .published_at()
-            .ok_or_else(|| anyhow!("Expected package to have a published addr"))?;
-        // published_ids.push(addr.clone());
-        let addr = NumericalAddress::new(
-            addr.0.into_bytes(),
-            move_compiler::shared::NumberFormat::Hex,
-        );
-        let pkg_name: Symbol = if names.contains_key(&node.name().as_str()) {
-            // return one of the standard aliases
-            (*names.get(node.name().as_str()).unwrap()).into()
-        } else {
-            node.name().as_str().into()
+        if !pkg.is_root() {
+            writeln!(w, "{} {name}", "INCLUDING DEPENDENCY".bold().green())?;
+        }
+
+        let mut addresses: BTreeMap<Symbol, NumericalAddress> = BTreeMap::new();
+        for (name, dep) in pkg.named_addresses() {
+            let name = name.as_str().into();
+            let addr = dep
+                .published()
+                .ok_or_else(|| anyhow!("Expected package {name} to be published"))?
+                .original_id
+                .0;
+            let addr: NumericalAddress =
+                NumericalAddress::new(addr.into_bytes(), move_compiler::shared::NumberFormat::Hex);
+            addresses.insert(name, addr);
+        }
+
+        let config = PackageConfig {
+            is_dependency: !pkg.is_root(),
+            edition: Edition::from_str(pkg.edition())?,
+            flavor: Flavor::from_str(pkg.flavor())?,
+            warning_filter: WarningFiltersBuilder::new_for_source(),
         };
 
-        named_address_map.insert(pkg_name, addr);
-    }
-
-    named_address_map.insert(
-        root_pkg.name().as_str().into(),
-        NumericalAddress::new(
-            AccountAddress::from_hex_literal("0x0")
-                .unwrap()
-                .into_bytes(),
-            move_compiler::shared::NumberFormat::Hex,
-        ),
-    );
-
-    // up to here
-
-    let mut dependencies_paths = vec![];
-
-    // Find the source paths for each dependency and build the PackagePaths
-    for node in &deps {
-        writeln!(
-            w,
-            "{} {}",
-            "INCLUDING DEPENDENCY".bold().green(),
-            node.name()
-        )?;
-        let sources = get_sources(node.path())?;
-        let is_dependency = node.name() != root_pkg.name();
-
-        debug!("Node: {:?}, is dependency: {is_dependency}", node.name());
-
-        // TODO: probably here we need to use a different type than Symbol
-        let source_package_paths: PackagePaths<Symbol, Symbol> = PackagePaths {
-            name: Some((
-                node.name().as_str().into(),
-                PackageConfig {
-                    is_dependency,
-                    warning_filter: WarningFiltersBuilder::new_for_source(),
-                    // TODO: we need to use this probably in the manifest for deserialization
-                    flavor: move_compiler::editions::Flavor::Sui,
-                    // TODO: we should add this to the type in the manifest.
-                    edition: move_compiler::editions::Edition {
-                        // TODO: we need edition in root pkg
-                        edition: Symbol::from(""), // root_pkg.edition().into(),
-                        // TODO: should we have this as a field?
-                        release: None,
-                    },
-                },
-            )),
-            // TODO: fixed named_address map for each package. It should contain the package
-            // and its direct deps
-            // named_address_map: BTreeMap::new(),
-            named_address_map: named_address_map.clone(),
-            paths: sources,
+        let paths = PackagePaths {
+            name: Some((name, config)),
+            paths: get_sources(pkg.path())?,
+            named_address_map: addresses,
         };
 
-        dependencies_paths.push(source_package_paths);
+        package_paths.push(paths);
     }
 
     writeln!(w, "{} {}", "BUILDING".bold().green(), root_pkg.name())?;
@@ -649,7 +601,7 @@ pub(crate) fn build_for_driver<W: Write, T, F: MoveFlavor>(
     let sui_mode = build_config.default_flavor == Some(Flavor::Sui);
     let flags = compiler_flags(build_config);
 
-    let mut compiler = Compiler::from_package_paths(vfs_root, dependencies_paths, vec![])
+    let mut compiler = Compiler::from_package_paths(vfs_root, package_paths, vec![])
         .unwrap()
         .set_flags(flags);
     if sui_mode {

--- a/external-crates/move/crates/move-package-alt-compilation/src/lib.rs
+++ b/external-crates/move/crates/move-package-alt-compilation/src/lib.rs
@@ -22,14 +22,13 @@ pub async fn compile_package<W: Write, F: MoveFlavor>(
     writer: &mut W,
 ) -> PackageResult<CompiledPackage> {
     let root_pkg = RootPackage::<F>::load(path, env.clone()).await?;
-    BuildPlan::create(root_pkg, build_config, env)?.compile(writer, |compiler| compiler)
+    BuildPlan::create(root_pkg, build_config)?.compile(writer, |compiler| compiler)
 }
 
 pub async fn compile_from_root_package<W: Write, F: MoveFlavor>(
     root_pkg: RootPackage<F>,
     build_config: &BuildConfig,
-    env: &Environment,
     writer: &mut W,
 ) -> PackageResult<CompiledPackage> {
-    BuildPlan::create(root_pkg, build_config, env)?.compile(writer, |compiler| compiler)
+    BuildPlan::create(root_pkg, build_config)?.compile(writer, |compiler| compiler)
 }

--- a/external-crates/move/crates/move-package-alt/src/cli/build.rs
+++ b/external-crates/move/crates/move-package-alt/src/cli/build.rs
@@ -26,8 +26,6 @@ pub struct Build {
 
 impl Build {
     pub async fn execute(&self) -> PackageResult<()> {
-        // TODO: consider moving this to move-compilation crate (but I think it's better just to
-        // print out what would happen)
         let path = self.path.clone().unwrap_or_else(|| PathBuf::from("."));
 
         let envs = RootPackage::<Vanilla>::environments(&path)?;
@@ -43,9 +41,19 @@ impl Build {
 
         let root_pkg = RootPackage::<Vanilla>::load(&path, environment).await?;
 
-        // TODO: continue
-
-        // TODO: Implement the actual build logic here.
+        for pkg in root_pkg.packages() {
+            println!("Package {}", pkg.name());
+            if pkg.is_root() {
+                println!("  (root package)");
+            }
+            println!("  path: {:?}", pkg.path());
+            println!("  named addresses:");
+            for (name, dep) in pkg.named_addresses() {
+                let addr = dep.published().map(|addrs| &addrs.original_id);
+                println!("    {name}: {addr:?}");
+            }
+            println!();
+        }
 
         root_pkg.save_to_disk();
         Ok(())

--- a/external-crates/move/crates/move-package-alt/src/graph/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/mod.rs
@@ -57,13 +57,13 @@ impl<'graph, F: MoveFlavor> PackageInfo<'graph, F> {
 
     /// The compiler edition for the package
     pub fn edition(&self) -> Option<&str> {
-        // TODO
+        // TODO: pull this from manifest
         Some("2024")
     }
 
     /// The flavor for the package
     pub fn flavor(&self) -> Option<&str> {
-        // TODO
+        // TODO: pull this from manifest
         Some("sui")
     }
 

--- a/external-crates/move/crates/move-package-alt/src/graph/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/mod.rs
@@ -10,25 +10,24 @@ mod to_lockfile;
 pub use linkage::LinkageError;
 pub use rename_from::RenameError;
 
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 use crate::{
     dependency::PinnedDependencyInfo,
     errors::PackageResult,
     flavor::MoveFlavor,
     package::{EnvironmentName, Package, paths::PackagePath},
-    schema::{Environment, PackageName},
+    schema::{Environment, PackageName, PublishAddresses},
 };
 use builder::PackageGraphBuilder;
 
 use derive_where::derive_where;
 use petgraph::{
-    algo::toposort,
     graph::{DiGraph, EdgeIndex, NodeIndex},
+    visit::EdgeRef,
 };
 
 #[derive(Debug)]
-#[derive_where(Clone)]
 pub struct PackageGraph<F: MoveFlavor> {
     root_idx: NodeIndex,
     inner: DiGraph<PackageNode<F>, PackageName>,
@@ -40,6 +39,76 @@ pub struct PackageGraph<F: MoveFlavor> {
 struct PackageNode<F: MoveFlavor> {
     package: Arc<Package<F>>,
     use_env: EnvironmentName,
+}
+
+/// A narrow interface for representing packages outside of `move-package-alt`
+#[derive(Copy)]
+#[derive_where(Clone)]
+pub struct PackageInfo<'a, F: MoveFlavor> {
+    graph: &'a PackageGraph<F>,
+    node: NodeIndex,
+}
+
+impl<'graph, F: MoveFlavor> PackageInfo<'graph, F> {
+    /// The name that the package has declared for itself
+    pub fn name(&self) -> &PackageName {
+        self.package().name()
+    }
+
+    /// The compiler edition for the package
+    pub fn edition(&self) -> Option<&str> {
+        // TODO
+        Some("2024")
+    }
+
+    /// The flavor for the package
+    pub fn flavor(&self) -> Option<&str> {
+        // TODO
+        Some("sui")
+    }
+
+    /// The path to the package's files on disk
+    pub fn path(&self) -> &PackagePath {
+        self.package().path()
+    }
+
+    /// Returns the published address of this package, if it is published
+    pub fn published(&self) -> Option<&PublishAddresses> {
+        self.package().publication()
+    }
+
+    /// Returns true if the node is the root of the package graph
+    pub fn is_root(&self) -> bool {
+        self.package().is_root()
+    }
+
+    /// The addresses for the names that are available to this package. For modern packages, this
+    /// contains only the package and its dependencies, but legacy packages may define additional
+    /// addresses as well
+    pub fn named_addresses(&self) -> BTreeMap<PackageName, PackageInfo<'graph, F>> {
+        let mut result: BTreeMap<PackageName, PackageInfo<F>> = self
+            .graph
+            .inner
+            .edges(self.node)
+            .map(|edge| {
+                (
+                    edge.weight().clone(),
+                    Self {
+                        graph: self.graph,
+                        node: edge.target(),
+                    },
+                )
+            })
+            .collect();
+        result.insert(self.package().name().clone(), self.clone());
+
+        result
+    }
+
+    /// The package corresponding to this node
+    fn package(&self) -> &Package<F> {
+        &self.graph.inner[self.node].package
+    }
 }
 
 impl<F: MoveFlavor> PackageGraph<F> {
@@ -85,7 +154,7 @@ impl<F: MoveFlavor> PackageGraph<F> {
     }
 
     /// Return the dependency corresponding to `edge`
-    pub fn dep_for_edge(&self, edge: EdgeIndex) -> &PinnedDependencyInfo {
+    fn dep_for_edge(&self, edge: EdgeIndex) -> &PinnedDependencyInfo {
         let (source_index, _) = self
             .inner
             .edge_endpoints(edge)
@@ -98,32 +167,11 @@ impl<F: MoveFlavor> PackageGraph<F> {
             .expect("edges in graph come from dependencies, so the dependency must exist")
     }
 
-    /// Return a list of package names that are topologically sorted
-    pub fn sorted_deps(&self) -> Vec<PackageName> {
-        let sorted = toposort(&self.inner, None).expect("non cyclic directed graph");
-
-        sorted
-            .into_iter()
-            .flat_map(|idx| {
-                self.inner
-                    .node_weight(idx)
-                    .map(|f| f.package.name().clone())
-            })
-            .collect()
-    }
-
     /// Return the list of dependencies in this package graph
-    pub(crate) fn dependencies(&self) -> Vec<Arc<Package<F>>> {
-        let mut output = vec![];
-
-        for (idx, n) in self.inner.node_weights().enumerate() {
-            if NodeIndex::new(idx) == self.root_idx {
-                continue;
-            }
-
-            output.push(n.package.clone())
-        }
-
-        output
+    pub(crate) fn dependencies(&self) -> Vec<PackageInfo<F>> {
+        self.inner
+            .node_indices()
+            .map(|node| PackageInfo { graph: self, node })
+            .collect()
     }
 }

--- a/external-crates/move/crates/move-package-alt/src/graph/rename_from.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/rename_from.rs
@@ -65,6 +65,9 @@ impl RenameError {
         // in example: dep_location is `local = "b_path"`
         let dep_location = "<TODO>";
 
+        // in example: dep_path is `~/.move/...`
+        let dep_path = target.path().path();
+
         // in example: rendered_dep is `dep = { local = "b_path", rename-from = "b_name" }`
         // TODO: use spans / diagnostics here instead; without that, `mvr` diagnostics will show
         //       the resolved dep rather than the original dep
@@ -76,7 +79,7 @@ impl RenameError {
 
         Self::RenameFromError(formatdoc!(
             "Package `{source_name}` (included from {path}) has a dependency `{rendered_dep}`, but the package at \
-            `{dep_location}` has `name = \"{target_name}\"`. If you intend to rename `{target_name}` to `{dep_name}` in `{source_name}`, add \
+            `{dep_path:?}` has `name = \"{target_name}\"`. If you intend to rename `{target_name}` to `{dep_name}` in `{source_name}`, add \
             `rename-from = \"{target_name}\"` to the dependency in the `Move.toml` for `a`:
 
                 {dep_name} = {{ {dep_location}, rename-from = \"{target_name}\", ... }}\n"

--- a/external-crates/move/crates/move-package-alt/src/graph/rename_from.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/rename_from.rs
@@ -65,9 +65,6 @@ impl RenameError {
         // in example: dep_location is `local = "b_path"`
         let dep_location = "<TODO>";
 
-        // in example: dep_path is `~/.move/...`
-        let dep_path = target.path().path();
-
         // in example: rendered_dep is `dep = { local = "b_path", rename-from = "b_name" }`
         // TODO: use spans / diagnostics here instead; without that, `mvr` diagnostics will show
         //       the resolved dep rather than the original dep
@@ -79,7 +76,7 @@ impl RenameError {
 
         Self::RenameFromError(formatdoc!(
             "Package `{source_name}` (included from {path}) has a dependency `{rendered_dep}`, but the package at \
-            `{dep_path:?}` has `name = \"{target_name}\"`. If you intend to rename `{target_name}` to `{dep_name}` in `{source_name}`, add \
+            `{dep_location}` has `name = \"{target_name}\"`. If you intend to rename `{target_name}` to `{dep_name}` in `{source_name}`, add \
             `rename-from = \"{target_name}\"` to the dependency in the `Move.toml` for `a`:
 
                 {dep_name} = {{ {dep_location}, rename-from = \"{target_name}\", ... }}\n"

--- a/external-crates/move/crates/move-package-alt/src/main.rs
+++ b/external-crates/move/crates/move-package-alt/src/main.rs
@@ -45,5 +45,9 @@ impl Cli {
 #[tokio::main]
 async fn main() -> PackageResult<()> {
     let cli = Cli::parse();
-    cli.execute().await
+    let result = cli.execute().await;
+    if let Err(ref e) = result {
+        e.emit();
+    }
+    result
 }

--- a/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
@@ -215,7 +215,7 @@ impl<F: MoveFlavor> Package<F> {
         &self.deps
     }
 
-    fn publication(&self) -> Option<&PublishAddresses> {
+    pub fn publication(&self) -> Option<&PublishAddresses> {
         self.publish_data.as_ref().map(|data| &data.addresses)
     }
 

--- a/external-crates/move/crates/move-package-alt/src/package/root_package.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/root_package.rs
@@ -144,6 +144,11 @@ impl<F: MoveFlavor + fmt::Debug> RootPackage<F> {
         self.graph.root_package().name()
     }
 
+    /// The path to the root of the package
+    pub fn path(&self) -> &PackagePath {
+        &self.package_path
+    }
+
     /// Return the list of all packages in the root package's package graph (including itself and all
     /// transitive dependencies).
     pub fn packages(&self) -> Vec<PackageInfo<F>> {

--- a/external-crates/move/crates/move-package-alt/src/package/root_package.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/root_package.rs
@@ -2,15 +2,14 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
 use std::{collections::BTreeMap, fmt, path::Path};
 
 use tracing::debug;
 
 use super::paths::PackagePath;
 use super::{EnvironmentID, manifest::Manifest};
-use crate::package::Package;
-use crate::schema::{Environment, PackageName, Publication};
+use crate::graph::PackageInfo;
+use crate::schema::{Environment, OriginalID, PackageName, Publication};
 use crate::{
     errors::{FileHandle, PackageError, PackageResult},
     flavor::MoveFlavor,
@@ -140,8 +139,22 @@ impl<F: MoveFlavor + fmt::Debug> RootPackage<F> {
             .insert(self.environment.name().clone(), BTreeMap::from(&self.graph));
     }
 
+    /// The name of the root package
     pub fn name(&self) -> &PackageName {
         self.graph.root_package().name()
+    }
+
+    /// Return the list of all packages in the root package's package graph (including itself and all
+    /// transitive dependencies).
+    pub fn packages(&self) -> Vec<PackageInfo<F>> {
+        self.graph.dependencies()
+    }
+
+    /// Return the linkage table for the root package. This contains an entry for each package that
+    /// this package depends on (transitively). Returns an error if any of the packages that this
+    /// package depends on is unpublished.
+    pub fn linkage(&self) -> PackageResult<BTreeMap<OriginalID, PackageInfo<F>>> {
+        todo!()
     }
 
     /// Output an updated lockfile containg the dependency graph represented by `self`. Note that
@@ -149,7 +162,7 @@ impl<F: MoveFlavor + fmt::Debug> RootPackage<F> {
     /// changed (since no repinning was performed).
     pub fn save_to_disk(&self) -> PackageResult<()> {
         std::fs::write(
-            self.package_path().lockfile_path(),
+            self.graph.root_package().path().lockfile_path(),
             self.lockfile.render_as_toml(),
         )?;
         Ok(())
@@ -180,30 +193,8 @@ impl<F: MoveFlavor + fmt::Debug> RootPackage<F> {
         Ok(toml_edit::de::from_str(file.source())?)
     }
 
-    /// Return the package graph for `env`
-    // TODO: what's the right API here?
-    pub fn package_graph(&self) -> &PackageGraph<F> {
-        &self.graph
-    }
-
     pub fn lockfile_for_testing(&self) -> &ParsedLockfile<F> {
         &self.lockfile
-    }
-    // *** PATHS RELATED FUNCTIONS ***
-
-    /// Return the package path wrapper
-    pub fn package_path(&self) -> &PackagePath {
-        &self.package_path
-    }
-
-    /// Return a list of sorted package names
-    pub fn sorted_deps(&self) -> Vec<PackageName> {
-        self.package_graph().sorted_deps()
-    }
-
-    /// Return the list of this root package's dependencies
-    pub fn dependencies(&self) -> Vec<Arc<Package<F>>> {
-        self.package_graph().dependencies()
     }
 }
 


### PR DESCRIPTION
## Description 

This adds a `PackageInfo` type which is a thin wrapper around a node in the package graph; this allows the compilation crate to not make use of the `Package` and `PackageGraph` internal types.

## Test plan 

It is currently untested

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
