### PR TITLE
[sui-framework-snapshot] Set full shas where possible

### DIFF
--- a/crates/bin-version/src/lib.rs
+++ b/crates/bin-version/src/lib.rs
@@ -37,6 +37,8 @@ macro_rules! bin_version {
 ///
 ///   `GIT_REVISION`: The git revision as specified by the `GIT_REVISION` env variable provided at
 ///   compile time, or the current git revision as discovered by running `git describe`.
+///   `GIT_FULL_SHA_REVISION`: The full git revision as specified by the `GIT_REVISION` env variable
+///   provided at compile time, or the current git revision as discovered by running `git describe`.
 ///
 /// Note: This macro must only be used from a binary, if used inside a library this will fail to
 /// compile.
@@ -65,5 +67,21 @@ macro_rules! git_revision {
                 version
             }
         };
+
+        const GIT_FULL_SHA_REVISION: &str = {
+            if let Some(revision) = option_env!("GIT_REVISION") {
+                revision
+            } else {
+                let version = $crate::_hidden::git_version!(
+                    args = ["--always", "--abbrev=40", "--dirty", "--exclude", "*"],
+                    fallback = ""
+                );
+
+                if version.is_empty() {
+                    panic!("unable to query git revision");
+                }
+                version
+            }
+        }
     };
 }

--- a/crates/bin-version/src/lib.rs
+++ b/crates/bin-version/src/lib.rs
@@ -82,6 +82,6 @@ macro_rules! git_revision {
                 }
                 version
             }
-        }
+        };
     };
 }

--- a/crates/sui-framework-snapshot/manifest.json
+++ b/crates/sui-framework-snapshot/manifest.json
@@ -315,7 +315,7 @@
     ]
   },
   "16": {
-    "git_revision": "0f31634377",
+    "git_revision": "0f316343778b3a17497acf76b04170020353be0e",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -365,7 +365,7 @@
     ]
   },
   "18": {
-    "git_revision": "1828bbd10",
+    "git_revision": "1828bbd103c76188d28ee15733707b7ec2579363",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -390,7 +390,7 @@
     ]
   },
   "19": {
-    "git_revision": "ee604ddd81",
+    "git_revision": "ee604ddd81b55cde041939ac0cc8f010821f77e8",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -490,7 +490,7 @@
     ]
   },
   "23": {
-    "git_revision": "f217258725",
+    "git_revision": "f2172587257b97360031f42039d5e45580bdcde4",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -640,7 +640,7 @@
     ]
   },
   "30": {
-    "git_revision": "4922d58a26",
+    "git_revision": "4922d58a26c4f61bb2d00b7c51db7557a3ab1b15",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -690,7 +690,7 @@
     ]
   },
   "32": {
-    "git_revision": "4927dc9a38",
+    "git_revision": "4927dc9a381f5bee365fb1e26fa43ff651f17369",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -740,7 +740,7 @@
     ]
   },
   "34": {
-    "git_revision": "66b3329fda",
+    "git_revision": "66b3329fda686d169dee8dd92d1b6ac59a606672",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1530,7 +1530,7 @@
     ]
   },
   "71": {
-    "git_revision": "ea3d71eb4d92",
+    "git_revision": "ea3d71eb4d92af38caebea268436188090eeed6e",
     "packages": [
       {
         "name": "MoveStdlib",

--- a/crates/sui-framework-snapshot/manifest.json
+++ b/crates/sui-framework-snapshot/manifest.json
@@ -190,7 +190,7 @@
     ]
   },
   "11": {
-    "git_revision": "2e08ae862d",
+    "git_revision": "2e08ae862dcfb06f3f79613719d3655e0bd7f407",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -215,7 +215,7 @@
     ]
   },
   "12": {
-    "git_revision": "f652942f12",
+    "git_revision": "f652942f12587fb4af21441c2b943c8b887db03e",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -240,7 +240,7 @@
     ]
   },
   "13": {
-    "git_revision": "434eb193a1",
+    "git_revision": "434eb193a1e8ba9f140f862cdd68f072e607da1c",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -265,7 +265,7 @@
     ]
   },
   "14": {
-    "git_revision": "a2af559f9e",
+    "git_revision": "a2af559f9ea21e09ca7e377e3b477fc2b5239fc7",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -290,7 +290,7 @@
     ]
   },
   "15": {
-    "git_revision": "1d1c34fa30",
+    "git_revision": "1d1c34fa307eea1afdcaa9121c28d31fc90069b8",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -340,7 +340,7 @@
     ]
   },
   "17": {
-    "git_revision": "a26be77372",
+    "git_revision": "a26be77372f9f8e7ff57a878ac8e8248211af74c",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -415,7 +415,7 @@
     ]
   },
   "20": {
-    "git_revision": "c42fe84a5",
+    "git_revision": "c42fe84a5bc94adeee1df0f68cf5517774b3b5e0",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -440,7 +440,7 @@
     ]
   },
   "21": {
-    "git_revision": "77a9e0d24e",
+    "git_revision": "77a9e0d24e2bb839dc4030eed1ddb1c56908f853",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -465,7 +465,7 @@
     ]
   },
   "22": {
-    "git_revision": "a83e5ac1fa",
+    "git_revision": "a83e5ac1fafa48fa57024b7649ac47ed07d9f180",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -515,7 +515,7 @@
     ]
   },
   "24": {
-    "git_revision": "d5e5d34d1",
+    "git_revision": "d5e5d34d1221c209bbf9baf4fcd9ecdb7cc50501",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -540,7 +540,7 @@
     ]
   },
   "25": {
-    "git_revision": "a0e136a04",
+    "git_revision": "a0e136a04c5c09371f30255f7d4dac1793504ecb",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -565,7 +565,7 @@
     ]
   },
   "26": {
-    "git_revision": "f82b8f7a5",
+    "git_revision": "f82b8f7a5c69b6e2abb74d3703808ad771618256",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -615,7 +615,7 @@
     ]
   },
   "28": {
-    "git_revision": "3c826825fc",
+    "git_revision": "3c826825fcbeea0df59e44fda31a855ba6405213",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -665,7 +665,7 @@
     ]
   },
   "31": {
-    "git_revision": "ac208a8cb1",
+    "git_revision": "ac208a8cb1df666536bf725e5aa81a186d688589",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -715,7 +715,7 @@
     ]
   },
   "33": {
-    "git_revision": "31b226d161",
+    "git_revision": "31b226d161fda465ac7da1404c3e0ec9a9c2374f",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -765,7 +765,7 @@
     ]
   },
   "35": {
-    "git_revision": "0a8dc2df9d",
+    "git_revision": "0a8dc2df9da780a61f12326d7e77e05d40af8280",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -790,7 +790,7 @@
     ]
   },
   "36": {
-    "git_revision": "bbc6060313",
+    "git_revision": "bbc6060313d6bc2df2798e8d7502c048ae77877f",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -815,7 +815,7 @@
     ]
   },
   "37": {
-    "git_revision": "417671d496",
+    "git_revision": "417671d49687067a726fa0a23d9551a567fdb132",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -840,7 +840,7 @@
     ]
   },
   "38": {
-    "git_revision": "95b939eb76",
+    "git_revision": "95b939eb76ecb43cf746c73f8c53e15d4b0b248b",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -865,7 +865,7 @@
     ]
   },
   "39": {
-    "git_revision": "3c33da179c",
+    "git_revision": "3c33da179c55bb206ef44ed898c9778811e35706",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -890,7 +890,7 @@
     ]
   },
   "40": {
-    "git_revision": "4e759d9b48",
+    "git_revision": "4e759d9b488388462154a996dc4a79209db02fa8",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -915,7 +915,7 @@
     ]
   },
   "42": {
-    "git_revision": "404b5aa266",
+    "git_revision": "404b5aa266bc1a65f291f712c6fd8b930c996fdd",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -940,7 +940,7 @@
     ]
   },
   "43": {
-    "git_revision": "127f2cb316",
+    "git_revision": "127f2cb31699ebddbe1ea4935d264a235ca2e9ca",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -965,7 +965,7 @@
     ]
   },
   "44": {
-    "git_revision": "a7b644cc47",
+    "git_revision": "a7b644cc4791672c8f6116652c0e6eacfc4ffc31",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -990,7 +990,7 @@
     ]
   },
   "45": {
-    "git_revision": "180aae21da3a",
+    "git_revision": "180aae21da3ace13ad8560e9f69ce0387f2d9bab",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1020,7 +1020,7 @@
     ]
   },
   "47": {
-    "git_revision": "b0138f3e7f21",
+    "git_revision": "b0138f3e7f2175b50081c9f895d8407925355359",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1050,7 +1050,7 @@
     ]
   },
   "48": {
-    "git_revision": "dedfac760bc7",
+    "git_revision": "dedfac760bc7d344fb42d5bad7f05a4177fa31f9",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1080,7 +1080,7 @@
     ]
   },
   "49": {
-    "git_revision": "50d489d4bf4a",
+    "git_revision": "50d489d4bf4a04b3102848c49ce89f5e9d0a40f1",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1110,7 +1110,7 @@
     ]
   },
   "51": {
-    "git_revision": "07501cae5293",
+    "git_revision": "07501cae5293836376daaf50888146dabeb990d7",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1140,7 +1140,7 @@
     ]
   },
   "52": {
-    "git_revision": "b608337971ee",
+    "git_revision": "b608337971ee8b9e05d05c530fa10b411500cf8a",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1170,7 +1170,7 @@
     ]
   },
   "53": {
-    "git_revision": "e2aab492da81",
+    "git_revision": "e2aab492da818c5960796919850a6768a0ebcd3c",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1200,7 +1200,7 @@
     ]
   },
   "54": {
-    "git_revision": "3f4cab62afbf",
+    "git_revision": "3f4cab62afbf86870d37b187a6bfaabf4f33d30e",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1230,7 +1230,7 @@
     ]
   },
   "55": {
-    "git_revision": "e19a8015fb45",
+    "git_revision": "e19a8015fb457e5c7f6b5524bd01fd74a5c0f73a",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1260,7 +1260,7 @@
     ]
   },
   "58": {
-    "git_revision": "2b3991a841ce",
+    "git_revision": "2b3991a841ce655bd790abfcbbdc5d2f27e14448",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1290,7 +1290,7 @@
     ]
   },
   "60": {
-    "git_revision": "dcdf415602dd",
+    "git_revision": "dcdf415602ddffdb6325b9bde5c425d67123c04f",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1320,7 +1320,7 @@
     ]
   },
   "62": {
-    "git_revision": "bfe1c64a258c",
+    "git_revision": "bfe1c64a258c6c629404f789306fcafbb28dd81e",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1350,7 +1350,7 @@
     ]
   },
   "65": {
-    "git_revision": "3e8d2312106e",
+    "git_revision": "3e8d2312106e66e9b24e6acfcbdb721aa1a78651",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1380,7 +1380,7 @@
     ]
   },
   "66": {
-    "git_revision": "86fa6e86b62a",
+    "git_revision": "86fa6e86b62a6984b741bab9c6440adff9aec669",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1410,7 +1410,7 @@
     ]
   },
   "67": {
-    "git_revision": "3ada97c109cc",
+    "git_revision": "3ada97c109cc7ae1b451cb384a1f2cfae49c8d3e",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1440,7 +1440,7 @@
     ]
   },
   "68": {
-    "git_revision": "ef0d78c638e3",
+    "git_revision": "ef0d78c638e3ef0d0a3b28787b618ea56a140284",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1470,7 +1470,7 @@
     ]
   },
   "69": {
-    "git_revision": "5d70ec6f5d4b",
+    "git_revision": "5d70ec6f5d4b7ff611649432aeb8c538efb63e80",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1500,7 +1500,7 @@
     ]
   },
   "70": {
-    "git_revision": "31775158335a",
+    "git_revision": "31775158335a1bf07123fa54d52871dccec86610",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1560,7 +1560,7 @@
     ]
   },
   "72": {
-    "git_revision": "acd6152865be",
+    "git_revision": "acd6152865be580525d4d5bfe4f97b40f36eb403",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1590,7 +1590,7 @@
     ]
   },
   "73": {
-    "git_revision": "2650370bb81e",
+    "git_revision": "2650370bb81e8d3496d67a752f05f6348301e7d4",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1620,7 +1620,7 @@
     ]
   },
   "74": {
-    "git_revision": "90d5c60d5a67",
+    "git_revision": "90d5c60d5a674e120ad81e4ef1a6b2dad352e20a",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1650,7 +1650,7 @@
     ]
   },
   "76": {
-    "git_revision": "050f3b9536b0",
+    "git_revision": "050f3b9536b07ab55aa7e80aa275020586ff0a11",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1680,7 +1680,7 @@
     ]
   },
   "77": {
-    "git_revision": "615516edb0ed",
+    "git_revision": "615516edb0ed55e45d599f042f9570b493ce9643",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1710,7 +1710,7 @@
     ]
   },
   "78": {
-    "git_revision": "9c04e1840eb5",
+    "git_revision": "9c04e1840eb56584c6a0904a65b3d04051711eaf",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1740,7 +1740,7 @@
     ]
   },
   "79": {
-    "git_revision": "04f11afaf5e0",
+    "git_revision": "04f11afaf5e0e6aab6a803cb03a12dc65875622a",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1770,7 +1770,7 @@
     ]
   },
   "81": {
-    "git_revision": "fbb68879cbd1",
+    "git_revision": "fbb68879cbd1132f4b9bab25286081588ce77969",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1800,7 +1800,7 @@
     ]
   },
   "82": {
-    "git_revision": "3802482bd4e3",
+    "git_revision": "3802482bd4e31468f787531ab43deceb0fe9c956",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1830,7 +1830,7 @@
     ]
   },
   "84": {
-    "git_revision": "25804c243d07",
+    "git_revision": "25804c243d07dd73c0d199e7794383bd855cd436",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1860,7 +1860,7 @@
     ]
   },
   "85": {
-    "git_revision": "af5297b292c3",
+    "git_revision": "af5297b292c3b7a1ae13a1af52c75d8b6656066b",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1890,7 +1890,7 @@
     ]
   },
   "86": {
-    "git_revision": "2c930c25f8d3",
+    "git_revision": "2c930c25f8d35a4aec31ba4c99ae577f4c37a27d",
     "packages": [
       {
         "name": "MoveStdlib",
@@ -1920,7 +1920,7 @@
     ]
   },
   "88": {
-    "git_revision": "209f0da8e316",
+    "git_revision": "209f0da8e316ba6eb7310d1667bdb22ae7fcb9c1",
     "packages": [
       {
         "name": "MoveStdlib",

--- a/crates/sui-framework-snapshot/src/main.rs
+++ b/crates/sui-framework-snapshot/src/main.rs
@@ -8,7 +8,7 @@ use sui_framework::{BuiltInFramework, SystemPackage};
 use sui_framework_snapshot::{update_bytecode_snapshot_manifest, SnapshotPackage};
 use sui_protocol_config::ProtocolVersion;
 
-// Define the `GIT_REVISION` const
+// Define the `GIT_FULL_SHA_REVISION` const
 bin_version::git_revision!();
 
 fn main() {
@@ -19,7 +19,7 @@ fn main() {
         write_package_to_file(version, &package.compiled);
         files.push(SnapshotPackage::from_system_package_metadata(package));
     }
-    update_bytecode_snapshot_manifest(GIT_REVISION, version, files);
+    update_bytecode_snapshot_manifest(GIT_FULL_SHA_REVISION, version, files);
 }
 
 fn write_package_to_file(version: u64, package: &SystemPackage) {


### PR DESCRIPTION
## Description 

This PR updates the short shas to full shas where possible in the already existing `sui-framework-snapshot/manifest.json`. The reason for this change is that the new pkg management system benefits from using full shas to avoid downloading the whole history to be able to checkout with only the short sha.

It also adds a new `GIT_FULL_SHA_REVISION` macro on `bin-version` crate to allow us to get the full 40 characters SHA to be used in `update_snapshot` in the `sui-framework-snapshot` crate.

## Test plan 

Existing tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK: