### PR TITLE
remove some autogenerated lines

### DIFF
--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_88.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_88.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
-snapshot_kind: text
 ---
 version: 88
 feature_flags:

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_89.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_89.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
-snapshot_kind: text
 ---
 version: 89
 feature_flags:


### PR DESCRIPTION
## Description 
Fixing:
```
eugene@eugene-dev ~/code/sui/scripts/compatibility (main) $ ./check-protocol-compatibility.sh mainnet
Found following versions on mainnet:
    175 1.52.2-7f45ba185ff0
     19 1.51.5-5a3745526511
      4 1.52.2-7f45ba185f
      2 1.51.5-5a37455265
      2 1.49.2-62b9f371e37e
      1 1.50.1-197ebfbc1ff0
      1 1.48.2-17a9eb8e1914
      1 1.47.1-74c8e45b63a1
      1 1.46.2-3c894a0ab474
      1 1.43.1-b3766e5fed72

Using most frequent version 1.52.2-7f45ba185ff0 for compatibility check
Source commit: 08d9fca206ca63be6e85c30c0b752f08567fa68e
Source branch: main
Checking protocol compatibility with mainnet (7f45ba185ff0)
Checking out mainnet snapshot files
Checking for changes to snapshot files matching *__Mainnet_version_*
Error: Detected changes to snapshot files since 7f45ba185ff0 - not safe to release
diff --git a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_88.snap b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_88.snap
index 60c6dd64ed..c4d107ddd1 100644
--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_88.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_88.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
-snapshot_kind: text
 ---
 version: 88
 feature_flags:
 ```

## Test plan 
```
eugene@eugene-dev ~/code/sui/scripts/compatibility (joy/fix-ci) $ ./check-protocol-compatibility.sh mainnet
Found following versions on mainnet:
    175 1.52.2-7f45ba185ff0
     19 1.51.5-5a3745526511
      4 1.52.2-7f45ba185f
      2 1.51.5-5a37455265
      2 1.49.2-62b9f371e37e
      1 1.50.1-197ebfbc1ff0
      1 1.48.2-17a9eb8e1914
      1 1.47.1-74c8e45b63a1
      1 1.46.2-3c894a0ab474
      1 1.43.1-b3766e5fed72

Using most frequent version 1.52.2-7f45ba185ff0 for compatibility check
Source commit: 62cd8b0bc61ab272f11d6688cbe2e2400260e466
Source branch: joy/fix-ci
Checking protocol compatibility with mainnet (7f45ba185ff0)
Checking out mainnet snapshot files
Checking for changes to snapshot files matching *__Mainnet_version_*
HEAD is now at 62cd8b0bc6 remove some autogenerated lines
Running snapshot tests...
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.39s
     Running unittests src/lib.rs (target/debug/deps/sui_protocol_config-7e53ebf79abab585)

running 1 test
test test::snapshot_tests ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.63s
```
