### PR TITLE
graphql-alt: Add Epoch.storageFund

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.move
@@ -51,6 +51,10 @@ fragment E on Epoch {
   netInflow
   fundInflow
   fundOutflow
+  storageFund {
+    totalObjectStorageRebates
+    nonRefundableBalance
+  }
 }
 
 //# run-graphql
@@ -92,4 +96,8 @@ fragment E on Epoch {
   netInflow
   fundInflow
   fundOutflow
+  storageFund {
+    totalObjectStorageRebates
+    nonRefundableBalance
+  }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
@@ -18,7 +18,7 @@ task 5, line 14:
 //# advance-epoch
 Epoch advanced: 3
 
-task 6, lines 16-54:
+task 6, lines 16-58:
 //# run-graphql
 Response: {
   "data": {
@@ -47,7 +47,11 @@ Response: {
       "fundSize": "0",
       "netInflow": "0",
       "fundInflow": "0",
-      "fundOutflow": "0"
+      "fundOutflow": "0",
+      "storageFund": {
+        "totalObjectStorageRebates": "0",
+        "nonRefundableBalance": "0"
+      }
     },
     "e0": {
       "epochId": 0,
@@ -74,7 +78,11 @@ Response: {
       "fundSize": "0",
       "netInflow": "0",
       "fundInflow": "0",
-      "fundOutflow": "0"
+      "fundOutflow": "0",
+      "storageFund": {
+        "totalObjectStorageRebates": "0",
+        "nonRefundableBalance": "0"
+      }
     },
     "e1": {
       "epochId": 1,
@@ -101,7 +109,11 @@ Response: {
       "fundSize": "0",
       "netInflow": "0",
       "fundInflow": "0",
-      "fundOutflow": "0"
+      "fundOutflow": "0",
+      "storageFund": {
+        "totalObjectStorageRebates": "0",
+        "nonRefundableBalance": "0"
+      }
     },
     "e2": {
       "epochId": 2,
@@ -128,13 +140,17 @@ Response: {
       "fundSize": "0",
       "netInflow": "0",
       "fundInflow": "0",
-      "fundOutflow": "0"
+      "fundOutflow": "0",
+      "storageFund": {
+        "totalObjectStorageRebates": "0",
+        "nonRefundableBalance": "0"
+      }
     },
     "e3": null
   }
 }
 
-task 7, lines 56-95:
+task 7, lines 60-103:
 //# run-graphql
 Response: {
   "data": {
@@ -165,7 +181,11 @@ Response: {
           "fundSize": "0",
           "netInflow": "0",
           "fundInflow": "0",
-          "fundOutflow": "0"
+          "fundOutflow": "0",
+          "storageFund": {
+            "totalObjectStorageRebates": "0",
+            "nonRefundableBalance": "0"
+          }
         },
         "e0": {
           "epochId": 0,
@@ -192,7 +212,11 @@ Response: {
           "fundSize": "0",
           "netInflow": "0",
           "fundInflow": "0",
-          "fundOutflow": "0"
+          "fundOutflow": "0",
+          "storageFund": {
+            "totalObjectStorageRebates": "0",
+            "nonRefundableBalance": "0"
+          }
         },
         "e1": {
           "epochId": 1,
@@ -219,7 +243,11 @@ Response: {
           "fundSize": "0",
           "netInflow": "0",
           "fundInflow": "0",
-          "fundOutflow": "0"
+          "fundOutflow": "0",
+          "storageFund": {
+            "totalObjectStorageRebates": "0",
+            "nonRefundableBalance": "0"
+          }
         },
         "e2": null
       }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/storageFund/storageFund.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/storageFund/storageFund.move
@@ -1,0 +1,42 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --simulator
+
+//# run-graphql
+{ # no storage fund initially
+  e0: epoch(epochId: 0) { ...E }
+  e1: epoch(epochId: 1) { ...E }
+}
+
+fragment E on Epoch {
+  storageFund {
+    totalObjectStorageRebates
+    nonRefundableBalance
+  }
+}
+
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# run-graphql
+{ # storage fund on first checkpoint of epoch 1
+  e0: epoch(epochId: 0) { ...E }
+  e1: epoch(epochId: 1) { ...E }
+}
+
+fragment E on Epoch {
+  storageFund {
+    totalObjectStorageRebates
+    nonRefundableBalance
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/storageFund/storageFund.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/storageFund/storageFund.snap
@@ -1,0 +1,64 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-17:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "storageFund": {
+        "totalObjectStorageRebates": "0",
+        "nonRefundableBalance": "0"
+      }
+    },
+    "e1": null
+  }
+}
+
+task 2, lines 19-21:
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 23-25:
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, line 27:
+//# advance-epoch
+Epoch advanced: 1
+
+task 5, line 29:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 6, lines 31-42:
+//# run-graphql
+Response: {
+  "data": {
+    "e0": {
+      "storageFund": {
+        "totalObjectStorageRebates": "0",
+        "nonRefundableBalance": "0"
+      }
+    },
+    "e1": {
+      "storageFund": {
+        "totalObjectStorageRebates": "2964000",
+        "nonRefundableBalance": "9880"
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -173,6 +173,11 @@ type Epoch {
 	The storage fee rebates paid to users who deleted the data associated with past transactions (or `null` if the epoch has not finished yet).
 	"""
 	fundOutflow: BigInt
+	"""
+	SUI set aside to account for objects stored on-chain, at the start of the epoch.
+	This is also used for storage rebates.
+	"""
+	storageFund: StorageFund
 }
 
 """
@@ -849,6 +854,21 @@ type ServiceConfig {
 	Maximum nesting allowed in datatype fields when calculating the layout of a single type.
 	"""
 	maxMoveValueDepth: Int
+}
+
+"""
+SUI set aside to account for objects stored on-chain.
+"""
+type StorageFund {
+	"""
+	Sum of storage rebates of live objects on chain.
+	"""
+	totalObjectStorageRebates: BigInt
+	"""
+	The portion of the storage fund that will never be refunded through storage rebates.
+	The system maintains an invariant that the sum of all storage fees into the storage fund is equal to the sum of all storage rebates out, the total storage rebates remaining, and the non-refundable balance.
+	"""
+	nonRefundableBalance: BigInt
 }
 
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod object;
 pub(crate) mod object_change;
 pub(crate) mod protocol_configs;
 pub(crate) mod service_config;
+pub(crate) mod storage_fund;
 pub(crate) mod transaction;
 pub(crate) mod transaction_effects;
 pub(crate) mod validator_aggregated_signature;

--- a/crates/sui-indexer-alt-graphql/src/api/types/storage_fund.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/storage_fund.rs
@@ -1,0 +1,26 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::api::scalars::big_int::BigInt;
+use async_graphql::SimpleObject;
+use sui_types::sui_system_state::sui_system_state_inner_v1::StorageFundV1;
+
+/// SUI set aside to account for objects stored on-chain.
+#[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
+pub(crate) struct StorageFund {
+    /// Sum of storage rebates of live objects on chain.
+    pub total_object_storage_rebates: Option<BigInt>,
+
+    /// The portion of the storage fund that will never be refunded through storage rebates.
+    /// The system maintains an invariant that the sum of all storage fees into the storage fund is equal to the sum of all storage rebates out, the total storage rebates remaining, and the non-refundable balance.
+    pub non_refundable_balance: Option<BigInt>,
+}
+
+impl From<StorageFundV1> for StorageFund {
+    fn from(value: StorageFundV1) -> Self {
+        StorageFund {
+            total_object_storage_rebates: Some(value.total_object_storage_rebates.value().into()),
+            non_refundable_balance: Some(value.non_refundable_balance.value().into()),
+        }
+    }
+}

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -177,6 +177,11 @@ type Epoch {
 	The storage fee rebates paid to users who deleted the data associated with past transactions (or `null` if the epoch has not finished yet).
 	"""
 	fundOutflow: BigInt
+	"""
+	SUI set aside to account for objects stored on-chain, at the start of the epoch.
+	This is also used for storage rebates.
+	"""
+	storageFund: StorageFund
 }
 
 """
@@ -853,6 +858,21 @@ type ServiceConfig {
 	Maximum nesting allowed in datatype fields when calculating the layout of a single type.
 	"""
 	maxMoveValueDepth: Int
+}
+
+"""
+SUI set aside to account for objects stored on-chain.
+"""
+type StorageFund {
+	"""
+	Sum of storage rebates of live objects on chain.
+	"""
+	totalObjectStorageRebates: BigInt
+	"""
+	The portion of the storage fund that will never be refunded through storage rebates.
+	The system maintains an invariant that the sum of all storage fees into the storage fund is equal to the sum of all storage rebates out, the total storage rebates remaining, and the non-refundable balance.
+	"""
+	nonRefundableBalance: BigInt
 }
 
 

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -177,6 +177,11 @@ type Epoch {
 	The storage fee rebates paid to users who deleted the data associated with past transactions (or `null` if the epoch has not finished yet).
 	"""
 	fundOutflow: BigInt
+	"""
+	SUI set aside to account for objects stored on-chain, at the start of the epoch.
+	This is also used for storage rebates.
+	"""
+	storageFund: StorageFund
 }
 
 """
@@ -853,6 +858,21 @@ type ServiceConfig {
 	Maximum nesting allowed in datatype fields when calculating the layout of a single type.
 	"""
 	maxMoveValueDepth: Int
+}
+
+"""
+SUI set aside to account for objects stored on-chain.
+"""
+type StorageFund {
+	"""
+	Sum of storage rebates of live objects on chain.
+	"""
+	totalObjectStorageRebates: BigInt
+	"""
+	The portion of the storage fund that will never be refunded through storage rebates.
+	The system maintains an invariant that the sum of all storage fees into the storage fund is equal to the sum of all storage rebates out, the total storage rebates remaining, and the non-refundable balance.
+	"""
+	nonRefundableBalance: BigInt
 }
 
 

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -173,6 +173,11 @@ type Epoch {
 	The storage fee rebates paid to users who deleted the data associated with past transactions (or `null` if the epoch has not finished yet).
 	"""
 	fundOutflow: BigInt
+	"""
+	SUI set aside to account for objects stored on-chain, at the start of the epoch.
+	This is also used for storage rebates.
+	"""
+	storageFund: StorageFund
 }
 
 """
@@ -849,6 +854,21 @@ type ServiceConfig {
 	Maximum nesting allowed in datatype fields when calculating the layout of a single type.
 	"""
 	maxMoveValueDepth: Int
+}
+
+"""
+SUI set aside to account for objects stored on-chain.
+"""
+type StorageFund {
+	"""
+	Sum of storage rebates of live objects on chain.
+	"""
+	totalObjectStorageRebates: BigInt
+	"""
+	The portion of the storage fund that will never be refunded through storage rebates.
+	The system maintains an invariant that the sum of all storage fees into the storage fund is equal to the sum of all storage rebates out, the total storage rebates remaining, and the non-refundable balance.
+	"""
+	nonRefundableBalance: BigInt
 }
 
 


### PR DESCRIPTION
## Description 

Implements `Epoch.storageFund` based on
https://github.com/MystenLabs/sui/blob/4275c1a55988d28b638be8720aebdf1e7da3b06b/crates/sui-graphql-rpc/src/types/epoch.rs#L168-L170

## Test plan 

1. Added `storageFund` to the `query.move` snapshot test.
2. Added new `storageFund.move` test file.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
