### PR TITLE
Loose the lifetime constraints of the `MoveTraceBuilder`

### DIFF
--- a/external-crates/move/crates/move-trace-format/src/format.rs
+++ b/external-crates/move/crates/move-trace-format/src/format.rs
@@ -200,8 +200,8 @@ pub struct MoveTrace {
 /// The Move trace format. The custom tracer is not serialized, but the events are.
 /// This is the format that the Move VM will output traces in, and the `tracer` can output
 /// additional events to the trace.
-pub struct MoveTraceBuilder {
-    pub tracer: Box<dyn Tracer>,
+pub struct MoveTraceBuilder<'a> {
+    pub tracer: Box<dyn Tracer + 'a>,
 
     pub trace: MoveTrace,
 }
@@ -302,7 +302,7 @@ impl Default for MoveTrace {
     }
 }
 
-impl MoveTraceBuilder {
+impl<'a> MoveTraceBuilder<'a> {
     /// Create a new `MoveTraceBuilder` with no additional tracing.
     pub fn new() -> Self {
         Self {
@@ -312,7 +312,7 @@ impl MoveTraceBuilder {
     }
 
     /// Create a new `MoveTraceBuilder` with a custom `tracer`.
-    pub fn new_with_tracer(tracer: Box<dyn Tracer>) -> Self {
+    pub fn new_with_tracer(tracer: Box<dyn Tracer + 'a>) -> Self {
         Self {
             tracer,
             trace: MoveTrace::new(),
@@ -401,7 +401,7 @@ impl MoveTraceBuilder {
     }
 }
 
-impl Default for MoveTraceBuilder {
+impl<'a> Default for MoveTraceBuilder<'a> {
     fn default() -> Self {
         Self::new()
     }

--- a/external-crates/move/crates/move-vm-runtime/src/interpreter.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/interpreter.rs
@@ -107,7 +107,7 @@ impl Interpreter {
         gas_meter: &mut impl GasMeter,
         extensions: &mut NativeContextExtensions,
         loader: &Loader,
-        tracer: &mut Option<VMTracer<'_>>,
+        tracer: &mut Option<VMTracer<'_, '_>>,
     ) -> VMResult<Vec<Value>> {
         let mut interpreter = Interpreter {
             operand_stack: Stack::new(),
@@ -178,7 +178,7 @@ impl Interpreter {
         function: Arc<Function>,
         ty_args: Vec<Type>,
         args: Vec<Value>,
-        tracer: &mut Option<VMTracer<'_>>,
+        tracer: &mut Option<VMTracer<'_, '_>>,
     ) -> VMResult<Vec<Value>> {
         let mut locals = Locals::new(function.local_count());
         for (i, value) in args.into_iter().enumerate() {
@@ -866,7 +866,7 @@ impl Frame {
         resolver: &Resolver,
         interpreter: &mut Interpreter,
         gas_meter: &mut impl GasMeter,
-        tracer: &mut Option<VMTracer<'_>>,
+        tracer: &mut Option<VMTracer<'_, '_>>,
     ) -> VMResult<ExitCode> {
         self.execute_code_impl(resolver, interpreter, gas_meter, tracer)
             .map_err(|e| {
@@ -1431,7 +1431,7 @@ impl Frame {
         resolver: &Resolver,
         interpreter: &mut Interpreter,
         gas_meter: &mut impl GasMeter,
-        tracer: &mut Option<VMTracer<'_>>,
+        tracer: &mut Option<VMTracer<'_, '_>>,
     ) -> PartialVMResult<ExitCode> {
         let code = self.function.code();
         loop {

--- a/external-crates/move/crates/move-vm-runtime/src/runtime.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/runtime.rs
@@ -322,7 +322,7 @@ impl VMRuntime {
         data_store: &mut impl DataStore,
         gas_meter: &mut impl GasMeter,
         extensions: &mut NativeContextExtensions,
-        tracer: &mut Option<VMTracer<'_>>,
+        tracer: &mut Option<VMTracer<'_, '_>>,
     ) -> VMResult<SerializedReturnValues> {
         let arg_types = param_types
             .into_iter()
@@ -392,7 +392,7 @@ impl VMRuntime {
         data_store: &mut impl DataStore,
         gas_meter: &mut impl GasMeter,
         extensions: &mut NativeContextExtensions,
-        tracer: &mut Option<VMTracer<'_>>,
+        tracer: &mut Option<VMTracer<'_, '_>>,
     ) -> VMResult<Vec<Value>> {
         Interpreter::entrypoint(
             func,

--- a/external-crates/move/crates/move-vm-runtime/src/tracing2/tracer.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/tracing2/tracer.rs
@@ -26,8 +26,8 @@ use smallvec::SmallVec;
 use std::collections::BTreeMap;
 
 /// Internal state for the tracer. This is where the actual tracing logic is implemented.
-pub(crate) struct VMTracer<'a> {
-    trace: &'a mut MoveTraceBuilder,
+pub(crate) struct VMTracer<'a, 'b> {
+    trace: &'a mut MoveTraceBuilder<'b>,
     link_context: Option<AccountAddress>,
     pc: Option<u16>,
     active_frames: BTreeMap<TraceIndex, FrameInfo>,
@@ -187,7 +187,7 @@ impl RootedType {
     }
 }
 
-impl VMTracer<'_> {
+impl VMTracer<'_, '_> {
     /// Emit an error event to the trace if `true`
     fn emit_trace_error_if_err(&mut self, is_err: bool) {
         if is_err {
@@ -1693,8 +1693,8 @@ impl VMTracer<'_> {
 }
 
 /// The (public crate) API for the VM tracer.
-impl<'a> VMTracer<'a> {
-    pub(crate) fn new(trace: &'a mut MoveTraceBuilder) -> Self {
+impl<'a, 'b> VMTracer<'a, 'b> {
+    pub(crate) fn new(trace: &'a mut MoveTraceBuilder<'b>) -> Self {
         Self {
             trace,
             link_context: None,


### PR DESCRIPTION
## Description 

As title, this add a lifetime parameter to `MoveTracerBuilder` because previous `Box<dyn Tracer>` implies `'static` lifetime, which is super inconvenient in many cases when tracing.

Thanks to Rust lifetime elimination mechanism, no API break changes are made.

## Test plan 

How did you test the new or updated feature?

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
