### PR TITLE
Changes to support non-exclusive mutable shared object access.

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,7 @@
+- first check compile errors and propose recommended fixes
+- ensure that the validity checks reject user transactions that attempt to use InputObjectMutability::NonExclusiveWrite
+- transactional tests:
+  - add new arg for trans test runner `nonexclusivewrite` which becomes a InputObjectMutability::NonExclusiveWrite
+  - create test that creates a shared object and passes the object as a nonexclusivewrite arg.
+    - it should be passed to a function that adds a dynamic field
+    - run the test and capture the output snapshot

--- a/crates/sui-benchmark/src/workloads/adversarial.rs
+++ b/crates/sui-benchmark/src/workloads/adversarial.rs
@@ -26,12 +26,15 @@ use strum::{EnumCount, IntoEnumIterator};
 use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
 use sui_protocol_config::ProtocolConfig;
 use sui_test_transaction_builder::TestTransactionBuilder;
-use sui_types::base_types::{random_object_ref, ObjectRef};
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::transaction::Command;
 use sui_types::transaction::{CallArg, ObjectArg};
 use sui_types::{base_types::ObjectID, object::Owner};
 use sui_types::{base_types::SuiAddress, crypto::get_key_pair, transaction::Transaction};
+use sui_types::{
+    base_types::{random_object_ref, ObjectRef},
+    transaction::SharedObjectMutability,
+};
 use sui_types::{transaction::TransactionData, utils::to_sender_signed_transaction};
 use tracing::debug;
 
@@ -530,7 +533,7 @@ impl Workload<dyn Payload> for AdversarialWorkload {
         // We've seen that the shared objects are indeed created,we store them so we can read them in MaxReads workload
         self.shared_objs = created
             .iter()
-            .map(|o| BenchMoveCallArg::Shared((o.0 .0, o.0 .1, false)))
+            .map(|o| BenchMoveCallArg::Shared((o.0 .0, o.0 .1, SharedObjectMutability::Immutable)))
             .collect();
     }
 

--- a/crates/sui-core/src/authority/execution_time_estimator.rs
+++ b/crates/sui-core/src/authority/execution_time_estimator.rs
@@ -300,11 +300,11 @@ impl ExecutionTimeObserver {
 
         let mut uses_indebted_object = false;
 
-        // Update the accumulated excess execution time for each mutable shared object
-        // used in this transaction, and determine the max overage.
+        // Update the accumulated excess execution time for shared object
+        // used for exclusive access in this transaction, and determine the max overage.
         let max_excess_per_object_execution_time = tx
             .shared_input_objects()
-            .filter_map(|obj| obj.mutable.then_some(obj.id))
+            .filter_map(|obj| obj.is_accessed_exclusively().then_some(obj.id))
             .map(|id| {
                 // Mark if any object used in the tx is indebted.
                 if !uses_indebted_object && self.indebted_objects.binary_search(&id).is_ok() {

--- a/crates/sui-core/src/congestion_tracker.rs
+++ b/crates/sui-core/src/congestion_tracker.rs
@@ -122,7 +122,7 @@ impl CongestionTracker {
             transaction
                 .shared_input_objects()
                 .into_iter()
-                .filter(|id| id.mutable)
+                .filter(|id| id.is_accessed_exclusively())
                 .map(|id| id.id),
         )
     }

--- a/crates/sui-core/src/execution_scheduler/overload_tracker.rs
+++ b/crates/sui-core/src/execution_scheduler/overload_tracker.rs
@@ -42,19 +42,21 @@ impl OverloadTracker {
 
     pub(crate) fn add_pending_certificate(&self, tx_data: &SenderSignedData) {
         let tx_digest = tx_data.digest();
-        let mutable_shared_objects = Self::get_mutable_shared_objects(tx_data);
+        let exclusively_accessed_shared_objects =
+            Self::get_exclusively_accessed_shared_objects(tx_data);
         let mut object_waiting_queue = self.object_waiting_queue.write();
         let instant = Instant::now();
-        for object_id in mutable_shared_objects {
+        for object_id in exclusively_accessed_shared_objects {
             let queue = object_waiting_queue.entry(object_id).or_default();
             queue.insert(tx_digest, instant);
         }
     }
 
     pub(crate) fn remove_pending_certificate(&self, tx_data: &SenderSignedData) {
-        let mutable_shared_objects = Self::get_mutable_shared_objects(tx_data);
+        let exclusively_accessed_shared_objects =
+            Self::get_exclusively_accessed_shared_objects(tx_data);
         let mut object_waiting_queue = self.object_waiting_queue.write();
-        for object_id in mutable_shared_objects {
+        for object_id in exclusively_accessed_shared_objects {
             if let Some(entry) = object_waiting_queue.get_mut(&object_id) {
                 entry.remove(&tx_data.digest());
                 if entry.is_empty() {
@@ -64,13 +66,13 @@ impl OverloadTracker {
         }
     }
 
-    fn get_mutable_shared_objects(tx_data: &SenderSignedData) -> Vec<FullObjectID> {
+    fn get_exclusively_accessed_shared_objects(tx_data: &SenderSignedData) -> Vec<FullObjectID> {
         tx_data
             .transaction_data()
             .shared_input_objects()
             .into_iter()
             .filter_map(|r| {
-                r.mutable
+                r.is_accessed_exclusively()
                     .then_some(FullObjectID::new(r.id, Some(r.initial_shared_version)))
             })
             .collect()
@@ -91,8 +93,9 @@ impl OverloadTracker {
             }
         );
 
-        let mutable_shared_objects = Self::get_mutable_shared_objects(tx_data);
-        let queue_len_and_age = self.objects_queue_len_and_age(mutable_shared_objects);
+        let exclusively_accessed_shared_objects =
+            Self::get_exclusively_accessed_shared_objects(tx_data);
+        let queue_len_and_age = self.objects_queue_len_and_age(exclusively_accessed_shared_objects);
         for (object_id, queue_len, txn_age) in queue_len_and_age {
             // When this occurs, most likely transactions piled up on a shared object.
             if queue_len >= overload_config.max_transaction_manager_per_object_queue_length {

--- a/crates/sui-core/src/execution_scheduler/transaction_manager.rs
+++ b/crates/sui-core/src/execution_scheduler/transaction_manager.rs
@@ -761,7 +761,7 @@ impl ExecutionSchedulerAPI for TransactionManager {
                 .shared_input_objects()
                 .into_iter()
                 .filter_map(|r| {
-                    r.mutable
+                    r.is_accessed_exclusively()
                         .then_some(FullObjectID::new(r.id, Some(r.initial_shared_version)))
                 })
                 .collect(),

--- a/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
+++ b/crates/sui-graphql-rpc/src/types/transaction_block_kind/programmable.rs
@@ -21,7 +21,7 @@ use sui_json_rpc_types::SuiArgument;
 use sui_types::transaction::{
     Argument as NativeArgument, CallArg as NativeCallArg, Command as NativeProgrammableTransaction,
     ObjectArg as NativeObjectArg, ProgrammableMoveCall as NativeMoveCallTransaction,
-    ProgrammableTransaction as NativeProgrammableTransactionBlock,
+    ProgrammableTransaction as NativeProgrammableTransactionBlock, SharedObjectMutability,
 };
 
 #[derive(Clone, Eq, PartialEq)]
@@ -440,6 +440,23 @@ impl TransactionInput {
                 address: id.into(),
                 initial_shared_version: initial_shared_version.value().into(),
                 mutable,
+            }),
+
+            N::Object(O::SharedObjectV2 {
+                id,
+                initial_shared_version,
+                mutability,
+            }) => I::SharedInput(SharedInput {
+                address: id.into(),
+                initial_shared_version: initial_shared_version.value().into(),
+                mutable: match mutability {
+                    SharedObjectMutability::Mutable => true,
+                    SharedObjectMutability::Immutable => false,
+                    SharedObjectMutability::NonExclusiveWrite => {
+                        // TODO: graphql should probably expose the full mutability enum
+                        true
+                    }
+                },
             }),
 
             N::Object(O::Receiving(oref)) => I::Receiving(Receiving {

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/inputs/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/inputs/mod.rs
@@ -43,6 +43,16 @@ impl TransactionInput {
                     initial_shared_version,
                     mutable,
                 )),
+                ObjectArg::SharedObjectV2 {
+                    id,
+                    initial_shared_version,
+                    mutability,
+                } => Self::SharedInput(SharedInput::from_shared_object(
+                    id,
+                    initial_shared_version,
+                    // TODO: extend schema to expose the full mutability enum
+                    mutability.is_exclusive(),
+                )),
                 ObjectArg::Receiving((object_id, version, digest)) => Self::Receiving(
                     Receiving::from_object_ref(object_id, version, digest, scope),
                 ),

--- a/crates/sui-replay-2/src/replay_txn.rs
+++ b/crates/sui-replay-2/src/replay_txn.rs
@@ -405,11 +405,7 @@ fn get_input_ids(txn_data: &TransactionData) -> Result<BTreeSet<ObjectKey>, anyh
                             object_id: *id,
                             version_query: VersionQuery::Version(seq_num.value()),
                         }),
-                        ObjectArg::SharedObject {
-                            id: _,
-                            initial_shared_version: _,
-                            mutable: _,
-                        } => {
+                        ObjectArg::SharedObject { .. } | ObjectArg::SharedObjectV2 { .. } => {
                             None // will be in transaction effects
                         }
                         ObjectArg::Receiving((id, seq_num, _digest)) => Some(ObjectKey {
@@ -535,12 +531,12 @@ pub fn get_input_objects_for_replay(
             InputObjectKind::SharedMoveObject {
                 id,
                 initial_shared_version,
-                mutable,
+                mutability,
             } => {
                 let input_object_kind = InputObjectKind::SharedMoveObject {
                     id: *id,
                     initial_shared_version: *initial_shared_version,
-                    mutable: *mutable,
+                    mutability: *mutability,
                 };
                 let versions =
                     object_cache

--- a/crates/sui-replay/src/displays/transaction_displays.rs
+++ b/crates/sui-replay/src/displays/transaction_displays.rs
@@ -71,7 +71,8 @@ impl Display for Pretty<'_, FullPTB> {
                     CallArg::Object(ObjectArg::ImmOrOwnedObject(o)) => {
                         builder.push_record(vec![format!("{i:<3} Imm/Owned Object  ID: {}", o.0)]);
                     }
-                    CallArg::Object(ObjectArg::SharedObject { id, .. }) => {
+                    CallArg::Object(ObjectArg::SharedObject { id, .. })
+                    | CallArg::Object(ObjectArg::SharedObjectV2 { id, .. }) => {
                         builder.push_record(vec![format!("{i:<3} Shared Object     ID: {}", id)]);
                     }
                     CallArg::Object(ObjectArg::Receiving(o)) => {

--- a/crates/sui-replay/src/replay.rs
+++ b/crates/sui-replay/src/replay.rs
@@ -1739,11 +1739,9 @@ impl LocalExec {
                     imm_owned_inputs.push((o_ref.0, o_ref.1));
                     Ok(())
                 }
-                InputObjectKind::SharedMoveObject {
-                    id,
-                    initial_shared_version: _,
-                    mutable: _,
-                } if !deleted_shared_info_map.contains_key(id) => {
+                InputObjectKind::SharedMoveObject { id, .. }
+                    if !deleted_shared_info_map.contains_key(id) =>
+                {
                     // We already downloaded
                     if let Some(o) = self
                         .storage

--- a/crates/sui-transaction-checks/src/lib.rs
+++ b/crates/sui-transaction-checks/src/lib.rs
@@ -17,8 +17,8 @@ mod checked {
     use sui_types::metrics::BytecodeVerifierMetrics;
     use sui_types::transaction::{
         CheckedInputObjects, InputObjectKind, InputObjects, ObjectReadResult, ObjectReadResultKind,
-        ReceivingObjectReadResult, ReceivingObjects, TransactionData, TransactionDataAPI,
-        TransactionKind,
+        ReceivingObjectReadResult, ReceivingObjects, SharedObjectMutability, TransactionData,
+        TransactionDataAPI, TransactionKind,
     };
     use sui_types::{
         base_types::{SequenceNumber, SuiAddress},
@@ -491,7 +491,7 @@ mod checked {
             InputObjectKind::SharedMoveObject {
                 id: SUI_CLOCK_OBJECT_ID,
                 initial_shared_version: SUI_CLOCK_OBJECT_SHARED_VERSION,
-                mutable: true,
+                mutability: SharedObjectMutability::Mutable,
             } => {
                 // Only system transactions can accept the Clock
                 // object as a mutable parameter.
@@ -517,7 +517,7 @@ mod checked {
             }
             InputObjectKind::SharedMoveObject {
                 id: SUI_RANDOMNESS_STATE_OBJECT_ID,
-                mutable: true,
+                mutability: SharedObjectMutability::Mutable,
                 ..
             } => {
                 // Only system transactions can accept the Random

--- a/crates/sui-types/src/execution.rs
+++ b/crates/sui-types/src/execution.rs
@@ -9,7 +9,7 @@ use crate::{
     is_system_package,
     object::{Data, Object, Owner},
     storage::{BackingPackageStore, ObjectChange},
-    transaction::{Argument, Command},
+    transaction::{Argument, Command, SharedObjectMutability},
     type_input::TypeInput,
 };
 use move_core_types::language_storage::TypeTag;
@@ -25,7 +25,12 @@ use std::time::Duration;
 /// 2. Whether the object appeared as mutable (or owned) in the transaction, or as read-only.
 /// 3. The transaction digest of the previous transaction that used this object mutably or
 ///    took it by value.
-pub type ConsensusStreamEndedInfo = (ObjectID, SequenceNumber, bool, TransactionDigest);
+pub type ConsensusStreamEndedInfo = (
+    ObjectID,
+    SequenceNumber,
+    SharedObjectMutability,
+    TransactionDigest,
+);
 
 /// A sequence of information about removed consensus objects in the transaction's inputs.
 pub type ConsensusStreamEndedObjects = Vec<ConsensusStreamEndedInfo>;

--- a/crates/sui-types/src/execution_params.rs
+++ b/crates/sui-types/src/execution_params.rs
@@ -114,7 +114,7 @@ mod tests {
         base_types::ObjectID,
         transaction::{
             CheckedInputObjects, InputObjectKind, InputObjects, ObjectReadResult,
-            ObjectReadResultKind,
+            ObjectReadResultKind, SharedObjectMutability,
         },
     };
 
@@ -174,7 +174,7 @@ mod tests {
                 input_object_kind: InputObjectKind::SharedMoveObject {
                     id: ObjectID::random(),
                     initial_shared_version: SequenceNumber::MIN,
-                    mutable: false,
+                    mutability: SharedObjectMutability::Immutable,
                 },
                 object: ObjectReadResultKind::ObjectConsensusStreamEnded(
                     SequenceNumber::MIN, // doesn't matter
@@ -198,7 +198,7 @@ mod tests {
                 input_object_kind: InputObjectKind::SharedMoveObject {
                     id: ObjectID::random(),
                     initial_shared_version: SequenceNumber::MIN,
-                    mutable: false,
+                    mutability: SharedObjectMutability::Immutable,
                 },
                 object: ObjectReadResultKind::CancelledTransactionSharedObject(
                     SequenceNumber::CONGESTED,

--- a/crates/sui-types/src/rpc_proto_conversions.rs
+++ b/crates/sui-types/src/rpc_proto_conversions.rs
@@ -2273,6 +2273,10 @@ impl From<crate::transaction::CallArg> for Input {
                     message.digest = Some(digest.to_string());
                     InputKind::Receiving
                 }
+                O::SharedObjectV2 { .. } => {
+                    // TODO(address-balances)
+                    todo!()
+                }
             },
             //TODO
             I::BalanceWithdraw(_) => InputKind::Unknown,

--- a/crates/sui-types/src/sui_sdk_types_conversions.rs
+++ b/crates/sui-types/src/sui_sdk_types_conversions.rs
@@ -1138,6 +1138,19 @@ impl From<crate::transaction::CallArg> for Input {
                     initial_shared_version: initial_shared_version.value(),
                     mutable,
                 },
+                crate::transaction::ObjectArg::SharedObjectV2 {
+                    id,
+                    initial_shared_version,
+                    mutability,
+                } => Self::Shared {
+                    object_id: id.into(),
+                    initial_shared_version: initial_shared_version.value(),
+                    mutable: match mutability {
+                        crate::transaction::SharedObjectMutability::Mutable => true,
+                        crate::transaction::SharedObjectMutability::Immutable => false,
+                        crate::transaction::SharedObjectMutability::NonExclusiveWrite => todo!(),
+                    },
+                },
                 crate::transaction::ObjectArg::Receiving((id, version, digest)) => Self::Receiving(
                     ObjectReference::new(id.into(), version.value(), digest.into()),
                 ),

--- a/crates/sui-types/src/unit_tests/messages_tests.rs
+++ b/crates/sui-types/src/unit_tests/messages_tests.rs
@@ -1055,7 +1055,7 @@ fn test_consensus_commit_prologue_transaction() {
         SharedInputObject {
             id: SUI_CLOCK_OBJECT_ID,
             initial_shared_version: SUI_CLOCK_OBJECT_SHARED_VERSION,
-            mutable: true,
+            mutability: SharedObjectMutability::Mutable,
         },
     );
     assert!(tx.is_system_tx());
@@ -1084,7 +1084,7 @@ fn test_consensus_commit_prologue_v2_transaction() {
         SharedInputObject {
             id: SUI_CLOCK_OBJECT_ID,
             initial_shared_version: SUI_CLOCK_OBJECT_SHARED_VERSION,
-            mutable: true,
+            mutability: SharedObjectMutability::Mutable,
         },
     );
     assert!(tx.is_system_tx());
@@ -1114,7 +1114,7 @@ fn test_consensus_commit_prologue_v3_transaction() {
         SharedInputObject {
             id: SUI_CLOCK_OBJECT_ID,
             initial_shared_version: SUI_CLOCK_OBJECT_SHARED_VERSION,
-            mutable: true,
+            mutability: SharedObjectMutability::Mutable,
         },
     );
     assert!(tx.is_system_tx());
@@ -1213,7 +1213,7 @@ fn test_move_input_objects() {
     rem!(InputObjectKind::SharedMoveObject {
         id: shared.0,
         initial_shared_version: shared.1,
-        mutable: true,
+        mutability: SharedObjectMutability::Mutable,
     });
     rem!(InputObjectKind::ImmOrOwnedMoveObject(gas_object_ref));
     assert!(input_objects.is_empty());

--- a/crates/sui/tests/ptb_files_tests.rs
+++ b/crates/sui/tests/ptb_files_tests.rs
@@ -109,6 +109,9 @@ fn stable_call_arg_display(ca: &CallArg) -> String {
             ObjectArg::SharedObject { mutable, .. } => {
                 format!("SharedObject(mutable: {})", mutable)
             }
+            ObjectArg::SharedObjectV2 { mutability, .. } => {
+                format!("SharedObjectV2(mutability: {})", mutability)
+            }
             ObjectArg::Receiving(_) => "Receiving".to_string(),
         },
         CallArg::BalanceWithdraw(_) => "BalanceWithdraw".to_string(),

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -162,6 +162,7 @@ impl<'backing> TemporaryStore<'backing> {
     /// mutated during the transaction execution, force mutating them by incrementing the
     /// sequence number. This is required to achieve safety.
     pub(crate) fn ensure_active_inputs_mutated(&mut self) {
+        // TODO: do not mutate input objects if they are non-exclusive write
         let mut to_be_updated = vec![];
         for id in self.mutable_input_refs.keys() {
             if !self.execution_results.modified_objects.contains(id) {

--- a/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v0/sui-adapter/src/programmable_transactions/context.rs
@@ -1263,6 +1263,9 @@ mod checked {
                 /* imm override */ !mutable,
                 id,
             ),
+            ObjectArg::SharedObjectV2 { .. } => {
+                unreachable!("Impossible to hit SharedObjectV2 in v0")
+            }
             ObjectArg::Receiving(_) => unreachable!("Impossible to hit Receiving in v0"),
         }
     }

--- a/sui-execution/v1/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v1/sui-adapter/src/programmable_transactions/context.rs
@@ -1262,6 +1262,9 @@ mod checked {
                 /* imm override */ !mutable,
                 id,
             ),
+            ObjectArg::SharedObjectV2 { .. } => {
+                unreachable!("Impossible to hit SharedObjectV2 in v1")
+            }
             ObjectArg::Receiving((id, version, _)) => {
                 Ok(InputValue::new_receiving_object(id, version))
             }

--- a/sui-execution/v2/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/v2/sui-adapter/src/programmable_transactions/context.rs
@@ -1319,6 +1319,9 @@ mod checked {
                 /* imm override */ !mutable,
                 id,
             ),
+            ObjectArg::SharedObjectV2 { .. } => {
+                unreachable!("Impossible to hit SharedObjectV2 in v2")
+            }
             ObjectArg::Receiving((id, version, _)) => {
                 Ok(InputValue::new_receiving_object(id, version))
             }


### PR DESCRIPTION
- A new ObjectArg variant is added which has an enum to express
  mutability rather than a boolean.
- Initially this will only be allowed for system transactions,
  specifically settlement transactions. Settlement transactions are
  guaranteed not to have overlapping DF writes.
- In the future, we could expose this to users, but we would have to
  abort transactions that do overlapping writes, or transactions that
  directly mutate the root.

The next steps for this feature are:
- Changes to execution to avoid bumping versions of non-exclusive write
  inputs.
- Consensus handler will schedule a system transaction to advance the
  object's version after all non-exclusive writes have completed. This
  ensures that all DF writes that happen at a given owner version become
  visible atomically.
