### PR TITLE
[static-ptbs] unify publication linkages

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/upgrade/multiple_diff_deps.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/multiple_diff_deps.move
@@ -1,0 +1,23 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses A1=0x0 A2=0x0 B=0x0 --accounts A
+
+//# publish --upgradeable --sender A
+module A1::a {
+    public struct Base()
+}
+
+//# upgrade --package A1 --upgrade-capability 1,1 --sender A
+module A2::a {
+    public struct Base()
+    public fun new_fun() {}
+}
+
+//# set-address A2 object(2,0)
+
+//# publish --upgradeable --sender A --dependencies A1 A2
+module B::b {
+    fun f() {
+    }
+}

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/multiple_diff_deps.snap
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/multiple_diff_deps.snap
@@ -1,0 +1,24 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-9:
+//# publish --upgradeable --sender A
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5335200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 11-15:
+//# upgrade --package A1 --upgrade-capability 1,1 --sender A
+created: object(2,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 5563200,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 4, lines 19-23:
+//# publish --upgradeable --sender A --dependencies A1 A2
+Error: Transaction Effects Status: A valid linkage was unable to be determined for the transaction
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidLinkage, source: None, command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/multiple_diff_deps@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/multiple_diff_deps@v2.snap
@@ -1,0 +1,24 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-9:
+//# publish --upgradeable --sender A
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5335200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 11-15:
+//# upgrade --package A1 --upgrade-capability 1,1 --sender A
+created: object(2,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 5563200,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 4, lines 19-23:
+//# publish --upgradeable --sender A --dependencies A1 A2
+Error: Transaction Effects Status: A valid linkage was unable to be determined for the transaction
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidLinkage, source: Some("exact/exact conflicting resolutions for package: linkage requires the same package at different versions. Linkage requires exactly A1 (version std) and A2 (version sui) to be used in the same transaction"), command: Some(0) } }

--- a/crates/sui-core/src/unit_tests/data/move_package/F/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_package/F/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "F"
+version = "0.0.1"
+edition = "2024.beta"
+
+[addresses]
+f = "0xf1"
+
+[dependencies]
+B = { local = "../B" }

--- a/crates/sui-core/src/unit_tests/data/move_package/F/sources/f.move
+++ b/crates/sui-core/src/unit_tests/data/move_package/F/sources/f.move
@@ -1,0 +1,8 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module f::f {
+    public fun f(): u64 {
+        b::b::b()
+    }
+}

--- a/crates/sui-core/src/unit_tests/data/move_package/H/Move.toml
+++ b/crates/sui-core/src/unit_tests/data/move_package/H/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "H"
+version = "0.0.1"
+edition = "2024.beta"
+
+[addresses]
+h = "0xd1"
+
+[dependencies]
+F = { local = "../F" }

--- a/crates/sui-core/src/unit_tests/data/move_package/H/sources/f.move
+++ b/crates/sui-core/src/unit_tests/data/move_package/H/sources/f.move
@@ -1,0 +1,8 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+module h::h {
+    public fun h(): u64 {
+        f::f::f()
+    }
+}

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/config.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/config.rs
@@ -4,7 +4,7 @@
 use crate::{
     data_store::PackageStore,
     static_programmable_transactions::linkage::resolution::{
-        ConflictResolution, ResolutionTable, get_package,
+        ConflictResolution, ResolutionTable, add_and_unify, get_package,
     },
 };
 use move_binary_format::binary_config::BinaryConfig;
@@ -67,9 +67,7 @@ impl LinkageConfig {
                 let package = get_package(id, store)?;
                 debug_assert_eq!(package.id(), *id);
                 debug_assert_eq!(package.original_package_id(), *id);
-                resolution_table
-                    .resolution_table
-                    .insert(*id, ConflictResolution::Exact(package.version(), *id));
+                add_and_unify(id, store, &mut resolution_table, ConflictResolution::exact)?;
                 resolution_table
                     .all_versions_resolution_table
                     .insert(*id, *id);

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/legacy_linkage.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/legacy_linkage.rs
@@ -104,10 +104,7 @@ impl LegacyLinkage {
             .resolution_table_with_native_packages(store)?;
         for id in deps {
             let pkg = get_package(id, store)?;
-            resolution_table.resolution_table.insert(
-                pkg.original_package_id(),
-                ConflictResolution::Exact(pkg.version(), pkg.id()),
-            );
+            add_and_unify(id, store, &mut resolution_table, ConflictResolution::exact)?;
             resolution_table
                 .all_versions_resolution_table
                 .insert(pkg.id(), pkg.original_package_id());


### PR DESCRIPTION
## Description 

Use `add_and_unify` to build the publication and upgrade linkages instead of just directly building it up.

## Test plan 

Ran some local tests 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
