### PR TITLE
[graphql-alt] Support EndOfEpoch-ChangeEpochTransaction kind for TransactionKind [6/n]

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.move
@@ -1,0 +1,41 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --simulator
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  # Test finding EndOfEpochTransaction in recent transactions
+  recentTransactions: transactions(last: 1) {
+    nodes {
+      digest
+      kind {
+        __typename
+        ... on EndOfEpochTransaction {
+          transactions {
+            nodes {
+              __typename
+              ... on ChangeEpochTransaction {
+                epoch {
+                  epochId
+                }
+                protocolConfigs {
+                  protocolVersion
+                }
+                storageCharge
+                computationCharge
+                storageRebate
+                nonRefundableStorageFee
+                epochStartTimestamp
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.snap
@@ -1,0 +1,47 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+task 1, line 6:
+//# advance-epoch
+Epoch advanced: 1
+
+task 2, line 8:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 3, lines 10-41:
+//# run-graphql
+Response: {
+  "data": {
+    "recentTransactions": {
+      "nodes": [
+        {
+          "digest": "REZjsEkDFhaJ8jE4tJKn7JE8VxtATeZMYMY7bkcLv8f",
+          "kind": {
+            "__typename": "EndOfEpochTransaction",
+            "transactions": {
+              "nodes": [
+                {
+                  "__typename": "ChangeEpochTransaction",
+                  "epoch": {
+                    "epochId": 1
+                  },
+                  "protocolConfigs": {
+                    "protocolVersion": 70
+                  },
+                  "storageCharge": 0,
+                  "computationCharge": 0,
+                  "storageRebate": 0,
+                  "nonRefundableStorageFee": 0,
+                  "epochStartTimestamp": "1970-01-01T00:00:00Z"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -301,7 +301,7 @@ System transaction that supersedes `ChangeEpochTransaction` as the new way to ru
 """
 type EndOfEpochTransaction {
 	"""
-	The list of system transactions that are allowed to run at the end of the epoch.
+	The list of system transactions that did run at the end of the epoch.
 	"""
 	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
 }

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -297,6 +297,47 @@ ISO-8601 Date and Time: RFC3339 in UTC with format: YYYY-MM-DDTHH:MM:SS.mmmZ. No
 scalar DateTime
 
 """
+System transaction that supersedes `ChangeEpochTransaction` as the new way to run transactions at the end of an epoch. Behaves similarly to `ChangeEpochTransaction` but can accommodate other optional transactions to run at the end of the epoch.
+"""
+type EndOfEpochTransaction {
+	"""
+	The list of system transactions that are allowed to run at the end of the epoch.
+	"""
+	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
+}
+
+union EndOfEpochTransactionKind = ChangeEpochTransaction
+
+type EndOfEpochTransactionKindConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [EndOfEpochTransactionKindEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [EndOfEpochTransactionKind!]!
+}
+
+"""
+An edge in a connection.
+"""
+type EndOfEpochTransactionKindEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: EndOfEpochTransactionKind!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
 Activity on Sui is partitioned in time, into epochs.
 
 Epoch changes are opportunities for the network to reconfigure itself (perform protocol or system package upgrades, or change the committee) and distribute staking rewards. The network aims to keep epochs roughly the same duration as each other.
@@ -1466,7 +1507,7 @@ input TransactionFilter {
 """
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction | EndOfEpochTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/end_of_epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/end_of_epoch.rs
@@ -1,0 +1,78 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::{connection::Connection, *};
+use sui_types::transaction::EndOfEpochTransactionKind as NativeEndOfEpochTransactionKind;
+
+use crate::{
+    api::{
+        scalars::cursor::JsonCursor, types::transaction_kind::change_epoch::ChangeEpochTransaction,
+    },
+    error::RpcError,
+    pagination::{Page, PaginationConfig},
+    scope::Scope,
+};
+
+type CTransaction = JsonCursor<usize>;
+
+#[derive(Clone)]
+pub struct EndOfEpochTransaction {
+    pub native: Vec<NativeEndOfEpochTransactionKind>,
+    pub scope: Scope,
+}
+
+#[derive(Union, Clone)]
+pub enum EndOfEpochTransactionKind {
+    ChangeEpoch(ChangeEpochTransaction),
+    // TODO: Add more transaction types incrementally
+}
+
+/// System transaction that supersedes `ChangeEpochTransaction` as the new way to run transactions at the end of an epoch. Behaves similarly to `ChangeEpochTransaction` but can accommodate other optional transactions to run at the end of the epoch.
+#[Object]
+impl EndOfEpochTransaction {
+    /// The list of system transactions that are allowed to run at the end of the epoch.
+    async fn transactions(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<CTransaction>,
+        last: Option<u64>,
+        before: Option<CTransaction>,
+    ) -> Result<Connection<String, EndOfEpochTransactionKind>, RpcError> {
+        let pagination: &PaginationConfig = ctx.data()?;
+        let limits = pagination.limits("EndOfEpochTransaction", "transactions");
+        let page = Page::from_params(limits, first, after, last, before)?;
+
+        let cursors = page.paginate_indices(self.native.len());
+        let mut conn = Connection::new(cursors.has_previous_page, cursors.has_next_page);
+
+        for edge in cursors.edges {
+            if let Some(tx_kind) = EndOfEpochTransactionKind::from(
+                self.native[*edge.cursor].clone(),
+                self.scope.clone(),
+            ) {
+                conn.edges.push(async_graphql::connection::Edge::new(
+                    edge.cursor.to_string(),
+                    tx_kind,
+                ));
+            }
+        }
+
+        Ok(conn)
+    }
+}
+
+impl EndOfEpochTransactionKind {
+    pub fn from(kind: NativeEndOfEpochTransactionKind, scope: Scope) -> Option<Self> {
+        use EndOfEpochTransactionKind as K;
+        use NativeEndOfEpochTransactionKind as N;
+
+        match kind {
+            N::ChangeEpoch(ce) => {
+                Some(K::ChangeEpoch(ChangeEpochTransaction { native: ce, scope }))
+            }
+            // TODO: Handle other transaction types incrementally
+            _ => None,
+        }
+    }
+}

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/end_of_epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/end_of_epoch.rs
@@ -30,7 +30,7 @@ pub enum EndOfEpochTransactionKind {
 /// System transaction that supersedes `ChangeEpochTransaction` as the new way to run transactions at the end of an epoch. Behaves similarly to `ChangeEpochTransaction` but can accommodate other optional transactions to run at the end of the epoch.
 #[Object]
 impl EndOfEpochTransaction {
-    /// The list of system transactions that are allowed to run at the end of the epoch.
+    /// The list of system transactions that did run at the end of the epoch.
     async fn transactions(
         &self,
         ctx: &Context<'_>,

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/mod.rs
@@ -9,13 +9,15 @@ use crate::scope::Scope;
 use self::{
     authenticator_state_update::AuthenticatorStateUpdateTransaction,
     change_epoch::ChangeEpochTransaction,
-    consensus_commit_prologue::ConsensusCommitPrologueTransaction, genesis::GenesisTransaction,
+    consensus_commit_prologue::ConsensusCommitPrologueTransaction,
+    end_of_epoch::EndOfEpochTransaction, genesis::GenesisTransaction,
     randomness_state_update::RandomnessStateUpdateTransaction,
 };
 
 pub(crate) mod authenticator_state_update;
 pub(crate) mod change_epoch;
 pub(crate) mod consensus_commit_prologue;
+pub(crate) mod end_of_epoch;
 pub(crate) mod genesis;
 pub(crate) mod randomness_state_update;
 
@@ -27,6 +29,7 @@ pub enum TransactionKind {
     ChangeEpoch(ChangeEpochTransaction),
     RandomnessStateUpdate(RandomnessStateUpdateTransaction),
     AuthenticatorStateUpdate(AuthenticatorStateUpdateTransaction),
+    EndOfEpoch(EndOfEpochTransaction),
 }
 
 impl TransactionKind {
@@ -59,6 +62,9 @@ impl TransactionKind {
             K::AuthenticatorStateUpdate(asu) => Some(T::AuthenticatorStateUpdate(
                 AuthenticatorStateUpdateTransaction { native: asu, scope },
             )),
+            K::EndOfEpochTransaction(eoe) => {
+                Some(T::EndOfEpoch(EndOfEpochTransaction { native: eoe, scope }))
+            }
             // Other types will return None for now
             _ => None,
         }

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -301,6 +301,47 @@ ISO-8601 Date and Time: RFC3339 in UTC with format: YYYY-MM-DDTHH:MM:SS.mmmZ. No
 scalar DateTime
 
 """
+System transaction that supersedes `ChangeEpochTransaction` as the new way to run transactions at the end of an epoch. Behaves similarly to `ChangeEpochTransaction` but can accommodate other optional transactions to run at the end of the epoch.
+"""
+type EndOfEpochTransaction {
+	"""
+	The list of system transactions that are allowed to run at the end of the epoch.
+	"""
+	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
+}
+
+union EndOfEpochTransactionKind = ChangeEpochTransaction
+
+type EndOfEpochTransactionKindConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [EndOfEpochTransactionKindEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [EndOfEpochTransactionKind!]!
+}
+
+"""
+An edge in a connection.
+"""
+type EndOfEpochTransactionKindEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: EndOfEpochTransactionKind!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
 Activity on Sui is partitioned in time, into epochs.
 
 Epoch changes are opportunities for the network to reconfigure itself (perform protocol or system package upgrades, or change the committee) and distribute staking rewards. The network aims to keep epochs roughly the same duration as each other.
@@ -1470,7 +1511,7 @@ input TransactionFilter {
 """
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction | EndOfEpochTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -305,7 +305,7 @@ System transaction that supersedes `ChangeEpochTransaction` as the new way to ru
 """
 type EndOfEpochTransaction {
 	"""
-	The list of system transactions that are allowed to run at the end of the epoch.
+	The list of system transactions that did run at the end of the epoch.
 	"""
 	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
 }

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -301,6 +301,47 @@ ISO-8601 Date and Time: RFC3339 in UTC with format: YYYY-MM-DDTHH:MM:SS.mmmZ. No
 scalar DateTime
 
 """
+System transaction that supersedes `ChangeEpochTransaction` as the new way to run transactions at the end of an epoch. Behaves similarly to `ChangeEpochTransaction` but can accommodate other optional transactions to run at the end of the epoch.
+"""
+type EndOfEpochTransaction {
+	"""
+	The list of system transactions that are allowed to run at the end of the epoch.
+	"""
+	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
+}
+
+union EndOfEpochTransactionKind = ChangeEpochTransaction
+
+type EndOfEpochTransactionKindConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [EndOfEpochTransactionKindEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [EndOfEpochTransactionKind!]!
+}
+
+"""
+An edge in a connection.
+"""
+type EndOfEpochTransactionKindEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: EndOfEpochTransactionKind!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
 Activity on Sui is partitioned in time, into epochs.
 
 Epoch changes are opportunities for the network to reconfigure itself (perform protocol or system package upgrades, or change the committee) and distribute staking rewards. The network aims to keep epochs roughly the same duration as each other.
@@ -1470,7 +1511,7 @@ input TransactionFilter {
 """
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction | EndOfEpochTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -305,7 +305,7 @@ System transaction that supersedes `ChangeEpochTransaction` as the new way to ru
 """
 type EndOfEpochTransaction {
 	"""
-	The list of system transactions that are allowed to run at the end of the epoch.
+	The list of system transactions that did run at the end of the epoch.
 	"""
 	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
 }

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -301,7 +301,7 @@ System transaction that supersedes `ChangeEpochTransaction` as the new way to ru
 """
 type EndOfEpochTransaction {
 	"""
-	The list of system transactions that are allowed to run at the end of the epoch.
+	The list of system transactions that did run at the end of the epoch.
 	"""
 	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
 }

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -297,6 +297,47 @@ ISO-8601 Date and Time: RFC3339 in UTC with format: YYYY-MM-DDTHH:MM:SS.mmmZ. No
 scalar DateTime
 
 """
+System transaction that supersedes `ChangeEpochTransaction` as the new way to run transactions at the end of an epoch. Behaves similarly to `ChangeEpochTransaction` but can accommodate other optional transactions to run at the end of the epoch.
+"""
+type EndOfEpochTransaction {
+	"""
+	The list of system transactions that are allowed to run at the end of the epoch.
+	"""
+	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
+}
+
+union EndOfEpochTransactionKind = ChangeEpochTransaction
+
+type EndOfEpochTransactionKindConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [EndOfEpochTransactionKindEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [EndOfEpochTransactionKind!]!
+}
+
+"""
+An edge in a connection.
+"""
+type EndOfEpochTransactionKindEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: EndOfEpochTransactionKind!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
 Activity on Sui is partitioned in time, into epochs.
 
 Epoch changes are opportunities for the network to reconfigure itself (perform protocol or system package upgrades, or change the committee) and distribute staking rewards. The network aims to keep epochs roughly the same duration as each other.
@@ -1466,7 +1507,7 @@ input TransactionFilter {
 """
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction | EndOfEpochTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.


### PR DESCRIPTION
## Description 

Adding the new `EndOfEpochTransaction` as a new enum field within `TransactionKind` union.

The new schema is on par with old GraphQL schema:
https://github.com/MystenLabs/sui/blob/b8d28ddbd06253373d2c02d001b3ba6c1ce8ea4f/crates/sui-graphql-rpc/schema.graphql#L1042-L1047

This PR only supports the enum `ChangeEpochTransaction`. Other types will be added in upcoming PRs

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-graphql
cargo nextest run -p sui-indexer-alt-reader
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

---

## Stack
- #22652 
- #22718 
- #22788 
- #22943
- #22950
- #22953
- #22955 
- #22972 
- #22989 ⬅️

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
