### PR TITLE
graphql-alt: IAddressable.objects coin order

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/coins.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/coins.move
@@ -1,0 +1,159 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --addresses T=0x0 --accounts A B --simulator
+
+//# publish --sender A
+module T::test {
+    use sui::coin;
+
+    public struct TEST has drop {}
+
+    fun init(otw: TEST, ctx: &mut TxContext){
+        let (mut treasury, metadata) =
+            coin::create_currency(otw, 6, b"", b"", b"", option::none(), ctx);
+
+        // Mint and transfer TEST coins with different amounts
+        transfer::public_transfer(treasury.mint(1_000000, ctx), ctx.sender());
+        transfer::public_transfer(treasury.mint(0_500000, ctx), ctx.sender());
+        transfer::public_transfer(treasury.mint(0_250000, ctx), ctx.sender());
+        transfer::public_transfer(treasury.mint(0_100000, ctx), ctx.sender());
+
+        transfer::public_freeze_object(metadata);
+        transfer::public_transfer(treasury, ctx.sender());
+    }
+}
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs 1000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 500 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs @A
+//> 0: sui::bag::new();
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs object(1,0) @B
+//> TransferObjects([Input(0)], Input(1))
+
+//# programmable --sender A --inputs object(3,0) @B
+//> TransferObjects([Input(0)], Input(1))
+
+//# create-checkpoint
+
+//# run-graphql
+{ # Account A queries
+  accountA: address(address: "@{A}") {
+    # All objects including coins and bags
+    allObjects: objects {
+      pageInfo { hasNextPage }
+      nodes {
+        address
+        contents {
+          type { repr }
+          json
+        }
+      }
+    }
+
+    # All coins (no marker filter)
+    allCoins: objects(filter: { type: "0x2::coin::Coin" }) {
+      pageInfo { hasNextPage }
+      nodes {
+        address
+        contents {
+          type { repr }
+          json
+        }
+      }
+    }
+
+
+    # Only TEST coin objects
+    testCoins: objects(filter: { type: "0x2::coin::Coin<@{T}::test::TEST>" }) {
+      pageInfo { hasNextPage }
+      nodes {
+        address
+        contents {
+          json
+        }
+      }
+    }
+
+    # Only SUI coin objects
+    suiCoins: objects(filter: { type: "0x2::coin::Coin<0x2::sui::SUI>" }) {
+      pageInfo { hasNextPage }
+      nodes {
+        address
+        contents {
+          json
+        }
+      }
+    }
+  }
+
+  # Account B queries
+  accountB: address(address: "@{B}") {
+    # All objects for B
+    allObjects: objects {
+      pageInfo { hasNextPage }
+      nodes {
+        address
+        contents {
+          type { repr }
+          json
+        }
+      }
+    }
+
+    # Only TEST coin objects for B
+    testCoins: objects(filter: { type: "0x2::coin::Coin<@{T}::test::TEST>" }) {
+      pageInfo { hasNextPage }
+      nodes {
+        address
+        contents {
+          json
+        }
+      }
+    }
+
+    # Only SUI coin objects for B
+    suiCoins: objects(filter: { type: "0x2::coin::Coin<0x2::sui::SUI>" }) {
+      pageInfo { hasNextPage }
+      nodes {
+        address
+        contents {
+          json
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{ # Time travel to checkpoint 2 (before transfers)
+  timeTravel: checkpoint(sequenceNumber: 2) {
+    query {
+      address(address: "@{A}") {
+        # Should have all coin objects at this point
+        objects(filter: { type: "0x2::coin::Coin" }) {
+          pageInfo { hasNextPage }
+          nodes {
+            address
+            contents {
+              type { repr }
+              json
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/coins.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/coins.snap
@@ -1,0 +1,481 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 12 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-25:
+//# publish --sender A
+created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5), object(1,6)
+mutated: object(0,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 16864400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 27:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 29-31:
+//# programmable --sender A --inputs 1000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 33-35:
+//# programmable --sender A --inputs 500 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 37-39:
+//# programmable --sender A --inputs @A
+//> 0: sui::bag::new();
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2287600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, line 41:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 7, lines 43-44:
+//# programmable --sender A --inputs object(1,0) @B
+//> TransferObjects([Input(0)], Input(1))
+mutated: object(0,0), object(1,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 2310400,  storage_rebate: 2287296, non_refundable_storage_fee: 23104
+
+task 8, lines 46-47:
+//# programmable --sender A --inputs object(3,0) @B
+//> TransferObjects([Input(0)], Input(1))
+mutated: object(0,0), object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 9, line 49:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 10, lines 51-138:
+//# run-graphql
+Response: {
+  "data": {
+    "accountA": {
+      "allObjects": {
+        "pageInfo": {
+          "hasNextPage": false
+        },
+        "nodes": [
+          {
+            "address": "0x5b9005409dd6d73b4d0e30ae70a8d736c52c59214a3b8ffd8d0c27bf3de5e7a2",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::bag::Bag"
+              },
+              "json": {
+                "id": "0x5b9005409dd6d73b4d0e30ae70a8d736c52c59214a3b8ffd8d0c27bf3de5e7a2",
+                "size": "0"
+              }
+            }
+          },
+          {
+            "address": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              },
+              "json": {
+                "balance": "299999973785996",
+                "id": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562"
+              }
+            }
+          },
+          {
+            "address": "0xaed246eecae370ed59ac3fecf309df4de8713c1694297f59c6a26e8950d8fb50",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              },
+              "json": {
+                "balance": "500",
+                "id": "0xaed246eecae370ed59ac3fecf309df4de8713c1694297f59c6a26e8950d8fb50"
+              }
+            }
+          },
+          {
+            "address": "0x32a23ae8faf51eac67c2e4d3399512a89230e4a6afbe5730ffbedb39a0ea568a",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+              },
+              "json": {
+                "balance": "1000000",
+                "id": "0x32a23ae8faf51eac67c2e4d3399512a89230e4a6afbe5730ffbedb39a0ea568a"
+              }
+            }
+          },
+          {
+            "address": "0x8b2b6b2c80d83549aa32fa6d06127eb0d4d3533454981f4a3535aa7f38d838ae",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+              },
+              "json": {
+                "balance": "500000",
+                "id": "0x8b2b6b2c80d83549aa32fa6d06127eb0d4d3533454981f4a3535aa7f38d838ae"
+              }
+            }
+          },
+          {
+            "address": "0x9eb66dea3cfa5c3b60900d2eab57d94bb7a19004086b900fb4f84bc79abcea0f",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+              },
+              "json": {
+                "balance": "250000",
+                "id": "0x9eb66dea3cfa5c3b60900d2eab57d94bb7a19004086b900fb4f84bc79abcea0f"
+              }
+            }
+          },
+          {
+            "address": "0x361c0d13ad78b43d14d2ed4c6d544864295996338644ed84ea841827799dc34e",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::TreasuryCap<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+              },
+              "json": {
+                "id": "0x361c0d13ad78b43d14d2ed4c6d544864295996338644ed84ea841827799dc34e",
+                "total_supply": {
+                  "value": "1850000"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "allCoins": {
+        "pageInfo": {
+          "hasNextPage": false
+        },
+        "nodes": [
+          {
+            "address": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              },
+              "json": {
+                "balance": "299999973785996",
+                "id": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562"
+              }
+            }
+          },
+          {
+            "address": "0xaed246eecae370ed59ac3fecf309df4de8713c1694297f59c6a26e8950d8fb50",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              },
+              "json": {
+                "balance": "500",
+                "id": "0xaed246eecae370ed59ac3fecf309df4de8713c1694297f59c6a26e8950d8fb50"
+              }
+            }
+          },
+          {
+            "address": "0x32a23ae8faf51eac67c2e4d3399512a89230e4a6afbe5730ffbedb39a0ea568a",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+              },
+              "json": {
+                "balance": "1000000",
+                "id": "0x32a23ae8faf51eac67c2e4d3399512a89230e4a6afbe5730ffbedb39a0ea568a"
+              }
+            }
+          },
+          {
+            "address": "0x8b2b6b2c80d83549aa32fa6d06127eb0d4d3533454981f4a3535aa7f38d838ae",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+              },
+              "json": {
+                "balance": "500000",
+                "id": "0x8b2b6b2c80d83549aa32fa6d06127eb0d4d3533454981f4a3535aa7f38d838ae"
+              }
+            }
+          },
+          {
+            "address": "0x9eb66dea3cfa5c3b60900d2eab57d94bb7a19004086b900fb4f84bc79abcea0f",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+              },
+              "json": {
+                "balance": "250000",
+                "id": "0x9eb66dea3cfa5c3b60900d2eab57d94bb7a19004086b900fb4f84bc79abcea0f"
+              }
+            }
+          }
+        ]
+      },
+      "testCoins": {
+        "pageInfo": {
+          "hasNextPage": false
+        },
+        "nodes": [
+          {
+            "address": "0x32a23ae8faf51eac67c2e4d3399512a89230e4a6afbe5730ffbedb39a0ea568a",
+            "contents": {
+              "json": {
+                "balance": "1000000",
+                "id": "0x32a23ae8faf51eac67c2e4d3399512a89230e4a6afbe5730ffbedb39a0ea568a"
+              }
+            }
+          },
+          {
+            "address": "0x8b2b6b2c80d83549aa32fa6d06127eb0d4d3533454981f4a3535aa7f38d838ae",
+            "contents": {
+              "json": {
+                "balance": "500000",
+                "id": "0x8b2b6b2c80d83549aa32fa6d06127eb0d4d3533454981f4a3535aa7f38d838ae"
+              }
+            }
+          },
+          {
+            "address": "0x9eb66dea3cfa5c3b60900d2eab57d94bb7a19004086b900fb4f84bc79abcea0f",
+            "contents": {
+              "json": {
+                "balance": "250000",
+                "id": "0x9eb66dea3cfa5c3b60900d2eab57d94bb7a19004086b900fb4f84bc79abcea0f"
+              }
+            }
+          }
+        ]
+      },
+      "suiCoins": {
+        "pageInfo": {
+          "hasNextPage": false
+        },
+        "nodes": [
+          {
+            "address": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
+            "contents": {
+              "json": {
+                "balance": "299999973785996",
+                "id": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562"
+              }
+            }
+          },
+          {
+            "address": "0xaed246eecae370ed59ac3fecf309df4de8713c1694297f59c6a26e8950d8fb50",
+            "contents": {
+              "json": {
+                "balance": "500",
+                "id": "0xaed246eecae370ed59ac3fecf309df4de8713c1694297f59c6a26e8950d8fb50"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "accountB": {
+      "allObjects": {
+        "pageInfo": {
+          "hasNextPage": false
+        },
+        "nodes": [
+          {
+            "address": "0xfdc25bc3b2d2b3664199d08f5275c3a6bb360b0629ab5784672f083149163417",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              },
+              "json": {
+                "balance": "300000000000000",
+                "id": "0xfdc25bc3b2d2b3664199d08f5275c3a6bb360b0629ab5784672f083149163417"
+              }
+            }
+          },
+          {
+            "address": "0x44c906c3b3b4be18871c55abc222a3c75383c7a229f8a1700b10584666be47f6",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              },
+              "json": {
+                "balance": "1000",
+                "id": "0x44c906c3b3b4be18871c55abc222a3c75383c7a229f8a1700b10584666be47f6"
+              }
+            }
+          },
+          {
+            "address": "0x16ce72994b48d46e73044edf9974203f4c821988f2bf27e8388ddc254b1cee5a",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+              },
+              "json": {
+                "balance": "100000",
+                "id": "0x16ce72994b48d46e73044edf9974203f4c821988f2bf27e8388ddc254b1cee5a"
+              }
+            }
+          }
+        ]
+      },
+      "testCoins": {
+        "pageInfo": {
+          "hasNextPage": false
+        },
+        "nodes": [
+          {
+            "address": "0x16ce72994b48d46e73044edf9974203f4c821988f2bf27e8388ddc254b1cee5a",
+            "contents": {
+              "json": {
+                "balance": "100000",
+                "id": "0x16ce72994b48d46e73044edf9974203f4c821988f2bf27e8388ddc254b1cee5a"
+              }
+            }
+          }
+        ]
+      },
+      "suiCoins": {
+        "pageInfo": {
+          "hasNextPage": false
+        },
+        "nodes": [
+          {
+            "address": "0xfdc25bc3b2d2b3664199d08f5275c3a6bb360b0629ab5784672f083149163417",
+            "contents": {
+              "json": {
+                "balance": "300000000000000",
+                "id": "0xfdc25bc3b2d2b3664199d08f5275c3a6bb360b0629ab5784672f083149163417"
+              }
+            }
+          },
+          {
+            "address": "0x44c906c3b3b4be18871c55abc222a3c75383c7a229f8a1700b10584666be47f6",
+            "contents": {
+              "json": {
+                "balance": "1000",
+                "id": "0x44c906c3b3b4be18871c55abc222a3c75383c7a229f8a1700b10584666be47f6"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 11, lines 140-159:
+//# run-graphql
+Response: {
+  "data": {
+    "timeTravel": {
+      "query": {
+        "address": {
+          "objects": {
+            "pageInfo": {
+              "hasNextPage": false
+            },
+            "nodes": [
+              {
+                "address": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
+                "contents": {
+                  "type": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                  },
+                  "json": {
+                    "balance": "299999975828860",
+                    "id": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562"
+                  }
+                }
+              },
+              {
+                "address": "0x44c906c3b3b4be18871c55abc222a3c75383c7a229f8a1700b10584666be47f6",
+                "contents": {
+                  "type": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                  },
+                  "json": {
+                    "balance": "1000",
+                    "id": "0x44c906c3b3b4be18871c55abc222a3c75383c7a229f8a1700b10584666be47f6"
+                  }
+                }
+              },
+              {
+                "address": "0xaed246eecae370ed59ac3fecf309df4de8713c1694297f59c6a26e8950d8fb50",
+                "contents": {
+                  "type": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                  },
+                  "json": {
+                    "balance": "500",
+                    "id": "0xaed246eecae370ed59ac3fecf309df4de8713c1694297f59c6a26e8950d8fb50"
+                  }
+                }
+              },
+              {
+                "address": "0x32a23ae8faf51eac67c2e4d3399512a89230e4a6afbe5730ffbedb39a0ea568a",
+                "contents": {
+                  "type": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+                  },
+                  "json": {
+                    "balance": "1000000",
+                    "id": "0x32a23ae8faf51eac67c2e4d3399512a89230e4a6afbe5730ffbedb39a0ea568a"
+                  }
+                }
+              },
+              {
+                "address": "0x8b2b6b2c80d83549aa32fa6d06127eb0d4d3533454981f4a3535aa7f38d838ae",
+                "contents": {
+                  "type": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+                  },
+                  "json": {
+                    "balance": "500000",
+                    "id": "0x8b2b6b2c80d83549aa32fa6d06127eb0d4d3533454981f4a3535aa7f38d838ae"
+                  }
+                }
+              },
+              {
+                "address": "0x9eb66dea3cfa5c3b60900d2eab57d94bb7a19004086b900fb4f84bc79abcea0f",
+                "contents": {
+                  "type": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+                  },
+                  "json": {
+                    "balance": "250000",
+                    "id": "0x9eb66dea3cfa5c3b60900d2eab57d94bb7a19004086b900fb4f84bc79abcea0f"
+                  }
+                }
+              },
+              {
+                "address": "0x16ce72994b48d46e73044edf9974203f4c821988f2bf27e8388ddc254b1cee5a",
+                "contents": {
+                  "type": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+                  },
+                  "json": {
+                    "balance": "100000",
+                    "id": "0x16ce72994b48d46e73044edf9974203f4c821988f2bf27e8388ddc254b1cee5a"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Add tests that coins are returned in inverse balance order.

## Test plan

```
$ cargo nextest run            \
  -p sui-indexer-alt-e2e-tests \
  -- graphql/addressable/coins
```

## Stack

- #23127 
- #23128 
- #23129 
- #23130 
- #23172 
- #23188
- #23210 
- #23211 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
