### PR TITLE
[rpc-alt] implement PinnedDrop for MetricsFuture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10040,18 +10040,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14694,6 +14694,7 @@ dependencies = [
  "jsonrpsee",
  "move-binary-format",
  "move-core-types",
+ "pin-project",
  "pin-project-lite",
  "prometheus",
  "reqwest 0.12.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -450,6 +450,7 @@ once_cell = "1.18.0"
 ouroboros = "0.17"
 parking_lot = { version = "0.12.3", features = ["arc_lock"] }
 parquet = "54"
+pin-project = "1"
 pin-project-lite = "0.2.13"
 pkcs8 = { version = "0.10.0", features = ["std"] }
 pprof = { version = "0.14.0", features = ["cpp", "frame-pointer"] }

--- a/crates/sui-indexer-alt-jsonrpc/Cargo.toml
+++ b/crates/sui-indexer-alt-jsonrpc/Cargo.toml
@@ -29,7 +29,7 @@ futures.workspace = true
 http.workspace = true
 jsonrpsee = { workspace = true, features = ["macros", "server"] }
 pin-project-lite.workspace = true
-pin-project = "1"
+pin-project.workspace = true
 prometheus.workspace = true
 schemars.workspace = true
 serde.workspace = true

--- a/crates/sui-indexer-alt-jsonrpc/Cargo.toml
+++ b/crates/sui-indexer-alt-jsonrpc/Cargo.toml
@@ -29,6 +29,7 @@ futures.workspace = true
 http.workspace = true
 jsonrpsee = { workspace = true, features = ["macros", "server"] }
 pin-project-lite.workspace = true
+pin-project = "1"
 prometheus.workspace = true
 schemars.workspace = true
 serde.workspace = true

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -60,6 +60,11 @@ pub struct RpcArgs {
     /// the query itself will be logged as a warning.
     #[clap(long, default_value_t = Self::default().request_timeout_ms)]
     pub request_timeout_ms: u64,
+
+    /// Requests that take longer than this (in milliseconds) will be logged even if they succeed.
+    /// This should be shorter than `request_timeout_ms`.
+    #[clap(long, default_value_t = Self::default().slow_request_threshold_ms)]
+    pub slow_request_threshold_ms: u64,
 }
 
 pub struct RpcService {
@@ -75,6 +80,9 @@ pub struct RpcService {
     /// Maximum time a request can take to complete.
     request_timeout: Duration,
 
+    /// Threshold for logging slow requests.
+    slow_request_threshold: Duration,
+
     /// All the methods added to the server so far.
     modules: jsonrpsee::RpcModule<()>,
 
@@ -86,9 +94,14 @@ pub struct RpcService {
 }
 
 impl RpcArgs {
-    /// Requests that take longer than this should be logged for debugging.
+    /// Requests that take longer than this are terminated and logged for debugging.
     fn request_timeout(&self) -> Duration {
         Duration::from_millis(self.request_timeout_ms)
+    }
+
+    /// Requests that take longer than this are logged for debugging even if they succeed.
+    fn slow_request_threshold(&self) -> Duration {
+        Duration::from_millis(self.slow_request_threshold_ms)
     }
 }
 
@@ -126,6 +139,7 @@ impl RpcService {
             server,
             metrics,
             request_timeout: rpc_args.request_timeout(),
+            slow_request_threshold: rpc_args.slow_request_threshold(),
             modules: jsonrpsee::RpcModule::new(()),
             schema,
             cancel,
@@ -154,6 +168,7 @@ impl RpcService {
             server,
             metrics,
             request_timeout,
+            slow_request_threshold,
             mut modules,
             schema,
             cancel,
@@ -172,6 +187,7 @@ impl RpcService {
             .layer(MetricsLayer::new(
                 metrics,
                 modules.method_names().map(|n| n.to_owned()).collect(),
+                slow_request_threshold,
             ));
 
         let handle = server
@@ -212,6 +228,7 @@ impl Default for RpcArgs {
             rpc_listen_address: "0.0.0.0:6000".parse().unwrap(),
             max_in_flight_requests: 2000,
             request_timeout_ms: 60_000,
+            slow_request_threshold_ms: 15_000,
         }
     }
 }

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -100,6 +100,7 @@ impl RpcArgs {
     }
 
     /// Requests that take longer than this are logged for debugging even if they succeed.
+    /// This threshold should be lower than the request timeout threshold.
     fn slow_request_threshold(&self) -> Duration {
         Duration::from_millis(self.slow_request_threshold_ms)
     }

--- a/crates/sui-indexer-alt-jsonrpc/src/metrics/middleware.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/metrics/middleware.rs
@@ -192,7 +192,6 @@ where
             }
         } else {
             metrics.succeeded.with_label_values(&[method]).inc();
-
             if elapsed_ms > slow_threshold_ms {
                 warn!(
                     method,

--- a/crates/sui-indexer-alt-jsonrpc/src/metrics/mod.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/metrics/mod.rs
@@ -30,6 +30,7 @@ pub struct RpcMetrics {
     pub requests_received: IntCounterVec,
     pub requests_succeeded: IntCounterVec,
     pub requests_failed: IntCounterVec,
+    pub requests_cancelled: IntCounterVec,
 
     pub owned_objects_filter_scans: Histogram,
     pub read_retries: IntCounterVec,
@@ -68,6 +69,14 @@ impl RpcMetrics {
                 "jsonrpc_requests_failed",
                 "Number of requests that completed with an error for each JSON-RPC method, by error code",
                 &["method", "code"],
+                registry
+            )
+            .unwrap(),
+
+            requests_cancelled: register_int_counter_vec_with_registry!(
+                "jsonrpc_requests_cancelled",
+                "Number of requests that were cancelled before completion for each JSON-RPC method",
+                &["method"],
                 registry
             )
             .unwrap(),


### PR DESCRIPTION
## Description 

Cancelled jsonrpc-alt requests are not logged or recored by success/failure metrics because they never reach deeply enough into the `MetricsFuture::poll` method because the future is still in pending state when the request is cancelled. A `Drop` implementation is needed to capture cancelled requests. Since the `inner` of `MetricsFuture` is pinned by `pin_project` where a regular `Drop` impl is not allowed, a `PinnedDrop` impl is needed. This PR implements that. More context under [this thread](https://mysten-labs.slack.com/archives/C08FWRBHW82/p1754118272614949?thread_ts=1754089823.227799&cid=C08FWRBHW82).

Also logging is added for slow requests even when they succeed to finish.

## Test plan 

Tested locally by simulating a long request with `sleep`:
```
2025-08-11T05:37:01.584092Z  INFO sui_indexer_alt_jsonrpc::metrics::middleware: Request cancelled method="suix_getReferenceGasPrice" elapsed_ms=6004.01525
2025-08-11T05:37:01.584158Z  WARN sui_indexer_alt_jsonrpc::metrics::middleware: Cancelled request took a long time method="suix_getReferenceGasPrice" params="[]" elapsed_ms=6004.01525
```
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
