### PR TITLE
Remove unused transaction_info request logic in authority aggregator

### DIFF
--- a/crates/sui-core/src/safe_client.rs
+++ b/crates/sui-core/src/safe_client.rs
@@ -586,6 +586,7 @@ where
     }
 
     /// Handle Transaction information requests for a given digest.
+    /// Only used for testing.
     #[instrument(level = "trace", skip_all, fields(authority = ?self.address.concise()))]
     pub async fn handle_transaction_info_request(
         &self,

--- a/crates/sui-core/src/transaction_driver/request_retrier.rs
+++ b/crates/sui-core/src/transaction_driver/request_retrier.rs
@@ -122,8 +122,6 @@ impl<A: Clone> RequestRetrier<A> {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
     use sui_types::error::{SuiError, UserInputError};
 
     use crate::{
@@ -136,10 +134,7 @@ mod tests {
     pub(crate) fn get_authority_aggregator(
         committee_size: usize,
     ) -> AuthorityAggregator<MockAuthorityApi> {
-        let timeouts_config = TimeoutConfig {
-            serial_authority_request_interval: Duration::from_millis(50),
-            ..Default::default()
-        };
+        let timeouts_config = TimeoutConfig::default();
         AuthorityAggregatorBuilder::from_committee_size(committee_size)
             .with_timeouts_config(timeouts_config)
             .build_mock_authority_aggregator()

--- a/crates/sui-core/src/unit_tests/unit_test_utils.rs
+++ b/crates/sui-core/src/unit_tests/unit_test_utils.rs
@@ -141,7 +141,6 @@ pub async fn init_local_authorities_with_genesis(
     let timeouts = TimeoutConfig {
         pre_quorum_timeout: Duration::from_secs(5),
         post_quorum_timeout: Duration::from_secs(5),
-        serial_authority_request_interval: Duration::from_secs(1),
     };
     AuthorityAggregatorBuilder::from_genesis(genesis)
         .with_timeouts_config(timeouts)


### PR DESCRIPTION
## Description 

These logic are unused now.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
