### PR TITLE
sui-indexer-alt-e2e-tests: add steps to output cluster logs in tests

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/README.md
+++ b/crates/sui-indexer-alt-e2e-tests/README.md
@@ -1,3 +1,11 @@
+### Capturing log output in tests
+1. Add this call at the top of the test
+   ```
+   telemetry_subscribers::init_for_testing();
+   ```
+2. Run the test with the `--nocapture` (goes after `--`) command line flag (see https://doc.rust-lang.org/cargo/commands/cargo-test.html#display-options).
+3. Optionally set the `RUST_LOG` (example `RUST_LOG=debug`) environment variable (defaults to `info`).
+
 ### Debugging transactional tests in RustRover
 
 1. Add new `Cargo` run configuration


### PR DESCRIPTION
## Description 

Add instructions to output cluster logs in tests to help with debugging.

## Test plan 

No tests needed for readme update.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
