### PR TITLE
[move][trace-format] remove `arbitrary_precision` requirement for `serde_json`

### DIFF
--- a/external-crates/move/crates/move-trace-format/Cargo.toml
+++ b/external-crates/move/crates/move-trace-format/Cargo.toml
@@ -12,8 +12,7 @@ move-core-types.workspace = true
 serde.workspace = true
 move-binary-format.workspace = true
 zstd.workspace = true
-
-serde_json = { workspace = true, features = ["arbitrary_precision"] }
+serde_json.workspace = true
 
 [features]
 default = []


### PR DESCRIPTION
## Description 

Remove `arbitrary_precision` feature flag from the `move-trace-format` crate as it is no longer needed after we switched to a typed-serialized value representation.

## Test plan 

CI + new tests to make sure we handle numbers that are outside the normal `Number` ranges in JSON.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
