### PR TITLE
[sui-indexer-alt-framework] Address `first_checkpoint` + pipeline with no watermark row commit stall

### DIFF
--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -449,6 +449,94 @@ pub mod testing;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pipeline::concurrent::ConcurrentConfig;
+    use crate::store::CommitterWatermark;
+    use crate::testing::mock_store::MockStore;
+    use crate::FieldCount;
+    use std::sync::Arc;
+    use tokio_util::sync::CancellationToken;
+
+    impl Processor for MockHandler {
+        const NAME: &'static str = "test_processor";
+        type Value = MockValue;
+        fn process(
+            &self,
+            _checkpoint: &Arc<sui_types::full_checkpoint_content::CheckpointData>,
+        ) -> anyhow::Result<Vec<Self::Value>> {
+            Ok(vec![MockValue(1)])
+        }
+    }
+
+    #[allow(dead_code)]
+    #[derive(Clone, FieldCount)]
+    struct MockValue(u64);
+
+    struct MockHandler;
+
+    #[async_trait::async_trait]
+    impl crate::pipeline::concurrent::Handler for MockHandler {
+        type Store = MockStore;
+
+        async fn commit<'a>(
+            _values: &[Self::Value],
+            _conn: &mut <Self::Store as Store>::Connection<'a>,
+        ) -> anyhow::Result<usize> {
+            Ok(1)
+        }
+    }
+
+    #[tokio::test]
+    async fn test_first_checkpoint_from_watermark() {
+        let cancel = CancellationToken::new();
+        let registry = Registry::new();
+
+        let store = MockStore::default();
+        let mut conn = store.connect().await.unwrap();
+        conn.set_committer_watermark(
+            "test_processor",
+            CommitterWatermark {
+                epoch_hi_inclusive: 1,
+                checkpoint_hi_inclusive: 100,
+                tx_hi: 1000,
+                timestamp_ms_hi_inclusive: 1000000,
+            },
+        )
+        .await
+        .unwrap();
+
+        let indexer_args = IndexerArgs {
+            first_checkpoint: Some(50),
+            last_checkpoint: None,
+            pipeline: vec![],
+            skip_watermark: false,
+        };
+        let temp_dir = tempfile::tempdir().unwrap();
+        let client_args = ClientArgs {
+            local_ingestion_path: Some(temp_dir.path().to_owned()),
+            ..Default::default()
+        };
+
+        let ingestion_config = IngestionConfig::default();
+
+        let mut indexer = Indexer::new(
+            store,
+            indexer_args,
+            client_args,
+            ingestion_config,
+            None,
+            &registry,
+            cancel,
+        )
+        .await
+        .unwrap();
+
+        indexer
+            .concurrent_pipeline::<MockHandler>(MockHandler, ConcurrentConfig::default())
+            .await
+            .unwrap();
+
+        assert_eq!(indexer.first_checkpoint_from_watermark, 101);
+    }
 
     #[test]
     fn test_initial_watermark_from_first_checkpoint() {

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -220,9 +220,12 @@ impl<S: Store> Indexer<S> {
             self.check_first_checkpoint_consistency::<H>(&watermark)?;
         }
 
+        let initial_watermark =
+            initial_watermark_from_first_checkpoint(watermark, self.first_checkpoint);
+
         self.handles.push(concurrent::pipeline::<H>(
             handler,
-            watermark,
+            initial_watermark,
             config,
             self.skip_watermark,
             self.store.clone(),
@@ -256,10 +259,13 @@ impl<S: Store> Indexer<S> {
         Ok(())
     }
 
-    /// Start ingesting checkpoints. Ingestion either starts from the configured
-    /// `first_checkpoint`, or it is calculated based on the watermarks of all active pipelines.
-    /// Ingestion will stop after consuming the configured `last_checkpoint`, if one is provided,
-    /// or will continue until it tracks the tip of the network.
+    /// Start ingesting checkpoints. Ingestion either starts from the
+    /// `first_checkpoint_from_watermark` calculated based on the smallest watermark of all active
+    /// pipelines or `first_checkpoint` if configured. Individual pipelines will start processing
+    /// and committing once the ingestion service has caught up to their respective watermarks.
+    ///
+    /// Ingestion will stop after consuming the configured `last_checkpoint`, if one is provided, or
+    /// will continue until it tracks the tip of the network.
     pub async fn run(mut self) -> Result<JoinHandle<()>> {
         if let Some(enabled_pipelines) = self.enabled_pipelines {
             ensure!(
@@ -298,10 +304,14 @@ impl<S: Store> Indexer<S> {
         }))
     }
 
-    /// Update the indexer's first checkpoint based on the watermark for the pipeline by adding for
-    /// handler `H` (as long as it's enabled). Returns `Ok(None)` if the pipeline is disabled,
-    /// `Ok(Some(None))` if the pipeline is enabled but its watermark is not found, and
-    /// `Ok(Some(Some(watermark)))` if the pipeline is enabled and the watermark is found.
+    /// Add a pipeline to the indexer and retrieve its watermark from the database to update the
+    /// indexer's `first_checkpoint_from_watermark`. If the watermark row for a pipeline does not
+    /// exist, this value is 0.
+    ///
+    /// Returns:
+    /// - `Ok(None)` if the pipeline is disabled (filtered out)
+    /// - `Ok(Some(None))` if the pipeline is enabled but no watermark exists in the database
+    /// - `Ok(Some(Some(watermark)))` if the pipeline is enabled and a watermark exists
     async fn add_pipeline<P: Processor + 'static>(
         &mut self,
     ) -> Result<Option<Option<CommitterWatermark>>> {
@@ -360,7 +370,7 @@ impl<T: TransactionalStore> Indexer<T> {
     where
         H: Handler<Store = T> + Send + Sync + 'static,
     {
-        let Some(watermark) = self.add_pipeline::<H>().await? else {
+        let Some(mut watermark) = self.add_pipeline::<H>().await? else {
             return Ok(());
         };
 
@@ -369,6 +379,19 @@ impl<T: TransactionalStore> Indexer<T> {
                 pipeline = H::NAME,
                 "--skip-watermarks enabled and ignored for sequential pipeline"
             );
+        }
+
+        // For sequential pipelines, if watermark already exists, ignore first_checkpoint
+        if let Some(first_checkpoint) = self.first_checkpoint {
+            if let Some(existing_watermark) = &watermark {
+                warn!(
+            "Pipeline {} has an existing watermark row, ignoring --first-checkpoint {} and resuming from committer_hi {}",
+            H::NAME, first_checkpoint, existing_watermark.checkpoint_hi_inclusive
+        );
+            } else {
+                watermark =
+                    initial_watermark_from_first_checkpoint(watermark, self.first_checkpoint);
+            }
         }
 
         // For a sequential pipeline, data must be written in the order of checkpoints.
@@ -392,5 +415,58 @@ impl<T: TransactionalStore> Indexer<T> {
     }
 }
 
+/// Determine the correct starting watermark for a pipeline. This function assumes the
+/// `first_checkpoint` is valid, and will return a synthetic watermark with its
+/// `checkpoint_hi_inclusive` set to the `first_checkpoint` - 1. Otherwise, this function returns
+/// the original pipeline watermark. If both values are `None`, this function returns `None`, which
+/// indicates to the pipeline components that they should start indexing from 0.
+fn initial_watermark_from_first_checkpoint(
+    pipeline_watermark: Option<CommitterWatermark>,
+    first_checkpoint: Option<u64>,
+) -> Option<CommitterWatermark> {
+    match (pipeline_watermark, first_checkpoint) {
+        (_, Some(first_checkpoint)) => {
+            // Special case - the pipelines assume that an extant watermark represents the last
+            // committed checkpoint. Thus, if trying to start from 0, we do not create a synthetic
+            // watermark.
+            if first_checkpoint == 0 {
+                None
+            } else {
+                Some(CommitterWatermark {
+                    checkpoint_hi_inclusive: first_checkpoint.saturating_sub(1),
+                    ..Default::default()
+                })
+            }
+        }
+        (Some(watermark), None) => Some(watermark),
+        (None, None) => None,
+    }
+}
+
 #[cfg(test)]
 pub mod testing;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_initial_watermark_from_first_checkpoint() {
+        // Test case 1: No watermark + first_checkpoint provided
+        let result = initial_watermark_from_first_checkpoint(None, Some(100));
+        assert_eq!(result.unwrap().checkpoint_hi_inclusive, 99);
+
+        // Test case 2: Existing watermark + no first_checkpoint
+        let existing = CommitterWatermark::new_for_testing(50);
+        let result = initial_watermark_from_first_checkpoint(Some(existing), None);
+        assert_eq!(result.unwrap().checkpoint_hi_inclusive, 50);
+
+        // Test case 3: No watermark + no first_checkpoint
+        let result = initial_watermark_from_first_checkpoint(None, None);
+        assert!(result.is_none());
+
+        // Test case 4: Edge case - first_checkpoint = 0
+        let result = initial_watermark_from_first_checkpoint(None, Some(0));
+        assert!(result.is_none());
+    }
+}

--- a/crates/sui-indexer-alt-framework/src/mocks/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/mocks/mod.rs
@@ -1,4 +1,4 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod mock_store;
+pub mod store;

--- a/crates/sui-indexer-alt-framework/src/mocks/store.rs
+++ b/crates/sui-indexer-alt-framework/src/mocks/store.rs
@@ -90,7 +90,7 @@ impl Connection for MockConnection<'_> {
         &mut self,
         _pipeline: &'static str,
     ) -> Result<Option<CommitterWatermark>, anyhow::Error> {
-        let watermark = self.0.get_watermark();
+        let watermark = self.0.watermark();
         Ok(watermark.map(|w| CommitterWatermark {
             epoch_hi_inclusive: w.epoch_hi_inclusive,
             checkpoint_hi_inclusive: w.checkpoint_hi_inclusive,
@@ -103,7 +103,7 @@ impl Connection for MockConnection<'_> {
         &mut self,
         _pipeline: &'static str,
     ) -> Result<Option<ReaderWatermark>, anyhow::Error> {
-        let watermark = self.0.get_watermark();
+        let watermark = self.0.watermark();
         Ok(watermark.map(|w| ReaderWatermark {
             checkpoint_hi_inclusive: w.checkpoint_hi_inclusive,
             reader_lo: w.reader_lo,
@@ -115,7 +115,7 @@ impl Connection for MockConnection<'_> {
         _pipeline: &'static str,
         delay: Duration,
     ) -> Result<Option<PrunerWatermark>, anyhow::Error> {
-        let watermark = self.0.get_watermark();
+        let watermark = self.0.watermark();
         Ok(watermark.map(|w| {
             let elapsed_ms = w.pruner_timestamp as i64
                 - SystemTime::now()
@@ -365,8 +365,8 @@ impl MockStore {
         self.sequential_checkpoint_data.lock().unwrap().clone()
     }
 
-    /// Helper to get the current watermark state for testing
-    pub fn get_watermark(&self) -> Option<MockWatermark> {
+    /// Helper to get the current watermark state for testing.
+    pub fn watermark(&self) -> Option<MockWatermark> {
         self.watermark.lock().unwrap().clone()
     }
 
@@ -455,7 +455,7 @@ impl MockStore {
     ) -> MockWatermark {
         let start = std::time::Instant::now();
         while start.elapsed() < timeout_duration {
-            if let Some(watermark) = self.get_watermark() {
+            if let Some(watermark) = self.watermark() {
                 if watermark.checkpoint_hi_inclusive >= checkpoint {
                     return watermark;
                 }

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/commit_watermark.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/commit_watermark.rs
@@ -44,7 +44,7 @@ use super::Handler;
 /// the watermark cannot be progressed. If `skip_watermark` is set, the task will shutdown
 /// immediately.
 pub(super) fn commit_watermark<H: Handler + 'static>(
-    initial_watermark: Option<CommitterWatermark>,
+    mut next_checkpoint: u64,
     config: CommitterConfig,
     skip_watermark: bool,
     mut rx: mpsc::Receiver<Vec<WatermarkPart>>,
@@ -67,11 +67,11 @@ pub(super) fn commit_watermark<H: Handler + 'static>(
         // watermark as much as possible without going over any holes in the sequence of
         // checkpoints (entirely missing watermarks, or incomplete watermarks).
         let mut precommitted: BTreeMap<u64, WatermarkPart> = BTreeMap::new();
-        let (mut watermark, mut next_checkpoint) = if let Some(watermark) = initial_watermark {
-            let next = watermark.checkpoint_hi_inclusive + 1;
-            (watermark, next)
-        } else {
-            (CommitterWatermark::default(), 0)
+        let mut watermark = CommitterWatermark {
+            checkpoint_hi_inclusive: next_checkpoint,
+            // This initial synthetic checkpoint is overwritten by a real watermark from a processed
+            // checkpoint.
+            ..Default::default()
         };
 
         // The watermark task will periodically output a log message at a higher log level to
@@ -275,9 +275,9 @@ mod tests {
 
     use crate::{
         metrics::IndexerMetrics,
+        mocks::store::*,
         pipeline::{CommitterConfig, Processor, WatermarkPart},
         store::CommitterWatermark,
-        testing::mock_store::*,
         FieldCount,
     };
 
@@ -318,7 +318,7 @@ mod tests {
 
     fn setup_test<H: Handler<Store = MockStore> + 'static>(
         config: CommitterConfig,
-        initial_watermark: Option<CommitterWatermark>,
+        next_checkpoint: u64,
         store: MockStore,
     ) -> TestSetup {
         let (watermark_tx, watermark_rx) = mpsc::channel(100);
@@ -329,7 +329,7 @@ mod tests {
         let cancel_clone = cancel.clone();
 
         let commit_watermark_handle = commit_watermark::<H>(
-            initial_watermark,
+            next_checkpoint,
             config,
             false,
             watermark_rx,
@@ -360,11 +360,7 @@ mod tests {
     #[tokio::test]
     async fn test_basic_watermark_progression() {
         let config = CommitterConfig::default();
-        let initial_watermark = Some(CommitterWatermark {
-            checkpoint_hi_inclusive: 0,
-            ..Default::default()
-        });
-        let setup = setup_test::<DataPipeline>(config, initial_watermark, MockStore::default());
+        let setup = setup_test::<DataPipeline>(config, 1, MockStore::default());
 
         // Send watermark parts in order
         for cp in 1..4 {
@@ -387,11 +383,7 @@ mod tests {
     #[tokio::test]
     async fn test_out_of_order_watermarks() {
         let config = CommitterConfig::default();
-        let initial_watermark = Some(CommitterWatermark {
-            checkpoint_hi_inclusive: 0,
-            ..Default::default()
-        });
-        let setup = setup_test::<DataPipeline>(config, initial_watermark, MockStore::default());
+        let setup = setup_test::<DataPipeline>(config, 1, MockStore::default());
 
         // Send watermark parts out of order
         let parts = vec![
@@ -433,12 +425,8 @@ mod tests {
             watermark_interval_ms: 1_000, // Long polling interval to test connection retry
             ..Default::default()
         };
-        let initial_watermark = Some(CommitterWatermark {
-            checkpoint_hi_inclusive: 0,
-            ..Default::default()
-        });
         let store = MockStore::default().with_connection_failures(1);
-        let setup = setup_test::<DataPipeline>(config, initial_watermark, store);
+        let setup = setup_test::<DataPipeline>(config, 1, store);
 
         // Send watermark part
         let part = create_watermark_part_for_checkpoint(1);
@@ -448,8 +436,8 @@ mod tests {
         tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
 
         // Verify watermark hasn't progressed
-        let watermark = setup.store.get_watermark().unwrap();
-        assert_eq!(watermark.checkpoint_hi_inclusive, 0);
+        let watermark = setup.store.get_watermark();
+        assert!(watermark.is_none());
 
         // Wait for next polling and processing
         tokio::time::sleep(tokio::time::Duration::from_millis(1_200)).await;
@@ -469,11 +457,7 @@ mod tests {
             watermark_interval_ms: 1_000, // Long polling interval to test adding complete part
             ..Default::default()
         };
-        let initial_watermark = Some(CommitterWatermark {
-            checkpoint_hi_inclusive: 0,
-            ..Default::default()
-        });
-        let setup = setup_test::<DataPipeline>(config, initial_watermark, MockStore::default());
+        let setup = setup_test::<DataPipeline>(config, 1, MockStore::default());
 
         // Send the first incomplete watermark part
         let part = WatermarkPart {
@@ -490,8 +474,8 @@ mod tests {
         tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
 
         // Verify watermark hasn't progressed
-        let watermark = setup.store.get_watermark().unwrap();
-        assert_eq!(watermark.checkpoint_hi_inclusive, 0);
+        let watermark = setup.store.get_watermark();
+        assert!(watermark.is_none());
 
         // Send the other two parts to complete the watermark
         setup
@@ -515,8 +499,7 @@ mod tests {
     #[tokio::test]
     async fn test_no_initial_watermark() {
         let config = CommitterConfig::default();
-        let initial_watermark = None;
-        let setup = setup_test::<DataPipeline>(config, initial_watermark, MockStore::default());
+        let setup = setup_test::<DataPipeline>(config, 0, MockStore::default());
 
         // Send the checkpoint 1 watermark
         setup
@@ -529,8 +512,8 @@ mod tests {
         tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
 
         // Verify watermark hasn't progressed
-        let watermark = setup.store.get_watermark().unwrap();
-        assert_eq!(watermark.checkpoint_hi_inclusive, 0);
+        let watermark = setup.store.get_watermark();
+        assert!(watermark.is_none());
 
         // Send the checkpoint 0 watermark to fill the gap.
         setup
@@ -556,12 +539,8 @@ mod tests {
     #[tokio::test]
     async fn test_initial_watermark() {
         let config = CommitterConfig::default();
-        let initial_watermark = Some(CommitterWatermark {
-            checkpoint_hi_inclusive: 4,
-            ..Default::default()
-        });
         let mock_store = MockStore::default();
-        let setup = setup_test::<DataPipeline>(config, initial_watermark, mock_store);
+        let setup = setup_test::<DataPipeline>(config, 5, mock_store);
 
         // Send checkpoint 6 first.
         setup

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/committer.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/committer.rs
@@ -232,12 +232,12 @@ mod tests {
 
     use crate::{
         metrics::IndexerMetrics,
+        mocks::store::*,
         pipeline::{
             concurrent::{BatchedRows, Handler},
             Processor, WatermarkPart,
         },
         store::CommitterWatermark,
-        testing::mock_store::*,
         FieldCount,
     };
 

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
@@ -604,7 +604,7 @@ mod tests {
         tokio::time::sleep(Duration::from_secs(1)).await;
 
         // Watermark should only progress to 1 (can't progress past the gap)
-        let watermark = setup.store.get_watermark();
+        let watermark = setup.store.get_watermark().unwrap();
         assert_eq!(watermark.checkpoint_hi_inclusive, 1);
 
         // Now send the missing checkpoint 2
@@ -880,7 +880,7 @@ mod tests {
         tokio::time::sleep(Duration::from_secs(2)).await;
 
         // Verify that reader watermark was eventually updated despite failures
-        let watermark = setup.store.get_watermark();
+        let watermark = setup.store.get_watermark().unwrap();
         assert_eq!(watermark.reader_lo, 3);
 
         setup.shutdown().await;

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
@@ -597,7 +597,7 @@ mod tests {
         tokio::time::sleep(Duration::from_secs(1)).await;
 
         // Watermark should only progress to 1 (can't progress past the gap)
-        let watermark = setup.store.get_watermark().unwrap();
+        let watermark = setup.store.watermark().unwrap();
         assert_eq!(watermark.checkpoint_hi_inclusive, 1);
 
         // Now send the missing checkpoint 2
@@ -873,7 +873,7 @@ mod tests {
         tokio::time::sleep(Duration::from_secs(2)).await;
 
         // Verify that reader watermark was eventually updated despite failures
-        let watermark = setup.store.get_watermark().unwrap();
+        let watermark = setup.store.watermark().unwrap();
         assert_eq!(watermark.reader_lo, 3);
 
         setup.shutdown().await;

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/mod.rs
@@ -9,9 +9,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::{
-    metrics::IndexerMetrics,
-    store::{CommitterWatermark, Store},
-    types::full_checkpoint_content::CheckpointData,
+    metrics::IndexerMetrics, store::Store, types::full_checkpoint_content::CheckpointData,
     FieldCount,
 };
 
@@ -187,7 +185,7 @@ impl Default for PrunerConfig {
 /// reports an issue.
 pub(crate) fn pipeline<H: Handler + Send + Sync + 'static>(
     handler: H,
-    initial_commit_watermark: Option<CommitterWatermark>,
+    next_checkpoint: u64,
     config: ConcurrentConfig,
     skip_watermark: bool,
     store: H::Store,
@@ -246,7 +244,7 @@ pub(crate) fn pipeline<H: Handler + Send + Sync + 'static>(
     );
 
     let commit_watermark = commit_watermark::<H>(
-        initial_commit_watermark,
+        next_checkpoint,
         committer_config,
         skip_watermark,
         watermark_rx,
@@ -297,9 +295,8 @@ mod tests {
 
     use crate::{
         metrics::IndexerMetrics,
+        mocks::store::{MockConnection, MockStore},
         pipeline::Processor,
-        store::CommitterWatermark,
-        testing::mock_store::MockStore,
         types::{
             full_checkpoint_content::CheckpointData,
             test_checkpoint_data_builder::TestCheckpointDataBuilder,
@@ -351,7 +348,7 @@ mod tests {
 
         async fn commit<'a>(
             values: &[Self::Value],
-            conn: &mut crate::testing::mock_store::MockConnection<'a>,
+            conn: &mut MockConnection<'a>,
         ) -> anyhow::Result<usize> {
             // Group values by checkpoint
             let mut grouped: std::collections::HashMap<u64, Vec<u64>> =
@@ -371,7 +368,7 @@ mod tests {
             &self,
             from: u64,
             to_exclusive: u64,
-            conn: &mut crate::testing::mock_store::MockConnection<'a>,
+            conn: &mut MockConnection<'a>,
         ) -> anyhow::Result<usize> {
             conn.0.prune_data(from, to_exclusive)
         }
@@ -385,11 +382,7 @@ mod tests {
     }
 
     impl TestSetup {
-        async fn new(
-            config: ConcurrentConfig,
-            store: MockStore,
-            initial_watermark: Option<CommitterWatermark>,
-        ) -> Self {
+        async fn new(config: ConcurrentConfig, store: MockStore, next_checkpoint: u64) -> Self {
             let (checkpoint_tx, checkpoint_rx) = mpsc::channel(TEST_CHECKPOINT_BUFFER_SIZE);
             let metrics = IndexerMetrics::new(None, &Registry::default());
             let cancel = CancellationToken::new();
@@ -397,7 +390,7 @@ mod tests {
             let skip_watermark = false;
             let pipeline_handle = pipeline(
                 DataPipeline,
-                initial_watermark,
+                next_checkpoint,
                 config,
                 skip_watermark,
                 store.clone(),
@@ -463,7 +456,7 @@ mod tests {
             ..Default::default()
         };
         let store = MockStore::default();
-        let setup = TestSetup::new(config, store, None).await;
+        let setup = TestSetup::new(config, store, 0).await;
 
         // Send initial checkpoints
         for i in 0..3 {
@@ -522,7 +515,7 @@ mod tests {
             ..Default::default()
         };
         let store = MockStore::default();
-        let setup = TestSetup::new(config, store, None).await;
+        let setup = TestSetup::new(config, store, 0).await;
 
         // Send several checkpoints
         for i in 0..10 {
@@ -560,7 +553,7 @@ mod tests {
     async fn test_out_of_order_processing() {
         let config = ConcurrentConfig::default();
         let store = MockStore::default();
-        let setup = TestSetup::new(config, store, None).await;
+        let setup = TestSetup::new(config, store, 0).await;
 
         // Send checkpoints out of order
         let checkpoints = vec![2, 0, 4, 1, 3];
@@ -590,7 +583,7 @@ mod tests {
     async fn test_watermark_progression_with_gaps() {
         let config = ConcurrentConfig::default();
         let store = MockStore::default();
-        let setup = TestSetup::new(config, store, None).await;
+        let setup = TestSetup::new(config, store, 0).await;
 
         // Send checkpoints with a gap (0, 1, 3, 4) - missing checkpoint 2
         for cp in [0, 1, 3, 4] {
@@ -645,7 +638,7 @@ mod tests {
             ..Default::default()
         };
         let store = MockStore::default();
-        let setup = TestSetup::new(config, store, None).await;
+        let setup = TestSetup::new(config, store, 0).await;
 
         // Wait for initial setup
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -709,7 +702,7 @@ mod tests {
             ..Default::default()
         };
         let store = MockStore::default().with_commit_delay(10_000); // 10 seconds delay
-        let setup = TestSetup::new(config, store, None).await;
+        let setup = TestSetup::new(config, store, 0).await;
 
         // Pipeline capacity analysis with slow commits:
         // Configuration: FANOUT=2, write_concurrency=1, PIPELINE_BUFFER=5
@@ -769,7 +762,7 @@ mod tests {
     async fn test_commit_failure_retry() {
         let config = ConcurrentConfig::default();
         let store = MockStore::default().with_commit_failures(2); // Fail 2 times, then succeed
-        let setup = TestSetup::new(config, store, None).await;
+        let setup = TestSetup::new(config, store, 0).await;
 
         // Send a checkpoint
         setup
@@ -801,7 +794,7 @@ mod tests {
 
         // Configure prune failures for range [0, 2) - fail twice then succeed
         let store = MockStore::default().with_prune_failures(0, 2, 1);
-        let setup = TestSetup::new(config, store, None).await;
+        let setup = TestSetup::new(config, store, 0).await;
 
         // Send enough checkpoints to trigger pruning
         for i in 0..4 {
@@ -863,7 +856,7 @@ mod tests {
 
         // Configure reader watermark failures - fail 2 times then succeed
         let store = MockStore::default().with_reader_watermark_failures(2);
-        let setup = TestSetup::new(config, store, None).await;
+        let setup = TestSetup::new(config, store, 0).await;
 
         // Send checkpoints to trigger reader watermark updates
         for i in 0..6 {
@@ -890,7 +883,7 @@ mod tests {
     async fn test_database_connection_failure_retry() {
         let config = ConcurrentConfig::default();
         let store = MockStore::default().with_connection_failures(2); // Fail 2 times, then succeed
-        let setup = TestSetup::new(config, store, None).await;
+        let setup = TestSetup::new(config, store, 0).await;
 
         // Send a checkpoint
         setup

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
@@ -549,7 +549,7 @@ mod tests {
             pruner_hi: 0,
         };
         let store = MockStore {
-            watermarks: Arc::new(Mutex::new(watermark)),
+            watermarks: Arc::new(Mutex::new(Some(watermark))),
             data: Arc::new(Mutex::new(test_data.clone())),
             ..Default::default()
         };
@@ -601,7 +601,7 @@ mod tests {
             assert!(data.contains_key(&3), "Checkpoint 3 should be preserved");
 
             // Check that the pruner_hi was updated past 1
-            let watermark = store.watermarks.lock().unwrap();
+            let watermark = store.get_watermark().unwrap();
             assert!(
                 watermark.pruner_hi > 1,
                 "Pruner watermark should be updated"
@@ -645,7 +645,7 @@ mod tests {
             pruner_hi: 0,
         };
         let store = MockStore {
-            watermarks: Arc::new(Mutex::new(watermark)),
+            watermarks: Arc::new(Mutex::new(Some(watermark))),
             data: Arc::new(Mutex::new(test_data.clone())),
             ..Default::default()
         };
@@ -679,7 +679,7 @@ mod tests {
             assert!(data.contains_key(&3), "Checkpoint 3 should be preserved");
 
             // Check that the pruner_hi was updated past 1
-            let watermark = store.watermarks.lock().unwrap();
+            let watermark = store.get_watermark().unwrap();
             assert!(
                 watermark.pruner_hi > 1,
                 "Pruner watermark should be updated"
@@ -730,7 +730,7 @@ mod tests {
 
         // Configure failing behavior: range [1,2) should fail once before succeeding
         let store = MockStore {
-            watermarks: Arc::new(Mutex::new(watermark)),
+            watermarks: Arc::new(Mutex::new(Some(watermark))),
             data: Arc::new(Mutex::new(test_data.clone())),
             ..Default::default()
         }
@@ -754,7 +754,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(500)).await;
         {
             let data = store.data.lock().unwrap();
-            let watermarks = store.watermarks.lock().unwrap();
+            let watermarks = store.get_watermark().unwrap();
 
             // Verify watermark doesn't advance past the failed range [1,2)
             assert_eq!(
@@ -771,7 +771,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(3000)).await;
         {
             let data = store.data.lock().unwrap();
-            let watermarks = store.watermarks.lock().unwrap();
+            let watermarks = store.get_watermark().unwrap();
 
             // Verify watermark advances after all ranges complete successfully
             assert_eq!(

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
@@ -357,7 +357,7 @@ mod tests {
     use tokio::time::Duration;
     use tokio_util::sync::CancellationToken;
 
-    use crate::{metrics::IndexerMetrics, pipeline::Processor, testing::mock_store::*, FieldCount};
+    use crate::{metrics::IndexerMetrics, mocks::store::*, pipeline::Processor, FieldCount};
 
     use super::*;
 
@@ -549,7 +549,7 @@ mod tests {
             pruner_hi: 0,
         };
         let store = MockStore {
-            watermarks: Arc::new(Mutex::new(Some(watermark))),
+            watermark: Arc::new(Mutex::new(Some(watermark))),
             data: Arc::new(Mutex::new(test_data.clone())),
             ..Default::default()
         };
@@ -645,7 +645,7 @@ mod tests {
             pruner_hi: 0,
         };
         let store = MockStore {
-            watermarks: Arc::new(Mutex::new(Some(watermark))),
+            watermark: Arc::new(Mutex::new(Some(watermark))),
             data: Arc::new(Mutex::new(test_data.clone())),
             ..Default::default()
         };
@@ -730,7 +730,7 @@ mod tests {
 
         // Configure failing behavior: range [1,2) should fail once before succeeding
         let store = MockStore {
-            watermarks: Arc::new(Mutex::new(Some(watermark))),
+            watermark: Arc::new(Mutex::new(Some(watermark))),
             data: Arc::new(Mutex::new(test_data.clone())),
             ..Default::default()
         }

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
@@ -601,7 +601,7 @@ mod tests {
             assert!(data.contains_key(&3), "Checkpoint 3 should be preserved");
 
             // Check that the pruner_hi was updated past 1
-            let watermark = store.get_watermark().unwrap();
+            let watermark = store.watermark().unwrap();
             assert!(
                 watermark.pruner_hi > 1,
                 "Pruner watermark should be updated"
@@ -679,7 +679,7 @@ mod tests {
             assert!(data.contains_key(&3), "Checkpoint 3 should be preserved");
 
             // Check that the pruner_hi was updated past 1
-            let watermark = store.get_watermark().unwrap();
+            let watermark = store.watermark().unwrap();
             assert!(
                 watermark.pruner_hi > 1,
                 "Pruner watermark should be updated"
@@ -754,7 +754,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(500)).await;
         {
             let data = store.data.lock().unwrap();
-            let watermarks = store.get_watermark().unwrap();
+            let watermarks = store.watermark().unwrap();
 
             // Verify watermark doesn't advance past the failed range [1,2)
             assert_eq!(
@@ -771,7 +771,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(3000)).await;
         {
             let data = store.data.lock().unwrap();
-            let watermarks = store.get_watermark().unwrap();
+            let watermarks = store.watermark().unwrap();
 
             // Verify watermark advances after all ranges complete successfully
             assert_eq!(

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
@@ -162,7 +162,7 @@ mod tests {
         set_reader_watermark_failure_attempts: usize,
     ) -> TestSetup {
         let store = MockStore {
-            watermarks: Arc::new(Mutex::new(watermark)),
+            watermarks: Arc::new(Mutex::new(Some(watermark))),
             set_reader_watermark_failure_attempts: Arc::new(Mutex::new(
                 set_reader_watermark_failure_attempts,
             )),
@@ -223,7 +223,7 @@ mod tests {
 
         // new reader_lo = checkpoint_hi_inclusive (10) - retention (5) + 1 = 6
         {
-            let watermarks = setup.store.watermarks.lock().unwrap();
+            let watermarks = setup.store.get_watermark().unwrap();
             assert_eq!(watermarks.reader_lo, 6);
         }
 
@@ -260,7 +260,7 @@ mod tests {
         // new reader_lo = checkpoint_hi_inclusive (10) - retention (5) + 1 = 6,
         // which is smaller than current reader_lo (7). Therefore, the reader_lo was not updated.
         {
-            let watermarks = setup.store.watermarks.lock().unwrap();
+            let watermarks = setup.store.get_watermark().unwrap();
             assert_eq!(
                 watermarks.reader_lo, 7,
                 "Reader watermark should not be updated when new value is smaller"
@@ -301,7 +301,7 @@ mod tests {
             .await;
 
         // Verify state before retry succeeds
-        let watermark = setup.store.get_watermark();
+        let watermark = setup.store.get_watermark().unwrap();
         assert_eq!(
             watermark.reader_lo, 0,
             "Reader watermark should not be updated due to DB connection failure"
@@ -317,7 +317,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         // Verify state after retry succeeds
-        let watermark = setup.store.get_watermark();
+        let watermark = setup.store.get_watermark().unwrap();
         assert_eq!(
             watermark.reader_lo, 6,
             "Reader watermark should be updated after retry succeeds"
@@ -355,7 +355,7 @@ mod tests {
 
         // Verify state before retry succeeds
         {
-            let watermarks = setup.store.watermarks.lock().unwrap();
+            let watermarks = setup.store.get_watermark().unwrap();
             assert_eq!(
                 watermarks.reader_lo, 0,
                 "Reader watermark should not be updated due to set_reader_watermark failure"
@@ -367,7 +367,7 @@ mod tests {
 
         // Verify state after retry succeeds
         {
-            let watermarks = setup.store.watermarks.lock().unwrap();
+            let watermarks = setup.store.get_watermark().unwrap();
             assert_eq!(watermarks.reader_lo, 6);
         }
 

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
@@ -114,7 +114,7 @@ mod tests {
     use tokio::time::Duration;
     use tokio_util::sync::CancellationToken;
 
-    use crate::{metrics::IndexerMetrics, pipeline::Processor, testing::mock_store::*};
+    use crate::{metrics::IndexerMetrics, mocks::store::*, pipeline::Processor};
 
     use super::*;
 
@@ -162,7 +162,7 @@ mod tests {
         set_reader_watermark_failure_attempts: usize,
     ) -> TestSetup {
         let store = MockStore {
-            watermarks: Arc::new(Mutex::new(Some(watermark))),
+            watermark: Arc::new(Mutex::new(Some(watermark))),
             set_reader_watermark_failure_attempts: Arc::new(Mutex::new(
                 set_reader_watermark_failure_attempts,
             )),

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/reader_watermark.rs
@@ -223,7 +223,7 @@ mod tests {
 
         // new reader_lo = checkpoint_hi_inclusive (10) - retention (5) + 1 = 6
         {
-            let watermarks = setup.store.get_watermark().unwrap();
+            let watermarks = setup.store.watermark().unwrap();
             assert_eq!(watermarks.reader_lo, 6);
         }
 
@@ -260,7 +260,7 @@ mod tests {
         // new reader_lo = checkpoint_hi_inclusive (10) - retention (5) + 1 = 6,
         // which is smaller than current reader_lo (7). Therefore, the reader_lo was not updated.
         {
-            let watermarks = setup.store.get_watermark().unwrap();
+            let watermarks = setup.store.watermark().unwrap();
             assert_eq!(
                 watermarks.reader_lo, 7,
                 "Reader watermark should not be updated when new value is smaller"
@@ -301,7 +301,7 @@ mod tests {
             .await;
 
         // Verify state before retry succeeds
-        let watermark = setup.store.get_watermark().unwrap();
+        let watermark = setup.store.watermark().unwrap();
         assert_eq!(
             watermark.reader_lo, 0,
             "Reader watermark should not be updated due to DB connection failure"
@@ -317,7 +317,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         // Verify state after retry succeeds
-        let watermark = setup.store.get_watermark().unwrap();
+        let watermark = setup.store.watermark().unwrap();
         assert_eq!(
             watermark.reader_lo, 6,
             "Reader watermark should be updated after retry succeeds"
@@ -355,7 +355,7 @@ mod tests {
 
         // Verify state before retry succeeds
         {
-            let watermarks = setup.store.get_watermark().unwrap();
+            let watermarks = setup.store.watermark().unwrap();
             assert_eq!(
                 watermarks.reader_lo, 0,
                 "Reader watermark should not be updated due to set_reader_watermark failure"
@@ -367,7 +367,7 @@ mod tests {
 
         // Verify state after retry succeeds
         {
-            let watermarks = setup.store.get_watermark().unwrap();
+            let watermarks = setup.store.watermark().unwrap();
             assert_eq!(watermarks.reader_lo, 6);
         }
 

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
@@ -516,7 +516,7 @@ mod tests {
 
         // Verify watermark was updated
         {
-            let watermark = setup.store.get_watermark().unwrap();
+            let watermark = setup.store.watermark().unwrap();
             assert_eq!(watermark.checkpoint_hi_inclusive, 2);
             assert_eq!(watermark.tx_hi, 2);
         }
@@ -542,7 +542,7 @@ mod tests {
         let mut setup = setup_test(5, config, MockStore::default());
 
         // Verify watermark hasn't progressed
-        let watermark = setup.store.get_watermark();
+        let watermark = setup.store.watermark();
         assert!(watermark.is_none());
 
         // Send checkpoints in order
@@ -554,7 +554,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(1000)).await;
 
         // Verify watermark hasn't progressed
-        let watermark = setup.store.get_watermark();
+        let watermark = setup.store.watermark();
         assert!(watermark.is_none());
 
         for i in 5..8 {
@@ -569,7 +569,7 @@ mod tests {
 
         // Verify watermark was updated
         {
-            let watermark = setup.store.get_watermark().unwrap();
+            let watermark = setup.store.watermark().unwrap();
             assert_eq!(watermark.checkpoint_hi_inclusive, 7);
             assert_eq!(watermark.tx_hi, 7);
         }
@@ -600,7 +600,7 @@ mod tests {
 
         // Verify watermark was updated
         {
-            let watermark = setup.store.get_watermark().unwrap();
+            let watermark = setup.store.watermark().unwrap();
             assert_eq!(watermark.checkpoint_hi_inclusive, 2);
             assert_eq!(watermark.tx_hi, 2);
         }

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
@@ -71,15 +71,11 @@ where
         let mut batch_rows = 0;
         let mut batch_checkpoints = 0;
 
-        // The task keeps track of the highest (inclusive) checkpoint it has added to the batch,
-        // and whether that batch needs to be written out. By extension it also knows the next
-        // checkpoint to expect and add to the batch.
-        let mut watermark = CommitterWatermark {
-            checkpoint_hi_inclusive: next_checkpoint,
-            // This initial synthetic checkpoint is overwritten by a real watermark from a processed
-            // checkpoint.
-            ..Default::default()
-        };
+        // The task keeps track of the highest (inclusive) checkpoint it has added to the batch, and
+        // whether that batch needs to be written out. By extension it also knows the next
+        // checkpoint to expect and add to the batch. Initially, this watermark is synthetic, and
+        // will be overwritten by a processed checkpoint.
+        let mut watermark = CommitterWatermark::default();
 
         // The committer task will periodically output a log message at a higher log level to
         // demonstrate that the pipeline is making progress.
@@ -535,10 +531,7 @@ mod tests {
     /// `initial_watermark` into the setup.
     #[tokio::test]
     async fn test_committer_processes_sequential_checkpoints_with_initial_watermark() {
-        let config = SequentialConfig {
-            committer: CommitterConfig::default(),
-            checkpoint_lag: 0, // Zero checkpoint lag to process new batch instantly
-        };
+        let config = SequentialConfig::default();
         let mut setup = setup_test(5, config, MockStore::default());
 
         // Verify watermark hasn't progressed

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
@@ -40,7 +40,7 @@ use super::{Handler, SequentialConfig};
 /// The task can be shutdown using its `cancel` token or if either of its channels are closed.
 pub(super) fn committer<H>(
     config: SequentialConfig,
-    watermark: Option<CommitterWatermark>,
+    mut next_checkpoint: u64,
     mut rx: mpsc::Receiver<IndexedCheckpoint<H>>,
     tx: mpsc::UnboundedSender<(&'static str, u64)>,
     store: H::Store,
@@ -74,11 +74,11 @@ where
         // The task keeps track of the highest (inclusive) checkpoint it has added to the batch,
         // and whether that batch needs to be written out. By extension it also knows the next
         // checkpoint to expect and add to the batch.
-        let (mut watermark, mut next_checkpoint) = if let Some(watermark) = watermark {
-            let next = watermark.checkpoint_hi_inclusive + 1;
-            (watermark, next)
-        } else {
-            (CommitterWatermark::default(), 0)
+        let mut watermark = CommitterWatermark {
+            checkpoint_hi_inclusive: next_checkpoint,
+            // This initial synthetic checkpoint is overwritten by a real watermark from a processed
+            // checkpoint.
+            ..Default::default()
         };
 
         // The committer task will periodically output a log message at a higher log level to
@@ -394,8 +394,8 @@ fn can_process_pending<T>(
 #[cfg(test)]
 mod tests {
     use crate::{
+        mocks::store::{MockConnection, MockStore},
         pipeline::{CommitterConfig, Processor},
-        testing::mock_store::{MockConnection, MockStore},
     };
 
     use super::*;
@@ -448,11 +448,9 @@ mod tests {
         committer_handle: JoinHandle<()>,
     }
 
-    fn setup_test(
-        initial_watermark: Option<CommitterWatermark>,
-        config: SequentialConfig,
-        store: MockStore,
-    ) -> TestSetup {
+    /// Emulates adding a sequential pipeline to the indexer. The next_checkpoint is the checkpoint
+    /// for the indexer to ingest from.
+    fn setup_test(next_checkpoint: u64, config: SequentialConfig, store: MockStore) -> TestSetup {
         let metrics = IndexerMetrics::new(None, &Registry::default());
         let cancel = CancellationToken::new();
 
@@ -463,7 +461,7 @@ mod tests {
         let store_clone = store.clone();
         let committer_handle = committer(
             config,
-            initial_watermark,
+            next_checkpoint,
             checkpoint_rx,
             watermark_tx,
             store_clone,
@@ -499,13 +497,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_committer_processes_sequential_checkpoints() {
-        // Setup with no initial watermark
-        let initial_watermark = None;
         let config = SequentialConfig {
             committer: CommitterConfig::default(),
             checkpoint_lag: 0, // Zero checkpoint lag to process new batch instantly
         };
-        let mut setup = setup_test(initial_watermark, config, MockStore::default());
+        let mut setup = setup_test(0, config, MockStore::default());
 
         // Send checkpoints in order
         for i in 0..3 {
@@ -539,17 +535,11 @@ mod tests {
     /// `initial_watermark` into the setup.
     #[tokio::test]
     async fn test_committer_processes_sequential_checkpoints_with_initial_watermark() {
-        // Setup with initial watermark
-        let initial_watermark = Some(CommitterWatermark {
-            checkpoint_hi_inclusive: 5,
-            ..Default::default()
-        });
-
         let config = SequentialConfig {
             committer: CommitterConfig::default(),
             checkpoint_lag: 0, // Zero checkpoint lag to process new batch instantly
         };
-        let mut setup = setup_test(initial_watermark, config, MockStore::default());
+        let mut setup = setup_test(5, config, MockStore::default());
 
         // Verify watermark hasn't progressed
         let watermark = setup.store.get_watermark();
@@ -575,7 +565,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(1000)).await;
 
         // Verify data was written in order
-        assert_eq!(setup.store.get_sequential_data(), vec![6, 7]);
+        assert_eq!(setup.store.get_sequential_data(), vec![5, 6, 7]);
 
         // Verify watermark was updated
         {
@@ -584,11 +574,6 @@ mod tests {
             assert_eq!(watermark.tx_hi, 7);
         }
 
-        // Verify watermark was sent to ingestion
-        let watermark = setup.watermark_rx.recv().await.unwrap();
-        assert_eq!(watermark.0, "test", "Pipeline name should be 'test'");
-        assert_eq!(watermark.1, 7, "Watermark should be at checkpoint 7");
-
         // Clean up
         drop(setup.checkpoint_tx);
         let _ = setup.committer_handle.await;
@@ -596,13 +581,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_committer_processes_out_of_order_checkpoints() {
-        // Setup with no initial watermark
-        let initial_watermark = None;
         let config = SequentialConfig {
             committer: CommitterConfig::default(),
             checkpoint_lag: 0, // Zero checkpoint lag to process new batch instantly
         };
-        let mut setup = setup_test(initial_watermark, config, MockStore::default());
+        let mut setup = setup_test(0, config, MockStore::default());
 
         // Send checkpoints out of order
         for i in [1, 0, 2] {
@@ -634,13 +617,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_committer_commit_up_to_max_batch_checkpoints() {
-        // Setup with no initial watermark
-        let initial_watermark = None;
         let config = SequentialConfig {
             committer: CommitterConfig::default(),
             checkpoint_lag: 0, // Zero checkpoint lag to process new batch instantly
         };
-        let mut setup = setup_test(initial_watermark, config, MockStore::default());
+        let mut setup = setup_test(0, config, MockStore::default());
 
         // Send checkpoints up to MAX_BATCH_CHECKPOINTS
         for i in 0..4 {
@@ -673,13 +654,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_committer_does_not_commit_until_checkpoint_lag() {
-        // Setup with no initial watermark
-        let initial_watermark = None;
         let config = SequentialConfig {
             committer: CommitterConfig::default(),
             checkpoint_lag: 1, // Only commit checkpoints that are at least 1 behind
         };
-        let mut setup = setup_test(initial_watermark, config, MockStore::default());
+        let mut setup = setup_test(0, config, MockStore::default());
 
         // Send checkpoints 0-2
         for i in 0..3 {
@@ -712,8 +691,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_committer_commits_eagerly() {
-        // Setup with no initial watermark
-        let initial_watermark = None;
         let config = SequentialConfig {
             committer: CommitterConfig {
                 collect_interval_ms: 4_000, // Long polling to test eager commit
@@ -721,7 +698,7 @@ mod tests {
             },
             checkpoint_lag: 0, // Zero checkpoint lag to not block the eager logic
         };
-        let mut setup = setup_test(initial_watermark, config, MockStore::default());
+        let mut setup = setup_test(0, config, MockStore::default());
 
         // Wait for initial poll to be over
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -750,8 +727,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_committer_cannot_commit_eagerly_due_to_checkpoint_lag() {
-        // Setup with no initial watermark
-        let initial_watermark = None;
         let config = SequentialConfig {
             committer: CommitterConfig {
                 collect_interval_ms: 4_000, // Long polling to test eager commit
@@ -759,7 +734,7 @@ mod tests {
             },
             checkpoint_lag: 4, // High checkpoint lag to block eager commits
         };
-        let mut setup = setup_test(initial_watermark, config, MockStore::default());
+        let mut setup = setup_test(0, config, MockStore::default());
 
         // Wait for initial poll to be over
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -791,8 +766,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_committer_retries_on_transaction_failure() {
-        // Setup with no initial watermark
-        let initial_watermark = None;
         let config = SequentialConfig {
             committer: CommitterConfig {
                 collect_interval_ms: 1_000, // Long polling to test retry logic
@@ -804,7 +777,7 @@ mod tests {
         // Create store with transaction failure configuration
         let store = MockStore::default().with_transaction_failures(1); // Will fail once before succeeding
 
-        let mut setup = setup_test(initial_watermark, config, store);
+        let mut setup = setup_test(0, config, store);
 
         // Send a checkpoint
         send_checkpoint(&mut setup, 0).await;

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/mod.rs
@@ -11,7 +11,7 @@ use super::{processor::processor, CommitterConfig, Processor, PIPELINE_BUFFER};
 
 use crate::{
     metrics::IndexerMetrics,
-    store::{CommitterWatermark, Store, TransactionalStore},
+    store::{Store, TransactionalStore},
     types::full_checkpoint_content::CheckpointData,
 };
 
@@ -102,7 +102,7 @@ pub struct SequentialConfig {
 /// channels close, or any of its independent tasks fail.
 pub(crate) fn pipeline<H: Handler + Send + Sync + 'static>(
     handler: H,
-    initial_watermark: Option<CommitterWatermark>,
+    next_checkpoint: u64,
     config: SequentialConfig,
     db: H::Store,
     checkpoint_rx: mpsc::Receiver<Arc<CheckpointData>>,
@@ -122,7 +122,7 @@ pub(crate) fn pipeline<H: Handler + Send + Sync + 'static>(
 
     let committer = committer::<H>(
         config,
-        initial_watermark,
+        next_checkpoint,
         committer_rx,
         watermark_tx,
         db,


### PR DESCRIPTION
## Description

Currently, if `first_checkpoint` is configured and a pipeline with no watermark row is added to the indexer, it'll essentially stall since the pipeline's committer task creates a default watermark with checkpoint_hi_inclusive = 0 and waits for this checkpoint. This prevents someone from using `first_checkpoint` to arbitrarily seed the starting point of pipelines for the first time. Consequently, indexer operators have to manually update the watermarks table to set a starting point that isn't 0. 

In this PR, the indexer is now responsible for determining the `next_checkpoint` to commit and make watermark updates for each pipeline. In practice, for a valid `first_checkpoint` (`next_checkpoint`), sequential pipelines will wait to commit the next processed checkpoint after its watermark, while concurrent pipelines will start from the same `first_checkpoint`.

Meanwhile, the pipeline tasks initialize a default watermark variable for the logger, but in practice will always be overwritten by the next processed checkpoint for metrics and other reporting.

## Test plan 

- Unit tests for the behavior above
- commit_watermark and sequential committer tests 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
