### PR TITLE
graphql-alt: Add Epoch.liveObjectSetDigest

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.move
@@ -82,6 +82,7 @@ fragment E on Epoch {
       periodLength
       decreaseRate
   }
+  liveObjectSetDigest
 }
 
 //# run-graphql
@@ -154,4 +155,5 @@ fragment E on Epoch {
       periodLength
       decreaseRate
   }
+  liveObjectSetDigest
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/query.snap
@@ -18,7 +18,7 @@ task 5, line 14:
 //# advance-epoch
 Epoch advanced: 3
 
-task 6, lines 16-85:
+task 6, lines 16-86:
 //# run-graphql
 Response: {
   "data": {
@@ -78,7 +78,8 @@ Response: {
         "currentDistributionAmount": "1000000000000000",
         "periodLength": 10,
         "decreaseRate": 1000
-      }
+      },
+      "liveObjectSetDigest": null
     },
     "e0": {
       "epochId": 0,
@@ -136,7 +137,8 @@ Response: {
         "currentDistributionAmount": "1000000000000000",
         "periodLength": 10,
         "decreaseRate": 1000
-      }
+      },
+      "liveObjectSetDigest": null
     },
     "e1": {
       "epochId": 1,
@@ -194,7 +196,8 @@ Response: {
         "currentDistributionAmount": "1000000000000000",
         "periodLength": 10,
         "decreaseRate": 1000
-      }
+      },
+      "liveObjectSetDigest": null
     },
     "e2": {
       "epochId": 2,
@@ -252,13 +255,14 @@ Response: {
         "currentDistributionAmount": "1000000000000000",
         "periodLength": 10,
         "decreaseRate": 1000
-      }
+      },
+      "liveObjectSetDigest": null
     },
     "e3": null
   }
 }
 
-task 7, lines 87-157:
+task 7, lines 88-159:
 //# run-graphql
 Response: {
   "data": {
@@ -320,7 +324,8 @@ Response: {
             "currentDistributionAmount": "1000000000000000",
             "periodLength": 10,
             "decreaseRate": 1000
-          }
+          },
+          "liveObjectSetDigest": null
         },
         "e0": {
           "epochId": 0,
@@ -378,7 +383,8 @@ Response: {
             "currentDistributionAmount": "1000000000000000",
             "periodLength": 10,
             "decreaseRate": 1000
-          }
+          },
+          "liveObjectSetDigest": null
         },
         "e1": {
           "epochId": 1,
@@ -436,7 +442,8 @@ Response: {
             "currentDistributionAmount": "1000000000000000",
             "periodLength": 10,
             "decreaseRate": 1000
-          }
+          },
+          "liveObjectSetDigest": null
         },
         "e2": null
       }

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -243,6 +243,11 @@ type Epoch {
 	Parameters related to the subsidy that supplements staking rewards
 	"""
 	systemStakeSubsidy: StakeSubsidy
+	"""
+	A commitment by the committee at the end of epoch on the contents of the live object set at that time.
+	This can be used to verify state snapshots.
+	"""
+	liveObjectSetDigest: String
 }
 
 type Event {

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -247,6 +247,11 @@ type Epoch {
 	Parameters related to the subsidy that supplements staking rewards
 	"""
 	systemStakeSubsidy: StakeSubsidy
+	"""
+	A commitment by the committee at the end of epoch on the contents of the live object set at that time.
+	This can be used to verify state snapshots.
+	"""
+	liveObjectSetDigest: String
 }
 
 type Event {

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -247,6 +247,11 @@ type Epoch {
 	Parameters related to the subsidy that supplements staking rewards
 	"""
 	systemStakeSubsidy: StakeSubsidy
+	"""
+	A commitment by the committee at the end of epoch on the contents of the live object set at that time.
+	This can be used to verify state snapshots.
+	"""
+	liveObjectSetDigest: String
 }
 
 type Event {

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -243,6 +243,11 @@ type Epoch {
 	Parameters related to the subsidy that supplements staking rewards
 	"""
 	systemStakeSubsidy: StakeSubsidy
+	"""
+	A commitment by the committee at the end of epoch on the contents of the live object set at that time.
+	This can be used to verify state snapshots.
+	"""
+	liveObjectSetDigest: String
 }
 
 type Event {


### PR DESCRIPTION
## Description 

Implements `Epoch.liveObjectSetDigest` based on
https://github.com/MystenLabs/sui/blob/4275c1a55988d28b638be8720aebdf1e7da3b06b/crates/sui-graphql-rpc/src/types/epoch.rs#L214-L228

## Test plan 

Added `liveObjectSetDigest` to the `query.move` snapshot test.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
