### PR TITLE
[sdk] add external signer to sui sdk

### DIFF
--- a/crates/sui-cluster-test/src/cluster.rs
+++ b/crates/sui-cluster-test/src/cluster.rs
@@ -371,6 +371,7 @@ pub async fn new_wallet_context_from_cluster(
         .unwrap();
     SuiClientConfig {
         keystore,
+        external_keys: None,
         envs: vec![SuiEnv {
             alias: "localnet".to_string(),
             rpc: fullnode_url.into(),

--- a/crates/sui-keys/src/external.rs
+++ b/crates/sui-keys/src/external.rs
@@ -1040,7 +1040,7 @@ mod tests {
         let external = load_external_keystore();
         let address = SuiAddress::from_str(ADDRESS).unwrap();
         let identity = KeyIdentity::Address(address);
-        let address = external.get_by_identity(identity).unwrap();
+        let address = external.get_by_identity(&identity).unwrap();
         assert_eq!(address.to_string(), ADDRESS);
     }
 

--- a/crates/sui-keys/src/keystore.rs
+++ b/crates/sui-keys/src/keystore.rs
@@ -142,13 +142,13 @@ pub trait AccountKeystore: Send + Sync {
     }
 
     /// Get address by its identity: a type which is either an address or an alias.
-    fn get_by_identity(&self, key_identity: KeyIdentity) -> Result<SuiAddress, anyhow::Error> {
+    fn get_by_identity(&self, key_identity: &KeyIdentity) -> Result<SuiAddress, anyhow::Error> {
         match key_identity {
-            KeyIdentity::Address(addr) => Ok(addr),
+            KeyIdentity::Address(addr) => Ok(addr.clone()),
             KeyIdentity::Alias(alias) => Ok(*self
                 .addresses_with_alias()
                 .iter()
-                .find(|(_, a)| a.alias == alias)
+                .find(|(_, a)| a.alias == *alias)
                 .ok_or_else(|| anyhow!("Cannot resolve alias {alias} to an address"))?
                 .0),
         }

--- a/crates/sui-keys/src/keystore.rs
+++ b/crates/sui-keys/src/keystore.rs
@@ -144,7 +144,7 @@ pub trait AccountKeystore: Send + Sync {
     /// Get address by its identity: a type which is either an address or an alias.
     fn get_by_identity(&self, key_identity: &KeyIdentity) -> Result<SuiAddress, anyhow::Error> {
         match key_identity {
-            KeyIdentity::Address(addr) => Ok(addr.clone()),
+            KeyIdentity::Address(addr) => Ok(*addr),
             KeyIdentity::Alias(alias) => Ok(*self
                 .addresses_with_alias()
                 .iter()

--- a/crates/sui-sdk/src/sui_client_config.rs
+++ b/crates/sui-sdk/src/sui_client_config.rs
@@ -16,6 +16,7 @@ use sui_types::base_types::*;
 #[derive(Serialize, Deserialize)]
 pub struct SuiClientConfig {
     pub keystore: Keystore,
+    pub external_keys: Option<Keystore>,
     pub envs: Vec<SuiEnv>,
     pub active_env: Option<String>,
     pub active_address: Option<SuiAddress>,
@@ -25,6 +26,7 @@ impl SuiClientConfig {
     pub fn new(keystore: Keystore) -> Self {
         SuiClientConfig {
             keystore,
+            external_keys: None,
             envs: vec![],
             active_env: None,
             active_address: None,

--- a/crates/sui-sdk/src/sui_client_config.rs
+++ b/crates/sui-sdk/src/sui_client_config.rs
@@ -15,10 +15,15 @@ use sui_types::base_types::*;
 #[serde_as]
 #[derive(Serialize, Deserialize)]
 pub struct SuiClientConfig {
+    /// The keystore that holds the user's private keys, typically filebased keystore
     pub keystore: Keystore,
+    /// Optional external keystore for managing keys that are not stored in the main keystore.
     pub external_keys: Option<Keystore>,
+    /// List of environments that the client can connect to.
     pub envs: Vec<SuiEnv>,
+    /// The alias of the currently active environment.
     pub active_env: Option<String>,
+    /// The address that is currently active in the keystore.
     pub active_address: Option<SuiAddress>,
 }
 

--- a/crates/sui-sdk/src/wallet_context.rs
+++ b/crates/sui-sdk/src/wallet_context.rs
@@ -15,9 +15,10 @@ use sui_json_rpc_types::{
     SuiObjectResponseQuery, SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
 };
 use sui_keys::key_identity::KeyIdentity;
-use sui_keys::keystore::AccountKeystore;
+use sui_keys::keystore::{AccountKeystore, Keystore};
 use sui_types::base_types::{FullObjectRef, ObjectID, ObjectRef, SuiAddress};
-use sui_types::crypto::SuiKeyPair;
+use sui_types::crypto::{Signature, SuiKeyPair};
+
 use sui_types::gas_coin::GasCoin;
 use sui_types::transaction::{Transaction, TransactionData, TransactionDataAPI};
 use tokio::sync::RwLock;
@@ -50,6 +51,17 @@ impl WalletContext {
         Ok(context)
     }
 
+    pub fn new_for_tests(keystore: Keystore) -> Self {
+        let config = SuiClientConfig::new(keystore).persisted(Path::new("test_config.yaml"));
+        Self {
+            config,
+            request_timeout: None,
+            client: Arc::new(Default::default()),
+            max_concurrent_requests: None,
+            env_override: None,
+        }
+    }
+
     pub fn with_request_timeout(mut self, request_timeout: std::time::Duration) -> Self {
         self.request_timeout = Some(request_timeout);
         self
@@ -78,7 +90,22 @@ impl WalletContext {
         input: Option<KeyIdentity>,
     ) -> Result<SuiAddress, anyhow::Error> {
         if let Some(key_identity) = input {
-            Ok(self.config.keystore.get_by_identity(key_identity)?)
+            if let Ok(address) = self.config.keystore.get_by_identity(&key_identity) {
+                return Ok(address);
+            }
+            if let Some(address) = self
+                .config
+                .external_keys
+                .as_ref()
+                .and_then(|external_keys| external_keys.get_by_identity(&key_identity).ok())
+            {
+                return Ok(address);
+            }
+
+            Err(anyhow!(
+                "No address found for the provided key identity: {:?}",
+                key_identity
+            ))
         } else {
             self.active_address()
         }
@@ -357,6 +384,57 @@ impl WalletContext {
     /// Add an account
     pub async fn add_account(&mut self, alias: Option<String>, keypair: SuiKeyPair) {
         self.config.keystore.import(alias, keypair).await.unwrap();
+    }
+
+    pub fn get_keystore_by_identity(
+        &self,
+        key_identity: &KeyIdentity,
+    ) -> Result<&Keystore, anyhow::Error> {
+        if self.config.keystore.get_by_identity(key_identity).is_ok() {
+            return Ok(&self.config.keystore);
+        }
+
+        if let Some(external_keys) = self.config.external_keys.as_ref() {
+            if external_keys.get_by_identity(key_identity).is_ok() {
+                return Ok(external_keys);
+            }
+        }
+
+        Err(anyhow!(
+            "No keystore found for the provided key identity: {:?}",
+            key_identity
+        ))
+    }
+
+    pub fn get_keystore_by_identity_mut(
+        &mut self,
+        key_identity: &KeyIdentity,
+    ) -> Result<&mut Keystore, anyhow::Error> {
+        if self.config.keystore.get_by_identity(key_identity).is_ok() {
+            return Ok(&mut self.config.keystore);
+        }
+
+        if let Some(external_keys) = self.config.external_keys.as_mut() {
+            if external_keys.get_by_identity(key_identity).is_ok() {
+                return Ok(external_keys);
+            }
+        }
+
+        Err(anyhow!(
+            "No keystore found for the provided key identity: {:?}",
+            key_identity
+        ))
+    }
+
+    pub async fn sign_secure(
+        &self,
+        key_identity: &KeyIdentity,
+        data: &TransactionData,
+        intent: Intent,
+    ) -> Result<Signature, anyhow::Error> {
+        let keystore = self.get_keystore_by_identity(key_identity)?;
+        let sig = keystore.sign_secure(&data.sender(), data, intent).await?;
+        Ok(sig)
     }
 
     /// Sign a transaction with a key currently managed by the WalletContext

--- a/crates/sui-sdk/src/wallet_context.rs
+++ b/crates/sui-sdk/src/wallet_context.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, ensure};
 use futures::future;
 use shared_crypto::intent::Intent;
 use std::collections::BTreeSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use sui_config::{Config, PersistedConfig};
 use sui_json_rpc_types::{
@@ -51,8 +51,9 @@ impl WalletContext {
         Ok(context)
     }
 
-    pub fn new_for_tests(keystore: Keystore) -> Self {
-        let config = SuiClientConfig::new(keystore).persisted(Path::new("test_config.yaml"));
+    pub fn new_for_tests(keystore: Keystore, path: Option<PathBuf>) -> Self {
+        let config = SuiClientConfig::new(keystore)
+            .persisted(&path.unwrap_or(PathBuf::from("test_config.yaml")));
         Self {
             config,
             request_timeout: None,
@@ -401,8 +402,7 @@ impl WalletContext {
         }
 
         Err(anyhow!(
-            "No keystore found for the provided key identity: {:?}",
-            key_identity
+            "No keystore found for the provided key identity: {key_identity}"
         ))
     }
 
@@ -421,8 +421,7 @@ impl WalletContext {
         }
 
         Err(anyhow!(
-            "No keystore found for the provided key identity: {:?}",
-            key_identity
+            "No keystore found for the provided key identity: {key_identity}"
         ))
     }
 

--- a/crates/sui-sdk/src/wallet_context.rs
+++ b/crates/sui-sdk/src/wallet_context.rs
@@ -109,8 +109,7 @@ impl WalletContext {
             }
 
             Err(anyhow!(
-                "No address found for the provided key identity: {:?}",
-                key_identity
+                "No address found for the provided key identity: {key_identity}"
             ))
         } else {
             self.active_address()

--- a/crates/sui-sdk/src/wallet_context.rs
+++ b/crates/sui-sdk/src/wallet_context.rs
@@ -51,9 +51,14 @@ impl WalletContext {
         Ok(context)
     }
 
-    pub fn new_for_tests(keystore: Keystore, path: Option<PathBuf>) -> Self {
-        let config = SuiClientConfig::new(keystore)
+    pub fn new_for_tests(
+        keystore: Keystore,
+        external: Option<Keystore>,
+        path: Option<PathBuf>,
+    ) -> Self {
+        let mut config = SuiClientConfig::new(keystore)
             .persisted(&path.unwrap_or(PathBuf::from("test_config.yaml")));
+        config.external_keys = external;
         Self {
             config,
             request_timeout: None,

--- a/crates/sui-sdk/tests/tests.rs
+++ b/crates/sui-sdk/tests/tests.rs
@@ -5,13 +5,18 @@ use tempfile::TempDir;
 use fastcrypto::ed25519::Ed25519KeyPair;
 use shared_crypto::intent::{Intent, IntentMessage, PersonalMessage};
 use sui_keys::key_derive::generate_new_key;
-use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, Keystore};
+use sui_keys::key_identity::KeyIdentity;
+use sui_keys::keystore::{AccountKeystore, FileBasedKeystore, InMemKeystore, Keystore};
 use sui_macros::sim_test;
-use sui_sdk::verify_personal_message_signature::verify_personal_message_signature;
-use sui_types::base_types::SuiAddress;
-use sui_types::crypto::{Ed25519SuiSignature, SuiKeyPair};
+use sui_sdk::{
+    verify_personal_message_signature::verify_personal_message_signature,
+    wallet_context::WalletContext,
+};
+use sui_types::base_types::{random_object_ref, SuiAddress};
+use sui_types::crypto::{Ed25519SuiSignature, SuiKeyPair, SuiSignature};
 use sui_types::crypto::{SignatureScheme, SuiSignatureInner};
 use sui_types::multisig::{MultiSig, MultiSigPublicKey};
+use sui_types::transaction::{ProgrammableTransaction, TransactionData, TransactionKind};
 use sui_types::{
     crypto::{get_key_pair, Signature},
     signature::GenericSignature,
@@ -133,4 +138,110 @@ async fn test_verify_signature_multisig() {
     let res =
         verify_personal_message_signature(generic_sig, "wrong msg".as_bytes(), address, None).await;
     assert!(res.is_err());
+}
+
+#[tokio::test]
+async fn test_get_wallet_key() {
+    // Test that we can get and sign with the wallet key from the "filebased" keystore.
+    let filebased = Keystore::from(InMemKeystore::new_insecure_for_tests(1));
+    let external = Keystore::from(InMemKeystore::new_insecure_for_tests(1));
+    let alias = filebased.aliases()[0].alias.clone();
+    let address = external.addresses()[0];
+    let alias_identity = KeyIdentity::Alias(alias.clone());
+
+    let mut wallet_context = WalletContext::new_for_tests(filebased, Some(external), None);
+
+    // get address for the alias
+    wallet_context
+        .get_identity_address(Some(alias_identity.clone()))
+        .unwrap();
+
+    // try to get a non-existing alias
+    wallet_context
+        .get_identity_address(Some(KeyIdentity::Alias("".to_string())))
+        .unwrap_err();
+
+    // get keystore by alias
+    wallet_context
+        .get_keystore_by_identity(&alias_identity)
+        .unwrap();
+    // get mutable keystore by alias
+    wallet_context
+        .get_keystore_by_identity_mut(&alias_identity)
+        .unwrap();
+
+    let transaction_kind = TransactionKind::ProgrammableTransaction(ProgrammableTransaction {
+        inputs: vec![],
+        commands: vec![],
+    });
+
+    let transaction = TransactionData::new(
+        transaction_kind,
+        address.clone(),
+        random_object_ref(),
+        1000,
+        1000,
+    );
+
+    let signature = wallet_context
+        .sign_secure(&alias_identity, &transaction, Intent::sui_transaction())
+        .await
+        .unwrap();
+
+    let intent_message = IntentMessage::new(Intent::sui_transaction(), transaction.clone());
+
+    signature
+        .verify_secure(&intent_message, address, SignatureScheme::ED25519)
+        .unwrap();
+
+    // Test that we can get and sign with the wallet key from the "external" keystore.
+    let filebased = Keystore::from(InMemKeystore::new_insecure_for_tests(1));
+    let external = Keystore::from(InMemKeystore::new_insecure_for_tests(1));
+    let alias = external.aliases()[0].alias.clone();
+    let address = external.addresses()[0];
+    let alias_identity = KeyIdentity::Alias(alias.clone());
+
+    let mut wallet_context = WalletContext::new_for_tests(filebased, Some(external), None);
+    // get address for the alias
+    wallet_context
+        .get_identity_address(Some(alias_identity.clone()))
+        .unwrap();
+
+    // try to get a non-existing alias
+    wallet_context
+        .get_identity_address(Some(KeyIdentity::Alias("".to_string())))
+        .unwrap_err();
+
+    // get keystore by alias
+    wallet_context
+        .get_keystore_by_identity(&alias_identity)
+        .unwrap();
+    // get mutable keystore by alias
+    wallet_context
+        .get_keystore_by_identity_mut(&alias_identity)
+        .unwrap();
+
+    let transaction_kind = TransactionKind::ProgrammableTransaction(ProgrammableTransaction {
+        inputs: vec![],
+        commands: vec![],
+    });
+
+    let transaction = TransactionData::new(
+        transaction_kind,
+        address.clone(),
+        random_object_ref(),
+        1000,
+        1000,
+    );
+
+    let signature = wallet_context
+        .sign_secure(&alias_identity, &transaction, Intent::sui_transaction())
+        .await
+        .unwrap();
+
+    let intent_message = IntentMessage::new(Intent::sui_transaction(), transaction.clone());
+
+    signature
+        .verify_secure(&intent_message, address, SignatureScheme::ED25519)
+        .unwrap();
 }

--- a/crates/sui-sdk/tests/tests.rs
+++ b/crates/sui-sdk/tests/tests.rs
@@ -175,13 +175,8 @@ async fn test_get_wallet_key() {
         commands: vec![],
     });
 
-    let transaction = TransactionData::new(
-        transaction_kind,
-        address.clone(),
-        random_object_ref(),
-        1000,
-        1000,
-    );
+    let transaction =
+        TransactionData::new(transaction_kind, address, random_object_ref(), 1000, 1000);
 
     let signature = wallet_context
         .sign_secure(&alias_identity, &transaction, Intent::sui_transaction())
@@ -226,13 +221,8 @@ async fn test_get_wallet_key() {
         commands: vec![],
     });
 
-    let transaction = TransactionData::new(
-        transaction_kind,
-        address.clone(),
-        random_object_ref(),
-        1000,
-        1000,
-    );
+    let transaction =
+        TransactionData::new(transaction_kind, address, random_object_ref(), 1000, 1000);
 
     let signature = wallet_context
         .sign_secure(&alias_identity, &transaction, Intent::sui_transaction())

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -1630,7 +1630,7 @@ impl SuiClientCommands {
             SuiClientCommands::RemoveAddress { alias_or_address } => {
                 let identity = KeyIdentity::from_str(&alias_or_address)
                     .map_err(|e| anyhow!("Invalid address or alias: {}", e))?;
-                let address: SuiAddress = context.config.keystore.get_by_identity(identity)?;
+                let address: SuiAddress = context.config.keystore.get_by_identity(&identity)?;
 
                 context.config.keystore.remove(address).await?;
 

--- a/crates/sui/src/keytool.rs
+++ b/crates/sui/src/keytool.rs
@@ -672,7 +672,7 @@ impl KeyToolCommand {
                 }
             }
             KeyToolCommand::Export { key_identity } => {
-                let address = keystore.get_by_identity(key_identity)?;
+                let address = keystore.get_by_identity(&key_identity)?;
                 let skp = keystore.export(&address)?;
                 let mut key = Key::from(skp);
                 key.alias = keystore.get_alias(&key.sui_address).ok();
@@ -834,7 +834,7 @@ impl KeyToolCommand {
                 data,
                 intent,
             } => {
-                let address = keystore.get_by_identity(address)?;
+                let address = keystore.get_by_identity(&address)?;
                 let intent = intent.unwrap_or_else(Intent::sui_transaction);
                 let intent_clone = intent.clone();
                 let msg: TransactionData =

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -1035,6 +1035,7 @@ async fn start(
                 .unwrap();
             SuiClientConfig {
                 keystore,
+                external_keys: None,
                 envs: vec![SuiEnv {
                     alias: "localnet".to_string(),
                     rpc: fullnode_url,
@@ -1442,6 +1443,7 @@ async fn prompt_if_no_config(
             let alias = env.alias.clone();
             SuiClientConfig {
                 keystore,
+                external_keys: None,
                 envs: vec![env],
                 active_address: Some(new_address),
                 active_env: Some(alias),

--- a/crates/test-cluster/src/lib.rs
+++ b/crates/test-cluster/src/lib.rs
@@ -1345,6 +1345,7 @@ impl TestClusterBuilder {
         // Create wallet config with stated authorities port
         SuiClientConfig {
             keystore: Keystore::from(FileBasedKeystore::load_or_create(&keystore_path)?),
+            external_keys: None,
             envs: Default::default(),
             active_address,
             active_env: Default::default(),


### PR DESCRIPTION
## Description 

Add external signer to SDK
- SuiClientConfig added optional external signer
- try both file based storage and external signer storage when signing/accessing keystore by address


## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
