### PR TITLE
[trace-view] Fixed parsing of manifest files and trace ingestion

### DIFF
--- a/external-crates/move/crates/move-analyzer/trace-adapter/package-lock.json
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/package-lock.json
@@ -8,6 +8,7 @@
       "name": "move-trace-adapter",
       "version": "0.0.1",
       "dependencies": {
+        "@iarna/toml": "^2.2.5",
         "fzstd": "^0.1.1",
         "lodash.snakecase": "^4.1.1"
       },
@@ -22,7 +23,6 @@
         "eslint": "^8.57.0",
         "line-diff": "^2.1.1",
         "mocha": "10.2.0",
-        "toml": "^3.0.0",
         "typescript": "^5.4.5"
       }
     },
@@ -160,6 +160,12 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true
+    },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "license": "ISC"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2068,12 +2074,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/toml": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
-      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
-      "dev": true
     },
     "node_modules/ts-api-utils": {
       "version": "1.3.0",

--- a/external-crates/move/crates/move-analyzer/trace-adapter/package.json
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/package.json
@@ -20,10 +20,10 @@
     "eslint": "^8.57.0",
     "line-diff": "^2.1.1",
     "mocha": "10.2.0",
-    "toml": "^3.0.0",
     "typescript": "^5.4.5"
   },
   "dependencies": {
+    "@iarna/toml": "^2.2.5",
     "fzstd": "^0.1.1",
     "lodash.snakecase": "^4.1.1"
   }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/runtime.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/runtime.ts
@@ -4,7 +4,7 @@
 import { EventEmitter } from 'events';
 import * as fs from 'fs';
 import * as path from 'path';
-import toml from 'toml';
+import toml from '@iarna/toml';
 import {
     createFileInfo,
     IFileInfo,
@@ -1776,7 +1776,7 @@ async function findPkgRoot(active_file_path: string): Promise<string | undefined
  */
 function getPkgNameFromManifest(pkgRoot: string): string | undefined {
     const manifest = fs.readFileSync(pkgRoot, 'utf8');
-    const parsedManifest = toml.parse(manifest);
+    const parsedManifest = toml.parse(manifest) as any;
     const packageName = parsedManifest.package.name;
     return packageName;
 }

--- a/external-crates/move/crates/move-analyzer/trace-adapter/src/trace_utils.ts
+++ b/external-crates/move/crates/move-analyzer/trace-adapter/src/trace_utils.ts
@@ -41,6 +41,7 @@ import {
     IDebugInfoFunction
 } from './debug_info_utils';
 import { decompress } from 'fzstd';
+import { logger } from '@vscode/debugadapter';
 
 
 // Data types corresponding to trace file JSON schema.
@@ -471,6 +472,35 @@ export const EXT_EVENT_FRAME_ID = Number.MAX_SAFE_INTEGER - 4;
 
 
 /**
+ * Splits decompressed trace file data into lines without creating a large intermediate string.
+ * This avoids hitting JavaScript's maximum string length limit for large trace files.
+ *
+ * @param decompressed the decompressed buffer containing trace data
+ * @returns array of strings representing lines from the trace file
+ */
+function splitTraceFileLines(decompressed: Uint8Array): string[] {
+    const NEWLINE_BYTE = 0x0A;
+    const decoder = new TextDecoder();
+    const lines: string[] = [];
+
+    let lineStart = 0;
+
+    for (let i = 0; i <= decompressed.length; i++) {
+        if (i === decompressed.length || decompressed[i] === NEWLINE_BYTE) {
+            // end of the buffer or a new line
+            if (i > lineStart) {
+                const lineBytes = decompressed.slice(lineStart, i);
+                const line = decoder.decode(lineBytes).trimEnd();
+                lines.push(line);
+            }
+            lineStart = i + 1;
+        }
+    }
+
+    return lines;
+}
+
+/**
  * Reads a Move VM execution trace from a JSON file.
  *
  * @param traceFilePath path to the trace JSON file.
@@ -491,7 +521,8 @@ export async function readTrace(
 ): Promise<ITrace> {
     const buf = Buffer.from(fs.readFileSync(traceFilePath));
     const decompressed = await decompress(buf);
-    const [header, ...rest] = new TextDecoder().decode(decompressed).trimEnd().split('\n');
+    const lines = splitTraceFileLines(decompressed);
+    const [header, ...rest] = lines;
     const jsonVersion: number = JSON.parse(header).version;
     const jsonEvents: JSONTraceEvent[] = rest.map((line) => {
         return JSON.parse(line);
@@ -571,6 +602,10 @@ export async function readTrace(
             }
             const srcFunEntry = debugInfo.functions.get(frame.function_name);
             if (!srcFunEntry) {
+                logger.log(`MODULE ${modInfo.name} FUNCTIONS`);
+                for (const [key, value] of debugInfo.functions) {
+                    logger.log(key);
+                }
                 throw new Error('Cannot find function entry in debug info for function '
                     + frame.function_name
                     + ' in module '

--- a/external-crates/move/crates/move-analyzer/trace-debug/package-lock.json
+++ b/external-crates/move/crates/move-analyzer/trace-debug/package-lock.json
@@ -1,20 +1,20 @@
 {
     "name": "move-trace-debug",
-    "version": "0.0.10",
+    "version": "0.0.12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "move-trace-debug",
-            "version": "0.0.10",
+            "version": "0.0.12",
             "license": "Apache-2.0",
             "dependencies": {
+                "@iarna/toml": "^2.2.5",
                 "@vscode/debugadapter": "^1.56.0",
                 "@vscode/debugadapter-testsupport": "^1.56.0",
                 "@vscode/debugprotocol": "1.66.0",
                 "fzstd": "^0.1.1",
-                "lodash.snakecase": "^4.1.1",
-                "toml": "^3.0.0"
+                "lodash.snakecase": "^4.1.1"
             },
             "devDependencies": {
                 "@types/lodash.snakecase": "^4.1.9",
@@ -163,6 +163,12 @@
             "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
             "deprecated": "Use @eslint/object-schema instead",
             "dev": true
+        },
+        "node_modules/@iarna/toml": {
+            "version": "2.2.5",
+            "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+            "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+            "license": "ISC"
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -1601,11 +1607,6 @@
             "engines": {
                 "node": ">=8.0"
             }
-        },
-        "node_modules/toml": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
-            "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
         },
         "node_modules/ts-api-utils": {
             "version": "1.3.0",

--- a/external-crates/move/crates/move-analyzer/trace-debug/package.json
+++ b/external-crates/move/crates/move-analyzer/trace-debug/package.json
@@ -5,7 +5,7 @@
     "publisher": "mysten",
     "icon": "images/move.png",
     "license": "Apache-2.0",
-    "version": "0.0.12",
+    "version": "0.0.14",
     "preview": true,
     "repository": {
         "url": "https://github.com/MystenLabs/sui.git",
@@ -162,12 +162,12 @@
         "prestart": "npm run compile; tsc -p ../trace-adapter; cp ../trace-adapter/out/*.* ./out/"
     },
     "dependencies": {
+        "@iarna/toml": "^2.2.5",
         "@vscode/debugadapter": "^1.56.0",
         "@vscode/debugadapter-testsupport": "^1.56.0",
         "@vscode/debugprotocol": "1.66.0",
         "fzstd": "^0.1.1",
-        "lodash.snakecase": "^4.1.1",
-        "toml": "^3.0.0"
+        "lodash.snakecase": "^4.1.1"
     },
     "devDependencies": {
         "@types/lodash.snakecase": "^4.1.9",


### PR DESCRIPTION
## Description 

This PR fixes two problems reported by early adopters:
- toml parser used in the previous version was incorrectly parsing some Move manifest files (we now use a more modern and compliant instead)
- reading a large trace into a string was previously violation JavaScript's max string size (we now read it directly into a string array)

## Test plan 

Manually tested that these fixes work. In particular a large trace generated by replaying the following transaction can now be trace-debugged correctly: CNiT7vcohmcLhCLKTTwLfiNDLsKLJCk2deCXph835fsf