### PR TITLE
[TD] return aggregated retriable error only when non-retriable error becomes impossible

### DIFF
--- a/crates/sui-benchmark/src/drivers/bench_driver.rs
+++ b/crates/sui-benchmark/src/drivers/bench_driver.rs
@@ -828,7 +828,11 @@ async fn run_bench_worker(
                 );
                 match payload.get_failure_type() {
                     Some(ExpectedFailureType::NoFailure) => {
-                        panic!("Transaction failed unexpectedly");
+                        panic!(
+                            "Transaction {} failed unexpectedly {}",
+                            transaction.digest(),
+                            err
+                        );
                     }
                     Some(_) => {
                         metrics

--- a/crates/sui-core/src/transaction_driver/unit_tests/effects_certifier_tests.rs
+++ b/crates/sui-core/src/transaction_driver/unit_tests/effects_certifier_tests.rs
@@ -49,6 +49,7 @@ use tokio::time::{sleep, Duration};
 #[derive(Clone)]
 struct MockAuthority {
     _name: AuthorityName,
+    response_delays: Arc<StdMutex<Option<Duration>>>,
     ack_responses: Arc<StdMutex<HashMap<TransactionDigest, WaitForEffectsResponse>>>,
     full_responses: Arc<StdMutex<HashMap<TransactionDigest, WaitForEffectsResponse>>>,
 }
@@ -57,9 +58,14 @@ impl MockAuthority {
     fn new(name: AuthorityName) -> Self {
         Self {
             _name: name,
+            response_delays: Arc::new(StdMutex::new(None)),
             ack_responses: Arc::new(StdMutex::new(HashMap::new())),
             full_responses: Arc::new(StdMutex::new(HashMap::new())),
         }
+    }
+
+    fn set_response_delay(&self, delay: Duration) {
+        *self.response_delays.lock().unwrap() = Some(delay);
     }
 
     fn set_ack_response(&self, tx_digest: TransactionDigest, response: WaitForEffectsResponse) {
@@ -84,6 +90,11 @@ impl AuthorityAPI for MockAuthority {
         request: RawWaitForEffectsRequest,
         _client_addr: Option<SocketAddr>,
     ) -> Result<RawWaitForEffectsResponse, SuiError> {
+        let response_delay = *self.response_delays.lock().unwrap();
+        if let Some(delay) = response_delay {
+            sleep(delay).await;
+        }
+
         let wait_request: WaitForEffectsRequest = request.try_into()?;
 
         // Choose the right response based on include_details flag
@@ -196,7 +207,7 @@ impl AuthorityAPI for MockAuthority {
         &self,
         _request: sui_types::messages_grpc::RawValidatorHealthRequest,
     ) -> Result<sui_types::messages_grpc::RawValidatorHealthResponse, SuiError> {
-        unimplemented!()
+        Ok(sui_types::messages_grpc::RawValidatorHealthResponse::default())
     }
 }
 
@@ -708,10 +719,293 @@ async fn test_mixed_rejected_and_expired() {
             observed_effects_digests,
         } => {
             assert_eq!(submission_non_retriable_errors.total_stake, 2500);
-            assert_eq!(submission_retriable_errors.total_stake, 5000);
+            assert_eq!(submission_retriable_errors.total_stake, 7500);
             assert_eq!(observed_effects_digests.total_stake(), 0);
         }
         e => panic!("Expected Aborted error, got: {:?}", e),
+    }
+}
+
+#[tokio::test]
+async fn test_mixed_rejected_reasons() {
+    telemetry_subscribers::init_for_testing();
+    let authority_aggregator = Arc::new(create_test_authority_aggregator());
+    let client_monitor = Arc::new(ValidatorClientMonitor::new_for_test(
+        authority_aggregator.clone(),
+    ));
+    let metrics = Arc::new(TransactionDriverMetrics::new_for_tests());
+    let certifier = EffectsCertifier::new(metrics);
+
+    let tx_digest = create_test_transaction_digest(1);
+    let name = authority_aggregator
+        .authority_clients
+        .keys()
+        .next()
+        .unwrap();
+
+    let epoch = 0;
+    let consensus_position = ConsensusPosition {
+        epoch,
+        block: BlockRef::MIN,
+        index: 0,
+    };
+    let options = SubmitTransactionOptions::default();
+
+    let retriable_rejected_response = WaitForEffectsResponse::Rejected {
+        error: Some(SuiError::UserInputError {
+            error: UserInputError::ObjectNotFound {
+                object_id: random_object_ref().0,
+                version: None,
+            },
+        }),
+    };
+    let non_retriable_rejected_response = WaitForEffectsResponse::Rejected {
+        error: Some(SuiError::UserInputError {
+            error: UserInputError::ObjectVersionUnavailableForConsumption {
+                provided_obj_ref: random_object_ref(),
+                current_version: 1.into(),
+            },
+        }),
+    };
+    let reason_not_found_response = WaitForEffectsResponse::Rejected { error: None };
+
+    {
+        tracing::debug!("Case #1: Test 2 retriable and 2 non-retriable reasons that arrive later");
+        let authority_aggregator = Arc::new(create_test_authority_aggregator());
+        let authorities: Vec<_> = authority_aggregator.authority_clients.keys().collect();
+        for (i, authority_name) in authorities.iter().enumerate() {
+            let client = authority_aggregator
+                .authority_clients
+                .get(authority_name)
+                .unwrap()
+                .authority_client();
+            if i < 2 {
+                client.set_ack_response(tx_digest, retriable_rejected_response.clone());
+                client.set_full_response(tx_digest, retriable_rejected_response.clone());
+            } else {
+                // Delay non-retriable responses to ensure they are aggregated.
+                client.set_response_delay(Duration::from_secs(1));
+                client.set_ack_response(tx_digest, non_retriable_rejected_response.clone());
+                client.set_full_response(tx_digest, non_retriable_rejected_response.clone());
+            }
+        }
+
+        let result = certifier
+            .get_certified_finalized_effects(
+                &authority_aggregator,
+                &client_monitor,
+                &tx_digest,
+                *name,
+                SubmitTxResponse::Submitted { consensus_position },
+                &options,
+            )
+            .await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            TransactionDriverError::InvalidTransaction {
+                submission_non_retriable_errors,
+                submission_retriable_errors: _,
+            } => {
+                assert_eq!(submission_non_retriable_errors.total_stake, 5000);
+            }
+            e => panic!("Expected InvalidTransaction error, got: {:?}", e),
+        }
+    }
+
+    {
+        tracing::debug!(
+            "Case #2: Test 1 retriable, 1 not found, and 2 non-retriable reasons that arrive later"
+        );
+        let authority_aggregator = Arc::new(create_test_authority_aggregator());
+        let authorities: Vec<_> = authority_aggregator.authority_clients.keys().collect();
+        for (i, authority_name) in authorities.iter().enumerate() {
+            let client = authority_aggregator
+                .authority_clients
+                .get(authority_name)
+                .unwrap()
+                .authority_client();
+            if i == 0 {
+                client.set_ack_response(tx_digest, retriable_rejected_response.clone());
+                client.set_full_response(tx_digest, retriable_rejected_response.clone());
+            } else if i == 1 {
+                client.set_ack_response(tx_digest, reason_not_found_response.clone());
+                client.set_full_response(tx_digest, reason_not_found_response.clone());
+            } else {
+                // Delay non-retriable responses to ensure they are aggregated.
+                client.set_response_delay(Duration::from_secs(1));
+                client.set_ack_response(tx_digest, non_retriable_rejected_response.clone());
+                client.set_full_response(tx_digest, non_retriable_rejected_response.clone());
+            }
+        }
+
+        let result = certifier
+            .get_certified_finalized_effects(
+                &authority_aggregator,
+                &client_monitor,
+                &tx_digest,
+                *name,
+                SubmitTxResponse::Submitted { consensus_position },
+                &options,
+            )
+            .await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            TransactionDriverError::InvalidTransaction {
+                submission_non_retriable_errors,
+                submission_retriable_errors: _,
+            } => {
+                assert_eq!(submission_non_retriable_errors.total_stake, 5000);
+            }
+            e => panic!("Expected InvalidTransaction error, got: {:?}", e),
+        }
+    }
+
+    {
+        tracing::debug!("Case #3: Test 2 retriable, 1 not found, and 1 non-retriable reason that arrives earlier");
+        let authority_aggregator = Arc::new(create_test_authority_aggregator());
+        let authorities: Vec<_> = authority_aggregator.authority_clients.keys().collect();
+        for (i, authority_name) in authorities.iter().enumerate() {
+            let client = authority_aggregator
+                .authority_clients
+                .get(authority_name)
+                .unwrap()
+                .authority_client();
+            if i == 0 || i == 1 {
+                client.set_response_delay(Duration::from_secs(1));
+                client.set_ack_response(tx_digest, retriable_rejected_response.clone());
+                client.set_full_response(tx_digest, retriable_rejected_response.clone());
+            } else if i == 2 {
+                client.set_response_delay(Duration::from_secs(1));
+                client.set_ack_response(tx_digest, reason_not_found_response.clone());
+                client.set_full_response(tx_digest, reason_not_found_response.clone());
+            } else {
+                client.set_ack_response(tx_digest, non_retriable_rejected_response.clone());
+                client.set_full_response(tx_digest, non_retriable_rejected_response.clone());
+            }
+        }
+
+        let result = certifier
+            .get_certified_finalized_effects(
+                &authority_aggregator,
+                &client_monitor,
+                &tx_digest,
+                *name,
+                SubmitTxResponse::Submitted { consensus_position },
+                &options,
+            )
+            .await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            TransactionDriverError::Aborted {
+                submission_retriable_errors,
+                submission_non_retriable_errors,
+                observed_effects_digests,
+            } => {
+                assert_eq!(submission_retriable_errors.total_stake, 5000);
+                assert_eq!(submission_non_retriable_errors.total_stake, 2500);
+                assert!(observed_effects_digests.digests.is_empty());
+            }
+            e => panic!("Expected InvalidTransaction error, got: {:?}", e),
+        }
+    }
+
+    {
+        tracing::debug!("Case #4: Test 1 retriable, 2 not found, and 1 non-retriable reason that arrives earlier");
+        let authority_aggregator = Arc::new(create_test_authority_aggregator());
+        let authorities: Vec<_> = authority_aggregator.authority_clients.keys().collect();
+        for (i, authority_name) in authorities.iter().enumerate() {
+            let client = authority_aggregator
+                .authority_clients
+                .get(authority_name)
+                .unwrap()
+                .authority_client();
+            if i == 0 {
+                client.set_response_delay(Duration::from_secs(1));
+                client.set_ack_response(tx_digest, retriable_rejected_response.clone());
+                client.set_full_response(tx_digest, retriable_rejected_response.clone());
+            } else if i == 1 || i == 2 {
+                client.set_response_delay(Duration::from_secs(1));
+                client.set_ack_response(tx_digest, reason_not_found_response.clone());
+                client.set_full_response(tx_digest, reason_not_found_response.clone());
+            } else {
+                client.set_ack_response(tx_digest, non_retriable_rejected_response.clone());
+                client.set_full_response(tx_digest, non_retriable_rejected_response.clone());
+            }
+        }
+
+        let result = certifier
+            .get_certified_finalized_effects(
+                &authority_aggregator,
+                &client_monitor,
+                &tx_digest,
+                *name,
+                SubmitTxResponse::Submitted { consensus_position },
+                &options,
+            )
+            .await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            TransactionDriverError::Aborted {
+                submission_retriable_errors,
+                submission_non_retriable_errors,
+                observed_effects_digests,
+            } => {
+                assert_eq!(submission_retriable_errors.total_stake, 2500);
+                assert_eq!(submission_non_retriable_errors.total_stake, 2500);
+                assert!(observed_effects_digests.digests.is_empty());
+            }
+            e => panic!("Expected InvalidTransaction error, got: {:?}", e),
+        }
+    }
+
+    {
+        tracing::debug!("Case #5: Test 2 retriable arriving later, 2 not found");
+        let authority_aggregator = Arc::new(create_test_authority_aggregator());
+        let authorities: Vec<_> = authority_aggregator.authority_clients.keys().collect();
+        for (i, authority_name) in authorities.iter().enumerate() {
+            let client = authority_aggregator
+                .authority_clients
+                .get(authority_name)
+                .unwrap()
+                .authority_client();
+            if i < 2 {
+                client.set_response_delay(Duration::from_secs(1));
+                client.set_ack_response(tx_digest, retriable_rejected_response.clone());
+                client.set_full_response(tx_digest, retriable_rejected_response.clone());
+            } else {
+                client.set_ack_response(tx_digest, reason_not_found_response.clone());
+                client.set_full_response(tx_digest, reason_not_found_response.clone());
+            }
+        }
+
+        let result = certifier
+            .get_certified_finalized_effects(
+                &authority_aggregator,
+                &client_monitor,
+                &tx_digest,
+                *name,
+                SubmitTxResponse::Submitted { consensus_position },
+                &options,
+            )
+            .await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            TransactionDriverError::Aborted {
+                submission_retriable_errors,
+                submission_non_retriable_errors,
+                observed_effects_digests,
+            } => {
+                assert_eq!(submission_retriable_errors.total_stake, 5000);
+                assert_eq!(submission_non_retriable_errors.total_stake, 0);
+                assert!(observed_effects_digests.digests.is_empty());
+            }
+            e => panic!("Expected InvalidTransaction error, got: {:?}", e),
+        }
     }
 }
 


### PR DESCRIPTION
## Description 

Otherwise, TD may keep retrying even though it could have gathered a few more responses and see a non-retriable aggregated error.

## Test plan 

CI
PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
