### PR TITLE
graphql-alt: Add Epoch.totalTransactions

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.move
@@ -43,6 +43,7 @@ fragment E on Epoch {
     validatorCandidatesSize
   }
   totalCheckpoints
+  totalTransactions
   totalGasFees
   totalStakeRewards
   totalStakeSubsidies
@@ -79,6 +80,7 @@ fragment E on Epoch {
     validatorCandidatesSize
   }
   totalCheckpoints
+  totalTransactions
   totalGasFees
   totalStakeRewards
   totalStakeSubsidies

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
@@ -18,7 +18,7 @@ task 5, line 14:
 //# advance-epoch
 Epoch advanced: 3
 
-task 6, lines 16-49:
+task 6, lines 16-50:
 //# run-graphql
 Response: {
   "data": {
@@ -40,6 +40,7 @@ Response: {
         "validatorCandidatesSize": 0
       },
       "totalCheckpoints": 1,
+      "totalTransactions": 1,
       "totalGasFees": "0",
       "totalStakeRewards": "0",
       "totalStakeSubsidies": "0"
@@ -62,6 +63,7 @@ Response: {
         "validatorCandidatesSize": 0
       },
       "totalCheckpoints": 2,
+      "totalTransactions": 3,
       "totalGasFees": "0",
       "totalStakeRewards": "0",
       "totalStakeSubsidies": "0"
@@ -84,6 +86,7 @@ Response: {
         "validatorCandidatesSize": 0
       },
       "totalCheckpoints": 1,
+      "totalTransactions": 2,
       "totalGasFees": "0",
       "totalStakeRewards": "0",
       "totalStakeSubsidies": "0"
@@ -106,6 +109,7 @@ Response: {
         "validatorCandidatesSize": 0
       },
       "totalCheckpoints": 1,
+      "totalTransactions": 1,
       "totalGasFees": "0",
       "totalStakeRewards": "0",
       "totalStakeSubsidies": "0"
@@ -114,7 +118,7 @@ Response: {
   }
 }
 
-task 7, lines 51-85:
+task 7, lines 52-87:
 //# run-graphql
 Response: {
   "data": {
@@ -138,6 +142,7 @@ Response: {
             "validatorCandidatesSize": 0
           },
           "totalCheckpoints": 1,
+          "totalTransactions": 2,
           "totalGasFees": "0",
           "totalStakeRewards": "0",
           "totalStakeSubsidies": "0"
@@ -160,6 +165,7 @@ Response: {
             "validatorCandidatesSize": 0
           },
           "totalCheckpoints": 2,
+          "totalTransactions": 3,
           "totalGasFees": "0",
           "totalStakeRewards": "0",
           "totalStakeSubsidies": "0"
@@ -182,6 +188,7 @@ Response: {
             "validatorCandidatesSize": 0
           },
           "totalCheckpoints": 1,
+          "totalTransactions": 2,
           "totalGasFees": "0",
           "totalStakeRewards": "0",
           "totalStakeSubsidies": "0"

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalTransactions/totalTransactions_empty_epoch.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalTransactions/totalTransactions_empty_epoch.move
@@ -1,0 +1,41 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --simulator
+
+//# run-graphql
+{ # genesis epoch
+  e0: epoch(epochId: 0) { ...E }
+  e1: epoch(epochId: 1) { ...E }
+  e2: epoch(epochId: 2) { ...E }
+}
+
+fragment E on Epoch {
+  totalTransactions
+}
+
+//# advance-epoch
+
+//# run-graphql
+{ # epochs without middle epoch
+  e0: epoch(epochId: 0) { ...E }
+  e1: epoch(epochId: 1) { ...E }
+  e2: epoch(epochId: 2) { ...E }
+}
+
+fragment E on Epoch {
+  totalTransactions
+}
+
+//# advance-epoch
+
+//# run-graphql
+{ # epochs with middle epoch
+  e0: epoch(epochId: 0) { ...E }
+  e1: epoch(epochId: 1) { ...E }
+  e2: epoch(epochId: 2) { ...E }
+}
+
+fragment E on Epoch {
+  totalTransactions
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalTransactions/totalTransactions_empty_epoch.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalTransactions/totalTransactions_empty_epoch.snap
@@ -1,0 +1,53 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-15:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "totalTransactions": null
+    },
+    "e1": null,
+    "e2": null
+  }
+}
+
+task 2, line 17:
+//# advance-epoch
+Epoch advanced: 1
+
+task 3, lines 19-28:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "totalTransactions": 2
+    },
+    "e1": null,
+    "e2": null
+  }
+}
+
+task 4, line 30:
+//# advance-epoch
+Epoch advanced: 2
+
+task 5, lines 32-41:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "totalTransactions": 2
+    },
+    "e1": {
+      "totalTransactions": 1
+    },
+    "e2": null
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalTransactions/totalTransactions_with_transaction.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalTransactions/totalTransactions_with_transaction.move
@@ -1,0 +1,53 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --simulator
+
+//# programmable --sender A --inputs 42 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# run-graphql
+{ # genesis epoch
+  e0: epoch(epochId: 0) { ...E }
+  e1: epoch(epochId: 1) { ...E }
+  e2: epoch(epochId: 2) { ...E }
+}
+
+fragment E on Epoch {
+  totalTransactions
+}
+
+//# advance-epoch
+
+//# programmable --sender A --inputs 42 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# run-graphql
+{ # epochs without middle epoch
+  e0: epoch(epochId: 0) { ...E }
+  e1: epoch(epochId: 1) { ...E }
+  e2: epoch(epochId: 2) { ...E }
+}
+
+fragment E on Epoch {
+  totalTransactions
+}
+
+//# advance-epoch
+
+//# programmable --sender A --inputs 42 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# run-graphql
+{ # epochs with middle epoch
+  e0: epoch(epochId: 0) { ...E }
+  e1: epoch(epochId: 1) { ...E }
+  e2: epoch(epochId: 2) { ...E }
+}
+
+fragment E on Epoch {
+  totalTransactions
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalTransactions/totalTransactions_with_transaction.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/totalTransactions/totalTransactions_with_transaction.snap
@@ -1,0 +1,77 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 9 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-8:
+//# programmable --sender A --inputs 42 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 10-19:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "totalTransactions": null
+    },
+    "e1": null,
+    "e2": null
+  }
+}
+
+task 3, line 21:
+//# advance-epoch
+Epoch advanced: 1
+
+task 4, lines 23-25:
+//# programmable --sender A --inputs 42 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 27-36:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "totalTransactions": 3
+    },
+    "e1": null,
+    "e2": null
+  }
+}
+
+task 6, line 38:
+//# advance-epoch
+Epoch advanced: 2
+
+task 7, lines 40-42:
+//# programmable --sender A --inputs 42 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(7,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 8, lines 44-53:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "totalTransactions": 3
+    },
+    "e1": {
+      "totalTransactions": 2
+    },
+    "e2": null
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -137,6 +137,10 @@ type Epoch {
 	"""
 	totalCheckpoints: UInt53
 	"""
+	The total number of transaction blocks in this epoch (or `null` if the epoch has not finished yet).
+	"""
+	totalTransactions: UInt53
+	"""
 	The total amount of gas fees (in MIST) that were paid in this epoch (or `null` if the epoch has not finished yet).
 	"""
 	totalGasFees: BigInt

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -141,6 +141,10 @@ type Epoch {
 	"""
 	totalCheckpoints: UInt53
 	"""
+	The total number of transaction blocks in this epoch (or `null` if the epoch has not finished yet).
+	"""
+	totalTransactions: UInt53
+	"""
 	The total amount of gas fees (in MIST) that were paid in this epoch (or `null` if the epoch has not finished yet).
 	"""
 	totalGasFees: BigInt

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -141,6 +141,10 @@ type Epoch {
 	"""
 	totalCheckpoints: UInt53
 	"""
+	The total number of transaction blocks in this epoch (or `null` if the epoch has not finished yet).
+	"""
+	totalTransactions: UInt53
+	"""
 	The total amount of gas fees (in MIST) that were paid in this epoch (or `null` if the epoch has not finished yet).
 	"""
 	totalGasFees: BigInt

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -137,6 +137,10 @@ type Epoch {
 	"""
 	totalCheckpoints: UInt53
 	"""
+	The total number of transaction blocks in this epoch (or `null` if the epoch has not finished yet).
+	"""
+	totalTransactions: UInt53
+	"""
 	The total amount of gas fees (in MIST) that were paid in this epoch (or `null` if the epoch has not finished yet).
 	"""
 	totalGasFees: BigInt

--- a/crates/sui-indexer-alt-reader/src/cp_sequence_numbers.rs
+++ b/crates/sui-indexer-alt-reader/src/cp_sequence_numbers.rs
@@ -1,0 +1,46 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::Error;
+use crate::pg_reader::PgReader;
+use async_graphql::dataloader::Loader;
+use diesel::{ExpressionMethods, QueryDsl};
+use std::collections::HashMap;
+use std::sync::Arc;
+use sui_indexer_alt_schema::{
+    cp_sequence_numbers::StoredCpSequenceNumbers, schema::cp_sequence_numbers,
+};
+
+/// Key for fetching information about checkpoint sequence numbers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CpSequenceNumberKey(pub u64);
+
+#[async_trait::async_trait]
+impl Loader<CpSequenceNumberKey> for PgReader {
+    type Value = StoredCpSequenceNumbers;
+    type Error = Arc<Error>;
+
+    async fn load(
+        &self,
+        keys: &[CpSequenceNumberKey],
+    ) -> Result<HashMap<CpSequenceNumberKey, Self::Value>, Self::Error> {
+        use cp_sequence_numbers::dsl as c;
+
+        if keys.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let mut conn = self.connect().await.map_err(Arc::new)?;
+
+        let ids: Vec<_> = keys.iter().map(|e| e.0 as i64).collect();
+        let epochs: Vec<StoredCpSequenceNumbers> = conn
+            .results(c::cp_sequence_numbers.filter(c::cp_sequence_number.eq_any(ids)))
+            .await
+            .map_err(Arc::new)?;
+
+        Ok(epochs
+            .into_iter()
+            .map(|c| (CpSequenceNumberKey(c.cp_sequence_number as u64), c))
+            .collect())
+    }
+}

--- a/crates/sui-indexer-alt-reader/src/lib.rs
+++ b/crates/sui-indexer-alt-reader/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod bigtable_reader;
 pub mod checkpoints;
 pub mod coin_metadata;
+pub mod cp_sequence_numbers;
 pub mod displays;
 pub mod epochs;
 pub mod error;


### PR DESCRIPTION
## Description 

Implements `Epoch.totalTransactions` based on
https://github.com/MystenLabs/sui/blob/4275c1a55988d28b638be8720aebdf1e7da3b06b/crates/sui-graphql-rpc/src/types/epoch.rs#L140-L146

## Test plan 

1. Added `totalTransactions` to the `query.move` snapshot test.
2. Added new `totalTransactions.move` test file.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
