### PR TITLE
[sui-framework] Update snapshot compatibility test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13968,6 +13968,7 @@ dependencies = [
  "sui-config",
  "sui-core",
  "sui-framework",
+ "sui-framework-snapshot",
  "sui-json-rpc",
  "sui-json-rpc-api",
  "sui-json-rpc-types",

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -5999,9 +5999,8 @@ pub mod framework_injection {
 
     pub fn set_system_packages(packages: Vec<SystemPackage>) {
         OVERRIDE.with(|bs| {
-            let mut new_packages_not_to_include = BuiltInFramework::all_package_ids()
-                .into_iter()
-                .collect::<BTreeSet<_>>();
+            let mut new_packages_not_to_include: BTreeSet<_> =
+                BuiltInFramework::all_package_ids().into_iter().collect();
             for pkg in &packages {
                 new_packages_not_to_include.remove(&pkg.id);
             }

--- a/crates/sui-e2e-tests/Cargo.toml
+++ b/crates/sui-e2e-tests/Cargo.toml
@@ -41,6 +41,7 @@ move-core-types.workspace = true
 
 mysten-common.workspace = true
 sui-core.workspace = true
+sui-framework-snapshot.workspace = true
 sui-framework.workspace = true
 sui-json-rpc.workspace = true
 sui-json-rpc-api.workspace = true

--- a/crates/sui-e2e-tests/tests/randomness_tests.rs
+++ b/crates/sui-e2e-tests/tests/randomness_tests.rs
@@ -2,6 +2,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use sui_types::supported_protocol_versions::SupportedProtocolVersions;
 use sui_types::SUI_RANDOMNESS_STATE_OBJECT_ID;
 use test_cluster::TestClusterBuilder;
 
@@ -9,9 +10,17 @@ use sui_macros::sim_test;
 
 #[sim_test]
 async fn test_create_randomness_state_object() {
+    #[cfg(msim)]
+    {
+        use sui_core::authority::framework_injection;
+        let framework = sui_framework_snapshot::load_bytecode_snapshot(54).unwrap();
+        framework_injection::set_system_packages(framework);
+    }
+
     let test_cluster = TestClusterBuilder::new()
         .with_protocol_version(31.into())
         .with_epoch_duration_ms(10000)
+        .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(31, 54))
         .build()
         .await;
 

--- a/crates/sui-e2e-tests/tests/zklogin_tests.rs
+++ b/crates/sui-e2e-tests/tests/zklogin_tests.rs
@@ -14,6 +14,7 @@ use sui_types::committee::EpochId;
 use sui_types::crypto::Signature;
 use sui_types::error::{SuiError, SuiResult, UserInputError};
 use sui_types::signature::GenericSignature;
+use sui_types::supported_protocol_versions::SupportedProtocolVersions;
 use sui_types::transaction::Transaction;
 use sui_types::utils::load_test_vectors;
 use sui_types::utils::{
@@ -218,10 +219,18 @@ async fn test_expired_zklogin_sig() {
 
 #[sim_test]
 async fn test_auth_state_creation() {
+    #[cfg(msim)]
+    {
+        use sui_core::authority::framework_injection;
+        let framework = sui_framework_snapshot::load_bytecode_snapshot(25).unwrap();
+        framework_injection::set_system_packages(framework);
+    }
+
     // Create test cluster without auth state object in genesis
     let test_cluster = TestClusterBuilder::new()
         .with_protocol_version(23.into())
         .with_epoch_duration_ms(15000)
+        .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(23, 25))
         .with_default_jwks()
         .build()
         .await;
@@ -234,9 +243,17 @@ async fn test_auth_state_creation() {
 
 #[sim_test]
 async fn test_create_authenticator_state_object() {
+    #[cfg(msim)]
+    {
+        use sui_core::authority::framework_injection;
+        let framework = sui_framework_snapshot::load_bytecode_snapshot(25).unwrap();
+        framework_injection::set_system_packages(framework);
+    }
+
     let test_cluster = TestClusterBuilder::new()
         .with_protocol_version(23.into())
         .with_epoch_duration_ms(15000)
+        .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(23, 25))
         .build()
         .await;
 

--- a/crates/sui-framework-snapshot/tests/compatibility_tests.rs
+++ b/crates/sui-framework-snapshot/tests/compatibility_tests.rs
@@ -13,15 +13,26 @@ mod compatibility_tests {
     use sui_protocol_config::{Chain, ProtocolConfig, ProtocolVersion};
     use sui_types::execution_config_utils::to_binary_config;
 
+    /// The number of bytecode snapshots to backtest against the current framework.
+    /// This should be set to a reasonable number to ensure that we are testing against any
+    /// possible running version of the framework, but not too large to avoid weird config
+    /// artifacts.
+    const SNAPSHOT_BACKTEST_WINDOW: usize = 10;
+
     #[tokio::test]
     async fn test_framework_compatibility() {
         // This test checks that the current framework is compatible with all previous framework
         // bytecode snapshots.
-        for (version, _snapshots) in load_bytecode_snapshot_manifest() {
+        for (version, _snapshots) in load_bytecode_snapshot_manifest()
+            .iter()
+            .rev()
+            .take(SNAPSHOT_BACKTEST_WINDOW)
+            .rev()
+        {
             let config =
-                ProtocolConfig::get_for_version(ProtocolVersion::new(version), Chain::Unknown);
+                ProtocolConfig::get_for_version(ProtocolVersion::new(*version), Chain::Unknown);
             let binary_config = to_binary_config(&config);
-            let framework = load_bytecode_snapshot(version).unwrap();
+            let framework = load_bytecode_snapshot(*version).unwrap();
             let old_framework_store: BTreeMap<_, _> = framework
                 .into_iter()
                 .map(|package| (package.id, package.genesis_object()))

--- a/crates/sui-framework-snapshot/tests/compatibility_tests.rs
+++ b/crates/sui-framework-snapshot/tests/compatibility_tests.rs
@@ -21,13 +21,12 @@ mod compatibility_tests {
 
     #[tokio::test]
     async fn test_framework_compatibility() {
-        // This test checks that the current framework is compatible with all previous framework
-        // bytecode snapshots.
+        // This test checks that the current framework is compatible with
+        // `SNAPSHOT_BACKTEST_WINDOW` previous framework bytecode snapshots.
         for (version, _snapshots) in load_bytecode_snapshot_manifest()
             .iter()
             .rev()
             .take(SNAPSHOT_BACKTEST_WINDOW)
-            .rev()
         {
             let config =
                 ProtocolConfig::get_for_version(ProtocolVersion::new(*version), Chain::Unknown);


### PR DESCRIPTION
## Description 

Some of the state creation tests were problematic due to very very large protocol version bumps on a single epoch (e.g., 22 -> 90). This would cause issues with execution versioning, and other features that may have had intermediate protocol gates that were skipped over.

This also updates the snapshot compatibility tests to only test back 10 snapshots instead of the entire history, as otherwise binary compatibility and how that has evolved over the lifespan of the network becomes an issue and is overly restrictive (e.g., being able to deserialize the current framework with the binary config from protocol version 2 isn't guaranteed, and too restrictive of a requirement).

## Test plan 

Make sure existing tests pass.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
