### PR TITLE
[sui-pg-db][sui-indexer-alt] support tls/ssl connections to postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15569,6 +15569,8 @@ dependencies = [
  "diesel-async",
  "diesel_migrations",
  "futures",
+ "rustls 0.23.25",
+ "rustls-pemfile 2.1.2",
  "scoped-futures",
  "sui-field-count",
  "sui-indexer-alt-framework-store-traits",
@@ -15576,8 +15578,11 @@ dependencies = [
  "telemetry-subscribers",
  "tempfile",
  "tokio",
+ "tokio-postgres",
+ "tokio-postgres-rustls",
  "tracing",
  "url",
+ "webpki-roots 0.26.3",
 ]
 
 [[package]]

--- a/crates/sui-pg-db/Cargo.toml
+++ b/crates/sui-pg-db/Cargo.toml
@@ -16,11 +16,16 @@ diesel = { workspace = true, features = ["chrono"] }
 diesel-async = { workspace = true, features = ["bb8", "postgres", "async-connection-wrapper"] }
 diesel_migrations.workspace = true
 futures.workspace = true
+rustls.workspace = true
+rustls-pemfile.workspace = true
 scoped-futures.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["full"] }
+tokio-postgres = "0.7.12"
+tokio-postgres-rustls = "0.12.0"
 tracing.workspace = true
 url.workspace = true
+webpki-roots = "0.26.3"
 
 sui-field-count.workspace = true
 sui-indexer-alt-framework-store-traits.workspace = true

--- a/crates/sui-pg-db/src/lib.rs
+++ b/crates/sui-pg-db/src/lib.rs
@@ -276,7 +276,7 @@ fn build_tls_config(args: &DbArgs) -> anyhow::Result<rustls::ClientConfig> {
 
         // Add custom CA certificate if provided
         if let Some(ca_cert_path) = &args.tls_ca_cert_path {
-            let ca_cert_bytes = std::fs::read(&ca_cert_path).map_err(|e| {
+            let ca_cert_bytes = std::fs::read(ca_cert_path).map_err(|e| {
                 anyhow::anyhow!("Failed to read CA certificate from {}: {}", ca_cert_path, e)
             })?;
 

--- a/crates/sui-pg-db/src/lib.rs
+++ b/crates/sui-pg-db/src/lib.rs
@@ -18,7 +18,7 @@ use diesel_async::{
     AsyncPgConnection, RunQueryDsl,
 };
 use futures::FutureExt;
-use tracing::info;
+use tracing::{error, info};
 use url::Url;
 
 mod model;
@@ -318,7 +318,7 @@ async fn establish_connection_with_config(
         .map_err(|e| ConnectionError::BadConnection(e.to_string()))?;
     tokio::spawn(async move {
         if let Err(e) = conn.await {
-            eprintln!("Database connection: {e}");
+            error!("Database connection terminated: {e}");
         }
     });
     AsyncPgConnection::try_from(client).await

--- a/crates/sui-pg-db/src/tls.rs
+++ b/crates/sui-pg-db/src/tls.rs
@@ -1,0 +1,145 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+
+use anyhow::Context;
+use diesel::{ConnectionError, ConnectionResult};
+use diesel_async::AsyncPgConnection;
+use tokio_postgres_rustls::MakeRustlsConnect;
+use tracing::error;
+
+/// A custom verifier that skips all server certificate verification. This mirrors libpq default
+/// behavior of not doing any server verification.
+#[derive(Debug)]
+pub(crate) struct SkipServerCertCheck;
+
+/// Implement the `ServerCertVerifier` trait for `SkipServerCertCheck` to always return valid. This
+/// skips all server certificate verification.
+impl rustls::client::danger::ServerCertVerifier for SkipServerCertCheck {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        rustls::client::WebPkiServerVerifier::builder(std::sync::Arc::new(root_certs()))
+            .build()
+            .unwrap()
+            .supported_verify_schemes()
+    }
+}
+
+/// Establish a PostgreSQL connection with custom TLS configuration using tokio-postgres. The
+/// returned connection is compatible with diesel-async. This is needed because diesel-async does
+/// not expose TLS configuration. Even with a TLS connector, the actual usage is negotiated with the
+/// postgres server:
+/// - Client sends SSLRequest, server responds 'S' (TLS supported) or 'N' (TLS not supported)
+/// - If server supports TLS: encrypted connection using the provided config
+/// - If server doesn't support TLS: falls back to plaintext (when using sslmode=prefer default)
+/// - If sslmode=disable in URL: no TLS attempted regardless of connector
+pub(crate) async fn establish_tls_connection(
+    database_url: &str,
+    tls_config: rustls::ClientConfig,
+) -> ConnectionResult<AsyncPgConnection> {
+    let tls = MakeRustlsConnect::new(tls_config);
+    let (client, conn) = tokio_postgres::connect(database_url, tls)
+        .await
+        .map_err(|e| ConnectionError::BadConnection(e.to_string()))?;
+
+    // The `conn` object performs actual IO with the database, and tokio-postgres suggests spawning
+    // it off to run in the background. This will resolve only when the connection is closed, either
+    // because of a fatal error or because its associated Client has dropped and all outstanding
+    // work has completed.
+    tokio::spawn(async move {
+        if let Err(e) = conn.await {
+            error!("Database connection terminated: {e}");
+        }
+    });
+
+    // Users interact with the database through the client object. We convert it into an
+    // AsyncPgConnection so it can be compatible with diesel.
+    AsyncPgConnection::try_from(client).await
+}
+
+/// Builds a TLS configuration from the provided DbArgs. If tls_verify_cert is false, disable server
+/// certificate verification. If tls_ca_cert_path is provided, add the custom CA certificate to the
+/// root certificates.
+pub(crate) fn build_tls_config(
+    tls_verify_cert: bool,
+    tls_ca_cert_path: Option<PathBuf>,
+) -> anyhow::Result<rustls::ClientConfig> {
+    if !tls_verify_cert {
+        return Ok(rustls::ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(std::sync::Arc::new(SkipServerCertCheck))
+            .with_no_client_auth());
+    }
+
+    let mut root_certs = root_certs();
+
+    // Add custom CA certificate if provided
+    if let Some(ca_cert_path) = &tls_ca_cert_path {
+        let ca_cert_bytes = std::fs::read(ca_cert_path).with_context(|| {
+            format!(
+                "Failed to read CA certificate from {}",
+                ca_cert_path.display()
+            )
+        })?;
+
+        let certs = if ca_cert_bytes.starts_with(b"-----BEGIN CERTIFICATE-----") {
+            rustls_pemfile::certs(&mut ca_cert_bytes.as_slice())
+                .collect::<Result<Vec<_>, _>>()
+                .with_context(|| {
+                    format!(
+                        "Failed to parse PEM certificates from {}",
+                        ca_cert_path.display()
+                    )
+                })?
+        } else {
+            // Assume DER format for binary files
+            vec![rustls::pki_types::CertificateDer::from(ca_cert_bytes)]
+        };
+
+        // Add all certificates to the root store
+        for cert in certs {
+            root_certs
+                .add(cert)
+                .with_context(|| "Failed to add CA certificate to root store".to_string())?;
+        }
+    }
+
+    Ok(rustls::ClientConfig::builder()
+        .with_root_certificates(root_certs)
+        .with_no_client_auth())
+}
+
+fn root_certs() -> rustls::RootCertStore {
+    rustls::RootCertStore {
+        roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+    }
+}


### PR DESCRIPTION
## Description 

Extend sui-pg-db to provide TLS support that diesel-async doesn't offer through its connection methods by default. Two new fields on `DbArgs`, `tls_verify_cert` and `tls_ca_cert_path` which defaults to false and None.

If `tls_verify_cert` is true, attempt to verify server cert with root certs, and if `tls_ca_cert_path`, tries to parse PEM or DER certificates.

The new default is TLS-enabled, no server cert verification, like libpq. Still works if db url explicitly has `?sslmode=disable`, or `=prefer` or left empty.


## Test plan 
Locally, created self-signed CA certificate
Configured PostgreSQL to require SSL-only connections (hostssl entries, commented out plain host entries)
Verified server rejects plain connections: sslmode=disable properly fails with "no encryption" error

Then `cargo run` `sui-indexer-alt` with
```bash
--database-url "postgres://postgres:postgrespw@localhost:5432/sui_indexer_v2?sslmode=require" \
--tls-verify-cert \
--tls-ca-cert-path /path/to/ca.crt
```

```bash
--database-url "postgres://postgres:postgrespw@localhost:5432/sui_indexer_v2?sslmode=require"
```

"Plain" connection (after re-enabling/ uncommenting plain connections in pg_hba.conf)
```bash
--database-url "postgres://postgres:postgrespw@localhost:5432/sui_indexer_v2?sslmode=disable"
```

Restore db config.
```
cargo run --bin sui-indexer-alt -- indexer \
  --database-url "postgres://postgres:postgrespw@localhost:5432/sui_indexer_v2?sslmode=require" \
  --tls-verify-cert \
  --tls-ca-cert-path /Users/williamyang/Mysten/sui/ssl-db/ssl-certs/ca.crt \
  --config cp_sequence_numbers.toml \
  --remote-store-url https://checkpoints.mainnet.sui.io
```
This will result in an error, "error performing TLS handshake: server does not support TLS"

```
cargo run --bin sui-indexer-alt -- indexer \
  --database-url "postgres://postgres@localhost:5432/sui_indexer_v2" \
  --config cp_sequence_numbers.toml \
  --remote-store-url https://checkpoints.mainnet.sui.io
```
Works as normal

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
