### PR TITLE
[MFP] gate sending EndOfPublish with draining FastpathCertified transactions

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3739,7 +3739,8 @@ impl AuthorityState {
 
         // TODO: revert_uncommitted_epoch_transactions will soon be unnecessary -
         // clear_state_end_of_epoch() can simply drop all uncommitted transactions
-        self.revert_uncommitted_epoch_transactions(cur_epoch_store)?;
+        self.revert_uncommitted_epoch_transactions(cur_epoch_store)
+            .await?;
         self.get_reconfig_api()
             .clear_state_end_of_epoch(&execution_lock);
         self.check_system_consistency(cur_epoch_store, state_hasher, expensive_safety_check_config);
@@ -5820,7 +5821,7 @@ impl AuthorityState {
     /// This function is called at the very end of the epoch.
     /// This step is required before updating new epoch in the db and calling reopen_epoch_db.
     #[instrument(level = "error", skip_all)]
-    fn revert_uncommitted_epoch_transactions(
+    async fn revert_uncommitted_epoch_transactions(
         &self,
         epoch_store: &AuthorityPerEpochStore,
     ) -> SuiResult {

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3739,8 +3739,7 @@ impl AuthorityState {
 
         // TODO: revert_uncommitted_epoch_transactions will soon be unnecessary -
         // clear_state_end_of_epoch() can simply drop all uncommitted transactions
-        self.revert_uncommitted_epoch_transactions(cur_epoch_store)
-            .await?;
+        self.revert_uncommitted_epoch_transactions(cur_epoch_store)?;
         self.get_reconfig_api()
             .clear_state_end_of_epoch(&execution_lock);
         self.check_system_consistency(cur_epoch_store, state_hasher, expensive_safety_check_config);
@@ -5821,7 +5820,7 @@ impl AuthorityState {
     /// This function is called at the very end of the epoch.
     /// This step is required before updating new epoch in the db and calling reopen_epoch_db.
     #[instrument(level = "error", skip_all)]
-    async fn revert_uncommitted_epoch_transactions(
+    fn revert_uncommitted_epoch_transactions(
         &self,
         epoch_store: &AuthorityPerEpochStore,
     ) -> SuiResult {

--- a/crates/sui-core/src/authority/consensus_tx_status_cache.rs
+++ b/crates/sui-core/src/authority/consensus_tx_status_cache.rs
@@ -250,8 +250,7 @@ impl ConsensusTxStatusCache {
         *self.last_committed_leader_round_rx.borrow()
     }
 
-    #[cfg(test)]
-    pub fn get_num_fastpath_certified(&self) -> usize {
+    pub(crate) fn get_num_fastpath_certified(&self) -> usize {
         self.inner.read().fastpath_certified.len()
     }
 

--- a/crates/sui-core/src/authority/consensus_tx_status_cache.rs
+++ b/crates/sui-core/src/authority/consensus_tx_status_cache.rs
@@ -60,7 +60,7 @@ struct Inner {
 }
 
 impl ConsensusTxStatusCache {
-    pub fn new(consensus_gc_depth: Round) -> Self {
+    pub(crate) fn new(consensus_gc_depth: Round) -> Self {
         assert!(
             consensus_gc_depth < CONSENSUS_STATUS_RETENTION_ROUNDS,
             "{} vs {}",
@@ -77,7 +77,7 @@ impl ConsensusTxStatusCache {
         }
     }
 
-    pub fn set_transaction_status(&self, pos: ConsensusPosition, status: ConsensusTxStatus) {
+    pub(crate) fn set_transaction_status(&self, pos: ConsensusPosition, status: ConsensusTxStatus) {
         if let Some(last_committed_leader_round) = *self.last_committed_leader_round_rx.borrow() {
             if pos.block.round + CONSENSUS_STATUS_RETENTION_ROUNDS <= last_committed_leader_round {
                 // Ignore stale status updates.
@@ -145,7 +145,7 @@ impl ConsensusTxStatusCache {
 
     /// Given a known previous status provided by `old_status`, this function will return a new
     /// status once the transaction status has changed, or if the consensus position has expired.
-    pub async fn notify_read_transaction_status_change(
+    pub(crate) async fn notify_read_transaction_status_change(
         &self,
         consensus_position: ConsensusPosition,
         old_status: Option<ConsensusTxStatus>,
@@ -191,7 +191,10 @@ impl ConsensusTxStatusCache {
         }
     }
 
-    pub async fn update_last_committed_leader_round(&self, last_committed_leader_round: u32) {
+    pub(crate) async fn update_last_committed_leader_round(
+        &self,
+        last_committed_leader_round: u32,
+    ) {
         debug!(
             "Updating last committed leader round: {}",
             last_committed_leader_round
@@ -246,7 +249,7 @@ impl ConsensusTxStatusCache {
         let _ = self.last_committed_leader_round_tx.send(Some(leader_round));
     }
 
-    pub fn get_last_committed_leader_round(&self) -> Option<u32> {
+    pub(crate) fn get_last_committed_leader_round(&self) -> Option<u32> {
         *self.last_committed_leader_round_rx.borrow()
     }
 
@@ -255,7 +258,7 @@ impl ConsensusTxStatusCache {
     }
 
     /// Returns true if the position is too far ahead of the last committed round.
-    pub fn check_position_too_ahead(&self, position: &ConsensusPosition) -> SuiResult<()> {
+    pub(crate) fn check_position_too_ahead(&self, position: &ConsensusPosition) -> SuiResult<()> {
         if let Some(last_committed_leader_round) = *self.last_committed_leader_round_rx.borrow() {
             if position.block.round
                 > last_committed_leader_round + CONSENSUS_STATUS_RETENTION_ROUNDS
@@ -270,7 +273,7 @@ impl ConsensusTxStatusCache {
     }
 
     #[cfg(test)]
-    pub fn get_transaction_status(
+    pub(crate) fn get_transaction_status(
         &self,
         position: &ConsensusPosition,
     ) -> Option<ConsensusTxStatus> {

--- a/crates/sui-core/src/checkpoints/checkpoint_output.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_output.rs
@@ -132,6 +132,10 @@ impl<T: SubmitToConsensus + ReconfigurationInitiator> CheckpointOutput
 
         if checkpoint_timestamp >= self.next_reconfiguration_timestamp_ms {
             // close_epoch is ok if called multiple times
+            info!(
+                "Closing epoch at sequence {checkpoint_seq} at timestamp {checkpoint_timestamp}. next_reconfiguration_timestamp_ms {}",
+                self.next_reconfiguration_timestamp_ms
+            );
             self.sender.close_epoch(epoch_store);
         }
         Ok(())

--- a/crates/sui-core/src/consensus_adapter.rs
+++ b/crates/sui-core/src/consensus_adapter.rs
@@ -341,8 +341,9 @@ impl ConsensusAdapter {
     }
 
     pub fn submit_recovered(self: &Arc<Self>, epoch_store: &Arc<AuthorityPerEpochStore>) {
-        // Transactions being sent to consensus may be lost on crash, before included in a proposed block.
-        // So they need to be resubmitted to consensus on restart.
+        // Transactions being sent to consensus can be dropped on crash, before included in a proposed block.
+        // System transactions do not have clients to retry them. They need to be resubmitted to consensus on restart.
+        // get_all_pending_consensus_transactions() can return both system and certified transactions though.
         //
         // todo - get_all_pending_consensus_transactions is called twice when
         // initializing AuthorityPerEpochStore and here, should not be a big deal but can be optimized
@@ -369,7 +370,6 @@ impl ConsensusAdapter {
         );
         for transaction in recovered {
             if transaction.is_end_of_publish() {
-                epoch_store.set_own_end_of_publish_sent(true);
                 info!(epoch=?epoch_store.epoch(), "Submitting EndOfPublish message to consensus");
             }
             self.submit_unchecked(&[transaction], epoch_store, None);
@@ -932,10 +932,7 @@ impl ConsensusAdapter {
                 transactions[0].kind,
                 ConsensusTransactionKind::UserTransaction(_)
             );
-        if is_user_tx
-            && epoch_store.should_send_end_of_publish()
-            && !epoch_store.has_sent_own_end_of_publish()
-        {
+        if is_user_tx && epoch_store.should_send_end_of_publish() {
             // sending message outside of any locks scope
             if let Err(err) = self.submit(
                 ConsensusTransaction::new_end_of_publish(self.authority),
@@ -945,7 +942,6 @@ impl ConsensusAdapter {
             ) {
                 warn!("Error when sending end of publish message: {:?}", err);
             } else {
-                epoch_store.set_own_end_of_publish_sent(true);
                 info!(epoch=?epoch_store.epoch(), "Sending EndOfPublish message to consensus");
             }
         }
@@ -1182,7 +1178,7 @@ impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
             }
             epoch_store.close_user_certs(reconfig_guard);
         }
-        if epoch_store.should_send_end_of_publish() && !epoch_store.has_sent_own_end_of_publish() {
+        if epoch_store.should_send_end_of_publish() {
             if let Err(err) = self.submit(
                 ConsensusTransaction::new_end_of_publish(self.authority),
                 None,
@@ -1191,7 +1187,6 @@ impl ReconfigurationInitiator for Arc<ConsensusAdapter> {
             ) {
                 warn!("Error when sending end of publish message: {:?}", err);
             } else {
-                epoch_store.set_own_end_of_publish_sent(true);
                 info!(epoch=?epoch_store.epoch(), "Sending EndOfPublish message to consensus");
             }
         }

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -934,9 +934,7 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
     }
 
     async fn send_end_of_publish_if_needed(&self) {
-        if !self.epoch_store.should_send_end_of_publish()
-            || self.epoch_store.has_sent_own_end_of_publish()
-        {
+        if !self.epoch_store.should_send_end_of_publish() {
             return;
         }
 
@@ -950,7 +948,6 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                 err
             );
         } else {
-            self.epoch_store.set_own_end_of_publish_sent(true);
             info!(epoch=?self.epoch_store.epoch(), "Sending EndOfPublish message to consensus");
         }
     }

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -55,6 +55,7 @@ use crate::{
         AuthorityMetrics, AuthorityState, ExecutionEnv,
     },
     checkpoints::{CheckpointService, CheckpointServiceNotify},
+    consensus_adapter::ConsensusAdapter,
     consensus_throughput_calculator::ConsensusThroughputCalculator,
     consensus_types::consensus_output_api::{parse_block_transactions, ConsensusCommitAPI},
     execution_cache::ObjectCacheRead,
@@ -66,6 +67,7 @@ pub struct ConsensusHandlerInitializer {
     state: Arc<AuthorityState>,
     checkpoint_service: Arc<CheckpointService>,
     epoch_store: Arc<AuthorityPerEpochStore>,
+    consensus_adapter: Arc<ConsensusAdapter>,
     low_scoring_authorities: Arc<ArcSwap<HashMap<AuthorityName, u64>>>,
     throughput_calculator: Arc<ConsensusThroughputCalculator>,
     backpressure_manager: Arc<BackpressureManager>,
@@ -76,6 +78,7 @@ impl ConsensusHandlerInitializer {
         state: Arc<AuthorityState>,
         checkpoint_service: Arc<CheckpointService>,
         epoch_store: Arc<AuthorityPerEpochStore>,
+        consensus_adapter: Arc<ConsensusAdapter>,
         low_scoring_authorities: Arc<ArcSwap<HashMap<AuthorityName, u64>>>,
         throughput_calculator: Arc<ConsensusThroughputCalculator>,
         backpressure_manager: Arc<BackpressureManager>,
@@ -84,6 +87,7 @@ impl ConsensusHandlerInitializer {
             state,
             checkpoint_service,
             epoch_store,
+            consensus_adapter,
             low_scoring_authorities,
             throughput_calculator,
             backpressure_manager,
@@ -95,11 +99,17 @@ impl ConsensusHandlerInitializer {
         state: Arc<AuthorityState>,
         checkpoint_service: Arc<CheckpointService>,
     ) -> Self {
+        use crate::consensus_adapter::consensus_tests::make_consensus_adapter_for_test;
+        use std::collections::HashSet;
+
         let backpressure_manager = BackpressureManager::new_for_tests();
+        let consensus_adapter =
+            make_consensus_adapter_for_test(state.clone(), HashSet::new(), false, vec![]);
         Self {
             state: state.clone(),
             checkpoint_service,
             epoch_store: state.epoch_store_for_testing().clone(),
+            consensus_adapter,
             low_scoring_authorities: Arc::new(Default::default()),
             throughput_calculator: Arc::new(ConsensusThroughputCalculator::new(
                 None,
@@ -117,6 +127,7 @@ impl ConsensusHandlerInitializer {
             self.epoch_store.clone(),
             self.checkpoint_service.clone(),
             self.state.execution_scheduler().clone(),
+            self.consensus_adapter.clone(),
             self.state.get_object_cache_reader().clone(),
             self.low_scoring_authorities.clone(),
             consensus_committee,
@@ -524,6 +535,9 @@ pub struct ConsensusHandler<C> {
     processed_cache: LruCache<SequencedConsensusTransactionKey, ()>,
     /// Enqueues transactions to the transaction manager via a separate task.
     transaction_manager_sender: TransactionManagerSender,
+    /// Consensus adapter for submitting transactions to consensus
+    consensus_adapter: Arc<ConsensusAdapter>,
+
     /// Using the throughput calculator to record the current consensus throughput
     throughput_calculator: Arc<ConsensusThroughputCalculator>,
 
@@ -539,6 +553,7 @@ impl<C> ConsensusHandler<C> {
         epoch_store: Arc<AuthorityPerEpochStore>,
         checkpoint_service: Arc<C>,
         execution_scheduler: Arc<ExecutionSchedulerWrapper>,
+        consensus_adapter: Arc<ConsensusAdapter>,
         cache_reader: Arc<dyn ObjectCacheRead>,
         low_scoring_authorities: Arc<ArcSwap<HashMap<AuthorityName, u64>>>,
         committee: ConsensusCommittee,
@@ -571,6 +586,7 @@ impl<C> ConsensusHandler<C> {
                 NonZeroUsize::new(randomize_cache_capacity_in_tests(PROCESSED_CACHE_CAP)).unwrap(),
             ),
             transaction_manager_sender,
+            consensus_adapter,
             throughput_calculator,
             additional_consensus_state: AdditionalConsensusState::new(
                 commit_rate_estimate_window_size,
@@ -912,6 +928,28 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             assigned_versions,
             SchedulingSource::NonFastPath,
         );
+
+        // Check if we should send EndOfPublish after processing consensus commit
+        self.send_end_of_publish_if_needed().await;
+    }
+
+    async fn send_end_of_publish_if_needed(&self) {
+        if !self.epoch_store.should_send_end_of_publish() {
+            return;
+        }
+
+        info!(epoch=?self.epoch_store.epoch(), "Sending EndOfPublish message from ConsensusHandler after restart or consensus commit");
+
+        let end_of_publish = ConsensusTransaction::new_end_of_publish(self.epoch_store.name);
+        if let Err(err) =
+            self.consensus_adapter
+                .submit(end_of_publish, None, &self.epoch_store, None)
+        {
+            warn!(
+                "Error when sending EndOfPublish message from ConsensusHandler: {:?}",
+                err
+            );
+        }
     }
 }
 
@@ -1450,6 +1488,8 @@ impl CommitIntervalObserver {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use consensus_core::{
         BlockAPI, CertifiedBlock, CommitDigest, CommitRef, CommittedSubDag, TestBlock, Transaction,
         VerifiedBlock,
@@ -1490,7 +1530,8 @@ mod tests {
         },
         checkpoints::CheckpointServiceNoop,
         consensus_adapter::consensus_tests::{
-            test_certificates_with_gas_objects, test_user_transaction,
+            make_consensus_adapter_for_test, test_certificates_with_gas_objects,
+            test_user_transaction,
         },
         post_consensus_tx_reorder::PostConsensusTxReorder,
     };
@@ -1544,10 +1585,13 @@ mod tests {
         let throughput_calculator = ConsensusThroughputCalculator::new(None, metrics.clone());
 
         let backpressure_manager = BackpressureManager::new_for_tests();
+        let consensus_adapter =
+            make_consensus_adapter_for_test(state.clone(), HashSet::new(), false, vec![]);
         let mut consensus_handler = ConsensusHandler::new(
             epoch_store,
             Arc::new(CheckpointServiceNoop {}),
             state.execution_scheduler().clone(),
+            consensus_adapter,
             state.get_object_cache_reader().clone(),
             Arc::new(ArcSwap::default()),
             consensus_committee.clone(),
@@ -2032,10 +2076,13 @@ mod tests {
         let metrics = Arc::new(AuthorityMetrics::new(&Registry::new()));
         let throughput = ConsensusThroughputCalculator::new(None, metrics.clone());
         let backpressure = BackpressureManager::new_for_tests();
+        let consensus_adapter =
+            make_consensus_adapter_for_test(state.clone(), HashSet::new(), false, vec![]);
         let mut handler = ConsensusHandler::new(
             epoch_store.clone(),
             Arc::new(CheckpointServiceNoop {}),
             state.execution_scheduler().clone(),
+            consensus_adapter,
             state.get_object_cache_reader().clone(),
             Arc::new(ArcSwap::default()),
             consensus_committee.clone(),

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1400,6 +1400,7 @@ impl SuiNode {
             state.clone(),
             checkpoint_service.clone(),
             epoch_store.clone(),
+            consensus_adapter.clone(),
             low_scoring_authorities,
             throughput_calculator,
             backpressure_manager,


### PR DESCRIPTION
## Description 

Send end of publish (EOP) message when both there is no pending consensus certificates (from QuorumDriver), or `FastpathCertified` status in `ConsensusTxStatusCache` (from TransactionDriver).

Avoid inserting UserTransaction into pending consensus tables. `UserTransaction` from MFP does not need to be reverted on epoch change, or resubmitted after recovery.

This change does not need to be gated behind protocol config. `UserTransaction` will be skipped from `pending_consensus_certificates` after restarting with this change. 

`FastpathCertified` transactions should already be recovered on restart so no additional crash recovery work should be needed.

## Test plan 

CI
Nightly simtests: https://github.com/MystenLabs/sui/actions/runs/17062274693