### PR TITLE
copy-paste sui-rosetta to sui-grpc-rosetta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14342,6 +14342,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "sui-grpc-rosetta"
+version = "1.55.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum 0.8.3",
+ "axum-extra 0.10.1",
+ "bcs",
+ "clap",
+ "eyre",
+ "fastcrypto",
+ "futures",
+ "hyper 1.5.2",
+ "lru 0.10.0",
+ "move-cli",
+ "move-core-types",
+ "mysten-metrics",
+ "once_cell",
+ "quick-js",
+ "rand 0.8.5",
+ "reqwest 0.12.9",
+ "serde",
+ "serde_json",
+ "shared-crypto",
+ "signature 1.6.4",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
+ "sui-config",
+ "sui-json-rpc-types",
+ "sui-keys",
+ "sui-move-build",
+ "sui-node",
+ "sui-sdk",
+ "sui-swarm-config",
+ "sui-types",
+ "telemetry-subscribers",
+ "tempfile",
+ "test-cluster",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "typed-store",
+]
+
+[[package]]
 name = "sui-http"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ members = [
   "crates/sui-graphql-rpc",
   "crates/sui-graphql-rpc-client",
   "crates/sui-graphql-rpc-headers",
+  "crates/sui-grpc-rosetta",
   "crates/sui-http",
   "crates/sui-indexer",
   "crates/sui-indexer-alt",
@@ -410,7 +411,10 @@ ipnetwork = "0.20.0"
 iso8601 = "0.6.3"
 itertools = "0.13.0"
 tikv-jemalloc-ctl = "^0.5"
-tikv-jemallocator = { version = "^0.5", features = ["profiling", "disable_initial_exec_tls"] }
+tikv-jemallocator = { version = "^0.5", features = [
+  "profiling",
+  "disable_initial_exec_tls",
+] }
 jsonrpsee = { version = "0.24.9", features = [
   "server",
   "macros",
@@ -745,6 +749,7 @@ sui-proxy = { path = "crates/sui-proxy" }
 sui-replay = { path = "crates/sui-replay" }
 sui-replay-2 = { path = "crates/sui-replay-2" }
 sui-rosetta = { path = "crates/sui-rosetta" }
+sui-grpc-rosetta = { path = "crates/sui-grpc-rosetta" }
 sui-rpc-loadgen = { path = "crates/sui-rpc-loadgen" }
 sui-sdk = { path = "crates/sui-sdk" }
 sui-simulator = { path = "crates/sui-simulator" }

--- a/crates/sui-grpc-rosetta/Cargo.toml
+++ b/crates/sui-grpc-rosetta/Cargo.toml
@@ -1,0 +1,54 @@
+[package]
+name = "sui-grpc-rosetta"
+version.workspace = true
+authors = ["Mysten Labs <build@mystenlabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[dependencies]
+axum.workspace = true
+axum-extra.workspace = true
+anyhow.workspace = true
+tracing.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+futures.workspace = true
+once_cell.workspace = true
+signature.workspace = true
+bcs.workspace = true
+hyper.workspace = true
+strum.workspace = true
+strum_macros.workspace = true
+async-trait.workspace = true
+clap.workspace = true
+thiserror.workspace = true
+eyre.workspace = true
+typed-store.workspace = true
+tempfile.workspace = true
+fastcrypto.workspace = true
+sui-swarm-config.workspace = true
+sui-types.workspace = true
+sui-sdk.workspace = true
+sui-node.workspace = true
+sui-config.workspace = true
+sui-keys.workspace = true
+sui-json-rpc-types.workspace = true
+mysten-metrics.workspace = true
+shared-crypto.workspace = true
+lru.workspace = true
+
+move-core-types.workspace = true
+
+telemetry-subscribers.workspace = true
+
+[dev-dependencies]
+sui-sdk.workspace = true
+sui-move-build.workspace = true
+test-cluster.workspace = true
+tempfile.workspace = true
+rand.workspace = true
+reqwest.workspace = true
+move-cli.workspace = true
+quick-js = "0.4.1"

--- a/crates/sui-grpc-rosetta/README.md
+++ b/crates/sui-grpc-rosetta/README.md
@@ -1,0 +1,213 @@
+# Rosetta API for Sui
+
+[Rosetta](https://www.rosetta-api.org/docs/welcome.html) is an open-source specification and set of tools for blockchain
+integration. Rosetta’s goal is to make blockchain integration simpler, faster, and more reliable than using a native
+integration.
+
+## Overview
+
+Sui-Rosetta is an implementation of the Rosetta API for the Sui network, the Sui-Rosetta server uses the Sui fullnode to
+read and write transactions to the Sui network.
+
+## Local network quick start
+
+### Build from source
+#### 0. Checkout and build Sui
+Checkout the [Sui source code](https://github.com/MystenLabs/sui) and compile using `cargo build --release`, the binaries will be located in `target/release` directory.
+
+#### 1. Genesis
+
+`./sui genesis -f`  
+The Sui genesis process will create configs and coins for testing, the config files are stored in `~/.sui/sui_config` by
+default.
+
+#### 2. Start local network
+
+`./sui start`
+
+#### 3. Start Rosetta Online server
+
+`./sui-grpc-rosetta start-online-server`
+
+#### 4. Start Rosetta Offline server
+
+`./sui-grpc-rosetta start-offline-server`
+
+#### 5. Generate configuration with prefunded accounts for rosetta-cli
+
+`./sui-grpc-rosetta generate-rosetta-cli-config`
+This will generate the `rosetta-cli.json` and `sui.ros` file to be used by the [Rosetta-CLI](https://github.com/coinbase/rosetta-cli)
+
+### Build local test network using Docker Compose
+
+#### 1. CD into the Dockerfile directory
+
+```shell
+cd <sui project directory>/crate/sui-grpc-rosetta/docker/sui-grpc-rosetta-local
+```   
+#### 2. Build the image
+```shell
+./build.sh
+```
+#### 3. Start the container
+
+```shell
+docker-compose up -d
+```
+Docker compose will start the rosetta-online and rosetta-offline containers, the ports for both rosetta server (9002, 9003 respectively) will be exposed to the host.  
+
+#### 4. Enter the rosetta service shell
+
+```shell
+docker-compose exec rosetta-online bash
+```
+
+#### 5. use the rosetta-cli to test the api
+```shell
+rosetta-cli --configuration-file rosetta-cli.json check:data
+rosetta-cli --configuration-file rosetta-cli.json check:construction
+```
+
+### Start Rosetta servers using docker run
+you can also start the individual server using docker run.
+To start the rosetta-online server, run
+```shell
+docker run mysten/sui-grpc-rosetta-devnet sui-grpc-rosetta start-online-server
+```
+Alternatively, to start the rosetta-offline server, run
+```shell
+docker run mysten/sui-grpc-rosetta-devnet sui-grpc-rosetta start-offline-server
+```
+
+## Supported APIs
+
+### Account
+
+| Method | Endpoint         | Description                    | Sui Supported? |  Server Type  |
+|--------|------------------|--------------------------------|:--------------:|:-------------:|
+| POST   | /account/balance | Get an Account's Balance       |      Yes       |    Online     |
+| POST   | /account/coins   | Get an Account's Unspent Coins |      Yes       |    Online     |
+
+### Block
+
+| Method | Endpoint           | Description             |                                      Sui Supported?                                       |  Server Type  |
+|--------|--------------------|-------------------------|:-----------------------------------------------------------------------------------------:|:-------------:|
+| POST   | /block             | Get a Block             | Yes (One transaction per block in phase 1, will be replaced by Sui checkpoint in phase 2) |    Online     |
+| POST   | /block/transaction | Get a Block Transaction |                                            Yes                                            |    Online     |
+
+### Call
+
+| Method | Endpoint | Description                            | Sui Supported? | Server Type |
+|--------|----------|----------------------------------------|:--------------:|:-----------:|
+| POST   | /call    | Make a Network-Specific Procedure Call |       No       |     --      |
+
+### Construction
+
+| Method | Endpoint                 | Description                                           | Sui Supported? | Server Type |
+|--------|--------------------------|-------------------------------------------------------|:--------------:|:-----------:|
+| POST   | /construction/combine    | Create Network Transaction from Signatures            |      Yes       |   Offline   |
+| POST   | /construction/derive     | Derive an AccountIdentifier from a PublicKey          |      Yes       |   Offline   |
+| POST   | /construction/hash       | Get the Hash of a Signed Transaction                  |      Yes       |   Offline   |
+| POST   | /construction/metadata   | Get Metadata for Transaction Construction             |      Yes       |   Online    |
+| POST   | /construction/parse      | Parse a Transaction                                   |      Yes       |   Offline   |
+| POST   | /construction/payloads   | Generate an Unsigned Transaction and Signing Payloads |      Yes       |   Offline   |
+| POST   | /construction/preprocess | Create a Request to Fetch Metadata                    |      Yes       |   Offline   |
+| POST   | /construction/submit     | Submit a Signed Transaction                           |      Yes       |   Online    |
+
+### Events
+
+| Method | Endpoint       | Description                          | Sui Supported? | Server Type |
+|--------|----------------|--------------------------------------|:--------------:|:-----------:|
+| POST   | /events/blocks | [INDEXER] Get a range of BlockEvents |       No       |     --      |
+
+### Mempool
+
+| Method | Endpoint             | Description                  | Sui Supported? | Server Type |
+|--------|----------------------|------------------------------|:--------------:|:-----------:|
+| POST   | /mempool             | Get All Mempool Transactions |       No       |     --      |
+| POST   | /mempool/transaction | Get a Mempool Transaction    |       No       |     --      |
+
+### Network
+
+| Method | Endpoint         | Description                    | Sui Supported? |  Server Type   |
+|--------|------------------|--------------------------------|:--------------:|:--------------:|
+| POST   | /network/list    | Get List of Available Networks |      Yes       | Online/Offline |
+| POST   | /network/options | Get Network Options            |      Yes       | Online/Offline |
+| POST   | /network/status  | Get Network Status             |      Yes       |     Online     |
+
+### Search
+
+| Method | Endpoint             | Description                       | Sui Supported? | Server Type |
+|--------|----------------------|-----------------------------------|:--------------:|:-----------:|
+| POST   | /search/transactions | [INDEXER] Search for Transactions |       No       |     --      |
+
+
+## Sui transaction <> Rosetta Operation conversion explained
+There are 2 places we convert Sui's transaction to Rosetta's operations, 
+one is in the `/construction/parse` endpoint and another one in `/block/transaction endpoint`.
+`/operation/parse` uses `Operation::from_data` to create the "intent" operations and `/block/transaction` uses `Operation::from_data_and_effect` to create the "confirmed" operations.
+the `/construction/parse` endpoint is used for checking transaction correctness during transaction construction, in our case we only support `TransferSui` for now, the operations created looks like this (negative amount indicate sender):
+```json
+{
+    "operation_identifier": {
+        "index": 0
+    },
+    "type": "TransferSUI",
+    "account": {
+        "address": "0xc4173a804406a365e69dfb297d4eaaf002546ebd"
+    },
+    "amount": {
+        "value": "-100000",
+        "currency": {
+            "symbol": "SUI",
+            "decimals": 9
+        }
+    },
+    "coin_change": {
+        "coin_identifier": {
+            "identifier": "0x0dce9190d54cde842d39537bf94efe128181b8a6:5549"
+        },
+        "coin_action": "coin_spent"
+    }
+},
+{
+    "operation_identifier": {
+        "index": 1
+    },
+    "type": "TransferSUI",
+    "account": {
+        "address": "0x96bc0b37b67103651d1f98c67b34df9558ea527a"
+    },
+    "amount": {
+        "value": "100000",
+        "currency": {
+            "symbol": "SUI",
+            "decimals": 9
+        }
+    }
+},
+{
+    "operation_identifier": {
+        "index": 2
+    },
+    "type": "GasBudget",
+    "account": {
+        "address": "0xc4173a804406a365e69dfb297d4eaaf002546ebd"
+    },
+    "coin_change": {
+        "coin_identifier": {
+            "identifier": "0x0dce9190d54cde842d39537bf94efe128181b8a6:5549"
+        },
+        "coin_action": "coin_spent"
+    },
+    "metadata": {
+        "budget": 1000
+    }
+}
+```
+The sender, recipients and transfer amounts are specified in the intent operations, 
+these data are being used to create TransactionData for signature.
+After the tx is executed, the rosetta-cli compare the intent operations with the confirmed operations , 
+the confirmed operations must contain the intent operations (the confirmed operations can have more operations than the intent).
+Since the intent operations of TransferSui contains all the balance change information(amount field) already, 
+we don't need to use the event to create the operations, also operation created by `get_coin_operation_from_event` will contain recipient's coin id, which will cause a mismatch.

--- a/crates/sui-grpc-rosetta/docker/sui-rosetta-devnet/Dockerfile
+++ b/crates/sui-grpc-rosetta/docker/sui-rosetta-devnet/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:latest AS chef
+WORKDIR sui
+ARG GIT_REVISION
+ENV GIT_REVISION=$GIT_REVISION
+RUN apt-get update && apt-get install -y build-essential libssl-dev pkg-config curl cmake clang git ca-certificates
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+FROM chef AS builder
+RUN git clone https://github.com/MystenLabs/sui .
+RUN git checkout devnet
+
+RUN curl -sSfL https://raw.githubusercontent.com/coinbase/rosetta-cli/master/scripts/install.sh | sh -s
+RUN curl -fLJO https://github.com/MystenLabs/sui-genesis/raw/main/devnet/genesis.blob
+RUN cargo build --release --bin sui --bin sui-grpc-rosetta --bin sui-node
+
+# Production Image
+FROM ubuntu:latest AS runtime
+WORKDIR sui
+RUN apt-get update && apt-get install -y ca-certificates
+COPY --from=builder /sui/target/release/sui /usr/local/bin
+COPY --from=builder /sui/target/release/sui-node /usr/local/bin
+COPY --from=builder /sui/target/release/sui-grpc-rosetta /usr/local/bin
+COPY --from=builder /sui/bin/rosetta-cli /usr/local/bin
+COPY --from=builder /sui/crates/sui-config/data/fullnode-template.yaml /sui/devnet/fullnode.yaml
+COPY --from=builder /sui/genesis.blob /sui/devnet/genesis.blob
+RUN /usr/local/bin/sui genesis
+
+ARG BUILD_DATE
+LABEL build-date=$BUILD_DATE
+LABEL git-revision=$GIT_REVISION

--- a/crates/sui-grpc-rosetta/docker/sui-rosetta-devnet/build.sh
+++ b/crates/sui-grpc-rosetta/docker/sui-rosetta-devnet/build.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# fast fail.
+set -e
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+DOCKERFILE="$DIR/Dockerfile"
+GIT_REVISION="$(git describe --always --abbrev=12 --dirty --exclude '*')"
+BUILD_DATE="$(date -u +'%Y-%m-%d')"
+
+echo
+echo "Building sui-grpc-rosetta docker image"
+echo "Dockerfile: \t$DOCKERFILE"
+echo "docker context: $REPO_ROOT"
+echo "build date: \t$BUILD_DATE"
+echo "git revision: \t$GIT_REVISION"
+echo
+
+docker build -f "$DOCKERFILE" "$REPO_ROOT" \
+  -t mysten/sui-grpc-rosetta-devnet \
+	--build-arg GIT_REVISION="$GIT_REVISION" \
+	--build-arg BUILD_DATE="$BUILD_DATE" \
+	"$@"

--- a/crates/sui-grpc-rosetta/docker/sui-rosetta-devnet/docker-compose.yaml
+++ b/crates/sui-grpc-rosetta/docker/sui-rosetta-devnet/docker-compose.yaml
@@ -1,0 +1,36 @@
+---
+version: "3.9"
+services:
+  rosetta-online:
+    image: mysten/sui-grpc-rosetta-devnet
+    ports:
+      - "9002:9002"
+    expose:
+      - "9002"
+    volumes:
+      - data:/data:rw
+    working_dir: /sui/devnet
+    command:
+      - /bin/bash
+      - -c
+      - |
+        /usr/local/bin/sui-grpc-rosetta generate-rosetta-cli-config --env devnet &
+        /usr/local/bin/sui-grpc-rosetta start-online-server --env devnet --node-config fullnode.yaml
+    stdin_open: true
+    tty: true
+  rosetta-offline:
+    image: mysten/sui-grpc-rosetta-devnet
+    ports:
+      - "9003:9003"
+    expose:
+      - "9003"
+    working_dir: /sui/devnet
+    command:
+      - /bin/bash
+      - -c
+      - |
+        /usr/local/bin/sui-grpc-rosetta start-offline-server --env devnet
+    stdin_open: true
+    tty: true
+volumes:
+  data:

--- a/crates/sui-grpc-rosetta/docker/sui-rosetta-devnet/remote/docker-compose.yaml
+++ b/crates/sui-grpc-rosetta/docker/sui-rosetta-devnet/remote/docker-compose.yaml
@@ -1,0 +1,33 @@
+---
+version: "3.9"
+services:
+  rosetta-online:
+    image: mysten/sui-grpc-rosetta-devnet
+    ports:
+      - "9002:9002"
+    expose:
+      - "9002"
+    working_dir: /sui/devnet
+    command:
+      - /bin/bash
+      - -c
+      - |
+        /usr/local/bin/sui-grpc-rosetta generate-rosetta-cli-config --env devnet &
+        /usr/local/bin/sui-grpc-rosetta start-online-remote-server --env devnet --genesis-path genesis.blob --full-node-url https://fullnode.devnet.sui.io:443
+    stdin_open: true
+    tty: true
+  rosetta-offline:
+    image: mysten/sui-grpc-rosetta-devnet
+    ports:
+      - "9003:9003"
+    expose:
+      - "9003"
+    working_dir: /sui/devnet
+    command:
+      - /bin/bash
+      - -c
+      - |
+        /usr/local/bin/sui-grpc-rosetta start-offline-server --env devnet
+    stdin_open: true
+    tty: true
+

--- a/crates/sui-grpc-rosetta/docker/sui-rosetta-local/Dockerfile
+++ b/crates/sui-grpc-rosetta/docker/sui-rosetta-local/Dockerfile
@@ -1,0 +1,33 @@
+FROM ubuntu:latest AS chef
+WORKDIR sui
+ARG GIT_REVISION
+ENV GIT_REVISION=$GIT_REVISION
+RUN apt-get update && apt-get install -y build-essential libssl-dev pkg-config curl cmake clang ca-certificates
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Build application
+FROM chef AS builder
+
+RUN curl -sSfL https://raw.githubusercontent.com/coinbase/rosetta-cli/master/scripts/install.sh | sh -s
+
+COPY Cargo.toml Cargo.lock ./
+COPY consensus consensus
+COPY crates crates
+COPY sui-execution sui-execution
+COPY external-crates external-crates
+RUN cargo build --release --bin sui --bin sui-grpc-rosetta
+
+# Production Image
+FROM ubuntu:latest AS runtime
+WORKDIR sui
+RUN apt-get update && apt-get install -y ca-certificates
+COPY --from=builder /sui/target/release/sui /usr/local/bin
+COPY --from=builder /sui/target/release/sui-grpc-rosetta /usr/local/bin
+COPY --from=builder /sui/bin/rosetta-cli /usr/local/bin
+COPY --from=builder /sui/crates/sui-config/data/fullnode-template.yaml /sui/devnet/fullnode.yaml
+RUN /usr/local/bin/sui genesis
+
+ARG BUILD_DATE
+LABEL build-date=$BUILD_DATE
+LABEL git-revision=$GIT_REVISION

--- a/crates/sui-grpc-rosetta/docker/sui-rosetta-local/build.sh
+++ b/crates/sui-grpc-rosetta/docker/sui-rosetta-local/build.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# fast fail.
+set -e
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+DOCKERFILE="$DIR/Dockerfile"
+GIT_REVISION="$(git describe --always --dirty)"
+BUILD_DATE="$(date -u +'%Y-%m-%d')"
+
+echo
+echo "Building sui-grpc-rosetta docker image"
+echo "Dockerfile: \t$DOCKERFILE"
+echo "docker context: $REPO_ROOT"
+echo "build date: \t$BUILD_DATE"
+echo "git revision: \t$GIT_REVISION"
+echo
+
+docker build -f "$DOCKERFILE" "$REPO_ROOT" \
+  -t mysten/sui-grpc-rosetta-local \
+	--build-arg GIT_REVISION="$GIT_REVISION" \
+	--build-arg BUILD_DATE="$BUILD_DATE" \
+	"$@"

--- a/crates/sui-grpc-rosetta/docker/sui-rosetta-local/docker-compose.yaml
+++ b/crates/sui-grpc-rosetta/docker/sui-rosetta-local/docker-compose.yaml
@@ -1,0 +1,40 @@
+---
+version: "3.9"
+services:
+  sui-network:
+    image: mysten/sui-grpc-rosetta-local
+    ports:
+      - "9000:9000"
+    expose:
+      - "9000"
+    command:
+      - /bin/bash
+      - -c
+      - |
+        /usr/local/bin/sui start
+  rosetta-online:
+    image: mysten/sui-grpc-rosetta-local
+    ports:
+      - "9002:9002"
+    expose:
+      - "9002"
+    working_dir: /sui/localnet
+    command:
+      - /bin/bash
+      - -c
+      - |
+        /usr/local/bin/sui-grpc-rosetta generate-rosetta-cli-config &
+        /usr/local/bin/sui-grpc-rosetta start-online-remote-server --full-node-url http://sui-network:9000
+    stdin_open: true
+    tty: true
+  rosetta-offline:
+    image: mysten/sui-grpc-rosetta-local
+    ports:
+      - "9003:9003"
+    expose:
+      - "9003"
+    command:
+      - /bin/bash
+      - -c
+      - |
+        /usr/local/bin/sui-grpc-rosetta start-offline-server

--- a/crates/sui-grpc-rosetta/resources/rosetta_cli.json
+++ b/crates/sui-grpc-rosetta/resources/rosetta_cli.json
@@ -1,0 +1,58 @@
+{
+  "network": {
+    "blockchain": "sui",
+    "network": "localnet"
+  },
+  "online_url": "http://rosetta-online:9002",
+  "data_directory": "data",
+  "http_timeout": 10,
+  "max_retries": 5,
+  "retry_elapsed_time": 0,
+  "max_online_connections": 120,
+  "max_sync_concurrency": 64,
+  "tip_delay": 300,
+  "max_reorg_depth": 100,
+  "log_configuration": false,
+  "compression_disabled": false,
+  "all_in_memory_enabled": false,
+  "error_stack_trace_disabled": false,
+  "coin_supported": false,
+  "construction": {
+    "offline_url": "http://rosetta-offline:9003",
+    "constructor_dsl_file": "sui.ros",
+    "end_conditions": {
+      "transfer": 20
+    },
+    "prefunded_accounts": []
+  },
+  "data": {
+    "active_reconciliation_concurrency": 16,
+    "inactive_reconciliation_concurrency": 4,
+    "inactive_reconciliation_frequency": 250,
+    "log_blocks": false,
+    "log_transactions": false,
+    "log_balance_changes": false,
+    "log_reconciliations": false,
+    "ignore_reconciliation_error": false,
+    "historical_balance_disabled": false,
+    "exempt_accounts": "",
+    "bootstrap_balances": "",
+    "interesting_accounts": "",
+    "reconciliation_disabled": false,
+    "reconciliation_drain_disabled": false,
+    "inactive_discrepancy_search_disabled": false,
+    "balance_tracking_disabled": false,
+    "coin_tracking_disabled": false,
+    "status_port": 9090,
+    "results_output_file": "",
+    "initial_balance_fetch_disabled": false,
+    "end_conditions": {
+      "tip": true,
+      "reconciliation_coverage": {
+        "coverage": 0.95,
+        "tip": true
+      }
+    }
+  },
+  "perf": null
+}

--- a/crates/sui-grpc-rosetta/resources/sui.ros
+++ b/crates/sui-grpc-rosetta/resources/sui.ros
@@ -1,0 +1,44 @@
+transfer(10){
+  transfer{
+    transfer.network = {"network":"{{sui.env}}", "blockchain":"sui"};
+    currency = {"symbol":"SUI", "decimals":9};
+    sender = find_balance({
+      "minimum_balance":{
+        "value": "100000",
+        "currency": {{currency}}
+      }
+    });
+    recipient_amount = random_number({"minimum": "1", "maximum": "100000"});
+    sender_amount = 0 - {{recipient_amount}};
+    print_message({"recipient_amount":{{recipient_amount}}});
+
+    // Find recipient and construct operations
+    recipient = find_balance({
+      "not_account_identifier":[{{sender.account_identifier}}],
+      "minimum_balance":{
+        "value": "0",
+        "currency": {{currency}}
+      }
+    });
+    transfer.confirmation_depth = "1";
+    transfer.operations = [
+      {
+        "operation_identifier":{"index":0},
+        "type":"PaySui",
+        "account":{{recipient.account_identifier}},
+        "amount":{
+          "value":{{recipient_amount}},
+          "currency":{{currency}}
+        }
+      },
+      {
+        "operation_identifier":{"index":1},
+        "type":"PaySui",
+        "account":{{sender.account_identifier}},
+        "amount":{
+          "value":{{sender_amount}},
+          "currency":{{currency}}
+        }
+      }];
+  }
+}

--- a/crates/sui-grpc-rosetta/src/account.rs
+++ b/crates/sui-grpc-rosetta/src/account.rs
@@ -1,0 +1,210 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//! This module implements the [Rosetta Account API](https://www.rosetta-api.org/docs/AccountApi.html)
+use axum::extract::State;
+use axum::{Extension, Json};
+use axum_extra::extract::WithRejection;
+use futures::{future::join_all, StreamExt};
+
+use sui_sdk::rpc_types::StakeStatus;
+use sui_sdk::{SuiClient, SUI_COIN_TYPE};
+use sui_types::base_types::SuiAddress;
+use tracing::info;
+
+use crate::errors::Error;
+use crate::types::{
+    AccountBalanceRequest, AccountBalanceResponse, AccountCoinsRequest, AccountCoinsResponse,
+    Amount, Coin, Currencies, Currency, SubAccountType, SubBalance,
+};
+use crate::{OnlineServerContext, SuiEnv};
+use std::time::Duration;
+use sui_sdk::error::SuiRpcResult;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+
+/// Get an array of all AccountBalances for an AccountIdentifier and the BlockIdentifier
+/// at which the balance lookup was performed.
+/// [Rosetta API Spec](https://www.rosetta-api.org/docs/AccountApi.html#accountbalance)
+pub async fn balance(
+    State(ctx): State<OnlineServerContext>,
+    Extension(env): Extension<SuiEnv>,
+    WithRejection(Json(request), _): WithRejection<Json<AccountBalanceRequest>, Error>,
+) -> Result<AccountBalanceResponse, Error> {
+    env.check_network_identifier(&request.network_identifier)?;
+    let address = request.account_identifier.address;
+    let currencies = &request.currencies;
+    let mut retry_attempts = 5;
+    while retry_attempts > 0 {
+        let balances_first = get_balances(&ctx, &request, address, currencies.clone()).await?;
+        let checkpoint1 = get_checkpoint(&ctx).await?;
+        let mut checkpoint2 = get_checkpoint(&ctx).await?;
+        while checkpoint2 <= checkpoint1 {
+            checkpoint2 = get_checkpoint(&ctx).await?;
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+        let balances_second = get_balances(&ctx, &request, address, currencies.clone()).await?;
+        if balances_first.eq(&balances_second) {
+            info!(
+                "same balance for account {} at checkpoint {}",
+                address, checkpoint2
+            );
+            return Ok(AccountBalanceResponse {
+                block_identifier: ctx.blocks().create_block_identifier(checkpoint2).await?,
+                balances: balances_first,
+            });
+        } else {
+            info!(
+                "different balance for account {} at checkpoint {}",
+                address, checkpoint2
+            );
+            retry_attempts -= 1;
+        }
+    }
+    Err(Error::RetryExhausted(String::from("retry")))
+}
+
+async fn get_checkpoint(ctx: &OnlineServerContext) -> SuiRpcResult<CheckpointSequenceNumber> {
+    ctx.client
+        .read_api()
+        .get_latest_checkpoint_sequence_number()
+        .await
+}
+
+async fn get_balances(
+    ctx: &OnlineServerContext,
+    request: &AccountBalanceRequest,
+    address: SuiAddress,
+    currencies: Currencies,
+) -> Result<Vec<Amount>, Error> {
+    if let Some(sub_account) = &request.account_identifier.sub_account {
+        let account_type = sub_account.account_type.clone();
+        get_sub_account_balances(account_type, &ctx.client, address).await
+    } else if !currencies.0.is_empty() {
+        let balance_futures = currencies.0.iter().map(|currency| {
+            let coin_type = currency.metadata.clone().coin_type.clone();
+            async move {
+                (
+                    currency.clone(),
+                    get_account_balances(ctx, address, &coin_type).await,
+                )
+            }
+        });
+        let balances: Vec<(Currency, Result<i128, Error>)> = join_all(balance_futures).await;
+        let mut amounts = Vec::new();
+        for (currency, balance_result) in balances {
+            match balance_result {
+                Ok(value) => amounts.push(Amount::new(value, Some(currency))),
+                Err(_e) => {
+                    return Err(Error::InvalidInput(format!(
+                        "{:?}",
+                        currency.metadata.coin_type
+                    )))
+                }
+            }
+        }
+        Ok(amounts)
+    } else {
+        Err(Error::InvalidInput(
+            "Coin type is required for this request".to_string(),
+        ))
+    }
+}
+
+async fn get_account_balances(
+    ctx: &OnlineServerContext,
+    address: SuiAddress,
+    coin_type: &String,
+) -> Result<i128, Error> {
+    Ok(ctx
+        .client
+        .coin_read_api()
+        .get_balance(address, Some(coin_type.to_string()))
+        .await?
+        .total_balance as i128)
+}
+
+async fn get_sub_account_balances(
+    account_type: SubAccountType,
+    client: &SuiClient,
+    address: SuiAddress,
+) -> Result<Vec<Amount>, Error> {
+    let amounts = match account_type {
+        SubAccountType::Stake => {
+            let delegations = client.governance_api().get_stakes(address).await?;
+            delegations.into_iter().fold(vec![], |mut amounts, stakes| {
+                for stake in &stakes.stakes {
+                    if let StakeStatus::Active { .. } = stake.status {
+                        amounts.push(SubBalance {
+                            stake_id: stake.staked_sui_id,
+                            validator: stakes.validator_address,
+                            value: stake.principal as i128,
+                        });
+                    }
+                }
+                amounts
+            })
+        }
+        SubAccountType::PendingStake => {
+            let delegations = client.governance_api().get_stakes(address).await?;
+            delegations.into_iter().fold(vec![], |mut amounts, stakes| {
+                for stake in &stakes.stakes {
+                    if let StakeStatus::Pending = stake.status {
+                        amounts.push(SubBalance {
+                            stake_id: stake.staked_sui_id,
+                            validator: stakes.validator_address,
+                            value: stake.principal as i128,
+                        });
+                    }
+                }
+                amounts
+            })
+        }
+
+        SubAccountType::EstimatedReward => {
+            let delegations = client.governance_api().get_stakes(address).await?;
+            delegations.into_iter().fold(vec![], |mut amounts, stakes| {
+                for stake in &stakes.stakes {
+                    if let StakeStatus::Active { estimated_reward } = stake.status {
+                        amounts.push(SubBalance {
+                            stake_id: stake.staked_sui_id,
+                            validator: stakes.validator_address,
+                            value: estimated_reward as i128,
+                        });
+                    }
+                }
+                amounts
+            })
+        }
+    };
+
+    // Make sure there are always one amount returned
+    Ok(if amounts.is_empty() {
+        vec![Amount::new(0, None)]
+    } else {
+        vec![Amount::new_from_sub_balances(amounts)]
+    })
+}
+
+/// Get an array of all unspent coins for an AccountIdentifier and the BlockIdentifier at which the lookup was performed. .
+/// [Rosetta API Spec](https://www.rosetta-api.org/docs/AccountApi.html#accountcoins)
+pub async fn coins(
+    State(context): State<OnlineServerContext>,
+    Extension(env): Extension<SuiEnv>,
+    WithRejection(Json(request), _): WithRejection<Json<AccountCoinsRequest>, Error>,
+) -> Result<AccountCoinsResponse, Error> {
+    env.check_network_identifier(&request.network_identifier)?;
+    let coins = context
+        .client
+        .coin_read_api()
+        .get_coins_stream(
+            request.account_identifier.address,
+            Some(SUI_COIN_TYPE.to_string()),
+        )
+        .map(Coin::from)
+        .collect()
+        .await;
+
+    Ok(AccountCoinsResponse {
+        block_identifier: context.blocks().current_block_identifier().await?,
+        coins,
+    })
+}

--- a/crates/sui-grpc-rosetta/src/block.rs
+++ b/crates/sui-grpc-rosetta/src/block.rs
@@ -1,0 +1,71 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use axum::extract::State;
+use axum::{Extension, Json};
+use axum_extra::extract::WithRejection;
+use tracing::debug;
+
+use crate::operations::Operations;
+use crate::types::{
+    BlockRequest, BlockResponse, BlockTransactionRequest, BlockTransactionResponse, Transaction,
+    TransactionIdentifier,
+};
+use crate::{Error, OnlineServerContext, SuiEnv};
+use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
+
+// This module implements the [Rosetta Block API](https://www.rosetta-api.org/docs/BlockApi.html)
+
+/// Get a block by its Block Identifier.
+/// [Rosetta API Spec](https://www.rosetta-api.org/docs/BlockApi.html#block)
+pub async fn block(
+    State(state): State<OnlineServerContext>,
+    Extension(env): Extension<SuiEnv>,
+    WithRejection(Json(request), _): WithRejection<Json<BlockRequest>, Error>,
+) -> Result<BlockResponse, Error> {
+    debug!("Called /block endpoint: {:?}", request.block_identifier);
+    env.check_network_identifier(&request.network_identifier)?;
+    let blocks = state.blocks();
+    if let Some(index) = request.block_identifier.index {
+        blocks.get_block_by_index(index).await
+    } else if let Some(hash) = request.block_identifier.hash {
+        blocks.get_block_by_hash(hash).await
+    } else {
+        blocks.current_block().await
+    }
+}
+
+/// Get a transaction in a block by its Transaction Identifier.
+/// [Rosetta API Spec](https://www.rosetta-api.org/docs/BlockApi.html#blocktransaction)
+pub async fn transaction(
+    State(context): State<OnlineServerContext>,
+    Extension(env): Extension<SuiEnv>,
+    WithRejection(Json(request), _): WithRejection<Json<BlockTransactionRequest>, Error>,
+) -> Result<BlockTransactionResponse, Error> {
+    env.check_network_identifier(&request.network_identifier)?;
+    let digest = request.transaction_identifier.hash;
+    let response = context
+        .client
+        .read_api()
+        .get_transaction_with_options(
+            digest,
+            SuiTransactionBlockResponseOptions::new()
+                .with_input()
+                .with_events()
+                .with_effects()
+                .with_balance_changes(),
+        )
+        .await?;
+    let hash = response.digest;
+
+    let operations = Operations::try_from_response(response, &context.coin_metadata_cache).await?;
+
+    let transaction = Transaction {
+        transaction_identifier: TransactionIdentifier { hash },
+        operations,
+        related_transactions: vec![],
+        metadata: None,
+    };
+
+    Ok(BlockTransactionResponse { transaction })
+}

--- a/crates/sui-grpc-rosetta/src/construction.rs
+++ b/crates/sui-grpc-rosetta/src/construction.rs
@@ -1,0 +1,428 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::{Extension, Json};
+use axum_extra::extract::WithRejection;
+use fastcrypto::encoding::{Encoding, Hex};
+use fastcrypto::hash::HashFunction;
+use futures::StreamExt;
+
+use shared_crypto::intent::{Intent, IntentMessage};
+use sui_json_rpc_types::{
+    StakeStatus, SuiObjectDataOptions, SuiTransactionBlockEffectsAPI,
+    SuiTransactionBlockResponseOptions,
+};
+use sui_sdk::rpc_types::SuiExecutionStatus;
+use sui_types::base_types::{ObjectRef, SuiAddress};
+use sui_types::crypto::{DefaultHash, SignatureScheme, ToFromBytes};
+use sui_types::error::SuiError;
+use sui_types::signature::{GenericSignature, VerifyParams};
+use sui_types::signature_verification::{
+    verify_sender_signed_data_message_signatures, VerifiedDigestCache,
+};
+use sui_types::transaction::{Transaction, TransactionData, TransactionDataAPI};
+
+use crate::errors::Error;
+use crate::types::{
+    Amount, ConstructionCombineRequest, ConstructionCombineResponse, ConstructionDeriveRequest,
+    ConstructionDeriveResponse, ConstructionHashRequest, ConstructionMetadata,
+    ConstructionMetadataRequest, ConstructionMetadataResponse, ConstructionParseRequest,
+    ConstructionParseResponse, ConstructionPayloadsRequest, ConstructionPayloadsResponse,
+    ConstructionPreprocessRequest, ConstructionPreprocessResponse, ConstructionSubmitRequest,
+    InternalOperation, MetadataOptions, SignatureType, SigningPayload, TransactionIdentifier,
+    TransactionIdentifierResponse,
+};
+use crate::{OnlineServerContext, SuiEnv};
+
+// This module implements the [Rosetta Construction API](https://www.rosetta-api.org/docs/ConstructionApi.html)
+
+/// Derive returns the AccountIdentifier associated with a public key.
+///
+/// [Rosetta API Spec](https://www.rosetta-api.org/docs/ConstructionApi.html#constructionderive)
+pub async fn derive(
+    Extension(env): Extension<SuiEnv>,
+    WithRejection(Json(request), _): WithRejection<Json<ConstructionDeriveRequest>, Error>,
+) -> Result<ConstructionDeriveResponse, Error> {
+    env.check_network_identifier(&request.network_identifier)?;
+    let address: SuiAddress = request.public_key.try_into()?;
+    Ok(ConstructionDeriveResponse {
+        account_identifier: address.into(),
+    })
+}
+
+/// Payloads is called with an array of operations and the response from /construction/metadata.
+/// It returns an unsigned transaction blob and a collection of payloads that must be signed by
+/// particular AccountIdentifiers using a certain SignatureType.
+///
+/// [Rosetta API Spec](https://www.rosetta-api.org/docs/ConstructionApi.html#constructionpayloads)
+pub async fn payloads(
+    Extension(env): Extension<SuiEnv>,
+    WithRejection(Json(request), _): WithRejection<Json<ConstructionPayloadsRequest>, Error>,
+) -> Result<ConstructionPayloadsResponse, Error> {
+    env.check_network_identifier(&request.network_identifier)?;
+    let metadata = request.metadata.ok_or(Error::MissingMetadata)?;
+    let address = metadata.sender;
+
+    let data = request
+        .operations
+        .into_internal()?
+        .try_into_data(metadata)?;
+    let intent_msg = IntentMessage::new(Intent::sui_transaction(), data);
+    let intent_msg_bytes = bcs::to_bytes(&intent_msg)?;
+
+    let mut hasher = DefaultHash::default();
+    hasher.update(bcs::to_bytes(&intent_msg).expect("Message serialization should not fail"));
+    let digest = hasher.finalize().digest;
+
+    Ok(ConstructionPayloadsResponse {
+        unsigned_transaction: Hex::from_bytes(&intent_msg_bytes),
+        payloads: vec![SigningPayload {
+            account_identifier: address.into(),
+            hex_bytes: Hex::encode(digest),
+            signature_type: Some(SignatureType::Ed25519),
+        }],
+    })
+}
+
+/// Combine creates a network-specific transaction from an unsigned transaction
+/// and an array of provided signatures.
+///
+/// [Rosetta API Spec](https://www.rosetta-api.org/docs/ConstructionApi.html#constructioncombine)
+pub async fn combine(
+    Extension(env): Extension<SuiEnv>,
+    WithRejection(Json(request), _): WithRejection<Json<ConstructionCombineRequest>, Error>,
+) -> Result<ConstructionCombineResponse, Error> {
+    env.check_network_identifier(&request.network_identifier)?;
+    let unsigned_tx = request.unsigned_transaction.to_vec()?;
+    let intent_msg: IntentMessage<TransactionData> = bcs::from_bytes(&unsigned_tx)?;
+    let sig = request
+        .signatures
+        .first()
+        .ok_or_else(|| Error::MissingInput("Signature".to_string()))?;
+    let sig_bytes = sig.hex_bytes.to_vec()?;
+    let pub_key = sig.public_key.hex_bytes.to_vec()?;
+    let flag = vec![match sig.signature_type {
+        SignatureType::Ed25519 => SignatureScheme::ED25519,
+        SignatureType::Ecdsa => SignatureScheme::Secp256k1,
+    }
+    .flag()];
+
+    let signed_tx = Transaction::from_generic_sig_data(
+        intent_msg.value,
+        vec![GenericSignature::from_bytes(
+            &[&*flag, &*sig_bytes, &*pub_key].concat(),
+        )?],
+    );
+    // TODO: this will likely fail with zklogin authenticator, since we do not know the current epoch.
+    // As long as coinbase doesn't need to use zklogin for custodial wallets this is okay.
+    let place_holder_epoch = 0;
+    verify_sender_signed_data_message_signatures(
+        &signed_tx,
+        place_holder_epoch,
+        &VerifyParams::default(),
+        Arc::new(VerifiedDigestCache::new_empty()), // no need to use cache in rosetta
+        None,
+    )?;
+    let signed_tx_bytes = bcs::to_bytes(&signed_tx)?;
+
+    Ok(ConstructionCombineResponse {
+        signed_transaction: Hex::from_bytes(&signed_tx_bytes),
+    })
+}
+
+/// Submit a pre-signed transaction to the node.
+///
+/// [Rosetta API Spec](https://www.rosetta-api.org/docs/ConstructionApi.html#constructionsubmit)
+pub async fn submit(
+    State(context): State<OnlineServerContext>,
+    Extension(env): Extension<SuiEnv>,
+    WithRejection(Json(request), _): WithRejection<Json<ConstructionSubmitRequest>, Error>,
+) -> Result<TransactionIdentifierResponse, Error> {
+    env.check_network_identifier(&request.network_identifier)?;
+    let signed_tx: Transaction = bcs::from_bytes(&request.signed_transaction.to_vec()?)?;
+
+    // According to RosettaClient.rosseta_flow() (see tests), this transaction has already passed
+    // through a dry_run with a possibly invalid budget (metadata endpoint), but the requirements
+    // are that it should pass from there and fail here.
+    let tx_data = signed_tx.data().transaction_data().clone();
+    let dry_run = context
+        .client
+        .read_api()
+        .dry_run_transaction_block(tx_data)
+        .await?;
+    if let SuiExecutionStatus::Failure { error } = dry_run.effects.status() {
+        return Err(Error::TransactionDryRunError(error.clone()));
+    };
+
+    let response = context
+        .client
+        .quorum_driver_api()
+        .execute_transaction_block(
+            signed_tx,
+            SuiTransactionBlockResponseOptions::new()
+                .with_input()
+                .with_effects()
+                .with_balance_changes(),
+            None,
+        )
+        .await?;
+
+    if let SuiExecutionStatus::Failure { error } = response
+        .effects
+        .expect("Execute transaction should return effects")
+        .status()
+    {
+        return Err(Error::TransactionExecutionError(error.to_string()));
+    }
+
+    Ok(TransactionIdentifierResponse {
+        transaction_identifier: TransactionIdentifier {
+            hash: response.digest,
+        },
+        metadata: None,
+    })
+}
+
+/// Preprocess is called prior to /construction/payloads to construct a request for any metadata
+/// that is needed for transaction construction given (i.e. account nonce).
+///
+/// [Rosetta API Spec](https://www.rosetta-api.org/docs/ConstructionApi.html#constructionpreprocess)
+pub async fn preprocess(
+    Extension(env): Extension<SuiEnv>,
+    WithRejection(Json(request), _): WithRejection<Json<ConstructionPreprocessRequest>, Error>,
+) -> Result<ConstructionPreprocessResponse, Error> {
+    env.check_network_identifier(&request.network_identifier)?;
+
+    let internal_operation = request.operations.into_internal()?;
+    let sender = internal_operation.sender();
+    let budget = request.metadata.and_then(|m| m.budget);
+    Ok(ConstructionPreprocessResponse {
+        options: Some(MetadataOptions {
+            internal_operation,
+            budget,
+        }),
+        required_public_keys: vec![sender.into()],
+    })
+}
+
+/// TransactionHash returns the network-specific transaction hash for a signed transaction.
+///
+/// [Rosetta API Spec](https://www.rosetta-api.org/docs/ConstructionApi.html#constructionhash)
+pub async fn hash(
+    Extension(env): Extension<SuiEnv>,
+    WithRejection(Json(request), _): WithRejection<Json<ConstructionHashRequest>, Error>,
+) -> Result<TransactionIdentifierResponse, Error> {
+    env.check_network_identifier(&request.network_identifier)?;
+    let tx_bytes = request.signed_transaction.to_vec()?;
+    let tx: Transaction = bcs::from_bytes(&tx_bytes)?;
+
+    Ok(TransactionIdentifierResponse {
+        transaction_identifier: TransactionIdentifier { hash: *tx.digest() },
+        metadata: None,
+    })
+}
+
+/// Get any information required to construct a transaction for a specific network.
+/// For Sui, we are returning the latest object refs for all the input objects,
+/// which will be used in transaction construction.
+///
+/// [Rosetta API Spec](https://www.rosetta-api.org/docs/ConstructionApi.html#constructionmetadata)
+pub async fn metadata(
+    State(context): State<OnlineServerContext>,
+    Extension(env): Extension<SuiEnv>,
+    WithRejection(Json(request), _): WithRejection<Json<ConstructionMetadataRequest>, Error>,
+) -> Result<ConstructionMetadataResponse, Error> {
+    env.check_network_identifier(&request.network_identifier)?;
+    let option = request.options.ok_or(Error::MissingMetadata)?;
+    let budget = option.budget;
+    let sender = option.internal_operation.sender();
+    let currency = match &option.internal_operation {
+        InternalOperation::PayCoin { currency, .. } => Some(currency.clone()),
+        _ => None,
+    };
+    let coin_type = currency.as_ref().map(|c| c.metadata.coin_type.clone());
+
+    let mut gas_price = context
+        .client
+        .governance_api()
+        .get_reference_gas_price()
+        .await?;
+    // make sure it works over epoch changes
+    gas_price += 100;
+
+    // Get amount, objects, for the operation
+    let (total_required_amount, objects) = match &option.internal_operation {
+        InternalOperation::PaySui { amounts, .. } => {
+            let amount = amounts.iter().sum::<u64>();
+            (Some(amount), vec![])
+        }
+        InternalOperation::PayCoin { amounts, .. } => {
+            let amount = amounts.iter().sum::<u64>();
+            let coin_objs: Vec<ObjectRef> = context
+                .client
+                .coin_read_api()
+                .select_coins(sender, coin_type, amount.into(), vec![])
+                .await
+                .ok()
+                .unwrap_or_default()
+                .iter()
+                .map(|coin| coin.object_ref())
+                .collect();
+            (Some(0), coin_objs) // amount is 0 for gas coin
+        }
+        InternalOperation::Stake { amount, .. } => (*amount, vec![]),
+        InternalOperation::WithdrawStake { sender, stake_ids } => {
+            let stake_ids = if stake_ids.is_empty() {
+                // unstake all
+                context
+                    .client
+                    .governance_api()
+                    .get_stakes(*sender)
+                    .await?
+                    .into_iter()
+                    .flat_map(|s| {
+                        s.stakes.into_iter().filter_map(|s| {
+                            if let StakeStatus::Active { .. } = s.status {
+                                Some(s.staked_sui_id)
+                            } else {
+                                None
+                            }
+                        })
+                    })
+                    .collect()
+            } else {
+                stake_ids.clone()
+            };
+
+            if stake_ids.is_empty() {
+                return Err(Error::InvalidInput("No active stake to withdraw".into()));
+            }
+
+            let responses = context
+                .client
+                .read_api()
+                .multi_get_object_with_options(stake_ids, SuiObjectDataOptions::default())
+                .await?;
+            let stake_refs = responses
+                .into_iter()
+                .map(|stake| stake.into_object().map(|o| o.object_ref()))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(SuiError::from)?;
+
+            (Some(0), stake_refs)
+        }
+    };
+
+    // Get budget for suggested_fee and metadata.budget
+    let budget = match budget {
+        Some(budget) => budget,
+        None => {
+            // Dry run the transaction to get the gas used, amount doesn't really matter here when using mock coins.
+            // get gas estimation from dry-run, this will also return any tx error.
+            let data = option
+                .internal_operation
+                .try_into_data(ConstructionMetadata {
+                    sender,
+                    coins: vec![],
+                    objects: objects.clone(),
+                    // Mock coin have 1B SUI
+                    total_coin_value: 1_000_000_000 * 1_000_000_000,
+                    gas_price,
+                    // MAX BUDGET
+                    budget: 50_000_000_000,
+                    currency: currency.clone(),
+                })?;
+
+            let dry_run = context
+                .client
+                .read_api()
+                .dry_run_transaction_block(data)
+                .await?;
+            let effects = dry_run.effects;
+
+            if let SuiExecutionStatus::Failure { error } = effects.status() {
+                return Err(Error::TransactionDryRunError(error.to_string()));
+            }
+            effects.gas_cost_summary().computation_cost + effects.gas_cost_summary().storage_cost
+        }
+    };
+
+    // Try select gas coins for required amounts
+    let coins = if let Some(amount) = total_required_amount {
+        let total_amount = amount + budget;
+        context
+            .client
+            .coin_read_api()
+            .select_coins(sender, None, total_amount.into(), vec![])
+            .await
+            .ok()
+    } else {
+        None
+    };
+
+    // If required amount is None (all SUI) or failed to select coin (might not have enough SUI), select all coins.
+    let coins = if let Some(coins) = coins {
+        coins
+    } else {
+        context
+            .client
+            .coin_read_api()
+            .get_coins_stream(sender, None)
+            .collect::<Vec<_>>()
+            .await
+    };
+
+    let total_coin_value = coins.iter().fold(0, |sum, coin| sum + coin.balance);
+
+    let coins = coins
+        .into_iter()
+        .map(|c| c.object_ref())
+        .collect::<Vec<_>>();
+
+    Ok(ConstructionMetadataResponse {
+        metadata: ConstructionMetadata {
+            sender,
+            coins,
+            objects,
+            total_coin_value: total_coin_value.into(),
+            gas_price,
+            budget,
+            currency,
+        },
+        suggested_fee: vec![Amount::new(budget as i128, None)],
+    })
+}
+
+///  This is run as a sanity check before signing (after /construction/payloads)
+/// and before broadcast (after /construction/combine).
+///
+/// [Rosetta API Spec](https://www.rosetta-api.org/docs/ConstructionApi.html#constructionparse)
+pub async fn parse(
+    Extension(env): Extension<SuiEnv>,
+    WithRejection(Json(request), _): WithRejection<Json<ConstructionParseRequest>, Error>,
+) -> Result<ConstructionParseResponse, Error> {
+    env.check_network_identifier(&request.network_identifier)?;
+
+    let data = if request.signed {
+        let tx: Transaction = bcs::from_bytes(&request.transaction.to_vec()?)?;
+        tx.into_data().intent_message().value.clone()
+    } else {
+        let intent: IntentMessage<TransactionData> =
+            bcs::from_bytes(&request.transaction.to_vec()?)?;
+        intent.value
+    };
+    let account_identifier_signers = if request.signed {
+        vec![data.sender().into()]
+    } else {
+        vec![]
+    };
+    let operations = data.try_into()?;
+    Ok(ConstructionParseResponse {
+        operations,
+        account_identifier_signers,
+        metadata: None,
+    })
+}

--- a/crates/sui-grpc-rosetta/src/errors.rs
+++ b/crates/sui-grpc-rosetta/src/errors.rs
@@ -1,0 +1,142 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use axum::extract::rejection::JsonRejection;
+use std::fmt::Debug;
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use fastcrypto::error::FastCryptoError;
+use serde::Serialize;
+use serde::Serializer;
+use serde_json::{json, Value};
+use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
+
+use sui_types::error::SuiError;
+
+use crate::types::{BlockHash, OperationType, PublicKey, SuiEnv};
+use strum::EnumProperty;
+use strum_macros::Display;
+use strum_macros::EnumDiscriminants;
+use thiserror::Error;
+use typed_store::TypedStoreError;
+
+/// Sui-Rosetta specific error types.
+/// This contains all the errors returns by the sui-grpc-rosetta server.
+#[derive(Debug, Error, EnumDiscriminants, EnumProperty)]
+#[strum_discriminants(
+    name(ErrorType),
+    derive(Display, EnumIter),
+    strum(serialize_all = "kebab-case")
+)]
+#[allow(clippy::enum_variant_names)]
+pub enum Error {
+    #[error("Unsupported blockchain: {0}")]
+    UnsupportedBlockchain(String),
+    #[error("Unsupported network: {0:?}")]
+    UnsupportedNetwork(SuiEnv),
+    #[error("Invalid input: {0}")]
+    InvalidInput(String),
+    #[error("Missing input: {0}")]
+    MissingInput(String),
+    #[error("Missing metadata")]
+    MissingMetadata,
+    #[error("{0}")]
+    MalformedOperationError(String),
+    #[error("Unsupported operation: {0:?}")]
+    UnsupportedOperation(OperationType),
+    #[error("Data error: {0}")]
+    DataError(String),
+    #[error("Block not found, index: {index:?}, hash: {hash:?}")]
+    BlockNotFound {
+        index: Option<u64>,
+        hash: Option<BlockHash>,
+    },
+    #[error("Public key deserialization error: {0:?}")]
+    PublicKeyDeserializationError(PublicKey),
+
+    #[error("Error executing transaction: {0}")]
+    TransactionExecutionError(String),
+
+    #[error("{0}")]
+    TransactionDryRunError(String),
+
+    #[error(transparent)]
+    InternalError(#[from] anyhow::Error),
+    #[error(transparent)]
+    BCSSerializationError(#[from] bcs::Error),
+    #[error(transparent)]
+    CryptoError(#[from] FastCryptoError),
+    #[error(transparent)]
+    SuiError(#[from] SuiError),
+    #[error(transparent)]
+    SuiRpcError(#[from] sui_sdk::error::Error),
+    #[error(transparent)]
+    EncodingError(#[from] eyre::Report),
+    #[error(transparent)]
+    DBError(#[from] TypedStoreError),
+    #[error(transparent)]
+    JsonExtractorRejection(#[from] JsonRejection),
+
+    #[error("Retries exhausted while getting balance. try again.")]
+    #[strum(props(retriable = "true"))]
+    RetryExhausted(String),
+}
+
+impl Serialize for ErrorType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.json().serialize(serializer)
+    }
+}
+
+trait CustomProperties {
+    fn retriable(&self) -> bool;
+}
+
+impl CustomProperties for Error {
+    fn retriable(&self) -> bool {
+        matches!(self.get_str("retriable"), Some("true"))
+    }
+}
+
+impl ErrorType {
+    fn json(&self) -> Value {
+        let retriable = false;
+        // Safe to unwrap
+        let error_code = ErrorType::iter().position(|e| &e == self).unwrap();
+        let message = format!("{self}").replace('-', " ");
+        let message = message[0..1].to_uppercase() + &message[1..];
+
+        json![{
+            "code": error_code,
+            "message": message,
+            "retriable": retriable,
+        }]
+    }
+}
+
+impl Serialize for Error {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let type_: ErrorType = self.into();
+        let mut json = type_.json();
+        // Safe to unwrap, we know ErrorType must be an object.
+        let error = json.as_object_mut().unwrap();
+        error.insert("details".into(), json!({ "error": format!("{self}") }));
+        error.insert("retriable".into(), json!(self.retriable()));
+        error.serialize(serializer)
+    }
+}
+
+impl IntoResponse for Error {
+    fn into_response(self) -> Response {
+        (StatusCode::INTERNAL_SERVER_ERROR, Json(self)).into_response()
+    }
+}

--- a/crates/sui-grpc-rosetta/src/lib.rs
+++ b/crates/sui-grpc-rosetta/src/lib.rs
@@ -1,0 +1,155 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::net::SocketAddr;
+use std::num::NonZeroUsize;
+use std::string::ToString;
+use std::sync::Arc;
+
+use axum::routing::post;
+use axum::{Extension, Router};
+use lru::LruCache;
+use move_core_types::language_storage::TypeTag;
+use once_cell::sync::Lazy;
+use tokio::sync::Mutex;
+use tracing::info;
+
+use sui_sdk::{SuiClient, SUI_COIN_TYPE};
+
+use crate::errors::Error;
+use crate::errors::Error::MissingMetadata;
+use crate::state::{CheckpointBlockProvider, OnlineServerContext};
+use crate::types::{Currency, CurrencyMetadata, SuiEnv};
+
+#[cfg(test)]
+#[path = "unit_tests/lib_tests.rs"]
+mod lib_tests;
+
+/// This lib implements the Rosetta online and offline server defined by the [Rosetta API Spec](https://www.rosetta-api.org/docs/Reference.html)
+mod account;
+mod block;
+mod construction;
+mod errors;
+mod network;
+pub mod operations;
+mod state;
+pub mod types;
+
+pub static SUI: Lazy<Currency> = Lazy::new(|| Currency {
+    symbol: "SUI".to_string(),
+    decimals: 9,
+    metadata: CurrencyMetadata {
+        coin_type: SUI_COIN_TYPE.to_string(),
+    },
+});
+
+pub struct RosettaOnlineServer {
+    env: SuiEnv,
+    context: OnlineServerContext,
+}
+
+impl RosettaOnlineServer {
+    pub fn new(env: SuiEnv, client: SuiClient) -> Self {
+        let coin_cache = CoinMetadataCache::new(client.clone(), NonZeroUsize::new(1000).unwrap());
+        let blocks = Arc::new(CheckpointBlockProvider::new(
+            client.clone(),
+            coin_cache.clone(),
+        ));
+        Self {
+            env,
+            context: OnlineServerContext::new(client, blocks, coin_cache),
+        }
+    }
+
+    pub async fn serve(self, addr: SocketAddr) {
+        // Online endpoints
+        let app = Router::new()
+            .route("/account/balance", post(account::balance))
+            .route("/account/coins", post(account::coins))
+            .route("/block", post(block::block))
+            .route("/block/transaction", post(block::transaction))
+            .route("/construction/submit", post(construction::submit))
+            .route("/construction/metadata", post(construction::metadata))
+            .route("/network/status", post(network::status))
+            .route("/network/list", post(network::list))
+            .route("/network/options", post(network::options))
+            .layer(Extension(self.env))
+            .with_state(self.context);
+
+        let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
+
+        info!(
+            "Sui Rosetta online server listening on {}",
+            listener.local_addr().unwrap()
+        );
+        axum::serve(listener, app).await.unwrap();
+    }
+}
+
+pub struct RosettaOfflineServer {
+    env: SuiEnv,
+}
+
+impl RosettaOfflineServer {
+    pub fn new(env: SuiEnv) -> Self {
+        Self { env }
+    }
+
+    pub async fn serve(self, addr: SocketAddr) {
+        // Online endpoints
+        let app = Router::new()
+            .route("/construction/derive", post(construction::derive))
+            .route("/construction/payloads", post(construction::payloads))
+            .route("/construction/combine", post(construction::combine))
+            .route("/construction/preprocess", post(construction::preprocess))
+            .route("/construction/hash", post(construction::hash))
+            .route("/construction/parse", post(construction::parse))
+            .route("/network/list", post(network::list))
+            .route("/network/options", post(network::options))
+            .layer(Extension(self.env));
+        let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
+
+        info!(
+            "Sui Rosetta offline server listening on {}",
+            listener.local_addr().unwrap()
+        );
+        axum::serve(listener, app).await.unwrap();
+    }
+}
+
+#[derive(Clone)]
+pub struct CoinMetadataCache {
+    client: SuiClient,
+    metadata: Arc<Mutex<LruCache<TypeTag, Currency>>>,
+}
+
+impl CoinMetadataCache {
+    pub fn new(client: SuiClient, size: NonZeroUsize) -> Self {
+        Self {
+            client,
+            metadata: Arc::new(Mutex::new(LruCache::new(size))),
+        }
+    }
+
+    pub async fn get_currency(&self, type_tag: &TypeTag) -> Result<Currency, Error> {
+        let mut cache = self.metadata.lock().await;
+        if !cache.contains(type_tag) {
+            let metadata = self
+                .client
+                .coin_read_api()
+                .get_coin_metadata(type_tag.to_string())
+                .await?
+                .ok_or(MissingMetadata)?;
+
+            let ccy = Currency {
+                symbol: metadata.symbol,
+                decimals: metadata.decimals as u64,
+                metadata: CurrencyMetadata {
+                    coin_type: type_tag.to_string(),
+                },
+            };
+            cache.push(type_tag.clone(), ccy);
+        }
+        cache.get(type_tag).cloned().ok_or(MissingMetadata)
+    }
+}

--- a/crates/sui-grpc-rosetta/src/main.rs
+++ b/crates/sui-grpc-rosetta/src/main.rs
@@ -1,0 +1,299 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::fs::File;
+use std::io::BufReader;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::anyhow;
+use clap::Parser;
+use fastcrypto::encoding::{Encoding, Hex};
+use fastcrypto::traits::EncodeDecodeBase64;
+use serde_json::{json, Value};
+use sui_config::{sui_config_dir, Config, NodeConfig, SUI_FULLNODE_CONFIG, SUI_KEYSTORE_FILENAME};
+use sui_grpc_rosetta::types::{CurveType, PrefundedAccount, SuiEnv};
+use sui_grpc_rosetta::{RosettaOfflineServer, RosettaOnlineServer, SUI};
+use sui_node::SuiNode;
+use sui_sdk::{SuiClient, SuiClientBuilder};
+use sui_types::base_types::SuiAddress;
+use sui_types::crypto::{KeypairTraits, SuiKeyPair, ToFromBytes};
+use tracing::info;
+use tracing::log::warn;
+
+#[derive(Parser)]
+#[clap(name = "sui-grpc-rosetta", rename_all = "kebab-case", author, version)]
+pub enum RosettaServerCommand {
+    GenerateRosettaCLIConfig {
+        #[clap(long)]
+        keystore_path: Option<PathBuf>,
+        #[clap(long, default_value = "localnet")]
+        env: SuiEnv,
+        #[clap(long, default_value = "http://rosetta-online:9002")]
+        online_url: String,
+        #[clap(long, default_value = "http://rosetta-offline:9003")]
+        offline_url: String,
+    },
+    StartOnlineRemoteServer {
+        #[clap(long, default_value = "localnet")]
+        env: SuiEnv,
+        #[clap(long, default_value = "0.0.0.0:9002")]
+        addr: SocketAddr,
+        #[clap(long)]
+        full_node_url: String,
+        #[clap(long, default_value = "/data")]
+        data_path: PathBuf,
+    },
+    StartOnlineServer {
+        #[clap(long, default_value = "localnet")]
+        env: SuiEnv,
+        #[clap(long, default_value = "0.0.0.0:9002")]
+        addr: SocketAddr,
+        #[clap(long)]
+        node_config: Option<PathBuf>,
+        #[clap(long, default_value = "/data")]
+        data_path: PathBuf,
+    },
+    StartOfflineServer {
+        #[clap(long, default_value = "localnet")]
+        env: SuiEnv,
+        #[clap(long, default_value = "0.0.0.0:9003")]
+        addr: SocketAddr,
+    },
+}
+
+impl RosettaServerCommand {
+    async fn execute(self) -> Result<(), anyhow::Error> {
+        match self {
+            RosettaServerCommand::GenerateRosettaCLIConfig {
+                keystore_path,
+                env,
+                online_url,
+                offline_url,
+            } => {
+                let path = keystore_path
+                    .unwrap_or_else(|| sui_config_dir().unwrap().join(SUI_KEYSTORE_FILENAME));
+
+                let prefunded_accounts = read_prefunded_account(&path)?;
+
+                info!(
+                    "Retrieved {} Sui address from keystore file {:?}",
+                    prefunded_accounts.len(),
+                    &path
+                );
+
+                let mut config: Value =
+                    serde_json::from_str(include_str!("../resources/rosetta_cli.json"))?;
+
+                config
+                    .as_object_mut()
+                    .unwrap()
+                    .insert("online_url".into(), json!(online_url));
+
+                // Set network.
+                let network = config.pointer_mut("/network").ok_or_else(|| {
+                    anyhow!("Cannot find construction config in default config file.")
+                })?;
+                network
+                    .as_object_mut()
+                    .unwrap()
+                    .insert("network".into(), json!(env));
+
+                // Add prefunded accounts.
+                let construction = config.pointer_mut("/construction").ok_or_else(|| {
+                    anyhow!("Cannot find construction config in default config file.")
+                })?;
+
+                let construction = construction.as_object_mut().unwrap();
+                construction.insert("prefunded_accounts".into(), json!(prefunded_accounts));
+                construction.insert("offline_url".into(), json!(offline_url));
+
+                let config_path = PathBuf::from(".").join("rosetta_cli.json");
+                fs::write(&config_path, serde_json::to_string_pretty(&config)?)?;
+                info!(
+                    "Rosetta CLI configuration file is stored in {:?}",
+                    config_path
+                );
+
+                let dsl_path = PathBuf::from(".").join("sui.ros");
+                let dsl = include_str!("../resources/sui.ros");
+                fs::write(
+                    &dsl_path,
+                    dsl.replace("{{sui.env}}", json!(env).as_str().unwrap()),
+                )?;
+                info!("Rosetta DSL file is stored in {:?}", dsl_path);
+            }
+            RosettaServerCommand::StartOfflineServer { env, addr } => {
+                info!("Starting Rosetta Offline Server.");
+                let server = RosettaOfflineServer::new(env);
+                server.serve(addr).await;
+            }
+            RosettaServerCommand::StartOnlineRemoteServer {
+                env,
+                addr,
+                full_node_url,
+                data_path,
+            } => {
+                info!(
+                    "Starting Rosetta Online Server with remove Sui full node [{full_node_url}]."
+                );
+                let sui_client = wait_for_sui_client(full_node_url).await;
+                let rosetta_path = data_path.join("rosetta_db");
+                info!("Rosetta db path : {rosetta_path:?}");
+                let rosetta = RosettaOnlineServer::new(env, sui_client);
+                rosetta.serve(addr).await;
+            }
+
+            RosettaServerCommand::StartOnlineServer {
+                env,
+                addr,
+                node_config,
+                data_path,
+            } => {
+                info!("Starting Rosetta Online Server with embedded Sui full node.");
+                info!("Data directory path: {data_path:?}");
+
+                let node_config = node_config.unwrap_or_else(|| {
+                    let path = sui_config_dir().unwrap().join(SUI_FULLNODE_CONFIG);
+                    info!("Using default node config from {path:?}");
+                    path
+                });
+
+                let mut config = NodeConfig::load(&node_config)?;
+                config.db_path = data_path.join("sui_db");
+                info!("Overriding Sui db path to : {:?}", config.db_path);
+
+                let registry_service =
+                    mysten_metrics::start_prometheus_server(config.metrics_address);
+                // Staring a full node for the rosetta server.
+                let rpc_address = format!("http://127.0.0.1:{}", config.json_rpc_address.port());
+                let _node = SuiNode::start(config, registry_service).await?;
+
+                let sui_client = wait_for_sui_client(rpc_address).await;
+
+                let rosetta_path = data_path.join("rosetta_db");
+                info!("Rosetta db path : {rosetta_path:?}");
+                let rosetta = RosettaOnlineServer::new(env, sui_client);
+                rosetta.serve(addr).await;
+            }
+        };
+        Ok(())
+    }
+}
+
+async fn wait_for_sui_client(rpc_address: String) -> SuiClient {
+    loop {
+        match SuiClientBuilder::default().build(&rpc_address).await {
+            Ok(client) => return client,
+            Err(e) => {
+                warn!("Error connecting to Sui RPC server [{rpc_address}]: {e}, retrying in 5 seconds.");
+                tokio::time::sleep(Duration::from_millis(5000)).await;
+            }
+        }
+    }
+}
+
+/// This method reads the keypairs from the Sui keystore to create the PrefundedAccount objects,
+/// PrefundedAccount will be written to the rosetta-cli config file for testing.
+///
+fn read_prefunded_account(path: &Path) -> Result<Vec<PrefundedAccount>, anyhow::Error> {
+    let reader = BufReader::new(File::open(path).unwrap());
+    let kp_strings: Vec<String> = serde_json::from_reader(reader).unwrap();
+    let keys = kp_strings
+        .iter()
+        .map(|kpstr| {
+            let key = SuiKeyPair::decode_base64(kpstr);
+            key.map(|k| (SuiAddress::from(&k.public()), k))
+        })
+        .collect::<Result<BTreeMap<_, _>, _>>()
+        .unwrap();
+
+    Ok(keys
+        .into_iter()
+        .map(|(address, key)| {
+            let (privkey, curve_type) = match key {
+                SuiKeyPair::Ed25519(k) => {
+                    (Hex::encode(k.private().as_bytes()), CurveType::Edwards25519)
+                }
+                SuiKeyPair::Secp256k1(k) => {
+                    (Hex::encode(k.private().as_bytes()), CurveType::Secp256k1)
+                }
+                SuiKeyPair::Secp256r1(k) => {
+                    (Hex::encode(k.private().as_bytes()), CurveType::Secp256r1)
+                }
+            };
+            PrefundedAccount {
+                privkey,
+                account_identifier: address.into(),
+                curve_type,
+                currency: SUI.clone(),
+            }
+        })
+        .collect())
+}
+
+#[tokio::test]
+async fn test_read_keystore() {
+    use sui_keys::keystore::{
+        AccountKeystore, FileBasedKeystore, GenerateOptions, Keystore, LocalGenerate,
+    };
+    use sui_types::crypto::SignatureScheme;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let path = temp_dir.path().join("sui.keystore");
+    let mut ks = Keystore::from(FileBasedKeystore::load_or_create(&path).unwrap());
+    let key1 = ks
+        .generate(
+            None,
+            GenerateOptions::Local(LocalGenerate {
+                key_scheme: SignatureScheme::ED25519,
+                derivation_path: None,
+                word_length: None,
+            }),
+        )
+        .await
+        .unwrap();
+    let key2 = ks
+        .generate(
+            None,
+            GenerateOptions::Local(LocalGenerate {
+                key_scheme: SignatureScheme::Secp256k1,
+                derivation_path: None,
+                word_length: None,
+            }),
+        )
+        .await
+        .unwrap();
+
+    let accounts = read_prefunded_account(&path).unwrap();
+    let acc_map = accounts
+        .into_iter()
+        .map(|acc| (acc.account_identifier.address, acc))
+        .collect::<BTreeMap<_, _>>();
+
+    assert_eq!(2, acc_map.len());
+    assert!(acc_map.contains_key(&key1.address));
+    assert!(acc_map.contains_key(&key2.address));
+
+    let acc1 = acc_map[&key1.address].clone();
+    let acc2 = acc_map[&key2.address].clone();
+
+    let schema1: SignatureScheme = acc1.curve_type.into();
+    let schema2: SignatureScheme = acc2.curve_type.into();
+    assert!(matches!(schema1, SignatureScheme::ED25519));
+    assert!(matches!(schema2, SignatureScheme::Secp256k1));
+}
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    let cmd: RosettaServerCommand = RosettaServerCommand::parse();
+
+    let (_guard, _) = telemetry_subscribers::TelemetryConfig::new()
+        .with_env()
+        .init();
+
+    cmd.execute().await
+}

--- a/crates/sui-grpc-rosetta/src/network.rs
+++ b/crates/sui-grpc-rosetta/src/network.rs
@@ -1,0 +1,120 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use axum::extract::State;
+use axum::{Extension, Json};
+use axum_extra::extract::WithRejection;
+use serde_json::json;
+use strum::IntoEnumIterator;
+
+use fastcrypto::encoding::Hex;
+use sui_types::base_types::ObjectID;
+
+use crate::errors::{Error, ErrorType};
+use crate::types::{
+    Allow, Case, NetworkIdentifier, NetworkListResponse, NetworkOptionsResponse, NetworkRequest,
+    NetworkStatusResponse, OperationStatus, OperationType, Peer, SyncStatus, Version,
+};
+use crate::{OnlineServerContext, SuiEnv};
+
+// This module implements the [Rosetta Network API](https://www.rosetta-api.org/docs/NetworkApi.html)
+
+/// This endpoint returns a list of NetworkIdentifiers that the Rosetta server supports.
+///
+/// [Rosetta API Spec](https://www.rosetta-api.org/docs/NetworkApi.html#networklist)
+pub async fn list(Extension(env): Extension<SuiEnv>) -> Result<NetworkListResponse, Error> {
+    Ok(NetworkListResponse {
+        network_identifiers: vec![NetworkIdentifier {
+            blockchain: "sui".to_string(),
+            network: env,
+        }],
+    })
+}
+
+/// This endpoint returns the current status of the network requested.
+///
+/// [Rosetta API Spec](https://www.rosetta-api.org/docs/NetworkApi.html#networkstatus)
+pub async fn status(
+    State(context): State<OnlineServerContext>,
+    Extension(env): Extension<SuiEnv>,
+    WithRejection(Json(request), _): WithRejection<Json<NetworkRequest>, Error>,
+) -> Result<NetworkStatusResponse, Error> {
+    env.check_network_identifier(&request.network_identifier)?;
+
+    let system_state = context
+        .client
+        .governance_api()
+        .get_latest_sui_system_state()
+        .await?;
+
+    let peers = system_state
+        .active_validators
+        .iter()
+        .map(|validator| Peer {
+            peer_id: ObjectID::from(validator.sui_address).into(),
+            metadata: Some(json!({
+                "public_key": Hex::from_bytes(&validator.protocol_pubkey_bytes),
+                "stake_amount": validator.staking_pool_sui_balance,
+            })),
+        })
+        .collect();
+    let blocks = context.blocks();
+    let current_block = blocks.current_block().await?;
+    let index = current_block.block.block_identifier.index;
+    let target = context
+        .client
+        .read_api()
+        .get_latest_checkpoint_sequence_number()
+        .await?;
+
+    Ok(NetworkStatusResponse {
+        current_block_identifier: current_block.block.block_identifier,
+        current_block_timestamp: current_block.block.timestamp,
+        genesis_block_identifier: blocks.genesis_block_identifier().await?,
+        oldest_block_identifier: Some(blocks.oldest_block_identifier().await?),
+        sync_status: Some(SyncStatus {
+            current_index: Some(index),
+            target_index: Some(target),
+            stage: None,
+            synced: Some(index == target),
+        }),
+        peers,
+    })
+}
+
+/// This endpoint returns the version information and allowed network-specific types for a NetworkIdentifier.
+///
+/// [Rosetta API Spec](https://www.rosetta-api.org/docs/NetworkApi.html#networkoptions)
+pub async fn options(
+    Extension(env): Extension<SuiEnv>,
+    WithRejection(Json(request), _): WithRejection<Json<NetworkRequest>, Error>,
+) -> Result<NetworkOptionsResponse, Error> {
+    env.check_network_identifier(&request.network_identifier)?;
+
+    let errors = ErrorType::iter().collect();
+    let operation_statuses = vec![
+        json!({"status": OperationStatus::Success, "successful" : true}),
+        json!({"status": OperationStatus::Failure, "successful" : false}),
+    ];
+
+    Ok(NetworkOptionsResponse {
+        version: Version {
+            rosetta_version: "1.4.14".to_string(),
+            node_version: env!("CARGO_PKG_VERSION").to_owned(),
+            middleware_version: None,
+            metadata: None,
+        },
+        allow: Allow {
+            operation_statuses,
+            operation_types: OperationType::iter().collect(),
+            errors,
+            historical_balance_lookup: true,
+            timestamp_start_index: None,
+            call_methods: vec![],
+            balance_exemptions: vec![],
+            mempool_coins: false,
+            block_hash_case: Some(Case::Null),
+            transaction_hash_case: Some(Case::Null),
+        },
+    })
+}

--- a/crates/sui-grpc-rosetta/src/operations.rs
+++ b/crates/sui-grpc-rosetta/src/operations.rs
@@ -1,0 +1,899 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::ops::Not;
+use std::str::FromStr;
+use std::vec;
+
+use anyhow::anyhow;
+use move_core_types::ident_str;
+use move_core_types::language_storage::{ModuleId, StructTag};
+use move_core_types::resolver::ModuleResolver;
+use serde::Deserialize;
+use serde::Serialize;
+
+use sui_json_rpc_types::SuiProgrammableMoveCall;
+use sui_json_rpc_types::SuiProgrammableTransactionBlock;
+use sui_json_rpc_types::{BalanceChange, SuiArgument};
+use sui_json_rpc_types::{SuiCallArg, SuiCommand};
+use sui_sdk::rpc_types::{
+    SuiTransactionBlockData, SuiTransactionBlockDataAPI, SuiTransactionBlockEffectsAPI,
+    SuiTransactionBlockKind, SuiTransactionBlockResponse,
+};
+use sui_types::base_types::{ObjectID, SequenceNumber, SuiAddress};
+use sui_types::gas_coin::GasCoin;
+use sui_types::governance::{ADD_STAKE_FUN_NAME, WITHDRAW_STAKE_FUN_NAME};
+use sui_types::object::Owner;
+use sui_types::sui_system_state::SUI_SYSTEM_MODULE_NAME;
+use sui_types::transaction::TransactionData;
+use sui_types::{SUI_SYSTEM_ADDRESS, SUI_SYSTEM_PACKAGE_ID};
+
+use crate::types::{
+    AccountIdentifier, Amount, CoinAction, CoinChange, CoinID, CoinIdentifier, Currency,
+    InternalOperation, OperationIdentifier, OperationStatus, OperationType,
+};
+use crate::{CoinMetadataCache, Error, SUI};
+
+#[cfg(test)]
+#[path = "unit_tests/operations_tests.rs"]
+mod operations_tests;
+
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
+pub struct Operations(Vec<Operation>);
+
+impl FromIterator<Operation> for Operations {
+    fn from_iter<T: IntoIterator<Item = Operation>>(iter: T) -> Self {
+        Operations::new(iter.into_iter().collect())
+    }
+}
+
+impl FromIterator<Vec<Operation>> for Operations {
+    fn from_iter<T: IntoIterator<Item = Vec<Operation>>>(iter: T) -> Self {
+        iter.into_iter().flatten().collect()
+    }
+}
+
+impl IntoIterator for Operations {
+    type Item = Operation;
+    type IntoIter = vec::IntoIter<Operation>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl Operations {
+    pub fn new(mut ops: Vec<Operation>) -> Self {
+        for (index, op) in ops.iter_mut().enumerate() {
+            op.operation_identifier = (index as u64).into()
+        }
+        Self(ops)
+    }
+
+    pub fn contains(&self, other: &Operations) -> bool {
+        for (i, other_op) in other.0.iter().enumerate() {
+            if let Some(op) = self.0.get(i) {
+                if op != other_op {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+        true
+    }
+
+    pub fn set_status(mut self, status: Option<OperationStatus>) -> Self {
+        for op in &mut self.0 {
+            op.status = status
+        }
+        self
+    }
+
+    pub fn type_(&self) -> Option<OperationType> {
+        self.0.first().map(|op| op.type_)
+    }
+
+    /// Parse operation input from rosetta operation to intermediate internal operation;
+    pub fn into_internal(self) -> Result<InternalOperation, Error> {
+        let type_ = self
+            .type_()
+            .ok_or_else(|| Error::MissingInput("Operation type".into()))?;
+        match type_ {
+            OperationType::PaySui => self.pay_sui_ops_to_internal(),
+            OperationType::PayCoin => self.pay_coin_ops_to_internal(),
+            OperationType::Stake => self.stake_ops_to_internal(),
+            OperationType::WithdrawStake => self.withdraw_stake_ops_to_internal(),
+            op => Err(Error::UnsupportedOperation(op)),
+        }
+    }
+
+    fn pay_sui_ops_to_internal(self) -> Result<InternalOperation, Error> {
+        let mut recipients = vec![];
+        let mut amounts = vec![];
+        let mut sender = None;
+        for op in self {
+            if let (Some(amount), Some(account)) = (op.amount.clone(), op.account.clone()) {
+                if amount.value.is_negative() {
+                    sender = Some(account.address)
+                } else {
+                    recipients.push(account.address);
+                    let amount = amount.value.abs();
+                    if amount > u64::MAX as i128 {
+                        return Err(Error::InvalidInput(
+                            "Input amount exceed u64::MAX".to_string(),
+                        ));
+                    }
+                    amounts.push(amount as u64)
+                }
+            }
+        }
+        let sender = sender.ok_or_else(|| Error::MissingInput("Sender address".to_string()))?;
+        Ok(InternalOperation::PaySui {
+            sender,
+            recipients,
+            amounts,
+        })
+    }
+
+    fn pay_coin_ops_to_internal(self) -> Result<InternalOperation, Error> {
+        let mut recipients = vec![];
+        let mut amounts = vec![];
+        let mut sender = None;
+        let mut currency = None;
+        for op in self {
+            if let (Some(amount), Some(account)) = (op.amount.clone(), op.account.clone()) {
+                currency = currency.or(Some(amount.currency));
+                if amount.value.is_negative() {
+                    sender = Some(account.address)
+                } else {
+                    recipients.push(account.address);
+                    let amount = amount.value.abs();
+                    if amount > u64::MAX as i128 {
+                        return Err(Error::InvalidInput(
+                            "Input amount exceed u64::MAX".to_string(),
+                        ));
+                    }
+                    amounts.push(amount as u64)
+                }
+            }
+        }
+        let sender = sender.ok_or_else(|| Error::MissingInput("Sender address".to_string()))?;
+        let currency = currency.ok_or_else(|| Error::MissingInput("Currency".to_string()))?;
+        Ok(InternalOperation::PayCoin {
+            sender,
+            recipients,
+            amounts,
+            currency,
+        })
+    }
+
+    fn stake_ops_to_internal(self) -> Result<InternalOperation, Error> {
+        let mut ops = self
+            .0
+            .into_iter()
+            .filter(|op| op.type_ == OperationType::Stake)
+            .collect::<Vec<_>>();
+        if ops.len() != 1 {
+            return Err(Error::MalformedOperationError(
+                "Delegation should only have one operation.".into(),
+            ));
+        }
+        // Checked above, safe to unwrap.
+        let op = ops.pop().unwrap();
+        let sender = op
+            .account
+            .ok_or_else(|| Error::MissingInput("Sender address".to_string()))?
+            .address;
+        let metadata = op
+            .metadata
+            .ok_or_else(|| Error::MissingInput("Stake metadata".to_string()))?;
+
+        // Total issued SUi is less than u64, safe to cast.
+        let amount = if let Some(amount) = op.amount {
+            if amount.value.is_positive() {
+                return Err(Error::MalformedOperationError(
+                    "Stake amount should be negative.".into(),
+                ));
+            }
+            Some(amount.value.unsigned_abs() as u64)
+        } else {
+            None
+        };
+
+        let OperationMetadata::Stake { validator } = metadata else {
+            return Err(Error::InvalidInput(
+                "Cannot find delegation info from metadata.".into(),
+            ));
+        };
+
+        Ok(InternalOperation::Stake {
+            sender,
+            validator,
+            amount,
+        })
+    }
+
+    fn withdraw_stake_ops_to_internal(self) -> Result<InternalOperation, Error> {
+        let mut ops = self
+            .0
+            .into_iter()
+            .filter(|op| op.type_ == OperationType::WithdrawStake)
+            .collect::<Vec<_>>();
+        if ops.len() != 1 {
+            return Err(Error::MalformedOperationError(
+                "Delegation should only have one operation.".into(),
+            ));
+        }
+        // Checked above, safe to unwrap.
+        let op = ops.pop().unwrap();
+        let sender = op
+            .account
+            .ok_or_else(|| Error::MissingInput("Sender address".to_string()))?
+            .address;
+
+        let stake_ids = if let Some(metadata) = op.metadata {
+            let OperationMetadata::WithdrawStake { stake_ids } = metadata else {
+                return Err(Error::InvalidInput(
+                    "Cannot find withdraw stake info from metadata.".into(),
+                ));
+            };
+            stake_ids
+        } else {
+            vec![]
+        };
+
+        Ok(InternalOperation::WithdrawStake { sender, stake_ids })
+    }
+
+    fn from_transaction(
+        tx: SuiTransactionBlockKind,
+        sender: SuiAddress,
+        status: Option<OperationStatus>,
+    ) -> Result<Vec<Operation>, Error> {
+        Ok(match tx {
+            SuiTransactionBlockKind::ProgrammableTransaction(pt)
+                if status != Some(OperationStatus::Failure) =>
+            {
+                Self::parse_programmable_transaction(sender, status, pt)?
+            }
+            _ => vec![Operation::generic_op(status, sender, tx)],
+        })
+    }
+
+    fn parse_programmable_transaction(
+        sender: SuiAddress,
+        status: Option<OperationStatus>,
+        pt: SuiProgrammableTransactionBlock,
+    ) -> Result<Vec<Operation>, Error> {
+        #[derive(Debug)]
+        enum KnownValue {
+            GasCoin(u64),
+        }
+        fn resolve_result(
+            known_results: &[Vec<KnownValue>],
+            i: u16,
+            j: u16,
+        ) -> Option<&KnownValue> {
+            known_results
+                .get(i as usize)
+                .and_then(|inner| inner.get(j as usize))
+        }
+        fn split_coins(
+            inputs: &[SuiCallArg],
+            known_results: &[Vec<KnownValue>],
+            coin: SuiArgument,
+            amounts: &[SuiArgument],
+        ) -> Option<Vec<KnownValue>> {
+            match coin {
+                SuiArgument::Result(i) => {
+                    let KnownValue::GasCoin(_) = resolve_result(known_results, i, 0)?;
+                }
+                SuiArgument::NestedResult(i, j) => {
+                    let KnownValue::GasCoin(_) = resolve_result(known_results, i, j)?;
+                }
+                SuiArgument::GasCoin => (),
+                // Might not be a SUI coin
+                SuiArgument::Input(_) => (),
+            };
+            let amounts = amounts
+                .iter()
+                .map(|amount| {
+                    let value: u64 = match *amount {
+                        SuiArgument::Input(i) => {
+                            u64::from_str(inputs.get(i as usize)?.pure()?.to_json_value().as_str()?)
+                                .ok()?
+                        }
+                        SuiArgument::GasCoin
+                        | SuiArgument::Result(_)
+                        | SuiArgument::NestedResult(_, _) => return None,
+                    };
+                    Some(KnownValue::GasCoin(value))
+                })
+                .collect::<Option<_>>()?;
+            Some(amounts)
+        }
+        fn transfer_object(
+            aggregated_recipients: &mut HashMap<SuiAddress, u64>,
+            inputs: &[SuiCallArg],
+            known_results: &[Vec<KnownValue>],
+            objs: &[SuiArgument],
+            recipient: SuiArgument,
+        ) -> Option<Vec<KnownValue>> {
+            let addr = match recipient {
+                SuiArgument::Input(i) => inputs.get(i as usize)?.pure()?.to_sui_address().ok()?,
+                SuiArgument::GasCoin | SuiArgument::Result(_) | SuiArgument::NestedResult(_, _) => {
+                    return None
+                }
+            };
+            for obj in objs {
+                let value = match *obj {
+                    SuiArgument::Result(i) => {
+                        let KnownValue::GasCoin(value) = resolve_result(known_results, i, 0)?;
+                        value
+                    }
+                    SuiArgument::NestedResult(i, j) => {
+                        let KnownValue::GasCoin(value) = resolve_result(known_results, i, j)?;
+                        value
+                    }
+                    SuiArgument::GasCoin | SuiArgument::Input(_) => return None,
+                };
+                let aggregate = aggregated_recipients.entry(addr).or_default();
+                *aggregate += value;
+            }
+            Some(vec![])
+        }
+        fn stake_call(
+            inputs: &[SuiCallArg],
+            known_results: &[Vec<KnownValue>],
+            call: &SuiProgrammableMoveCall,
+        ) -> Result<Option<(Option<u64>, SuiAddress)>, Error> {
+            let SuiProgrammableMoveCall { arguments, .. } = call;
+            let (amount, validator) = match &arguments[..] {
+                [_, coin, validator] => {
+                    let amount = match coin {
+                        SuiArgument::Result(i) =>{
+                            let KnownValue::GasCoin(value) = resolve_result(known_results, *i, 0).ok_or_else(||anyhow!("Cannot resolve Gas coin value at Result({i})"))?;
+                            value
+                        },
+                        _ => return Ok(None),
+                    };
+                    let (some_amount, validator) = match validator {
+                        // [WORKAROUND] - this is a hack to work out if the staking ops is for a selected amount or None amount (whole wallet).
+                        // We use the position of the validator arg as a indicator of if the rosetta stake
+                        // transaction is staking the whole wallet or not, if staking whole wallet,
+                        // we have to omit the amount value in the final operation output.
+                        SuiArgument::Input(i) => (*i==1, inputs.get(*i as usize).and_then(|input| input.pure()).map(|v|v.to_sui_address()).transpose()),
+                        _=> return Ok(None),
+                    };
+                    (some_amount.then_some(*amount), validator)
+                },
+                _ => Err(anyhow!("Error encountered when extracting arguments from move call, expecting 3 elements, got {}", arguments.len()))?,
+            };
+            Ok(validator.map(|v| v.map(|v| (amount, v)))?)
+        }
+
+        fn unstake_call(
+            inputs: &[SuiCallArg],
+            call: &SuiProgrammableMoveCall,
+        ) -> Result<Option<ObjectID>, Error> {
+            let SuiProgrammableMoveCall { arguments, .. } = call;
+            let id = match &arguments[..] {
+                [_, stake_id] => {
+                    match stake_id {
+                        SuiArgument::Input(i) => {
+                            let id = inputs.get(*i as usize).and_then(|input| input.object()).ok_or_else(|| anyhow!("Cannot find stake id from input args."))?;
+                            // [WORKAROUND] - this is a hack to work out if the withdraw stake ops is for a selected stake or None (all stakes).
+                            // this hack is similar to the one in stake_call.
+                            let some_id = i % 2 == 1;
+                            some_id.then_some(id)
+                        },
+                        _=> return Ok(None),
+                    }
+                },
+                _ => Err(anyhow!("Error encountered when extracting arguments from move call, expecting 3 elements, got {}", arguments.len()))?,
+            };
+            Ok(id.cloned())
+        }
+        let SuiProgrammableTransactionBlock { inputs, commands } = &pt;
+        let mut known_results: Vec<Vec<KnownValue>> = vec![];
+        let mut aggregated_recipients: HashMap<SuiAddress, u64> = HashMap::new();
+        let mut needs_generic = false;
+        let mut operations = vec![];
+        let mut stake_ids = vec![];
+        let mut currency: Option<Currency> = None;
+        for command in commands {
+            let result = match command {
+                SuiCommand::SplitCoins(coin, amounts) => {
+                    split_coins(inputs, &known_results, *coin, amounts)
+                }
+                SuiCommand::TransferObjects(objs, addr) => transfer_object(
+                    &mut aggregated_recipients,
+                    inputs,
+                    &known_results,
+                    objs,
+                    *addr,
+                ),
+                SuiCommand::MoveCall(m) if Self::is_stake_call(m) => {
+                    stake_call(inputs, &known_results, m)?.map(|(amount, validator)| {
+                        let amount = amount.map(|amount| Amount::new(-(amount as i128), None));
+                        operations.push(Operation {
+                            operation_identifier: Default::default(),
+                            type_: OperationType::Stake,
+                            status,
+                            account: Some(sender.into()),
+                            amount,
+                            coin_change: None,
+                            metadata: Some(OperationMetadata::Stake { validator }),
+                        });
+                        vec![]
+                    })
+                }
+                SuiCommand::MoveCall(m) if Self::is_unstake_call(m) => {
+                    let stake_id = unstake_call(inputs, m)?;
+                    stake_ids.push(stake_id);
+                    Some(vec![])
+                }
+                _ => None,
+            };
+            if let Some(result) = result {
+                known_results.push(result)
+            } else {
+                needs_generic = true;
+                break;
+            }
+        }
+
+        if !needs_generic && !aggregated_recipients.is_empty() {
+            let total_paid: u64 = aggregated_recipients.values().copied().sum();
+            operations.extend(
+                aggregated_recipients
+                    .into_iter()
+                    .map(|(recipient, amount)| {
+                        currency = inputs.iter().last().and_then(|arg| {
+                            if let SuiCallArg::Pure(value) = arg {
+                                let bytes = value
+                                    .value()
+                                    .to_json_value()
+                                    .as_array()?
+                                    .clone()
+                                    .into_iter()
+                                    .map(|v| v.as_u64().map(|n| n as u8))
+                                    .collect::<Option<Vec<u8>>>()?;
+                                bcs::from_bytes::<String>(&bytes)
+                                    .ok()
+                                    .and_then(|bcs_str| serde_json::from_str(&bcs_str).ok())
+                            } else {
+                                None
+                            }
+                        });
+                        match currency {
+                            Some(_) => Operation::pay_coin(
+                                status,
+                                recipient,
+                                amount.into(),
+                                currency.clone(),
+                            ),
+                            None => Operation::pay_sui(status, recipient, amount.into()),
+                        }
+                    }),
+            );
+            match currency {
+                Some(_) => operations.push(Operation::pay_coin(
+                    status,
+                    sender,
+                    -(total_paid as i128),
+                    currency.clone(),
+                )),
+                _ => operations.push(Operation::pay_sui(status, sender, -(total_paid as i128))),
+            }
+        } else if !stake_ids.is_empty() {
+            let stake_ids = stake_ids.into_iter().flatten().collect::<Vec<_>>();
+            let metadata = stake_ids
+                .is_empty()
+                .not()
+                .then_some(OperationMetadata::WithdrawStake { stake_ids });
+            operations.push(Operation {
+                operation_identifier: Default::default(),
+                type_: OperationType::WithdrawStake,
+                status,
+                account: Some(sender.into()),
+                amount: None,
+                coin_change: None,
+                metadata,
+            });
+        } else if operations.is_empty() {
+            operations.push(Operation::generic_op(
+                status,
+                sender,
+                SuiTransactionBlockKind::ProgrammableTransaction(pt),
+            ))
+        }
+        Ok(operations)
+    }
+
+    fn is_stake_call(tx: &SuiProgrammableMoveCall) -> bool {
+        tx.package == SUI_SYSTEM_PACKAGE_ID
+            && tx.module == SUI_SYSTEM_MODULE_NAME.as_str()
+            && tx.function == ADD_STAKE_FUN_NAME.as_str()
+    }
+
+    fn is_unstake_call(tx: &SuiProgrammableMoveCall) -> bool {
+        tx.package == SUI_SYSTEM_PACKAGE_ID
+            && tx.module == SUI_SYSTEM_MODULE_NAME.as_str()
+            && tx.function == WITHDRAW_STAKE_FUN_NAME.as_str()
+    }
+
+    fn process_balance_change(
+        gas_owner: SuiAddress,
+        gas_used: i128,
+        balance_changes: Vec<(BalanceChange, Currency)>,
+        status: Option<OperationStatus>,
+        balances: HashMap<(SuiAddress, Currency), i128>,
+    ) -> impl Iterator<Item = Operation> {
+        let mut balances =
+            balance_changes
+                .iter()
+                .fold(balances, |mut balances, (balance_change, ccy)| {
+                    // Rosetta only care about address owner
+                    if let Owner::AddressOwner(owner) = balance_change.owner {
+                        *balances.entry((owner, ccy.clone())).or_default() += balance_change.amount;
+                    }
+                    balances
+                });
+        // separate gas from balances
+        *balances.entry((gas_owner, SUI.clone())).or_default() -= gas_used;
+
+        let balance_change = balances.into_iter().filter(|(_, amount)| *amount != 0).map(
+            move |((addr, currency), amount)| {
+                Operation::balance_change(status, addr, amount, currency)
+            },
+        );
+
+        let gas = if gas_used != 0 {
+            vec![Operation::gas(gas_owner, gas_used)]
+        } else {
+            // Gas can be 0 for system tx
+            vec![]
+        };
+        balance_change.chain(gas)
+    }
+}
+
+impl Operations {
+    fn try_from_data(
+        data: SuiTransactionBlockData,
+        status: Option<OperationStatus>,
+    ) -> Result<Self, anyhow::Error> {
+        let sender = *data.sender();
+        Ok(Self::new(Self::from_transaction(
+            data.transaction().clone(),
+            sender,
+            status,
+        )?))
+    }
+}
+impl Operations {
+    pub async fn try_from_response(
+        response: SuiTransactionBlockResponse,
+        cache: &CoinMetadataCache,
+    ) -> Result<Self, Error> {
+        let tx = response
+            .transaction
+            .ok_or_else(|| anyhow!("Response input should not be empty"))?;
+        let sender = *tx.data.sender();
+        let effect = response
+            .effects
+            .ok_or_else(|| anyhow!("Response effects should not be empty"))?;
+        let gas_owner = effect.gas_object().owner.get_owner_address()?;
+        let gas_summary = effect.gas_cost_summary();
+        let gas_used = gas_summary.storage_rebate as i128
+            - gas_summary.storage_cost as i128
+            - gas_summary.computation_cost as i128;
+
+        let status = Some(effect.into_status().into());
+        let ops = Operations::try_from_data(tx.data, status)?;
+        let ops = ops.into_iter();
+
+        // We will need to subtract the operation amounts from the actual balance
+        // change amount extracted from event to prevent double counting.
+        let mut accounted_balances =
+            ops.as_ref()
+                .iter()
+                .fold(HashMap::new(), |mut balances, op| {
+                    if let (Some(acc), Some(amount), Some(OperationStatus::Success)) =
+                        (&op.account, &op.amount, &op.status)
+                    {
+                        *balances
+                            .entry((acc.address, amount.clone().currency))
+                            .or_default() -= amount.value;
+                    }
+                    balances
+                });
+
+        let mut principal_amounts = 0;
+        let mut reward_amounts = 0;
+        // Extract balance change from unstake events
+
+        if let Some(events) = response.events {
+            for event in events.data {
+                if is_unstake_event(&event.type_) {
+                    let principal_amount = event
+                        .parsed_json
+                        .pointer("/principal_amount")
+                        .and_then(|v| v.as_str())
+                        .and_then(|v| i128::from_str(v).ok());
+                    let reward_amount = event
+                        .parsed_json
+                        .pointer("/reward_amount")
+                        .and_then(|v| v.as_str())
+                        .and_then(|v| i128::from_str(v).ok());
+                    if let (Some(principal_amount), Some(reward_amount)) =
+                        (principal_amount, reward_amount)
+                    {
+                        principal_amounts += principal_amount;
+                        reward_amounts += reward_amount;
+                    }
+                }
+            }
+        }
+        let staking_balance = if principal_amounts != 0 {
+            *accounted_balances.entry((sender, SUI.clone())).or_default() -= principal_amounts;
+            *accounted_balances.entry((sender, SUI.clone())).or_default() -= reward_amounts;
+            vec![
+                Operation::stake_principle(status, sender, principal_amounts),
+                Operation::stake_reward(status, sender, reward_amounts),
+            ]
+        } else {
+            vec![]
+        };
+
+        let mut balance_changes = vec![];
+
+        for balance_change in &response
+            .balance_changes
+            .ok_or_else(|| anyhow!("Response balance changes should not be empty."))?
+        {
+            if let Ok(currency) = cache.get_currency(&balance_change.coin_type).await {
+                if !currency.symbol.is_empty() {
+                    balance_changes.push((balance_change.clone(), currency));
+                }
+            }
+        }
+
+        // Extract coin change operations from balance changes
+        let coin_change_operations = Self::process_balance_change(
+            gas_owner,
+            gas_used,
+            balance_changes,
+            status,
+            accounted_balances,
+        );
+
+        let ops: Operations = ops
+            .into_iter()
+            .chain(coin_change_operations)
+            .chain(staking_balance)
+            .collect();
+
+        // This is a workaround for the payCoin cases that are mistakenly considered to be paySui operations
+        // In this case we remove any irrelevant, SUI specific operation entries that sum up to 0 balance changes per address
+        // and keep only the actual entries for the right coin type transfers, as they have been extracted from the transaction's
+        // balance changes section.
+        let mutually_cancelling_balances: HashMap<_, _> = ops
+            .clone()
+            .into_iter()
+            .fold(
+                HashMap::new(),
+                |mut balances: HashMap<(SuiAddress, Currency), i128>, op| {
+                    if let (Some(acc), Some(amount), Some(OperationStatus::Success)) =
+                        (&op.account, &op.amount, &op.status)
+                    {
+                        if op.type_ != OperationType::Gas {
+                            *balances
+                                .entry((acc.address, amount.clone().currency))
+                                .or_default() += amount.value;
+                        }
+                    }
+                    balances
+                },
+            )
+            .into_iter()
+            .filter(|balance| {
+                let (_, amount) = balance;
+                *amount == 0
+            })
+            .collect();
+
+        let ops: Operations = ops
+            .clone()
+            .into_iter()
+            .filter(|op| {
+                if let (Some(acc), Some(amount)) = (&op.account, &op.amount) {
+                    return op.type_ == OperationType::Gas
+                        || !mutually_cancelling_balances
+                            .contains_key(&(acc.address, amount.clone().currency));
+                }
+                true
+            })
+            .collect();
+
+        Ok(ops)
+    }
+}
+
+fn is_unstake_event(tag: &StructTag) -> bool {
+    tag.address == SUI_SYSTEM_ADDRESS
+        && tag.module.as_ident_str() == ident_str!("validator")
+        && tag.name.as_ident_str() == ident_str!("UnstakingRequestEvent")
+}
+
+impl TryFrom<TransactionData> for Operations {
+    type Error = Error;
+    fn try_from(data: TransactionData) -> Result<Self, Self::Error> {
+        struct NoOpsModuleResolver;
+        impl ModuleResolver for NoOpsModuleResolver {
+            type Error = Error;
+            fn get_module(&self, _id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
+                Ok(None)
+            }
+        }
+        // Rosetta don't need the call args to be parsed into readable format
+        Ok(Operations::try_from_data(
+            SuiTransactionBlockData::try_from_with_module_cache(data, &&mut NoOpsModuleResolver)?,
+            None,
+        )?)
+    }
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct Operation {
+    operation_identifier: OperationIdentifier,
+    #[serde(rename = "type")]
+    pub type_: OperationType,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<OperationStatus>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub account: Option<AccountIdentifier>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub amount: Option<Amount>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coin_change: Option<CoinChange>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<OperationMetadata>,
+}
+
+impl PartialEq for Operation {
+    fn eq(&self, other: &Self) -> bool {
+        self.operation_identifier == other.operation_identifier
+            && self.type_ == other.type_
+            && self.account == other.account
+            && self.amount == other.amount
+            && self.coin_change == other.coin_change
+            && self.metadata == other.metadata
+    }
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, Eq, PartialEq)]
+pub enum OperationMetadata {
+    GenericTransaction(SuiTransactionBlockKind),
+    Stake { validator: SuiAddress },
+    WithdrawStake { stake_ids: Vec<ObjectID> },
+}
+
+impl Operation {
+    fn generic_op(
+        status: Option<OperationStatus>,
+        sender: SuiAddress,
+        tx: SuiTransactionBlockKind,
+    ) -> Self {
+        Operation {
+            operation_identifier: Default::default(),
+            type_: (&tx).into(),
+            status,
+            account: Some(sender.into()),
+            amount: None,
+            coin_change: None,
+            metadata: Some(OperationMetadata::GenericTransaction(tx)),
+        }
+    }
+
+    pub fn genesis(index: u64, sender: SuiAddress, coin: GasCoin) -> Self {
+        Operation {
+            operation_identifier: index.into(),
+            type_: OperationType::Genesis,
+            status: Some(OperationStatus::Success),
+            account: Some(sender.into()),
+            amount: Some(Amount::new(coin.value().into(), None)),
+            coin_change: Some(CoinChange {
+                coin_identifier: CoinIdentifier {
+                    identifier: CoinID {
+                        id: *coin.id(),
+                        version: SequenceNumber::new(),
+                    },
+                },
+                coin_action: CoinAction::CoinCreated,
+            }),
+            metadata: None,
+        }
+    }
+
+    fn pay_sui(status: Option<OperationStatus>, address: SuiAddress, amount: i128) -> Self {
+        Operation {
+            operation_identifier: Default::default(),
+            type_: OperationType::PaySui,
+            status,
+            account: Some(address.into()),
+            amount: Some(Amount::new(amount, None)),
+            coin_change: None,
+            metadata: None,
+        }
+    }
+
+    fn pay_coin(
+        status: Option<OperationStatus>,
+        address: SuiAddress,
+        amount: i128,
+        currency: Option<Currency>,
+    ) -> Self {
+        Operation {
+            operation_identifier: Default::default(),
+            type_: OperationType::PayCoin,
+            status,
+            account: Some(address.into()),
+            amount: Some(Amount::new(amount, currency)),
+            coin_change: None,
+            metadata: None,
+        }
+    }
+
+    fn balance_change(
+        status: Option<OperationStatus>,
+        addr: SuiAddress,
+        amount: i128,
+        currency: Currency,
+    ) -> Self {
+        Self {
+            operation_identifier: Default::default(),
+            type_: OperationType::SuiBalanceChange,
+            status,
+            account: Some(addr.into()),
+            amount: Some(Amount::new(amount, Some(currency))),
+            coin_change: None,
+            metadata: None,
+        }
+    }
+    fn gas(addr: SuiAddress, amount: i128) -> Self {
+        Self {
+            operation_identifier: Default::default(),
+            type_: OperationType::Gas,
+            status: Some(OperationStatus::Success),
+            account: Some(addr.into()),
+            amount: Some(Amount::new(amount, None)),
+            coin_change: None,
+            metadata: None,
+        }
+    }
+    fn stake_reward(status: Option<OperationStatus>, addr: SuiAddress, amount: i128) -> Self {
+        Self {
+            operation_identifier: Default::default(),
+            type_: OperationType::StakeReward,
+            status,
+            account: Some(addr.into()),
+            amount: Some(Amount::new(amount, None)),
+            coin_change: None,
+            metadata: None,
+        }
+    }
+    fn stake_principle(status: Option<OperationStatus>, addr: SuiAddress, amount: i128) -> Self {
+        Self {
+            operation_identifier: Default::default(),
+            type_: OperationType::StakePrinciple,
+            status,
+            account: Some(addr.into()),
+            amount: Some(Amount::new(amount, None)),
+            coin_change: None,
+            metadata: None,
+        }
+    }
+}

--- a/crates/sui-grpc-rosetta/src/state.rs
+++ b/crates/sui-grpc-rosetta/src/state.rs
@@ -1,0 +1,204 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use futures::future::try_join_all;
+use std::sync::Arc;
+use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
+use sui_sdk::rpc_types::Checkpoint;
+use sui_sdk::SuiClient;
+use sui_types::messages_checkpoint::CheckpointSequenceNumber;
+
+use crate::operations::Operations;
+use crate::types::{
+    Block, BlockHash, BlockIdentifier, BlockResponse, Transaction, TransactionIdentifier,
+};
+use crate::{CoinMetadataCache, Error};
+
+#[cfg(test)]
+#[path = "unit_tests/balance_changing_tx_tests.rs"]
+mod balance_changing_tx_tests;
+
+#[derive(Clone)]
+pub struct OnlineServerContext {
+    pub client: SuiClient,
+    pub coin_metadata_cache: CoinMetadataCache,
+    block_provider: Arc<dyn BlockProvider + Send + Sync>,
+}
+
+impl OnlineServerContext {
+    pub fn new(
+        client: SuiClient,
+        block_provider: Arc<dyn BlockProvider + Send + Sync>,
+        coin_metadata_cache: CoinMetadataCache,
+    ) -> Self {
+        Self {
+            client: client.clone(),
+            block_provider,
+            coin_metadata_cache,
+        }
+    }
+
+    pub fn blocks(&self) -> &(dyn BlockProvider + Sync + Send) {
+        &*self.block_provider
+    }
+}
+
+#[async_trait]
+pub trait BlockProvider {
+    async fn get_block_by_index(&self, index: u64) -> Result<BlockResponse, Error>;
+    async fn get_block_by_hash(&self, hash: BlockHash) -> Result<BlockResponse, Error>;
+    async fn current_block(&self) -> Result<BlockResponse, Error>;
+    async fn genesis_block_identifier(&self) -> Result<BlockIdentifier, Error>;
+    async fn oldest_block_identifier(&self) -> Result<BlockIdentifier, Error>;
+    async fn current_block_identifier(&self) -> Result<BlockIdentifier, Error>;
+    async fn create_block_identifier(
+        &self,
+        checkpoint: CheckpointSequenceNumber,
+    ) -> Result<BlockIdentifier, Error>;
+}
+
+#[derive(Clone)]
+pub struct CheckpointBlockProvider {
+    client: SuiClient,
+    coin_metadata_cache: CoinMetadataCache,
+}
+
+#[async_trait]
+impl BlockProvider for CheckpointBlockProvider {
+    async fn get_block_by_index(&self, index: u64) -> Result<BlockResponse, Error> {
+        let checkpoint = self.client.read_api().get_checkpoint(index.into()).await?;
+        self.create_block_response(checkpoint).await
+    }
+
+    async fn get_block_by_hash(&self, hash: BlockHash) -> Result<BlockResponse, Error> {
+        let checkpoint = self.client.read_api().get_checkpoint(hash.into()).await?;
+        self.create_block_response(checkpoint).await
+    }
+
+    async fn current_block(&self) -> Result<BlockResponse, Error> {
+        let checkpoint = self
+            .client
+            .read_api()
+            .get_latest_checkpoint_sequence_number()
+            .await?;
+        self.get_block_by_index(checkpoint).await
+    }
+
+    async fn genesis_block_identifier(&self) -> Result<BlockIdentifier, Error> {
+        self.create_block_identifier(0).await
+    }
+
+    async fn oldest_block_identifier(&self) -> Result<BlockIdentifier, Error> {
+        self.create_block_identifier(0).await
+    }
+
+    async fn current_block_identifier(&self) -> Result<BlockIdentifier, Error> {
+        let checkpoint = self
+            .client
+            .read_api()
+            .get_latest_checkpoint_sequence_number()
+            .await?;
+
+        self.create_block_identifier(checkpoint).await
+    }
+
+    async fn create_block_identifier(
+        &self,
+        checkpoint: CheckpointSequenceNumber,
+    ) -> Result<BlockIdentifier, Error> {
+        self.create_block_identifier(checkpoint).await
+    }
+}
+
+impl CheckpointBlockProvider {
+    pub fn new(client: SuiClient, coin_metadata_cache: CoinMetadataCache) -> Self {
+        Self {
+            client,
+            coin_metadata_cache,
+        }
+    }
+
+    async fn create_block_response(&self, checkpoint: Checkpoint) -> Result<BlockResponse, Error> {
+        let index = checkpoint.sequence_number;
+        let hash = checkpoint.digest;
+
+        let chunks = checkpoint
+            .transactions
+            .chunks(5)
+            .map(|batch| async {
+                let transaction_responses = self
+                    .client
+                    .read_api()
+                    .multi_get_transactions_with_options(
+                        batch.to_vec(),
+                        SuiTransactionBlockResponseOptions::new()
+                            .with_input()
+                            .with_effects()
+                            .with_balance_changes()
+                            .with_events(),
+                    )
+                    .await?;
+
+                let mut transactions = vec![];
+                for tx in transaction_responses.into_iter() {
+                    transactions.push(Transaction {
+                        transaction_identifier: TransactionIdentifier { hash: tx.digest },
+                        operations: Operations::try_from_response(tx, &self.coin_metadata_cache)
+                            .await?,
+                        related_transactions: vec![],
+                        metadata: None,
+                    })
+                }
+                Ok::<Vec<_>, anyhow::Error>(transactions)
+            })
+            .collect::<Vec<_>>();
+
+        let transactions = try_join_all(chunks)
+            .await?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+
+        // previous digest should only be None for genesis block.
+        if checkpoint.previous_digest.is_none() && index != 0 {
+            return Err(Error::DataError(format!(
+                "Previous digest is None for checkpoint [{index}], digest: [{hash:?}]"
+            )));
+        }
+
+        let parent_block_identifier = checkpoint
+            .previous_digest
+            .map(|hash| BlockIdentifier {
+                index: index - 1,
+                hash,
+            })
+            .unwrap_or_else(|| BlockIdentifier { index, hash });
+
+        Ok(BlockResponse {
+            block: Block {
+                block_identifier: BlockIdentifier { index, hash },
+                parent_block_identifier,
+                timestamp: checkpoint.timestamp_ms,
+                transactions,
+                metadata: None,
+            },
+            other_transactions: vec![],
+        })
+    }
+
+    async fn create_block_identifier(
+        &self,
+        seq_number: CheckpointSequenceNumber,
+    ) -> Result<BlockIdentifier, Error> {
+        let checkpoint = self
+            .client
+            .read_api()
+            .get_checkpoint(seq_number.into())
+            .await?;
+        Ok(BlockIdentifier {
+            index: checkpoint.sequence_number,
+            hash: checkpoint.digest,
+        })
+    }
+}

--- a/crates/sui-grpc-rosetta/src/types.rs
+++ b/crates/sui-grpc-rosetta/src/types.rs
@@ -1,0 +1,1052 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt::Debug;
+use std::str::FromStr;
+
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use fastcrypto::encoding::Hex;
+use serde::de::Error as DeError;
+use serde::{Deserialize, Serializer};
+use serde::{Deserializer, Serialize};
+use serde_json::Value;
+use strum_macros::EnumIter;
+use strum_macros::EnumString;
+
+use sui_sdk::rpc_types::{SuiExecutionStatus, SuiTransactionBlockKind};
+use sui_types::base_types::{ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest};
+use sui_types::crypto::PublicKey as SuiPublicKey;
+use sui_types::crypto::SignatureScheme;
+use sui_types::governance::{ADD_STAKE_FUN_NAME, WITHDRAW_STAKE_FUN_NAME};
+use sui_types::messages_checkpoint::CheckpointDigest;
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+use sui_types::sui_system_state::SUI_SYSTEM_MODULE_NAME;
+use sui_types::transaction::{Argument, CallArg, Command, ObjectArg, TransactionData};
+use sui_types::SUI_SYSTEM_PACKAGE_ID;
+
+use crate::errors::{Error, ErrorType};
+use crate::operations::Operations;
+use crate::SUI;
+
+#[cfg(test)]
+#[path = "unit_tests/types_tests.rs"]
+mod types_tests;
+
+pub type BlockHeight = u64;
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct NetworkIdentifier {
+    pub blockchain: String,
+    pub network: SuiEnv,
+}
+
+#[derive(
+    Serialize, Deserialize, Ord, PartialOrd, Eq, PartialEq, Debug, Clone, Copy, EnumString,
+)]
+#[strum(serialize_all = "lowercase")]
+#[serde(rename_all = "lowercase")]
+pub enum SuiEnv {
+    MainNet,
+    DevNet,
+    TestNet,
+    LocalNet,
+}
+
+impl SuiEnv {
+    pub fn check_network_identifier(
+        &self,
+        network_identifier: &NetworkIdentifier,
+    ) -> Result<(), Error> {
+        if &network_identifier.blockchain != "sui" {
+            return Err(Error::UnsupportedBlockchain(
+                network_identifier.blockchain.clone(),
+            ));
+        }
+        if &network_identifier.network != self {
+            return Err(Error::UnsupportedNetwork(network_identifier.network));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct AccountIdentifier {
+    pub address: SuiAddress,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sub_account: Option<SubAccount>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct SubAccount {
+    #[serde(rename = "address")]
+    pub account_type: SubAccountType,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub enum SubAccountType {
+    Stake,
+    PendingStake,
+    EstimatedReward,
+}
+
+impl From<SuiAddress> for AccountIdentifier {
+    fn from(address: SuiAddress) -> Self {
+        AccountIdentifier {
+            address,
+            sub_account: None,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct Currency {
+    pub symbol: String,
+    pub decimals: u64,
+    #[serde(default)]
+    pub metadata: CurrencyMetadata,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct CurrencyMetadata {
+    pub coin_type: String,
+}
+
+impl Default for CurrencyMetadata {
+    fn default() -> Self {
+        SUI.metadata.clone()
+    }
+}
+
+impl Default for Currency {
+    fn default() -> Self {
+        SUI.clone()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[serde(transparent)]
+pub struct Currencies(pub Vec<Currency>);
+
+impl Default for Currencies {
+    fn default() -> Self {
+        Currencies(vec![Currency::default()])
+    }
+}
+
+fn deserialize_or_default_currencies<'de, D>(deserializer: D) -> Result<Currencies, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt: Option<Vec<Currency>> = Option::deserialize(deserializer)?;
+    match opt {
+        Some(vec) if vec.is_empty() => Ok(Currencies::default()),
+        Some(vec) => Ok(Currencies(vec)),
+        None => Ok(Currencies::default()),
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AccountBalanceRequest {
+    pub network_identifier: NetworkIdentifier,
+    pub account_identifier: AccountIdentifier,
+    #[serde(default)]
+    pub block_identifier: PartialBlockIdentifier,
+    #[serde(default, deserialize_with = "deserialize_or_default_currencies")]
+    pub currencies: Currencies,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AccountBalanceResponse {
+    pub block_identifier: BlockIdentifier,
+    pub balances: Vec<Amount>,
+}
+
+impl IntoResponse for AccountBalanceResponse {
+    fn into_response(self) -> Response {
+        Json(self).into_response()
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Copy)]
+pub struct BlockIdentifier {
+    pub index: BlockHeight,
+    pub hash: BlockHash,
+}
+
+pub type BlockHash = CheckpointDigest;
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct Amount {
+    #[serde(with = "str_format")]
+    pub value: i128,
+    #[serde(default)]
+    pub currency: Currency,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<AmountMetadata>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct AmountMetadata {
+    pub sub_balances: Vec<SubBalance>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct SubBalance {
+    pub stake_id: ObjectID,
+    pub validator: SuiAddress,
+    #[serde(with = "str_format")]
+    pub value: i128,
+}
+
+impl Amount {
+    pub fn new(value: i128, currency: Option<Currency>) -> Self {
+        Self {
+            value,
+            currency: currency.unwrap_or_default(),
+            metadata: None,
+        }
+    }
+    pub fn new_from_sub_balances(sub_balances: Vec<SubBalance>) -> Self {
+        let value = sub_balances.iter().map(|b| b.value).sum();
+
+        Self {
+            value,
+            currency: Currency::default(),
+            metadata: Some(AmountMetadata { sub_balances }),
+        }
+    }
+}
+
+mod str_format {
+    use std::str::FromStr;
+
+    use serde::de::Error;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S>(value: &i128, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        value.to_string().serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<i128, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        i128::from_str(&s).map_err(Error::custom)
+    }
+}
+
+#[derive(Deserialize)]
+pub struct AccountCoinsRequest {
+    pub network_identifier: NetworkIdentifier,
+    pub account_identifier: AccountIdentifier,
+    pub include_mempool: bool,
+}
+#[derive(Serialize)]
+pub struct AccountCoinsResponse {
+    pub block_identifier: BlockIdentifier,
+    pub coins: Vec<Coin>,
+}
+impl IntoResponse for AccountCoinsResponse {
+    fn into_response(self) -> Response {
+        Json(self).into_response()
+    }
+}
+#[derive(Serialize)]
+pub struct Coin {
+    pub coin_identifier: CoinIdentifier,
+    pub amount: Amount,
+}
+
+impl From<sui_sdk::rpc_types::Coin> for Coin {
+    fn from(coin: sui_sdk::rpc_types::Coin) -> Self {
+        Self {
+            coin_identifier: CoinIdentifier {
+                identifier: CoinID {
+                    id: coin.coin_object_id,
+                    version: coin.version,
+                },
+            },
+            amount: Amount {
+                value: coin.balance as i128,
+                currency: SUI.clone(),
+                metadata: None,
+            },
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct CoinIdentifier {
+    pub identifier: CoinID,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CoinID {
+    pub id: ObjectID,
+    pub version: SequenceNumber,
+}
+
+impl Serialize for CoinID {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        format!("{}:{}", self.id, self.version.value()).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for CoinID {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+
+        let (id, version) = s.split_at(
+            s.find(':')
+                .ok_or_else(|| D::Error::custom(format!("Malformed Coin id [{s}].")))?,
+        );
+        let version = version.trim_start_matches(':');
+        let id = ObjectID::from_hex_literal(id).map_err(D::Error::custom)?;
+        let version = SequenceNumber::from_u64(u64::from_str(version).map_err(D::Error::custom)?);
+
+        Ok(Self { id, version })
+    }
+}
+
+#[test]
+fn test_coin_id_serde() {
+    let id = ObjectID::random();
+    let coin_id = CoinID {
+        id,
+        version: SequenceNumber::from_u64(10),
+    };
+    let s = serde_json::to_string(&coin_id).unwrap();
+    assert_eq!(format!("\"{}:{}\"", id, 10), s);
+
+    let deserialized: CoinID = serde_json::from_str(&s).unwrap();
+
+    assert_eq!(id, deserialized.id);
+    assert_eq!(SequenceNumber::from_u64(10), deserialized.version)
+}
+
+impl From<ObjectRef> for CoinID {
+    fn from((id, version, _): ObjectRef) -> Self {
+        Self { id, version }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct MetadataRequest {
+    #[serde(default)]
+    pub metadata: Option<Value>,
+}
+
+#[derive(Serialize)]
+pub struct NetworkListResponse {
+    pub network_identifiers: Vec<NetworkIdentifier>,
+}
+
+impl IntoResponse for NetworkListResponse {
+    fn into_response(self) -> Response {
+        Json(self).into_response()
+    }
+}
+
+#[derive(Deserialize)]
+pub struct ConstructionDeriveRequest {
+    pub network_identifier: NetworkIdentifier,
+    pub public_key: PublicKey,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PublicKey {
+    pub hex_bytes: Hex,
+    pub curve_type: CurveType,
+}
+
+impl From<SuiPublicKey> for PublicKey {
+    fn from(pk: SuiPublicKey) -> Self {
+        match pk {
+            SuiPublicKey::Ed25519(k) => PublicKey {
+                hex_bytes: Hex::from_bytes(&k.0),
+                curve_type: CurveType::Edwards25519,
+            },
+            SuiPublicKey::Secp256k1(k) => PublicKey {
+                hex_bytes: Hex::from_bytes(&k.0),
+                curve_type: CurveType::Secp256k1,
+            },
+            SuiPublicKey::Secp256r1(k) => PublicKey {
+                hex_bytes: Hex::from_bytes(&k.0),
+                curve_type: CurveType::Secp256r1,
+            },
+            SuiPublicKey::ZkLogin(k) => PublicKey {
+                hex_bytes: Hex::from_bytes(&k.0),
+                curve_type: CurveType::ZkLogin, // inaccurate but added for completeness.
+            },
+            SuiPublicKey::Passkey(k) => PublicKey {
+                hex_bytes: Hex::from_bytes(&k.0),
+                curve_type: CurveType::Secp256r1,
+            },
+        }
+    }
+}
+
+impl TryInto<SuiAddress> for PublicKey {
+    type Error = Error;
+
+    fn try_into(self) -> Result<SuiAddress, Self::Error> {
+        let key_bytes = self.hex_bytes.to_vec()?;
+        let pub_key = SuiPublicKey::try_from_bytes(self.curve_type.into(), &key_bytes)?;
+        Ok((&pub_key).into())
+    }
+}
+
+#[derive(Deserialize, Serialize, Copy, Clone, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum CurveType {
+    Secp256k1,
+    Edwards25519,
+    Secp256r1,
+    ZkLogin,
+}
+
+impl From<CurveType> for SignatureScheme {
+    fn from(type_: CurveType) -> Self {
+        match type_ {
+            CurveType::Secp256k1 => SignatureScheme::Secp256k1,
+            CurveType::Edwards25519 => SignatureScheme::ED25519,
+            CurveType::Secp256r1 => SignatureScheme::Secp256r1,
+            CurveType::ZkLogin => SignatureScheme::ZkLoginAuthenticator,
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct ConstructionDeriveResponse {
+    pub account_identifier: AccountIdentifier,
+}
+
+impl IntoResponse for ConstructionDeriveResponse {
+    fn into_response(self) -> Response {
+        Json(self).into_response()
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ConstructionPayloadsRequest {
+    pub network_identifier: NetworkIdentifier,
+    pub operations: Operations,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<ConstructionMetadata>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub public_keys: Vec<PublicKey>,
+}
+
+#[derive(Deserialize, Serialize, Copy, Clone, Debug, EnumIter, Eq, PartialEq)]
+pub enum OperationType {
+    // Balance changing operations from TransactionEffect
+    Gas,
+    SuiBalanceChange,
+    StakeReward,
+    StakePrinciple,
+    // sui-grpc-rosetta supported operation type
+    PaySui,
+    PayCoin,
+    Stake,
+    WithdrawStake,
+    // All other Sui transaction types, readonly
+    EpochChange,
+    Genesis,
+    ConsensusCommitPrologue,
+    ProgrammableTransaction,
+    AuthenticatorStateUpdate,
+    RandomnessStateUpdate,
+    EndOfEpochTransaction,
+    ProgrammableSystemTransaction,
+}
+
+impl From<&SuiTransactionBlockKind> for OperationType {
+    fn from(tx: &SuiTransactionBlockKind) -> Self {
+        match tx {
+            SuiTransactionBlockKind::ChangeEpoch(_) => OperationType::EpochChange,
+            SuiTransactionBlockKind::Genesis(_) => OperationType::Genesis,
+            SuiTransactionBlockKind::ConsensusCommitPrologue(_)
+            | SuiTransactionBlockKind::ConsensusCommitPrologueV2(_)
+            | SuiTransactionBlockKind::ConsensusCommitPrologueV3(_)
+            | SuiTransactionBlockKind::ConsensusCommitPrologueV4(_) => {
+                OperationType::ConsensusCommitPrologue
+            }
+            SuiTransactionBlockKind::ProgrammableTransaction(_) => {
+                OperationType::ProgrammableTransaction
+            }
+            SuiTransactionBlockKind::AuthenticatorStateUpdate(_) => {
+                OperationType::AuthenticatorStateUpdate
+            }
+            SuiTransactionBlockKind::RandomnessStateUpdate(_) => {
+                OperationType::RandomnessStateUpdate
+            }
+            SuiTransactionBlockKind::EndOfEpochTransaction(_) => {
+                OperationType::EndOfEpochTransaction
+            }
+            SuiTransactionBlockKind::ProgrammableSystemTransaction(_) => {
+                OperationType::ProgrammableSystemTransaction
+            }
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, Default, Eq, PartialEq)]
+pub struct OperationIdentifier {
+    index: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    network_index: Option<u64>,
+}
+
+impl From<u64> for OperationIdentifier {
+    fn from(index: u64) -> Self {
+        OperationIdentifier {
+            index,
+            network_index: None,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, Eq, PartialEq)]
+pub struct CoinChange {
+    pub coin_identifier: CoinIdentifier,
+    pub coin_action: CoinAction,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum CoinAction {
+    CoinCreated,
+    CoinSpent,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ConstructionPayloadsResponse {
+    pub unsigned_transaction: Hex,
+    pub payloads: Vec<SigningPayload>,
+}
+
+impl IntoResponse for ConstructionPayloadsResponse {
+    fn into_response(self) -> Response {
+        Json(self).into_response()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SigningPayload {
+    pub account_identifier: AccountIdentifier,
+    // Rosetta need the hex string without `0x`, cannot use fastcrypto's Hex
+    pub hex_bytes: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature_type: Option<SignatureType>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum SignatureType {
+    Ed25519,
+    Ecdsa,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct ConstructionCombineRequest {
+    pub network_identifier: NetworkIdentifier,
+    pub unsigned_transaction: Hex,
+    pub signatures: Vec<Signature>,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct Signature {
+    pub signing_payload: SigningPayload,
+    pub public_key: PublicKey,
+    pub signature_type: SignatureType,
+    pub hex_bytes: Hex,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ConstructionCombineResponse {
+    pub signed_transaction: Hex,
+}
+
+impl IntoResponse for ConstructionCombineResponse {
+    fn into_response(self) -> Response {
+        Json(self).into_response()
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ConstructionSubmitRequest {
+    pub network_identifier: NetworkIdentifier,
+    pub signed_transaction: Hex,
+}
+#[derive(Serialize, Deserialize, Debug)]
+pub struct TransactionIdentifierResponse {
+    pub transaction_identifier: TransactionIdentifier,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}
+
+impl IntoResponse for TransactionIdentifierResponse {
+    fn into_response(self) -> Response {
+        Json(self).into_response()
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct TransactionIdentifier {
+    pub hash: TransactionDigest,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ConstructionPreprocessRequest {
+    pub network_identifier: NetworkIdentifier,
+    pub operations: Operations,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<PreprocessMetadata>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PreprocessMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub budget: Option<u64>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ConstructionPreprocessResponse {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub options: Option<MetadataOptions>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_public_keys: Vec<AccountIdentifier>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct MetadataOptions {
+    pub internal_operation: InternalOperation,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub budget: Option<u64>,
+}
+
+impl IntoResponse for ConstructionPreprocessResponse {
+    fn into_response(self) -> Response {
+        Json(self).into_response()
+    }
+}
+#[derive(Deserialize)]
+pub struct ConstructionHashRequest {
+    pub network_identifier: NetworkIdentifier,
+    pub signed_transaction: Hex,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ConstructionMetadataRequest {
+    pub network_identifier: NetworkIdentifier,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub options: Option<MetadataOptions>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub public_keys: Vec<PublicKey>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ConstructionMetadataResponse {
+    pub metadata: ConstructionMetadata,
+    #[serde(default)]
+    pub suggested_fee: Vec<Amount>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ConstructionMetadata {
+    pub sender: SuiAddress,
+    pub coins: Vec<ObjectRef>,
+    pub objects: Vec<ObjectRef>,
+    #[serde(with = "str_format")]
+    pub total_coin_value: i128,
+    pub gas_price: u64,
+    pub budget: u64,
+    pub currency: Option<Currency>,
+}
+
+impl IntoResponse for ConstructionMetadataResponse {
+    fn into_response(self) -> Response {
+        Json(self).into_response()
+    }
+}
+
+#[derive(Deserialize)]
+pub struct ConstructionParseRequest {
+    pub network_identifier: NetworkIdentifier,
+    pub signed: bool,
+    pub transaction: Hex,
+}
+
+#[derive(Serialize)]
+pub struct ConstructionParseResponse {
+    pub operations: Operations,
+    pub account_identifier_signers: Vec<AccountIdentifier>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}
+
+impl IntoResponse for ConstructionParseResponse {
+    fn into_response(self) -> Response {
+        Json(self).into_response()
+    }
+}
+
+#[derive(Deserialize)]
+pub struct NetworkRequest {
+    pub network_identifier: NetworkIdentifier,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}
+
+#[derive(Serialize)]
+pub struct NetworkStatusResponse {
+    pub current_block_identifier: BlockIdentifier,
+    pub current_block_timestamp: u64,
+    pub genesis_block_identifier: BlockIdentifier,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oldest_block_identifier: Option<BlockIdentifier>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sync_status: Option<SyncStatus>,
+    pub peers: Vec<Peer>,
+}
+
+impl IntoResponse for NetworkStatusResponse {
+    fn into_response(self) -> Response {
+        Json(self).into_response()
+    }
+}
+
+#[derive(Serialize)]
+pub struct SyncStatus {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_index: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_index: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stage: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub synced: Option<bool>,
+}
+#[derive(Serialize)]
+pub struct Peer {
+    pub peer_id: SuiAddress,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}
+
+#[derive(Serialize)]
+pub struct NetworkOptionsResponse {
+    pub version: Version,
+    pub allow: Allow,
+}
+
+impl IntoResponse for NetworkOptionsResponse {
+    fn into_response(self) -> Response {
+        Json(self).into_response()
+    }
+}
+
+#[derive(Serialize)]
+pub struct Version {
+    pub rosetta_version: String,
+    pub node_version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub middleware_version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}
+
+#[derive(Serialize)]
+pub struct Allow {
+    pub operation_statuses: Vec<Value>,
+    pub operation_types: Vec<OperationType>,
+    pub errors: Vec<ErrorType>,
+    pub historical_balance_lookup: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timestamp_start_index: Option<u64>,
+    pub call_methods: Vec<String>,
+    pub balance_exemptions: Vec<BalanceExemption>,
+    pub mempool_coins: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_hash_case: Option<Case>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transaction_hash_case: Option<Case>,
+}
+
+#[derive(Copy, Clone, Deserialize, Serialize, Debug, Eq, PartialEq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum OperationStatus {
+    Success,
+    Failure,
+}
+
+impl From<SuiExecutionStatus> for OperationStatus {
+    fn from(es: SuiExecutionStatus) -> Self {
+        match es {
+            SuiExecutionStatus::Success => OperationStatus::Success,
+            SuiExecutionStatus::Failure { .. } => OperationStatus::Failure,
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct BalanceExemption {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sub_account_address: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub currency: Option<Currency>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exemption_type: Option<ExemptionType>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+#[allow(dead_code)]
+pub enum ExemptionType {
+    GreaterOrEqual,
+    LessOrEqual,
+    Dynamic,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+#[allow(clippy::enum_variant_names, dead_code)]
+pub enum Case {
+    UpperCase,
+    LowerCase,
+    CaseSensitive,
+    Null,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Block {
+    pub block_identifier: BlockIdentifier,
+    pub parent_block_identifier: BlockIdentifier,
+    pub timestamp: u64,
+    pub transactions: Vec<Transaction>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Transaction {
+    pub transaction_identifier: TransactionIdentifier,
+    pub operations: Operations,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub related_transactions: Vec<RelatedTransaction>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Value>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct RelatedTransaction {
+    network_identifier: NetworkIdentifier,
+    transaction_identifier: TransactionIdentifier,
+    direction: Direction,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "lowercase")]
+#[allow(dead_code)]
+pub enum Direction {
+    Forward,
+    Backward,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct BlockResponse {
+    pub block: Block,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub other_transactions: Vec<TransactionIdentifier>,
+}
+
+impl IntoResponse for BlockResponse {
+    fn into_response(self) -> Response {
+        Json(self).into_response()
+    }
+}
+#[derive(Serialize, Deserialize, Default, Debug)]
+pub struct PartialBlockIdentifier {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub index: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hash: Option<BlockHash>,
+}
+#[derive(Deserialize)]
+pub struct BlockRequest {
+    pub network_identifier: NetworkIdentifier,
+    #[serde(default)]
+    pub block_identifier: PartialBlockIdentifier,
+}
+
+#[derive(Deserialize)]
+pub struct BlockTransactionRequest {
+    pub network_identifier: NetworkIdentifier,
+    pub block_identifier: BlockIdentifier,
+    pub transaction_identifier: TransactionIdentifier,
+}
+
+#[derive(Serialize)]
+pub struct BlockTransactionResponse {
+    pub transaction: Transaction,
+}
+
+impl IntoResponse for BlockTransactionResponse {
+    fn into_response(self) -> Response {
+        Json(self).into_response()
+    }
+}
+
+#[derive(Serialize, Clone)]
+pub struct PrefundedAccount {
+    pub privkey: String,
+    pub account_identifier: AccountIdentifier,
+    pub curve_type: CurveType,
+    pub currency: Currency,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum InternalOperation {
+    PaySui {
+        sender: SuiAddress,
+        recipients: Vec<SuiAddress>,
+        amounts: Vec<u64>,
+    },
+    PayCoin {
+        sender: SuiAddress,
+        recipients: Vec<SuiAddress>,
+        amounts: Vec<u64>,
+        currency: Currency,
+    },
+    Stake {
+        sender: SuiAddress,
+        validator: SuiAddress,
+        amount: Option<u64>,
+    },
+    WithdrawStake {
+        sender: SuiAddress,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        stake_ids: Vec<ObjectID>,
+    },
+}
+
+impl InternalOperation {
+    pub fn sender(&self) -> SuiAddress {
+        match self {
+            InternalOperation::PaySui { sender, .. }
+            | InternalOperation::PayCoin { sender, .. }
+            | InternalOperation::Stake { sender, .. }
+            | InternalOperation::WithdrawStake { sender, .. } => *sender,
+        }
+    }
+    /// Combine with ConstructionMetadata to form the TransactionData
+    pub fn try_into_data(self, metadata: ConstructionMetadata) -> Result<TransactionData, Error> {
+        let pt = match self {
+            Self::PaySui {
+                recipients,
+                amounts,
+                ..
+            } => {
+                let mut builder = ProgrammableTransactionBuilder::new();
+                builder.pay_sui(recipients, amounts)?;
+                builder.finish()
+            }
+            Self::PayCoin {
+                recipients,
+                amounts,
+                ..
+            } => {
+                let mut builder = ProgrammableTransactionBuilder::new();
+                builder.pay(metadata.objects.clone(), recipients, amounts)?;
+                let currency_str = serde_json::to_string(&metadata.currency.unwrap()).unwrap();
+                // This is a workaround in order to have the currency info available during the process
+                // of constructing back the Operations object from the transaction data. A process that
+                // takes place upon the request to the construction's /parse endpoint. The pure value is
+                // not actually being used in any on-chain transaction execution and its sole purpose
+                // is to act as a bearer of the currency info between the various steps of the flow.
+                // See also the value is being later accessed within the operations.rs file's
+                // parse_programmable_transaction function.
+                builder.pure(currency_str)?;
+                builder.finish()
+            }
+            InternalOperation::Stake {
+                validator, amount, ..
+            } => {
+                let mut builder = ProgrammableTransactionBuilder::new();
+
+                // [WORKAROUND] - this is a hack to work out if the staking ops is for a selected amount or None amount (whole wallet).
+                // if amount is none, validator input will be created after the system object input
+                let (validator, system_state, amount) = if let Some(amount) = amount {
+                    let amount = builder.pure(amount)?;
+                    let validator = builder.input(CallArg::Pure(bcs::to_bytes(&validator)?))?;
+                    let state = builder.input(CallArg::SUI_SYSTEM_MUT)?;
+                    (validator, state, amount)
+                } else {
+                    let amount =
+                        builder.pure(metadata.total_coin_value as u64 - metadata.budget)?;
+                    let state = builder.input(CallArg::SUI_SYSTEM_MUT)?;
+                    let validator = builder.input(CallArg::Pure(bcs::to_bytes(&validator)?))?;
+                    (validator, state, amount)
+                };
+                let coin = builder.command(Command::SplitCoins(Argument::GasCoin, vec![amount]));
+
+                let arguments = vec![system_state, coin, validator];
+
+                builder.command(Command::move_call(
+                    SUI_SYSTEM_PACKAGE_ID,
+                    SUI_SYSTEM_MODULE_NAME.to_owned(),
+                    ADD_STAKE_FUN_NAME.to_owned(),
+                    vec![],
+                    arguments,
+                ));
+                builder.finish()
+            }
+            InternalOperation::WithdrawStake { stake_ids, .. } => {
+                let mut builder = ProgrammableTransactionBuilder::new();
+
+                for stake_id in metadata.objects {
+                    // [WORKAROUND] - this is a hack to work out if the withdraw stake ops is for selected stake_ids or None (all stakes) using the index of the call args.
+                    // if stake_ids is not empty, id input will be created after the system object input
+                    let (system_state, id) = if !stake_ids.is_empty() {
+                        let system_state = builder.input(CallArg::SUI_SYSTEM_MUT)?;
+                        let id = builder.obj(ObjectArg::ImmOrOwnedObject(stake_id))?;
+                        (system_state, id)
+                    } else {
+                        let id = builder.obj(ObjectArg::ImmOrOwnedObject(stake_id))?;
+                        let system_state = builder.input(CallArg::SUI_SYSTEM_MUT)?;
+                        (system_state, id)
+                    };
+
+                    let arguments = vec![system_state, id];
+                    builder.command(Command::move_call(
+                        SUI_SYSTEM_PACKAGE_ID,
+                        SUI_SYSTEM_MODULE_NAME.to_owned(),
+                        WITHDRAW_STAKE_FUN_NAME.to_owned(),
+                        vec![],
+                        arguments,
+                    ));
+                }
+                builder.finish()
+            }
+        };
+
+        Ok(TransactionData::new_programmable(
+            metadata.sender,
+            metadata.coins,
+            pt,
+            metadata.budget,
+            metadata.gas_price,
+        ))
+    }
+}

--- a/crates/sui-grpc-rosetta/src/unit_tests/balance_changing_tx_tests.rs
+++ b/crates/sui-grpc-rosetta/src/unit_tests/balance_changing_tx_tests.rs
@@ -1,0 +1,887 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::operations::Operations;
+use crate::types::{ConstructionMetadata, OperationStatus, OperationType};
+use crate::CoinMetadataCache;
+use anyhow::anyhow;
+use move_core_types::identifier::Identifier;
+use move_core_types::language_storage::StructTag;
+use rand::seq::{IteratorRandom, SliceRandom};
+use serde_json::json;
+use shared_crypto::intent::Intent;
+use signature::rand_core::OsRng;
+use std::collections::{BTreeMap, HashMap};
+use std::num::NonZeroUsize;
+use std::path::PathBuf;
+use std::str::FromStr;
+use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
+use sui_json_rpc_types::{
+    ObjectChange, SuiObjectDataOptions, SuiObjectRef, SuiObjectResponseQuery,
+};
+use sui_keys::keystore::AccountKeystore;
+use sui_keys::keystore::Keystore;
+use sui_move_build::BuildConfig;
+use sui_sdk::rpc_types::{
+    OwnedObjectRef, SuiData, SuiExecutionStatus, SuiTransactionBlockEffectsAPI,
+    SuiTransactionBlockResponse,
+};
+use sui_sdk::SuiClient;
+use sui_types::base_types::{FullObjectRef, ObjectID, ObjectRef, SuiAddress};
+use sui_types::gas_coin::{GasCoin, GAS};
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+use sui_types::quorum_driver_types::ExecuteTransactionRequestType;
+use sui_types::transaction::{
+    CallArg, InputObjectKind, ObjectArg, ProgrammableTransaction, Transaction, TransactionData,
+    TransactionDataAPI, TransactionKind, TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+    TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE, TEST_ONLY_GAS_UNIT_FOR_SPLIT_COIN,
+    TEST_ONLY_GAS_UNIT_FOR_STAKING, TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+};
+use sui_types::TypeTag;
+use test_cluster::TestClusterBuilder;
+
+#[tokio::test]
+async fn test_transfer_sui() {
+    let network = TestClusterBuilder::new().build().await;
+    let client = network.wallet.get_client().await.unwrap();
+    let keystore = &network.wallet.config.keystore;
+    let rgp = network.get_reference_gas_price().await;
+
+    // Test Transfer Sui
+    let addresses = network.get_addresses();
+    let sender = get_random_address(&addresses, vec![]);
+    let recipient = get_random_address(&addresses, vec![sender]);
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.transfer_sui(recipient, Some(50000));
+        builder.finish()
+    };
+    test_transaction(
+        &client,
+        keystore,
+        vec![recipient],
+        sender,
+        pt,
+        vec![],
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+        false,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_transfer_sui_whole_coin() {
+    let network = TestClusterBuilder::new().build().await;
+    let client = network.wallet.get_client().await.unwrap();
+    let keystore = &network.wallet.config.keystore;
+    let rgp = network.get_reference_gas_price().await;
+
+    // Test transfer sui whole coin
+    let addresses = network.get_addresses();
+    let sender = get_random_address(&addresses, vec![]);
+    let recipient = get_random_address(&addresses, vec![sender]);
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.transfer_sui(recipient, None);
+        builder.finish()
+    };
+    test_transaction(
+        &client,
+        keystore,
+        vec![recipient],
+        sender,
+        pt,
+        vec![],
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+        false,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_transfer_object() {
+    let network = TestClusterBuilder::new().build().await;
+    let client = network.wallet.get_client().await.unwrap();
+    let keystore = &network.wallet.config.keystore;
+    let rgp = network.get_reference_gas_price().await;
+
+    // Test transfer object
+    let addresses = network.get_addresses();
+    let sender = get_random_address(&addresses, vec![]);
+    let recipient = get_random_address(&addresses, vec![sender]);
+    let object_ref = get_random_sui(&client, sender, vec![]).await;
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder
+            .transfer_object(recipient, FullObjectRef::from_fastpath_ref(object_ref))
+            .unwrap();
+        builder.finish()
+    };
+    test_transaction(
+        &client,
+        keystore,
+        vec![recipient],
+        sender,
+        pt,
+        vec![],
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+        false,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_publish_and_move_call() {
+    let network = TestClusterBuilder::new().build().await;
+    let client = network.wallet.get_client().await.unwrap();
+    let keystore = &network.wallet.config.keystore;
+    let rgp = network.get_reference_gas_price().await;
+
+    // Test publish
+    let addresses = network.get_addresses();
+    let sender = get_random_address(&addresses, vec![]);
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.extend(["..", "..", "examples", "move", "coin"]);
+    let compiled_package = BuildConfig::new_for_testing().build(&path).unwrap();
+    let compiled_modules_bytes =
+        compiled_package.get_package_bytes(/* with_unpublished_deps */ false);
+    let dependencies = compiled_package.get_dependency_storage_package_ids();
+
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.publish_immutable(compiled_modules_bytes, dependencies);
+        builder.finish()
+    };
+    let response = test_transaction(
+        &client,
+        keystore,
+        vec![],
+        sender,
+        pt,
+        vec![],
+        rgp * TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE,
+        rgp,
+        false,
+    )
+    .await;
+    let object_changes = response.object_changes.unwrap();
+
+    // Test move call (reuse published module from above test)
+    let package = object_changes
+        .iter()
+        .find_map(|change| {
+            if let ObjectChange::Published { package_id, .. } = change {
+                Some(package_id)
+            } else {
+                None
+            }
+        })
+        .unwrap();
+
+    let treasury = find_module_object(&object_changes, |type_| {
+        if type_.name.as_str() != "TreasuryCap" {
+            return false;
+        }
+
+        let Some(TypeTag::Struct(otw)) = type_.type_params.first() else {
+            return false;
+        };
+
+        otw.name.as_str() == "MY_COIN"
+    });
+
+    let treasury = treasury.clone().reference.to_object_ref();
+    let recipient = *addresses.choose(&mut OsRng).unwrap();
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder
+            .move_call(
+                *package,
+                Identifier::from_str("my_coin").unwrap(),
+                Identifier::from_str("mint").unwrap(),
+                vec![],
+                vec![
+                    CallArg::Object(ObjectArg::ImmOrOwnedObject(treasury)),
+                    CallArg::Pure(bcs::to_bytes(&10000u64).unwrap()),
+                    CallArg::Pure(bcs::to_bytes(&recipient).unwrap()),
+                ],
+            )
+            .unwrap();
+        builder.finish()
+    };
+
+    test_transaction(
+        &client,
+        keystore,
+        vec![],
+        sender,
+        pt,
+        vec![],
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp,
+        false,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_split_coin() {
+    let network = TestClusterBuilder::new().build().await;
+    let client = network.wallet.get_client().await.unwrap();
+    let keystore = &network.wallet.config.keystore;
+    let rgp = network.get_reference_gas_price().await;
+
+    // Test spilt coin
+    let sender = get_random_address(&network.get_addresses(), vec![]);
+    let coin = get_random_sui(&client, sender, vec![]).await;
+    let tx = client
+        .transaction_builder()
+        .split_coin(sender, coin.0, vec![100000], None, 10000)
+        .await
+        .unwrap();
+    let pt = match tx.into_kind() {
+        TransactionKind::ProgrammableTransaction(pt) => pt,
+        _ => unreachable!(),
+    };
+    test_transaction(
+        &client,
+        keystore,
+        vec![],
+        sender,
+        pt,
+        vec![],
+        rgp * TEST_ONLY_GAS_UNIT_FOR_SPLIT_COIN,
+        rgp,
+        false,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_merge_coin() {
+    let network = TestClusterBuilder::new().build().await;
+    let client = network.wallet.get_client().await.unwrap();
+    let keystore = &network.wallet.config.keystore;
+    let rgp = network.get_reference_gas_price().await;
+
+    // Test merge coin
+    let sender = get_random_address(&network.get_addresses(), vec![]);
+    let coin = get_random_sui(&client, sender, vec![]).await;
+    let coin2 = get_random_sui(&client, sender, vec![coin.0]).await;
+    let tx = client
+        .transaction_builder()
+        .merge_coins(sender, coin.0, coin2.0, None, 10000)
+        .await
+        .unwrap();
+    let pt = match tx.into_kind() {
+        TransactionKind::ProgrammableTransaction(pt) => pt,
+        _ => unreachable!(),
+    };
+    test_transaction(
+        &client,
+        keystore,
+        vec![],
+        sender,
+        pt,
+        vec![],
+        rgp * TEST_ONLY_GAS_UNIT_FOR_GENERIC,
+        rgp,
+        false,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_pay() {
+    let network = TestClusterBuilder::new().build().await;
+    let client = network.wallet.get_client().await.unwrap();
+    let keystore = &network.wallet.config.keystore;
+    let rgp = network.get_reference_gas_price().await;
+
+    // Test Pay
+    let addresses = network.get_addresses();
+    let sender = get_random_address(&addresses, vec![]);
+    let recipient = get_random_address(&addresses, vec![sender]);
+    let coin = get_random_sui(&client, sender, vec![]).await;
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder
+            .pay(vec![coin], vec![recipient], vec![100000])
+            .unwrap();
+        builder.finish()
+    };
+    test_transaction(
+        &client,
+        keystore,
+        vec![recipient],
+        sender,
+        pt,
+        vec![],
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+        false,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_pay_multiple_coin_multiple_recipient() {
+    let network = TestClusterBuilder::new().build().await;
+    let client = network.wallet.get_client().await.unwrap();
+    let keystore = &network.wallet.config.keystore;
+    let rgp = network.get_reference_gas_price().await;
+
+    // Test Pay multiple coin multiple recipient
+    let addresses = network.get_addresses();
+    let sender = get_random_address(&addresses, vec![]);
+    let recipient1 = get_random_address(&addresses, vec![sender]);
+    let recipient2 = get_random_address(&addresses, vec![sender, recipient1]);
+    let coin1 = get_random_sui(&client, sender, vec![]).await;
+    let coin2 = get_random_sui(&client, sender, vec![coin1.0]).await;
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder
+            .pay(
+                vec![coin1, coin2],
+                vec![recipient1, recipient2],
+                vec![100000, 200000],
+            )
+            .unwrap();
+        builder.finish()
+    };
+    test_transaction(
+        &client,
+        keystore,
+        vec![recipient1, recipient2],
+        sender,
+        pt,
+        vec![],
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+        false,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_pay_sui_multiple_coin_same_recipient() {
+    let network = TestClusterBuilder::new().build().await;
+    let client = network.wallet.get_client().await.unwrap();
+    let keystore = &network.wallet.config.keystore;
+    let rgp = network.get_reference_gas_price().await;
+
+    // Test Pay multiple coin same recipient
+    let addresses = network.get_addresses();
+    let sender = get_random_address(&addresses, vec![]);
+    let recipient1 = get_random_address(&addresses, vec![sender]);
+    let coin1 = get_random_sui(&client, sender, vec![]).await;
+    let coin2 = get_random_sui(&client, sender, vec![coin1.0]).await;
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder
+            .pay_sui(
+                vec![recipient1, recipient1, recipient1],
+                vec![100000, 100000, 100000],
+            )
+            .unwrap();
+        builder.finish()
+    };
+    test_transaction(
+        &client,
+        keystore,
+        vec![recipient1],
+        sender,
+        pt,
+        vec![coin1, coin2],
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+        false,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_pay_sui() {
+    let network = TestClusterBuilder::new().build().await;
+    let client = network.wallet.get_client().await.unwrap();
+    let keystore = &network.wallet.config.keystore;
+    let rgp = network.get_reference_gas_price().await;
+
+    // Test Pay Sui
+    let addresses = network.get_addresses();
+    let sender = get_random_address(&addresses, vec![]);
+    let recipient1 = get_random_address(&addresses, vec![sender]);
+    let recipient2 = get_random_address(&addresses, vec![sender, recipient1]);
+    let coin1 = get_random_sui(&client, sender, vec![]).await;
+    let coin2 = get_random_sui(&client, sender, vec![coin1.0]).await;
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder
+            .pay_sui(vec![recipient1, recipient2], vec![1000000, 2000000])
+            .unwrap();
+        builder.finish()
+    };
+    test_transaction(
+        &client,
+        keystore,
+        vec![recipient1, recipient2],
+        sender,
+        pt,
+        vec![coin1, coin2],
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+        false,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_failed_pay_sui() {
+    let network = TestClusterBuilder::new().build().await;
+    let client = network.wallet.get_client().await.unwrap();
+    let keystore = &network.wallet.config.keystore;
+    let rgp = network.get_reference_gas_price().await;
+
+    // Test failed Pay Sui
+    let addresses = network.get_addresses();
+    let sender = get_random_address(&addresses, vec![]);
+    let recipient1 = get_random_address(&addresses, vec![sender]);
+    let recipient2 = get_random_address(&addresses, vec![sender, recipient1]);
+    let coin1 = get_random_sui(&client, sender, vec![]).await;
+    let coin2 = get_random_sui(&client, sender, vec![coin1.0]).await;
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder
+            .pay_sui(vec![recipient1, recipient2], vec![1000000, 2000000])
+            .unwrap();
+        builder.finish()
+    };
+    test_transaction(
+        &client,
+        keystore,
+        vec![],
+        sender,
+        pt,
+        vec![coin1, coin2],
+        2000000,
+        rgp,
+        true,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_stake_sui() {
+    let network = TestClusterBuilder::new().build().await;
+    let client = network.wallet.get_client().await.unwrap();
+    let keystore = &network.wallet.config.keystore;
+    let rgp = network.get_reference_gas_price().await;
+
+    // Test Delegate Sui
+    let sender = get_random_address(&network.get_addresses(), vec![]);
+    let coin1 = get_random_sui(&client, sender, vec![]).await;
+    let coin2 = get_random_sui(&client, sender, vec![coin1.0]).await;
+    let validator = client
+        .governance_api()
+        .get_latest_sui_system_state()
+        .await
+        .unwrap()
+        .active_validators[0]
+        .sui_address;
+    let tx = client
+        .transaction_builder()
+        .request_add_stake(
+            sender,
+            vec![coin1.0, coin2.0],
+            Some(1000000000),
+            validator,
+            None,
+            10_000_000,
+        )
+        .await
+        .unwrap();
+    let pt = match tx.into_kind() {
+        TransactionKind::ProgrammableTransaction(pt) => pt,
+        _ => unreachable!(),
+    };
+    test_transaction(
+        &client,
+        keystore,
+        vec![],
+        sender,
+        pt,
+        vec![],
+        rgp * TEST_ONLY_GAS_UNIT_FOR_STAKING,
+        rgp,
+        false,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_stake_sui_with_none_amount() {
+    let network = TestClusterBuilder::new().build().await;
+    let client = network.wallet.get_client().await.unwrap();
+    let keystore = &network.wallet.config.keystore;
+    let rgp = network.get_reference_gas_price().await;
+
+    // Test Staking Sui
+    let sender = get_random_address(&network.get_addresses(), vec![]);
+    let coin1 = get_random_sui(&client, sender, vec![]).await;
+    let coin2 = get_random_sui(&client, sender, vec![coin1.0]).await;
+    let validator = client
+        .governance_api()
+        .get_latest_sui_system_state()
+        .await
+        .unwrap()
+        .active_validators[0]
+        .sui_address;
+    let tx = client
+        .transaction_builder()
+        .request_add_stake(
+            sender,
+            vec![coin1.0, coin2.0],
+            None,
+            validator,
+            None,
+            rgp * TEST_ONLY_GAS_UNIT_FOR_STAKING,
+        )
+        .await
+        .unwrap();
+    let pt = match tx.into_kind() {
+        TransactionKind::ProgrammableTransaction(pt) => pt,
+        _ => unreachable!(),
+    };
+    test_transaction(
+        &client,
+        keystore,
+        vec![],
+        sender,
+        pt,
+        vec![],
+        rgp * TEST_ONLY_GAS_UNIT_FOR_STAKING,
+        rgp,
+        false,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_pay_all_sui() {
+    let network = TestClusterBuilder::new().build().await;
+    let client = network.wallet.get_client().await.unwrap();
+    let keystore = &network.wallet.config.keystore;
+    let rgp = network.get_reference_gas_price().await;
+
+    // Test Pay All Sui
+    let addresses = network.get_addresses();
+    let sender = get_random_address(&addresses, vec![]);
+    let recipient = get_random_address(&addresses, vec![sender]);
+    let coin1 = get_random_sui(&client, sender, vec![]).await;
+    let coin2 = get_random_sui(&client, sender, vec![coin1.0]).await;
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.pay_all_sui(recipient);
+        builder.finish()
+    };
+    test_transaction(
+        &client,
+        keystore,
+        vec![recipient],
+        sender,
+        pt,
+        vec![coin1, coin2],
+        rgp * TEST_ONLY_GAS_UNIT_FOR_TRANSFER,
+        rgp,
+        false,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_delegation_parsing() -> Result<(), anyhow::Error> {
+    let network = TestClusterBuilder::new().build().await;
+    let rgp = network.get_reference_gas_price().await;
+    let client = network.wallet.get_client().await.unwrap();
+    let sender = get_random_address(&network.get_addresses(), vec![]);
+    let gas = get_random_sui(&client, sender, vec![]).await;
+    let validator = client
+        .governance_api()
+        .get_latest_sui_system_state()
+        .await
+        .unwrap()
+        .active_validators[0]
+        .sui_address;
+
+    let ops: Operations = serde_json::from_value(json!(
+        [{
+            "operation_identifier":{"index":0},
+            "type":"Stake",
+            "account": { "address" : sender.to_string() },
+            "amount" : { "value": "-100000" , "currency": { "symbol": "SUI", "decimals": 9}},
+            "metadata": { "Stake" : {"validator": validator.to_string()} }
+        }]
+    ))
+    .unwrap();
+    let metadata = ConstructionMetadata {
+        sender,
+        coins: vec![gas],
+        objects: vec![],
+        total_coin_value: 0,
+        gas_price: rgp,
+        budget: rgp * TEST_ONLY_GAS_UNIT_FOR_STAKING,
+        currency: None,
+    };
+    let parsed_data = ops.clone().into_internal()?.try_into_data(metadata)?;
+    assert_eq!(ops, Operations::try_from(parsed_data)?);
+
+    Ok(())
+}
+
+fn find_module_object(
+    changes: &[ObjectChange],
+    type_pred: impl Fn(&StructTag) -> bool,
+) -> OwnedObjectRef {
+    let mut results: Vec<_> = changes
+        .iter()
+        .filter_map(|change| {
+            if let ObjectChange::Created {
+                object_id,
+                object_type,
+                owner,
+                version,
+                digest,
+                ..
+            } = change
+            {
+                if type_pred(object_type) {
+                    return Some(OwnedObjectRef {
+                        owner: owner.clone(),
+                        reference: SuiObjectRef {
+                            object_id: *object_id,
+                            version: *version,
+                            digest: *digest,
+                        },
+                    });
+                }
+            };
+            None
+        })
+        .collect();
+    // Check that there is only one object found, and hence no ambiguity.
+    assert_eq!(results.len(), 1);
+    results.pop().unwrap()
+}
+
+// Record current Sui balance of an address then execute the transaction,
+// and compare the balance change reported by the event against the actual balance change.
+async fn test_transaction(
+    client: &SuiClient,
+    keystore: &Keystore,
+    addr_to_check: Vec<SuiAddress>,
+    sender: SuiAddress,
+    tx: ProgrammableTransaction,
+    gas: Vec<ObjectRef>,
+    gas_budget: u64,
+    gas_price: u64,
+    expect_fail: bool,
+) -> SuiTransactionBlockResponse {
+    let gas = if !gas.is_empty() {
+        gas
+    } else {
+        let input_objects = tx
+            .input_objects()
+            .unwrap_or_default()
+            .iter()
+            .flat_map(|obj| {
+                if let InputObjectKind::ImmOrOwnedMoveObject((id, ..)) = obj {
+                    Some(*id)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        vec![get_random_sui(client, sender, input_objects).await]
+    };
+
+    let data = TransactionData::new_with_gas_coins(
+        TransactionKind::programmable(tx.clone()),
+        sender,
+        gas,
+        gas_budget,
+        gas_price,
+    );
+
+    let signature = keystore
+        .sign_secure(&data.sender(), &data, Intent::sui_transaction())
+        .await
+        .unwrap();
+
+    // Balance before execution
+    let mut balances = BTreeMap::new();
+    let mut addr_to_check = addr_to_check;
+    addr_to_check.push(sender);
+    for addr in addr_to_check {
+        balances.insert(addr, get_balance(client, addr).await);
+    }
+
+    let response = client
+        .quorum_driver_api()
+        .execute_transaction_block(
+            Transaction::from_data(data.clone(), vec![signature]),
+            SuiTransactionBlockResponseOptions::full_content(),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await
+        .map_err(|e| anyhow!("TX execution failed for {data:#?}, error : {e}"))
+        .unwrap();
+
+    let effects = response.effects.as_ref().unwrap();
+
+    if !expect_fail {
+        assert_eq!(
+            SuiExecutionStatus::Success,
+            *effects.status(),
+            "TX execution failed for {:#?}",
+            data
+        );
+    } else {
+        assert!(matches!(
+            effects.status(),
+            SuiExecutionStatus::Failure { .. }
+        ));
+    }
+    let coin_cache = CoinMetadataCache::new(client.clone(), NonZeroUsize::new(2).unwrap());
+    let ops = Operations::try_from_response(response.clone(), &coin_cache)
+        .await
+        .unwrap();
+    let balances_from_ops = extract_balance_changes_from_ops(ops);
+
+    // get actual balance changed after transaction
+    let mut actual_balance_change = HashMap::new();
+    for (addr, balance) in balances {
+        let new_balance = get_balance(client, addr).await as i128;
+        let balance_changed = new_balance - balance as i128;
+        actual_balance_change.insert(addr, balance_changed);
+    }
+    assert_eq!(
+        actual_balance_change, balances_from_ops,
+        "balance check failed for tx: {}\neffect:{:#?}",
+        tx, effects
+    );
+    response
+}
+
+fn extract_balance_changes_from_ops(ops: Operations) -> HashMap<SuiAddress, i128> {
+    ops.into_iter()
+        .fold(HashMap::<SuiAddress, i128>::new(), |mut changes, op| {
+            if let Some(OperationStatus::Success) = op.status {
+                match op.type_ {
+                    OperationType::SuiBalanceChange
+                    | OperationType::Gas
+                    | OperationType::PaySui
+                    | OperationType::PayCoin
+                    | OperationType::StakeReward
+                    | OperationType::StakePrinciple
+                    | OperationType::Stake => {
+                        if let (Some(addr), Some(amount)) = (op.account, op.amount) {
+                            // Todo: amend this method and tests to cover other coin types too (eg. test_publish_and_move_call also mints MY_COIN)
+                            if amount.currency.metadata.coin_type == GAS::type_().to_string() {
+                                *changes.entry(addr.address).or_default() += amount.value
+                            }
+                        }
+                    }
+                    _ => {}
+                };
+            }
+            changes
+        })
+}
+
+async fn get_random_sui(
+    client: &SuiClient,
+    sender: SuiAddress,
+    except: Vec<ObjectID>,
+) -> ObjectRef {
+    let coins = client
+        .read_api()
+        .get_owned_objects(
+            sender,
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
+            /* cursor */ None,
+            /* limit */ None,
+        )
+        .await
+        .unwrap()
+        .data;
+
+    let coin_resp = coins
+        .iter()
+        .filter(|object| {
+            let obj = object.object().unwrap();
+            obj.is_gas_coin() && !except.contains(&obj.object_id)
+        })
+        .choose(&mut OsRng)
+        .unwrap();
+
+    let coin = coin_resp.object().unwrap();
+    (coin.object_id, coin.version, coin.digest)
+}
+
+fn get_random_address(addresses: &[SuiAddress], except: Vec<SuiAddress>) -> SuiAddress {
+    *addresses
+        .iter()
+        .filter(|addr| !except.contains(*addr))
+        .choose(&mut OsRng)
+        .unwrap()
+}
+
+async fn get_balance(client: &SuiClient, address: SuiAddress) -> u64 {
+    let coins = client
+        .read_api()
+        .get_owned_objects(
+            address,
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
+            /* cursor */ None,
+            /* limit */ None,
+        )
+        .await
+        .unwrap()
+        .data;
+
+    let mut balance = 0u64;
+    for coin in coins {
+        let obj = coin.into_object().unwrap();
+        if obj.is_gas_coin() {
+            let object = client
+                .read_api()
+                .get_object_with_options(obj.object_id, SuiObjectDataOptions::new().with_bcs())
+                .await
+                .unwrap();
+            let coin: GasCoin = object
+                .into_object()
+                .unwrap()
+                .bcs
+                .unwrap()
+                .try_as_move()
+                .unwrap()
+                .deserialize()
+                .unwrap();
+            balance += coin.value()
+        }
+    }
+    balance
+}

--- a/crates/sui-grpc-rosetta/src/unit_tests/lib_tests.rs
+++ b/crates/sui-grpc-rosetta/src/unit_tests/lib_tests.rs
@@ -1,0 +1,148 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::CoinMetadataCache;
+use anyhow::anyhow;
+use rand::prelude::IteratorRandom;
+use rand::rngs::OsRng;
+use shared_crypto::intent::Intent;
+use std::num::NonZeroUsize;
+use std::path::PathBuf;
+use sui_json_rpc_types::{
+    ObjectChange, SuiObjectDataOptions, SuiObjectResponseQuery, SuiTransactionBlockResponseOptions,
+};
+use sui_keys::keystore::AccountKeystore;
+use sui_move_build::BuildConfig;
+use sui_sdk::SuiClient;
+use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
+use sui_types::gas_coin::GAS;
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+use sui_types::quorum_driver_types::ExecuteTransactionRequestType;
+use sui_types::transaction::{
+    InputObjectKind, Transaction, TransactionData, TransactionDataAPI, TransactionKind,
+    TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE,
+};
+use test_cluster::TestClusterBuilder;
+
+#[tokio::test]
+async fn test_cache() {
+    let network = TestClusterBuilder::new().build().await;
+    let client = network.wallet.get_client().await.unwrap();
+    let keystore = &network.wallet.config.keystore;
+    let rgp = network.get_reference_gas_price().await;
+
+    // Test publish
+    let addresses = network.get_addresses();
+    let sender = addresses[0];
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.extend(["..", "..", "examples", "move", "coin"]);
+    let compiled_package = BuildConfig::new_for_testing().build(&path).unwrap();
+    let compiled_modules_bytes =
+        compiled_package.get_package_bytes(/* with_unpublished_deps */ false);
+    let dependencies = compiled_package.get_dependency_storage_package_ids();
+
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder.publish_immutable(compiled_modules_bytes, dependencies);
+        builder.finish()
+    };
+    let input_objects = pt
+        .input_objects()
+        .unwrap_or_default()
+        .iter()
+        .flat_map(|obj| {
+            if let InputObjectKind::ImmOrOwnedMoveObject((id, ..)) = obj {
+                Some(*id)
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    let gas = vec![get_random_sui(&client, sender, input_objects).await];
+    let data = TransactionData::new_with_gas_coins(
+        TransactionKind::programmable(pt.clone()),
+        sender,
+        gas,
+        rgp * TEST_ONLY_GAS_UNIT_FOR_HEAVY_COMPUTATION_STORAGE,
+        rgp,
+    );
+
+    let signature = keystore
+        .sign_secure(&data.sender(), &data, Intent::sui_transaction())
+        .await
+        .unwrap();
+    let response = client
+        .quorum_driver_api()
+        .execute_transaction_block(
+            Transaction::from_data(data.clone(), vec![signature]),
+            SuiTransactionBlockResponseOptions::full_content(),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await
+        .map_err(|e| anyhow!("TX execution failed for {data:#?}, error : {e}"))
+        .unwrap();
+    let object_changes = response.object_changes.unwrap();
+    let my_coin_type = object_changes
+        .into_iter()
+        .find_map(|change| {
+            if let ObjectChange::Created { object_type, .. } = change {
+                if object_type.to_string().contains("2::coin::TreasuryCap") {
+                    let coin_tag = object_type.type_params.into_iter().next().unwrap();
+                    return Some(coin_tag);
+                }
+            }
+            None
+        })
+        .unwrap();
+
+    let coin_cache = CoinMetadataCache::new(client.clone(), NonZeroUsize::new(1).unwrap());
+
+    assert_eq!(0, coin_cache.metadata.lock().await.len());
+
+    let _ = coin_cache.get_currency(&GAS::type_tag()).await;
+
+    assert_eq!(1, coin_cache.metadata.lock().await.len());
+    assert!(coin_cache.metadata.lock().await.contains(&GAS::type_tag()));
+    assert!(!coin_cache.metadata.lock().await.contains(&my_coin_type));
+
+    let _ = coin_cache.get_currency(&my_coin_type).await;
+
+    assert_eq!(1, coin_cache.metadata.lock().await.len());
+    assert!(coin_cache.metadata.lock().await.contains(&my_coin_type));
+    assert!(!coin_cache.metadata.lock().await.contains(&GAS::type_tag()));
+}
+
+async fn get_random_sui(
+    client: &SuiClient,
+    sender: SuiAddress,
+    except: Vec<ObjectID>,
+) -> ObjectRef {
+    let coins = client
+        .read_api()
+        .get_owned_objects(
+            sender,
+            Some(SuiObjectResponseQuery::new_with_options(
+                SuiObjectDataOptions::new()
+                    .with_type()
+                    .with_owner()
+                    .with_previous_transaction(),
+            )),
+            /* cursor */ None,
+            /* limit */ None,
+        )
+        .await
+        .unwrap()
+        .data;
+
+    let coin_resp = coins
+        .iter()
+        .filter(|object| {
+            let obj = object.object().unwrap();
+            obj.is_gas_coin() && !except.contains(&obj.object_id)
+        })
+        .choose(&mut OsRng)
+        .unwrap();
+
+    let coin = coin_resp.object().unwrap();
+    (coin.object_id, coin.version, coin.digest)
+}

--- a/crates/sui-grpc-rosetta/src/unit_tests/operations_tests.rs
+++ b/crates/sui-grpc-rosetta/src/unit_tests/operations_tests.rs
@@ -1,0 +1,121 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use move_core_types::annotated_value::MoveTypeLayout;
+use sui_json_rpc_types::SuiCallArg;
+use sui_types::base_types::{ObjectDigest, ObjectID, SequenceNumber, SuiAddress};
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+use sui_types::transaction::{CallArg, TransactionData, TEST_ONLY_GAS_UNIT_FOR_TRANSFER};
+
+use crate::operations::Operations;
+use crate::types::{ConstructionMetadata, OperationType};
+use crate::SUI;
+
+#[tokio::test]
+async fn test_operation_data_parsing_pay_sui() -> Result<(), anyhow::Error> {
+    let gas = (
+        ObjectID::random(),
+        SequenceNumber::new(),
+        ObjectDigest::random(),
+    );
+
+    let sender = SuiAddress::random_for_testing_only();
+
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder
+            .pay_sui(vec![SuiAddress::random_for_testing_only()], vec![10000])
+            .unwrap();
+        builder.finish()
+    };
+    let gas_price = 10;
+    let data = TransactionData::new_programmable(
+        sender,
+        vec![gas],
+        pt,
+        TEST_ONLY_GAS_UNIT_FOR_TRANSFER * gas_price,
+        gas_price,
+    );
+
+    let ops: Operations = data.clone().try_into()?;
+    ops.0
+        .iter()
+        .for_each(|op| assert_eq!(op.type_, OperationType::PaySui));
+    let metadata = ConstructionMetadata {
+        sender,
+        coins: vec![gas],
+        objects: vec![],
+        total_coin_value: 0,
+        gas_price,
+        budget: TEST_ONLY_GAS_UNIT_FOR_TRANSFER * gas_price,
+        currency: None,
+    };
+    let parsed_data = ops.into_internal()?.try_into_data(metadata)?;
+    assert_eq!(data, parsed_data);
+
+    Ok(())
+}
+#[tokio::test]
+async fn test_operation_data_parsing_pay_coin() -> Result<(), anyhow::Error> {
+    let gas = (
+        ObjectID::random(),
+        SequenceNumber::new(),
+        ObjectDigest::random(),
+    );
+
+    let coin = (
+        ObjectID::random(),
+        SequenceNumber::new(),
+        ObjectDigest::random(),
+    );
+
+    let sender = SuiAddress::random_for_testing_only();
+
+    let pt = {
+        let mut builder = ProgrammableTransactionBuilder::new();
+        builder
+            .pay(
+                vec![coin],
+                vec![SuiAddress::random_for_testing_only()],
+                vec![10000],
+            )
+            .unwrap();
+        // the following is important in order to be able to transfer the coin type info between the various flow steps
+        builder.pure(serde_json::to_string(&SUI.clone())?)?;
+        builder.finish()
+    };
+    let gas_price = 10;
+    let data = TransactionData::new_programmable(
+        sender,
+        vec![gas],
+        pt,
+        TEST_ONLY_GAS_UNIT_FOR_TRANSFER * gas_price,
+        gas_price,
+    );
+
+    let ops: Operations = data.clone().try_into()?;
+    ops.0
+        .iter()
+        .for_each(|op| assert_eq!(op.type_, OperationType::PayCoin));
+    let metadata = ConstructionMetadata {
+        sender,
+        coins: vec![gas],
+        objects: vec![coin],
+        total_coin_value: 0,
+        gas_price,
+        budget: TEST_ONLY_GAS_UNIT_FOR_TRANSFER * gas_price,
+        currency: Some(SUI.clone()),
+    };
+    let parsed_data = ops.into_internal()?.try_into_data(metadata)?;
+    assert_eq!(data, parsed_data);
+
+    Ok(())
+}
+#[tokio::test]
+async fn test_sui_json() {
+    let arg1 = CallArg::Pure(bcs::to_bytes(&1000000u64).unwrap());
+    let arg2 = CallArg::Pure(bcs::to_bytes(&30215u64).unwrap());
+    let json1 = SuiCallArg::try_from(arg1, Some(&MoveTypeLayout::U64)).unwrap();
+    let json2 = SuiCallArg::try_from(arg2, Some(&MoveTypeLayout::U64)).unwrap();
+    println!("{:?}, {:?}", json1, json2);
+}

--- a/crates/sui-grpc-rosetta/src/unit_tests/types_tests.rs
+++ b/crates/sui-grpc-rosetta/src/unit_tests/types_tests.rs
@@ -1,0 +1,125 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+use crate::types::{
+    AccountBalanceRequest, Amount, ConstructionMetadata, Currency, CurrencyMetadata,
+};
+use quick_js::Context;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use sui_types::base_types::{ObjectRef, SuiAddress};
+
+#[tokio::test]
+async fn test_currency_defaults() {
+    let expected = Currency {
+        symbol: "SUI".to_string(),
+        decimals: 9,
+        metadata: CurrencyMetadata {
+            coin_type: "0x2::sui::SUI".to_string(),
+        },
+    };
+
+    let currency: Currency = serde_json::from_value(json!(
+        {
+            "symbol": "SUI",
+            "decimals": 9,
+        }
+    ))
+    .unwrap();
+    assert_eq!(expected, currency);
+
+    let amount: Amount = serde_json::from_value(json!(
+        {
+            "value": "1000000000",
+        }
+    ))
+    .unwrap();
+    assert_eq!(expected, amount.currency);
+
+    let account_balance_request: AccountBalanceRequest = serde_json::from_value(json!(
+        {
+            "network_identifier": {
+                "blockchain": "sui",
+                "network": "mainnet"
+            },
+            "account_identifier": {
+                "address": "0xadc3a0bb21840f732435f8b649e99df6b29cd27854dfa4b020e3bee07ea09b96"
+            }
+        }
+    ))
+    .unwrap();
+    assert_eq!(
+        expected,
+        account_balance_request.currencies.0.clone().pop().unwrap()
+    );
+
+    let account_balance_request: AccountBalanceRequest = serde_json::from_value(json!(
+        {
+            "network_identifier": {
+                "blockchain": "sui",
+                "network": "mainnet"
+            },
+            "account_identifier": {
+                "address": "0xadc3a0bb21840f732435f8b649e99df6b29cd27854dfa4b020e3bee07ea09b96"
+            },
+            "currencies": []
+        }
+    ))
+    .unwrap();
+    assert_eq!(
+        expected,
+        account_balance_request.currencies.0.clone().pop().unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_metadata_total_coin_value_js_conversion_for_large_balance() {
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct TestConstructionMetadata {
+        pub sender: SuiAddress,
+        pub coins: Vec<ObjectRef>,
+        pub objects: Vec<ObjectRef>,
+        pub total_coin_value: u64,
+        pub gas_price: u64,
+        pub budget: u64,
+        pub currency: Option<Currency>,
+    }
+
+    let test_metadata = TestConstructionMetadata {
+        sender: Default::default(),
+        coins: vec![],
+        objects: vec![],
+        total_coin_value: 65_000_004_233_578_496,
+        gas_price: 0,
+        budget: 0,
+        currency: None,
+    };
+    let test_metadata_json = serde_json::to_string(&test_metadata).unwrap();
+
+    let prod_metadata = ConstructionMetadata {
+        sender: Default::default(),
+        coins: vec![],
+        objects: vec![],
+        total_coin_value: 65_000_004_233_578_496,
+        gas_price: 0,
+        budget: 0,
+        currency: None,
+    };
+    let prod_metadata_json = serde_json::to_string(&prod_metadata).unwrap();
+
+    let context = Context::new().unwrap();
+
+    let test_total_coin_value = format!(
+        "JSON.parse({:?}).total_coin_value.toString()",
+        test_metadata_json
+    );
+    let js_test_total_coin_value = context.eval_as::<String>(&test_total_coin_value).unwrap();
+
+    let prod_total_coin_value = format!(
+        "JSON.parse({:?}).total_coin_value.toString()",
+        prod_metadata_json
+    );
+    let js_prod_total_coin_value = context.eval_as::<String>(&prod_total_coin_value).unwrap();
+
+    assert_eq!("65000004233578500", js_test_total_coin_value);
+    assert_eq!("65000004233578496", js_prod_total_coin_value);
+}

--- a/crates/sui-grpc-rosetta/tests/custom_coins/test_coin/Move.toml
+++ b/crates/sui-grpc-rosetta/tests/custom_coins/test_coin/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "test_coin"
+edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+
+[dependencies]
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }
+
+[addresses]
+test_coin = "0x0"

--- a/crates/sui-grpc-rosetta/tests/custom_coins/test_coin/sources/test_coin.move
+++ b/crates/sui-grpc-rosetta/tests/custom_coins/test_coin/sources/test_coin.move
@@ -1,0 +1,24 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Module: test_coin
+module test_coin::test_coin {
+
+    use sui::coin;
+
+    public struct TEST_COIN has drop {}
+
+    fun init(witness: TEST_COIN, ctx: &mut TxContext) {
+        let (treasury, metadata) = coin::create_currency(
+            witness,
+            6,
+            b"TEST_COIN",
+            b"",
+            b"",
+            option::none(),
+            ctx
+        );
+        transfer::public_freeze_object(metadata);
+        transfer::public_transfer(treasury, ctx.sender())
+    }
+}

--- a/crates/sui-grpc-rosetta/tests/custom_coins/test_coin_no_symbol/Move.toml
+++ b/crates/sui-grpc-rosetta/tests/custom_coins/test_coin_no_symbol/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "test_coin"
+edition = "2024.beta" # edition = "legacy" to use legacy (pre-2024) Move
+
+[dependencies]
+Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/testnet" }
+
+[addresses]
+test_coin = "0x0"

--- a/crates/sui-grpc-rosetta/tests/custom_coins/test_coin_no_symbol/sources/test_coin.move
+++ b/crates/sui-grpc-rosetta/tests/custom_coins/test_coin_no_symbol/sources/test_coin.move
@@ -1,0 +1,24 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Module: test_coin
+module test_coin::test_coin {
+
+    use sui::coin;
+
+    public struct TEST_COIN has drop {}
+
+    fun init(witness: TEST_COIN, ctx: &mut TxContext) {
+        let (treasury, metadata) = coin::create_currency(
+            witness,
+            6,
+            b"",
+            b"",
+            b"",
+            option::none(),
+            ctx
+        );
+        transfer::public_freeze_object(metadata);
+        transfer::public_transfer(treasury, ctx.sender())
+    }
+}

--- a/crates/sui-grpc-rosetta/tests/custom_coins/test_coin_utils.rs
+++ b/crates/sui-grpc-rosetta/tests/custom_coins/test_coin_utils.rs
@@ -1,0 +1,311 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::Path;
+use std::str::FromStr;
+
+use anyhow::{anyhow, Result};
+
+use move_cli::base;
+use shared_crypto::intent::Intent;
+use sui_json_rpc_types::{
+    ObjectChange, SuiObjectDataFilter, SuiObjectDataOptions, SuiObjectResponseQuery, SuiRawData,
+    SuiTransactionBlockResponse, SuiTransactionBlockResponseOptions,
+};
+use sui_keys::keystore::{AccountKeystore, Keystore};
+use sui_move_build::BuildConfig;
+
+use sui_sdk::SuiClient;
+use sui_types::base_types::{ObjectID, ObjectRef, SuiAddress};
+use sui_types::coin::COIN_MODULE_NAME;
+use sui_types::gas_coin::GasCoin;
+use sui_types::object::Owner;
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+use sui_types::quorum_driver_types::ExecuteTransactionRequestType;
+use sui_types::transaction::{
+    Command, ObjectArg, Transaction, TransactionData, TransactionDataAPI,
+};
+use sui_types::{Identifier, TypeTag, SUI_FRAMEWORK_PACKAGE_ID};
+use test_cluster::TestClusterBuilder;
+
+use tracing::debug;
+
+const DEFAULT_GAS_BUDGET: u64 = 900_000_000;
+
+pub struct GasRet {
+    pub object: ObjectRef,
+    pub budget: u64,
+    pub price: u64,
+}
+
+pub async fn select_gas(
+    client: &SuiClient,
+    signer_addr: SuiAddress,
+    input_gas: Option<ObjectID>,
+    budget: Option<u64>,
+    exclude_objects: Vec<ObjectID>,
+    gas_price: Option<u64>,
+) -> Result<GasRet> {
+    let price = match gas_price {
+        Some(p) => p,
+        None => {
+            debug!("No gas price given, fetching from fullnode");
+            client.read_api().get_reference_gas_price().await?
+        }
+    };
+    let budget = budget.unwrap_or_else(|| {
+        debug!("No gas budget given, defaulting to {DEFAULT_GAS_BUDGET}");
+        debug_assert!(DEFAULT_GAS_BUDGET > price);
+        DEFAULT_GAS_BUDGET
+    });
+    if budget < price {
+        return Err(anyhow!(
+            "Gas budget {budget} is less than the reference gas price {price}.
+              The gas budget must be at least the current reference gas price of {price}."
+        ));
+    }
+
+    if let Some(gas) = input_gas {
+        let read_api = client.read_api();
+        let object = read_api
+            .get_object_with_options(gas, SuiObjectDataOptions::new())
+            .await?
+            .object_ref_if_exists()
+            .ok_or(anyhow!("No object-ref"))?;
+        return Ok(GasRet {
+            object,
+            budget,
+            price,
+        });
+    }
+
+    let read_api = client.read_api();
+    let gas_objs = read_api
+        .get_owned_objects(
+            signer_addr,
+            Some(SuiObjectResponseQuery {
+                filter: Some(SuiObjectDataFilter::StructType(GasCoin::type_())),
+                options: Some(SuiObjectDataOptions::new().with_bcs()),
+            }),
+            None,
+            None,
+        )
+        .await?
+        .data;
+
+    for obj in gas_objs {
+        let SuiRawData::MoveObject(raw_obj) = &obj
+            .data
+            .as_ref()
+            .ok_or_else(|| anyhow!("data field is unexpectedly empty"))?
+            .bcs
+            .as_ref()
+            .ok_or_else(|| anyhow!("bcs field is unexpectedly empty"))?
+        else {
+            continue;
+        };
+
+        let gas: GasCoin = bcs::from_bytes(&raw_obj.bcs_bytes)?;
+
+        let Some(obj_ref) = obj.object_ref_if_exists() else {
+            continue;
+        };
+        if !exclude_objects.contains(&obj_ref.0) && gas.value() >= budget {
+            return Ok(GasRet {
+                object: obj_ref,
+                budget,
+                price,
+            });
+        }
+    }
+    Err(anyhow!("Cannot find gas coin for signer address [{signer_addr}] with amount sufficient for the required gas amount [{budget}]."))
+}
+
+#[derive(Debug)]
+pub struct InitRet {
+    pub owner: SuiAddress,
+    pub treasury_cap: ObjectRef,
+    pub coin_tag: TypeTag,
+}
+pub async fn init_package(
+    client: &SuiClient,
+    keystore: &Keystore,
+    sender: SuiAddress,
+    path: &Path,
+) -> Result<InitRet> {
+    let path_buf = base::reroot_path(Some(path))?;
+
+    let move_build_config = BuildConfig::new_for_testing();
+    let compiled_modules = move_build_config.build(path_buf.as_path())?;
+    let modules_bytes = compiled_modules.get_package_bytes(false);
+
+    let tx_kind = client
+        .transaction_builder()
+        .publish_tx_kind(
+            sender,
+            modules_bytes,
+            vec![
+                ObjectID::from_hex_literal("0x1").unwrap(),
+                ObjectID::from_hex_literal("0x2").unwrap(),
+            ],
+        )
+        .await?;
+
+    let gas_data = select_gas(client, sender, None, None, vec![], None).await?;
+    let tx_data = TransactionData::new_with_gas_coins_allow_sponsor(
+        tx_kind,
+        sender,
+        vec![gas_data.object],
+        gas_data.budget,
+        gas_data.price,
+        sender,
+    );
+
+    let sig = keystore
+        .sign_secure(&tx_data.sender(), &tx_data, Intent::sui_transaction())
+        .await?;
+
+    let res = client
+        .quorum_driver_api()
+        .execute_transaction_block(
+            Transaction::from_data(tx_data, vec![sig]),
+            SuiTransactionBlockResponseOptions::new()
+                .with_effects()
+                .with_object_changes()
+                .with_input(),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await?;
+
+    let treasury_cap = res.object_changes.unwrap().into_iter().find_map(|change| {
+        if let ObjectChange::Created {
+            object_type,
+            object_id,
+            version,
+            digest,
+            owner,
+            ..
+        } = change
+        {
+            if object_type.to_string().contains("2::coin::TreasuryCap") {
+                let Owner::AddressOwner(owner) = owner else {
+                    return None;
+                };
+                let coin_tag = object_type.type_params.into_iter().next().unwrap();
+                return Some(InitRet {
+                    owner,
+                    treasury_cap: (object_id, version, digest),
+                    coin_tag,
+                });
+            }
+        }
+        None
+    });
+
+    Ok(treasury_cap.unwrap())
+}
+
+pub async fn mint(
+    client: &SuiClient,
+    keystore: &Keystore,
+    init_ret: InitRet,
+    balances_to: Vec<(u64, SuiAddress)>,
+) -> Result<SuiTransactionBlockResponse> {
+    let treasury_cap_owner = init_ret.owner;
+    let gas_data = select_gas(client, treasury_cap_owner, None, None, vec![], None).await?;
+
+    let mut ptb = ProgrammableTransactionBuilder::new();
+
+    let treasury_cap = ptb.obj(ObjectArg::ImmOrOwnedObject(init_ret.treasury_cap))?;
+    for (balance, to) in balances_to {
+        let balance = ptb.pure(balance)?;
+        let coin = ptb.command(Command::move_call(
+            SUI_FRAMEWORK_PACKAGE_ID,
+            Identifier::from(COIN_MODULE_NAME),
+            Identifier::from_str("mint")?,
+            vec![init_ret.coin_tag.clone()],
+            vec![treasury_cap, balance],
+        ));
+        ptb.transfer_arg(to, coin);
+    }
+    let builder = ptb.finish();
+
+    // Sign transaction
+    let tx_data = TransactionData::new_programmable(
+        treasury_cap_owner,
+        vec![gas_data.object],
+        builder,
+        gas_data.budget,
+        gas_data.price,
+    );
+
+    let sig = keystore
+        .sign_secure(&tx_data.sender(), &tx_data, Intent::sui_transaction())
+        .await?;
+
+    let res = client
+        .quorum_driver_api()
+        .execute_transaction_block(
+            Transaction::from_data(tx_data, vec![sig]),
+            SuiTransactionBlockResponseOptions::new()
+                .with_effects()
+                .with_object_changes()
+                .with_input(),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await?;
+
+    Ok(res)
+}
+
+#[tokio::test]
+async fn test_mint() {
+    const COIN1_BALANCE: u64 = 100_000_000;
+    const COIN2_BALANCE: u64 = 200_000_000;
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let client = test_cluster.wallet.get_client().await.unwrap();
+    let keystore = &test_cluster.wallet.config.keystore;
+
+    let sender = test_cluster.get_address_0();
+    let init_ret = init_package(
+        &client,
+        keystore,
+        sender,
+        Path::new("tests/custom_coins/test_coin"),
+    )
+    .await
+    .unwrap();
+
+    let address1 = test_cluster.get_address_1();
+    let address2 = test_cluster.get_address_2();
+    let balances_to = vec![(COIN1_BALANCE, address1), (COIN2_BALANCE, address2)];
+
+    let mint_res = mint(&client, keystore, init_ret, balances_to)
+        .await
+        .unwrap();
+    let coins = mint_res
+        .object_changes
+        .unwrap()
+        .into_iter()
+        .filter_map(|change| {
+            if let ObjectChange::Created {
+                object_type, owner, ..
+            } = change
+            {
+                Some((object_type, owner))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    let coin1 = coins
+        .iter()
+        .find(|coin| coin.1.get_address_owner_address().unwrap() == address1)
+        .unwrap();
+    let coin2 = coins
+        .iter()
+        .find(|coin| coin.1.get_address_owner_address().unwrap() == address2)
+        .unwrap();
+    assert!(coin1.0.to_string().contains("::test_coin::TEST_COIN"));
+    assert!(coin2.0.to_string().contains("::test_coin::TEST_COIN"));
+}

--- a/crates/sui-grpc-rosetta/tests/custom_coins_tests.rs
+++ b/crates/sui-grpc-rosetta/tests/custom_coins_tests.rs
@@ -1,0 +1,303 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[allow(dead_code)]
+mod rosetta_client;
+#[path = "custom_coins/test_coin_utils.rs"]
+mod test_coin_utils;
+
+use serde_json::json;
+use std::num::NonZeroUsize;
+use std::path::Path;
+use sui_grpc_rosetta::operations::Operations;
+use sui_grpc_rosetta::types::{
+    AccountBalanceRequest, AccountBalanceResponse, AccountIdentifier, Currency, CurrencyMetadata,
+    NetworkIdentifier, SuiEnv,
+};
+use sui_grpc_rosetta::types::{Currencies, OperationType};
+use sui_grpc_rosetta::CoinMetadataCache;
+use sui_grpc_rosetta::SUI;
+use sui_json_rpc_types::{
+    SuiExecutionStatus, SuiTransactionBlockEffectsAPI, SuiTransactionBlockResponseOptions,
+};
+use test_cluster::TestClusterBuilder;
+use test_coin_utils::{init_package, mint};
+
+use crate::rosetta_client::{start_rosetta_test_server, RosettaEndpoint};
+
+#[tokio::test]
+async fn test_custom_coin_balance() {
+    // mint coins to `test_culset.get_address_1()` and `test_culset.get_address_2()`
+    const SUI_BALANCE: u64 = 150_000_000_000_000_000;
+    const COIN1_BALANCE: u64 = 100_000_000;
+    const COIN2_BALANCE: u64 = 200_000_000;
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let client = test_cluster.wallet.get_client().await.unwrap();
+    let keystore = &test_cluster.wallet.config.keystore;
+
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    let sender = test_cluster.get_address_0();
+    let init_ret = init_package(
+        &client,
+        keystore,
+        sender,
+        Path::new("tests/custom_coins/test_coin"),
+    )
+    .await
+    .unwrap();
+
+    let address1 = test_cluster.get_address_1();
+    let address2 = test_cluster.get_address_2();
+    let balances_to = vec![(COIN1_BALANCE, address1), (COIN2_BALANCE, address2)];
+    let coin_type = init_ret.coin_tag.to_canonical_string(true);
+
+    let _mint_res = mint(&client, keystore, init_ret, balances_to)
+        .await
+        .unwrap();
+
+    // setup AccountBalanceRequest
+    let network_identifier = NetworkIdentifier {
+        blockchain: "sui".to_string(),
+        network: SuiEnv::LocalNet,
+    };
+
+    let sui_currency = SUI.clone();
+    let test_coin_currency = Currency {
+        symbol: "TEST_COIN".to_string(),
+        decimals: 6,
+        metadata: CurrencyMetadata {
+            coin_type: coin_type.clone(),
+        },
+    };
+
+    // Verify initial balance and stake
+    let request = AccountBalanceRequest {
+        network_identifier: network_identifier.clone(),
+        account_identifier: AccountIdentifier {
+            address: address1,
+            sub_account: None,
+        },
+        block_identifier: Default::default(),
+        currencies: Currencies(vec![sui_currency, test_coin_currency]),
+    };
+
+    println!(
+        "request: {}",
+        serde_json::to_string_pretty(&request).unwrap()
+    );
+    let response: AccountBalanceResponse = rosetta_client
+        .call(RosettaEndpoint::Balance, &request)
+        .await;
+    println!(
+        "response: {}",
+        serde_json::to_string_pretty(&response).unwrap()
+    );
+    assert_eq!(response.balances.len(), 2);
+    assert_eq!(response.balances[0].value, SUI_BALANCE as i128);
+    assert_eq!(
+        response.balances[0].currency.clone().metadata.coin_type,
+        "0x2::sui::SUI"
+    );
+    assert_eq!(response.balances[1].value, COIN1_BALANCE as i128);
+    assert_eq!(
+        response.balances[1].currency.clone().metadata.coin_type,
+        coin_type
+    );
+}
+
+#[tokio::test]
+async fn test_default_balance() {
+    // mint coins to `test_culset.get_address_1()` and `test_culset.get_address_2()`
+    const SUI_BALANCE: u64 = 150_000_000_000_000_000;
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let client = test_cluster.wallet.get_client().await.unwrap();
+
+    let (rosetta_client, _handles) = start_rosetta_test_server(client.clone()).await;
+
+    let request: AccountBalanceRequest = serde_json::from_value(json!(
+        {
+            "network_identifier": {
+                "blockchain": "sui",
+                "network": "localnet"
+            },
+            "account_identifier": {
+                "address": test_cluster.get_address_0()
+            }
+        }
+    ))
+    .unwrap();
+    let response: AccountBalanceResponse = rosetta_client
+        .call(RosettaEndpoint::Balance, &request)
+        .await;
+    println!(
+        "response: {}",
+        serde_json::to_string_pretty(&response).unwrap()
+    );
+    assert_eq!(response.balances.len(), 1);
+    assert_eq!(response.balances[0].value, SUI_BALANCE as i128);
+
+    // Keep server running for testing with bash/curl
+    // To test with curl,
+    // 1. Uncomment the following lines
+    // 2. use `cargo test -- --nocapture` to print the server <port> and <address0>
+    // 3. run curl 'localhost:<port>/account/balance' --header 'Content-Type: application/json' \
+    // --data-raw '{
+    //     "network_identifier": {
+    //         "blockchain": "sui",
+    //         "network": "localnet"
+    //     },
+    //     "account_identifier": {
+    //         "address": "<address0 above>"
+    //     }
+    // }'
+    // println!("port: {}", rosetta_client.online_port());
+    // println!("address0: {}", test_cluster.get_address_0());
+    // for handle in _handles.into_iter() {
+    //     handle.await.unwrap();
+    // }
+}
+
+#[tokio::test]
+async fn test_custom_coin_transfer() {
+    const COIN1_BALANCE: u64 = 100_000_000_000_000_000;
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let recipient = test_cluster.get_address_1();
+    let client = test_cluster.wallet.get_client().await.unwrap();
+    let keystore = &test_cluster.wallet.config.keystore;
+
+    // TEST_COIN setup and mint
+    let init_ret = init_package(
+        &client,
+        keystore,
+        sender,
+        Path::new("tests/custom_coins/test_coin"),
+    )
+    .await
+    .unwrap();
+    let balances_to = vec![(COIN1_BALANCE, sender)];
+    let coin_type = init_ret.coin_tag.to_canonical_string(true);
+    let _mint_res = mint(&client, keystore, init_ret, balances_to)
+        .await
+        .unwrap();
+
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    let ops = serde_json::from_value(json!(
+        [{
+            "operation_identifier":{"index":0},
+            "type":"PayCoin",
+            "account": { "address" : recipient.to_string() },
+            "amount" : {
+                "value": "30000000",
+                "currency": {
+                    "symbol": "TEST_COIN",
+                    "decimals": 6,
+                    "metadata": {
+                        "coin_type": coin_type.clone(),
+                    }
+                }
+            },
+        },
+        {
+            "operation_identifier":{"index":1},
+            "type":"PayCoin",
+            "account": { "address" : sender.to_string() },
+            "amount" : {
+                "value": "-30000000",
+                "currency": {
+                    "symbol": "TEST_COIN",
+                    "decimals": 6,
+                    "metadata": {
+                        "coin_type": coin_type.clone(),
+                    }
+                }
+            },
+        }]
+    ))
+    .unwrap();
+
+    let response = rosetta_client.rosetta_flow(&ops, keystore).await;
+
+    let tx = client
+        .read_api()
+        .get_transaction_with_options(
+            response.transaction_identifier.hash,
+            SuiTransactionBlockResponseOptions::new()
+                .with_input()
+                .with_effects()
+                .with_balance_changes()
+                .with_events(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        &SuiExecutionStatus::Success,
+        tx.effects.as_ref().unwrap().status()
+    );
+    println!("Sui TX: {tx:?}");
+    let coin_cache = CoinMetadataCache::new(client, NonZeroUsize::new(2).unwrap());
+    let ops2 = Operations::try_from_response(tx, &coin_cache)
+        .await
+        .unwrap();
+    assert!(
+        ops2.contains(&ops),
+        "Operation mismatch. expecting:{}, got:{}",
+        serde_json::to_string(&ops).unwrap(),
+        serde_json::to_string(&ops2).unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_custom_coin_without_symbol() {
+    const COIN1_BALANCE: u64 = 100_000_000_000_000_000;
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let client = test_cluster.wallet.get_client().await.unwrap();
+    let keystore = &test_cluster.wallet.config.keystore;
+
+    // TEST_COIN setup and mint
+    let init_ret = init_package(
+        &client,
+        keystore,
+        sender,
+        Path::new("tests/custom_coins/test_coin_no_symbol"),
+    )
+    .await
+    .unwrap();
+
+    let balances_to = vec![(COIN1_BALANCE, sender)];
+    let mint_res = mint(&client, keystore, init_ret, balances_to)
+        .await
+        .unwrap();
+
+    let tx = client
+        .read_api()
+        .get_transaction_with_options(
+            mint_res.digest,
+            SuiTransactionBlockResponseOptions::new()
+                .with_input()
+                .with_effects()
+                .with_balance_changes()
+                .with_events(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        &SuiExecutionStatus::Success,
+        tx.effects.as_ref().unwrap().status()
+    );
+    let coin_cache = CoinMetadataCache::new(client, NonZeroUsize::new(2).unwrap());
+    let ops = Operations::try_from_response(tx, &coin_cache)
+        .await
+        .unwrap();
+
+    for op in ops {
+        if op.type_ == OperationType::SuiBalanceChange {
+            assert!(!op.amount.unwrap().currency.symbol.is_empty())
+        }
+    }
+}

--- a/crates/sui-grpc-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-grpc-rosetta/tests/end_to_end_tests.rs
@@ -1,0 +1,503 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use serde_json::json;
+use std::num::NonZeroUsize;
+use std::time::Duration;
+
+use rosetta_client::start_rosetta_test_server;
+use sui_grpc_rosetta::operations::Operations;
+use sui_grpc_rosetta::types::Currencies;
+use sui_grpc_rosetta::types::{
+    AccountBalanceRequest, AccountBalanceResponse, AccountIdentifier, Currency, NetworkIdentifier,
+    SubAccount, SubAccountType, SuiEnv,
+};
+use sui_grpc_rosetta::CoinMetadataCache;
+use sui_json_rpc_types::SuiTransactionBlockResponseOptions;
+use sui_keys::keystore::AccountKeystore;
+use sui_sdk::rpc_types::{SuiExecutionStatus, SuiTransactionBlockEffectsAPI};
+use sui_swarm_config::genesis_config::{DEFAULT_GAS_AMOUNT, DEFAULT_NUMBER_OF_OBJECT_PER_ACCOUNT};
+use sui_types::quorum_driver_types::ExecuteTransactionRequestType;
+use sui_types::utils::to_sender_signed_transaction;
+use test_cluster::TestClusterBuilder;
+
+use crate::rosetta_client::RosettaEndpoint;
+
+mod rosetta_client;
+
+#[tokio::test]
+async fn test_get_staked_sui() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let address = test_cluster.get_address_0();
+    let client = test_cluster.wallet.get_client().await.unwrap();
+    let keystore = &test_cluster.wallet.config.keystore;
+
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let network_identifier = NetworkIdentifier {
+        blockchain: "sui".to_string(),
+        network: SuiEnv::LocalNet,
+    };
+    // Verify initial balance and stake
+    let request = AccountBalanceRequest {
+        network_identifier: network_identifier.clone(),
+        account_identifier: AccountIdentifier {
+            address,
+            sub_account: None,
+        },
+        block_identifier: Default::default(),
+        currencies: Currencies(vec![Currency::default()]),
+    };
+
+    let response: AccountBalanceResponse = rosetta_client
+        .call(RosettaEndpoint::Balance, &request)
+        .await;
+    assert_eq!(1, response.balances.len());
+    assert_eq!(
+        (DEFAULT_GAS_AMOUNT * DEFAULT_NUMBER_OF_OBJECT_PER_ACCOUNT as u64) as i128,
+        response.balances[0].value
+    );
+
+    let request = AccountBalanceRequest {
+        network_identifier: network_identifier.clone(),
+        account_identifier: AccountIdentifier {
+            address,
+            sub_account: Some(SubAccount {
+                account_type: SubAccountType::PendingStake,
+            }),
+        },
+        block_identifier: Default::default(),
+        currencies: Currencies(vec![Currency::default()]),
+    };
+    let response: AccountBalanceResponse = rosetta_client
+        .call(RosettaEndpoint::Balance, &request)
+        .await;
+    assert_eq!(response.balances[0].value, 0);
+
+    // Stake some sui
+    let validator = client
+        .governance_api()
+        .get_latest_sui_system_state()
+        .await
+        .unwrap()
+        .active_validators[0]
+        .sui_address;
+    let coins = client
+        .coin_read_api()
+        .get_coins(address, None, None, None)
+        .await
+        .unwrap()
+        .data;
+    let delegation_tx = client
+        .transaction_builder()
+        .request_add_stake(
+            address,
+            vec![coins[0].coin_object_id],
+            Some(1_000_000_000),
+            validator,
+            None,
+            1_000_000_000,
+        )
+        .await
+        .unwrap();
+    let tx = to_sender_signed_transaction(delegation_tx, keystore.export(&address).unwrap());
+    client
+        .quorum_driver_api()
+        .execute_transaction_block(
+            tx,
+            SuiTransactionBlockResponseOptions::new(),
+            Some(ExecuteTransactionRequestType::WaitForLocalExecution),
+        )
+        .await
+        .unwrap();
+
+    let response = rosetta_client
+        .get_balance(
+            network_identifier.clone(),
+            address,
+            Some(SubAccountType::PendingStake),
+        )
+        .await;
+    assert_eq!(1, response.balances.len());
+    assert_eq!(1_000_000_000, response.balances[0].value);
+
+    println!("{}", serde_json::to_string_pretty(&response).unwrap());
+}
+
+#[tokio::test]
+async fn test_stake() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let client = test_cluster.wallet.get_client().await.unwrap();
+    let keystore = &test_cluster.wallet.config.keystore;
+
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    let validator = client
+        .governance_api()
+        .get_latest_sui_system_state()
+        .await
+        .unwrap()
+        .active_validators[0]
+        .sui_address;
+
+    let ops = serde_json::from_value(json!(
+        [{
+            "operation_identifier":{"index":0},
+            "type":"Stake",
+            "account": { "address" : sender.to_string() },
+            "amount" : { "value": "-1000000000" },
+            "metadata": { "Stake" : {"validator": validator.to_string()} }
+        }]
+    ))
+    .unwrap();
+
+    let response = rosetta_client.rosetta_flow(&ops, keystore).await;
+
+    let tx = client
+        .read_api()
+        .get_transaction_with_options(
+            response.transaction_identifier.hash,
+            SuiTransactionBlockResponseOptions::new()
+                .with_input()
+                .with_effects()
+                .with_balance_changes()
+                .with_events(),
+        )
+        .await
+        .unwrap();
+
+    println!("Sui TX: {tx:?}");
+
+    assert_eq!(
+        &SuiExecutionStatus::Success,
+        tx.effects.as_ref().unwrap().status()
+    );
+
+    let coin_cache = CoinMetadataCache::new(client, NonZeroUsize::new(2).unwrap());
+    let ops2 = Operations::try_from_response(tx, &coin_cache)
+        .await
+        .unwrap();
+    assert!(
+        ops2.contains(&ops),
+        "Operation mismatch. expecting:{}, got:{}",
+        serde_json::to_string(&ops).unwrap(),
+        serde_json::to_string(&ops2).unwrap()
+    );
+
+    println!("{}", serde_json::to_string_pretty(&ops2).unwrap())
+}
+
+#[tokio::test]
+async fn test_stake_all() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let client = test_cluster.wallet.get_client().await.unwrap();
+    let keystore = &test_cluster.wallet.config.keystore;
+
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    let validator = client
+        .governance_api()
+        .get_latest_sui_system_state()
+        .await
+        .unwrap()
+        .active_validators[0]
+        .sui_address;
+
+    let ops = serde_json::from_value(json!(
+        [{
+            "operation_identifier":{"index":0},
+            "type":"Stake",
+            "account": { "address" : sender.to_string() },
+            "metadata": { "Stake" : {"validator": validator.to_string()} }
+        }]
+    ))
+    .unwrap();
+
+    let response = rosetta_client.rosetta_flow(&ops, keystore).await;
+
+    let tx = client
+        .read_api()
+        .get_transaction_with_options(
+            response.transaction_identifier.hash,
+            SuiTransactionBlockResponseOptions::new()
+                .with_input()
+                .with_effects()
+                .with_balance_changes()
+                .with_events(),
+        )
+        .await
+        .unwrap();
+
+    println!("Sui TX: {tx:?}");
+
+    assert_eq!(
+        &SuiExecutionStatus::Success,
+        tx.effects.as_ref().unwrap().status()
+    );
+
+    let coin_cache = CoinMetadataCache::new(client, NonZeroUsize::new(2).unwrap());
+    let ops2 = Operations::try_from_response(tx, &coin_cache)
+        .await
+        .unwrap();
+    assert!(
+        ops2.contains(&ops),
+        "Operation mismatch. expecting:{}, got:{}",
+        serde_json::to_string(&ops).unwrap(),
+        serde_json::to_string(&ops2).unwrap()
+    );
+
+    println!("{}", serde_json::to_string_pretty(&ops2).unwrap())
+}
+
+#[tokio::test]
+async fn test_withdraw_stake() {
+    telemetry_subscribers::init_for_testing();
+
+    let test_cluster = TestClusterBuilder::new()
+        .with_epoch_duration_ms(60000)
+        .build()
+        .await;
+    let sender = test_cluster.get_address_0();
+    let client = test_cluster.wallet.get_client().await.unwrap();
+    let keystore = &test_cluster.wallet.config.keystore;
+
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    // First add some stakes
+    let validator = client
+        .governance_api()
+        .get_latest_sui_system_state()
+        .await
+        .unwrap()
+        .active_validators[0]
+        .sui_address;
+
+    let ops = serde_json::from_value(json!(
+        [{
+            "operation_identifier":{"index":0},
+            "type":"Stake",
+            "account": { "address" : sender.to_string() },
+            "amount" : { "value": "-1000000000" },
+            "metadata": { "Stake" : {"validator": validator.to_string()} }
+        }]
+    ))
+    .unwrap();
+
+    let response = rosetta_client.rosetta_flow(&ops, keystore).await;
+
+    let tx = client
+        .read_api()
+        .get_transaction_with_options(
+            response.transaction_identifier.hash,
+            SuiTransactionBlockResponseOptions::new()
+                .with_input()
+                .with_effects()
+                .with_balance_changes()
+                .with_events(),
+        )
+        .await
+        .unwrap();
+
+    println!("Sui TX: {tx:?}");
+
+    assert_eq!(
+        &SuiExecutionStatus::Success,
+        tx.effects.as_ref().unwrap().status()
+    );
+    // verify balance
+    let network_identifier = NetworkIdentifier {
+        blockchain: "sui".to_string(),
+        network: SuiEnv::LocalNet,
+    };
+    let response = rosetta_client
+        .get_balance(
+            network_identifier.clone(),
+            sender,
+            Some(SubAccountType::PendingStake),
+        )
+        .await;
+
+    assert_eq!(1, response.balances.len());
+    assert_eq!(1000000000, response.balances[0].value);
+
+    // Trigger epoch change.
+    test_cluster.trigger_reconfiguration().await;
+
+    // withdraw all stake
+    let ops = serde_json::from_value(json!(
+        [{
+            "operation_identifier":{"index":0},
+            "type":"WithdrawStake",
+            "account": { "address" : sender.to_string() }
+        }]
+    ))
+    .unwrap();
+
+    let response = rosetta_client.rosetta_flow(&ops, keystore).await;
+
+    let tx = client
+        .read_api()
+        .get_transaction_with_options(
+            response.transaction_identifier.hash,
+            SuiTransactionBlockResponseOptions::new()
+                .with_input()
+                .with_effects()
+                .with_balance_changes()
+                .with_events(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        &SuiExecutionStatus::Success,
+        tx.effects.as_ref().unwrap().status()
+    );
+    println!("Sui TX: {tx:?}");
+    let coin_cache = CoinMetadataCache::new(client, NonZeroUsize::new(2).unwrap());
+    let ops2 = Operations::try_from_response(tx, &coin_cache)
+        .await
+        .unwrap();
+    assert!(
+        ops2.contains(&ops),
+        "Operation mismatch. expecting:{}, got:{}",
+        serde_json::to_string(&ops).unwrap(),
+        serde_json::to_string(&ops2).unwrap()
+    );
+
+    println!("{}", serde_json::to_string_pretty(&ops2).unwrap());
+
+    // stake should be 0
+    let response = rosetta_client
+        .get_balance(
+            network_identifier.clone(),
+            sender,
+            Some(SubAccountType::PendingStake),
+        )
+        .await;
+
+    assert_eq!(1, response.balances.len());
+    assert_eq!(0, response.balances[0].value);
+}
+
+#[tokio::test]
+async fn test_pay_sui() {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let recipient = test_cluster.get_address_1();
+    let client = test_cluster.wallet.get_client().await.unwrap();
+    let keystore = &test_cluster.wallet.config.keystore;
+
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    let ops = serde_json::from_value(json!(
+        [{
+            "operation_identifier":{"index":0},
+            "type":"PaySui",
+            "account": { "address" : recipient.to_string() },
+            "amount" : { "value": "1000000000" }
+        },{
+            "operation_identifier":{"index":1},
+            "type":"PaySui",
+            "account": { "address" : sender.to_string() },
+            "amount" : { "value": "-1000000000" }
+        }]
+    ))
+    .unwrap();
+
+    let response = rosetta_client.rosetta_flow(&ops, keystore).await;
+
+    let tx = client
+        .read_api()
+        .get_transaction_with_options(
+            response.transaction_identifier.hash,
+            SuiTransactionBlockResponseOptions::new()
+                .with_input()
+                .with_effects()
+                .with_balance_changes()
+                .with_events(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        &SuiExecutionStatus::Success,
+        tx.effects.as_ref().unwrap().status()
+    );
+    println!("Sui TX: {tx:?}");
+    let coin_cache = CoinMetadataCache::new(client, NonZeroUsize::new(2).unwrap());
+    let ops2 = Operations::try_from_response(tx, &coin_cache)
+        .await
+        .unwrap();
+    assert!(
+        ops2.contains(&ops),
+        "Operation mismatch. expecting:{}, got:{}",
+        serde_json::to_string(&ops).unwrap(),
+        serde_json::to_string(&ops2).unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_pay_sui_multiple_times() {
+    let test_cluster = TestClusterBuilder::new()
+        .with_epoch_duration_ms(36000000)
+        .build()
+        .await;
+    let sender = test_cluster.get_address_0();
+    let recipient = test_cluster.get_address_1();
+    let client = test_cluster.wallet.get_client().await.unwrap();
+    let keystore = &test_cluster.wallet.config.keystore;
+
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+    let coin_cache = CoinMetadataCache::new(client.clone(), NonZeroUsize::new(2).unwrap());
+
+    for i in 1..20 {
+        println!("Iteration: {}", i);
+        let ops = serde_json::from_value(json!(
+            [{
+                "operation_identifier":{"index":0},
+                "type":"PaySui",
+                "account": { "address" : recipient.to_string() },
+                "amount" : { "value": "1000000000" }
+            },{
+                "operation_identifier":{"index":1},
+                "type":"PaySui",
+                "account": { "address" : sender.to_string() },
+                "amount" : { "value": "-1000000000" }
+            }]
+        ))
+        .unwrap();
+
+        let response = rosetta_client.rosetta_flow(&ops, keystore).await;
+
+        let tx = client
+            .read_api()
+            .get_transaction_with_options(
+                response.transaction_identifier.hash,
+                SuiTransactionBlockResponseOptions::new()
+                    .with_input()
+                    .with_effects()
+                    .with_balance_changes()
+                    .with_events(),
+            )
+            .await
+            .unwrap();
+        println!("Sui TX: {tx:?}");
+        assert_eq!(
+            &SuiExecutionStatus::Success,
+            tx.effects.as_ref().unwrap().status()
+        );
+        let ops2 = Operations::try_from_response(tx, &coin_cache)
+            .await
+            .unwrap();
+        assert!(
+            ops2.contains(&ops),
+            "Operation mismatch. expecting:{}, got:{}",
+            serde_json::to_string(&ops).unwrap(),
+            serde_json::to_string(&ops2).unwrap()
+        );
+    }
+}

--- a/crates/sui-grpc-rosetta/tests/gas_budget_tests.rs
+++ b/crates/sui-grpc-rosetta/tests/gas_budget_tests.rs
@@ -1,0 +1,199 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use fastcrypto::encoding::{Encoding, Hex};
+use serde::Deserialize;
+use serde_json::json;
+
+use rosetta_client::start_rosetta_test_server;
+use sui_grpc_rosetta::operations::Operations;
+use sui_grpc_rosetta::types::{
+    ConstructionCombineRequest, ConstructionCombineResponse, ConstructionMetadataRequest,
+    ConstructionMetadataResponse, ConstructionPayloadsRequest, ConstructionPayloadsResponse,
+    ConstructionPreprocessRequest, ConstructionPreprocessResponse, ConstructionSubmitRequest,
+    NetworkIdentifier, PreprocessMetadata, Signature, SignatureType, SuiEnv,
+    TransactionIdentifierResponse,
+};
+use sui_keys::keystore::AccountKeystore;
+use sui_types::crypto::SuiSignature;
+use test_cluster::TestClusterBuilder;
+
+use crate::rosetta_client::RosettaEndpoint;
+
+#[allow(dead_code)]
+mod rosetta_client;
+
+#[derive(Deserialize, Debug)]
+#[serde(untagged)]
+enum TransactionIdentifierResponseResult {
+    #[allow(unused)]
+    Success(TransactionIdentifierResponse),
+    Error(RosettaSubmitGasError),
+}
+
+#[derive(Deserialize, PartialEq, Eq, Debug)]
+struct RosettaSubmitGasError {
+    pub code: i32,
+    pub message: String,
+    pub description: Option<String>,
+    pub retriable: bool,
+    pub details: RosettaSubmitGasErrorDetails,
+}
+
+#[derive(Deserialize, PartialEq, Eq, Debug)]
+struct RosettaSubmitGasErrorDetails {
+    error: String,
+}
+
+async fn pay_with_gas_budget(budget: u64) -> TransactionIdentifierResponseResult {
+    let test_cluster = TestClusterBuilder::new().build().await;
+    let sender = test_cluster.get_address_0();
+    let recipient = test_cluster.get_address_1();
+    let client = test_cluster.wallet.get_client().await.unwrap();
+    let keystore = &test_cluster.wallet.config.keystore;
+
+    let (rosetta_client, _handle) = start_rosetta_test_server(client.clone()).await;
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let network_identifier = NetworkIdentifier {
+        blockchain: "sui".to_string(),
+        network: SuiEnv::LocalNet,
+    };
+
+    let ops: Operations = serde_json::from_value(json!(
+        [{
+            "operation_identifier":{"index":0},
+            "type":"PaySui",
+            "account": { "address" : recipient.to_string() },
+            "amount" : { "value": "1000000000" , "currency": { "symbol": "SUI", "decimals": 9}}
+        },{
+            "operation_identifier":{"index":1},
+            "type":"PaySui",
+            "account": { "address" : sender.to_string() },
+            "amount" : {
+                "value": "-1000000000",
+                "currency": {
+                    "symbol": "SUI",
+                    "decimals": 9,
+                }
+            },
+        }]
+    ))
+    .unwrap();
+
+    let metadata = Some(PreprocessMetadata {
+        budget: Some(budget),
+    });
+
+    let preprocess: ConstructionPreprocessResponse = rosetta_client
+        .call(
+            RosettaEndpoint::Preprocess,
+            &ConstructionPreprocessRequest {
+                network_identifier: network_identifier.clone(),
+                operations: ops.clone(),
+                metadata,
+            },
+        )
+        .await;
+    println!("Preprocess : {preprocess:?}");
+    assert_eq!(preprocess.options.as_ref().unwrap().budget.unwrap(), budget);
+
+    let metadata: ConstructionMetadataResponse = rosetta_client
+        .call(
+            RosettaEndpoint::Metadata,
+            &ConstructionMetadataRequest {
+                network_identifier: network_identifier.clone(),
+                options: preprocess.options,
+                public_keys: vec![],
+            },
+        )
+        .await;
+    println!("Metadata : {metadata:?}");
+    assert_eq!(metadata.metadata.budget, budget);
+
+    let payloads: ConstructionPayloadsResponse = rosetta_client
+        .call(
+            RosettaEndpoint::Payloads,
+            &ConstructionPayloadsRequest {
+                network_identifier: network_identifier.clone(),
+                operations: ops.clone(),
+                metadata: Some(metadata.metadata),
+                public_keys: vec![],
+            },
+        )
+        .await;
+    println!("Payload : {payloads:?}");
+
+    // Combine
+    let signing_payload = payloads.payloads.first().unwrap();
+    let bytes = Hex::decode(&signing_payload.hex_bytes).unwrap();
+    let signer = signing_payload.account_identifier.address;
+    let signature = keystore.sign_hashed(&signer, &bytes).await.unwrap();
+    let public_key = keystore.export(&signer).unwrap().public();
+
+    let combine: ConstructionCombineResponse = rosetta_client
+        .call(
+            RosettaEndpoint::Combine,
+            &ConstructionCombineRequest {
+                network_identifier: network_identifier.clone(),
+                unsigned_transaction: payloads.unsigned_transaction,
+                signatures: vec![Signature {
+                    signing_payload: signing_payload.clone(),
+                    public_key: public_key.into(),
+                    signature_type: SignatureType::Ed25519,
+                    hex_bytes: Hex::from_bytes(SuiSignature::signature_bytes(&signature)),
+                }],
+            },
+        )
+        .await;
+    println!("Combine : {combine:?}");
+
+    // Submit
+    let submit: TransactionIdentifierResponseResult = rosetta_client
+        .call(
+            RosettaEndpoint::Submit,
+            &ConstructionSubmitRequest {
+                network_identifier,
+                signed_transaction: combine.signed_transaction,
+            },
+        )
+        .await;
+    println!("Submit : {submit:?}");
+    submit
+}
+
+#[tokio::test]
+async fn test_pay_with_gas_budget() {
+    const TX_BUDGET_PASS: u64 = 5_000_000;
+    let submit = pay_with_gas_budget(TX_BUDGET_PASS).await;
+    match submit {
+        TransactionIdentifierResponseResult::Success(_) => {}
+        _ => panic!("Expected transaction to succeed"),
+    }
+}
+
+#[tokio::test]
+async fn test_pay_with_gas_budget_fail() {
+    const TX_BUDGET_FAIL: u64 = 1_100_000;
+    let submit = pay_with_gas_budget(TX_BUDGET_FAIL).await;
+    match submit {
+        TransactionIdentifierResponseResult::Error(rosetta_submit_gas_error) => {
+            assert_eq!(
+                rosetta_submit_gas_error,
+                RosettaSubmitGasError {
+                    code: 11,
+                    message: "Transaction dry run error".to_string(),
+                    description: None,
+                    retriable: false,
+                    details: RosettaSubmitGasErrorDetails {
+                        error: "InsufficientGas".to_string()
+                    }
+                }
+            )
+        }
+        _ => panic!("Expected transaction to fail"),
+    }
+}

--- a/crates/sui-grpc-rosetta/tests/rosetta_client.rs
+++ b/crates/sui-grpc-rosetta/tests/rosetta_client.rs
@@ -1,0 +1,273 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt::{Display, Formatter};
+use std::net::SocketAddr;
+use std::str::FromStr;
+
+use fastcrypto::encoding::{Encoding, Hex};
+use reqwest::Client;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_json::Value;
+use tokio::task::JoinHandle;
+
+use sui_config::local_ip_utils;
+use sui_grpc_rosetta::operations::Operations;
+use sui_grpc_rosetta::types::{
+    AccountBalanceRequest, AccountBalanceResponse, AccountIdentifier, ConstructionCombineRequest,
+    ConstructionCombineResponse, ConstructionMetadataRequest, ConstructionMetadataResponse,
+    ConstructionPayloadsRequest, ConstructionPayloadsResponse, ConstructionPreprocessRequest,
+    ConstructionPreprocessResponse, ConstructionSubmitRequest, Currencies, NetworkIdentifier,
+    Signature, SignatureType, SubAccount, SubAccountType, SuiEnv, TransactionIdentifierResponse,
+};
+use sui_grpc_rosetta::{RosettaOfflineServer, RosettaOnlineServer};
+use sui_keys::keystore::AccountKeystore;
+use sui_keys::keystore::Keystore;
+use sui_sdk::SuiClient;
+use sui_types::base_types::SuiAddress;
+use sui_types::crypto::SuiSignature;
+
+pub async fn start_rosetta_test_server(client: SuiClient) -> (RosettaClient, Vec<JoinHandle<()>>) {
+    let online_server = RosettaOnlineServer::new(SuiEnv::LocalNet, client);
+    let offline_server = RosettaOfflineServer::new(SuiEnv::LocalNet);
+    let local_ip = local_ip_utils::localhost_for_testing();
+    let port = local_ip_utils::get_available_port(&local_ip);
+    let rosetta_address = format!("{}:{}", local_ip, port);
+    let online_handle = tokio::spawn(async move {
+        online_server
+            .serve(SocketAddr::from_str(&rosetta_address).unwrap())
+            .await
+    });
+    let offline_port = local_ip_utils::get_available_port(&local_ip);
+    let offline_address = format!("{}:{}", local_ip, offline_port);
+    let offline_handle = tokio::spawn(async move {
+        offline_server
+            .serve(SocketAddr::from_str(&offline_address).unwrap())
+            .await
+    });
+
+    // allow rosetta to process the genesis block.
+    tokio::task::yield_now().await;
+    (
+        RosettaClient::new(port, offline_port),
+        vec![online_handle, offline_handle],
+    )
+}
+
+pub struct RosettaClient {
+    client: Client,
+    online_port: u16,
+    offline_port: u16,
+}
+
+impl RosettaClient {
+    fn new(online: u16, offline: u16) -> Self {
+        let client = Client::new();
+        Self {
+            client,
+            online_port: online,
+            offline_port: offline,
+        }
+    }
+
+    // Used to print port, when keeping test running by waiting for online server handle.
+    #[allow(dead_code)]
+    pub fn online_port(&self) -> u16 {
+        self.online_port
+    }
+
+    pub async fn call<R: Serialize, T: DeserializeOwned>(
+        &self,
+        endpoint: RosettaEndpoint,
+        request: &R,
+    ) -> T {
+        let port = if endpoint.online() {
+            self.online_port
+        } else {
+            self.offline_port
+        };
+        let response = self
+            .client
+            .post(format!("http://127.0.0.1:{port}/{endpoint}"))
+            .json(&serde_json::to_value(request).unwrap())
+            .send()
+            .await
+            .unwrap();
+        let json: Value = response.json().await.unwrap();
+        if let Ok(v) = serde_json::from_value(json.clone()) {
+            v
+        } else {
+            panic!("Failed to deserialize json value: {json:#?}")
+        }
+    }
+
+    /// rosetta construction e2e flow, see https://www.rosetta-api.org/docs/flow.html#construction-api
+    pub async fn rosetta_flow(
+        &self,
+        operations: &Operations,
+        keystore: &Keystore,
+    ) -> TransactionIdentifierResponse {
+        let network_identifier = NetworkIdentifier {
+            blockchain: "sui".to_string(),
+            network: SuiEnv::LocalNet,
+        };
+        // Preprocess
+        let preprocess: ConstructionPreprocessResponse = self
+            .call(
+                RosettaEndpoint::Preprocess,
+                &ConstructionPreprocessRequest {
+                    network_identifier: network_identifier.clone(),
+                    operations: operations.clone(),
+                    metadata: None,
+                },
+            )
+            .await;
+        println!("Preprocess : {preprocess:?}");
+        // Metadata
+        let metadata: ConstructionMetadataResponse = self
+            .call(
+                RosettaEndpoint::Metadata,
+                &ConstructionMetadataRequest {
+                    network_identifier: network_identifier.clone(),
+                    options: preprocess.options,
+                    public_keys: vec![],
+                },
+            )
+            .await;
+        println!("Metadata : {metadata:?}");
+        // Payload
+        let payloads: ConstructionPayloadsResponse = self
+            .call(
+                RosettaEndpoint::Payloads,
+                &ConstructionPayloadsRequest {
+                    network_identifier: network_identifier.clone(),
+                    operations: operations.clone(),
+                    metadata: Some(metadata.metadata),
+                    public_keys: vec![],
+                },
+            )
+            .await;
+        println!("Payload : {payloads:?}");
+        // Combine
+        let signing_payload = payloads.payloads.first().unwrap();
+        let bytes = Hex::decode(&signing_payload.hex_bytes).unwrap();
+        let signer = signing_payload.account_identifier.address;
+        let signature = keystore.sign_hashed(&signer, &bytes).await.unwrap();
+        let public_key = keystore.export(&signer).unwrap().public();
+        let combine: ConstructionCombineResponse = self
+            .call(
+                RosettaEndpoint::Combine,
+                &ConstructionCombineRequest {
+                    network_identifier: network_identifier.clone(),
+                    unsigned_transaction: payloads.unsigned_transaction,
+                    signatures: vec![Signature {
+                        signing_payload: signing_payload.clone(),
+                        public_key: public_key.into(),
+                        signature_type: SignatureType::Ed25519,
+                        hex_bytes: Hex::from_bytes(SuiSignature::signature_bytes(&signature)),
+                    }],
+                },
+            )
+            .await;
+        println!("Combine : {combine:?}");
+        // Submit
+        let submit = self
+            .call(
+                RosettaEndpoint::Submit,
+                &ConstructionSubmitRequest {
+                    network_identifier,
+                    signed_transaction: combine.signed_transaction,
+                },
+            )
+            .await;
+        println!("Submit : {submit:?}");
+        submit
+    }
+
+    pub async fn get_balance(
+        &self,
+        network_identifier: NetworkIdentifier,
+        address: SuiAddress,
+        sub_account: Option<SubAccountType>,
+    ) -> AccountBalanceResponse {
+        let sub_account = sub_account.map(|account_type| SubAccount { account_type });
+        let request = AccountBalanceRequest {
+            network_identifier,
+            account_identifier: AccountIdentifier {
+                address,
+                sub_account,
+            },
+            block_identifier: Default::default(),
+            currencies: Currencies(vec![]),
+        };
+        self.call(RosettaEndpoint::Balance, &request).await
+    }
+}
+
+#[allow(dead_code)]
+pub enum RosettaEndpoint {
+    Derive,
+    Payloads,
+    Combine,
+    Preprocess,
+    Hash,
+    Parse,
+    List,
+    Options,
+    Block,
+    Balance,
+    Coins,
+    Transaction,
+    Submit,
+    Metadata,
+    Status,
+}
+
+impl RosettaEndpoint {
+    pub fn endpoint(&self) -> &str {
+        match self {
+            RosettaEndpoint::Derive => "construction/derive",
+            RosettaEndpoint::Payloads => "construction/payloads",
+            RosettaEndpoint::Combine => "construction/combine",
+            RosettaEndpoint::Preprocess => "construction/preprocess",
+            RosettaEndpoint::Hash => "construction/hash",
+            RosettaEndpoint::Parse => "construction/parse",
+            RosettaEndpoint::List => "network/list",
+            RosettaEndpoint::Options => "network/options",
+            RosettaEndpoint::Block => "block",
+            RosettaEndpoint::Balance => "account/balance",
+            RosettaEndpoint::Coins => "account/coins",
+            RosettaEndpoint::Transaction => "block/transaction",
+            RosettaEndpoint::Submit => "construction/submit",
+            RosettaEndpoint::Metadata => "construction/metadata",
+            RosettaEndpoint::Status => "network/status",
+        }
+    }
+
+    pub fn online(&self) -> bool {
+        match self {
+            RosettaEndpoint::Derive
+            | RosettaEndpoint::Payloads
+            | RosettaEndpoint::Combine
+            | RosettaEndpoint::Preprocess
+            | RosettaEndpoint::Hash
+            | RosettaEndpoint::Parse
+            | RosettaEndpoint::List
+            | RosettaEndpoint::Options => false,
+            RosettaEndpoint::Block
+            | RosettaEndpoint::Balance
+            | RosettaEndpoint::Coins
+            | RosettaEndpoint::Transaction
+            | RosettaEndpoint::Submit
+            | RosettaEndpoint::Metadata
+            | RosettaEndpoint::Status => true,
+        }
+    }
+}
+
+impl Display for RosettaEndpoint {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.endpoint())
+    }
+}


### PR DESCRIPTION
## Description

Copying the sui-rosetta repo to sui-grpc-rosetta. This is to enable a migration to grpc while leaving json-rpc support in our back pocket. Once grpc has been deployed we will delete sui-rosetta.
