### PR TITLE
graphql-alt: Add Epoch.netInflow, Epoch.fundInflow, Epoch.fundOutflow

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/fundInflow/fundInflow.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/fundInflow/fundInflow.move
@@ -1,0 +1,31 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --simulator
+
+//# run-graphql
+{ # no fund inflow initially
+  e0: epoch(epochId: 0) {
+    fundInflow
+  }
+}
+
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# run-graphql
+{ # no fund inflow before epoch end
+  e0: epoch(epochId: 0) {
+    fundInflow
+  }
+}
+
+//# advance-epoch
+
+//# run-graphql
+{ # fund inflow after epoch end
+  e0: epoch(epochId: 0) {
+    fundInflow
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/fundInflow/fundInflow.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/fundInflow/fundInflow.snap
@@ -1,0 +1,49 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-11:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "fundInflow": null
+    }
+  }
+}
+
+task 2, lines 13-15:
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 17-22:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "fundInflow": null
+    }
+  }
+}
+
+task 4, line 24:
+//# advance-epoch
+Epoch advanced: 1
+
+task 5, lines 26-31:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "fundInflow": "1976000"
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/fundOutflow/fundOutflow.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/fundOutflow/fundOutflow.move
@@ -1,0 +1,35 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --simulator
+
+//# run-graphql
+{ # no fund outflow initially
+  e0: epoch(epochId: 0) {
+    fundOutflow
+  }
+}
+
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# run-graphql
+{ # no fund outflow before epoch end
+  e0: epoch(epochId: 0) {
+    fundOutflow
+  }
+}
+
+//# advance-epoch
+
+//# run-graphql
+{ # fund outflow after epoch end
+  e0: epoch(epochId: 0) {
+    fundOutflow
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/fundOutflow/fundOutflow.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/fundOutflow/fundOutflow.snap
@@ -1,0 +1,57 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-11:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "fundOutflow": null
+    }
+  }
+}
+
+task 2, lines 13-15:
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 17-19:
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 21-26:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "fundOutflow": null
+    }
+  }
+}
+
+task 5, line 28:
+//# advance-epoch
+Epoch advanced: 1
+
+task 6, lines 30-35:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "fundOutflow": "978120"
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/netInflow/netInflow.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/netInflow/netInflow.move
@@ -1,0 +1,35 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --simulator
+
+//# run-graphql
+{ # no net inflow initially
+  e0: epoch(epochId: 0) {
+    netInflow
+  }
+}
+
+//# programmable --sender A --inputs 42 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 42 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# run-graphql
+{ # no net inflow before epoch end
+  e0: epoch(epochId: 0) {
+    netInflow
+  }
+}
+
+//# advance-epoch
+
+//# run-graphql
+{ # net inflow after epoch end
+  e0: epoch(epochId: 0) {
+    netInflow
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/netInflow/netInflow.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/netInflow/netInflow.snap
@@ -1,0 +1,57 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-11:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "netInflow": null
+    }
+  }
+}
+
+task 2, lines 13-15:
+//# programmable --sender A --inputs 42 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 17-19:
+//# programmable --sender A --inputs 42 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 21-26:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "netInflow": null
+    }
+  }
+}
+
+task 5, line 28:
+//# advance-epoch
+Epoch advanced: 1
+
+task 6, lines 30-35:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "netInflow": "2973880"
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.move
@@ -48,6 +48,9 @@ fragment E on Epoch {
   totalStakeRewards
   totalStakeSubsidies
   fundSize
+  netInflow
+  fundInflow
+  fundOutflow
 }
 
 //# run-graphql
@@ -86,4 +89,7 @@ fragment E on Epoch {
   totalStakeRewards
   totalStakeSubsidies
   fundSize
+  netInflow
+  fundInflow
+  fundOutflow
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
@@ -18,7 +18,7 @@ task 5, line 14:
 //# advance-epoch
 Epoch advanced: 3
 
-task 6, lines 16-51:
+task 6, lines 16-54:
 //# run-graphql
 Response: {
   "data": {
@@ -44,7 +44,10 @@ Response: {
       "totalGasFees": "0",
       "totalStakeRewards": "0",
       "totalStakeSubsidies": "0",
-      "fundSize": "0"
+      "fundSize": "0",
+      "netInflow": "0",
+      "fundInflow": "0",
+      "fundOutflow": "0"
     },
     "e0": {
       "epochId": 0,
@@ -68,7 +71,10 @@ Response: {
       "totalGasFees": "0",
       "totalStakeRewards": "0",
       "totalStakeSubsidies": "0",
-      "fundSize": "0"
+      "fundSize": "0",
+      "netInflow": "0",
+      "fundInflow": "0",
+      "fundOutflow": "0"
     },
     "e1": {
       "epochId": 1,
@@ -92,7 +98,10 @@ Response: {
       "totalGasFees": "0",
       "totalStakeRewards": "0",
       "totalStakeSubsidies": "0",
-      "fundSize": "0"
+      "fundSize": "0",
+      "netInflow": "0",
+      "fundInflow": "0",
+      "fundOutflow": "0"
     },
     "e2": {
       "epochId": 2,
@@ -116,13 +125,16 @@ Response: {
       "totalGasFees": "0",
       "totalStakeRewards": "0",
       "totalStakeSubsidies": "0",
-      "fundSize": "0"
+      "fundSize": "0",
+      "netInflow": "0",
+      "fundInflow": "0",
+      "fundOutflow": "0"
     },
     "e3": null
   }
 }
 
-task 7, lines 53-89:
+task 7, lines 56-95:
 //# run-graphql
 Response: {
   "data": {
@@ -150,7 +162,10 @@ Response: {
           "totalGasFees": "0",
           "totalStakeRewards": "0",
           "totalStakeSubsidies": "0",
-          "fundSize": "0"
+          "fundSize": "0",
+          "netInflow": "0",
+          "fundInflow": "0",
+          "fundOutflow": "0"
         },
         "e0": {
           "epochId": 0,
@@ -174,7 +189,10 @@ Response: {
           "totalGasFees": "0",
           "totalStakeRewards": "0",
           "totalStakeSubsidies": "0",
-          "fundSize": "0"
+          "fundSize": "0",
+          "netInflow": "0",
+          "fundInflow": "0",
+          "fundOutflow": "0"
         },
         "e1": {
           "epochId": 1,
@@ -198,7 +216,10 @@ Response: {
           "totalGasFees": "0",
           "totalStakeRewards": "0",
           "totalStakeSubsidies": "0",
-          "fundSize": "0"
+          "fundSize": "0",
+          "netInflow": "0",
+          "fundInflow": "0",
+          "fundOutflow": "0"
         },
         "e2": null
       }

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -149,15 +149,26 @@ type Epoch {
 	"""
 	totalStakeRewards: BigInt
 	"""
-	The amount added to total gas fees to make up the total stake rewards.
+	The amount added to total gas fees to make up the total stake rewards (or `null` if the epoch has not finished yet).
 	"""
 	totalStakeSubsidies: BigInt
 	"""
-	The storage fund available in this epoch.
-	This fund is used to redistribute storage fees from past transactions
-	to future validators.
+	The storage fund available in this epoch (or `null` if the epoch has not finished yet).
+	This fund is used to redistribute storage fees from past transactions to future validators.
 	"""
 	fundSize: BigInt
+	"""
+	The difference between the fund inflow and outflow, representing the net amount of storage fees accumulated in this epoch (or `null` if the epoch has not finished yet).
+	"""
+	netInflow: BigInt
+	"""
+	The storage fees paid for transactions executed during the epoch (or `null` if the epoch has not finished yet).
+	"""
+	fundInflow: BigInt
+	"""
+	The storage fee rebates paid to users who deleted the data associated with past transactions (or `null` if the epoch has not finished yet).
+	"""
+	fundOutflow: BigInt
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -153,15 +153,26 @@ type Epoch {
 	"""
 	totalStakeRewards: BigInt
 	"""
-	The amount added to total gas fees to make up the total stake rewards.
+	The amount added to total gas fees to make up the total stake rewards (or `null` if the epoch has not finished yet).
 	"""
 	totalStakeSubsidies: BigInt
 	"""
-	The storage fund available in this epoch.
-	This fund is used to redistribute storage fees from past transactions
-	to future validators.
+	The storage fund available in this epoch (or `null` if the epoch has not finished yet).
+	This fund is used to redistribute storage fees from past transactions to future validators.
 	"""
 	fundSize: BigInt
+	"""
+	The difference between the fund inflow and outflow, representing the net amount of storage fees accumulated in this epoch (or `null` if the epoch has not finished yet).
+	"""
+	netInflow: BigInt
+	"""
+	The storage fees paid for transactions executed during the epoch (or `null` if the epoch has not finished yet).
+	"""
+	fundInflow: BigInt
+	"""
+	The storage fee rebates paid to users who deleted the data associated with past transactions (or `null` if the epoch has not finished yet).
+	"""
+	fundOutflow: BigInt
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -153,15 +153,26 @@ type Epoch {
 	"""
 	totalStakeRewards: BigInt
 	"""
-	The amount added to total gas fees to make up the total stake rewards.
+	The amount added to total gas fees to make up the total stake rewards (or `null` if the epoch has not finished yet).
 	"""
 	totalStakeSubsidies: BigInt
 	"""
-	The storage fund available in this epoch.
-	This fund is used to redistribute storage fees from past transactions
-	to future validators.
+	The storage fund available in this epoch (or `null` if the epoch has not finished yet).
+	This fund is used to redistribute storage fees from past transactions to future validators.
 	"""
 	fundSize: BigInt
+	"""
+	The difference between the fund inflow and outflow, representing the net amount of storage fees accumulated in this epoch (or `null` if the epoch has not finished yet).
+	"""
+	netInflow: BigInt
+	"""
+	The storage fees paid for transactions executed during the epoch (or `null` if the epoch has not finished yet).
+	"""
+	fundInflow: BigInt
+	"""
+	The storage fee rebates paid to users who deleted the data associated with past transactions (or `null` if the epoch has not finished yet).
+	"""
+	fundOutflow: BigInt
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -149,15 +149,26 @@ type Epoch {
 	"""
 	totalStakeRewards: BigInt
 	"""
-	The amount added to total gas fees to make up the total stake rewards.
+	The amount added to total gas fees to make up the total stake rewards (or `null` if the epoch has not finished yet).
 	"""
 	totalStakeSubsidies: BigInt
 	"""
-	The storage fund available in this epoch.
-	This fund is used to redistribute storage fees from past transactions
-	to future validators.
+	The storage fund available in this epoch (or `null` if the epoch has not finished yet).
+	This fund is used to redistribute storage fees from past transactions to future validators.
 	"""
 	fundSize: BigInt
+	"""
+	The difference between the fund inflow and outflow, representing the net amount of storage fees accumulated in this epoch (or `null` if the epoch has not finished yet).
+	"""
+	netInflow: BigInt
+	"""
+	The storage fees paid for transactions executed during the epoch (or `null` if the epoch has not finished yet).
+	"""
+	fundInflow: BigInt
+	"""
+	The storage fee rebates paid to users who deleted the data associated with past transactions (or `null` if the epoch has not finished yet).
+	"""
+	fundOutflow: BigInt
 }
 
 """


### PR DESCRIPTION
## Description 

Implements
1. `Epoch.netInflow` based on https://github.com/MystenLabs/sui/blob/4275c1a55988d28b638be8720aebdf1e7da3b06b/crates/sui-graphql-rpc/src/types/epoch.rs#L174-L182
2. `Epoch.fundInflow` based on https://github.com/MystenLabs/sui/blob/4275c1a55988d28b638be8720aebdf1e7da3b06b/crates/sui-graphql-rpc/src/types/epoch.rs#L185-L187
3. `Epoch.fundOutflow` based on https://github.com/MystenLabs/sui/blob/4275c1a55988d28b638be8720aebdf1e7da3b06b/crates/sui-graphql-rpc/src/types/epoch.rs#L191-L193

## Test plan 

1. Added `netInflow`, `fundInflow`, `fundOutflow` to the `query.move` snapshot test.
2. Added new `netInflow.move` test file.
3. Added new `fundInflow.move` test file.
4. Added new `fundOutflow.move` test file.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
