### PR TITLE
Make a few APIs in SuiTransactionBlockResponse more discoverable

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_fn_delegation_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_fn_delegation_tests.rs
@@ -12,7 +12,6 @@ use sui_indexer_alt_jsonrpc::{
     args::SystemPackageTaskArgs, config::RpcConfig, start_rpc, NodeArgs, RpcArgs,
 };
 use sui_indexer_alt_reader::bigtable_reader::BigtableArgs;
-use sui_json_rpc_types::get_new_package_obj_from_response;
 use sui_macros::sim_test;
 use sui_pg_db::{temp::get_available_port, DbArgs};
 use sui_swarm_config::genesis_config::AccountConfig;
@@ -567,9 +566,7 @@ async fn test_get_balance() {
         .execute_transaction_must_succeed(publish_transaction)
         .await;
 
-    let package_id = get_new_package_obj_from_response(&execution_result)
-        .unwrap()
-        .0;
+    let package_id = execution_result.get_new_package_obj().unwrap().0;
 
     // Test out the specified coin type.
     // Parse the coin type so we have the same string representation as the used by fullnode.

--- a/crates/sui-package-management/src/lib.rs
+++ b/crates/sui-package-management/src/lib.rs
@@ -14,7 +14,7 @@ use move_package::{
     source_package::layout::SourcePackageLayout,
 };
 use move_symbol_pool::Symbol;
-use sui_json_rpc_types::{get_new_package_obj_from_response, SuiTransactionBlockResponse};
+use sui_json_rpc_types::SuiTransactionBlockResponse;
 use sui_sdk::wallet_context::WalletContext;
 use sui_types::base_types::ObjectID;
 
@@ -91,7 +91,7 @@ pub async fn update_lock_file_for_chain_env(
     lock_file: Option<PathBuf>,
     response: &SuiTransactionBlockResponse,
 ) -> Result<(), anyhow::Error> {
-    let (original_id, version, _) = get_new_package_obj_from_response(response).context(
+    let (original_id, version, _) = response.get_new_package_obj().context(
         "Expected a valid published package response but didn't see \
          one when attempting to update the `Move.lock`.",
     )?;

--- a/crates/sui-source-validation/src/tests.rs
+++ b/crates/sui-source-validation/src/tests.rs
@@ -6,9 +6,6 @@ use move_core_types::account_address::AccountAddress;
 use std::collections::HashMap;
 use std::{fs, io, path::Path};
 use std::{path::PathBuf, str};
-use sui_json_rpc_types::{
-    get_new_package_obj_from_response, get_new_package_upgrade_cap_from_response,
-};
 use sui_move_build::{BuildConfig, CompiledPackage, SuiPackageHooks};
 use sui_sdk::wallet_context::WalletContext;
 use sui_test_transaction_builder::{make_publish_transaction, make_publish_transaction_with_deps};
@@ -531,7 +528,7 @@ async fn linkage_differs() -> anyhow::Result<()> {
         upgrade_package(context, b_v1.0, b_cap.0, b_src).await
     };
 
-    // Publish b-v2 a second time, to create a third version of the package that is othewise
+    // Publish b-v2 a second time, to create a third version of the package that is otherwise
     // byte-for-byte identical with the second version;
     let b_v3_fixtures = tempfile::tempdir()?;
     let b_v3 = {
@@ -747,8 +744,8 @@ fn sanitize_id(mut message: String, m: &HashMap<SuiAddress, &str>) -> String {
 async fn publish_package(context: &WalletContext, package: PathBuf) -> (ObjectRef, ObjectRef) {
     let txn = make_publish_transaction(context, package).await;
     let response = context.execute_transaction_must_succeed(txn).await;
-    let package = get_new_package_obj_from_response(&response).unwrap();
-    let cap = get_new_package_upgrade_cap_from_response(&response).unwrap();
+    let package = response.get_new_package_obj().unwrap();
+    let cap = response.get_new_package_upgrade_cap().unwrap();
     (package, cap)
 }
 
@@ -781,7 +778,7 @@ async fn upgrade_package(
 async fn publish_package_and_deps(context: &WalletContext, package: PathBuf) -> ObjectRef {
     let txn = make_publish_transaction_with_deps(context, package).await;
     let response = context.execute_transaction_must_succeed(txn).await;
-    get_new_package_obj_from_response(&response).unwrap()
+    response.get_new_package_obj().unwrap()
 }
 
 /// Copy `package` from fixtures into `directory`, setting its named address in the copied package's
@@ -884,8 +881,5 @@ pub async fn upgrade_package_with_wallet(
 
     let resp = context.execute_transaction_must_succeed(transaction).await;
 
-    (
-        get_new_package_obj_from_response(&resp).unwrap(),
-        resp.digest,
-    )
+    (resp.get_new_package_obj().unwrap(), resp.digest)
 }

--- a/crates/sui-test-transaction-builder/src/lib.rs
+++ b/crates/sui-test-transaction-builder/src/lib.rs
@@ -7,8 +7,7 @@ use std::path::PathBuf;
 use sui_genesis_builder::validator_info::GenesisValidatorMetadata;
 use sui_move_build::{BuildConfig, CompiledPackage};
 use sui_sdk::rpc_types::{
-    get_new_package_obj_from_response, SuiObjectDataOptions, SuiTransactionBlockEffectsAPI,
-    SuiTransactionBlockResponse,
+    SuiObjectDataOptions, SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponse,
 };
 use sui_sdk::wallet_context::WalletContext;
 use sui_types::base_types::{FullObjectRef, ObjectID, ObjectRef, SequenceNumber, SuiAddress};
@@ -622,7 +621,7 @@ pub async fn publish_package(context: &WalletContext, path: PathBuf) -> ObjectRe
         )
         .await;
     let resp = context.execute_transaction_must_succeed(txn).await;
-    get_new_package_obj_from_response(&resp).unwrap()
+    resp.get_new_package_obj().unwrap()
 }
 
 /// Executes a transaction to publish the `basics` package and returns the package object ref.
@@ -637,7 +636,7 @@ pub async fn publish_basics_package(context: &WalletContext) -> ObjectRef {
         )
         .await;
     let resp = context.execute_transaction_must_succeed(txn).await;
-    get_new_package_obj_from_response(&resp).unwrap()
+    resp.get_new_package_obj().unwrap()
 }
 
 /// Executes a transaction to publish the `basics` package and another one to create a counter.
@@ -791,7 +790,7 @@ pub async fn publish_nfts_package(
         )
         .await;
     let resp = context.execute_transaction_must_succeed(txn).await;
-    let package_id = get_new_package_obj_from_response(&resp).unwrap().0;
+    let package_id = resp.get_new_package_obj().unwrap().0;
     (package_id, gas_id, resp.digest)
 }
 

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -44,10 +44,9 @@ use sui_config::{
 };
 use sui_json::SuiJsonValue;
 use sui_json_rpc_types::{
-    get_new_package_obj_from_response, OwnedObjectRef, SuiExecutionStatus, SuiObjectData,
-    SuiObjectDataFilter, SuiObjectDataOptions, SuiObjectResponse, SuiObjectResponseQuery,
-    SuiRawData, SuiTransactionBlockDataAPI, SuiTransactionBlockEffects,
-    SuiTransactionBlockEffectsAPI,
+    OwnedObjectRef, SuiExecutionStatus, SuiObjectData, SuiObjectDataFilter, SuiObjectDataOptions,
+    SuiObjectResponse, SuiObjectResponseQuery, SuiRawData, SuiTransactionBlockDataAPI,
+    SuiTransactionBlockEffects, SuiTransactionBlockEffectsAPI,
 };
 use sui_keys::keystore::AccountKeystore;
 use sui_macros::sim_test;
@@ -1200,7 +1199,8 @@ async fn test_package_management_on_publish_command() -> Result<(), anyhow::Erro
                 response.effects.as_ref().unwrap().gas_object().object_id(),
                 gas_obj_id
             );
-            get_new_package_obj_from_response(&response)
+            response
+                .get_new_package_obj()
                 .ok_or_else(|| anyhow::anyhow!("No package object response"))?
         } else {
             unreachable!("Invalid response");
@@ -2433,7 +2433,8 @@ async fn test_package_management_on_upgrade_command() -> Result<(), anyhow::Erro
     .await?;
 
     // Get Original Package ID and version
-    let (expect_original_id, _, _) = get_new_package_obj_from_response(&publish_response)
+    let (expect_original_id, _, _) = publish_response
+        .get_new_package_obj()
         .ok_or_else(|| anyhow::anyhow!("No package object response"))?;
 
     // Get Upgraded Package ID and version
@@ -2443,7 +2444,8 @@ async fn test_package_management_on_upgrade_command() -> Result<(), anyhow::Erro
                 response.effects.as_ref().unwrap().gas_object().object_id(),
                 gas_obj_id
             );
-            get_new_package_obj_from_response(&response)
+            response
+                .get_new_package_obj()
                 .ok_or_else(|| anyhow::anyhow!("No package object response"))?
         } else {
             unreachable!("Invalid response");
@@ -4143,7 +4145,7 @@ async fn test_pay_sui() -> Result<(), anyhow::Error> {
     .await?;
 
     // pay sui takes the input coins and transfers from each of them (in order) the amounts to the
-    // respective receipients.
+    // respective recipients.
     // check if each recipient has one object, if the tx status is success,
     // and if the gas object used was the first object in the input coins
     // we also check if the balances of each recipient are right!


### PR DESCRIPTION
## Description 

Make them struct methods instead of open functions.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
