### PR TITLE
[cli] Add `analyze-trace` command to `sui client` and add `gas-profile` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13104,6 +13104,7 @@ dependencies = [
  "move-ir-types",
  "move-package",
  "move-symbol-pool",
+ "move-trace-format",
  "move-vm-config",
  "move-vm-profiler",
  "msim",

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -72,6 +72,7 @@ sui-protocol-config.workspace = true
 shared-crypto.workspace = true
 sui-transaction-builder.workspace = true
 move-binary-format.workspace = true
+move-trace-format.workspace = true
 move-bytecode-source-map.workspace = true
 mysten-common.workspace = true
 test-cluster.workspace = true

--- a/crates/sui/src/lib.rs
+++ b/crates/sui/src/lib.rs
@@ -17,3 +17,5 @@ pub mod upgrade_compatibility;
 pub mod validator_commands;
 mod verifier_meter;
 pub mod zklogin_commands_util;
+pub mod trace_analysis_commands;
+

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -7,6 +7,7 @@ use crate::client_commands::{
 use crate::fire_drill::{run_fire_drill, FireDrill};
 use crate::genesis_ceremony::{run, Ceremony};
 use crate::keytool::KeyToolCommand;
+use crate::trace_analysis_commands::AnalyzeTraceCommand;
 use crate::validator_commands::SuiValidatorCommand;
 use anyhow::{anyhow, bail, ensure, Context};
 use clap::*;
@@ -364,6 +365,21 @@ pub enum SuiCommand {
     /// Invoke Sui's move-analyzer via CLI
     #[clap(name = "analyzer", hide = true)]
     Analyzer,
+
+    /// Analyze and/or transform a trace file
+    #[clap(name = "analyze-trace")]
+    AnalyzeTrace {
+        /// The path to the trace file to analyze
+        #[arg(long, short)]
+        path: PathBuf,
+
+        /// The output directory for any generated artifacts. Defaults `<cur_dir>`
+        #[arg(long, short)]
+        output_dir: Option<PathBuf>,
+
+        #[clap(subcommand)]
+        command: AnalyzeTraceCommand,
+    },
 }
 
 impl SuiCommand {
@@ -753,6 +769,11 @@ impl SuiCommand {
                 analyzer::run(implicit_deps(latest_system_packages()));
                 Ok(())
             }
+            SuiCommand::AnalyzeTrace {
+                path,
+                output_dir,
+                command,
+            } => command.execute(path, output_dir).await,
         }
     }
 }

--- a/crates/sui/src/trace_analysis_commands.rs
+++ b/crates/sui/src/trace_analysis_commands.rs
@@ -1,0 +1,55 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::anyhow;
+use clap::*;
+use move_trace_format::format::MoveTraceReader;
+use move_vm_profiler::trace_converter::{GasProfiler, ProfilerConfig};
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[clap(rename_all = "kebab-case")]
+pub enum AnalyzeTraceCommand {
+    /// Generate a gas profile for the trace file compatible with the `speedscope.app` profiler.
+    GasProfile {
+        /// Whether function names should be fully qualified with their module and package
+        /// addresses or if only the function name should be used.
+        #[arg(long, short)]
+        use_long_function_name: bool,
+    },
+}
+
+impl AnalyzeTraceCommand {
+    pub async fn execute(
+        self,
+        path: PathBuf,
+        output_dir: Option<PathBuf>,
+    ) -> Result<(), anyhow::Error> {
+        let trace_file = std::fs::File::open(&path).map_err(|e| {
+            anyhow!(
+                "Failed to open trace file at {}: {e}",
+                path.to_string_lossy()
+            )
+        })?;
+        let trace_reader = MoveTraceReader::new(trace_file)
+            .map_err(|e| anyhow!("Failed to read trace file: {e}"))?;
+
+        match self {
+            AnalyzeTraceCommand::GasProfile {
+                use_long_function_name,
+            } => {
+                let mut profiler = GasProfiler::init(
+                    ProfilerConfig {
+                        output_dir,
+                        use_long_function_name,
+                    },
+                    path.to_string_lossy().to_string(),
+                );
+                profiler.generate_from_trace(trace_reader);
+                profiler.save_profile();
+            }
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Description 

This adds tha `analyze-trace` command to `sui client` that is meant to house the different trace analysises and adds a `gas-profile` analysis as the first such analysis.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [X] CLI: Added a new `sui client analyze-trace` command that holds different analyses over Move traces, and added the first analysis -- `gas-profile` which outputs a gas profile that can be loaded into flamegraph viewers (e.g., `speedscope.app`).
- [ ] Rust SDK:
