### PR TITLE
Enable 50% TD through TO in simtests

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -621,13 +621,31 @@ impl ValidatorService {
             // Proceed with input checks to generate a proper error.
         }
 
-        state
-            .handle_vote_transaction(&epoch_store, transaction.clone())
-            .tap_err(|e| {
-                if let SuiError::ValidatorHaltedAtEpochEnd = e {
-                    metrics.num_rejected_tx_in_epoch_boundary.inc();
+        match state.handle_vote_transaction(&epoch_store, transaction.clone()) {
+            Ok(_) => { /* continue processing */ }
+            Err(e) => {
+                // It happens that while we are checking the validity of the transaction, it
+                // has just been executed.
+                // In that case, we could still return Ok to avoid showing confusing errors.
+                if let Some(effects) = self
+                    .state
+                    .get_transaction_cache_reader()
+                    .get_executed_effects(tx_digest)
+                {
+                    let effects_digest = effects.digest();
+                    if let Ok(executed_data) = self.complete_executed_data(effects, None).await {
+                        let executed_resp = SubmitTxResponse::Executed {
+                            effects_digest,
+                            details: Some(executed_data),
+                        };
+                        let executed_resp = executed_resp.try_into()?;
+                        return Ok((tonic::Response::new(executed_resp), Weight::zero()));
+                    }
                 }
-            })?;
+                // If not executed, return original error
+                return Err(e.into());
+            }
+        }
 
         let _latency_metric_guard = metrics
             .handle_submit_transaction_consensus_latency

--- a/crates/sui-core/src/transaction_driver/error.rs
+++ b/crates/sui-core/src/transaction_driver/error.rs
@@ -211,6 +211,18 @@ impl std::fmt::Display for AggregatedRequestErrors {
     }
 }
 
+// TODO(fastpath): This is a temporary fix to unify the error message between QD and TD.
+// Match special handling of UserInputError in sui-json-rpc/src/error.rs NonRecoverableTransactionError
+fn format_transaction_request_error(error: &TransactionRequestError) -> String {
+    match error {
+        TransactionRequestError::RejectedAtValidator(sui_error) => match sui_error {
+            SuiError::UserInputError { error: user_error } => user_error.to_string(),
+            _ => sui_error.to_string(),
+        },
+        _ => error.to_string(),
+    }
+}
+
 pub(crate) fn aggregate_request_errors(
     errors: Vec<(AuthorityName, StakeUnit, TransactionRequestError)>,
 ) -> AggregatedRequestErrors {
@@ -219,7 +231,7 @@ pub(crate) fn aggregate_request_errors(
 
     for (name, stake, error) in errors {
         total_stake += stake;
-        let key = error.to_string();
+        let key = format_transaction_request_error(&error);
         let entry = aggregated_errors.entry(key).or_default();
         entry.0.push(name);
         entry.1 += stake;

--- a/crates/sui-core/src/transaction_driver/mod.rs
+++ b/crates/sui-core/src/transaction_driver/mod.rs
@@ -193,9 +193,13 @@ where
 
 // Chooses the percentage of transactions to be driven by TransactionDriver.
 pub fn choose_transaction_driver_percentage() -> u8 {
-    // Currently, TD cannot work in non-test environments.
-    if std::env::var(sui_types::digests::SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE_ENV_VAR_NAME).is_ok() {
-        return 0;
+    // Currently, TD cannot work in mainnet.
+    if let Ok(chain) =
+        std::env::var(sui_types::digests::SUI_PROTOCOL_CONFIG_CHAIN_OVERRIDE_ENV_VAR_NAME)
+    {
+        if chain == "mainnet" {
+            return 0;
+        }
     }
 
     if let Ok(v) = std::env::var("TRANSACTION_DRIVER") {

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -316,7 +316,7 @@ where
                 // Execution result returned
                 execution_result = &mut execution_future => {
                     match execution_result {
-                        Err(QuorumDriverError::TransactionPendingExecution) => {
+                        Err(QuorumDriverError::PendingExecutionInTransactionOrchestrator) => {
                             debug!(
                                 ?tx_digest,
                                 "Transaction already being processed, disabling execution branch and waiting for local effects"
@@ -540,10 +540,10 @@ where
         if !is_new_transaction {
             debug!(
                 ?tx_digest,
-                "Transaction already in pending_tx_log, returning TransactionPendingExecution"
+                "Transaction already in pending_tx_log, returning PendingExecutionInTransactionOrchestrator"
             );
             // Return the special error to signal that we should wait for effects
-            return Err(QuorumDriverError::TransactionPendingExecution);
+            return Err(QuorumDriverError::PendingExecutionInTransactionOrchestrator);
         }
 
         debug!(

--- a/crates/sui-e2e-tests/tests/full_node_tests.rs
+++ b/crates/sui-e2e-tests/tests/full_node_tests.rs
@@ -10,6 +10,7 @@ use rand::rngs::OsRng;
 use std::path::PathBuf;
 use std::sync::Arc;
 use sui_config::node::RunWithRange;
+use sui_core::transaction_driver::QuorumTransactionResponse;
 use sui_json_rpc_types::{EventFilter, TransactionFilter};
 use sui_json_rpc_types::{
     EventPage, SuiEvent, SuiExecutionStatus, SuiTransactionBlockEffectsAPI,
@@ -35,9 +36,7 @@ use sui_types::message_envelope::Message;
 use sui_types::messages_grpc::TransactionInfoRequest;
 use sui_types::object::{Object, ObjectRead, Owner, PastObjectRead};
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use sui_types::quorum_driver_types::{
-    ExecuteTransactionRequestType, ExecuteTransactionRequestV3, QuorumDriverResponse,
-};
+use sui_types::quorum_driver_types::{ExecuteTransactionRequestType, ExecuteTransactionRequestV3};
 use sui_types::storage::ObjectStore;
 use sui_types::transaction::{
     CallArg, GasData, TransactionData, TransactionKind, TEST_ONLY_GAS_UNIT_FOR_OBJECT_BASICS,
@@ -748,8 +747,8 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
 
     let (
         tx,
-        QuorumDriverResponse {
-            effects_cert: certified_txn_effects,
+        QuorumTransactionResponse {
+            effects: finalized_effects,
             events: txn_events,
             ..
         },
@@ -758,7 +757,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     assert_eq!(*tx.digest(), digest);
     assert_eq!(
         response.effects.effects.digest(),
-        *certified_txn_effects.digest()
+        finalized_effects.effects.digest()
     );
     assert!(is_executed_locally);
     assert_eq!(
@@ -783,8 +782,8 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
 
     let (
         tx,
-        QuorumDriverResponse {
-            effects_cert: certified_txn_effects,
+        QuorumTransactionResponse {
+            effects: finalized_effects,
             events: txn_events,
             ..
         },
@@ -793,7 +792,7 @@ async fn test_full_node_transaction_orchestrator_basic() -> Result<(), anyhow::E
     assert_eq!(*tx.digest(), digest);
     assert_eq!(
         response.effects.effects.digest(),
-        *certified_txn_effects.digest()
+        finalized_effects.effects.digest()
     );
     assert_eq!(
         txn_events.unwrap_or_default().digest(),
@@ -1213,8 +1212,8 @@ async fn test_pass_back_no_object() -> Result<(), anyhow::Error> {
 
     let (
         _tx,
-        QuorumDriverResponse {
-            effects_cert: _certified_txn_effects,
+        QuorumTransactionResponse {
+            effects: _finalized_effects,
             events: _txn_events,
             ..
         },

--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -283,6 +283,14 @@ impl From<Error> for ErrorObjectOwned {
                             None::<()>,
                         )
                     }
+                    QuorumDriverError::TransactionPendingExecution => {
+                        // TODO(fastpath): Remove once traffic is 100% TD
+                        ErrorObject::owned(
+                            TRANSIENT_ERROR_CODE,
+                            "[MFP experimental]: Transaction already being processed (most likely by QD), wait for results",
+                            None::<()>,
+                        )
+                    }
                 }
             }
             _ => failed(e),

--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -283,11 +283,11 @@ impl From<Error> for ErrorObjectOwned {
                             None::<()>,
                         )
                     }
-                    QuorumDriverError::TransactionPendingExecution => {
+                    QuorumDriverError::PendingExecutionInTransactionOrchestrator => {
                         // TODO(fastpath): Remove once traffic is 100% TD
                         ErrorObject::owned(
                             TRANSIENT_ERROR_CODE,
-                            "[MFP experimental]: Transaction already being processed (most likely by QD), wait for results",
+                            "[MFP experimental]: Transaction already being processed in transaction orchestrator (most likely by quorum driver), wait for results",
                             None::<()>,
                         )
                     }

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -105,6 +105,7 @@ use sui_core::overload_monitor::overload_monitor;
 use sui_core::rpc_index::RpcIndexStore;
 use sui_core::signature_verifier::SignatureVerifierMetrics;
 use sui_core::storage::RocksDbStore;
+use sui_core::transaction_orchestrator::QuorumTransactionEffectsResult;
 use sui_core::transaction_orchestrator::TransactionOrchestrator;
 use sui_core::{
     authority::{AuthorityState, AuthorityStore},
@@ -138,7 +139,6 @@ use sui_types::error::{SuiError, SuiResult};
 use sui_types::messages_consensus::{
     check_total_jwk_size, AuthorityCapabilitiesV1, ConsensusTransaction,
 };
-use sui_types::quorum_driver_types::QuorumDriverEffectsQueueResult;
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemState;
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemStateTrait;
 use sui_types::sui_system_state::SuiSystemStateTrait;
@@ -1716,7 +1716,7 @@ impl SuiNode {
 
     pub fn subscribe_to_transaction_orchestrator_effects(
         &self,
-    ) -> Result<tokio::sync::broadcast::Receiver<QuorumDriverEffectsQueueResult>> {
+    ) -> Result<tokio::sync::broadcast::Receiver<QuorumTransactionEffectsResult>> {
         self.transaction_orchestrator
             .as_ref()
             .map(|to| to.subscribe_to_effects_queue())

--- a/crates/sui-rpc-api/src/error.rs
+++ b/crates/sui-rpc-api/src/error.rs
@@ -201,9 +201,9 @@ impl From<sui_types::quorum_driver_types::QuorumDriverError> for RpcError {
                 },
                 format!("[MFP experimental]: {details}"),
             ),
-            TransactionPendingExecution => RpcError::new(
+            PendingExecutionInTransactionOrchestrator => RpcError::new(
                 Code::AlreadyExists,
-                "Transaction is already being processed (most likely by QD), wait for results",
+                "Transaction is already being processed in transaction orchestrator (most likely by quorum driver), wait for results",
             ),
         }
     }

--- a/crates/sui-rpc-api/src/error.rs
+++ b/crates/sui-rpc-api/src/error.rs
@@ -201,6 +201,10 @@ impl From<sui_types::quorum_driver_types::QuorumDriverError> for RpcError {
                 },
                 format!("[MFP experimental]: {details}"),
             ),
+            TransactionPendingExecution => RpcError::new(
+                Code::AlreadyExists,
+                "Transaction is already being processed (most likely by QD), wait for results",
+            ),
         }
     }
 }

--- a/crates/sui-types/src/quorum_driver_types.rs
+++ b/crates/sui-types/src/quorum_driver_types.rs
@@ -65,8 +65,8 @@ pub enum QuorumDriverError {
     #[error("Transaction processing failed. Retriable with new attempts: {retriable}. Details: {details}")]
     TransactionFailed { retriable: bool, details: String },
 
-    #[error("Transaction is already being processed (most likely by QD), wait for results")]
-    TransactionPendingExecution,
+    #[error("Transaction is already being processed in transaction orchestrator (most likely by quorum driver), wait for results")]
+    PendingExecutionInTransactionOrchestrator,
 }
 
 pub type GroupedErrors = Vec<(SuiError, StakeUnit, Vec<ConciseAuthorityPublicKeyBytes>)>;

--- a/crates/sui-types/src/quorum_driver_types.rs
+++ b/crates/sui-types/src/quorum_driver_types.rs
@@ -64,6 +64,9 @@ pub enum QuorumDriverError {
     // Wrapped error from Transaction Driver.
     #[error("Transaction processing failed. Retriable with new attempts: {retriable}. Details: {details}")]
     TransactionFailed { retriable: bool, details: String },
+
+    #[error("Transaction is already being processed (most likely by QD), wait for results")]
+    TransactionPendingExecution,
 }
 
 pub type GroupedErrors = Vec<(SuiError, StakeUnit, Vec<ConciseAuthorityPublicKeyBytes>)>;


### PR DESCRIPTION
Additional changes
- Check for effects after handle_vote_transaction failures
- Add both TD & QD to subscription stream provided by TO
- Dedupe tx submitted by either TD or QD

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
