### PR TITLE
[graphql-alt] Support EndOfEpoch-BridgeState kind for TransactionKind [8/n]

### DIFF
--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -256,7 +256,12 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
     ///
     /// NOTE: This function does not currently support updating the protocol version or the system
     /// packages
-    pub fn advance_epoch(&mut self, create_random_state: bool) {
+    pub fn advance_epoch(
+        &mut self,
+        create_random_state: bool,
+        create_authenticator_state: bool,
+        create_deny_list_state: bool,
+    ) {
         let next_epoch = self.epoch_state.epoch() + 1;
         let next_epoch_protocol_version = self.epoch_state.protocol_version();
         let gas_cost_summary = self.checkpoint_builder.epoch_rolling_gas_cost_summary();
@@ -267,6 +272,14 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
 
         if create_random_state {
             kinds.push(EndOfEpochTransactionKind::new_randomness_state_create());
+        }
+
+        if create_authenticator_state {
+            kinds.push(EndOfEpochTransactionKind::new_authenticator_state_create());
+        }
+
+        if create_deny_list_state {
+            kinds.push(EndOfEpochTransactionKind::new_deny_list_state_create());
         }
 
         kinds.push(EndOfEpochTransactionKind::new_change_epoch(
@@ -720,7 +733,10 @@ mod tests {
 
         let start_epoch = chain.store.get_highest_checkpint().unwrap().epoch;
         for i in 0..steps {
-            chain.advance_epoch(/* create_random_state */ false);
+            chain.advance_epoch(
+                /* create_random_state */ false, /* create_authenticator_state */ false,
+                /* create_deny_list_state */ false,
+            );
             chain.advance_clock(Duration::from_millis(1));
             chain.create_checkpoint();
             println!("{i}");

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -239,7 +239,7 @@ pub async fn prep_executor_cluster() -> ExecutorCluster {
     sim.create_checkpoint();
     sim.create_checkpoint();
     sim.create_checkpoint();
-    sim.advance_epoch(true);
+    sim.advance_epoch(true, false, false);
     sim.create_checkpoint();
     sim.advance_clock(
         std::time::SystemTime::now()

--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -239,7 +239,7 @@ pub async fn prep_executor_cluster() -> ExecutorCluster {
     sim.create_checkpoint();
     sim.create_checkpoint();
     sim.create_checkpoint();
-    sim.advance_epoch(true, false, false);
+    sim.advance_epoch(true, false, false, false);
     sim.create_checkpoint();
     sim.advance_clock(
         std::time::SystemTime::now()

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.move
@@ -3,14 +3,14 @@
 
 //# init --protocol-version 70 --simulator
 
-//# advance-epoch
+//# advance-epoch --create-random-state --create-authenticator-state --create-deny-list-state
 
 //# create-checkpoint
 
 //# run-graphql
 {
-  # Test finding EndOfEpochTransaction in recent transactions
-  recentTransactions: transactions(last: 1) {
+  # Test EndOfEpochTransaction with multiple transaction types
+  endOfEpochTransaction: transactions(last: 1) {
     nodes {
       digest
       kind {
@@ -31,6 +31,15 @@
                 storageRebate
                 nonRefundableStorageFee
                 epochStartTimestamp
+              }
+              ... on RandomnessStateCreateTransaction {
+                _
+              }
+              ... on AuthenticatorStateCreateTransaction {
+                _
+              }
+              ... on CoinDenyListStateCreateTransaction {
+                _
               }
             }
           }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.move
@@ -3,7 +3,7 @@
 
 //# init --protocol-version 70 --simulator
 
-//# advance-epoch --create-random-state --create-authenticator-state --create-deny-list-state
+//# advance-epoch --create-random-state --create-authenticator-state --create-deny-list-state --create-bridge-state
 
 //# create-checkpoint
 
@@ -40,6 +40,9 @@
               }
               ... on CoinDenyListStateCreateTransaction {
                 _
+              }
+              ... on BridgeStateCreateTransaction {
+                chainIdentifier
               }
             }
           }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.move
@@ -1,0 +1,41 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --simulator
+
+//# advance-epoch
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  # Test finding EndOfEpochTransaction in recent transactions
+  recentTransactions: transactions(last: 1) {
+    nodes {
+      digest
+      kind {
+        __typename
+        ... on EndOfEpochTransaction {
+          transactions {
+            nodes {
+              __typename
+              ... on ChangeEpochTransaction {
+                epoch {
+                  epochId
+                }
+                protocolConfigs {
+                  protocolVersion
+                }
+                storageCharge
+                computationCharge
+                storageRebate
+                nonRefundableStorageFee
+                epochStartTimestamp
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.snap
@@ -4,25 +4,37 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 processed 4 tasks
 
 task 1, line 6:
-//# advance-epoch
+//# advance-epoch --create-random-state --create-authenticator-state --create-deny-list-state
 Epoch advanced: 1
 
 task 2, line 8:
 //# create-checkpoint
 Checkpoint created: 2
 
-task 3, lines 10-41:
+task 3, lines 10-50:
 //# run-graphql
 Response: {
   "data": {
-    "recentTransactions": {
+    "endOfEpochTransaction": {
       "nodes": [
         {
-          "digest": "REZjsEkDFhaJ8jE4tJKn7JE8VxtATeZMYMY7bkcLv8f",
+          "digest": "EJ9xXBeLaq56gu3MrEh4dY5F49gRaVUrc7NVZtkhjbLi",
           "kind": {
             "__typename": "EndOfEpochTransaction",
             "transactions": {
               "nodes": [
+                {
+                  "__typename": "RandomnessStateCreateTransaction",
+                  "_": null
+                },
+                {
+                  "__typename": "AuthenticatorStateCreateTransaction",
+                  "_": null
+                },
+                {
+                  "__typename": "CoinDenyListStateCreateTransaction",
+                  "_": null
+                },
                 {
                   "__typename": "ChangeEpochTransaction",
                   "epoch": {

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.snap
@@ -4,21 +4,21 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 processed 4 tasks
 
 task 1, line 6:
-//# advance-epoch --create-random-state --create-authenticator-state --create-deny-list-state
+//# advance-epoch --create-random-state --create-authenticator-state --create-deny-list-state --create-bridge-state
 Epoch advanced: 1
 
 task 2, line 8:
 //# create-checkpoint
 Checkpoint created: 2
 
-task 3, lines 10-50:
+task 3, lines 10-53:
 //# run-graphql
 Response: {
   "data": {
     "endOfEpochTransaction": {
       "nodes": [
         {
-          "digest": "EJ9xXBeLaq56gu3MrEh4dY5F49gRaVUrc7NVZtkhjbLi",
+          "digest": "HbgooKodztrd2bWKVgBrJL68pvEew5hjd14W5vfV18Lq",
           "kind": {
             "__typename": "EndOfEpochTransaction",
             "transactions": {
@@ -34,6 +34,10 @@ Response: {
                 {
                   "__typename": "CoinDenyListStateCreateTransaction",
                   "_": null
+                },
+                {
+                  "__typename": "BridgeStateCreateTransaction",
+                  "chainIdentifier": "00000000"
                 },
                 {
                   "__typename": "ChangeEpochTransaction",

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.snap
@@ -1,0 +1,47 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+task 1, line 6:
+//# advance-epoch
+Epoch advanced: 1
+
+task 2, line 8:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 3, lines 10-41:
+//# run-graphql
+Response: {
+  "data": {
+    "recentTransactions": {
+      "nodes": [
+        {
+          "digest": "REZjsEkDFhaJ8jE4tJKn7JE8VxtATeZMYMY7bkcLv8f",
+          "kind": {
+            "__typename": "EndOfEpochTransaction",
+            "transactions": {
+              "nodes": [
+                {
+                  "__typename": "ChangeEpochTransaction",
+                  "epoch": {
+                    "epochId": 1
+                  },
+                  "protocolConfigs": {
+                    "protocolVersion": 70
+                  },
+                  "storageCharge": 0,
+                  "computationCharge": 0,
+                  "storageRebate": 0,
+                  "nonRefundableStorageFee": 0,
+                  "epochStartTimestamp": "1970-01-01T00:00:00Z"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -297,6 +297,47 @@ ISO-8601 Date and Time: RFC3339 in UTC with format: YYYY-MM-DDTHH:MM:SS.mmmZ. No
 scalar DateTime
 
 """
+System transaction that supersedes `ChangeEpochTransaction` as the new way to run transactions at the end of an epoch. Behaves similarly to `ChangeEpochTransaction` but can accommodate other optional transactions to run at the end of the epoch.
+"""
+type EndOfEpochTransaction {
+	"""
+	The list of system transactions that are allowed to run at the end of the epoch.
+	"""
+	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
+}
+
+union EndOfEpochTransactionKind = ChangeEpochTransaction
+
+type EndOfEpochTransactionKindConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [EndOfEpochTransactionKindEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [EndOfEpochTransactionKind!]!
+}
+
+"""
+An edge in a connection.
+"""
+type EndOfEpochTransactionKindEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: EndOfEpochTransactionKind!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
 Activity on Sui is partitioned in time, into epochs.
 
 Epoch changes are opportunities for the network to reconfigure itself (perform protocol or system package upgrades, or change the committee) and distribute staking rewards. The network aims to keep epochs roughly the same duration as each other.
@@ -1466,7 +1507,7 @@ input TransactionFilter {
 """
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction | EndOfEpochTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -163,6 +163,16 @@ scalar BigInt
 
 
 """
+System transaction for creating bridge state for cross-chain operations.
+"""
+type BridgeStateCreateTransaction {
+	"""
+	The chain identifier for which this bridge state is being created.
+	"""
+	chainIdentifier: String
+}
+
+"""
 A system transaction that updates epoch information on-chain (increments the current epoch). Executed by the system once per epoch, without using gas. Epoch change transactions cannot be submitted by users, because validators will refuse to sign them.
 
 This transaction kind is deprecated in favour of `EndOfEpochTransaction`.
@@ -336,7 +346,7 @@ type EndOfEpochTransaction {
 	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
 }
 
-union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | RandomnessStateCreateTransaction | CoinDenyListStateCreateTransaction | StoreExecutionTimeObservationsTransaction | AccumulatorRootCreateTransaction
+union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | RandomnessStateCreateTransaction | CoinDenyListStateCreateTransaction | StoreExecutionTimeObservationsTransaction | BridgeStateCreateTransaction | AccumulatorRootCreateTransaction
 
 type EndOfEpochTransactionKindConnection {
 	"""

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -1,3 +1,13 @@
+"""
+System transaction for creating the accumulator root.
+"""
+type AccumulatorRootCreateTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
+}
+
 type ActiveJwk {
 	"""
 	The string (Issuing Authority) that identifies the OIDC provider.
@@ -63,6 +73,16 @@ type Address implements IAddressable {
 	The Address' identifier, a 32-byte number represented as a 64-character hex string, with a lead "0x".
 	"""
 	address: SuiAddress!
+}
+
+"""
+System transaction for creating the on-chain state used by zkLogin.
+"""
+type AuthenticatorStateCreateTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
 }
 
 type AuthenticatorStateUpdateTransaction {
@@ -248,6 +268,16 @@ input CheckpointFilter {
 }
 
 """
+System transaction for creating the coin deny list state.
+"""
+type CoinDenyListStateCreateTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
+}
+
+"""
 System transaction that runs at the beginning of a checkpoint, and is responsible for setting the current value of the clock, based on the timestamp from consensus.
 """
 type ConsensusCommitPrologueTransaction {
@@ -306,7 +336,7 @@ type EndOfEpochTransaction {
 	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
 }
 
-union EndOfEpochTransactionKind = ChangeEpochTransaction
+union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | RandomnessStateCreateTransaction | CoinDenyListStateCreateTransaction | StoreExecutionTimeObservationsTransaction | AccumulatorRootCreateTransaction
 
 type EndOfEpochTransactionKindConnection {
 	"""
@@ -1138,6 +1168,16 @@ type Query {
 }
 
 """
+System transaction for creating the on-chain randomness state.
+"""
+type RandomnessStateCreateTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
+}
+
+"""
 System transaction to update the source of on-chain randomness.
 """
 type RandomnessStateUpdateTransaction {
@@ -1312,6 +1352,16 @@ type StorageFund {
 	The system maintains an invariant that the sum of all storage fees into the storage fund is equal to the sum of all storage rebates out, the total storage rebates remaining, and the non-refundable balance.
 	"""
 	nonRefundableBalance: BigInt
+}
+
+"""
+System transaction for storing execution time observations.
+"""
+type StoreExecutionTimeObservationsTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
 }
 
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/end_of_epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/end_of_epoch.rs
@@ -24,7 +24,52 @@ pub struct EndOfEpochTransaction {
 #[derive(Union, Clone)]
 pub enum EndOfEpochTransactionKind {
     ChangeEpoch(ChangeEpochTransaction),
-    // TODO: Add more transaction types incrementally
+    AuthenticatorStateCreate(AuthenticatorStateCreateTransaction),
+    RandomnessStateCreate(RandomnessStateCreateTransaction),
+    CoinDenyListStateCreate(CoinDenyListStateCreateTransaction),
+    StoreExecutionTimeObservations(StoreExecutionTimeObservationsTransaction),
+    AccumulatorRootCreate(AccumulatorRootCreateTransaction),
+    // TODO: Add more complex transaction types incrementally
+}
+
+/// System transaction for creating the on-chain state used by zkLogin.
+#[derive(SimpleObject, Clone)]
+pub struct AuthenticatorStateCreateTransaction {
+    /// A workaround to define an empty variant of a GraphQL union.
+    #[graphql(name = "_")]
+    dummy: Option<bool>,
+}
+
+/// System transaction for creating the on-chain randomness state.
+#[derive(SimpleObject, Clone)]
+pub struct RandomnessStateCreateTransaction {
+    /// A workaround to define an empty variant of a GraphQL union.
+    #[graphql(name = "_")]
+    dummy: Option<bool>,
+}
+
+/// System transaction for creating the coin deny list state.
+#[derive(SimpleObject, Clone)]
+pub struct CoinDenyListStateCreateTransaction {
+    /// A workaround to define an empty variant of a GraphQL union.
+    #[graphql(name = "_")]
+    dummy: Option<bool>,
+}
+
+/// System transaction for storing execution time observations.
+#[derive(SimpleObject, Clone)]
+pub struct StoreExecutionTimeObservationsTransaction {
+    /// A workaround to define an empty variant of a GraphQL union.
+    #[graphql(name = "_")]
+    dummy: Option<bool>,
+}
+
+/// System transaction for creating the accumulator root.
+#[derive(SimpleObject, Clone)]
+pub struct AccumulatorRootCreateTransaction {
+    /// A workaround to define an empty variant of a GraphQL union.
+    #[graphql(name = "_")]
+    dummy: Option<bool>,
 }
 
 /// System transaction that supersedes `ChangeEpochTransaction` as the new way to run transactions at the end of an epoch. Behaves similarly to `ChangeEpochTransaction` but can accommodate other optional transactions to run at the end of the epoch.
@@ -71,7 +116,26 @@ impl EndOfEpochTransactionKind {
             N::ChangeEpoch(ce) => {
                 Some(K::ChangeEpoch(ChangeEpochTransaction { native: ce, scope }))
             }
-            // TODO: Handle other transaction types incrementally
+            N::AuthenticatorStateCreate => Some(K::AuthenticatorStateCreate(
+                AuthenticatorStateCreateTransaction { dummy: None },
+            )),
+            N::RandomnessStateCreate => {
+                Some(K::RandomnessStateCreate(RandomnessStateCreateTransaction {
+                    dummy: None,
+                }))
+            }
+            N::DenyListStateCreate => Some(K::CoinDenyListStateCreate(
+                CoinDenyListStateCreateTransaction { dummy: None },
+            )),
+            N::StoreExecutionTimeObservations(_) => Some(K::StoreExecutionTimeObservations(
+                StoreExecutionTimeObservationsTransaction { dummy: None },
+            )),
+            N::AccumulatorRootCreate => {
+                Some(K::AccumulatorRootCreate(AccumulatorRootCreateTransaction {
+                    dummy: None,
+                }))
+            }
+            // TODO: Handle more complex transaction types incrementally
             _ => None,
         }
     }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/end_of_epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/end_of_epoch.rs
@@ -1,0 +1,78 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::{connection::Connection, *};
+use sui_types::transaction::EndOfEpochTransactionKind as NativeEndOfEpochTransactionKind;
+
+use crate::{
+    api::{
+        scalars::cursor::JsonCursor, types::transaction_kind::change_epoch::ChangeEpochTransaction,
+    },
+    error::RpcError,
+    pagination::{Page, PaginationConfig},
+    scope::Scope,
+};
+
+type CTransaction = JsonCursor<usize>;
+
+#[derive(Clone)]
+pub struct EndOfEpochTransaction {
+    pub native: Vec<NativeEndOfEpochTransactionKind>,
+    pub scope: Scope,
+}
+
+#[derive(Union, Clone)]
+pub enum EndOfEpochTransactionKind {
+    ChangeEpoch(ChangeEpochTransaction),
+    // TODO: Add more transaction types incrementally
+}
+
+/// System transaction that supersedes `ChangeEpochTransaction` as the new way to run transactions at the end of an epoch. Behaves similarly to `ChangeEpochTransaction` but can accommodate other optional transactions to run at the end of the epoch.
+#[Object]
+impl EndOfEpochTransaction {
+    /// The list of system transactions that are allowed to run at the end of the epoch.
+    async fn transactions(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<CTransaction>,
+        last: Option<u64>,
+        before: Option<CTransaction>,
+    ) -> Result<Connection<String, EndOfEpochTransactionKind>, RpcError> {
+        let pagination: &PaginationConfig = ctx.data()?;
+        let limits = pagination.limits("EndOfEpochTransaction", "transactions");
+        let page = Page::from_params(limits, first, after, last, before)?;
+
+        let cursors = page.paginate_indices(self.native.len());
+        let mut conn = Connection::new(cursors.has_previous_page, cursors.has_next_page);
+
+        for edge in cursors.edges {
+            if let Some(tx_kind) = EndOfEpochTransactionKind::from(
+                self.native[*edge.cursor].clone(),
+                self.scope.clone(),
+            ) {
+                conn.edges.push(async_graphql::connection::Edge::new(
+                    edge.cursor.to_string(),
+                    tx_kind,
+                ));
+            }
+        }
+
+        Ok(conn)
+    }
+}
+
+impl EndOfEpochTransactionKind {
+    pub fn from(kind: NativeEndOfEpochTransactionKind, scope: Scope) -> Option<Self> {
+        use EndOfEpochTransactionKind as K;
+        use NativeEndOfEpochTransactionKind as N;
+
+        match kind {
+            N::ChangeEpoch(ce) => {
+                Some(K::ChangeEpoch(ChangeEpochTransaction { native: ce, scope }))
+            }
+            // TODO: Handle other transaction types incrementally
+            _ => None,
+        }
+    }
+}

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/mod.rs
@@ -9,13 +9,15 @@ use crate::scope::Scope;
 use self::{
     authenticator_state_update::AuthenticatorStateUpdateTransaction,
     change_epoch::ChangeEpochTransaction,
-    consensus_commit_prologue::ConsensusCommitPrologueTransaction, genesis::GenesisTransaction,
+    consensus_commit_prologue::ConsensusCommitPrologueTransaction,
+    end_of_epoch::EndOfEpochTransaction, genesis::GenesisTransaction,
     randomness_state_update::RandomnessStateUpdateTransaction,
 };
 
 pub(crate) mod authenticator_state_update;
 pub(crate) mod change_epoch;
 pub(crate) mod consensus_commit_prologue;
+pub(crate) mod end_of_epoch;
 pub(crate) mod genesis;
 pub(crate) mod randomness_state_update;
 
@@ -27,6 +29,7 @@ pub enum TransactionKind {
     ChangeEpoch(ChangeEpochTransaction),
     RandomnessStateUpdate(RandomnessStateUpdateTransaction),
     AuthenticatorStateUpdate(AuthenticatorStateUpdateTransaction),
+    EndOfEpoch(EndOfEpochTransaction),
 }
 
 impl TransactionKind {
@@ -59,6 +62,9 @@ impl TransactionKind {
             K::AuthenticatorStateUpdate(asu) => Some(T::AuthenticatorStateUpdate(
                 AuthenticatorStateUpdateTransaction { native: asu, scope },
             )),
+            K::EndOfEpochTransaction(eoe) => {
+                Some(T::EndOfEpoch(EndOfEpochTransaction { native: eoe, scope }))
+            }
             // Other types will return None for now
             _ => None,
         }

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -301,6 +301,47 @@ ISO-8601 Date and Time: RFC3339 in UTC with format: YYYY-MM-DDTHH:MM:SS.mmmZ. No
 scalar DateTime
 
 """
+System transaction that supersedes `ChangeEpochTransaction` as the new way to run transactions at the end of an epoch. Behaves similarly to `ChangeEpochTransaction` but can accommodate other optional transactions to run at the end of the epoch.
+"""
+type EndOfEpochTransaction {
+	"""
+	The list of system transactions that are allowed to run at the end of the epoch.
+	"""
+	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
+}
+
+union EndOfEpochTransactionKind = ChangeEpochTransaction
+
+type EndOfEpochTransactionKindConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [EndOfEpochTransactionKindEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [EndOfEpochTransactionKind!]!
+}
+
+"""
+An edge in a connection.
+"""
+type EndOfEpochTransactionKindEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: EndOfEpochTransactionKind!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
 Activity on Sui is partitioned in time, into epochs.
 
 Epoch changes are opportunities for the network to reconfigure itself (perform protocol or system package upgrades, or change the committee) and distribute staking rewards. The network aims to keep epochs roughly the same duration as each other.
@@ -1470,7 +1511,7 @@ input TransactionFilter {
 """
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction | EndOfEpochTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -2,6 +2,16 @@
 source: crates/sui-indexer-alt-graphql/src/lib.rs
 expression: sdl
 ---
+"""
+System transaction for creating the accumulator root.
+"""
+type AccumulatorRootCreateTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
+}
+
 type ActiveJwk {
 	"""
 	The string (Issuing Authority) that identifies the OIDC provider.
@@ -67,6 +77,16 @@ type Address implements IAddressable {
 	The Address' identifier, a 32-byte number represented as a 64-character hex string, with a lead "0x".
 	"""
 	address: SuiAddress!
+}
+
+"""
+System transaction for creating the on-chain state used by zkLogin.
+"""
+type AuthenticatorStateCreateTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
 }
 
 type AuthenticatorStateUpdateTransaction {
@@ -252,6 +272,16 @@ input CheckpointFilter {
 }
 
 """
+System transaction for creating the coin deny list state.
+"""
+type CoinDenyListStateCreateTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
+}
+
+"""
 System transaction that runs at the beginning of a checkpoint, and is responsible for setting the current value of the clock, based on the timestamp from consensus.
 """
 type ConsensusCommitPrologueTransaction {
@@ -310,7 +340,7 @@ type EndOfEpochTransaction {
 	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
 }
 
-union EndOfEpochTransactionKind = ChangeEpochTransaction
+union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | RandomnessStateCreateTransaction | CoinDenyListStateCreateTransaction | StoreExecutionTimeObservationsTransaction | AccumulatorRootCreateTransaction
 
 type EndOfEpochTransactionKindConnection {
 	"""
@@ -1142,6 +1172,16 @@ type Query {
 }
 
 """
+System transaction for creating the on-chain randomness state.
+"""
+type RandomnessStateCreateTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
+}
+
+"""
 System transaction to update the source of on-chain randomness.
 """
 type RandomnessStateUpdateTransaction {
@@ -1316,6 +1356,16 @@ type StorageFund {
 	The system maintains an invariant that the sum of all storage fees into the storage fund is equal to the sum of all storage rebates out, the total storage rebates remaining, and the non-refundable balance.
 	"""
 	nonRefundableBalance: BigInt
+}
+
+"""
+System transaction for storing execution time observations.
+"""
+type StoreExecutionTimeObservationsTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
 }
 
 

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -167,6 +167,16 @@ scalar BigInt
 
 
 """
+System transaction for creating bridge state for cross-chain operations.
+"""
+type BridgeStateCreateTransaction {
+	"""
+	The chain identifier for which this bridge state is being created.
+	"""
+	chainIdentifier: String
+}
+
+"""
 A system transaction that updates epoch information on-chain (increments the current epoch). Executed by the system once per epoch, without using gas. Epoch change transactions cannot be submitted by users, because validators will refuse to sign them.
 
 This transaction kind is deprecated in favour of `EndOfEpochTransaction`.
@@ -340,7 +350,7 @@ type EndOfEpochTransaction {
 	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
 }
 
-union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | RandomnessStateCreateTransaction | CoinDenyListStateCreateTransaction | StoreExecutionTimeObservationsTransaction | AccumulatorRootCreateTransaction
+union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | RandomnessStateCreateTransaction | CoinDenyListStateCreateTransaction | StoreExecutionTimeObservationsTransaction | BridgeStateCreateTransaction | AccumulatorRootCreateTransaction
 
 type EndOfEpochTransactionKindConnection {
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -301,6 +301,47 @@ ISO-8601 Date and Time: RFC3339 in UTC with format: YYYY-MM-DDTHH:MM:SS.mmmZ. No
 scalar DateTime
 
 """
+System transaction that supersedes `ChangeEpochTransaction` as the new way to run transactions at the end of an epoch. Behaves similarly to `ChangeEpochTransaction` but can accommodate other optional transactions to run at the end of the epoch.
+"""
+type EndOfEpochTransaction {
+	"""
+	The list of system transactions that are allowed to run at the end of the epoch.
+	"""
+	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
+}
+
+union EndOfEpochTransactionKind = ChangeEpochTransaction
+
+type EndOfEpochTransactionKindConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [EndOfEpochTransactionKindEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [EndOfEpochTransactionKind!]!
+}
+
+"""
+An edge in a connection.
+"""
+type EndOfEpochTransactionKindEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: EndOfEpochTransactionKind!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
 Activity on Sui is partitioned in time, into epochs.
 
 Epoch changes are opportunities for the network to reconfigure itself (perform protocol or system package upgrades, or change the committee) and distribute staking rewards. The network aims to keep epochs roughly the same duration as each other.
@@ -1470,7 +1511,7 @@ input TransactionFilter {
 """
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction | EndOfEpochTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -2,6 +2,16 @@
 source: crates/sui-indexer-alt-graphql/src/lib.rs
 expression: sdl
 ---
+"""
+System transaction for creating the accumulator root.
+"""
+type AccumulatorRootCreateTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
+}
+
 type ActiveJwk {
 	"""
 	The string (Issuing Authority) that identifies the OIDC provider.
@@ -67,6 +77,16 @@ type Address implements IAddressable {
 	The Address' identifier, a 32-byte number represented as a 64-character hex string, with a lead "0x".
 	"""
 	address: SuiAddress!
+}
+
+"""
+System transaction for creating the on-chain state used by zkLogin.
+"""
+type AuthenticatorStateCreateTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
 }
 
 type AuthenticatorStateUpdateTransaction {
@@ -252,6 +272,16 @@ input CheckpointFilter {
 }
 
 """
+System transaction for creating the coin deny list state.
+"""
+type CoinDenyListStateCreateTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
+}
+
+"""
 System transaction that runs at the beginning of a checkpoint, and is responsible for setting the current value of the clock, based on the timestamp from consensus.
 """
 type ConsensusCommitPrologueTransaction {
@@ -310,7 +340,7 @@ type EndOfEpochTransaction {
 	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
 }
 
-union EndOfEpochTransactionKind = ChangeEpochTransaction
+union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | RandomnessStateCreateTransaction | CoinDenyListStateCreateTransaction | StoreExecutionTimeObservationsTransaction | AccumulatorRootCreateTransaction
 
 type EndOfEpochTransactionKindConnection {
 	"""
@@ -1142,6 +1172,16 @@ type Query {
 }
 
 """
+System transaction for creating the on-chain randomness state.
+"""
+type RandomnessStateCreateTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
+}
+
+"""
 System transaction to update the source of on-chain randomness.
 """
 type RandomnessStateUpdateTransaction {
@@ -1316,6 +1356,16 @@ type StorageFund {
 	The system maintains an invariant that the sum of all storage fees into the storage fund is equal to the sum of all storage rebates out, the total storage rebates remaining, and the non-refundable balance.
 	"""
 	nonRefundableBalance: BigInt
+}
+
+"""
+System transaction for storing execution time observations.
+"""
+type StoreExecutionTimeObservationsTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
 }
 
 

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -167,6 +167,16 @@ scalar BigInt
 
 
 """
+System transaction for creating bridge state for cross-chain operations.
+"""
+type BridgeStateCreateTransaction {
+	"""
+	The chain identifier for which this bridge state is being created.
+	"""
+	chainIdentifier: String
+}
+
+"""
 A system transaction that updates epoch information on-chain (increments the current epoch). Executed by the system once per epoch, without using gas. Epoch change transactions cannot be submitted by users, because validators will refuse to sign them.
 
 This transaction kind is deprecated in favour of `EndOfEpochTransaction`.
@@ -340,7 +350,7 @@ type EndOfEpochTransaction {
 	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
 }
 
-union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | RandomnessStateCreateTransaction | CoinDenyListStateCreateTransaction | StoreExecutionTimeObservationsTransaction | AccumulatorRootCreateTransaction
+union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | RandomnessStateCreateTransaction | CoinDenyListStateCreateTransaction | StoreExecutionTimeObservationsTransaction | BridgeStateCreateTransaction | AccumulatorRootCreateTransaction
 
 type EndOfEpochTransactionKindConnection {
 	"""

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -297,6 +297,47 @@ ISO-8601 Date and Time: RFC3339 in UTC with format: YYYY-MM-DDTHH:MM:SS.mmmZ. No
 scalar DateTime
 
 """
+System transaction that supersedes `ChangeEpochTransaction` as the new way to run transactions at the end of an epoch. Behaves similarly to `ChangeEpochTransaction` but can accommodate other optional transactions to run at the end of the epoch.
+"""
+type EndOfEpochTransaction {
+	"""
+	The list of system transactions that are allowed to run at the end of the epoch.
+	"""
+	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
+}
+
+union EndOfEpochTransactionKind = ChangeEpochTransaction
+
+type EndOfEpochTransactionKindConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [EndOfEpochTransactionKindEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [EndOfEpochTransactionKind!]!
+}
+
+"""
+An edge in a connection.
+"""
+type EndOfEpochTransactionKindEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: EndOfEpochTransactionKind!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
 Activity on Sui is partitioned in time, into epochs.
 
 Epoch changes are opportunities for the network to reconfigure itself (perform protocol or system package upgrades, or change the committee) and distribute staking rewards. The network aims to keep epochs roughly the same duration as each other.
@@ -1466,7 +1507,7 @@ input TransactionFilter {
 """
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction | EndOfEpochTransaction
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -163,6 +163,16 @@ scalar BigInt
 
 
 """
+System transaction for creating bridge state for cross-chain operations.
+"""
+type BridgeStateCreateTransaction {
+	"""
+	The chain identifier for which this bridge state is being created.
+	"""
+	chainIdentifier: String
+}
+
+"""
 A system transaction that updates epoch information on-chain (increments the current epoch). Executed by the system once per epoch, without using gas. Epoch change transactions cannot be submitted by users, because validators will refuse to sign them.
 
 This transaction kind is deprecated in favour of `EndOfEpochTransaction`.
@@ -336,7 +346,7 @@ type EndOfEpochTransaction {
 	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
 }
 
-union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | RandomnessStateCreateTransaction | CoinDenyListStateCreateTransaction | StoreExecutionTimeObservationsTransaction | AccumulatorRootCreateTransaction
+union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | RandomnessStateCreateTransaction | CoinDenyListStateCreateTransaction | StoreExecutionTimeObservationsTransaction | BridgeStateCreateTransaction | AccumulatorRootCreateTransaction
 
 type EndOfEpochTransactionKindConnection {
 	"""

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -1,3 +1,13 @@
+"""
+System transaction for creating the accumulator root.
+"""
+type AccumulatorRootCreateTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
+}
+
 type ActiveJwk {
 	"""
 	The string (Issuing Authority) that identifies the OIDC provider.
@@ -63,6 +73,16 @@ type Address implements IAddressable {
 	The Address' identifier, a 32-byte number represented as a 64-character hex string, with a lead "0x".
 	"""
 	address: SuiAddress!
+}
+
+"""
+System transaction for creating the on-chain state used by zkLogin.
+"""
+type AuthenticatorStateCreateTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
 }
 
 type AuthenticatorStateUpdateTransaction {
@@ -248,6 +268,16 @@ input CheckpointFilter {
 }
 
 """
+System transaction for creating the coin deny list state.
+"""
+type CoinDenyListStateCreateTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
+}
+
+"""
 System transaction that runs at the beginning of a checkpoint, and is responsible for setting the current value of the clock, based on the timestamp from consensus.
 """
 type ConsensusCommitPrologueTransaction {
@@ -306,7 +336,7 @@ type EndOfEpochTransaction {
 	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
 }
 
-union EndOfEpochTransactionKind = ChangeEpochTransaction
+union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | RandomnessStateCreateTransaction | CoinDenyListStateCreateTransaction | StoreExecutionTimeObservationsTransaction | AccumulatorRootCreateTransaction
 
 type EndOfEpochTransactionKindConnection {
 	"""
@@ -1138,6 +1168,16 @@ type Query {
 }
 
 """
+System transaction for creating the on-chain randomness state.
+"""
+type RandomnessStateCreateTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
+}
+
+"""
 System transaction to update the source of on-chain randomness.
 """
 type RandomnessStateUpdateTransaction {
@@ -1312,6 +1352,16 @@ type StorageFund {
 	The system maintains an invariant that the sum of all storage fees into the storage fund is equal to the sum of all storage rebates out, the total storage rebates remaining, and the non-refundable balance.
 	"""
 	nonRefundableBalance: BigInt
+}
+
+"""
+System transaction for storing execution time observations.
+"""
+type StoreExecutionTimeObservationsTransaction {
+	"""
+	A workaround to define an empty variant of a GraphQL union.
+	"""
+	_: Boolean
 }
 
 

--- a/crates/sui-indexer/tests/ingestion_tests.rs
+++ b/crates/sui-indexer/tests/ingestion_tests.rs
@@ -320,7 +320,7 @@ pub async fn test_epoch_boundary() -> Result<(), IndexerError> {
     assert!(err.is_none());
 
     sim.create_checkpoint(); // checkpoint 1
-    sim.advance_epoch(true); // checkpoint 2 and epoch 1
+    sim.advance_epoch(true, false, false); // checkpoint 2 and epoch 1
 
     let (transaction, _) = sim.transfer_txn(transfer_recipient);
     let (_, err) = sim.execute_transaction(transaction.clone()).unwrap();

--- a/crates/sui-indexer/tests/ingestion_tests.rs
+++ b/crates/sui-indexer/tests/ingestion_tests.rs
@@ -320,7 +320,7 @@ pub async fn test_epoch_boundary() -> Result<(), IndexerError> {
     assert!(err.is_none());
 
     sim.create_checkpoint(); // checkpoint 1
-    sim.advance_epoch(true, false, false); // checkpoint 2 and epoch 1
+    sim.advance_epoch(true, false, false, false); // checkpoint 2 and epoch 1
 
     let (transaction, _) = sim.transfer_txn(transfer_recipient);
     let (_, err) = sim.execute_transaction(transaction.clone()).unwrap();

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -216,6 +216,10 @@ pub struct AdvanceEpochCommand {
     pub count: Option<u64>,
     #[clap(long = "create-random-state")]
     pub create_random_state: bool,
+    #[clap(long = "create-authenticator-state")]
+    pub create_authenticator_state: bool,
+    #[clap(long = "create-deny-list-state")]
+    pub create_deny_list_state: bool,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -220,6 +220,8 @@ pub struct AdvanceEpochCommand {
     pub create_authenticator_state: bool,
     #[clap(long = "create-deny-list-state")]
     pub create_deny_list_state: bool,
+    #[clap(long = "create-bridge-state")]
+    pub create_bridge_state: bool,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -117,7 +117,12 @@ pub trait TransactionalAdapter: Send + Sync + ReadStore {
         duration: std::time::Duration,
     ) -> anyhow::Result<TransactionEffects>;
 
-    async fn advance_epoch(&mut self, create_random_state: bool) -> anyhow::Result<()>;
+    async fn advance_epoch(
+        &mut self,
+        create_random_state: bool,
+        create_authenticator_state: bool,
+        create_deny_list_state: bool,
+    ) -> anyhow::Result<()>;
 
     async fn request_gas(
         &mut self,
@@ -270,7 +275,12 @@ impl TransactionalAdapter for ValidatorWithFullnode {
         unimplemented!("advance_clock not supported")
     }
 
-    async fn advance_epoch(&mut self, _create_random_state: bool) -> anyhow::Result<()> {
+    async fn advance_epoch(
+        &mut self,
+        _create_random_state: bool,
+        _create_authenticator_state: bool,
+        _create_deny_list_state: bool,
+    ) -> anyhow::Result<()> {
         self.validator.reconfigure_for_testing().await;
         self.fullnode.reconfigure_for_testing().await;
         Ok(())
@@ -488,8 +498,17 @@ impl TransactionalAdapter for Simulacrum<StdRng, PersistedStore> {
         Ok(self.advance_clock(duration))
     }
 
-    async fn advance_epoch(&mut self, create_random_state: bool) -> anyhow::Result<()> {
-        self.advance_epoch(create_random_state);
+    async fn advance_epoch(
+        &mut self,
+        create_random_state: bool,
+        create_authenticator_state: bool,
+        create_deny_list_state: bool,
+    ) -> anyhow::Result<()> {
+        self.advance_epoch(
+            create_random_state,
+            create_authenticator_state,
+            create_deny_list_state,
+        );
         Ok(())
     }
 

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -122,6 +122,7 @@ pub trait TransactionalAdapter: Send + Sync + ReadStore {
         create_random_state: bool,
         create_authenticator_state: bool,
         create_deny_list_state: bool,
+        create_bridge_state: bool,
     ) -> anyhow::Result<()>;
 
     async fn request_gas(
@@ -280,6 +281,7 @@ impl TransactionalAdapter for ValidatorWithFullnode {
         _create_random_state: bool,
         _create_authenticator_state: bool,
         _create_deny_list_state: bool,
+        _create_bridge_state: bool,
     ) -> anyhow::Result<()> {
         self.validator.reconfigure_for_testing().await;
         self.fullnode.reconfigure_for_testing().await;
@@ -503,11 +505,13 @@ impl TransactionalAdapter for Simulacrum<StdRng, PersistedStore> {
         create_random_state: bool,
         create_authenticator_state: bool,
         create_deny_list_state: bool,
+        create_bridge_state: bool,
     ) -> anyhow::Result<()> {
         self.advance_epoch(
             create_random_state,
             create_authenticator_state,
             create_deny_list_state,
+            create_bridge_state,
         );
         Ok(())
     }

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -767,9 +767,17 @@ impl MoveTestAdapter<'_> for SuiTestAdapter {
             SuiSubcommand::AdvanceEpoch(AdvanceEpochCommand {
                 count,
                 create_random_state,
+                create_authenticator_state,
+                create_deny_list_state,
             }) => {
                 for _ in 0..count.unwrap_or(1) {
-                    self.executor.advance_epoch(create_random_state).await?;
+                    self.executor
+                        .advance_epoch(
+                            create_random_state,
+                            create_authenticator_state,
+                            create_deny_list_state,
+                        )
+                        .await?;
                 }
                 let epoch = self.get_latest_epoch_id()?;
                 Ok(Some(format!("Epoch advanced: {epoch}")))

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -769,6 +769,7 @@ impl MoveTestAdapter<'_> for SuiTestAdapter {
                 create_random_state,
                 create_authenticator_state,
                 create_deny_list_state,
+                create_bridge_state,
             }) => {
                 for _ in 0..count.unwrap_or(1) {
                     self.executor
@@ -776,6 +777,7 @@ impl MoveTestAdapter<'_> for SuiTestAdapter {
                             create_random_state,
                             create_authenticator_state,
                             create_deny_list_state,
+                            create_bridge_state,
                         )
                         .await?;
                 }


### PR DESCRIPTION
## Description 

Support `BridgeStateCreateTransaction` for `EndOfEpochTransactionKind`

The new schema is on par with old GraphQL schema:
https://github.com/MystenLabs/sui/blob/b8d28ddbd06253373d2c02d001b3ba6c1ce8ea4f/crates/sui-graphql-rpc/schema.graphql#L344-L346

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-graphql
cargo nextest run -p sui-indexer-alt-reader
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

---

## Stack
- #22652 
- #22718 
- #22788 
- #22943
- #22950
- #22953
- #22955 
- #22972 
- #22989
- #22991 ⬅️

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
