### PR TITLE
Fix clippy warnings due to auto-deref

### DIFF
--- a/sui-execution/latest/sui-move-natives/src/crypto/hmac.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/hmac.rs
@@ -74,14 +74,14 @@ pub fn hmac_sha3_256(
                     .into()
     );
 
-    let hmac_key = hmac::HmacKey::from_bytes(&*key.as_bytes_ref())
+    let hmac_key = hmac::HmacKey::from_bytes(&key.as_bytes_ref())
         .expect("HMAC key can be of any length and from_bytes should always succeed");
     let cost = context.gas_used();
 
     Ok(NativeResult::ok(
         cost,
         smallvec![Value::vector_u8(
-            hmac::hmac_sha3_256(&hmac_key, &*message.as_bytes_ref()).to_vec()
+            hmac::hmac_sha3_256(&hmac_key, &message.as_bytes_ref()).to_vec()
         )],
     ))
 }

--- a/sui-execution/latest/sui-move-natives/src/crypto/vdf.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/vdf.rs
@@ -90,17 +90,17 @@ pub fn vdf_verify_internal(
     let output_bytes = pop_arg!(args, VectorRef);
     let input_bytes = pop_arg!(args, VectorRef);
 
-    let input = match bcs::from_bytes::<QuadraticForm>(&*input_bytes.as_bytes_ref()) {
+    let input = match bcs::from_bytes::<QuadraticForm>(&input_bytes.as_bytes_ref()) {
         Ok(input) => input,
         Err(_) => return Ok(NativeResult::err(context.gas_used(), INVALID_INPUT_ERROR)),
     };
 
-    let proof = match bcs::from_bytes::<QuadraticForm>(&*proof_bytes.as_bytes_ref()) {
+    let proof = match bcs::from_bytes::<QuadraticForm>(&proof_bytes.as_bytes_ref()) {
         Ok(proof) => proof,
         Err(_) => return Ok(NativeResult::err(context.gas_used(), INVALID_INPUT_ERROR)),
     };
 
-    let output = match bcs::from_bytes::<QuadraticForm>(&*output_bytes.as_bytes_ref()) {
+    let output = match bcs::from_bytes::<QuadraticForm>(&output_bytes.as_bytes_ref()) {
         Ok(output) => output,
         Err(_) => return Ok(NativeResult::err(context.gas_used(), INVALID_INPUT_ERROR)),
     };
@@ -157,7 +157,7 @@ pub fn hash_to_input_internal(
     let message = pop_arg!(args, VectorRef);
 
     let output = match QuadraticForm::hash_to_group_with_default_parameters(
-        &*message.as_bytes_ref(),
+        &message.as_bytes_ref(),
         &DISCRIMINANT_3072,
     ) {
         Ok(output) => output,

--- a/sui-execution/latest/sui-move-natives/src/crypto/zklogin.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/zklogin.rs
@@ -88,10 +88,10 @@ pub fn check_zklogin_id_internal(
 
     let result = check_id_internal(
         &address,
-        &*key_claim_name.as_bytes_ref(),
-        &*key_claim_value.as_bytes_ref(),
-        &*audience.as_bytes_ref(),
-        &*issuer.as_bytes_ref(),
+        &key_claim_name.as_bytes_ref(),
+        &key_claim_value.as_bytes_ref(),
+        &audience.as_bytes_ref(),
+        &issuer.as_bytes_ref(),
         &pin_hash,
     );
 
@@ -179,7 +179,7 @@ pub fn check_zklogin_issuer_internal(
     // The address to check
     let address = pop_arg!(args, AccountAddress);
 
-    let result = check_issuer_internal(&address, &address_seed, &*issuer.as_bytes_ref());
+    let result = check_issuer_internal(&address, &address_seed, &issuer.as_bytes_ref());
 
     match result {
         Ok(result) => Ok(NativeResult::ok(


### PR DESCRIPTION
## Description 

A typical warning looks like this:
```
error: deref which would be done by auto-deref
  --> sui-execution/latest/sui-move-natives/src/crypto/zklogin.rs:93:9
   |
93 |         &*audience.as_bytes_ref(),
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `&audience.as_bytes_ref()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#explicit_auto_deref
```

This is currently failing in CI e.g., https://github.com/MystenLabs/sui/actions/runs/16843368393/job/47718719732?pr=22893

## Test plan 
```
cargo xclippy -D warnings
```
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
