### PR TITLE
[pkg-alt] Cache the repository when doing short sha -> long sha lookups

### DIFF
--- a/external-crates/move/crates/move-package-alt/src/git/cache.rs
+++ b/external-crates/move/crates/move-package-alt/src/git/cache.rs
@@ -443,13 +443,13 @@ async fn try_find_full_sha(repo: &str, rev: &str) -> GitResult<Option<GitSha>> {
     std::fs::create_dir_all(&lookup_path).map_err(GitError::TempDirectory)?;
 
     let path_to_clone = lookup_path.join(url_to_file_name(repo));
+    let path_to_clone_str = path_to_clone.to_string_lossy();
 
     if path_to_clone.exists() {
         debug!("Repository is already in the cache for lookups, fetching the list of new history.");
         // We are fetching the "latest" history for that repository.
         run_git_cmd_with_args(&["fetch", "--filter=blob:none"], Some(&path_to_clone)).await?;
     } else {
-        let path_to_clone_str = path_to_clone.to_string_lossy();
         debug!(
             "downloading temporary git repo with full history to {}",
             path_to_clone_str


### PR DESCRIPTION
## Description 

Cache repository when going from short sha to long sha, to avoid re-downloading the entire history each time.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
