### PR TITLE
[Cherrypick] Do not inject simulated execution latency by default

### DIFF
--- a/crates/sui-benchmark/tests/simtest.rs
+++ b/crates/sui-benchmark/tests/simtest.rs
@@ -1056,10 +1056,12 @@ mod test {
         default_num_validators: usize,
         default_epoch_duration_ms: u64,
     ) -> TestClusterBuilder {
-        let mut builder = TestClusterBuilder::new().with_num_validators(get_var(
-            "SIM_STRESS_TEST_NUM_VALIDATORS",
-            default_num_validators,
-        ));
+        let mut builder = TestClusterBuilder::new()
+            .with_num_validators(get_var(
+                "SIM_STRESS_TEST_NUM_VALIDATORS",
+                default_num_validators,
+            ))
+            .with_synthetic_execution_time_injection();
         if std::env::var("CHECKPOINTS_PER_EPOCH").is_ok() {
             eprintln!("CHECKPOINTS_PER_EPOCH env var is deprecated, use EPOCH_DURATION_MS");
         }

--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -291,6 +291,14 @@ pub struct ExecutionTimeObserverConfig {
     ///
     /// If unspecified, this will default to `20`.
     pub weighted_moving_average_window_size: Option<usize>,
+
+    /// Whether to inject synthetic execution time for testing in simtest.
+    /// When enabled, synthetic timings will be generated for execution time observations
+    /// to enable deterministic testing of congestion control features.
+    ///
+    /// If unspecified, this will default to `false`.
+    #[cfg(msim)]
+    pub inject_synthetic_execution_time: Option<bool>,
 }
 
 impl ExecutionTimeObserverConfig {
@@ -348,6 +356,11 @@ impl ExecutionTimeObserverConfig {
 
     pub fn weighted_moving_average_window_size(&self) -> usize {
         self.weighted_moving_average_window_size.unwrap_or(20)
+    }
+
+    #[cfg(msim)]
+    pub fn inject_synthetic_execution_time(&self) -> bool {
+        self.inject_synthetic_execution_time.unwrap_or(false)
     }
 }
 


### PR DESCRIPTION
[Cherrypick] Do not inject simulated execution latency by default

Cherry-picking commit eecbb502a64daf708c8c086e6a797e5811c3e7d4 from main branch.

Original PR: #22978

This cherry-pick brings the fix to the 1.53 release branch.