### PR TITLE
[graphql-alt] Support ProgrammableSystem for TransactionKind

### DIFF
--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -1606,15 +1606,18 @@ type PerEpochConfig {
 	object: Object
 }
 
+"""
+ProgrammableSystemTransaction is identical to ProgrammableTransaction, but GraphQL does not allow multiple variants with the same type.
+"""
 type ProgrammableSystemTransaction {
-	"""
-	Input objects or primitive values.
-	"""
-	inputs(first: Int, after: String, last: Int, before: String): TransactionInputConnection!
 	"""
 	The transaction commands, executed sequentially.
 	"""
 	commands(first: Int, after: String, last: Int, before: String): CommandConnection!
+	"""
+	Input objects or primitive values.
+	"""
+	inputs(first: Int, after: String, last: Int, before: String): TransactionInputConnection!
 }
 
 type ProgrammableTransaction {

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/mod.rs
@@ -77,8 +77,7 @@ impl TransactionKind {
             })),
             K::ProgrammableSystemTransaction(pt) => {
                 Some(T::ProgrammableSystem(ProgrammableSystemTransaction {
-                    native: pt,
-                    scope,
+                    inner: ProgrammableTransaction { native: pt, scope },
                 }))
             }
         }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable_system.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable_system.rs
@@ -1,87 +1,13 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use async_graphql::{
-    connection::{Connection, CursorType, Edge},
-    Context, Object,
-};
-use sui_types::transaction::ProgrammableTransaction as NativeProgrammableTransaction;
+use async_graphql::SimpleObject;
 
-use crate::{
-    api::scalars::cursor::JsonCursor,
-    error::RpcError,
-    pagination::{Page, PaginationConfig},
-    scope::Scope,
-};
-
-use super::programmable::{Command, TransactionInput};
-
-type CInput = JsonCursor<usize>;
-type CCommand = JsonCursor<usize>;
+use super::programmable::ProgrammableTransaction;
 
 /// ProgrammableSystemTransaction is identical to ProgrammableTransaction, but GraphQL does not allow multiple variants with the same type.
-#[derive(Clone)]
+#[derive(SimpleObject, Clone)]
 pub struct ProgrammableSystemTransaction {
-    pub native: NativeProgrammableTransaction,
-    pub scope: Scope,
-}
-
-#[Object]
-impl ProgrammableSystemTransaction {
-    /// Input objects or primitive values.
-    async fn inputs(
-        &self,
-        ctx: &Context<'_>,
-        first: Option<u64>,
-        after: Option<CInput>,
-        last: Option<u64>,
-        before: Option<CInput>,
-    ) -> Result<Connection<String, TransactionInput>, RpcError> {
-        let pagination = ctx.data::<PaginationConfig>()?;
-        let limits = pagination.limits("ProgrammableSystemTransaction", "inputs");
-        let page = Page::from_params(limits, first, after, last, before)?;
-
-        let cursors = page.paginate_indices(self.native.inputs.len());
-        let mut conn = Connection::new(cursors.has_previous_page, cursors.has_next_page);
-
-        for edge in cursors.edges {
-            let input = TransactionInput::from(
-                self.native.inputs[*edge.cursor].clone(),
-                self.scope.clone(),
-            );
-            conn.edges
-                .push(Edge::new(edge.cursor.encode_cursor(), input));
-        }
-
-        Ok(conn)
-    }
-
-    /// The transaction commands, executed sequentially.
-    async fn commands(
-        &self,
-        ctx: &Context<'_>,
-        first: Option<u64>,
-        after: Option<CCommand>,
-        last: Option<u64>,
-        before: Option<CCommand>,
-    ) -> Result<Connection<String, Command>, RpcError> {
-        let pagination = ctx.data::<PaginationConfig>()?;
-        let limits = pagination.limits("ProgrammableSystemTransaction", "commands");
-        let page = Page::from_params(limits, first, after, last, before)?;
-
-        let cursors = page.paginate_indices(self.native.commands.len());
-        let mut conn = Connection::new(cursors.has_previous_page, cursors.has_next_page);
-
-        for edge in cursors.edges {
-            let command = Command::from(
-                self.scope.clone(),
-                self.native.commands[*edge.cursor].clone(),
-            );
-
-            conn.edges
-                .push(Edge::new(edge.cursor.encode_cursor(), command));
-        }
-
-        Ok(conn)
-    }
+    #[graphql(flatten)]
+    pub(crate) inner: ProgrammableTransaction,
 }

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -1610,15 +1610,18 @@ type PerEpochConfig {
 	object: Object
 }
 
+"""
+ProgrammableSystemTransaction is identical to ProgrammableTransaction, but GraphQL does not allow multiple variants with the same type.
+"""
 type ProgrammableSystemTransaction {
-	"""
-	Input objects or primitive values.
-	"""
-	inputs(first: Int, after: String, last: Int, before: String): TransactionInputConnection!
 	"""
 	The transaction commands, executed sequentially.
 	"""
 	commands(first: Int, after: String, last: Int, before: String): CommandConnection!
+	"""
+	Input objects or primitive values.
+	"""
+	inputs(first: Int, after: String, last: Int, before: String): TransactionInputConnection!
 }
 
 type ProgrammableTransaction {

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -1610,15 +1610,18 @@ type PerEpochConfig {
 	object: Object
 }
 
+"""
+ProgrammableSystemTransaction is identical to ProgrammableTransaction, but GraphQL does not allow multiple variants with the same type.
+"""
 type ProgrammableSystemTransaction {
-	"""
-	Input objects or primitive values.
-	"""
-	inputs(first: Int, after: String, last: Int, before: String): TransactionInputConnection!
 	"""
 	The transaction commands, executed sequentially.
 	"""
 	commands(first: Int, after: String, last: Int, before: String): CommandConnection!
+	"""
+	Input objects or primitive values.
+	"""
+	inputs(first: Int, after: String, last: Int, before: String): TransactionInputConnection!
 }
 
 type ProgrammableTransaction {

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -1606,15 +1606,18 @@ type PerEpochConfig {
 	object: Object
 }
 
+"""
+ProgrammableSystemTransaction is identical to ProgrammableTransaction, but GraphQL does not allow multiple variants with the same type.
+"""
 type ProgrammableSystemTransaction {
-	"""
-	Input objects or primitive values.
-	"""
-	inputs(first: Int, after: String, last: Int, before: String): TransactionInputConnection!
 	"""
 	The transaction commands, executed sequentially.
 	"""
 	commands(first: Int, after: String, last: Int, before: String): CommandConnection!
+	"""
+	Input objects or primitive values.
+	"""
+	inputs(first: Int, after: String, last: Int, before: String): TransactionInputConnection!
 }
 
 type ProgrammableTransaction {


### PR DESCRIPTION
## Description 

Adding the new ProgrammableSystem within TransactionKind union

The new schema is on par with old GraphQL schema:
https://github.com/MystenLabs/sui/blob/b8d28ddbd06253373d2c02d001b3ba6c1ce8ea4f/crates/sui-graphql-rpc/schema.graphql#L3106-L3115


## Test plan 

How did you test the new or updated feature?

ci

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
