### PR TITLE
[MFP] enhance non-retryable error list & test 

### DIFF
--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -936,6 +936,22 @@ impl SuiError {
                     _ => false,
                 }
             }
+
+            // Non retryable errors
+            SuiError::ExecutionError(..) => false,
+            SuiError::ByzantineAuthoritySuspicion { .. } => false,
+            SuiError::TxAlreadyFinalizedWithDifferentUserSigs => false,
+            SuiError::FailedToVerifyTxCertWithExecutedEffects { .. } => false,
+            SuiError::ObjectLockConflict { .. } => false,
+            SuiError::TransactionExpired => false,
+            SuiError::InvalidTxKindInSoftBundle { .. } => false,
+
+            SuiError::InvalidSignature { .. } => false,
+            SuiError::SignerSignatureAbsent { .. } => false,
+            SuiError::SignerSignatureNumberMismatch { .. } => false,
+            SuiError::IncorrectSigner { .. } => false,
+            SuiError::UnknownSigner { .. } => false,
+
             // Other variants are assumed to be retriable.
             _ => true,
         }

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -940,8 +940,6 @@ impl SuiError {
             // Non retryable errors
             SuiError::ExecutionError(..) => false,
             SuiError::ByzantineAuthoritySuspicion { .. } => false,
-            SuiError::TxAlreadyFinalizedWithDifferentUserSigs => false,
-            SuiError::FailedToVerifyTxCertWithExecutedEffects { .. } => false,
             SuiError::ObjectLockConflict { .. } => false,
             SuiError::TransactionExpired => false,
             SuiError::InvalidTxKindInSoftBundle { .. } => false,

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -938,11 +938,11 @@ impl SuiError {
             }
 
             // Non retryable errors
-            SuiError::ExecutionError(..) => false,
             SuiError::ByzantineAuthoritySuspicion { .. } => false,
             SuiError::ObjectLockConflict { .. } => false,
             SuiError::TransactionExpired => false,
             SuiError::InvalidTxKindInSoftBundle { .. } => false,
+            SuiError::UnsupportedFeatureError { .. } => false,
 
             SuiError::InvalidSignature { .. } => false,
             SuiError::SignerSignatureAbsent { .. } => false,


### PR DESCRIPTION
## Description 

* Adding some errors that should not be retriable during tx submission. We can probably expand the list, but used only the ones that look certain that shouldn't be retried
* Exercise the vote reject cache on the `wait_for_effects` integration test.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
