### PR TITLE
[TD] improve handling of transactions rejected by consensus but accepted by some validators

### DIFF
--- a/crates/sui-core/src/test_authority_clients.rs
+++ b/crates/sui-core/src/test_authority_clients.rs
@@ -85,7 +85,17 @@ impl AuthorityAPI for LocalAuthorityClient {
         }
         let state = self.state.clone();
         let epoch_store = self.state.load_epoch_store_one_call_per_task();
-        let deserialized_transaction = bcs::from_bytes::<Transaction>(&request.transaction)
+        // TODO(fastpath): handle multiple transactions.
+        if request.transactions.len() != 1 {
+            return Err(SuiError::UnsupportedFeatureError {
+                error: format!(
+                    "Expected exactly 1 transaction in request, got {}",
+                    request.transactions.len()
+                ),
+            });
+        }
+
+        let deserialized_transaction = bcs::from_bytes::<Transaction>(&request.transactions[0])
             .map_err(|e| SuiError::TransactionDeserializationError {
                 error: e.to_string(),
             })?;

--- a/crates/sui-core/src/transaction_driver/effects_certifier.rs
+++ b/crates/sui-core/src/transaction_driver/effects_certifier.rs
@@ -223,9 +223,12 @@ impl EffectsCertifier {
                         Err(TransactionRequestError::ExecutionDataNotFound)
                     }
                 }
-                WaitForEffectsResponse::Rejected { error } => {
-                    Err(TransactionRequestError::RejectedAtValidator(error))
-                }
+                WaitForEffectsResponse::Rejected { error } => match error {
+                    Some(e) => Err(TransactionRequestError::RejectedAtValidator(e)),
+                    // Even though this response is not an error, returning an error which is required
+                    // by the function signature. This will get ignored by the caller as a retriable error.
+                    None => Err(TransactionRequestError::RejectedByConsensus),
+                },
                 WaitForEffectsResponse::Expired { epoch, round } => Err(
                     TransactionRequestError::StatusExpired(epoch, round.unwrap_or(0)),
                 ),
@@ -260,71 +263,39 @@ impl EffectsCertifier {
         })
         .unwrap();
 
-        // Send digest-only requests to all validators in parallel to minimize latency
+        // Broadcast requests for digest acknowledgments against all validators.
         let mut futures = FuturesUnordered::new();
         for (name, client) in clients {
             let client = client.clone();
             let name = *name;
+            let display_name = authority_aggregator.get_display_name(&name);
+
             let raw_request = raw_request.clone();
             let future = async move {
-                let effects_start = Instant::now();
-                // This loop can only retry RPC errors, timeouts, and other errors retriable
-                // without new submission.
-                let backoff = ExponentialBackoff::from_millis(100)
-                    .max_delay(Duration::from_secs(2))
-                    .map(jitter)
-                    .take(5);
-                for (attempt, delay) in backoff.enumerate() {
-                    let result = timeout(
-                        WAIT_FOR_EFFECTS_TIMEOUT,
-                        client.wait_for_effects(raw_request.clone(), options.forwarded_client_addr),
-                    )
-                    .await;
-                    let display_name = authority_aggregator.get_display_name(&name);
-                    match result {
-                        Ok(Ok(response)) => {
-                            let latency = effects_start.elapsed();
-                            client_monitor.record_interaction_result(OperationFeedback {
-                                authority_name: name,
-                                display_name,
-                                operation: OperationType::Effects,
-                                result: Ok(latency),
-                            });
-                            return (name, Ok(response));
-                        }
-                        Ok(Err(e)) => {
-                            let _latency = effects_start.elapsed();
-                            client_monitor.record_interaction_result(OperationFeedback {
-                                authority_name: name,
-                                display_name,
-                                operation: OperationType::Effects,
-                                result: Err(()),
-                            });
-                            if !matches!(e, SuiError::RpcError(_, _)) {
-                                return (name, Err(e));
-                            }
-                            tracing::trace!(
-                                ?name,
-                                "Wait for effects acknowledgement (attempt {attempt}): rpc error: {:?}",
-                                e
-                            );
-                        }
-                        Err(_) => {
-                            client_monitor.record_interaction_result(OperationFeedback {
-                                authority_name: name,
-                                display_name,
-                                operation: OperationType::Effects,
-                                result: Err(()),
-                            });
-                            tracing::trace!(
-                                ?name,
-                                "Wait for effects acknowledgement (attempt {attempt}): timeout"
-                            );
-                        }
-                    };
-                    sleep(delay).await;
+                match timeout(
+                    WAIT_FOR_EFFECTS_TIMEOUT,
+                    self.wait_for_acknowledgment_rpc(
+                        name,
+                        display_name.clone(),
+                        &client,
+                        client_monitor,
+                        &raw_request,
+                        options,
+                    ),
+                )
+                .await
+                {
+                    Ok(result) => result,
+                    Err(_) => {
+                        client_monitor.record_interaction_result(OperationFeedback {
+                            authority_name: name,
+                            display_name,
+                            operation: OperationType::Effects,
+                            result: Err(()),
+                        });
+                        (name, Err(SuiError::TimeoutError))
+                    }
                 }
-                (name, Err(SuiError::TimeoutError))
             };
 
             futures.push(future);
@@ -340,6 +311,9 @@ impl EffectsCertifier {
         // Collect errors retriable with new transaction submission.
         let mut retriable_errors_aggregator =
             StatusAggregator::<TransactionRequestError>::new(committee.clone());
+        // Collect validators that voted to accept the transaction, even though these validators believe
+        // consensus has rejected it.
+        let mut accept_aggregator = StatusAggregator::<()>::new(committee.clone());
 
         // Every validator returns at most one WaitForEffectsResponse.
         while let Some((name, response)) = futures.next().await {
@@ -373,11 +347,15 @@ impl EffectsCertifier {
                     }
                 }
                 Ok(WaitForEffectsResponse::Rejected { error }) => {
-                    let error = TransactionRequestError::RejectedAtValidator(error);
-                    if error.is_submission_retriable() {
-                        retriable_errors_aggregator.insert(name, error);
+                    if let Some(e) = error {
+                        let error = TransactionRequestError::RejectedAtValidator(e);
+                        if error.is_submission_retriable() {
+                            retriable_errors_aggregator.insert(name, error);
+                        } else {
+                            non_retriable_errors_aggregator.insert(name, error);
+                        }
                     } else {
-                        non_retriable_errors_aggregator.insert(name, error);
+                        accept_aggregator.insert(name, ());
                     }
                     self.metrics.rejection_acks.inc();
                 }
@@ -403,16 +381,16 @@ impl EffectsCertifier {
                 .values()
                 .map(|agg| agg.total_votes())
                 .sum();
-            let non_retriable_weight = non_retriable_errors_aggregator.total_votes();
-            let retriable_weight = retriable_errors_aggregator.total_votes();
-            let total_weight = executed_weight + non_retriable_weight + retriable_weight;
+            let total_weight = executed_weight
+                + accept_aggregator.total_votes()
+                + non_retriable_errors_aggregator.total_votes()
+                + retriable_errors_aggregator.total_votes();
 
-            // Quorum threshold is used here to gather as many responses as possible for summary,
-            // while making sure the loop can still exit with < 1/3 malicious stake.
-            if total_weight >= committee.quorum_threshold()
-                && non_retriable_weight + retriable_weight >= committee.validity_threshold()
-            {
-                if non_retriable_errors_aggregator.reached_validity_threshold() {
+            // Wait for a quorum of responses, to not summarize the responses too early.
+            if total_weight >= committee.quorum_threshold() {
+                // If neither of the branches below can exit the loop, the loop will eventually terminate
+                // when responses are gathered from all validators. The time is bounded by WAIT_FOR_EFFECTS_TIMEOUT.
+                if non_retriable_errors_aggregator.total_votes() >= committee.validity_threshold() {
                     return Err(TransactionDriverError::InvalidTransaction {
                         submission_non_retriable_errors: aggregate_request_errors(
                             non_retriable_errors_aggregator.status_by_authority(),
@@ -421,7 +399,10 @@ impl EffectsCertifier {
                             retriable_errors_aggregator.status_by_authority(),
                         ),
                     });
-                } else {
+                } else if non_retriable_errors_aggregator.total_votes()
+                    + retriable_errors_aggregator.total_votes()
+                    >= committee.validity_threshold()
+                {
                     let mut observed_effects_digests =
                         Vec::<(TransactionEffectsDigest, Vec<AuthorityName>, StakeUnit)>::new();
                     for (effects_digest, aggregator) in effects_digest_aggregators {
@@ -446,15 +427,19 @@ impl EffectsCertifier {
             }
         }
 
-        // At this point, no effects digest has reached quorum. But there is not a validity threshold
-        // of failed responses either.
-        let retriable_weight = retriable_errors_aggregator.total_votes();
+        // At this point, no effects digest has reached quorum. But failed responses do not reach
+        // validity threshold either.
+        let retriable_and_accept_weight =
+            retriable_errors_aggregator.total_votes() + accept_aggregator.total_votes();
+        // Whether the transaction is retriable regardless of known effects.
+        let mut submission_retriable = retriable_and_accept_weight >= committee.quorum_threshold();
         let mut observed_effects_digests =
             Vec::<(TransactionEffectsDigest, Vec<AuthorityName>, StakeUnit)>::new();
-        let mut submission_retriable = false;
         for (effects_digest, aggregator) in effects_digest_aggregators {
-            // An effects digest can still get certified, so the transaction is retriable.
-            if aggregator.total_votes() + retriable_weight >= committee.quorum_threshold() {
+            // This effects digest can still get certified, so the transaction is retriable.
+            if aggregator.total_votes() + retriable_and_accept_weight
+                >= committee.quorum_threshold()
+            {
                 submission_retriable = true;
             }
             observed_effects_digests.push((
@@ -462,12 +447,6 @@ impl EffectsCertifier {
                 aggregator.authorities(),
                 aggregator.total_votes(),
             ));
-        }
-        if observed_effects_digests.len() <= 1 {
-            debug_fatal!(
-                "Expect at least 2 effects digests, but got {:?}",
-                observed_effects_digests
-            );
         }
         if submission_retriable {
             Err(TransactionDriverError::Aborted {
@@ -482,6 +461,12 @@ impl EffectsCertifier {
                 },
             })
         } else {
+            if observed_effects_digests.len() <= 1 {
+                debug_fatal!(
+                    "Expect at least 2 effects digests, but got {:?}",
+                    observed_effects_digests
+                );
+            }
             Err(TransactionDriverError::ForkedExecution {
                 observed_effects_digests: AggregatedEffectsDigests {
                     digests: observed_effects_digests,
@@ -494,6 +479,60 @@ impl EffectsCertifier {
                 ),
             })
         }
+    }
+
+    async fn wait_for_acknowledgment_rpc<A>(
+        &self,
+        name: AuthorityName,
+        display_name: String,
+        client: &Arc<SafeClient<A>>,
+        client_monitor: &Arc<ValidatorClientMonitor<A>>,
+        raw_request: &RawWaitForEffectsRequest,
+        options: &SubmitTransactionOptions,
+    ) -> (AuthorityName, Result<WaitForEffectsResponse, SuiError>)
+    where
+        A: AuthorityAPI + Send + Sync + 'static + Clone,
+    {
+        let effects_start = Instant::now();
+        let backoff = ExponentialBackoff::from_millis(100)
+            .max_delay(Duration::from_secs(2))
+            .map(jitter);
+        // This loop should only retry errors that are retriable without new submission.
+        for (attempt, delay) in backoff.enumerate() {
+            let result = client
+                .wait_for_effects(raw_request.clone(), options.forwarded_client_addr)
+                .await;
+            match result {
+                Ok(response) => {
+                    let latency = effects_start.elapsed();
+                    client_monitor.record_interaction_result(OperationFeedback {
+                        authority_name: name,
+                        display_name: display_name.clone(),
+                        operation: OperationType::Effects,
+                        result: Ok(latency),
+                    });
+                    return (name, Ok(response));
+                }
+                Err(e) => {
+                    client_monitor.record_interaction_result(OperationFeedback {
+                        authority_name: name,
+                        display_name: display_name.clone(),
+                        operation: OperationType::Effects,
+                        result: Err(()),
+                    });
+                    if !matches!(e, SuiError::RpcError(_, _)) {
+                        return (name, Err(e));
+                    }
+                    tracing::trace!(
+                        ?name,
+                        "Wait for effects acknowledgement (attempt {attempt}): rpc error: {:?}",
+                        e
+                    );
+                }
+            };
+            sleep(delay).await;
+        }
+        (name, Err(SuiError::TimeoutError))
     }
 
     /// Creates the final full response.

--- a/crates/sui-core/src/transaction_driver/error.rs
+++ b/crates/sui-core/src/transaction_driver/error.rs
@@ -31,6 +31,8 @@ pub(crate) enum TransactionRequestError {
     // Rejected by the validator when voting on the transaction.
     #[error("{0}")]
     RejectedAtValidator(SuiError),
+    #[error("Transaction rejected by consensus")]
+    RejectedByConsensus,
     // Transaction status has been dropped from cache at the validator.
     #[error("Transaction status expired")]
     StatusExpired(EpochId, u32),

--- a/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
@@ -96,7 +96,7 @@ impl TestContext {
 
     fn build_submit_request(&self, transaction: Transaction) -> RawSubmitTxRequest {
         RawSubmitTxRequest {
-            transaction: bcs::to_bytes(&transaction).unwrap().into(),
+            transactions: vec![bcs::to_bytes(&transaction).unwrap().into()],
         }
     }
 }
@@ -130,7 +130,7 @@ async fn test_submit_transaction_invalid_transaction() {
 
     // Create an invalid request with malformed transaction bytes
     let request = RawSubmitTxRequest {
-        transaction: vec![0xFF, 0xFF, 0xFF].into(),
+        transactions: vec![vec![0xFF, 0xFF, 0xFF].into()],
     };
 
     let response = test_context.client.submit_transaction(request, None).await;

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -649,7 +649,6 @@ pub enum SuiError {
     #[error("Method not allowed")]
     InvalidRpcMethodError,
 
-    // TODO: We should fold this into UserInputError::Unsupported.
     #[error("Use of disabled feature: {:?}", error)]
     UnsupportedFeatureError { error: String },
 

--- a/crates/sui-types/src/messages_grpc.rs
+++ b/crates/sui-types/src/messages_grpc.rs
@@ -222,14 +222,20 @@ pub struct HandleCertificateRequestV3 {
 
 #[derive(Clone, prost::Message)]
 pub struct RawSubmitTxRequest {
-    #[prost(bytes = "bytes", tag = "1")]
-    pub transaction: Bytes,
+    #[prost(bytes = "bytes", repeated, tag = "1")]
+    pub transactions: Vec<Bytes>,
 }
 
 #[derive(Clone, prost::Message)]
 pub struct RawSubmitTxResponse {
-    // Serialized Consensus Position
-    #[prost(oneof = "RawValidatorSubmitStatus", tags = "1, 2, 3")]
+    // Results for each transaction in the request
+    #[prost(message, repeated, tag = "1")]
+    pub results: Vec<RawSubmitTxResult>,
+}
+
+#[derive(Clone, prost::Message)]
+pub struct RawSubmitTxResult {
+    #[prost(oneof = "RawValidatorSubmitStatus", tags = "1, 2")]
     pub inner: Option<RawValidatorSubmitStatus>,
 }
 
@@ -303,8 +309,8 @@ pub struct RawExecutedData {
 
 #[derive(Clone, prost::Message)]
 pub struct RawRejectedStatus {
-    #[prost(bytes = "bytes", tag = "1")]
-    pub error: Bytes,
+    #[prost(bytes = "bytes", optional, tag = "1")]
+    pub error: Option<Bytes>,
 }
 
 #[derive(Clone, prost::Message)]


### PR DESCRIPTION
## Description 

When a validator observes consensus rejecting a txn but did not reject the txn itself, do not treat its WaitForEffects response an error. This allows more accurate categorization of errors when there are conflicting votes on the transaction. For example when there are f+1 lock conflict errors and 2f accept votes on a transaction, current logic will abort with retriable error after seeing enough accept votes. After this change, EffectsCertifier will wait until f+1 lock conflict errors are observed and do not retry the txn afterwards.

Change RPC API to support this. Also change RPC API to allow submitting multiple transactions in the same request.

## Test plan 

CI & PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
