### PR TITLE
Bench all the functions starting with bench in move files

### DIFF
--- a/external-crates/move/crates/language-benchmarks/src/move_vm.rs
+++ b/external-crates/move/crates/language-benchmarks/src/move_vm.rs
@@ -90,6 +90,27 @@ fn create_vm() -> InMemoryTestAdapter {
     ))
 }
 
+fn find_bench_functions(modules: &Vec<CompiledModule>) -> Vec<Identifier> {
+    let name = "bench";
+    modules
+        .iter()
+        .flat_map(|module| {
+            module
+                .function_defs()
+                .iter()
+                .enumerate()
+                .filter_map(|(_idx, def)| {
+                    let handle = module.function_handle_at(def.function);
+                    if module.identifier_at(handle.name).as_str().starts_with(name) {
+                        Some(Identifier::new(module.identifier_at(handle.name).as_str()).unwrap())
+                    } else {
+                        None
+                    }
+                })
+        })
+        .collect()
+}
+
 // execute a given function in the Bench module
 fn execute<M: Measurement + 'static>(
     c: &mut Criterion<M>,
@@ -99,6 +120,7 @@ fn execute<M: Measurement + 'static>(
 ) {
     // establish running context
     let sender = CORE_CODE_ADDRESS;
+    let fun_names = find_bench_functions(&modules);
 
     let linkage = adapter
         .generate_linkage_context(sender, sender, &modules)
@@ -111,26 +133,29 @@ fn execute<M: Measurement + 'static>(
 
     // module and function to call
     let module_id = ModuleId::new(sender, Identifier::new("bench").unwrap());
-    let fun_name = Identifier::new("bench").unwrap();
+    // let fun_name = Identifier::new("bench").unwrap();
 
-    // benchmark
-    // TODO: we may want to use a real gas meter to make benchmarks more realistic.
-    c.bench_function(file, |b| {
-        b.iter_with_large_drop(|| {
-            adapter
-                .make_vm(linkage.clone())
-                .unwrap()
-                .execute_function_bypass_visibility(
-                    &module_id,
-                    &fun_name,
-                    vec![],
-                    Vec::<Vec<u8>>::new(),
-                    &mut UnmeteredGasMeter,
-                    None,
-                )
-                .unwrap_or_else(|err| {
-                    panic!("{:?}::bench in {file} failed with {:?}", &module_id, err)
-                })
-        })
+    fun_names.iter().for_each(|fun_name| {
+        // benchmark
+        // TODO: we may want to use a real gas meter to make benchmarks more realistic.
+        let bench_name = format!("{}::{}", file, fun_name);
+        c.bench_function(&bench_name, |b| {
+            b.iter_with_large_drop(|| {
+                adapter
+                    .make_vm(linkage.clone())
+                    .unwrap()
+                    .execute_function_bypass_visibility(
+                        &module_id,
+                        &fun_name,
+                        vec![],
+                        Vec::<Vec<u8>>::new(),
+                        &mut UnmeteredGasMeter,
+                        None,
+                    )
+                    .unwrap_or_else(|err| {
+                        panic!("{:?}::bench in {file} failed with {:?}", &module_id, err)
+                    })
+            })
+        });
     });
 }

--- a/external-crates/move/crates/language-benchmarks/src/move_vm.rs
+++ b/external-crates/move/crates/language-benchmarks/src/move_vm.rs
@@ -22,6 +22,8 @@ use move_vm_runtime::{runtime::MoveRuntime, shared::gas::UnmeteredGasMeter};
 use once_cell::sync::Lazy;
 use std::{path::PathBuf, sync::Arc};
 
+const BENCH_FUNCTION_PREFIX: &str = "bench_";
+
 static PRECOMPILED_MOVE_STDLIB: Lazy<FullyCompiledProgram> = Lazy::new(|| {
     let program_res = move_compiler::construct_pre_compiled_lib(
         vec![PackagePaths {
@@ -91,13 +93,12 @@ fn create_vm() -> InMemoryTestAdapter {
 }
 
 fn find_bench_functions(modules: &[CompiledModule]) -> Vec<Identifier> {
-    let name = "bench";
     modules
         .iter()
         .flat_map(|module| {
             module.function_defs().iter().filter_map(|def| {
                 let handle = module.function_handle_at(def.function);
-                if module.identifier_at(handle.name).as_str().starts_with(name) {
+                if module.identifier_at(handle.name).as_str().starts_with(BENCH_FUNCTION_PREFIX) {
                     Some(Identifier::new(module.identifier_at(handle.name).as_str()).unwrap())
                 } else {
                     None

--- a/external-crates/move/crates/language-benchmarks/src/move_vm.rs
+++ b/external-crates/move/crates/language-benchmarks/src/move_vm.rs
@@ -98,8 +98,9 @@ fn find_bench_functions(modules: &[CompiledModule]) -> Vec<Identifier> {
         .flat_map(|module| {
             module.function_defs().iter().filter_map(|def| {
                 let handle = module.function_handle_at(def.function);
-                if module.identifier_at(handle.name).as_str().starts_with(BENCH_FUNCTION_PREFIX) {
-                    Some(Identifier::new(module.identifier_at(handle.name).as_str()).unwrap())
+                let fn_name = module.identifier_at(handle.name);
+                if fn_name.as_str().starts_with(BENCH_FUNCTION_PREFIX) {
+                    Some(fn_name.to_owned())
                 } else {
                     None
                 }

--- a/external-crates/move/crates/language-benchmarks/src/move_vm.rs
+++ b/external-crates/move/crates/language-benchmarks/src/move_vm.rs
@@ -90,23 +90,19 @@ fn create_vm() -> InMemoryTestAdapter {
     ))
 }
 
-fn find_bench_functions(modules: &Vec<CompiledModule>) -> Vec<Identifier> {
+fn find_bench_functions(modules: &[CompiledModule]) -> Vec<Identifier> {
     let name = "bench";
     modules
         .iter()
         .flat_map(|module| {
-            module
-                .function_defs()
-                .iter()
-                .enumerate()
-                .filter_map(|(_idx, def)| {
-                    let handle = module.function_handle_at(def.function);
-                    if module.identifier_at(handle.name).as_str().starts_with(name) {
-                        Some(Identifier::new(module.identifier_at(handle.name).as_str()).unwrap())
-                    } else {
-                        None
-                    }
-                })
+            module.function_defs().iter().filter_map(|def| {
+                let handle = module.function_handle_at(def.function);
+                if module.identifier_at(handle.name).as_str().starts_with(name) {
+                    Some(Identifier::new(module.identifier_at(handle.name).as_str()).unwrap())
+                } else {
+                    None
+                }
+            })
         })
         .collect()
 }
@@ -133,7 +129,6 @@ fn execute<M: Measurement + 'static>(
 
     // module and function to call
     let module_id = ModuleId::new(sender, Identifier::new("bench").unwrap());
-    // let fun_name = Identifier::new("bench").unwrap();
 
     fun_names.iter().for_each(|fun_name| {
         // benchmark
@@ -146,7 +141,7 @@ fn execute<M: Measurement + 'static>(
                     .unwrap()
                     .execute_function_bypass_visibility(
                         &module_id,
-                        &fun_name,
+                        fun_name,
                         vec![],
                         Vec::<Vec<u8>>::new(),
                         &mut UnmeteredGasMeter,

--- a/external-crates/move/crates/language-benchmarks/tests/arith.move
+++ b/external-crates/move/crates/language-benchmarks/tests/arith.move
@@ -3,7 +3,7 @@ module 0x1::bench {
         if (check) () else abort code
     }
 
-    public fun bench() {
+    public fun bench_add() {
         let mut i = 0;
         // 10000 is the number of loops to make the benchmark run for a couple of minutes,
         // which is an eternity.

--- a/external-crates/move/crates/language-benchmarks/tests/arith_2.move
+++ b/external-crates/move/crates/language-benchmarks/tests/arith_2.move
@@ -1,7 +1,7 @@
 module 0x1::bench {
     const COUNT: u64 = 10_000u64;
 
-    public fun bench() {
+    public fun bench_add() {
         let mut sum = 0;
         let mut i = 0;
         while (i < COUNT) {

--- a/external-crates/move/crates/language-benchmarks/tests/basic_alloc.move
+++ b/external-crates/move/crates/language-benchmarks/tests/basic_alloc.move
@@ -15,7 +15,7 @@ module 0x1::bench {
         alloc
     }
 
-    public fun bench() {
+    public fun bench_alloc_struct() {
 	    let LargeStruct { a: _, b: _, c: _, d: _, e: _, f: _, g: _, h: i } = bench_inner();
         let _i = i;
     }

--- a/external-crates/move/crates/language-benchmarks/tests/call.move
+++ b/external-crates/move/crates/language-benchmarks/tests/call.move
@@ -6,7 +6,7 @@ module 0x1::bench {
         if (check) () else abort code
     }
 
-    public fun bench() {
+    public fun bench_call() {
         let mut i = 0;
         // 3000 is the number of loops to make the benchmark run for a couple of minutes,
         // which is an eternity.

--- a/external-crates/move/crates/language-benchmarks/tests/call_2.move
+++ b/external-crates/move/crates/language-benchmarks/tests/call_2.move
@@ -2,7 +2,7 @@ module 0x1::bench {
 
     const COUNT: u64 = 10_000u64;
 
-    public fun bench(): u64 {
+    public fun bench_call_empty_function(): u64 {
         let mut i = 0;
         while (i < COUNT) {
             i = i + call_empty_function();

--- a/external-crates/move/crates/language-benchmarks/tests/natives.move
+++ b/external-crates/move/crates/language-benchmarks/tests/natives.move
@@ -35,7 +35,7 @@ module 0x1::bench {
         test_vector_ops<vector<u8>>(vector::empty(), vector::empty());
     }
 
-    public fun bench() {
+    public fun bench_vector_ops() {
         let mut i = 0;
         // 300 is the number of loops to make the benchmark run for a couple of minutes,
         // which is an eternity.

--- a/external-crates/move/crates/language-benchmarks/tests/transfers.move
+++ b/external-crates/move/crates/language-benchmarks/tests/transfers.move
@@ -8,7 +8,7 @@ module 0x1::bench {
         let Account { balance: _ } = account;
     }
 
-    public fun bench() {
+    public fun bench_account_transfers() {
         let mut accounts = vector::empty<Account>();
         let num_accounts = COUNT;
         let transfer_amount = 10;

--- a/external-crates/move/crates/language-benchmarks/tests/vector.move
+++ b/external-crates/move/crates/language-benchmarks/tests/vector.move
@@ -1,7 +1,7 @@
 module 0x1::bench {
     const COUNT: u64 = 100_000u64;
 
-    public fun bench() {
+    public fun bench_vector_push_pop() {
         let mut v = vector::empty<u64>();
         let mut i = 0;
         while (i < COUNT) {


### PR DESCRIPTION
## Description 

Current setup only looked for function named `bench`. That approach is not scalable to bench all ops and types. This patch enables benching of all functions starting with `bench`. This way every module can test several related things. e.g., arith can test all arithmetic operations.

With this patch the output will have be of form `module_name::function_name`

```
arith.move::bench_add   time:   [5.7281 ms 5.7358 ms 5.7432 ms]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild

arith_2.move::bench_add time:   [1.3407 ms 1.3494 ms 1.3580 ms]
Found 20 outliers among 100 measurements (20.00%)
  7 (7.00%) high mild
  13 (13.00%) high severe

basic_alloc.move::bench_inner
                        time:   [4.9826 ms 4.9929 ms 5.0036 ms]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

basic_alloc.move::bench_alloc_struct
                        time:   [4.9637 ms 4.9753 ms 4.9867 ms]

Benchmarking call.move::bench_call: Warming up for 10.000 s
call.move::bench_call   time:   [8.1187 ms 8.1446 ms 8.1718 ms]
Found 15 outliers among 100 measurements (15.00%)
  2 (2.00%) low mild
  8 (8.00%) high mild
  5 (5.00%) high severe

call_2.move::bench_call_empty_function
                        time:   [2.8640 ms 2.8736 ms 2.8830 ms]
```

## Test plan 

$ cd external-crates/move/crates/language-benchmarks
$ cargo bench

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
