### PR TITLE
Implement From<bcs::Error> for RpcError<E>

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
@@ -148,15 +148,16 @@ impl Epoch {
             return Ok(None);
         };
 
-        let validator_set: ValidatorSet =
-            match bcs::from_bytes::<SuiSystemState>(&start.system_state)? {
-                SuiSystemState::V1(inner) => inner.validators.into(),
-                SuiSystemState::V2(inner) => inner.validators.into(),
-                #[cfg(msim)]
-                SuiSystemState::SimTestV1(_)
-                | SuiSystemState::SimTestShallowV2(_)
-                | SuiSystemState::SimTestDeepV2(_) => return Ok(None),
-            };
+        let validator_set = match bcs::from_bytes::<SuiSystemState>(&start.system_state)
+            .context("Failed to deserialize system state")?
+        {
+            SuiSystemState::V1(inner) => inner.validators.into(),
+            SuiSystemState::V2(inner) => inner.validators.into(),
+            #[cfg(msim)]
+            SuiSystemState::SimTestV1(_)
+            | SuiSystemState::SimTestShallowV2(_)
+            | SuiSystemState::SimTestDeepV2(_) => return Ok(None),
+        };
 
         Ok(Some(validator_set))
     }

--- a/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
@@ -149,14 +149,13 @@ impl Epoch {
         };
 
         let validator_set: ValidatorSet =
-            match bcs::from_bytes::<SuiSystemState>(&start.system_state) {
-                Ok(SuiSystemState::V1(inner)) => inner.validators.into(),
-                Ok(SuiSystemState::V2(inner)) => inner.validators.into(),
+            match bcs::from_bytes::<SuiSystemState>(&start.system_state)? {
+                SuiSystemState::V1(inner) => inner.validators.into(),
+                SuiSystemState::V2(inner) => inner.validators.into(),
                 #[cfg(msim)]
-                Ok(SuiSystemState::SimTestV1(_))
-                | Ok(SuiSystemState::SimTestShallowV2(_))
-                | Ok(SuiSystemState::SimTestDeepV2(_)) => return Ok(None),
-                Err(e) => return Err(RpcError::InternalError(Arc::new(e.into()))),
+                SuiSystemState::SimTestV1(_)
+                | SuiSystemState::SimTestShallowV2(_)
+                | SuiSystemState::SimTestDeepV2(_) => return Ok(None),
             };
 
         Ok(Some(validator_set))

--- a/crates/sui-indexer-alt-graphql/src/error.rs
+++ b/crates/sui-indexer-alt-graphql/src/error.rs
@@ -3,9 +3,8 @@
 
 use std::{convert::Infallible, sync::Arc, time::Duration};
 
-use async_graphql::{ErrorExtensionValues, ErrorExtensions, Response, Value};
-
 use crate::pagination;
+use async_graphql::{ErrorExtensionValues, ErrorExtensions, Response, Value};
 
 /// Error codes for the `extensions.code` field of a GraphQL error that originates from outside
 /// GraphQL.
@@ -113,6 +112,12 @@ impl<E: std::error::Error> From<RpcError<E>> for async_graphql::ServerError {
             path: vec![],
             extensions,
         }
+    }
+}
+
+impl<E: std::error::Error> From<bcs::Error> for RpcError<E> {
+    fn from(err: bcs::Error) -> Self {
+        RpcError::InternalError(Arc::new(err.into()))
     }
 }
 


### PR DESCRIPTION
## Description 

Implements `From<bcs::Error> for RpcError<E>` to allow using `?` operator.

## Test plan 

No functional changes so existing tests should pass.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
