### PR TITLE
graphql-alt: Add Epoch.fundSize

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/fundSize/fundSize.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/fundSize/fundSize.move
@@ -1,0 +1,31 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --simulator
+
+//# run-graphql
+{ # no fund size initially
+  e0: epoch(epochId: 0) {
+    fundSize
+  }
+}
+
+//# programmable --sender A --inputs 42 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# run-graphql
+{ # no fund size after SplitCoins before epoch has end
+  e0: epoch(epochId: 0) {
+    fundSize
+  }
+}
+
+//# advance-epoch
+
+//# run-graphql
+{ # fund size after epoch has end
+  e0: epoch(epochId: 0) {
+    fundSize
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/fundSize/fundSize.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/fundSize/fundSize.snap
@@ -1,0 +1,49 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-11:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "fundSize": null
+    }
+  }
+}
+
+task 2, lines 13-15:
+//# programmable --sender A --inputs 42 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 17-22:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "fundSize": null
+    }
+  }
+}
+
+task 4, line 24:
+//# advance-epoch
+Epoch advanced: 1
+
+task 5, lines 26-31:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "fundSize": "1976000"
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.move
@@ -47,6 +47,7 @@ fragment E on Epoch {
   totalGasFees
   totalStakeRewards
   totalStakeSubsidies
+  fundSize
 }
 
 //# run-graphql
@@ -84,4 +85,5 @@ fragment E on Epoch {
   totalGasFees
   totalStakeRewards
   totalStakeSubsidies
+  fundSize
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
@@ -18,7 +18,7 @@ task 5, line 14:
 //# advance-epoch
 Epoch advanced: 3
 
-task 6, lines 16-50:
+task 6, lines 16-51:
 //# run-graphql
 Response: {
   "data": {
@@ -43,7 +43,8 @@ Response: {
       "totalTransactions": 1,
       "totalGasFees": "0",
       "totalStakeRewards": "0",
-      "totalStakeSubsidies": "0"
+      "totalStakeSubsidies": "0",
+      "fundSize": "0"
     },
     "e0": {
       "epochId": 0,
@@ -66,7 +67,8 @@ Response: {
       "totalTransactions": 3,
       "totalGasFees": "0",
       "totalStakeRewards": "0",
-      "totalStakeSubsidies": "0"
+      "totalStakeSubsidies": "0",
+      "fundSize": "0"
     },
     "e1": {
       "epochId": 1,
@@ -89,7 +91,8 @@ Response: {
       "totalTransactions": 2,
       "totalGasFees": "0",
       "totalStakeRewards": "0",
-      "totalStakeSubsidies": "0"
+      "totalStakeSubsidies": "0",
+      "fundSize": "0"
     },
     "e2": {
       "epochId": 2,
@@ -112,13 +115,14 @@ Response: {
       "totalTransactions": 1,
       "totalGasFees": "0",
       "totalStakeRewards": "0",
-      "totalStakeSubsidies": "0"
+      "totalStakeSubsidies": "0",
+      "fundSize": "0"
     },
     "e3": null
   }
 }
 
-task 7, lines 52-87:
+task 7, lines 53-89:
 //# run-graphql
 Response: {
   "data": {
@@ -145,7 +149,8 @@ Response: {
           "totalTransactions": 2,
           "totalGasFees": "0",
           "totalStakeRewards": "0",
-          "totalStakeSubsidies": "0"
+          "totalStakeSubsidies": "0",
+          "fundSize": "0"
         },
         "e0": {
           "epochId": 0,
@@ -168,7 +173,8 @@ Response: {
           "totalTransactions": 3,
           "totalGasFees": "0",
           "totalStakeRewards": "0",
-          "totalStakeSubsidies": "0"
+          "totalStakeSubsidies": "0",
+          "fundSize": "0"
         },
         "e1": {
           "epochId": 1,
@@ -191,7 +197,8 @@ Response: {
           "totalTransactions": 2,
           "totalGasFees": "0",
           "totalStakeRewards": "0",
-          "totalStakeSubsidies": "0"
+          "totalStakeSubsidies": "0",
+          "fundSize": "0"
         },
         "e2": null
       }

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -152,6 +152,12 @@ type Epoch {
 	The amount added to total gas fees to make up the total stake rewards.
 	"""
 	totalStakeSubsidies: BigInt
+	"""
+	The storage fund available in this epoch.
+	This fund is used to redistribute storage fees from past transactions
+	to future validators.
+	"""
+	fundSize: BigInt
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
@@ -225,6 +225,21 @@ impl Epoch {
 
         Ok(stake_subsidy_amount.map(BigInt::from))
     }
+
+    /// The storage fund available in this epoch.
+    /// This fund is used to redistribute storage fees from past transactions
+    /// to future validators.
+    async fn fund_size(&self, ctx: &Context<'_>) -> Result<Option<BigInt>, RpcError> {
+        let Some(StoredEpochEnd {
+            storage_fund_balance,
+            ..
+        }) = self.end(ctx).await?
+        else {
+            return Ok(None);
+        };
+
+        Ok(storage_fund_balance.map(BigInt::from))
+    }
 }
 
 impl Epoch {

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -156,6 +156,12 @@ type Epoch {
 	The amount added to total gas fees to make up the total stake rewards.
 	"""
 	totalStakeSubsidies: BigInt
+	"""
+	The storage fund available in this epoch.
+	This fund is used to redistribute storage fees from past transactions
+	to future validators.
+	"""
+	fundSize: BigInt
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -156,6 +156,12 @@ type Epoch {
 	The amount added to total gas fees to make up the total stake rewards.
 	"""
 	totalStakeSubsidies: BigInt
+	"""
+	The storage fund available in this epoch.
+	This fund is used to redistribute storage fees from past transactions
+	to future validators.
+	"""
+	fundSize: BigInt
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -152,6 +152,12 @@ type Epoch {
 	The amount added to total gas fees to make up the total stake rewards.
 	"""
 	totalStakeSubsidies: BigInt
+	"""
+	The storage fund available in this epoch.
+	This fund is used to redistribute storage fees from past transactions
+	to future validators.
+	"""
+	fundSize: BigInt
 }
 
 """


### PR DESCRIPTION
## Description 

Implements `Epoch.fundSize` based on
https://github.com/MystenLabs/sui/blob/4275c1a55988d28b638be8720aebdf1e7da3b06b/crates/sui-graphql-rpc/src/types/epoch.rs#L168-L170

## Test plan 

1. Added `fundSize` to the `query.move` snapshot test.
2. Added new `fundSize.move` test file.
3. 
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
