### PR TITLE
[graphql-alt] Support ChangeEpochTransaction kind for TransactionKind [4/n]

### DIFF
--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -70,33 +70,33 @@ This transaction kind is deprecated in favour of `EndOfEpochTransaction`.
 """
 type ChangeEpochTransaction {
 	"""
-	The next (to become) epoch ID.
+	The next (to become) epoch.
 	"""
-	epoch: Int
+	epoch: Epoch
 	"""
-	The protocol version in effect in the new epoch.
+	The epoch's corresponding protocol configuration.
 	"""
-	protocolVersion: Int
+	protocolConfigs: ProtocolConfigs
 	"""
 	The total amount of gas charged for storage during the epoch.
 	"""
-	storageCharge: Int
+	storageCharge: UInt53
 	"""
 	The total amount of gas charged for computation during the epoch.
 	"""
-	computationCharge: Int
+	computationCharge: UInt53
 	"""
 	The amount of storage rebate refunded to the transaction senders.
 	"""
-	storageRebate: Int
+	storageRebate: UInt53
 	"""
 	The non-refundable storage fee.
 	"""
-	nonRefundableStorageFee: Int
+	nonRefundableStorageFee: UInt53
 	"""
-	Unix timestamp when epoch started (in milliseconds).
+	Unix timestamp when epoch started.
 	"""
-	epochStartTimestampMs: Int
+	epochStartTimestamp: DateTime
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -64,6 +64,42 @@ scalar BigInt
 
 
 """
+A system transaction that updates epoch information on-chain (increments the current epoch). Executed by the system once per epoch, without using gas. Epoch change transactions cannot be submitted by users, because validators will refuse to sign them.
+
+This transaction kind is deprecated in favour of `EndOfEpochTransaction`.
+"""
+type ChangeEpochTransaction {
+	"""
+	The next (to become) epoch ID.
+	"""
+	epoch: Int
+	"""
+	The protocol version in effect in the new epoch.
+	"""
+	protocolVersion: Int
+	"""
+	The total amount of gas charged for storage during the epoch.
+	"""
+	storageCharge: Int
+	"""
+	The total amount of gas charged for computation during the epoch.
+	"""
+	computationCharge: Int
+	"""
+	The amount of storage rebate refunded to the transaction senders.
+	"""
+	storageRebate: Int
+	"""
+	The non-refundable storage fee.
+	"""
+	nonRefundableStorageFee: Int
+	"""
+	Unix timestamp when epoch started (in milliseconds).
+	"""
+	epochStartTimestampMs: Int
+}
+
+"""
 Checkpoints contain finalized transactions and are used for node synchronization and global transaction ordering.
 """
 type Checkpoint {
@@ -1351,7 +1387,7 @@ input TransactionFilter {
 """
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | RandomnessStateUpdateTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/change_epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/change_epoch.rs
@@ -4,49 +4,63 @@
 use async_graphql::Object;
 use sui_types::transaction::ChangeEpoch as NativeChangeEpoch;
 
+use crate::{
+    api::{
+        scalars::{date_time::DateTime, uint53::UInt53},
+        types::{epoch::Epoch, protocol_configs::ProtocolConfigs},
+    },
+    error::RpcError,
+    scope::Scope,
+};
+
 #[derive(Clone)]
 pub(crate) struct ChangeEpochTransaction {
+    pub(crate) scope: Scope,
     pub(crate) native: NativeChangeEpoch,
 }
 
-// TODO(DVX-1372): Support systemPackages when MovePackage is available.
+// TODO(DVX-1158): Support systemPackages.
 /// A system transaction that updates epoch information on-chain (increments the current epoch). Executed by the system once per epoch, without using gas. Epoch change transactions cannot be submitted by users, because validators will refuse to sign them.
 ///
 /// This transaction kind is deprecated in favour of `EndOfEpochTransaction`.
 #[Object]
 impl ChangeEpochTransaction {
-    /// The next (to become) epoch ID.
-    async fn epoch(&self) -> Option<u64> {
-        Some(self.native.epoch)
+    /// The next (to become) epoch.
+    async fn epoch(&self) -> Option<Epoch> {
+        Some(Epoch::with_id(self.scope.clone(), self.native.epoch))
     }
 
-    /// The protocol version in effect in the new epoch.
-    async fn protocol_version(&self) -> Option<u64> {
-        Some(self.native.protocol_version.as_u64())
+    /// The epoch's corresponding protocol configuration.
+    async fn protocol_configs(&self) -> Option<ProtocolConfigs> {
+        Some(ProtocolConfigs::with_protocol_version(
+            self.native.protocol_version.as_u64(),
+        ))
     }
 
     /// The total amount of gas charged for storage during the epoch.
-    async fn storage_charge(&self) -> Option<u64> {
-        Some(self.native.storage_charge)
+    async fn storage_charge(&self) -> Option<UInt53> {
+        Some(self.native.storage_charge.into())
     }
 
     /// The total amount of gas charged for computation during the epoch.
-    async fn computation_charge(&self) -> Option<u64> {
-        Some(self.native.computation_charge)
+    async fn computation_charge(&self) -> Option<UInt53> {
+        Some(self.native.computation_charge.into())
     }
 
     /// The amount of storage rebate refunded to the transaction senders.
-    async fn storage_rebate(&self) -> Option<u64> {
-        Some(self.native.storage_rebate)
+    async fn storage_rebate(&self) -> Option<UInt53> {
+        Some(self.native.storage_rebate.into())
     }
 
     /// The non-refundable storage fee.
-    async fn non_refundable_storage_fee(&self) -> Option<u64> {
-        Some(self.native.non_refundable_storage_fee)
+    async fn non_refundable_storage_fee(&self) -> Option<UInt53> {
+        Some(self.native.non_refundable_storage_fee.into())
     }
 
-    /// Unix timestamp when epoch started (in milliseconds).
-    async fn epoch_start_timestamp_ms(&self) -> Option<u64> {
-        Some(self.native.epoch_start_timestamp_ms)
+    /// Unix timestamp when epoch started.
+    async fn epoch_start_timestamp(&self) -> Result<Option<DateTime>, RpcError> {
+        Ok(Some(DateTime::from_ms(
+            self.native.epoch_start_timestamp_ms as i64,
+        )?))
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/change_epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/change_epoch.rs
@@ -1,0 +1,52 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::Object;
+use sui_types::transaction::ChangeEpoch as NativeChangeEpoch;
+
+#[derive(Clone)]
+pub(crate) struct ChangeEpochTransaction {
+    pub(crate) native: NativeChangeEpoch,
+}
+
+// TODO(DVX-1372): Support systemPackages when MovePackage is available.
+/// A system transaction that updates epoch information on-chain (increments the current epoch). Executed by the system once per epoch, without using gas. Epoch change transactions cannot be submitted by users, because validators will refuse to sign them.
+///
+/// This transaction kind is deprecated in favour of `EndOfEpochTransaction`.
+#[Object]
+impl ChangeEpochTransaction {
+    /// The next (to become) epoch ID.
+    async fn epoch(&self) -> Option<u64> {
+        Some(self.native.epoch)
+    }
+
+    /// The protocol version in effect in the new epoch.
+    async fn protocol_version(&self) -> Option<u64> {
+        Some(self.native.protocol_version.as_u64())
+    }
+
+    /// The total amount of gas charged for storage during the epoch.
+    async fn storage_charge(&self) -> Option<u64> {
+        Some(self.native.storage_charge)
+    }
+
+    /// The total amount of gas charged for computation during the epoch.
+    async fn computation_charge(&self) -> Option<u64> {
+        Some(self.native.computation_charge)
+    }
+
+    /// The amount of storage rebate refunded to the transaction senders.
+    async fn storage_rebate(&self) -> Option<u64> {
+        Some(self.native.storage_rebate)
+    }
+
+    /// The non-refundable storage fee.
+    async fn non_refundable_storage_fee(&self) -> Option<u64> {
+        Some(self.native.non_refundable_storage_fee)
+    }
+
+    /// Unix timestamp when epoch started (in milliseconds).
+    async fn epoch_start_timestamp_ms(&self) -> Option<u64> {
+        Some(self.native.epoch_start_timestamp_ms)
+    }
+}

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/mod.rs
@@ -45,7 +45,9 @@ impl TransactionKind {
             K::ConsensusCommitPrologueV4(ccp) => Some(T::ConsensusCommitPrologue(
                 ConsensusCommitPrologueTransaction::from_v4(ccp, scope),
             )),
-            K::ChangeEpoch(ce) => Some(T::ChangeEpoch(ChangeEpochTransaction { native: ce })),
+            K::ChangeEpoch(ce) => {
+                Some(T::ChangeEpoch(ChangeEpochTransaction { native: ce, scope }))
+            }
             K::RandomnessStateUpdate(rsu) => {
                 Some(T::RandomnessStateUpdate(RandomnessStateUpdateTransaction {
                     native: rsu,

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/mod.rs
@@ -7,10 +7,12 @@ use sui_types::transaction::TransactionKind as NativeTransactionKind;
 use crate::scope::Scope;
 
 use self::{
+    change_epoch::ChangeEpochTransaction,
     consensus_commit_prologue::ConsensusCommitPrologueTransaction, genesis::GenesisTransaction,
     randomness_state_update::RandomnessStateUpdateTransaction,
 };
 
+pub(crate) mod change_epoch;
 pub(crate) mod consensus_commit_prologue;
 pub(crate) mod genesis;
 pub(crate) mod randomness_state_update;
@@ -20,6 +22,7 @@ pub(crate) mod randomness_state_update;
 pub enum TransactionKind {
     Genesis(GenesisTransaction),
     ConsensusCommitPrologue(ConsensusCommitPrologueTransaction),
+    ChangeEpoch(ChangeEpochTransaction),
     RandomnessStateUpdate(RandomnessStateUpdateTransaction),
 }
 
@@ -42,6 +45,7 @@ impl TransactionKind {
             K::ConsensusCommitPrologueV4(ccp) => Some(T::ConsensusCommitPrologue(
                 ConsensusCommitPrologueTransaction::from_v4(ccp, scope),
             )),
+            K::ChangeEpoch(ce) => Some(T::ChangeEpoch(ChangeEpochTransaction { native: ce })),
             K::RandomnessStateUpdate(rsu) => {
                 Some(T::RandomnessStateUpdate(RandomnessStateUpdateTransaction {
                     native: rsu,

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -68,6 +68,42 @@ scalar BigInt
 
 
 """
+A system transaction that updates epoch information on-chain (increments the current epoch). Executed by the system once per epoch, without using gas. Epoch change transactions cannot be submitted by users, because validators will refuse to sign them.
+
+This transaction kind is deprecated in favour of `EndOfEpochTransaction`.
+"""
+type ChangeEpochTransaction {
+	"""
+	The next (to become) epoch ID.
+	"""
+	epoch: Int
+	"""
+	The protocol version in effect in the new epoch.
+	"""
+	protocolVersion: Int
+	"""
+	The total amount of gas charged for storage during the epoch.
+	"""
+	storageCharge: Int
+	"""
+	The total amount of gas charged for computation during the epoch.
+	"""
+	computationCharge: Int
+	"""
+	The amount of storage rebate refunded to the transaction senders.
+	"""
+	storageRebate: Int
+	"""
+	The non-refundable storage fee.
+	"""
+	nonRefundableStorageFee: Int
+	"""
+	Unix timestamp when epoch started (in milliseconds).
+	"""
+	epochStartTimestampMs: Int
+}
+
+"""
 Checkpoints contain finalized transactions and are used for node synchronization and global transaction ordering.
 """
 type Checkpoint {
@@ -1355,7 +1391,7 @@ input TransactionFilter {
 """
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | RandomnessStateUpdateTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -74,33 +74,33 @@ This transaction kind is deprecated in favour of `EndOfEpochTransaction`.
 """
 type ChangeEpochTransaction {
 	"""
-	The next (to become) epoch ID.
+	The next (to become) epoch.
 	"""
-	epoch: Int
+	epoch: Epoch
 	"""
-	The protocol version in effect in the new epoch.
+	The epoch's corresponding protocol configuration.
 	"""
-	protocolVersion: Int
+	protocolConfigs: ProtocolConfigs
 	"""
 	The total amount of gas charged for storage during the epoch.
 	"""
-	storageCharge: Int
+	storageCharge: UInt53
 	"""
 	The total amount of gas charged for computation during the epoch.
 	"""
-	computationCharge: Int
+	computationCharge: UInt53
 	"""
 	The amount of storage rebate refunded to the transaction senders.
 	"""
-	storageRebate: Int
+	storageRebate: UInt53
 	"""
 	The non-refundable storage fee.
 	"""
-	nonRefundableStorageFee: Int
+	nonRefundableStorageFee: UInt53
 	"""
-	Unix timestamp when epoch started (in milliseconds).
+	Unix timestamp when epoch started.
 	"""
-	epochStartTimestampMs: Int
+	epochStartTimestamp: DateTime
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -68,6 +68,42 @@ scalar BigInt
 
 
 """
+A system transaction that updates epoch information on-chain (increments the current epoch). Executed by the system once per epoch, without using gas. Epoch change transactions cannot be submitted by users, because validators will refuse to sign them.
+
+This transaction kind is deprecated in favour of `EndOfEpochTransaction`.
+"""
+type ChangeEpochTransaction {
+	"""
+	The next (to become) epoch ID.
+	"""
+	epoch: Int
+	"""
+	The protocol version in effect in the new epoch.
+	"""
+	protocolVersion: Int
+	"""
+	The total amount of gas charged for storage during the epoch.
+	"""
+	storageCharge: Int
+	"""
+	The total amount of gas charged for computation during the epoch.
+	"""
+	computationCharge: Int
+	"""
+	The amount of storage rebate refunded to the transaction senders.
+	"""
+	storageRebate: Int
+	"""
+	The non-refundable storage fee.
+	"""
+	nonRefundableStorageFee: Int
+	"""
+	Unix timestamp when epoch started (in milliseconds).
+	"""
+	epochStartTimestampMs: Int
+}
+
+"""
 Checkpoints contain finalized transactions and are used for node synchronization and global transaction ordering.
 """
 type Checkpoint {
@@ -1355,7 +1391,7 @@ input TransactionFilter {
 """
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | RandomnessStateUpdateTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -74,33 +74,33 @@ This transaction kind is deprecated in favour of `EndOfEpochTransaction`.
 """
 type ChangeEpochTransaction {
 	"""
-	The next (to become) epoch ID.
+	The next (to become) epoch.
 	"""
-	epoch: Int
+	epoch: Epoch
 	"""
-	The protocol version in effect in the new epoch.
+	The epoch's corresponding protocol configuration.
 	"""
-	protocolVersion: Int
+	protocolConfigs: ProtocolConfigs
 	"""
 	The total amount of gas charged for storage during the epoch.
 	"""
-	storageCharge: Int
+	storageCharge: UInt53
 	"""
 	The total amount of gas charged for computation during the epoch.
 	"""
-	computationCharge: Int
+	computationCharge: UInt53
 	"""
 	The amount of storage rebate refunded to the transaction senders.
 	"""
-	storageRebate: Int
+	storageRebate: UInt53
 	"""
 	The non-refundable storage fee.
 	"""
-	nonRefundableStorageFee: Int
+	nonRefundableStorageFee: UInt53
 	"""
-	Unix timestamp when epoch started (in milliseconds).
+	Unix timestamp when epoch started.
 	"""
-	epochStartTimestampMs: Int
+	epochStartTimestamp: DateTime
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -70,33 +70,33 @@ This transaction kind is deprecated in favour of `EndOfEpochTransaction`.
 """
 type ChangeEpochTransaction {
 	"""
-	The next (to become) epoch ID.
+	The next (to become) epoch.
 	"""
-	epoch: Int
+	epoch: Epoch
 	"""
-	The protocol version in effect in the new epoch.
+	The epoch's corresponding protocol configuration.
 	"""
-	protocolVersion: Int
+	protocolConfigs: ProtocolConfigs
 	"""
 	The total amount of gas charged for storage during the epoch.
 	"""
-	storageCharge: Int
+	storageCharge: UInt53
 	"""
 	The total amount of gas charged for computation during the epoch.
 	"""
-	computationCharge: Int
+	computationCharge: UInt53
 	"""
 	The amount of storage rebate refunded to the transaction senders.
 	"""
-	storageRebate: Int
+	storageRebate: UInt53
 	"""
 	The non-refundable storage fee.
 	"""
-	nonRefundableStorageFee: Int
+	nonRefundableStorageFee: UInt53
 	"""
-	Unix timestamp when epoch started (in milliseconds).
+	Unix timestamp when epoch started.
 	"""
-	epochStartTimestampMs: Int
+	epochStartTimestamp: DateTime
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -64,6 +64,42 @@ scalar BigInt
 
 
 """
+A system transaction that updates epoch information on-chain (increments the current epoch). Executed by the system once per epoch, without using gas. Epoch change transactions cannot be submitted by users, because validators will refuse to sign them.
+
+This transaction kind is deprecated in favour of `EndOfEpochTransaction`.
+"""
+type ChangeEpochTransaction {
+	"""
+	The next (to become) epoch ID.
+	"""
+	epoch: Int
+	"""
+	The protocol version in effect in the new epoch.
+	"""
+	protocolVersion: Int
+	"""
+	The total amount of gas charged for storage during the epoch.
+	"""
+	storageCharge: Int
+	"""
+	The total amount of gas charged for computation during the epoch.
+	"""
+	computationCharge: Int
+	"""
+	The amount of storage rebate refunded to the transaction senders.
+	"""
+	storageRebate: Int
+	"""
+	The non-refundable storage fee.
+	"""
+	nonRefundableStorageFee: Int
+	"""
+	Unix timestamp when epoch started (in milliseconds).
+	"""
+	epochStartTimestampMs: Int
+}
+
+"""
 Checkpoints contain finalized transactions and are used for node synchronization and global transaction ordering.
 """
 type Checkpoint {
@@ -1351,7 +1387,7 @@ input TransactionFilter {
 """
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | RandomnessStateUpdateTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.


### PR DESCRIPTION
## Description 

Adding the new `ChangeEpochTransaction` as a new enum field within `TransactionKind` union

The new schema is on par with old GraphQL schema:
https://github.com/MystenLabs/sui/blob/b8d28ddbd06253373d2c02d001b3ba6c1ce8ea4f/crates/sui-graphql-rpc/schema.graphql#L355-L391

There are 2 points that are worth mentioning:
1. systemPackages is blocked by MovePackage work ([DVX-818](https://linear.app/mysten-labs/issue/DVX-818/movepackage)), and I have added a TODO to add it later.
2. no snapshot tests for this as this is already deprecated in protocol, and `Simulacrum` crate is just having support for `EndOfEpochTransaction`, which will be added in upcoming PRs

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-graphql
cargo nextest run -p sui-indexer-alt-reader
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

---

## Stack 
- #22652 
- #22718 
- #22788 
- #22943
- #22950
- #22953
- #22955 ⬅️

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
