### PR TITLE
docs: Add frontmatter to `references/contribute` docs

### DIFF
--- a/docs/content/references/contribute/code-of-conduct.mdx
+++ b/docs/content/references/contribute/code-of-conduct.mdx
@@ -2,6 +2,8 @@
 title: Sui Contributor Covenant Code of Conduct
 sidebar_label: Code of Conduct
 slug: /code-of-conduct
+description: All contributions to Sui must adhere to the Contributor Code of Conduct. 
+keywords: [ code of conduct, contribute to sui, open-source contributions, contributing to sui, contribution guidelines, how to contribute ]
 ---
 
 Sui, as an open-source project, encourages free discussion rooted in respect.

--- a/docs/content/references/contribute/contribute-to-sui-repos.mdx
+++ b/docs/content/references/contribute/contribute-to-sui-repos.mdx
@@ -1,6 +1,8 @@
 ---
 title: Contribute to Sui Repositories
 slug: /contribute-to-sui-repos
+description: Sui repositories are open-source and welcome community contributions. 
+keywords: [ contribute to sui, open-source contributions, contributing to sui, contribution guidelines, how to contribute, open an issue, contribute via SIP, sui improvement proposal  ]
 ---
 
 This page describes how to contribute to Sui, and provides additional information about participating in the Sui community.

--- a/docs/content/references/contribute/contribution-process.mdx
+++ b/docs/content/references/contribute/contribution-process.mdx
@@ -2,9 +2,10 @@
 title: Contribute to Sui Documentation
 sidebar_label: Docs Contribution
 description: Help the Sui community through documentation contributions. Whether its to fix errors or add new content, the entire Sui community benefits from your contributions.
+keywords: [ contribute docs, style guide compliance, add new docs page, change existing docs page ]
 ---
 
-As open source software, Sui depends on community contributions. This page covers the process for contributing to Sui's documentation.
+As open-source software, Sui depends on community contributions. This page covers the process for contributing to Sui's documentation.
 
 To make changes to the documentation, you can fork and clone the Sui repository to your local machine and make changes from your preferred IDE of choice, or by the web interface on GitHub. This guide covers both scenarios.
 
@@ -30,11 +31,11 @@ Cloning the documentation locally is recommended when you are creating larger, m
 
 Editing the documentation via the GitHub web interface is recommended if you are not familiar with working in an IDE, or for smaller changes and fixes.
 
-**Add New Page**
+**Add new page**
 
 Navigate to the `docs/content` directory, then navigate to the appropriate subdirectory and click the `Add file` button in the top-right. Select `create new file` to create a new file and edit it directly on GitHub's web interface.
 
-**Change Existing Page**
+**Change existing page**
 
 To change an existing page, navigate to the file you want to edit, click on the pencil icon in the top-right, and edit your changes there.
 

--- a/docs/content/references/contribute/localize-sui-docs.mdx
+++ b/docs/content/references/contribute/localize-sui-docs.mdx
@@ -1,6 +1,8 @@
 ---
 title: Localize Sui Documentation
 slug: /localize-sui-docs
+description: The Sui documentation can be translated into any language using Crowdin.
+keywords: [ translate docs, translate documentation, translate, crowdin, localize, localization, docs localization, docs translations ]
 ---
 
 The Sui documentation can be localized (translated) into any language of your choosing. The localization platform utilized is Crowdin. For more information regarding the localization process please see [here](https://support.crowdin.com/crowdin-intro/).

--- a/docs/content/references/contribute/style-guide.mdx
+++ b/docs/content/references/contribute/style-guide.mdx
@@ -1,6 +1,8 @@
 ---
 title: Style Guide
 slug: /style-guide
+description: All contributions to the Sui documentation must adhere to the style guide.
+keywords: [ style guide, documentation style, accessibility of docs, formatting of docs, capitalization, grammar, tense, headings, lists, tables, word choice ]
 ---
 
 This document defines the styles, vocabulary usage, and content formatting for Sui documentation. Entries are in alphabetical order. A style guide is never finished. Expect continued iterations to add additional styles, additional information to existing styles, and infrequently a change to an existing style.

--- a/docs/content/references/contribute/sui-environment.mdx
+++ b/docs/content/references/contribute/sui-environment.mdx
@@ -1,6 +1,7 @@
 ---
 title: Sui Environment Setup
 description: Get the background information you need before you start developing on Sui. Learn the layout of the Sui monorepository and the suggested development environment for working with Move.
+keywords: [ setup environment, setup dev environment, setup mono repo, download mono repo, monorepo, fork sui repo, how to contribute to sui repo, contribute to sui, develop sui locally ]
 ---
 
 Before you start developing with Sui and Move, you should familiarize yourself with how to contribute to Sui, how Sui is structured, what tools and SDKs exist, and what plugins are available to use in your IDE.


### PR DESCRIPTION
## Description 

Adding description and keyword frontmatter to `references/contribute` docs

## Test plan 

N/A

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
