### PR TITLE
[graphql-alt] Support source_line_number for ExectionError

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/execution_error.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/execution_error.move
@@ -99,6 +99,7 @@ module test::execution_error_tests {
   successTransaction: transactionEffects(digest: "@{digest_2}") {
     executionError {
       abortCode
+      sourceLineNumber
     }
   }
 }
@@ -109,12 +110,14 @@ module test::execution_error_tests {
   abort42: transactionEffects(digest: "@{digest_3}") {
     executionError {
       abortCode
+      sourceLineNumber
     }
   }
   
   abort255: transactionEffects(digest: "@{digest_4}") {
     executionError {
       abortCode
+      sourceLineNumber
     }
   }
 }
@@ -125,48 +128,56 @@ module test::execution_error_tests {
   cleverU8: transactionEffects(digest: "@{digest_5}") {
     executionError {
       abortCode
+      sourceLineNumber
     }
   }
   
   cleverU16: transactionEffects(digest: "@{digest_6}") {
     executionError {
       abortCode
+      sourceLineNumber
     }
   }
   
   cleverU64: transactionEffects(digest: "@{digest_7}") {
     executionError {
       abortCode
+      sourceLineNumber
     }
   }
   
   cleverAddress: transactionEffects(digest: "@{digest_8}") {
     executionError {
       abortCode
+      sourceLineNumber
     }
   }
   
   cleverString: transactionEffects(digest: "@{digest_9}") {
     executionError {
       abortCode
+      sourceLineNumber
     }
   }
   
   cleverWithCode: transactionEffects(digest: "@{digest_10}") {
     executionError {
       abortCode
+      sourceLineNumber
     }
   }
   
   assertFailure: transactionEffects(digest: "@{digest_11}") {
     executionError {
       abortCode
+      sourceLineNumber
     }
   }
 
   nonExistentFunction: transactionEffects(digest: "@{digest_12}") {
     executionError {
       abortCode
+      sourceLineNumber
     }
   }
 } 

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/execution_error.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/execution_error.snap
@@ -72,7 +72,7 @@ task 13, line 94:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 14, lines 96-104:
+task 14, lines 96-105:
 //# run-graphql
 Response: {
   "data": {
@@ -82,65 +82,75 @@ Response: {
   }
 }
 
-task 15, lines 106-120:
+task 15, lines 107-123:
 //# run-graphql
 Response: {
   "data": {
     "abort42": {
       "executionError": {
-        "abortCode": "42"
+        "abortCode": "42",
+        "sourceLineNumber": null
       }
     },
     "abort255": {
       "executionError": {
-        "abortCode": "255"
+        "abortCode": "255",
+        "sourceLineNumber": null
       }
     }
   }
 }
 
-task 16, lines 122-172:
+task 16, lines 125-183:
 //# run-graphql
 Response: {
   "data": {
     "cleverU8": {
       "executionError": {
-        "abortCode": "13906834320372269057"
+        "abortCode": "13906834320372269057",
+        "sourceLineNumber": 34
       }
     },
     "cleverU16": {
       "executionError": {
-        "abortCode": "13906834333257302019"
+        "abortCode": "13906834333257302019",
+        "sourceLineNumber": 37
       }
     },
     "cleverU64": {
       "executionError": {
-        "abortCode": "13906834346142334981"
+        "abortCode": "13906834346142334981",
+        "sourceLineNumber": 40
       }
     },
     "cleverAddress": {
       "executionError": {
-        "abortCode": "13906834359027367943"
+        "abortCode": "13906834359027367943",
+        "sourceLineNumber": 43
       }
     },
     "cleverString": {
       "executionError": {
-        "abortCode": "13906834371912400905"
+        "abortCode": "13906834371912400905",
+        "sourceLineNumber": 46
       }
     },
     "cleverWithCode": {
       "executionError": {
-        "abortCode": "15"
+        "abortCode": "15",
+        "sourceLineNumber": 49
       }
     },
     "assertFailure": {
       "executionError": {
-        "abortCode": "13906834401976647679"
+        "abortCode": "13906834401976647679",
+        "sourceLineNumber": 52
       }
     },
     "nonExistentFunction": {
       "executionError": {
-        "abortCode": null
+        "abortCode": null,
+        "sourceLineNumber": null
       }
     }
   }

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -190,6 +190,10 @@ type ExecutionError {
 	Returns the explicit code if the abort used `code` annotation (e.g., `abort(ERR, code = 5)` returns 5), otherwise returns the raw abort code containing encoded error information.
 	"""
 	abortCode: BigInt
+	"""
+	The source line number for the abort. Only populated for clever errors.
+	"""
+	sourceLineNumber: Int
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/api/types/execution_error.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/execution_error.rs
@@ -91,6 +91,15 @@ impl ExecutionError {
                 .map_or(*raw_code, |code| code as u64),
         )))
     }
+
+    /// The source line number for the abort. Only populated for clever errors.
+    async fn source_line_number(&self, ctx: &Context<'_>) -> Result<Option<u64>, RpcError> {
+        let Some(clever_error) = self.clever_error(ctx).await? else {
+            return Ok(None);
+        };
+
+        Ok(Some(clever_error.source_line_number as u64))
+    }
 }
 
 impl ExecutionError {

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -194,6 +194,10 @@ type ExecutionError {
 	Returns the explicit code if the abort used `code` annotation (e.g., `abort(ERR, code = 5)` returns 5), otherwise returns the raw abort code containing encoded error information.
 	"""
 	abortCode: BigInt
+	"""
+	The source line number for the abort. Only populated for clever errors.
+	"""
+	sourceLineNumber: Int
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -194,6 +194,10 @@ type ExecutionError {
 	Returns the explicit code if the abort used `code` annotation (e.g., `abort(ERR, code = 5)` returns 5), otherwise returns the raw abort code containing encoded error information.
 	"""
 	abortCode: BigInt
+	"""
+	The source line number for the abort. Only populated for clever errors.
+	"""
+	sourceLineNumber: Int
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -190,6 +190,10 @@ type ExecutionError {
 	Returns the explicit code if the abort used `code` annotation (e.g., `abort(ERR, code = 5)` returns 5), otherwise returns the raw abort code containing encoded error information.
 	"""
 	abortCode: BigInt
+	"""
+	The source line number for the abort. Only populated for clever errors.
+	"""
+	sourceLineNumber: Int
 }
 
 """


### PR DESCRIPTION
## Description 

Implement `source_line_number` field support for `ExectionError` type.

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-graphql
cargo nextest run -p sui-indexer-alt-reader
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

---

## Stack 
- #22791
- #22864 ⬅️

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
