### PR TITLE
[pkg-alt] Fix converting tags to git SHAs

### DIFF
--- a/external-crates/move/crates/move-package-alt/src/git/cache.rs
+++ b/external-crates/move/crates/move-package-alt/src/git/cache.rs
@@ -371,7 +371,7 @@ fn display_cmd(cmd: &Command) -> String {
 /// Note: a "no results" search for tags or branches returns an empty result (`Ok("")`)
 /// and not an error, which is why we manually cast an empty result into an error.
 ///
-/// Results from `ls-remote` are in the format of `<hash> \t <name>`, which is why we parse
+/// Results from `ls-remote` are expected in format `<hash> \t <name>`.
 async fn find_branch_or_tag_sha(repo: &str, rev: &str) -> GitResult<GitSha> {
     // Try to find a tag matching the `rev`:
     // git ls-remote https://github.com/user/repo.git refs/heads/<tag_name>

--- a/external-crates/move/crates/move-package-alt/src/git/cache.rs
+++ b/external-crates/move/crates/move-package-alt/src/git/cache.rs
@@ -372,6 +372,8 @@ async fn find_branch_or_tag_sha(repo: &str, rev: &str) -> GitResult<GitSha> {
     // and not an error, which is why we manually cast an empty result into an error.
     // Results from `ls-remote` are expected in format `<hash> \t <name>`.
 
+    // TODO(manos): Figure out if doing both lookups at once works fine (and add appropriate tests)
+
     // Try to find a tag matching the `rev`:
     // git ls-remote https://github.com/user/repo.git refs/heads/<tag_name>
     let tag = run_git_cmd_with_args(&["ls-remote", repo, &format!("refs/tags/{rev}")], None)

--- a/external-crates/move/crates/move-package-alt/src/git/cache.rs
+++ b/external-crates/move/crates/move-package-alt/src/git/cache.rs
@@ -279,20 +279,8 @@ async fn find_sha(repo: &str, rev: &Option<String>) -> GitResult<GitSha> {
         // letter), then we have a different set of arguments than if there is no revision. In no
         // revision case, we need to find the default branch of that remote.
 
-        // we have a branch or tag
-        // git ls-remote https://github.com/user/repo.git refs/heads/main
-        let stdout =
-            run_git_cmd_with_args(&["ls-remote", repo, &format!("refs/heads/{r}")], None).await?;
-
-        let sha = stdout
-            .split_whitespace()
-            .next()
-            .ok_or(GitError::no_sha(repo, r))?
-            .to_string()
-            .try_into()
-            .expect("git returns valid shas");
-
-        Ok(sha)
+        // we have a branch or tag so we need to look up its Sha.
+        find_branch_or_tag_sha(repo, r).await
     } else {
         // nothing specified, so we need to find the default branch
         find_default_branch_and_get_sha(repo).await
@@ -375,6 +363,40 @@ fn display_cmd(cmd: &Command) -> String {
         result.push_str(arg.to_string_lossy().as_ref());
     }
     result
+}
+
+/// Tries to convert a "branch" or "tag" into a full SHA, using `ls-remote`.
+/// It first tries to find a tag, and if that fails, it fallbacks into a branch lookup.
+///
+/// Note: a "no results" search for tags or branches returns an empty result (`Ok("")`)
+/// and not an error, which is why we manually cast an empty result into an error.
+///
+/// Results from `ls-remote` are in the format of `<hash> \t <name>`, which is why we parse
+async fn find_branch_or_tag_sha(repo: &str, rev: &str) -> GitResult<GitSha> {
+    // Try to find a tag matching the `rev`:
+    // git ls-remote https://github.com/user/repo.git refs/heads/<tag_name>
+    let tag = run_git_cmd_with_args(&["ls-remote", repo, &format!("refs/tags/{rev}")], None)
+        .await?
+        .split_whitespace()
+        .next()
+        .map(|s| s.to_string())
+        .ok_or(GitError::no_sha(repo, rev));
+
+    // return early if `rev` maps to a valid tag.
+    if let Ok(tag_sha) = tag {
+        return Ok(tag_sha.try_into().expect("git returns valid shas"));
+    }
+
+    // Try to find a branch matching the `rev`:
+    // git ls-remote https://github.com/user/repo.git refs/heads/<branch_name>
+    let branch = run_git_cmd_with_args(&["ls-remote", repo, &format!("refs/heads/{rev}")], None)
+        .await?
+        .split_whitespace()
+        .next()
+        .map(|s| s.to_string())
+        .ok_or(GitError::no_sha(repo, rev))?;
+
+    Ok(branch.try_into().expect("git returns valid shas"))
 }
 
 #[cfg(test)]
@@ -752,5 +774,42 @@ pkg_git = {{ git = "{}", rev = "{short_sha}" }}
                 .await
                 .is_ok()
         )
+    }
+
+    #[tokio::test]
+    async fn test_tag_checkout() {
+        let tag = "releases/1";
+
+        let project = git::new("git_repo", |project| {
+            project.file("packages/pkg_a/Move.toml", &basic_manifest("a", "0.0.1"))
+        });
+
+        project.add_tag(tag);
+
+        let cache_dir = tempdir().unwrap();
+        let cache = GitCache::new_from_dir(cache_dir.path());
+
+        let git_tree = cache
+            .resolve_to_tree(project.root_path_str(), &Some(tag.to_string()), None)
+            .await
+            .unwrap();
+
+        let result = git_tree.fetch().await;
+        assert!(result.is_ok());
+
+        let another_tag = "releases/2";
+        project.add_tag(another_tag);
+
+        let git_tree = cache
+            .resolve_to_tree(
+                project.root_path_str(),
+                &Some(another_tag.to_string()),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let result = git_tree.fetch().await;
+        assert!(result.is_ok());
     }
 }

--- a/external-crates/move/crates/move-package-alt/src/git/cache.rs
+++ b/external-crates/move/crates/move-package-alt/src/git/cache.rs
@@ -367,12 +367,11 @@ fn display_cmd(cmd: &Command) -> String {
 
 /// Tries to convert a "branch" or "tag" into a full SHA, using `ls-remote`.
 /// It first tries to find a tag, and if that fails, it fallbacks into a branch lookup.
-///
-/// Note: a "no results" search for tags or branches returns an empty result (`Ok("")`)
-/// and not an error, which is why we manually cast an empty result into an error.
-///
-/// Results from `ls-remote` are expected in format `<hash> \t <name>`.
 async fn find_branch_or_tag_sha(repo: &str, rev: &str) -> GitResult<GitSha> {
+    // Note: a "no results" search for tags or branches returns an empty result (`Ok("")`)
+    // and not an error, which is why we manually cast an empty result into an error.
+    // Results from `ls-remote` are expected in format `<hash> \t <name>`.
+
     // Try to find a tag matching the `rev`:
     // git ls-remote https://github.com/user/repo.git refs/heads/<tag_name>
     let tag = run_git_cmd_with_args(&["ls-remote", repo, &format!("refs/tags/{rev}")], None)

--- a/external-crates/move/crates/move-package-alt/src/test_utils/git.rs
+++ b/external-crates/move/crates/move-package-alt/src/test_utils/git.rs
@@ -217,7 +217,7 @@ fn commit(repo: &git2::Repository) -> git2::Oid {
 }
 
 /// *(`git2`)* Create a new tag in the git repository
-fn tag(repo: &git2::Repository, name: &str) {
+pub fn tag(repo: &git2::Repository, name: &str) {
     let head = repo.head().unwrap().target().unwrap();
     t!(repo.tag(
         name,

--- a/external-crates/move/crates/move-package-alt/src/test_utils/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/test_utils/mod.rs
@@ -223,6 +223,12 @@ impl Project {
         let contents = self.read_file("Move.toml").replace("#", "");
         fs::write(self.root().join("Move.toml"), contents).unwrap();
     }
+
+    pub fn add_tag(&self, name: &str) {
+        let repo = git2::Repository::open(self.root.clone())
+            .unwrap_or_else(|_| panic!("failed to open git repository at {}", self.root.display()));
+        git::tag(&repo, name);
+    }
 }
 
 /// Generates a project layout, see [`ProjectBuilder`]

--- a/external-crates/move/crates/move-package-alt/src/test_utils/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/test_utils/mod.rs
@@ -174,8 +174,7 @@ impl Project {
     /// Try to get the git commits in the project, but it will panic if this is not a git
     /// repository.
     pub fn commits(&self) -> Vec<String> {
-        let repo = git2::Repository::open(self.root.clone())
-            .unwrap_or_else(|_| panic!("failed to open git repository at {}", self.root.display()));
+        let repo = self._open();
         git::commits(&repo)
             .into_iter()
             .map(|c| c.id().to_string())
@@ -225,9 +224,13 @@ impl Project {
     }
 
     pub fn add_tag(&self, name: &str) {
-        let repo = git2::Repository::open(self.root.clone())
-            .unwrap_or_else(|_| panic!("failed to open git repository at {}", self.root.display()));
+        let repo = self._open();
         git::tag(&repo, name);
+    }
+
+    fn _open(&self) -> git2::Repository {
+        git2::Repository::open(self.root.clone())
+            .unwrap_or_else(|_| panic!("failed to open git repository at {}", self.root.display()))
     }
 }
 

--- a/external-crates/move/crates/move-package-alt/src/test_utils/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/test_utils/mod.rs
@@ -174,7 +174,7 @@ impl Project {
     /// Try to get the git commits in the project, but it will panic if this is not a git
     /// repository.
     pub fn commits(&self) -> Vec<String> {
-        let repo = self._open();
+        let repo = self.open();
         git::commits(&repo)
             .into_iter()
             .map(|c| c.id().to_string())
@@ -224,11 +224,11 @@ impl Project {
     }
 
     pub fn add_tag(&self, name: &str) {
-        let repo = self._open();
+        let repo = self.open();
         git::tag(&repo, name);
     }
 
-    fn _open(&self) -> git2::Repository {
+    fn open(&self) -> git2::Repository {
         git2::Repository::open(self.root.clone())
             .unwrap_or_else(|_| panic!("failed to open git repository at {}", self.root.display()))
     }


### PR DESCRIPTION
## Description 

Previously, git would only convert branches to shas, but would fail with tags.

## Test plan 

Added a unit test for a valid tag lookup

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
