### PR TITLE
Use antithesis_sdk::assert_unreachable to get better reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8698,6 +8698,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "rand 0.8.5",
  "reqwest 0.12.9",
+ "serde_json",
  "snap",
  "sui-macros",
  "tempfile",

--- a/crates/mysten-common/Cargo.toml
+++ b/crates/mysten-common/Cargo.toml
@@ -25,3 +25,4 @@ sui-macros.workspace = true
 tempfile.workspace = true
 tracing.workspace = true
 anyhow.workspace = true
+serde_json.workspace = true

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3910,7 +3910,7 @@ impl AuthorityState {
             None => {
                 debug_fatal!(
                     "Object with in parent_entry is missing from object store, datastore is \
-                     inconsistent",
+                     inconsistent"
                 );
                 Err(UserInputError::ObjectNotFound {
                     object_id: *object_id,

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -2430,7 +2430,7 @@ impl CheckpointSignatureAggregator {
                 "Split brain detected in checkpoint signature aggregation for checkpoint {:?}. Remaining stake: {:?}, Digests by stake: {:?}",
                 self.summary.sequence_number,
                 self.signatures_by_digest.uncommitted_stake(),
-                digests_by_stake_messages,
+                digests_by_stake_messages
             );
             self.metrics.split_brain_checkpoint_forks.inc();
 

--- a/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
+++ b/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
@@ -451,7 +451,7 @@ impl ExecutionSchedulerAPI for ExecutionScheduler {
                     debug_fatal!(
                         "We should never enqueue certificate from wrong epoch. Expected={} Certificate={:?}",
                         epoch_store.epoch(),
-                        cert.0.epoch(),
+                        cert.0.epoch()
                     );
                     None
                 }


### PR DESCRIPTION
Also, we no longer panic for debug_fatal in antithesis. This is preferable because now we can both:
- learn that debug_fatal was hit in antithesis
- find out if the fact that we hit debug_fatal leads to even worse problems later
