### PR TITLE
chore: disable mismatched_lifetime_syntaxes lint

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -29,4 +29,4 @@ move-clippy = [
 ]
 
 [build]
-rustflags = ["-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes"]
+rustflags = ["-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes", "-A", "mismatched_lifetime_syntaxes"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -277,6 +277,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(msim)',
   'cfg(fail_points)',
 ] }
+mismatched_lifetime_syntaxes = "allow"
 
 # Dependencies that should be kept in sync through the whole workspace
 [workspace.dependencies]


### PR DESCRIPTION
## Description 

disable mismatched_lifetime_syntaxes lint in the cargo build config and lint config.

## Test plan 

cargo build with rust 1.89, no more mismatched_lifetime_syntaxes warnnings.
