### PR TITLE
docs: add frontmatter to `first-app` pages

### DIFF
--- a/docs/content/guides/developer/first-app/build-test.mdx
+++ b/docs/content/guides/developer/first-app/build-test.mdx
@@ -1,5 +1,7 @@
 ---
 title: Build and Test Packages
+description: Move packages must be built and tested using the terminal interface. 
+keywords: [ move package, move, build move package, test move package, build package, test package, build move, test move ]
 ---
 
 If you followed [Write a Move Package](./write-package.mdx), you have a basic module that you need to build. If you didn't, then either start with that topic or use your package, substituting that information where appropriate.

--- a/docs/content/guides/developer/first-app/client-tssdk.mdx
+++ b/docs/content/guides/developer/first-app/client-tssdk.mdx
@@ -1,5 +1,7 @@
 ---
 title: Client App with Sui TypeScript SDK
+description: Build a client-side application using the Sui TypeScript SDK.
+keywords: [ typescript, typescript sdk, build app, create app, client app, client-side, client-side application, build client app, build client, dapp kit, dapp-kit ]
 ---
 
 This exercise diverges from the example built in the previous topics in this section. Rather than adding a frontend to the running example, the instruction walks you through setting up dApp Kit in a React App, allowing you to connect to wallets, and query data from Sui RPC nodes to display in your app. You can use it to create your own frontend for the example used previously, but if you want to get a fully functional app up and running quickly, run the following command in a terminal or console to scaffold a new app with all steps in this exercise already implemented:

--- a/docs/content/guides/developer/first-app/debug.mdx
+++ b/docs/content/guides/developer/first-app/debug.mdx
@@ -1,6 +1,7 @@
 ---
 title: Debugging
 description: Move does not have a native debugger. You can, however, use the std::debug module to monitor variable values while your code executes.
+keywords: [ debugging, debug move, how to debug move, debugging move, std::debug, debug, how to debug, debug code, debugging code ]
 ---
 
 Move does not currently have a native debugger. You can use the `std::debug` module, however, to print arbitrary values to the console. Monitoring variable values in this manner can provide insight into the logic of your modules. To do so, first declare an alias to the debug module in your source file for more concise access:

--- a/docs/content/guides/developer/first-app/publish.mdx
+++ b/docs/content/guides/developer/first-app/publish.mdx
@@ -1,6 +1,6 @@
 ---
 title: Publish a Package
-description: Move packages must be published on the Sui network before its functions can be called.
+description: You must publish Move packages on the Sui network before you can call its functions.
 keywords: [ publish, publish package, how to publish, publishing, how to publish move package, publish move package, publish transactions ]
 ---
 

--- a/docs/content/guides/developer/first-app/publish.mdx
+++ b/docs/content/guides/developer/first-app/publish.mdx
@@ -1,5 +1,7 @@
 ---
 title: Publish a Package
+description: Move packages must be published on the Sui network before its functions can be called.
+keywords: [ publish, publish package, how to publish, publishing, how to publish move package, publish move package, publish transactions ]
 ---
 
 Before you can call functions in a Move package (beyond an emulated Sui execution scenario), that package must be available on the Sui network. When you publish a package, you are actually creating an immutable Sui object on the network that anyone can access.

--- a/docs/content/guides/developer/first-app/write-package.mdx
+++ b/docs/content/guides/developer/first-app/write-package.mdx
@@ -1,6 +1,7 @@
 ---
 title: Write a Move Package
-description: The first step in getting a package on chain is to write the Move code that defines the logic of your package. The structure of a Move package is similar to those in Rust.
+description: The first step in getting a package on-chain is to write the Move code that defines the logic of your package. The structure of a Move package is similar to those in Rust.
+keywords: [ move package, move packages, packages, create a package, write a package, write a move package, create a move package, creating packages, create move smart contract, move smart contracts ]
 ---
 
 To begin, open a terminal or console at the location you plan to store your package. Use the `sui move new` command to create an empty Move package with the name `my_first_package`:


### PR DESCRIPTION
## Description 

Adding description and keyword frontmatter to the `first-app` pages.

## Test plan 

N/A
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
