### PR TITLE
Cherry-pick: Increase signing-time congestion check thresholds (#22998)

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -1246,7 +1246,7 @@ pub struct AuthorityOverloadConfig {
 }
 
 fn default_max_txn_age_in_queue() -> Duration {
-    Duration::from_millis(500)
+    Duration::from_millis(1000)
 }
 
 fn default_overload_monitor_interval() -> Duration {
@@ -1282,7 +1282,7 @@ fn default_max_transaction_manager_queue_length() -> usize {
 }
 
 fn default_max_transaction_manager_per_object_queue_length() -> usize {
-    20
+    2000
 }
 
 impl Default for AuthorityOverloadConfig {

--- a/crates/sui-core/src/unit_tests/execution_driver_tests.rs
+++ b/crates/sui-core/src/unit_tests/execution_driver_tests.rs
@@ -500,14 +500,24 @@ async fn test_per_object_overload() {
         config
     });
 
-    // Initialize a network with 1 account and 2000 gas objects.
+    // Initialize a network with 1 account and gas objects.
     let (addr, key): (_, AccountKeyPair) = get_key_pair();
-    const NUM_GAS_OBJECTS_PER_ACCOUNT: usize = 2000;
+    // Use a small threshold for testing to avoid creating too many objects
+    const TEST_PER_OBJECT_QUEUE_LENGTH: usize = 20;
+    const NUM_GAS_OBJECTS_PER_ACCOUNT: usize = TEST_PER_OBJECT_QUEUE_LENGTH + 10; // Some buffer
     let gas_objects = (0..NUM_GAS_OBJECTS_PER_ACCOUNT)
         .map(|_| Object::with_owner_for_testing(addr))
         .collect_vec();
     let (aggregator, authorities, _genesis, package) =
-        init_local_authorities(4, gas_objects.clone()).await;
+        init_local_authorities_with_overload_thresholds(
+            4,
+            gas_objects.clone(),
+            AuthorityOverloadConfig {
+                max_transaction_manager_per_object_queue_length: TEST_PER_OBJECT_QUEUE_LENGTH,
+                ..Default::default()
+            },
+        )
+        .await;
     let rgp = authorities
         .first()
         .unwrap()

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__network_config_snapshot_matches.snap
@@ -121,8 +121,8 @@ validator_configs:
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
-        secs: 0
-        nanos: 500000000
+        secs: 1
+        nanos: 0
       overload-monitor-interval:
         secs: 10
         nanos: 0
@@ -137,7 +137,7 @@ validator_configs:
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
-      max-transaction-manager-per-object-queue-length: 20
+      max-transaction-manager-per-object-queue-length: 2000
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -279,8 +279,8 @@ validator_configs:
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
-        secs: 0
-        nanos: 500000000
+        secs: 1
+        nanos: 0
       overload-monitor-interval:
         secs: 10
         nanos: 0
@@ -295,7 +295,7 @@ validator_configs:
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
-      max-transaction-manager-per-object-queue-length: 20
+      max-transaction-manager-per-object-queue-length: 2000
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -437,8 +437,8 @@ validator_configs:
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
-        secs: 0
-        nanos: 500000000
+        secs: 1
+        nanos: 0
       overload-monitor-interval:
         secs: 10
         nanos: 0
@@ -453,7 +453,7 @@ validator_configs:
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
-      max-transaction-manager-per-object-queue-length: 20
+      max-transaction-manager-per-object-queue-length: 2000
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -595,8 +595,8 @@ validator_configs:
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
-        secs: 0
-        nanos: 500000000
+        secs: 1
+        nanos: 0
       overload-monitor-interval:
         secs: 10
         nanos: 0
@@ -611,7 +611,7 @@ validator_configs:
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
-      max-transaction-manager-per-object-queue-length: 20
+      max-transaction-manager-per-object-queue-length: 2000
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -753,8 +753,8 @@ validator_configs:
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
-        secs: 0
-        nanos: 500000000
+        secs: 1
+        nanos: 0
       overload-monitor-interval:
         secs: 10
         nanos: 0
@@ -769,7 +769,7 @@ validator_configs:
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
-      max-transaction-manager-per-object-queue-length: 20
+      max-transaction-manager-per-object-queue-length: 2000
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -911,8 +911,8 @@ validator_configs:
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
-        secs: 0
-        nanos: 500000000
+        secs: 1
+        nanos: 0
       overload-monitor-interval:
         secs: 10
         nanos: 0
@@ -927,7 +927,7 @@ validator_configs:
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
-      max-transaction-manager-per-object-queue-length: 20
+      max-transaction-manager-per-object-queue-length: 2000
     execution-cache:
       writeback-cache:
         max_cache_size: ~
@@ -1069,8 +1069,8 @@ validator_configs:
         - Twitch
     authority-overload-config:
       max-txn-age-in-queue:
-        secs: 0
-        nanos: 500000000
+        secs: 1
+        nanos: 0
       overload-monitor-interval:
         secs: 10
         nanos: 0
@@ -1085,7 +1085,7 @@ validator_configs:
       safe-transaction-ready-rate: 100
       check-system-overload-at-signing: true
       max-transaction-manager-queue-length: 100000
-      max-transaction-manager-per-object-queue-length: 20
+      max-transaction-manager-per-object-queue-length: 2000
     execution-cache:
       writeback-cache:
         max_cache_size: ~


### PR DESCRIPTION
## Description 

These thresholds are meant only as a backstop to protect against failure of scheduling-time congestion control. The existing values were low enough to prevent tx from being signed under normal conditions.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
