### PR TITLE
[MFP] enable validator logic in testnet

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -3868,6 +3868,11 @@ impl ProtocolConfig {
                     cfg.feature_flags.additional_consensus_digest_indirect_state = true;
                     cfg.feature_flags.accept_passkey_in_multisig = true;
                     cfg.feature_flags.passkey_auth = true;
+
+                    // Enable Mysticeti fastpath handlers on testnet.
+                    if chain != Chain::Mainnet {
+                        cfg.feature_flags.mysticeti_fastpath = true;
+                    }
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_89.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_89.snap
@@ -78,6 +78,7 @@ feature_flags:
   consensus_round_prober: true
   validate_identifier_inputs: true
   disallow_self_identifier: true
+  mysticeti_fastpath: true
   relocate_event_module: true
   uncompressed_g1_group_elements: true
   disallow_new_modules_in_deps_only_packages: true


### PR DESCRIPTION
## Description 

Validator side logic, although still experimental, is ready to be enabled on public testnet.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
