### PR TITLE
[graphql-alt] Support Object Input for Programmable TransactionKind [2/n] 

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/programmable.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/programmable.snap
@@ -39,8 +39,7 @@ Response: {
           },
           "nodes": [
             {
-              "__typename": "Pure",
-              "bytes": "VE9ETzogVW5zdXBwb3J0ZWQgaW5wdXQgdHlwZQ=="
+              "__typename": "SharedInput"
             },
             {
               "__typename": "Pure",
@@ -92,8 +91,7 @@ Response: {
           },
           "nodes": [
             {
-              "__typename": "Pure",
-              "bytes": "VE9ETzogVW5zdXBwb3J0ZWQgaW5wdXQgdHlwZQ=="
+              "__typename": "SharedInput"
             },
             {
               "__typename": "Pure",

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/programmable_inputs.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/programmable_inputs.move
@@ -1,0 +1,176 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --addresses test=0x0 --simulator
+
+//# publish
+module test::simple {
+  use sui::transfer::Receiving;
+
+  public struct Counter has key {
+    id: UID,
+    value: u64,
+  }
+
+  public struct Coin has key, store {
+    id: UID,
+    value: u64,
+  }
+
+  fun init(ctx: &mut TxContext) {
+    transfer::share_object(Counter {
+        id: object::new(ctx),
+        value: 0,
+    });
+  }
+
+  public fun add(counter: &mut Counter, amount: u64) {
+    counter.value = counter.value + amount;
+  }
+
+  public fun new_coin(value: u64, ctx: &mut TxContext): Coin {
+    Coin { id: object::new(ctx), value }
+  }
+
+  public fun get_value(coin: &Coin): u64 {
+    coin.value
+  }
+
+  public fun transfer_coin_to_address(coin: Coin, to_address: address) {
+    transfer::transfer(coin, to_address)
+  }
+
+  public fun receive_coin(receiver: &mut Coin, incoming: Receiving<Coin>): Coin {
+    transfer::receive(&mut receiver.id, incoming)
+  }
+}
+
+// Test 1: Pure input only - demonstrates Pure TransactionInput type
+//# programmable --sender A --inputs 42u64 @A
+//> 0: test::simple::new_coin(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+
+//# create-checkpoint
+
+// Test 2: SharedInput only - demonstrates SharedInput TransactionInput type
+//# programmable --sender A --inputs object(1,0) 10  
+//> 0: test::simple::add(Input(0), Input(1))
+
+//# create-checkpoint
+
+// Test 3: OwnedOrImmutable only - demonstrates OwnedOrImmutable TransactionInput type
+// Reuses the coin created in Test 1 (object(2,0))
+//# programmable --sender A --inputs object(2,0)
+//> 0: test::simple::get_value(Input(0))
+
+//# create-checkpoint
+
+// Test 4: Receiving only - demonstrates Receiving TransactionInput type
+//# programmable --sender A --inputs 200u64 @A  
+// Setup: Create coin and transfer it to A's address for Receiving test
+//> 0: test::simple::new_coin(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs object(8,0) @A
+// Setup: Transfer coin to A's address (creates a pending receive)
+//> 0: test::simple::transfer_coin_to_address(Input(0), Input(1))
+
+//# programmable --sender A --inputs object(2,0) receiving(8,0) @A
+//> 0: test::simple::receive_coin(Input(0), Input(1));
+//> TransferObjects([Result(0)], Input(2))
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  # Test 1: Pure input only
+  pureInputTest: transaction(digest: "@{digest_2}") {
+    digest
+    kind {
+      __typename
+      ... on ProgrammableTransaction {
+        inputs(first: 10) {
+          nodes {
+            __typename
+            ... on Pure {
+              bytes
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql  
+{
+  # Test 2: SharedInput only
+  sharedInputTest: transaction(digest: "@{digest_4}") {
+    digest
+    kind {
+      __typename
+      ... on ProgrammableTransaction {
+        inputs(first: 10) {
+          nodes {
+            __typename
+            ... on SharedInput {
+              address
+              initialSharedVersion
+              mutable
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # Test 3: OwnedOrImmutable input only  
+  ownedOrImmutableTest: transaction(digest: "@{digest_6}") {
+    digest
+    kind {
+      __typename
+      ... on ProgrammableTransaction {
+        inputs(first: 10) {
+          nodes {
+            __typename
+            ... on OwnedOrImmutable {
+              object {
+                address
+                version
+                digest
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # Test 4: Receiving input only
+  receivingInputTest: transaction(digest: "@{digest_10}") {
+    digest
+    kind {
+      __typename
+      ... on ProgrammableTransaction {
+        inputs(first: 10) {
+          nodes {
+            __typename
+            ... on Receiving {
+              object {
+                address
+                version
+                digest
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+} 

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/programmable_inputs.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/programmable_inputs.snap
@@ -1,0 +1,179 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 16 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-48:
+//# publish
+created: object(1,0), object(1,1)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 8990800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 49-51:
+//# programmable --sender A --inputs 42u64 @A
+//> 0: test::simple::new_coin(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2318000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 53-55:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 56-57:
+//# programmable --sender A --inputs object(1,0) 10  
+//> 0: test::simple::add(Input(0), Input(1))
+mutated: object(0,0), object(1,0)
+gas summary: computation_cost: 1000000, storage_cost: 2340800,  storage_rebate: 2317392, non_refundable_storage_fee: 23408
+
+task 5, lines 59-62:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 6, lines 63-64:
+//# programmable --sender A --inputs object(2,0)
+//> 0: test::simple::get_value(Input(0))
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2318000,  storage_rebate: 2294820, non_refundable_storage_fee: 23180
+
+task 7, lines 66-68:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 8, lines 69-72:
+//# programmable --sender A --inputs 200u64 @A  
+// Setup: Create coin and transfer it to A's address for Receiving test
+//> 0: test::simple::new_coin(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+created: object(8,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2318000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 9, lines 74-76:
+//# programmable --sender A --inputs object(8,0) @A
+// Setup: Transfer coin to A's address (creates a pending receive)
+//> 0: test::simple::transfer_coin_to_address(Input(0), Input(1))
+mutated: object(0,0), object(8,0)
+gas summary: computation_cost: 1000000, storage_cost: 2318000,  storage_rebate: 2294820, non_refundable_storage_fee: 23180
+
+task 10, lines 78-80:
+//# programmable --sender A --inputs object(2,0) receiving(8,0) @A
+//> 0: test::simple::receive_coin(Input(0), Input(1));
+//> TransferObjects([Result(0)], Input(2))
+Error: Transaction Effects Status: Move Runtime Abort. Location: sui::transfer::receive_impl (function index 12) at offset 0, Abort Code: 3
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("transfer") }, function: 12, instruction: 0, function_name: Some("receive_impl") }, 3), source: Some(VMError { major_status: ABORTED, sub_status: Some(3), message: None, exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("transfer") }), indices: [], offsets: [(FunctionDefinitionIndex(12), 0)] }), command: Some(0) } }
+
+task 11, line 82:
+//# create-checkpoint
+Checkpoint created: 4
+
+task 12, lines 84-103:
+//# run-graphql
+Response: {
+  "data": {
+    "pureInputTest": {
+      "digest": "3vN92ssd7QUH46pRkq3x2nzj8TEYwX1LJPeqH82BCoD8",
+      "kind": {
+        "__typename": "ProgrammableTransaction",
+        "inputs": {
+          "nodes": [
+            {
+              "__typename": "Pure",
+              "bytes": "KgAAAAAAAAA="
+            },
+            {
+              "__typename": "Pure",
+              "bytes": "/MyaQhu7E8GmahqpjwrXUCnt6UhXd5xpFbRPlAaLkh4="
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+
+task 13, lines 105-126:
+//# run-graphql  
+Response: {
+  "data": {
+    "sharedInputTest": {
+      "digest": "7orny7x5fKU9h9FAfgqxNoSyxHCJ4izRsFPHqBBCDL6w",
+      "kind": {
+        "__typename": "ProgrammableTransaction",
+        "inputs": {
+          "nodes": [
+            {
+              "__typename": "SharedInput",
+              "address": "0x15f1a98bf64d17ecdc077a0a59848ee92a7e0005f86b67a7bac566c1c7926126",
+              "initialSharedVersion": 2,
+              "mutable": true
+            },
+            {
+              "__typename": "Pure"
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+
+task 14, lines 128-151:
+//# run-graphql
+Response: {
+  "data": {
+    "ownedOrImmutableTest": {
+      "digest": "EpTKN5v4qda3khSqP3osYfN7JsQ7HxPbaYQAm7d1RJte",
+      "kind": {
+        "__typename": "ProgrammableTransaction",
+        "inputs": {
+          "nodes": [
+            {
+              "__typename": "OwnedOrImmutable",
+              "object": {
+                "address": "0xe99fcfc6846da366c584674afc52d37c71ce3bf076adeff83d52c4e3322d12e6",
+                "version": 2,
+                "digest": "Fd5gUnMRjAegAQiJJkLraQCcSeph4XzvbpDiV1eo9w24"
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+
+task 15, lines 153-176:
+//# run-graphql
+Response: {
+  "data": {
+    "receivingInputTest": {
+      "digest": "AuuQ6MmSz5avpGWLGoFfd4kV4KhNp2PyvBF1VPnfWuBm",
+      "kind": {
+        "__typename": "ProgrammableTransaction",
+        "inputs": {
+          "nodes": [
+            {
+              "__typename": "OwnedOrImmutable"
+            },
+            {
+              "__typename": "Receiving",
+              "object": {
+                "address": "0xa6f9693563a3a8c260656930577e22bcfd621a2380037a68c99f73cf28235146",
+                "version": 6,
+                "digest": "5Gh3wL6s5ezhdQi6PWK11PEBgSGh65tb4Mtcyh4eZDDQ"
+              }
+            },
+            {
+              "__typename": "Pure"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -1089,6 +1089,13 @@ input ObjectKey {
 }
 
 """
+A Move object, either immutable, or owned mutable.
+"""
+type OwnedOrImmutable {
+	object: Object
+}
+
+"""
 Identifies a specific version of a package.
 
 The `address` field must be specified, as well as at most one of `version`, or `atCheckpoint`. If neither is provided, the package is fetched at the current checkpoint.
@@ -1376,6 +1383,13 @@ type ReadConsensusStreamEnded {
 	sequenceNumber: UInt53
 }
 
+"""
+A Move object that can be received in this transaction.
+"""
+type Receiving {
+	object: Object
+}
+
 type SafeMode {
 	"""
 	Whether safe mode was used for the last epoch change.
@@ -1487,6 +1501,26 @@ type ServiceConfig {
 	Maximum nesting allowed in datatype fields when calculating the layout of a single type.
 	"""
 	maxMoveValueDepth: Int
+}
+
+"""
+A Move object that's shared.
+"""
+type SharedInput {
+	"""
+	The address of the shared object.
+	"""
+	address: SuiAddress
+	"""
+	The version that this object was shared at.
+	"""
+	initialSharedVersion: UInt53
+	"""
+	Controls whether the transaction block can reference the shared object as a mutable reference or by value.
+	
+	This has implications for scheduling: Transactions that just read shared objects at a certain version (mutable = false) can be executed concurrently, while transactions that write shared objects (mutable = true) must be executed serially with respect to each other.
+	"""
+	mutable: Boolean
 }
 
 """
@@ -1738,7 +1772,7 @@ input TransactionFilter {
 """
 Input argument to a Programmable Transaction Block (PTB) command.
 """
-union TransactionInput = Pure
+union TransactionInput = Pure | OwnedOrImmutable | SharedInput | Receiving
 
 type TransactionInputConnection {
 	"""

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/inputs/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/inputs/mod.rs
@@ -1,30 +1,57 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod object;
 pub mod pure;
 
 use async_graphql::*;
 
 use crate::{api::scalars::base64::Base64, scope::Scope};
+pub use object::{OwnedOrImmutable, Receiving, SharedInput};
 pub use pure::Pure;
 
 /// Input argument to a Programmable Transaction Block (PTB) command.
-#[derive(Union, Clone)]
+#[derive(Union)]
 pub enum TransactionInput {
     Pure(Pure),
+    OwnedOrImmutable(OwnedOrImmutable),
+    SharedInput(SharedInput),
+    Receiving(Receiving),
+    // TODO: Add BalanceWithdraw variant
 }
 
 impl TransactionInput {
-    pub fn from(input: sui_types::transaction::CallArg, _scope: Scope) -> Self {
-        use sui_types::transaction::CallArg;
+    pub fn from(input: sui_types::transaction::CallArg, scope: Scope) -> Self {
+        use sui_types::transaction::{CallArg, ObjectArg};
 
         match input {
             CallArg::Pure(bytes) => Self::Pure(Pure {
                 bytes: Some(Base64::from(bytes)),
             }),
-            // TODO: Handle other input types
-            _ => Self::Pure(Pure {
-                bytes: Some(Base64::from(b"TODO: Unsupported input type".to_vec())),
+            CallArg::Object(obj_arg) => match obj_arg {
+                ObjectArg::ImmOrOwnedObject((object_id, version, digest)) => {
+                    Self::OwnedOrImmutable(OwnedOrImmutable::from_object_ref(
+                        object_id, version, digest, scope,
+                    ))
+                }
+                ObjectArg::SharedObject {
+                    id,
+                    initial_shared_version,
+                    mutable,
+                } => Self::SharedInput(SharedInput::from_shared_object(
+                    id,
+                    initial_shared_version,
+                    mutable,
+                )),
+                ObjectArg::Receiving((object_id, version, digest)) => Self::Receiving(
+                    Receiving::from_object_ref(object_id, version, digest, scope),
+                ),
+            },
+            // TODO: Handle BalanceWithdraw
+            CallArg::BalanceWithdraw(_) => Self::Pure(Pure {
+                bytes: Some(Base64::from(
+                    b"TODO: BalanceWithdraw not supported".to_vec(),
+                )),
             }),
         }
     }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/inputs/object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/inputs/object.rs
@@ -1,0 +1,87 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::*;
+
+use crate::{
+    api::{
+        scalars::{sui_address::SuiAddress, uint53::UInt53},
+        types::{address::Address, object::Object},
+    },
+    scope::Scope,
+};
+use sui_types::{
+    base_types::{ObjectID, SequenceNumber},
+    digests::ObjectDigest,
+};
+
+/// A Move object, either immutable, or owned mutable.
+#[derive(SimpleObject)]
+pub struct OwnedOrImmutable {
+    pub object: Option<Object>,
+}
+
+/// A Move object that's shared.
+#[derive(SimpleObject)]
+pub struct SharedInput {
+    /// The address of the shared object.
+    pub address: Option<SuiAddress>,
+
+    /// The version that this object was shared at.
+    pub initial_shared_version: Option<UInt53>,
+
+    /// Controls whether the transaction block can reference the shared object as a mutable reference or by value.
+    ///
+    /// This has implications for scheduling: Transactions that just read shared objects at a certain version (mutable = false) can be executed concurrently, while transactions that write shared objects (mutable = true) must be executed serially with respect to each other.
+    pub mutable: Option<bool>,
+}
+
+/// A Move object that can be received in this transaction.
+#[derive(SimpleObject)]
+pub struct Receiving {
+    pub object: Option<Object>,
+}
+
+impl OwnedOrImmutable {
+    pub fn from_object_ref(
+        object_id: ObjectID,
+        version: SequenceNumber,
+        digest: ObjectDigest,
+        scope: Scope,
+    ) -> Self {
+        let address = Address::with_address(scope, object_id.into());
+        let object = Object::with_ref(address, version, digest);
+        Self {
+            object: Some(object),
+        }
+    }
+}
+
+impl SharedInput {
+    pub fn from_shared_object(
+        object_id: ObjectID,
+        initial_shared_version: SequenceNumber,
+        mutable: bool,
+    ) -> Self {
+        Self {
+            address: Some(object_id.into()),
+            initial_shared_version: Some(initial_shared_version.value().into()),
+            mutable: Some(mutable),
+        }
+    }
+}
+
+impl Receiving {
+    pub fn from_object_ref(
+        object_id: ObjectID,
+        version: SequenceNumber,
+        digest: ObjectDigest,
+        scope: Scope,
+    ) -> Self {
+        let address = Address::with_address(scope, object_id.into());
+        let object = Object::with_ref(address, version, digest);
+        Self {
+            object: Some(object),
+        }
+    }
+}

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -1093,6 +1093,13 @@ input ObjectKey {
 }
 
 """
+A Move object, either immutable, or owned mutable.
+"""
+type OwnedOrImmutable {
+	object: Object
+}
+
+"""
 Identifies a specific version of a package.
 
 The `address` field must be specified, as well as at most one of `version`, or `atCheckpoint`. If neither is provided, the package is fetched at the current checkpoint.
@@ -1380,6 +1387,13 @@ type ReadConsensusStreamEnded {
 	sequenceNumber: UInt53
 }
 
+"""
+A Move object that can be received in this transaction.
+"""
+type Receiving {
+	object: Object
+}
+
 type SafeMode {
 	"""
 	Whether safe mode was used for the last epoch change.
@@ -1491,6 +1505,26 @@ type ServiceConfig {
 	Maximum nesting allowed in datatype fields when calculating the layout of a single type.
 	"""
 	maxMoveValueDepth: Int
+}
+
+"""
+A Move object that's shared.
+"""
+type SharedInput {
+	"""
+	The address of the shared object.
+	"""
+	address: SuiAddress
+	"""
+	The version that this object was shared at.
+	"""
+	initialSharedVersion: UInt53
+	"""
+	Controls whether the transaction block can reference the shared object as a mutable reference or by value.
+	
+	This has implications for scheduling: Transactions that just read shared objects at a certain version (mutable = false) can be executed concurrently, while transactions that write shared objects (mutable = true) must be executed serially with respect to each other.
+	"""
+	mutable: Boolean
 }
 
 """
@@ -1742,7 +1776,7 @@ input TransactionFilter {
 """
 Input argument to a Programmable Transaction Block (PTB) command.
 """
-union TransactionInput = Pure
+union TransactionInput = Pure | OwnedOrImmutable | SharedInput | Receiving
 
 type TransactionInputConnection {
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -1093,6 +1093,13 @@ input ObjectKey {
 }
 
 """
+A Move object, either immutable, or owned mutable.
+"""
+type OwnedOrImmutable {
+	object: Object
+}
+
+"""
 Identifies a specific version of a package.
 
 The `address` field must be specified, as well as at most one of `version`, or `atCheckpoint`. If neither is provided, the package is fetched at the current checkpoint.
@@ -1380,6 +1387,13 @@ type ReadConsensusStreamEnded {
 	sequenceNumber: UInt53
 }
 
+"""
+A Move object that can be received in this transaction.
+"""
+type Receiving {
+	object: Object
+}
+
 type SafeMode {
 	"""
 	Whether safe mode was used for the last epoch change.
@@ -1491,6 +1505,26 @@ type ServiceConfig {
 	Maximum nesting allowed in datatype fields when calculating the layout of a single type.
 	"""
 	maxMoveValueDepth: Int
+}
+
+"""
+A Move object that's shared.
+"""
+type SharedInput {
+	"""
+	The address of the shared object.
+	"""
+	address: SuiAddress
+	"""
+	The version that this object was shared at.
+	"""
+	initialSharedVersion: UInt53
+	"""
+	Controls whether the transaction block can reference the shared object as a mutable reference or by value.
+	
+	This has implications for scheduling: Transactions that just read shared objects at a certain version (mutable = false) can be executed concurrently, while transactions that write shared objects (mutable = true) must be executed serially with respect to each other.
+	"""
+	mutable: Boolean
 }
 
 """
@@ -1742,7 +1776,7 @@ input TransactionFilter {
 """
 Input argument to a Programmable Transaction Block (PTB) command.
 """
-union TransactionInput = Pure
+union TransactionInput = Pure | OwnedOrImmutable | SharedInput | Receiving
 
 type TransactionInputConnection {
 	"""

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -1089,6 +1089,13 @@ input ObjectKey {
 }
 
 """
+A Move object, either immutable, or owned mutable.
+"""
+type OwnedOrImmutable {
+	object: Object
+}
+
+"""
 Identifies a specific version of a package.
 
 The `address` field must be specified, as well as at most one of `version`, or `atCheckpoint`. If neither is provided, the package is fetched at the current checkpoint.
@@ -1376,6 +1383,13 @@ type ReadConsensusStreamEnded {
 	sequenceNumber: UInt53
 }
 
+"""
+A Move object that can be received in this transaction.
+"""
+type Receiving {
+	object: Object
+}
+
 type SafeMode {
 	"""
 	Whether safe mode was used for the last epoch change.
@@ -1487,6 +1501,26 @@ type ServiceConfig {
 	Maximum nesting allowed in datatype fields when calculating the layout of a single type.
 	"""
 	maxMoveValueDepth: Int
+}
+
+"""
+A Move object that's shared.
+"""
+type SharedInput {
+	"""
+	The address of the shared object.
+	"""
+	address: SuiAddress
+	"""
+	The version that this object was shared at.
+	"""
+	initialSharedVersion: UInt53
+	"""
+	Controls whether the transaction block can reference the shared object as a mutable reference or by value.
+	
+	This has implications for scheduling: Transactions that just read shared objects at a certain version (mutable = false) can be executed concurrently, while transactions that write shared objects (mutable = true) must be executed serially with respect to each other.
+	"""
+	mutable: Boolean
 }
 
 """
@@ -1738,7 +1772,7 @@ input TransactionFilter {
 """
 Input argument to a Programmable Transaction Block (PTB) command.
 """
-union TransactionInput = Pure
+union TransactionInput = Pure | OwnedOrImmutable | SharedInput | Receiving
 
 type TransactionInputConnection {
 	"""


### PR DESCRIPTION
## Description 

Support all Object Inputs for Programmable TransactionInput:
* OwnedOrImmutable
* SharedInput
* Receiving

The new schema is on par with old GraphQL schema:
https://github.com/MystenLabs/sui/blob/b8d28ddbd06253373d2c02d001b3ba6c1ce8ea4f/crates/sui-graphql-rpc/schema.graphql#L4436

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-graphql
cargo nextest run -p sui-indexer-alt-reader
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

---

## Stack
- #22997 
- #23000 ⬅️

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
