### PR TITLE
[graphql-alt] Support GasEffects for TransactionEffects

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/gas_effects.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/gas_effects.move
@@ -1,0 +1,81 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --addresses test=0x0 --simulator
+
+//# programmable --sender A --inputs 100 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# publish
+module test::gas_test {
+    public entry fun simple_function() {
+        // Simple function that does minimal work for predictable gas costs
+    }
+}
+
+//# run test::gas_test::simple_function --sender A
+
+//# create-checkpoint
+
+// Test system transaction created by advance-clock
+//# advance-clock --duration-ns 1000000
+
+//# create-checkpoint
+
+//# run-graphql
+{ # Test gas_effects field with gasObject and gasSummary
+  transferTransaction: transactionEffects(digest: "@{digest_1}") {
+    gasEffects {
+      gasObject {
+        address
+        version
+        digest
+      }
+      gasSummary {
+        computationCost
+        storageCost
+        storageRebate
+        nonRefundableStorageFee
+      }
+    }
+  }
+}
+
+//# run-graphql
+{ # Test gas_effects on function call transaction
+  functionCallTransaction: transactionEffects(digest: "@{digest_3}") {
+    gasEffects {
+      gasObject {
+        address
+        version
+        digest
+      }
+      gasSummary {
+        computationCost
+        storageCost
+        storageRebate
+        nonRefundableStorageFee
+      }
+    }
+  }
+} 
+
+//# run-graphql
+{ # Test gas_effects on system transaction
+  functionCallTransaction: transactionEffects(digest: "@{digest_5}") {
+    gasEffects {
+      gasObject {
+        address
+        version
+        digest
+      }
+      gasSummary {
+        computationCost
+        storageCost
+        storageRebate
+        nonRefundableStorageFee
+      }
+    }
+  }
+} 

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/gas_effects.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/gas_effects.snap
@@ -1,0 +1,100 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 10 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-8:
+//# programmable --sender A --inputs 100 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 10-15:
+//# publish
+created: object(2,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 3572000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 17:
+//# run test::gas_test::simple_function --sender A
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 19-21:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 6, line 24:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 7, lines 26-43:
+//# run-graphql
+Response: {
+  "data": {
+    "transferTransaction": {
+      "gasEffects": {
+        "gasObject": {
+          "address": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
+          "version": 2,
+          "digest": "5oZq28MSbMZczmoEx7NppwgfS39saKEDR5kPUGJL3xhR"
+        },
+        "gasSummary": {
+          "computationCost": 1000000,
+          "storageCost": 1976000,
+          "storageRebate": 0,
+          "nonRefundableStorageFee": 0
+        }
+      }
+    }
+  }
+}
+
+task 8, lines 45-62:
+//# run-graphql
+Response: {
+  "data": {
+    "functionCallTransaction": {
+      "gasEffects": {
+        "gasObject": {
+          "address": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
+          "version": 3,
+          "digest": "CarkTNvzXbUZPij4ebGttPTGtMwugEjXavBgjQLzABiC"
+        },
+        "gasSummary": {
+          "computationCost": 1000000,
+          "storageCost": 988000,
+          "storageRebate": 978120,
+          "nonRefundableStorageFee": 9880
+        }
+      }
+    }
+  }
+}
+
+task 9, lines 64-81:
+//# run-graphql
+Response: {
+  "data": {
+    "functionCallTransaction": {
+      "gasEffects": {
+        "gasObject": {
+          "address": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "version": 0,
+          "digest": "11111111111111111111111111111111"
+        },
+        "gasSummary": {
+          "computationCost": 0,
+          "storageCost": 0,
+          "storageRebate": 0,
+          "nonRefundableStorageFee": 0
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -244,7 +244,25 @@ type GasCostSummary {
 	"""
 	Amount that is retained by the system in the storage fund from the cost of the previous versions of objects being mutated or deleted.
 	"""
+<<<<<<< HEAD
 	nonRefundableStorageFee: UInt53
+=======
+	nonRefundableStorageFee: BigInt
+}
+
+"""
+Effects related to gas (costs incurred and the identity of the smashed gas object returned).
+"""
+type GasEffects {
+	"""
+	The gas object used to pay for this transaction, after being smashed.
+	"""
+	gasObject: Object
+	"""
+	Breakdown of the gas costs for this transaction.
+	"""
+	gasSummary: GasCostSummary
+>>>>>>> ea696eac10 (update comment)
 }
 
 type GasInput {
@@ -950,7 +968,11 @@ type TransactionEffects {
 	"""
 	lamportVersion: UInt53
 	"""
+<<<<<<< HEAD
 	Rich execution error information for failed transactions.
+=======
+	Effects related to the gas object used for the transaction (costs incurred and the identity of the smashed gas object returned).
+>>>>>>> ea696eac10 (update comment)
 	"""
 	executionError: ExecutionError
 	"""

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -252,7 +252,7 @@ Effects related to gas (costs incurred and the identity of the smashed gas objec
 """
 type GasEffects {
 	"""
-	The gas object used to pay for this transaction, after being smashed.
+	The gas object used to pay for this transaction. If multiple gas coins were provided, this represents the combined coin after smashing.
 	"""
 	gasObject: Object
 	"""

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -244,10 +244,7 @@ type GasCostSummary {
 	"""
 	Amount that is retained by the system in the storage fund from the cost of the previous versions of objects being mutated or deleted.
 	"""
-<<<<<<< HEAD
 	nonRefundableStorageFee: UInt53
-=======
-	nonRefundableStorageFee: BigInt
 }
 
 """
@@ -262,7 +259,6 @@ type GasEffects {
 	Breakdown of the gas costs for this transaction.
 	"""
 	gasSummary: GasCostSummary
->>>>>>> ea696eac10 (update comment)
 }
 
 type GasInput {
@@ -968,11 +964,7 @@ type TransactionEffects {
 	"""
 	lamportVersion: UInt53
 	"""
-<<<<<<< HEAD
 	Rich execution error information for failed transactions.
-=======
-	Effects related to the gas object used for the transaction (costs incurred and the identity of the smashed gas object returned).
->>>>>>> ea696eac10 (update comment)
 	"""
 	executionError: ExecutionError
 	"""
@@ -987,6 +979,10 @@ type TransactionEffects {
 	The before and after state of objects that were modified by this transaction.
 	"""
 	objectChanges(first: Int, after: String, last: Int, before: String): ObjectChangeConnection
+	"""
+	Effects related to the gas object used for the transaction (costs incurred and the identity of the smashed gas object returned).
+	"""
+	gasEffects: GasEffects
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/api/types/gas_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/gas_effects.rs
@@ -1,45 +1,35 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use async_graphql::Object;
-use sui_types::{
-    effects::{TransactionEffects as NativeTransactionEffects, TransactionEffectsAPI},
-};
+use async_graphql::SimpleObject;
+use sui_types::effects::{TransactionEffects as NativeTransactionEffects, TransactionEffectsAPI};
 
 use crate::{
-    api::{types::{address::Address, gas::GasCostSummary}},
-    error::RpcError,
+    api::types::{address::Address, gas::GasCostSummary},
     scope::Scope,
 };
 
 use super::object::Object;
 
-pub(crate) struct GasEffects {
-    pub(crate) scope: Scope,
-    pub(crate) native: NativeTransactionEffects,
-}
-
 /// Effects related to gas (costs incurred and the identity of the smashed gas object returned).
-#[Object]
-impl GasEffects {
-    /// The gas object used to pay for this transaction, after being smashed.
-    async fn gas_object(&self) -> Result<Option<Object>, RpcError> {
-        let ((id, version, digest), _owner) = self.native.gas_object();
-        let address = Address::with_address(self.scope.clone(), id.into());
-        Ok(Some(Object::with_ref(address, version, digest)))
-    }
-
+#[derive(SimpleObject)]
+pub(crate) struct GasEffects {
+    /// The gas object used to pay for this transaction. If multiple gas coins were provided, this represents the combined coin after smashing.
+    gas_object: Option<Object>,
     /// Breakdown of the gas costs for this transaction.
-    async fn gas_summary(&self) -> Option<GasCostSummary> {
-        Some(self.native.gas_cost_summary().clone().into())
-    }
+    gas_summary: Option<GasCostSummary>,
 }
 
 impl GasEffects {
-    pub(crate) fn from(scope: Scope, effects: NativeTransactionEffects) -> Self {
+    pub(crate) fn from_effects(scope: Scope, effects: &NativeTransactionEffects) -> Self {
+        let ((id, version, digest), _owner) = effects.gas_object();
+        let address = Address::with_address(scope, id.into());
+        let gas_object = Some(Object::with_ref(address, version, digest));
+        let gas_summary = Some(effects.gas_cost_summary().clone().into());
+
         Self {
-            scope,
-            native: effects,
+            gas_object,
+            gas_summary,
         }
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/gas_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/gas_effects.rs
@@ -1,0 +1,88 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::Object;
+use sui_types::{
+    effects::{TransactionEffects as NativeTransactionEffects, TransactionEffectsAPI},
+    gas::GasCostSummary as NativeGasCostSummary,
+};
+
+use crate::{
+    api::{scalars::big_int::BigInt, types::address::Address},
+    error::RpcError,
+    scope::Scope,
+};
+
+use super::object::Object;
+
+pub(crate) struct GasCostSummary {
+    pub(crate) computation_cost: u64,
+    pub(crate) storage_cost: u64,
+    pub(crate) storage_rebate: u64,
+    pub(crate) non_refundable_storage_fee: u64,
+}
+
+pub(crate) struct GasEffects {
+    pub(crate) scope: Scope,
+    pub(crate) native: NativeTransactionEffects,
+}
+
+/// Breakdown of gas costs in effects.
+#[Object]
+impl GasCostSummary {
+    /// Gas paid for executing this transaction (in MIST).
+    async fn computation_cost(&self) -> Option<BigInt> {
+        Some(BigInt::from(self.computation_cost))
+    }
+
+    /// Gas paid for the data stored on-chain by this transaction (in MIST).
+    async fn storage_cost(&self) -> Option<BigInt> {
+        Some(BigInt::from(self.storage_cost))
+    }
+
+    /// Part of storage cost that can be reclaimed by cleaning up data created by this transaction (when objects are deleted or an object is modified, which is treated as a deletion followed by a creation) (in MIST).
+    async fn storage_rebate(&self) -> Option<BigInt> {
+        Some(BigInt::from(self.storage_rebate))
+    }
+
+    /// Part of storage cost that is not reclaimed when data created by this transaction is cleaned up (in MIST).
+    async fn non_refundable_storage_fee(&self) -> Option<BigInt> {
+        Some(BigInt::from(self.non_refundable_storage_fee))
+    }
+}
+
+/// Effects related to gas (costs incurred and the identity of the smashed gas object returned).
+#[Object]
+impl GasEffects {
+    /// The gas object used to pay for this transaction, after being smashed.
+    async fn gas_object(&self) -> Result<Option<Object>, RpcError> {
+        let ((id, version, digest), _owner) = self.native.gas_object();
+        let address = Address::with_address(self.scope.clone(), id.into());
+        Ok(Some(Object::with_ref(address, version, digest)))
+    }
+
+    /// Breakdown of the gas costs for this transaction.
+    async fn gas_summary(&self) -> Option<GasCostSummary> {
+        Some(GasCostSummary::from(self.native.gas_cost_summary()))
+    }
+}
+
+impl GasEffects {
+    pub(crate) fn from(scope: Scope, effects: NativeTransactionEffects) -> Self {
+        Self {
+            scope,
+            native: effects,
+        }
+    }
+}
+
+impl From<&NativeGasCostSummary> for GasCostSummary {
+    fn from(gcs: &NativeGasCostSummary) -> Self {
+        Self {
+            computation_cost: gcs.computation_cost,
+            storage_cost: gcs.storage_cost,
+            storage_rebate: gcs.storage_rebate,
+            non_refundable_storage_fee: gcs.non_refundable_storage_fee,
+        }
+    }
+}

--- a/crates/sui-indexer-alt-graphql/src/api/types/gas_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/gas_effects.rs
@@ -4,51 +4,19 @@
 use async_graphql::Object;
 use sui_types::{
     effects::{TransactionEffects as NativeTransactionEffects, TransactionEffectsAPI},
-    gas::GasCostSummary as NativeGasCostSummary,
 };
 
 use crate::{
-    api::{scalars::big_int::BigInt, types::address::Address},
+    api::{types::{address::Address, gas::GasCostSummary}},
     error::RpcError,
     scope::Scope,
 };
 
 use super::object::Object;
 
-pub(crate) struct GasCostSummary {
-    pub(crate) computation_cost: u64,
-    pub(crate) storage_cost: u64,
-    pub(crate) storage_rebate: u64,
-    pub(crate) non_refundable_storage_fee: u64,
-}
-
 pub(crate) struct GasEffects {
     pub(crate) scope: Scope,
     pub(crate) native: NativeTransactionEffects,
-}
-
-/// Breakdown of gas costs in effects.
-#[Object]
-impl GasCostSummary {
-    /// Gas paid for executing this transaction (in MIST).
-    async fn computation_cost(&self) -> Option<BigInt> {
-        Some(BigInt::from(self.computation_cost))
-    }
-
-    /// Gas paid for the data stored on-chain by this transaction (in MIST).
-    async fn storage_cost(&self) -> Option<BigInt> {
-        Some(BigInt::from(self.storage_cost))
-    }
-
-    /// Part of storage cost that can be reclaimed by cleaning up data created by this transaction (when objects are deleted or an object is modified, which is treated as a deletion followed by a creation) (in MIST).
-    async fn storage_rebate(&self) -> Option<BigInt> {
-        Some(BigInt::from(self.storage_rebate))
-    }
-
-    /// Part of storage cost that is not reclaimed when data created by this transaction is cleaned up (in MIST).
-    async fn non_refundable_storage_fee(&self) -> Option<BigInt> {
-        Some(BigInt::from(self.non_refundable_storage_fee))
-    }
 }
 
 /// Effects related to gas (costs incurred and the identity of the smashed gas object returned).
@@ -63,7 +31,7 @@ impl GasEffects {
 
     /// Breakdown of the gas costs for this transaction.
     async fn gas_summary(&self) -> Option<GasCostSummary> {
-        Some(GasCostSummary::from(self.native.gas_cost_summary()))
+        Some(self.native.gas_cost_summary().clone().into())
     }
 }
 
@@ -72,17 +40,6 @@ impl GasEffects {
         Self {
             scope,
             native: effects,
-        }
-    }
-}
-
-impl From<&NativeGasCostSummary> for GasCostSummary {
-    fn from(gcs: &NativeGasCostSummary) -> Self {
-        Self {
-            computation_cost: gcs.computation_cost,
-            storage_cost: gcs.storage_cost,
-            storage_rebate: gcs.storage_rebate,
-            non_refundable_storage_fee: gcs.non_refundable_storage_fee,
         }
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod checkpoint;
 pub(crate) mod epoch;
 pub(crate) mod execution_error;
 pub(crate) mod gas;
+pub(crate) mod gas_effects;
 pub(crate) mod gas_input;
 pub(crate) mod move_package;
 pub(crate) mod object;

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -27,6 +27,7 @@ use crate::{
 use super::{
     checkpoint::Checkpoint,
     execution_error::ExecutionError,
+    gas_effects::GasEffects,
     object_change::ObjectChange,
     transaction::{Transaction, TransactionContents},
 };
@@ -111,13 +112,8 @@ impl EffectsContents {
         Ok(Some(UInt53::from(effects.lamport_version().value())))
     }
 
-<<<<<<< HEAD
     /// Rich execution error information for failed transactions.
     async fn execution_error(&self, ctx: &Context<'_>) -> Result<Option<ExecutionError>, RpcError> {
-=======
-    /// Effects related to the gas object used for the transaction (costs incurred and the identity of the smashed gas object returned).
-    async fn gas_effects(&self) -> Result<Option<GasEffects>, RpcError> {
->>>>>>> ea696eac10 (update comment)
         let Some(content) = &self.contents else {
             return Ok(None);
         };
@@ -186,6 +182,16 @@ impl EffectsContents {
         }
 
         Ok(Some(conn))
+    }
+
+    /// Effects related to the gas object used for the transaction (costs incurred and the identity of the smashed gas object returned).
+    async fn gas_effects(&self) -> Result<Option<GasEffects>, RpcError> {
+        let Some(content) = &self.contents else {
+            return Ok(None);
+        };
+
+        let effects = content.effects()?;
+        Ok(Some(GasEffects::from(self.scope.clone(), effects)))
     }
 }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -191,7 +191,7 @@ impl EffectsContents {
         };
 
         let effects = content.effects()?;
-        Ok(Some(GasEffects::from(self.scope.clone(), effects)))
+        Ok(Some(GasEffects::from_effects(self.scope.clone(), &effects)))
     }
 }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -111,8 +111,13 @@ impl EffectsContents {
         Ok(Some(UInt53::from(effects.lamport_version().value())))
     }
 
+<<<<<<< HEAD
     /// Rich execution error information for failed transactions.
     async fn execution_error(&self, ctx: &Context<'_>) -> Result<Option<ExecutionError>, RpcError> {
+=======
+    /// Effects related to the gas object used for the transaction (costs incurred and the identity of the smashed gas object returned).
+    async fn gas_effects(&self) -> Result<Option<GasEffects>, RpcError> {
+>>>>>>> ea696eac10 (update comment)
         let Some(content) = &self.contents else {
             return Ok(None);
         };

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -248,7 +248,25 @@ type GasCostSummary {
 	"""
 	Amount that is retained by the system in the storage fund from the cost of the previous versions of objects being mutated or deleted.
 	"""
+<<<<<<< HEAD
 	nonRefundableStorageFee: UInt53
+=======
+	nonRefundableStorageFee: BigInt
+}
+
+"""
+Effects related to gas (costs incurred and the identity of the smashed gas object returned).
+"""
+type GasEffects {
+	"""
+	The gas object used to pay for this transaction, after being smashed.
+	"""
+	gasObject: Object
+	"""
+	Breakdown of the gas costs for this transaction.
+	"""
+	gasSummary: GasCostSummary
+>>>>>>> ea696eac10 (update comment)
 }
 
 type GasInput {
@@ -954,7 +972,11 @@ type TransactionEffects {
 	"""
 	lamportVersion: UInt53
 	"""
+<<<<<<< HEAD
 	Rich execution error information for failed transactions.
+=======
+	Effects related to the gas object used for the transaction (costs incurred and the identity of the smashed gas object returned).
+>>>>>>> ea696eac10 (update comment)
 	"""
 	executionError: ExecutionError
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -248,10 +248,7 @@ type GasCostSummary {
 	"""
 	Amount that is retained by the system in the storage fund from the cost of the previous versions of objects being mutated or deleted.
 	"""
-<<<<<<< HEAD
 	nonRefundableStorageFee: UInt53
-=======
-	nonRefundableStorageFee: BigInt
 }
 
 """
@@ -266,7 +263,6 @@ type GasEffects {
 	Breakdown of the gas costs for this transaction.
 	"""
 	gasSummary: GasCostSummary
->>>>>>> ea696eac10 (update comment)
 }
 
 type GasInput {
@@ -972,11 +968,7 @@ type TransactionEffects {
 	"""
 	lamportVersion: UInt53
 	"""
-<<<<<<< HEAD
 	Rich execution error information for failed transactions.
-=======
-	Effects related to the gas object used for the transaction (costs incurred and the identity of the smashed gas object returned).
->>>>>>> ea696eac10 (update comment)
 	"""
 	executionError: ExecutionError
 	"""
@@ -991,6 +983,10 @@ type TransactionEffects {
 	The before and after state of objects that were modified by this transaction.
 	"""
 	objectChanges(first: Int, after: String, last: Int, before: String): ObjectChangeConnection
+	"""
+	Effects related to the gas object used for the transaction (costs incurred and the identity of the smashed gas object returned).
+	"""
+	gasEffects: GasEffects
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -256,7 +256,7 @@ Effects related to gas (costs incurred and the identity of the smashed gas objec
 """
 type GasEffects {
 	"""
-	The gas object used to pay for this transaction, after being smashed.
+	The gas object used to pay for this transaction. If multiple gas coins were provided, this represents the combined coin after smashing.
 	"""
 	gasObject: Object
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -248,7 +248,25 @@ type GasCostSummary {
 	"""
 	Amount that is retained by the system in the storage fund from the cost of the previous versions of objects being mutated or deleted.
 	"""
+<<<<<<< HEAD
 	nonRefundableStorageFee: UInt53
+=======
+	nonRefundableStorageFee: BigInt
+}
+
+"""
+Effects related to gas (costs incurred and the identity of the smashed gas object returned).
+"""
+type GasEffects {
+	"""
+	The gas object used to pay for this transaction, after being smashed.
+	"""
+	gasObject: Object
+	"""
+	Breakdown of the gas costs for this transaction.
+	"""
+	gasSummary: GasCostSummary
+>>>>>>> ea696eac10 (update comment)
 }
 
 type GasInput {
@@ -954,7 +972,11 @@ type TransactionEffects {
 	"""
 	lamportVersion: UInt53
 	"""
+<<<<<<< HEAD
 	Rich execution error information for failed transactions.
+=======
+	Effects related to the gas object used for the transaction (costs incurred and the identity of the smashed gas object returned).
+>>>>>>> ea696eac10 (update comment)
 	"""
 	executionError: ExecutionError
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -248,10 +248,7 @@ type GasCostSummary {
 	"""
 	Amount that is retained by the system in the storage fund from the cost of the previous versions of objects being mutated or deleted.
 	"""
-<<<<<<< HEAD
 	nonRefundableStorageFee: UInt53
-=======
-	nonRefundableStorageFee: BigInt
 }
 
 """
@@ -266,7 +263,6 @@ type GasEffects {
 	Breakdown of the gas costs for this transaction.
 	"""
 	gasSummary: GasCostSummary
->>>>>>> ea696eac10 (update comment)
 }
 
 type GasInput {
@@ -972,11 +968,7 @@ type TransactionEffects {
 	"""
 	lamportVersion: UInt53
 	"""
-<<<<<<< HEAD
 	Rich execution error information for failed transactions.
-=======
-	Effects related to the gas object used for the transaction (costs incurred and the identity of the smashed gas object returned).
->>>>>>> ea696eac10 (update comment)
 	"""
 	executionError: ExecutionError
 	"""
@@ -991,6 +983,10 @@ type TransactionEffects {
 	The before and after state of objects that were modified by this transaction.
 	"""
 	objectChanges(first: Int, after: String, last: Int, before: String): ObjectChangeConnection
+	"""
+	Effects related to the gas object used for the transaction (costs incurred and the identity of the smashed gas object returned).
+	"""
+	gasEffects: GasEffects
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -256,7 +256,7 @@ Effects related to gas (costs incurred and the identity of the smashed gas objec
 """
 type GasEffects {
 	"""
-	The gas object used to pay for this transaction, after being smashed.
+	The gas object used to pay for this transaction. If multiple gas coins were provided, this represents the combined coin after smashing.
 	"""
 	gasObject: Object
 	"""

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -244,7 +244,25 @@ type GasCostSummary {
 	"""
 	Amount that is retained by the system in the storage fund from the cost of the previous versions of objects being mutated or deleted.
 	"""
+<<<<<<< HEAD
 	nonRefundableStorageFee: UInt53
+=======
+	nonRefundableStorageFee: BigInt
+}
+
+"""
+Effects related to gas (costs incurred and the identity of the smashed gas object returned).
+"""
+type GasEffects {
+	"""
+	The gas object used to pay for this transaction, after being smashed.
+	"""
+	gasObject: Object
+	"""
+	Breakdown of the gas costs for this transaction.
+	"""
+	gasSummary: GasCostSummary
+>>>>>>> ea696eac10 (update comment)
 }
 
 type GasInput {
@@ -950,7 +968,11 @@ type TransactionEffects {
 	"""
 	lamportVersion: UInt53
 	"""
+<<<<<<< HEAD
 	Rich execution error information for failed transactions.
+=======
+	Effects related to the gas object used for the transaction (costs incurred and the identity of the smashed gas object returned).
+>>>>>>> ea696eac10 (update comment)
 	"""
 	executionError: ExecutionError
 	"""

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -252,7 +252,7 @@ Effects related to gas (costs incurred and the identity of the smashed gas objec
 """
 type GasEffects {
 	"""
-	The gas object used to pay for this transaction, after being smashed.
+	The gas object used to pay for this transaction. If multiple gas coins were provided, this represents the combined coin after smashing.
 	"""
 	gasObject: Object
 	"""

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -244,10 +244,7 @@ type GasCostSummary {
 	"""
 	Amount that is retained by the system in the storage fund from the cost of the previous versions of objects being mutated or deleted.
 	"""
-<<<<<<< HEAD
 	nonRefundableStorageFee: UInt53
-=======
-	nonRefundableStorageFee: BigInt
 }
 
 """
@@ -262,7 +259,6 @@ type GasEffects {
 	Breakdown of the gas costs for this transaction.
 	"""
 	gasSummary: GasCostSummary
->>>>>>> ea696eac10 (update comment)
 }
 
 type GasInput {
@@ -968,11 +964,7 @@ type TransactionEffects {
 	"""
 	lamportVersion: UInt53
 	"""
-<<<<<<< HEAD
 	Rich execution error information for failed transactions.
-=======
-	Effects related to the gas object used for the transaction (costs incurred and the identity of the smashed gas object returned).
->>>>>>> ea696eac10 (update comment)
 	"""
 	executionError: ExecutionError
 	"""
@@ -987,6 +979,10 @@ type TransactionEffects {
 	The before and after state of objects that were modified by this transaction.
 	"""
 	objectChanges(first: Int, after: String, last: Int, before: String): ObjectChangeConnection
+	"""
+	Effects related to the gas object used for the transaction (costs incurred and the identity of the smashed gas object returned).
+	"""
+	gasEffects: GasEffects
 }
 
 """


### PR DESCRIPTION
## Description 

Implement `gas_effects` field support for `TransactionEffects` type.

Reference: Based on legacy implementation in sui/crates/sui-graphql-rpc/src/types /transaction_block_effects.rs

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-graphql
cargo nextest run -p sui-indexer-alt-reader
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

---

## Stack
- #22789 
- #22790 
- #22822 ⬅️

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
