### PR TITLE
[graphql-alt] Support RandomnessStateUpdate kind for TransactionKind [3/n]

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/randomness_state_update.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/randomness_state_update.move
@@ -15,6 +15,7 @@
   randomnessStateUpdateTransaction: transaction(digest: "@{digest_2}") {
     digest
     kind {
+      __typename
       ... on RandomnessStateUpdateTransaction {
         epoch
         randomnessRound

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/randomness_state_update.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/randomness_state_update.move
@@ -1,0 +1,26 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --simulator
+
+//# advance-epoch --create-random-state
+
+//# set-random-state --randomness-round 0 --random-bytes SGVsbG8gU3VpIFJhbmRvbW5lc3M= --randomness-initial-version 2
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  # Test the RandomnessStateUpdate transaction created by set-random-state
+  randomnessStateUpdateTransaction: transaction(digest: "@{digest_2}") {
+    digest
+    kind {
+      ... on RandomnessStateUpdateTransaction {
+        epoch
+        randomnessRound
+        randomBytes
+        randomnessObjInitialSharedVersion
+      }
+    }
+  }
+} 

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/randomness_state_update.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/randomness_state_update.snap
@@ -11,13 +11,14 @@ task 3, line 10:
 //# create-checkpoint
 Checkpoint created: 2
 
-task 4, lines 12-26:
+task 4, lines 12-27:
 //# run-graphql
 Response: {
   "data": {
     "randomnessStateUpdateTransaction": {
       "digest": "FL1Q5ppJXWGN7C7kenCgtTRxABCaKjzahYeq66hJasP2",
       "kind": {
+        "__typename": "RandomnessStateUpdateTransaction",
         "epoch": 1,
         "randomnessRound": 0,
         "randomBytes": "SGVsbG8gU3VpIFJhbmRvbW5lc3M=",

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/randomness_state_update.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/randomness_state_update.snap
@@ -1,0 +1,28 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+task 1, line 6:
+//# advance-epoch --create-random-state
+Epoch advanced: 1
+
+task 3, line 10:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 4, lines 12-26:
+//# run-graphql
+Response: {
+  "data": {
+    "randomnessStateUpdateTransaction": {
+      "digest": "FL1Q5ppJXWGN7C7kenCgtTRxABCaKjzahYeq66hJasP2",
+      "kind": {
+        "epoch": 1,
+        "randomnessRound": 0,
+        "randomBytes": "SGVsbG8gU3VpIFJhbmRvbW5lc3M=",
+        "randomnessObjInitialSharedVersion": 2
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -981,6 +981,28 @@ type Query {
 	transactions(first: Int, after: String, last: Int, before: String, filter: TransactionFilter): TransactionConnection!
 }
 
+"""
+System transaction to update the source of on-chain randomness.
+"""
+type RandomnessStateUpdateTransaction {
+	"""
+	Epoch of the randomness state update transaction.
+	"""
+	epoch: Int
+	"""
+	Randomness round of the update.
+	"""
+	randomnessRound: Int
+	"""
+	Updated random bytes, Base64 encoded.
+	"""
+	randomBytes: Base64
+	"""
+	The initial version of the randomness object that it was shared at.
+	"""
+	randomnessObjInitialSharedVersion: Int
+}
+
 type SafeMode {
 	"""
 	Whether safe mode was used for the last epoch change.
@@ -1329,7 +1351,7 @@ input TransactionFilter {
 """
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | RandomnessStateUpdateTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/mod.rs
@@ -8,16 +8,19 @@ use crate::scope::Scope;
 
 use self::{
     consensus_commit_prologue::ConsensusCommitPrologueTransaction, genesis::GenesisTransaction,
+    randomness_state_update::RandomnessStateUpdateTransaction,
 };
 
 pub(crate) mod consensus_commit_prologue;
 pub(crate) mod genesis;
+pub(crate) mod randomness_state_update;
 
 /// Different types of transactions that can be executed on the Sui network.
 #[derive(Union, Clone)]
 pub enum TransactionKind {
     Genesis(GenesisTransaction),
     ConsensusCommitPrologue(ConsensusCommitPrologueTransaction),
+    RandomnessStateUpdate(RandomnessStateUpdateTransaction),
 }
 
 impl TransactionKind {
@@ -39,6 +42,11 @@ impl TransactionKind {
             K::ConsensusCommitPrologueV4(ccp) => Some(T::ConsensusCommitPrologue(
                 ConsensusCommitPrologueTransaction::from_v4(ccp, scope),
             )),
+            K::RandomnessStateUpdate(rsu) => {
+                Some(T::RandomnessStateUpdate(RandomnessStateUpdateTransaction {
+                    native: rsu,
+                }))
+            }
             // Other types will return None for now
             _ => None,
         }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/randomness_state_update.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/randomness_state_update.rs
@@ -1,0 +1,36 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::Object;
+use sui_types::transaction::RandomnessStateUpdate as NativeRandomnessStateUpdate;
+
+use crate::api::scalars::base64::Base64;
+
+#[derive(Clone)]
+pub(crate) struct RandomnessStateUpdateTransaction {
+    pub(crate) native: NativeRandomnessStateUpdate,
+}
+
+/// System transaction to update the source of on-chain randomness.
+#[Object]
+impl RandomnessStateUpdateTransaction {
+    /// Epoch of the randomness state update transaction.
+    async fn epoch(&self) -> Option<u64> {
+        Some(self.native.epoch)
+    }
+
+    /// Randomness round of the update.
+    async fn randomness_round(&self) -> Option<u64> {
+        Some(self.native.randomness_round.0)
+    }
+
+    /// Updated random bytes, Base64 encoded.
+    async fn random_bytes(&self) -> Option<Base64> {
+        Some(Base64::from(self.native.random_bytes.clone()))
+    }
+
+    /// The initial version of the randomness object that it was shared at.
+    async fn randomness_obj_initial_shared_version(&self) -> Option<u64> {
+        Some(self.native.randomness_obj_initial_shared_version.value())
+    }
+}

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -985,6 +985,28 @@ type Query {
 	transactions(first: Int, after: String, last: Int, before: String, filter: TransactionFilter): TransactionConnection!
 }
 
+"""
+System transaction to update the source of on-chain randomness.
+"""
+type RandomnessStateUpdateTransaction {
+	"""
+	Epoch of the randomness state update transaction.
+	"""
+	epoch: Int
+	"""
+	Randomness round of the update.
+	"""
+	randomnessRound: Int
+	"""
+	Updated random bytes, Base64 encoded.
+	"""
+	randomBytes: Base64
+	"""
+	The initial version of the randomness object that it was shared at.
+	"""
+	randomnessObjInitialSharedVersion: Int
+}
+
 type SafeMode {
 	"""
 	Whether safe mode was used for the last epoch change.
@@ -1333,7 +1355,7 @@ input TransactionFilter {
 """
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | RandomnessStateUpdateTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -985,6 +985,28 @@ type Query {
 	transactions(first: Int, after: String, last: Int, before: String, filter: TransactionFilter): TransactionConnection!
 }
 
+"""
+System transaction to update the source of on-chain randomness.
+"""
+type RandomnessStateUpdateTransaction {
+	"""
+	Epoch of the randomness state update transaction.
+	"""
+	epoch: Int
+	"""
+	Randomness round of the update.
+	"""
+	randomnessRound: Int
+	"""
+	Updated random bytes, Base64 encoded.
+	"""
+	randomBytes: Base64
+	"""
+	The initial version of the randomness object that it was shared at.
+	"""
+	randomnessObjInitialSharedVersion: Int
+}
+
 type SafeMode {
 	"""
 	Whether safe mode was used for the last epoch change.
@@ -1333,7 +1355,7 @@ input TransactionFilter {
 """
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | RandomnessStateUpdateTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -981,6 +981,28 @@ type Query {
 	transactions(first: Int, after: String, last: Int, before: String, filter: TransactionFilter): TransactionConnection!
 }
 
+"""
+System transaction to update the source of on-chain randomness.
+"""
+type RandomnessStateUpdateTransaction {
+	"""
+	Epoch of the randomness state update transaction.
+	"""
+	epoch: Int
+	"""
+	Randomness round of the update.
+	"""
+	randomnessRound: Int
+	"""
+	Updated random bytes, Base64 encoded.
+	"""
+	randomBytes: Base64
+	"""
+	The initial version of the randomness object that it was shared at.
+	"""
+	randomnessObjInitialSharedVersion: Int
+}
+
 type SafeMode {
 	"""
 	Whether safe mode was used for the last epoch change.
@@ -1329,7 +1351,7 @@ input TransactionFilter {
 """
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | RandomnessStateUpdateTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.


### PR DESCRIPTION
## Description 

Adding the new `RandomnessStateUpdate` as a new enum field within `TransactionKind` union

The new schema is on par with old GraphQL schema: https://github.com/MystenLabs/sui/blob/b8d28ddbd06253373d2c02d001b3ba6c1ce8ea4f/crates/sui-graphql-rpc/schema.graphql#L3449-L3466

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-graphql
cargo nextest run -p sui-indexer-alt-reader
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

---

## Stack 
- #22652 
- #22718 
- #22788 
- #22943
- #22950
- #22953 ⬅️


## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
