### PR TITLE
Add `Eq` trait for sui json-rpc types

### DIFF
--- a/crates/sui-json-rpc-types/src/sui_move.rs
+++ b/crates/sui-json-rpc-types/src/sui_move.rs
@@ -33,7 +33,7 @@ pub type SuiMoveTypeParameterIndex = u16;
 #[path = "unit_tests/sui_move_tests.rs"]
 mod sui_move_tests;
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, Eq, PartialEq)]
 pub enum SuiMoveAbility {
     Copy,
     Drop,
@@ -41,33 +41,33 @@ pub enum SuiMoveAbility {
     Key,
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, Eq, PartialEq)]
 pub struct SuiMoveAbilitySet {
     pub abilities: Vec<SuiMoveAbility>,
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, Eq, PartialEq)]
 pub enum SuiMoveVisibility {
     Private,
     Public,
     Friend,
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct SuiMoveStructTypeParameter {
     pub constraints: SuiMoveAbilitySet,
     pub is_phantom: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, Eq, PartialEq)]
 pub struct SuiMoveNormalizedField {
     pub name: String,
     #[serde(rename = "type")]
     pub type_: SuiMoveNormalizedType,
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct SuiMoveNormalizedStruct {
     pub abilities: SuiMoveAbilitySet,
@@ -75,7 +75,7 @@ pub struct SuiMoveNormalizedStruct {
     pub fields: Vec<SuiMoveNormalizedField>,
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct SuiMoveNormalizedEnum {
     pub abilities: SuiMoveAbilitySet,
@@ -85,7 +85,7 @@ pub struct SuiMoveNormalizedEnum {
     pub variant_declaration_order: Option<Vec<String>>,
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, Eq, PartialEq)]
 pub enum SuiMoveNormalizedType {
     Bool,
     U8,
@@ -106,7 +106,7 @@ pub enum SuiMoveNormalizedType {
     MutableReference(Box<SuiMoveNormalizedType>),
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct SuiMoveNormalizedStructType {
     pub address: String,
@@ -115,7 +115,7 @@ pub struct SuiMoveNormalizedStructType {
     pub type_arguments: Vec<SuiMoveNormalizedType>,
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct SuiMoveNormalizedFunction {
     pub visibility: SuiMoveVisibility,
@@ -125,7 +125,7 @@ pub struct SuiMoveNormalizedFunction {
     pub return_: Vec<SuiMoveNormalizedType>,
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, Eq, PartialEq)]
 pub struct SuiMoveModuleId {
     address: String,
     name: String,


### PR DESCRIPTION
## Description 

Trivial PR to enable JSON-RPC types to be compared. 

## Test plan 

How did you test the new or updated feature?

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
