### PR TITLE
Fix lifetime marker warning on the nightly toolchain

### DIFF
--- a/consensus/core/src/test_dag_builder.rs
+++ b/consensus/core/src/test_dag_builder.rs
@@ -297,11 +297,11 @@ impl DagBuilder {
             .map(|(_block_ref, block)| block.clone())
     }
 
-    pub(crate) fn layer(&mut self, round: Round) -> LayerBuilder {
+    pub(crate) fn layer(&mut self, round: Round) -> LayerBuilder<'_> {
         LayerBuilder::new(self, round)
     }
 
-    pub fn layers(&mut self, rounds: RangeInclusive<Round>) -> LayerBuilder {
+    pub fn layers(&mut self, rounds: RangeInclusive<Round>) -> LayerBuilder<'_> {
         let mut builder = LayerBuilder::new(self, *rounds.start());
         builder.end_round = Some(*rounds.end());
         builder

--- a/crates/mysten-common/src/sync/notify_read.rs
+++ b/crates/mysten-common/src/sync/notify_read.rs
@@ -83,7 +83,7 @@ impl<K: Eq + Hash + Clone, V: Clone> NotifyRead<K, V> {
         rem
     }
 
-    pub fn register_one(&self, key: &K) -> Registration<K, V> {
+    pub fn register_one(&self, key: &K) -> Registration<'_, K, V> {
         self.count_pending.fetch_add(1, Ordering::Relaxed);
         let (sender, receiver) = oneshot::channel();
         self.register(key, sender);
@@ -93,7 +93,7 @@ impl<K: Eq + Hash + Clone, V: Clone> NotifyRead<K, V> {
         }
     }
 
-    pub fn register_all(&self, keys: &[K]) -> Vec<Registration<K, V>> {
+    pub fn register_all(&self, keys: &[K]) -> Vec<Registration<'_, K, V>> {
         self.count_pending.fetch_add(keys.len(), Ordering::Relaxed);
         let mut registrations = vec![];
         for key in keys.iter() {
@@ -115,7 +115,7 @@ impl<K: Eq + Hash + Clone, V: Clone> NotifyRead<K, V> {
             .push(sender);
     }
 
-    fn pending(&self, key: &K) -> MutexGuard<HashMap<K, Registrations<V>>> {
+    fn pending(&self, key: &K) -> MutexGuard<'_, HashMap<K, Registrations<V>>> {
         let mut state = DefaultHasher::new();
         key.hash(&mut state);
         let hash = state.finish();

--- a/crates/mysten-metrics/src/histogram.rs
+++ b/crates/mysten-metrics/src/histogram.rs
@@ -193,7 +193,7 @@ impl Histogram {
         }
     }
 
-    pub fn start_timer(&self) -> HistogramTimerGuard {
+    pub fn start_timer(&self) -> HistogramTimerGuard<'_> {
         HistogramTimerGuard {
             histogram: self,
             start: Instant::now(),

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3443,7 +3443,7 @@ impl AuthorityState {
     pub fn execution_lock_for_executable_transaction(
         &self,
         transaction: &VerifiedExecutableTransaction,
-    ) -> SuiResult<ExecutionLockReadGuard> {
+    ) -> SuiResult<ExecutionLockReadGuard<'_>> {
         let lock = self
             .execution_lock
             .try_read()
@@ -3462,13 +3462,13 @@ impl AuthorityState {
     /// This prevents reconfiguration from starting until we are finished handling the signing request.
     /// Otherwise, in-memory lock state could be cleared (by `ObjectLocks::clear_cached_locks`)
     /// while we are attempting to acquire locks for the transaction.
-    pub fn execution_lock_for_signing(&self) -> SuiResult<ExecutionLockReadGuard> {
+    pub fn execution_lock_for_signing(&self) -> SuiResult<ExecutionLockReadGuard<'_>> {
         self.execution_lock
             .try_read()
             .map_err(|_| SuiError::ValidatorHaltedAtEpochEnd)
     }
 
-    pub async fn execution_lock_for_reconfiguration(&self) -> ExecutionLockWriteGuard {
+    pub async fn execution_lock_for_reconfiguration(&self) -> ExecutionLockWriteGuard<'_> {
         self.execution_lock.write().await
     }
 

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1363,7 +1363,7 @@ impl AuthorityPerEpochStore {
         self.committee.epoch
     }
 
-    pub fn tx_validity_check_context(&self) -> TxValidityCheckContext {
+    pub fn tx_validity_check_context(&self) -> TxValidityCheckContext<'_> {
         TxValidityCheckContext {
             config: &self.protocol_config,
             epoch: self.epoch(),
@@ -2869,11 +2869,11 @@ impl AuthorityPerEpochStore {
         }
     }
 
-    pub fn get_reconfig_state_read_lock_guard(&self) -> RwLockReadGuard<ReconfigState> {
+    pub fn get_reconfig_state_read_lock_guard(&self) -> RwLockReadGuard<'_, ReconfigState> {
         self.reconfig_state_mem.read()
     }
 
-    pub fn get_reconfig_state_write_lock_guard(&self) -> RwLockWriteGuard<ReconfigState> {
+    pub fn get_reconfig_state_write_lock_guard(&self) -> RwLockWriteGuard<'_, ReconfigState> {
         self.reconfig_state_mem.write()
     }
 
@@ -3746,7 +3746,7 @@ impl AuthorityPerEpochStore {
         Vec<Schedulable>,                      // non-randomness transactions to schedule
         Vec<Schedulable>,                      // randomness transactions to schedule
         Vec<SequencedConsensusTransactionKey>, // keys to notify as complete
-        Option<RwLockWriteGuard<ReconfigState>>,
+        Option<RwLockWriteGuard<'_, ReconfigState>>,
         bool,                   // true if final round
         Option<TransactionKey>, // consensus commit prologue root
         AssignedTxAndVersions,
@@ -3990,7 +3990,7 @@ impl AuthorityPerEpochStore {
         transactions: &[VerifiedSequencedConsensusTransaction],
         commit_has_deferred_txns: bool,
     ) -> SuiResult<(
-        Option<RwLockWriteGuard<ReconfigState>>,
+        Option<RwLockWriteGuard<'_, ReconfigState>>,
         bool, // true if final round
     )> {
         let mut lock = None;

--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -246,7 +246,7 @@ where
     pub async fn submit_transaction(
         &self,
         request: ExecuteTransactionRequestV3,
-    ) -> SuiResult<Registration<TransactionDigest, QuorumDriverResult>> {
+    ) -> SuiResult<Registration<'_, TransactionDigest, QuorumDriverResult>> {
         let tx_digest = request.transaction.digest();
         debug!(?tx_digest, "Received transaction execution request.");
         self.metrics.total_requests.inc();
@@ -513,7 +513,7 @@ where
     pub async fn submit_transaction(
         &self,
         request: ExecuteTransactionRequestV3,
-    ) -> SuiResult<Registration<TransactionDigest, QuorumDriverResult>> {
+    ) -> SuiResult<Registration<'_, TransactionDigest, QuorumDriverResult>> {
         self.quorum_driver.submit_transaction(request).await
     }
 

--- a/crates/sui-indexer-alt-consistent-store/src/db/map.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/db/map.rs
@@ -156,7 +156,7 @@ where
         Ok(())
     }
 
-    fn cf(&self) -> Result<Arc<rocksdb::BoundColumnFamily>, Error> {
+    fn cf(&self) -> Result<Arc<rocksdb::BoundColumnFamily<'_>>, Error> {
         self.db
             .cf(&self.cf)
             .ok_or_else(|| Error::NoColumnFamily(self.cf.clone()))

--- a/crates/sui-replay-2/src/artifacts.rs
+++ b/crates/sui-replay-2/src/artifacts.rs
@@ -136,7 +136,7 @@ impl ArtifactMember<'_, '_> {
 
     /// Try to get the trace reader if the artifact type is a trace.
     /// If the artifact type is not `Trace` `None` is returned.
-    pub fn try_get_trace(&self) -> Option<anyhow::Result<MoveTraceReader<std::fs::File>>> {
+    pub fn try_get_trace(&self) -> Option<anyhow::Result<MoveTraceReader<'_, std::fs::File>>> {
         if self.artifact_type == Artifact::Trace {
             Some(
                 std::fs::File::open(&self.artifact_path)

--- a/crates/suins-indexer/src/lib.rs
+++ b/crates/suins-indexer/src/lib.rs
@@ -42,7 +42,7 @@ pub async fn get_connection_pool() -> PgConnectionPool {
         .expect("Could not build Postgres DB connection pool")
 }
 
-fn establish_connection(config: &str) -> BoxFuture<ConnectionResult<AsyncPgConnection>> {
+fn establish_connection(config: &str) -> BoxFuture<'_, ConnectionResult<AsyncPgConnection>> {
     let fut = async {
         // We first set up the way we want rustls to work.
         let rustls_config = rustls::ClientConfig::builder()

--- a/external-crates/move/crates/move-borrow-graph/src/references.rs
+++ b/external-crates/move/crates/move-borrow-graph/src/references.rs
@@ -130,7 +130,7 @@ impl<Loc: Copy, Lbl: Clone + Ord> BorrowEdgeSet<Loc, Lbl> {
         self.edges.is_empty()
     }
 
-    pub(crate) fn iter(&self) -> std::collections::btree_set::Iter<BorrowEdge<Loc, Lbl>> {
+    pub(crate) fn iter(&self) -> std::collections::btree_set::Iter<'_, BorrowEdge<Loc, Lbl>> {
         debug_assert!(self.overflown || !self.is_empty());
         self.edges.iter()
     }

--- a/external-crates/move/crates/move-bytecode-viewer/src/tui/tui_interface.rs
+++ b/external-crates/move/crates/move-bytecode-viewer/src/tui/tui_interface.rs
@@ -34,7 +34,7 @@ pub trait TUIInterface {
 
     /// Function called on each redraw. The `TUIOutput` contains that updated
     /// data to display on each pane.
-    fn on_redraw(&mut self, line_number: u16, column_number: u16) -> TUIOutput;
+    fn on_redraw(&mut self, line_number: u16, column_number: u16) -> TUIOutput<'_>;
 
     /// Bounds the line number so that it does not run past the text.
     fn bound_line(&self, line_number: u16) -> u16;
@@ -60,7 +60,7 @@ impl DebugInterface {
 impl TUIInterface for DebugInterface {
     const LEFT_TITLE: &'static str = "Left pane";
     const RIGHT_TITLE: &'static str = "Right pane";
-    fn on_redraw(&mut self, line_number: u16, column_number: u16) -> TUIOutput {
+    fn on_redraw(&mut self, line_number: u16, column_number: u16) -> TUIOutput<'_> {
         TUIOutput {
             left_screen: self
                 .text

--- a/external-crates/move/crates/move-bytecode-viewer/src/viewer.rs
+++ b/external-crates/move/crates/move-bytecode-viewer/src/viewer.rs
@@ -46,7 +46,7 @@ impl<BytecodeViewer: LeftScreen, SourceViewer: RightScreen<BytecodeViewer>> TUII
     const LEFT_TITLE: &'static str = "Bytecode";
     const RIGHT_TITLE: &'static str = "Source Code";
 
-    fn on_redraw(&mut self, line_number: u16, column_number: u16) -> TUIOutput {
+    fn on_redraw(&mut self, line_number: u16, column_number: u16) -> TUIOutput<'_> {
         // Highlight style
         let style: Style = Style::default().bg(Color::Red);
         let report = match self

--- a/external-crates/move/crates/move-cli/src/sandbox/utils/mod.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/utils/mod.rs
@@ -43,7 +43,7 @@ use move_vm_test_utils::gas_schedule::{CostTable, GasStatus};
 pub use on_disk_state_view::*;
 pub use package_context::*;
 
-pub fn get_gas_status(cost_table: &CostTable, gas_budget: Option<u64>) -> Result<GasStatus> {
+pub fn get_gas_status(cost_table: &CostTable, gas_budget: Option<u64>) -> Result<GasStatus<'_>> {
     let gas_status = if let Some(gas_budget) = gas_budget {
         // TODO(Gas): This should not be hardcoded.
         let max_gas_budget = u64::MAX.checked_div(1000).unwrap();

--- a/external-crates/move/crates/move-compiler/src/expansion/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/ast.rs
@@ -686,7 +686,7 @@ impl AbilitySet {
         self.0.is_subset(&other.0)
     }
 
-    pub fn iter(&self) -> AbilitySetIter {
+    pub fn iter(&self) -> AbilitySetIter<'_> {
         self.into_iter()
     }
 

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -128,7 +128,7 @@ impl<'env> Context<'env> {
         self.defn_context.env
     }
 
-    pub(super) fn reporter(&self) -> &DiagnosticReporter {
+    pub(super) fn reporter(&self) -> &DiagnosticReporter<'_> {
         &self.defn_context.reporter
     }
 

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -274,7 +274,7 @@ impl MatchContext<true> for Context<'_> {
         self.env
     }
 
-    fn reporter(&self) -> &DiagnosticReporter {
+    fn reporter(&self) -> &DiagnosticReporter<'_> {
         &self.reporter
     }
 

--- a/external-crates/move/crates/move-compiler/src/shared/matching.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/matching.rs
@@ -67,7 +67,7 @@ pub struct ArmResult {
 /// compilation in HLIR lowering.
 pub trait MatchContext<const AFTER_TYPING: bool> {
     fn env(&self) -> &CompilationEnv;
-    fn reporter(&self) -> &DiagnosticReporter;
+    fn reporter(&self) -> &DiagnosticReporter<'_>;
     fn new_match_var(&mut self, name: String, loc: Loc) -> N::Var;
     fn program_info(&self) -> &ProgramInfo<AFTER_TYPING>;
 

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -349,7 +349,7 @@ impl CompilationEnv {
         &self.mapped_files
     }
 
-    pub fn diagnostic_reporter_at_top_level(&self) -> DiagnosticReporter {
+    pub fn diagnostic_reporter_at_top_level(&self) -> DiagnosticReporter<'_> {
         DiagnosticReporter::new(
             &self.flags,
             &self.known_filter_names,

--- a/external-crates/move/crates/move-compiler/src/shared/remembering_unique_map.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/remembering_unique_map.rs
@@ -104,11 +104,11 @@ impl<K: TName, V> RememberingUniqueMap<K, V> {
         }
     }
 
-    pub fn iter(&self) -> Iter<K, V> {
+    pub fn iter(&self) -> Iter<'_, K, V> {
         self.into_iter()
     }
 
-    pub fn iter_mut(&mut self) -> IterMut<K, V> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
         self.into_iter()
     }
 

--- a/external-crates/move/crates/move-compiler/src/shared/unique_map.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/unique_map.rs
@@ -184,7 +184,7 @@ impl<K: TName, V> UniqueMap<K, V> {
         joined
     }
 
-    pub fn iter(&self) -> Iter<K, V> {
+    pub fn iter(&self) -> Iter<'_, K, V> {
         self.into_iter()
     }
 
@@ -193,7 +193,7 @@ impl<K: TName, V> UniqueMap<K, V> {
             .map(|(loc, k_, v)| (K::add_loc(loc, k_.clone()), v))
     }
 
-    pub fn iter_mut(&mut self) -> IterMut<K, V> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
         self.into_iter()
     }
 

--- a/external-crates/move/crates/move-compiler/src/shared/unique_set.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/unique_set.rs
@@ -87,7 +87,7 @@ impl<T: TName> UniqueSet<T> {
         self.iter().all(|(_, x_)| other.contains_(x_))
     }
 
-    pub fn iter(&self) -> Iter<T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         self.into_iter()
     }
 

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -1209,7 +1209,7 @@ impl MatchContext<false> for Context<'_, '_> {
         self.env()
     }
 
-    fn reporter(&self) -> &DiagnosticReporter {
+    fn reporter(&self) -> &DiagnosticReporter<'_> {
         &self.reporter
     }
 

--- a/external-crates/move/crates/move-ir-to-bytecode/src/context.rs
+++ b/external-crates/move/crates/move-ir-to-bytecode/src/context.rs
@@ -836,7 +836,7 @@ impl<'a> Context<'a> {
     // Dependency Resolution
     //**********************************************************************************************
 
-    fn dependency(&self, m: &ModuleIdent) -> Result<&CompiledDependencyView> {
+    fn dependency(&self, m: &ModuleIdent) -> Result<&CompiledDependencyView<'_>> {
         let dep = self
             .dependencies
             .get(m)

--- a/external-crates/move/crates/move-model-2/src/model.rs
+++ b/external-crates/move/crates/move-model-2/src/model.rs
@@ -190,7 +190,7 @@ impl<K: SourceKind> Model<K> {
         package.maybe_module(name)
     }
 
-    pub fn module(&self, module: impl TModuleId) -> Module<K> {
+    pub fn module(&self, module: impl TModuleId) -> Module<'_, K> {
         self.maybe_module(module).unwrap()
     }
 

--- a/external-crates/move/crates/move-model/src/model.rs
+++ b/external-crates/move/crates/move-model/src/model.rs
@@ -599,7 +599,7 @@ impl GlobalEnv {
     }
 
     /// Find all target modules and return in a vector
-    pub fn get_target_modules(&self) -> Vec<ModuleEnv> {
+    pub fn get_target_modules(&self) -> Vec<ModuleEnv<'_>> {
         let mut target_modules: Vec<ModuleEnv> = vec![];
         for module_env in self.get_modules() {
             if module_env.is_target() {
@@ -1335,7 +1335,7 @@ impl GlobalEnv {
     }
 
     /// Produce a TypeDisplayContext to print types within the scope of this env
-    pub fn get_type_display_ctx(&self) -> TypeDisplayContext {
+    pub fn get_type_display_ctx(&self) -> TypeDisplayContext<'_> {
         TypeDisplayContext::WithEnv {
             env: self,
             type_param_names: None,
@@ -3409,7 +3409,7 @@ impl<'env> FunctionEnv<'env> {
     }
 
     /// Produce a TypeDisplayContext to print types within the scope of this env
-    pub fn get_type_display_ctx(&self) -> TypeDisplayContext {
+    pub fn get_type_display_ctx(&self) -> TypeDisplayContext<'_> {
         let type_param_names = self
             .get_type_parameters()
             .iter()

--- a/external-crates/move/crates/move-package-alt/src/dependency/dependency_set.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/dependency_set.rs
@@ -63,7 +63,7 @@ impl<T> DependencySet<T> {
     }
 
     /// Iterate over the declared entries of this set
-    pub fn iter(&self) -> Iter<T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         self.into_iter()
     }
 

--- a/external-crates/move/crates/move-package-alt/src/graph/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/mod.rs
@@ -217,7 +217,7 @@ impl<F: MoveFlavor> PackageGraph<F> {
         &self.inner[self.root_index]
     }
 
-    pub fn root_package_info(&self) -> PackageInfo<F> {
+    pub fn root_package_info(&self) -> PackageInfo<'_, F> {
         PackageInfo {
             graph: self,
             node: self.root_index,
@@ -227,7 +227,7 @@ impl<F: MoveFlavor> PackageGraph<F> {
     /// Return the list of packages that are in the linkage table, as well as
     /// the unpublished ones in the package graph.
     // TODO: Do we want a way to access ALL packages and not the "de-duplicated" ones?
-    pub(crate) fn packages(&self) -> PackageResult<Vec<PackageInfo<F>>> {
+    pub(crate) fn packages(&self) -> PackageResult<Vec<PackageInfo<'_, F>>> {
         let mut linkage = self.linkage()?;
 
         // Populate ALL the linkage elements

--- a/external-crates/move/crates/move-package-alt/src/package/root_package.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/root_package.rs
@@ -158,14 +158,14 @@ impl<F: MoveFlavor + fmt::Debug> RootPackage<F> {
 
     /// Return the list of all packages in the root package's package graph (including itself and all
     /// transitive dependencies). This includes the non-duplicate addresses only.
-    pub fn packages(&self) -> PackageResult<Vec<PackageInfo<F>>> {
+    pub fn packages(&self) -> PackageResult<Vec<PackageInfo<'_, F>>> {
         self.graph.packages()
     }
 
     /// Return the linkage table for the root package. This contains an entry for each package that
     /// this package depends on (transitively). Returns an error if any of the packages that this
     /// package depends on is unpublished.
-    pub fn linkage(&self) -> PackageResult<BTreeMap<OriginalID, PackageInfo<F>>> {
+    pub fn linkage(&self) -> PackageResult<BTreeMap<OriginalID, PackageInfo<'_, F>>> {
         todo!()
     }
 

--- a/external-crates/move/crates/move-package/src/compilation/build_plan.rs
+++ b/external-crates/move/crates/move-package/src/compilation/build_plan.rs
@@ -170,7 +170,7 @@ impl<'a> BuildPlan<'a> {
         res
     }
 
-    pub fn compute_dependencies(&self) -> CompilationDependencies {
+    pub fn compute_dependencies(&self) -> CompilationDependencies<'_> {
         let root_package = &self.resolution_graph.package_table[&self.root];
         let project_root = match &self.resolution_graph.build_options.install_dir {
             Some(under_path) => under_path.clone(),

--- a/external-crates/move/crates/move-package/src/compilation/compiled_package.rs
+++ b/external-crates/move/crates/move-package/src/compilation/compiled_package.rs
@@ -414,11 +414,11 @@ impl CompiledPackage {
     }
 
     /// Returns compiled modules for this package and its transitive dependencies
-    pub fn all_modules_map(&self) -> Modules {
+    pub fn all_modules_map(&self) -> Modules<'_> {
         Modules::new(self.all_compiled_units().map(|unit| &unit.module))
     }
 
-    pub fn root_modules_map(&self) -> Modules {
+    pub fn root_modules_map(&self) -> Modules<'_> {
         Modules::new(
             self.root_compiled_units
                 .iter()

--- a/external-crates/move/crates/move-regex-borrow-graph/src/regex.rs
+++ b/external-crates/move/crates/move-regex-borrow-graph/src/regex.rs
@@ -188,7 +188,7 @@ impl<Lbl> Regex<Lbl> {
         }
     }
 
-    fn walk(&self) -> Walk<Lbl> {
+    fn walk(&self) -> Walk<'_, Lbl> {
         if self.is_epsilon() {
             Walk::Epsilon
         } else {

--- a/external-crates/move/crates/move-unit-test/src/test_runner.rs
+++ b/external-crates/move/crates/move-unit-test/src/test_runner.rs
@@ -263,7 +263,7 @@ impl SharedTestingConfig {
         arguments: Vec<MoveValue>,
     ) -> (
         VMResult<ChangeSet>,
-        VMResult<NativeContextExtensions>,
+        VMResult<NativeContextExtensions<'_>>,
         VMResult<Vec<Vec<u8>>>,
         TestRunInfo,
     ) {

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -263,7 +263,7 @@ mod checked {
             })
         }
 
-        pub fn object_runtime(&self) -> Result<&ObjectRuntime, ExecutionError> {
+        pub fn object_runtime(&self) -> Result<&ObjectRuntime<'_>, ExecutionError> {
             self.native_extensions
                 .get::<ObjectRuntime>()
                 .map_err(|e| self.convert_vm_error(e.finish(Location::Undefined)))

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
@@ -162,7 +162,7 @@ pub struct Context<'env, 'pc, 'vm, 'state, 'linkage, 'gas> {
 impl Locations {
     /// NOTE! This does not charge gas and should not be used directly. It is exposed for
     /// dev-inspect
-    fn resolve(&mut self, location: T::Location) -> Result<ResolvedLocation, ExecutionError> {
+    fn resolve(&mut self, location: T::Location) -> Result<ResolvedLocation<'_>, ExecutionError> {
         Ok(match location {
             T::Location::TxContext => ResolvedLocation::Local(self.tx_context_value.local(0)?),
             T::Location::GasCoin => {
@@ -461,7 +461,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas> Context<'env, 'pc, 'vm, 'state, 'li
         )
     }
 
-    pub fn object_runtime(&self) -> Result<&ObjectRuntime, ExecutionError> {
+    pub fn object_runtime(&self) -> Result<&ObjectRuntime<'_>, ExecutionError> {
         self.native_extensions
             .get::<ObjectRuntime>()
             .map_err(|e| self.env.convert_vm_error(e.finish(Location::Undefined)))

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/values.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/values.rs
@@ -65,7 +65,7 @@ impl Locals {
         Ok(Self(VMLocals::new(n)))
     }
 
-    pub fn local(&mut self, index: u16) -> Result<Local, ExecutionError> {
+    pub fn local(&mut self, index: u16) -> Result<Local<'_>, ExecutionError> {
         Ok(Local(self, index))
     }
 }

--- a/sui-execution/v1/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v1/sui-adapter/src/programmable_transactions/context.rs
@@ -226,7 +226,7 @@ mod checked {
             })
         }
 
-        pub fn object_runtime(&mut self) -> &ObjectRuntime {
+        pub fn object_runtime(&mut self) -> &ObjectRuntime<'_> {
             self.native_extensions.get()
         }
 

--- a/sui-execution/v2/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v2/sui-adapter/src/programmable_transactions/context.rs
@@ -231,7 +231,7 @@ mod checked {
             })
         }
 
-        pub fn object_runtime(&mut self) -> &ObjectRuntime {
+        pub fn object_runtime(&mut self) -> &ObjectRuntime<'_> {
             self.native_extensions.get()
         }
 


### PR DESCRIPTION
## Description 

A typical warning looks like this:
```
warning: hiding a lifetime that's elided elsewhere is confusing
  --> external-crates/move/crates/move-package-alt/src/dependency/dependency_set.rs:66:17
   |
66 |     pub fn iter(&self) -> Iter<T> {
   |                 ^^^^^     ------- the same lifetime is hidden here
   |                 |
   |                 the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
   |
66 |     pub fn iter(&self) -> Iter<'_, T> {
   |                                +++
```

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
