### PR TITLE
Refactor checkpoint builder to handle change-epoch-tx-already-executed edge case more gracefully

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -5310,7 +5310,7 @@ impl AuthorityState {
         // This may be less than `checkpoint - 1` if the end-of-epoch PendingCheckpoint produced
         // >1 checkpoint.
         last_checkpoint: CheckpointSequenceNumber,
-    ) -> anyhow::Result<(SuiSystemState, TransactionEffects)> {
+    ) -> anyhow::Result<Option<(SuiSystemState, TransactionEffects)>> {
         let mut txns = Vec::new();
 
         if let Some(tx) = self.create_authenticator_state_tx(epoch_store) {
@@ -5451,9 +5451,7 @@ impl AuthorityState {
             .is_tx_already_executed(tx_digest)
         {
             warn!("change epoch tx has already been executed via state sync");
-            return Err(anyhow::anyhow!(
-                "change epoch tx has already been executed via state sync"
-            ));
+            return Ok(None);
         }
 
         let execution_guard = self.execution_lock_for_executable_transaction(&executable_tx)?;
@@ -5499,7 +5497,7 @@ impl AuthorityState {
         epoch_store.record_checkpoint_builder_is_safe_mode_metric(system_obj.safe_mode());
         // The change epoch transaction cannot fail to execute.
         assert!(effects.status().is_ok());
-        Ok((system_obj, effects))
+        Ok(Some((system_obj, effects)))
     }
 
     /// This function is called at the very end of the epoch.

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -1009,6 +1009,21 @@ impl CheckpointStateHasher {
     }
 }
 
+enum CheckpointBuilderError {
+    StopCheckpointBuilder,
+    Retry(anyhow::Error),
+}
+
+impl<SuiError: std::error::Error + Send + Sync + 'static> From<SuiError>
+    for CheckpointBuilderError
+{
+    fn from(e: SuiError) -> Self {
+        Self::Retry(e.into())
+    }
+}
+
+type CheckpointBuilderResult<T = ()> = Result<T, CheckpointBuilderError>;
+
 pub struct CheckpointBuilder {
     state: Arc<AuthorityState>,
     store: Arc<CheckpointStore>,
@@ -1097,13 +1112,26 @@ impl CheckpointBuilder {
         }
         info!("Starting CheckpointBuilder");
         loop {
-            self.maybe_build_checkpoints().await;
+            match self.maybe_build_checkpoints().await {
+                Ok(()) => {}
+                Err(CheckpointBuilderError::StopCheckpointBuilder) => {
+                    info!("CheckpointBuilder stopping");
+                    return;
+                }
+                Err(CheckpointBuilderError::Retry(inner)) => {
+                    let msg = format!("{:?}", inner);
+                    debug_fatal!("Error while making checkpoint, will retry in 1s: {}", msg);
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    self.metrics.checkpoint_errors.inc();
+                    continue;
+                }
+            }
 
             self.notify.notified().await;
         }
     }
 
-    async fn maybe_build_checkpoints(&mut self) {
+    async fn maybe_build_checkpoints(&mut self) -> CheckpointBuilderResult {
         let _scope = monitored_scope("BuildCheckpoints");
 
         // Collect info about the most recently built checkpoint.
@@ -1166,36 +1194,20 @@ impl CheckpointBuilder {
                 "Making checkpoint with commit height range"
             );
 
-            match self
+            let seq = self
                 .make_checkpoint(std::mem::take(&mut grouped_pending_checkpoints))
-                .await
-            {
-                Ok(seq) => {
-                    self.last_built.send_if_modified(|cur| {
-                        // when rebuilding checkpoints at startup, seq can be for an old checkpoint
-                        if seq > *cur {
-                            *cur = seq;
-                            true
-                        } else {
-                            false
-                        }
-                    });
-                }
-                Err(e) => {
-                    let msg = format!("{:?}", e);
-                    // This particular error is expected to happen from time to time. Any other error during checkpoint
-                    // building is most likely a bug.
-                    if msg.contains("change epoch tx has already been executed via state sync") {
-                        info!("change epoch tx has already been executed via state sync. Checkpoint builder will be shut down briefly");
-                    } else {
-                        debug_fatal!("Error while making checkpoint, will retry in 1s: {}", msg);
-                    }
+                .await?;
 
-                    tokio::time::sleep(Duration::from_secs(1)).await;
-                    self.metrics.checkpoint_errors.inc();
-                    return;
+            self.last_built.send_if_modified(|cur| {
+                // when rebuilding checkpoints at startup, seq can be for an old checkpoint
+                if seq > *cur {
+                    *cur = seq;
+                    true
+                } else {
+                    false
                 }
-            }
+            });
+
             // ensure that the task can be cancelled at end of epoch, even if no other await yields
             // execution.
             tokio::task::yield_now().await;
@@ -1204,13 +1216,15 @@ impl CheckpointBuilder {
             "Waiting for more checkpoints from consensus after processing {last_height:?}; {} pending checkpoints left unprocessed until next interval",
             grouped_pending_checkpoints.len(),
         );
+
+        Ok(())
     }
 
     #[instrument(level = "debug", skip_all, fields(last_height = pendings.last().unwrap().details().checkpoint_height))]
     async fn make_checkpoint(
         &self,
         pendings: Vec<PendingCheckpointV2>,
-    ) -> anyhow::Result<CheckpointSequenceNumber> {
+    ) -> CheckpointBuilderResult<CheckpointSequenceNumber> {
         let _scope = monitored_scope("CheckpointBuilder::make_checkpoint");
         let last_details = pendings.last().unwrap().details().clone();
 
@@ -1578,7 +1592,7 @@ impl CheckpointBuilder {
         &self,
         effects_and_transaction_sizes: Vec<(TransactionEffects, usize)>,
         signatures: Vec<Vec<GenericSignature>>,
-    ) -> anyhow::Result<Vec<Vec<(TransactionEffects, Vec<GenericSignature>)>>> {
+    ) -> CheckpointBuilderResult<Vec<Vec<(TransactionEffects, Vec<GenericSignature>)>>> {
         let _guard = monitored_scope("CheckpointBuilder::split_checkpoint_chunks");
         let mut chunks = Vec::new();
         let mut chunk = Vec::new();
@@ -1653,7 +1667,7 @@ impl CheckpointBuilder {
         all_effects: Vec<TransactionEffects>,
         details: &PendingCheckpointInfo,
         all_roots: &HashSet<TransactionDigest>,
-    ) -> anyhow::Result<NonEmpty<(CheckpointSummary, CheckpointContents)>> {
+    ) -> CheckpointBuilderResult<NonEmpty<(CheckpointSummary, CheckpointContents)>> {
         let _scope = monitored_scope("CheckpointBuilder::create_checkpoints");
 
         let total = all_effects.len();
@@ -1978,9 +1992,8 @@ impl CheckpointBuilder {
         // This may be less than `checkpoint - 1` if the end-of-epoch PendingCheckpoint produced
         // >1 checkpoint.
         last_checkpoint: CheckpointSequenceNumber,
-        // TODO: Check whether we must use anyhow::Result or can we use SuiResult.
-    ) -> anyhow::Result<SuiSystemState> {
-        let (system_state, effects) = self
+    ) -> CheckpointBuilderResult<SuiSystemState> {
+        match self
             .state
             .create_and_execute_advance_epoch_tx(
                 &self.epoch_store,
@@ -1990,10 +2003,19 @@ impl CheckpointBuilder {
                 end_of_epoch_observation_keys,
                 last_checkpoint,
             )
-            .await?;
-        checkpoint_effects.push(effects);
-        signatures.push(vec![]);
-        Ok(system_state)
+            .await
+        {
+            Ok(Some((system_state, effects))) => {
+                checkpoint_effects.push(effects);
+                signatures.push(vec![]);
+                Ok(system_state)
+            }
+            Ok(None) => {
+                info!("change epoch tx has already been executed via state sync. Checkpoint builder will be shut down briefly");
+                Err(CheckpointBuilderError::StopCheckpointBuilder)
+            }
+            Err(e) => Err(CheckpointBuilderError::Retry(e)),
+        }
     }
 
     /// For the given roots return complete list of effects to include in checkpoint

--- a/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
+++ b/crates/sui-e2e-tests/tests/reconfiguration_tests.rs
@@ -422,6 +422,9 @@ async fn test_create_advance_epoch_tx_race() {
     // proceeded with reconfiguration.
     sleep(Duration::from_secs(1)).await;
     reconfig_delay_tx.send(()).unwrap();
+
+    // wait for reconfiguration to complete
+    test_cluster.wait_for_epoch(None).await;
 }
 
 #[sim_test]


### PR DESCRIPTION
This should reduce the number of bogus `debug_fatal` test failures we get when hitting this edge case
