### PR TITLE
graphql-alt: Query.checkpoints, Epoch.checkpoints

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/query.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/query.move
@@ -19,6 +19,24 @@
 
 //# create-checkpoint
 
+//# advance-epoch
+
+//# programmable --sender A --inputs object(1,0) 1
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+
+//# programmable --sender A --inputs object(1,0) 2
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs object(1,0) 3
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+
+//# create-checkpoint
+
 //# create-checkpoint
 
 //# run-graphql
@@ -39,7 +57,7 @@
 
   # This checkpoint doesn't exist, so it shouldn't be possible to time-travel
   # to it
-  nonexistent: checkpoint(sequenceNumber: 4) { query { ...State } }
+  nonexistent: checkpoint(sequenceNumber: 10) { query { ...State } }
 }
 
 fragment State on Query {
@@ -71,4 +89,163 @@ fragment State on Query {
     }
   }
 
+}
+
+//# run-graphql
+{ # Fetch checkpoints without filters
+  checkpoints(first: 10) {
+    pageInfo {
+      startCursor
+      endCursor
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      node {
+        sequenceNumber
+        digest
+        epoch {epochId}
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # Fetch checkpoints at an epoch filter, should have next page
+  checkpoints(first: 5, filter: {atEpoch: 1}) {
+    pageInfo {
+      startCursor
+      endCursor
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      node {
+        sequenceNumber
+        digest
+        epoch {epochId}
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors 0
+{
+  # Fetch checkpoints at an epoch that appear after a cursor
+  checkpoints(first: 10, after: "@{cursor_0}", filter: {atEpoch: 0}) {
+    pageInfo {
+      startCursor
+      endCursor
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      node {
+        sequenceNumber
+        digest
+        epoch {epochId}
+      }
+    }
+  }
+}
+
+//# run-graphql  --cursors 3
+{
+  # Fetch checkpoints at an epoch that appear before a cursor
+  checkpoints(first: 10, filter: {atEpoch: 0}, before: "@{cursor_0}") {
+    pageInfo {
+      startCursor
+      endCursor
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      node {
+        sequenceNumber
+        digest
+        epoch {epochId}
+      }
+    }
+  }
+}
+
+//# run-graphql  --cursors 0 3
+{
+  # Fetch checkpoints at an epoch that appear between two cursors, page from the front
+  checkpoints(first: 1, filter: {atEpoch: 0}, after: "@{cursor_0}", before: "@{cursor_1}") {
+    pageInfo {
+      startCursor
+      endCursor
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      node {
+        sequenceNumber
+        digest
+        epoch {epochId}
+      }
+    }
+  }
+}
+
+//# run-graphql  --cursors 0 3
+{
+  # Fetch checkpoints at an epoch that appear between two cursors, page from the back
+  checkpoints(last: 1, filter: {atEpoch: 0}, after: "@{cursor_0}", before: "@{cursor_1}") {
+    pageInfo {
+      startCursor
+      endCursor
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      node {
+        sequenceNumber
+        digest
+        epoch {epochId}
+      }
+    }
+  }
+}
+
+//# run-graphql  --cursors 6
+{
+  # Fetch checkpoints at an epoch that appear before a cursor, page from the back
+  checkpoints(last: 10, filter: {atEpoch: 1}, before: "@{cursor_0}") {
+    pageInfo {
+      startCursor
+      endCursor
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      node {
+        sequenceNumber
+        digest
+        epoch {epochId}
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # Fetch checkpoints at nonexistent epoch
+  checkpoints(first: 10, filter: {atEpoch: 5}) {
+    pageInfo {
+      startCursor
+      endCursor
+      hasPreviousPage
+      hasNextPage
+    }
+    edges {
+      node {
+        sequenceNumber
+        digest
+        epoch {epochId}
+      }
+    }
+  }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/query.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/query.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 10 tasks
+processed 24 tasks
 
 init:
 A: object(0,0)
@@ -37,18 +37,51 @@ task 5, line 20:
 Checkpoint created: 2
 
 task 6, line 22:
-//# create-checkpoint
-Checkpoint created: 3
+//# advance-epoch
+Epoch advanced: 1
 
-task 7, lines 24-48:
+task 7, lines 24-26:
+//# programmable --sender A --inputs object(1,0) 1
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+mutated: object(0,0), object(1,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 8, lines 28-30:
+//# programmable --sender A --inputs object(1,0) 2
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+mutated: object(0,0), object(1,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 9, line 32:
+//# create-checkpoint
+Checkpoint created: 4
+
+task 10, lines 34-36:
+//# programmable --sender A --inputs object(1,0) 3
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+mutated: object(0,0), object(1,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 11, line 38:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 12, line 40:
+//# create-checkpoint
+Checkpoint created: 6
+
+task 13, lines 42-66:
 //# run-graphql
 Response: {
   "data": {
     "checkpoint": {
-      "sequenceNumber": 3
+      "sequenceNumber": 6
     },
     "object": {
-      "version": 4
+      "version": 7
     },
     "genesis": {
       "query": {
@@ -92,7 +125,7 @@ Response: {
   }
 }
 
-task 8, lines 50-62:
+task 14, lines 68-80:
 //# run-graphql
 Response: {
   "data": {
@@ -107,7 +140,7 @@ Response: {
   }
 }
 
-task 9, lines 64-74:
+task 15, lines 82-92:
 //# run-graphql
 Response: {
   "data": {
@@ -134,4 +167,319 @@ Response: {
       }
     }
   ]
+}
+
+task 16, lines 94-111:
+//# run-graphql
+Response: {
+  "data": {
+    "checkpoints": {
+      "pageInfo": {
+        "startCursor": "MA==",
+        "endCursor": "Ng==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "node": {
+            "sequenceNumber": 0,
+            "digest": "EznTSQyzQqRf8tuPhLWZDdhny9jgA7Rw81nWB486rW8C",
+            "epoch": {
+              "epochId": 0
+            }
+          }
+        },
+        {
+          "node": {
+            "sequenceNumber": 1,
+            "digest": "6KC42LBjuKZP3F9Nfmdz8nC3nvXtMYsX8cEDeMQBkE6P",
+            "epoch": {
+              "epochId": 0
+            }
+          }
+        },
+        {
+          "node": {
+            "sequenceNumber": 2,
+            "digest": "2HqixJnQgrp9A74ddZLxNFaJfUeqCci5hUws5pUN7d1R",
+            "epoch": {
+              "epochId": 0
+            }
+          }
+        },
+        {
+          "node": {
+            "sequenceNumber": 3,
+            "digest": "BpHa37pAosru2sLoCShqJB9ya2QMAYApdwfnjZYzNZPR",
+            "epoch": {
+              "epochId": 0
+            }
+          }
+        },
+        {
+          "node": {
+            "sequenceNumber": 4,
+            "digest": "4aUMZk8P9km8GycBn3CMiECz4t1dajXzD7Xm64j2Cd8T",
+            "epoch": {
+              "epochId": 1
+            }
+          }
+        },
+        {
+          "node": {
+            "sequenceNumber": 5,
+            "digest": "FA9ZXv3FJTMTq241DsSDtdevsRcfY8R86ZHSxGSZiqQ7",
+            "epoch": {
+              "epochId": 1
+            }
+          }
+        },
+        {
+          "node": {
+            "sequenceNumber": 6,
+            "digest": "3VFpuqFaqvvCVLjkJcupWiMyqGE3hjHfr2Yq2hkau6N1",
+            "epoch": {
+              "epochId": 1
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 17, lines 113-131:
+//# run-graphql
+Response: {
+  "data": {
+    "checkpoints": {
+      "pageInfo": {
+        "startCursor": "NA==",
+        "endCursor": "Ng==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "node": {
+            "sequenceNumber": 4,
+            "digest": "4aUMZk8P9km8GycBn3CMiECz4t1dajXzD7Xm64j2Cd8T",
+            "epoch": {
+              "epochId": 1
+            }
+          }
+        },
+        {
+          "node": {
+            "sequenceNumber": 5,
+            "digest": "FA9ZXv3FJTMTq241DsSDtdevsRcfY8R86ZHSxGSZiqQ7",
+            "epoch": {
+              "epochId": 1
+            }
+          }
+        },
+        {
+          "node": {
+            "sequenceNumber": 6,
+            "digest": "3VFpuqFaqvvCVLjkJcupWiMyqGE3hjHfr2Yq2hkau6N1",
+            "epoch": {
+              "epochId": 1
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 18, lines 133-151:
+//# run-graphql --cursors 0
+Response: {
+  "data": {
+    "checkpoints": {
+      "pageInfo": {
+        "startCursor": "MQ==",
+        "endCursor": "Mw==",
+        "hasPreviousPage": true,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "node": {
+            "sequenceNumber": 1,
+            "digest": "6KC42LBjuKZP3F9Nfmdz8nC3nvXtMYsX8cEDeMQBkE6P",
+            "epoch": {
+              "epochId": 0
+            }
+          }
+        },
+        {
+          "node": {
+            "sequenceNumber": 2,
+            "digest": "2HqixJnQgrp9A74ddZLxNFaJfUeqCci5hUws5pUN7d1R",
+            "epoch": {
+              "epochId": 0
+            }
+          }
+        },
+        {
+          "node": {
+            "sequenceNumber": 3,
+            "digest": "BpHa37pAosru2sLoCShqJB9ya2QMAYApdwfnjZYzNZPR",
+            "epoch": {
+              "epochId": 0
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 19, lines 153-171:
+//# run-graphql  --cursors 3
+Response: {
+  "data": {
+    "checkpoints": {
+      "pageInfo": {
+        "startCursor": "MA==",
+        "endCursor": "Mg==",
+        "hasPreviousPage": false,
+        "hasNextPage": true
+      },
+      "edges": [
+        {
+          "node": {
+            "sequenceNumber": 0,
+            "digest": "EznTSQyzQqRf8tuPhLWZDdhny9jgA7Rw81nWB486rW8C",
+            "epoch": {
+              "epochId": 0
+            }
+          }
+        },
+        {
+          "node": {
+            "sequenceNumber": 1,
+            "digest": "6KC42LBjuKZP3F9Nfmdz8nC3nvXtMYsX8cEDeMQBkE6P",
+            "epoch": {
+              "epochId": 0
+            }
+          }
+        },
+        {
+          "node": {
+            "sequenceNumber": 2,
+            "digest": "2HqixJnQgrp9A74ddZLxNFaJfUeqCci5hUws5pUN7d1R",
+            "epoch": {
+              "epochId": 0
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 20, lines 173-191:
+//# run-graphql  --cursors 0 3
+Response: {
+  "data": {
+    "checkpoints": {
+      "pageInfo": {
+        "startCursor": "MQ==",
+        "endCursor": "MQ==",
+        "hasPreviousPage": true,
+        "hasNextPage": true
+      },
+      "edges": [
+        {
+          "node": {
+            "sequenceNumber": 1,
+            "digest": "6KC42LBjuKZP3F9Nfmdz8nC3nvXtMYsX8cEDeMQBkE6P",
+            "epoch": {
+              "epochId": 0
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 21, lines 193-211:
+//# run-graphql  --cursors 0 3
+Response: {
+  "data": {
+    "checkpoints": {
+      "pageInfo": {
+        "startCursor": "Mg==",
+        "endCursor": "Mg==",
+        "hasPreviousPage": true,
+        "hasNextPage": true
+      },
+      "edges": [
+        {
+          "node": {
+            "sequenceNumber": 2,
+            "digest": "2HqixJnQgrp9A74ddZLxNFaJfUeqCci5hUws5pUN7d1R",
+            "epoch": {
+              "epochId": 0
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 22, lines 213-231:
+//# run-graphql  --cursors 6
+Response: {
+  "data": {
+    "checkpoints": {
+      "pageInfo": {
+        "startCursor": "NA==",
+        "endCursor": "NQ==",
+        "hasPreviousPage": false,
+        "hasNextPage": true
+      },
+      "edges": [
+        {
+          "node": {
+            "sequenceNumber": 4,
+            "digest": "4aUMZk8P9km8GycBn3CMiECz4t1dajXzD7Xm64j2Cd8T",
+            "epoch": {
+              "epochId": 1
+            }
+          }
+        },
+        {
+          "node": {
+            "sequenceNumber": 5,
+            "digest": "FA9ZXv3FJTMTq241DsSDtdevsRcfY8R86ZHSxGSZiqQ7",
+            "epoch": {
+              "epochId": 1
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 23, lines 233-251:
+//# run-graphql
+Response: {
+  "data": {
+    "checkpoints": {
+      "pageInfo": {
+        "startCursor": null,
+        "endCursor": null,
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": []
+    }
+  }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/checkpoints.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/checkpoints.move
@@ -1,0 +1,132 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --simulator
+
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs object(1,0) 1
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+
+//# programmable --sender A --inputs object(1,0) 2
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+
+//# create-checkpoint
+
+//# advance-epoch
+
+//# programmable --sender A --inputs object(1,0) 1
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+
+//# programmable --sender A --inputs object(1,0) 2
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs object(1,0) 3
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+
+//# create-checkpoint
+
+//# create-checkpoint
+
+//# run-graphql
+{ 
+  # Fetch an epoch and its checkpoints
+  epoch(epochId: 0) {
+    totalCheckpoints
+    checkpoints(first: 10) {
+      pageInfo {
+        startCursor
+        endCursor
+        hasPreviousPage
+        hasNextPage
+      }
+      edges {
+        node {
+          sequenceNumber
+          digest
+          epoch {epochId}
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql --cursors 1
+{ 
+  # Fetch an epoch and its checkpoints with cursors applied
+  epoch(epochId: 0) {
+    totalCheckpoints
+    checkpoints(first: 2, after: "@{cursor_0}") {
+      pageInfo {
+        startCursor
+        endCursor
+        hasPreviousPage
+        hasNextPage
+      }
+      edges {
+        node {
+          sequenceNumber
+          digest
+          epoch {epochId}
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{ 
+  # Fetch an epoch and its checkpoints, try to filter on epoch 2, should fail
+  epoch(epochId: 0) {
+    totalCheckpoints
+    checkpoints(first: 10, filter: {atEpoch: 2}) {
+      pageInfo {
+        startCursor
+        endCursor
+        hasPreviousPage
+        hasNextPage
+      }
+      edges {
+        node {
+          sequenceNumber
+          digest
+          epoch {epochId}
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{ 
+  # Fetch a nonexistent epoch and its checkpoints.
+  epoch(epochId: 4) {
+    totalCheckpoints
+    checkpoints(first: 5) {
+      pageInfo {
+        startCursor
+        endCursor
+        hasPreviousPage
+        hasNextPage
+      }
+      edges {
+        node {
+          sequenceNumber
+          digest
+          epoch {epochId}
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/checkpoints.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/checkpoints.snap
@@ -1,0 +1,196 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 17 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-8:
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 10:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 12-14:
+//# programmable --sender A --inputs object(1,0) 1
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+mutated: object(0,0), object(1,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 4, lines 16-18:
+//# programmable --sender A --inputs object(1,0) 2
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+mutated: object(0,0), object(1,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 5, line 20:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 6, line 22:
+//# advance-epoch
+Epoch advanced: 1
+
+task 7, lines 24-26:
+//# programmable --sender A --inputs object(1,0) 1
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+mutated: object(0,0), object(1,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 8, lines 28-30:
+//# programmable --sender A --inputs object(1,0) 2
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+mutated: object(0,0), object(1,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 9, line 32:
+//# create-checkpoint
+Checkpoint created: 4
+
+task 10, lines 34-36:
+//# programmable --sender A --inputs object(1,0) 3
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+mutated: object(0,0), object(1,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 11, line 38:
+//# create-checkpoint
+Checkpoint created: 5
+
+task 12, line 40:
+//# create-checkpoint
+Checkpoint created: 6
+
+task 13, lines 42-63:
+//# run-graphql
+Response: {
+  "data": {
+    "epoch": {
+      "totalCheckpoints": 4,
+      "checkpoints": {
+        "pageInfo": {
+          "startCursor": "MA==",
+          "endCursor": "Mw==",
+          "hasPreviousPage": false,
+          "hasNextPage": false
+        },
+        "edges": [
+          {
+            "node": {
+              "sequenceNumber": 0,
+              "digest": "EznTSQyzQqRf8tuPhLWZDdhny9jgA7Rw81nWB486rW8C",
+              "epoch": {
+                "epochId": 0
+              }
+            }
+          },
+          {
+            "node": {
+              "sequenceNumber": 1,
+              "digest": "6KC42LBjuKZP3F9Nfmdz8nC3nvXtMYsX8cEDeMQBkE6P",
+              "epoch": {
+                "epochId": 0
+              }
+            }
+          },
+          {
+            "node": {
+              "sequenceNumber": 2,
+              "digest": "2HqixJnQgrp9A74ddZLxNFaJfUeqCci5hUws5pUN7d1R",
+              "epoch": {
+                "epochId": 0
+              }
+            }
+          },
+          {
+            "node": {
+              "sequenceNumber": 3,
+              "digest": "BpHa37pAosru2sLoCShqJB9ya2QMAYApdwfnjZYzNZPR",
+              "epoch": {
+                "epochId": 0
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 14, lines 65-86:
+//# run-graphql --cursors 1
+Response: {
+  "data": {
+    "epoch": {
+      "totalCheckpoints": 4,
+      "checkpoints": {
+        "pageInfo": {
+          "startCursor": "Mg==",
+          "endCursor": "Mw==",
+          "hasPreviousPage": true,
+          "hasNextPage": false
+        },
+        "edges": [
+          {
+            "node": {
+              "sequenceNumber": 2,
+              "digest": "2HqixJnQgrp9A74ddZLxNFaJfUeqCci5hUws5pUN7d1R",
+              "epoch": {
+                "epochId": 0
+              }
+            }
+          },
+          {
+            "node": {
+              "sequenceNumber": 3,
+              "digest": "BpHa37pAosru2sLoCShqJB9ya2QMAYApdwfnjZYzNZPR",
+              "epoch": {
+                "epochId": 0
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 15, lines 88-109:
+//# run-graphql
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Unknown argument \"filter\" on field \"checkpoints\" of type \"Epoch\".",
+      "locations": [
+        {
+          "line": 5,
+          "column": 28
+        }
+      ],
+      "extensions": {
+        "code": "GRAPHQL_VALIDATION_FAILED"
+      }
+    }
+  ]
+}
+
+task 16, lines 111-132:
+//# run-graphql
+Response: {
+  "data": {
+    "epoch": null
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -118,6 +118,35 @@ type Checkpoint {
 	transactions(first: Int, after: String, last: Int, before: String, filter: TransactionFilter): TransactionConnection
 }
 
+type CheckpointConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [CheckpointEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Checkpoint!]!
+}
+
+"""
+An edge in a connection.
+"""
+type CheckpointEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Checkpoint!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
 """
 Filter for paginating packages published within a range of checkpoints.
 """
@@ -154,6 +183,10 @@ type Epoch {
 	The epoch's id as a sequence number that starts at 0 and is incremented by one at every epoch change.
 	"""
 	epochId: UInt53!
+	"""
+	The epoch's corresponding checkpoints.
+	"""
+	checkpoints(first: Int, after: String, last: Int, before: String): CheckpointConnection!
 	"""
 	State of the Coin DenyList object (0x403) at the start of this epoch.
 	
@@ -248,6 +281,13 @@ type Epoch {
 	This can be used to verify state snapshots.
 	"""
 	liveObjectSetDigest: String
+}
+
+input EpochFilter {
+	"""
+	Filter to checkpoints at this epoch.
+	"""
+	atEpoch: Int
 }
 
 type Event {
@@ -797,6 +837,10 @@ type Query {
 	Returns `null` if the checkpoint does not exist in the store, either because it never existed or because it was pruned.
 	"""
 	checkpoint(sequenceNumber: UInt53): Checkpoint
+	"""
+	Paginate checkpoints in the network, optionally bounded to checkpoints in the given epoch.
+	"""
+	checkpoints(first: Int, after: String, last: Int, before: String, filter: EpochFilter): CheckpointConnection!
 	"""
 	Fetch an epoch by its ID, or fetch the latest epoch if no ID is provided.
 	

--- a/crates/sui-indexer-alt-graphql/src/api/query.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/query.rs
@@ -6,6 +6,7 @@ use futures::future::try_join_all;
 use sui_types::digests::ChainIdentifier;
 
 use crate::{
+    api::types::checkpoint::{CCheckpoint, EpochFilter},
     error::RpcError,
     pagination::{Page, PaginationConfig},
     scope::Scope,
@@ -61,6 +62,26 @@ impl Query {
             .unwrap_or(scope.checkpoint_viewed_at());
 
         Ok(Checkpoint::with_sequence_number(scope, sequence_number))
+    }
+
+    /// Paginate checkpoints in the network, optionally bounded to checkpoints in the given epoch.
+    async fn checkpoints(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<CCheckpoint>,
+        last: Option<u64>,
+        before: Option<CCheckpoint>,
+        filter: Option<EpochFilter>,
+    ) -> Result<Connection<String, Checkpoint>, RpcError> {
+        let scope = self.scope(ctx)?;
+        let pagination: &PaginationConfig = ctx.data()?;
+        let limits = pagination.limits("Query", "checkpoints");
+        let page = Page::from_params(limits, first, after, last, before)?;
+
+        let filter = filter.unwrap_or_default();
+
+        Checkpoint::paginate(ctx, scope, page, filter).await
     }
 
     /// Fetch an epoch by its ID, or fetch the latest epoch if no ID is provided.

--- a/crates/sui-indexer-alt-graphql/src/api/types/checkpoint.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/checkpoint.rs
@@ -1,10 +1,19 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Context as _;
-use async_graphql::{connection::Connection, Context, Object};
+use std::sync::Arc;
 
-use sui_indexer_alt_reader::kv_loader::KvLoader;
+use anyhow::Context as _;
+use async_graphql::{
+    connection::{Connection, CursorType, Edge},
+    Context, InputObject, Object,
+};
+use diesel::{ExpressionMethods, QueryDsl};
+use sui_indexer_alt_reader::{kv_loader::KvLoader, pg_reader::PgReader};
+use sui_indexer_alt_schema::{
+    cp_sequence_numbers::StoredCpSequenceNumbers, schema::cp_sequence_numbers,
+};
+
 use sui_types::{
     crypto::AuthorityStrongQuorumSignInfo,
     message_envelope::Message,
@@ -14,11 +23,12 @@ use sui_types::{
 use crate::{
     api::{
         query::Query,
-        scalars::{base64::Base64, date_time::DateTime, uint53::UInt53},
+        scalars::{base64::Base64, cursor::JsonCursor, date_time::DateTime, uint53::UInt53},
     },
     error::RpcError,
     pagination::{Page, PaginationConfig},
     scope::Scope,
+    task::watermark::Watermarks,
 };
 
 use super::{
@@ -43,6 +53,15 @@ struct CheckpointContents {
         NativeCheckpointContents,
         AuthorityStrongQuorumSignInfo,
     )>,
+}
+
+pub(crate) type CCheckpoint = JsonCursor<u64>;
+
+// Filter for paginating checkpoints at a given epoch.
+#[derive(InputObject, Debug, Default, Clone)]
+pub(crate) struct EpochFilter {
+    /// Filter to checkpoints at this epoch.
+    pub at_epoch: Option<u64>,
 }
 
 /// Checkpoints contain finalized transactions and are used for node synchronization and global transaction ordering.
@@ -198,6 +217,80 @@ impl Checkpoint {
             scope,
             sequence_number,
         })
+    }
+
+    /// Paginate through checkpoints with filters applied.
+    pub(crate) async fn paginate(
+        ctx: &Context<'_>,
+        scope: Scope,
+        page: Page<CCheckpoint>,
+        filter: EpochFilter,
+    ) -> Result<Connection<String, Checkpoint>, RpcError> {
+        use cp_sequence_numbers::dsl as cp;
+
+        let mut conn = Connection::new(false, false);
+
+        let checkpoint_viewed_at = scope.checkpoint_viewed_at();
+        let watermarks: &Arc<Watermarks> = ctx.data()?;
+
+        let reader_lo = watermarks
+            .pipeline_lo_watermark("cp_sequence_numbers")?
+            .checkpoint();
+
+        let mut query = cp::cp_sequence_numbers
+            .filter(cp::cp_sequence_number.ge(reader_lo as i64))
+            .filter(cp::cp_sequence_number.le(checkpoint_viewed_at as i64))
+            .limit(page.limit_with_overhead() as i64)
+            .into_boxed();
+
+        if let Some(epoch) = filter.at_epoch {
+            query = query.filter(cp::epoch.eq(epoch as i64));
+        }
+
+        query = if page.is_from_front() {
+            query.order_by(cp::cp_sequence_number)
+        } else {
+            query.order_by(cp::cp_sequence_number.desc())
+        };
+
+        if let Some(after) = page.after() {
+            query = query.filter(cp::cp_sequence_number.ge(**after as i64));
+        }
+        if let Some(before) = page.before() {
+            query = query.filter(cp::cp_sequence_number.le(**before as i64));
+        }
+
+        let pg_reader: &PgReader = ctx.data()?;
+
+        let mut c = pg_reader
+            .connect()
+            .await
+            .context("Failed to connect to database")?;
+
+        let mut results: Vec<StoredCpSequenceNumbers> = c
+            .results(query)
+            .await
+            .context("Failed to read from database")?;
+
+        if !page.is_from_front() {
+            results.reverse();
+        }
+
+        let (prev, next, results) =
+            page.paginate_results(results, |c| JsonCursor::new(c.cp_sequence_number as u64));
+
+        conn.has_previous_page = prev;
+        conn.has_next_page = next;
+
+        for (cursor, stored) in results {
+            conn.edges.push(Edge::new(
+                cursor.encode_cursor(),
+                Self::with_sequence_number(scope.clone(), stored.cp_sequence_number as u64)
+                    .unwrap(),
+            ));
+        }
+
+        Ok(conn)
     }
 }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
+    checkpoint::{CCheckpoint, Checkpoint, EpochFilter},
     move_package::{self, CSysPackage, MovePackage},
     object::{self, Object},
     protocol_configs::ProtocolConfigs,
@@ -60,6 +61,26 @@ impl Epoch {
     /// The epoch's id as a sequence number that starts at 0 and is incremented by one at every epoch change.
     async fn epoch_id(&self) -> UInt53 {
         self.epoch_id.into()
+    }
+
+    /// The epoch's corresponding checkpoints.
+    async fn checkpoints(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<CCheckpoint>,
+        last: Option<u64>,
+        before: Option<CCheckpoint>,
+    ) -> Result<Connection<String, Checkpoint>, RpcError> {
+        let pagination: &PaginationConfig = ctx.data()?;
+        let limits = pagination.limits("Epoch", "checkpoints");
+        let page = Page::from_params(limits, first, after, last, before)?;
+
+        let filter = EpochFilter {
+            at_epoch: Some(self.epoch_id as u64),
+        };
+
+        Checkpoint::paginate(ctx, self.scope.clone(), page, filter).await
     }
 
     /// State of the Coin DenyList object (0x403) at the start of this epoch.

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -180,7 +180,7 @@ impl Transaction {
         }))
     }
 
-    /// Cursor based pagination through transactions based on filters.
+    /// Cursor based pagination through transactions with filters applied.
     pub(crate) async fn paginate(
         ctx: &Context<'_>,
         scope: Scope,
@@ -316,18 +316,14 @@ async fn tx_unfiltered(
         .map(|cursor| cursor.saturating_add(1))
         .map_or(tx_hi, |cursor| cursor.min(tx_hi));
 
-    const PAGINATION_OVERHEAD: usize = 2; // For has_previous_page and has_next_page calculations.
-
     Ok(if page.is_from_front() {
-        (pg_lo..pg_hi)
-            .take(page.limit() + PAGINATION_OVERHEAD)
-            .collect()
+        (pg_lo..pg_hi).take(page.limit_with_overhead()).collect()
     } else {
         // Graphql last syntax expects results to be in ascending order. If we are paginating backwards,
         // we reverse the results after applying limits.
         let mut results: Vec<_> = (pg_lo..pg_hi)
             .rev()
-            .take(page.limit() + PAGINATION_OVERHEAD)
+            .take(page.limit_with_overhead())
             .collect();
         results.reverse();
         results

--- a/crates/sui-indexer-alt-graphql/src/pagination.rs
+++ b/crates/sui-indexer-alt-graphql/src/pagination.rs
@@ -64,6 +64,10 @@ pub(crate) enum Error {
     TooLarge { limit: u64, max: u32 },
 }
 
+/// Number of extra items to fetch for pagination (for has_previous_page and has_next_page
+/// calculations)
+pub(crate) const PAGINATION_OVERHEAD: usize = 2;
+
 impl PaginationConfig {
     pub(crate) fn new(
         max_multi_get_size: u32,
@@ -146,6 +150,11 @@ impl<C> Page<C> {
 
     pub(crate) fn limit(&self) -> usize {
         self.limit as usize
+    }
+
+    /// Returns the limit plus pagination overhead for has_previous_page and has_next_page.
+    pub(crate) fn limit_with_overhead(&self) -> usize {
+        self.limit() + PAGINATION_OVERHEAD
     }
 
     pub(crate) fn is_from_front(&self) -> bool {

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -122,6 +122,35 @@ type Checkpoint {
 	transactions(first: Int, after: String, last: Int, before: String, filter: TransactionFilter): TransactionConnection
 }
 
+type CheckpointConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [CheckpointEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Checkpoint!]!
+}
+
+"""
+An edge in a connection.
+"""
+type CheckpointEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Checkpoint!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
 """
 Filter for paginating packages published within a range of checkpoints.
 """
@@ -158,6 +187,10 @@ type Epoch {
 	The epoch's id as a sequence number that starts at 0 and is incremented by one at every epoch change.
 	"""
 	epochId: UInt53!
+	"""
+	The epoch's corresponding checkpoints.
+	"""
+	checkpoints(first: Int, after: String, last: Int, before: String): CheckpointConnection!
 	"""
 	State of the Coin DenyList object (0x403) at the start of this epoch.
 	
@@ -252,6 +285,13 @@ type Epoch {
 	This can be used to verify state snapshots.
 	"""
 	liveObjectSetDigest: String
+}
+
+input EpochFilter {
+	"""
+	Filter to checkpoints at this epoch.
+	"""
+	atEpoch: Int
 }
 
 type Event {
@@ -801,6 +841,10 @@ type Query {
 	Returns `null` if the checkpoint does not exist in the store, either because it never existed or because it was pruned.
 	"""
 	checkpoint(sequenceNumber: UInt53): Checkpoint
+	"""
+	Paginate checkpoints in the network, optionally bounded to checkpoints in the given epoch.
+	"""
+	checkpoints(first: Int, after: String, last: Int, before: String, filter: EpochFilter): CheckpointConnection!
 	"""
 	Fetch an epoch by its ID, or fetch the latest epoch if no ID is provided.
 	

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -122,6 +122,35 @@ type Checkpoint {
 	transactions(first: Int, after: String, last: Int, before: String, filter: TransactionFilter): TransactionConnection
 }
 
+type CheckpointConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [CheckpointEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Checkpoint!]!
+}
+
+"""
+An edge in a connection.
+"""
+type CheckpointEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Checkpoint!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
 """
 Filter for paginating packages published within a range of checkpoints.
 """
@@ -158,6 +187,10 @@ type Epoch {
 	The epoch's id as a sequence number that starts at 0 and is incremented by one at every epoch change.
 	"""
 	epochId: UInt53!
+	"""
+	The epoch's corresponding checkpoints.
+	"""
+	checkpoints(first: Int, after: String, last: Int, before: String): CheckpointConnection!
 	"""
 	State of the Coin DenyList object (0x403) at the start of this epoch.
 	
@@ -252,6 +285,13 @@ type Epoch {
 	This can be used to verify state snapshots.
 	"""
 	liveObjectSetDigest: String
+}
+
+input EpochFilter {
+	"""
+	Filter to checkpoints at this epoch.
+	"""
+	atEpoch: Int
 }
 
 type Event {
@@ -801,6 +841,10 @@ type Query {
 	Returns `null` if the checkpoint does not exist in the store, either because it never existed or because it was pruned.
 	"""
 	checkpoint(sequenceNumber: UInt53): Checkpoint
+	"""
+	Paginate checkpoints in the network, optionally bounded to checkpoints in the given epoch.
+	"""
+	checkpoints(first: Int, after: String, last: Int, before: String, filter: EpochFilter): CheckpointConnection!
 	"""
 	Fetch an epoch by its ID, or fetch the latest epoch if no ID is provided.
 	

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -118,6 +118,35 @@ type Checkpoint {
 	transactions(first: Int, after: String, last: Int, before: String, filter: TransactionFilter): TransactionConnection
 }
 
+type CheckpointConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [CheckpointEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Checkpoint!]!
+}
+
+"""
+An edge in a connection.
+"""
+type CheckpointEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: Checkpoint!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
 """
 Filter for paginating packages published within a range of checkpoints.
 """
@@ -154,6 +183,10 @@ type Epoch {
 	The epoch's id as a sequence number that starts at 0 and is incremented by one at every epoch change.
 	"""
 	epochId: UInt53!
+	"""
+	The epoch's corresponding checkpoints.
+	"""
+	checkpoints(first: Int, after: String, last: Int, before: String): CheckpointConnection!
 	"""
 	State of the Coin DenyList object (0x403) at the start of this epoch.
 	
@@ -248,6 +281,13 @@ type Epoch {
 	This can be used to verify state snapshots.
 	"""
 	liveObjectSetDigest: String
+}
+
+input EpochFilter {
+	"""
+	Filter to checkpoints at this epoch.
+	"""
+	atEpoch: Int
 }
 
 type Event {
@@ -797,6 +837,10 @@ type Query {
 	Returns `null` if the checkpoint does not exist in the store, either because it never existed or because it was pruned.
 	"""
 	checkpoint(sequenceNumber: UInt53): Checkpoint
+	"""
+	Paginate checkpoints in the network, optionally bounded to checkpoints in the given epoch.
+	"""
+	checkpoints(first: Int, after: String, last: Int, before: String, filter: EpochFilter): CheckpointConnection!
 	"""
 	Fetch an epoch by its ID, or fetch the latest epoch if no ID is provided.
 	


### PR DESCRIPTION
## Description 

- Added `paginate` to `Checkpoint`
- `Query.checkpoints`: Paginate checkpoints in the network, optionally bounded to checkpoints in a given epoch.
-  `Epoch.checkpoints`: Paginate through an epoch's checkpoints

## Test plan 

```
cargo nextest run -p sui-indexer-alt-graphql schema_sdl
cargo nextest run -p sui-indexer-alt-graphql --features staging schema_sdl
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
