### PR TITLE
[move][move-compiler] Revise path expansion to return errors 

### DIFF
--- a/external-crates/move/crates/move-compiler/src/expansion/attributes.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/attributes.rs
@@ -247,7 +247,9 @@ fn attribute(
             let note = note.and_then(|symbol| match byte_string::decode(loc, symbol.as_ref()) {
                 Ok(v) => Some(v),
                 Err(e) => {
-                    context.add_diags(e);
+                    for diag in e.into_iter() {
+                        context.add_diag(diag.into_diagnostic());
+                    }
                     None
                 }
             });
@@ -606,7 +608,7 @@ fn attribute_value_to_minor_code(
         }
         P::AttributeValue_::ModuleAccess(chain) => {
             let chain_loc = chain.loc;
-            let crate::expansion::path_expander::ModuleAccessResult {
+            let crate::expansion::path_expander::AccessPath {
                 access,
                 ptys_opt,
                 is_macro,

--- a/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/path_expander.rs
@@ -4,7 +4,6 @@
 /// Name access chain (path) resolution. This is driven by the trait PathExpander, which works over
 /// a DefnContext and resolves according to the rules of the selected expander.
 use crate::{
-    diag,
     diagnostics::Diagnostic,
     editions::{Edition, FeatureGate, create_feature_error},
     expansion::{
@@ -14,8 +13,8 @@ use crate::{
         legacy_aliases,
         name_validation::is_valid_datatype_or_constant_name,
         translate::{
-            DefnContext, make_address, module_ident, top_level_address, top_level_address_opt,
-            value,
+            DefnContext, ValueError, make_address, module_ident, top_level_address,
+            top_level_address_opt, value_result,
         },
     },
     ice, ice_assert,
@@ -36,7 +35,7 @@ use move_ir_types::location::{Loc, Spanned, sp};
 // Definitions
 //**************************************************************************************************
 
-pub struct ModuleAccessResult {
+pub struct AccessPath {
     pub access: E::ModuleAccess,
     pub ptys_opt: Option<Spanned<Vec<P::Type>>>,
     pub is_macro: Option<Loc>,
@@ -50,6 +49,109 @@ pub enum Access {
     Term,
     Pattern,
     Module, // Just used for errors
+}
+
+// -----------------------------------------------
+// Errors
+// -----------------------------------------------
+
+// ----------------------
+// Primary Errors
+
+pub struct UnexpectedAccessError {
+    result: AccessChainNameResult,
+    access: Access,
+    note: Option<&'static str>,
+}
+
+pub struct UnboundModuleError {
+    module: Name,
+}
+
+pub struct AccessChainResolutionError {
+    result: AccessChainNameResult,
+}
+
+pub struct IncompleteAccessError {
+    loc: Loc,
+}
+
+pub struct AmbiguousAccessError {
+    loc: Loc,
+    kind: &'static str,
+    possibles: (&'static str, &'static str),
+}
+
+pub struct UnexpectedAddressOrModule {
+    loc: Loc,
+    name_loc: Loc,
+    access: Access,
+}
+
+pub struct LegacyGlobalAddressError {
+    loc: Loc,
+    edition: Edition,
+}
+
+pub struct LegacyInvalidName {
+    loc: Loc,
+    msg: &'static str,
+    note: Option<&'static str>,
+}
+
+pub struct LegacyInvalidModule {
+    loc: Loc,
+    msg: &'static str,
+}
+
+// ----------------------
+// Secondary Errors
+
+pub struct InvalidTypeParameterError {
+    loc: Loc,
+    kind: &'static str,
+    /// Since this is built from a name access chain, this must be a realized string. Otherwise we
+    /// would need to copy the name access chain to compute it later.
+    note: Option<String>,
+}
+
+pub struct InvalidMacroError {
+    loc: Loc,
+    kind: &'static str,
+}
+
+pub struct NeedsGlobalQualificationError {
+    loc: Loc,
+}
+
+// ----------------------
+// Expansion Error Enum
+
+pub enum PathExpansionError {
+    // Primary Errors
+    UnexpectedAccessError(UnexpectedAccessError),
+    UnboundModule(UnboundModuleError),
+    AccessChainResolutionError(AccessChainResolutionError),
+    IncompleteAccessError(IncompleteAccessError),
+    AmbiguousAccessError(AmbiguousAccessError),
+    UnexpectedAddressOrModule(UnexpectedAddressOrModule),
+    ValueError(ValueError),
+    LegacyGlobalAddressError(LegacyGlobalAddressError),
+    LegacyInvalidName(LegacyInvalidName),
+    LegacyInvalidModule(LegacyInvalidModule),
+    // Secondary Errors
+    InvalidTypeParameterError(InvalidTypeParameterError),
+    InvalidMacroError(InvalidMacroError),
+    NeedsGlobalQualificationError(NeedsGlobalQualificationError),
+}
+
+// -----------------------------------------------
+// Path Expander
+// -----------------------------------------------
+
+pub struct PathExpanderResult<T> {
+    pub result: Option<T>,
+    pub errors: Vec<PathExpansionError>,
 }
 
 /// This trait describes the commands available to handle alias scopes and expanding name access
@@ -69,34 +171,50 @@ pub trait PathExpander {
     // Pop the innermost alias scope
     fn pop_alias_scope(&mut self) -> AliasSet;
 
+    /// Returns an attribute value from a name access chain, plus possibly some error.
+    /// These errors may be separate from the access chain resolution errors, allowing the
+    /// compiler to continue processing the access chain and report later errors.
     fn name_access_chain_to_attribute_value(
         &mut self,
         context: &mut DefnContext,
         attribute_value: P::AttributeValue,
-    ) -> Option<ExternalAttributeValue>;
+    ) -> PathExpanderResult<ExternalAttributeValue>;
 
     fn name_access_chain_to_module_access(
         &mut self,
         context: &mut DefnContext,
         access: Access,
         name_chain: P::NameAccessChain,
-    ) -> Option<ModuleAccessResult>;
+    ) -> PathExpanderResult<AccessPath>;
 
     fn name_access_chain_to_module_ident(
         &mut self,
         context: &mut DefnContext,
         name_chain: P::NameAccessChain,
-    ) -> Option<E::ModuleIdent>;
+    ) -> PathExpanderResult<E::ModuleIdent>;
 
     fn ide_autocomplete_suggestion(&mut self, context: &mut DefnContext, loc: Loc);
 }
 
-pub fn make_access_result(
+// -------------------------------------------------------------------------------------------------
+// Impls
+// -------------------------------------------------------------------------------------------------
+
+impl<T> PathExpanderResult<T> {
+    pub fn err(errors: Vec<PathExpansionError>) -> Self {
+        PathExpanderResult {
+            result: None,
+            errors,
+        }
+    }
+}
+
+pub fn make_access_path(
     access: E::ModuleAccess,
     ptys_opt: Option<Spanned<Vec<P::Type>>>,
     is_macro: Option<Loc>,
-) -> ModuleAccessResult {
-    ModuleAccessResult {
+) -> AccessPath {
+    AccessPath {
         access,
         ptys_opt,
         is_macro,
@@ -119,9 +237,9 @@ macro_rules! single_entry {
     };
 }
 
-macro_rules! access_result {
+macro_rules! access {
     ($access:pat, $ptys_opt:pat, $is_macro:pat) => {
-        ModuleAccessResult {
+        AccessPath {
             access: $access,
             ptys_opt: $ptys_opt,
             is_macro: $is_macro,
@@ -129,7 +247,304 @@ macro_rules! access_result {
     };
 }
 
-pub(crate) use access_result;
+pub(crate) use access;
+
+// -----------------------------------------------
+// Error Impls
+// -----------------------------------------------
+
+// ----------------------
+// Primary Errors
+
+impl UnexpectedAccessError {
+    fn into_diagnostic(self) -> Diagnostic {
+        let UnexpectedAccessError {
+            result,
+            access,
+            note,
+        } = self;
+        let loc = result.loc();
+        let result = result.name();
+        let case = match access {
+            Access::Type | Access::ApplyNamed => "type",
+            Access::ApplyPositional => "expression",
+            Access::Term => "expression",
+            Access::Pattern => "pattern constructor",
+            Access::Module => "module",
+        };
+        let unexpected_msg = if result.starts_with('a') | result.starts_with('e') {
+            format!(
+                "Unexpected {0} identifier. An {0} identifier is not a valid {1}",
+                result, case
+            )
+        } else {
+            format!(
+                "Unexpected {0} identifier. A {0} identifier is not a valid {1}",
+                result, case
+            )
+        };
+        let mut diag = crate::diag!(NameResolution::NamePositionMismatch, (loc, unexpected_msg));
+        if let Some(note) = note {
+            diag.add_note(note)
+        };
+        diag
+    }
+}
+
+impl UnboundModuleError {
+    fn into_diagnostic(self) -> Diagnostic {
+        let UnboundModuleError { module } = self;
+        crate::diag!(
+            NameResolution::UnboundModule,
+            (module.loc, format!("Unbound module alias '{}'", module))
+        )
+    }
+}
+
+impl AccessChainResolutionError {
+    fn into_diagnostic(self) -> Diagnostic {
+        let AccessChainResolutionError { result } = self;
+        if let AccessChainNameResult::ResolutionFailure(inner, reason) = result {
+            let loc = inner.loc();
+            let msg = match reason {
+                AccessChainFailure::InvalidKind(kind) => format!(
+                    "Expected {} in this position, not {}",
+                    kind,
+                    inner.err_name()
+                ),
+                AccessChainFailure::UnresolvedAlias(name) => {
+                    format!("Could not resolve the name '{}'", name)
+                }
+            };
+            crate::diag!(NameResolution::NamePositionMismatch, (loc, msg))
+        } else {
+            ice!((
+                result.loc(),
+                "ICE compiler miscalled access chain resolution error handler"
+            ))
+        }
+    }
+}
+
+impl AmbiguousAccessError {
+    fn into_diagnostic(self) -> Diagnostic {
+        let AmbiguousAccessError {
+            loc,
+            kind,
+            possibles: (p0, p1),
+        } = self;
+        let msg = format!(
+            "Ambiguous {} value. It can resolve to both {} and {}",
+            kind, p0, p1
+        );
+        crate::diag!(Attributes::AmbiguousAttributeValue, (loc, msg))
+    }
+}
+
+impl UnexpectedAddressOrModule {
+    fn into_diagnostic(self) -> Diagnostic {
+        let UnexpectedAddressOrModule {
+            loc,
+            name_loc,
+            access,
+        } = self;
+        let case = match access {
+            Access::Type | Access::ApplyNamed | Access::ApplyPositional => "type",
+            Access::Term => "expression",
+            Access::Pattern => "pattern constructor",
+            Access::Module => {
+                return ice!(
+                    (
+                        loc,
+                        "ICE expected a module name and got one, but tried to report an error"
+                    ),
+                    (name_loc, "Name location")
+                );
+            }
+        };
+        let unexpected_msg = format!(
+            "Unexpected module identifier. A module identifier is not a valid {}",
+            case
+        );
+        crate::diag!(
+            NameResolution::NamePositionMismatch,
+            (loc, unexpected_msg),
+            (name_loc, "Expected a module member name".to_owned()),
+        )
+    }
+}
+
+impl LegacyGlobalAddressError {
+    fn into_diagnostic(self) -> Diagnostic {
+        let LegacyGlobalAddressError { loc, edition } = self;
+        let mut diag: Diagnostic = create_feature_error(edition, FeatureGate::Move2024Paths, loc);
+        diag.add_secondary_label((
+            loc,
+            "Paths that start with `::` are not valid in legacy move.",
+        ));
+        diag
+    }
+}
+
+impl LegacyInvalidName {
+    fn into_diagnostic(self) -> Diagnostic {
+        let LegacyInvalidName { loc, msg, note } = self;
+        let mut diag = crate::diag!(Syntax::InvalidName, (loc, msg));
+        if let Some(note) = note {
+            diag.add_note(note);
+        }
+        diag
+    }
+}
+
+impl LegacyInvalidModule {
+    fn into_diagnostic(self) -> Diagnostic {
+        let LegacyInvalidModule { loc, msg } = self;
+        crate::diag!(NameResolution::NamePositionMismatch, (loc, msg))
+    }
+}
+
+// ----------------------
+// Secondary Errors
+
+impl IncompleteAccessError {
+    fn into_diagnostic(self) -> Diagnostic {
+        let loc = self.loc;
+        let msg = "Incomplete name in this position. Expected an identifier after '::'";
+        crate::diag!(Syntax::InvalidName, (loc, msg))
+    }
+}
+
+impl InvalidTypeParameterError {
+    fn into_diagnostic(self) -> Diagnostic {
+        let InvalidTypeParameterError { loc, kind, note } = self;
+        let mut diag = crate::diag!(
+            NameResolution::InvalidTypeParameter,
+            (loc, format!("Cannot use type parameters on {kind}"))
+        );
+        if let Some(note) = note {
+            diag.add_note(note);
+        };
+        diag
+    }
+}
+
+impl InvalidMacroError {
+    fn into_diagnostic(self) -> Diagnostic {
+        let InvalidMacroError { loc, kind } = self;
+        crate::diag!(
+            NameResolution::InvalidTypeParameter,
+            (loc, format!("Cannot use {kind} as a macro invocation"))
+        )
+    }
+}
+
+impl NeedsGlobalQualificationError {
+    fn into_diagnostic(self) -> Diagnostic {
+        let NeedsGlobalQualificationError { loc } = self;
+        crate::diag!(
+            Migration::NeedsGlobalQualification,
+            (loc, "Must globally qualify name")
+        )
+    }
+}
+
+// ----------------------
+// Expander Error Enum
+
+impl PathExpansionError {
+    pub fn into_diagnostic(self) -> Diagnostic {
+        match self {
+            // Primary Errors
+            PathExpansionError::UnexpectedAccessError(err) => err.into_diagnostic(),
+            PathExpansionError::UnboundModule(err) => err.into_diagnostic(),
+            PathExpansionError::AccessChainResolutionError(err) => err.into_diagnostic(),
+            PathExpansionError::IncompleteAccessError(err) => err.into_diagnostic(),
+            PathExpansionError::AmbiguousAccessError(err) => err.into_diagnostic(),
+            PathExpansionError::UnexpectedAddressOrModule(err) => err.into_diagnostic(),
+            PathExpansionError::ValueError(err) => err.into_diagnostic(),
+            PathExpansionError::LegacyGlobalAddressError(err) => err.into_diagnostic(),
+            PathExpansionError::LegacyInvalidName(err) => err.into_diagnostic(),
+            PathExpansionError::LegacyInvalidModule(err) => err.into_diagnostic(),
+            // Secondary Errors
+            PathExpansionError::InvalidTypeParameterError(err) => err.into_diagnostic(),
+            PathExpansionError::InvalidMacroError(err) => err.into_diagnostic(),
+            PathExpansionError::NeedsGlobalQualificationError(err) => err.into_diagnostic(),
+        }
+    }
+
+    // Primary Errors
+
+    fn unexpected_access(
+        result: AccessChainNameResult,
+        access: Access,
+        note: Option<&'static str>,
+    ) -> Self {
+        PathExpansionError::UnexpectedAccessError(UnexpectedAccessError {
+            result,
+            access,
+            note,
+        })
+    }
+
+    fn unbound_module(module: Name) -> Self {
+        PathExpansionError::UnboundModule(UnboundModuleError { module })
+    }
+
+    fn access_chain_resolution(result: AccessChainNameResult) -> Self {
+        PathExpansionError::AccessChainResolutionError(AccessChainResolutionError { result })
+    }
+
+    fn incomplete_access(loc: Loc) -> Self {
+        PathExpansionError::IncompleteAccessError(IncompleteAccessError { loc })
+    }
+
+    fn ambiguous_access(
+        loc: Loc,
+        kind: &'static str,
+        possibles: (&'static str, &'static str),
+    ) -> Self {
+        PathExpansionError::AmbiguousAccessError(AmbiguousAccessError {
+            loc,
+            kind,
+            possibles,
+        })
+    }
+
+    fn unexpected_address_or_module(loc: Loc, name_loc: Loc, access: Access) -> Self {
+        PathExpansionError::UnexpectedAddressOrModule(UnexpectedAddressOrModule {
+            loc,
+            name_loc,
+            access,
+        })
+    }
+
+    fn legacy_global_address(loc: Loc, edition: Edition) -> Self {
+        PathExpansionError::LegacyGlobalAddressError(LegacyGlobalAddressError { loc, edition })
+    }
+
+    fn legacy_invalid_name(loc: Loc, msg: &'static str, note: Option<&'static str>) -> Self {
+        PathExpansionError::LegacyInvalidName(LegacyInvalidName { loc, msg, note })
+    }
+
+    fn legacy_invalid_module(loc: Loc, msg: &'static str) -> Self {
+        PathExpansionError::LegacyInvalidModule(LegacyInvalidModule { loc, msg })
+    }
+
+    // Secondary Errors
+
+    fn invalid_type_parameter(loc: Loc, kind: &'static str, note: Option<String>) -> Self {
+        PathExpansionError::InvalidTypeParameterError(InvalidTypeParameterError { loc, kind, note })
+    }
+
+    fn invalid_macro(loc: Loc, kind: &'static str) -> Self {
+        PathExpansionError::InvalidMacroError(InvalidMacroError { loc, kind })
+    }
+
+    fn needs_global_qualification(loc: Loc) -> Self {
+        PathExpansionError::NeedsGlobalQualificationError(NeedsGlobalQualificationError { loc })
+    }
+}
 
 //**************************************************************************************************
 // Move 2024 Path Expander
@@ -154,23 +569,30 @@ struct AccessChainResult {
     result: AccessChainNameResult,
     ptys_opt: Option<Spanned<Vec<P::Type>>>,
     is_macro: Option<Loc>,
+    errors: Vec<PathExpansionError>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
 enum AccessChainFailure {
     UnresolvedAlias(Name),
-    InvalidKind(String),
+    InvalidKind(&'static str),
 }
 
 macro_rules! chain_result {
-    ($result:pat, $ptys_opt:pat, $is_macro:pat) => {
+    ($result:pat, $ptys_opt:pat, $is_macro:pat, $errs:pat) => {
         AccessChainResult {
             result: $result,
             ptys_opt: $ptys_opt,
             is_macro: $is_macro,
+            errors: $errs,
         }
     };
 }
+
+const MODULE_MEMBER_ACCESS: &str = "a type, function, or constant";
+const LEADING_ACCESS: &str = "an address or module";
+const ADDRESS_ACCESS: &str = "an address";
+const ALL_ACCESS: &str = "a module, module member, or address";
 
 impl Move2024PathExpander {
     pub(super) fn new() -> Move2024PathExpander {
@@ -258,10 +680,10 @@ impl Move2024PathExpander {
             None => {
                 if let Some(entry) = self.aliases.resolve_any_for_error(&name) {
                     let msg = match namespace {
-                        NameSpace::ModuleMembers => "a type, function, or constant".to_string(),
+                        NameSpace::ModuleMembers => MODULE_MEMBER_ACCESS,
                         // we exclude types from this message since it would have been caught in
                         // the other namespace
-                        NameSpace::LeadingAccess => "an address or module".to_string(),
+                        NameSpace::LeadingAccess => LEADING_ACCESS,
                     };
                     let result = match entry {
                         AliasEntry::Address(_, address) => {
@@ -297,20 +719,18 @@ impl Move2024PathExpander {
         use AccessChainNameResult as NR;
         use P::NameAccessChain_ as PN;
 
+        let mut errors = Vec::new();
+
         fn check_tyargs(
-            context: &mut DefnContext,
+            errors: &mut Vec<PathExpansionError>,
             tyargs: &Option<Spanned<Vec<Type>>>,
             result: &NR,
         ) {
             if let NR::Address(_, _) | NR::ModuleIdent(_, _) | NR::Variant(_, _, _) = result {
                 if let Some(tyargs) = tyargs {
-                    let mut diag = diag!(
-                        NameResolution::InvalidTypeParameter,
-                        (
-                            tyargs.loc,
-                            format!("Cannot use type parameters on {}", result.err_name())
-                        )
-                    );
+                    let loc = tyargs.loc;
+                    let kind = result.err_name();
+                    let mut note = None;
                     if let NR::Variant(_, sp!(_, (mident, name)), variant) = result {
                         let tys = tyargs
                             .value
@@ -318,23 +738,23 @@ impl Move2024PathExpander {
                             .map(|ty| format!("{}", ty.value))
                             .collect::<Vec<_>>()
                             .join(",");
-                        diag.add_note(format!("Type arguments are used with the enum, as '{mident}::{name}<{tys}>::{variant}'"))
+                        note = Some(format!(
+                            "Type arguments are used with the enum, as '{mident}::{name}<{tys}>::{variant}'"
+                        ));
                     }
-                    context.add_diag(diag);
+                    errors.push(PathExpansionError::invalid_type_parameter(loc, kind, note));
                 }
             }
         }
 
-        fn check_is_macro(context: &mut DefnContext, is_macro: &Option<Loc>, result: &NR) {
+        fn check_is_macro(
+            errors: &mut Vec<PathExpansionError>,
+            is_macro: &Option<Loc>,
+            result: &NR,
+        ) {
             if let NR::Address(_, _) | NR::ModuleIdent(_, _) = result {
                 if let Some(loc) = is_macro {
-                    context.add_diag(diag!(
-                        NameResolution::InvalidTypeParameter,
-                        (
-                            *loc,
-                            format!("Cannot use {} as a macro invocation", result.err_name())
-                        )
-                    ));
+                    errors.push(PathExpansionError::invalid_macro(*loc, result.err_name()));
                 }
             }
         }
@@ -366,6 +786,7 @@ impl Move2024PathExpander {
                     result,
                     ptys_opt,
                     is_macro,
+                    errors,
                 }
             }
             PN::Path(path) => {
@@ -387,16 +808,12 @@ impl Move2024PathExpander {
                             && root.tyargs.is_none() =>
                     {
                         if let Some(address) = top_level_address_opt(context, root.name) {
-                            context.add_diag(diag!(
-                                Migration::NeedsGlobalQualification,
-                                (root.name.loc, "Must globally qualify name")
+                            errors.push(PathExpansionError::needs_global_qualification(
+                                root.name.loc,
                             ));
                             NR::Address(root.name.loc, address)
                         } else {
-                            NR::ResolutionFailure(
-                                Box::new(result),
-                                NF::InvalidKind("an address".to_string()),
-                            )
+                            NR::ResolutionFailure(Box::new(result), NF::InvalidKind(ADDRESS_ACCESS))
                         }
                     }
                     result => result,
@@ -405,15 +822,15 @@ impl Move2024PathExpander {
                 let mut is_macro = root.is_macro;
 
                 for entry in entries {
-                    check_tyargs(context, &ptys_opt, &result);
-                    check_is_macro(context, &is_macro, &result);
+                    check_tyargs(&mut errors, &ptys_opt, &result);
+                    check_is_macro(&mut errors, &is_macro, &result);
                     // ModuleAccess(ModuleIdent, Name),
                     // Variant(Spanned<(ModuleIdent, Name)>, Name),
                     match result {
                         NR::Variant(_, _, _) => {
                             result = NR::ResolutionFailure(
                                 Box::new(result),
-                                NF::InvalidKind("a module, module member, or address".to_string()),
+                                NF::InvalidKind(ALL_ACCESS),
                             );
                             break;
                         }
@@ -430,17 +847,17 @@ impl Move2024PathExpander {
                             result = NR::Variant(loc, sp(mloc, (mident, member)), entry.name);
                             // For a variant, we use the type args from the access. We check these
                             // are empty or error.
-                            check_tyargs(context, &entry.tyargs, &result);
+                            check_tyargs(&mut errors, &entry.tyargs, &result);
                             if ptys_opt.is_none() && entry.tyargs.is_some() {
                                 // This is an error, but we can try to be helpful.
                                 ptys_opt = entry.tyargs;
                             }
-                            check_is_macro(context, &entry.is_macro, &result);
+                            check_is_macro(&mut errors, &entry.is_macro, &result);
                         }
                         NR::ModuleAccess(_mloc, _mident, _member) => {
                             result = NR::ResolutionFailure(
                                 Box::new(result),
-                                NF::InvalidKind("a module or address".to_string()),
+                                NF::InvalidKind(LEADING_ACCESS),
                             );
                             break;
                         }
@@ -484,6 +901,7 @@ impl Move2024PathExpander {
                     result,
                     ptys_opt,
                     is_macro,
+                    errors,
                 }
             }
         }
@@ -511,86 +929,91 @@ impl PathExpander for Move2024PathExpander {
         &mut self,
         context: &mut DefnContext,
         sp!(loc, avalue_): P::AttributeValue,
-    ) -> Option<ExternalAttributeValue> {
+    ) -> PathExpanderResult<ExternalAttributeValue> {
         use AccessChainNameResult as NR;
         use ExternalAttributeValue_ as EV;
         use P::AttributeValue_ as PV;
-        Some(sp(
-            loc,
-            match avalue_ {
-                PV::Value(v) => EV::Value(value(context, v)?),
-                // A bit strange, but we try to resolve it as a term and a module, and report
-                // an error if they both resolve (to different things)
-                PV::ModuleAccess(access_chain) => {
-                    ice_assert!(
-                        context.reporter,
-                        access_chain.value.tyargs().is_none(),
-                        loc,
-                        "Found tyargs"
-                    );
-                    ice_assert!(
-                        context.reporter,
-                        access_chain.value.is_macro().is_none(),
-                        loc,
-                        "Found macro"
-                    );
-                    let chain_result!(term_result, term_tyargs, term_is_macro) =
-                        self.resolve_name_access_chain(context, Access::Term, access_chain.clone());
-                    assert!(term_tyargs.is_none());
-                    assert!(term_is_macro.is_none());
-                    let chain_result!(module_result, module_tyargs, module_is_macro) =
-                        self.resolve_name_access_chain(context, Access::Module, access_chain);
-                    assert!(module_tyargs.is_none());
-                    assert!(module_is_macro.is_none());
-                    let result = match (term_result, module_result) {
-                        (t_res, m_res) if t_res == m_res => t_res,
-                        (NR::ResolutionFailure(_, _) | NR::UnresolvedName(_, _), other)
-                        | (other, NR::ResolutionFailure(_, _) | NR::UnresolvedName(_, _)) => other,
-                        (t_res, m_res) => {
-                            let msg = format!(
-                                "Ambiguous attribute value. It can resolve to both {} and {}",
-                                t_res.err_name(),
-                                m_res.err_name()
-                            );
-                            context
-                                .add_diag(diag!(Attributes::AmbiguousAttributeValue, (loc, msg)));
-                            return None;
-                        }
-                    };
-                    match result {
-                        NR::ModuleIdent(_, mident) => {
-                            if context.module_members.get(&mident).is_none() {
-                                context.add_diag(diag!(
-                                    NameResolution::UnboundModule,
-                                    (loc, format!("Unbound module '{}'", mident))
-                                ));
-                            }
-                            EV::Module(mident)
-                        }
-                        NR::ModuleAccess(loc, mident, member) => {
-                            let access = sp(loc, E::ModuleAccess_::ModuleAccess(mident, member));
-                            EV::ModuleAccess(access)
-                        }
-                        NR::Variant(loc, member_path, variant) => {
-                            let access = sp(loc, E::ModuleAccess_::Variant(member_path, variant));
-                            EV::ModuleAccess(access)
-                        }
-                        NR::UnresolvedName(loc, name) => {
-                            EV::ModuleAccess(sp(loc, E::ModuleAccess_::Name(name)))
-                        }
-                        NR::Address(_, a) => EV::Address(a),
-                        result @ NR::ResolutionFailure(_, _) => {
-                            context.add_diag(access_chain_resolution_error(result));
-                            return None;
-                        }
-                        NR::IncompleteChain(loc) => {
-                            context.add_diag(access_chain_incomplete_error(loc));
-                            return None;
-                        }
-                    }
+
+        let mut errors = Vec::new();
+        let value_ = match avalue_ {
+            PV::Value(v) => match value_result(context, v) {
+                Ok(value) => EV::Value(value),
+                Err(errs) => {
+                    errors.extend(errs.into_iter().map(PathExpansionError::ValueError));
+                    return PathExpanderResult::err(errors);
                 }
             },
-        ))
+            // A bit strange, but we try to resolve it as a term and a module, and report
+            // an error if they both resolve (to different things)
+            PV::ModuleAccess(access_chain) => {
+                ice_assert!(
+                    context.reporter,
+                    access_chain.value.tyargs().is_none(),
+                    loc,
+                    "Found tyargs"
+                );
+                ice_assert!(
+                    context.reporter,
+                    access_chain.value.is_macro().is_none(),
+                    loc,
+                    "Found macro"
+                );
+                let chain_result!(term_result, term_tyargs, term_is_macro, new_errors) =
+                    self.resolve_name_access_chain(context, Access::Term, access_chain.clone());
+                errors.extend(new_errors);
+                assert!(term_tyargs.is_none());
+                assert!(term_is_macro.is_none());
+                let chain_result!(module_result, module_tyargs, module_is_macro, new_errors) =
+                    self.resolve_name_access_chain(context, Access::Module, access_chain);
+                errors.extend(new_errors);
+                assert!(module_tyargs.is_none());
+                assert!(module_is_macro.is_none());
+                let result = match (term_result, module_result) {
+                    (t_res, m_res) if t_res == m_res => t_res,
+                    (NR::ResolutionFailure(_, _) | NR::UnresolvedName(_, _), other)
+                    | (other, NR::ResolutionFailure(_, _) | NR::UnresolvedName(_, _)) => other,
+                    (t_res, m_res) => {
+                        let err = PathExpansionError::ambiguous_access(
+                            loc,
+                            "attribute",
+                            (t_res.err_name(), m_res.err_name()),
+                        );
+                        errors.push(err);
+                        return PathExpanderResult::err(errors);
+                    }
+                };
+                match result {
+                    NR::ModuleIdent(_, mident) => {
+                        if context.module_members.get(&mident).is_none() {
+                            errors.push(PathExpansionError::unbound_module(mident.value.module.0));
+                        }
+                        EV::Module(mident)
+                    }
+                    NR::ModuleAccess(loc, mident, member) => {
+                        let access = sp(loc, E::ModuleAccess_::ModuleAccess(mident, member));
+                        EV::ModuleAccess(access)
+                    }
+                    NR::Variant(loc, member_path, variant) => {
+                        let access = sp(loc, E::ModuleAccess_::Variant(member_path, variant));
+                        EV::ModuleAccess(access)
+                    }
+                    NR::UnresolvedName(loc, name) => {
+                        EV::ModuleAccess(sp(loc, E::ModuleAccess_::Name(name)))
+                    }
+                    NR::Address(_, a) => EV::Address(a),
+                    result @ NR::ResolutionFailure(_, _) => {
+                        errors.push(PathExpansionError::access_chain_resolution(result));
+                        return PathExpanderResult::err(errors);
+                    }
+                    NR::IncompleteChain(loc) => {
+                        errors.push(PathExpansionError::incomplete_access(loc));
+                        return PathExpanderResult::err(errors);
+                    }
+                }
+            }
+        };
+        let result = Some(sp(loc, value_));
+        PathExpanderResult { result, errors }
     }
 
     fn name_access_chain_to_module_access(
@@ -598,17 +1021,20 @@ impl PathExpander for Move2024PathExpander {
         context: &mut DefnContext,
         access: Access,
         chain: P::NameAccessChain,
-    ) -> Option<ModuleAccessResult> {
+    ) -> PathExpanderResult<AccessPath> {
         use AccessChainNameResult as NR;
         use E::ModuleAccess_ as EN;
         use P::NameAccessChain_ as PN;
 
         let mut loc = chain.loc;
+        let mut errors = Vec::new();
 
         let (module_access, tyargs, is_macro) = match access {
             Access::ApplyPositional | Access::ApplyNamed | Access::Type => {
-                let chain_result!(resolved_name, tyargs, is_macro) =
+                let chain_result!(resolved_name, tyargs, is_macro, new_errors) =
                     self.resolve_name_access_chain(context, access, chain.clone());
+                errors.extend(new_errors);
+
                 match resolved_name {
                     NR::UnresolvedName(_, name) => {
                         loc = name.loc;
@@ -621,52 +1047,41 @@ impl PathExpander for Move2024PathExpander {
                     NR::Variant(_loc, sp!(_mloc, (_mident, _member)), _)
                         if access == Access::Type =>
                     {
-                        let mut diag = unexpected_access_error(
-                            resolved_name.loc(),
-                            resolved_name.name(),
+                        errors.push(PathExpansionError::unexpected_access(
+                            resolved_name,
                             access,
-                        );
-                        diag.add_note("Variants may not be used as types. Use the enum instead.");
-                        context.add_diag(diag);
+                            Some("Variants may not be used as types. Use the enum instead."),
+                        ));
                         // We could try to use the member access to try to keep going.
-                        return None;
+                        return PathExpanderResult::err(errors);
                     }
                     NR::Variant(_loc, member_path, variant) => {
                         let access = E::ModuleAccess_::Variant(member_path, variant);
                         (access, tyargs, is_macro)
                     }
                     NR::Address(_, _) => {
-                        context.add_diag(unexpected_access_error(
-                            resolved_name.loc(),
-                            resolved_name.name(),
+                        errors.push(PathExpansionError::unexpected_access(
+                            resolved_name,
                             access,
+                            None,
                         ));
-                        return None;
+                        return PathExpanderResult::err(errors);
                     }
-                    NR::ModuleIdent(_, sp!(_, ModuleIdent_ { address, module })) => {
-                        let mut diag = unexpected_access_error(
-                            resolved_name.loc(),
-                            resolved_name.name(),
+                    NR::ModuleIdent(_, sp!(_, ModuleIdent_ { .. })) => {
+                        errors.push(PathExpansionError::unexpected_access(
+                            resolved_name,
                             access,
-                        );
-                        let base_str = format!("{}", chain);
-                        let realized_str = format!("{}::{}", address, module);
-                        if base_str != realized_str {
-                            diag.add_note(format!(
-                                "Resolved '{}' to module identifier '{}'",
-                                base_str, realized_str
-                            ));
-                        }
-                        context.add_diag(diag);
-                        return None;
+                            None,
+                        ));
+                        return PathExpanderResult::err(errors);
                     }
                     result @ NR::ResolutionFailure(_, _) => {
-                        context.add_diag(access_chain_resolution_error(result));
-                        return None;
+                        errors.push(PathExpansionError::access_chain_resolution(result));
+                        return PathExpanderResult::err(errors);
                     }
                     NR::IncompleteChain(loc) => {
-                        context.add_diag(access_chain_incomplete_error(loc));
-                        return None;
+                        errors.push(PathExpansionError::incomplete_access(loc));
+                        return PathExpanderResult::err(errors);
                     }
                 }
             }
@@ -678,8 +1093,10 @@ impl PathExpander for Move2024PathExpander {
                     (EN::Name(name), tyargs, is_macro)
                 }
                 _ => {
-                    let chain_result!(resolved_name, tyargs, is_macro) =
+                    let chain_result!(resolved_name, tyargs, is_macro, new_errors) =
                         self.resolve_name_access_chain(context, access, chain);
+                    errors.extend(new_errors);
+
                     match resolved_name {
                         NR::UnresolvedName(_, name) => (EN::Name(name), tyargs, is_macro),
                         NR::ModuleAccess(_loc, mident, member) => {
@@ -691,20 +1108,20 @@ impl PathExpander for Move2024PathExpander {
                             (access, tyargs, is_macro)
                         }
                         NR::Address(_, _) | NR::ModuleIdent(_, _) => {
-                            context.add_diag(unexpected_access_error(
-                                resolved_name.loc(),
-                                resolved_name.name(),
+                            errors.push(PathExpansionError::unexpected_access(
+                                resolved_name,
                                 access,
+                                None,
                             ));
-                            return None;
+                            return PathExpanderResult::err(errors);
                         }
                         result @ NR::ResolutionFailure(_, _) => {
-                            context.add_diag(access_chain_resolution_error(result));
-                            return None;
+                            errors.push(PathExpansionError::access_chain_resolution(result));
+                            return PathExpanderResult::err(errors);
                         }
                         NR::IncompleteChain(loc) => {
-                            context.add_diag(access_chain_incomplete_error(loc));
-                            return None;
+                            errors.push(PathExpansionError::incomplete_access(loc));
+                            return PathExpanderResult::err(errors);
                         }
                     }
                 }
@@ -714,53 +1131,63 @@ impl PathExpander for Move2024PathExpander {
                     loc,
                     "ICE module access should never resolve to a module member"
                 )));
-                return None;
+                return PathExpanderResult::err(errors);
             }
         };
-        Some(make_access_result(sp(loc, module_access), tyargs, is_macro))
+        let result = Some(make_access_path(sp(loc, module_access), tyargs, is_macro));
+        PathExpanderResult { result, errors }
     }
 
     fn name_access_chain_to_module_ident(
         &mut self,
         context: &mut DefnContext,
         chain: P::NameAccessChain,
-    ) -> Option<E::ModuleIdent> {
+    ) -> PathExpanderResult<E::ModuleIdent> {
         use AccessChainNameResult as NR;
-        let chain_result!(resolved_name, tyargs, is_macro) =
+
+        let mut errors = Vec::new();
+
+        let chain_result!(resolved_name, tyargs, is_macro, new_errors) =
             self.resolve_name_access_chain(context, Access::Module, chain);
+
+        errors.extend(new_errors);
+
         assert!(tyargs.is_none());
         assert!(is_macro.is_none());
-        match resolved_name {
-            NR::ModuleIdent(_, mident) => Some(mident),
+
+        let name = match resolved_name {
+            NR::ModuleIdent(_, mident) => mident,
             NR::UnresolvedName(_, name) => {
-                context.add_diag(unbound_module_error(name));
-                None
+                errors.push(PathExpansionError::unbound_module(name));
+                return PathExpanderResult::err(errors);
             }
             NR::Address(_, _) => {
-                context.add_diag(unexpected_access_error(
-                    resolved_name.loc(),
-                    "address".to_string(),
+                errors.push(PathExpansionError::unexpected_access(
+                    resolved_name,
                     Access::Module,
+                    None,
                 ));
-                None
+                return PathExpanderResult::err(errors);
             }
             NR::ModuleAccess(_, _, _) | NR::Variant(_, _, _) => {
-                context.add_diag(unexpected_access_error(
-                    resolved_name.loc(),
-                    "module member".to_string(),
+                errors.push(PathExpansionError::unexpected_access(
+                    resolved_name,
                     Access::Module,
+                    None,
                 ));
-                None
+                return PathExpanderResult::err(errors);
             }
             result @ NR::ResolutionFailure(_, _) => {
-                context.add_diag(access_chain_resolution_error(result));
-                None
+                errors.push(PathExpansionError::access_chain_resolution(result));
+                return PathExpanderResult::err(errors);
             }
             NR::IncompleteChain(loc) => {
-                context.add_diag(access_chain_incomplete_error(loc));
-                None
+                errors.push(PathExpansionError::incomplete_access(loc));
+                return PathExpanderResult::err(errors);
             }
-        }
+        };
+        let result = Some(name);
+        PathExpanderResult { result, errors }
     }
 
     fn ide_autocomplete_suggestion(&mut self, context: &mut DefnContext, loc: Loc) {
@@ -784,85 +1211,29 @@ impl AccessChainNameResult {
         }
     }
 
-    fn name(&self) -> String {
+    const fn name(&self) -> &'static str {
         match self {
-            AccessChainNameResult::ModuleAccess(_, _, _) => "module member".to_string(),
-            AccessChainNameResult::Variant(_, _, _) => "enum variant".to_string(),
-            AccessChainNameResult::ModuleIdent(_, _) => "module".to_string(),
-            AccessChainNameResult::UnresolvedName(_, _) => "name".to_string(),
-            AccessChainNameResult::Address(_, _) => "address".to_string(),
+            AccessChainNameResult::ModuleAccess(_, _, _) => "module member",
+            AccessChainNameResult::Variant(_, _, _) => "enum variant",
+            AccessChainNameResult::ModuleIdent(_, _) => "module",
+            AccessChainNameResult::UnresolvedName(_, _) => "name",
+            AccessChainNameResult::Address(_, _) => "address",
             AccessChainNameResult::ResolutionFailure(inner, _) => inner.err_name(),
-            AccessChainNameResult::IncompleteChain(_) => "".to_string(),
+            AccessChainNameResult::IncompleteChain(_) => "",
         }
     }
 
-    fn err_name(&self) -> String {
+    const fn err_name(&self) -> &'static str {
         match self {
-            AccessChainNameResult::ModuleAccess(_, _, _) => "a module member".to_string(),
-            AccessChainNameResult::Variant(_, _, _) => "an enum variant".to_string(),
-            AccessChainNameResult::ModuleIdent(_, _) => "a module".to_string(),
-            AccessChainNameResult::UnresolvedName(_, _) => "a name".to_string(),
-            AccessChainNameResult::Address(_, _) => "an address".to_string(),
+            AccessChainNameResult::ModuleAccess(_, _, _) => "a module member",
+            AccessChainNameResult::Variant(_, _, _) => "an enum variant",
+            AccessChainNameResult::ModuleIdent(_, _) => "a module",
+            AccessChainNameResult::UnresolvedName(_, _) => "a name",
+            AccessChainNameResult::Address(_, _) => "an address",
             AccessChainNameResult::ResolutionFailure(inner, _) => inner.err_name(),
-            AccessChainNameResult::IncompleteChain(_) => "".to_string(),
+            AccessChainNameResult::IncompleteChain(_) => "",
         }
     }
-}
-
-fn unexpected_access_error(loc: Loc, result: String, access: Access) -> Diagnostic {
-    let case = match access {
-        Access::Type | Access::ApplyNamed => "type",
-        Access::ApplyPositional => "expression",
-        Access::Term => "expression",
-        Access::Pattern => "pattern constructor",
-        Access::Module => "module",
-    };
-    let unexpected_msg = if result.starts_with('a') | result.starts_with('e') {
-        format!(
-            "Unexpected {0} identifier. An {0} identifier is not a valid {1}",
-            result, case
-        )
-    } else {
-        format!(
-            "Unexpected {0} identifier. A {0} identifier is not a valid {1}",
-            result, case
-        )
-    };
-    diag!(NameResolution::NamePositionMismatch, (loc, unexpected_msg),)
-}
-
-fn unbound_module_error(name: Name) -> Diagnostic {
-    diag!(
-        NameResolution::UnboundModule,
-        (name.loc, format!("Unbound module alias '{}'", name))
-    )
-}
-
-fn access_chain_resolution_error(result: AccessChainNameResult) -> Diagnostic {
-    if let AccessChainNameResult::ResolutionFailure(inner, reason) = result {
-        let loc = inner.loc();
-        let msg = match reason {
-            AccessChainFailure::InvalidKind(kind) => format!(
-                "Expected {} in this position, not {}",
-                kind,
-                inner.err_name()
-            ),
-            AccessChainFailure::UnresolvedAlias(name) => {
-                format!("Could not resolve the name '{}'", name)
-            }
-        };
-        diag!(NameResolution::NamePositionMismatch, (loc, msg))
-    } else {
-        ice!((
-            result.loc(),
-            "ICE compiler miscalled access chain resolution error handler"
-        ))
-    }
-}
-
-fn access_chain_incomplete_error(loc: Loc) -> Diagnostic {
-    let msg = "Incomplete name in this position. Expected an identifier after '::'";
-    diag!(Syntax::InvalidName, (loc, msg))
 }
 
 //**************************************************************************************************
@@ -911,91 +1282,106 @@ impl PathExpander for LegacyPathExpander {
         &mut self,
         context: &mut DefnContext,
         sp!(loc, avalue_): P::AttributeValue,
-    ) -> Option<ExternalAttributeValue> {
+    ) -> PathExpanderResult<ExternalAttributeValue> {
         use ExternalAttributeValue_ as EV;
         use P::{AttributeValue_ as PV, LeadingNameAccess_ as LN, NameAccessChain_ as PN};
-        Some(sp(
-            loc,
-            match avalue_ {
-                PV::Value(v) => EV::Value(value(context, v)?),
-                // bit wonky, but this is the only spot currently where modules and expressions
-                // exist in the same namespace.
-                // TODO: consider if we want to just force all of these checks into the well-known
-                // attribute setup
-                PV::ModuleAccess(sp!(ident_loc, single_entry!(name, tyargs, is_macro)))
-                    if self.aliases.module_alias_get(&name).is_some() =>
-                {
-                    self.ide_autocomplete_suggestion(context, loc);
-                    ice_assert!(context.reporter, tyargs.is_none(), loc, "Found tyargs");
-                    ice_assert!(context.reporter, is_macro.is_none(), loc, "Found macro");
-                    let sp!(_, mident_) = self.aliases.module_alias_get(&name).unwrap();
-                    let mident = sp(ident_loc, mident_);
-                    if context.module_members.get(&mident).is_none() {
-                        context.add_diag(diag!(
-                            NameResolution::UnboundModule,
-                            (ident_loc, format!("Unbound module '{}'", mident))
-                        ));
-                    }
-                    EV::Module(mident)
+
+        let mut errors = Vec::new();
+
+        let value = match avalue_ {
+            PV::Value(v) => match value_result(context, v) {
+                Ok(value) => EV::Value(value),
+                Err(errs) => {
+                    errors.extend(errs.into_iter().map(PathExpansionError::ValueError));
+                    return PathExpanderResult::err(errors);
                 }
-                PV::ModuleAccess(sp!(ident_loc, PN::Path(path))) => {
-                    ice_assert!(context.reporter, !path.has_tyargs(), loc, "Found tyargs");
-                    ice_assert!(
-                        context.reporter,
-                        path.is_macro().is_none(),
-                        loc,
-                        "Found macro"
-                    );
-                    match (&path.root.name, &path.entries[..]) {
-                        (sp!(aloc, LN::AnonymousAddress(a)), [n]) => {
-                            let addr = Address::anonymous(*aloc, *a);
-                            let mident = sp(ident_loc, ModuleIdent_::new(addr, ModuleName(n.name)));
-                            if context.module_members.get(&mident).is_none() {
-                                context.add_diag(diag!(
-                                    NameResolution::UnboundModule,
-                                    (ident_loc, format!("Unbound module '{}'", mident))
-                                ));
-                            }
-                            EV::Module(mident)
-                        }
-                        (sp!(aloc, LN::GlobalAddress(n1) | LN::Name(n1)), [n2])
-                            if context
-                                .named_address_mapping
-                                .as_ref()
-                                .map(|m| m.contains_key(&n1.value))
-                                .unwrap_or(false) =>
-                        {
-                            let addr = top_level_address(
-                                context,
-                                /* suggest_declaration */ false,
-                                sp(*aloc, LN::Name(*n1)),
-                            );
-                            let mident =
-                                sp(ident_loc, ModuleIdent_::new(addr, ModuleName(n2.name)));
-                            if context.module_members.get(&mident).is_none() {
-                                context.add_diag(diag!(
-                                    NameResolution::UnboundModule,
-                                    (ident_loc, format!("Unbound module '{}'", mident))
-                                ));
-                            }
-                            EV::Module(mident)
-                        }
-                        _ => EV::ModuleAccess(
-                            self.name_access_chain_to_module_access(
-                                context,
-                                Access::Type,
-                                sp(ident_loc, PN::Path(path)),
-                            )?
-                            .access,
-                        ),
-                    }
-                }
-                PV::ModuleAccess(ma) => EV::ModuleAccess(
-                    self.name_access_chain_to_module_access(context, Access::Type, ma)?
-                        .access,
-                ),
             },
-        ))
+            // bit wonky, but this is the only spot currently where modules and expressions
+            // exist in the same namespace.
+            // TODO: consider if we want to just force all of these checks into the well-known
+            // attribute setup
+            PV::ModuleAccess(sp!(ident_loc, single_entry!(name, tyargs, is_macro)))
+                if self.aliases.module_alias_get(&name).is_some() =>
+            {
+                self.ide_autocomplete_suggestion(context, loc);
+                ice_assert!(context.reporter, tyargs.is_none(), loc, "Found tyargs");
+                ice_assert!(context.reporter, is_macro.is_none(), loc, "Found macro");
+                let sp!(_, mident_) = self.aliases.module_alias_get(&name).unwrap();
+                let mident = sp(ident_loc, mident_);
+                if !context.module_members.contains_key(&mident) {
+                    errors.push(PathExpansionError::unbound_module(mident.value.module.0));
+                }
+                EV::Module(mident)
+            }
+            PV::ModuleAccess(sp!(ident_loc, PN::Path(path))) => {
+                ice_assert!(context.reporter, !path.has_tyargs(), loc, "Found tyargs");
+                ice_assert!(
+                    context.reporter,
+                    path.is_macro().is_none(),
+                    loc,
+                    "Found macro"
+                );
+                match (&path.root.name, &path.entries[..]) {
+                    (sp!(aloc, LN::AnonymousAddress(a)), [n]) => {
+                        let addr = Address::anonymous(*aloc, *a);
+                        let mident = sp(ident_loc, ModuleIdent_::new(addr, ModuleName(n.name)));
+                        if !context.module_members.contains_key(&mident) {
+                            errors.push(PathExpansionError::unbound_module(mident.value.module.0));
+                        }
+                        EV::Module(mident)
+                    }
+                    (sp!(aloc, LN::GlobalAddress(n1) | LN::Name(n1)), [n2])
+                        if context
+                            .named_address_mapping
+                            .as_ref()
+                            .map(|m| m.contains_key(&n1.value))
+                            .unwrap_or(false) =>
+                    {
+                        let addr = top_level_address(
+                            context,
+                            /* suggest_declaration */ false,
+                            sp(*aloc, LN::Name(*n1)),
+                        );
+                        let mident = sp(ident_loc, ModuleIdent_::new(addr, ModuleName(n2.name)));
+
+                        if context.module_members.get(&mident).is_none() {
+                            errors.push(PathExpansionError::unbound_module(mident.value.module.0));
+                        }
+                        EV::Module(mident)
+                    }
+                    _ => {
+                        let result = self.name_access_chain_to_module_access(
+                            context,
+                            Access::Type,
+                            sp(ident_loc, PN::Path(path)),
+                        );
+                        let PathExpanderResult {
+                            result,
+                            errors: new_errors,
+                        } = result;
+                        errors.extend(new_errors);
+                        let Some(access) = result else {
+                            return PathExpanderResult::err(errors);
+                        };
+                        EV::ModuleAccess(access.access)
+                    }
+                }
+            }
+            PV::ModuleAccess(ma) => {
+                let result = self.name_access_chain_to_module_access(context, Access::Type, ma);
+                let PathExpanderResult {
+                    result,
+                    errors: new_errors,
+                } = result;
+                errors.extend(new_errors);
+                let Some(access) = result else {
+                    return PathExpanderResult::err(errors);
+                };
+                EV::ModuleAccess(access.access)
+            }
+        };
+        let result = Some(sp(loc, value));
+        PathExpanderResult { result, errors }
     }
 
     fn name_access_chain_to_module_access(
@@ -1003,17 +1389,19 @@ impl PathExpander for LegacyPathExpander {
         context: &mut DefnContext,
         access: Access,
         sp!(loc, ptn_): P::NameAccessChain,
-    ) -> Option<ModuleAccessResult> {
+    ) -> PathExpanderResult<AccessPath> {
         use E::ModuleAccess_ as EN;
         use P::{LeadingNameAccess_ as LN, NameAccessChain_ as PN};
 
-        let tn_: ModuleAccessResult = match (access, ptn_) {
+        let mut errors = Vec::new();
+
+        let tn_: AccessPath = match (access, ptn_) {
             (Access::Pattern, _) => {
                 context.add_diag(ice!((
                     loc,
                     "Attempted to expand a variant with the legacy path expander"
                 )));
-                return None;
+                return PathExpanderResult::err(errors);
             }
             (
                 Access::ApplyPositional | Access::ApplyNamed | Access::Type,
@@ -1027,7 +1415,7 @@ impl PathExpander for LegacyPathExpander {
                     Some((mident, mem)) => EN::ModuleAccess(mident, mem),
                     None => EN::Name(name),
                 };
-                make_access_result(sp(name.loc, access), tyargs, is_macro)
+                make_access_path(sp(name.loc, access), tyargs, is_macro)
             }
             (Access::Term, single_entry!(name, tyargs, is_macro))
                 if is_valid_datatype_or_constant_name(name.value.as_str()) =>
@@ -1037,18 +1425,18 @@ impl PathExpander for LegacyPathExpander {
                     Some((mident, mem)) => EN::ModuleAccess(mident, mem),
                     None => EN::Name(name),
                 };
-                make_access_result(sp(name.loc, access), tyargs, is_macro)
+                make_access_path(sp(name.loc, access), tyargs, is_macro)
             }
             (Access::Term, single_entry!(name, tyargs, is_macro)) => {
                 self.ide_autocomplete_suggestion(context, loc);
-                make_access_result(sp(name.loc, EN::Name(name)), tyargs, is_macro)
+                make_access_path(sp(name.loc, EN::Name(name)), tyargs, is_macro)
             }
             (Access::Module, single_entry!(_name, _tyargs, _is_macro)) => {
                 context.add_diag(ice!((
                     loc,
                     "ICE path resolution produced an impossible path for a module"
                 )));
-                return None;
+                return PathExpanderResult::err(errors);
             }
             (_, PN::Path(mut path)) => {
                 if access == Access::Type {
@@ -1062,22 +1450,17 @@ impl PathExpander for LegacyPathExpander {
                 match (&path.root.name, &path.entries[..]) {
                     // Error cases
                     (sp!(aloc, LN::AnonymousAddress(_)), [_]) => {
-                        let diag = unexpected_address_module_error(loc, *aloc, access);
-                        context.add_diag(diag);
-                        return None;
+                        errors.push(PathExpansionError::unexpected_address_or_module(
+                            loc, *aloc, access,
+                        ));
+                        return PathExpanderResult::err(errors);
                     }
                     (sp!(_aloc, LN::GlobalAddress(_)), [_]) => {
-                        let mut diag: Diagnostic = create_feature_error(
-                            context.env.edition(None), // We already know we are failing, so no package.
-                            FeatureGate::Move2024Paths,
+                        errors.push(PathExpansionError::legacy_global_address(
                             loc,
-                        );
-                        diag.add_secondary_label((
-                            loc,
-                            "Paths that start with `::` are not valid in legacy move.",
+                            context.env.edition(context.current_package),
                         ));
-                        context.add_diag(diag);
-                        return None;
+                        return PathExpanderResult::err(errors);
                     }
                     // Others
                     (sp!(_, LN::Name(n1)), [n2]) => {
@@ -1085,29 +1468,23 @@ impl PathExpander for LegacyPathExpander {
                         if let Some(mident) = self.aliases.module_alias_get(n1) {
                             let n2_name = n2.name;
                             let (tyargs, is_macro) = if !path.has_tyargs_last() {
-                                let mut diag = diag!(
-                                    Syntax::InvalidName,
-                                    (path.tyargs_loc().unwrap(), "Invalid type argument position")
-                                );
-                                diag.add_note(
-                                    "Type arguments may only be used with module members",
-                                );
-                                context.add_diag(diag);
+                                errors.push(PathExpansionError::legacy_invalid_name(
+                                    path.tyargs_loc().unwrap_or(n2_name.loc),
+                                    "Invalid type argument position",
+                                    Some("Type arguments may only be used with module members"),
+                                ));
                                 (None, path.is_macro())
                             } else {
                                 (path.take_tyargs(), path.is_macro())
                             };
-                            make_access_result(
+                            make_access_path(
                                 sp(loc, EN::ModuleAccess(mident, n2_name)),
                                 tyargs,
                                 is_macro.copied(),
                             )
                         } else {
-                            context.add_diag(diag!(
-                                NameResolution::UnboundModule,
-                                (n1.loc, format!("Unbound module alias '{}'", n1))
-                            ));
-                            return None;
+                            errors.push(PathExpansionError::unbound_module(*n1));
+                            return PathExpanderResult::err(errors);
                         }
                     }
                     (ln, [n2, n3]) => {
@@ -1122,42 +1499,47 @@ impl PathExpander for LegacyPathExpander {
                         let mident = sp(ident_loc, ModuleIdent_::new(addr, ModuleName(n2.name)));
                         let access = EN::ModuleAccess(mident, n3.name);
                         let (tyargs, is_macro) = if !(path.has_tyargs_last()) {
-                            let mut diag = diag!(
-                                Syntax::InvalidName,
-                                (path.tyargs_loc().unwrap(), "Invalid type argument position")
-                            );
-                            diag.add_note("Type arguments may only be used with module members");
-                            context.add_diag(diag);
+                            errors.push(PathExpansionError::legacy_invalid_name(
+                                path.tyargs_loc().unwrap_or(n3.name.loc),
+                                "Invalid type argument position",
+                                Some("Type arguments may only be used with module members"),
+                            ));
                             (None, path.is_macro())
                         } else {
                             (path.take_tyargs(), path.is_macro())
                         };
-                        make_access_result(sp(loc, access), tyargs, is_macro.copied())
+                        make_access_path(sp(loc, access), tyargs, is_macro.copied())
                     }
                     (_ln, []) => {
                         let diag = ice!((loc, "Found a root path with no additional entries"));
                         context.add_diag(diag);
-                        return None;
+                        return PathExpanderResult::err(errors);
                     }
                     (ln, [_n1, _n2, ..]) => {
                         self.ide_autocomplete_suggestion(context, ln.loc);
-                        let mut diag = diag!(Syntax::InvalidName, (loc, "Too many name segments"));
-                        diag.add_note("Names may only have 0, 1, or 2 segments separated by '::'");
-                        context.add_diag(diag);
-                        return None;
+                        errors.push(PathExpansionError::legacy_invalid_name(
+                            loc,
+                            "Too many name segments",
+                            Some("Names may only have 0, 1, or 2 segments separated by '::'"),
+                        ));
+                        return PathExpanderResult::err(errors);
                     }
                 }
             }
         };
-        Some(tn_)
+        let result = Some(tn_);
+        PathExpanderResult { result, errors }
     }
 
     fn name_access_chain_to_module_ident(
         &mut self,
         context: &mut DefnContext,
         sp!(loc, pn_): P::NameAccessChain,
-    ) -> Option<E::ModuleIdent> {
+    ) -> PathExpanderResult<E::ModuleIdent> {
         use P::NameAccessChain_ as PN;
+
+        let mut errors = Vec::new();
+
         match pn_ {
             PN::Single(single) => {
                 ice_assert!(
@@ -1174,16 +1556,13 @@ impl PathExpander for LegacyPathExpander {
                 );
                 match self.aliases.module_alias_get(&single.name) {
                     None => {
-                        context.add_diag(diag!(
-                            NameResolution::UnboundModule,
-                            (
-                                single.name.loc,
-                                format!("Unbound module alias '{}'", single.name)
-                            ),
-                        ));
-                        None
+                        errors.push(PathExpansionError::unbound_module(single.name));
+                        PathExpanderResult::err(errors)
                     }
-                    Some(mident) => Some(mident),
+                    Some(mident) => {
+                        let result = Some(mident);
+                        PathExpanderResult { result, errors }
+                    }
                 }
             }
             PN::Path(path) => {
@@ -1200,12 +1579,13 @@ impl PathExpander for LegacyPathExpander {
                             address: *ln,
                             module: ModuleName(n.name),
                         };
-                        Some(module_ident(context, sp(loc, pmident_)))
+                        let result = Some(module_ident(context, sp(loc, pmident_)));
+                        PathExpanderResult { result, errors }
                     }
                     // Error cases
                     (_ln, []) => {
                         context.add_diag(ice!((loc, "Found path with no path entries")));
-                        None
+                        PathExpanderResult::err(errors)
                     }
                     (ln, [n, m, ..]) => {
                         let ident_loc = make_loc(
@@ -1219,15 +1599,16 @@ impl PathExpander for LegacyPathExpander {
                             module: ModuleName(n.name),
                         };
                         let _ = module_ident(context, sp(ident_loc, pmident_));
-                        context.add_diag(diag!(
-                            NameResolution::NamePositionMismatch,
-                                if path.entries.len() < 3 {
-                                    (m.name.loc, "Unexpected module member access. Expected a module identifier only")
-                                } else {
-                                    (loc, "Unexpected access. Expected a module identifier only")
-                                }
-                        ));
-                        None
+                        let (loc, msg) = if path.entries.len() < 3 {
+                            (
+                                m.name.loc,
+                                "Unexpected module member access. Expected a module identifier only",
+                            )
+                        } else {
+                            (loc, "Unexpected access. Expected a module identifier only")
+                        };
+                        errors.push(PathExpansionError::legacy_invalid_module(loc, msg));
+                        PathExpanderResult::err(errors)
                     }
                 }
             }
@@ -1253,30 +1634,4 @@ impl PathExpander for LegacyPathExpander {
             context.add_ide_annotation(loc, annotation)
         }
     }
-}
-
-fn unexpected_address_module_error(loc: Loc, nloc: Loc, access: Access) -> Diagnostic {
-    let case = match access {
-        Access::Type | Access::ApplyNamed | Access::ApplyPositional => "type",
-        Access::Term => "expression",
-        Access::Pattern => "pattern constructor",
-        Access::Module => {
-            return ice!(
-                (
-                    loc,
-                    "ICE expected a module name and got one, but tried to report an error"
-                ),
-                (nloc, "Name location")
-            );
-        }
-    };
-    let unexpected_msg = format!(
-        "Unexpected module identifier. A module identifier is not a valid {}",
-        case
-    );
-    diag!(
-        NameResolution::NamePositionMismatch,
-        (loc, unexpected_msg),
-        (nloc, "Expected a module name".to_owned()),
-    )
 }

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -28,8 +28,8 @@ use crate::{
             check_valid_type_parameter_name, valid_local_variable_name,
         },
         path_expander::{
-            Access, LegacyPathExpander, ModuleAccessResult, Move2024PathExpander, PathExpander,
-            access_result,
+            Access, AccessPath, LegacyPathExpander, Move2024PathExpander, PathExpander,
+            PathExpanderResult, access,
         },
         translate::known_attributes::{DiagnosticAttribute, KnownAttribute},
     },
@@ -94,6 +94,16 @@ pub(super) struct Context<'env> {
     // and dependency packages
     all_filter_alls: WarningFilters,
     pub path_expander: Option<Box<dyn PathExpander>>,
+}
+
+macro_rules! report_path_expansion_error {
+    ($context:expr, $exp:expr) => {{
+        let PathExpanderResult { result, errors } = $exp;
+        for err in errors {
+            $context.add_diag(err.into_diagnostic());
+        }
+        result
+    }};
 }
 
 impl<'env> Context<'env> {
@@ -235,10 +245,13 @@ impl<'env> Context<'env> {
             defn_context: inner_context,
             ..
         } = self;
-        path_expander
-            .as_mut()
-            .unwrap()
-            .name_access_chain_to_attribute_value(inner_context, attribute_value)
+        report_path_expansion_error!(
+            self,
+            path_expander
+                .as_mut()
+                .unwrap()
+                .name_access_chain_to_attribute_value(inner_context, attribute_value)
+        )
     }
 
     pub fn value_opt(&mut self, pvalue_opt: Option<P::Value>) -> Option<E::Value> {
@@ -257,11 +270,11 @@ impl<'env> Context<'env> {
         value(inner_context, pvalue)
     }
 
-    pub fn name_access_chain_to_module_access(
+    pub fn name_access_chain_to_module_access_result(
         &mut self,
         access: Access,
         chain: P::NameAccessChain,
-    ) -> Option<ModuleAccessResult> {
+    ) -> PathExpanderResult<AccessPath> {
         let Context {
             path_expander,
             defn_context: inner_context,
@@ -273,6 +286,17 @@ impl<'env> Context<'env> {
             .name_access_chain_to_module_access(inner_context, access, chain)
     }
 
+    pub fn name_access_chain_to_module_access(
+        &mut self,
+        access: Access,
+        chain: P::NameAccessChain,
+    ) -> Option<AccessPath> {
+        report_path_expansion_error!(
+            self,
+            self.name_access_chain_to_module_access_result(access, chain)
+        )
+    }
+
     pub fn name_access_chain_to_module_ident(
         &mut self,
         chain: P::NameAccessChain,
@@ -282,10 +306,13 @@ impl<'env> Context<'env> {
             defn_context: inner_context,
             ..
         } = self;
-        path_expander
-            .as_mut()
-            .unwrap()
-            .name_access_chain_to_module_ident(inner_context, chain)
+        report_path_expansion_error!(
+            self,
+            path_expander
+                .as_mut()
+                .unwrap()
+                .name_access_chain_to_module_ident(inner_context, chain)
+        )
     }
 
     fn error_ide_autocomplete_suggestion(&mut self, loc: Loc) {
@@ -579,6 +606,44 @@ fn default_aliases(context: &mut Context) -> AliasMapBuilder {
             .unwrap();
     }
     builder
+}
+
+//************************************************
+// ERRORS
+//************************************************
+
+pub(super) enum ValueError {
+    NumTooBig {
+        loc: Loc,
+        type_description: &'static str,
+    },
+    InvalidByteString {
+        error: byte_string::BytestringError,
+    },
+    InvalidHexString {
+        error: hex_string::HexstringError,
+    },
+}
+
+impl ValueError {
+    pub fn into_diagnostic(self) -> Diagnostic {
+        match self {
+            ValueError::NumTooBig {
+                loc,
+                type_description,
+            } => diag!(
+                Syntax::InvalidNumber,
+                (
+                    loc,
+                    format!(
+                        "Invalid number literal. The given literal is too large to fit into {type_description}",
+                    )
+                ),
+            ),
+            ValueError::InvalidByteString { error } => error.into_diagnostic(),
+            ValueError::InvalidHexString { error } => error.into_diagnostic(),
+        }
+    }
 }
 
 //**************************************************************************************************
@@ -1374,18 +1439,6 @@ fn stdlib_definitions(context: &mut Context, mloc: Loc) -> StdlibDefinitions {
         };
     }
 
-    // TODO: This is not a satisfactory way to suppress these errors. The _correct_ thing is to
-    // revise legacy path resolution to unify it with the Move 2024 one to use a shared
-    // `AccessNameChainResult` form, and resolve to that here. This would allow us to elide errors
-    // without building them and emitting them into a dummy reporter (and also the awful memory
-    // manipulation here).
-
-    // We don't want to report errors here if we can't find the thing.
-    let cur_diag_reporter = std::mem::replace(
-        &mut context.defn_context.reporter,
-        context.defn_context.env.dummy_diagnostic_reporter(),
-    );
-
     let stdlib_functions = shared::stdlib_definitions::stdlib_function_definition(mloc);
     let stdlib_types = shared::stdlib_definitions::stdlib_type_definition(mloc);
 
@@ -1393,7 +1446,8 @@ fn stdlib_definitions(context: &mut Context, mloc: Loc) -> StdlibDefinitions {
         .into_iter()
         .filter_map(|(key, name)| {
             context
-                .name_access_chain_to_module_access(Access::ApplyPositional, name)
+                .name_access_chain_to_module_access_result(Access::ApplyPositional, name)
+                .result
                 .map(|name| (key, name.access.value))
         })
         .collect::<BTreeMap<_, _>>();
@@ -1402,12 +1456,11 @@ fn stdlib_definitions(context: &mut Context, mloc: Loc) -> StdlibDefinitions {
         .into_iter()
         .filter_map(|(key, name)| {
             context
-                .name_access_chain_to_module_access(Access::Type, name)
+                .name_access_chain_to_module_access_result(Access::Type, name)
+                .result
                 .map(|name| (key, name.access.value))
         })
         .collect::<BTreeMap<_, _>>();
-
-    let _ = std::mem::replace(&mut context.defn_context.reporter, cur_diag_reporter);
 
     StdlibDefinitions { functions, types }
 }
@@ -1963,7 +2016,7 @@ fn explicit_use_fun(
         ty,
         method,
     } = pexplicit;
-    let access_result!(function, tyargs, is_macro) =
+    let access!(function, tyargs, is_macro) =
         context.name_access_chain_to_module_access(Access::ApplyPositional, *function)?;
     ice_assert!(
         context.reporter(),
@@ -1977,7 +2030,7 @@ fn explicit_use_fun(
         loc,
         "Found a 'use fun' as a macro"
     );
-    let access_result!(ty, tyargs, is_macro) =
+    let access!(ty, tyargs, is_macro) =
         context.name_access_chain_to_module_access(Access::Type, *ty)?;
     ice_assert!(
         context.reporter(),
@@ -2582,7 +2635,7 @@ fn type_(context: &mut Context, sp!(loc, pt_): P::Type) -> E::Type {
                 assert!(context.env().has_errors());
                 ET::UnresolvedError
             }
-            Some(access_result!(n, ptyargs, _)) => ET::Apply(n, sp_types(context, ptyargs)),
+            Some(access!(n, ptyargs, _)) => ET::Apply(n, sp_types(context, ptyargs)),
         },
         PT::Ref(mut_, inner) => ET::Ref(mut_, Box::new(type_(context, *inner))),
         PT::Fun(args, result) => {
@@ -2769,7 +2822,7 @@ fn exp(context: &mut Context, pe: Box<P::Exp>) -> Box<E::Exp> {
         PE::Name(pn) => {
             bind_access_result!(
                 context.name_access_chain_to_module_access(Access::Term, pn) =>
-                    Some(access_result!(name, ptys_opt, is_macro)) in {
+                    Some(access!(name, ptys_opt, is_macro)) in {
                         assert!(ptys_opt.is_none());
                         assert!(is_macro.is_none());
                         EE::Name(name, None)
@@ -2781,7 +2834,7 @@ fn exp(context: &mut Context, pe: Box<P::Exp>) -> Box<E::Exp> {
             let ers = sp(rloc, exps(context, prs));
             bind_access_result!(
                 en_opt =>
-                    Some(access_result!(name, ptys_opt, is_macro))
+                    Some(access!(name, ptys_opt, is_macro))
                     in EE::Call(name, is_macro, optional_sp_types(context, ptys_opt), ers)
             )
         }
@@ -2794,7 +2847,7 @@ fn exp(context: &mut Context, pe: Box<P::Exp>) -> Box<E::Exp> {
             let efields = named_fields(context, loc, "construction", "argument", efields_vec);
             bind_access_result!(
                 en_opt =>
-                    Some(access_result!(name, ptys_opt, is_macro)) in {
+                    Some(access!(name, ptys_opt, is_macro)) in {
                         assert!(is_macro.is_none());
                         EE::Pack(name, optional_sp_types(context, ptys_opt), efields)
                     }
@@ -3238,7 +3291,7 @@ fn match_pattern(context: &mut Context, sp!(loc, pat_): P::MatchPattern) -> E::M
         name_chain: P::NameAccessChain,
         identifier_okay: bool,
     ) -> Option<(E::ModuleAccess, Option<Spanned<Vec<P::Type>>>)> {
-        let ModuleAccessResult {
+        let AccessPath {
             access,
             ptys_opt,
             is_macro,
@@ -3418,105 +3471,89 @@ fn match_pattern(context: &mut Context, sp!(loc, pat_): P::MatchPattern) -> E::M
 // Values
 //**************************************************************************************************
 
-pub(super) fn value(context: &mut DefnContext, sp!(loc, pvalue_): P::Value) -> Option<E::Value> {
-    use E::Value_ as EV;
-    use P::Value_ as PV;
-    let value_ = match pvalue_ {
-        PV::Address(addr) => {
-            let addr = top_level_address(context, /* suggest_declaration */ true, addr);
-            EV::Address(addr)
+pub(super) fn value(context: &mut DefnContext, value: P::Value) -> Option<E::Value> {
+    match value_result(context, value) {
+        Ok(value) => Some(value),
+        Err(errs) => {
+            for err in errs {
+                context.add_diag(err.into_diagnostic());
+            }
+            None
         }
-        PV::Num(s) if s.ends_with("u8") => match parse_u8(&s[..s.len() - 2]) {
-            Ok((u, _format)) => EV::U8(u),
-            Err(_) => {
-                context.add_diag(num_too_big_error(loc, "'u8'"));
-                return None;
-            }
-        },
-        PV::Num(s) if s.ends_with("u16") => match parse_u16(&s[..s.len() - 3]) {
-            Ok((u, _format)) => EV::U16(u),
-            Err(_) => {
-                context.add_diag(num_too_big_error(loc, "'u16'"));
-                return None;
-            }
-        },
-        PV::Num(s) if s.ends_with("u32") => match parse_u32(&s[..s.len() - 3]) {
-            Ok((u, _format)) => EV::U32(u),
-            Err(_) => {
-                context.add_diag(num_too_big_error(loc, "'u32'"));
-                return None;
-            }
-        },
-        PV::Num(s) if s.ends_with("u64") => match parse_u64(&s[..s.len() - 3]) {
-            Ok((u, _format)) => EV::U64(u),
-            Err(_) => {
-                context.add_diag(num_too_big_error(loc, "'u64'"));
-                return None;
-            }
-        },
-        PV::Num(s) if s.ends_with("u128") => match parse_u128(&s[..s.len() - 4]) {
-            Ok((u, _format)) => EV::U128(u),
-            Err(_) => {
-                context.add_diag(num_too_big_error(loc, "'u128'"));
-                return None;
-            }
-        },
-        PV::Num(s) if s.ends_with("u256") => match parse_u256(&s[..s.len() - 4]) {
-            Ok((u, _format)) => EV::U256(u),
-            Err(_) => {
-                context.add_diag(num_too_big_error(loc, "'u256'"));
-                return None;
-            }
-        },
-        PV::Num(s) => match parse_u256(&s) {
-            Ok((u, _format)) => EV::InferredNum(u),
-            Err(_) => {
-                context.add_diag(num_too_big_error(
-                    loc,
-                    "the largest possible integer type, 'u256'",
-                ));
-                return None;
-            }
-        },
-        PV::Bool(b) => EV::Bool(b),
-        PV::HexString(s) => match hex_string::decode(loc, &s) {
-            Ok(v) => EV::Bytearray(v),
-            Err(e) => {
-                context.add_diag(*e);
-                return None;
-            }
-        },
-        PV::ByteString(s) => match byte_string::decode(loc, &s) {
-            Ok(v) => EV::Bytearray(v),
-            Err(e) => {
-                context.add_diags(e);
-                return None;
-            }
-        },
-        PV::String(s) => match byte_string::decode(loc, &s) {
-            Ok(v) => EV::InferredString(v),
-            Err(e) => {
-                context.add_diags(e);
-                return None;
-            }
-        },
-    };
-    Some(sp(loc, value_))
+    }
 }
 
-// Create an error for an integer literal that is too big to fit in its type.
-// This assumes that the literal is the current token.
-fn num_too_big_error(loc: Loc, type_description: &'static str) -> Diagnostic {
-    diag!(
-        Syntax::InvalidNumber,
-        (
+pub(super) fn value_result(
+    context: &mut DefnContext,
+    sp!(loc, pvalue_): P::Value,
+) -> Result<E::Value, Vec<ValueError>> {
+    use E::Value_ as EV;
+    use P::Value_ as PV;
+
+    fn num_too_big_error(loc: Loc, type_description: &'static str) -> Vec<ValueError> {
+        vec![ValueError::NumTooBig {
             loc,
-            format!(
-                "Invalid number literal. The given literal is too large to fit into {}",
-                type_description
-            )
+            type_description,
+        }]
+    }
+
+    fn hex_error(error: hex_string::HexstringError) -> Vec<ValueError> {
+        vec![ValueError::InvalidHexString { error }]
+    }
+
+    fn string_error(errors: Vec<byte_string::BytestringError>) -> Vec<ValueError> {
+        errors
+            .into_iter()
+            .map(|error| ValueError::InvalidByteString { error })
+            .collect()
+    }
+
+    macro_rules! parse_num {
+        ($exp:expr, $ctor:expr, $ty:expr) => {
+            $exp.map(|(u, _format)| $ctor(u))
+                .map_err(|_| num_too_big_error(loc, $ty))
+        };
+    }
+
+    let value_ = match pvalue_ {
+        PV::Address(addr) => {
+            Ok(EV::Address(top_level_address(
+                context, /* suggest_declaration */ true, addr,
+            )))
+        }
+        PV::Num(s) if s.ends_with("u8") => parse_num!(parse_u8(&s[..s.len() - 2]), EV::U8, "'u8'"),
+        PV::Num(s) if s.ends_with("u16") => {
+            parse_num!(parse_u16(&s[..s.len() - 3]), EV::U16, "'u16'")
+        }
+        PV::Num(s) if s.ends_with("u32") => {
+            parse_num!(parse_u32(&s[..s.len() - 3]), EV::U32, "'u32'")
+        }
+        PV::Num(s) if s.ends_with("u64") => {
+            parse_num!(parse_u64(&s[..s.len() - 3]), EV::U64, "'u64'")
+        }
+        PV::Num(s) if s.ends_with("u128") => {
+            parse_num!(parse_u128(&s[..s.len() - 4]), EV::U128, "'u128'")
+        }
+        PV::Num(s) if s.ends_with("u256") => {
+            parse_num!(parse_u256(&s[..s.len() - 4]), EV::U256, "'u256'")
+        }
+        PV::Num(s) => parse_num!(
+            parse_u256(&s),
+            EV::InferredNum,
+            "the largest possible integer type, 'u256'"
         ),
-    )
+        PV::Bool(b) => Ok(EV::Bool(b)),
+        PV::HexString(s) => hex_string::decode(loc, &s)
+            .map(EV::Bytearray)
+            .map_err(hex_error),
+        PV::ByteString(s) => byte_string::decode(loc, &s)
+            .map(EV::Bytearray)
+            .map_err(string_error),
+        PV::String(s) => byte_string::decode(loc, &s)
+            .map(EV::InferredString)
+            .map_err(string_error),
+    };
+    value_.map(|value_| sp(loc, value_))
 }
 
 //**************************************************************************************************
@@ -3566,7 +3603,7 @@ fn bind(context: &mut Context, sp!(loc, pb_): P::Bind) -> Option<E::LValue> {
             EL::Var(Some(emut), sp(loc, E::ModuleAccess_::Name(v.0)), None)
         }
         PB::Unpack(ptn, pfields) => {
-            let access_result!(name, ptys_opt, is_macro) =
+            let access!(name, ptys_opt, is_macro) =
                 context.name_access_chain_to_module_access(Access::ApplyNamed, *ptn)?;
             ice_assert!(
                 context.reporter(),
@@ -3675,7 +3712,7 @@ fn assign(context: &mut Context, sp!(loc, e_): P::Exp) -> Option<E::LValue> {
     match e_ {
         PE::Name(name) => {
             match context.name_access_chain_to_module_access(Access::Term, name.clone()) {
-                Some(access_result!(sp!(_, name @ M::Name(_)), Some(_), _is_macro)) => {
+                Some(access!(sp!(_, name @ M::Name(_)), Some(_), _is_macro)) => {
                     let msg = "Unexpected assignment of instantiated type without fields";
                     let mut diag = diag!(Syntax::InvalidLValue, (loc, msg));
                     diag.add_note(format!(
@@ -3685,17 +3722,17 @@ fn assign(context: &mut Context, sp!(loc, e_): P::Exp) -> Option<E::LValue> {
                     context.add_diag(diag);
                     None
                 }
-                Some(access_result!(_, _ptys_opt, Some(_))) => {
+                Some(access!(_, _ptys_opt, Some(_))) => {
                     let msg = "Unexpected assignment of name with macro invocation";
                     let mut diag = diag!(Syntax::InvalidLValue, (loc, msg));
                     diag.add_note("Macro invocation '!' must appear on an invocation");
                     context.add_diag(diag);
                     None
                 }
-                Some(access_result!(sp!(_, name @ M::Name(_)), None, None)) => {
+                Some(access!(sp!(_, name @ M::Name(_)), None, None)) => {
                     Some(sp(loc, EL::Var(None, sp(loc, name), None)))
                 }
-                Some(access_result!(sp!(_, M::ModuleAccess(_, _)), _ptys_opt, _is_macro)) => {
+                Some(access!(sp!(_, M::ModuleAccess(_, _)), _ptys_opt, _is_macro)) => {
                     let msg = "Unexpected assignment of module access without fields";
                     let mut diag = diag!(Syntax::InvalidLValue, (loc, msg));
                     diag.add_note(format!(
@@ -3705,7 +3742,7 @@ fn assign(context: &mut Context, sp!(loc, e_): P::Exp) -> Option<E::LValue> {
                     context.add_diag(diag);
                     None
                 }
-                Some(access_result!(sp!(loc, M::Variant(_, _)), _tys_opt, _is_macro)) => {
+                Some(access!(sp!(loc, M::Variant(_, _)), _tys_opt, _is_macro)) => {
                     let cur_pkg = context.current_package();
                     if context.check_feature(cur_pkg, FeatureGate::Enums, loc) {
                         let msg = "Unexpected assignment of variant";
@@ -3722,7 +3759,7 @@ fn assign(context: &mut Context, sp!(loc, e_): P::Exp) -> Option<E::LValue> {
             }
         }
         PE::Pack(pn, pfields) => {
-            let access_result!(name, ptys_opt, is_macro) =
+            let access!(name, ptys_opt, is_macro) =
                 context.name_access_chain_to_module_access(Access::ApplyNamed, pn)?;
             ice_assert!(
                 context.reporter(),
@@ -3740,7 +3777,7 @@ fn assign(context: &mut Context, sp!(loc, e_): P::Exp) -> Option<E::LValue> {
         PE::Call(pn, sp!(_, exprs)) => {
             let pkg = context.current_package();
             context.check_feature(pkg, FeatureGate::PositionalFields, loc);
-            let access_result!(name, ptys_opt, is_macro) =
+            let access!(name, ptys_opt, is_macro) =
                 context.name_access_chain_to_module_access(Access::ApplyNamed, pn)?;
             ice_assert!(
                 context.reporter(),

--- a/external-crates/move/crates/move-compiler/tests/move_check/naming/standalone_module_ident.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/naming/standalone_module_ident.snap
@@ -26,7 +26,7 @@ error[E03006]: unexpected name in this position
   │                 ^^^^^^
   │                 │
   │                 Unexpected module identifier. A module identifier is not a valid expression
-  │                 Expected a module name
+  │                 Expected a module member name
 
 error[E03006]: unexpected name in this position
    ┌─ tests/move_check/naming/standalone_module_ident.move:10:17
@@ -35,4 +35,4 @@ error[E03006]: unexpected name in this position
    │                 ^^^^^^
    │                 │
    │                 Unexpected module identifier. A module identifier is not a valid expression
-   │                 Expected a module name
+   │                 Expected a module member name

--- a/external-crates/move/crates/move-compiler/tests/move_check/parser/invalid_unpack_assign_lhs_mdot_no_addr.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/parser/invalid_unpack_assign_lhs_mdot_no_addr.snap
@@ -21,7 +21,7 @@ error[E03006]: unexpected name in this position
   │         ^^^^
   │         │
   │         Unexpected module identifier. A module identifier is not a valid type
-  │         Expected a module name
+  │         Expected a module member name
 
 error[E04005]: expected a single type
    ┌─ tests/move_check/parser/invalid_unpack_assign_lhs_mdot_no_addr.move:10:9


### PR DESCRIPTION
## Description 

This modifies the path expansion error path to directly hand back errors instead of reporting them to the diagnostic reporter. This required a few changes around values in expansion translation as well, but ultimately produced the results we were after.

## Test plan 

No significant test drift.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
