### PR TITLE
docs: Add frontmatter to `concepts/cryptography/transaction-auth` pages

### DIFF
--- a/docs/content/concepts/cryptography/transaction-auth/intent-signing.mdx
+++ b/docs/content/concepts/cryptography/transaction-auth/intent-signing.mdx
@@ -1,5 +1,7 @@
 ---
 title: Intent Signing
+description: Intent signing provides a compact domain separator to data signed by both user and authority signatures. Data that each signature commits to is called an intent message, which all signatures on Sui must include. 
+keywords: intent, signing, intent signatures, intent message, domain separators, compact structs, signing standard, compact domain separator, user signatures, authority signatures, proof of possession, generate proof of possession
 ---
 
 In Sui, an intent is a compact struct that serves as the domain separator for a message that a signature commits to. The data that the signature commits to is an intent message. All signatures in Sui must commit to an intent message, instead of the message itself.
@@ -45,7 +47,7 @@ The serialization of an `Intent` is a 3-byte array where each field is represent
 
 The serialization of an `IntentMessage<T>` is the 3 bytes of the intent concatenated with the BCS serialized message.
 
-## User Signature
+## User signature
 
 To create a user signature, construct an intent message first, and create the signature over the 32-byte Blake2b hash of the BCS serialized value of the intent message of the transaction data (`intent || message`).
 
@@ -70,11 +72,11 @@ Under the hood, the `new_secure` method in Rust and the `signData` method in Typ
 1.  Applies Blake2b hash to get the 32-byte digest
 1.  Passes the digest to the signing API for each corresponding scheme of the signer. The supported signature schemes are pure Ed25519, ECDSA Secp256k1 and ECDSA Secp256r1. See [Sui Signatures](./signatures.mdx#signature-requirements) for requirements of each scheme.
 
-## Authority Signature
+## Authority signature
 
 The authority signature is created using the protocol key. The data that it commits to is also an intent message `intent || message`. See all available intent scopes [in the source code](https://github.com/MystenLabs/sui/blob/0dc1a38f800fc2d8fabe11477fdef702058cf00d/crates/sui-types/src/intent.rs#L66)
 
-### How to Generate Proof of Possession for an Authority
+### How to generate proof of possession for an authority
 
 When an authority request to join the network, the protocol public key and its proof of possession (PoP) are required to be submitted. PoP is required to prevent [rogue key attack](https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html).
 

--- a/docs/content/concepts/cryptography/transaction-auth/intent-signing.mdx
+++ b/docs/content/concepts/cryptography/transaction-auth/intent-signing.mdx
@@ -1,7 +1,7 @@
 ---
 title: Intent Signing
 description: Intent signing provides a compact domain separator to data signed by both user and authority signatures. Data that each signature commits to is called an intent message, which all signatures on Sui must include. 
-keywords: intent, signing, intent signatures, intent message, domain separators, compact structs, signing standard, compact domain separator, user signatures, authority signatures, proof of possession, generate proof of possession
+keywords: [ intent, signing, intent signatures, intent message, domain separators, compact structs, signing standard, compact domain separator, user signatures, authority signatures, proof of possession, generate proof of possession ]
 ---
 
 In Sui, an intent is a compact struct that serves as the domain separator for a message that a signature commits to. The data that the signature commits to is an intent message. All signatures in Sui must commit to an intent message, instead of the message itself.

--- a/docs/content/concepts/cryptography/transaction-auth/keys-addresses.mdx
+++ b/docs/content/concepts/cryptography/transaction-auth/keys-addresses.mdx
@@ -1,7 +1,7 @@
 ---
 title: Keys and Addresses
 description: Sui supports the wallet specifications BIP-32, SLIP-0010, BIP-44, and BIP-39. For signed transactions, Sui supports pure Ed25519, ECDSA Secp256k1, ECDSA Secp256r1, and multisig. 
-keywords: BIP-32, SLIP-0010, BIP-44, BIP-39, Ed25519, ECDSA Secp256k1, ECDSA Secp256r1, multisig, key derivation, key derivation paths, key derivation schemes, address format
+keywords: [ BIP-32, SLIP-0010, BIP-44, BIP-39, Ed25519, ECDSA Secp256k1, ECDSA Secp256r1, multisig, key derivation, key derivation paths, key derivation schemes, address format ]
 ---
 
 Sui adheres to widely accepted wallet specifications in the cryptocurrency industry, including BIP-32 and its variation SLIP-0010, BIP-44, and BIP-39, to facilitate key management for users. At present, Sui supports pure Ed25519, ECDSA Secp256k1, ECDSA Secp256r1, and multisig for signed transactions.

--- a/docs/content/concepts/cryptography/transaction-auth/keys-addresses.mdx
+++ b/docs/content/concepts/cryptography/transaction-auth/keys-addresses.mdx
@@ -1,10 +1,12 @@
 ---
 title: Keys and Addresses
+description: Sui supports the wallet specifications BIP-32, SLIP-0010, BIP-44, and BIP-39. For signed transactions, Sui supports pure Ed25519, ECDSA Secp256k1, ECDSA Secp256r1, and multisig. 
+keywords: BIP-32, SLIP-0010, BIP-44, BIP-39, Ed25519, ECDSA Secp256k1, ECDSA Secp256r1, multisig, key derivation, key derivation paths, key derivation schemes, address format
 ---
 
 Sui adheres to widely accepted wallet specifications in the cryptocurrency industry, including BIP-32 and its variation SLIP-0010, BIP-44, and BIP-39, to facilitate key management for users. At present, Sui supports pure Ed25519, ECDSA Secp256k1, ECDSA Secp256r1, and multisig for signed transactions.
 
-Follow the relevant link for more information on each wallet specification:
+Follow the relevant links for more information on each wallet specification:
 
 - [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki)
 - [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki)

--- a/docs/content/concepts/cryptography/transaction-auth/multisig.mdx
+++ b/docs/content/concepts/cryptography/transaction-auth/multisig.mdx
@@ -1,18 +1,20 @@
 ---
 title: Multisig
+description: Multi-signature (multisig) transactions require multiple keys for authentication rather than a single key. Sui supports multisig transactions for pure Ed25519, ECDSA Secp256k1, and ECDSA Secp256r1 encryption keys.
+keywords: multi-signature, multi-sig, multisig, multiple signatures, pure Ed25519, ECDSA Secp256k1, ECDSA Secp256r1
 ---
 
 Sui supports multi-signature (multisig) transactions, which require multiple keys for authorization rather than a single, one-key signature. In technical terms, Sui supports `k` out of `n` multisig transactions, where `k` is the threshold and `n` is the total weights of all participating parties. The maximum number of parties is 10. To learn more about the single key signatures that Sui supports, see [Signatures](./signatures.mdx).
 
-Valid participating keys for multisig are Pure Ed25519, ECDSA Secp256k1, and ECDSA Secp256r1. A ([u8](https://doc.rust-lang.org/std/primitive.u8.html)) weight is set for each participating keys and the threshold can be set as [u16](https://doc.rust-lang.org/std/primitive.u16.html). If the serialized multisig contains enough valid signatures of which the sum of weights passes the threshold, Sui considers the multisig valid and the transaction executes.
+Valid participating keys for multisig are pure Ed25519, ECDSA Secp256k1, and ECDSA Secp256r1. A ([u8](https://doc.rust-lang.org/std/primitive.u8.html)) weight is set for each participating keys and the threshold can be set as [u16](https://doc.rust-lang.org/std/primitive.u16.html). If the serialized multisig contains enough valid signatures of which the sum of weights passes the threshold, Sui considers the multisig valid and the transaction executes.
 
 ## Applications of multisig
 
-Sui allows you to mix and match key schemes in a single multisig account. For example, you can pick a single Ed25519 mnemonic-based key and two ECDSA secp256r1 keys to create a multisig account that always requires the Ed25519 key, but also one of the ECDSA secp256r1 keys to sign. You could use this structure for mobile secure enclave stored keys as two-factor authentication.
+Sui allows you to mix and match key schemes in a single multisig account. For example, you can pick a single Ed25519 mnemonic-based key and two ECDSA Secp256r1 keys to create a multisig account that always requires the Ed25519 key, but also one of the ECDSA Secp256r1 keys to sign. You could use this structure for mobile secure enclave stored keys as two-factor authentication.
 
 :::info
 
-Currently, iPhone and high-end Android devices support only ECDSA secp256r1 enclave-stored keys.
+Currently, iPhone and high-end Android devices support only ECDSA Secp256r1 enclave-stored keys.
 
 :::
 

--- a/docs/content/concepts/cryptography/transaction-auth/multisig.mdx
+++ b/docs/content/concepts/cryptography/transaction-auth/multisig.mdx
@@ -1,7 +1,7 @@
 ---
 title: Multisig
 description: Multi-signature (multisig) transactions require multiple keys for authentication rather than a single key. Sui supports multisig transactions for pure Ed25519, ECDSA Secp256k1, and ECDSA Secp256r1 encryption keys.
-keywords: multi-signature, multi-sig, multisig, multiple signatures, pure Ed25519, ECDSA Secp256k1, ECDSA Secp256r1
+keywords: [ multi-signature, multi-sig, multisig, multiple signatures, pure Ed25519, ECDSA Secp256k1, ECDSA Secp256r1 ]
 ---
 
 Sui supports multi-signature (multisig) transactions, which require multiple keys for authorization rather than a single, one-key signature. In technical terms, Sui supports `k` out of `n` multisig transactions, where `k` is the threshold and `n` is the total weights of all participating parties. The maximum number of parties is 10. To learn more about the single key signatures that Sui supports, see [Signatures](./signatures.mdx).

--- a/docs/content/concepts/cryptography/transaction-auth/offline-signing.mdx
+++ b/docs/content/concepts/cryptography/transaction-auth/offline-signing.mdx
@@ -1,5 +1,7 @@
 ---
 title: Offline Signing
+description: Offline signing can be used to sign a Sui transaction when a device is not connected to a Sui network, or if the signing wallet uses a different programming language than that of the transaction being signed.
+keywords: offline signing, sign offline, sign transaction offline, offline transaction, serialize data, sign data, sign serialized data, sign with sui keystore, sui keystore, keystore
 ---
 
 Sui supports offline signing, which is signing transactions using a device not connected to a Sui network, or in a wallet implemented in a different programming language without relying on the Sui key store. The steps to implement offline signing include:
@@ -76,7 +78,7 @@ Mutated Objects:
  - ID: <OBJECT_ID> , Owner: Account Address ( <SUI-ADDRESS> )
 ```
 
-## Alternative: Sign with Sui Keystore and Execute Transaction
+## Alternative: Sign with Sui Keystore and execute transaction
 
 Alternatively, you can use the active key in Sui Keystore to sign and output a Base64-encoded sender signed data with flag `--serialize-signed-transaction`. 
 

--- a/docs/content/concepts/cryptography/transaction-auth/offline-signing.mdx
+++ b/docs/content/concepts/cryptography/transaction-auth/offline-signing.mdx
@@ -1,7 +1,7 @@
 ---
 title: Offline Signing
 description: Offline signing can be used to sign a Sui transaction when a device is not connected to a Sui network, or if the signing wallet uses a different programming language than that of the transaction being signed.
-keywords: offline signing, sign offline, sign transaction offline, offline transaction, serialize data, sign data, sign serialized data, sign with sui keystore, sui keystore, keystore
+keywords: [ offline signing, sign offline, sign transaction offline, offline transaction, serialize data, sign data, sign serialized data, sign with sui keystore, sui keystore, keystore ]
 ---
 
 Sui supports offline signing, which is signing transactions using a device not connected to a Sui network, or in a wallet implemented in a different programming language without relying on the Sui key store. The steps to implement offline signing include:

--- a/docs/content/concepts/cryptography/transaction-auth/signatures.mdx
+++ b/docs/content/concepts/cryptography/transaction-auth/signatures.mdx
@@ -1,7 +1,7 @@
 ---
 title: Signatures
 description: Sui supports multiple cryptography algorithms and primitives. Switching between them rapidly is supported.
-keywords: Ed25519 Pure, pure Ed255190, ECDSA Secp256k1, ECDSA Secp256r1, multisig, zkLogin, passkey, signature requirements, signature authority, authority signature, account key pair, account key pair, network key pair
+keywords: Ed25519 pure, pure Ed255190, ECDSA Secp256k1, ECDSA Secp256r1, multisig, zkLogin, passkey, signature requirements, signature authority, authority signature, account key pair, account key pair, network key pair
 ---
 
 When a user submits a signed transaction, a serialized signature and a serialized transaction data is submitted. The serialized transaction data is the BCS serialized bytes of the struct `TransactionData` and the serialized signature is defined as a concatenation of bytes of `flag || sig || pk`.
@@ -10,7 +10,7 @@ The `flag` is a 1-byte representation corresponding to the signature scheme that
 
 | Scheme          | Flag |
 | --------------- | ---- |
-| Ed25519 Pure    | 0x00 |
+| Pure Ed25519    | 0x00 |
 | ECDSA Secp256k1 | 0x01 |
 | ECDSA Secp256r1 | 0x02 |
 | multisig        | 0x03 |

--- a/docs/content/concepts/cryptography/transaction-auth/signatures.mdx
+++ b/docs/content/concepts/cryptography/transaction-auth/signatures.mdx
@@ -1,7 +1,7 @@
 ---
 title: Signatures
 description: Sui supports multiple cryptography algorithms and primitives. Switching between them rapidly is supported.
-keywords: Ed25519 pure, pure Ed255190, ECDSA Secp256k1, ECDSA Secp256r1, multisig, zkLogin, passkey, signature requirements, signature authority, authority signature, account key pair, account key pair, network key pair
+keywords: [ Ed25519 pure, pure Ed255190, ECDSA Secp256k1, ECDSA Secp256r1, multisig, zkLogin, passkey, signature requirements, signature authority, authority signature, account key pair, account key pair, network key pair ]
 ---
 
 When a user submits a signed transaction, a serialized signature and a serialized transaction data is submitted. The serialized transaction data is the BCS serialized bytes of the struct `TransactionData` and the serialized signature is defined as a concatenation of bytes of `flag || sig || pk`.

--- a/docs/content/concepts/cryptography/transaction-auth/signatures.mdx
+++ b/docs/content/concepts/cryptography/transaction-auth/signatures.mdx
@@ -1,6 +1,7 @@
 ---
 title: Signatures
-description: Sui supports multiple cryptography algorithms and primitives and can switch between them rapidly.
+description: Sui supports multiple cryptography algorithms and primitives. Switching between them rapidly is supported.
+keywords: Ed25519 Pure, pure Ed255190, ECDSA Secp256k1, ECDSA Secp256r1, multisig, zkLogin, passkey, signature requirements, signature authority, authority signature, account key pair, account key pair, network key pair
 ---
 
 When a user submits a signed transaction, a serialized signature and a serialized transaction data is submitted. The serialized transaction data is the BCS serialized bytes of the struct `TransactionData` and the serialized signature is defined as a concatenation of bytes of `flag || sig || pk`.
@@ -44,12 +45,12 @@ The signature must commit to the hash of the intent message of the transaction d
 
 When invoking the signing API, you must first hash the intent message of the transaction data to 32 bytes using Blake2b. This external hashing is distinct from the hashing performed inside the signing API. To be compatible with existing standards and hardware secure modules (HSMs), the signing algorithms perform additional hashing internally. For ECDSA Secp256k1 and Secp256r1, you must use SHA-2 SHA256 as the internal hash function. For pure Ed25519, you must use SHA-512.
 
-An accepted ECDSA secp256k1 and secp256r1 signature must follow:
+An accepted ECDSA Secp256k1 and Secp256r1 signature must follow:
 
 1. The internal hash used by ECDSA must be SHA256 [SHA-2](https://en.wikipedia.org/wiki/SHA-2) hash of the transaction data. Sui uses SHA256 because it is supported by [Apple](https://developer.apple.com/forums/thread/89619), HSMs, and [cloud](https://developer.apple.com/forums/thread/89619), and it is widely adopted by [Bitcoin](https://en.bitcoin.it/wiki/Elliptic_Curve_Digital_Signature_Algorithm).
 1. The signature must be of length 64 bytes in the form of `[r, s]` where the first 32 bytes are `r`, the second 32 bytes are `s`.
 1. The `r` value can be between `0x1` and `0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE BAAEDCE6 AF48A03B BFD25E8C D0364140` (inclusive).
-1. The `s` value must be in the lower half of the curve order. If the signature is too high, convert it to a lower `s` according to [BIP-0062](https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#low-s-values-in-signatures) with the corresponding curve orders using `order - s`. For secp256k1, the curve order is `0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141`. For secp256r1, the curve order is `0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551` defined in [Standards for Efficient Cryptography](https://secg.org/SEC2-Ver-1.0.pdf).
+1. The `s` value must be in the lower half of the curve order. If the signature is too high, convert it to a lower `s` according to [BIP-0062](https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#low-s-values-in-signatures) with the corresponding curve orders using `order - s`. For Secp256k1, the curve order is `0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141`. For Secp256r1, the curve order is `0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551` defined in [Standards for Efficient Cryptography](https://secg.org/SEC2-Ver-1.0.pdf).
 1. Ideally, the signature must be generated with deterministic nonce according to [RFC6979](https://www.rfc-editor.org/rfc/rfc6979).
 
 An accepted pure Ed25519 signature must follow:
@@ -65,7 +66,7 @@ For more on passkey signature, see [SIP-8](https://github.com/sui-foundation/sip
 
 ## Authority signature
 
-The Authority on Sui (collection of validators) holds three distinctive keypairs:
+The Authority on Sui (collection of validators) holds three distinctive key pairs:
 
 1.  [Protocol key pair](#protocol-pair)
 1.  [Account key pair](#account-pair)


### PR DESCRIPTION
## Description 

Adding description and keyword frontmatter to the `concepts/cryptography/transaction-auth` pages.

Also a few misc capitalization/spelling fixes.

## Test plan 

N/A - docs

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
