### PR TITLE
Move CheckpointSignatureV2 to protocol version 92

### DIFF
--- a/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v92.snap
+++ b/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v92.snap
@@ -1,0 +1,156 @@
+---
+source: crates/sui-core/src/authority/execution_time_estimator.rs
+expression: snapshot_data
+---
+protocol_version: 92
+consensus_observations:
+  - - MakeMoveVec
+    - observations:
+        - - 0
+          - ~
+        - - 4
+          - secs: 0
+            nanos: 28000000
+        - - 5
+          - secs: 0
+            nanos: 19000000
+        - - 1
+          - secs: 0
+            nanos: 25000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 25000000
+  - - MergeCoins
+    - observations:
+        - - 6
+          - secs: 0
+            nanos: 63000000
+        - - 4
+          - secs: 0
+            nanos: 29000000
+        - - 6
+          - secs: 0
+            nanos: 64000000
+        - - 7
+          - secs: 0
+            nanos: 0
+      stake_weighted_median:
+        secs: 0
+        nanos: 63000000
+  - - SplitCoins
+    - observations:
+        - - 6
+          - secs: 0
+            nanos: 51000000
+        - - 1
+          - secs: 0
+            nanos: 28000000
+        - - 5
+          - secs: 0
+            nanos: 54000000
+        - - 7
+          - secs: 0
+            nanos: 34000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 51000000
+  - - TransferObjects
+    - observations:
+        - - 0
+          - ~
+        - - 3
+          - secs: 0
+            nanos: 75000000
+        - - 2
+          - secs: 0
+            nanos: 67000000
+        - - 6
+          - secs: 0
+            nanos: 61000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 67000000
+  - - Upgrade
+    - observations:
+        - - 3
+          - secs: 0
+            nanos: 112000000
+        - - 0
+          - ~
+        - - 10
+          - secs: 0
+            nanos: 178000000
+        - - 7
+          - secs: 0
+            nanos: 806000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 178000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000001"
+        module: coin
+        function: transfer
+        type_arguments: []
+    - observations:
+        - - 9
+          - secs: 0
+            nanos: 275000000
+        - - 9
+          - secs: 0
+            nanos: 424000000
+        - - 9
+          - secs: 0
+            nanos: 268000000
+        - - 10
+          - secs: 0
+            nanos: 363000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 363000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000002"
+        module: nft
+        function: mint
+        type_arguments: []
+    - observations:
+        - - 0
+          - ~
+        - - 0
+          - ~
+        - - 9
+          - secs: 0
+            nanos: 339000000
+        - - 8
+          - secs: 0
+            nanos: 499000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 499000000
+transaction_estimates:
+  - - coin_transfer_call
+    - secs: 0
+      nanos: 363000000
+  - - mixed_move_calls
+    - secs: 0
+      nanos: 862000000
+  - - native_commands_with_observations
+    - secs: 0
+      nanos: 412000000
+  - - transfer_objects_1_items
+    - secs: 0
+      nanos: 134000000
+  - - split_coins_4_amounts
+    - secs: 0
+      nanos: 255000000
+  - - merge_coins_3_sources
+    - secs: 0
+      nanos: 252000000
+  - - make_move_vec_4_elements
+    - secs: 0
+      nanos: 125000000
+  - - mixed_commands
+    - secs: 0
+      nanos: 304000000
+  - - upgrade_package
+    - secs: 0
+      nanos: 178000000

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -496,12 +496,12 @@ mod tests {
 
     #[sim_test]
     async fn reject_checkpoint_signature_v2_when_flag_disabled() {
-        // Build a single-validator network and authority with protocol version < 91 (flag disabled)
+        // Build a single-validator network and authority with protocol version < 92 (flag disabled)
         let network_config =
             sui_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir().build();
 
         let disabled_cfg =
-            ProtocolConfig::get_for_version(ProtocolVersion::new(90), Chain::Unknown);
+            ProtocolConfig::get_for_version(ProtocolVersion::new(91), Chain::Unknown);
         let state = TestAuthorityBuilder::new()
             .with_network_config(&network_config, 0)
             .with_protocol_config(disabled_cfg)
@@ -550,11 +550,11 @@ mod tests {
 
     #[sim_test]
     async fn accept_checkpoint_signature_v2_when_flag_enabled() {
-        // Build a single-validator network and authority with protocol version >= 91 (flag enabled)
+        // Build a single-validator network and authority with protocol version >= 92 (flag enabled)
         let network_config =
             sui_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir().build();
 
-        let enabled_cfg = ProtocolConfig::get_for_version(ProtocolVersion::new(91), Chain::Unknown);
+        let enabled_cfg = ProtocolConfig::get_for_version(ProtocolVersion::new(92), Chain::Unknown);
         let state = TestAuthorityBuilder::new()
             .with_network_config(&network_config, 0)
             .with_protocol_config(enabled_cfg)

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1294,7 +1294,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "91",
+              "maxSupportedProtocolVersion": "92",
               "protocolVersion": "6",
               "featureFlags": {
                 "accept_passkey_in_multisig": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -19,7 +19,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-const MAX_PROTOCOL_VERSION: u64 = 91;
+const MAX_PROTOCOL_VERSION: u64 = 92;
 
 // Record history of protocol version allocations here:
 //
@@ -255,6 +255,7 @@ const MAX_PROTOCOL_VERSION: u64 = 91;
 //             Enable `debug_fatal` on Move invariant violations.
 //             Enable passkey and passkey inside multisig for mainnet.
 // Version 91: Minor changes in Sui Framework. Include CheckpointDigest in consensus dedup key for checkpoint signatures (V2).
+// Version 92: Enable CheckpointDigest in consensus dedup key for checkpoint signatures.
 
 #[derive(Copy, Clone, Debug, Hash, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(u64);
@@ -3925,6 +3926,8 @@ impl ProtocolConfig {
                 }
                 91 => {
                     cfg.feature_flags.per_command_shared_object_transfer_rules = true;
+                }
+                92 => {
                     cfg.feature_flags
                         .consensus_checkpoint_signature_key_includes_digest = true;
                 }

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_91.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_91.snap
@@ -32,7 +32,6 @@ feature_flags:
   simple_conservation_checks: true
   loaded_child_object_format_type: true
   receive_objects: true
-  consensus_checkpoint_signature_key_includes_digest: true
   random_beacon: true
   bridge: true
   enable_effects_v2: true

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_92.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_92.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 91
+version: 92
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true
@@ -32,6 +32,7 @@ feature_flags:
   simple_conservation_checks: true
   loaded_child_object_format_type: true
   receive_objects: true
+  consensus_checkpoint_signature_key_includes_digest: true
   random_beacon: true
   bridge: true
   enable_effects_v2: true
@@ -78,7 +79,6 @@ feature_flags:
   consensus_round_prober: true
   validate_identifier_inputs: true
   disallow_self_identifier: true
-  mysticeti_fastpath: true
   relocate_event_module: true
   uncompressed_g1_group_elements: true
   disallow_new_modules_in_deps_only_packages: true
@@ -98,7 +98,6 @@ feature_flags:
   enforce_checkpoint_timestamp_monotonicity: true
   max_ptb_value_size_v2: true
   resolve_type_input_ids_to_defining_id: true
-  enable_party_transfer: true
   allow_unbounded_system_objects: true
   type_tags_in_object_runtime: true
   better_adapter_type_resolution_errors: true
@@ -406,3 +405,202 @@ gas_budget_based_txn_cost_absolute_cap_commit_count: 50
 sip_45_consensus_amplification_threshold: 5
 use_object_per_epoch_marker_table_v2: true
 consensus_commit_rate_estimation_window_size: 10
+aliased_addresses:
+  - original:
+      - 205
+      - 137
+      - 98
+      - 218
+      - 210
+      - 120
+      - 216
+      - 181
+      - 15
+      - 160
+      - 249
+      - 235
+      - 1
+      - 134
+      - 191
+      - 164
+      - 203
+      - 222
+      - 204
+      - 109
+      - 89
+      - 55
+      - 114
+      - 20
+      - 200
+      - 141
+      - 2
+      - 134
+      - 160
+      - 172
+      - 149
+      - 98
+    aliased:
+      - 11
+      - 45
+      - 163
+      - 39
+      - 186
+      - 106
+      - 76
+      - 172
+      - 190
+      - 117
+      - 221
+      - 221
+      - 80
+      - 230
+      - 232
+      - 187
+      - 248
+      - 29
+      - 100
+      - 150
+      - 233
+      - 45
+      - 102
+      - 175
+      - 145
+      - 84
+      - 198
+      - 28
+      - 119
+      - 247
+      - 51
+      - 47
+    allowed_tx_digests:
+      - - 2
+        - 145
+        - 170
+        - 78
+        - 99
+        - 246
+        - 130
+        - 221
+        - 11
+        - 53
+        - 228
+        - 241
+        - 202
+        - 113
+        - 56
+        - 105
+        - 120
+        - 236
+        - 143
+        - 114
+        - 165
+        - 106
+        - 212
+        - 165
+        - 196
+        - 178
+        - 239
+        - 253
+        - 97
+        - 66
+        - 98
+        - 197
+  - original:
+      - 226
+      - 139
+      - 80
+      - 206
+      - 241
+      - 214
+      - 51
+      - 234
+      - 67
+      - 211
+      - 41
+      - 106
+      - 63
+      - 107
+      - 103
+      - 255
+      - 3
+      - 18
+      - 165
+      - 241
+      - 169
+      - 159
+      - 10
+      - 247
+      - 83
+      - 200
+      - 91
+      - 139
+      - 93
+      - 232
+      - 255
+      - 6
+    aliased:
+      - 11
+      - 45
+      - 163
+      - 39
+      - 186
+      - 106
+      - 76
+      - 172
+      - 190
+      - 117
+      - 221
+      - 221
+      - 80
+      - 230
+      - 232
+      - 187
+      - 248
+      - 29
+      - 100
+      - 150
+      - 233
+      - 45
+      - 102
+      - 175
+      - 145
+      - 84
+      - 198
+      - 28
+      - 119
+      - 247
+      - 51
+      - 47
+    allowed_tx_digests:
+      - - 253
+        - 118
+        - 94
+        - 221
+        - 205
+        - 105
+        - 164
+        - 185
+        - 146
+        - 65
+        - 207
+        - 179
+        - 194
+        - 136
+        - 51
+        - 126
+        - 222
+        - 28
+        - 78
+        - 230
+        - 151
+        - 0
+        - 147
+        - 120
+        - 44
+        - 55
+        - 155
+        - 111
+        - 243
+        - 35
+        - 173
+        - 119

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_92.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_92.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 91
+version: 92
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true
@@ -32,6 +32,7 @@ feature_flags:
   simple_conservation_checks: true
   loaded_child_object_format_type: true
   receive_objects: true
+  consensus_checkpoint_signature_key_includes_digest: true
   random_beacon: true
   bridge: true
   enable_effects_v2: true

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_91.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_91.snap
@@ -32,7 +32,6 @@ feature_flags:
   simple_conservation_checks: true
   loaded_child_object_format_type: true
   receive_objects: true
-  consensus_checkpoint_signature_key_includes_digest: true
   random_beacon: true
   bridge: true
   enable_effects_v2: true

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_92.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_92.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 91
+version: 92
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true
@@ -32,6 +32,7 @@ feature_flags:
   simple_conservation_checks: true
   loaded_child_object_format_type: true
   receive_objects: true
+  consensus_checkpoint_signature_key_includes_digest: true
   random_beacon: true
   bridge: true
   enable_effects_v2: true
@@ -43,8 +44,10 @@ feature_flags:
   include_consensus_digest_in_prologue: true
   hardened_otw_check: true
   allow_receiving_object_id: true
+  enable_poseidon: true
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
+  enable_group_ops_native_function_msm: true
   enable_nitro_attestation: true
   enable_nitro_attestation_upgraded_parsing: true
   reject_mutable_random_on_entry_functions: true
@@ -65,6 +68,7 @@ feature_flags:
   reshare_at_same_initial_version: true
   resolve_abort_locations_to_package_id: true
   mysticeti_use_committed_subdag_digest: true
+  enable_vdf: true
   record_consensus_determined_version_assignments_in_prologue: true
   record_consensus_determined_version_assignments_in_prologue_v2: true
   fresh_vm_on_framework_upgrade: true
@@ -73,6 +77,7 @@ feature_flags:
   soft_bundle: true
   enable_coin_deny_list_v2: true
   passkey_auth: true
+  authority_capabilities_v2: true
   rethrow_serialization_type_layout_errors: true
   consensus_distributed_vote_scoring_strategy: true
   consensus_round_prober: true
@@ -303,6 +308,7 @@ hash_blake2b256_data_cost_per_block: 2
 hash_keccak256_cost_base: 10
 hash_keccak256_data_cost_per_byte: 2
 hash_keccak256_data_cost_per_block: 2
+poseidon_bn254_cost_base: 260
 poseidon_bn254_cost_per_block: 388
 group_ops_bls12381_decode_scalar_cost: 7
 group_ops_bls12381_decode_g1_cost: 2848
@@ -344,6 +350,8 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
+vdf_verify_vdf_cost: 1500
+vdf_hash_to_input_cost: 100
 nitro_attestation_parse_base_cost: 2650
 nitro_attestation_parse_cost_per_byte: 50
 nitro_attestation_verify_base_cost: 2481600

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -6,7 +6,7 @@ ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 91
+  protocol_version: 92
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
   stake_subsidy_start_epoch: 0

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -3,7 +3,7 @@ source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis.sui_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 91
+protocol_version: 92
 system_state_version: 1
 validators:
   total_stake: 20000000000000000
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0xa5630d012a2dd93078ec96fc9d026cd0ae925d070f40a74f4b35b97f74c0fcca"
+            id: "0x7867086683ee613862d2a77b3abc7c892e03b9e2353a0d5d6d694aa0ecf28cce"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x00de5c7c8df11841f552d1ab9bb1b204266969bca5de2acd692d3c6938e9b6b1"
+      operation_cap_id: "0x77387d1a805b7ca88da10bb088674e6f287f9e1f7bc2d59ef16a24bdc4526b9b"
       gas_price: 1000
       staking_pool:
-        id: "0xa160b49421d9504829bd7e8200f986c6845352420b11ebc247722cfe92326070"
+        id: "0x56de4b4b2fec72085bf0a889f58a75d663efc6a99ce824c5fe0ec1d60a041176"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x2d3b2de650cad29ec08057d704e0d1ee34a6f4381f884ba316aa79312eb150a7"
+          id: "0x9504fc1bfd9d4e2fbf86806590d97a105d89e9205a22320b8d1efb4515426c7f"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0xb8df8757885f608d417968e14b7b3f7944660553f97154fae0ee5cbc838fc7dd"
+            id: "0xd8a436b3093c62fe9a81922bb9a663514f14f3af151282826f5602428b516653"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x164387b697b178baa5364556daddd228a9e0dfef6095c39715b0a0e25abf331e"
+          id: "0x427909a8ae430465d9ea3860b93bd1633cec1cfd173f62af153e0c99bb875090"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x11268bad7596319c91291ab0dbd18414845bc89438cc1f4b44b7703e99261f75"
+      id: "0x8100793a18e638d580612260e50c2c4f1a27cb3ceb783b367129e694c4891218"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0x58d1b518eb36c991a1e60f80be89c871e78c4f37d88d34d86d6263b7f7472e5f"
+    id: "0xbdde03f0a57af92abfa40fe2d6f8e492d2c8d05331fa56abaf066070f5d202a2"
     size: 1
   inactive_validators:
-    id: "0x86418bf89e8b93789b8ec878bd98f8588159e836e4e4adc1f9eaef9116d55cf2"
+    id: "0x44bcc26100c94faf7fe649431e086340c495e1af14ddeed03f318561dcdfc2ab"
     size: 0
   validator_candidates:
-    id: "0x5f337c224623acc0f55975e3fc175149654ca6debe82ffdfa0dfa9c1a2910c9d"
+    id: "0x0c4b347c2c794e502bf5d7d4048f42dcf102381a448e8e1e457fc04371016945"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x3214d806b5747b4963888f785d1df81e64331ac4859440fc6e0b1e288866a384"
+      id: "0x4bc2c3725d6ffac8fd2c56aeced71d984f4c463bbf730eba2b8961eecbe7e8fa"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0x6ce73a00d271c39300e0db3e593e1408f99295e21f542939bec5cbbaf2e6c8f2"
+      id: "0xd35b602b4163e17ca50adc8f806ca9c2db3e727c65b8b08015a98d3ddd284e74"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0xf6ecec3e96472e97ae31dd379791206b96a4564a18c59303c5fa4ee9d897bfb3"
+      id: "0x96d7e41a049dbb406f89f227125a7f28dd6270d264ac142cd76e9e02c9baaacc"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,5 +332,5 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0x9211a7abf82a1d70e74efa9b5c1c583956e4dc41c4792ac6e3f5153b312c8340"
+    id: "0xca4b55516c15d6b02abdbf2a6d5aad9ef1325a6ac84f0b80922b4941c6ff7b33"
   size: 0


### PR DESCRIPTION
91 had already been included in 1.54.0
