### PR TITLE
[pkg-alt] Refactor implicit deps to system dependencies

### DIFF
--- a/crates/sui-package-alt/src/sui_flavor.rs
+++ b/crates/sui-package-alt/src/sui_flavor.rs
@@ -51,6 +51,14 @@ impl SuiFlavor {
             ),
         ])
     }
+
+    /// The default dependencies are `sui` and `std`
+    fn default_system_dep_names() -> BTreeSet<PackageName> {
+        BTreeSet::from([
+            PackageName::new("sui").unwrap(),
+            PackageName::new("std").unwrap(),
+        ])
+    }
 }
 
 impl MoveFlavor for SuiFlavor {
@@ -71,14 +79,10 @@ impl MoveFlavor for SuiFlavor {
         ])
     }
 
-    fn system_deps_names() -> BTreeSet<PackageName> {
-        SuiFlavor::system_deps_names_map()
-            .into_keys()
-            .collect::<BTreeSet<_>>()
-    }
-
     // TODO this needs fixing, see todos
-    fn implicit_deps(environment: EnvironmentID) -> BTreeMap<PackageName, ReplacementDependency> {
+    fn system_dependencies(
+        environment: EnvironmentID,
+    ) -> BTreeMap<PackageName, ReplacementDependency> {
         let mut deps = BTreeMap::new();
         let deps_to_skip = ["DeepBook".into()];
         // TODO: we need to use packages for protocol version as well, so we need to fix this
@@ -123,6 +127,17 @@ impl MoveFlavor for SuiFlavor {
 
         deps
     }
+
+    fn default_system_dependencies(
+        environment: EnvironmentID,
+    ) -> BTreeMap<PackageName, ReplacementDependency> {
+        let default_deps = Self::default_system_dep_names();
+
+        Self::system_dependencies(environment)
+            .into_iter()
+            .filter(|(name, _)| default_deps.contains(name))
+            .collect()
+    }
 }
 
 #[cfg(test)]
@@ -138,7 +153,7 @@ mod tests {
         let implicit_deps = ["sui", "std", "sui_system", "bridge"];
         let env = Environment::new("mainnet".into(), "35834a8a".into());
 
-        let deps = SuiFlavor::implicit_deps(env.id().into());
+        let deps = SuiFlavor::system_dependencies(env.id().into());
 
         for i in implicit_deps {
             assert!(

--- a/external-crates/move/crates/move-package-alt/src/compatibility/legacy_parser.rs
+++ b/external-crates/move/crates/move-package-alt/src/compatibility/legacy_parser.rs
@@ -11,9 +11,9 @@ use crate::{
     errors::FileHandle,
     package::{EnvironmentName, layout::SourcePackageLayout, paths::PackagePath},
     schema::{
-        DefaultDependency, ExternalDependency, ImplicitDepMode, LocalDepInfo,
-        ManifestDependencyInfo, ManifestGitDependency, OnChainDepInfo, OriginalID, PackageMetadata,
-        PackageName, PublishAddresses, PublishedID,
+        DefaultDependency, ExternalDependency, LocalDepInfo, ManifestDependencyInfo,
+        ManifestGitDependency, OnChainDepInfo, OriginalID, PackageMetadata, PackageName,
+        PublishAddresses, PublishedID,
     },
 };
 use anyhow::{Context, Result, anyhow, bail, format_err};
@@ -292,18 +292,17 @@ fn parse_source_manifest(
 
             // IF we have one system package OR this package is a system package itself,
             // we disable implicit deps.
-            let implicit_deps = if has_system_package || is_system_package {
-                ImplicitDepMode::Disabled
+            let system_dependencies = if has_system_package || is_system_package {
+                Some(vec![])
             } else {
-                // Otherwise we enable implicit deps (unfortunately all of them)
-                ImplicitDepMode::Enabled(None)
+                None
             };
 
             Ok(ParsedLegacyPackage {
                 metadata: PackageMetadata {
                     name: new_name,
                     edition: metadata.edition,
-                    implicit_deps,
+                    system_dependencies,
                     unrecognized_fields: metadata.unrecognized_fields,
                 },
                 deps: dependencies,

--- a/external-crates/move/crates/move-package-alt/src/dependency/combine.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/combine.rs
@@ -33,7 +33,7 @@ impl CombinedDependency {
         env: &Environment,
         dep_replacements: &BTreeMap<PackageName, Spanned<ReplacementDependency>>,
         dependencies: &BTreeMap<PackageName, DefaultDependency>,
-        implicit_deps: &BTreeMap<PackageName, ReplacementDependency>,
+        system_dependencies: &BTreeMap<PackageName, ReplacementDependency>,
     ) -> ManifestResult<BTreeMap<PackageName, Self>> {
         let mut result = BTreeMap::new();
 
@@ -60,7 +60,7 @@ impl CombinedDependency {
             );
         }
 
-        for (pkg_name, dep) in implicit_deps {
+        for (pkg_name, dep) in system_dependencies {
             result.insert(
                 pkg_name.clone(),
                 Self::from_replacement(*file, env.name().to_string(), dep.clone())?,

--- a/external-crates/move/crates/move-package-alt/src/flavor/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/flavor/mod.rs
@@ -6,10 +6,7 @@ pub mod vanilla;
 
 pub use vanilla::Vanilla;
 
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    fmt::Debug,
-};
+use std::{collections::BTreeMap, fmt::Debug};
 
 use serde::{Serialize, de::DeserializeOwned};
 
@@ -40,13 +37,13 @@ pub trait MoveFlavor: Debug {
     /// Used for populating new manifests & migration purposes.
     fn default_environments() -> BTreeMap<EnvironmentName, EnvironmentID>;
 
-    /// Return the implicit dependencies for the environments listed in [environments]
-    fn implicit_deps(environment: EnvironmentID) -> BTreeMap<PackageName, ReplacementDependency>;
+    /// Return ALL the system dependencies for the requested environment.
+    fn system_dependencies(
+        environment: EnvironmentID,
+    ) -> BTreeMap<PackageName, ReplacementDependency>;
 
-    /// Return the names of the system dependencies for this flavor.
-    fn system_deps_names() -> BTreeSet<PackageName> {
-        // Default implementation returns an empty map.
-        // Specific flavors can override this to provide system dependencies.
-        BTreeSet::new()
-    }
+    /// Return the default system dependencies for the requested environment.
+    fn default_system_dependencies(
+        environment: EnvironmentID,
+    ) -> BTreeMap<PackageName, ReplacementDependency>;
 }

--- a/external-crates/move/crates/move-package-alt/src/flavor/vanilla.rs
+++ b/external-crates/move/crates/move-package-alt/src/flavor/vanilla.rs
@@ -45,7 +45,15 @@ impl MoveFlavor for Vanilla {
         envs
     }
 
-    fn implicit_deps(environment: EnvironmentID) -> BTreeMap<PackageName, ReplacementDependency> {
+    fn system_dependencies(
+        environment: EnvironmentID,
+    ) -> BTreeMap<PackageName, ReplacementDependency> {
         empty().collect()
+    }
+
+    fn default_system_dependencies(
+        environment: EnvironmentID,
+    ) -> BTreeMap<PackageName, ReplacementDependency> {
+        Self::system_dependencies(environment)
     }
 }

--- a/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/package_impl.rs
@@ -11,7 +11,7 @@ use super::manifest::{Manifest, ManifestError, ManifestErrorKind};
 use super::paths::PackagePath;
 use crate::dependency::FetchedDependency;
 use crate::errors::{FileHandle, Location};
-use crate::schema::{ImplicitDepMode, ReplacementDependency};
+use crate::schema::ReplacementDependency;
 use crate::{
     compatibility::{
         legacy::LegacyData,
@@ -26,7 +26,7 @@ use crate::{
         PublishedID,
     },
 };
-use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+use move_core_types::account_address::AccountAddress;
 use std::sync::{LazyLock, Mutex};
 
 // TODO: is this the right way to handle this?
@@ -116,9 +116,11 @@ impl<F: MoveFlavor> Package<F> {
 
             let publish_data = Self::load_published_info_from_lockfile(&path)?;
 
-            debug!("adding implicit dependencies");
-            let implicit_deps =
-                Self::implicit_deps(env, manifest.parsed().package.implicit_deps.clone())?;
+            debug!("adding system dependencies");
+            let system_dependencies = Self::system_dependencies(
+                env,
+                manifest.parsed().package.system_dependencies.clone(),
+            )?;
 
             // TODO: We should error if there environment is not supported!
             debug!("combining [dependencies] with [dep-replacements] for {env:?}");
@@ -130,7 +132,7 @@ impl<F: MoveFlavor> Package<F> {
                     .get(env.name())
                     .unwrap_or(&BTreeMap::new()),
                 &manifest.dependencies(),
-                &implicit_deps,
+                &system_dependencies,
             )?;
 
             debug!("pinning dependencies");
@@ -158,15 +160,15 @@ impl<F: MoveFlavor> Package<F> {
         // Here, that means that we're working on legacy package, so we can throw its errors.
         let legacy_manifest = parse_legacy_manifest_from_file(&path)?;
 
-        let implicit_deps =
-            Self::implicit_deps(env, legacy_manifest.metadata.implicit_deps.clone())?;
+        let system_dependencies =
+            Self::system_dependencies(env, legacy_manifest.metadata.system_dependencies.clone())?;
 
         let combined_deps = CombinedDependency::combine_deps(
             &legacy_manifest.file_handle,
             env,
             &BTreeMap::new(),
             &legacy_manifest.deps,
-            &implicit_deps,
+            &system_dependencies,
         )?;
 
         let deps = PinnedDependencyInfo::pin::<F>(&source, combined_deps, env.id()).await?;
@@ -272,41 +274,37 @@ impl<F: MoveFlavor> Package<F> {
     }
 
     /// Return the implicit deps depending on the implicit dep mode.
-    fn implicit_deps(
+    fn system_dependencies(
         env: &Environment,
-        implicit_dep_mode: ImplicitDepMode,
+        system_dependencies: Option<Vec<String>>,
     ) -> PackageResult<BTreeMap<PackageName, ReplacementDependency>> {
-        match implicit_dep_mode {
-            // For enabled state, we need to pick the deps based on whether there is
-            // a specfiied
-            ImplicitDepMode::Enabled(specified_deps) => {
-                let deps = F::implicit_deps(env.id().to_string());
+        if let Some(system_dependencies) = system_dependencies {
+            // The case were we do not want any system dependencies.
+            if system_dependencies.is_empty() {
+                return Ok(BTreeMap::new());
+            }
 
-                if let Some(specified_deps) = specified_deps {
-                    // If a list of deps is specified, we need to make sure
-                    // that all of the deps are valid in the implicit deps list, or warn.
-                    for dep in &specified_deps {
-                        if !deps.contains_key(&Identifier::new(dep.as_str())?) {
-                            return Err(PackageError::Generic(format!(
-                                "The implicit dependency `{}` does not exist in the implicit deps list.",
-                                dep
-                            )));
-                        }
-                    }
+            // Only include the specified system dependencies.
+            let all_flavor_deps = F::system_dependencies(env.id().to_string());
 
-                    // If we have a "specified" list of deps, we need to filter the implicit deps to only support
-                    // the ones that are in the specified list.
-                    Ok(deps
-                        .into_iter()
-                        .filter(|(name, _)| specified_deps.contains(&name.to_string()))
-                        .collect())
+            let mut result = BTreeMap::new();
+
+            for dep in &system_dependencies {
+                let name = PackageName::new(dep.clone())?;
+                if let Some(dep) = all_flavor_deps.get(&name) {
+                    result.insert(name, dep.clone());
                 } else {
-                    Ok(deps)
+                    return Err(PackageError::Generic(format!(
+                        "The system dependency `{}` does not exist in the implicit deps list.",
+                        dep
+                    )));
                 }
             }
-            ImplicitDepMode::Disabled => Ok(BTreeMap::new()),
-            ImplicitDepMode::Testing => todo!(),
+            return Ok(result);
         }
+
+        // If no system dependencies are specified, we include the default system dependencies.
+        Ok(F::default_system_dependencies(env.id().to_string()))
     }
 
     /// Validate the manifest contents, after deserialization.
@@ -366,8 +364,8 @@ mod tests {
             BTreeMap::new()
         }
 
-        // Our test flavor has "foo" and "bar" accessible.
-        fn implicit_deps(_: String) -> BTreeMap<PackageName, ReplacementDependency> {
+        // Our test flavor has `[foo, bar, baz]` system dependencies.
+        fn system_dependencies(_: String) -> BTreeMap<PackageName, ReplacementDependency> {
             let mut deps = BTreeMap::new();
             deps.insert(
                 new_package_name("foo"),
@@ -385,17 +383,39 @@ mod tests {
                     use_environment: None,
                 },
             );
+
+            deps.insert(
+                new_package_name("baz"),
+                ReplacementDependency {
+                    dependency: None,
+                    addresses: None,
+                    use_environment: None,
+                },
+            );
+
             deps
+        }
+
+        // In this flavor, only `[foo, bar]` are enabled by default.
+        fn default_system_dependencies(
+            environment: EnvironmentID,
+        ) -> BTreeMap<PackageName, ReplacementDependency> {
+            let default_deps = [new_package_name("foo"), new_package_name("bar")];
+
+            Self::system_dependencies(environment)
+                .into_iter()
+                .filter(|(name, _)| default_deps.contains(name))
+                .collect()
         }
     }
 
     #[test]
-    /// We enable ALL implicit-deps.
-    fn test_all_implicit_deps() {
+    /// We enable the default system deps.
+    fn test_default_system_dependencies() {
         let env = test_environment();
-        let implicit_deps = ImplicitDepMode::Enabled(None);
+        let implicit_deps = None;
 
-        let deps = Package::<TestFlavor>::implicit_deps(&env, implicit_deps).unwrap();
+        let deps = Package::<TestFlavor>::system_dependencies(&env, implicit_deps).unwrap();
         let dep_keys: Vec<_> = deps.keys().cloned().collect();
 
         assert_eq!(dep_keys.len(), 2);
@@ -404,12 +424,12 @@ mod tests {
     }
 
     #[test]
-    /// We enable implicit-deps, but specifying which ones we want.
-    fn test_explicit_implicit_deps() {
+    /// We enable system deps, but specifying which ones we want.
+    fn test_explicit_system_deps() {
         let env = test_environment();
-        let implicit_deps = ImplicitDepMode::Enabled(Some(vec!["foo".to_string()]));
+        let implicit_deps = Some(vec!["foo".to_string()]);
 
-        let deps = Package::<TestFlavor>::implicit_deps(&env, implicit_deps).unwrap();
+        let deps = Package::<TestFlavor>::system_dependencies(&env, implicit_deps).unwrap();
         let dep_keys: Vec<_> = deps.keys().cloned().collect();
 
         assert_eq!(dep_keys.len(), 1);
@@ -418,33 +438,34 @@ mod tests {
     }
 
     #[test]
-    fn test_explicit_implicit_deps_with_invalid_names() {
+    /// Test that we can also "add" deps that are not in the default list of the flavor.
+    fn test_explicit_deps_with_more_than_default_names() {
         let env = test_environment();
-        let implicit_deps =
-            ImplicitDepMode::Enabled(Some(vec!["ignore".to_string(), "foo".to_string()]));
+        let implicit_deps = Some(vec!["foo".to_string(), "baz".to_string()]);
 
-        assert!(Package::<TestFlavor>::implicit_deps(&env, implicit_deps).is_err());
+        let deps = Package::<TestFlavor>::system_dependencies(&env, implicit_deps).unwrap();
+        let dep_keys: Vec<_> = deps.keys().cloned().collect();
+
+        assert_eq!(dep_keys.len(), 2);
+        assert!(dep_keys.contains(&new_package_name("foo")));
+        assert!(dep_keys.contains(&new_package_name("baz")));
     }
 
     #[test]
-    /// We disable implicit deps.
-    fn test_no_implicit_deps() {
+    fn test_explicit_system_deps_with_invalid_names() {
         let env = test_environment();
-        let implicit_deps = ImplicitDepMode::Disabled;
+        let implicit_deps = Some(vec!["ignore".to_string(), "foo".to_string()]);
 
-        let deps = Package::<TestFlavor>::implicit_deps(&env, implicit_deps).unwrap();
-
-        assert_eq!(deps.len(), 0);
+        assert!(Package::<TestFlavor>::system_dependencies(&env, implicit_deps).is_err());
     }
 
     #[test]
-    /// We disable implicit deps by providing empty array
-    ///
-    fn test_empty_implicit_deps() {
+    /// We disable system dependencies altogether.
+    fn test_no_system_deps() {
         let env = test_environment();
-        let implicit_deps = ImplicitDepMode::Enabled(Some(vec![]));
+        let implicit_deps = Some(vec![]);
 
-        let deps = Package::<TestFlavor>::implicit_deps(&env, implicit_deps).unwrap();
+        let deps = Package::<TestFlavor>::system_dependencies(&env, implicit_deps).unwrap();
 
         assert_eq!(deps.len(), 0);
     }

--- a/external-crates/move/crates/move-package-alt/src/schema/manifest.rs
+++ b/external-crates/move/crates/move-package-alt/src/schema/manifest.rs
@@ -1,9 +1,6 @@
 use std::{collections::BTreeMap, path::PathBuf};
 
-use serde::{
-    Deserialize, Deserializer,
-    de::{self, SeqAccess, Visitor},
-};
+use serde::{Deserialize, Deserializer, de};
 use serde_spanned::Spanned;
 
 use super::{
@@ -42,23 +39,10 @@ pub struct PackageMetadata {
     pub edition: String,
 
     #[serde(default)]
-    pub implicit_deps: ImplicitDepMode,
+    pub system_dependencies: Option<Vec<String>>,
 
     #[serde(flatten)]
     pub unrecognized_fields: BTreeMap<String, toml::Value>,
-}
-
-/// The `implicit-deps` field of a manifest
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ImplicitDepMode {
-    /// There is no `implicit-deps` field, or there's `implicit-deps = ["foo", "bar"]`
-    Enabled(Option<Vec<String>>),
-
-    /// `implicit-deps = false`
-    Disabled,
-
-    /// `implicit-deps = "internal"`
-    Testing,
 }
 
 /// An entry in the `[dependencies]` section of a manifest
@@ -137,65 +121,6 @@ struct RField {
     r: BTreeMap<String, toml::Value>,
 }
 
-impl Default for ImplicitDepMode {
-    fn default() -> Self {
-        Self::Enabled(None)
-    }
-}
-
-impl<'de> Deserialize<'de> for ImplicitDepMode {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct ImplicitDepModeVisitor;
-        impl<'de> Visitor<'de> for ImplicitDepModeVisitor {
-            type Value = ImplicitDepMode;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                // there's other things you can write, but we won't advertise that
-                formatter.write_str("the value false or a vector of names")
-            }
-
-            fn visit_bool<E: de::Error>(self, b: bool) -> Result<Self::Value, E> {
-                if b {
-                    Err(E::custom(
-                        "implicit-deps = true is the default behavior, so should be omitted",
-                    ))
-                } else {
-                    Ok(Self::Value::Disabled)
-                }
-            }
-
-            fn visit_str<E: de::Error>(self, s: &str) -> Result<Self::Value, E> {
-                if s == "internal" {
-                    Ok(Self::Value::Testing)
-                } else {
-                    // We hide the truth from the users! For testing in the monorepo, you may also pass
-                    // `implicit-deps = "internal"`
-                    Err(E::custom(
-                        "the only valid value for `implicit-deps` is `implicit-deps = false`",
-                    ))
-                }
-            }
-
-            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where
-                A: SeqAccess<'de>,
-            {
-                let mut values = Vec::new();
-                while let Some(s) = seq.next_element::<String>()? {
-                    values.push(s)
-                }
-
-                Ok(Self::Value::Enabled(Some(values)))
-            }
-        }
-
-        deserializer.deserialize_any(ImplicitDepModeVisitor)
-    }
-}
-
 impl<'de> Deserialize<'de> for ManifestDependencyInfo {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -251,7 +176,7 @@ impl TryFrom<RField> for ExternalDependency {
 mod tests {
     use insta::assert_snapshot;
 
-    use crate::schema::{ImplicitDepMode, LocalDepInfo, OnChainDepInfo};
+    use crate::schema::{LocalDepInfo, OnChainDepInfo};
 
     use super::{
         DefaultDependency, ExternalDependency, ManifestDependencyInfo, ManifestGitDependency,
@@ -447,7 +372,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(manifest.package.implicit_deps == ImplicitDepMode::Enabled(None));
+        assert!(manifest.package.system_dependencies == None);
     }
 
     /// You can turn implicit deps off
@@ -458,12 +383,12 @@ mod tests {
             [package]
             name = "test"
             edition = "2024"
-            implicit-deps = false
+            system-dependencies = []
             "#,
         )
         .unwrap();
 
-        assert!(manifest.package.implicit_deps == ImplicitDepMode::Disabled);
+        assert!(manifest.package.system_dependencies == Some(vec![]));
     }
 
     /// You can define specific implicit deps.
@@ -474,53 +399,15 @@ mod tests {
                 [package]
                 name = "test"
                 edition = "2024"
-                implicit-deps = ["foo", "bar"]
+                system-dependencies = ["foo", "bar"]
                 "#,
         )
         .unwrap();
 
         assert!(
-            manifest.package.implicit_deps
-                == ImplicitDepMode::Enabled(Some(vec!["foo".to_string(), "bar".to_string()]))
+            manifest.package.system_dependencies
+                == Some(vec!["foo".to_string(), "bar".to_string()])
         );
-    }
-
-    /// You can ask for internal implicit deps
-    #[test]
-    fn parse_internal_implicit_deps() {
-        let manifest: ParsedManifest = toml_edit::de::from_str(
-            r#"
-            [package]
-            name = "test"
-            edition = "2024"
-            implicit-deps = "internal"
-            "#,
-        )
-        .unwrap();
-
-        assert!(manifest.package.implicit_deps == ImplicitDepMode::Testing);
-    }
-
-    /// implicit deps can't be a random string
-    #[test]
-    fn parse_bad_implicit_deps() {
-        let error = toml_edit::de::from_str::<ParsedManifest>(
-            r#"
-            [package]
-            name = "test"
-            edition = "2024"
-            implicit-deps = "bogus"
-            "#,
-        )
-        .unwrap_err()
-        .to_string();
-        assert_snapshot!(error, @r###"
-        TOML parse error at line 5, column 29
-          |
-        5 |             implicit-deps = "bogus"
-          |                             ^^^^^^^
-        the only valid value for `implicit-deps` is `implicit-deps = false`
-        "###);
     }
 
     // Dependency and dep-replacement parsing ////////////////////////////////////////////


### PR DESCRIPTION
## Description 

This PR introduces these changes:
1. Refactor `implicit-deps` to become `system-dependencies`
2. Simplify parsing (no more custom type)
3. Introduce the concept of `default` system dependencies 

## Test plan 

Updated / expanded the unit tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
