### PR TITLE
graphql-alt: Add MovePackage.typeOrigins

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/packages/type_origins/empty_type_origins.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/packages/type_origins/empty_type_origins.move
@@ -1,0 +1,20 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --addresses P1=0x0 --simulator
+
+//# publish --upgradeable --sender A
+module P1::M { }
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  package(address: "@{obj_1_0}") {
+    typeOrigins {
+        module
+        struct
+        definingId
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/packages/type_origins/empty_type_origins.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/packages/type_origins/empty_type_origins.snap
@@ -1,0 +1,27 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-7:
+//# publish --upgradeable --sender A
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 4810800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 9:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 11-20:
+//# run-graphql
+Response: {
+  "data": {
+    "package": {
+      "typeOrigins": []
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/packages/type_origins/multiple_type_origins.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/packages/type_origins/multiple_type_origins.move
@@ -1,0 +1,28 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --addresses P1=0x0 P2=0x0 --simulator
+
+//# publish --upgradeable --sender A
+module P1::M {
+  public struct S1 { }
+}
+
+//# upgrade --package P1 --upgrade-capability 1,1 --sender A
+module P2::M {
+  public struct S1 { }
+  public struct S2 { }
+}
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  package(address: "@{obj_1_0}") {
+    typeOrigins {
+        module
+        struct
+        definingId
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/packages/type_origins/multiple_type_origins.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/packages/type_origins/multiple_type_origins.snap
@@ -1,0 +1,44 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-9:
+//# publish --upgradeable --sender A
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5304800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 11-15:
+//# upgrade --package P1 --upgrade-capability 1,1 --sender A
+created: object(2,0)
+mutated: object(0,0), object(1,1)
+gas summary: computation_cost: 1000000, storage_cost: 5662000,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 3, line 17:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 19-28:
+//# run-graphql
+Response: {
+  "data": {
+    "package": {
+      "typeOrigins": [
+        {
+          "module": "M",
+          "struct": "S1",
+          "definingId": "0x64f698dbaa0f8a2f061a417a6310dc7787b03e32a2d7429dc6909360731a4e9a"
+        },
+        {
+          "module": "M",
+          "struct": "S2",
+          "definingId": "0xa0ac404709b0d0366e01570209e69c7900a53851544f6937504f911eaf9e2fd3"
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/packages/type_origins/single_type_origins.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/packages/type_origins/single_type_origins.move
@@ -1,0 +1,22 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --addresses P1=0x0 --simulator
+
+//# publish --upgradeable --sender A
+module P1::M {
+  public struct S1 { }
+}
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  package(address: "@{obj_1_0}") {
+    typeOrigins {
+        module
+        struct
+        definingId
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/packages/type_origins/single_type_origins.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/packages/type_origins/single_type_origins.snap
@@ -1,0 +1,33 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-9:
+//# publish --upgradeable --sender A
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5304800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 11:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 13-22:
+//# run-graphql
+Response: {
+  "data": {
+    "package": {
+      "typeOrigins": [
+        {
+          "module": "M",
+          "struct": "S1",
+          "definingId": "0x64f698dbaa0f8a2f061a417a6310dc7787b03e32a2d7429dc6909360731a4e9a"
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -914,6 +914,10 @@ type MovePackage implements IAddressable & IObject {
 	The transaction that created this version of the object.
 	"""
 	previousTransaction: Transaction
+	"""
+	A table identifying which versions of a package introduced each of its types.
+	"""
+	typeOrigins: [TypeOrigin!]!
 }
 
 type MovePackageConnection {
@@ -1879,6 +1883,24 @@ type TxResult {
 	For nested results, the index within the result.
 	"""
 	ix: Int
+}
+
+"""
+Information about which previous versions of a package introduced its types.
+"""
+type TypeOrigin {
+	"""
+	Module defining the type.
+	"""
+	module: String!
+	"""
+	Name of the struct.
+	"""
+	struct: String!
+	"""
+	The storage ID of the package that first defined this type.
+	"""
+	definingId: SuiAddress!
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -918,6 +918,10 @@ type MovePackage implements IAddressable & IObject {
 	The transaction that created this version of the object.
 	"""
 	previousTransaction: Transaction
+	"""
+	A table identifying which versions of a package introduced each of its types.
+	"""
+	typeOrigins: [TypeOrigin!]!
 }
 
 type MovePackageConnection {
@@ -1883,6 +1887,24 @@ type TxResult {
 	For nested results, the index within the result.
 	"""
 	ix: Int
+}
+
+"""
+Information about which previous versions of a package introduced its types.
+"""
+type TypeOrigin {
+	"""
+	Module defining the type.
+	"""
+	module: String!
+	"""
+	Name of the struct.
+	"""
+	struct: String!
+	"""
+	The storage ID of the package that first defined this type.
+	"""
+	definingId: SuiAddress!
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -918,6 +918,10 @@ type MovePackage implements IAddressable & IObject {
 	The transaction that created this version of the object.
 	"""
 	previousTransaction: Transaction
+	"""
+	A table identifying which versions of a package introduced each of its types.
+	"""
+	typeOrigins: [TypeOrigin!]!
 }
 
 type MovePackageConnection {
@@ -1883,6 +1887,24 @@ type TxResult {
 	For nested results, the index within the result.
 	"""
 	ix: Int
+}
+
+"""
+Information about which previous versions of a package introduced its types.
+"""
+type TypeOrigin {
+	"""
+	Module defining the type.
+	"""
+	module: String!
+	"""
+	Name of the struct.
+	"""
+	struct: String!
+	"""
+	The storage ID of the package that first defined this type.
+	"""
+	definingId: SuiAddress!
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -914,6 +914,10 @@ type MovePackage implements IAddressable & IObject {
 	The transaction that created this version of the object.
 	"""
 	previousTransaction: Transaction
+	"""
+	A table identifying which versions of a package introduced each of its types.
+	"""
+	typeOrigins: [TypeOrigin!]!
 }
 
 type MovePackageConnection {
@@ -1879,6 +1883,24 @@ type TxResult {
 	For nested results, the index within the result.
 	"""
 	ix: Int
+}
+
+"""
+Information about which previous versions of a package introduced its types.
+"""
+type TypeOrigin {
+	"""
+	Module defining the type.
+	"""
+	module: String!
+	"""
+	Name of the struct.
+	"""
+	struct: String!
+	"""
+	The storage ID of the package that first defined this type.
+	"""
+	definingId: SuiAddress!
 }
 
 """


### PR DESCRIPTION
## Description 

Implements `MovePackage.typeOrigins` based on https://github.com/MystenLabs/sui/blob/4275c1a55988d28b638be8720aebdf1e7da3b06b/crates/sui-graphql-rpc/src/types/move_package.rs#L536-L549

## Test plan 

Added new `typeOrigins` snapshot tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
