### PR TITLE
[graphql-alt] Support EndOfEpoch-BridgeCommitteeInt kind for TransactionKind [9/n]

### DIFF
--- a/crates/sui-graphql-rpc/src/test_infra/cluster.rs
+++ b/crates/sui-graphql-rpc/src/test_infra/cluster.rs
@@ -239,7 +239,7 @@ pub async fn prep_executor_cluster() -> ExecutorCluster {
     sim.create_checkpoint();
     sim.create_checkpoint();
     sim.create_checkpoint();
-    sim.advance_epoch(true, false, false, false);
+    sim.advance_epoch(true, false, false, false, false);
     sim.create_checkpoint();
     sim.advance_clock(
         std::time::SystemTime::now()

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.move
@@ -3,7 +3,7 @@
 
 //# init --protocol-version 70 --simulator
 
-//# advance-epoch --create-random-state --create-authenticator-state --create-deny-list-state --create-bridge-state
+//# advance-epoch --create-random-state --create-authenticator-state --create-deny-list-state --create-bridge-state --create-bridge-committee
 
 //# create-checkpoint
 
@@ -43,6 +43,9 @@
               }
               ... on BridgeStateCreateTransaction {
                 chainIdentifier
+              }
+              ... on BridgeCommitteeInitTransaction {
+                bridgeObjectVersion
               }
             }
           }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.snap
@@ -4,21 +4,21 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 processed 4 tasks
 
 task 1, line 6:
-//# advance-epoch --create-random-state --create-authenticator-state --create-deny-list-state --create-bridge-state
+//# advance-epoch --create-random-state --create-authenticator-state --create-deny-list-state --create-bridge-state --create-bridge-committee
 Epoch advanced: 1
 
 task 2, line 8:
 //# create-checkpoint
 Checkpoint created: 2
 
-task 3, lines 10-53:
+task 3, lines 10-56:
 //# run-graphql
 Response: {
   "data": {
     "endOfEpochTransaction": {
       "nodes": [
         {
-          "digest": "HbgooKodztrd2bWKVgBrJL68pvEew5hjd14W5vfV18Lq",
+          "digest": "Ap4cKQqRE7qqcoFFgdDMrj8P7StogBouS3ThBREXGqDS",
           "kind": {
             "__typename": "EndOfEpochTransaction",
             "transactions": {
@@ -38,6 +38,10 @@ Response: {
                 {
                   "__typename": "BridgeStateCreateTransaction",
                   "chainIdentifier": "00000000"
+                },
+                {
+                  "__typename": "BridgeCommitteeInitTransaction",
+                  "bridgeObjectVersion": 1
                 },
                 {
                   "__typename": "ChangeEpochTransaction",

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -163,6 +163,16 @@ scalar BigInt
 
 
 """
+System transaction for initializing bridge committee.
+"""
+type BridgeCommitteeInitTransaction {
+	"""
+	The initial shared version of the bridge object.
+	"""
+	bridgeObjectVersion: UInt53
+}
+
+"""
 System transaction for creating bridge state for cross-chain operations.
 """
 type BridgeStateCreateTransaction {
@@ -384,12 +394,12 @@ System transaction that supersedes `ChangeEpochTransaction` as the new way to ru
 """
 type EndOfEpochTransaction {
 	"""
-	The list of system transactions that did run at the end of the epoch.
+	The list of system transactions that are allowed to run at the end of the epoch.
 	"""
 	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
 }
 
-union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | RandomnessStateCreateTransaction | CoinDenyListStateCreateTransaction | StoreExecutionTimeObservationsTransaction | BridgeStateCreateTransaction | AccumulatorRootCreateTransaction
+union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | RandomnessStateCreateTransaction | CoinDenyListStateCreateTransaction | StoreExecutionTimeObservationsTransaction | BridgeStateCreateTransaction | BridgeCommitteeInitTransaction | AccumulatorRootCreateTransaction
 
 type EndOfEpochTransactionKindConnection {
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -167,6 +167,16 @@ scalar BigInt
 
 
 """
+System transaction for initializing bridge committee.
+"""
+type BridgeCommitteeInitTransaction {
+	"""
+	The initial shared version of the bridge object.
+	"""
+	bridgeObjectVersion: UInt53
+}
+
+"""
 System transaction for creating bridge state for cross-chain operations.
 """
 type BridgeStateCreateTransaction {
@@ -388,12 +398,12 @@ System transaction that supersedes `ChangeEpochTransaction` as the new way to ru
 """
 type EndOfEpochTransaction {
 	"""
-	The list of system transactions that did run at the end of the epoch.
+	The list of system transactions that are allowed to run at the end of the epoch.
 	"""
 	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
 }
 
-union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | RandomnessStateCreateTransaction | CoinDenyListStateCreateTransaction | StoreExecutionTimeObservationsTransaction | BridgeStateCreateTransaction | AccumulatorRootCreateTransaction
+union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | RandomnessStateCreateTransaction | CoinDenyListStateCreateTransaction | StoreExecutionTimeObservationsTransaction | BridgeStateCreateTransaction | BridgeCommitteeInitTransaction | AccumulatorRootCreateTransaction
 
 type EndOfEpochTransactionKindConnection {
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -167,6 +167,16 @@ scalar BigInt
 
 
 """
+System transaction for initializing bridge committee.
+"""
+type BridgeCommitteeInitTransaction {
+	"""
+	The initial shared version of the bridge object.
+	"""
+	bridgeObjectVersion: UInt53
+}
+
+"""
 System transaction for creating bridge state for cross-chain operations.
 """
 type BridgeStateCreateTransaction {
@@ -388,12 +398,12 @@ System transaction that supersedes `ChangeEpochTransaction` as the new way to ru
 """
 type EndOfEpochTransaction {
 	"""
-	The list of system transactions that did run at the end of the epoch.
+	The list of system transactions that are allowed to run at the end of the epoch.
 	"""
 	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
 }
 
-union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | RandomnessStateCreateTransaction | CoinDenyListStateCreateTransaction | StoreExecutionTimeObservationsTransaction | BridgeStateCreateTransaction | AccumulatorRootCreateTransaction
+union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | RandomnessStateCreateTransaction | CoinDenyListStateCreateTransaction | StoreExecutionTimeObservationsTransaction | BridgeStateCreateTransaction | BridgeCommitteeInitTransaction | AccumulatorRootCreateTransaction
 
 type EndOfEpochTransactionKindConnection {
 	"""

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -163,6 +163,16 @@ scalar BigInt
 
 
 """
+System transaction for initializing bridge committee.
+"""
+type BridgeCommitteeInitTransaction {
+	"""
+	The initial shared version of the bridge object.
+	"""
+	bridgeObjectVersion: UInt53
+}
+
+"""
 System transaction for creating bridge state for cross-chain operations.
 """
 type BridgeStateCreateTransaction {
@@ -384,12 +394,12 @@ System transaction that supersedes `ChangeEpochTransaction` as the new way to ru
 """
 type EndOfEpochTransaction {
 	"""
-	The list of system transactions that did run at the end of the epoch.
+	The list of system transactions that are allowed to run at the end of the epoch.
 	"""
 	transactions(first: Int, after: String, last: Int, before: String): EndOfEpochTransactionKindConnection!
 }
 
-union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | RandomnessStateCreateTransaction | CoinDenyListStateCreateTransaction | StoreExecutionTimeObservationsTransaction | BridgeStateCreateTransaction | AccumulatorRootCreateTransaction
+union EndOfEpochTransactionKind = ChangeEpochTransaction | AuthenticatorStateCreateTransaction | RandomnessStateCreateTransaction | CoinDenyListStateCreateTransaction | StoreExecutionTimeObservationsTransaction | BridgeStateCreateTransaction | BridgeCommitteeInitTransaction | AccumulatorRootCreateTransaction
 
 type EndOfEpochTransactionKindConnection {
 	"""

--- a/crates/sui-indexer/tests/ingestion_tests.rs
+++ b/crates/sui-indexer/tests/ingestion_tests.rs
@@ -320,7 +320,7 @@ pub async fn test_epoch_boundary() -> Result<(), IndexerError> {
     assert!(err.is_none());
 
     sim.create_checkpoint(); // checkpoint 1
-    sim.advance_epoch(true, false, false, false); // checkpoint 2 and epoch 1
+    sim.advance_epoch(true, false, false, false, false); // checkpoint 2 and epoch 1
 
     let (transaction, _) = sim.transfer_txn(transfer_recipient);
     let (_, err) = sim.execute_transaction(transaction.clone()).unwrap();

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -222,6 +222,8 @@ pub struct AdvanceEpochCommand {
     pub create_deny_list_state: bool,
     #[clap(long = "create-bridge-state")]
     pub create_bridge_state: bool,
+    #[clap(long = "create-bridge-committee")]
+    pub create_bridge_committee: bool,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -123,6 +123,7 @@ pub trait TransactionalAdapter: Send + Sync + ReadStore {
         create_authenticator_state: bool,
         create_deny_list_state: bool,
         create_bridge_state: bool,
+        create_bridge_committee: bool,
     ) -> anyhow::Result<()>;
 
     async fn request_gas(
@@ -282,6 +283,7 @@ impl TransactionalAdapter for ValidatorWithFullnode {
         _create_authenticator_state: bool,
         _create_deny_list_state: bool,
         _create_bridge_state: bool,
+        _create_bridge_committee: bool,
     ) -> anyhow::Result<()> {
         self.validator.reconfigure_for_testing().await;
         self.fullnode.reconfigure_for_testing().await;
@@ -506,12 +508,14 @@ impl TransactionalAdapter for Simulacrum<StdRng, PersistedStore> {
         create_authenticator_state: bool,
         create_deny_list_state: bool,
         create_bridge_state: bool,
+        create_bridge_committee: bool,
     ) -> anyhow::Result<()> {
         self.advance_epoch(
             create_random_state,
             create_authenticator_state,
             create_deny_list_state,
             create_bridge_state,
+            create_bridge_committee,
         );
         Ok(())
     }

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -770,6 +770,7 @@ impl MoveTestAdapter<'_> for SuiTestAdapter {
                 create_authenticator_state,
                 create_deny_list_state,
                 create_bridge_state,
+                create_bridge_committee,
             }) => {
                 for _ in 0..count.unwrap_or(1) {
                     self.executor
@@ -778,6 +779,7 @@ impl MoveTestAdapter<'_> for SuiTestAdapter {
                             create_authenticator_state,
                             create_deny_list_state,
                             create_bridge_state,
+                            create_bridge_committee,
                         )
                         .await?;
                 }


### PR DESCRIPTION
## Description 

Support `BridgeCommitteeInt` for `EndOfEpochTransactionKind`

The new schema is on par with old GraphQL schema:
https://github.com/MystenLabs/sui/blob/b8d28ddbd06253373d2c02d001b3ba6c1ce8ea4f/crates/sui-graphql-rpc/schema.graphql#L340-L342

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-graphql
cargo nextest run -p sui-indexer-alt-reader
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

---

## Stack
- #22652 
- #22718 
- #22788 
- #22943
- #22950
- #22953
- #22955 
- #22972 
- #22989
- #22991
- #22992 
- #22993 ⬅️

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
