### PR TITLE
[graphql-alt] Support Programmable for TransactionKind [1/n]

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable.move
@@ -1,0 +1,108 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --addresses test=0x0 --simulator
+
+//# publish
+module test::simple {
+  public struct Counter has key {
+    id: UID,
+    value: u64,
+  }
+
+  fun init(ctx: &mut TxContext) {
+    transfer::share_object(Counter {
+        id: object::new(ctx),
+        value: 0,
+    })
+  }
+
+  public fun increment(counter: &mut Counter) {
+    counter.value = counter.value + 1;
+  }
+
+  public fun add(counter: &mut Counter, amount: u64) {
+    counter.value = counter.value + amount;
+  }
+}
+
+//# programmable --sender A --inputs object(1,0) 42 @B
+//> 0: test::simple::increment(Input(0));
+//> 1: test::simple::add(Input(0), Input(1));
+//> 2: TransferObjects([Gas], Input(2))
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  # Test basic ProgrammableTransaction structure
+  programmableTransaction: transaction(digest: "@{digest_2}") {
+    digest
+    kind {
+      __typename
+      ... on ProgrammableTransactionBlock {
+        inputs(first: 5) {
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+          }
+          nodes {
+            __typename
+            ... on Pure {
+              bytes
+            }
+          }
+        }
+        transactions(first: 5) {
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+          }
+          nodes {
+            __typename
+            ... on MoveCallTransaction {
+              _
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # Test pagination on the same transaction - limiting results to show pagination working
+  paginationTest: transaction(digest: "@{digest_2}") {
+    digest
+    kind {
+      __typename
+      ... on ProgrammableTransactionBlock {
+        inputs(first: 2) {
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+          }
+          nodes {
+            __typename
+            ... on Pure {
+              bytes
+            }
+          }
+        }
+        transactions(first: 2) {
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+          }
+          nodes {
+            __typename
+            ... on MoveCallTransaction {
+              _
+            }
+          }
+        }
+      }
+    }
+  }
+} 

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable.snap
@@ -1,0 +1,123 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-27:
+//# publish
+created: object(1,0), object(1,1)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 7235200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 29-32:
+//# programmable --sender A --inputs object(1,0) 42 @B
+//> 0: test::simple::increment(Input(0));
+//> 1: test::simple::add(Input(0), Input(1));
+//> 2: TransferObjects([Gas], Input(2))
+mutated: object(0,0), object(1,0)
+gas summary: computation_cost: 1000000, storage_cost: 2340800,  storage_rebate: 1339272, non_refundable_storage_fee: 13528
+
+task 3, line 34:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 36-71:
+//# run-graphql
+Response: {
+  "data": {
+    "programmableTransaction": {
+      "digest": "Cb4FEv3L9zJvp1dKq9LETDYhwNyp6XQHKDm4XqRqET8q",
+      "kind": {
+        "__typename": "ProgrammableTransactionBlock",
+        "inputs": {
+          "pageInfo": {
+            "hasNextPage": false,
+            "hasPreviousPage": false
+          },
+          "nodes": [
+            {
+              "__typename": "Pure",
+              "bytes": "VE9ETzogVW5zdXBwb3J0ZWQgaW5wdXQgdHlwZQ=="
+            },
+            {
+              "__typename": "Pure",
+              "bytes": "KgAAAAAAAAA="
+            },
+            {
+              "__typename": "Pure",
+              "bytes": "p7AycDh4qnTDEmk1eJ/R1NfhEdWRGwkkfWljBhwxK1o="
+            }
+          ]
+        },
+        "transactions": {
+          "pageInfo": {
+            "hasNextPage": false,
+            "hasPreviousPage": false
+          },
+          "nodes": [
+            {
+              "__typename": "MoveCallTransaction",
+              "_": null
+            },
+            {
+              "__typename": "MoveCallTransaction",
+              "_": null
+            },
+            {
+              "__typename": "MoveCallTransaction",
+              "_": null
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+
+task 5, lines 73-108:
+//# run-graphql
+Response: {
+  "data": {
+    "paginationTest": {
+      "digest": "Cb4FEv3L9zJvp1dKq9LETDYhwNyp6XQHKDm4XqRqET8q",
+      "kind": {
+        "__typename": "ProgrammableTransactionBlock",
+        "inputs": {
+          "pageInfo": {
+            "hasNextPage": true,
+            "hasPreviousPage": false
+          },
+          "nodes": [
+            {
+              "__typename": "Pure",
+              "bytes": "VE9ETzogVW5zdXBwb3J0ZWQgaW5wdXQgdHlwZQ=="
+            },
+            {
+              "__typename": "Pure",
+              "bytes": "KgAAAAAAAAA="
+            }
+          ]
+        },
+        "transactions": {
+          "pageInfo": {
+            "hasNextPage": true,
+            "hasPreviousPage": false
+          },
+          "nodes": [
+            {
+              "__typename": "MoveCallTransaction",
+              "_": null
+            },
+            {
+              "__typename": "MoveCallTransaction",
+              "_": null
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -637,6 +637,16 @@ interface IObject {
 
 
 """
+A call to either an entry or a public Move function.
+"""
+type MoveCallTransaction {
+	"""
+	Placeholder field
+	"""
+	_: Boolean
+}
+
+"""
 A MovePackage is a kind of Object that represents code that has been published on-chain. It exposes information about its modules, type definitions, functions, and dependencies.
 """
 type MovePackage implements IAddressable & IObject {
@@ -927,6 +937,51 @@ type PageInfo {
 }
 
 """
+A single transaction, or command, in the programmable transaction block.
+"""
+union ProgrammableTransaction = MoveCallTransaction
+
+type ProgrammableTransactionBlock {
+	"""
+	Input objects or primitive values.
+	"""
+	inputs(first: Int, after: String, last: Int, before: String): TransactionInputConnection!
+	"""
+	The transaction commands, executed sequentially.
+	"""
+	transactions(first: Int, after: String, last: Int, before: String): ProgrammableTransactionConnection!
+}
+
+type ProgrammableTransactionConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [ProgrammableTransactionEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [ProgrammableTransaction!]!
+}
+
+"""
+An edge in a connection.
+"""
+type ProgrammableTransactionEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: ProgrammableTransaction!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
 A protocol configuration that can hold an arbitrary value (or no value at all).
 """
 type ProtocolConfig {
@@ -963,6 +1018,16 @@ type ProtocolConfigs {
 	List all available feature flags and their values.
 	"""
 	featureFlags: [FeatureFlag!]!
+}
+
+"""
+BCS encoded primitive value (not an object or Move struct).
+"""
+type Pure {
+	"""
+	BCS serialized and Base64 encoded primitive value.
+	"""
+	bytes: Base64
 }
 
 type Query {
@@ -1464,9 +1529,43 @@ input TransactionFilter {
 }
 
 """
+Input argument to a Programmable Transaction Block (PTB) command.
+"""
+union TransactionInput = Pure
+
+type TransactionInputConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [TransactionInputEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [TransactionInput!]!
+}
+
+"""
+An edge in a connection.
+"""
+type TransactionInputEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: TransactionInput!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction | ProgrammableTransactionBlock
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/mod.rs
@@ -10,6 +10,7 @@ use self::{
     authenticator_state_update::AuthenticatorStateUpdateTransaction,
     change_epoch::ChangeEpochTransaction,
     consensus_commit_prologue::ConsensusCommitPrologueTransaction, genesis::GenesisTransaction,
+    programmable::ProgrammableTransactionBlock,
     randomness_state_update::RandomnessStateUpdateTransaction,
 };
 
@@ -17,6 +18,7 @@ pub(crate) mod authenticator_state_update;
 pub(crate) mod change_epoch;
 pub(crate) mod consensus_commit_prologue;
 pub(crate) mod genesis;
+pub(crate) mod programmable;
 pub(crate) mod randomness_state_update;
 
 /// Different types of transactions that can be executed on the Sui network.
@@ -27,6 +29,7 @@ pub enum TransactionKind {
     ChangeEpoch(ChangeEpochTransaction),
     RandomnessStateUpdate(RandomnessStateUpdateTransaction),
     AuthenticatorStateUpdate(AuthenticatorStateUpdateTransaction),
+    Programmable(ProgrammableTransactionBlock),
 }
 
 impl TransactionKind {
@@ -59,6 +62,10 @@ impl TransactionKind {
             K::AuthenticatorStateUpdate(asu) => Some(T::AuthenticatorStateUpdate(
                 AuthenticatorStateUpdateTransaction { native: asu, scope },
             )),
+            K::ProgrammableTransaction(pt) => Some(T::Programmable(ProgrammableTransactionBlock {
+                native: pt,
+                scope,
+            })),
             // Other types will return None for now
             _ => None,
         }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable.rs
@@ -1,0 +1,141 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::{
+    connection::{Connection, CursorType, Edge},
+    *,
+};
+use sui_types::transaction::ProgrammableTransaction as NativeProgrammableTransaction;
+
+use crate::{
+    api::scalars::{base64::Base64, cursor::JsonCursor},
+    error::RpcError,
+    pagination::{Page, PaginationConfig},
+    scope::Scope,
+};
+
+type CInput = JsonCursor<usize>;
+type CTransaction = JsonCursor<usize>;
+
+/// A user transaction that allows the interleaving of native commands (like transfer, split coins, merge coins, etc) and move calls, executed atomically.
+#[derive(Clone)]
+pub struct ProgrammableTransactionBlock {
+    pub native: NativeProgrammableTransaction,
+    pub scope: Scope,
+}
+
+#[Object]
+impl ProgrammableTransactionBlock {
+    /// Input objects or primitive values.
+    async fn inputs(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<CInput>,
+        last: Option<u64>,
+        before: Option<CInput>,
+    ) -> Result<Connection<String, TransactionInput>, RpcError> {
+        let pagination = ctx.data::<PaginationConfig>()?;
+        let limits = pagination.limits("ProgrammableTransactionBlock", "inputs");
+        let page = Page::from_params(limits, first, after, last, before)?;
+
+        let cursors = page.paginate_indices(self.native.inputs.len());
+        let mut conn = Connection::new(cursors.has_previous_page, cursors.has_next_page);
+
+        for edge in cursors.edges {
+            let input = TransactionInput::from(
+                self.native.inputs[*edge.cursor].clone(),
+                self.scope.clone(),
+            );
+            conn.edges
+                .push(Edge::new(edge.cursor.encode_cursor(), input));
+        }
+
+        Ok(conn)
+    }
+
+    /// The transaction commands, executed sequentially.
+    async fn transactions(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<CTransaction>,
+        last: Option<u64>,
+        before: Option<CTransaction>,
+    ) -> Result<Connection<String, ProgrammableTransaction>, RpcError> {
+        let pagination = ctx.data::<PaginationConfig>()?;
+        let limits = pagination.limits("ProgrammableTransactionBlock", "transactions");
+        let page = Page::from_params(limits, first, after, last, before)?;
+
+        let cursors = page.paginate_indices(self.native.commands.len());
+        let mut conn = Connection::new(cursors.has_previous_page, cursors.has_next_page);
+
+        for edge in cursors.edges {
+            let transaction = ProgrammableTransaction::from(
+                self.native.commands[*edge.cursor].clone(),
+                self.scope.clone(),
+            );
+
+            conn.edges
+                .push(Edge::new(edge.cursor.encode_cursor(), transaction));
+        }
+
+        Ok(conn)
+    }
+}
+
+/// Input argument to a Programmable Transaction Block (PTB) command.
+#[derive(Union, Clone)]
+pub enum TransactionInput {
+    Pure(Pure),
+}
+
+/// A single transaction, or command, in the programmable transaction block.
+#[derive(Union, Clone)]
+pub enum ProgrammableTransaction {
+    MoveCall(MoveCallTransaction),
+}
+
+/// BCS encoded primitive value (not an object or Move struct).
+#[derive(SimpleObject, Clone)]
+pub struct Pure {
+    /// BCS serialized and Base64 encoded primitive value.
+    bytes: Option<Base64>,
+}
+
+// TODO(DVX-1373): Implement MoveCallTransaction
+/// A call to either an entry or a public Move function.
+#[derive(SimpleObject, Clone)]
+pub struct MoveCallTransaction {
+    /// Placeholder field
+    #[graphql(name = "_")]
+    dummy: Option<bool>,
+}
+
+impl TransactionInput {
+    pub fn from(input: sui_types::transaction::CallArg, _scope: Scope) -> Self {
+        use sui_types::transaction::CallArg;
+
+        match input {
+            CallArg::Pure(bytes) => Self::Pure(Pure {
+                bytes: Some(Base64::from(bytes)),
+            }),
+            // TODO: Handle other input types
+            _ => Self::Pure(Pure {
+                bytes: Some(Base64::from(b"TODO: Unsupported input type".to_vec())),
+            }),
+        }
+    }
+}
+
+impl ProgrammableTransaction {
+    pub fn from(command: sui_types::transaction::Command, _scope: Scope) -> Self {
+        use sui_types::transaction::Command;
+
+        match command {
+            Command::MoveCall(_) => Self::MoveCall(MoveCallTransaction { dummy: None }),
+            // TODO: Handle other command types, for now just use MoveCall as placeholder
+            _ => Self::MoveCall(MoveCallTransaction { dummy: None }),
+        }
+    }
+}

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -641,6 +641,16 @@ interface IObject {
 
 
 """
+A call to either an entry or a public Move function.
+"""
+type MoveCallTransaction {
+	"""
+	Placeholder field
+	"""
+	_: Boolean
+}
+
+"""
 A MovePackage is a kind of Object that represents code that has been published on-chain. It exposes information about its modules, type definitions, functions, and dependencies.
 """
 type MovePackage implements IAddressable & IObject {
@@ -931,6 +941,51 @@ type PageInfo {
 }
 
 """
+A single transaction, or command, in the programmable transaction block.
+"""
+union ProgrammableTransaction = MoveCallTransaction
+
+type ProgrammableTransactionBlock {
+	"""
+	Input objects or primitive values.
+	"""
+	inputs(first: Int, after: String, last: Int, before: String): TransactionInputConnection!
+	"""
+	The transaction commands, executed sequentially.
+	"""
+	transactions(first: Int, after: String, last: Int, before: String): ProgrammableTransactionConnection!
+}
+
+type ProgrammableTransactionConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [ProgrammableTransactionEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [ProgrammableTransaction!]!
+}
+
+"""
+An edge in a connection.
+"""
+type ProgrammableTransactionEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: ProgrammableTransaction!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
 A protocol configuration that can hold an arbitrary value (or no value at all).
 """
 type ProtocolConfig {
@@ -967,6 +1022,16 @@ type ProtocolConfigs {
 	List all available feature flags and their values.
 	"""
 	featureFlags: [FeatureFlag!]!
+}
+
+"""
+BCS encoded primitive value (not an object or Move struct).
+"""
+type Pure {
+	"""
+	BCS serialized and Base64 encoded primitive value.
+	"""
+	bytes: Base64
 }
 
 type Query {
@@ -1468,9 +1533,43 @@ input TransactionFilter {
 }
 
 """
+Input argument to a Programmable Transaction Block (PTB) command.
+"""
+union TransactionInput = Pure
+
+type TransactionInputConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [TransactionInputEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [TransactionInput!]!
+}
+
+"""
+An edge in a connection.
+"""
+type TransactionInputEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: TransactionInput!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction | ProgrammableTransactionBlock
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -641,6 +641,16 @@ interface IObject {
 
 
 """
+A call to either an entry or a public Move function.
+"""
+type MoveCallTransaction {
+	"""
+	Placeholder field
+	"""
+	_: Boolean
+}
+
+"""
 A MovePackage is a kind of Object that represents code that has been published on-chain. It exposes information about its modules, type definitions, functions, and dependencies.
 """
 type MovePackage implements IAddressable & IObject {
@@ -931,6 +941,51 @@ type PageInfo {
 }
 
 """
+A single transaction, or command, in the programmable transaction block.
+"""
+union ProgrammableTransaction = MoveCallTransaction
+
+type ProgrammableTransactionBlock {
+	"""
+	Input objects or primitive values.
+	"""
+	inputs(first: Int, after: String, last: Int, before: String): TransactionInputConnection!
+	"""
+	The transaction commands, executed sequentially.
+	"""
+	transactions(first: Int, after: String, last: Int, before: String): ProgrammableTransactionConnection!
+}
+
+type ProgrammableTransactionConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [ProgrammableTransactionEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [ProgrammableTransaction!]!
+}
+
+"""
+An edge in a connection.
+"""
+type ProgrammableTransactionEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: ProgrammableTransaction!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
 A protocol configuration that can hold an arbitrary value (or no value at all).
 """
 type ProtocolConfig {
@@ -967,6 +1022,16 @@ type ProtocolConfigs {
 	List all available feature flags and their values.
 	"""
 	featureFlags: [FeatureFlag!]!
+}
+
+"""
+BCS encoded primitive value (not an object or Move struct).
+"""
+type Pure {
+	"""
+	BCS serialized and Base64 encoded primitive value.
+	"""
+	bytes: Base64
 }
 
 type Query {
@@ -1468,9 +1533,43 @@ input TransactionFilter {
 }
 
 """
+Input argument to a Programmable Transaction Block (PTB) command.
+"""
+union TransactionInput = Pure
+
+type TransactionInputConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [TransactionInputEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [TransactionInput!]!
+}
+
+"""
+An edge in a connection.
+"""
+type TransactionInputEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: TransactionInput!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction | ProgrammableTransactionBlock
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -637,6 +637,16 @@ interface IObject {
 
 
 """
+A call to either an entry or a public Move function.
+"""
+type MoveCallTransaction {
+	"""
+	Placeholder field
+	"""
+	_: Boolean
+}
+
+"""
 A MovePackage is a kind of Object that represents code that has been published on-chain. It exposes information about its modules, type definitions, functions, and dependencies.
 """
 type MovePackage implements IAddressable & IObject {
@@ -927,6 +937,51 @@ type PageInfo {
 }
 
 """
+A single transaction, or command, in the programmable transaction block.
+"""
+union ProgrammableTransaction = MoveCallTransaction
+
+type ProgrammableTransactionBlock {
+	"""
+	Input objects or primitive values.
+	"""
+	inputs(first: Int, after: String, last: Int, before: String): TransactionInputConnection!
+	"""
+	The transaction commands, executed sequentially.
+	"""
+	transactions(first: Int, after: String, last: Int, before: String): ProgrammableTransactionConnection!
+}
+
+type ProgrammableTransactionConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [ProgrammableTransactionEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [ProgrammableTransaction!]!
+}
+
+"""
+An edge in a connection.
+"""
+type ProgrammableTransactionEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: ProgrammableTransaction!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
 A protocol configuration that can hold an arbitrary value (or no value at all).
 """
 type ProtocolConfig {
@@ -963,6 +1018,16 @@ type ProtocolConfigs {
 	List all available feature flags and their values.
 	"""
 	featureFlags: [FeatureFlag!]!
+}
+
+"""
+BCS encoded primitive value (not an object or Move struct).
+"""
+type Pure {
+	"""
+	BCS serialized and Base64 encoded primitive value.
+	"""
+	bytes: Base64
 }
 
 type Query {
@@ -1464,9 +1529,43 @@ input TransactionFilter {
 }
 
 """
+Input argument to a Programmable Transaction Block (PTB) command.
+"""
+union TransactionInput = Pure
+
+type TransactionInputConnection {
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+	"""
+	A list of edges.
+	"""
+	edges: [TransactionInputEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [TransactionInput!]!
+}
+
+"""
+An edge in a connection.
+"""
+type TransactionInputEdge {
+	"""
+	The item at the end of the edge
+	"""
+	node: TransactionInput!
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+}
+
+"""
 Different types of transactions that can be executed on the Sui network.
 """
-union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction
+union TransactionKind = GenesisTransaction | ConsensusCommitPrologueTransaction | ChangeEpochTransaction | RandomnessStateUpdateTransaction | AuthenticatorStateUpdateTransaction | ProgrammableTransactionBlock
 
 """
 An unsigned integer that can hold values up to 2^53 - 1. This can be treated similarly to `Int`, but it is guaranteed to be non-negative, and it may be larger than 2^32 - 1.


### PR DESCRIPTION
## Description 

This is the first PR to support `Programmable` for `TransactionKind`:

Implement a foundation for `Programmable` type:
1. TransactionInput as a Union with first field `Pure`. Other fields will be added in upcoming PRs
2. ProgrammableTransaction as a Union with first field `MoveCall`. Other fields will also be added in upcoming PRs

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-graphql
cargo nextest run -p sui-indexer-alt-reader
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
