### PR TITLE
Use serialize_with_version to get around build error

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/vm_arguments_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/vm_arguments_tests.rs
@@ -143,7 +143,9 @@ impl RemoteStore {
     fn add_module(&mut self, compiled_module: CompiledModule) {
         let id = compiled_module.self_id();
         let mut bytes = vec![];
-        compiled_module.serialize(&mut bytes).unwrap();
+        compiled_module
+            .serialize_with_version(compiled_module.version(), &mut bytes)
+            .unwrap();
         self.modules.insert(id, bytes);
     }
 }


### PR DESCRIPTION
## Description 

the CompiledModule::serialize has cfg test and errors out on `cargo test` for vm_arguments_tests.rs

## Test plan 

cargo test

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
