### PR TITLE
Add `party-transfer` command to sui CLI tool

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -4045,6 +4045,10 @@ impl ProtocolConfig {
         self.feature_flags.passkey_auth = val
     }
 
+    pub fn set_enable_party_transfer_for_testing(&mut self, val: bool) {
+        self.feature_flags.enable_party_transfer = val
+    }
+
     pub fn set_consensus_distributed_vote_scoring_strategy_for_testing(&mut self, val: bool) {
         self.feature_flags
             .consensus_distributed_vote_scoring_strategy = val;

--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -1044,4 +1044,25 @@ impl TransactionBuilder {
 
         Ok((object.object_ref(), object.object_type()?))
     }
+
+    pub async fn get_full_object_ref_and_type(
+        &self,
+        object_id: ObjectID,
+    ) -> anyhow::Result<(FullObjectRef, ObjectType)> {
+        let object_data = self
+            .0
+            .get_object_with_options(
+                object_id,
+                SuiObjectDataOptions::new().with_owner().with_type(),
+            )
+            .await?
+            .into_object()?;
+
+        let object_ref = object_data.object_ref();
+        let object_type = object_data.object_type()?;
+        let owner = object_data.owner.unwrap();
+
+        let full_object_ref = FullObjectRef::from_object_ref_and_owner(object_ref, &owner);
+        Ok((full_object_ref, object_type))
+    }
 }

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -19,6 +19,7 @@ use sui::client_commands::{GasDataArgs, PaymentArgs, TxProcessingArgs};
 use sui::client_ptb::ptb::PTB;
 use sui::sui_commands::IndexerArgs;
 use sui_keys::key_identity::KeyIdentity;
+use sui_protocol_config::ProtocolConfig;
 use sui_sdk::SuiClient;
 use sui_test_transaction_builder::batch_make_transfer_transactions;
 use sui_types::object::Owner;
@@ -5407,6 +5408,12 @@ async fn test_tree_shaking_package_system_deps() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_party_transfer() -> Result<(), anyhow::Error> {
+    // TODO: this test override can be removed when party objects are enabled on mainnet.
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_party_transfer_for_testing(true);
+        config
+    });
+
     let (mut test_cluster, client, rgp, objects, recipients, addresses) =
         test_cluster_helper().await;
     let (object_id1, object_id2) = (objects[0], objects[1]);
@@ -5458,6 +5465,12 @@ async fn test_party_transfer() -> Result<(), anyhow::Error> {
 
 #[sim_test]
 async fn test_party_transfer_gas_object_as_transfer_object() -> Result<(), anyhow::Error> {
+    // TODO: this test override can be removed when party objects are enabled on mainnet.
+    let _guard = ProtocolConfig::apply_overrides_for_testing(|_, mut config| {
+        config.set_enable_party_transfer_for_testing(true);
+        config
+    });
+
     let (mut test_cluster, _client, rgp, objects, _recipients, addresses) =
         test_cluster_helper().await;
     let object_id1 = objects[0];


### PR DESCRIPTION
## Description 

Makes it easy to transfer an object to single-address party ownership (ConsensusAddressOwned).

## Test plan 

Manual testing

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Adds `party-transfer` command to transfer objects to single-address party ownership. 
- [ ] Rust SDK:
