### PR TITLE
[Rust] update toolchain version to 1.89.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -490,7 +490,7 @@ ron = "0.8.0"
 rstest = "0.16.0"
 russh = "0.38.0"
 russh-keys = "0.38.0"
-rust-version = "1.56.1"
+rust-version = "1.89.0"
 rustls = { version = "0.23", default-features = false, features = [
   "std",
   "tls12",


### PR DESCRIPTION
## Description 

To the most recent stable toolchain

## Test plan 

CI and local testing

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
