### PR TITLE
jsonrpc CoinRegistry integration

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_coin.rs
+++ b/crates/sui-json-rpc-types/src/sui_coin.rs
@@ -12,6 +12,7 @@ use sui_types::base_types::{
     EpochId, ObjectDigest, ObjectID, ObjectRef, SequenceNumber, TransactionDigest,
 };
 use sui_types::coin::CoinMetadata;
+use sui_types::coin_registry;
 use sui_types::error::SuiError;
 use sui_types::object::Object;
 use sui_types::sui_serde::BigInt;
@@ -104,5 +105,18 @@ impl TryFrom<Object> for SuiCoinMetadata {
             description,
             icon_url,
         })
+    }
+}
+
+impl From<coin_registry::CoinData> for SuiCoinMetadata {
+    fn from(coin_data: coin_registry::CoinData) -> Self {
+        Self {
+            id: Some(coin_data.id.id.bytes),
+            decimals: coin_data.decimals,
+            name: coin_data.name,
+            symbol: coin_data.symbol,
+            description: coin_data.description,
+            icon_url: Some(coin_data.icon_url),
+        }
     }
 }

--- a/crates/sui-json-rpc-types/src/sui_coin.rs
+++ b/crates/sui-json-rpc-types/src/sui_coin.rs
@@ -108,15 +108,15 @@ impl TryFrom<Object> for SuiCoinMetadata {
     }
 }
 
-impl From<coin_registry::CoinData> for SuiCoinMetadata {
-    fn from(coin_data: coin_registry::CoinData) -> Self {
+impl From<coin_registry::Currency> for SuiCoinMetadata {
+    fn from(currency: coin_registry::Currency) -> Self {
         Self {
-            id: Some(coin_data.id.id.bytes),
-            decimals: coin_data.decimals,
-            name: coin_data.name,
-            symbol: coin_data.symbol,
-            description: coin_data.description,
-            icon_url: Some(coin_data.icon_url),
+            id: Some(currency.id.id.bytes),
+            decimals: currency.decimals,
+            name: currency.name,
+            symbol: currency.symbol,
+            description: currency.description,
+            icon_url: Some(currency.icon_url),
         }
     }
 }


### PR DESCRIPTION
## Description

Checking CoinRegistry for metadata/supply before falling back to indexes.

## Test plan

Added unit tests with mocked coin registry data.

## Release notes

- [x] JSON-RPC: Integrating coin metadata and total supply apis with CoinRegistry system object.
