### PR TITLE
Remove coin type validity check

### DIFF
--- a/crates/sui-e2e-tests/tests/rpc/v2beta2/live_data_service/balance.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2beta2/live_data_service/balance.rs
@@ -463,24 +463,6 @@ async fn test_invalid_requests() {
         error.message()
     );
 
-    // Test with non-existent coin type (well-formed but doesn't exist)
-    let fake_coin_type =
-        "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef::fakecoin::FAKECOIN";
-    let result = grpc_client
-        .get_balance(GetBalanceRequest {
-            owner: Some(address.to_string()),
-            coin_type: Some(fake_coin_type.to_string()),
-        })
-        .await;
-    assert!(result.is_err(), "Expected error for non-existent coin type");
-    let error = result.unwrap_err();
-    assert_eq!(error.code(), tonic::Code::InvalidArgument);
-    assert!(
-        error.message().contains("coin type does not exist"),
-        "Expected error message to contain 'coin type does not exist', but got: {}",
-        error.message()
-    );
-
     // Test ListBalancesRequest with missing owner
     let result = grpc_client
         .list_balances(ListBalancesRequest {

--- a/crates/sui-rpc-api/src/grpc/v2beta2/live_data_service/get_balance.rs
+++ b/crates/sui-rpc-api/src/grpc/v2beta2/live_data_service/get_balance.rs
@@ -48,15 +48,6 @@ pub fn get_balance(service: &RpcService, request: GetBalanceRequest) -> Result<G
 
     let core_coin_type = struct_tag_sdk_to_core(coin_type.clone())?;
 
-    // Check if coin type exists
-    let coin_info = indexes.get_coin_info(&core_coin_type)?;
-    if coin_info.is_none() {
-        return Err(RpcError::new(
-            tonic::Code::InvalidArgument,
-            format!("coin type does not exist: {}", coin_type),
-        ));
-    }
-
     let balance_info = indexes
         .get_balance(&owner, &core_coin_type)?
         .unwrap_or_default(); // Use default (zero) if no balance found


### PR DESCRIPTION
## Description

Removing the coin type validation logic on the balance api to ensure compatibility with coin registry and match the behavior of the consistent store. Now we will simply get a zero coin balance instead of an error if an invalid coin type is passed in.
