### PR TITLE
feat: add --verify-first flag

### DIFF
--- a/crates/sui/src/client_ptb/ptb.rs
+++ b/crates/sui/src/client_ptb/ptb.rs
@@ -214,6 +214,7 @@ impl PTB {
         let processing = TxProcessingArgs {
             tx_digest: program_metadata.tx_digest_set,
             dry_run: program_metadata.dry_run_set,
+            verify_first: false, // PTB flow currently does not expose --verify-first; set default
             dev_inspect: program_metadata.dev_inspect_set,
             serialize_unsigned_transaction: program_metadata.serialize_unsigned_set,
             serialize_signed_transaction: program_metadata.serialize_signed_set,


### PR DESCRIPTION
## Description 

PR for https://github.com/MystenLabs/sui/issues/22161 #1

Adds a `--verify-first` flag to sui client call that automatically performs a dry run of the transaction first and only submits the real transaction if the dry run succeeds. If the dry run fails, it prints the diagnostic result and exits without broadcasting. It is mutually exclusive with `--dry-run` and does not alter transaction construction beyond the pre-flight check.

## Test plan 

```sh
cargo test --test cli_tests test_call_verify_first_success_and_failure -- --nocapture
```
passed

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: no break changes, add another `--verify-first` flag
- [ ] Rust SDK:
