### PR TITLE
[graphql-alt] Support epoch for TransactionEffects

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/epoch.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/epoch.move
@@ -1,0 +1,52 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --simulator
+
+// Transaction in Epoch 0
+//# programmable --sender A --inputs 100 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+// Advance to Epoch 1
+//# advance-epoch
+
+// Transaction in Epoch 1
+//# programmable --sender A --inputs 200 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+// Advance to Epoch 2
+//# advance-epoch
+
+// Transaction in Epoch 2
+//# programmable --sender A --inputs 300 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# run-graphql
+{ # Test epoch field across multiple epochs
+  epoch0Transaction: transactionEffects(digest: "@{digest_1}") {
+    epoch {
+      epochId
+    }
+  }
+
+  epoch1Transaction: transactionEffects(digest: "@{digest_4}") {
+    epoch {
+      epochId
+    }
+  }
+
+  epoch2Transaction: transactionEffects(digest: "@{digest_7}") {
+    epoch {
+      epochId
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/epoch.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/epoch.snap
@@ -1,0 +1,73 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 10 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 7-9:
+//# programmable --sender A --inputs 100 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 11-13:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 14-16:
+//# advance-epoch
+Epoch advanced: 1
+
+task 4, lines 17-19:
+//# programmable --sender A --inputs 200 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 21-23:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 6, lines 24-26:
+//# advance-epoch
+Epoch advanced: 2
+
+task 7, lines 27-29:
+//# programmable --sender A --inputs 300 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(7,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 8, line 31:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 9, lines 33-52:
+//# run-graphql
+Response: {
+  "data": {
+    "epoch0Transaction": {
+      "epoch": {
+        "epochId": 0
+      }
+    },
+    "epoch1Transaction": {
+      "epoch": {
+        "epochId": 1
+      }
+    },
+    "epoch2Transaction": {
+      "epoch": {
+        "epochId": 2
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -962,6 +962,10 @@ type TransactionEffects {
 	"""
 	timestamp: DateTime
 	"""
+	The epoch this transaction was finalized in.
+	"""
+	epoch: Epoch
+	"""
 	The Base64-encoded BCS serialization of these effects, as `TransactionEffects`.
 	"""
 	effectsBcs: Base64

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -28,6 +28,7 @@ use crate::{
 
 use super::{
     checkpoint::Checkpoint,
+    epoch::Epoch,
     execution_error::ExecutionError,
     object_change::ObjectChange,
     transaction::{Transaction, TransactionContents},
@@ -141,6 +142,19 @@ impl EffectsContents {
         };
 
         Ok(Some(DateTime::from_ms(content.timestamp_ms() as i64)?))
+    }
+
+    /// The epoch this transaction was finalized in.
+    async fn epoch(&self) -> Result<Option<Epoch>, RpcError> {
+        let Some(content) = &self.contents else {
+            return Ok(None);
+        };
+
+        let effects = content.effects()?;
+        Ok(Some(Epoch::with_id(
+            self.scope.clone(),
+            effects.executed_epoch(),
+        )))
     }
 
     /// The Base64-encoded BCS serialization of these effects, as `TransactionEffects`.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -966,6 +966,10 @@ type TransactionEffects {
 	"""
 	timestamp: DateTime
 	"""
+	The epoch this transaction was finalized in.
+	"""
+	epoch: Epoch
+	"""
 	The Base64-encoded BCS serialization of these effects, as `TransactionEffects`.
 	"""
 	effectsBcs: Base64

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -966,6 +966,10 @@ type TransactionEffects {
 	"""
 	timestamp: DateTime
 	"""
+	The epoch this transaction was finalized in.
+	"""
+	epoch: Epoch
+	"""
 	The Base64-encoded BCS serialization of these effects, as `TransactionEffects`.
 	"""
 	effectsBcs: Base64

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -962,6 +962,10 @@ type TransactionEffects {
 	"""
 	timestamp: DateTime
 	"""
+	The epoch this transaction was finalized in.
+	"""
+	epoch: Epoch
+	"""
 	The Base64-encoded BCS serialization of these effects, as `TransactionEffects`.
 	"""
 	effectsBcs: Base64


### PR DESCRIPTION
## Description 

Implement `epoch` field support for `TransactionEffects` type.

Reference: Based on legacy implementation in sui/crates/sui-graphql-rpc/src/types /transaction_block_effects.rs

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-graphql
cargo nextest run -p sui-indexer-alt-reader
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

---

## Stack
- #22789 
- #22790 
- #22822 
- #22823 
- #22825 ⬅️

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
