### PR TITLE
graphql-alt: improve object version pagination performance

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/types/object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object.rs
@@ -9,7 +9,7 @@ use async_graphql::{
     dataloader::DataLoader,
     Context, InputObject, Interface, Object,
 };
-use diesel::{ExpressionMethods, QueryDsl};
+use diesel::{sql_types::Bool, ExpressionMethods, QueryDsl};
 use fastcrypto::encoding::{Base58, Encoding};
 use sui_indexer_alt_reader::{
     kv_loader::KvLoader,
@@ -20,6 +20,7 @@ use sui_indexer_alt_reader::{
     pg_reader::PgReader,
 };
 use sui_indexer_alt_schema::{objects::StoredObjVersion, schema::obj_versions};
+use sui_pg_db::sql;
 use sui_types::{
     base_types::{SequenceNumber, SuiAddress as NativeSuiAddress},
     digests::ObjectDigest,
@@ -425,9 +426,25 @@ impl Object {
         let mut conn = Connection::new(false, false);
 
         let pg_reader: &PgReader = ctx.data()?;
+
         let mut query = v::obj_versions
-            .filter(v::cp_sequence_number.le(scope.checkpoint_viewed_at() as i64))
             .filter(v::object_id.eq(address.to_vec()))
+            .filter(sql!(as Bool,
+                r#"
+                    object_version <= (SELECT
+                        m.object_version
+                    FROM
+                        obj_versions m
+                    WHERE
+                        m.object_id = obj_versions.object_id
+                    AND m.cp_sequence_number <= {BigInt}
+                    ORDER BY
+                        m.cp_sequence_number DESC,
+                        m.object_version DESC
+                    LIMIT 1)
+                "#,
+                scope.checkpoint_viewed_at() as i64,
+            ))
             .limit(page.limit() as i64 + 2)
             .into_boxed();
 
@@ -440,13 +457,9 @@ impl Object {
         }
 
         query = if page.is_from_front() {
-            query
-                .order_by(v::cp_sequence_number)
-                .then_order_by(v::object_version)
+            query.order_by(v::object_version)
         } else {
-            query
-                .order_by(v::cp_sequence_number.desc())
-                .then_order_by(v::object_version.desc())
+            query.order_by(v::object_version.desc())
         };
 
         if let Some(after) = page.after() {


### PR DESCRIPTION
## Description

The previous implementation of object version pagination resulted in an index scan backwards that could, in pathological cases, end up scanning through an object's full history (for example if a version lowerbound was given which was actually in the future.

The core issue was that the query planner did not know that object versions grew monotonically with checkpoint sequence numbers. The new implementation gives the query planner this information by translating the checkpoint bound into a version bound.

## Test plan

Run the existing E2E tests, for correctness:

```
$ cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

Run the following GraphQL queries, which would previously have taken a long time to run:

```graphql
query InFuture {
  # Should return no results, quickly
  objectVersions(address:"0x6", filter: {afterVersion: 519529334}) {
    nodes {
      address
      version
      digest
    }
  }
}

query InPast {
  # Should produce results, from the past
  objectVersions(address:"0x6", filter: {afterVersion: 319529334}) {
    nodes {
      address
      version
      digest
    }
  }
}
```

Also test the performance of the query itself:

```sql
EXPLAIN (ANALYZE, BUFFERS) SELECT
      "obj_versions"."object_id",
      "obj_versions"."object_version",
      "obj_versions"."object_digest",
      "obj_versions"."cp_sequence_number"
  FROM "obj_versions"
  WHERE (
      ("obj_versions"."object_id" = '\x0000000000000000000000000000000000000000000000000000000000000006'::bytea)
      AND object_version <= (
          SELECT m.object_version
          FROM obj_versions m
          WHERE m.object_id = obj_versions.object_id
              AND m.cp_sequence_number <= 173859907
          ORDER BY
              m.cp_sequence_number DESC,
              m.object_version DESC
          LIMIT 1
      )
      AND ("obj_versions"."object_version" > 519529334)
  )
  ORDER BY "obj_versions"."object_version"
  LIMIT 22;
                                                                     QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.84..323.68 rows=22 width=82) (actual time=0.065..0.065 rows=0 loops=1)
   Buffers: shared hit=9
   ->  Index Scan using obj_versions_pkey on obj_versions  (cost=0.84..76011693.70 rows=5179720 width=82) (actual time=0.063..0.063 rows=0 loops=1)
         Index Cond: ((object_id = '\x0000000000000000000000000000000000000000000000000000000000000006'::bytea) AND (object_version > 519529334))
         Filter: (object_version <= (SubPlan 1))
         Buffers: shared hit=9
         SubPlan 1
           ->  Limit  (cost=0.84..0.92 rows=1 width=16) (never executed)
                 ->  Index Only Scan using obj_versions_id_cp_version on obj_versions m  (cost=0.84..41826.83 rows=530149 width=16) (never executed)
                       Index Cond: ((object_id = obj_versions.object_id) AND (cp_sequence_number <= 173859907))
                       Heap Fetches: 0
 Planning:
   Buffers: shared hit=5
 Planning Time: 0.172 ms
 Execution Time: 0.084 ms
(15 rows)
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
