### PR TITLE
[chore] Update slab version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12600,9 +12600,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slip10_ed25519"


### PR DESCRIPTION
## Description 

Got this warning from `cargo-deny` test to fix the vunerability.

<img width="1324" height="610" alt="Screenshot 2025-08-12 at 4 03 32 PM" src="https://github.com/user-attachments/assets/ac0cacb5-adf5-42c2-aabe-4fa42ab794ab" />


## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
