### PR TITLE
[pkg-alt] Use install dir when passed to the build config

### DIFF
--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -2624,6 +2624,8 @@ dependencies = [
  "petgraph",
  "serde",
  "serde_yaml",
+ "tempfile",
+ "tokio",
  "tracing",
  "vfs",
 ]

--- a/external-crates/move/crates/move-package-alt-compilation/Cargo.toml
+++ b/external-crates/move/crates/move-package-alt-compilation/Cargo.toml
@@ -27,3 +27,7 @@ serde.workspace = true
 serde_yaml.workspace = true
 tracing.workspace = true
 vfs.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+tokio.workspace = true

--- a/external-crates/move/crates/move-package-alt-compilation/src/compiled_package.rs
+++ b/external-crates/move/crates/move-package-alt-compilation/src/compiled_package.rs
@@ -536,7 +536,8 @@ pub fn build_all<W: Write, F: MoveFlavor>(
     };
 
     let compiled_package_info = CompiledPackageInfo {
-        package_name: root_package_name,
+        // TODO: should this be package_name or root_package_name?
+        package_name,
         // // TODO: correct address alias instantiation
         // address_alias_instantiation: BTreeMap::new(),
         // TODO: compute source digest
@@ -544,15 +545,26 @@ pub fn build_all<W: Write, F: MoveFlavor>(
         build_flags: build_config.clone(),
     };
 
-    // TODO: take into consideration install dir flag
-    let under_path = project_root.join("build");
+    // set the build folder
+    let base_path = build_config
+        .install_dir
+        .as_ref()
+        .map(|dir| {
+            if dir.is_relative() {
+                project_root.join(dir)
+            } else {
+                dir.clone()
+            }
+        })
+        .unwrap_or_else(|| project_root.clone());
+    let under_path = base_path.join("build");
 
     save_to_disk(
         root_compiled_units.clone(),
         compiled_package_info.clone(),
         deps_compiled_units.clone(),
         compiled_docs,
-        root_package_name,
+        package_name,
         under_path,
     )?;
 

--- a/external-crates/move/crates/move-package-alt-compilation/tests/install_dir_tests.rs
+++ b/external-crates/move/crates/move-package-alt-compilation/tests/install_dir_tests.rs
@@ -1,0 +1,216 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+
+use move_package_alt::flavor::vanilla::{Vanilla, default_environment};
+use move_package_alt::package::layout::SourcePackageLayout;
+use move_package_alt_compilation::{build_config::BuildConfig, compile_package};
+
+fn create_test_package(dir: &Path) -> std::io::Result<()> {
+    let toml_content = r#"
+[package]
+name = "test_package"
+edition = "2024"
+"#;
+    fs::write(dir.join("Move.toml"), toml_content)?;
+
+    let sources_dir = dir.join(SourcePackageLayout::Sources.path());
+    fs::create_dir_all(&sources_dir)?;
+
+    let module_content = r#"
+module test_package::test_module {
+    public fun test_function(): u64 {
+        42
+    }
+}
+"#;
+    fs::write(sources_dir.join("test_module.move"), module_content)?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_install_dir_creates_directory() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let package_path = temp_dir.path().join("test_package");
+    fs::create_dir(&package_path).expect("Failed to create package dir");
+
+    create_test_package(&package_path).expect("Failed to create test package");
+
+    let install_dir = PathBuf::from("custom_install");
+    let mut build_config = BuildConfig::default();
+    build_config.install_dir = Some(install_dir.clone());
+    build_config.default_flavor = Some(move_compiler::editions::Flavor::Core);
+
+    let env = default_environment();
+
+    let result =
+        compile_package::<_, Vanilla>(&package_path, &build_config, &env, &mut Vec::new()).await;
+
+    assert!(result.is_ok(), "Compilation should succeed");
+
+    assert!(
+        package_path.join(&install_dir).exists(),
+        "Install dir should be created"
+    );
+    assert!(
+        package_path.join(&install_dir).join("build").exists(),
+        "Build directory should exist"
+    );
+
+    assert!(
+        package_path
+            .join(&install_dir)
+            .join("build")
+            .join("test_package")
+            .exists(),
+        "Package build directory should exist"
+    );
+}
+
+#[tokio::test]
+async fn test_install_dir_relative_path() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let package_path = temp_dir.path().join("test_package");
+    fs::create_dir(&package_path).expect("Failed to create package dir");
+
+    create_test_package(&package_path).expect("Failed to create test package");
+
+    let relative_install_dir = PathBuf::from("../install_output");
+
+    let mut build_config = BuildConfig::default();
+    build_config.install_dir = Some(relative_install_dir.clone());
+    build_config.default_flavor = Some(move_compiler::editions::Flavor::Core);
+
+    let env = default_environment();
+    let mut output = Cursor::new(Vec::new());
+
+    let result =
+        compile_package::<_, Vanilla>(&package_path, &build_config, &env, &mut output).await;
+
+    assert!(result.is_ok(), "Compilation should succeed");
+
+    let expected_install_path = package_path.join("../install_output");
+    assert!(
+        expected_install_path.exists(),
+        "Install dir should be created at relative path"
+    );
+    assert!(
+        expected_install_path.join("build").exists(),
+        "Build directory should exist at relative path"
+    );
+}
+
+#[tokio::test]
+async fn test_install_dir_absolute_path() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let package_path = temp_dir.path().join("test_package");
+    fs::create_dir(&package_path).expect("Failed to create package dir");
+
+    create_test_package(&package_path).expect("Failed to create test package");
+
+    let absolute_install_dir = temp_dir.path().join("absolute_install");
+    assert!(absolute_install_dir.is_absolute());
+
+    let mut build_config = BuildConfig::default();
+    build_config.install_dir = Some(absolute_install_dir.clone());
+    build_config.default_flavor = Some(move_compiler::editions::Flavor::Core);
+
+    let env = default_environment();
+    let mut output = Cursor::new(Vec::new());
+
+    let result =
+        compile_package::<_, Vanilla>(&package_path, &build_config, &env, &mut output).await;
+
+    assert!(result.is_ok(), "Compilation should succeed");
+
+    assert!(
+        absolute_install_dir.exists(),
+        "Install dir should be created at absolute path"
+    );
+    assert!(
+        absolute_install_dir.join("build").exists(),
+        "Build directory should exist at absolute path"
+    );
+    assert!(
+        absolute_install_dir
+            .join("build")
+            .join("test_package")
+            .exists(),
+        "Package build directory should exist at absolute path"
+    );
+}
+
+#[tokio::test]
+async fn test_no_install_dir_uses_default() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let package_path = temp_dir.path().join("test_package");
+    fs::create_dir(&package_path).expect("Failed to create package dir");
+
+    create_test_package(&package_path).expect("Failed to create test package");
+
+    let mut build_config = BuildConfig::default();
+    build_config.default_flavor = Some(move_compiler::editions::Flavor::Core);
+
+    let env = default_environment();
+    let mut output = Cursor::new(Vec::new());
+
+    let result =
+        compile_package::<_, Vanilla>(&package_path, &build_config, &env, &mut output).await;
+
+    assert!(result.is_ok(), "Compilation should succeed");
+
+    assert!(
+        package_path.join("build").exists(),
+        "Build directory should exist in package directory when no install_dir specified"
+    );
+    assert!(
+        package_path.join("build").join("test_package").exists(),
+        "Package build directory should exist in default location"
+    );
+}
+
+#[tokio::test]
+async fn test_install_dir_existing_directory() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let package_path = temp_dir.path().join("test_package");
+    fs::create_dir(&package_path).expect("Failed to create package dir");
+
+    create_test_package(&package_path).expect("Failed to create test package");
+
+    let install_dir = temp_dir.path().join("existing_install");
+    fs::create_dir(&install_dir).expect("Failed to create existing install dir");
+
+    let test_file = install_dir.join("existing_file.txt");
+    fs::write(&test_file, "existing content").expect("Failed to write test file");
+
+    let mut build_config = BuildConfig::default();
+    build_config.install_dir = Some(install_dir.clone());
+    build_config.default_flavor = Some(move_compiler::editions::Flavor::Core);
+
+    let env = default_environment();
+    let mut output = Cursor::new(Vec::new());
+
+    let result =
+        compile_package::<_, Vanilla>(&package_path, &build_config, &env, &mut output).await;
+
+    assert!(
+        result.is_ok(),
+        "Compilation should succeed with existing directory"
+    );
+
+    assert!(test_file.exists(), "Existing files should be preserved");
+    assert!(
+        install_dir.join("build").exists(),
+        "Build directory should be created in existing directory"
+    );
+    assert!(
+        install_dir.join("build").join("test_package").exists(),
+        "Package build directory should exist"
+    );
+}

--- a/external-crates/move/crates/move-package-alt-compilation/tests/install_dir_tests.rs
+++ b/external-crates/move/crates/move-package-alt-compilation/tests/install_dir_tests.rs
@@ -43,9 +43,11 @@ async fn test_install_dir_creates_directory() {
     create_test_package(&package_path).expect("Failed to create test package");
 
     let install_dir = PathBuf::from("custom_install");
-    let mut build_config = BuildConfig::default();
-    build_config.install_dir = Some(install_dir.clone());
-    build_config.default_flavor = Some(move_compiler::editions::Flavor::Core);
+    let build_config = BuildConfig {
+        install_dir: Some(install_dir.clone()),
+        default_flavor: Some(move_compiler::editions::Flavor::Core),
+        ..Default::default()
+    };
 
     let env = default_environment();
 
@@ -83,9 +85,11 @@ async fn test_install_dir_relative_path() {
 
     let relative_install_dir = PathBuf::from("../install_output");
 
-    let mut build_config = BuildConfig::default();
-    build_config.install_dir = Some(relative_install_dir.clone());
-    build_config.default_flavor = Some(move_compiler::editions::Flavor::Core);
+    let build_config = BuildConfig {
+        install_dir: Some(relative_install_dir.clone()),
+        default_flavor: Some(move_compiler::editions::Flavor::Core),
+        ..Default::default()
+    };
 
     let env = default_environment();
     let mut output = Cursor::new(Vec::new());
@@ -117,9 +121,11 @@ async fn test_install_dir_absolute_path() {
     let absolute_install_dir = temp_dir.path().join("absolute_install");
     assert!(absolute_install_dir.is_absolute());
 
-    let mut build_config = BuildConfig::default();
-    build_config.install_dir = Some(absolute_install_dir.clone());
-    build_config.default_flavor = Some(move_compiler::editions::Flavor::Core);
+    let build_config = BuildConfig {
+        install_dir: Some(absolute_install_dir.clone()),
+        default_flavor: Some(move_compiler::editions::Flavor::Core),
+        ..Default::default()
+    };
 
     let env = default_environment();
     let mut output = Cursor::new(Vec::new());
@@ -154,8 +160,10 @@ async fn test_no_install_dir_uses_default() {
 
     create_test_package(&package_path).expect("Failed to create test package");
 
-    let mut build_config = BuildConfig::default();
-    build_config.default_flavor = Some(move_compiler::editions::Flavor::Core);
+    let build_config = BuildConfig {
+        default_flavor: Some(move_compiler::editions::Flavor::Core),
+        ..Default::default()
+    };
 
     let env = default_environment();
     let mut output = Cursor::new(Vec::new());
@@ -189,9 +197,11 @@ async fn test_install_dir_existing_directory() {
     let test_file = install_dir.join("existing_file.txt");
     fs::write(&test_file, "existing content").expect("Failed to write test file");
 
-    let mut build_config = BuildConfig::default();
-    build_config.install_dir = Some(install_dir.clone());
-    build_config.default_flavor = Some(move_compiler::editions::Flavor::Core);
+    let build_config = BuildConfig {
+        install_dir: Some(install_dir.clone()),
+        default_flavor: Some(move_compiler::editions::Flavor::Core),
+        ..Default::default()
+    };
 
     let env = default_environment();
     let mut output = Cursor::new(Vec::new());


### PR DESCRIPTION
## Description 

This PR fixes the issue with `--install-dir` not being used for saving the build artifacts.

## Test plan 

Added new tests.
```
cargo nextest run -p move-package-alt-compilation
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
