### PR TITLE
[graphql-alt] Support MakeMoveVec command for Programmable TransactionKind [9/n]

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/make_move_vec.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/make_move_vec.move
@@ -1,0 +1,94 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A B --addresses test=0x0 --simulator
+
+// Test 1: Single element MakeMoveVec
+//# programmable --sender A --inputs 10u64
+//> 0: MakeMoveVec<u64>([Input(0)]);
+
+//# create-checkpoint
+
+// Test 2: Multiple elements MakeMoveVec  
+//# programmable --sender A --inputs 10u64 11u64
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+
+//# create-checkpoint
+
+// Test 3: Empty MakeMoveVec
+//# programmable --sender A
+//> 0: MakeMoveVec<u64>([]);
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  # Test single element
+  singleElement: transaction(digest: "@{digest_1}") {
+    kind {
+      ... on ProgrammableTransaction {
+        commands(first: 10) {
+          nodes {
+            __typename
+            ... on MakeMoveVecCommand {
+              elements {
+                __typename
+                ... on Input { ix }
+                ... on TxResult { cmd ix }
+                ... on GasCoin { _ }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{
+  # Test multiple elements
+  multipleElements: transaction(digest: "@{digest_3}") {
+    kind {
+      ... on ProgrammableTransaction {
+        commands(first: 10) {
+          nodes {
+            __typename
+            ... on MakeMoveVecCommand {
+              elements {
+                __typename
+                ... on Input { ix }
+                ... on TxResult { cmd ix }
+                ... on GasCoin { _ }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{ 
+  # Test empty vector
+  emptyVector: transaction(digest: "@{digest_5}") {
+    kind {
+      ... on ProgrammableTransaction {
+        commands(first: 10) {
+          nodes {
+            __typename
+            ... on MakeMoveVecCommand {
+              elements {
+                __typename
+                ... on Input { ix }
+                ... on TxResult { cmd ix }
+                ... on GasCoin { _ }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/make_move_vec.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/make_move_vec.snap
@@ -1,0 +1,108 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 10 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 7-8:
+//# programmable --sender A --inputs 10u64
+//> 0: MakeMoveVec<u64>([Input(0)]);
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 10-12:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 13-14:
+//# programmable --sender A --inputs 10u64 11u64
+//> 0: MakeMoveVec<u64>([Input(0), Input(1)]);
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 16-18:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 5, lines 19-20:
+//# programmable --sender A
+//> 0: MakeMoveVec<u64>([]);
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, line 22:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 7, lines 24-46:
+//# run-graphql
+Response: {
+  "data": {
+    "singleElement": {
+      "kind": {
+        "commands": {
+          "nodes": [
+            {
+              "__typename": "MakeMoveVecCommand",
+              "elements": [
+                {
+                  "__typename": "Input",
+                  "ix": 0
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+
+task 8, lines 48-70:
+//# run-graphql
+Response: {
+  "data": {
+    "multipleElements": {
+      "kind": {
+        "commands": {
+          "nodes": [
+            {
+              "__typename": "MakeMoveVecCommand",
+              "elements": [
+                {
+                  "__typename": "Input",
+                  "ix": 0
+                },
+                {
+                  "__typename": "Input",
+                  "ix": 1
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+
+task 9, lines 72-94:
+//# run-graphql
+Response: {
+  "data": {
+    "emptyVector": {
+      "kind": {
+        "commands": {
+          "nodes": [
+            {
+              "__typename": "MakeMoveVecCommand",
+              "elements": []
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -318,7 +318,7 @@ type CoinDenyListStateCreateTransaction {
 """
 A single command in the programmable transaction.
 """
-union Command = MergeCoinsCommand | MoveCallCommand | PublishCommand | SplitCoinsCommand | TransferObjectsCommand | UpgradeCommand | OtherCommand
+union Command = MakeMoveVecCommand | MergeCoinsCommand | MoveCallCommand | PublishCommand | SplitCoinsCommand | TransferObjectsCommand | UpgradeCommand | OtherCommand
 
 type CommandConnection {
 	"""
@@ -842,6 +842,16 @@ type Input {
 	ix: Int
 }
 
+
+"""
+Create a vector (can be empty).
+"""
+type MakeMoveVecCommand {
+	"""
+	The values to pack into the vector, all of the same type.
+	"""
+	elements: [TransactionArgument!]
+}
 
 """
 Merges `coins` into the first `coin` (produces no results).

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/commands/make_move_vec.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/commands/make_move_vec.rs
@@ -1,0 +1,14 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::*;
+
+use crate::api::types::transaction_kind::programmable::commands::TransactionArgument;
+
+/// Create a vector (can be empty).
+#[derive(SimpleObject, Clone)]
+pub struct MakeMoveVecCommand {
+    /// The values to pack into the vector, all of the same type.
+    pub elements: Option<Vec<TransactionArgument>>,
+    // TODO(DVX-1373): Support MoveType once available
+}

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -322,7 +322,7 @@ type CoinDenyListStateCreateTransaction {
 """
 A single command in the programmable transaction.
 """
-union Command = MergeCoinsCommand | MoveCallCommand | PublishCommand | SplitCoinsCommand | TransferObjectsCommand | UpgradeCommand | OtherCommand
+union Command = MakeMoveVecCommand | MergeCoinsCommand | MoveCallCommand | PublishCommand | SplitCoinsCommand | TransferObjectsCommand | UpgradeCommand | OtherCommand
 
 type CommandConnection {
 	"""
@@ -846,6 +846,16 @@ type Input {
 	ix: Int
 }
 
+
+"""
+Create a vector (can be empty).
+"""
+type MakeMoveVecCommand {
+	"""
+	The values to pack into the vector, all of the same type.
+	"""
+	elements: [TransactionArgument!]
+}
 
 """
 Merges `coins` into the first `coin` (produces no results).

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -322,7 +322,7 @@ type CoinDenyListStateCreateTransaction {
 """
 A single command in the programmable transaction.
 """
-union Command = MergeCoinsCommand | MoveCallCommand | PublishCommand | SplitCoinsCommand | TransferObjectsCommand | UpgradeCommand | OtherCommand
+union Command = MakeMoveVecCommand | MergeCoinsCommand | MoveCallCommand | PublishCommand | SplitCoinsCommand | TransferObjectsCommand | UpgradeCommand | OtherCommand
 
 type CommandConnection {
 	"""
@@ -846,6 +846,16 @@ type Input {
 	ix: Int
 }
 
+
+"""
+Create a vector (can be empty).
+"""
+type MakeMoveVecCommand {
+	"""
+	The values to pack into the vector, all of the same type.
+	"""
+	elements: [TransactionArgument!]
+}
 
 """
 Merges `coins` into the first `coin` (produces no results).

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -318,7 +318,7 @@ type CoinDenyListStateCreateTransaction {
 """
 A single command in the programmable transaction.
 """
-union Command = MergeCoinsCommand | MoveCallCommand | PublishCommand | SplitCoinsCommand | TransferObjectsCommand | UpgradeCommand | OtherCommand
+union Command = MakeMoveVecCommand | MergeCoinsCommand | MoveCallCommand | PublishCommand | SplitCoinsCommand | TransferObjectsCommand | UpgradeCommand | OtherCommand
 
 type CommandConnection {
 	"""
@@ -842,6 +842,16 @@ type Input {
 	ix: Int
 }
 
+
+"""
+Create a vector (can be empty).
+"""
+type MakeMoveVecCommand {
+	"""
+	The values to pack into the vector, all of the same type.
+	"""
+	elements: [TransactionArgument!]
+}
 
 """
 Merges `coins` into the first `coin` (produces no results).


### PR DESCRIPTION
## Description 

Support `MakeMoveVec` for Programmable TransactionKind

The new schema is on par with old schema:

https://github.com/MystenLabs/sui/blob/b8d28ddbd06253373d2c02d001b3ba6c1ce8ea4f/crates/sui-graphql-rpc/schema.graphql#L1663-L1672

`type` field is not supported yet and I have added a TODO to add it later

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-graphql
cargo nextest run -p sui-indexer-alt-reader
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

---

## Stack
- #22997 
- #23000 
- #23008
- #23009 
- #23010
- #23011 
- #23019
- #23020 
- #23175 ⬅️

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
