### PR TITLE
graphql-alt: Add MovePackage.moduleBcs

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/packages/module_bcs.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/packages/module_bcs.move
@@ -1,0 +1,16 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --addresses P1=0x0 --simulator
+
+//# publish --upgradeable --sender A
+module P1::M { }
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  package(address: "@{P1}") {
+    moduleBcs
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/packages/module_bcs.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/packages/module_bcs.snap
@@ -1,0 +1,27 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-7:
+//# publish --upgradeable --sender A
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 4810800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 9:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 11-16:
+//# run-graphql
+Response: {
+  "data": {
+    "package": {
+      "moduleBcs": "AQFNN6Ec6wsGAAAAAwEAAgcCAggEIAAAAU1vbqFT1veuYKGtHi/VigC94HiimlBidoR8hPzC+wfJMAA="
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -921,6 +921,11 @@ type MovePackage implements IAddressable & IObject {
 	"""
 	digest: String!
 	"""
+	BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
+	name, followed by module bytes), in alphabetic order by module name.
+	"""
+	moduleBcs: Base64
+	"""
 	Fetch the package as an object with the same ID, at a different version, root version bound, or checkpoint.
 	
 	If no additional bound is provided, the latest version of this object is fetched at the latest checkpoint.
@@ -968,11 +973,6 @@ type MovePackage implements IAddressable & IObject {
 	A table identifying which versions of a package introduced each of its types.
 	"""
 	typeOrigins: [TypeOrigin!]
-	"""
-	BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
-	name, followed by module bytes), in alphabetic order by module name.
-	"""
-	moduleBcs: Base64
 }
 
 type MovePackageConnection {

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -968,6 +968,11 @@ type MovePackage implements IAddressable & IObject {
 	A table identifying which versions of a package introduced each of its types.
 	"""
 	typeOrigins: [TypeOrigin!]
+	"""
+	BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
+	name, followed by module bytes), in alphabetic order by module name.
+	"""
+	moduleBcs: Base64
 }
 
 type MovePackageConnection {

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
@@ -120,6 +120,13 @@ impl MovePackage {
         ObjectImpl::from(&self.super_).digest()
     }
 
+    /// BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
+    /// name, followed by module bytes), in alphabetic order by module name.
+    async fn module_bcs(&self) -> Result<Option<Base64>, RpcError> {
+        let bytes = bcs::to_bytes(self.contents.serialized_module_map())?;
+        Ok(Some(bytes.into()))
+    }
+
     /// Fetch the package as an object with the same ID, at a different version, root version bound, or checkpoint.
     ///
     /// If no additional bound is provided, the latest version of this object is fetched at the latest checkpoint.
@@ -301,13 +308,6 @@ impl MovePackage {
             .collect();
 
         Some(type_origins)
-    }
-
-    /// BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
-    /// name, followed by module bytes), in alphabetic order by module name.
-    async fn module_bcs(&self) -> Result<Option<Base64>, RpcError> {
-        let bytes = bcs::to_bytes(self.contents.serialized_module_map())?;
-        Ok(Some(bytes.into()))
     }
 }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
@@ -302,6 +302,13 @@ impl MovePackage {
 
         Some(type_origins)
     }
+
+    /// BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
+    /// name, followed by module bytes), in alphabetic order by module name.
+    async fn module_bcs(&self) -> Result<Option<Base64>, RpcError> {
+        let bytes = bcs::to_bytes(self.contents.serialized_module_map())?;
+        Ok(Some(bytes.into()))
+    }
 }
 
 impl MovePackage {

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -925,6 +925,11 @@ type MovePackage implements IAddressable & IObject {
 	"""
 	digest: String!
 	"""
+	BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
+	name, followed by module bytes), in alphabetic order by module name.
+	"""
+	moduleBcs: Base64
+	"""
 	Fetch the package as an object with the same ID, at a different version, root version bound, or checkpoint.
 	
 	If no additional bound is provided, the latest version of this object is fetched at the latest checkpoint.
@@ -972,11 +977,6 @@ type MovePackage implements IAddressable & IObject {
 	A table identifying which versions of a package introduced each of its types.
 	"""
 	typeOrigins: [TypeOrigin!]
-	"""
-	BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
-	name, followed by module bytes), in alphabetic order by module name.
-	"""
-	moduleBcs: Base64
 }
 
 type MovePackageConnection {

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -972,6 +972,11 @@ type MovePackage implements IAddressable & IObject {
 	A table identifying which versions of a package introduced each of its types.
 	"""
 	typeOrigins: [TypeOrigin!]
+	"""
+	BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
+	name, followed by module bytes), in alphabetic order by module name.
+	"""
+	moduleBcs: Base64
 }
 
 type MovePackageConnection {

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -925,6 +925,11 @@ type MovePackage implements IAddressable & IObject {
 	"""
 	digest: String!
 	"""
+	BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
+	name, followed by module bytes), in alphabetic order by module name.
+	"""
+	moduleBcs: Base64
+	"""
 	Fetch the package as an object with the same ID, at a different version, root version bound, or checkpoint.
 	
 	If no additional bound is provided, the latest version of this object is fetched at the latest checkpoint.
@@ -972,11 +977,6 @@ type MovePackage implements IAddressable & IObject {
 	A table identifying which versions of a package introduced each of its types.
 	"""
 	typeOrigins: [TypeOrigin!]
-	"""
-	BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
-	name, followed by module bytes), in alphabetic order by module name.
-	"""
-	moduleBcs: Base64
 }
 
 type MovePackageConnection {

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -972,6 +972,11 @@ type MovePackage implements IAddressable & IObject {
 	A table identifying which versions of a package introduced each of its types.
 	"""
 	typeOrigins: [TypeOrigin!]
+	"""
+	BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
+	name, followed by module bytes), in alphabetic order by module name.
+	"""
+	moduleBcs: Base64
 }
 
 type MovePackageConnection {

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -921,6 +921,11 @@ type MovePackage implements IAddressable & IObject {
 	"""
 	digest: String!
 	"""
+	BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
+	name, followed by module bytes), in alphabetic order by module name.
+	"""
+	moduleBcs: Base64
+	"""
 	Fetch the package as an object with the same ID, at a different version, root version bound, or checkpoint.
 	
 	If no additional bound is provided, the latest version of this object is fetched at the latest checkpoint.
@@ -968,11 +973,6 @@ type MovePackage implements IAddressable & IObject {
 	A table identifying which versions of a package introduced each of its types.
 	"""
 	typeOrigins: [TypeOrigin!]
-	"""
-	BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
-	name, followed by module bytes), in alphabetic order by module name.
-	"""
-	moduleBcs: Base64
 }
 
 type MovePackageConnection {

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -968,6 +968,11 @@ type MovePackage implements IAddressable & IObject {
 	A table identifying which versions of a package introduced each of its types.
 	"""
 	typeOrigins: [TypeOrigin!]
+	"""
+	BCS representation of the package's modules.  Modules appear as a sequence of pairs (module
+	name, followed by module bytes), in alphabetic order by module name.
+	"""
+	moduleBcs: Base64
 }
 
 type MovePackageConnection {


### PR DESCRIPTION
## Description 

Implements `MovePackage.moduleBcs` based on 
https://github.com/MystenLabs/sui/blob/4275c1a55988d28b638be8720aebdf1e7da3b06b/crates/sui-graphql-rpc/src/types/move_package.rs#L564-L573

## Test plan 

Added new `moduleBcs` snapshot test.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
