### PR TITLE
[graphql-alt] Support constant for ExectionError

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/execution_error.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/execution_error.move
@@ -140,6 +140,7 @@ module test::execution_error_tests {
       sourceLineNumber
       instructionOffset
       identifier
+      constant
     }
   }
 }
@@ -153,6 +154,7 @@ module test::execution_error_tests {
       sourceLineNumber
       instructionOffset
       identifier
+      constant
     }
   }
   
@@ -162,6 +164,7 @@ module test::execution_error_tests {
       sourceLineNumber
       instructionOffset
       identifier
+      constant
     }
   }
 }
@@ -175,6 +178,7 @@ module test::execution_error_tests {
       sourceLineNumber
       instructionOffset
       identifier
+      constant
     }
   }
   
@@ -184,6 +188,7 @@ module test::execution_error_tests {
       sourceLineNumber
       instructionOffset
       identifier
+      constant
     }
   }
   
@@ -193,6 +198,7 @@ module test::execution_error_tests {
       sourceLineNumber
       instructionOffset
       identifier
+      constant
     }
   }
   
@@ -202,6 +208,7 @@ module test::execution_error_tests {
       sourceLineNumber
       instructionOffset
       identifier
+      constant
     }
   }
   
@@ -211,6 +218,7 @@ module test::execution_error_tests {
       sourceLineNumber
       instructionOffset
       identifier
+      constant
     }
   }
   
@@ -220,6 +228,7 @@ module test::execution_error_tests {
       sourceLineNumber
       instructionOffset
       identifier
+      constant
     }
   }
 
@@ -229,6 +238,7 @@ module test::execution_error_tests {
       sourceLineNumber
       instructionOffset
       identifier
+      constant
     }
   }
   
@@ -238,6 +248,7 @@ module test::execution_error_tests {
       sourceLineNumber
       instructionOffset
       identifier
+      constant
     }
   }
 
@@ -247,6 +258,7 @@ module test::execution_error_tests {
       sourceLineNumber
       instructionOffset
       identifier
+      constant
     }
   }
 }
@@ -260,6 +272,7 @@ module test::execution_error_tests {
       sourceLineNumber
       instructionOffset
       identifier
+      constant
     }
   }
   
@@ -269,6 +282,7 @@ module test::execution_error_tests {
       sourceLineNumber
       instructionOffset
       identifier
+      constant
     }
   }
   
@@ -278,6 +292,7 @@ module test::execution_error_tests {
       sourceLineNumber
       instructionOffset
       identifier
+      constant
     }
   }
   
@@ -287,6 +302,7 @@ module test::execution_error_tests {
       sourceLineNumber
       instructionOffset
       identifier
+      constant
     }
   }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/execution_error.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/execution_error.snap
@@ -97,7 +97,7 @@ task 18, line 132:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 19, lines 134-145:
+task 19, lines 134-146:
 //# run-graphql
 Response: {
   "data": {
@@ -107,7 +107,7 @@ Response: {
   }
 }
 
-task 20, lines 147-167:
+task 20, lines 148-170:
 //# run-graphql
 Response: {
   "data": {
@@ -116,7 +116,8 @@ Response: {
         "abortCode": "42",
         "sourceLineNumber": null,
         "instructionOffset": 1,
-        "identifier": null
+        "identifier": null,
+        "constant": null
       }
     },
     "abort255": {
@@ -124,13 +125,14 @@ Response: {
         "abortCode": "255",
         "sourceLineNumber": null,
         "instructionOffset": 1,
-        "identifier": null
+        "identifier": null,
+        "constant": null
       }
     }
   }
 }
 
-task 21, lines 169-252:
+task 21, lines 172-264:
 //# run-graphql
 Response: {
   "data": {
@@ -139,7 +141,8 @@ Response: {
         "abortCode": "13906834328962203649",
         "sourceLineNumber": 36,
         "instructionOffset": 1,
-        "identifier": "ECleverU8"
+        "identifier": "ECleverU8",
+        "constant": "10"
       }
     },
     "cleverU16": {
@@ -147,7 +150,8 @@ Response: {
         "abortCode": "13906834341847236611",
         "sourceLineNumber": 39,
         "instructionOffset": 1,
-        "identifier": "ECleverU16"
+        "identifier": "ECleverU16",
+        "constant": "20"
       }
     },
     "cleverU64": {
@@ -155,7 +159,8 @@ Response: {
         "abortCode": "13906834354732269573",
         "sourceLineNumber": 42,
         "instructionOffset": 1,
-        "identifier": "ECleverU64"
+        "identifier": "ECleverU64",
+        "constant": "100"
       }
     },
     "cleverAddress": {
@@ -163,7 +168,8 @@ Response: {
         "abortCode": "13906834367617302535",
         "sourceLineNumber": 45,
         "instructionOffset": 1,
-        "identifier": "ECleverAddress"
+        "identifier": "ECleverAddress",
+        "constant": "0x0000000000000000000000000000000000000000000000000000000000000042"
       }
     },
     "cleverString": {
@@ -171,7 +177,8 @@ Response: {
         "abortCode": "13906834380502335497",
         "sourceLineNumber": 48,
         "instructionOffset": 1,
-        "identifier": "ECleverString"
+        "identifier": "ECleverString",
+        "constant": "This is a clever error message"
       }
     },
     "cleverWithCode": {
@@ -179,7 +186,8 @@ Response: {
         "abortCode": "15",
         "sourceLineNumber": 51,
         "instructionOffset": 1,
-        "identifier": "ECleverWithCode"
+        "identifier": "ECleverWithCode",
+        "constant": "Error with explicit code"
       }
     },
     "cleverRaw": {
@@ -187,7 +195,8 @@ Response: {
         "abortCode": "13906834406272401421",
         "sourceLineNumber": 54,
         "instructionOffset": 1,
-        "identifier": "ECleverRaw"
+        "identifier": "ECleverRaw",
+        "constant": null
       }
     },
     "assertFailure": {
@@ -195,7 +204,8 @@ Response: {
         "abortCode": "13906834423451484159",
         "sourceLineNumber": 57,
         "instructionOffset": 1,
-        "identifier": null
+        "identifier": null,
+        "constant": null
       }
     },
     "nonExistentFunction": {
@@ -203,13 +213,14 @@ Response: {
         "abortCode": null,
         "sourceLineNumber": null,
         "instructionOffset": null,
-        "identifier": null
+        "identifier": null,
+        "constant": null
       }
     }
   }
 }
 
-task 22, lines 254-292:
+task 22, lines 266-308:
 //# run-graphql
 Response: {
   "data": {
@@ -218,7 +229,8 @@ Response: {
         "abortCode": null,
         "sourceLineNumber": null,
         "instructionOffset": 2,
-        "identifier": null
+        "identifier": null,
+        "constant": null
       }
     },
     "arithmeticOverflow": {
@@ -226,7 +238,8 @@ Response: {
         "abortCode": null,
         "sourceLineNumber": null,
         "instructionOffset": 2,
-        "identifier": null
+        "identifier": null,
+        "constant": null
       }
     },
     "divisionByZero": {
@@ -234,7 +247,8 @@ Response: {
         "abortCode": null,
         "sourceLineNumber": null,
         "instructionOffset": 2,
-        "identifier": null
+        "identifier": null,
+        "constant": null
       }
     },
     "vectorOutOfBounds": {
@@ -242,7 +256,8 @@ Response: {
         "abortCode": null,
         "sourceLineNumber": null,
         "instructionOffset": 4,
-        "identifier": null
+        "identifier": null,
+        "constant": null
       }
     }
   }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/execution_error.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/execution_error.snap
@@ -196,7 +196,7 @@ Response: {
         "sourceLineNumber": 54,
         "instructionOffset": 1,
         "identifier": "ECleverRaw",
-        "constant": null
+        "constant": "AwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAw=="
       }
     },
     "assertFailure": {

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -258,6 +258,8 @@ type ExecutionError {
 	identifier: String
 	"""
 	An associated constant for the error. Only populated for clever errors.
+	
+	Constants are returned as human-readable strings when possible. Complex types are returned as Base64-encoded bytes.
 	"""
 	constant: String
 }

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -256,6 +256,10 @@ type ExecutionError {
 	The error's name. Only populated for clever errors.
 	"""
 	identifier: String
+	"""
+	An associated constant for the error. Only populated for clever errors.
+	"""
+	constant: String
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/api/types/execution_error.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/execution_error.rs
@@ -3,6 +3,7 @@
 
 use anyhow::{self, Context as _};
 use async_graphql::{Context, Object};
+use fastcrypto::encoding::{Base64, Encoding};
 use sui_indexer_alt_reader::package_resolver::PackageResolver;
 use sui_package_resolver::CleverError;
 use sui_types::{
@@ -128,6 +129,8 @@ impl ExecutionError {
     }
 
     /// An associated constant for the error. Only populated for clever errors.
+    ///
+    /// Constants are returned as human-readable strings when possible. Complex types are returned as Base64-encoded bytes.
     async fn constant(&self, ctx: &Context<'_>) -> Result<Option<String>, RpcError> {
         use sui_package_resolver::ErrorConstants;
 
@@ -138,7 +141,7 @@ impl ExecutionError {
         let constant = match &clever_error.error_info {
             ErrorConstants::None => None,
             ErrorConstants::Rendered { constant, .. } => Some(constant.clone()),
-            ErrorConstants::Raw { .. } => None, // Raw bytes are not human-readable constants
+            ErrorConstants::Raw { bytes, .. } => Some(Base64::encode(bytes)),
         };
 
         Ok(constant)

--- a/crates/sui-indexer-alt-graphql/src/api/types/execution_error.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/execution_error.rs
@@ -126,6 +126,23 @@ impl ExecutionError {
             ErrorConstants::Raw { identifier, .. } => Some(identifier.clone()),
         })
     }
+
+    /// An associated constant for the error. Only populated for clever errors.
+    async fn constant(&self, ctx: &Context<'_>) -> Result<Option<String>, RpcError> {
+        use sui_package_resolver::ErrorConstants;
+
+        let Some(clever_error) = self.clever_error(ctx).await? else {
+            return Ok(None);
+        };
+
+        let constant = match &clever_error.error_info {
+            ErrorConstants::None => None,
+            ErrorConstants::Rendered { constant, .. } => Some(constant.clone()),
+            ErrorConstants::Raw { .. } => None, // Raw bytes are not human-readable constants
+        };
+
+        Ok(constant)
+    }
 }
 
 impl ExecutionError {

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -260,6 +260,10 @@ type ExecutionError {
 	The error's name. Only populated for clever errors.
 	"""
 	identifier: String
+	"""
+	An associated constant for the error. Only populated for clever errors.
+	"""
+	constant: String
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -262,6 +262,8 @@ type ExecutionError {
 	identifier: String
 	"""
 	An associated constant for the error. Only populated for clever errors.
+	
+	Constants are returned as human-readable strings when possible. Complex types are returned as Base64-encoded bytes.
 	"""
 	constant: String
 }

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -260,6 +260,10 @@ type ExecutionError {
 	The error's name. Only populated for clever errors.
 	"""
 	identifier: String
+	"""
+	An associated constant for the error. Only populated for clever errors.
+	"""
+	constant: String
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -262,6 +262,8 @@ type ExecutionError {
 	identifier: String
 	"""
 	An associated constant for the error. Only populated for clever errors.
+	
+	Constants are returned as human-readable strings when possible. Complex types are returned as Base64-encoded bytes.
 	"""
 	constant: String
 }

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -258,6 +258,8 @@ type ExecutionError {
 	identifier: String
 	"""
 	An associated constant for the error. Only populated for clever errors.
+	
+	Constants are returned as human-readable strings when possible. Complex types are returned as Base64-encoded bytes.
 	"""
 	constant: String
 }

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -256,6 +256,10 @@ type ExecutionError {
 	The error's name. Only populated for clever errors.
 	"""
 	identifier: String
+	"""
+	An associated constant for the error. Only populated for clever errors.
+	"""
+	constant: String
 }
 
 """


### PR DESCRIPTION
## Description 

Implement `constant` field support for `ExectionError` type.

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-graphql
cargo nextest run -p sui-indexer-alt-reader
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

---

## Stack 
- #22791
- #22864 
- #22865
- #22866 
- #22867 ⬅️


## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
