### PR TITLE
[graphql-alt] Support events for TransactionEffects

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/events.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/events.move
@@ -1,0 +1,161 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --addresses test=0x0 --simulator
+
+//# publish
+module test::events_test {
+    use sui::event;
+
+    public struct TestEvent has copy, drop {
+        message: vector<u8>,
+        value: u64,
+    }
+
+    public entry fun emit_event(value: u64) {
+        event::emit(TestEvent {
+            message: b"Hello from test event",
+            value,
+        });
+    }
+
+    public entry fun emit_multiple_events() {
+        event::emit(TestEvent {
+            message: b"First event",
+            value: 1,
+        });
+
+        event::emit(TestEvent {
+            message: b"Second event",
+            value: 2,
+        });
+    }
+}
+
+// Transaction that emits a single event
+//# run test::events_test::emit_event --sender A --args 42
+
+// Transaction that emits multiple events
+//# run test::events_test::emit_multiple_events --sender A
+
+// Transaction with no events (transfer)
+//# programmable --sender A --inputs 100 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# run-graphql
+{ # Test events field on transaction with single event
+  singleEventTransaction: transactionEffects(digest: "@{digest_2}") {
+    events {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+      }
+      nodes {
+        sender {
+          address
+        }
+        sequenceNumber
+        timestamp
+        eventBcs
+        transaction {
+          digest
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{ # Test events field on transaction with multiple events
+  multipleEventsTransaction: transactionEffects(digest: "@{digest_3}") {
+    events {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+      }
+      nodes {
+        sender {
+          address
+        }
+        sequenceNumber
+        timestamp
+        eventBcs
+        transaction {
+          digest
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{ # Test pagination functionality with multiple events
+  paginationTest: transactionEffects(digest: "@{digest_3}") {
+    events(first: 1) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+      }
+      nodes {
+        sender {
+          address
+        }
+        sequenceNumber
+        timestamp
+        eventBcs
+        transaction {
+          digest
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{ # Test backward pagination functionality with with multiple events
+  backwardPaginationTest: transactionEffects(digest: "@{digest_3}") {
+    events(last: 1) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+      }
+      nodes {
+        sender {
+          address
+        }
+        sequenceNumber
+        timestamp
+        eventBcs
+        transaction {
+          digest
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{ # Test events field on transaction with no events
+  noEventsTransaction: transactionEffects(digest: "@{digest_4}") {
+    events {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+      }
+      nodes {
+        sender {
+          address
+        }
+        sequenceNumber
+        timestamp
+        eventBcs
+        transaction {
+          digest
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/events.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/events.snap
@@ -1,0 +1,176 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 11 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-35:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 5791200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 36-38:
+//# run test::events_test::emit_event --sender A --args 42
+events: Event { package_id: test, transaction_module: Identifier("events_test"), sender: A, type_: StructTag { address: test, module: Identifier("events_test"), name: Identifier("TestEvent"), type_params: [] }, contents: [21, 72, 101, 108, 108, 111, 32, 102, 114, 111, 109, 32, 116, 101, 115, 116, 32, 101, 118, 101, 110, 116, 42, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 39-41:
+//# run test::events_test::emit_multiple_events --sender A
+events: Event { package_id: test, transaction_module: Identifier("events_test"), sender: A, type_: StructTag { address: test, module: Identifier("events_test"), name: Identifier("TestEvent"), type_params: [] }, contents: [11, 70, 105, 114, 115, 116, 32, 101, 118, 101, 110, 116, 1, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: test, transaction_module: Identifier("events_test"), sender: A, type_: StructTag { address: test, module: Identifier("events_test"), name: Identifier("TestEvent"), type_params: [] }, contents: [12, 83, 101, 99, 111, 110, 100, 32, 101, 118, 101, 110, 116, 2, 0, 0, 0, 0, 0, 0, 0] }
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 42-44:
+//# programmable --sender A --inputs 100 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, line 46:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 6, lines 48-69:
+//# run-graphql
+Response: {
+  "data": {
+    "singleEventTransaction": {
+      "events": {
+        "pageInfo": {
+          "hasNextPage": false,
+          "hasPreviousPage": false
+        },
+        "nodes": [
+          {
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "sequenceNumber": 0,
+            "timestamp": "1970-01-01T00:00:00Z",
+            "eventBcs": "edM4dqCRDBjUHGiAu4szEwUBOC1V1mKE2m5fjiGoJY8LZXZlbnRzX3Rlc3T8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHnnTOHagkQwY1BxogLuLMxMFATgtVdZihNpuX44hqCWPC2V2ZW50c190ZXN0CVRlc3RFdmVudAAeFUhlbGxvIGZyb20gdGVzdCBldmVudCoAAAAAAAAA",
+            "transaction": {
+              "digest": "EBQvwCcAgXNESe6T4uzbcJjXvcRZMdqcQDab5u87vY4o"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 7, lines 71-92:
+//# run-graphql
+Response: {
+  "data": {
+    "multipleEventsTransaction": {
+      "events": {
+        "pageInfo": {
+          "hasNextPage": false,
+          "hasPreviousPage": false
+        },
+        "nodes": [
+          {
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "sequenceNumber": 0,
+            "timestamp": "1970-01-01T00:00:00Z",
+            "eventBcs": "edM4dqCRDBjUHGiAu4szEwUBOC1V1mKE2m5fjiGoJY8LZXZlbnRzX3Rlc3T8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHnnTOHagkQwY1BxogLuLMxMFATgtVdZihNpuX44hqCWPC2V2ZW50c190ZXN0CVRlc3RFdmVudAAUC0ZpcnN0IGV2ZW50AQAAAAAAAAA=",
+            "transaction": {
+              "digest": "2XgXXUkgPn7j8RtqDKeNm6782kHHwbqJ7az6o92sVSg4"
+            }
+          },
+          {
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "sequenceNumber": 1,
+            "timestamp": "1970-01-01T00:00:00Z",
+            "eventBcs": "edM4dqCRDBjUHGiAu4szEwUBOC1V1mKE2m5fjiGoJY8LZXZlbnRzX3Rlc3T8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHnnTOHagkQwY1BxogLuLMxMFATgtVdZihNpuX44hqCWPC2V2ZW50c190ZXN0CVRlc3RFdmVudAAVDFNlY29uZCBldmVudAIAAAAAAAAA",
+            "transaction": {
+              "digest": "2XgXXUkgPn7j8RtqDKeNm6782kHHwbqJ7az6o92sVSg4"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 8, lines 94-115:
+//# run-graphql
+Response: {
+  "data": {
+    "paginationTest": {
+      "events": {
+        "pageInfo": {
+          "hasNextPage": true,
+          "hasPreviousPage": false
+        },
+        "nodes": [
+          {
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "sequenceNumber": 0,
+            "timestamp": "1970-01-01T00:00:00Z",
+            "eventBcs": "edM4dqCRDBjUHGiAu4szEwUBOC1V1mKE2m5fjiGoJY8LZXZlbnRzX3Rlc3T8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHnnTOHagkQwY1BxogLuLMxMFATgtVdZihNpuX44hqCWPC2V2ZW50c190ZXN0CVRlc3RFdmVudAAUC0ZpcnN0IGV2ZW50AQAAAAAAAAA=",
+            "transaction": {
+              "digest": "2XgXXUkgPn7j8RtqDKeNm6782kHHwbqJ7az6o92sVSg4"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 9, lines 117-138:
+//# run-graphql
+Response: {
+  "data": {
+    "backwardPaginationTest": {
+      "events": {
+        "pageInfo": {
+          "hasNextPage": false,
+          "hasPreviousPage": true
+        },
+        "nodes": [
+          {
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "sequenceNumber": 1,
+            "timestamp": "1970-01-01T00:00:00Z",
+            "eventBcs": "edM4dqCRDBjUHGiAu4szEwUBOC1V1mKE2m5fjiGoJY8LZXZlbnRzX3Rlc3T8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHnnTOHagkQwY1BxogLuLMxMFATgtVdZihNpuX44hqCWPC2V2ZW50c190ZXN0CVRlc3RFdmVudAAVDFNlY29uZCBldmVudAIAAAAAAAAA",
+            "transaction": {
+              "digest": "2XgXXUkgPn7j8RtqDKeNm6782kHHwbqJ7az6o92sVSg4"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 10, lines 140-161:
+//# run-graphql
+Response: {
+  "data": {
+    "noEventsTransaction": {
+      "events": {
+        "pageInfo": {
+          "hasNextPage": false,
+          "hasPreviousPage": false
+        },
+        "nodes": []
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -180,33 +180,18 @@ type Epoch {
 	storageFund: StorageFund
 }
 
-"""
-Represents execution error information for failed transactions.
-"""
-type ExecutionError {
-	"""
-	The error code of the Move abort, populated if this transaction failed with a Move abort.
-	
-	Returns the explicit code if the abort used `code` annotation (e.g., `abort(ERR, code = 5)` returns 5), otherwise returns the raw abort code containing encoded error information.
-	"""
-	abortCode: BigInt
-	"""
-	The source line number for the abort. Only populated for clever errors.
-	"""
-	sourceLineNumber: Int
-}
-
 type Event {
 	"""
-	The Base64 encoded BCS serialized bytes of the entire event structure.
+	The Base64 encoded BCS serialized bytes of the entire Event structure from sui-types.
+	This includes: package_id, transaction_module, sender, type, and contents (which itself contains the BCS-serialized Move struct data).
 	"""
 	eventBcs: Base64
 	"""
-	Address of the sender of the event.
+	Address of the sender of the transaction that emitted this event.
 	"""
 	sender: Address
 	"""
-	The position of the event among the events from the same transaction — useful for distinguishing between events with the same content that appeared from the same transaction.
+	The position of the event among the events from the same transaction.
 	"""
 	sequenceNumber: UInt53!
 	"""
@@ -247,6 +232,22 @@ type EventEdge {
 	A cursor for use in pagination
 	"""
 	cursor: String!
+}
+
+"""
+Represents execution error information for failed transactions.
+"""
+type ExecutionError {
+	"""
+	The error code of the Move abort, populated if this transaction failed with a Move abort.
+	
+	Returns the explicit code if the abort used `code` annotation (e.g., `abort(ERR, code = 5)` returns 5), otherwise returns the raw abort code containing encoded error information.
+	"""
+	abortCode: BigInt
+	"""
+	The source line number for the abort. Only populated for clever errors.
+	"""
+	sourceLineNumber: Int
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -196,6 +196,59 @@ type ExecutionError {
 	sourceLineNumber: Int
 }
 
+type Event {
+	"""
+	The Base64 encoded BCS serialized bytes of the entire event structure.
+	"""
+	eventBcs: Base64
+	"""
+	Address of the sender of the event.
+	"""
+	sender: Address
+	"""
+	The position of the event among the events from the same transaction — useful for distinguishing between events with the same content that appeared from the same transaction.
+	"""
+	sequenceNumber: UInt53!
+	"""
+	Timestamp corresponding to the checkpoint this event's transaction was finalized in.
+	All events from the same transaction share the same timestamp.
+	"""
+	timestamp: DateTime
+	"""
+	The transaction that emitted this event. This information is only available for events from indexed transactions, and not from transactions that have just been executed or dry-run.
+	"""
+	transaction: Transaction
+}
+
+type EventConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [EventEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Event!]!
+}
+
+"""
+An edge in a connection.
+"""
+type EventEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Event!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
 """
 The execution status of this transaction: success or failure.
 """
@@ -965,6 +1018,10 @@ type TransactionEffects {
 	The epoch this transaction was finalized in.
 	"""
 	epoch: Epoch
+	"""
+	Events emitted by this transaction.
+	"""
+	events(first: Int, after: String, last: Int, before: String): EventConnection
 	"""
 	The Base64-encoded BCS serialization of these effects, as `TransactionEffects`.
 	"""

--- a/crates/sui-indexer-alt-graphql/src/api/types/event.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event.rs
@@ -32,13 +32,14 @@ pub(crate) struct Event {
 // TODO(DVX-1203): contents - MoveValue
 #[Object]
 impl Event {
-    /// The Base64 encoded BCS serialized bytes of the entire event structure.
+    /// The Base64 encoded BCS serialized bytes of the entire Event structure from sui-types.
+    /// This includes: package_id, transaction_module, sender, type, and contents (which itself contains the BCS-serialized Move struct data).
     async fn event_bcs(&self) -> Result<Option<Base64>, RpcError> {
         let bcs_bytes = bcs::to_bytes(&self.native).context("Failed to serialize event")?;
         Ok(Some(Base64(bcs_bytes)))
     }
 
-    /// Address of the sender of the event.
+    /// Address of the sender of the transaction that emitted this event.
     async fn sender(&self) -> Option<Address> {
         if self.native.sender == NativeSuiAddress::ZERO {
             return None;
@@ -50,7 +51,7 @@ impl Event {
         ))
     }
 
-    /// The position of the event among the events from the same transaction — useful for distinguishing between events with the same content that appeared from the same transaction.
+    /// The position of the event among the events from the same transaction.
     async fn sequence_number(&self) -> UInt53 {
         UInt53::from(self.sequence_number)
     }
@@ -67,31 +68,5 @@ impl Event {
             self.scope.clone(),
             self.transaction_digest,
         ))
-    }
-}
-
-impl Event {
-    /// Create an Event from native Sui types with additional context.
-    ///
-    /// # Arguments
-    /// * `scope` - GraphQL query scope for data consistency
-    /// * `native` - The native Sui event structure
-    /// * `transaction_digest` - Digest of the transaction that emitted this event
-    /// * `sequence_number` - Position of this event in the transaction's events list
-    /// * `timestamp_ms` - Checkpoint timestamp when the transaction was finalized
-    pub(crate) fn from_native(
-        scope: Scope,
-        native: NativeEvent,
-        transaction_digest: TransactionDigest,
-        sequence_number: u64,
-        timestamp_ms: u64,
-    ) -> Self {
-        Self {
-            scope,
-            native,
-            transaction_digest,
-            sequence_number,
-            timestamp_ms,
-        }
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/event.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event.rs
@@ -1,0 +1,97 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Context as _;
+use async_graphql::Object;
+use sui_types::{
+    base_types::SuiAddress as NativeSuiAddress, digests::TransactionDigest,
+    event::Event as NativeEvent,
+};
+
+use crate::{
+    api::scalars::{base64::Base64, date_time::DateTime, uint53::UInt53},
+    error::RpcError,
+    scope::Scope,
+};
+
+use super::{address::Address, transaction::Transaction};
+
+#[derive(Clone)]
+pub(crate) struct Event {
+    pub(crate) scope: Scope,
+    pub(crate) native: NativeEvent,
+    /// Digest of the transaction that emitted this event
+    pub(crate) transaction_digest: TransactionDigest,
+    /// Position of this event within the transaction's events list (0-indexed)
+    pub(crate) sequence_number: u64,
+    /// Timestamp when the transaction containing this event was finalized (checkpoint time)
+    pub(crate) timestamp_ms: u64,
+}
+
+// TODO(DVX-1200): Support sendingModule - MoveModule
+// TODO(DVX-1203): contents - MoveValue
+#[Object]
+impl Event {
+    /// The Base64 encoded BCS serialized bytes of the entire event structure.
+    async fn event_bcs(&self) -> Result<Option<Base64>, RpcError> {
+        let bcs_bytes = bcs::to_bytes(&self.native).context("Failed to serialize event")?;
+        Ok(Some(Base64(bcs_bytes)))
+    }
+
+    /// Address of the sender of the event.
+    async fn sender(&self) -> Option<Address> {
+        if self.native.sender == NativeSuiAddress::ZERO {
+            return None;
+        }
+
+        Some(Address::with_address(
+            self.scope.clone(),
+            self.native.sender,
+        ))
+    }
+
+    /// The position of the event among the events from the same transaction — useful for distinguishing between events with the same content that appeared from the same transaction.
+    async fn sequence_number(&self) -> UInt53 {
+        UInt53::from(self.sequence_number)
+    }
+
+    /// Timestamp corresponding to the checkpoint this event's transaction was finalized in.
+    /// All events from the same transaction share the same timestamp.
+    async fn timestamp(&self) -> Result<Option<DateTime>, RpcError> {
+        Ok(Some(DateTime::from_ms(self.timestamp_ms as i64)?))
+    }
+
+    /// The transaction that emitted this event. This information is only available for events from indexed transactions, and not from transactions that have just been executed or dry-run.
+    async fn transaction(&self) -> Option<Transaction> {
+        Some(Transaction::with_id(
+            self.scope.clone(),
+            self.transaction_digest,
+        ))
+    }
+}
+
+impl Event {
+    /// Create an Event from native Sui types with additional context.
+    ///
+    /// # Arguments
+    /// * `scope` - GraphQL query scope for data consistency
+    /// * `native` - The native Sui event structure
+    /// * `transaction_digest` - Digest of the transaction that emitted this event
+    /// * `sequence_number` - Position of this event in the transaction's events list
+    /// * `timestamp_ms` - Checkpoint timestamp when the transaction was finalized
+    pub(crate) fn from_native(
+        scope: Scope,
+        native: NativeEvent,
+        transaction_digest: TransactionDigest,
+        sequence_number: u64,
+        timestamp_ms: u64,
+    ) -> Self {
+        Self {
+            scope,
+            native,
+            transaction_digest,
+            sequence_number,
+            timestamp_ms,
+        }
+    }
+}

--- a/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
@@ -4,6 +4,7 @@
 pub(crate) mod address;
 pub(crate) mod checkpoint;
 pub(crate) mod epoch;
+pub(crate) mod event;
 pub(crate) mod execution_error;
 pub(crate) mod gas;
 pub(crate) mod gas_input;

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use async_graphql::{
-    connection::{Connection, Edge},
+    connection::{Connection, CursorType, Edge},
     Context, Enum, Object,
 };
 use fastcrypto::encoding::{Base58, Encoding};
@@ -29,6 +29,7 @@ use crate::{
 use super::{
     checkpoint::Checkpoint,
     epoch::Epoch,
+    event::Event,
     execution_error::ExecutionError,
     object_change::ObjectChange,
     transaction::{Transaction, TransactionContents},
@@ -56,6 +57,7 @@ pub(crate) struct EffectsContents {
 }
 
 type CObjectChange = JsonCursor<usize>;
+type CEvent = JsonCursor<usize>;
 
 /// The results of executing a transaction.
 #[Object]
@@ -155,6 +157,46 @@ impl EffectsContents {
             self.scope.clone(),
             effects.executed_epoch(),
         )))
+    }
+
+    /// Events emitted by this transaction.
+    async fn events(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<CEvent>,
+        last: Option<u64>,
+        before: Option<CEvent>,
+    ) -> Result<Option<Connection<String, Event>>, RpcError> {
+        let Some(content) = &self.contents else {
+            return Ok(Some(Connection::new(false, false)));
+        };
+
+        let pagination: &PaginationConfig = ctx.data()?;
+        let limits = pagination.limits("TransactionEffects", "events");
+        let page = Page::from_params(limits, first, after, last, before)?;
+
+        let events = content.events()?;
+        let cursors = page.paginate_indices(events.len());
+        let mut conn = Connection::new(cursors.has_previous_page, cursors.has_next_page);
+
+        let transaction_digest = content.digest()?;
+        let timestamp_ms = content.timestamp_ms();
+
+        for edge in cursors.edges {
+            let event = Event::from_native(
+                self.scope.clone(),
+                events[*edge.cursor].clone(),
+                transaction_digest,
+                *edge.cursor as u64,
+                timestamp_ms,
+            );
+
+            conn.edges
+                .push(Edge::new(edge.cursor.encode_cursor(), event));
+        }
+
+        Ok(Some(conn))
     }
 
     /// The Base64-encoded BCS serialization of these effects, as `TransactionEffects`.

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -184,13 +184,13 @@ impl EffectsContents {
         let timestamp_ms = content.timestamp_ms();
 
         for edge in cursors.edges {
-            let event = Event::from_native(
-                self.scope.clone(),
-                events[*edge.cursor].clone(),
+            let event = Event {
+                scope: self.scope.clone(),
+                native: events[*edge.cursor].clone(),
                 transaction_digest,
-                *edge.cursor as u64,
+                sequence_number: *edge.cursor as u64,
                 timestamp_ms,
-            );
+            };
 
             conn.edges
                 .push(Edge::new(edge.cursor.encode_cursor(), event));

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -200,6 +200,59 @@ type ExecutionError {
 	sourceLineNumber: Int
 }
 
+type Event {
+	"""
+	The Base64 encoded BCS serialized bytes of the entire event structure.
+	"""
+	eventBcs: Base64
+	"""
+	Address of the sender of the event.
+	"""
+	sender: Address
+	"""
+	The position of the event among the events from the same transaction — useful for distinguishing between events with the same content that appeared from the same transaction.
+	"""
+	sequenceNumber: UInt53!
+	"""
+	Timestamp corresponding to the checkpoint this event's transaction was finalized in.
+	All events from the same transaction share the same timestamp.
+	"""
+	timestamp: DateTime
+	"""
+	The transaction that emitted this event. This information is only available for events from indexed transactions, and not from transactions that have just been executed or dry-run.
+	"""
+	transaction: Transaction
+}
+
+type EventConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [EventEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Event!]!
+}
+
+"""
+An edge in a connection.
+"""
+type EventEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Event!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
 """
 The execution status of this transaction: success or failure.
 """
@@ -969,6 +1022,10 @@ type TransactionEffects {
 	The epoch this transaction was finalized in.
 	"""
 	epoch: Epoch
+	"""
+	Events emitted by this transaction.
+	"""
+	events(first: Int, after: String, last: Int, before: String): EventConnection
 	"""
 	The Base64-encoded BCS serialization of these effects, as `TransactionEffects`.
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -184,33 +184,18 @@ type Epoch {
 	storageFund: StorageFund
 }
 
-"""
-Represents execution error information for failed transactions.
-"""
-type ExecutionError {
-	"""
-	The error code of the Move abort, populated if this transaction failed with a Move abort.
-	
-	Returns the explicit code if the abort used `code` annotation (e.g., `abort(ERR, code = 5)` returns 5), otherwise returns the raw abort code containing encoded error information.
-	"""
-	abortCode: BigInt
-	"""
-	The source line number for the abort. Only populated for clever errors.
-	"""
-	sourceLineNumber: Int
-}
-
 type Event {
 	"""
-	The Base64 encoded BCS serialized bytes of the entire event structure.
+	The Base64 encoded BCS serialized bytes of the entire Event structure from sui-types.
+	This includes: package_id, transaction_module, sender, type, and contents (which itself contains the BCS-serialized Move struct data).
 	"""
 	eventBcs: Base64
 	"""
-	Address of the sender of the event.
+	Address of the sender of the transaction that emitted this event.
 	"""
 	sender: Address
 	"""
-	The position of the event among the events from the same transaction — useful for distinguishing between events with the same content that appeared from the same transaction.
+	The position of the event among the events from the same transaction.
 	"""
 	sequenceNumber: UInt53!
 	"""
@@ -251,6 +236,22 @@ type EventEdge {
 	A cursor for use in pagination
 	"""
 	cursor: String!
+}
+
+"""
+Represents execution error information for failed transactions.
+"""
+type ExecutionError {
+	"""
+	The error code of the Move abort, populated if this transaction failed with a Move abort.
+	
+	Returns the explicit code if the abort used `code` annotation (e.g., `abort(ERR, code = 5)` returns 5), otherwise returns the raw abort code containing encoded error information.
+	"""
+	abortCode: BigInt
+	"""
+	The source line number for the abort. Only populated for clever errors.
+	"""
+	sourceLineNumber: Int
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -200,6 +200,59 @@ type ExecutionError {
 	sourceLineNumber: Int
 }
 
+type Event {
+	"""
+	The Base64 encoded BCS serialized bytes of the entire event structure.
+	"""
+	eventBcs: Base64
+	"""
+	Address of the sender of the event.
+	"""
+	sender: Address
+	"""
+	The position of the event among the events from the same transaction — useful for distinguishing between events with the same content that appeared from the same transaction.
+	"""
+	sequenceNumber: UInt53!
+	"""
+	Timestamp corresponding to the checkpoint this event's transaction was finalized in.
+	All events from the same transaction share the same timestamp.
+	"""
+	timestamp: DateTime
+	"""
+	The transaction that emitted this event. This information is only available for events from indexed transactions, and not from transactions that have just been executed or dry-run.
+	"""
+	transaction: Transaction
+}
+
+type EventConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [EventEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Event!]!
+}
+
+"""
+An edge in a connection.
+"""
+type EventEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Event!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
 """
 The execution status of this transaction: success or failure.
 """
@@ -969,6 +1022,10 @@ type TransactionEffects {
 	The epoch this transaction was finalized in.
 	"""
 	epoch: Epoch
+	"""
+	Events emitted by this transaction.
+	"""
+	events(first: Int, after: String, last: Int, before: String): EventConnection
 	"""
 	The Base64-encoded BCS serialization of these effects, as `TransactionEffects`.
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -184,33 +184,18 @@ type Epoch {
 	storageFund: StorageFund
 }
 
-"""
-Represents execution error information for failed transactions.
-"""
-type ExecutionError {
-	"""
-	The error code of the Move abort, populated if this transaction failed with a Move abort.
-	
-	Returns the explicit code if the abort used `code` annotation (e.g., `abort(ERR, code = 5)` returns 5), otherwise returns the raw abort code containing encoded error information.
-	"""
-	abortCode: BigInt
-	"""
-	The source line number for the abort. Only populated for clever errors.
-	"""
-	sourceLineNumber: Int
-}
-
 type Event {
 	"""
-	The Base64 encoded BCS serialized bytes of the entire event structure.
+	The Base64 encoded BCS serialized bytes of the entire Event structure from sui-types.
+	This includes: package_id, transaction_module, sender, type, and contents (which itself contains the BCS-serialized Move struct data).
 	"""
 	eventBcs: Base64
 	"""
-	Address of the sender of the event.
+	Address of the sender of the transaction that emitted this event.
 	"""
 	sender: Address
 	"""
-	The position of the event among the events from the same transaction — useful for distinguishing between events with the same content that appeared from the same transaction.
+	The position of the event among the events from the same transaction.
 	"""
 	sequenceNumber: UInt53!
 	"""
@@ -251,6 +236,22 @@ type EventEdge {
 	A cursor for use in pagination
 	"""
 	cursor: String!
+}
+
+"""
+Represents execution error information for failed transactions.
+"""
+type ExecutionError {
+	"""
+	The error code of the Move abort, populated if this transaction failed with a Move abort.
+	
+	Returns the explicit code if the abort used `code` annotation (e.g., `abort(ERR, code = 5)` returns 5), otherwise returns the raw abort code containing encoded error information.
+	"""
+	abortCode: BigInt
+	"""
+	The source line number for the abort. Only populated for clever errors.
+	"""
+	sourceLineNumber: Int
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -180,33 +180,18 @@ type Epoch {
 	storageFund: StorageFund
 }
 
-"""
-Represents execution error information for failed transactions.
-"""
-type ExecutionError {
-	"""
-	The error code of the Move abort, populated if this transaction failed with a Move abort.
-	
-	Returns the explicit code if the abort used `code` annotation (e.g., `abort(ERR, code = 5)` returns 5), otherwise returns the raw abort code containing encoded error information.
-	"""
-	abortCode: BigInt
-	"""
-	The source line number for the abort. Only populated for clever errors.
-	"""
-	sourceLineNumber: Int
-}
-
 type Event {
 	"""
-	The Base64 encoded BCS serialized bytes of the entire event structure.
+	The Base64 encoded BCS serialized bytes of the entire Event structure from sui-types.
+	This includes: package_id, transaction_module, sender, type, and contents (which itself contains the BCS-serialized Move struct data).
 	"""
 	eventBcs: Base64
 	"""
-	Address of the sender of the event.
+	Address of the sender of the transaction that emitted this event.
 	"""
 	sender: Address
 	"""
-	The position of the event among the events from the same transaction — useful for distinguishing between events with the same content that appeared from the same transaction.
+	The position of the event among the events from the same transaction.
 	"""
 	sequenceNumber: UInt53!
 	"""
@@ -247,6 +232,22 @@ type EventEdge {
 	A cursor for use in pagination
 	"""
 	cursor: String!
+}
+
+"""
+Represents execution error information for failed transactions.
+"""
+type ExecutionError {
+	"""
+	The error code of the Move abort, populated if this transaction failed with a Move abort.
+	
+	Returns the explicit code if the abort used `code` annotation (e.g., `abort(ERR, code = 5)` returns 5), otherwise returns the raw abort code containing encoded error information.
+	"""
+	abortCode: BigInt
+	"""
+	The source line number for the abort. Only populated for clever errors.
+	"""
+	sourceLineNumber: Int
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -196,6 +196,59 @@ type ExecutionError {
 	sourceLineNumber: Int
 }
 
+type Event {
+	"""
+	The Base64 encoded BCS serialized bytes of the entire event structure.
+	"""
+	eventBcs: Base64
+	"""
+	Address of the sender of the event.
+	"""
+	sender: Address
+	"""
+	The position of the event among the events from the same transaction — useful for distinguishing between events with the same content that appeared from the same transaction.
+	"""
+	sequenceNumber: UInt53!
+	"""
+	Timestamp corresponding to the checkpoint this event's transaction was finalized in.
+	All events from the same transaction share the same timestamp.
+	"""
+	timestamp: DateTime
+	"""
+	The transaction that emitted this event. This information is only available for events from indexed transactions, and not from transactions that have just been executed or dry-run.
+	"""
+	transaction: Transaction
+}
+
+type EventConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [EventEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Event!]!
+}
+
+"""
+An edge in a connection.
+"""
+type EventEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Event!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
 """
 The execution status of this transaction: success or failure.
 """
@@ -965,6 +1018,10 @@ type TransactionEffects {
 	The epoch this transaction was finalized in.
 	"""
 	epoch: Epoch
+	"""
+	Events emitted by this transaction.
+	"""
+	events(first: Int, after: String, last: Int, before: String): EventConnection
 	"""
 	The Base64-encoded BCS serialization of these effects, as `TransactionEffects`.
 	"""


### PR DESCRIPTION
## Description 

Implement `events` field for `TransactionEffects` type.

Within this PR, I also create a scheme for new `Event` type with following fields:
* eventBcs
* sequenceNumber
* sender
* transaction
* timestamp

Currently, we cannot support 2 fields `sendingModule` and `contents` as `MoveModule` ([DVX-1205](https://linear.app/mysten-labs/issue/DVX-1205/movemodule)) and `MoveValue` ([DVX-1206](https://linear.app/mysten-labs/issue/DVX-1206/movevalue)) have not yet been supported. I already added a TODO to support that field later after getting unblocked.

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-graphql
cargo nextest run -p sui-indexer-alt-reader
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

---

## Stack
- #22789 
- #22790 
- #22822 
- #22823 
- #22825 
- #22835 ⬅️

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
