### PR TITLE
Use FullObjectRef everywhere for transfers

### DIFF
--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -9,6 +9,7 @@ use core::default::Default;
 use fastcrypto::hash::MultisetHash;
 use fastcrypto::traits::KeyPair;
 use sui_protocol_config::Chain;
+use sui_types::base_types::FullObjectRef;
 use sui_types::crypto::{AccountKeyPair, AuthorityKeyPair};
 use sui_types::messages_consensus::ConsensusTransaction;
 use sui_types::utils::to_sender_signed_transaction;
@@ -297,7 +298,7 @@ pub fn init_transfer_transaction(
 ) -> VerifiedTransaction {
     let data = TransactionData::new_transfer(
         recipient,
-        object_ref,
+        FullObjectRef::from_fastpath_ref(object_ref),
         sender,
         gas_object_ref,
         gas_budget,

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -1440,7 +1440,7 @@ mod tests {
         Chain, ConsensusTransactionOrdering, PerObjectCongestionControlMode, ProtocolVersion,
     };
     use sui_types::{
-        base_types::{random_object_ref, AuthorityName, ObjectID, SuiAddress},
+        base_types::{random_object_ref, AuthorityName, FullObjectRef, ObjectID, SuiAddress},
         committee::Committee,
         crypto::deterministic_random_account_key,
         messages_consensus::{
@@ -1950,7 +1950,7 @@ mod tests {
         let data = SenderSignedData::new(
             TransactionData::new_transfer(
                 SuiAddress::default(),
-                random_object_ref(),
+                FullObjectRef::from_fastpath_ref(random_object_ref()),
                 SuiAddress::default(),
                 random_object_ref(),
                 1000 * gas_price,

--- a/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -16,7 +16,7 @@ use std::{
 use sui_framework::BuiltInFramework;
 use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::{
-    base_types::{random_object_ref, SuiAddress},
+    base_types::{random_object_ref, FullObjectRef, SuiAddress},
     crypto::{deterministic_random_account_key, get_key_pair_from_rng, AccountKeyPair},
     object::{MoveObject, Owner, OBJECT_START_VERSION},
     storage::ChildObjectResolver,
@@ -147,7 +147,10 @@ impl Scenario {
         // Tx is opaque to the cache, so we just build a dummy tx. The only requirement is
         // that it has a unique digest every time.
         let tx = TestTransactionBuilder::new(sender, random_object_ref(), 100)
-            .transfer(random_object_ref(), receiver)
+            .transfer(
+                FullObjectRef::from_fastpath_ref(random_object_ref()),
+                receiver,
+            )
             .build_and_sign(&keypair);
 
         let tx = VerifiedTransaction::new_unchecked(tx);

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use sui_config::genesis::Genesis;
 use sui_macros::nondeterministic;
-use sui_types::base_types::{random_object_ref, ObjectID};
+use sui_types::base_types::{random_object_ref, FullObjectRef, ObjectID};
 use sui_types::crypto::AuthorityKeyPair;
 use sui_types::crypto::{AccountKeyPair, AuthorityPublicKeyBytes, Signer};
 use sui_types::effects::{SignedTransactionEffects, TestEffectsBuilder};
@@ -225,7 +225,7 @@ pub fn make_transfer_object_transaction(
 ) -> Transaction {
     let data = TransactionData::new_transfer(
         recipient,
-        object_ref,
+        FullObjectRef::from_fastpath_ref(object_ref),
         sender,
         gas_object,
         gas_price * TEST_ONLY_GAS_UNIT_FOR_TRANSFER * 10,
@@ -275,7 +275,7 @@ pub fn make_dummy_tx(
     Transaction::from_data_and_signer(
         TransactionData::new_transfer(
             receiver,
-            random_object_ref(),
+            FullObjectRef::from_fastpath_ref(random_object_ref()),
             sender,
             random_object_ref(),
             TEST_ONLY_GAS_UNIT_FOR_TRANSFER * 10,

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -55,7 +55,7 @@ use sui_types::utils::{
     to_sender_signed_transaction, to_sender_signed_transaction_with_multi_signers,
 };
 use sui_types::{
-    base_types::dbg_addr,
+    base_types::{dbg_addr, FullObjectRef},
     crypto::{get_key_pair, Signature},
     crypto::{AccountKeyPair, AuthorityKeyPair},
     object::{Owner, GAS_VALUE_FOR_TESTING, OBJECT_START_VERSION},
@@ -1435,7 +1435,10 @@ async fn test_handle_sponsored_transaction() {
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
         builder
-            .transfer_object(recipient, object.compute_object_reference())
+            .transfer_object(
+                recipient,
+                FullObjectRef::from_fastpath_ref(object.compute_object_reference()),
+            )
             .unwrap();
         builder.finish()
     };
@@ -2630,8 +2633,14 @@ async fn test_move_call_insufficient_gas() {
         2000
     };
     // Now we try to construct a transaction with a smaller gas budget than required.
-    let data =
-        TransactionData::new_transfer(sender, obj_ref, recipient, gas_ref, gas_used - 5, rgp);
+    let data = TransactionData::new_transfer(
+        recipient,
+        FullObjectRef::from_fastpath_ref(obj_ref),
+        sender,
+        gas_ref,
+        gas_used - 5,
+        rgp,
+    );
 
     let transaction = to_sender_signed_transaction(data, &recipient_key);
     let tx_digest = *transaction.digest();

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -2634,9 +2634,9 @@ async fn test_move_call_insufficient_gas() {
     };
     // Now we try to construct a transaction with a smaller gas budget than required.
     let data = TransactionData::new_transfer(
-        recipient,
-        FullObjectRef::from_fastpath_ref(obj_ref),
         sender,
+        FullObjectRef::from_fastpath_ref(obj_ref),
+        recipient,
         gas_ref,
         gas_used - 5,
         rgp,

--- a/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/batch_transaction_tests.rs
@@ -5,7 +5,7 @@ use super::*;
 use crate::authority::authority_tests::init_state_with_ids_and_object_basics;
 use bcs;
 use sui_types::{
-    execution_status::ExecutionStatus,
+    base_types::FullObjectRef, execution_status::ExecutionStatus,
     programmable_transaction_builder::ProgrammableTransactionBuilder,
     utils::to_sender_signed_transaction,
 };
@@ -36,11 +36,13 @@ async fn test_batch_transaction_ok() -> anyhow::Result<()> {
         builder
             .transfer_object(
                 recipient,
-                authority_state
-                    .get_object(obj_id)
-                    .await
-                    .unwrap()
-                    .compute_object_reference(),
+                FullObjectRef::from_fastpath_ref(
+                    authority_state
+                        .get_object(obj_id)
+                        .await
+                        .unwrap()
+                        .compute_object_reference(),
+                ),
             )
             .unwrap()
     }
@@ -114,11 +116,13 @@ async fn test_batch_transaction_last_one_fail() -> anyhow::Result<()> {
         builder
             .transfer_object(
                 recipient,
-                authority_state
-                    .get_object(obj_id)
-                    .await
-                    .unwrap()
-                    .compute_object_reference(),
+                FullObjectRef::from_fastpath_ref(
+                    authority_state
+                        .get_object(obj_id)
+                        .await
+                        .unwrap()
+                        .compute_object_reference(),
+                ),
             )
             .unwrap()
     }

--- a/crates/sui-core/src/unit_tests/gas_tests.rs
+++ b/crates/sui-core/src/unit_tests/gas_tests.rs
@@ -18,7 +18,10 @@ use sui_types::gas_coin::GasCoin;
 use sui_types::object::GAS_VALUE_FOR_TESTING;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::utils::to_sender_signed_transaction;
-use sui_types::{base_types::dbg_addr, crypto::get_key_pair};
+use sui_types::{
+    base_types::{dbg_addr, FullObjectRef},
+    crypto::get_key_pair,
+};
 
 // The cost table is used only to get the max budget available which is not dependent on
 // the gas price
@@ -278,7 +281,9 @@ async fn touch_gas_coins(
             .await
             .unwrap()
             .compute_object_reference();
-        builder.transfer_object(recipient, coin_ref).unwrap();
+        builder
+            .transfer_object(recipient, FullObjectRef::from_fastpath_ref(coin_ref))
+            .unwrap();
     }
     let pt = builder.finish();
     let kind = TransactionKind::ProgrammableTransaction(pt);
@@ -1049,7 +1054,10 @@ async fn execute_transfer_with_price(
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
         builder
-            .transfer_object(recipient, object.compute_object_reference())
+            .transfer_object(
+                recipient,
+                FullObjectRef::from_fastpath_ref(object.compute_object_reference()),
+            )
             .unwrap();
         builder.finish()
     };

--- a/crates/sui-core/src/unit_tests/transfer_to_object_tests.rs
+++ b/crates/sui-core/src/unit_tests/transfer_to_object_tests.rs
@@ -5,7 +5,7 @@ use std::{collections::HashSet, sync::Arc};
 
 use sui_protocol_config::{Chain, PerObjectCongestionControlMode, ProtocolConfig, ProtocolVersion};
 use sui_types::{
-    base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress},
+    base_types::{FullObjectRef, ObjectID, ObjectRef, SequenceNumber, SuiAddress},
     crypto::{get_key_pair, AccountKeyPair},
     digests::ObjectDigest,
     effects::{TransactionEffects, TransactionEffectsAPI},
@@ -1095,7 +1095,7 @@ async fn test_tto_valid_dependencies() {
                 {
                     let mut builder = ProgrammableTransactionBuilder::new();
                     builder
-                        .transfer_object(SuiAddress::from(parent.0 .0), child.0)
+                        .transfer_object(SuiAddress::from(parent.0 .0), FullObjectRef::from_object_ref_and_owner(child.0, &child.1))
                         .unwrap();
                     builder.finish()
                 },
@@ -1195,7 +1195,7 @@ async fn test_tto_valid_dependencies_delete_on_receive() {
                 {
                     let mut builder = ProgrammableTransactionBuilder::new();
                     builder
-                        .transfer_object(SuiAddress::from(parent.0 .0), child.0)
+                        .transfer_object(SuiAddress::from(parent.0 .0), FullObjectRef::from_object_ref_and_owner(child.0, &child.1))
                         .unwrap();
                     builder.finish()
                 },
@@ -1291,7 +1291,7 @@ async fn test_tto_dependencies_dont_receive() {
                 {
                     let mut builder = ProgrammableTransactionBuilder::new();
                     builder
-                        .transfer_object(SuiAddress::from(parent.0 .0), old_child.0)
+                        .transfer_object(SuiAddress::from(parent.0 .0), FullObjectRef::from_object_ref_and_owner(old_child.0, &old_child.1))
                         .unwrap();
                     builder.finish()
                 },
@@ -1389,7 +1389,7 @@ async fn test_tto_dependencies_dont_receive_but_abort() {
                 {
                     let mut builder = ProgrammableTransactionBuilder::new();
                     builder
-                        .transfer_object(SuiAddress::from(parent.0 .0), old_child.0)
+                        .transfer_object(SuiAddress::from(parent.0 .0), FullObjectRef::from_object_ref_and_owner(old_child.0, &old_child.1))
                         .unwrap();
                     builder.finish()
                 },
@@ -1485,7 +1485,7 @@ async fn test_tto_dependencies_receive_and_abort() {
                 {
                     let mut builder = ProgrammableTransactionBuilder::new();
                     builder
-                        .transfer_object(SuiAddress::from(parent.0 .0), old_child.0)
+                        .transfer_object(SuiAddress::from(parent.0 .0), FullObjectRef::from_object_ref_and_owner(old_child.0, &old_child.1))
                         .unwrap();
                     builder.finish()
                 },
@@ -1580,7 +1580,7 @@ async fn test_tto_dependencies_receive_and_type_mismatch() {
                 {
                     let mut builder = ProgrammableTransactionBuilder::new();
                     builder
-                        .transfer_object(SuiAddress::from(parent.0 .0), old_child.0)
+                        .transfer_object(SuiAddress::from(parent.0 .0), FullObjectRef::from_object_ref_and_owner(old_child.0, &old_child.1))
                         .unwrap();
                     builder.finish()
                 },

--- a/crates/sui-cost/tests/empirical_transaction_cost.rs
+++ b/crates/sui-cost/tests/empirical_transaction_cost.rs
@@ -10,7 +10,7 @@ use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
 use sui_swarm_config::genesis_config::{AccountConfig, DEFAULT_GAS_AMOUNT};
 use sui_test_transaction_builder::publish_basics_package_and_make_counter;
 use sui_test_transaction_builder::TestTransactionBuilder;
-use sui_types::base_types::{ObjectRef, SuiAddress};
+use sui_types::base_types::{FullObjectRef, ObjectRef, SuiAddress};
 use sui_types::coin::PAY_JOIN_FUNC_NAME;
 use sui_types::coin::PAY_MODULE_NAME;
 use sui_types::coin::PAY_SPLIT_VEC_FUNC_NAME;
@@ -140,7 +140,10 @@ async fn create_txes(
     // Transfer Whole Coin Object
     //
     let whole_coin_tx = TestTransactionBuilder::new(sender, gas_objects.pop().unwrap(), gas_price)
-        .transfer(gas_objects.pop().unwrap(), SuiAddress::default())
+        .transfer(
+            FullObjectRef::from_fastpath_ref(gas_objects.pop().unwrap()),
+            SuiAddress::default(),
+        )
         .build();
 
     ret.insert(CommonTransactionCosts::TransferWholeCoin, whole_coin_tx);

--- a/crates/sui-e2e-tests/tests/party_objects_tests.rs
+++ b/crates/sui-e2e-tests/tests/party_objects_tests.rs
@@ -8,7 +8,7 @@ use sui_json_rpc_types::SuiTransactionBlockEffectsAPI;
 use sui_macros::sim_test;
 use sui_swarm_config::genesis_config::{AccountConfig, DEFAULT_GAS_AMOUNT};
 use sui_test_transaction_builder::publish_basics_package_and_make_party_object;
-use sui_types::base_types::SuiAddress;
+use sui_types::base_types::{FullObjectRef, SuiAddress};
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::object::Owner;
 use sui_types::transaction::{CallArg, ObjectArg};
@@ -840,7 +840,9 @@ async fn party_coin_grpc() {
         vec!["0x2::coin::Coin<0x2::sui::SUI>".parse().unwrap()],
         vec![party_coin_arg, party_owner],
     );
-    builder.transfer_object(recipient, owned_coin).unwrap();
+    builder
+        .transfer_object(recipient, FullObjectRef::from_fastpath_ref(owned_coin))
+        .unwrap();
     let ptb = builder.finish();
 
     let gas_data = sui_types::transaction::GasData {

--- a/crates/sui-e2e-tests/tests/rpc/main.rs
+++ b/crates/sui-e2e-tests/tests/rpc/main.rs
@@ -17,7 +17,10 @@ async fn transfer_coin(
     let object_to_send = accounts_and_objs[0].1[1];
     let txn = context.sign_transaction(
         &sui_test_transaction_builder::TestTransactionBuilder::new(sender, gas_object, gas_price)
-            .transfer(object_to_send, receiver)
+            .transfer(
+                sui_types::base_types::FullObjectRef::from_fastpath_ref(object_to_send),
+                receiver,
+            )
             .build(),
     );
     let resp = context.execute_transaction_must_succeed(txn).await;

--- a/crates/sui-indexer-alt-e2e-tests/tests/consistent_store_list_owned_objects_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/consistent_store_list_owned_objects_tests.rs
@@ -10,7 +10,7 @@ use sui_indexer_alt_consistent_api::proto::rpc::consistent::v1alpha::{
 };
 use sui_indexer_alt_e2e_tests::{find_address_mutated, find_address_owned, FullCluster};
 use sui_types::{
-    base_types::{ObjectRef, SuiAddress},
+    base_types::{FullObjectRef, ObjectRef, SuiAddress},
     crypto::{get_account_key_pair, Signature, Signer},
     effects::{TransactionEffects, TransactionEffectsAPI},
     programmable_transaction_builder::ProgrammableTransactionBuilder,
@@ -657,7 +657,9 @@ fn transfer_object(
     recipient: SuiAddress,
 ) -> TransactionEffects {
     let mut builder = ProgrammableTransactionBuilder::new();
-    builder.transfer_object(recipient, object).unwrap();
+    builder
+        .transfer_object(recipient, FullObjectRef::from_fastpath_ref(object))
+        .unwrap();
 
     let data = TransactionData::new_programmable(
         sender,

--- a/crates/sui-open-rpc/src/examples.rs
+++ b/crates/sui-open-rpc/src/examples.rs
@@ -43,7 +43,7 @@ use sui_protocol_config::ProtocolConfig;
 use sui_types::balance::Supply;
 use sui_types::base_types::random_object_ref;
 use sui_types::base_types::{
-    MoveObjectType, ObjectDigest, ObjectID, ObjectType, SequenceNumber, SuiAddress,
+    FullObjectRef, MoveObjectType, ObjectDigest, ObjectID, ObjectType, SequenceNumber, SuiAddress,
     TransactionDigest,
 };
 use sui_types::committee::Committee;
@@ -185,11 +185,11 @@ impl RpcExampleProvider {
             builder
                 .transfer_object(
                     recipient,
-                    (
+                    FullObjectRef::from_fastpath_ref((
                         object_id,
                         SequenceNumber::from_u64(1),
                         ObjectDigest::new(self.rng.gen()),
-                    ),
+                    )),
                 )
                 .unwrap();
             builder.finish()
@@ -675,11 +675,11 @@ impl RpcExampleProvider {
             SequenceNumber::from_u64(2),
             ObjectDigest::new(self.rng.gen()),
         );
-        let object_ref = (
+        let object_ref = FullObjectRef::from_fastpath_ref((
             obj_id,
             SequenceNumber::from_u64(2),
             ObjectDigest::new(self.rng.gen()),
-        );
+        ));
 
         let data = TransactionData::new_transfer(
             recipient,
@@ -701,7 +701,7 @@ impl RpcExampleProvider {
             sender: signer,
             recipient: Owner::AddressOwner(recipient),
             object_type: parse_sui_struct_tag("0x2::example::Object").unwrap(),
-            object_id: object_ref.0,
+            object_id: object_ref.0.id(),
             version: object_ref.1,
             digest: ObjectDigest::new(self.rng.gen()),
         };
@@ -735,7 +735,7 @@ impl RpcExampleProvider {
                         },
                         OwnedObjectRef {
                             owner: Owner::AddressOwner(recipient),
-                            reference: object_ref.into(),
+                            reference: object_ref.as_object_ref().into(),
                         },
                     ],
                     unwrapped: vec![],

--- a/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -27,7 +27,7 @@ use sui_sdk::rpc_types::{
     SuiTransactionBlockResponse,
 };
 use sui_sdk::SuiClient;
-use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
+use sui_types::base_types::{FullObjectRef, ObjectID, ObjectRef, SuiAddress};
 use sui_types::gas_coin::{GasCoin, GAS};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::quorum_driver_types::ExecuteTransactionRequestType;
@@ -114,7 +114,9 @@ async fn test_transfer_object() {
     let object_ref = get_random_sui(&client, sender, vec![]).await;
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
-        builder.transfer_object(recipient, object_ref).unwrap();
+        builder
+            .transfer_object(recipient, FullObjectRef::from_fastpath_ref(object_ref))
+            .unwrap();
         builder.finish()
     };
     test_transaction(

--- a/crates/sui-single-node-benchmark/src/tx_generator/move_tx_generator.rs
+++ b/crates/sui-single-node-benchmark/src/tx_generator/move_tx_generator.rs
@@ -6,7 +6,7 @@ use crate::tx_generator::TxGenerator;
 use move_core_types::identifier::Identifier;
 use std::collections::HashMap;
 use sui_test_transaction_builder::TestTransactionBuilder;
-use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress};
+use sui_types::base_types::{FullObjectRef, ObjectID, ObjectRef, SequenceNumber, SuiAddress};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::transaction::{CallArg, ObjectArg, Transaction, DEFAULT_VALIDATOR_GAS_PRICE};
 
@@ -57,7 +57,9 @@ impl TxGenerator for MoveTxGenerator {
             for i in 1..=self.num_transfers {
                 let object = account.gas_objects[i as usize];
                 if self.use_native_transfer {
-                    builder.transfer_object(account.sender, object).unwrap();
+                    builder
+                        .transfer_object(account.sender, FullObjectRef::from_fastpath_ref(object))
+                        .unwrap();
                 } else {
                     builder
                         .move_call(

--- a/crates/sui-storage/tests/key_value_tests.rs
+++ b/crates/sui-storage/tests/key_value_tests.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use sui_protocol_config::ProtocolConfig;
 use sui_test_transaction_builder::TestTransactionBuilder;
 use sui_types::base_types::{
-    random_object_ref, ExecutionDigests, ObjectID, SequenceNumber, VersionNumber,
+    random_object_ref, ExecutionDigests, FullObjectRef, ObjectID, SequenceNumber, VersionNumber,
 };
 use sui_types::committee::Committee;
 use sui_types::crypto::KeypairTraits;
@@ -34,7 +34,10 @@ fn random_tx() -> Transaction {
     let (sender, key): (_, AccountKeyPair) = get_key_pair();
     let gas = random_object_ref();
     TestTransactionBuilder::new(sender, gas, 1)
-        .transfer(random_object_ref(), sender)
+        .transfer(
+            FullObjectRef::from_fastpath_ref(random_object_ref()),
+            sender,
+        )
         .build_and_sign(&key)
 }
 

--- a/crates/sui-test-transaction-builder/src/lib.rs
+++ b/crates/sui-test-transaction-builder/src/lib.rs
@@ -11,7 +11,7 @@ use sui_sdk::rpc_types::{
     SuiTransactionBlockResponse,
 };
 use sui_sdk::wallet_context::WalletContext;
-use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress};
+use sui_types::base_types::{FullObjectRef, ObjectID, ObjectRef, SequenceNumber, SuiAddress};
 use sui_types::crypto::{get_key_pair, AccountKeyPair, Signature, Signer};
 use sui_types::digests::TransactionDigest;
 use sui_types::multisig::{BitmapUnit, MultiSig, MultiSigPublicKey};
@@ -285,7 +285,7 @@ impl TestTransactionBuilder {
         )
     }
 
-    pub fn transfer(mut self, object: ObjectRef, recipient: SuiAddress) -> Self {
+    pub fn transfer(mut self, object: FullObjectRef, recipient: SuiAddress) -> Self {
         self.test_data = TestTransactionData::Transfer(TransferData { object, recipient });
         self
     }
@@ -497,7 +497,7 @@ pub enum PublishData {
 }
 
 struct TransferData {
-    object: ObjectRef,
+    object: FullObjectRef,
     recipient: SuiAddress,
 }
 

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -198,6 +198,15 @@ impl FullObjectRef {
         )
     }
 
+    pub fn from_object_ref_and_owner(object_ref: ObjectRef, owner: &Owner) -> Self {
+        let full_id = if let Some(start_version) = owner.start_version() {
+            FullObjectID::Consensus((object_ref.0, start_version))
+        } else {
+            FullObjectID::Fastpath(object_ref.0)
+        };
+        Self(full_id, object_ref.1, object_ref.2)
+    }
+
     pub fn as_object_ref(&self) -> ObjectRef {
         (self.0.id(), self.1, self.2)
     }

--- a/crates/sui-types/src/messages_checkpoint.rs
+++ b/crates/sui-types/src/messages_checkpoint.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::base_types::{
-    random_object_ref, ExecutionData, ExecutionDigests, VerifiedExecutionData,
+    random_object_ref, ExecutionData, ExecutionDigests, FullObjectRef, VerifiedExecutionData,
 };
 use crate::committee::{EpochId, ProtocolVersion, StakeUnit};
 use crate::crypto::{
@@ -639,7 +639,7 @@ impl FullCheckpointContents {
         let transaction = Transaction::from_data_and_signer(
             TransactionData::new_transfer(
                 a,
-                random_object_ref(),
+                FullObjectRef::from_fastpath_ref(random_object_ref()),
                 a,
                 random_object_ref(),
                 100000000000,

--- a/crates/sui-types/src/programmable_transaction_builder.rs
+++ b/crates/sui-types/src/programmable_transaction_builder.rs
@@ -242,19 +242,6 @@ impl ProgrammableTransactionBuilder {
     pub fn transfer_object(
         &mut self,
         recipient: SuiAddress,
-        object_ref: ObjectRef,
-    ) -> anyhow::Result<()> {
-        let rec_arg = self.pure(recipient).unwrap();
-        let obj_arg = self.obj(ObjectArg::ImmOrOwnedObject(object_ref));
-        self.commands
-            .push(Command::TransferObjects(vec![obj_arg?], rec_arg));
-        Ok(())
-    }
-
-    // TODO: Merge with `transfer_object` above and update existing callers.
-    pub fn transfer_object_full(
-        &mut self,
-        recipient: SuiAddress,
         full_object_ref: FullObjectRef,
     ) -> anyhow::Result<()> {
         let rec_arg = self.pure(recipient).unwrap();

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -1861,23 +1861,6 @@ impl TransactionData {
 
     pub fn new_transfer(
         recipient: SuiAddress,
-        object_ref: ObjectRef,
-        sender: SuiAddress,
-        gas_payment: ObjectRef,
-        gas_budget: u64,
-        gas_price: u64,
-    ) -> Self {
-        let pt = {
-            let mut builder = ProgrammableTransactionBuilder::new();
-            builder.transfer_object(recipient, object_ref).unwrap();
-            builder.finish()
-        };
-        Self::new_programmable(sender, vec![gas_payment], pt, gas_budget, gas_price)
-    }
-
-    // TODO: Merge with `new_transfer` above and update existing callers.
-    pub fn new_transfer_full(
-        recipient: SuiAddress,
         full_object_ref: FullObjectRef,
         sender: SuiAddress,
         gas_payment: ObjectRef,
@@ -1886,9 +1869,7 @@ impl TransactionData {
     ) -> Self {
         let pt = {
             let mut builder = ProgrammableTransactionBuilder::new();
-            builder
-                .transfer_object_full(recipient, full_object_ref)
-                .unwrap();
+            builder.transfer_object(recipient, full_object_ref).unwrap();
             builder.finish()
         };
         Self::new_programmable(sender, vec![gas_payment], pt, gas_budget, gas_price)

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::base_types::random_object_ref;
+use crate::base_types::{random_object_ref, FullObjectRef};
 use crate::committee::Committee;
 use crate::crypto::bcs_signable_test::{get_obligation_input, Foo};
 use crate::crypto::Secp256k1SuiSignature;
@@ -51,7 +51,7 @@ fn test_signed_values() {
     let transaction = Transaction::from_data_and_signer(
         TransactionData::new_transfer(
             _a2,
-            random_object_ref(),
+            FullObjectRef::from_fastpath_ref(random_object_ref()),
             a_sender,
             random_object_ref(),
             TEST_ONLY_GAS_UNIT_FOR_TRANSFER * gas_price,
@@ -65,7 +65,7 @@ fn test_signed_values() {
     let bad_transaction = VerifiedTransaction::new_unchecked(Transaction::from_data_and_signer(
         TransactionData::new_transfer(
             _a2,
-            random_object_ref(),
+            FullObjectRef::from_fastpath_ref(random_object_ref()),
             a_sender,
             random_object_ref(),
             TEST_ONLY_GAS_UNIT_FOR_TRANSFER * gas_price,
@@ -136,7 +136,7 @@ fn test_certificates() {
     let transaction = Transaction::from_data_and_signer(
         TransactionData::new_transfer(
             a2,
-            random_object_ref(),
+            FullObjectRef::from_fastpath_ref(random_object_ref()),
             a_sender,
             random_object_ref(),
             TEST_ONLY_GAS_UNIT_FOR_TRANSFER * gas_price,
@@ -477,7 +477,7 @@ fn test_digest_caching() {
     let transaction = Transaction::from_data_and_signer(
         TransactionData::new_transfer(
             sa1,
-            random_object_ref(),
+            FullObjectRef::from_fastpath_ref(random_object_ref()),
             sa2,
             random_object_ref(),
             TEST_ONLY_GAS_UNIT_FOR_TRANSFER * gas_price,
@@ -553,7 +553,7 @@ fn test_user_signature_committed_in_transactions() {
     let gas_price = 10;
     let tx_data = TransactionData::new_transfer(
         a_sender2,
-        random_object_ref(),
+        FullObjectRef::from_fastpath_ref(random_object_ref()),
         a_sender,
         random_object_ref(),
         TEST_ONLY_GAS_UNIT_FOR_TRANSFER * gas_price,
@@ -602,7 +602,7 @@ fn test_user_signature_committed_in_signed_transactions() {
     let gas_price = 10;
     let tx_data = TransactionData::new_transfer(
         a_sender2,
-        random_object_ref(),
+        FullObjectRef::from_fastpath_ref(random_object_ref()),
         a_sender,
         random_object_ref(),
         TEST_ONLY_GAS_UNIT_FOR_TRANSFER * gas_price,
@@ -689,7 +689,10 @@ fn test_sponsored_transaction_message() {
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
         builder
-            .transfer_object(dbg_addr(1), random_object_ref())
+            .transfer_object(
+                dbg_addr(1),
+                FullObjectRef::from_fastpath_ref(random_object_ref()),
+            )
             .unwrap();
         builder.finish()
     };
@@ -796,7 +799,10 @@ fn test_sponsored_transaction_validity_check() {
     let pt = {
         let mut builder = ProgrammableTransactionBuilder::new();
         builder
-            .transfer_object(dbg_addr(1), random_object_ref())
+            .transfer_object(
+                dbg_addr(1),
+                FullObjectRef::from_fastpath_ref(random_object_ref()),
+            )
             .unwrap();
         builder.finish()
     };
@@ -906,7 +912,7 @@ fn verify_sender_signature_correctly_with_flag() {
     let gas_price = 10;
     let tx_data = TransactionData::new_transfer(
         receiver_address,
-        random_object_ref(),
+        FullObjectRef::from_fastpath_ref(random_object_ref()),
         (&sender_kp.public()).into(),
         random_object_ref(),
         TEST_ONLY_GAS_UNIT_FOR_TRANSFER * gas_price,
@@ -1310,7 +1316,7 @@ fn test_certificate_digest() {
         Transaction::from_data_and_signer(
             TransactionData::new_transfer(
                 receiver,
-                random_object_ref(),
+                FullObjectRef::from_fastpath_ref(random_object_ref()),
                 sender,
                 random_object_ref(),
                 TEST_ONLY_GAS_UNIT_FOR_TRANSFER * gas_price,


### PR DESCRIPTION
## Description 

- Enables sui CLI `transfer` command to work on party input objects
- Unifies separate functions for FullObjectRef vs. ObjectRef transfers and updates all callers/tests

## Test plan 

Many tests updated

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: now supports transfer of party objects via `client transfer` command 
- [ ] Rust SDK:
