### PR TITLE
docs: add frontmatter to `getting-started` pages

### DIFF
--- a/docs/content/guides/developer/getting-started/connect.mdx
+++ b/docs/content/guides/developer/getting-started/connect.mdx
@@ -1,6 +1,7 @@
 ---
 title: Connect to a Sui Network
 description: Besides Mainnet, Sui offers Testnet, Devnet, and local networks that you can connect to for development. You can also configure a custom RPC endpoint. 
+keywords: [ testnet, devnet, mainnet, connect to network, available networks, sui networks, connect to a network, connect to testnet, connect to devnet, connect to mainnet, sui testnet, sui devnet, sui mainnet ]
 ---
 
 Sui has Mainnet, Devnet, and Testnet networks available. You can use one of the test networks, Devnet or Testnet, to experiment with the version of Sui running on that network. You can also spin up a [local Sui network](./local-network.mdx) for local development. 

--- a/docs/content/guides/developer/getting-started/data-serving.mdx
+++ b/docs/content/guides/developer/getting-started/data-serving.mdx
@@ -1,6 +1,7 @@
 ---
 title: Access Sui Data
 description: Overview of the types of data access mechanisms available in Sui.
+keywords: [ data types, data access, data access interfaces, json RPC, custom indexers, indexers, gRPC, graphql RPC, indexer 2.0 ]
 ---
 
 You can access Sui network data like [Transactions](/concepts/transactions.mdx), [Checkpoints](/concepts/cryptography/system/checkpoint-verification.mdx), [Objects](/concepts/object-model.mdx), [Events](/guides/developer/sui-101/using-events.mdx), and more through the available interfaces. You can use this data in your application workflows, to analyze network behavior across applications or protocols of interest, or to perform audits on parts or the whole of the network.

--- a/docs/content/guides/developer/getting-started/get-address.mdx
+++ b/docs/content/guides/developer/getting-started/get-address.mdx
@@ -1,6 +1,7 @@
 ---
 title: Get Sui Address
 description: You need an address on the Sui network before you can start trading NFTs, purchase SUI tokens, or perform other transactions.
+keywords: [ get an address, sui address, how to get sui address, sui wallets, slush, suiet, glass wallet, martian extension, surf wallet, private keys ]
 ---
 
 An address is a way to uniquely and anonymously identify an account that exists on the Sui blockchain network. In other words, an address is a way for a user to store and use tokens on the Sui network, without providing any personally identifying information (such as email address, phone number, and so on). For example, if you want to purchase a number of SUI tokens to play a game, you must specify an address where these tokens are to be deposited.

--- a/docs/content/guides/developer/getting-started/get-coins.mdx
+++ b/docs/content/guides/developer/getting-started/get-coins.mdx
@@ -1,8 +1,10 @@
 ---
 title: Get SUI Tokens
+description: The Sui faucet can be used to obtain free SUI test tokens for use on the Sui Devnet and Testnet networks. 
+keywords: [ sui faucet, faucet, token faucet, sui devnet, sui testnet, devnet, testnet, get free tokens, free tokens ]
 ---
 
-Sui faucet is a helpful tool where Sui developers can get free test SUI tokens to deploy and interact with their programs on Sui's Devnet and Testnet networks. There is no faucet for Sui Mainnet...
+Sui faucet is a helpful tool where Sui developers can get free test SUI tokens to deploy and interact with their programs on Sui's Devnet and Testnet networks. There is no faucet for Sui Mainnet.
 
 ## Prerequisites
 

--- a/docs/content/guides/developer/getting-started/get-coins.mdx
+++ b/docs/content/guides/developer/getting-started/get-coins.mdx
@@ -1,6 +1,6 @@
 ---
 title: Get SUI Tokens
-description: The Sui faucet can be used to obtain free SUI test tokens for use on the Sui Devnet and Testnet networks. 
+description: Use the Sui faucet to obtain free SUI test tokens for use on the Sui Devnet and Testnet networks. 
 keywords: [ sui faucet, faucet, token faucet, sui devnet, sui testnet, devnet, testnet, get free tokens, free tokens ]
 ---
 

--- a/docs/content/guides/developer/getting-started/graphql-rpc.mdx
+++ b/docs/content/guides/developer/getting-started/graphql-rpc.mdx
@@ -1,6 +1,7 @@
 ---
 title: Querying Sui RPC with GraphQL (Alpha)
 description: Introductory guide to making queries of the Sui RPC using the GraphQL service.
+keywords: [ rpc, sui rpc, graphql, how to use graphql, schema, graphql schema, query transactions, query blocks, query block info, query dynamic field, execute transaction ]
 ---
 
 :::info

--- a/docs/content/guides/developer/getting-started/local-network.mdx
+++ b/docs/content/guides/developer/getting-started/local-network.mdx
@@ -1,5 +1,7 @@
 ---
 title: Connect to a Local Network
+description: Connect to a Sui local network using the Sui CLI. Local networks are used to test your applications and prepare for launching them on the Devnet or Testnet. 
+keywords: [ local network, testnet, devnet, test application, deploy app locally, customize local network, configure local network, use local network, local network state, local faucet, using the local faucet, local sui faucet ]
 ---
 
 Use a Sui local network to test your dApps against the latest changes to Sui, and to prepare for the next Sui release to the Devnet or Testnet network. Sui CLI provides the `sui start` command to start a local network. There are several services that can be started when using `sui start`, such as an indexer, a faucet, or a local instance of the GraphQL service (including the web-based GraphiQL IDE). You can use the included faucet to get test SUI to use on the local network.

--- a/docs/content/guides/developer/getting-started/local-network.mdx
+++ b/docs/content/guides/developer/getting-started/local-network.mdx
@@ -1,6 +1,6 @@
 ---
 title: Connect to a Local Network
-description: Connect to a Sui local network using the Sui CLI. Local networks are used to test your applications and prepare for launching them on the Devnet or Testnet. 
+description: Connect to a Sui local network using the Sui CLI. Use local networks to test your applications and prepare for launching them on the Devnet or Testnet. 
 keywords: [ local network, testnet, devnet, test application, deploy app locally, customize local network, configure local network, use local network, local network state, local faucet, using the local faucet, local sui faucet ]
 ---
 

--- a/docs/content/guides/developer/getting-started/sui-install.mdx
+++ b/docs/content/guides/developer/getting-started/sui-install.mdx
@@ -1,6 +1,7 @@
 ---
 title: Install Sui
 description: Install the Sui framework and required prerequisites on your system, including the Sui command line interface to interact with the Sui network.
+keywords: [ install sui, how to install sui, install sui cli, interact with sui networks, connect to sui networks, sui command line interface ]
 ---
 
 The quickest way to install Sui is using the binaries delivered with every release. If you require more control over the install process, you can install from source. To take advantage of containerization, you can utilize the Docker images in the `docker` folder of the sui repository.


### PR DESCRIPTION
## Description 

Adding description and keyword frontmatter to `getting-started` pages.

## Test plan 

N/A

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
