### PR TITLE
Accept balance withdraw in execution layer

### DIFF
--- a/crates/sui-json-rpc-types/src/displays/transaction_displays.rs
+++ b/crates/sui-json-rpc-types/src/displays/transaction_displays.rs
@@ -52,6 +52,9 @@ impl Display for Pretty<'_, SuiProgrammableTransactionBlock> {
                             object_id
                         )]);
                     }
+                    SuiCallArg::BalanceWithdraw(arg) => {
+                        builder.push_record(vec![format!("{i:<3} Balance Withdraw: {:?}", arg)]);
+                    }
                 }
             }
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -8752,6 +8752,32 @@
                 ]
               }
             }
+          },
+          {
+            "type": "object",
+            "required": [
+              "reservation",
+              "type",
+              "typeParam",
+              "withdrawFrom"
+            ],
+            "properties": {
+              "reservation": {
+                "$ref": "#/components/schemas/SuiReservation"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "balanceWithdraw"
+                ]
+              },
+              "typeParam": {
+                "$ref": "#/components/schemas/SuiWithdrawTypeParam"
+              },
+              "withdrawFrom": {
+                "$ref": "#/components/schemas/SuiWithdrawFrom"
+              }
+            }
           }
         ]
       },
@@ -9576,6 +9602,28 @@
           }
         }
       },
+      "SuiReservation": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "entireBalance"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "maxAmountU64"
+            ],
+            "properties": {
+              "maxAmountU64": {
+                "$ref": "#/components/schemas/BigInt_for_uint64"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
       "SuiSystemStateSummary": {
         "description": "This is the JSON-RPC type for the SUI system state object. It flattens all fields to make them top-level fields such that it as minimum dependencies to the internal data structures of the SUI system state type.",
         "type": "object",
@@ -10378,6 +10426,28 @@
             "$ref": "#/components/schemas/Base64"
           }
         }
+      },
+      "SuiWithdrawFrom": {
+        "type": "string",
+        "enum": [
+          "sender"
+        ]
+      },
+      "SuiWithdrawTypeParam": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "balance"
+            ],
+            "properties": {
+              "balance": {
+                "$ref": "#/components/schemas/TypeTag"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "Supply": {
         "type": "object",

--- a/sui-execution/latest/sui-adapter/src/execution_value.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_value.rs
@@ -178,6 +178,17 @@ impl InputValue {
             inner: ResultValue::new(Value::Receiving(id, version, None)),
         }
     }
+
+    // TODO(address-balances): Populate withdraw reservation information.
+    pub fn new_balance_withdraw() -> Self {
+        InputValue {
+            object_metadata: None,
+            inner: ResultValue {
+                last_usage_kind: None,
+                value: None,
+            },
+        }
+    }
 }
 
 impl ResultValue {

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -1675,7 +1675,7 @@ mod checked {
             )?,
             CallArg::BalanceWithdraw(_) => {
                 // TODO(address-balances): Add support for balance withdraws.
-                todo!("Load balance withdraw call arg")
+                InputValue::new_balance_withdraw()
             }
         })
     }


### PR DESCRIPTION
## Description 

This PR accepts (but ignores) withdraw reservation arguments in a transaction.
This will allow us to provide withdraw reservation in a transaction and test balance withdraw scheduling end to end.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
