### PR TITLE
[graphql-alt] Support Publish command for Programmable TransactionKind [7/n]

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/publish.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/publish.move
@@ -1,0 +1,33 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --addresses test=0x0 --simulator
+
+//# publish --sender A
+module test::simple_module {
+    public fun hello(): u64 {
+        42
+    }
+}
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  # Test PublishCommand
+  publishTest: transaction(digest: "@{digest_1}") {
+    kind {
+      ... on ProgrammableTransaction {
+        commands {
+          nodes {
+            __typename
+            ... on PublishCommand {
+              modules
+              dependencies
+            }
+          }
+        }
+      }
+    }
+  }
+} 

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/publish.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/publish.snap
@@ -1,0 +1,45 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-11:
+//# publish --sender A
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3655600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 13:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 15-33:
+//# run-graphql
+Response: {
+  "data": {
+    "publishTest": {
+      "kind": {
+        "commands": {
+          "nodes": [
+            {
+              "__typename": "PublishCommand",
+              "modules": [
+                "oRzrCwYAAAAGAQACAwIFBQcDBwoUCB4gDD4QAAEAAAABAAABAwVoZWxsbw1zaW1wbGVfbW9kdWxlAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAIGKgAAAAAAAAACAA=="
+              ],
+              "dependencies": [
+                "0x0000000000000000000000000000000000000000000000000000000000000001",
+                "0x0000000000000000000000000000000000000000000000000000000000000002"
+              ]
+            },
+            {
+              "__typename": "MoveCallCommand"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -1265,11 +1265,11 @@ type PublishCommand {
 	"""
 	Bytecode for the modules to be published, BCS serialized and Base64 encoded.
 	"""
-	modules: [Base64!]!
+	modules: [Base64!]
 	"""
 	IDs of the transitive dependencies of the package to be published.
 	"""
-	dependencies: [SuiAddress!]!
+	dependencies: [SuiAddress!]
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -318,7 +318,7 @@ type CoinDenyListStateCreateTransaction {
 """
 A single command in the programmable transaction.
 """
-union Command = MergeCoinsCommand | MoveCallCommand | SplitCoinsCommand | TransferObjectsCommand | OtherCommand
+union Command = MergeCoinsCommand | MoveCallCommand | PublishCommand | SplitCoinsCommand | TransferObjectsCommand | OtherCommand
 
 type CommandConnection {
 	"""
@@ -1256,6 +1256,20 @@ type ProtocolConfigs {
 	List all available feature flags and their values.
 	"""
 	featureFlags: [FeatureFlag!]!
+}
+
+"""
+Publishes a Move Package.
+"""
+type PublishCommand {
+	"""
+	Bytecode for the modules to be published, BCS serialized and Base64 encoded.
+	"""
+	modules: [Base64!]!
+	"""
+	IDs of the transitive dependencies of the package to be published.
+	"""
+	dependencies: [SuiAddress!]!
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/commands/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/commands/mod.rs
@@ -60,8 +60,8 @@ impl Command {
                 })
             }
             NativeCommand::Publish(modules, dependencies) => Command::Publish(PublishCommand {
-                modules: modules.into_iter().map(Base64::from).collect(),
-                dependencies: dependencies.into_iter().map(SuiAddress::from).collect(),
+                modules: Some(modules.into_iter().map(Base64::from).collect()),
+                dependencies: Some(dependencies.into_iter().map(SuiAddress::from).collect()),
             }),
             _ => Command::Other(OtherCommand { dummy: None }),
         }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/commands/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/commands/mod.rs
@@ -3,6 +3,7 @@
 
 mod merge_coins;
 mod move_call;
+mod publish;
 mod split_coins;
 mod transaction_argument;
 mod transfer_objects;
@@ -10,8 +11,11 @@ mod transfer_objects;
 use async_graphql::*;
 use sui_types::transaction::Command as NativeCommand;
 
+use crate::api::scalars::{base64::Base64, sui_address::SuiAddress};
+
 pub use merge_coins::MergeCoinsCommand;
 pub use move_call::MoveCallCommand;
+pub use publish::PublishCommand;
 pub use split_coins::SplitCoinsCommand;
 pub use transaction_argument::TransactionArgument;
 pub use transfer_objects::TransferObjectsCommand;
@@ -23,6 +27,7 @@ use crate::scope::Scope;
 pub enum Command {
     MergeCoins(MergeCoinsCommand),
     MoveCall(MoveCallCommand),
+    Publish(PublishCommand),
     SplitCoins(SplitCoinsCommand),
     TransferObjects(TransferObjectsCommand),
     Other(OtherCommand),
@@ -54,6 +59,10 @@ impl Command {
                     address: Some(TransactionArgument::from(address)),
                 })
             }
+            NativeCommand::Publish(modules, dependencies) => Command::Publish(PublishCommand {
+                modules: modules.into_iter().map(Base64::from).collect(),
+                dependencies: dependencies.into_iter().map(SuiAddress::from).collect(),
+            }),
             _ => Command::Other(OtherCommand { dummy: None }),
         }
     }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/commands/publish.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/commands/publish.rs
@@ -9,8 +9,8 @@ use crate::api::scalars::{base64::Base64, sui_address::SuiAddress};
 #[derive(SimpleObject, Clone)]
 pub struct PublishCommand {
     /// Bytecode for the modules to be published, BCS serialized and Base64 encoded.
-    pub modules: Vec<Base64>,
+    pub modules: Option<Vec<Base64>>,
 
     /// IDs of the transitive dependencies of the package to be published.
-    pub dependencies: Vec<SuiAddress>,
+    pub dependencies: Option<Vec<SuiAddress>>,
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/commands/publish.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/commands/publish.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::*;
+
+use crate::api::scalars::{base64::Base64, sui_address::SuiAddress};
+
+/// Publishes a Move Package.
+#[derive(SimpleObject, Clone)]
+pub struct PublishCommand {
+    /// Bytecode for the modules to be published, BCS serialized and Base64 encoded.
+    pub modules: Vec<Base64>,
+
+    /// IDs of the transitive dependencies of the package to be published.
+    pub dependencies: Vec<SuiAddress>,
+}

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -322,7 +322,7 @@ type CoinDenyListStateCreateTransaction {
 """
 A single command in the programmable transaction.
 """
-union Command = MergeCoinsCommand | MoveCallCommand | SplitCoinsCommand | TransferObjectsCommand | OtherCommand
+union Command = MergeCoinsCommand | MoveCallCommand | PublishCommand | SplitCoinsCommand | TransferObjectsCommand | OtherCommand
 
 type CommandConnection {
 	"""
@@ -1260,6 +1260,20 @@ type ProtocolConfigs {
 	List all available feature flags and their values.
 	"""
 	featureFlags: [FeatureFlag!]!
+}
+
+"""
+Publishes a Move Package.
+"""
+type PublishCommand {
+	"""
+	Bytecode for the modules to be published, BCS serialized and Base64 encoded.
+	"""
+	modules: [Base64!]!
+	"""
+	IDs of the transitive dependencies of the package to be published.
+	"""
+	dependencies: [SuiAddress!]!
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -1269,11 +1269,11 @@ type PublishCommand {
 	"""
 	Bytecode for the modules to be published, BCS serialized and Base64 encoded.
 	"""
-	modules: [Base64!]!
+	modules: [Base64!]
 	"""
 	IDs of the transitive dependencies of the package to be published.
 	"""
-	dependencies: [SuiAddress!]!
+	dependencies: [SuiAddress!]
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -322,7 +322,7 @@ type CoinDenyListStateCreateTransaction {
 """
 A single command in the programmable transaction.
 """
-union Command = MergeCoinsCommand | MoveCallCommand | SplitCoinsCommand | TransferObjectsCommand | OtherCommand
+union Command = MergeCoinsCommand | MoveCallCommand | PublishCommand | SplitCoinsCommand | TransferObjectsCommand | OtherCommand
 
 type CommandConnection {
 	"""
@@ -1260,6 +1260,20 @@ type ProtocolConfigs {
 	List all available feature flags and their values.
 	"""
 	featureFlags: [FeatureFlag!]!
+}
+
+"""
+Publishes a Move Package.
+"""
+type PublishCommand {
+	"""
+	Bytecode for the modules to be published, BCS serialized and Base64 encoded.
+	"""
+	modules: [Base64!]!
+	"""
+	IDs of the transitive dependencies of the package to be published.
+	"""
+	dependencies: [SuiAddress!]!
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -1269,11 +1269,11 @@ type PublishCommand {
 	"""
 	Bytecode for the modules to be published, BCS serialized and Base64 encoded.
 	"""
-	modules: [Base64!]!
+	modules: [Base64!]
 	"""
 	IDs of the transitive dependencies of the package to be published.
 	"""
-	dependencies: [SuiAddress!]!
+	dependencies: [SuiAddress!]
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -1265,11 +1265,11 @@ type PublishCommand {
 	"""
 	Bytecode for the modules to be published, BCS serialized and Base64 encoded.
 	"""
-	modules: [Base64!]!
+	modules: [Base64!]
 	"""
 	IDs of the transitive dependencies of the package to be published.
 	"""
-	dependencies: [SuiAddress!]!
+	dependencies: [SuiAddress!]
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -318,7 +318,7 @@ type CoinDenyListStateCreateTransaction {
 """
 A single command in the programmable transaction.
 """
-union Command = MergeCoinsCommand | MoveCallCommand | SplitCoinsCommand | TransferObjectsCommand | OtherCommand
+union Command = MergeCoinsCommand | MoveCallCommand | PublishCommand | SplitCoinsCommand | TransferObjectsCommand | OtherCommand
 
 type CommandConnection {
 	"""
@@ -1256,6 +1256,20 @@ type ProtocolConfigs {
 	List all available feature flags and their values.
 	"""
 	featureFlags: [FeatureFlag!]!
+}
+
+"""
+Publishes a Move Package.
+"""
+type PublishCommand {
+	"""
+	Bytecode for the modules to be published, BCS serialized and Base64 encoded.
+	"""
+	modules: [Base64!]!
+	"""
+	IDs of the transitive dependencies of the package to be published.
+	"""
+	dependencies: [SuiAddress!]!
 }
 
 """


### PR DESCRIPTION
## Description 

Support `Publish` command for Programmable TransactionKind

The new schema is on par with old schema:
https://github.com/MystenLabs/sui/blob/b8d28ddbd06253373d2c02d001b3ba6c1ce8ea4f/crates/sui-graphql-rpc/schema.graphql#L3217-L3226


## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-graphql
cargo nextest run -p sui-indexer-alt-reader
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

---

## Stack
- #22997 
- #23000 
- #23008
- #23009 
- #23010
- #23011 
- #23019 ⬅️

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
