### PR TITLE
docs: fix typos

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/loader.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/loader.rs
@@ -682,7 +682,7 @@ impl ModuleCache {
 
 // Helpers to load/verify modules without recursion
 
-// In order to traverse the transitive dependencies of a module (when verifing the module),
+// In order to traverse the transitive dependencies of a module (when verifying the module),
 // we create a stack and iterate over the dependencies to avoid recursion.
 // An entry on the stack is conceptually a pair (module, dependencies) where dependencies
 // is used to visit them and to track when a module is ready for linkage checks
@@ -1843,7 +1843,7 @@ pub(crate) struct LoadedModule {
     // hence, a single type.
     single_signature_token_map: BTreeMap<SignatureIndex, Type>,
 
-    // a map from signatures in instantiations to the `Vec<Type>` that reperesent it.
+    // a map from signatures in instantiations to the `Vec<Type>` that represent it.
     instantiation_signatures: BTreeMap<SignatureIndex, Vec<Type>>,
 }
 

--- a/external-crates/move/tooling/prettier-move/src/cst/formatting.ts
+++ b/external-crates/move/tooling/prettier-move/src/cst/formatting.ts
@@ -6,7 +6,7 @@ import { treeFn } from '../printer';
 import { AstPath, Doc } from 'prettier';
 
 /**
- * Creates a callback function to print commments and comment-related nodes.
+ * Creates a callback function to print comments and comment-related nodes.
  *
  * @param path
  * @returns


### PR DESCRIPTION
## Description 

Corrected misspellings:
- `verifing` → `verifying`
- `reperesent` → `represent`
- `commments` → `comments`
