### PR TITLE
Allow checkpoint height to be non-increasing

### DIFF
--- a/crates/sui-core/src/authority/consensus_quarantine.rs
+++ b/crates/sui-core/src/authority/consensus_quarantine.rs
@@ -612,7 +612,12 @@ impl ConsensusOutputQuarantine {
                 .checkpoint_height
                 .expect("non-genesis checkpoint must have height");
             if let Some(highest) = highest_committed_height {
-                assert!(checkpoint_height > highest);
+                assert!(
+                    checkpoint_height >= highest,
+                    "current checkpoint height {} must be no less than highest committed height {}",
+                    checkpoint_height,
+                    highest
+                );
             }
 
             highest_committed_height = Some(checkpoint_height);

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -94,6 +94,8 @@ pub struct EpochStats {
 pub struct PendingCheckpointInfo {
     pub timestamp_ms: CheckpointTimestamp,
     pub last_of_epoch: bool,
+    // Computed in calculate_pending_checkpoint_height() from consensus round,
+    // there is no guarantee that this is increasing per checkpoint, because of checkpoint splitting.
     pub checkpoint_height: CheckpointHeight,
 }
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -3923,7 +3923,11 @@ impl ProtocolConfig {
 
         // Simtest specific overrides.
         if cfg!(msim) {
+            // Trigger GC more often.
             cfg.consensus_gc_depth = Some(5);
+
+            // Trigger checkpoint splitting more often.
+            cfg.max_transactions_per_checkpoint = Some(10);
         }
 
         cfg


### PR DESCRIPTION
## Description 

Pending checkpoint height is computed in `calculate_pending_checkpoint_height()` with consensus round as input. One consensus commit results in one pending checkpoint and checkpoint height. But a consensus commit and pending checkpoint can result in building multiple actual checkpoints when the commit contains more transactions than `max_transactions_per_checkpoint`. So multiple (built) checkpoints can share the same commit height and we cannot assert on (built) checkpoint height always increasing.

The original problem can be observed by using `max_transactions_per_checkpoint = 10` in simtests.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
