### PR TITLE
[pkg-alt] Use linkage table to list packages, instead of having duplicates

### DIFF
--- a/external-crates/move/crates/move-cli/src/base/test.rs
+++ b/external-crates/move/crates/move-cli/src/base/test.rs
@@ -187,9 +187,9 @@ pub async fn run_move_unit_tests<F: MoveFlavor, W: Write + Send>(
     };
 
     let root_pkg = RootPackage::<F>::load(pkg_path, env).await?;
-    let package_name = Symbol::from(root_pkg.name().as_str());
+    let package_name = Symbol::from(format!("{}_root", root_pkg.name().as_str()));
 
-    let packages = root_pkg.packages();
+    let packages = root_pkg.packages()?;
 
     let mut dummy_addr = 0x1000;
     let mut addresses: Vec<(String, NumericalAddress)> = vec![];

--- a/external-crates/move/crates/move-package-alt/src/cli/build.rs
+++ b/external-crates/move/crates/move-package-alt/src/cli/build.rs
@@ -41,7 +41,7 @@ impl Build {
 
         let root_pkg = RootPackage::<Vanilla>::load(&path, environment).await?;
 
-        for pkg in root_pkg.packages() {
+        for pkg in root_pkg.packages()? {
             println!("Package {}", pkg.name());
             if pkg.is_root() {
                 println!("  (root package)");

--- a/external-crates/move/crates/move-package-alt/src/compatibility/legacy_parser.rs
+++ b/external-crates/move/crates/move-package-alt/src/compatibility/legacy_parser.rs
@@ -357,7 +357,7 @@ fn parse_package_info(tval: TV) -> Result<LegacyPackageMetadata> {
             let edition = table
                 .remove("edition")
                 .map(|v| v.as_str().unwrap_or_default().to_string())
-                .unwrap_or_default();
+                .unwrap_or("legacy".to_string());
 
             Ok(LegacyPackageMetadata {
                 legacy_name: name,

--- a/external-crates/move/crates/move-package-alt/src/graph/linkage.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/linkage.rs
@@ -6,7 +6,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use itertools::Itertools;
 use petgraph::{
-    algo::{toposort, Cycle},
+    algo::{Cycle, toposort},
     graph::NodeIndex,
     visit::EdgeRef,
 };

--- a/external-crates/move/crates/move-package-alt/src/graph/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/mod.rs
@@ -63,9 +63,8 @@ impl<F: MoveFlavor> PackageInfo<'_, F> {
     }
 
     /// The compiler edition for the package
-    pub fn edition(&self) -> Option<&str> {
-        // TODO: pull this from manifest
-        Some("2024")
+    pub fn edition(&self) -> &str {
+        self.package().metadata().edition.as_str()
     }
 
     /// The flavor for the package
@@ -218,13 +217,36 @@ impl<F: MoveFlavor> PackageGraph<F> {
         self.inner[self.root_index].as_ref()
     }
 
-    /// Return the list of dependencies in this package graph
-    // TODO: I don't like the name dependencies for this. Maybe packages?
-    pub(crate) fn dependencies(&self) -> Vec<PackageInfo<F>> {
-        self.inner
-            .node_indices()
+    /// Return the list of packages that are in the linkage table, as well as
+    /// the unpublished ones in the package graph.
+    // TODO: Do we want a way to access ALL packages and not the "de-duplicated" ones?
+    pub(crate) fn packages(&self) -> PackageResult<Vec<PackageInfo<F>>> {
+        let mut linkage = self.linkage()?;
+
+        // Populate ALL the linkage elements
+        let mut result: Vec<PackageInfo<F>> = linkage
+            .values()
+            .cloned()
             .map(|node| PackageInfo { graph: self, node })
-            .collect()
+            .collect();
+
+        // Add all nodes that exist but are not in the linkage table.
+        // This is done to support unpublished packages, as linkage only includes
+        // published packages.
+        for node in self.inner.node_indices().into_iter() {
+            let package = &self.inner[node];
+
+            if package
+                .original_id()
+                .is_some_and(|oid| linkage.contains_key(&oid))
+            {
+                continue;
+            }
+
+            result.push(PackageInfo { graph: self, node });
+        }
+
+        Ok(result)
     }
 
     /// Return the sorted list of dependencies' name
@@ -257,7 +279,8 @@ mod tests {
         graph: &PackageGraph<Vanilla>,
     ) -> BTreeMap<PackageName, PackageInfo<Vanilla>> {
         graph
-            .dependencies()
+            .packages()
+            .expect("failed to get packages from graph")
             .into_iter()
             .map(|node| (node.name().clone(), node))
             .collect()

--- a/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
@@ -264,6 +264,10 @@ impl<F: MoveFlavor> Package<F> {
         self.publication().map(|data| data.original_id.clone())
     }
 
+    pub fn metadata(&self) -> &PackageMetadata {
+        &self.metadata
+    }
+
     /// Return the implicit deps depending on the implicit dep mode. Note that if `implicit_dep_mode`
     /// is ImplicitDepMode::Legacy, a `legacy_manifest` is required otherwise it will panic.
     // TODO this needs to be moved into a ImplicitDeps trait

--- a/external-crates/move/crates/move-package-alt/src/package/root_package.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/root_package.rs
@@ -157,9 +157,9 @@ impl<F: MoveFlavor + fmt::Debug> RootPackage<F> {
     }
 
     /// Return the list of all packages in the root package's package graph (including itself and all
-    /// transitive dependencies).
-    pub fn packages(&self) -> Vec<PackageInfo<F>> {
-        self.graph.dependencies()
+    /// transitive dependencies). This includes the non-duplicate addresses only.
+    pub fn packages(&self) -> PackageResult<Vec<PackageInfo<F>>> {
+        self.graph.packages()
     }
 
     /// Return the linkage table for the root package. This contains an entry for each package that
@@ -244,11 +244,6 @@ impl<F: MoveFlavor + fmt::Debug> RootPackage<F> {
     /// Return a list of sorted package names
     pub fn sorted_deps(&self) -> Vec<&PackageName> {
         self.package_graph().sorted_deps()
-    }
-
-    /// Return the list of this root package's dependencies
-    pub fn dependencies(&self) -> Vec<PackageInfo<F>> {
-        self.package_graph().dependencies()
     }
 
     pub fn deps_published_ids(&self) -> &Vec<OriginalID> {


### PR DESCRIPTION
## Description 

Fixes:
1. Uses the linkage table & unpublished addresses to remove duplicates
2. Uses the manifest's edition to pass in the compiler

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
