### PR TITLE
Cache txn digest -> executed effects directly

### DIFF
--- a/crates/sui-core/src/execution_cache/writeback_cache.rs
+++ b/crates/sui-core/src/execution_cache/writeback_cache.rs
@@ -222,13 +222,13 @@ struct UncommittedData {
     // marker_cache.
     markers: DashMap<MarkerKey, CachedVersionMap<MarkerValue>>,
 
-    transaction_effects: DashMap<TransactionEffectsDigest, TransactionEffects>,
+    transaction_effects: DashMap<TransactionEffectsDigest, Arc<TransactionEffects>>,
 
     transaction_events: DashMap<TransactionDigest, TransactionEvents>,
 
     unchanged_loaded_runtime_objects: DashMap<TransactionDigest, Vec<ObjectKey>>,
 
-    executed_effects_digests: DashMap<TransactionDigest, TransactionEffectsDigest>,
+    executed_effects: DashMap<TransactionDigest, Arc<TransactionEffects>>,
 
     // Transaction outputs that have not yet been written to the DB. Items are removed from this
     // table as they are flushed to the db.
@@ -258,7 +258,7 @@ impl UncommittedData {
             objects: DashMap::with_shard_amount(2048),
             markers: DashMap::with_shard_amount(2048),
             transaction_effects: DashMap::with_shard_amount(2048),
-            executed_effects_digests: DashMap::with_shard_amount(2048),
+            executed_effects: DashMap::with_shard_amount(2048),
             pending_transaction_writes: DashMap::with_shard_amount(2048),
             fastpath_transaction_outputs: MokaCache::builder(8)
                 .max_capacity(randomize_cache_capacity_in_tests(
@@ -276,7 +276,7 @@ impl UncommittedData {
         self.objects.clear();
         self.markers.clear();
         self.transaction_effects.clear();
-        self.executed_effects_digests.clear();
+        self.executed_effects.clear();
         self.pending_transaction_writes.clear();
         self.fastpath_transaction_outputs.invalidate_all();
         self.transaction_events.clear();
@@ -294,7 +294,7 @@ impl UncommittedData {
                 self.objects.is_empty()
                     && self.markers.is_empty()
                     && self.transaction_effects.is_empty()
-                    && self.executed_effects_digests.is_empty()
+                    && self.executed_effects.is_empty()
                     && self.transaction_events.is_empty()
                     && self.unchanged_loaded_runtime_objects.is_empty()
                     && self
@@ -345,8 +345,7 @@ struct CachedCommittedData {
 
     transaction_events: MonotonicCache<TransactionDigest, PointCacheItem<Arc<TransactionEvents>>>,
 
-    executed_effects_digests:
-        MonotonicCache<TransactionDigest, PointCacheItem<TransactionEffectsDigest>>,
+    executed_effects: MonotonicCache<TransactionDigest, PointCacheItem<Arc<TransactionEffects>>>,
 
     transaction_executed_in_last_epoch:
         MonotonicCache<(EpochId, TransactionDigest), PointCacheItem<()>>,
@@ -378,7 +377,7 @@ impl CachedCommittedData {
         let transaction_events = MonotonicCache::new(randomize_cache_capacity_in_tests(
             config.events_cache_size(),
         ));
-        let executed_effects_digests = MonotonicCache::new(randomize_cache_capacity_in_tests(
+        let executed_effects = MonotonicCache::new(randomize_cache_capacity_in_tests(
             config.executed_effect_cache_size(),
         ));
 
@@ -398,7 +397,7 @@ impl CachedCommittedData {
             transactions,
             transaction_effects,
             transaction_events,
-            executed_effects_digests,
+            executed_effects,
             transaction_executed_in_last_epoch,
             _transaction_objects: transaction_objects,
         }
@@ -410,7 +409,7 @@ impl CachedCommittedData {
         self.transactions.invalidate_all();
         self.transaction_effects.invalidate_all();
         self.transaction_events.invalidate_all();
-        self.executed_effects_digests.invalidate_all();
+        self.executed_effects.invalidate_all();
         self.transaction_executed_in_last_epoch.invalidate_all();
         self._transaction_objects.invalidate_all();
 
@@ -419,7 +418,7 @@ impl CachedCommittedData {
         assert!(self.transactions.is_empty());
         assert!(self.transaction_effects.is_empty());
         assert!(self.transaction_events.is_empty());
-        assert!(self.executed_effects_digests.is_empty());
+        assert!(self.executed_effects.is_empty());
         assert!(self.transaction_executed_in_last_epoch.is_empty());
         assert_empty(&self._transaction_objects);
     }
@@ -461,7 +460,7 @@ pub struct WritebackCache {
 
     object_locks: ObjectLocks,
 
-    executed_effects_digests_notify_read: NotifyRead<TransactionDigest, TransactionEffectsDigest>,
+    executed_effects_notify_read: NotifyRead<TransactionDigest, TransactionEffects>,
     object_notify_read: NotifyRead<InputKey, ()>,
     fastpath_transaction_outputs_notify_read:
         NotifyRead<TransactionDigest, Arc<TransactionOutputs>>,
@@ -529,7 +528,7 @@ impl WritebackCache {
             )),
             packages,
             object_locks: ObjectLocks::new(),
-            executed_effects_digests_notify_read: NotifyRead::new(),
+            executed_effects_notify_read: NotifyRead::new(),
             object_notify_read: NotifyRead::new(),
             fastpath_transaction_outputs_notify_read: NotifyRead::new(),
             store,
@@ -560,7 +559,7 @@ impl WritebackCache {
     }
 
     pub fn evict_executed_effects_from_cache_for_testing(&self, tx_digest: &TransactionDigest) {
-        self.cached.executed_effects_digests.invalidate(tx_digest);
+        self.cached.executed_effects.invalidate(tx_digest);
         self.cached.transaction_events.invalidate(tx_digest);
         self.cached.transactions.invalidate(tx_digest);
     }
@@ -981,18 +980,19 @@ impl WritebackCache {
                 .collect::<Vec<_>>(),
         );
         let effects_digest = effects.digest();
+        let effects_content = Arc::new(effects.clone());
 
         self.metrics.record_cache_write("transaction_block");
         self.dirty
             .pending_transaction_writes
             .insert(tx_digest, tx_outputs.clone());
 
-        // insert transaction effects before executed_effects_digests so that there
-        // are never dangling entries in executed_effects_digests
+        // insert transaction effects before executed_effects so that we don't observe
+        // executed effects before transaction effects are available.
         self.metrics.record_cache_write("transaction_effects");
         self.dirty
             .transaction_effects
-            .insert(effects_digest, effects.clone());
+            .insert(effects_digest, effects_content.clone());
 
         // note: if events.data.is_empty(), then there are no events for this transaction. We
         // store it anyway to avoid special cases in commint_transaction_outputs, and translate
@@ -1008,17 +1008,17 @@ impl WritebackCache {
             .unchanged_loaded_runtime_objects
             .insert(tx_digest, unchanged_loaded_runtime_objects.clone());
 
-        self.metrics.record_cache_write("executed_effects_digests");
+        self.metrics.record_cache_write("executed_effects");
         self.dirty
-            .executed_effects_digests
-            .insert(tx_digest, effects_digest);
+            .executed_effects
+            .insert(tx_digest, effects_content);
 
-        self.executed_effects_digests_notify_read
-            .notify(&tx_digest, &effects_digest);
+        self.executed_effects_notify_read
+            .notify(&tx_digest, effects);
 
         self.metrics
             .pending_notify_read
-            .set(self.executed_effects_digests_notify_read.num_pending() as i64);
+            .set(self.executed_effects_notify_read.num_pending() as i64);
 
         let prev = self
             .dirty
@@ -1163,21 +1163,18 @@ impl WritebackCache {
                 Ticket::Write,
             )
             .ok();
+        let effects = Arc::new(effects.clone());
         self.cached
             .transaction_effects
             .insert(
                 &effects_digest,
-                PointCacheItem::Some(effects.clone().into()),
+                PointCacheItem::Some(effects.clone()),
                 Ticket::Write,
             )
             .ok();
         self.cached
-            .executed_effects_digests
-            .insert(
-                &tx_digest,
-                PointCacheItem::Some(effects_digest),
-                Ticket::Write,
-            )
+            .executed_effects
+            .insert(&tx_digest, PointCacheItem::Some(effects), Ticket::Write)
             .ok();
         self.cached
             .transaction_events
@@ -1204,7 +1201,7 @@ impl WritebackCache {
             .expect("unchanged_loaded_runtime_objects must exist");
 
         self.dirty
-            .executed_effects_digests
+            .executed_effects
             .remove(&tx_digest)
             .expect("executed effects must exist");
 
@@ -1982,40 +1979,39 @@ impl TransactionCacheRead for WritebackCache {
         &self,
         digests: &[TransactionDigest],
     ) -> Vec<Option<TransactionEffectsDigest>> {
+        // We implement this separately from multi_get_executed_effects() to avoid
+        // the two-step DB lookup (tx_digest -> effects_digest -> effects), which
+        // can introduce consistency issues and is more expensive.
+        // For just getting the executed effects digests, we only need to look up the
+        // executed_effects table (tx_digest -> effects_digest)..
         let digests_and_tickets: Vec<_> = digests
             .iter()
-            .map(|d| {
-                (
-                    *d,
-                    self.cached.executed_effects_digests.get_ticket_for_read(d),
-                )
-            })
+            .map(|d| (*d, self.cached.executed_effects.get_ticket_for_read(d)))
             .collect();
         do_fallback_lookup(
             &digests_and_tickets,
             |(digest, _)| {
                 self.metrics
                     .record_cache_request("executed_effects_digests", "uncommitted");
-                if let Some(digest) = self.dirty.executed_effects_digests.get(digest) {
+                if let Some(effects) = self.dirty.executed_effects.get(digest) {
                     self.metrics
                         .record_cache_hit("executed_effects_digests", "uncommitted");
-                    return CacheResult::Hit(Some(*digest));
+                    return CacheResult::Hit(Some(effects.digest()));
                 }
                 self.metrics
                     .record_cache_miss("executed_effects_digests", "uncommitted");
-
                 self.metrics
                     .record_cache_request("executed_effects_digests", "committed");
                 match self
                     .cached
-                    .executed_effects_digests
+                    .executed_effects
                     .get(digest)
-                    .map(|l| *l.lock())
+                    .map(|l| l.lock().clone())
                 {
-                    Some(PointCacheItem::Some(digest)) => {
+                    Some(PointCacheItem::Some(effects)) => {
                         self.metrics
                             .record_cache_hit("executed_effects_digests", "committed");
-                        CacheResult::Hit(Some(digest))
+                        CacheResult::Hit(Some(effects.digest()))
                     }
                     Some(PointCacheItem::None) => CacheResult::NegativeHit,
                     None => {
@@ -2027,6 +2023,7 @@ impl TransactionCacheRead for WritebackCache {
             },
             |remaining| {
                 let remaining_digests: Vec<_> = remaining.iter().map(|(d, _)| *d).collect();
+                // multi_get_executed_effects_digests() is a one-step DB lookup (tx_digest -> effects_digest).
                 let results = self
                     .record_db_multi_get("executed_effects_digests", remaining.len())
                     .multi_get_executed_effects_digests(&remaining_digests)
@@ -2034,7 +2031,69 @@ impl TransactionCacheRead for WritebackCache {
                 for ((digest, ticket), result) in remaining.iter().zip(results.iter()) {
                     if result.is_none() {
                         self.cached
-                            .executed_effects_digests
+                            .executed_effects
+                            .insert(digest, None, *ticket)
+                            .ok();
+                    }
+                }
+                results
+            },
+        )
+    }
+
+    fn multi_get_executed_effects(
+        &self,
+        digests: &[TransactionDigest],
+    ) -> Vec<Option<TransactionEffects>> {
+        let digests_and_tickets: Vec<_> = digests
+            .iter()
+            .map(|d| (*d, self.cached.executed_effects.get_ticket_for_read(d)))
+            .collect();
+        do_fallback_lookup(
+            &digests_and_tickets,
+            |(digest, _)| {
+                self.metrics
+                    .record_cache_request("executed_effects", "uncommitted");
+                if let Some(effects) = self.dirty.executed_effects.get(digest) {
+                    self.metrics
+                        .record_cache_hit("executed_effects", "uncommitted");
+                    return CacheResult::Hit(Some((**effects).clone()));
+                }
+                self.metrics
+                    .record_cache_miss("executed_effects", "uncommitted");
+                self.metrics
+                    .record_cache_request("executed_effects", "committed");
+                match self
+                    .cached
+                    .executed_effects
+                    .get(digest)
+                    .map(|l| l.lock().clone())
+                {
+                    Some(PointCacheItem::Some(effects)) => {
+                        self.metrics
+                            .record_cache_hit("executed_effects", "committed");
+                        CacheResult::Hit(Some((*effects).clone()))
+                    }
+                    Some(PointCacheItem::None) => CacheResult::NegativeHit,
+                    None => {
+                        self.metrics
+                            .record_cache_miss("executed_effects", "committed");
+                        CacheResult::Miss
+                    }
+                }
+            },
+            |remaining| {
+                let remaining_digests: Vec<_> = remaining.iter().map(|(d, _)| *d).collect();
+                // multi_get_executed_effects() is a two-step DB lookup (tx_digest -> effects_digest -> effects).
+                // It returns None if any step found no results.
+                let results = self
+                    .record_db_multi_get("executed_effects", remaining.len())
+                    .multi_get_executed_effects(&remaining_digests)
+                    .expect("db error");
+                for ((digest, ticket), result) in remaining.iter().zip(results.iter()) {
+                    if result.is_none() {
+                        self.cached
+                            .executed_effects
                             .insert(digest, None, *ticket)
                             .ok();
                     }
@@ -2060,7 +2119,7 @@ impl TransactionCacheRead for WritebackCache {
                 if let Some(effects) = self.dirty.transaction_effects.get(digest) {
                     self.metrics
                         .record_cache_hit("transaction_effects", "uncommitted");
-                    return CacheResult::Hit(Some(effects.clone()));
+                    return CacheResult::Hit(Some((**effects).clone()));
                 }
                 self.metrics
                     .record_cache_miss("transaction_effects", "uncommitted");
@@ -2148,9 +2207,19 @@ impl TransactionCacheRead for WritebackCache {
         task_name: &'static str,
         digests: &'a [TransactionDigest],
     ) -> BoxFuture<'a, Vec<TransactionEffectsDigest>> {
-        self.executed_effects_digests_notify_read
+        self.notify_read_executed_effects(task_name, digests)
+            .map(|effects| effects.iter().map(|e| e.digest()).collect())
+            .boxed()
+    }
+
+    fn notify_read_executed_effects<'a>(
+        &'a self,
+        task_name: &'static str,
+        digests: &'a [TransactionDigest],
+    ) -> BoxFuture<'a, Vec<TransactionEffects>> {
+        self.executed_effects_notify_read
             .read(task_name, digests, |digests| {
-                self.multi_get_executed_effects_digests(digests)
+                self.multi_get_executed_effects(digests)
             })
             .boxed()
     }
@@ -2481,6 +2550,7 @@ impl StateSyncAPI for WritebackCache {
                 Ticket::Write,
             )
             .ok();
+        // NOTE: intentionally not caching in executed_effects.
     }
 
     fn multi_insert_transaction_and_effects(
@@ -2511,6 +2581,7 @@ impl StateSyncAPI for WritebackCache {
                     Ticket::Write,
                 )
                 .ok();
+            // NOTE: intentionally not caching in executed_effects.
         }
     }
 }


### PR DESCRIPTION
## Description 

Fixing this simtest failure: `notify_read_executed_effects()` gets woken up by `executed_effects_digests` notified read, but reading the executed effects content fails later because they get pruned.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
