### PR TITLE
Introduce max_total_package_size that accounts for total size

### DIFF
--- a/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v123.snap
+++ b/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v123.snap
@@ -1,0 +1,155 @@
+---
+source: crates/sui-core/src/authority/execution_time_estimator.rs
+expression: snapshot_data
+---
+protocol_version: 123
+consensus_observations:
+  - - MakeMoveVec
+    - observations:
+        - - 0
+          - ~
+        - - 8
+          - secs: 0
+            nanos: 29000000
+        - - 5
+          - secs: 0
+            nanos: 19000000
+        - - 7
+          - secs: 0
+            nanos: 21000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 21000000
+  - - MergeCoins
+    - observations:
+        - - 6
+          - secs: 0
+            nanos: 63000000
+        - - 7
+          - secs: 0
+            nanos: 21000000
+        - - 5
+          - secs: 0
+            nanos: 45000000
+        - - 7
+          - secs: 0
+            nanos: 0
+      stake_weighted_median:
+        secs: 0
+        nanos: 45000000
+  - - SplitCoins
+    - observations:
+        - - 9
+          - secs: 0
+            nanos: 46000000
+        - - 0
+          - ~
+        - - 5
+          - secs: 0
+            nanos: 54000000
+        - - 6
+          - secs: 0
+            nanos: 30000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 46000000
+  - - TransferObjects
+    - observations:
+        - - 7
+          - secs: 0
+            nanos: 24000000
+        - - 0
+          - ~
+        - - 10
+          - secs: 0
+            nanos: 52000000
+        - - 8
+          - secs: 0
+            nanos: 64000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 52000000
+  - - Upgrade
+    - observations:
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 6
+          - secs: 0
+            nanos: 981000000
+        - - 8
+          - secs: 0
+            nanos: 297000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 981000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000001"
+        module: coin
+        function: transfer
+        type_arguments: []
+    - observations:
+        - - 9
+          - secs: 0
+            nanos: 0
+        - - 6
+          - secs: 0
+            nanos: 162000000
+        - - 9
+          - secs: 0
+            nanos: 268000000
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 162000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000002"
+        module: nft
+        function: mint
+        type_arguments: []
+    - observations:
+        - - 3
+          - secs: 0
+            nanos: 69000000
+        - - 2
+          - secs: 0
+            nanos: 327000000
+        - - 3
+          - secs: 0
+            nanos: 317000000
+        - - 8
+          - secs: 0
+            nanos: 499000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 327000000
+transaction_estimates:
+  - - coin_transfer_call
+    - secs: 0
+      nanos: 162000000
+  - - mixed_move_calls
+    - secs: 0
+      nanos: 489000000
+  - - native_commands_with_observations
+    - secs: 0
+      nanos: 328000000
+  - - transfer_objects_4_items
+    - secs: 0
+      nanos: 260000000
+  - - split_coins_1_amounts
+    - secs: 0
+      nanos: 92000000
+  - - merge_coins_1_sources
+    - secs: 0
+      nanos: 90000000
+  - - make_move_vec_4_elements
+    - secs: 0
+      nanos: 105000000
+  - - mixed_commands
+    - secs: 0
+      nanos: 249000000
+  - - upgrade_package
+    - secs: 0
+      nanos: 981000000

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -28,7 +28,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-const MAX_PROTOCOL_VERSION: u64 = 122;
+const MAX_PROTOCOL_VERSION: u64 = 123;
 
 const TESTNET_USDC: &str =
     "0xa1ec7fc00a6f40db9693ad1415d0c193ad3906494428cf252621037bd7117e29::usdc::USDC";
@@ -1285,8 +1285,8 @@ pub struct ProtocolConfig {
     /// Maximum size of a Move package object, in bytes. Enforced by the Sui adapter at the end of a publish transaction.
     max_move_package_size: Option<u64>,
 
-    /// Maximum size of a Move package with its dependencies, in bytes. This limits the overall size of a loaded package and its dependencies.
-    /// TODO: Enforced by the <WHO?> at <WHERE?>.
+    /// Maximum size of a Move package with its transitive dependencies, in bytes. Enforced by
+    /// `MovePackage::new_initial` / `new_upgraded` at publish / upgrade time.
     max_total_linkage_size: Option<u64>,
 
     /// Max number of publish or upgrade commands allowed in a programmable transaction block.
@@ -4588,10 +4588,6 @@ impl ProtocolConfig {
                     cfg.event_emit_auth_stream_cost = Some(52);
                     cfg.feature_flags.better_loader_errors = true;
                     cfg.feature_flags.generate_df_type_layouts = true;
-                    cfg.max_package_dependencies = Some(100);
-                    cfg.max_move_package_size = Some(1024 * 1024);
-                    // Product of previous package and dependency limits.
-                    cfg.max_total_linkage_size = Some(32 * 100 * 1024);
                 }
                 99 => {
                     cfg.feature_flags.use_new_commit_handler = true;
@@ -4809,6 +4805,15 @@ impl ProtocolConfig {
                         .early_return_receive_object_mismatched_type = true;
                 }
                 122 => {}
+                123 => {
+                    // Raise per-package and per-dependency caps, but add a total-linkage
+                    // cap so the on-disk footprint of a package plus its transitive deps
+                    // can't grow as the product of the two previous limits.
+                    cfg.max_package_dependencies = Some(100);
+                    cfg.max_move_package_size = Some(1024 * 1024);
+                    // Product of previous package and dependency limits.
+                    cfg.max_total_linkage_size = Some(32 * 100 * 1024);
+                }
                 // Use this template when making changes:
                 //
                 //     // modify an existing constant.

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1285,6 +1285,10 @@ pub struct ProtocolConfig {
     /// Maximum size of a Move package object, in bytes. Enforced by the Sui adapter at the end of a publish transaction.
     max_move_package_size: Option<u64>,
 
+    /// Maximum size of a Move package with its dependencies, in bytes. This limits the overall size of a loaded package and its dependencies.
+    /// TODO: Enforced by the <WHO?> at <WHERE?>.
+    max_total_linkage_size: Option<u64>,
+
     /// Max number of publish or upgrade commands allowed in a programmable transaction block.
     max_publish_or_upgrade_per_ptb: Option<u64>,
 
@@ -2910,6 +2914,7 @@ impl ProtocolConfig {
             binary_variant_instantiation_handles: None,
             max_move_object_size: Some(250 * 1024),
             max_move_package_size: Some(100 * 1024),
+            max_total_linkage_size: None,
             max_publish_or_upgrade_per_ptb: None,
             max_tx_gas: Some(10_000_000_000),
             max_gas_price: Some(100_000),
@@ -4583,6 +4588,10 @@ impl ProtocolConfig {
                     cfg.event_emit_auth_stream_cost = Some(52);
                     cfg.feature_flags.better_loader_errors = true;
                     cfg.feature_flags.generate_df_type_layouts = true;
+                    cfg.max_package_dependencies = Some(100);
+                    cfg.max_move_package_size = Some(1024 * 1024);
+                    // Product of previous package and dependency limits.
+                    cfg.max_total_linkage_size = Some(32 * 100 * 1024);
                 }
                 99 => {
                     cfg.feature_flags.use_new_commit_handler = true;

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_123.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_123.snap
@@ -1,0 +1,678 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 123
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  shared_object_deletion: true
+  narwhal_new_leader_election_schedule: true
+  loaded_child_object_format: true
+  enable_jwk_consensus_updates: true
+  end_of_epoch_transaction_supported: true
+  simple_conservation_checks: true
+  loaded_child_object_format_type: true
+  receive_objects: true
+  consensus_checkpoint_signature_key_includes_digest: true
+  random_beacon: true
+  bridge: true
+  enable_effects_v2: true
+  narwhal_certificate_v2: true
+  verify_legacy_zklogin_address: true
+  recompute_has_public_transfer_in_execution: true
+  accept_zklogin_in_multisig: true
+  accept_passkey_in_multisig: true
+  validate_zklogin_public_identifier: true
+  include_consensus_digest_in_prologue: true
+  hardened_otw_check: true
+  allow_receiving_object_id: true
+  enable_poseidon: true
+  enable_coin_deny_list: true
+  enable_group_ops_native_functions: true
+  enable_nitro_attestation: true
+  enable_nitro_attestation_upgraded_parsing: true
+  enable_nitro_attestation_all_nonzero_pcrs_parsing: true
+  enable_nitro_attestation_always_include_required_pcrs_parsing: true
+  reject_mutable_random_on_entry_functions: true
+  per_object_congestion_control_mode:
+    ExecutionTimeEstimate:
+      target_utilization: 50
+      allowed_txn_cost_overage_burst_limit_us: 500000
+      randomness_scalar: 20
+      max_estimate_us: 1500000
+      stored_observations_num_included_checkpoints: 10
+      stored_observations_limit: 180
+      stake_weighted_median_threshold: 3334
+      default_none_duration_for_new_keys: true
+      observations_chunk_size: 18
+  consensus_choice: Mysticeti
+  consensus_network: Tonic
+  correct_gas_payment_limit_check: true
+  zklogin_max_epoch_upper_bound_delta: 30
+  mysticeti_leader_scoring_and_schedule: true
+  reshare_at_same_initial_version: true
+  resolve_abort_locations_to_package_id: true
+  mysticeti_use_committed_subdag_digest: true
+  record_consensus_determined_version_assignments_in_prologue: true
+  record_consensus_determined_version_assignments_in_prologue_v2: true
+  fresh_vm_on_framework_upgrade: true
+  prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
+  mysticeti_num_leaders_per_round: 1
+  soft_bundle: true
+  enable_coin_deny_list_v2: true
+  passkey_auth: true
+  authority_capabilities_v2: true
+  rethrow_serialization_type_layout_errors: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_round_prober: true
+  validate_identifier_inputs: true
+  disallow_self_identifier: true
+  mysticeti_fastpath: true
+  disable_preconsensus_locking: true
+  relocate_event_module: true
+  uncompressed_g1_group_elements: true
+  disallow_new_modules_in_deps_only_packages: true
+  consensus_smart_ancestor_selection: true
+  consensus_round_prober_probe_accepted_rounds: true
+  native_charging_v2: true
+  consensus_linearize_subdag_v2: true
+  convert_type_argument_error: true
+  variant_nodes: true
+  consensus_zstd_compression: true
+  minimize_child_object_mutations: true
+  record_additional_state_digest_in_prologue: true
+  move_native_context: true
+  consensus_median_based_commit_timestamp: true
+  normalize_ptb_arguments: true
+  consensus_batched_block_sync: true
+  enforce_checkpoint_timestamp_monotonicity: true
+  max_ptb_value_size_v2: true
+  resolve_type_input_ids_to_defining_id: true
+  enable_party_transfer: true
+  allow_unbounded_system_objects: true
+  type_tags_in_object_runtime: true
+  create_root_accumulator_object: true
+  address_balance_gas_check_rgp_at_signing: true
+  enable_multi_epoch_transaction_expiration: true
+  relax_valid_during_for_owned_inputs: true
+  enable_ptb_execution_v2: true
+  better_adapter_type_resolution_errors: true
+  record_time_estimate_processed: true
+  dependency_linkage_error: true
+  additional_multisig_checks: true
+  ignore_execution_time_observations_after_certs_closed: true
+  debug_fatal_on_move_invariant_violation: true
+  additional_consensus_digest_indirect_state: true
+  check_for_init_during_upgrade: true
+  use_mfp_txns_in_load_initial_object_debts: true
+  cancel_for_failed_dkg_early: true
+  enable_coin_registry: true
+  abstract_size_in_object_runtime: true
+  object_runtime_charge_cache_load_gas: true
+  additional_borrow_checks: true
+  use_new_commit_handler: true
+  better_loader_errors: true
+  generate_df_type_layouts: true
+  enable_display_registry: true
+  private_generics_verifier_v2: true
+  deprecate_global_storage_ops: true
+  normalize_depth_formula: true
+  consensus_skip_gced_accept_votes: true
+  include_cancelled_randomness_txns_in_prologue: true
+  address_aliases: true
+  fix_checkpoint_signature_mapping: true
+  consensus_skip_gced_blocks_in_direct_finalization: true
+  gas_rounding_halve_digits: true
+  flexible_tx_context_positions: true
+  disable_entry_point_signature_check: true
+  restrict_hot_or_not_entry_functions: true
+  consensus_always_accept_system_transactions: true
+  validator_metadata_verify_v2: true
+  randomize_checkpoint_tx_limit_in_tests: true
+  gasless_transaction_drop_safety: true
+  merge_randomness_into_checkpoint: true
+  use_coin_party_owner: true
+  disallow_jump_orphans: true
+  early_return_receive_object_mismatched_type: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 100
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+binary_variant_handles: 1024
+binary_variant_instantiation_handles: 1024
+max_move_object_size: 256000
+max_move_package_size: 1048576
+max_total_linkage_size: 3276800
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000000
+max_gas_price: 50000000000
+max_gas_price_rgp_factor_for_aborted_transactions: 100
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_move_enum_variants: 127
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
+gas_model_version: 11
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+accumulator_object_storage_cost: 7600
+max_transactions_per_checkpoint: 20000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 52
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 52
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 1
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 52
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 1
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 52
+dynamic_field_remove_child_object_child_cost_per_byte: 1
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 52
+dynamic_field_has_child_object_with_ty_cost_base: 52
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+event_emit_auth_stream_cost: 52
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_party_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
+transfer_receive_object_cost_per_byte: 1
+transfer_receive_object_type_cost_per_byte: 2
+tx_context_derive_id_cost_base: 52
+tx_context_fresh_id_cost_base: 52
+tx_context_sender_cost_base: 30
+tx_context_epoch_cost_base: 30
+tx_context_epoch_timestamp_ms_cost_base: 30
+tx_context_sponsor_cost_base: 30
+tx_context_rgp_cost_base: 30
+tx_context_gas_price_cost_base: 30
+tx_context_gas_budget_cost_base: 30
+tx_context_ids_created_cost_base: 30
+tx_context_replace_cost_base: 30
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 20000
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 44064
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 49282
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 500
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 500
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 1173
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 1173
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 4848
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 1802
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 53838
+groth16_prepare_verifying_key_bn254_cost_base: 82010
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 72090
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 8213
+groth16_verify_groth16_proof_internal_bn254_cost_base: 115502
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 9484
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 10
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 10
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_base: 260
+poseidon_bn254_cost_per_block: 388
+group_ops_bls12381_decode_scalar_cost: 7
+group_ops_bls12381_decode_g1_cost: 2848
+group_ops_bls12381_decode_g2_cost: 3770
+group_ops_bls12381_decode_gt_cost: 3068
+group_ops_bls12381_scalar_add_cost: 10
+group_ops_bls12381_g1_add_cost: 1556
+group_ops_bls12381_g2_add_cost: 3048
+group_ops_bls12381_gt_add_cost: 188
+group_ops_bls12381_scalar_sub_cost: 10
+group_ops_bls12381_g1_sub_cost: 1550
+group_ops_bls12381_g2_sub_cost: 3019
+group_ops_bls12381_gt_sub_cost: 497
+group_ops_bls12381_scalar_mul_cost: 11
+group_ops_bls12381_g1_mul_cost: 4842
+group_ops_bls12381_g2_mul_cost: 9108
+group_ops_bls12381_gt_mul_cost: 27490
+group_ops_bls12381_scalar_div_cost: 91
+group_ops_bls12381_g1_div_cost: 5091
+group_ops_bls12381_g2_div_cost: 9206
+group_ops_bls12381_gt_div_cost: 27804
+group_ops_bls12381_g1_hash_to_base_cost: 2962
+group_ops_bls12381_g2_hash_to_base_cost: 8688
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 62648
+group_ops_bls12381_g2_msm_base_cost: 131192
+group_ops_bls12381_g1_msm_base_cost_per_input: 1333
+group_ops_bls12381_g2_msm_base_cost_per_input: 3216
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 26897
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 2099
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 677
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 77
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 26
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 1200
+group_ops_ristretto_decode_scalar_cost: 7
+group_ops_ristretto_decode_point_cost: 200
+group_ops_ristretto_scalar_add_cost: 10
+group_ops_ristretto_point_add_cost: 500
+group_ops_ristretto_scalar_sub_cost: 10
+group_ops_ristretto_point_sub_cost: 500
+group_ops_ristretto_scalar_mul_cost: 11
+group_ops_ristretto_point_mul_cost: 1200
+group_ops_ristretto_scalar_div_cost: 151
+group_ops_ristretto_point_div_cost: 2500
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+nitro_attestation_parse_base_cost: 2650
+nitro_attestation_parse_cost_per_byte: 50
+nitro_attestation_verify_base_cost: 2481600
+nitro_attestation_verify_cost_per_cert: 2618450
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+type_name_id_base_cost: 52
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 4
+consensus_bad_nodes_stake_threshold: 30
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 500
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+consensus_voting_rounds: 40
+max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
+max_deferral_rounds_for_congestion_control: 10
+max_txn_cost_overage_per_object_in_commit: 18446744073709551615
+allowed_txn_cost_overage_burst_per_object_in_commit: 370000000
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+bridge_should_try_to_finalize_committee: true
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 37000000
+max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 7400000
+consensus_gc_depth: 60
+gas_budget_based_txn_cost_cap_factor: 400000
+gas_budget_based_txn_cost_absolute_cap_commit_count: 50
+sip_45_consensus_amplification_threshold: 5
+use_object_per_epoch_marker_table_v2: true
+consensus_commit_rate_estimation_window_size: 10
+aliased_addresses:
+  - original:
+      - 205
+      - 137
+      - 98
+      - 218
+      - 210
+      - 120
+      - 216
+      - 181
+      - 15
+      - 160
+      - 249
+      - 235
+      - 1
+      - 134
+      - 191
+      - 164
+      - 203
+      - 222
+      - 204
+      - 109
+      - 89
+      - 55
+      - 114
+      - 20
+      - 200
+      - 141
+      - 2
+      - 134
+      - 160
+      - 172
+      - 149
+      - 98
+    aliased:
+      - 11
+      - 45
+      - 163
+      - 39
+      - 186
+      - 106
+      - 76
+      - 172
+      - 190
+      - 117
+      - 221
+      - 221
+      - 80
+      - 230
+      - 232
+      - 187
+      - 248
+      - 29
+      - 100
+      - 150
+      - 233
+      - 45
+      - 102
+      - 175
+      - 145
+      - 84
+      - 198
+      - 28
+      - 119
+      - 247
+      - 51
+      - 47
+    allowed_tx_digests:
+      - - 2
+        - 145
+        - 170
+        - 78
+        - 99
+        - 246
+        - 130
+        - 221
+        - 11
+        - 53
+        - 228
+        - 241
+        - 202
+        - 113
+        - 56
+        - 105
+        - 120
+        - 236
+        - 143
+        - 114
+        - 165
+        - 106
+        - 212
+        - 165
+        - 196
+        - 178
+        - 239
+        - 253
+        - 97
+        - 66
+        - 98
+        - 197
+  - original:
+      - 226
+      - 139
+      - 80
+      - 206
+      - 241
+      - 214
+      - 51
+      - 234
+      - 67
+      - 211
+      - 41
+      - 106
+      - 63
+      - 107
+      - 103
+      - 255
+      - 3
+      - 18
+      - 165
+      - 241
+      - 169
+      - 159
+      - 10
+      - 247
+      - 83
+      - 200
+      - 91
+      - 139
+      - 93
+      - 232
+      - 255
+      - 6
+    aliased:
+      - 11
+      - 45
+      - 163
+      - 39
+      - 186
+      - 106
+      - 76
+      - 172
+      - 190
+      - 117
+      - 221
+      - 221
+      - 80
+      - 230
+      - 232
+      - 187
+      - 248
+      - 29
+      - 100
+      - 150
+      - 233
+      - 45
+      - 102
+      - 175
+      - 145
+      - 84
+      - 198
+      - 28
+      - 119
+      - 247
+      - 51
+      - 47
+    allowed_tx_digests:
+      - - 253
+        - 118
+        - 94
+        - 221
+        - 205
+        - 105
+        - 164
+        - 185
+        - 146
+        - 65
+        - 207
+        - 179
+        - 194
+        - 136
+        - 51
+        - 126
+        - 222
+        - 28
+        - 78
+        - 230
+        - 151
+        - 0
+        - 147
+        - 120
+        - 44
+        - 55
+        - 155
+        - 111
+        - 243
+        - 35
+        - 173
+        - 119
+translation_per_command_base_charge: 1
+translation_per_input_base_charge: 1
+translation_pure_input_per_byte_charge: 1
+translation_per_type_node_charge: 1
+translation_per_reference_node_charge: 1
+translation_per_linkage_entry_charge: 10
+max_updates_per_settlement_txn: 100
+gasless_max_unused_inputs: 1
+gasless_max_pure_input_bytes: 32

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_123.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_123.snap
@@ -1,0 +1,494 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 123
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  shared_object_deletion: true
+  narwhal_new_leader_election_schedule: true
+  loaded_child_object_format: true
+  enable_jwk_consensus_updates: true
+  end_of_epoch_transaction_supported: true
+  simple_conservation_checks: true
+  loaded_child_object_format_type: true
+  receive_objects: true
+  consensus_checkpoint_signature_key_includes_digest: true
+  random_beacon: true
+  bridge: true
+  enable_effects_v2: true
+  narwhal_certificate_v2: true
+  verify_legacy_zklogin_address: true
+  recompute_has_public_transfer_in_execution: true
+  accept_zklogin_in_multisig: true
+  accept_passkey_in_multisig: true
+  validate_zklogin_public_identifier: true
+  include_consensus_digest_in_prologue: true
+  hardened_otw_check: true
+  allow_receiving_object_id: true
+  enable_poseidon: true
+  enable_coin_deny_list: true
+  enable_group_ops_native_functions: true
+  enable_nitro_attestation: true
+  enable_nitro_attestation_upgraded_parsing: true
+  enable_nitro_attestation_all_nonzero_pcrs_parsing: true
+  enable_nitro_attestation_always_include_required_pcrs_parsing: true
+  reject_mutable_random_on_entry_functions: true
+  per_object_congestion_control_mode:
+    ExecutionTimeEstimate:
+      target_utilization: 50
+      allowed_txn_cost_overage_burst_limit_us: 500000
+      randomness_scalar: 20
+      max_estimate_us: 1500000
+      stored_observations_num_included_checkpoints: 10
+      stored_observations_limit: 180
+      stake_weighted_median_threshold: 3334
+      default_none_duration_for_new_keys: true
+      observations_chunk_size: 18
+  consensus_choice: Mysticeti
+  consensus_network: Tonic
+  correct_gas_payment_limit_check: true
+  zklogin_max_epoch_upper_bound_delta: 30
+  mysticeti_leader_scoring_and_schedule: true
+  reshare_at_same_initial_version: true
+  resolve_abort_locations_to_package_id: true
+  mysticeti_use_committed_subdag_digest: true
+  record_consensus_determined_version_assignments_in_prologue: true
+  record_consensus_determined_version_assignments_in_prologue_v2: true
+  fresh_vm_on_framework_upgrade: true
+  prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
+  mysticeti_num_leaders_per_round: 1
+  soft_bundle: true
+  enable_coin_deny_list_v2: true
+  passkey_auth: true
+  authority_capabilities_v2: true
+  rethrow_serialization_type_layout_errors: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_round_prober: true
+  validate_identifier_inputs: true
+  disallow_self_identifier: true
+  mysticeti_fastpath: true
+  disable_preconsensus_locking: true
+  relocate_event_module: true
+  uncompressed_g1_group_elements: true
+  disallow_new_modules_in_deps_only_packages: true
+  consensus_smart_ancestor_selection: true
+  consensus_round_prober_probe_accepted_rounds: true
+  native_charging_v2: true
+  consensus_linearize_subdag_v2: true
+  convert_type_argument_error: true
+  variant_nodes: true
+  consensus_zstd_compression: true
+  minimize_child_object_mutations: true
+  record_additional_state_digest_in_prologue: true
+  move_native_context: true
+  consensus_median_based_commit_timestamp: true
+  normalize_ptb_arguments: true
+  consensus_batched_block_sync: true
+  enforce_checkpoint_timestamp_monotonicity: true
+  max_ptb_value_size_v2: true
+  resolve_type_input_ids_to_defining_id: true
+  enable_party_transfer: true
+  allow_unbounded_system_objects: true
+  type_tags_in_object_runtime: true
+  enable_accumulators: true
+  enable_coin_reservation_obj_refs: true
+  create_root_accumulator_object: true
+  enable_authenticated_event_streams: true
+  enable_address_balance_gas_payments: true
+  address_balance_gas_check_rgp_at_signing: true
+  enable_multi_epoch_transaction_expiration: true
+  relax_valid_during_for_owned_inputs: true
+  enable_ptb_execution_v2: true
+  better_adapter_type_resolution_errors: true
+  record_time_estimate_processed: true
+  dependency_linkage_error: true
+  additional_multisig_checks: true
+  ignore_execution_time_observations_after_certs_closed: true
+  debug_fatal_on_move_invariant_violation: true
+  additional_consensus_digest_indirect_state: true
+  check_for_init_during_upgrade: true
+  include_checkpoint_artifacts_digest_in_summary: true
+  use_mfp_txns_in_load_initial_object_debts: true
+  cancel_for_failed_dkg_early: true
+  enable_coin_registry: true
+  abstract_size_in_object_runtime: true
+  object_runtime_charge_cache_load_gas: true
+  additional_borrow_checks: true
+  use_new_commit_handler: true
+  better_loader_errors: true
+  generate_df_type_layouts: true
+  enable_display_registry: true
+  private_generics_verifier_v2: true
+  deprecate_global_storage_ops: true
+  normalize_depth_formula: true
+  consensus_skip_gced_accept_votes: true
+  include_cancelled_randomness_txns_in_prologue: true
+  address_aliases: true
+  fix_checkpoint_signature_mapping: true
+  enable_object_funds_withdraw: true
+  consensus_skip_gced_blocks_in_direct_finalization: true
+  gas_rounding_halve_digits: true
+  flexible_tx_context_positions: true
+  disable_entry_point_signature_check: true
+  convert_withdrawal_compatibility_ptb_arguments: true
+  restrict_hot_or_not_entry_functions: true
+  split_checkpoints_in_consensus_handler: true
+  consensus_always_accept_system_transactions: true
+  validator_metadata_verify_v2: true
+  defer_unpaid_amplification: true
+  randomize_checkpoint_tx_limit_in_tests: true
+  gasless_transaction_drop_safety: true
+  merge_randomness_into_checkpoint: true
+  use_coin_party_owner: true
+  enable_gasless: true
+  disallow_jump_orphans: true
+  early_return_receive_object_mismatched_type: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 100
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+binary_variant_handles: 1024
+binary_variant_instantiation_handles: 1024
+max_move_object_size: 256000
+max_move_package_size: 1048576
+max_total_linkage_size: 3276800
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000000
+max_gas_price: 50000000000
+max_gas_price_rgp_factor_for_aborted_transactions: 100
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_move_enum_variants: 127
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
+gas_model_version: 11
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+accumulator_object_storage_cost: 7600
+max_transactions_per_checkpoint: 20000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 52
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 52
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 1
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 52
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 1
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 52
+dynamic_field_remove_child_object_child_cost_per_byte: 1
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 52
+dynamic_field_has_child_object_with_ty_cost_base: 52
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+event_emit_auth_stream_cost: 52
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_party_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
+transfer_receive_object_cost_per_byte: 1
+transfer_receive_object_type_cost_per_byte: 2
+tx_context_derive_id_cost_base: 52
+tx_context_fresh_id_cost_base: 52
+tx_context_sender_cost_base: 30
+tx_context_epoch_cost_base: 30
+tx_context_epoch_timestamp_ms_cost_base: 30
+tx_context_sponsor_cost_base: 30
+tx_context_rgp_cost_base: 30
+tx_context_gas_price_cost_base: 30
+tx_context_gas_budget_cost_base: 30
+tx_context_ids_created_cost_base: 30
+tx_context_replace_cost_base: 30
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 20000
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 44064
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 49282
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 500
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 500
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 1173
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 1173
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 4848
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 1802
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 53838
+groth16_prepare_verifying_key_bn254_cost_base: 82010
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 72090
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 8213
+groth16_verify_groth16_proof_internal_bn254_cost_base: 115502
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 9484
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 10
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 10
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_base: 260
+poseidon_bn254_cost_per_block: 388
+group_ops_bls12381_decode_scalar_cost: 7
+group_ops_bls12381_decode_g1_cost: 2848
+group_ops_bls12381_decode_g2_cost: 3770
+group_ops_bls12381_decode_gt_cost: 3068
+group_ops_bls12381_scalar_add_cost: 10
+group_ops_bls12381_g1_add_cost: 1556
+group_ops_bls12381_g2_add_cost: 3048
+group_ops_bls12381_gt_add_cost: 188
+group_ops_bls12381_scalar_sub_cost: 10
+group_ops_bls12381_g1_sub_cost: 1550
+group_ops_bls12381_g2_sub_cost: 3019
+group_ops_bls12381_gt_sub_cost: 497
+group_ops_bls12381_scalar_mul_cost: 11
+group_ops_bls12381_g1_mul_cost: 4842
+group_ops_bls12381_g2_mul_cost: 9108
+group_ops_bls12381_gt_mul_cost: 27490
+group_ops_bls12381_scalar_div_cost: 91
+group_ops_bls12381_g1_div_cost: 5091
+group_ops_bls12381_g2_div_cost: 9206
+group_ops_bls12381_gt_div_cost: 27804
+group_ops_bls12381_g1_hash_to_base_cost: 2962
+group_ops_bls12381_g2_hash_to_base_cost: 8688
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 62648
+group_ops_bls12381_g2_msm_base_cost: 131192
+group_ops_bls12381_g1_msm_base_cost_per_input: 1333
+group_ops_bls12381_g2_msm_base_cost_per_input: 3216
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 26897
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 2099
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 677
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 77
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 26
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 1200
+group_ops_ristretto_decode_scalar_cost: 7
+group_ops_ristretto_decode_point_cost: 200
+group_ops_ristretto_scalar_add_cost: 10
+group_ops_ristretto_point_add_cost: 500
+group_ops_ristretto_scalar_sub_cost: 10
+group_ops_ristretto_point_sub_cost: 500
+group_ops_ristretto_scalar_mul_cost: 11
+group_ops_ristretto_point_mul_cost: 1200
+group_ops_ristretto_scalar_div_cost: 151
+group_ops_ristretto_point_div_cost: 2500
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+nitro_attestation_parse_base_cost: 2650
+nitro_attestation_parse_cost_per_byte: 50
+nitro_attestation_verify_base_cost: 2481600
+nitro_attestation_verify_cost_per_cert: 2618450
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+type_name_id_base_cost: 52
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 4
+consensus_bad_nodes_stake_threshold: 30
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 500
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+consensus_voting_rounds: 40
+max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
+max_deferral_rounds_for_congestion_control: 10
+max_txn_cost_overage_per_object_in_commit: 18446744073709551615
+allowed_txn_cost_overage_burst_per_object_in_commit: 370000000
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+bridge_should_try_to_finalize_committee: true
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 37000000
+max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 7400000
+consensus_gc_depth: 60
+gas_budget_based_txn_cost_cap_factor: 400000
+gas_budget_based_txn_cost_absolute_cap_commit_count: 50
+sip_45_consensus_amplification_threshold: 5
+use_object_per_epoch_marker_table_v2: true
+consensus_commit_rate_estimation_window_size: 10
+translation_per_command_base_charge: 1
+translation_per_input_base_charge: 1
+translation_pure_input_per_byte_charge: 1
+translation_per_type_node_charge: 1
+translation_per_reference_node_charge: 1
+translation_per_linkage_entry_charge: 10
+max_updates_per_settlement_txn: 100
+gasless_max_computation_units: 50000
+gasless_allowed_token_types:
+  - - "0xa1ec7fc00a6f40db9693ad1415d0c193ad3906494428cf252621037bd7117e29::usdc::USDC"
+    - 0
+gasless_max_unused_inputs: 1
+gasless_max_pure_input_bytes: 32
+gasless_max_tps: 50

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_123.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_123.snap
@@ -1,0 +1,497 @@
+---
+source: crates/sui-protocol-config/src/lib.rs
+expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+---
+version: 123
+feature_flags:
+  package_upgrades: true
+  commit_root_state_digest: true
+  advance_epoch_start_time_in_safe_mode: true
+  loaded_child_objects_fixed: true
+  missing_type_is_compatibility_error: true
+  scoring_decision_with_validity_cutoff: true
+  consensus_order_end_of_epoch_last: true
+  disallow_adding_abilities_on_upgrade: true
+  disable_invariant_violation_check_in_swap_loc: true
+  advance_to_highest_supported_protocol_version: true
+  ban_entry_init: true
+  package_digest_hash_module: true
+  disallow_change_struct_type_params_on_upgrade: true
+  no_extraneous_module_bytes: true
+  narwhal_versioned_metadata: true
+  zklogin_auth: true
+  consensus_transaction_ordering: ByGasPrice
+  simplified_unwrap_then_delete: true
+  upgraded_multisig_supported: true
+  txn_base_cost_as_multiplier: true
+  shared_object_deletion: true
+  narwhal_new_leader_election_schedule: true
+  loaded_child_object_format: true
+  enable_jwk_consensus_updates: true
+  end_of_epoch_transaction_supported: true
+  simple_conservation_checks: true
+  loaded_child_object_format_type: true
+  receive_objects: true
+  consensus_checkpoint_signature_key_includes_digest: true
+  random_beacon: true
+  bridge: true
+  enable_effects_v2: true
+  narwhal_certificate_v2: true
+  verify_legacy_zklogin_address: true
+  recompute_has_public_transfer_in_execution: true
+  accept_zklogin_in_multisig: true
+  accept_passkey_in_multisig: true
+  validate_zklogin_public_identifier: true
+  include_consensus_digest_in_prologue: true
+  hardened_otw_check: true
+  allow_receiving_object_id: true
+  enable_poseidon: true
+  enable_coin_deny_list: true
+  enable_group_ops_native_functions: true
+  enable_group_ops_native_function_msm: true
+  enable_ristretto255_group_ops: true
+  enable_nitro_attestation: true
+  enable_nitro_attestation_upgraded_parsing: true
+  enable_nitro_attestation_all_nonzero_pcrs_parsing: true
+  enable_nitro_attestation_always_include_required_pcrs_parsing: true
+  reject_mutable_random_on_entry_functions: true
+  per_object_congestion_control_mode:
+    ExecutionTimeEstimate:
+      target_utilization: 50
+      allowed_txn_cost_overage_burst_limit_us: 500000
+      randomness_scalar: 20
+      max_estimate_us: 1500000
+      stored_observations_num_included_checkpoints: 10
+      stored_observations_limit: 180
+      stake_weighted_median_threshold: 3334
+      default_none_duration_for_new_keys: true
+      observations_chunk_size: 18
+  consensus_choice: Mysticeti
+  consensus_network: Tonic
+  correct_gas_payment_limit_check: true
+  zklogin_max_epoch_upper_bound_delta: 30
+  mysticeti_leader_scoring_and_schedule: true
+  reshare_at_same_initial_version: true
+  resolve_abort_locations_to_package_id: true
+  mysticeti_use_committed_subdag_digest: true
+  enable_vdf: true
+  record_consensus_determined_version_assignments_in_prologue: true
+  record_consensus_determined_version_assignments_in_prologue_v2: true
+  fresh_vm_on_framework_upgrade: true
+  prepend_prologue_tx_in_consensus_commit_in_checkpoints: true
+  mysticeti_num_leaders_per_round: 1
+  soft_bundle: true
+  enable_coin_deny_list_v2: true
+  passkey_auth: true
+  authority_capabilities_v2: true
+  rethrow_serialization_type_layout_errors: true
+  consensus_distributed_vote_scoring_strategy: true
+  consensus_round_prober: true
+  validate_identifier_inputs: true
+  disallow_self_identifier: true
+  mysticeti_fastpath: true
+  disable_preconsensus_locking: true
+  relocate_event_module: true
+  uncompressed_g1_group_elements: true
+  disallow_new_modules_in_deps_only_packages: true
+  consensus_smart_ancestor_selection: true
+  consensus_round_prober_probe_accepted_rounds: true
+  native_charging_v2: true
+  consensus_linearize_subdag_v2: true
+  convert_type_argument_error: true
+  variant_nodes: true
+  consensus_zstd_compression: true
+  minimize_child_object_mutations: true
+  record_additional_state_digest_in_prologue: true
+  move_native_context: true
+  consensus_median_based_commit_timestamp: true
+  normalize_ptb_arguments: true
+  consensus_batched_block_sync: true
+  enforce_checkpoint_timestamp_monotonicity: true
+  max_ptb_value_size_v2: true
+  resolve_type_input_ids_to_defining_id: true
+  enable_party_transfer: true
+  allow_unbounded_system_objects: true
+  type_tags_in_object_runtime: true
+  enable_accumulators: true
+  enable_coin_reservation_obj_refs: true
+  create_root_accumulator_object: true
+  enable_authenticated_event_streams: true
+  enable_address_balance_gas_payments: true
+  address_balance_gas_check_rgp_at_signing: true
+  enable_multi_epoch_transaction_expiration: true
+  relax_valid_during_for_owned_inputs: true
+  enable_ptb_execution_v2: true
+  better_adapter_type_resolution_errors: true
+  record_time_estimate_processed: true
+  dependency_linkage_error: true
+  additional_multisig_checks: true
+  ignore_execution_time_observations_after_certs_closed: true
+  debug_fatal_on_move_invariant_violation: true
+  additional_consensus_digest_indirect_state: true
+  check_for_init_during_upgrade: true
+  include_checkpoint_artifacts_digest_in_summary: true
+  use_mfp_txns_in_load_initial_object_debts: true
+  cancel_for_failed_dkg_early: true
+  enable_coin_registry: true
+  abstract_size_in_object_runtime: true
+  object_runtime_charge_cache_load_gas: true
+  additional_borrow_checks: true
+  use_new_commit_handler: true
+  better_loader_errors: true
+  generate_df_type_layouts: true
+  enable_display_registry: true
+  private_generics_verifier_v2: true
+  deprecate_global_storage_ops: true
+  normalize_depth_formula: true
+  consensus_skip_gced_accept_votes: true
+  include_cancelled_randomness_txns_in_prologue: true
+  address_aliases: true
+  fix_checkpoint_signature_mapping: true
+  enable_object_funds_withdraw: true
+  consensus_skip_gced_blocks_in_direct_finalization: true
+  gas_rounding_halve_digits: true
+  flexible_tx_context_positions: true
+  disable_entry_point_signature_check: true
+  convert_withdrawal_compatibility_ptb_arguments: true
+  restrict_hot_or_not_entry_functions: true
+  split_checkpoints_in_consensus_handler: true
+  consensus_always_accept_system_transactions: true
+  validator_metadata_verify_v2: true
+  defer_unpaid_amplification: true
+  randomize_checkpoint_tx_limit_in_tests: true
+  gasless_transaction_drop_safety: true
+  merge_randomness_into_checkpoint: true
+  use_coin_party_owner: true
+  enable_gasless: true
+  disallow_jump_orphans: true
+  early_return_receive_object_mismatched_type: true
+max_tx_size_bytes: 131072
+max_input_objects: 2048
+max_size_written_objects: 5000000
+max_size_written_objects_system_tx: 50000000
+max_serialized_tx_effects_size_bytes: 524288
+max_serialized_tx_effects_size_bytes_system_tx: 8388608
+max_gas_payment_objects: 256
+max_modules_in_publish: 64
+max_package_dependencies: 100
+max_arguments: 512
+max_type_arguments: 16
+max_type_argument_depth: 16
+max_pure_argument_size: 16384
+max_programmable_tx_commands: 1024
+move_binary_format_version: 7
+min_move_binary_format_version: 6
+binary_module_handles: 100
+binary_struct_handles: 300
+binary_function_handles: 1500
+binary_function_instantiations: 750
+binary_signatures: 1000
+binary_constant_pool: 4000
+binary_identifiers: 10000
+binary_address_identifiers: 100
+binary_struct_defs: 200
+binary_struct_def_instantiations: 100
+binary_function_defs: 1000
+binary_field_handles: 500
+binary_field_instantiations: 250
+binary_friend_decls: 100
+binary_variant_handles: 1024
+binary_variant_instantiation_handles: 1024
+max_move_object_size: 256000
+max_move_package_size: 1048576
+max_total_linkage_size: 3276800
+max_publish_or_upgrade_per_ptb: 5
+max_tx_gas: 50000000000000
+max_gas_price: 50000000000
+max_gas_price_rgp_factor_for_aborted_transactions: 100
+max_gas_computation_bucket: 5000000
+gas_rounding_step: 1000
+max_loop_depth: 5
+max_generic_instantiation_length: 32
+max_function_parameters: 128
+max_basic_blocks: 1024
+max_value_stack_size: 1024
+max_type_nodes: 256
+max_push_size: 10000
+max_struct_definitions: 200
+max_function_definitions: 1000
+max_fields_in_struct: 32
+max_dependency_depth: 100
+max_num_event_emit: 1024
+max_num_new_move_object_ids: 2048
+max_num_new_move_object_ids_system_tx: 32768
+max_num_deleted_move_object_ids: 2048
+max_num_deleted_move_object_ids_system_tx: 32768
+max_num_transferred_move_object_ids: 2048
+max_num_transferred_move_object_ids_system_tx: 32768
+max_event_emit_size: 256000
+max_event_emit_size_total: 65536000
+max_move_vector_len: 262144
+max_move_identifier_len: 128
+max_move_value_depth: 128
+max_move_enum_variants: 127
+max_back_edges_per_function: 10000
+max_back_edges_per_module: 10000
+max_verifier_meter_ticks_per_function: 16000000
+max_meter_ticks_per_module: 16000000
+max_meter_ticks_per_package: 16000000
+object_runtime_max_num_cached_objects: 1000
+object_runtime_max_num_cached_objects_system_tx: 16000
+object_runtime_max_num_store_entries: 1000
+object_runtime_max_num_store_entries_system_tx: 16000
+base_tx_cost_fixed: 1000
+package_publish_cost_fixed: 1000
+base_tx_cost_per_byte: 0
+package_publish_cost_per_byte: 80
+obj_access_cost_read_per_byte: 15
+obj_access_cost_mutate_per_byte: 40
+obj_access_cost_delete_per_byte: 40
+obj_access_cost_verify_per_byte: 200
+max_type_to_layout_nodes: 512
+max_ptb_value_size: 1048576
+gas_model_version: 11
+obj_data_cost_refundable: 100
+obj_metadata_cost_non_refundable: 50
+storage_rebate_rate: 9900
+storage_fund_reinvest_rate: 500
+reward_slashing_rate: 10000
+storage_gas_price: 76
+accumulator_object_storage_cost: 7600
+max_transactions_per_checkpoint: 20000
+max_checkpoint_size_bytes: 31457280
+buffer_stake_for_protocol_upgrade_bps: 5000
+address_from_bytes_cost_base: 52
+address_to_u256_cost_base: 52
+address_from_u256_cost_base: 52
+config_read_setting_impl_cost_base: 100
+config_read_setting_impl_cost_per_byte: 40
+dynamic_field_hash_type_and_key_cost_base: 52
+dynamic_field_hash_type_and_key_type_cost_per_byte: 2
+dynamic_field_hash_type_and_key_value_cost_per_byte: 2
+dynamic_field_hash_type_and_key_type_tag_cost_per_byte: 2
+dynamic_field_add_child_object_cost_base: 52
+dynamic_field_add_child_object_type_cost_per_byte: 10
+dynamic_field_add_child_object_value_cost_per_byte: 1
+dynamic_field_add_child_object_struct_tag_cost_per_byte: 10
+dynamic_field_borrow_child_object_cost_base: 52
+dynamic_field_borrow_child_object_child_ref_cost_per_byte: 1
+dynamic_field_borrow_child_object_type_cost_per_byte: 10
+dynamic_field_remove_child_object_cost_base: 52
+dynamic_field_remove_child_object_child_cost_per_byte: 1
+dynamic_field_remove_child_object_type_cost_per_byte: 2
+dynamic_field_has_child_object_cost_base: 52
+dynamic_field_has_child_object_with_ty_cost_base: 52
+dynamic_field_has_child_object_with_ty_type_cost_per_byte: 2
+dynamic_field_has_child_object_with_ty_type_tag_cost_per_byte: 2
+event_emit_cost_base: 52
+event_emit_value_size_derivation_cost_per_byte: 2
+event_emit_tag_size_derivation_cost_per_byte: 5
+event_emit_output_cost_per_byte: 10
+event_emit_auth_stream_cost: 52
+object_borrow_uid_cost_base: 52
+object_delete_impl_cost_base: 52
+object_record_new_uid_cost_base: 52
+transfer_transfer_internal_cost_base: 52
+transfer_party_transfer_internal_cost_base: 52
+transfer_freeze_object_cost_base: 52
+transfer_share_object_cost_base: 52
+transfer_receive_object_cost_base: 52
+transfer_receive_object_cost_per_byte: 1
+transfer_receive_object_type_cost_per_byte: 2
+tx_context_derive_id_cost_base: 52
+tx_context_fresh_id_cost_base: 52
+tx_context_sender_cost_base: 30
+tx_context_epoch_cost_base: 30
+tx_context_epoch_timestamp_ms_cost_base: 30
+tx_context_sponsor_cost_base: 30
+tx_context_rgp_cost_base: 30
+tx_context_gas_price_cost_base: 30
+tx_context_gas_budget_cost_base: 30
+tx_context_ids_created_cost_base: 30
+tx_context_replace_cost_base: 30
+types_is_one_time_witness_cost_base: 52
+types_is_one_time_witness_type_tag_cost_per_byte: 2
+types_is_one_time_witness_type_cost_per_byte: 2
+validator_validate_metadata_cost_base: 20000
+validator_validate_metadata_data_cost_per_byte: 2
+crypto_invalid_arguments_cost: 100
+bls12381_bls12381_min_sig_verify_cost_base: 44064
+bls12381_bls12381_min_sig_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_sig_verify_msg_cost_per_block: 2
+bls12381_bls12381_min_pk_verify_cost_base: 49282
+bls12381_bls12381_min_pk_verify_msg_cost_per_byte: 2
+bls12381_bls12381_min_pk_verify_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_keccak256_cost_base: 500
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_k1_ecrecover_sha256_cost_base: 500
+ecdsa_k1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_k1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_k1_decompress_pubkey_cost_base: 52
+ecdsa_k1_secp256k1_verify_keccak256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_k1_secp256k1_verify_sha256_cost_base: 1470
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_k1_secp256k1_verify_sha256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_keccak256_cost_base: 1173
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_keccak256_msg_cost_per_block: 2
+ecdsa_r1_ecrecover_sha256_cost_base: 1173
+ecdsa_r1_ecrecover_sha256_msg_cost_per_byte: 2
+ecdsa_r1_ecrecover_sha256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_keccak256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_keccak256_msg_cost_per_block: 2
+ecdsa_r1_secp256r1_verify_sha256_cost_base: 4225
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_byte: 2
+ecdsa_r1_secp256r1_verify_sha256_msg_cost_per_block: 2
+ecvrf_ecvrf_verify_cost_base: 4848
+ecvrf_ecvrf_verify_alpha_string_cost_per_byte: 2
+ecvrf_ecvrf_verify_alpha_string_cost_per_block: 2
+ed25519_ed25519_verify_cost_base: 1802
+ed25519_ed25519_verify_msg_cost_per_byte: 2
+ed25519_ed25519_verify_msg_cost_per_block: 2
+groth16_prepare_verifying_key_bls12381_cost_base: 53838
+groth16_prepare_verifying_key_bn254_cost_base: 82010
+groth16_verify_groth16_proof_internal_bls12381_cost_base: 72090
+groth16_verify_groth16_proof_internal_bls12381_cost_per_public_input: 8213
+groth16_verify_groth16_proof_internal_bn254_cost_base: 115502
+groth16_verify_groth16_proof_internal_bn254_cost_per_public_input: 9484
+groth16_verify_groth16_proof_internal_public_input_cost_per_byte: 2
+hash_blake2b256_cost_base: 10
+hash_blake2b256_data_cost_per_byte: 2
+hash_blake2b256_data_cost_per_block: 2
+hash_keccak256_cost_base: 10
+hash_keccak256_data_cost_per_byte: 2
+hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_base: 260
+poseidon_bn254_cost_per_block: 388
+group_ops_bls12381_decode_scalar_cost: 7
+group_ops_bls12381_decode_g1_cost: 2848
+group_ops_bls12381_decode_g2_cost: 3770
+group_ops_bls12381_decode_gt_cost: 3068
+group_ops_bls12381_scalar_add_cost: 10
+group_ops_bls12381_g1_add_cost: 1556
+group_ops_bls12381_g2_add_cost: 3048
+group_ops_bls12381_gt_add_cost: 188
+group_ops_bls12381_scalar_sub_cost: 10
+group_ops_bls12381_g1_sub_cost: 1550
+group_ops_bls12381_g2_sub_cost: 3019
+group_ops_bls12381_gt_sub_cost: 497
+group_ops_bls12381_scalar_mul_cost: 11
+group_ops_bls12381_g1_mul_cost: 4842
+group_ops_bls12381_g2_mul_cost: 9108
+group_ops_bls12381_gt_mul_cost: 27490
+group_ops_bls12381_scalar_div_cost: 91
+group_ops_bls12381_g1_div_cost: 5091
+group_ops_bls12381_g2_div_cost: 9206
+group_ops_bls12381_gt_div_cost: 27804
+group_ops_bls12381_g1_hash_to_base_cost: 2962
+group_ops_bls12381_g2_hash_to_base_cost: 8688
+group_ops_bls12381_g1_hash_to_cost_per_byte: 2
+group_ops_bls12381_g2_hash_to_cost_per_byte: 2
+group_ops_bls12381_g1_msm_base_cost: 62648
+group_ops_bls12381_g2_msm_base_cost: 131192
+group_ops_bls12381_g1_msm_base_cost_per_input: 1333
+group_ops_bls12381_g2_msm_base_cost_per_input: 3216
+group_ops_bls12381_msm_max_len: 32
+group_ops_bls12381_pairing_cost: 26897
+group_ops_bls12381_g1_to_uncompressed_g1_cost: 2099
+group_ops_bls12381_uncompressed_g1_to_g1_cost: 677
+group_ops_bls12381_uncompressed_g1_sum_base_cost: 77
+group_ops_bls12381_uncompressed_g1_sum_cost_per_term: 26
+group_ops_bls12381_uncompressed_g1_sum_max_terms: 1200
+group_ops_ristretto_decode_scalar_cost: 7
+group_ops_ristretto_decode_point_cost: 200
+group_ops_ristretto_scalar_add_cost: 10
+group_ops_ristretto_point_add_cost: 500
+group_ops_ristretto_scalar_sub_cost: 10
+group_ops_ristretto_point_sub_cost: 500
+group_ops_ristretto_scalar_mul_cost: 11
+group_ops_ristretto_point_mul_cost: 1200
+group_ops_ristretto_scalar_div_cost: 151
+group_ops_ristretto_point_div_cost: 2500
+hmac_hmac_sha3_256_cost_base: 52
+hmac_hmac_sha3_256_input_cost_per_byte: 2
+hmac_hmac_sha3_256_input_cost_per_block: 2
+check_zklogin_id_cost_base: 200
+check_zklogin_issuer_cost_base: 200
+vdf_verify_vdf_cost: 1500
+vdf_hash_to_input_cost: 100
+nitro_attestation_parse_base_cost: 2650
+nitro_attestation_parse_cost_per_byte: 50
+nitro_attestation_verify_base_cost: 2481600
+nitro_attestation_verify_cost_per_cert: 2618450
+bcs_per_byte_serialized_cost: 2
+bcs_legacy_min_output_size_cost: 1
+bcs_failure_cost: 52
+hash_sha2_256_base_cost: 52
+hash_sha2_256_per_byte_cost: 2
+hash_sha2_256_legacy_min_input_len_cost: 1
+hash_sha3_256_base_cost: 52
+hash_sha3_256_per_byte_cost: 2
+hash_sha3_256_legacy_min_input_len_cost: 1
+type_name_get_base_cost: 52
+type_name_get_per_byte_cost: 2
+type_name_id_base_cost: 52
+string_check_utf8_base_cost: 52
+string_check_utf8_per_byte_cost: 2
+string_is_char_boundary_base_cost: 52
+string_sub_string_base_cost: 52
+string_sub_string_per_byte_cost: 2
+string_index_of_base_cost: 52
+string_index_of_per_byte_pattern_cost: 2
+string_index_of_per_byte_searched_cost: 2
+vector_empty_base_cost: 52
+vector_length_base_cost: 52
+vector_push_back_base_cost: 52
+vector_push_back_legacy_per_abstract_memory_unit_cost: 2
+vector_borrow_base_cost: 52
+vector_pop_back_base_cost: 52
+vector_destroy_empty_base_cost: 52
+vector_swap_base_cost: 52
+debug_print_base_cost: 52
+debug_print_stack_trace_base_cost: 52
+execution_version: 4
+consensus_bad_nodes_stake_threshold: 30
+max_jwk_votes_per_validator_per_epoch: 240
+max_age_of_jwk_in_epochs: 1
+random_beacon_reduction_allowed_delta: 800
+random_beacon_reduction_lower_bound: 500
+random_beacon_dkg_timeout_round: 3000
+random_beacon_min_round_interval_ms: 500
+random_beacon_dkg_version: 1
+consensus_max_transaction_size_bytes: 262144
+consensus_max_transactions_in_block_bytes: 524288
+consensus_max_num_transactions_in_block: 512
+consensus_voting_rounds: 40
+max_accumulated_txn_cost_per_object_in_narwhal_commit: 40
+max_deferral_rounds_for_congestion_control: 10
+max_txn_cost_overage_per_object_in_commit: 18446744073709551615
+allowed_txn_cost_overage_burst_per_object_in_commit: 370000000
+min_checkpoint_interval_ms: 200
+checkpoint_summary_version_specific_data: 1
+max_soft_bundle_size: 5
+bridge_should_try_to_finalize_committee: true
+max_accumulated_txn_cost_per_object_in_mysticeti_commit: 37000000
+max_accumulated_randomness_txn_cost_per_object_in_mysticeti_commit: 7400000
+consensus_gc_depth: 60
+gas_budget_based_txn_cost_cap_factor: 400000
+gas_budget_based_txn_cost_absolute_cap_commit_count: 50
+sip_45_consensus_amplification_threshold: 5
+use_object_per_epoch_marker_table_v2: true
+consensus_commit_rate_estimation_window_size: 10
+translation_per_command_base_charge: 1
+translation_per_input_base_charge: 1
+translation_pure_input_per_byte_charge: 1
+translation_per_type_node_charge: 1
+translation_per_reference_node_charge: 1
+translation_per_linkage_entry_charge: 10
+max_updates_per_settlement_txn: 100
+gasless_max_computation_units: 50000
+gasless_allowed_token_types: []
+gasless_max_unused_inputs: 1
+gasless_max_pure_input_bytes: 32
+gasless_max_tps: 50

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -3,7 +3,7 @@ source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis.sui_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 122
+protocol_version: 123
 system_state_version: 1
 validators:
   total_stake: 20000000000000000
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x5592627d5f5e0149c334dc8b8d46e05de59cd63814f2e228c3dc4897edf22d41"
+            id: "0x509ab92949a85887c2f35ba902993ea649956831e5874af8f0d73a6e2dd4d7ba"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x80375253581c8fcdfcc9dbaa549ac0ae80e880f9b227fb9f62101cc60be84702"
+      operation_cap_id: "0x0a0969e2518f510d3ca38a7ab3f865953822b71d8aec3027bdeb814f8bdabe12"
       gas_price: 1000
       staking_pool:
-        id: "0xbcca79e3eb346e7c892447dbbbb5e9e8ad55e3ce630bc4b8c92c9823395a0903"
+        id: "0xaf5291159df30f2144b45a044fbd5cd60e56599ac4cc0399bf90035db6da047a"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x450c9c1c33305ca5d9c12e703d11fb127d5eb0c6d039abba9c3923b270edb5b4"
+          id: "0xa42819b10457bee812e251dd065f5841b8e41be89124bfeedbf72f4b17568de7"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0x2b08158be9a7bf52b96073761a819727e139405487ea8e47f66ab9c7462a094f"
+            id: "0x76f5842a1d1f738405ed2eed7ec454975dbb75d5fbb332622324e4acfb6c2986"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x2b615e6ef39aa58765a2dc2768f5c4b426e9cbeb89f254805136dd89e14f3b45"
+          id: "0xd1175dde0750fcc1c9bceba505f6c3bcf06f31363312e5785640a5f68c1156ed"
         size: 0
   pending_active_validators:
     contents:
-      id: "0xa66f0dfabf84d3ba1723f8458286945bff0593e11d66252e5459d7e8e1b05005"
+      id: "0x6ba07bd183fb26d54f6ed057304821a063c4c0c87db9277537905d8d383b3841"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x0cf6bf4ade64556ffdd335686f9bf8d37c4763254fb78331a6625d6ab7e97c68"
+    id: "0x00299e77a2657a5c8429aa7e2e4184c09ad8bedfcebc7a56c34bfe25d3b426ee"
     size: 1
   inactive_validators:
-    id: "0xadc62a5dc6f52f853f20d326cfb1195a6c907df904ab49599d38a8e9fd5dbad7"
+    id: "0xb8b9eb8280bbf1fb94b6c9e679c57328f593ef19684460a2a2f9166cbcf0a878"
     size: 0
   validator_candidates:
-    id: "0xdcc13e9f1ef81afbded928119f8641bf448296ac5b3d3df0818eda9b370ce70d"
+    id: "0x149d6e451e23ec7ea44234b5bd1ec39f0f2868bfb776abe40543e0b7998e03a8"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x3ef113289f5908e4d77325a63a0e6ed19b4530e7da2c8a15d1f848772d460d6c"
+      id: "0xed073a4001a779f7744e71cc9122fd0143e6ec91bd3c79c0fabd4dba8acbaf65"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0xe4b429988dbb27b6acbf8cc3841815ac71b0772d5694b9124bd6e0a8dfaf5335"
+      id: "0x2ab0f9dbb905daaf40e35294b1eda47cbe3189af81a16504de46859b2bfde0b0"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x5dd4ae7ae0d781aa9c2ef1b5256187e1f97dd9968767a60cd82b6ea5f8e1a9c6"
+      id: "0x398279e286c80f0c4d51ead071448fce70f04135c8072b96bb299b14f2ae7dbe"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,5 +332,5 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0xb3c3d4e2268e1a0016c8401735693257b5275c7684d0b8800337c75fa54688e8"
+    id: "0xddbc7df2f87a0ea8eba6ce262700da88925d4602a57072142efddfaedc1746e0"
   size: 0

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -1027,6 +1027,105 @@ mod tests {
     }
 
     #[test]
+    fn test_max_total_linkage_size_fails_on_many_small_deps() {
+        // A small package with many small deps that individually fit under
+        // `max_move_package_size` but collectively exceed the total linkage cap.
+        let deps: Vec<_> = (0..20)
+            .map(|i| make_dep_package(&format!("dep_{}", i), 10).1)
+            .collect();
+        let main_module = create_test_module("main", AccountAddress::random(), 10);
+
+        let per_dep = deps[0].size() as u64;
+        // Cap sized so a handful of deps fit, but not all 20.
+        let max = per_dep * 5;
+        let protocol_config = test_protocol_config(Some(max));
+
+        let result = MovePackage::new_initial(
+            &[main_module],
+            &protocol_config,
+            deps.iter().collect::<Vec<_>>(),
+        );
+
+        let err = result.expect_err("many small deps should exceed the total linkage cap");
+        match err.kind() {
+            ExecutionErrorKind::MovePackageTooBig {
+                object_size,
+                max_object_size,
+            } => {
+                assert_eq!(*max_object_size, max);
+                // 20 deps × per_dep + main pkg — comfortably above the cap.
+                assert!(*object_size > per_dep * 20);
+            }
+            k => panic!("Expected MovePackageTooBig, got: {:?}", k),
+        }
+    }
+
+    #[test]
+    fn test_max_total_linkage_size_fails_on_single_huge_dep() {
+        // A single dependency whose own size exceeds the total linkage cap, even
+        // though it is under the per-package cap (which is u64::MAX in this test).
+        let (_, huge_dep) = make_dep_package("huge_dep", 500);
+        let main_module = create_test_module("main", AccountAddress::random(), 5);
+
+        let huge_size = huge_dep.size() as u64;
+        let max = huge_size - 1; // dep alone is already over.
+        let protocol_config = test_protocol_config(Some(max));
+
+        let result =
+            MovePackage::new_initial(&[main_module], &protocol_config, vec![&huge_dep]);
+
+        let err = result.expect_err("single huge dep should exceed the total linkage cap");
+        match err.kind() {
+            ExecutionErrorKind::MovePackageTooBig {
+                object_size,
+                max_object_size,
+            } => {
+                assert_eq!(*max_object_size, max);
+                assert!(*object_size > huge_size);
+            }
+            k => panic!("Expected MovePackageTooBig, got: {:?}", k),
+        }
+    }
+
+    #[test]
+    fn test_max_total_linkage_size_enforced_on_upgrade() {
+        // The check must also fire on the upgrade path (`new_upgraded`), not just
+        // `new_initial`.
+        let (_, dep_package) = make_dep_package("dep", 50);
+        let original_module = create_test_module("upgraded", AccountAddress::random(), 5);
+
+        // First publish the original under a permissive cap so we have a package
+        // to upgrade.
+        let permissive = test_protocol_config(Some(u64::MAX));
+        let original = MovePackage::new_initial(
+            &[original_module.clone()],
+            &permissive,
+            vec![&dep_package],
+        )
+        .expect("original publish should succeed under permissive cap");
+
+        // Now upgrade with the same modules, but tighten the cap so
+        // original.size() + dep.size() exceeds it.
+        let tight_max = dep_package.size() as u64;
+        let strict = test_protocol_config(Some(tight_max));
+
+        let result =
+            original.new_upgraded(original.id(), &[original_module], &strict, vec![&dep_package]);
+
+        let err = result.expect_err("upgrade should be rejected when total linkage exceeds cap");
+        match err.kind() {
+            ExecutionErrorKind::MovePackageTooBig {
+                object_size,
+                max_object_size,
+            } => {
+                assert_eq!(*max_object_size, tight_max);
+                assert!(*object_size > tight_max);
+            }
+            k => panic!("Expected MovePackageTooBig on upgrade, got: {:?}", k),
+        }
+    }
+
+    #[test]
     fn test_max_total_linkage_size_check_fails() {
         let (_, dep_package) = make_dep_package("large_dependency", 200);
         let main_module = create_test_module("large_main", AccountAddress::random(), 200);

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -198,29 +198,6 @@ impl MovePackage {
         type_origin_table: Vec<TypeOrigin>,
         linkage_table: BTreeMap<ObjectID, UpgradeInfo>,
     ) -> Result<Self, ExecutionError> {
-        Self::new_with_linkage_size(
-            id,
-            version,
-            module_map,
-            max_move_package_size,
-            type_origin_table,
-            linkage_table,
-            None,
-            None,
-        )
-    }
-
-    /// Create a package with all required data and optional total linkage size check.
-    pub fn new_with_linkage_size(
-        id: ObjectID,
-        version: SequenceNumber,
-        module_map: BTreeMap<String, Vec<u8>>,
-        max_move_package_size: u64,
-        type_origin_table: Vec<TypeOrigin>,
-        linkage_table: BTreeMap<ObjectID, UpgradeInfo>,
-        total_linkage_size: Option<u64>,
-        max_total_linkage_size: Option<u64>,
-    ) -> Result<Self, ExecutionError> {
         let pkg = Self {
             id,
             version,
@@ -236,17 +213,6 @@ impl MovePackage {
             }
             .into());
         }
-
-        if let (Some(total_size), Some(max_size)) = (total_linkage_size, max_total_linkage_size) {
-            if total_size > max_size {
-                return Err(ExecutionErrorKind::MovePackageTooBig {
-                    object_size: total_size,
-                    max_object_size: max_size,
-                }
-                .into());
-            }
-        }
-
         Ok(pkg)
     }
 
@@ -453,25 +419,30 @@ impl MovePackage {
             protocol_config,
         )?;
 
-        let pkg = Self {
-            id: storage_id,
-            version,
-            module_map,
-            type_origin_table,
-            linkage_table,
-        };
-        let total_linkage_size = pkg.size() as u64 + total_deps_size;
-
-        Self::new_with_linkage_size(
+        let pkg = Self::new(
             storage_id,
             version,
-            pkg.module_map,
+            module_map,
             protocol_config.max_move_package_size(),
-            pkg.type_origin_table,
-            pkg.linkage_table,
-            Some(total_linkage_size),
-            protocol_config.max_total_linkage_size_as_option(),
-        )
+            type_origin_table,
+            linkage_table,
+        )?;
+
+        // Gated by protocol version: bound the on-disk footprint of this package plus
+        // all of its transitive dependencies, so the effective linkage size can't be
+        // max_move_package_size * max_package_dependencies.
+        if let Some(max_total_linkage_size) = protocol_config.max_total_linkage_size_as_option() {
+            let total_linkage_size = pkg.size() as u64 + total_deps_size;
+            if total_linkage_size > max_total_linkage_size {
+                return Err(ExecutionErrorKind::MovePackageTooBig {
+                    object_size: total_linkage_size,
+                    max_object_size: max_total_linkage_size,
+                }
+                .into());
+            }
+        }
+
+        Ok(pkg)
     }
 
     // Retrieve the module with `ModuleId` in the given package.
@@ -943,6 +914,7 @@ fn build_upgraded_type_origin_table(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sui_protocol_config::{Chain, ProtocolVersion};
     use move_binary_format::file_format::{
         empty_module, Bytecode, CodeUnit, FunctionDefinition, FunctionHandle,
         FunctionHandleIndex, IdentifierIndex, ModuleHandleIndex, Signature, SignatureIndex,
@@ -993,106 +965,95 @@ mod tests {
         module
     }
 
-    #[test]
-    fn test_max_total_linkage_size_check_passes() {
-        let addr1 = AccountAddress::random();
-        let addr2 = AccountAddress::random();
+    fn serialize_module(module: &CompiledModule) -> Vec<u8> {
+        let mut bytes = vec![];
+        module.serialize_with_version(VERSION_6, &mut bytes).unwrap();
+        bytes
+    }
 
-        let dep_module = create_test_module("dependency", addr1, 5);
-        let dep_package = MovePackage::new(
-            ObjectID::from(addr1),
+    fn make_dep_package(name: &str, num_functions: usize) -> (AccountAddress, MovePackage) {
+        let addr = AccountAddress::random();
+        let module = create_test_module(name, addr, num_functions);
+        let pkg = MovePackage::new(
+            ObjectID::from(addr),
             OBJECT_START_VERSION,
-            BTreeMap::from([(
-                "dependency".to_string(),
-                {
-                    let mut bytes = vec![];
-                    dep_module.serialize_with_version(6, &mut bytes).unwrap();
-                    bytes
-                },
-            )]),
+            BTreeMap::from([(name.to_string(), serialize_module(&module))]),
             u64::MAX,
             vec![],
             BTreeMap::new(),
         )
         .unwrap();
+        (addr, pkg)
+    }
 
-        let main_module = create_test_module("main", addr2, 5);
-        let main_modules = vec![main_module];
+    // Build a protocol config at the version that introduced max_total_linkage_size, then
+    // override the relevant limits to keep the test modules small.
+    fn test_protocol_config(max_total_linkage_size: Option<u64>) -> ProtocolConfig {
+        let mut cfg = ProtocolConfig::get_for_version(ProtocolVersion::new(123), Chain::Unknown);
+        cfg.set_max_move_package_size_for_testing(u64::MAX);
+        match max_total_linkage_size {
+            Some(v) => cfg.set_max_total_linkage_size_for_testing(v),
+            None => cfg.disable_max_total_linkage_size_for_testing(),
+        }
+        cfg
+    }
 
-        let protocol_config = ProtocolConfig::get_for_min_version();
+    #[test]
+    fn test_max_total_linkage_size_check_passes() {
+        let (_, dep_package) = make_dep_package("dependency", 5);
+        let main_module = create_test_module("main", AccountAddress::random(), 5);
+        let protocol_config = test_protocol_config(Some(1024 * 1024));
 
-        let result = MovePackage::new_initial(
-            &main_modules,
-            &protocol_config,
-            vec![&dep_package],
+        let result =
+            MovePackage::new_initial(&[main_module], &protocol_config, vec![&dep_package]);
+
+        assert!(
+            result.is_ok(),
+            "Package creation should succeed when under size limit: {:?}",
+            result.err()
         );
+    }
 
-        assert!(result.is_ok(), "Package creation should succeed when under size limit");
+    #[test]
+    fn test_max_total_linkage_size_disabled_allows_oversize() {
+        let (_, dep_package) = make_dep_package("dependency", 5);
+        let main_module = create_test_module("main", AccountAddress::random(), 5);
+        // No total linkage cap => check is skipped entirely.
+        let protocol_config = test_protocol_config(None);
+
+        let result =
+            MovePackage::new_initial(&[main_module], &protocol_config, vec![&dep_package]);
+        assert!(result.is_ok(), "Check must be disabled when config is None");
     }
 
     #[test]
     fn test_max_total_linkage_size_check_fails() {
-        let addr1 = AccountAddress::random();
-        let addr2 = AccountAddress::random();
+        let (_, dep_package) = make_dep_package("large_dependency", 200);
+        let main_module = create_test_module("large_main", AccountAddress::random(), 200);
 
-        let dep_module = create_test_module("large_dependency", addr1, 200);
-        let dep_package = MovePackage::new(
-            ObjectID::from(addr1),
-            OBJECT_START_VERSION,
-            BTreeMap::from([(
-                "large_dependency".to_string(),
-                {
-                    let mut bytes = vec![];
-                    dep_module.serialize_with_version(VERSION_6, &mut bytes).unwrap();
-                    bytes
-                },
-            )]),
-            u64::MAX,
-            vec![],
-            BTreeMap::new(),
-        )
-        .unwrap();
+        // Cap the total just below what dep + main would sum to.
+        let dep_size = dep_package.size() as u64;
+        let max = dep_size; // main package alone will push us over.
+        let protocol_config = test_protocol_config(Some(max));
 
-        let main_module = create_test_module("large_main", addr2, 200);
-        let main_modules = vec![main_module];
+        let result =
+            MovePackage::new_initial(&[main_module], &protocol_config, vec![&dep_package]);
 
-        let protocol_config = ProtocolConfig::get_for_min_version();
-        let total_size = dep_package.size() as u64;
-
-        let result = MovePackage::new_with_linkage_size(
-            ObjectID::from(addr2),
-            OBJECT_START_VERSION,
-            BTreeMap::from([(
-                "large_main".to_string(),
-                {
-                    let mut bytes = vec![];
-                    main_modules[0].serialize_with_version(VERSION_6, &mut bytes).unwrap();
-                    bytes
-                },
-            )]),
-            protocol_config.max_move_package_size(),
-            vec![],
-            BTreeMap::from([(
-                ObjectID::from(addr1),
-                UpgradeInfo {
-                    upgraded_id: ObjectID::from(addr1),
-                    upgraded_version: OBJECT_START_VERSION,
-                },
-            )]),
-            Some(total_size + 1000),
-            Some(100),
-        );
-
-        assert!(result.is_err(), "Expected error for package exceeding max_total_linkage_size");
-
-        if let Err(err) = result {
-            match err.kind() {
-                ExecutionErrorKind::MovePackageTooBig { object_size, max_object_size } => {
-                    assert_eq!(*object_size, total_size + 1000);
-                    assert_eq!(*max_object_size, 100);
-                }
-                _ => panic!("Expected MovePackageTooBig error, got: {:?}", err.kind()),
+        let err = result.expect_err("Expected error for package exceeding max_total_linkage_size");
+        match err.kind() {
+            ExecutionErrorKind::MovePackageTooBig {
+                object_size,
+                max_object_size,
+            } => {
+                assert!(
+                    *object_size > *max_object_size,
+                    "reported object_size {} should exceed max {}",
+                    object_size,
+                    max_object_size,
+                );
+                assert_eq!(*max_object_size, max);
             }
+            k => panic!("Expected MovePackageTooBig error, got: {:?}", k),
         }
     }
 }

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -914,15 +914,18 @@ fn build_upgraded_type_origin_table(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sui_protocol_config::{Chain, ProtocolVersion};
     use move_binary_format::file_format::{
-        empty_module, Bytecode, CodeUnit, FunctionDefinition, FunctionHandle,
-        FunctionHandleIndex, IdentifierIndex, ModuleHandleIndex, Signature, SignatureIndex,
-        Visibility,
+        Bytecode, CodeUnit, FunctionDefinition, FunctionHandle, FunctionHandleIndex,
+        IdentifierIndex, ModuleHandleIndex, Signature, SignatureIndex, Visibility, empty_module,
     };
     use move_core_types::identifier::Identifier;
+    use sui_protocol_config::{Chain, ProtocolVersion};
 
-    fn create_test_module(name: &str, address: AccountAddress, num_functions: usize) -> CompiledModule {
+    fn create_test_module(
+        name: &str,
+        address: AccountAddress,
+        num_functions: usize,
+    ) -> CompiledModule {
         let mut module = empty_module();
         module.version = VERSION_6;
 
@@ -967,7 +970,9 @@ mod tests {
 
     fn serialize_module(module: &CompiledModule) -> Vec<u8> {
         let mut bytes = vec![];
-        module.serialize_with_version(VERSION_6, &mut bytes).unwrap();
+        module
+            .serialize_with_version(VERSION_6, &mut bytes)
+            .unwrap();
         bytes
     }
 
@@ -1004,8 +1009,7 @@ mod tests {
         let main_module = create_test_module("main", AccountAddress::random(), 5);
         let protocol_config = test_protocol_config(Some(1024 * 1024));
 
-        let result =
-            MovePackage::new_initial(&[main_module], &protocol_config, vec![&dep_package]);
+        let result = MovePackage::new_initial(&[main_module], &protocol_config, vec![&dep_package]);
 
         assert!(
             result.is_ok(),
@@ -1021,8 +1025,7 @@ mod tests {
         // No total linkage cap => check is skipped entirely.
         let protocol_config = test_protocol_config(None);
 
-        let result =
-            MovePackage::new_initial(&[main_module], &protocol_config, vec![&dep_package]);
+        let result = MovePackage::new_initial(&[main_module], &protocol_config, vec![&dep_package]);
         assert!(result.is_ok(), "Check must be disabled when config is None");
     }
 
@@ -1071,8 +1074,7 @@ mod tests {
         let max = huge_size - 1; // dep alone is already over.
         let protocol_config = test_protocol_config(Some(max));
 
-        let result =
-            MovePackage::new_initial(&[main_module], &protocol_config, vec![&huge_dep]);
+        let result = MovePackage::new_initial(&[main_module], &protocol_config, vec![&huge_dep]);
 
         let err = result.expect_err("single huge dep should exceed the total linkage cap");
         match err.kind() {
@@ -1098,7 +1100,7 @@ mod tests {
         // to upgrade.
         let permissive = test_protocol_config(Some(u64::MAX));
         let original = MovePackage::new_initial(
-            &[original_module.clone()],
+            std::slice::from_ref(&original_module),
             &permissive,
             vec![&dep_package],
         )
@@ -1109,8 +1111,12 @@ mod tests {
         let tight_max = dep_package.size() as u64;
         let strict = test_protocol_config(Some(tight_max));
 
-        let result =
-            original.new_upgraded(original.id(), &[original_module], &strict, vec![&dep_package]);
+        let result = original.new_upgraded(
+            original.id(),
+            &[original_module],
+            &strict,
+            vec![&dep_package],
+        );
 
         let err = result.expect_err("upgrade should be rejected when total linkage exceeds cap");
         match err.kind() {
@@ -1135,8 +1141,7 @@ mod tests {
         let max = dep_size; // main package alone will push us over.
         let protocol_config = test_protocol_config(Some(max));
 
-        let result =
-            MovePackage::new_initial(&[main_module], &protocol_config, vec![&dep_package]);
+        let result = MovePackage::new_initial(&[main_module], &protocol_config, vec![&dep_package]);
 
         let err = result.expect_err("Expected error for package exceeding max_total_linkage_size");
         match err.kind() {

--- a/crates/sui-types/src/move_package.rs
+++ b/crates/sui-types/src/move_package.rs
@@ -198,6 +198,29 @@ impl MovePackage {
         type_origin_table: Vec<TypeOrigin>,
         linkage_table: BTreeMap<ObjectID, UpgradeInfo>,
     ) -> Result<Self, ExecutionError> {
+        Self::new_with_linkage_size(
+            id,
+            version,
+            module_map,
+            max_move_package_size,
+            type_origin_table,
+            linkage_table,
+            None,
+            None,
+        )
+    }
+
+    /// Create a package with all required data and optional total linkage size check.
+    pub fn new_with_linkage_size(
+        id: ObjectID,
+        version: SequenceNumber,
+        module_map: BTreeMap<String, Vec<u8>>,
+        max_move_package_size: u64,
+        type_origin_table: Vec<TypeOrigin>,
+        linkage_table: BTreeMap<ObjectID, UpgradeInfo>,
+        total_linkage_size: Option<u64>,
+        max_total_linkage_size: Option<u64>,
+    ) -> Result<Self, ExecutionError> {
         let pkg = Self {
             id,
             version,
@@ -213,6 +236,17 @@ impl MovePackage {
             }
             .into());
         }
+
+        if let (Some(total_size), Some(max_size)) = (total_linkage_size, max_total_linkage_size) {
+            if total_size > max_size {
+                return Err(ExecutionErrorKind::MovePackageTooBig {
+                    object_size: total_size,
+                    max_object_size: max_size,
+                }
+                .into());
+            }
+        }
+
         Ok(pkg)
     }
 
@@ -413,18 +447,30 @@ impl MovePackage {
         }
 
         immediate_dependencies.remove(&self_id);
-        let linkage_table = build_linkage_table(
+        let (linkage_table, total_deps_size) = build_linkage_table(
             immediate_dependencies,
             transitive_dependencies,
             protocol_config,
         )?;
-        Self::new(
-            storage_id,
+
+        let pkg = Self {
+            id: storage_id,
             version,
             module_map,
-            protocol_config.max_move_package_size(),
             type_origin_table,
             linkage_table,
+        };
+        let total_linkage_size = pkg.size() as u64 + total_deps_size;
+
+        Self::new_with_linkage_size(
+            storage_id,
+            version,
+            pkg.module_map,
+            protocol_config.max_move_package_size(),
+            pkg.type_origin_table,
+            pkg.linkage_table,
+            Some(total_linkage_size),
+            protocol_config.max_total_linkage_size_as_option(),
         )
     }
 
@@ -741,9 +787,10 @@ fn build_linkage_table<'p>(
     mut immediate_dependencies: BTreeSet<ObjectID>,
     transitive_dependencies: impl IntoIterator<Item = &'p MovePackage>,
     protocol_config: &ProtocolConfig,
-) -> Result<BTreeMap<ObjectID, UpgradeInfo>, ExecutionError> {
+) -> Result<(BTreeMap<ObjectID, UpgradeInfo>, u64), ExecutionError> {
     let mut linkage_table = BTreeMap::new();
     let mut dep_linkage_tables = vec![];
+    let mut total_deps_size = 0u64;
 
     for transitive_dep in transitive_dependencies.into_iter() {
         // original_package_id will deserialize a module but only for the purpose of obtaining
@@ -780,6 +827,8 @@ fn build_linkage_table<'p>(
                 },
             );
         }
+
+        total_deps_size += transitive_dep.size() as u64;
     }
     // (1) Every dependency is represented in the transitive dependencies
     if !immediate_dependencies.is_empty() {
@@ -799,7 +848,7 @@ fn build_linkage_table<'p>(
         }
     }
 
-    Ok(linkage_table)
+    Ok((linkage_table, total_deps_size))
 }
 
 fn build_initial_type_origin_table(modules: &[CompiledModule]) -> Vec<TypeOrigin> {
@@ -888,5 +937,162 @@ fn build_upgraded_type_origin_table(
         }
     } else {
         Ok(new_table)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use move_binary_format::file_format::{
+        empty_module, Bytecode, CodeUnit, FunctionDefinition, FunctionHandle,
+        FunctionHandleIndex, IdentifierIndex, ModuleHandleIndex, Signature, SignatureIndex,
+        Visibility,
+    };
+    use move_core_types::identifier::Identifier;
+
+    fn create_test_module(name: &str, address: AccountAddress, num_functions: usize) -> CompiledModule {
+        let mut module = empty_module();
+        module.version = VERSION_6;
+
+        module.address_identifiers.push(address);
+        module.identifiers.push(Identifier::new(name).unwrap());
+
+        module.module_handles[0] = move_binary_format::file_format::ModuleHandle {
+            address: move_binary_format::file_format::AddressIdentifierIndex(0),
+            name: IdentifierIndex(0),
+        };
+
+        for i in 0..num_functions {
+            let func_name = format!("func_{}", i);
+            module.identifiers.push(Identifier::new(func_name).unwrap());
+
+            let sig_idx = module.signatures.len();
+            module.signatures.push(Signature(vec![]));
+
+            module.function_handles.push(FunctionHandle {
+                module: ModuleHandleIndex(0),
+                name: IdentifierIndex((module.identifiers.len() - 1) as u16),
+                parameters: SignatureIndex(sig_idx as u16),
+                return_: SignatureIndex(sig_idx as u16),
+                type_parameters: vec![],
+            });
+
+            module.function_defs.push(FunctionDefinition {
+                function: FunctionHandleIndex(module.function_handles.len() as u16 - 1),
+                visibility: Visibility::Public,
+                is_entry: false,
+                acquires_global_resources: vec![],
+                code: Some(CodeUnit {
+                    locals: SignatureIndex(sig_idx as u16),
+                    code: vec![Bytecode::Ret],
+                    jump_tables: vec![],
+                }),
+            });
+        }
+
+        module
+    }
+
+    #[test]
+    fn test_max_total_linkage_size_check_passes() {
+        let addr1 = AccountAddress::random();
+        let addr2 = AccountAddress::random();
+
+        let dep_module = create_test_module("dependency", addr1, 5);
+        let dep_package = MovePackage::new(
+            ObjectID::from(addr1),
+            OBJECT_START_VERSION,
+            BTreeMap::from([(
+                "dependency".to_string(),
+                {
+                    let mut bytes = vec![];
+                    dep_module.serialize_with_version(6, &mut bytes).unwrap();
+                    bytes
+                },
+            )]),
+            u64::MAX,
+            vec![],
+            BTreeMap::new(),
+        )
+        .unwrap();
+
+        let main_module = create_test_module("main", addr2, 5);
+        let main_modules = vec![main_module];
+
+        let protocol_config = ProtocolConfig::get_for_min_version();
+
+        let result = MovePackage::new_initial(
+            &main_modules,
+            &protocol_config,
+            vec![&dep_package],
+        );
+
+        assert!(result.is_ok(), "Package creation should succeed when under size limit");
+    }
+
+    #[test]
+    fn test_max_total_linkage_size_check_fails() {
+        let addr1 = AccountAddress::random();
+        let addr2 = AccountAddress::random();
+
+        let dep_module = create_test_module("large_dependency", addr1, 200);
+        let dep_package = MovePackage::new(
+            ObjectID::from(addr1),
+            OBJECT_START_VERSION,
+            BTreeMap::from([(
+                "large_dependency".to_string(),
+                {
+                    let mut bytes = vec![];
+                    dep_module.serialize_with_version(VERSION_6, &mut bytes).unwrap();
+                    bytes
+                },
+            )]),
+            u64::MAX,
+            vec![],
+            BTreeMap::new(),
+        )
+        .unwrap();
+
+        let main_module = create_test_module("large_main", addr2, 200);
+        let main_modules = vec![main_module];
+
+        let protocol_config = ProtocolConfig::get_for_min_version();
+        let total_size = dep_package.size() as u64;
+
+        let result = MovePackage::new_with_linkage_size(
+            ObjectID::from(addr2),
+            OBJECT_START_VERSION,
+            BTreeMap::from([(
+                "large_main".to_string(),
+                {
+                    let mut bytes = vec![];
+                    main_modules[0].serialize_with_version(VERSION_6, &mut bytes).unwrap();
+                    bytes
+                },
+            )]),
+            protocol_config.max_move_package_size(),
+            vec![],
+            BTreeMap::from([(
+                ObjectID::from(addr1),
+                UpgradeInfo {
+                    upgraded_id: ObjectID::from(addr1),
+                    upgraded_version: OBJECT_START_VERSION,
+                },
+            )]),
+            Some(total_size + 1000),
+            Some(100),
+        );
+
+        assert!(result.is_err(), "Expected error for package exceeding max_total_linkage_size");
+
+        if let Err(err) = result {
+            match err.kind() {
+                ExecutionErrorKind::MovePackageTooBig { object_size, max_object_size } => {
+                    assert_eq!(*object_size, total_size + 1000);
+                    assert_eq!(*max_object_size, 100);
+                }
+                _ => panic!("Expected MovePackageTooBig error, got: {:?}", err.kind()),
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description 

Introduce `max_total_linkage_size`: a protocol-gated cap on the total
on-disk footprint of a Move package plus all of its transitive
dependencies, enforced at publish and upgrade time.

Previously we had two independent caps — `max_move_package_size` (per
package) and `max_package_dependencies` (max transitive deps) — and the
effective upper bound on a loaded linkage was their product. That made
it hard to relax either one without blowing up the worst-case linkage
size, which is what actually matters for storage, loading, and the
verifier.

This PR adds a single total-linkage cap so the two per-unit limits can
be raised independently of the aggregate bound. At v123:

- `max_move_package_size`: 100 KB → 1 MB
- `max_package_dependencies`: 32 → 100
- `max_total_linkage_size`: new, set to `32 * 100 * 1024` (the product
  of the *previous* limits), so the worst-case total footprint does
  not regress relative to v122.

## Protocol gating

All three changes ship under a new **protocol version 123**:

- `MAX_PROTOCOL_VERSION` bumped 122 → 123.
- New `123 => { … }` arm in `ProtocolConfig::get_for_version_impl`.
- `max_total_linkage_size_as_option()` is used at the call site so the
  check is a no-op on pre-v123 configs — v122 and earlier are
  byte-identical to today.

Snapshots regenerated:

- `version_122.snap` unchanged — still `max_move_package_size: 102400`,
  `max_package_dependencies: 32`, no `max_total_linkage_size`.
- `version_123.snap` (and Mainnet/Testnet variants) show
  `max_move_package_size: 1048576`, `max_package_dependencies: 100`,
  `max_total_linkage_size: 3276800`.

## Implementation

- `MovePackage::from_module_iter_with_type_origin_table` (the single
  site shared by `new_initial` and `new_upgraded`) now sums the size
  of the new package plus each transitive dep and, when
  `max_total_linkage_size_as_option()` is `Some`, rejects publishes /
  upgrades whose total exceeds the cap with `MovePackageTooBig`.
- `build_linkage_table` returns `(linkage_table, total_deps_size)` so
  the caller gets the dep footprint without a second pass.
- `MovePackage::new` is unchanged in signature and still enforces the
  per-package `max_move_package_size`; the total-linkage check lives
  one level up, where the transitive deps are in scope.
- Field doc on `max_total_linkage_size` names the real enforcement
  site instead of a `TODO`.

## Tests

New unit tests in `sui-types/src/move_package.rs` — all go end-to-end
through `MovePackage::new_initial` against a real `ProtocolConfig` at
v123, with per-field `set_*_for_testing` / `disable_*_for_testing`
overrides to keep the synthetic modules small:

- `test_max_total_linkage_size_check_passes` — package + dep well
  under the cap; creation succeeds.
- `test_max_total_linkage_size_check_fails` — cap sized just below
  `dep.size() + pkg.size()`; returns `MovePackageTooBig` with the
  aggregate size and the configured max.
- `test_max_total_linkage_size_disabled_allows_oversize` — when the
  config field is `None`, the check is skipped entirely (guards the
  pre-v123 gate path).

## Test plan

- [x] `cargo nextest run -p sui-types --lib move_package::` — 3/3 new
      tests pass; no regressions in existing `move_package` tests.
- [x] `cargo nextest run -p sui-protocol-config` — 7/7 pass; v123
      snapshots accepted, v122 and earlier unchanged.
- [x] `cargo clippy -p sui-types -p sui-protocol-config --tests
      --no-deps` — clean.
- [ ] `/protocol-config` review to double-check v123 gating before
      merge.
- [ ] Full `cargo simtest -p sui-e2e-tests` before merge.

## Follow-ups (not in this PR)

- Introduce a dedicated `MovePackageLinkageTooBig` variant of
  `ExecutionErrorKind` so operators/tools can distinguish "this one
  package is too big" from "the transitive linkage is too big."
  Deferred because it changes the on-wire execution status enum and
  requires proto / SDK conversion + YAML snapshot updates.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
