### PR TITLE
[graphql-alt] Support GenesisTransaction kind for TransactionKind [1/n]

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/genesis.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/genesis.move
@@ -1,0 +1,92 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --simulator
+
+//# programmable --sender A --inputs 42 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  # Test that kind field returns null for non-genesis transactions (programmable transactions)
+  nonGenesisTransaction: transaction(digest: "@{digest_1}") {
+    digest
+    kind {
+      ... on GenesisTransaction {
+        objects {
+          nodes {
+            address
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # Test accessing genesis transactions through checkpoint 0
+  genesisTransaction: checkpoint(sequenceNumber: 0) {
+    sequenceNumber
+    transactions {
+      nodes {
+        digest
+        kind {
+          ... on GenesisTransaction {
+            objects(first: 50) {
+              nodes {
+                address
+                version
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+} 
+
+//# run-graphql
+{ 
+  # Test pagination functionality with genesis transactions through checkpoint 0
+  paginationTest: checkpoint(sequenceNumber: 0) {
+    sequenceNumber
+    transactions {
+      nodes {
+        digest
+        kind {
+          ... on GenesisTransaction {
+            objects(first: 3) {
+              nodes {
+                address
+                version
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  backwardPaginationTest: checkpoint(sequenceNumber: 0) {
+    sequenceNumber
+    transactions {
+      nodes {
+        digest
+        kind {
+          ... on GenesisTransaction {
+            objects(last: 3) {
+              nodes {
+                address
+                version
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/genesis.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/genesis.move
@@ -26,44 +26,39 @@
   }
 }
 
+# TODO(DVX-1386): Add __typename field to `kind` block.
 //# run-graphql
 {
-  # Test accessing genesis transactions through checkpoint 0
-  genesisTransaction: checkpoint(sequenceNumber: 0) {
-    sequenceNumber
-    transactions {
-      nodes {
-        digest
-        kind {
-          ... on GenesisTransaction {
-            objects(first: 50) {
-              nodes {
-                address
-                version
-              }
+  # Test accessing genesis transactions directly
+  genesisTransaction: transactions(first: 1) {
+    nodes {
+      digest
+      kind {
+        ... on GenesisTransaction {
+          objects(first: 50) {
+            nodes {
+              address
+              version
             }
           }
         }
       }
     }
   }
-} 
+}
 
 //# run-graphql
 { 
-  # Test pagination functionality with genesis transactions through checkpoint 0
-  paginationTest: checkpoint(sequenceNumber: 0) {
-    sequenceNumber
-    transactions {
-      nodes {
-        digest
-        kind {
-          ... on GenesisTransaction {
-            objects(first: 3) {
-              nodes {
-                address
-                version
-              }
+  # Test pagination functionality with genesis transactions
+  paginationTest: transactions(first: 1) {
+    nodes {
+      digest
+      kind {
+        ... on GenesisTransaction {
+          objects(first: 3) {
+            nodes {
+              address
+              version
             }
           }
         }
@@ -71,18 +66,15 @@
     }
   }
 
-  backwardPaginationTest: checkpoint(sequenceNumber: 0) {
-    sequenceNumber
-    transactions {
-      nodes {
-        digest
-        kind {
-          ... on GenesisTransaction {
-            objects(last: 3) {
-              nodes {
-                address
-                version
-              }
+  backwardPaginationTest: transactions(first: 1) {
+    nodes {
+      digest
+      kind {
+        ... on GenesisTransaction {
+          objects(last: 3) {
+            nodes {
+              address
+              version
             }
           }
         }
@@ -95,26 +87,23 @@
 //# run-graphql --cursors 2
 { 
   # Test cursor-based pagination - after first cursor, get 3 objects
-  paginationAfterCursor: checkpoint(sequenceNumber: 0) {
-    sequenceNumber
-    transactions {
-      nodes {
-        digest
-        kind {
-          ... on GenesisTransaction {
-            objects(after: "@{cursor_0}", first: 3) {
-              pageInfo {
-                hasNextPage
-                hasPreviousPage
-                startCursor
-                endCursor
-              }
-              edges {
-                cursor
-                node {
-                  address
-                  version
-                }
+  paginationAfterCursor: transactions(first: 1) {
+    nodes {
+      digest
+      kind {
+        ... on GenesisTransaction {
+          objects(after: "@{cursor_0}", first: 3) {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+              startCursor
+              endCursor
+            }
+            edges {
+              cursor
+              node {
+                address
+                version
               }
             }
           }
@@ -127,26 +116,23 @@
 //# run-graphql --cursors 5
 { 
   # Test cursor-based pagination - before a specific cursor, get last 2 objects
-  paginationBeforeCursor: checkpoint(sequenceNumber: 0) {
-    sequenceNumber
-    transactions {
-      nodes {
-        digest
-        kind {
-          ... on GenesisTransaction {
-            objects(before: "@{cursor_0}", last: 2) {
-              pageInfo {
-                hasNextPage
-                hasPreviousPage
-                startCursor
-                endCursor
-              }
-              edges {
-                cursor
-                node {
-                  address
-                  version
-                }
+  paginationBeforeCursor: transactions(first: 1) {
+    nodes {
+      digest
+      kind {
+        ... on GenesisTransaction {
+          objects(before: "@{cursor_0}", last: 2) {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+              startCursor
+              endCursor
+            }
+            edges {
+              cursor
+              node {
+                address
+                version
               }
             }
           }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/genesis.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/genesis.move
@@ -90,3 +90,68 @@
     }
   }
 }
+
+
+//# run-graphql --cursors 2
+{ 
+  # Test cursor-based pagination - after first cursor, get 3 objects
+  paginationAfterCursor: checkpoint(sequenceNumber: 0) {
+    sequenceNumber
+    transactions {
+      nodes {
+        digest
+        kind {
+          ... on GenesisTransaction {
+            objects(after: "@{cursor_0}", first: 3) {
+              pageInfo {
+                hasNextPage
+                hasPreviousPage
+                startCursor
+                endCursor
+              }
+              edges {
+                cursor
+                node {
+                  address
+                  version
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors 5
+{ 
+  # Test cursor-based pagination - before a specific cursor, get last 2 objects
+  paginationBeforeCursor: checkpoint(sequenceNumber: 0) {
+    sequenceNumber
+    transactions {
+      nodes {
+        digest
+        kind {
+          ... on GenesisTransaction {
+            objects(before: "@{cursor_0}", last: 2) {
+              pageInfo {
+                hasNextPage
+                hasPreviousPage
+                startCursor
+                endCursor
+              }
+              edges {
+                cursor
+                node {
+                  address
+                  version
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/genesis.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/genesis.move
@@ -26,7 +26,6 @@
   }
 }
 
-# TODO(DVX-1386): Add __typename field to `kind` block.
 //# run-graphql
 {
   # Test accessing genesis transactions directly
@@ -34,6 +33,7 @@
     nodes {
       digest
       kind {
+        __typename
         ... on GenesisTransaction {
           objects(first: 50) {
             nodes {
@@ -54,6 +54,7 @@
     nodes {
       digest
       kind {
+        __typename
         ... on GenesisTransaction {
           objects(first: 3) {
             nodes {
@@ -70,6 +71,7 @@
     nodes {
       digest
       kind {
+        __typename
         ... on GenesisTransaction {
           objects(last: 3) {
             nodes {
@@ -91,6 +93,7 @@
     nodes {
       digest
       kind {
+        __typename
         ... on GenesisTransaction {
           objects(after: "@{cursor_0}", first: 3) {
             pageInfo {
@@ -120,6 +123,7 @@
     nodes {
       digest
       kind {
+        __typename
         ... on GenesisTransaction {
           objects(before: "@{cursor_0}", last: 2) {
             pageInfo {

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/genesis.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/genesis.snap
@@ -18,7 +18,7 @@ task 2, line 10:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 3, lines 12-29:
+task 3, lines 12-27:
 //# run-graphql
 Response: {
   "data": {
@@ -29,7 +29,7 @@ Response: {
   }
 }
 
-task 4, lines 30-48:
+task 4, lines 29-48:
 //# run-graphql
 Response: {
   "data": {
@@ -38,6 +38,7 @@ Response: {
         {
           "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
           "kind": {
+            "__typename": "GenesisTransaction",
             "objects": {
               "nodes": [
                 {
@@ -149,7 +150,7 @@ Response: {
   }
 }
 
-task 5, lines 50-84:
+task 5, lines 50-86:
 //# run-graphql
 Response: {
   "data": {
@@ -158,6 +159,7 @@ Response: {
         {
           "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
           "kind": {
+            "__typename": "GenesisTransaction",
             "objects": {
               "nodes": [
                 {
@@ -183,6 +185,7 @@ Response: {
         {
           "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
           "kind": {
+            "__typename": "GenesisTransaction",
             "objects": {
               "nodes": [
                 {
@@ -206,7 +209,7 @@ Response: {
   }
 }
 
-task 6, lines 87-114:
+task 6, lines 89-117:
 //# run-graphql --cursors 2
 Response: {
   "data": {
@@ -215,6 +218,7 @@ Response: {
         {
           "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
           "kind": {
+            "__typename": "GenesisTransaction",
             "objects": {
               "pageInfo": {
                 "hasNextPage": true,
@@ -253,7 +257,7 @@ Response: {
   }
 }
 
-task 7, lines 116-143:
+task 7, lines 119-147:
 //# run-graphql --cursors 5
 Response: {
   "data": {
@@ -262,6 +266,7 @@ Response: {
         {
           "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
           "kind": {
+            "__typename": "GenesisTransaction",
             "objects": {
               "pageInfo": {
                 "hasNextPage": true,

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/genesis.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/genesis.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 6 tasks
+processed 8 tasks
 
 init:
 A: object(0,0), B: object(0,1)
@@ -204,6 +204,99 @@ Response: {
                   {
                     "address": "0xfdc25bc3b2d2b3664199d08f5275c3a6bb360b0629ab5784672f083149163417",
                     "version": 0
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 6, lines 95-125:
+//# run-graphql --cursors 2
+Response: {
+  "data": {
+    "paginationAfterCursor": {
+      "sequenceNumber": 0,
+      "transactions": {
+        "nodes": [
+          {
+            "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
+            "kind": {
+              "objects": {
+                "pageInfo": {
+                  "hasNextPage": true,
+                  "hasPreviousPage": true,
+                  "startCursor": "Mw==",
+                  "endCursor": "NQ=="
+                },
+                "edges": [
+                  {
+                    "cursor": "Mw==",
+                    "node": {
+                      "address": "0x0000000000000000000000000000000000000000000000000000000000000005",
+                      "version": 0
+                    }
+                  },
+                  {
+                    "cursor": "NA==",
+                    "node": {
+                      "address": "0x0000000000000000000000000000000000000000000000000000000000000006",
+                      "version": 0
+                    }
+                  },
+                  {
+                    "cursor": "NQ==",
+                    "node": {
+                      "address": "0x0000000000000000000000000000000000000000000000000000000000000007",
+                      "version": 0
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 7, lines 127-157:
+//# run-graphql --cursors 5
+Response: {
+  "data": {
+    "paginationBeforeCursor": {
+      "sequenceNumber": 0,
+      "transactions": {
+        "nodes": [
+          {
+            "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
+            "kind": {
+              "objects": {
+                "pageInfo": {
+                  "hasNextPage": true,
+                  "hasPreviousPage": true,
+                  "startCursor": "Mw==",
+                  "endCursor": "NA=="
+                },
+                "edges": [
+                  {
+                    "cursor": "Mw==",
+                    "node": {
+                      "address": "0x0000000000000000000000000000000000000000000000000000000000000005",
+                      "version": 0
+                    }
+                  },
+                  {
+                    "cursor": "NA==",
+                    "node": {
+                      "address": "0x0000000000000000000000000000000000000000000000000000000000000006",
+                      "version": 0
+                    }
                   }
                 ]
               }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/genesis.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/genesis.snap
@@ -18,7 +18,7 @@ task 2, line 10:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 3, lines 12-27:
+task 3, lines 12-29:
 //# run-graphql
 Response: {
   "data": {
@@ -29,281 +29,266 @@ Response: {
   }
 }
 
-task 4, lines 29-50:
+task 4, lines 30-48:
 //# run-graphql
 Response: {
   "data": {
     "genesisTransaction": {
-      "sequenceNumber": 0,
-      "transactions": {
-        "nodes": [
-          {
-            "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
-            "kind": {
-              "objects": {
-                "nodes": [
-                  {
-                    "address": "0x0000000000000000000000000000000000000000000000000000000000000001",
-                    "version": 1
-                  },
-                  {
-                    "address": "0x0000000000000000000000000000000000000000000000000000000000000002",
-                    "version": 1
-                  },
-                  {
-                    "address": "0x0000000000000000000000000000000000000000000000000000000000000003",
-                    "version": 1
-                  },
-                  {
-                    "address": "0x0000000000000000000000000000000000000000000000000000000000000005",
-                    "version": 0
-                  },
-                  {
-                    "address": "0x0000000000000000000000000000000000000000000000000000000000000006",
-                    "version": 0
-                  },
-                  {
-                    "address": "0x0000000000000000000000000000000000000000000000000000000000000007",
-                    "version": 0
-                  },
-                  {
-                    "address": "0x0000000000000000000000000000000000000000000000000000000000000008",
-                    "version": 0
-                  },
-                  {
-                    "address": "0x0000000000000000000000000000000000000000000000000000000000000009",
-                    "version": 0
-                  },
-                  {
-                    "address": "0x000000000000000000000000000000000000000000000000000000000000000b",
-                    "version": 1
-                  },
-                  {
-                    "address": "0x0000000000000000000000000000000000000000000000000000000000000403",
-                    "version": 0
-                  },
-                  {
-                    "address": "0x000000000000000000000000000000000000000000000000000000000000dee9",
-                    "version": 1
-                  },
-                  {
-                    "address": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
-                    "version": 0
-                  },
-                  {
-                    "address": "0x29efa2355bad50325946d9243062b64110c7fab283c88ff9514d6e08b16b4d9d",
-                    "version": 0
-                  },
-                  {
-                    "address": "0x6af2a2b7ca60bf76174adfd3e9c4957f8e937759603182f9b46c7f6c5f19c6d2",
-                    "version": 0
-                  },
-                  {
-                    "address": "0x6d0b9758ab130cfb5c8c79dae3643aacb01a01ee013214ac1aefce0e61b2d54c",
-                    "version": 0
-                  },
-                  {
-                    "address": "0x6d33474042ca5b7b77083b1fa13d699b1f65ddce5ad7c87eb6f66eb9deb014dd",
-                    "version": 0
-                  },
-                  {
-                    "address": "0x793898ba83ca8a41d0a635be4f3c3ec696dc4df77afbb652c95057e7620af112",
-                    "version": 0
-                  },
-                  {
-                    "address": "0x989b8b78d36d1199f9c3bad347b822009d8ae730dacc501b13633f6c491c6dc8",
-                    "version": 0
-                  },
-                  {
-                    "address": "0xadc60c5485f3e8db89130dabf5bb0e2b728dff8306d49e79e14bd7d285ed662d",
-                    "version": 0
-                  },
-                  {
-                    "address": "0xb5f1cff9e175de3ada5201af3530ff1cfb794cdf766ec839ddcf644fbd78d372",
-                    "version": 0
-                  },
-                  {
-                    "address": "0xcfecb053c69314e75f36561910f3535dd466b6e2e3593708f370e80424617ae7",
-                    "version": 0
-                  },
-                  {
-                    "address": "0xee1a26743f5025d6a8eda005159be9594c8554227ccbbe0d315f08bc7c4fe0d5",
-                    "version": 0
-                  },
-                  {
-                    "address": "0xf0b6039716354c46639d0c84ae011def2ae2232a4e1e7a104f2acff9a126cad2",
-                    "version": 0
-                  },
-                  {
-                    "address": "0xf354b8eb4321881a7d6012c665bbece1241bfd36459ec784fc98e836fcf25b42",
-                    "version": 0
-                  },
-                  {
-                    "address": "0xfdc25bc3b2d2b3664199d08f5275c3a6bb360b0629ab5784672f083149163417",
-                    "version": 0
-                  }
-                ]
-              }
+      "nodes": [
+        {
+          "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
+          "kind": {
+            "objects": {
+              "nodes": [
+                {
+                  "address": "0x0000000000000000000000000000000000000000000000000000000000000001",
+                  "version": 1
+                },
+                {
+                  "address": "0x0000000000000000000000000000000000000000000000000000000000000002",
+                  "version": 1
+                },
+                {
+                  "address": "0x0000000000000000000000000000000000000000000000000000000000000003",
+                  "version": 1
+                },
+                {
+                  "address": "0x0000000000000000000000000000000000000000000000000000000000000005",
+                  "version": 0
+                },
+                {
+                  "address": "0x0000000000000000000000000000000000000000000000000000000000000006",
+                  "version": 0
+                },
+                {
+                  "address": "0x0000000000000000000000000000000000000000000000000000000000000007",
+                  "version": 0
+                },
+                {
+                  "address": "0x0000000000000000000000000000000000000000000000000000000000000008",
+                  "version": 0
+                },
+                {
+                  "address": "0x0000000000000000000000000000000000000000000000000000000000000009",
+                  "version": 0
+                },
+                {
+                  "address": "0x000000000000000000000000000000000000000000000000000000000000000b",
+                  "version": 1
+                },
+                {
+                  "address": "0x0000000000000000000000000000000000000000000000000000000000000403",
+                  "version": 0
+                },
+                {
+                  "address": "0x000000000000000000000000000000000000000000000000000000000000dee9",
+                  "version": 1
+                },
+                {
+                  "address": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
+                  "version": 0
+                },
+                {
+                  "address": "0x29efa2355bad50325946d9243062b64110c7fab283c88ff9514d6e08b16b4d9d",
+                  "version": 0
+                },
+                {
+                  "address": "0x6af2a2b7ca60bf76174adfd3e9c4957f8e937759603182f9b46c7f6c5f19c6d2",
+                  "version": 0
+                },
+                {
+                  "address": "0x6d0b9758ab130cfb5c8c79dae3643aacb01a01ee013214ac1aefce0e61b2d54c",
+                  "version": 0
+                },
+                {
+                  "address": "0x6d33474042ca5b7b77083b1fa13d699b1f65ddce5ad7c87eb6f66eb9deb014dd",
+                  "version": 0
+                },
+                {
+                  "address": "0x793898ba83ca8a41d0a635be4f3c3ec696dc4df77afbb652c95057e7620af112",
+                  "version": 0
+                },
+                {
+                  "address": "0x989b8b78d36d1199f9c3bad347b822009d8ae730dacc501b13633f6c491c6dc8",
+                  "version": 0
+                },
+                {
+                  "address": "0xadc60c5485f3e8db89130dabf5bb0e2b728dff8306d49e79e14bd7d285ed662d",
+                  "version": 0
+                },
+                {
+                  "address": "0xb5f1cff9e175de3ada5201af3530ff1cfb794cdf766ec839ddcf644fbd78d372",
+                  "version": 0
+                },
+                {
+                  "address": "0xcfecb053c69314e75f36561910f3535dd466b6e2e3593708f370e80424617ae7",
+                  "version": 0
+                },
+                {
+                  "address": "0xee1a26743f5025d6a8eda005159be9594c8554227ccbbe0d315f08bc7c4fe0d5",
+                  "version": 0
+                },
+                {
+                  "address": "0xf0b6039716354c46639d0c84ae011def2ae2232a4e1e7a104f2acff9a126cad2",
+                  "version": 0
+                },
+                {
+                  "address": "0xf354b8eb4321881a7d6012c665bbece1241bfd36459ec784fc98e836fcf25b42",
+                  "version": 0
+                },
+                {
+                  "address": "0xfdc25bc3b2d2b3664199d08f5275c3a6bb360b0629ab5784672f083149163417",
+                  "version": 0
+                }
+              ]
             }
           }
-        ]
-      }
+        }
+      ]
     }
   }
 }
 
-task 5, lines 52-92:
+task 5, lines 50-84:
 //# run-graphql
 Response: {
   "data": {
     "paginationTest": {
-      "sequenceNumber": 0,
-      "transactions": {
-        "nodes": [
-          {
-            "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
-            "kind": {
-              "objects": {
-                "nodes": [
-                  {
-                    "address": "0x0000000000000000000000000000000000000000000000000000000000000001",
-                    "version": 1
-                  },
-                  {
-                    "address": "0x0000000000000000000000000000000000000000000000000000000000000002",
-                    "version": 1
-                  },
-                  {
-                    "address": "0x0000000000000000000000000000000000000000000000000000000000000003",
-                    "version": 1
-                  }
-                ]
-              }
+      "nodes": [
+        {
+          "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
+          "kind": {
+            "objects": {
+              "nodes": [
+                {
+                  "address": "0x0000000000000000000000000000000000000000000000000000000000000001",
+                  "version": 1
+                },
+                {
+                  "address": "0x0000000000000000000000000000000000000000000000000000000000000002",
+                  "version": 1
+                },
+                {
+                  "address": "0x0000000000000000000000000000000000000000000000000000000000000003",
+                  "version": 1
+                }
+              ]
             }
           }
-        ]
-      }
+        }
+      ]
     },
     "backwardPaginationTest": {
-      "sequenceNumber": 0,
-      "transactions": {
-        "nodes": [
-          {
-            "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
-            "kind": {
-              "objects": {
-                "nodes": [
-                  {
-                    "address": "0xf0b6039716354c46639d0c84ae011def2ae2232a4e1e7a104f2acff9a126cad2",
-                    "version": 0
-                  },
-                  {
-                    "address": "0xf354b8eb4321881a7d6012c665bbece1241bfd36459ec784fc98e836fcf25b42",
-                    "version": 0
-                  },
-                  {
-                    "address": "0xfdc25bc3b2d2b3664199d08f5275c3a6bb360b0629ab5784672f083149163417",
-                    "version": 0
-                  }
-                ]
-              }
+      "nodes": [
+        {
+          "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
+          "kind": {
+            "objects": {
+              "nodes": [
+                {
+                  "address": "0xf0b6039716354c46639d0c84ae011def2ae2232a4e1e7a104f2acff9a126cad2",
+                  "version": 0
+                },
+                {
+                  "address": "0xf354b8eb4321881a7d6012c665bbece1241bfd36459ec784fc98e836fcf25b42",
+                  "version": 0
+                },
+                {
+                  "address": "0xfdc25bc3b2d2b3664199d08f5275c3a6bb360b0629ab5784672f083149163417",
+                  "version": 0
+                }
+              ]
             }
           }
-        ]
-      }
+        }
+      ]
     }
   }
 }
 
-task 6, lines 95-125:
+task 6, lines 87-114:
 //# run-graphql --cursors 2
 Response: {
   "data": {
     "paginationAfterCursor": {
-      "sequenceNumber": 0,
-      "transactions": {
-        "nodes": [
-          {
-            "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
-            "kind": {
-              "objects": {
-                "pageInfo": {
-                  "hasNextPage": true,
-                  "hasPreviousPage": true,
-                  "startCursor": "Mw==",
-                  "endCursor": "NQ=="
-                },
-                "edges": [
-                  {
-                    "cursor": "Mw==",
-                    "node": {
-                      "address": "0x0000000000000000000000000000000000000000000000000000000000000005",
-                      "version": 0
-                    }
-                  },
-                  {
-                    "cursor": "NA==",
-                    "node": {
-                      "address": "0x0000000000000000000000000000000000000000000000000000000000000006",
-                      "version": 0
-                    }
-                  },
-                  {
-                    "cursor": "NQ==",
-                    "node": {
-                      "address": "0x0000000000000000000000000000000000000000000000000000000000000007",
-                      "version": 0
-                    }
+      "nodes": [
+        {
+          "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
+          "kind": {
+            "objects": {
+              "pageInfo": {
+                "hasNextPage": true,
+                "hasPreviousPage": true,
+                "startCursor": "Mw==",
+                "endCursor": "NQ=="
+              },
+              "edges": [
+                {
+                  "cursor": "Mw==",
+                  "node": {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000005",
+                    "version": 0
                   }
-                ]
-              }
+                },
+                {
+                  "cursor": "NA==",
+                  "node": {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000006",
+                    "version": 0
+                  }
+                },
+                {
+                  "cursor": "NQ==",
+                  "node": {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000007",
+                    "version": 0
+                  }
+                }
+              ]
             }
           }
-        ]
-      }
+        }
+      ]
     }
   }
 }
 
-task 7, lines 127-157:
+task 7, lines 116-143:
 //# run-graphql --cursors 5
 Response: {
   "data": {
     "paginationBeforeCursor": {
-      "sequenceNumber": 0,
-      "transactions": {
-        "nodes": [
-          {
-            "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
-            "kind": {
-              "objects": {
-                "pageInfo": {
-                  "hasNextPage": true,
-                  "hasPreviousPage": true,
-                  "startCursor": "Mw==",
-                  "endCursor": "NA=="
-                },
-                "edges": [
-                  {
-                    "cursor": "Mw==",
-                    "node": {
-                      "address": "0x0000000000000000000000000000000000000000000000000000000000000005",
-                      "version": 0
-                    }
-                  },
-                  {
-                    "cursor": "NA==",
-                    "node": {
-                      "address": "0x0000000000000000000000000000000000000000000000000000000000000006",
-                      "version": 0
-                    }
+      "nodes": [
+        {
+          "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
+          "kind": {
+            "objects": {
+              "pageInfo": {
+                "hasNextPage": true,
+                "hasPreviousPage": true,
+                "startCursor": "Mw==",
+                "endCursor": "NA=="
+              },
+              "edges": [
+                {
+                  "cursor": "Mw==",
+                  "node": {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000005",
+                    "version": 0
                   }
-                ]
-              }
+                },
+                {
+                  "cursor": "NA==",
+                  "node": {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000006",
+                    "version": 0
+                  }
+                }
+              ]
             }
           }
-        ]
-      }
+        }
+      ]
     }
   }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/genesis.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/genesis.snap
@@ -1,0 +1,216 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-8:
+//# programmable --sender A --inputs 42 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 10:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 12-27:
+//# run-graphql
+Response: {
+  "data": {
+    "nonGenesisTransaction": {
+      "digest": "BHbfKkkQWomffJrjJ5PdxGUm5mREWMyNGDeky4dt9rnw",
+      "kind": null
+    }
+  }
+}
+
+task 4, lines 29-50:
+//# run-graphql
+Response: {
+  "data": {
+    "genesisTransaction": {
+      "sequenceNumber": 0,
+      "transactions": {
+        "nodes": [
+          {
+            "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
+            "kind": {
+              "objects": {
+                "nodes": [
+                  {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000001",
+                    "version": 1
+                  },
+                  {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000002",
+                    "version": 1
+                  },
+                  {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000003",
+                    "version": 1
+                  },
+                  {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000005",
+                    "version": 0
+                  },
+                  {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000006",
+                    "version": 0
+                  },
+                  {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000007",
+                    "version": 0
+                  },
+                  {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000008",
+                    "version": 0
+                  },
+                  {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000009",
+                    "version": 0
+                  },
+                  {
+                    "address": "0x000000000000000000000000000000000000000000000000000000000000000b",
+                    "version": 1
+                  },
+                  {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000403",
+                    "version": 0
+                  },
+                  {
+                    "address": "0x000000000000000000000000000000000000000000000000000000000000dee9",
+                    "version": 1
+                  },
+                  {
+                    "address": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
+                    "version": 0
+                  },
+                  {
+                    "address": "0x29efa2355bad50325946d9243062b64110c7fab283c88ff9514d6e08b16b4d9d",
+                    "version": 0
+                  },
+                  {
+                    "address": "0x6af2a2b7ca60bf76174adfd3e9c4957f8e937759603182f9b46c7f6c5f19c6d2",
+                    "version": 0
+                  },
+                  {
+                    "address": "0x6d0b9758ab130cfb5c8c79dae3643aacb01a01ee013214ac1aefce0e61b2d54c",
+                    "version": 0
+                  },
+                  {
+                    "address": "0x6d33474042ca5b7b77083b1fa13d699b1f65ddce5ad7c87eb6f66eb9deb014dd",
+                    "version": 0
+                  },
+                  {
+                    "address": "0x793898ba83ca8a41d0a635be4f3c3ec696dc4df77afbb652c95057e7620af112",
+                    "version": 0
+                  },
+                  {
+                    "address": "0x989b8b78d36d1199f9c3bad347b822009d8ae730dacc501b13633f6c491c6dc8",
+                    "version": 0
+                  },
+                  {
+                    "address": "0xadc60c5485f3e8db89130dabf5bb0e2b728dff8306d49e79e14bd7d285ed662d",
+                    "version": 0
+                  },
+                  {
+                    "address": "0xb5f1cff9e175de3ada5201af3530ff1cfb794cdf766ec839ddcf644fbd78d372",
+                    "version": 0
+                  },
+                  {
+                    "address": "0xcfecb053c69314e75f36561910f3535dd466b6e2e3593708f370e80424617ae7",
+                    "version": 0
+                  },
+                  {
+                    "address": "0xee1a26743f5025d6a8eda005159be9594c8554227ccbbe0d315f08bc7c4fe0d5",
+                    "version": 0
+                  },
+                  {
+                    "address": "0xf0b6039716354c46639d0c84ae011def2ae2232a4e1e7a104f2acff9a126cad2",
+                    "version": 0
+                  },
+                  {
+                    "address": "0xf354b8eb4321881a7d6012c665bbece1241bfd36459ec784fc98e836fcf25b42",
+                    "version": 0
+                  },
+                  {
+                    "address": "0xfdc25bc3b2d2b3664199d08f5275c3a6bb360b0629ab5784672f083149163417",
+                    "version": 0
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 5, lines 52-92:
+//# run-graphql
+Response: {
+  "data": {
+    "paginationTest": {
+      "sequenceNumber": 0,
+      "transactions": {
+        "nodes": [
+          {
+            "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
+            "kind": {
+              "objects": {
+                "nodes": [
+                  {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000001",
+                    "version": 1
+                  },
+                  {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000002",
+                    "version": 1
+                  },
+                  {
+                    "address": "0x0000000000000000000000000000000000000000000000000000000000000003",
+                    "version": 1
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    "backwardPaginationTest": {
+      "sequenceNumber": 0,
+      "transactions": {
+        "nodes": [
+          {
+            "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
+            "kind": {
+              "objects": {
+                "nodes": [
+                  {
+                    "address": "0xf0b6039716354c46639d0c84ae011def2ae2232a4e1e7a104f2acff9a126cad2",
+                    "version": 0
+                  },
+                  {
+                    "address": "0xf354b8eb4321881a7d6012c665bbece1241bfd36459ec784fc98e836fcf25b42",
+                    "version": 0
+                  },
+                  {
+                    "address": "0xfdc25bc3b2d2b3664199d08f5275c3a6bb360b0629ab5784672f083149163417",
+                    "version": 0
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -423,6 +423,16 @@ type GasInput {
 }
 
 """
+System transaction that initializes the network and writes the initial set of objects on-chain.
+"""
+type GenesisTransaction {
+	"""
+	Objects to be created during genesis.
+	"""
+	objects(first: Int, after: String, last: Int, before: String): ObjectConnection
+}
+
+"""
 Interface implemented by GraphQL types representing entities that are identified by an address.
 
 An address uniquely represents either the public key of an account, or an object's ID, but never both. It is not possible to determine which type an address represents up-front. If an object is wrapped, its contents will not be accessible via its address, but it will still be possible to access other objects it owns.
@@ -1139,6 +1149,10 @@ type Transaction {
 	"""
 	effects: TransactionEffects
 	"""
+	The type of this transaction as well as the commands and/or parameters comprising the transaction of this kind.
+	"""
+	kind: TransactionKind
+	"""
 	This field is set by senders of a transaction block. It is an epoch reference that sets a deadline after which validators will no longer consider the transaction valid. By default, there is no deadline for when a transaction must execute.
 	"""
 	expiration: Epoch
@@ -1267,6 +1281,11 @@ input TransactionFilter {
 	"""
 	beforeCheckpoint: UInt53
 }
+
+"""
+Different types of transactions that can be executed on the Sui network.
+"""
+union TransactionKind = GenesisTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.

--- a/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod storage_fund;
 pub(crate) mod system_parameters;
 pub(crate) mod transaction;
 pub(crate) mod transaction_effects;
+pub(crate) mod transaction_kind;
 pub(crate) mod user_signature;
 pub(crate) mod validator_aggregated_signature;
 pub(crate) mod validator_set;

--- a/crates/sui-indexer-alt-graphql/src/api/types/object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object.rs
@@ -21,9 +21,10 @@ use sui_indexer_alt_reader::{
 };
 use sui_indexer_alt_schema::{objects::StoredObjVersion, schema::obj_versions};
 use sui_types::{
-    base_types::{SequenceNumber, SuiAddress as NativeSuiAddress},
+    base_types::{SequenceNumber, SuiAddress as NativeSuiAddress, TransactionDigest},
     digests::ObjectDigest,
     object::Object as NativeObject,
+    transaction::GenesisObject,
 };
 use tokio::join;
 
@@ -258,6 +259,21 @@ impl Object {
             version,
             digest,
             contents: None,
+        }
+    }
+
+    /// Construct a GraphQL representation of an `Object` from a genesis object.
+    pub(crate) fn from_genesis_object(scope: Scope, genesis_obj: GenesisObject) -> Self {
+        let GenesisObject::RawObject { data, owner } = genesis_obj;
+        let native =
+            NativeObject::new_from_genesis(data, owner, TransactionDigest::genesis_marker());
+        let address = Address::with_address(scope, native.id().into());
+
+        Self {
+            super_: address,
+            version: native.version(),
+            digest: native.digest(),
+            contents: Some(Arc::new(native)),
         }
     }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object.rs
@@ -262,7 +262,7 @@ impl Object {
         }
     }
 
-    /// Construct a GraphQL representation of an `Object` from a genesis object.
+    /// Construct a GraphQL representation of an `Object` from a raw object bundled into the genesis transaction.
     pub(crate) fn from_genesis_object(scope: Scope, genesis_obj: GenesisObject) -> Self {
         let GenesisObject::RawObject { data, owner } = genesis_obj;
         let native =

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/genesis.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/genesis.rs
@@ -1,0 +1,56 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::{
+    connection::{Connection, CursorType, Edge},
+    Context, Object,
+};
+use sui_types::transaction::GenesisTransaction as NativeGenesisTransaction;
+
+use crate::{
+    api::{scalars::cursor::JsonCursor, types::object::Object},
+    error::RpcError,
+    pagination::{Page, PaginationConfig},
+    scope::Scope,
+};
+
+type CObject = JsonCursor<usize>;
+
+#[derive(Clone)]
+pub(crate) struct GenesisTransaction {
+    pub(crate) native: NativeGenesisTransaction,
+    pub(crate) scope: Scope,
+}
+
+/// System transaction that initializes the network and writes the initial set of objects on-chain.
+#[Object]
+impl GenesisTransaction {
+    /// Objects to be created during genesis.
+    async fn objects(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<CObject>,
+        last: Option<u64>,
+        before: Option<CObject>,
+    ) -> Result<Option<Connection<String, Object>>, RpcError> {
+        let pagination: &PaginationConfig = ctx.data()?;
+        let limits = pagination.limits("GenesisTransaction", "objects");
+        let page = Page::from_params(limits, first, after, last, before)?;
+
+        let objects = &self.native.objects;
+        let cursors = page.paginate_indices(objects.len());
+        let mut conn = Connection::new(cursors.has_previous_page, cursors.has_next_page);
+
+        for edge in cursors.edges {
+            // Create Object from GenesisObject
+            let object =
+                Object::from_genesis_object(self.scope.clone(), objects[*edge.cursor].clone());
+
+            conn.edges
+                .push(Edge::new(edge.cursor.encode_cursor(), object));
+        }
+
+        Ok(Some(conn))
+    }
+}

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/mod.rs
@@ -1,0 +1,30 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::Union;
+use sui_types::transaction::TransactionKind as NativeTransactionKind;
+
+use crate::scope::Scope;
+
+use self::genesis::GenesisTransaction;
+
+pub(crate) mod genesis;
+
+/// Different types of transactions that can be executed on the Sui network.
+#[derive(Union, Clone)]
+pub enum TransactionKind {
+    Genesis(GenesisTransaction),
+}
+
+impl TransactionKind {
+    pub fn from(kind: NativeTransactionKind, scope: Scope) -> Option<Self> {
+        use NativeTransactionKind as K;
+        use TransactionKind as T;
+
+        match kind {
+            K::Genesis(g) => Some(T::Genesis(GenesisTransaction { native: g, scope })),
+            // For now, only support Genesis - other types will return None
+            _ => None,
+        }
+    }
+}

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -427,6 +427,16 @@ type GasInput {
 }
 
 """
+System transaction that initializes the network and writes the initial set of objects on-chain.
+"""
+type GenesisTransaction {
+	"""
+	Objects to be created during genesis.
+	"""
+	objects(first: Int, after: String, last: Int, before: String): ObjectConnection
+}
+
+"""
 Interface implemented by GraphQL types representing entities that are identified by an address.
 
 An address uniquely represents either the public key of an account, or an object's ID, but never both. It is not possible to determine which type an address represents up-front. If an object is wrapped, its contents will not be accessible via its address, but it will still be possible to access other objects it owns.
@@ -1143,6 +1153,10 @@ type Transaction {
 	"""
 	effects: TransactionEffects
 	"""
+	The type of this transaction as well as the commands and/or parameters comprising the transaction of this kind.
+	"""
+	kind: TransactionKind
+	"""
 	This field is set by senders of a transaction block. It is an epoch reference that sets a deadline after which validators will no longer consider the transaction valid. By default, there is no deadline for when a transaction must execute.
 	"""
 	expiration: Epoch
@@ -1271,6 +1285,11 @@ input TransactionFilter {
 	"""
 	beforeCheckpoint: UInt53
 }
+
+"""
+Different types of transactions that can be executed on the Sui network.
+"""
+union TransactionKind = GenesisTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -427,6 +427,16 @@ type GasInput {
 }
 
 """
+System transaction that initializes the network and writes the initial set of objects on-chain.
+"""
+type GenesisTransaction {
+	"""
+	Objects to be created during genesis.
+	"""
+	objects(first: Int, after: String, last: Int, before: String): ObjectConnection
+}
+
+"""
 Interface implemented by GraphQL types representing entities that are identified by an address.
 
 An address uniquely represents either the public key of an account, or an object's ID, but never both. It is not possible to determine which type an address represents up-front. If an object is wrapped, its contents will not be accessible via its address, but it will still be possible to access other objects it owns.
@@ -1143,6 +1153,10 @@ type Transaction {
 	"""
 	effects: TransactionEffects
 	"""
+	The type of this transaction as well as the commands and/or parameters comprising the transaction of this kind.
+	"""
+	kind: TransactionKind
+	"""
 	This field is set by senders of a transaction block. It is an epoch reference that sets a deadline after which validators will no longer consider the transaction valid. By default, there is no deadline for when a transaction must execute.
 	"""
 	expiration: Epoch
@@ -1271,6 +1285,11 @@ input TransactionFilter {
 	"""
 	beforeCheckpoint: UInt53
 }
+
+"""
+Different types of transactions that can be executed on the Sui network.
+"""
+union TransactionKind = GenesisTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -423,6 +423,16 @@ type GasInput {
 }
 
 """
+System transaction that initializes the network and writes the initial set of objects on-chain.
+"""
+type GenesisTransaction {
+	"""
+	Objects to be created during genesis.
+	"""
+	objects(first: Int, after: String, last: Int, before: String): ObjectConnection
+}
+
+"""
 Interface implemented by GraphQL types representing entities that are identified by an address.
 
 An address uniquely represents either the public key of an account, or an object's ID, but never both. It is not possible to determine which type an address represents up-front. If an object is wrapped, its contents will not be accessible via its address, but it will still be possible to access other objects it owns.
@@ -1139,6 +1149,10 @@ type Transaction {
 	"""
 	effects: TransactionEffects
 	"""
+	The type of this transaction as well as the commands and/or parameters comprising the transaction of this kind.
+	"""
+	kind: TransactionKind
+	"""
 	This field is set by senders of a transaction block. It is an epoch reference that sets a deadline after which validators will no longer consider the transaction valid. By default, there is no deadline for when a transaction must execute.
 	"""
 	expiration: Epoch
@@ -1267,6 +1281,11 @@ input TransactionFilter {
 	"""
 	beforeCheckpoint: UInt53
 }
+
+"""
+Different types of transactions that can be executed on the Sui network.
+"""
+union TransactionKind = GenesisTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.


### PR DESCRIPTION
## Description 

This is the first PR to support `TransactionKind` for `Transaction`:
1. Implement a foundation for `TransactionKind` type by using Union which allows us to easily add other types (e.g. ChangeEpochTransaction, Programmable, etc) in upcoming PRs
2. Implement the first kind `GenesisTransaction`

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-graphql
cargo nextest run -p sui-indexer-alt-reader
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

---

## Stack 
- #22652 
- #22718 
- #22788 
- #22943 ⬅️

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
