### PR TITLE
fix: Fix lifetime issues in external Move crates

### DIFF
--- a/external-crates/move/crates/move-borrow-graph/src/references.rs
+++ b/external-crates/move/crates/move-borrow-graph/src/references.rs
@@ -130,7 +130,7 @@ impl<Loc: Copy, Lbl: Clone + Ord> BorrowEdgeSet<Loc, Lbl> {
         self.edges.is_empty()
     }
 
-    pub(crate) fn iter(&self) -> std::collections::btree_set::Iter<BorrowEdge<Loc, Lbl>> {
+    pub(crate) fn iter(&self) -> std::collections::btree_set::Iter<'_, BorrowEdge<Loc, Lbl>> {
         debug_assert!(self.overflown || !self.is_empty());
         self.edges.iter()
     }

--- a/external-crates/move/crates/move-bytecode-viewer/src/tui/tui_interface.rs
+++ b/external-crates/move/crates/move-bytecode-viewer/src/tui/tui_interface.rs
@@ -34,7 +34,7 @@ pub trait TUIInterface {
 
     /// Function called on each redraw. The `TUIOutput` contains that updated
     /// data to display on each pane.
-    fn on_redraw(&mut self, line_number: u16, column_number: u16) -> TUIOutput;
+    fn on_redraw(&mut self, line_number: u16, column_number: u16) -> TUIOutput<'_>;
 
     /// Bounds the line number so that it does not run past the text.
     fn bound_line(&self, line_number: u16) -> u16;
@@ -60,7 +60,7 @@ impl DebugInterface {
 impl TUIInterface for DebugInterface {
     const LEFT_TITLE: &'static str = "Left pane";
     const RIGHT_TITLE: &'static str = "Right pane";
-    fn on_redraw(&mut self, line_number: u16, column_number: u16) -> TUIOutput {
+    fn on_redraw(&mut self, line_number: u16, column_number: u16) -> TUIOutput<'_> {
         TUIOutput {
             left_screen: self
                 .text

--- a/external-crates/move/crates/move-bytecode-viewer/src/viewer.rs
+++ b/external-crates/move/crates/move-bytecode-viewer/src/viewer.rs
@@ -46,7 +46,7 @@ impl<BytecodeViewer: LeftScreen, SourceViewer: RightScreen<BytecodeViewer>> TUII
     const LEFT_TITLE: &'static str = "Bytecode";
     const RIGHT_TITLE: &'static str = "Source Code";
 
-    fn on_redraw(&mut self, line_number: u16, column_number: u16) -> TUIOutput {
+    fn on_redraw(&mut self, line_number: u16, column_number: u16) -> TUIOutput<'_> {
         // Highlight style
         let style: Style = Style::default().bg(Color::Red);
         let report = match self

--- a/external-crates/move/crates/move-cli/src/sandbox/utils/mod.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/utils/mod.rs
@@ -43,7 +43,7 @@ use move_vm_test_utils::gas_schedule::{CostTable, GasStatus};
 pub use on_disk_state_view::*;
 pub use package_context::*;
 
-pub fn get_gas_status(cost_table: &CostTable, gas_budget: Option<u64>) -> Result<GasStatus> {
+pub fn get_gas_status(cost_table: &CostTable, gas_budget: Option<u64>) -> Result<GasStatus<'_>> {
     let gas_status = if let Some(gas_budget) = gas_budget {
         // TODO(Gas): This should not be hardcoded.
         let max_gas_budget = u64::MAX.checked_div(1000).unwrap();

--- a/external-crates/move/crates/move-compiler/src/expansion/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/ast.rs
@@ -686,7 +686,7 @@ impl AbilitySet {
         self.0.is_subset(&other.0)
     }
 
-    pub fn iter(&self) -> AbilitySetIter {
+    pub fn iter(&self) -> AbilitySetIter<'_> {
         self.into_iter()
     }
 

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -128,7 +128,7 @@ impl<'env> Context<'env> {
         self.defn_context.env
     }
 
-    pub(super) fn reporter(&self) -> &DiagnosticReporter {
+    pub(super) fn reporter(&self) -> &DiagnosticReporter<'_> {
         &self.defn_context.reporter
     }
 

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -274,7 +274,7 @@ impl MatchContext<true> for Context<'_> {
         self.env
     }
 
-    fn reporter(&self) -> &DiagnosticReporter {
+    fn reporter(&self) -> &DiagnosticReporter<'_> {
         &self.reporter
     }
 

--- a/external-crates/move/crates/move-compiler/src/shared/matching.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/matching.rs
@@ -67,7 +67,7 @@ pub struct ArmResult {
 /// compilation in HLIR lowering.
 pub trait MatchContext<const AFTER_TYPING: bool> {
     fn env(&self) -> &CompilationEnv;
-    fn reporter(&self) -> &DiagnosticReporter;
+    fn reporter(&self) -> &DiagnosticReporter<'_>;
     fn new_match_var(&mut self, name: String, loc: Loc) -> N::Var;
     fn program_info(&self) -> &ProgramInfo<AFTER_TYPING>;
 

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -349,7 +349,7 @@ impl CompilationEnv {
         &self.mapped_files
     }
 
-    pub fn diagnostic_reporter_at_top_level(&self) -> DiagnosticReporter {
+    pub fn diagnostic_reporter_at_top_level(&self) -> DiagnosticReporter<'_> {
         DiagnosticReporter::new(
             &self.flags,
             &self.known_filter_names,

--- a/external-crates/move/crates/move-compiler/src/shared/remembering_unique_map.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/remembering_unique_map.rs
@@ -104,11 +104,11 @@ impl<K: TName, V> RememberingUniqueMap<K, V> {
         }
     }
 
-    pub fn iter(&self) -> Iter<K, V> {
+    pub fn iter(&self) -> Iter<'_, K, V> {
         self.into_iter()
     }
 
-    pub fn iter_mut(&mut self) -> IterMut<K, V> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
         self.into_iter()
     }
 

--- a/external-crates/move/crates/move-compiler/src/shared/unique_map.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/unique_map.rs
@@ -184,7 +184,7 @@ impl<K: TName, V> UniqueMap<K, V> {
         joined
     }
 
-    pub fn iter(&self) -> Iter<K, V> {
+    pub fn iter(&self) -> Iter<'_, K, V> {
         self.into_iter()
     }
 
@@ -193,7 +193,7 @@ impl<K: TName, V> UniqueMap<K, V> {
             .map(|(loc, k_, v)| (K::add_loc(loc, k_.clone()), v))
     }
 
-    pub fn iter_mut(&mut self) -> IterMut<K, V> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
         self.into_iter()
     }
 

--- a/external-crates/move/crates/move-compiler/src/shared/unique_set.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/unique_set.rs
@@ -87,7 +87,7 @@ impl<T: TName> UniqueSet<T> {
         self.iter().all(|(_, x_)| other.contains_(x_))
     }
 
-    pub fn iter(&self) -> Iter<T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         self.into_iter()
     }
 

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -1209,7 +1209,7 @@ impl MatchContext<false> for Context<'_, '_> {
         self.env()
     }
 
-    fn reporter(&self) -> &DiagnosticReporter {
+    fn reporter(&self) -> &DiagnosticReporter<'_> {
         &self.reporter
     }
 

--- a/external-crates/move/crates/move-ir-to-bytecode/src/context.rs
+++ b/external-crates/move/crates/move-ir-to-bytecode/src/context.rs
@@ -836,7 +836,7 @@ impl<'a> Context<'a> {
     // Dependency Resolution
     //**********************************************************************************************
 
-    fn dependency(&self, m: &ModuleIdent) -> Result<&CompiledDependencyView> {
+    fn dependency(&self, m: &ModuleIdent) -> Result<&CompiledDependencyView<'_>> {
         let dep = self
             .dependencies
             .get(m)

--- a/external-crates/move/crates/move-model-2/src/model.rs
+++ b/external-crates/move/crates/move-model-2/src/model.rs
@@ -190,7 +190,7 @@ impl<K: SourceKind> Model<K> {
         package.maybe_module(name)
     }
 
-    pub fn module(&self, module: impl TModuleId) -> Module<K> {
+    pub fn module(&self, module: impl TModuleId) -> Module<'_, K> {
         self.maybe_module(module).unwrap()
     }
 

--- a/external-crates/move/crates/move-model/src/model.rs
+++ b/external-crates/move/crates/move-model/src/model.rs
@@ -599,7 +599,7 @@ impl GlobalEnv {
     }
 
     /// Find all target modules and return in a vector
-    pub fn get_target_modules(&self) -> Vec<ModuleEnv> {
+    pub fn get_target_modules(&self) -> Vec<ModuleEnv<'_>> {
         let mut target_modules: Vec<ModuleEnv> = vec![];
         for module_env in self.get_modules() {
             if module_env.is_target() {
@@ -1335,7 +1335,7 @@ impl GlobalEnv {
     }
 
     /// Produce a TypeDisplayContext to print types within the scope of this env
-    pub fn get_type_display_ctx(&self) -> TypeDisplayContext {
+    pub fn get_type_display_ctx(&self) -> TypeDisplayContext<'_> {
         TypeDisplayContext::WithEnv {
             env: self,
             type_param_names: None,
@@ -3409,7 +3409,7 @@ impl<'env> FunctionEnv<'env> {
     }
 
     /// Produce a TypeDisplayContext to print types within the scope of this env
-    pub fn get_type_display_ctx(&self) -> TypeDisplayContext {
+    pub fn get_type_display_ctx(&self) -> TypeDisplayContext<'_> {
         let type_param_names = self
             .get_type_parameters()
             .iter()

--- a/external-crates/move/crates/move-package-alt/src/dependency/dependency_set.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/dependency_set.rs
@@ -63,7 +63,7 @@ impl<T> DependencySet<T> {
     }
 
     /// Iterate over the declared entries of this set
-    pub fn iter(&self) -> Iter<T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         self.into_iter()
     }
 

--- a/external-crates/move/crates/move-package-alt/src/graph/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/mod.rs
@@ -217,7 +217,7 @@ impl<F: MoveFlavor> PackageGraph<F> {
         &self.inner[self.root_index]
     }
 
-    pub fn root_package_info(&self) -> PackageInfo<F> {
+    pub fn root_package_info(&self) -> PackageInfo<'_, F> {
         PackageInfo {
             graph: self,
             node: self.root_index,
@@ -227,7 +227,7 @@ impl<F: MoveFlavor> PackageGraph<F> {
     /// Return the list of packages that are in the linkage table, as well as
     /// the unpublished ones in the package graph.
     // TODO: Do we want a way to access ALL packages and not the "de-duplicated" ones?
-    pub(crate) fn packages(&self) -> PackageResult<Vec<PackageInfo<F>>> {
+    pub(crate) fn packages(&self) -> PackageResult<Vec<PackageInfo<'_, F>>> {
         let mut linkage = self.linkage()?;
 
         // Populate ALL the linkage elements

--- a/external-crates/move/crates/move-package-alt/src/package/root_package.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/root_package.rs
@@ -158,14 +158,14 @@ impl<F: MoveFlavor + fmt::Debug> RootPackage<F> {
 
     /// Return the list of all packages in the root package's package graph (including itself and all
     /// transitive dependencies). This includes the non-duplicate addresses only.
-    pub fn packages(&self) -> PackageResult<Vec<PackageInfo<F>>> {
+    pub fn packages(&self) -> PackageResult<Vec<PackageInfo<'_, F>>> {
         self.graph.packages()
     }
 
     /// Return the linkage table for the root package. This contains an entry for each package that
     /// this package depends on (transitively). Returns an error if any of the packages that this
     /// package depends on is unpublished.
-    pub fn linkage(&self) -> PackageResult<BTreeMap<OriginalID, PackageInfo<F>>> {
+    pub fn linkage(&self) -> PackageResult<BTreeMap<OriginalID, PackageInfo<'_, F>>> {
         todo!()
     }
 

--- a/external-crates/move/crates/move-package/src/compilation/build_plan.rs
+++ b/external-crates/move/crates/move-package/src/compilation/build_plan.rs
@@ -170,7 +170,7 @@ impl<'a> BuildPlan<'a> {
         res
     }
 
-    pub fn compute_dependencies(&self) -> CompilationDependencies {
+    pub fn compute_dependencies(&self) -> CompilationDependencies<'_> {
         let root_package = &self.resolution_graph.package_table[&self.root];
         let project_root = match &self.resolution_graph.build_options.install_dir {
             Some(under_path) => under_path.clone(),

--- a/external-crates/move/crates/move-package/src/compilation/compiled_package.rs
+++ b/external-crates/move/crates/move-package/src/compilation/compiled_package.rs
@@ -414,11 +414,11 @@ impl CompiledPackage {
     }
 
     /// Returns compiled modules for this package and its transitive dependencies
-    pub fn all_modules_map(&self) -> Modules {
+    pub fn all_modules_map(&self) -> Modules<'_> {
         Modules::new(self.all_compiled_units().map(|unit| &unit.module))
     }
 
-    pub fn root_modules_map(&self) -> Modules {
+    pub fn root_modules_map(&self) -> Modules<'_> {
         Modules::new(
             self.root_compiled_units
                 .iter()

--- a/external-crates/move/crates/move-regex-borrow-graph/src/regex.rs
+++ b/external-crates/move/crates/move-regex-borrow-graph/src/regex.rs
@@ -188,7 +188,7 @@ impl<Lbl> Regex<Lbl> {
         }
     }
 
-    fn walk(&self) -> Walk<Lbl> {
+    fn walk(&self) -> Walk<'_, Lbl> {
         if self.is_epsilon() {
             Walk::Epsilon
         } else {

--- a/external-crates/move/crates/move-unit-test/src/test_runner.rs
+++ b/external-crates/move/crates/move-unit-test/src/test_runner.rs
@@ -263,7 +263,7 @@ impl SharedTestingConfig {
         arguments: Vec<MoveValue>,
     ) -> (
         VMResult<ChangeSet>,
-        VMResult<NativeContextExtensions>,
+        VMResult<NativeContextExtensions<'_>>,
         VMResult<Vec<Vec<u8>>>,
         TestRunInfo,
     ) {


### PR DESCRIPTION
## Description 

The compiler was emittingmismatched_lifetime_syntaxeswarnings. This change adds the required'_lifetime annotations to the function signatures to resolve the lint.

## Test plan 

Run unit tests

