### PR TITLE
[pkg-alt] Make sure transitive local deps are accessible (as we do sparse checkouts)

### DIFF
--- a/external-crates/move/crates/move-package-alt/src/dependency/pin.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/pin.rs
@@ -197,11 +197,10 @@ impl LocalDepInfo {
         // 1. "Parent" is a git dependency, so we need to first make sure the dir is accessible due to sparse checkouts.
         // 2. "Parent" is not a git dependency, so we need to return an error as the local dep does not exist.
 
-        // For 1: We try to add the dir to the sparse-checkout list.
-
+        // (1.): We try to add the dir to the sparse-checkout list:
         git_cache_try_make_local_dir_accessible(parent_dir.to_path_buf(), path.to_path_buf()).await;
 
-        // If the local directory still does not exist, we return an error.
+        // (2.): If the local directory still does not exist, we return an error.
         if !path.exists() {
             return Err(PackageError::Generic(format!(
                 "Failed to fetch local dependency: {:?}",

--- a/external-crates/move/crates/move-package-alt/src/dependency/pin.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/pin.rs
@@ -198,7 +198,8 @@ impl LocalDepInfo {
         // 2. "Parent" is not a git dependency, so we need to return an error as the local dep does not exist.
 
         // (1.): We try to add the dir to the sparse-checkout list:
-        git_cache_try_make_local_dir_accessible(parent_dir.to_path_buf(), path.to_path_buf()).await;
+        git_cache_try_make_local_dir_accessible(parent_dir.to_path_buf(), self.local.to_path_buf())
+            .await;
 
         // (2.): If the local directory still does not exist, we return an error.
         if !path.exists() {

--- a/external-crates/move/crates/move-package-alt/src/dependency/pin.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/pin.rs
@@ -183,9 +183,7 @@ impl LocalDepInfo {
     pub async fn fetch(&self, containing_file: impl AsRef<Path>) -> PackageResult<PathBuf> {
         let path = self.absolute_path(containing_file.as_ref());
 
-        eprintln!("path: {:?}", path);
-
-        // If the path is already accessibel, we can return it.
+        // If the path is already accessible, we can return early.
         if path.exists() {
             return Ok(path);
         }
@@ -200,7 +198,8 @@ impl LocalDepInfo {
         // 2. "Parent" is not a git dependency, so we need to return an error as the local dep does not exist.
 
         // For 1: We try to add the dir to the sparse-checkout list.
-        let _ = git_cache_try_make_local_dir_accessible(parent_dir.to_path_buf(), path.to_path_buf()).await;
+
+        git_cache_try_make_local_dir_accessible(parent_dir.to_path_buf(), path.to_path_buf()).await;
 
         // If the local directory still does not exist, we return an error.
         if !path.exists() {

--- a/external-crates/move/crates/move-package-alt/src/git/cache.rs
+++ b/external-crates/move/crates/move-package-alt/src/git/cache.rs
@@ -424,8 +424,8 @@ pub async fn git_cache_try_make_local_dir_accessible(
     // git sparce-checkout add <child_relative_path>
     // NOTE: this needs to run from the root of the repository, otherwise git won't fetch
     // the requested subdirectories.
-    let res = run_git_cmd_with_args(
-        &vec!["sparse-checkout", "add", &relative_path.to_string_lossy()],
+    run_git_cmd_with_args(
+        &["sparse-checkout", "add", &relative_path.to_string_lossy()],
         Some(&root_path),
     )
     .await?;

--- a/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
@@ -204,9 +204,7 @@ impl<F: MoveFlavor> Package<F> {
     /// to hold for exactly one package for a valid package graph (see [Self::dep_for_self] for
     /// more information)
     pub fn is_root(&self) -> bool {
-        let result = (self.dep_for_self()
-            == &LockfileDependencyInfo::Local(LocalDepInfo { local: ".".into() }));
-        result
+        self.dep_for_self().is_root()
     }
 
     /// The resolved and pinned dependencies from the manifest for environment `env`

--- a/external-crates/move/crates/move-package-alt/src/schema/lockfile.rs
+++ b/external-crates/move/crates/move-package-alt/src/schema/lockfile.rs
@@ -83,6 +83,15 @@ pub enum LockfileDependencyInfo {
     Git(LockfileGitDepInfo),
 }
 
+impl LockfileDependencyInfo {
+    pub fn is_root(&self) -> bool {
+        match self {
+            LockfileDependencyInfo::Local(dep) => dep.local == PathBuf::from("."),
+            _ => false,
+        }
+    }
+}
+
 /// A serialized lockfile dependency of the form `{git = "...", rev = "...", subdir = "..."}`
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct LockfileGitDepInfo {


### PR DESCRIPTION
## Description 

When we have transitive local deps, the directories could be non-accessible because of our sparse checkouts.

This PR tries (when applicable) to add the paths to the downloaded files in the locally cloned repo.

## Test plan 

Added a unit test for the git logic

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
