### PR TITLE
[move-ide] Support for caching pre-compiled libs across pkgs

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
   "publisher": "mysten",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "preview": true,
   "repository": {
     "url": "https://github.com/MystenLabs/sui.git",

--- a/external-crates/move/crates/move-analyzer/src/analyzer.rs
+++ b/external-crates/move/crates/move-analyzer/src/analyzer.rs
@@ -27,7 +27,7 @@ use crate::{
     inlay_hints,
     symbols::{
         self,
-        compilation::PrecomputedPkgInfo,
+        compilation::CachedPackages,
         requests::{
             on_document_symbol_request, on_go_to_def_request, on_go_to_type_def_request,
             on_hover_request, on_references_request,
@@ -59,7 +59,7 @@ pub fn run(implicit_deps: Dependencies) {
 
     let (connection, io_threads) = Connection::stdio();
     let symbols_map = Arc::new(Mutex::new(BTreeMap::new()));
-    let pkg_deps = Arc::new(Mutex::new(BTreeMap::<PathBuf, PrecomputedPkgInfo>::new()));
+    let pkg_deps = Arc::new(Mutex::new(CachedPackages::new()));
     let ide_files_root: VfsPath = MemoryFS::new().into();
 
     let (id, client_response) = connection
@@ -170,7 +170,7 @@ pub fn run(implicit_deps: Dependencies) {
         let build_path = uri.to_file_path().unwrap();
         if let Some(p) = SymbolicatorRunner::root_dir(&build_path) {
             if let Ok((Some(new_symbols), _)) = symbols::get_symbols(
-                Arc::new(Mutex::new(BTreeMap::new())),
+                Arc::new(Mutex::new(CachedPackages::new())),
                 ide_files_root.clone(),
                 p.as_path(),
                 None,
@@ -310,7 +310,7 @@ fn on_request(
     context: &Context,
     request: &Request,
     ide_files_root: VfsPath,
-    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgInfo>>>,
+    pkg_dependencies: Arc<Mutex<CachedPackages>>,
     shutdown_request_received: bool,
     implicit_deps: Dependencies,
 ) -> bool {

--- a/external-crates/move/crates/move-analyzer/src/code_action.rs
+++ b/external-crates/move/crates/move-analyzer/src/code_action.rs
@@ -9,7 +9,7 @@ use crate::{
     context::Context,
     symbols::{
         Symbols,
-        compilation::{CompiledPkgInfo, PrecomputedPkgInfo, get_compiled_pkg},
+        compilation::{CachedPackages, CompiledPkgInfo, get_compiled_pkg},
         cursor::{ChainInfo, CursorContext},
         runner::SymbolicatorRunner,
     },
@@ -23,7 +23,7 @@ use lsp_types::{
 };
 use move_symbol_pool::Symbol;
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeSet, HashMap},
     path::PathBuf,
     sync::{Arc, Mutex},
 };
@@ -84,7 +84,7 @@ pub fn on_code_action_request(
     context: &Context,
     request: &Request,
     ide_files_root: VfsPath,
-    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgInfo>>>,
+    pkg_dependencies: Arc<Mutex<CachedPackages>>,
     implicit_deps: Dependencies,
 ) {
     let response = Response::new_ok(
@@ -108,7 +108,7 @@ fn access_chain_autofix_actions(
     context: &Context,
     request: &Request,
     ide_files_root: VfsPath,
-    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgInfo>>>,
+    pkg_dependencies: Arc<Mutex<CachedPackages>>,
     implicit_deps: Dependencies,
 ) -> Vec<CodeAction> {
     let mut code_actions = vec![];

--- a/external-crates/move/crates/move-analyzer/src/completions/mod.rs
+++ b/external-crates/move/crates/move-analyzer/src/completions/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     context::Context,
     symbols::{
-        self, Symbols, compilation::PrecomputedPkgInfo, cursor::CursorContext,
+        self, Symbols, compilation::CachedPackages, cursor::CursorContext,
         runner::SymbolicatorRunner,
     },
 };
@@ -32,8 +32,8 @@ use move_symbol_pool::Symbol;
 use once_cell::sync::Lazy;
 
 use std::{
-    collections::{BTreeMap, HashSet},
-    path::{Path, PathBuf},
+    collections::HashSet,
+    path::Path,
     sync::{Arc, Mutex},
 };
 use vfs::VfsPath;
@@ -82,7 +82,7 @@ pub fn on_completion_request(
     context: &Context,
     request: &Request,
     ide_files_root: VfsPath,
-    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgInfo>>>,
+    pkg_dependencies: Arc<Mutex<CachedPackages>>,
     implicit_deps: Dependencies,
 ) {
     eprintln!("handling completion request");
@@ -128,7 +128,7 @@ pub fn on_completion_request(
 fn completions(
     context: &Context,
     ide_files_root: VfsPath,
-    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgInfo>>>,
+    pkg_dependencies: Arc<Mutex<CachedPackages>>,
     path: &Path,
     pos: Position,
     implicit_deps: Dependencies,
@@ -156,7 +156,7 @@ fn completions(
 pub fn compute_completions(
     current_symbols: &Symbols,
     ide_files_root: VfsPath,
-    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgInfo>>>,
+    pkg_dependencies: Arc<Mutex<CachedPackages>>,
     path: &Path,
     pos: Position,
     implicit_deps: Dependencies,
@@ -178,7 +178,7 @@ pub fn compute_completions(
 /// view of the code (returns `None` if the symbols could not be re-computed).
 fn compute_completions_new_symbols(
     ide_files_root: VfsPath,
-    pkg_dependencies: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgInfo>>>,
+    pkg_dependencies: Arc<Mutex<CachedPackages>>,
     path: &Path,
     cursor_position: Position,
     implicit_deps: Dependencies,

--- a/external-crates/move/crates/move-analyzer/src/symbols/mod.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols/mod.rs
@@ -59,7 +59,7 @@ use crate::{
     compiler_info::CompilerInfo,
     symbols::{
         compilation::{
-            CompiledPkgInfo, CompiledProgram, ParsedDefinitions, PrecomputedPkgInfo,
+            CachedPackages, CachedPkgInfo, CompiledPkgInfo, CompiledProgram, ParsedDefinitions,
             SymbolsComputationData, get_compiled_pkg,
         },
         cursor::CursorContext,
@@ -154,7 +154,7 @@ pub type FileModules = BTreeMap<PathBuf, BTreeSet<ModuleDefs>>;
 /// the ones in `modified_files` (if `modified_paths` contains a path not representing
 /// a Move file but rather a directory, then we conservatively do not re-use any cached info).
 pub fn get_symbols(
-    packages_info: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgInfo>>>,
+    packages_info: Arc<Mutex<CachedPackages>>,
     ide_files_root: VfsPath,
     pkg_path: &Path,
     modified_files: Option<Vec<PathBuf>>,
@@ -186,7 +186,7 @@ pub fn get_symbols(
 /// Compute symbols for a given package from the parsed and typed ASTs,
 /// as well as other auxiliary data provided in `compiled_pkg_info`.
 pub fn compute_symbols(
-    packages_info: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgInfo>>>,
+    packages_info: Arc<Mutex<CachedPackages>>,
     mut compiled_pkg_info: CompiledPkgInfo,
     cursor_info: Option<(&PathBuf, Position)>,
 ) -> Symbols {
@@ -234,9 +234,9 @@ pub fn compute_symbols(
         if let Some(deps_symbols_data) = deps_symbols_data_opt {
             // dependencies may have changed or not, but we still need to update the cache
             // with new file hashes and user program info
-            pkg_deps.insert(
+            pkg_deps.pkg_info.insert(
                 pkg_path,
-                PrecomputedPkgInfo {
+                CachedPkgInfo {
                     manifest_hash,
                     deps_hash,
                     deps: cached_deps.program_deps.clone(),

--- a/external-crates/move/crates/move-analyzer/src/symbols/runner.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols/runner.rs
@@ -7,7 +7,7 @@
 
 use crate::symbols::{
     Symbols,
-    compilation::{MANIFEST_FILE_NAME, PrecomputedPkgInfo},
+    compilation::{CachedPackages, MANIFEST_FILE_NAME},
     get_symbols,
 };
 
@@ -48,7 +48,7 @@ impl SymbolicatorRunner {
     pub fn new(
         ide_files_root: VfsPath,
         symbols_map: Arc<Mutex<BTreeMap<PathBuf, Symbols>>>,
-        packages_info: Arc<Mutex<BTreeMap<PathBuf, PrecomputedPkgInfo>>>,
+        packages_info: Arc<Mutex<CachedPackages>>,
         sender: Sender<Result<BTreeMap<PathBuf, Vec<Diagnostic>>>>,
         lint: LintLevel,
         implicit_deps: Dependencies,

--- a/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
+++ b/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
@@ -17,7 +17,7 @@ use move_analyzer::{
     inlay_hints::inlay_hints_internal,
     symbols::{
         Symbols,
-        compilation::{CompiledPkgInfo, SymbolsComputationData, get_compiled_pkg},
+        compilation::{CachedPackages, CompiledPkgInfo, SymbolsComputationData, get_compiled_pkg},
         compute_symbols, compute_symbols_parsed_program, compute_symbols_pre_process,
         requests::{def_info_doc_string, maybe_convert_for_guard},
         use_def::UseDefMap,
@@ -444,7 +444,7 @@ fn initial_symbols(
     project_path.push(project);
 
     let ide_files_root: VfsPath = MemoryFS::new().into();
-    let pkg_deps = Arc::new(Mutex::new(BTreeMap::new()));
+    let pkg_deps = Arc::new(Mutex::new(CachedPackages::new()));
 
     let (mut compiled_pkg_info_opt, _) = get_compiled_pkg(
         pkg_deps.clone(),

--- a/external-crates/move/crates/move-analyzer/trace-debug/package-lock.json
+++ b/external-crates/move/crates/move-analyzer/trace-debug/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "move-trace-debug",
-    "version": "0.0.12",
+    "version": "0.0.14",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "move-trace-debug",
-            "version": "0.0.12",
+            "version": "0.0.14",
             "license": "Apache-2.0",
             "dependencies": {
                 "@iarna/toml": "^2.2.5",

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -795,6 +795,13 @@ impl Flags {
         }
     }
 
+    pub fn set_test_mode(self, value: bool) -> Self {
+        Self {
+            test: value,
+            ..self
+        }
+    }
+
     pub fn set_ide_test_mode(self, value: bool) -> Self {
         Self {
             ide_test_mode: value,


### PR DESCRIPTION
## Description 

This PR adds the ability to cache pre-compiled libs (dependencies) across different packages in Move analyzer.

## Test plan 

All automated tests must pass. Tested manually to verify memory savings

