### PR TITLE
[mfp] stop fastpath execution when the epoch starts to close

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1118,7 +1118,9 @@ impl AuthorityPerEpochStore {
             };
 
         let consensus_tx_status_cache = if protocol_config.mysticeti_fastpath() {
-            Some(ConsensusTxStatusCache::new())
+            Some(ConsensusTxStatusCache::new(
+                protocol_config.consensus_gc_depth(),
+            ))
         } else {
             None
         };

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1118,9 +1118,7 @@ impl AuthorityPerEpochStore {
             };
 
         let consensus_tx_status_cache = if protocol_config.mysticeti_fastpath() {
-            Some(ConsensusTxStatusCache::new(
-                protocol_config.consensus_gc_depth(),
-            ))
+            Some(ConsensusTxStatusCache::new(protocol_config.gc_depth()))
         } else {
             None
         };

--- a/crates/sui-core/src/authority/transaction_reject_reason_cache.rs
+++ b/crates/sui-core/src/authority/transaction_reject_reason_cache.rs
@@ -1,22 +1,21 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeMap;
+
 use consensus_config::AuthorityIndex;
 use consensus_types::block::{BlockDigest, BlockRef, TransactionIndex};
 use mysten_metrics::monitored_scope;
 use parking_lot::RwLock;
-use std::collections::BTreeMap;
 use sui_types::committee::EpochId;
 use sui_types::error::SuiError;
 use sui_types::messages_consensus::ConsensusPosition;
 use tracing::trace;
 
+use crate::authority::consensus_tx_status_cache::CONSENSUS_STATUS_RETENTION_ROUNDS;
+
 #[cfg(test)]
 use consensus_types::block::Round;
-
-/// The number of consensus rounds to retain the reject vote reason information before garbage collection.
-/// Assuming a max round rate of 15/sec, this allows status updates to be valid within a window of ~25-30 seconds.
-const DEFAULT_RETENTION_ROUNDS: u32 = 400;
 
 /// A cache that maintains rejection reasons (SuiError) when validators cast reject votes for transactions
 /// during the Mysticeti consensus fast path voting process.
@@ -45,7 +44,7 @@ impl TransactionRejectReasonCache {
     pub fn new(retention_rounds: Option<u32>, epoch: EpochId) -> Self {
         Self {
             cache: Default::default(),
-            retention_rounds: retention_rounds.unwrap_or(DEFAULT_RETENTION_ROUNDS),
+            retention_rounds: retention_rounds.unwrap_or(CONSENSUS_STATUS_RETENTION_ROUNDS),
             epoch,
         }
     }

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -1824,11 +1824,17 @@ mod tests {
                     consensus_tx_status_cache.get_transaction_status(&position),
                     Some(ConsensusTxStatus::Rejected)
                 );
-            } else {
-                // Expect non-rejected transactions to be marked as fastpath certified.
+            } else if txn_idx % 2 == 0 {
+                // Expect owned object transactions to be marked as fastpath certified.
                 assert_eq!(
                     consensus_tx_status_cache.get_transaction_status(&position),
-                    Some(ConsensusTxStatus::FastpathCertified)
+                    Some(ConsensusTxStatus::FastpathCertified),
+                );
+            } else {
+                // Expect shared object transactions to be marked as fastpath certified.
+                assert_eq!(
+                    consensus_tx_status_cache.get_transaction_status(&position),
+                    None,
                 );
             }
         }


### PR DESCRIPTION
## Description 

Also,
- Track fastpath certified statuses in `ConsensusTxStatusCache`, which will be used in future for end of publish.
- Use the same const across status and reject reason caches for expiration limit.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
