### PR TITLE
[graphql-alt] Support dependencies for TransactionEffects

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/dependencies.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/dependencies.move
@@ -1,0 +1,142 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --addresses test=0x0 --simulator
+
+//# publish
+module test::dependency_test {
+    public struct TestObject has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public fun create_object(value: u64, ctx: &mut TxContext): TestObject {
+        TestObject {
+            id: object::new(ctx),
+            value,
+        }
+    }
+
+    public fun object_value(obj: &TestObject): u64 {
+        obj.value
+    }
+}
+
+// Transaction 1: Create an object
+// Dependencies: publish transaction, system transactions
+//# programmable --sender A --inputs 100u64 @A
+//> 0: test::dependency_test::create_object(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+
+// Transaction 2: Use objects created in previous transactions
+// Dependencies: Transaction 1 (uses object(2,0)), system transactions
+//# programmable --sender A --inputs object(2,0)
+//> 0: test::dependency_test::object_value(Input(0));
+
+//# create-checkpoint
+
+//# run-graphql
+{ # Test dependencies with no dependencies
+  genesisTransaction: transactions(first: 1) {
+    nodes {
+      digest
+        effects {
+          dependencies {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+            }
+            nodes {
+              digest
+            }
+          }
+        }
+      }
+  }
+}
+
+//# run-graphql
+{ # Test dependencies field on first user transaction (depends on system transactions)
+  systemTransactionDependencies: transactionEffects(digest: "@{digest_2}") {
+    digest
+    dependencies {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+      }
+      nodes {
+        digest
+        sender {
+          address
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{ # Test dependencies field on second user transaction (depends on both previous user transactions + system transactions)
+  userTransactionDependencies: transactionEffects(digest: "@{digest_3}") {
+    digest
+    dependencies {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+      }
+      nodes {
+        digest
+        sender {
+          address
+        }
+        gasInput {
+          gasBudget
+          gasPrice
+        }
+        kind {
+          __typename
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{ # Test pagination functionality with multiple dependencies
+  paginationTest: transactionEffects(digest: "@{digest_3}") {
+    digest
+    dependencies(first: 1) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+      }
+      edges {
+        cursor
+        node {
+          digest
+          sender {
+            address
+          }
+        }
+      }
+    }
+  }
+
+  backwardPaginationTest: transactionEffects(digest: "@{digest_3}") {
+    digest
+    dependencies(last: 1) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+      }
+      edges {
+        cursor
+        node {
+          digest
+          sender {
+            address
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/dependencies.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/dependencies.snap
@@ -1,0 +1,175 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 9 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-26:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 5548000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 27-32:
+//# programmable --sender A --inputs 100u64 @A
+//> 0: test::dependency_test::create_object(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+// Transaction 2: Use objects created in previous transactions
+// Dependencies: Transaction 1 (uses object(2,0)), system transactions
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2432000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 33-34:
+//# programmable --sender A --inputs object(2,0)
+//> 0: test::dependency_test::object_value(Input(0));
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2432000,  storage_rebate: 2407680, non_refundable_storage_fee: 24320
+
+task 4, line 36:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, lines 38-56:
+//# run-graphql
+Response: {
+  "data": {
+    "genesisTransaction": {
+      "nodes": [
+        {
+          "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
+          "effects": {
+            "dependencies": {
+              "pageInfo": {
+                "hasNextPage": false,
+                "hasPreviousPage": false
+              },
+              "nodes": []
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 6, lines 58-75:
+//# run-graphql
+Response: {
+  "data": {
+    "systemTransactionDependencies": {
+      "digest": "EryreUUK41LJwEELmUbbFUGioFKJUe21SJD3b69AWn3z",
+      "dependencies": {
+        "pageInfo": {
+          "hasNextPage": false,
+          "hasPreviousPage": false
+        },
+        "nodes": [
+          {
+            "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
+            "sender": null
+          },
+          {
+            "digest": "ATmvpUHzATrVhwFQmXU8YUuKWYmRESNPUDmWzTuyXbvV",
+            "sender": {
+              "address": "0xda83166d01afd7ddcf8af5f844f45aaa53f48548e5117c23f5a2978cfd422244"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 7, lines 77-101:
+//# run-graphql
+Response: {
+  "data": {
+    "userTransactionDependencies": {
+      "digest": "3jwXUvcEfnAL6k6zertRAieMqDYxiB1bDwfAjYEHTdTq",
+      "dependencies": {
+        "pageInfo": {
+          "hasNextPage": false,
+          "hasPreviousPage": false
+        },
+        "nodes": [
+          {
+            "digest": "ATmvpUHzATrVhwFQmXU8YUuKWYmRESNPUDmWzTuyXbvV",
+            "sender": {
+              "address": "0xda83166d01afd7ddcf8af5f844f45aaa53f48548e5117c23f5a2978cfd422244"
+            },
+            "gasInput": {
+              "gasBudget": "5000000000",
+              "gasPrice": "1000"
+            },
+            "kind": {
+              "__typename": "ProgrammableTransaction"
+            }
+          },
+          {
+            "digest": "EryreUUK41LJwEELmUbbFUGioFKJUe21SJD3b69AWn3z",
+            "sender": {
+              "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+            },
+            "gasInput": {
+              "gasBudget": "5000000000",
+              "gasPrice": "1000"
+            },
+            "kind": {
+              "__typename": "ProgrammableTransaction"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 8, lines 103-142:
+//# run-graphql
+Response: {
+  "data": {
+    "paginationTest": {
+      "digest": "3jwXUvcEfnAL6k6zertRAieMqDYxiB1bDwfAjYEHTdTq",
+      "dependencies": {
+        "pageInfo": {
+          "hasNextPage": true,
+          "hasPreviousPage": false
+        },
+        "edges": [
+          {
+            "cursor": "MA==",
+            "node": {
+              "digest": "ATmvpUHzATrVhwFQmXU8YUuKWYmRESNPUDmWzTuyXbvV",
+              "sender": {
+                "address": "0xda83166d01afd7ddcf8af5f844f45aaa53f48548e5117c23f5a2978cfd422244"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "backwardPaginationTest": {
+      "digest": "3jwXUvcEfnAL6k6zertRAieMqDYxiB1bDwfAjYEHTdTq",
+      "dependencies": {
+        "pageInfo": {
+          "hasNextPage": false,
+          "hasPreviousPage": true
+        },
+        "edges": [
+          {
+            "cursor": "MQ==",
+            "node": {
+              "digest": "EryreUUK41LJwEELmUbbFUGioFKJUe21SJD3b69AWn3z",
+              "sender": {
+                "address": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -1793,6 +1793,10 @@ type TransactionEffects {
 	The unchanged consensus-managed objects that were referenced by this transaction.
 	"""
 	unchangedConsensusObjects(first: Int, after: String, last: Int, before: String): UnchangedConsensusObjectConnection
+	"""
+	Transactions whose outputs this transaction depends upon.
+	"""
+	dependencies(first: Int, after: String, last: Int, before: String): TransactionConnection
 }
 
 input TransactionFilter {

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -1797,6 +1797,10 @@ type TransactionEffects {
 	The unchanged consensus-managed objects that were referenced by this transaction.
 	"""
 	unchangedConsensusObjects(first: Int, after: String, last: Int, before: String): UnchangedConsensusObjectConnection
+	"""
+	Transactions whose outputs this transaction depends upon.
+	"""
+	dependencies(first: Int, after: String, last: Int, before: String): TransactionConnection
 }
 
 input TransactionFilter {

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -1797,6 +1797,10 @@ type TransactionEffects {
 	The unchanged consensus-managed objects that were referenced by this transaction.
 	"""
 	unchangedConsensusObjects(first: Int, after: String, last: Int, before: String): UnchangedConsensusObjectConnection
+	"""
+	Transactions whose outputs this transaction depends upon.
+	"""
+	dependencies(first: Int, after: String, last: Int, before: String): TransactionConnection
 }
 
 input TransactionFilter {

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -1793,6 +1793,10 @@ type TransactionEffects {
 	The unchanged consensus-managed objects that were referenced by this transaction.
 	"""
 	unchangedConsensusObjects(first: Int, after: String, last: Int, before: String): UnchangedConsensusObjectConnection
+	"""
+	Transactions whose outputs this transaction depends upon.
+	"""
+	dependencies(first: Int, after: String, last: Int, before: String): TransactionConnection
 }
 
 input TransactionFilter {


### PR DESCRIPTION
## Description 

Implement `dependencies` field support for TransactionEffects type.

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-graphql
cargo nextest run -p sui-indexer-alt-reader
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

---

## Stack
- #22789 
- #22790 
- #22822 
- #22823 
- #22825 
- #22835
- #22843 
- #22873
- #23106 ⬅️

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
