### PR TITLE
[pkg-alt] fix modern name discovery bug

### DIFF
--- a/external-crates/move/crates/move-package-alt/src/compatibility/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/compatibility/mod.rs
@@ -95,16 +95,69 @@ fn find_files(files: &mut Vec<PathBuf>, dir: &Path, extension: &str, max_depth: 
 
 // Consider supporting the legacy `address { module {} }` format.
 fn parse_module_names(contents: &str) -> Result<HashSet<String>> {
+    let clean = strip_doc_comments(contents);
     let mut set = HashSet::new();
     // This matches `module a::b {}`, and `module a::b;` cases.
     // In both cases, the match is the 2nd group (so `match.get(1)`)
     let regex = Regex::new(MODULE_REGEX).unwrap();
 
-    for cap in regex.captures_iter(contents) {
+    for cap in regex.captures_iter(&clean) {
         set.insert(cap[1].to_string());
     }
 
     Ok(set)
+}
+
+/// A naive implememntation to strip doc comments out of a file, to avoid
+/// detecting invalid module names.
+fn strip_doc_comments(source: &str) -> String {
+    let mut result = String::new();
+    let mut in_block_doc = false;
+
+    for line in source.lines() {
+        let mut line_cleaned = line.to_string();
+        let trimmed = line.trim_start();
+
+        // Regular comments case -- whole line is a comment.
+        if trimmed.starts_with("///") || trimmed.starts_with("//!") {
+            continue;
+        }
+
+        if in_block_doc {
+            if let Some(end) = line_cleaned.find("*/") {
+                line_cleaned.replace_range(..=end + 1, ""); // remove up to and including */
+                in_block_doc = false;
+            } else {
+                continue; // inside block doc, skip entire line
+            }
+        }
+
+        // Remove any inline doc block comments (multiple if present)
+        loop {
+            if let Some(start) = line_cleaned.find("/*").or_else(|| line_cleaned.find("/*!")) {
+                if let Some(end) = line_cleaned[start..].find("*/") {
+                    line_cleaned.replace_range(start..start + end + 2, "");
+                } else {
+                    // Start of multiline doc block; remove to end of line and set flag
+                    line_cleaned.replace_range(start.., "");
+                    in_block_doc = true;
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+
+        // Only add non-empty lines
+        if line_cleaned.trim().is_empty() {
+            continue;
+        }
+
+        result.push_str(&line_cleaned);
+        result.push('\n');
+    }
+
+    result
 }
 
 #[cfg(test)]
@@ -144,6 +197,57 @@ mod tests {
                 r" module b {}
             ",
                 set(vec![]),
+            ),
+            (
+                r"
+                /// module yy::ff {
+                ///     module a::b {}
+                /// }
+                module works::perfectly {}
+            ",
+                set(vec!["works"]),
+            ),
+            (
+                r"
+                /* module yy::ff {
+                    module a::b {}
+                }
+                */
+                /// module aa::bb {
+                /// 
+                /// }
+                module works::perfectly {}
+            ",
+                set(vec!["works"]),
+            ),
+            (
+                r"
+                /* module aa::bb {} */
+                /* module ee::dd {} */
+                module a::b {}
+                ",
+                set(vec!["a"]),
+            ),
+            (
+                r"
+                /*
+                    multi-line comments
+                    module a::b {} */
+                    module works::perfectly {}
+                ",
+                set(vec!["works"]),
+            ),
+            (
+                r"
+                /* module aa::bb {} */ module a::b {}
+                ",
+                set(vec!["a"]),
+            ),
+            (
+                r"
+                /* module aa::bb {} */ /* module ee::dd {} */ module a::b {}
+                ",
+                set(vec!["a"]),
             ),
         ];
 

--- a/external-crates/move/crates/move-package-alt/src/compatibility/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/compatibility/mod.rs
@@ -133,17 +133,13 @@ fn strip_doc_comments(source: &str) -> String {
         }
 
         // Remove any inline doc block comments (multiple if present)
-        loop {
-            if let Some(start) = line_cleaned.find("/*").or_else(|| line_cleaned.find("/*!")) {
-                if let Some(end) = line_cleaned[start..].find("*/") {
-                    line_cleaned.replace_range(start..start + end + 2, "");
-                } else {
-                    // Start of multiline doc block; remove to end of line and set flag
-                    line_cleaned.replace_range(start.., "");
-                    in_block_doc = true;
-                    break;
-                }
+        while let Some(start) = line_cleaned.find("/*").or_else(|| line_cleaned.find("/*!")) {
+            if let Some(end) = line_cleaned[start..].find("*/") {
+                line_cleaned.replace_range(start..start + end + 2, "");
             } else {
+                // Start of multiline doc block; remove to end of line and set flag
+                line_cleaned.replace_range(start.., "");
+                in_block_doc = true;
                 break;
             }
         }

--- a/external-crates/move/crates/move-package-alt/src/compatibility/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/compatibility/mod.rs
@@ -119,7 +119,7 @@ fn strip_doc_comments(source: &str) -> String {
         let trimmed = line.trim_start();
 
         // Regular comments case -- whole line is a comment.
-        if trimmed.starts_with("///") || trimmed.starts_with("//!") {
+        if trimmed.starts_with("///") || trimmed.starts_with("//") {
             continue;
         }
 
@@ -133,7 +133,7 @@ fn strip_doc_comments(source: &str) -> String {
         }
 
         // Remove any inline doc block comments (multiple if present)
-        while let Some(start) = line_cleaned.find("/*").or_else(|| line_cleaned.find("/*!")) {
+        while let Some(start) = line_cleaned.find("/*") {
             if let Some(end) = line_cleaned[start..].find("*/") {
                 line_cleaned.replace_range(start..start + end + 2, "");
             } else {


### PR DESCRIPTION
## Description 

Fixes the issue where doc comments caused trouble on figuring out the modern name for a package.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
