### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/move-formatter.yml
+++ b/.github/workflows/move-formatter.yml
@@ -30,7 +30,7 @@ jobs:
       run:
         working-directory: ${{ matrix.working-directory }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js
         uses: actions/setup-node@v4
       - run: npm install --no-warnings @mysten/prettier-plugin-move@${{ env.VERSION }}


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates. Requires runner v2.327.1+. Workflows compile the same.

More info: https://github.com/actions/checkout/releases/tag/v5.0.0