### PR TITLE
docs: add frontmatter for `reference/cli` docs

### DIFF
--- a/docs/content/references/cli/cheatsheet.mdx
+++ b/docs/content/references/cli/cheatsheet.mdx
@@ -1,5 +1,7 @@
 ---
 title: Sui CLI Cheat Sheet
+description: Use this cheat sheet to learn common Sui CLI commands.
+keywords: [ sui cli, common sui cli commands, cli cheat sheet, quick reference ]
 ---
 
 The cheat sheet highlights common Sui CLI commands.
@@ -10,7 +12,7 @@ The cheat sheet highlights common Sui CLI commands.
 
 :::
 
-## Addresses & Aliases
+## Addresses & aliases
 
 <table class="w-100">
 	<thead>
@@ -59,7 +61,7 @@ The cheat sheet highlights common Sui CLI commands.
 	</tbody>
 </table>
 
-## Faucet & Gas
+## Faucet & gas
 
 <table class="w-100">
 	<thead>
@@ -92,7 +94,7 @@ The cheat sheet highlights common Sui CLI commands.
 	</tbody>
 </table>
 
-## Network Command Description
+## Network command description
 
 <table class="w-100">
 	<thead>
@@ -133,7 +135,7 @@ The cheat sheet highlights common Sui CLI commands.
 	</tbody>
 </table>
 
-## Create, Build, and Test a Move Project
+## Create, build, and test a Move project
 
 <table class="w-100">
 	<thead>
@@ -170,7 +172,7 @@ The cheat sheet highlights common Sui CLI commands.
 	</tbody>
 </table>
 
-## Executing Transactions
+## Executing transactions
 
 <table class="w-100">
 	<thead>
@@ -205,7 +207,7 @@ The cheat sheet highlights common Sui CLI commands.
 	</tbody>
 </table>
 
-## Programmable Transaction Blocks (PTBs)
+## Programmable transaction blocks (PTBs)
 
 <table class="w-100">
 	<thead>

--- a/docs/content/references/cli/client.mdx
+++ b/docs/content/references/cli/client.mdx
@@ -1,6 +1,7 @@
 ---
 title: Sui Client CLI
 description: The Sui Client CLI provides command-level access to interact with the Sui network.
+keywords: [ sui cli, sui client cli, sui client cli, sui client, sui cli help, sui cli reference, sui cli commands, cli commands, cli reference ]
 ---
 
 The Sui CLI `client` command provides command-level access to interact with the Sui network. Typical uses for `sui client` include publishing Move smart contracts, getting the information of an object, executing transactions, or managing addresses.
@@ -28,7 +29,7 @@ Commands:
   faucet                      Request gas coin from faucet. By default, it will use the active address and the active network
   gas                         Obtain all gas objects owned by the address. An address' alias can be used instead of the address
   merge-coin                  Merge two coin objects into one coin
-  new-address                 Generate new address and keypair with keypair scheme flag {ed25519 | secp256k1 | secp256r1} with optional derivation path, default to m/44'/784'/0'/0'/0' for ed25519 or m/54'/784'/0'/0/0
+  new-address                 Generate new address and key pair with key pair scheme flag {ed25519 | secp256k1 | secp256r1} with optional derivation path, default to m/44'/784'/0'/0'/0' for ed25519 or m/54'/784'/0'/0/0
                                   for secp256k1 or m/74'/784'/0'/0/0 for secp256r1. Word length can be { word12 | word15 | word18 | word21 | word24} default to word12 if not specified
   new-env                     Add new Sui environment
   object                      Get object info

--- a/docs/content/references/cli/keytool.mdx
+++ b/docs/content/references/cli/keytool.mdx
@@ -1,6 +1,7 @@
 ---
 title: Sui Keytool CLI
 description: The Sui Keytool CLI has commands for managing and generating addresses, working with private keys, signatures, or zkLogin. 
+keywords: [ keytool cli, keytool reference, keytool, sui keytool, keytool help, how to use keytool, key tool ]
 ---
 
 The Sui CLI `keytool` command provides several command-level access for the management and generation of addresses, as well as working with private keys, signatures, or zkLogin. For example, a user could export a private key from the Sui Wallet and import it into the local Sui CLI wallet using the `sui keytool import [...]` command.
@@ -17,16 +18,16 @@ Commands:
   decode-or-verify-tx                   Given a Base64 encoded transaction bytes, decode its components. If a signature is provided, verify the signature against the transaction 
   											and output the result.
   decode-multi-sig                  	Given a Base64 encoded MultiSig signature, decode its components. If tx_bytes is passed in, verify the multisig
-  generate                          	Generate a new keypair with key scheme flag {ed25519 | secp256k1 | secp256r1} with optional derivation path, default to
+  generate                          	Generate a new key pair with key scheme flag {ed25519 | secp256k1 | secp256r1} with optional derivation path, default to
                                         	m/44'/784'/0'/0'/0' for ed25519 or m/54'/784'/0'/0/0 for secp256k1 or m/74'/784'/0'/0/0 for secp256r1. Word length can be { word12 |
                                         	word15 | word18 | word21 | word24} default to word12 if not specified
   import                            	Add a new key to sui.keystore using either the input mnemonic phrase or a private key (from the Wallet), the key scheme flag {ed25519 |
                                         	secp256k1 | secp256r1} and an optional derivation path, default to m/44'/784'/0'/0'/0' for ed25519 or m/54'/784'/0'/0/0 for secp256k1
                                         	or m/74'/784'/0'/0/0 for secp256r1. Supports mnemonic phrase of word length 12, 15, 18`, 21, 24
   list                              	List all keys by its Sui address, Base64 encoded public key, key scheme name in sui.keystore
-  load-keypair                      	This reads the content at the provided file path. The accepted format can be [enum SuiKeyPair] (Base64 encoded of 33-byte `flag ||
-                                        	privkey`) or `type AuthorityKeyPair` (Base64 encoded `privkey`). This prints out the account keypair as Base64 encoded `flag ||
-                                        	privkey`, the network keypair, worker keypair, protocol keypair as Base64 encoded `privkey`
+  load-key pair                      	This reads the content at the provided file path. The accepted format can be [enum SuiKeyPair] (Base64 encoded of 33-byte `flag ||
+                                        	privkey`) or `type AuthorityKeyPair` (Base64 encoded `privkey`). This prints out the account key pair as Base64 encoded `flag ||
+                                        	privkey`, the network key pair, worker key pair, protocol key pair as Base64 encoded `privkey`
   multi-sig-address                 	To MultiSig Sui Address. Pass in a list of all public keys `flag || pk` in Base64. See `keytool list` for example public keys
   multi-sig-combine-partial-sig     	Provides a list of participating signatures (`flag || sig || pk` encoded in Base64), threshold, a list of all public keys and a list of
                                         	their weights that define the MultiSig address. Returns a valid MultiSig signature and its sender address. The result can be used as
@@ -40,7 +41,7 @@ Commands:
   sign-kms                          	Creates a signature by leveraging AWS KMS. Pass in a key-id to leverage Amazon KMS to sign a message and the base64 pubkey. Generate
                                         	PubKey from pem using MystenLabs/base64pemkey Any signature commits to a [struct IntentMessage] consisting of the Base64 encoded of the
                                         	BCS serialized transaction bytes itself and its intent. If intent is absent, default will be used
-  unpack                            	This takes [enum SuiKeyPair] of Base64 encoded of 33-byte `flag || privkey`). It outputs the keypair into a file at the current
+  unpack                            	This takes [enum SuiKeyPair] of Base64 encoded of 33-byte (`flag || privkey`). It outputs the key pair into a file at the current
                                         	directory where the address is the filename, and prints out its Sui address, Base64 encoded public key, the key scheme, and the key
                                         	scheme flag
   zk-login-sign-and-execute-tx      	Given the max_epoch, generate an OAuth url, ask user to paste the redirect with id_token, call salt server, then call the prover

--- a/docs/content/references/cli/move.mdx
+++ b/docs/content/references/cli/move.mdx
@@ -1,6 +1,7 @@
 ---
 title: Sui Move CLI
 description: The Sui CLI move command provides commands for working with Move source code directly from a terminal or console.
+keywords: [ sui move, sui move help, move, move reference, move commands, sui move commands, use move cli, cli move, create a move project, interact with move project, move project, move project cli ]
 ---
 
 The Sui CLI `move` command provides several commands for working with Move source code. A typical usage of `sui move` is to compile and test the Move code, or to generate a new Move project by using `sui move new project_name`, which creates the needed directories and the `Move.toml` file.

--- a/docs/content/references/cli/ptb.mdx
+++ b/docs/content/references/cli/ptb.mdx
@@ -1,6 +1,7 @@
 ---
 title: Sui Client PTB CLI
 description: The Sui Client PTB CLI enables a user to construct a PTB and execute it from the command line or a file.
+keywords: [ client ptb, sui client ptb, programmable transaction block, ptbs, sui cli ptbs, sui ptb cli, ptb cli, execute ptb from cli, execute ptb from file, ptb help ]
 ---
 
 The `client ptb` command allows you to specify the transactions for execution in a programmable transaction block (PTB) directly from your CLI or through bash scripts.

--- a/docs/content/references/cli/validator.mdx
+++ b/docs/content/references/cli/validator.mdx
@@ -1,5 +1,7 @@
 ---
 title: Sui Validator CLI
+description: The Sui Validator CLI is used to access the validator features of the Sui network. 
+keywords: [ sui validator cli, sui validator, sui cli validator, interact with validator from cli, validator cli, validator commands ]
 ---
 
 The Sui CLI `validator` command provides command-level access to validator features of the Sui network.
@@ -21,7 +23,7 @@ Commands:
   update-gas-price              	Update gas price that is used to calculate Reference Gas Price
   report-validator              	Report or un-report a validator
   serialize-payload-pop         	Serialize the payload that is used to generate Proof of Possession. This is useful to take the payload offline for an Authority protocol
-                                    	keypair to sign
+                                    	key pair to sign
   display-gas-price-update-raw-txn  Print out the serialized data of a transaction that sets the gas price quote for a validator
   help                          	Print this message or the help of the given subcommand(s)
 


### PR DESCRIPTION
## Description 

Adding description and keyword frontmatter for `reference/cli` docs pages.

## Test plan 

N/A

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
