### PR TITLE
[graphql-alt] Support timestamp for TransactionEffects

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/timestamp.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/timestamp.move
@@ -1,0 +1,29 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --simulator
+
+//# programmable --sender A --inputs 100 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+// Test system transaction created by advance-clock
+//# advance-clock --duration-ns 1000000
+
+//# create-checkpoint
+
+//# run-graphql
+{ # Test timestamp field on transfer transaction
+  transferTransaction: transactionEffects(digest: "@{digest_1}") {
+    timestamp
+  }
+}
+
+//# run-graphql
+{ # Test timestamp field on system transaction
+  systemTransaction: transactionEffects(digest: "@{digest_3}") {
+    timestamp
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/timestamp.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/timestamp.snap
@@ -1,0 +1,43 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-8:
+//# programmable --sender A --inputs 100 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 10-12:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, line 15:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 5, lines 17-22:
+//# run-graphql
+Response: {
+  "data": {
+    "transferTransaction": {
+      "timestamp": "1970-01-01T00:00:00Z"
+    }
+  }
+}
+
+task 6, lines 24-29:
+//# run-graphql
+Response: {
+  "data": {
+    "systemTransaction": {
+      "timestamp": "1970-01-01T00:00:00.001Z"
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -954,6 +954,10 @@ type TransactionEffects {
 	"""
 	executionError: ExecutionError
 	"""
+	Timestamp corresponding to the checkpoint this transaction was finalized in.
+	"""
+	timestamp: DateTime
+	"""
 	The Base64-encoded BCS serialization of these effects, as `TransactionEffects`.
 	"""
 	effectsBcs: Base64

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -18,7 +18,9 @@ use sui_types::{
 };
 
 use crate::{
-    api::scalars::{base64::Base64, cursor::JsonCursor, digest::Digest, uint53::UInt53},
+    api::scalars::{
+        base64::Base64, cursor::JsonCursor, date_time::DateTime, digest::Digest, uint53::UInt53,
+    },
     error::RpcError,
     pagination::{Page, PaginationConfig},
     scope::Scope,
@@ -130,6 +132,15 @@ impl EffectsContents {
             });
 
         ExecutionError::from_execution_status(ctx, status, programmable_tx.as_ref()).await
+    }
+
+    /// Timestamp corresponding to the checkpoint this transaction was finalized in.
+    async fn timestamp(&self) -> Result<Option<DateTime>, RpcError> {
+        let Some(content) = &self.contents else {
+            return Ok(None);
+        };
+
+        Ok(Some(DateTime::from_ms(content.timestamp_ms() as i64)?))
     }
 
     /// The Base64-encoded BCS serialization of these effects, as `TransactionEffects`.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -958,6 +958,10 @@ type TransactionEffects {
 	"""
 	executionError: ExecutionError
 	"""
+	Timestamp corresponding to the checkpoint this transaction was finalized in.
+	"""
+	timestamp: DateTime
+	"""
 	The Base64-encoded BCS serialization of these effects, as `TransactionEffects`.
 	"""
 	effectsBcs: Base64

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -958,6 +958,10 @@ type TransactionEffects {
 	"""
 	executionError: ExecutionError
 	"""
+	Timestamp corresponding to the checkpoint this transaction was finalized in.
+	"""
+	timestamp: DateTime
+	"""
 	The Base64-encoded BCS serialization of these effects, as `TransactionEffects`.
 	"""
 	effectsBcs: Base64

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -954,6 +954,10 @@ type TransactionEffects {
 	"""
 	executionError: ExecutionError
 	"""
+	Timestamp corresponding to the checkpoint this transaction was finalized in.
+	"""
+	timestamp: DateTime
+	"""
 	The Base64-encoded BCS serialization of these effects, as `TransactionEffects`.
 	"""
 	effectsBcs: Base64


### PR DESCRIPTION
## Description 

Implement `timestamp` field support for `TransactionEffects` type.

Reference: Based on legacy implementation in sui/crates/sui-graphql-rpc/src/types /transaction_block_effects.rs

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-graphql
cargo nextest run -p sui-indexer-alt-reader
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

---

## Stack
- #22789 
- #22790 
- #22822 
- #22823 ⬅️

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
