### PR TITLE
docs: Add frontmatter to `reference/*` pages

### DIFF
--- a/docs/content/references/cli.mdx
+++ b/docs/content/references/cli.mdx
@@ -1,6 +1,7 @@
 ---
 title: Sui CLI
 description: Sui provides command line tools to interact with the network, its features, and the Move programming language. Individual command groups are referred to as Sui Client CLI, Sui Keytool CLI, Sui Move CLI, and Sui Validator CLI.
+keywords: [ Sui Client CLI, Sui Keytool CLI, Sui Move CLI, Sui Validator CLI, sui cli, update cli, sui cli commands, sui client PTB CLI, sui PTB CLI ] 
 ---
 
 Sui provides a command line interface (CLI) tool to interact with the Sui network, its features, and the Move programming language. The complete suite of tools is called the Sui CLI, with commands grouped together by feature. Each group of commands is commonly referred to by its top-level command: Sui Client CLI, Sui Keytool CLI, Sui Move CLI, and Sui Validator CLI.

--- a/docs/content/references/exchange-integration-guide.mdx
+++ b/docs/content/references/exchange-integration-guide.mdx
@@ -2,6 +2,8 @@
 title: Exchange Integration Guide
 sidebar_label: Exchange Integration
 slug: /exchange-integration-guide
+description: Learn the primary tasks necessary to integrate the SUI token with a cryptocurrency exchange. 
+keywords: [ integrate sui, sui token, SUI, integrate with exchange, integrate with cryptocurrency exchange, decentralized exchange, dex, integration with dex, dex integration, sui staking, staking ]
 ---
 
 This topic describes how to integrate SUI, the token native to the Sui network, into a cryptocurrency exchange. The specific requirements and processes to implement an integration vary between exchanges. Rather than provide a step-by-step guide, this topic provides information about the primary tasks necessary to complete an integration. After the guidance about how to configure an integration, you can also find information and code samples related to staking on the Sui network.

--- a/docs/content/references/framework.mdx
+++ b/docs/content/references/framework.mdx
@@ -1,6 +1,7 @@
 ---
 title: Sui Framework
 description: The Sui framework libraries include Move modules that provide the logic for Sui and its standards. A Rust process creates the documentation for the modules directly from comments in the code.
+keywords: [ sui framework, sui libraries, move modules, sui standards, rust, documentation from modules, generate framework documentation, crate documentation, build documentation locally, build docs ]
 ---
 
 import DocCardList from '@theme/DocCardList';

--- a/docs/content/references/fullnode-protocol.mdx
+++ b/docs/content/references/fullnode-protocol.mdx
@@ -2,6 +2,7 @@
 title: Sui Full Node gRPC
 description: The Sui Full node gRPC protocol is available on all Sui Full nodes.
 beta: devnet, testnet, mainnet
+keywords: [ sui full node, grpc, g rpc, rpc, rpc api, json-rpc, json rpc api, grpc api ]
 ---
 
 import Protocol from "../../site/src/components/Protocol";

--- a/docs/content/references/rust-sdk.mdx
+++ b/docs/content/references/rust-sdk.mdx
@@ -1,6 +1,7 @@
 ---
 title: Rust SDK
 description: The Sui Rust SDK provides Rust wrappers around the Sui API. Using the SDK, you can interact with Sui networks using the Rust programming language.
+keywords: [ rust, rust sdk, sui rust sdk, crates/sui-sdk, sui-sdk ]
 ---
 
 The Sui Rust SDK crate is in the [**crates\sui-sdk** directory](https://github.com/MystenLabs/sui/tree/main/crates/sui-sdk) of the Sui repository.

--- a/docs/content/references/sui-api.mdx
+++ b/docs/content/references/sui-api.mdx
@@ -1,5 +1,7 @@
 ---
 title: Sui RPC
+description: SuiJSON is a JSON-based format that enables JSON inputs to be aligned with Move call arguments. 
+keywords: [suijson, json, json-based, json format, move call arguments, json inputs, move types, expected move types, move type mapping ]
 ---
 
 :::info

--- a/docs/content/references/sui-compared.mdx
+++ b/docs/content/references/sui-compared.mdx
@@ -1,9 +1,11 @@
 ---
 title: Comparison
 slug: /sui-compared
+description: Learn how Sui's unique architecture compares with other blockchain networks. 
+keywords: [ sui compared to other chains, sui compared to other blockchains, sui compared to other networks, how sui compares to other networks, sui architecture, unique features of sui, what makes sui different, sui key features ]
 ---
 
-This page summarizes how Sui compares with existing blockchains and is intended for potential adopters of Sui to decide whether it fits their use cases. See How Sui Works for an introduction to the Sui architecture.
+This page summarizes how Sui compares with other blockchains and is intended for potential adopters of Sui to decide whether it fits their use cases. See How Sui Works for an introduction to the Sui architecture.
 
 Here are Sui's key features:
 

--- a/docs/content/references/sui-framework-reference.mdx
+++ b/docs/content/references/sui-framework-reference.mdx
@@ -1,6 +1,8 @@
 ---
 title: Sui Framework Reference
 slug: /sui-framework-reference
+description: The Sui Framework includes the essential libraries necessary for developing Move packages.
+keywords: [ sui framework, libraries, on-chain libraries, sui framework reference ]
 ---
 
 The Sui Framework includes the core on-chain libraries for Move developers. You can view the [Sui Framework Reference docs](https://github.com/MystenLabs/sui/tree/main/crates/sui-framework/docs) in Markdown format in the Sui GitHub repo.

--- a/docs/content/references/sui-glossary.mdx
+++ b/docs/content/references/sui-glossary.mdx
@@ -1,6 +1,8 @@
 ---
 title: Glossary
 slug: /sui-glossary
+description: Learn about terminology specific to Sui.
+keywords: [ casual history, casual order, certificate, epoch, equivocation, eventual consistency, finality, gas, genesis, multi-writer objects, objects, proof-of-stake, proof of stake, single-writer objects, sui, sui token, total order, transaction, transfer, validator ]
 ---
 
 Find terms used in Sui defined below.

--- a/docs/content/references/sui-graphql.mdx
+++ b/docs/content/references/sui-graphql.mdx
@@ -3,6 +3,7 @@ title: GraphQL for Sui RPC (Alpha)
 sidebar_label: GraphQL (Beta)
 description: GraphQL is a public service for the Sui RPC that enables you to efficiently interact with the Sui network.
 beta: devnet, testnet, mainnet
+keywords: [ graphql, sui rpc, rpc service, public rpc service, graphql api, api, graphql migration, graphql quick-start, graphql concepts, interact with sui through rpc, use rpc, graphql rpc ]
 ---
 
 GraphQL for the Sui RPC is a public service that enables interacting with the Sui [network](https://sui.io/networkinfo).
@@ -17,7 +18,7 @@ To get started with GraphQL for the Sui RPC, check out the [Getting Started](../
 
 :::
 
-## Key Types
+## Key types
 
 All GraphQL API elements are accessible via the left sidebar, the following are good starting points to explore from.
 

--- a/docs/content/references/sui-move.mdx
+++ b/docs/content/references/sui-move.mdx
@@ -1,5 +1,7 @@
 ---
 title: Move References
+description: Learn more about Move.
+keywords: [ move, move reference, move book ]
 ---
 
 {@include: ../snippets/move-summary.mdx}

--- a/docs/content/references/sui-sdks.mdx
+++ b/docs/content/references/sui-sdks.mdx
@@ -1,6 +1,7 @@
 ---
 title: Sui and Community SDKs
 description: Collection of SDKs and utilities for developing on Sui using various programming languages.
+keywords: [ sui sdks, dapp kit, sui dapp kit, rust sdk, sui rust sdk, rust sdk auto-generated docs, rust sdk docs, zksend sdk, community sdks, dapp kit vue, dark sdk, go sdk, kotlin sdk, swift sdk, python sdk ]
 ---
 
 Sui provides developer kits that act as wrappers for the Sui API. The Sui community broadens the code coverage with its own set of developer kits targeting the Sui blockchain. 


### PR DESCRIPTION
## Description 

Adding description and keyword frontmatter to misc `reference` pages.

## Test plan 

N/A

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
