### PR TITLE
[cherry pick] Disable per_command_shared_object_transfer_rules

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/dynamic_fields/shared_object.snap
+++ b/crates/sui-adapter-transactional-tests/tests/dynamic_fields/shared_object.snap
@@ -27,7 +27,7 @@ gas summary: computation_cost: 1000000, storage_cost: 2287600,  storage_rebate: 
 task 4, line 79:
 //# run test::m::add_field --sender A --args object(2,0) object(3,0)
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(0)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 5, line 81:
 //# view-object 3,0

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/split_coin_share.snap
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/split_coin_share.snap
@@ -64,4 +64,4 @@ task 7, lines 38-41:
 //> 1: TransferObjects([Result(0)], Input(2));
 //> 2: TransferObjects([Input(1)], Input(2));
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(2)
+Debug of error: SharedObjectOperationNotAllowed at command None

--- a/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/transfer_shared.snap
+++ b/crates/sui-adapter-transactional-tests/tests/programmable_transaction_examples/transfer_shared.snap
@@ -34,4 +34,4 @@ task 4, lines 28-29:
 //# programmable --sender A --inputs object(2,0) @B
 //> TransferObjects([Input(0)], Input(1))
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(0)
+Debug of error: SharedObjectOperationNotAllowed at command None

--- a/crates/sui-adapter-transactional-tests/tests/shared/become_dynamic_field.snap
+++ b/crates/sui-adapter-transactional-tests/tests/shared/become_dynamic_field.snap
@@ -33,7 +33,7 @@ Contents: a::m::Inner {
 task 4, line 45:
 //# run a::m::add_dynamic_field --sender A --args object(2,0)
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(0)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 5, line 47:
 //# run a::m::create_shared --sender A

--- a/crates/sui-adapter-transactional-tests/tests/shared/become_dynamic_object_field.snap
+++ b/crates/sui-adapter-transactional-tests/tests/shared/become_dynamic_object_field.snap
@@ -33,7 +33,7 @@ Contents: a::m::Inner {
 task 4, line 45:
 //# run a::m::add_dynamic_object_field --sender A --args object(2,0)
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(0)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 5, line 47:
 //# run a::m::create_shared --sender A

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec.snap
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec.snap
@@ -81,5 +81,6 @@ task 9, lines 65-70:
 //> 2: SplitCoins(Result(1), [Input(0)]);
 //> 3: TransferObjects([Result(2)], Input(2));
 //> 4: t2::o2::share_coin(Result(1));
-Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+created: object(9,0)
+mutated: object(0,0), object(7,0)
+gas summary: computation_cost: 1000000, storage_cost: 2964000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec_fails.snap
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_make_move_vec_fails.snap
@@ -51,7 +51,7 @@ task 6, lines 108-112:
 //> 1: t2::o2::freezee(Result(0));
 // Make MoveVec and then try to add as dof
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 7, lines 113-117:
 //# programmable --inputs object(2,0) object(3,0)
@@ -59,7 +59,7 @@ task 7, lines 113-117:
 //> 1: t2::o2::dof_(Input(0), Result(0));
 // Make MoveVec and then try to add as df
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 8, lines 118-122:
 //# programmable --inputs object(2,0) object(3,0)
@@ -67,7 +67,7 @@ task 8, lines 118-122:
 //> 1: t2::o2::df_(Input(0), Result(0));
 // Make MoveVec and then try to transfer it
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 9, lines 123-127:
 //# programmable --inputs object(2,0) object(3,0)
@@ -75,7 +75,7 @@ task 9, lines 123-127:
 //> 1: t2::o2::transfer_(Result(0));
 // Make MoveVec pop and return it, then try to freeze
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 10, lines 128-133:
 //# programmable --inputs object(2,0) object(3,0)
@@ -84,7 +84,7 @@ task 10, lines 128-133:
 //> 2: t2::o2::freezer(Result(1));
 // Make MoveVec pop and return it, then try to add as dof
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 11, lines 134-139:
 //# programmable --inputs object(2,0) object(3,0)
@@ -93,7 +93,7 @@ task 11, lines 134-139:
 //> 2: t2::o2::dofer(Input(0), Result(1));
 // Make MoveVec pop and return it, then try to add as df
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 12, lines 140-145:
 //# programmable --inputs object(2,0) object(3,0)
@@ -102,7 +102,7 @@ task 12, lines 140-145:
 //> 2: t2::o2::dfer(Input(0), Result(1));
 // Make MoveVec pop and return it, then try to transfer it
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 13, lines 146-151:
 //# programmable --inputs object(2,0) object(3,0)
@@ -111,7 +111,7 @@ task 13, lines 146-151:
 //> 2: t2::o2::transferer(Result(1));
 // Make MoveVec pop and return it, then try to transfer it with PT transfer
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 14, lines 152-155:
 //# programmable --inputs object(3,0) @0x0
@@ -119,7 +119,7 @@ task 14, lines 152-155:
 //> 1: t2::o2::pop_it(Result(0));
 //> 2: TransferObjects([Result(1)], Input(1));
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 15, line 157:
 //# run t2::o2::mint_shared_coin
@@ -149,8 +149,8 @@ task 17, lines 163-169:
 //> 2: SplitCoins(Result(1), [Input(0)]);
 //> 3: TransferObjects([Result(2)], Input(2));
 // Try to call public_share_object directly -- this should fail
-Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Error: Transaction Effects Status: Unused result without the drop ability. Command result 1, return value 0
+Debug of error: UnusedValueWithoutDrop { result_idx: 1, secondary_idx: 0 } at command None
 
 task 18, lines 170-178:
 //# programmable --inputs 0 object(15,0) @0x0
@@ -161,8 +161,8 @@ task 18, lines 170-178:
 //> 4: sui::transfer::public_share_object<sui::coin::Coin<sui::sui::SUI>>(Input(1));
 // Try to reshare the shared object -- this should fail since the input was
 // used for the `MakeMoveVec` call
-Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.
+Debug of error: CommandArgumentError { arg_idx: 0, kind: InvalidValueUsage } at command Some(4)
 
 task 19, lines 179-187:
 //# programmable --inputs 0 object(15,0) @0x0
@@ -173,8 +173,8 @@ task 19, lines 179-187:
 //> 4: t2::o2::share_coin(Input(1));
 // Try to transfer the shared object -- this should fail since the input was
 // used for the `MakeMoveVec` call
-Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.
+Debug of error: CommandArgumentError { arg_idx: 0, kind: InvalidValueUsage } at command Some(4)
 
 task 20, lines 188-195:
 //# programmable --inputs 0 object(15,0) @0x0
@@ -184,8 +184,8 @@ task 20, lines 188-195:
 //> 3: TransferObjects([Result(2)], Input(2));
 //> 4: TransferObjects([Input(1)], Input(2));
 // Try to transfer the shared object
-Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.
+Debug of error: CommandArgumentError { arg_idx: 0, kind: InvalidValueUsage } at command Some(4)
 
 task 21, lines 196-201:
 //# programmable --inputs 0 object(15,0) @0x0
@@ -195,4 +195,4 @@ task 21, lines 196-201:
 //> 3: TransferObjects([Result(2)], Input(2));
 //> 4: TransferObjects([Result(1)], Input(2));
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Debug of error: SharedObjectOperationNotAllowed at command None

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge_fails.snap
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_merge_fails.snap
@@ -78,7 +78,7 @@ task 8, lines 77-81:
 //> 1: t2::o2::freezer(Input(1));
 // Merge and then try to add as dof
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 9, lines 82-86:
 //# programmable --sender A --inputs object(2,0) object(3,0) object(4,0)
@@ -86,7 +86,7 @@ task 9, lines 82-86:
 //> 1: t2::o2::dofer(Input(2), Input(1));
 // Merge and then try to add as df
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 10, lines 87-91:
 //# programmable --sender A --inputs object(2,0) object(3,0) object(4,0)
@@ -94,7 +94,7 @@ task 10, lines 87-91:
 //> 1: t2::o2::dfer(Input(2), Input(1));
 // Merge and then try to transfer it
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 11, lines 92-96:
 //# programmable --sender A --inputs object(2,0) object(3,0) object(4,0)
@@ -102,7 +102,7 @@ task 11, lines 92-96:
 //> 1: t2::o2::transferer(Input(1));
 // Merge and then try to transfer it with PTB transfer
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 12, lines 97-101:
 //# programmable --sender A --inputs object(2,0) object(3,0) object(4,0) @A
@@ -110,7 +110,7 @@ task 12, lines 97-101:
 //> 1: TransferObjects([Input(1)], Input(3));
 // **Merge shared into shared**
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 13, line 103:
 //# run t2::o2::mint_shared_coin
@@ -178,7 +178,7 @@ task 19, lines 116-120:
 //> 1: t2::o2::freezer(Input(1));
 // Merge and then try to add as dof
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 20, lines 121-125:
 //# programmable --sender A --inputs object(13,0) object(14,0) object(15,0)
@@ -186,7 +186,7 @@ task 20, lines 121-125:
 //> 1: t2::o2::dofer(Input(2), Input(1));
 // Merge and then try to add as df
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 21, lines 126-130:
 //# programmable --sender A --inputs object(13,0) object(14,0) object(15,0)
@@ -194,7 +194,7 @@ task 21, lines 126-130:
 //> 1: t2::o2::dfer(Input(2), Input(1));
 // Merge and then try to transfer it
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 22, lines 131-135:
 //# programmable --sender A --inputs object(13,0) object(14,0) object(15,0)
@@ -202,11 +202,11 @@ task 22, lines 131-135:
 //> 1: t2::o2::transferer(Input(1));
 // Merge and then try to transfer it with PTB transfer
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 23, lines 136-138:
 //# programmable --sender A --inputs object(13,0) object(14,0) object(15,0) @A
 //> 0: MergeCoins(Input(1), [Input(0)]);
 //> 1: TransferObjects([Input(1)], Input(3));
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(1)
+Debug of error: SharedObjectOperationNotAllowed at command None

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call.snap
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call.snap
@@ -49,8 +49,9 @@ task 6, lines 46-48:
 //# programmable --inputs object(2,0) object(3,0)
 //> 0: t2::o2::id<t2::o2::Obj2>(Input(1));
 //> 1: t2::o2::deleter(Result(0));
-Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(0)
+mutated: object(0,0), object(2,0)
+deleted: object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 2226800,  storage_rebate: 3430944, non_refundable_storage_fee: 34656
 
 task 7, line 50:
 //# run t2::o2::mint_shared_coin
@@ -80,8 +81,9 @@ task 9, lines 55-61:
 //> 2: TransferObjects([Result(1)], Input(2));
 //> 3: t2::o2::share_coin(Result(0));
 // Try to call public_share_object directly -- this should work because the coin has `store`.
-Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(0)
+created: object(9,0)
+mutated: object(0,0), object(7,0)
+gas summary: computation_cost: 1000000, storage_cost: 2964000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
 
 task 10, lines 62-66:
 //# programmable --inputs 0 object(7,0) @0x0
@@ -89,5 +91,6 @@ task 10, lines 62-66:
 //> 1: SplitCoins(Result(0), [Input(0)]);
 //> 2: TransferObjects([Result(1)], Input(2));
 //> 3: sui::transfer::public_share_object<sui::coin::Coin<sui::sui::SUI>>(Result(0));
-Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(0)
+created: object(10,0)
+mutated: object(0,0), object(7,0)
+gas summary: computation_cost: 1000000, storage_cost: 2964000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760

--- a/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call_fails.snap
+++ b/crates/sui-adapter-transactional-tests/tests/shared/by_value_shared_object_deletion_via_move_call_fails.snap
@@ -51,7 +51,7 @@ task 6, lines 68-72:
 //> 1: t2::o2::freezer(Result(0));
 // pass through a move function and then try to add as dof
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(0)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 7, lines 73-77:
 //# programmable --inputs object(2,0) object(3,0)
@@ -59,7 +59,7 @@ task 7, lines 73-77:
 //> 1: t2::o2::dofer(Input(0), Result(0));
 // pass through a move function and then try to add as df
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(0)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 8, lines 78-82:
 //# programmable --inputs object(2,0) object(3,0)
@@ -67,14 +67,14 @@ task 8, lines 78-82:
 //> 1: t2::o2::dfer(Input(0), Result(0));
 // pass through a move function and then try to transfer it
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(0)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 9, lines 83-85:
 //# programmable --inputs object(2,0) object(3,0)
 //> 0: t2::o2::id<t2::o2::Obj2>(Input(1));
 //> 1: t2::o2::transferer(Result(0));
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(0)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 10, line 87:
 //# run t2::o2::mint_shared_coin
@@ -104,8 +104,8 @@ task 12, lines 92-98:
 //> 2: TransferObjects([Result(1)], Input(2));
 //> 3: sui::transfer::public_share_object<sui::coin::Coin<sui::sui::SUI>>(Input(1));
 // Try to double-use the input using a user-defined function
-Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(0)
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.
+Debug of error: CommandArgumentError { arg_idx: 0, kind: InvalidValueUsage } at command Some(3)
 
 task 13, lines 99-105:
 //# programmable --inputs 0 object(10,0) @0x0
@@ -114,8 +114,8 @@ task 13, lines 99-105:
 //> 2: TransferObjects([Result(1)], Input(2));
 //> 3: t2::o2::share_coin(Input(1));
 // Try to transfer the shared object and double-use the input
-Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(0)
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.
+Debug of error: CommandArgumentError { arg_idx: 0, kind: InvalidValueUsage } at command Some(3)
 
 task 14, lines 106-112:
 //# programmable --inputs 0 object(10,0) @0x0
@@ -124,8 +124,8 @@ task 14, lines 106-112:
 //> 2: TransferObjects([Result(1)], Input(2));
 //> 3: TransferObjects([Input(1)], Input(2));
 // Try to transfer the shared object
-Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(0)
+Error: Transaction Effects Status: Invalid command argument at 0. Invalid usage of value. Mutably borrowed values require unique usage. Immutably borrowed values cannot be taken or borrowed mutably. Taken values cannot be used again.
+Debug of error: CommandArgumentError { arg_idx: 0, kind: InvalidValueUsage } at command Some(3)
 
 task 15, lines 113-117:
 //# programmable --inputs 0 object(10,0) @0x0
@@ -134,4 +134,4 @@ task 15, lines 113-117:
 //> 2: TransferObjects([Result(1)], Input(2));
 //> 3: TransferObjects([Result(0)], Input(2));
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(0)
+Debug of error: SharedObjectOperationNotAllowed at command None

--- a/crates/sui-adapter-transactional-tests/tests/shared/freeze.snap
+++ b/crates/sui-adapter-transactional-tests/tests/shared/freeze.snap
@@ -30,4 +30,4 @@ Contents: t2::o2::Obj2 {
 task 4, line 31:
 //# run t2::o2::freeze_o2 --args object(2,0)
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(0)
+Debug of error: SharedObjectOperationNotAllowed at command None

--- a/crates/sui-adapter-transactional-tests/tests/shared/transfer.snap
+++ b/crates/sui-adapter-transactional-tests/tests/shared/transfer.snap
@@ -30,4 +30,4 @@ Contents: t2::o2::Obj2 {
 task 4, line 30:
 //# run t2::o2::transfer_to_single_owner --args object(2,0)
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(0)
+Debug of error: SharedObjectOperationNotAllowed at command None

--- a/crates/sui-adapter-transactional-tests/tests/shared/wrap.snap
+++ b/crates/sui-adapter-transactional-tests/tests/shared/wrap.snap
@@ -30,4 +30,4 @@ Contents: t2::o2::Obj2 {
 task 4, line 34:
 //# run t2::o2::wrap_o2 --args object(2,0)
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(0)
+Debug of error: SharedObjectOperationNotAllowed at command None

--- a/crates/sui-adapter-transactional-tests/tests/transfer_object/shared.snap
+++ b/crates/sui-adapter-transactional-tests/tests/transfer_object/shared.snap
@@ -56,7 +56,7 @@ Debug of error: InvalidTransferObject at command Some(0)
 task 7, line 37:
 //# transfer-object 3,0 --sender A --recipient B
 Error: Transaction Effects Status: The shared object operation is not allowed.
-Debug of error: SharedObjectOperationNotAllowed at command Some(0)
+Debug of error: SharedObjectOperationNotAllowed at command None
 
 task 8, line 39:
 //# view-object 2,0

--- a/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v93.snap
+++ b/crates/sui-core/src/authority/snapshots/sui_core__authority__execution_time_estimator__tests__execution_time_observer_v93.snap
@@ -1,0 +1,155 @@
+---
+source: crates/sui-core/src/authority/execution_time_estimator.rs
+expression: snapshot_data
+---
+protocol_version: 93
+consensus_observations:
+  - - MakeMoveVec
+    - observations:
+        - - 0
+          - ~
+        - - 4
+          - secs: 0
+            nanos: 28000000
+        - - 7
+          - secs: 0
+            nanos: 21000000
+        - - 9
+          - secs: 0
+            nanos: 5000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 21000000
+  - - MergeCoins
+    - observations:
+        - - 6
+          - secs: 0
+            nanos: 63000000
+        - - 1
+          - secs: 0
+            nanos: 21000000
+        - - 4
+          - secs: 0
+            nanos: 49000000
+        - - 8
+          - secs: 0
+            nanos: 56000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 56000000
+  - - SplitCoins
+    - observations:
+        - - 7
+          - secs: 0
+            nanos: 78000000
+        - - 0
+          - ~
+        - - 10
+          - secs: 0
+            nanos: 30000000
+        - - 3
+          - secs: 0
+            nanos: 61000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 61000000
+  - - TransferObjects
+    - observations:
+        - - 7
+          - secs: 0
+            nanos: 53000000
+        - - 0
+          - ~
+        - - 4
+          - secs: 0
+            nanos: 28000000
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 53000000
+  - - Upgrade
+    - observations:
+        - - 8
+          - secs: 0
+            nanos: 191000000
+        - - 10
+          - secs: 0
+            nanos: 654000000
+        - - 6
+          - secs: 0
+            nanos: 981000000
+        - - 4
+          - secs: 0
+            nanos: 587000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 654000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000001"
+        module: coin
+        function: transfer
+        type_arguments: []
+    - observations:
+        - - 7
+          - secs: 0
+            nanos: 404000000
+        - - 6
+          - secs: 0
+            nanos: 162000000
+        - - 9
+          - secs: 0
+            nanos: 268000000
+        - - 0
+          - ~
+      stake_weighted_median:
+        secs: 0
+        nanos: 268000000
+  - - MoveEntryPoint:
+        package: "0x0000000000000000000000000000000000000000000000000000000000000002"
+        module: nft
+        function: mint
+        type_arguments: []
+    - observations:
+        - - 0
+          - ~
+        - - 8
+          - secs: 0
+            nanos: 337000000
+        - - 8
+          - secs: 0
+            nanos: 90000000
+        - - 8
+          - secs: 0
+            nanos: 499000000
+      stake_weighted_median:
+        secs: 0
+        nanos: 337000000
+transaction_estimates:
+  - - coin_transfer_call
+    - secs: 0
+      nanos: 268000000
+  - - mixed_move_calls
+    - secs: 0
+      nanos: 605000000
+  - - native_commands_with_observations
+    - secs: 0
+      nanos: 382000000
+  - - transfer_objects_1_items
+    - secs: 0
+      nanos: 106000000
+  - - split_coins_4_amounts
+    - secs: 0
+      nanos: 305000000
+  - - merge_coins_3_sources
+    - secs: 0
+      nanos: 224000000
+  - - make_move_vec_2_elements
+    - secs: 0
+      nanos: 63000000
+  - - mixed_commands
+    - secs: 0
+      nanos: 282000000
+  - - upgrade_package
+    - secs: 0
+      nanos: 654000000

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -496,12 +496,12 @@ mod tests {
 
     #[sim_test]
     async fn reject_checkpoint_signature_v2_when_flag_disabled() {
-        // Build a single-validator network and authority with protocol version < 92 (flag disabled)
+        // Build a single-validator network and authority with protocol version < 93 (flag disabled)
         let network_config =
             sui_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir().build();
 
         let disabled_cfg =
-            ProtocolConfig::get_for_version(ProtocolVersion::new(91), Chain::Unknown);
+            ProtocolConfig::get_for_version(ProtocolVersion::new(92), Chain::Unknown);
         let state = TestAuthorityBuilder::new()
             .with_network_config(&network_config, 0)
             .with_protocol_config(disabled_cfg)
@@ -550,11 +550,11 @@ mod tests {
 
     #[sim_test]
     async fn accept_checkpoint_signature_v2_when_flag_enabled() {
-        // Build a single-validator network and authority with protocol version >= 92 (flag enabled)
+        // Build a single-validator network and authority with protocol version >= 93 (flag enabled)
         let network_config =
             sui_swarm_config::network_config_builder::ConfigBuilder::new_with_temp_dir().build();
 
-        let enabled_cfg = ProtocolConfig::get_for_version(ProtocolVersion::new(92), Chain::Unknown);
+        let enabled_cfg = ProtocolConfig::get_for_version(ProtocolVersion::new(93), Chain::Unknown);
         let state = TestAuthorityBuilder::new()
             .with_network_config(&network_config, 0)
             .with_protocol_config(enabled_cfg)

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1294,7 +1294,7 @@
             "name": "Result",
             "value": {
               "minSupportedProtocolVersion": "1",
-              "maxSupportedProtocolVersion": "92",
+              "maxSupportedProtocolVersion": "93",
               "protocolVersion": "6",
               "featureFlags": {
                 "accept_passkey_in_multisig": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -19,7 +19,7 @@ use tracing::{info, warn};
 
 /// The minimum and maximum protocol versions supported by this build.
 const MIN_PROTOCOL_VERSION: u64 = 1;
-const MAX_PROTOCOL_VERSION: u64 = 92;
+const MAX_PROTOCOL_VERSION: u64 = 93;
 
 // Record history of protocol version allocations here:
 //
@@ -3928,6 +3928,9 @@ impl ProtocolConfig {
                     cfg.feature_flags.per_command_shared_object_transfer_rules = true;
                 }
                 92 => {
+                    cfg.feature_flags.per_command_shared_object_transfer_rules = false;
+                }
+                93 => {
                     cfg.feature_flags
                         .consensus_checkpoint_signature_key_includes_digest = true;
                 }

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_92.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_92.snap
@@ -32,7 +32,6 @@ feature_flags:
   simple_conservation_checks: true
   loaded_child_object_format_type: true
   receive_objects: true
-  consensus_checkpoint_signature_key_includes_digest: true
   random_beacon: true
   bridge: true
   enable_effects_v2: true
@@ -108,7 +107,6 @@ feature_flags:
   debug_fatal_on_move_invariant_violation: true
   additional_consensus_digest_indirect_state: true
   check_for_init_during_upgrade: true
-  per_command_shared_object_transfer_rules: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_93.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_93.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 92
+version: 93
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true
@@ -32,6 +32,7 @@ feature_flags:
   simple_conservation_checks: true
   loaded_child_object_format_type: true
   receive_objects: true
+  consensus_checkpoint_signature_key_includes_digest: true
   random_beacon: true
   bridge: true
   enable_effects_v2: true
@@ -43,10 +44,8 @@ feature_flags:
   include_consensus_digest_in_prologue: true
   hardened_otw_check: true
   allow_receiving_object_id: true
-  enable_poseidon: true
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
-  enable_group_ops_native_function_msm: true
   enable_nitro_attestation: true
   enable_nitro_attestation_upgraded_parsing: true
   reject_mutable_random_on_entry_functions: true
@@ -67,7 +66,6 @@ feature_flags:
   reshare_at_same_initial_version: true
   resolve_abort_locations_to_package_id: true
   mysticeti_use_committed_subdag_digest: true
-  enable_vdf: true
   record_consensus_determined_version_assignments_in_prologue: true
   record_consensus_determined_version_assignments_in_prologue_v2: true
   fresh_vm_on_framework_upgrade: true
@@ -76,13 +74,11 @@ feature_flags:
   soft_bundle: true
   enable_coin_deny_list_v2: true
   passkey_auth: true
-  authority_capabilities_v2: true
   rethrow_serialization_type_layout_errors: true
   consensus_distributed_vote_scoring_strategy: true
   consensus_round_prober: true
   validate_identifier_inputs: true
   disallow_self_identifier: true
-  mysticeti_fastpath: true
   relocate_event_module: true
   uncompressed_g1_group_elements: true
   disallow_new_modules_in_deps_only_packages: true
@@ -102,7 +98,6 @@ feature_flags:
   enforce_checkpoint_timestamp_monotonicity: true
   max_ptb_value_size_v2: true
   resolve_type_input_ids_to_defining_id: true
-  enable_party_transfer: true
   allow_unbounded_system_objects: true
   type_tags_in_object_runtime: true
   better_adapter_type_resolution_errors: true
@@ -306,7 +301,6 @@ hash_blake2b256_data_cost_per_block: 2
 hash_keccak256_cost_base: 10
 hash_keccak256_data_cost_per_byte: 2
 hash_keccak256_data_cost_per_block: 2
-poseidon_bn254_cost_base: 260
 poseidon_bn254_cost_per_block: 388
 group_ops_bls12381_decode_scalar_cost: 7
 group_ops_bls12381_decode_g1_cost: 2848
@@ -348,8 +342,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-vdf_verify_vdf_cost: 1500
-vdf_hash_to_input_cost: 100
 nitro_attestation_parse_base_cost: 2650
 nitro_attestation_parse_cost_per_byte: 50
 nitro_attestation_verify_base_cost: 2481600
@@ -412,3 +404,202 @@ gas_budget_based_txn_cost_absolute_cap_commit_count: 50
 sip_45_consensus_amplification_threshold: 5
 use_object_per_epoch_marker_table_v2: true
 consensus_commit_rate_estimation_window_size: 10
+aliased_addresses:
+  - original:
+      - 205
+      - 137
+      - 98
+      - 218
+      - 210
+      - 120
+      - 216
+      - 181
+      - 15
+      - 160
+      - 249
+      - 235
+      - 1
+      - 134
+      - 191
+      - 164
+      - 203
+      - 222
+      - 204
+      - 109
+      - 89
+      - 55
+      - 114
+      - 20
+      - 200
+      - 141
+      - 2
+      - 134
+      - 160
+      - 172
+      - 149
+      - 98
+    aliased:
+      - 11
+      - 45
+      - 163
+      - 39
+      - 186
+      - 106
+      - 76
+      - 172
+      - 190
+      - 117
+      - 221
+      - 221
+      - 80
+      - 230
+      - 232
+      - 187
+      - 248
+      - 29
+      - 100
+      - 150
+      - 233
+      - 45
+      - 102
+      - 175
+      - 145
+      - 84
+      - 198
+      - 28
+      - 119
+      - 247
+      - 51
+      - 47
+    allowed_tx_digests:
+      - - 2
+        - 145
+        - 170
+        - 78
+        - 99
+        - 246
+        - 130
+        - 221
+        - 11
+        - 53
+        - 228
+        - 241
+        - 202
+        - 113
+        - 56
+        - 105
+        - 120
+        - 236
+        - 143
+        - 114
+        - 165
+        - 106
+        - 212
+        - 165
+        - 196
+        - 178
+        - 239
+        - 253
+        - 97
+        - 66
+        - 98
+        - 197
+  - original:
+      - 226
+      - 139
+      - 80
+      - 206
+      - 241
+      - 214
+      - 51
+      - 234
+      - 67
+      - 211
+      - 41
+      - 106
+      - 63
+      - 107
+      - 103
+      - 255
+      - 3
+      - 18
+      - 165
+      - 241
+      - 169
+      - 159
+      - 10
+      - 247
+      - 83
+      - 200
+      - 91
+      - 139
+      - 93
+      - 232
+      - 255
+      - 6
+    aliased:
+      - 11
+      - 45
+      - 163
+      - 39
+      - 186
+      - 106
+      - 76
+      - 172
+      - 190
+      - 117
+      - 221
+      - 221
+      - 80
+      - 230
+      - 232
+      - 187
+      - 248
+      - 29
+      - 100
+      - 150
+      - 233
+      - 45
+      - 102
+      - 175
+      - 145
+      - 84
+      - 198
+      - 28
+      - 119
+      - 247
+      - 51
+      - 47
+    allowed_tx_digests:
+      - - 253
+        - 118
+        - 94
+        - 221
+        - 205
+        - 105
+        - 164
+        - 185
+        - 146
+        - 65
+        - 207
+        - 179
+        - 194
+        - 136
+        - 51
+        - 126
+        - 222
+        - 28
+        - 78
+        - 230
+        - 151
+        - 0
+        - 147
+        - 120
+        - 44
+        - 55
+        - 155
+        - 111
+        - 243
+        - 35
+        - 173
+        - 119

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_92.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_92.snap
@@ -32,7 +32,6 @@ feature_flags:
   simple_conservation_checks: true
   loaded_child_object_format_type: true
   receive_objects: true
-  consensus_checkpoint_signature_key_includes_digest: true
   random_beacon: true
   bridge: true
   enable_effects_v2: true
@@ -110,7 +109,6 @@ feature_flags:
   debug_fatal_on_move_invariant_violation: true
   additional_consensus_digest_indirect_state: true
   check_for_init_during_upgrade: true
-  per_command_shared_object_transfer_rules: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_93.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_93.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 92
+version: 93
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true
@@ -32,6 +32,7 @@ feature_flags:
   simple_conservation_checks: true
   loaded_child_object_format_type: true
   receive_objects: true
+  consensus_checkpoint_signature_key_includes_digest: true
   random_beacon: true
   bridge: true
   enable_effects_v2: true
@@ -43,10 +44,8 @@ feature_flags:
   include_consensus_digest_in_prologue: true
   hardened_otw_check: true
   allow_receiving_object_id: true
-  enable_poseidon: true
   enable_coin_deny_list: true
   enable_group_ops_native_functions: true
-  enable_group_ops_native_function_msm: true
   enable_nitro_attestation: true
   enable_nitro_attestation_upgraded_parsing: true
   reject_mutable_random_on_entry_functions: true
@@ -67,7 +66,6 @@ feature_flags:
   reshare_at_same_initial_version: true
   resolve_abort_locations_to_package_id: true
   mysticeti_use_committed_subdag_digest: true
-  enable_vdf: true
   record_consensus_determined_version_assignments_in_prologue: true
   record_consensus_determined_version_assignments_in_prologue_v2: true
   fresh_vm_on_framework_upgrade: true
@@ -76,7 +74,6 @@ feature_flags:
   soft_bundle: true
   enable_coin_deny_list_v2: true
   passkey_auth: true
-  authority_capabilities_v2: true
   rethrow_serialization_type_layout_errors: true
   consensus_distributed_vote_scoring_strategy: true
   consensus_round_prober: true
@@ -306,7 +303,6 @@ hash_blake2b256_data_cost_per_block: 2
 hash_keccak256_cost_base: 10
 hash_keccak256_data_cost_per_byte: 2
 hash_keccak256_data_cost_per_block: 2
-poseidon_bn254_cost_base: 260
 poseidon_bn254_cost_per_block: 388
 group_ops_bls12381_decode_scalar_cost: 7
 group_ops_bls12381_decode_g1_cost: 2848
@@ -348,8 +344,6 @@ hmac_hmac_sha3_256_input_cost_per_byte: 2
 hmac_hmac_sha3_256_input_cost_per_block: 2
 check_zklogin_id_cost_base: 200
 check_zklogin_issuer_cost_base: 200
-vdf_verify_vdf_cost: 1500
-vdf_hash_to_input_cost: 100
 nitro_attestation_parse_base_cost: 2650
 nitro_attestation_parse_cost_per_byte: 50
 nitro_attestation_verify_base_cost: 2481600

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_93.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_93.snap
@@ -2,7 +2,7 @@
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
 ---
-version: 92
+version: 93
 feature_flags:
   package_upgrades: true
   commit_root_state_digest: true
@@ -32,6 +32,7 @@ feature_flags:
   simple_conservation_checks: true
   loaded_child_object_format_type: true
   receive_objects: true
+  consensus_checkpoint_signature_key_includes_digest: true
   random_beacon: true
   bridge: true
   enable_effects_v2: true

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__genesis_config_snapshot_matches.snap
@@ -6,7 +6,7 @@ ssfn_config_info: ~
 validator_config_info: ~
 parameters:
   chain_start_timestamp_ms: 0
-  protocol_version: 92
+  protocol_version: 93
   allow_insertion_of_extra_objects: true
   epoch_duration_ms: 86400000
   stake_subsidy_start_epoch: 0

--- a/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
+++ b/crates/sui-swarm-config/tests/snapshots/snapshot_tests__populated_genesis_snapshot_matches-2.snap
@@ -3,7 +3,7 @@ source: crates/sui-swarm-config/tests/snapshot_tests.rs
 expression: genesis.sui_system_object().into_genesis_version_for_tooling()
 ---
 epoch: 0
-protocol_version: 92
+protocol_version: 93
 system_state_version: 1
 validators:
   total_stake: 20000000000000000
@@ -240,13 +240,13 @@ validators:
         next_epoch_worker_address: ~
         extra_fields:
           id:
-            id: "0x7867086683ee613862d2a77b3abc7c892e03b9e2353a0d5d6d694aa0ecf28cce"
+            id: "0xa15d19e44c801d754be85bad90f0c610e6f160116e233f5c301ed07bd2e7b2a1"
           size: 0
       voting_power: 10000
-      operation_cap_id: "0x77387d1a805b7ca88da10bb088674e6f287f9e1f7bc2d59ef16a24bdc4526b9b"
+      operation_cap_id: "0x6197d368bd166a63b5058a5640337cc9a34523dc48ff9a6b075c695a94b5c510"
       gas_price: 1000
       staking_pool:
-        id: "0x56de4b4b2fec72085bf0a889f58a75d663efc6a99ce824c5fe0ec1d60a041176"
+        id: "0x374c77a8688b7ab3bc25fabc642fa59c782d8709f61c64b3813bcf3f8a2a3327"
         activation_epoch: 0
         deactivation_epoch: ~
         sui_balance: 20000000000000000
@@ -254,14 +254,14 @@ validators:
           value: 0
         pool_token_balance: 20000000000000000
         exchange_rates:
-          id: "0x9504fc1bfd9d4e2fbf86806590d97a105d89e9205a22320b8d1efb4515426c7f"
+          id: "0xdadf3afb51e07f8c91468e850a1e8d1a4447f55fae1bc142be643ab3ceae5f0d"
           size: 1
         pending_stake: 0
         pending_total_sui_withdraw: 0
         pending_pool_token_withdraw: 0
         extra_fields:
           id:
-            id: "0xd8a436b3093c62fe9a81922bb9a663514f14f3af151282826f5602428b516653"
+            id: "0xcfef078f0fb8a04746b2523fa2198a942fa06bc0f0de7ad6fab25cd5ff318dfd"
           size: 0
       commission_rate: 200
       next_epoch_stake: 20000000000000000
@@ -269,27 +269,27 @@ validators:
       next_epoch_commission_rate: 200
       extra_fields:
         id:
-          id: "0x427909a8ae430465d9ea3860b93bd1633cec1cfd173f62af153e0c99bb875090"
+          id: "0xa83ccdca9b4297f801ce41e588b478ba1d700f93acb45bfc474f350284a7939b"
         size: 0
   pending_active_validators:
     contents:
-      id: "0x8100793a18e638d580612260e50c2c4f1a27cb3ceb783b367129e694c4891218"
+      id: "0x2c8f2d5a9c5cff364286d4a097c0f9d59c500dde7eeb7eb8b7802c9a690b8e5b"
       size: 0
   pending_removals: []
   staking_pool_mappings:
-    id: "0xbdde03f0a57af92abfa40fe2d6f8e492d2c8d05331fa56abaf066070f5d202a2"
+    id: "0x3ff9321fd03979ea1b86e1c23e88fbf261ea98e19bc475a95782958dcb2cce10"
     size: 1
   inactive_validators:
-    id: "0x44bcc26100c94faf7fe649431e086340c495e1af14ddeed03f318561dcdfc2ab"
+    id: "0x53e2fa49c8d6ad32f9f165a95e6a7986961dc1e433c254812c3f691d284574e7"
     size: 0
   validator_candidates:
-    id: "0x0c4b347c2c794e502bf5d7d4048f42dcf102381a448e8e1e457fc04371016945"
+    id: "0x8194a9c9d02e563a7ee3c18414d66906b9a11cc09dce48670277833ae64a716f"
     size: 0
   at_risk_validators:
     contents: []
   extra_fields:
     id:
-      id: "0x4bc2c3725d6ffac8fd2c56aeced71d984f4c463bbf730eba2b8961eecbe7e8fa"
+      id: "0x2d275e3396de7eef119e8437bcbfe6ba012a9d40fb3ef5f38a7f609e1467287a"
     size: 0
 storage_fund:
   total_object_storage_rebates:
@@ -306,7 +306,7 @@ parameters:
   validator_low_stake_grace_period: 7
   extra_fields:
     id:
-      id: "0xd35b602b4163e17ca50adc8f806ca9c2db3e727c65b8b08015a98d3ddd284e74"
+      id: "0xf8623b33d64f8c58d7694e13f26a8bbe56625425d3a340af23ce6f4b3d4fcde8"
     size: 0
 reference_gas_price: 1000
 validator_report_records:
@@ -320,7 +320,7 @@ stake_subsidy:
   stake_subsidy_decrease_rate: 1000
   extra_fields:
     id:
-      id: "0x96d7e41a049dbb406f89f227125a7f28dd6270d264ac142cd76e9e02c9baaacc"
+      id: "0x894d178956248cab9b6b1cfb1e9bcf66a059eece174cacce8bfba56735cfcc69"
     size: 0
 safe_mode: false
 safe_mode_storage_rewards:
@@ -332,5 +332,5 @@ safe_mode_non_refundable_storage_fee: 0
 epoch_start_timestamp_ms: 10
 extra_fields:
   id:
-    id: "0xca4b55516c15d6b02abdbf2a6d5aad9ef1325a6ac84f0b80922b4941c6ff7b33"
+    id: "0xf9ef58f6bfa8382a7474a54a3ca16304c2063596efc1c5df3fd953974d2f53ac"
   size: 0


### PR DESCRIPTION
## Description 

- To keep in line with changes of #23163, this disables `per_command_shared_object_transfer_rules`
- Shifts config 92 on main to 93

## Test plan 

- Updated tests 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
