### PR TITLE
[graphql-alt] Support SplitObjects command for Programmable TransactionKind [5/n]

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/split_coins.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/split_coins.move
@@ -1,0 +1,76 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --addresses test=0x0 --simulator
+
+//# programmable --sender A --inputs 100 200 @B  
+//> 0: SplitCoins(Gas, [Input(0), Input(1)]);
+//> 1: TransferObjects([NestedResult(0, 0), NestedResult(0, 1)], Input(2));
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs 50 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([NestedResult(0, 0)], Input(1));
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  # Split Gas with multiple amounts 
+  splitMultipleAmounts: transaction(digest: "@{digest_1}") {
+    kind {
+      ... on ProgrammableTransaction {
+        commands {
+          nodes {
+            __typename
+            ... on SplitCoinsCommand {
+              coin {
+                __typename
+                ... on Input { ix }
+                ... on TxResult { cmd ix }
+                ... on GasCoin { _ }
+              }
+              amounts {
+                __typename
+                ... on Input { ix }
+                ... on TxResult { cmd ix }
+                ... on GasCoin { _ }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{ 
+  # Split Gas with single amount
+  splitSingleAmount: transaction(digest: "@{digest_3}") {
+    kind {
+      ... on ProgrammableTransaction {
+        commands {
+          nodes {
+            __typename
+            ... on SplitCoinsCommand {
+              coin {
+                __typename
+                ... on Input { ix }
+                ... on TxResult { cmd ix }
+                ... on GasCoin { _ }
+              }
+              amounts {
+                __typename
+                ... on Input { ix }
+                ... on TxResult { cmd ix }
+                ... on GasCoin { _ }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+} 

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/split_coins.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/split_coins.move
@@ -25,24 +25,20 @@
           nodes {
             __typename
             ... on SplitCoinsCommand {
-              coin {
-                __typename
-                ... on Input { ix }
-                ... on TxResult { cmd ix }
-                ... on GasCoin { _ }
-              }
-              amounts {
-                __typename
-                ... on Input { ix }
-                ... on TxResult { cmd ix }
-                ... on GasCoin { _ }
-              }
+              coin { ...Arg }
+              amounts { ...Arg }
             }
           }
         }
       }
     }
   }
+}
+
+fragment Arg on TransactionArgument {
+  __typename
+  ... on Input { ix }
+  ... on TxResult { cmd ix }
 }
 
 //# run-graphql

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/split_coins.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/split_coins.snap
@@ -1,0 +1,97 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-8:
+//# programmable --sender A --inputs 100 200 @B  
+//> 0: SplitCoins(Gas, [Input(0), Input(1)]);
+//> 1: TransferObjects([NestedResult(0, 0), NestedResult(0, 1)], Input(2));
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2964000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 10:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 12-14:
+//# programmable --sender A --inputs 50 @B
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([NestedResult(0, 0)], Input(1));
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, line 16:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 5, lines 18-46:
+//# run-graphql
+Response: {
+  "data": {
+    "splitMultipleAmounts": {
+      "kind": {
+        "commands": {
+          "nodes": [
+            {
+              "__typename": "SplitCoinsCommand",
+              "coin": {
+                "__typename": "GasCoin",
+                "_": null
+              },
+              "amounts": [
+                {
+                  "__typename": "Input",
+                  "ix": 0
+                },
+                {
+                  "__typename": "Input",
+                  "ix": 1
+                }
+              ]
+            },
+            {
+              "__typename": "TransferObjectsCommand"
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+
+task 6, lines 48-76:
+//# run-graphql
+Response: {
+  "data": {
+    "splitSingleAmount": {
+      "kind": {
+        "commands": {
+          "nodes": [
+            {
+              "__typename": "SplitCoinsCommand",
+              "coin": {
+                "__typename": "GasCoin",
+                "_": null
+              },
+              "amounts": [
+                {
+                  "__typename": "Input",
+                  "ix": 0
+                }
+              ]
+            },
+            {
+              "__typename": "TransferObjectsCommand"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/split_coins.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/split_coins.snap
@@ -30,7 +30,7 @@ task 4, line 16:
 //# create-checkpoint
 Checkpoint created: 2
 
-task 5, lines 18-46:
+task 5, lines 18-42:
 //# run-graphql
 Response: {
   "data": {
@@ -41,8 +41,7 @@ Response: {
             {
               "__typename": "SplitCoinsCommand",
               "coin": {
-                "__typename": "GasCoin",
-                "_": null
+                "__typename": "GasCoin"
               },
               "amounts": [
                 {
@@ -65,7 +64,7 @@ Response: {
   }
 }
 
-task 6, lines 48-76:
+task 6, lines 44-72:
 //# run-graphql
 Response: {
   "data": {

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -314,7 +314,7 @@ type CoinDenyListStateCreateTransaction {
 """
 A single command in the programmable transaction.
 """
-union Command = MoveCallCommand | TransferObjectsCommand | OtherCommand
+union Command = MoveCallCommand | SplitCoinsCommand | TransferObjectsCommand | OtherCommand
 
 type CommandConnection {
 	"""
@@ -1557,6 +1557,20 @@ type SharedInput {
 	This has implications for scheduling: Transactions that just read shared objects at a certain version (mutable = false) can be executed concurrently, while transactions that write shared objects (mutable = true) must be executed serially with respect to each other.
 	"""
 	mutable: Boolean
+}
+
+"""
+Splits off coins with denominations in `amounts` from `coin`, returning multiple results (as many as there are amounts.)
+"""
+type SplitCoinsCommand {
+	"""
+	The coin to split.
+	"""
+	coin: TransactionArgument
+	"""
+	The denominations to split off from the coin.
+	"""
+	amounts: [TransactionArgument!]!
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/commands/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/commands/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod move_call;
+mod split_coins;
 mod transaction_argument;
 mod transfer_objects;
 
@@ -9,6 +10,7 @@ use async_graphql::*;
 use sui_types::transaction::Command as NativeCommand;
 
 pub use move_call::MoveCallCommand;
+pub use split_coins::SplitCoinsCommand;
 pub use transaction_argument::TransactionArgument;
 pub use transfer_objects::TransferObjectsCommand;
 
@@ -18,6 +20,7 @@ use crate::scope::Scope;
 #[derive(Union, Clone)]
 pub enum Command {
     MoveCall(MoveCallCommand),
+    SplitCoins(SplitCoinsCommand),
     TransferObjects(TransferObjectsCommand),
     Other(OtherCommand),
 }
@@ -34,6 +37,10 @@ impl Command {
     pub fn from(_scope: Scope, command: NativeCommand) -> Self {
         match command {
             NativeCommand::MoveCall(call) => Command::MoveCall(MoveCallCommand { native: *call }),
+            NativeCommand::SplitCoins(coin, amounts) => Command::SplitCoins(SplitCoinsCommand {
+                coin: Some(TransactionArgument::from(coin)),
+                amounts: amounts.into_iter().map(TransactionArgument::from).collect(),
+            }),
             NativeCommand::TransferObjects(objects, address) => {
                 Command::TransferObjects(TransferObjectsCommand {
                     inputs: objects.into_iter().map(TransactionArgument::from).collect(),

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/commands/split_coins.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/commands/split_coins.rs
@@ -1,0 +1,15 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::*;
+
+use super::TransactionArgument;
+
+/// Splits off coins with denominations in `amounts` from `coin`, returning multiple results (as many as there are amounts.)
+#[derive(SimpleObject, Clone)]
+pub struct SplitCoinsCommand {
+    /// The coin to split.
+    pub coin: Option<TransactionArgument>,
+    /// The denominations to split off from the coin.
+    pub amounts: Vec<TransactionArgument>,
+}

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -318,7 +318,7 @@ type CoinDenyListStateCreateTransaction {
 """
 A single command in the programmable transaction.
 """
-union Command = MoveCallCommand | TransferObjectsCommand | OtherCommand
+union Command = MoveCallCommand | SplitCoinsCommand | TransferObjectsCommand | OtherCommand
 
 type CommandConnection {
 	"""
@@ -1561,6 +1561,20 @@ type SharedInput {
 	This has implications for scheduling: Transactions that just read shared objects at a certain version (mutable = false) can be executed concurrently, while transactions that write shared objects (mutable = true) must be executed serially with respect to each other.
 	"""
 	mutable: Boolean
+}
+
+"""
+Splits off coins with denominations in `amounts` from `coin`, returning multiple results (as many as there are amounts.)
+"""
+type SplitCoinsCommand {
+	"""
+	The coin to split.
+	"""
+	coin: TransactionArgument
+	"""
+	The denominations to split off from the coin.
+	"""
+	amounts: [TransactionArgument!]!
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -318,7 +318,7 @@ type CoinDenyListStateCreateTransaction {
 """
 A single command in the programmable transaction.
 """
-union Command = MoveCallCommand | TransferObjectsCommand | OtherCommand
+union Command = MoveCallCommand | SplitCoinsCommand | TransferObjectsCommand | OtherCommand
 
 type CommandConnection {
 	"""
@@ -1561,6 +1561,20 @@ type SharedInput {
 	This has implications for scheduling: Transactions that just read shared objects at a certain version (mutable = false) can be executed concurrently, while transactions that write shared objects (mutable = true) must be executed serially with respect to each other.
 	"""
 	mutable: Boolean
+}
+
+"""
+Splits off coins with denominations in `amounts` from `coin`, returning multiple results (as many as there are amounts.)
+"""
+type SplitCoinsCommand {
+	"""
+	The coin to split.
+	"""
+	coin: TransactionArgument
+	"""
+	The denominations to split off from the coin.
+	"""
+	amounts: [TransactionArgument!]!
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -314,7 +314,7 @@ type CoinDenyListStateCreateTransaction {
 """
 A single command in the programmable transaction.
 """
-union Command = MoveCallCommand | TransferObjectsCommand | OtherCommand
+union Command = MoveCallCommand | SplitCoinsCommand | TransferObjectsCommand | OtherCommand
 
 type CommandConnection {
 	"""
@@ -1557,6 +1557,20 @@ type SharedInput {
 	This has implications for scheduling: Transactions that just read shared objects at a certain version (mutable = false) can be executed concurrently, while transactions that write shared objects (mutable = true) must be executed serially with respect to each other.
 	"""
 	mutable: Boolean
+}
+
+"""
+Splits off coins with denominations in `amounts` from `coin`, returning multiple results (as many as there are amounts.)
+"""
+type SplitCoinsCommand {
+	"""
+	The coin to split.
+	"""
+	coin: TransactionArgument
+	"""
+	The denominations to split off from the coin.
+	"""
+	amounts: [TransactionArgument!]!
 }
 
 """


### PR DESCRIPTION
## Description 

Support `SplitObjects` command for Programmable TransactionKind

The new schema is on par with old schema:
https://github.com/MystenLabs/sui/blob/b8d28ddbd06253373d2c02d001b3ba6c1ce8ea4f/crates/sui-graphql-rpc/schema.graphql#L3715-L3724


## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-graphql
cargo nextest run -p sui-indexer-alt-reader
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

---

## Stack

- #22997 
- #23000 
- #23008
- #23009 
- #23010 ⬅️

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
