### PR TITLE
fix: remove invalid "type" field from suix_queryEvents example

### DIFF
--- a/docs/content/guides/developer/sui-101/using-events.mdx
+++ b/docs/content/guides/developer/sui-101/using-events.mdx
@@ -49,8 +49,7 @@ $ curl -X POST https://fullnode.mainnet.sui.io:443 \
     {
       "MoveModule": {
         "package": "0x158f2027f60c89bb91526d9bf08831d27f5a0fcb0f74e6698b9f0e1fb2be5d05",
-        "module": "deepbook_utils",
-        "type": "0xdee9::clob_v2::DepositAsset<0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN>"
+        "module": "deepbook_utils"
       }
     },
     null,


### PR DESCRIPTION
Fix incorrect parameter in suix_queryEvents example (remove "type" field)