### PR TITLE
indexer-alt: checkpoint lag for sequential pipelines

### DIFF
--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
@@ -13,7 +13,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::{
-    metrics::IndexerMetrics,
+    metrics::{CheckpointLagMetricReporter, IndexerMetrics},
     pipeline::{logging::WatermarkLogger, IndexedCheckpoint, WARN_PENDING_WATERMARKS},
     store::{CommitterWatermark, Connection, TransactionalStore},
 };
@@ -84,6 +84,12 @@ where
         // The committer task will periodically output a log message at a higher log level to
         // demonstrate that the pipeline is making progress.
         let mut logger = WatermarkLogger::new("sequential_committer", &watermark);
+
+        let checkpoint_lag_reporter = CheckpointLagMetricReporter::new_for_pipeline::<H>(
+            &metrics.watermarked_checkpoint_timestamp_lag,
+            &metrics.latest_watermarked_checkpoint_timestamp_lag_ms,
+            &metrics.watermark_checkpoint_in_db,
+        );
 
         // Data for checkpoint that haven't been written yet. Note that `pending_rows` includes
         // rows in `batch`.
@@ -263,6 +269,11 @@ where
                     );
 
                     logger.log::<H>(&watermark, elapsed);
+
+                    checkpoint_lag_reporter.report_lag(
+                        watermark.checkpoint_hi_inclusive,
+                        watermark.timestamp_ms_hi_inclusive
+                    );
 
                     metrics
                         .total_committer_batches_succeeded


### PR DESCRIPTION
## Description

Hook up the checkpoint lag metric reporter for sequential pipelines, just like for concurrent pipelines, so that we can track checkpoint lag in our dashboards.

## Test plan

Manually tested by running the consistent store locally and confirming that we see the lag metrics show up in metrics output.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
