### PR TITLE
[rpc-benchmark] add support to pull logs from mainnet jsonrpc-alt proxy

### DIFF
--- a/crates/sui-rpc-benchmark/src/bin/pull_grafana_logs.rs
+++ b/crates/sui-rpc-benchmark/src/bin/pull_grafana_logs.rs
@@ -90,6 +90,58 @@ fn extract_from_message(message: &str) -> Option<LogEntry> {
     None
 }
 
+/// Example log format:
+/// 2025-08-10T00:05:45.423808Z  INFO sui_indexer_alt_jsonrpc_proxy::handlers: Request: Method: suix_getAllBalances, Params: ["0x10e8a57972082d89f8e2a31589a96da4a0ade2ac003e4f41a0f7b77dbfd752ba"] | Response body (UTF-8): {"jsonrpc":"2.0","id":47539,"result":[...]}
+fn extract_from_proxy_message(message: &str) -> Option<LogEntry> {
+    // Extract timestamp (first token in the message)
+    let timestamp = message.split_whitespace().next()?.to_string();
+
+    // Find the request info
+    let request_start = message.find("Request: ")?;
+    let request_str = &message[request_start..];
+    let request_split: Vec<&str> = request_str.split(" | Response body (UTF-8): ").collect();
+
+    if request_split.len() == 2 {
+        let request_details = request_split[0];
+        let response_body = request_split[1];
+
+        // Extract method from "Request: Method: suix_getAllBalances, Params: ..."
+        let method_start = request_details.find("Method: ")?;
+        let method_str = &request_details[method_start + 8..]; // Skip "Method: "
+        let method = method_str.split(',').next()?.trim().to_string();
+
+        // Extract params from "Params: [...]"
+        let params_start = request_details.find("Params: ")?;
+        let params_str = &request_details[params_start + 8..]; // Skip "Params: "
+        let params = params_str.trim();
+
+        // Extract the id from the response body to reconstruct the request
+        let id = if let Ok(response_json) = serde_json::from_str::<Value>(response_body) {
+            response_json.get("id").cloned().unwrap_or(Value::Null)
+        } else {
+            Value::Null
+        };
+
+        // Construct the JSON-RPC request body
+        let request_body = format!(
+            r#"{{"jsonrpc":"2.0","id":{},"method":"{}","params":{}}}"#,
+            id, method, params
+        );
+
+        // Host is not in this format, use a placeholder
+        let host = "unknown".to_string();
+
+        return Some(LogEntry {
+            timestamp,
+            host,
+            method,
+            body: request_body,
+        });
+    }
+
+    None
+}
+
 async fn fetch_logs(
     client: &reqwest::Client,
     url: &str,
@@ -109,9 +161,12 @@ async fn fetch_logs(
         params.push(("start_from".to_string(), o.to_string()));
     }
 
+    info!("Fetching logs from {} with params: {:?}", url, params);
+
     let resp = client
         .get(url)
         .header(ACCEPT, "application/json")
+        .header("X-Scope-OrgID", "sui-fleet")
         .query(&params)
         .send()
         .await?;
@@ -144,14 +199,22 @@ async fn run() -> Result<(), Box<dyn Error>> {
         "rpc-testnet".to_string()
     } else if net == "mainnet" {
         "rpc-mainnet".to_string()
+    } else if net == "mainnet-proxy" {
+        "sui-indexer-alt-jsonrpc-proxy-mainnet".to_string()
     } else {
         "UNKNOWN_NET".to_string()
     };
-    let substring = env::var("SUBSTRING").unwrap_or_else(|_| "Sampled read request".to_string());
-    let query = format!(
-        r#"{{namespace="{}", container="sui-edge-proxy-mysten"}} |= "{}""#,
-        namespace, substring
-    );
+
+    let query = if net == "mainnet-proxy" {
+        format!(r#"{{namespace="{}"}} |= "{}""#, namespace, "Request:")
+    } else {
+        let substring =
+            env::var("SUBSTRING").unwrap_or_else(|_| "Sampled read request".to_string());
+        format!(
+            r#"{{namespace="{}", container="sui-edge-proxy-mysten"}} |= "{}""#,
+            namespace, substring
+        )
+    };
     debug!("Query: {}", query);
 
     let now = chrono::Utc::now();
@@ -185,6 +248,7 @@ async fn run() -> Result<(), Box<dyn Error>> {
             offset,
         )
         .await?;
+
         let batch: Vec<_> = response
             .data
             .result
@@ -211,7 +275,11 @@ async fn run() -> Result<(), Box<dyn Error>> {
     let mut method_map: HashMap<String, usize> = HashMap::new();
     let mut asc_log_entries = Vec::new();
     for log_entry in all_logs.into_iter().rev() {
-        if let Some(entry) = extract_from_message(&log_entry.message) {
+        if let Some(entry) = if net == "mainnet-proxy" {
+            extract_from_proxy_message(&log_entry.message)
+        } else {
+            extract_from_message(&log_entry.message)
+        } {
             *method_map.entry(entry.method.clone()).or_default() += 1;
             asc_log_entries.push(entry);
         }


### PR DESCRIPTION
## Description 

The sui-rpc-benchmark tool currently only supports fetching logs from the edge proxy which can contain requests from all over. This PR adds support for fetching logs from the mainnet proxy as well, which only contains the requests we care about.

## Test plan 

Tested fetching locally.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
