### PR TITLE
[easy][rpc-alt] use longer epoch duration to avoid flaky tests

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_fn_delegation_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/jsonrpc_fn_delegation_tests.rs
@@ -36,7 +36,7 @@ impl FnDelegationTestCluster {
     async fn new() -> anyhow::Result<Self> {
         let onchain_cluster = TestClusterBuilder::new()
             .with_num_validators(1)
-            .with_epoch_duration_ms(2000)
+            .with_epoch_duration_ms(300_000) // 5 minutes
             .with_accounts(vec![
                 AccountConfig {
                     address: None,


### PR DESCRIPTION
## Description 

Changing the epoch duration to 5 minutes so we don't accidentally trigger epoch changes in this test, which can change the response of stake and validator related tests.

## Test plan 

Existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
