### PR TITLE
[move][tracing] Update event API to allow it to specify which events to save in the trace

### DIFF
--- a/external-crates/move/crates/move-trace-format/src/interface.rs
+++ b/external-crates/move/crates/move-trace-format/src/interface.rs
@@ -12,12 +12,15 @@ use serde::Serialize;
 pub trait Tracer {
     /// Notify the tracer of a new event in the VM. This is called for every event that is emitted,
     /// and immediatlye _after_ the `event` has been added to the trace held inside of the `writer`.
-    fn notify(&mut self, event: &TraceEvent, writer: Writer<'_>);
+    fn notify(&mut self, event: &TraceEvent, writer: Writer<'_>) -> bool;
 }
 
 pub struct NopTracer;
 impl Tracer for NopTracer {
-    fn notify(&mut self, _event: &TraceEvent, _writer: Writer<'_>) {}
+    fn notify(&mut self, _event: &TraceEvent, _writer: Writer<'_>) -> bool {
+        // keep all events
+        true
+    }
 }
 
 /// A writer that allows you to push custom events to the trace but encapsulates the trace so that

--- a/external-crates/move/crates/move-trace-format/src/memory_tracer.rs
+++ b/external-crates/move/crates/move-trace-format/src/memory_tracer.rs
@@ -145,7 +145,7 @@ impl Default for TraceState {
 }
 
 impl Tracer for TraceState {
-    fn notify(&mut self, event: &TraceEvent, mut write: Writer<'_>) {
+    fn notify(&mut self, event: &TraceEvent, mut write: Writer<'_>) -> bool {
         self.apply_event(event);
         // We only emit the state when we hit a non-effect internal event. This coincides with
         // emitting the current state of the VM before each instruction/function call.
@@ -157,6 +157,7 @@ impl Tracer for TraceState {
             }
             _ => (),
         }
+        true
     }
 }
 


### PR DESCRIPTION
## Description 

This allows the `notify` implementation to decide which events should be saved in the trace or not. This makes it easy to define custom sparse traces of Move execution.

## Test plan 

CI + local replays with tracing enabled.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
