### PR TITLE
[docs] fix file path in e2e counter example docs

### DIFF
--- a/docs/content/guides/developer/app-examples/e2e-counter.mdx
+++ b/docs/content/guides/developer/app-examples/e2e-counter.mdx
@@ -65,7 +65,7 @@ If you are targeting a network other than Testnet, be sure to update the `rev` v
 
 ### `Counter` struct
 
-To begin creating the smart contract that defines the on-chain counter, create a `counter.move` file inside your `react-e2e-counter/move/counter` folder. Define the module that holds your smart contract logic.
+To begin creating the smart contract that defines the on-chain counter, create a `counter.move` file inside your `react-e2e-counter/move/counter/sources` folder. Define the module that holds your smart contract logic.
 
 ```move
 module counter::counter {


### PR DESCRIPTION
## Description 

The file path mentioned in the example guide should refer to the `sources` directory, instead it refers to the parent. This can be confusing for beginners.