### PR TITLE
[graphql-alt] Support ConsensusCommitPrologueTransaction kind for TransactionKind [2/n]

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/consensus_commit_prologue.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/consensus_commit_prologue.move
@@ -1,0 +1,28 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --simulator
+
+//# advance-clock --duration-ns 1000000
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  # Test the ConsensusCommitPrologue transaction created by advance-clock
+  consensusCommitPrologueTransaction: transaction(digest: "@{digest_1}") {
+    digest
+    kind {
+      ... on ConsensusCommitPrologueTransaction {
+        epoch {
+          epochId
+        }
+        round
+        commitTimestamp
+        consensusCommitDigest
+        subDagIndex
+        additionalStateDigest
+      }
+    }
+  }
+} 

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/consensus_commit_prologue.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/consensus_commit_prologue.move
@@ -13,6 +13,7 @@
   consensusCommitPrologueTransaction: transaction(digest: "@{digest_1}") {
     digest
     kind {
+      __typename
       ... on ConsensusCommitPrologueTransaction {
         epoch {
           epochId

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/consensus_commit_prologue.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/consensus_commit_prologue.snap
@@ -1,0 +1,28 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+task 2, line 5:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 7-25:
+//# run-graphql
+Response: {
+  "data": {
+    "consensusCommitPrologueTransaction": {
+      "digest": "2RfSVhowkzr4JQQVD42D4XgUbtyLoVsm8ns8vAJPWMDx",
+      "kind": {
+        "epoch": {
+          "epochId": 0
+        },
+        "round": 0,
+        "commitTimestamp": "1970-01-01T00:00:00.001Z",
+        "consensusCommitDigest": "11111111111111111111111111111111",
+        "subDagIndex": null,
+        "additionalStateDigest": null
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/consensus_commit_prologue.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/consensus_commit_prologue.snap
@@ -3,17 +3,18 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 ---
 processed 4 tasks
 
-task 2, line 5:
+task 2, line 8:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 3, lines 7-25:
+task 3, lines 10-29:
 //# run-graphql
 Response: {
   "data": {
     "consensusCommitPrologueTransaction": {
       "digest": "2RfSVhowkzr4JQQVD42D4XgUbtyLoVsm8ns8vAJPWMDx",
       "kind": {
+        "__typename": "ConsensusCommitPrologueTransaction",
         "epoch": {
           "epochId": 0
         },

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -138,26 +138,40 @@ System transaction that runs at the beginning of a checkpoint, and is responsibl
 type ConsensusCommitPrologueTransaction {
 	"""
 	Epoch of the commit prologue transaction.
+	
+	Present in V1, V2, V3, V4.
 	"""
 	epoch: Epoch
 	"""
 	Consensus round of the commit.
+	
+	Present in V1, V2, V3, V4.
 	"""
 	round: UInt53
 	"""
 	Unix timestamp from consensus.
+	
+	Present in V1, V2, V3, V4.
 	"""
 	commitTimestamp: DateTime
 	"""
-	Digest of consensus output, encoded as a Base58 string (only available from V2+ of the transaction).
+	Digest of consensus output, encoded as a Base58 string.
+	
+	Present in V2, V3, V4.
 	"""
 	consensusCommitDigest: String
 	"""
-	Sub-DAG index for consensus ordering (only available from V3+ of the transaction).
+	The sub DAG index of the consensus commit. This field is populated if there
+	are multiple consensus commits per round.
+	
+	Present in V3, V4.
 	"""
 	subDagIndex: UInt53
 	"""
-	Additional state digest for enhanced security (only available from V4+ of the transaction).
+	Digest of any additional state computed by the consensus handler.
+	Used to detect forking bugs as early as possible.
+	
+	Present in V4.
 	"""
 	additionalStateDigest: String
 }

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -133,6 +133,36 @@ input CheckpointFilter {
 }
 
 """
+System transaction that runs at the beginning of a checkpoint, and is responsible for setting the current value of the clock, based on the timestamp from consensus.
+"""
+type ConsensusCommitPrologueTransaction {
+	"""
+	Epoch of the commit prologue transaction.
+	"""
+	epoch: Epoch
+	"""
+	Consensus round of the commit.
+	"""
+	round: UInt53
+	"""
+	Unix timestamp from consensus.
+	"""
+	commitTimestamp: DateTime
+	"""
+	Digest of consensus output, encoded as a Base58 string (only available from V2+ of the transaction).
+	"""
+	consensusCommitDigest: String
+	"""
+	Sub-DAG index for consensus ordering (only available from V3+ of the transaction).
+	"""
+	subDagIndex: UInt53
+	"""
+	Additional state digest for enhanced security (only available from V4+ of the transaction).
+	"""
+	additionalStateDigest: String
+}
+
+"""
 ISO-8601 Date and Time: RFC3339 in UTC with format: YYYY-MM-DDTHH:MM:SS.mmmZ. Note that the milliseconds part is optional, and it may be omitted if its value is 0.
 """
 scalar DateTime
@@ -1285,7 +1315,7 @@ input TransactionFilter {
 """
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/consensus_commit_prologue.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/consensus_commit_prologue.rs
@@ -37,33 +37,47 @@ pub(crate) struct ConsensusCommitPrologueTransaction {
 #[Object]
 impl ConsensusCommitPrologueTransaction {
     /// Epoch of the commit prologue transaction.
+    ///
+    /// Present in V1, V2, V3, V4.
     async fn epoch(&self) -> Option<Epoch> {
         Some(Epoch::with_id(self.scope.clone(), self.epoch))
     }
 
     /// Consensus round of the commit.
+    ///
+    /// Present in V1, V2, V3, V4.
     async fn round(&self) -> Option<UInt53> {
         Some(self.round.into())
     }
 
     /// Unix timestamp from consensus.
+    ///
+    /// Present in V1, V2, V3, V4.
     async fn commit_timestamp(&self) -> Result<Option<DateTime>, RpcError> {
         Ok(Some(DateTime::from_ms(self.commit_timestamp_ms as i64)?))
     }
 
-    /// Digest of consensus output, encoded as a Base58 string (only available from V2+ of the transaction).
+    /// Digest of consensus output, encoded as a Base58 string.
+    ///
+    /// Present in V2, V3, V4.
     async fn consensus_commit_digest(&self) -> Option<String> {
         self.consensus_commit_digest
             .as_ref()
             .map(|digest| Base58::encode(digest.inner()))
     }
 
-    /// Sub-DAG index for consensus ordering (only available from V3+ of the transaction).
+    /// The sub DAG index of the consensus commit. This field is populated if there
+    /// are multiple consensus commits per round.
+    ///
+    /// Present in V3, V4.
     async fn sub_dag_index(&self) -> Option<UInt53> {
         self.sub_dag_index.map(|idx| idx.into())
     }
 
-    /// Additional state digest for enhanced security (only available from V4+ of the transaction).
+    /// Digest of any additional state computed by the consensus handler.
+    /// Used to detect forking bugs as early as possible.
+    ///
+    /// Present in V4.
     async fn additional_state_digest(&self) -> Option<String> {
         self.additional_state_digest
             .as_ref()

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/consensus_commit_prologue.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/consensus_commit_prologue.rs
@@ -1,0 +1,122 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::Object;
+use fastcrypto::encoding::{Base58, Encoding};
+use sui_types::{
+    digests::{AdditionalConsensusStateDigest, ConsensusCommitDigest},
+    messages_consensus::{
+        ConsensusCommitPrologue as NativeConsensusCommitPrologueV1,
+        ConsensusCommitPrologueV2 as NativeConsensusCommitPrologueV2,
+        ConsensusCommitPrologueV3 as NativeConsensusCommitPrologueV3,
+        ConsensusCommitPrologueV4 as NativeConsensusCommitPrologueV4,
+    },
+};
+
+use crate::{
+    api::{
+        scalars::{date_time::DateTime, uint53::UInt53},
+        types::epoch::Epoch,
+    },
+    error::RpcError,
+    scope::Scope,
+};
+
+#[derive(Clone)]
+pub(crate) struct ConsensusCommitPrologueTransaction {
+    pub(crate) scope: Scope,
+    pub(crate) epoch: u64,
+    pub(crate) round: u64,
+    pub(crate) sub_dag_index: Option<u64>,
+    pub(crate) commit_timestamp_ms: u64,
+    pub(crate) consensus_commit_digest: Option<ConsensusCommitDigest>,
+    pub(crate) additional_state_digest: Option<AdditionalConsensusStateDigest>,
+}
+
+/// System transaction that runs at the beginning of a checkpoint, and is responsible for setting the current value of the clock, based on the timestamp from consensus.
+#[Object]
+impl ConsensusCommitPrologueTransaction {
+    /// Epoch of the commit prologue transaction.
+    async fn epoch(&self) -> Option<Epoch> {
+        Some(Epoch::with_id(self.scope.clone(), self.epoch))
+    }
+
+    /// Consensus round of the commit.
+    async fn round(&self) -> Option<UInt53> {
+        Some(self.round.into())
+    }
+
+    /// Unix timestamp from consensus.
+    async fn commit_timestamp(&self) -> Result<Option<DateTime>, RpcError> {
+        Ok(Some(DateTime::from_ms(self.commit_timestamp_ms as i64)?))
+    }
+
+    /// Digest of consensus output, encoded as a Base58 string (only available from V2+ of the transaction).
+    async fn consensus_commit_digest(&self) -> Option<String> {
+        self.consensus_commit_digest
+            .as_ref()
+            .map(|digest| Base58::encode(digest.inner()))
+    }
+
+    /// Sub-DAG index for consensus ordering (only available from V3+ of the transaction).
+    async fn sub_dag_index(&self) -> Option<UInt53> {
+        self.sub_dag_index.map(|idx| idx.into())
+    }
+
+    /// Additional state digest for enhanced security (only available from V4+ of the transaction).
+    async fn additional_state_digest(&self) -> Option<String> {
+        self.additional_state_digest
+            .as_ref()
+            .map(|digest| digest.to_string())
+    }
+}
+
+impl ConsensusCommitPrologueTransaction {
+    pub(crate) fn from_v1(native: NativeConsensusCommitPrologueV1, scope: Scope) -> Self {
+        Self {
+            scope,
+            epoch: native.epoch,
+            round: native.round,
+            sub_dag_index: None,
+            commit_timestamp_ms: native.commit_timestamp_ms,
+            consensus_commit_digest: None,
+            additional_state_digest: None,
+        }
+    }
+
+    pub(crate) fn from_v2(native: NativeConsensusCommitPrologueV2, scope: Scope) -> Self {
+        Self {
+            scope,
+            epoch: native.epoch,
+            round: native.round,
+            sub_dag_index: None,
+            commit_timestamp_ms: native.commit_timestamp_ms,
+            consensus_commit_digest: Some(native.consensus_commit_digest),
+            additional_state_digest: None,
+        }
+    }
+
+    pub(crate) fn from_v3(native: NativeConsensusCommitPrologueV3, scope: Scope) -> Self {
+        Self {
+            scope,
+            epoch: native.epoch,
+            round: native.round,
+            sub_dag_index: native.sub_dag_index,
+            commit_timestamp_ms: native.commit_timestamp_ms,
+            consensus_commit_digest: Some(native.consensus_commit_digest),
+            additional_state_digest: None,
+        }
+    }
+
+    pub(crate) fn from_v4(native: NativeConsensusCommitPrologueV4, scope: Scope) -> Self {
+        Self {
+            scope,
+            epoch: native.epoch,
+            round: native.round,
+            sub_dag_index: native.sub_dag_index,
+            commit_timestamp_ms: native.commit_timestamp_ms,
+            consensus_commit_digest: Some(native.consensus_commit_digest),
+            additional_state_digest: Some(native.additional_state_digest),
+        }
+    }
+}

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/mod.rs
@@ -6,14 +6,18 @@ use sui_types::transaction::TransactionKind as NativeTransactionKind;
 
 use crate::scope::Scope;
 
-use self::genesis::GenesisTransaction;
+use self::{
+    consensus_commit_prologue::ConsensusCommitPrologueTransaction, genesis::GenesisTransaction,
+};
 
+pub(crate) mod consensus_commit_prologue;
 pub(crate) mod genesis;
 
 /// Different types of transactions that can be executed on the Sui network.
 #[derive(Union, Clone)]
 pub enum TransactionKind {
     Genesis(GenesisTransaction),
+    ConsensusCommitPrologue(ConsensusCommitPrologueTransaction),
 }
 
 impl TransactionKind {
@@ -23,7 +27,19 @@ impl TransactionKind {
 
         match kind {
             K::Genesis(g) => Some(T::Genesis(GenesisTransaction { native: g, scope })),
-            // For now, only support Genesis - other types will return None
+            K::ConsensusCommitPrologue(ccp) => Some(T::ConsensusCommitPrologue(
+                ConsensusCommitPrologueTransaction::from_v1(ccp, scope),
+            )),
+            K::ConsensusCommitPrologueV2(ccp) => Some(T::ConsensusCommitPrologue(
+                ConsensusCommitPrologueTransaction::from_v2(ccp, scope),
+            )),
+            K::ConsensusCommitPrologueV3(ccp) => Some(T::ConsensusCommitPrologue(
+                ConsensusCommitPrologueTransaction::from_v3(ccp, scope),
+            )),
+            K::ConsensusCommitPrologueV4(ccp) => Some(T::ConsensusCommitPrologue(
+                ConsensusCommitPrologueTransaction::from_v4(ccp, scope),
+            )),
+            // Other types will return None for now
             _ => None,
         }
     }

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -142,26 +142,40 @@ System transaction that runs at the beginning of a checkpoint, and is responsibl
 type ConsensusCommitPrologueTransaction {
 	"""
 	Epoch of the commit prologue transaction.
+	
+	Present in V1, V2, V3, V4.
 	"""
 	epoch: Epoch
 	"""
 	Consensus round of the commit.
+	
+	Present in V1, V2, V3, V4.
 	"""
 	round: UInt53
 	"""
 	Unix timestamp from consensus.
+	
+	Present in V1, V2, V3, V4.
 	"""
 	commitTimestamp: DateTime
 	"""
-	Digest of consensus output, encoded as a Base58 string (only available from V2+ of the transaction).
+	Digest of consensus output, encoded as a Base58 string.
+	
+	Present in V2, V3, V4.
 	"""
 	consensusCommitDigest: String
 	"""
-	Sub-DAG index for consensus ordering (only available from V3+ of the transaction).
+	The sub DAG index of the consensus commit. This field is populated if there
+	are multiple consensus commits per round.
+	
+	Present in V3, V4.
 	"""
 	subDagIndex: UInt53
 	"""
-	Additional state digest for enhanced security (only available from V4+ of the transaction).
+	Digest of any additional state computed by the consensus handler.
+	Used to detect forking bugs as early as possible.
+	
+	Present in V4.
 	"""
 	additionalStateDigest: String
 }

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -137,6 +137,36 @@ input CheckpointFilter {
 }
 
 """
+System transaction that runs at the beginning of a checkpoint, and is responsible for setting the current value of the clock, based on the timestamp from consensus.
+"""
+type ConsensusCommitPrologueTransaction {
+	"""
+	Epoch of the commit prologue transaction.
+	"""
+	epoch: Epoch
+	"""
+	Consensus round of the commit.
+	"""
+	round: UInt53
+	"""
+	Unix timestamp from consensus.
+	"""
+	commitTimestamp: DateTime
+	"""
+	Digest of consensus output, encoded as a Base58 string (only available from V2+ of the transaction).
+	"""
+	consensusCommitDigest: String
+	"""
+	Sub-DAG index for consensus ordering (only available from V3+ of the transaction).
+	"""
+	subDagIndex: UInt53
+	"""
+	Additional state digest for enhanced security (only available from V4+ of the transaction).
+	"""
+	additionalStateDigest: String
+}
+
+"""
 ISO-8601 Date and Time: RFC3339 in UTC with format: YYYY-MM-DDTHH:MM:SS.mmmZ. Note that the milliseconds part is optional, and it may be omitted if its value is 0.
 """
 scalar DateTime
@@ -1289,7 +1319,7 @@ input TransactionFilter {
 """
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -142,26 +142,40 @@ System transaction that runs at the beginning of a checkpoint, and is responsibl
 type ConsensusCommitPrologueTransaction {
 	"""
 	Epoch of the commit prologue transaction.
+	
+	Present in V1, V2, V3, V4.
 	"""
 	epoch: Epoch
 	"""
 	Consensus round of the commit.
+	
+	Present in V1, V2, V3, V4.
 	"""
 	round: UInt53
 	"""
 	Unix timestamp from consensus.
+	
+	Present in V1, V2, V3, V4.
 	"""
 	commitTimestamp: DateTime
 	"""
-	Digest of consensus output, encoded as a Base58 string (only available from V2+ of the transaction).
+	Digest of consensus output, encoded as a Base58 string.
+	
+	Present in V2, V3, V4.
 	"""
 	consensusCommitDigest: String
 	"""
-	Sub-DAG index for consensus ordering (only available from V3+ of the transaction).
+	The sub DAG index of the consensus commit. This field is populated if there
+	are multiple consensus commits per round.
+	
+	Present in V3, V4.
 	"""
 	subDagIndex: UInt53
 	"""
-	Additional state digest for enhanced security (only available from V4+ of the transaction).
+	Digest of any additional state computed by the consensus handler.
+	Used to detect forking bugs as early as possible.
+	
+	Present in V4.
 	"""
 	additionalStateDigest: String
 }

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -137,6 +137,36 @@ input CheckpointFilter {
 }
 
 """
+System transaction that runs at the beginning of a checkpoint, and is responsible for setting the current value of the clock, based on the timestamp from consensus.
+"""
+type ConsensusCommitPrologueTransaction {
+	"""
+	Epoch of the commit prologue transaction.
+	"""
+	epoch: Epoch
+	"""
+	Consensus round of the commit.
+	"""
+	round: UInt53
+	"""
+	Unix timestamp from consensus.
+	"""
+	commitTimestamp: DateTime
+	"""
+	Digest of consensus output, encoded as a Base58 string (only available from V2+ of the transaction).
+	"""
+	consensusCommitDigest: String
+	"""
+	Sub-DAG index for consensus ordering (only available from V3+ of the transaction).
+	"""
+	subDagIndex: UInt53
+	"""
+	Additional state digest for enhanced security (only available from V4+ of the transaction).
+	"""
+	additionalStateDigest: String
+}
+
+"""
 ISO-8601 Date and Time: RFC3339 in UTC with format: YYYY-MM-DDTHH:MM:SS.mmmZ. Note that the milliseconds part is optional, and it may be omitted if its value is 0.
 """
 scalar DateTime
@@ -1289,7 +1319,7 @@ input TransactionFilter {
 """
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -138,26 +138,40 @@ System transaction that runs at the beginning of a checkpoint, and is responsibl
 type ConsensusCommitPrologueTransaction {
 	"""
 	Epoch of the commit prologue transaction.
+	
+	Present in V1, V2, V3, V4.
 	"""
 	epoch: Epoch
 	"""
 	Consensus round of the commit.
+	
+	Present in V1, V2, V3, V4.
 	"""
 	round: UInt53
 	"""
 	Unix timestamp from consensus.
+	
+	Present in V1, V2, V3, V4.
 	"""
 	commitTimestamp: DateTime
 	"""
-	Digest of consensus output, encoded as a Base58 string (only available from V2+ of the transaction).
+	Digest of consensus output, encoded as a Base58 string.
+	
+	Present in V2, V3, V4.
 	"""
 	consensusCommitDigest: String
 	"""
-	Sub-DAG index for consensus ordering (only available from V3+ of the transaction).
+	The sub DAG index of the consensus commit. This field is populated if there
+	are multiple consensus commits per round.
+	
+	Present in V3, V4.
 	"""
 	subDagIndex: UInt53
 	"""
-	Additional state digest for enhanced security (only available from V4+ of the transaction).
+	Digest of any additional state computed by the consensus handler.
+	Used to detect forking bugs as early as possible.
+	
+	Present in V4.
 	"""
 	additionalStateDigest: String
 }

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -133,6 +133,36 @@ input CheckpointFilter {
 }
 
 """
+System transaction that runs at the beginning of a checkpoint, and is responsible for setting the current value of the clock, based on the timestamp from consensus.
+"""
+type ConsensusCommitPrologueTransaction {
+	"""
+	Epoch of the commit prologue transaction.
+	"""
+	epoch: Epoch
+	"""
+	Consensus round of the commit.
+	"""
+	round: UInt53
+	"""
+	Unix timestamp from consensus.
+	"""
+	commitTimestamp: DateTime
+	"""
+	Digest of consensus output, encoded as a Base58 string (only available from V2+ of the transaction).
+	"""
+	consensusCommitDigest: String
+	"""
+	Sub-DAG index for consensus ordering (only available from V3+ of the transaction).
+	"""
+	subDagIndex: UInt53
+	"""
+	Additional state digest for enhanced security (only available from V4+ of the transaction).
+	"""
+	additionalStateDigest: String
+}
+
+"""
 ISO-8601 Date and Time: RFC3339 in UTC with format: YYYY-MM-DDTHH:MM:SS.mmmZ. Note that the milliseconds part is optional, and it may be omitted if its value is 0.
 """
 scalar DateTime
@@ -1285,7 +1315,7 @@ input TransactionFilter {
 """
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.


### PR DESCRIPTION
## Description 

Adding the new `ConsensusCommitPrologueTransaction` as a new enum field within `TransactionKind` union

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-graphql
cargo nextest run -p sui-indexer-alt-reader
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

---

## Stack 
- #22652 
- #22718 
- #22788 
- #22943
- #22950 ⬅️


## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
