### PR TITLE
graphql-alt: MoveValue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14696,6 +14696,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "prometheus",
+ "prost-types",
  "serde",
  "serde_json",
  "sui-default-config",

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/coins.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/coins.move
@@ -1,0 +1,159 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --addresses T=0x0 --accounts A B --simulator
+
+//# publish --sender A
+module T::test {
+    use sui::coin;
+
+    public struct TEST has drop {}
+
+    fun init(otw: TEST, ctx: &mut TxContext){
+        let (mut treasury, metadata) =
+            coin::create_currency(otw, 6, b"", b"", b"", option::none(), ctx);
+
+        // Mint and transfer TEST coins with different amounts
+        transfer::public_transfer(treasury.mint(1_000000, ctx), ctx.sender());
+        transfer::public_transfer(treasury.mint(0_500000, ctx), ctx.sender());
+        transfer::public_transfer(treasury.mint(0_250000, ctx), ctx.sender());
+        transfer::public_transfer(treasury.mint(0_100000, ctx), ctx.sender());
+
+        transfer::public_freeze_object(metadata);
+        transfer::public_transfer(treasury, ctx.sender());
+    }
+}
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs 1000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 500 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs @A
+//> 0: sui::bag::new();
+//> 1: TransferObjects([Result(0)], Input(0))
+
+//# create-checkpoint
+
+//# programmable --sender A --inputs object(1,0) @B
+//> TransferObjects([Input(0)], Input(1))
+
+//# programmable --sender A --inputs object(3,0) @B
+//> TransferObjects([Input(0)], Input(1))
+
+//# create-checkpoint
+
+//# run-graphql
+{ # Account A queries
+  accountA: address(address: "@{A}") {
+    # All objects including coins and bags
+    allObjects: objects {
+      pageInfo { hasNextPage }
+      nodes {
+        address
+        contents {
+          type { repr }
+          json
+        }
+      }
+    }
+
+    # All coins (no marker filter)
+    allCoins: objects(filter: { type: "0x2::coin::Coin" }) {
+      pageInfo { hasNextPage }
+      nodes {
+        address
+        contents {
+          type { repr }
+          json
+        }
+      }
+    }
+
+
+    # Only TEST coin objects
+    testCoins: objects(filter: { type: "0x2::coin::Coin<@{T}::test::TEST>" }) {
+      pageInfo { hasNextPage }
+      nodes {
+        address
+        contents {
+          json
+        }
+      }
+    }
+
+    # Only SUI coin objects
+    suiCoins: objects(filter: { type: "0x2::coin::Coin<0x2::sui::SUI>" }) {
+      pageInfo { hasNextPage }
+      nodes {
+        address
+        contents {
+          json
+        }
+      }
+    }
+  }
+
+  # Account B queries
+  accountB: address(address: "@{B}") {
+    # All objects for B
+    allObjects: objects {
+      pageInfo { hasNextPage }
+      nodes {
+        address
+        contents {
+          type { repr }
+          json
+        }
+      }
+    }
+
+    # Only TEST coin objects for B
+    testCoins: objects(filter: { type: "0x2::coin::Coin<@{T}::test::TEST>" }) {
+      pageInfo { hasNextPage }
+      nodes {
+        address
+        contents {
+          json
+        }
+      }
+    }
+
+    # Only SUI coin objects for B
+    suiCoins: objects(filter: { type: "0x2::coin::Coin<0x2::sui::SUI>" }) {
+      pageInfo { hasNextPage }
+      nodes {
+        address
+        contents {
+          json
+        }
+      }
+    }
+  }
+}
+
+//# run-graphql
+{ # Time travel to checkpoint 2 (before transfers)
+  timeTravel: checkpoint(sequenceNumber: 2) {
+    query {
+      address(address: "@{A}") {
+        # Should have all coin objects at this point
+        objects(filter: { type: "0x2::coin::Coin" }) {
+          pageInfo { hasNextPage }
+          nodes {
+            address
+            contents {
+              type { repr }
+              json
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/coins.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/coins.snap
@@ -1,0 +1,481 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 12 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-25:
+//# publish --sender A
+created: object(1,0), object(1,1), object(1,2), object(1,3), object(1,4), object(1,5), object(1,6)
+mutated: object(0,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 16864400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 27:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 29-31:
+//# programmable --sender A --inputs 1000 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 33-35:
+//# programmable --sender A --inputs 500 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 37-39:
+//# programmable --sender A --inputs @A
+//> 0: sui::bag::new();
+//> 1: TransferObjects([Result(0)], Input(0))
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2287600,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, line 41:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 7, lines 43-44:
+//# programmable --sender A --inputs object(1,0) @B
+//> TransferObjects([Input(0)], Input(1))
+mutated: object(0,0), object(1,0)
+unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
+gas summary: computation_cost: 1000000, storage_cost: 2310400,  storage_rebate: 2287296, non_refundable_storage_fee: 23104
+
+task 8, lines 46-47:
+//# programmable --sender A --inputs object(3,0) @B
+//> TransferObjects([Input(0)], Input(1))
+mutated: object(0,0), object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 9, line 49:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 10, lines 51-138:
+//# run-graphql
+Response: {
+  "data": {
+    "accountA": {
+      "allObjects": {
+        "pageInfo": {
+          "hasNextPage": false
+        },
+        "nodes": [
+          {
+            "address": "0x5b9005409dd6d73b4d0e30ae70a8d736c52c59214a3b8ffd8d0c27bf3de5e7a2",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::bag::Bag"
+              },
+              "json": {
+                "id": "0x5b9005409dd6d73b4d0e30ae70a8d736c52c59214a3b8ffd8d0c27bf3de5e7a2",
+                "size": "0"
+              }
+            }
+          },
+          {
+            "address": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              },
+              "json": {
+                "balance": "299999973785996",
+                "id": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562"
+              }
+            }
+          },
+          {
+            "address": "0xaed246eecae370ed59ac3fecf309df4de8713c1694297f59c6a26e8950d8fb50",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              },
+              "json": {
+                "balance": "500",
+                "id": "0xaed246eecae370ed59ac3fecf309df4de8713c1694297f59c6a26e8950d8fb50"
+              }
+            }
+          },
+          {
+            "address": "0x32a23ae8faf51eac67c2e4d3399512a89230e4a6afbe5730ffbedb39a0ea568a",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+              },
+              "json": {
+                "balance": "1000000",
+                "id": "0x32a23ae8faf51eac67c2e4d3399512a89230e4a6afbe5730ffbedb39a0ea568a"
+              }
+            }
+          },
+          {
+            "address": "0x8b2b6b2c80d83549aa32fa6d06127eb0d4d3533454981f4a3535aa7f38d838ae",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+              },
+              "json": {
+                "balance": "500000",
+                "id": "0x8b2b6b2c80d83549aa32fa6d06127eb0d4d3533454981f4a3535aa7f38d838ae"
+              }
+            }
+          },
+          {
+            "address": "0x9eb66dea3cfa5c3b60900d2eab57d94bb7a19004086b900fb4f84bc79abcea0f",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+              },
+              "json": {
+                "balance": "250000",
+                "id": "0x9eb66dea3cfa5c3b60900d2eab57d94bb7a19004086b900fb4f84bc79abcea0f"
+              }
+            }
+          },
+          {
+            "address": "0x361c0d13ad78b43d14d2ed4c6d544864295996338644ed84ea841827799dc34e",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::TreasuryCap<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+              },
+              "json": {
+                "id": "0x361c0d13ad78b43d14d2ed4c6d544864295996338644ed84ea841827799dc34e",
+                "total_supply": {
+                  "value": "1850000"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "allCoins": {
+        "pageInfo": {
+          "hasNextPage": false
+        },
+        "nodes": [
+          {
+            "address": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              },
+              "json": {
+                "balance": "299999973785996",
+                "id": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562"
+              }
+            }
+          },
+          {
+            "address": "0xaed246eecae370ed59ac3fecf309df4de8713c1694297f59c6a26e8950d8fb50",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              },
+              "json": {
+                "balance": "500",
+                "id": "0xaed246eecae370ed59ac3fecf309df4de8713c1694297f59c6a26e8950d8fb50"
+              }
+            }
+          },
+          {
+            "address": "0x32a23ae8faf51eac67c2e4d3399512a89230e4a6afbe5730ffbedb39a0ea568a",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+              },
+              "json": {
+                "balance": "1000000",
+                "id": "0x32a23ae8faf51eac67c2e4d3399512a89230e4a6afbe5730ffbedb39a0ea568a"
+              }
+            }
+          },
+          {
+            "address": "0x8b2b6b2c80d83549aa32fa6d06127eb0d4d3533454981f4a3535aa7f38d838ae",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+              },
+              "json": {
+                "balance": "500000",
+                "id": "0x8b2b6b2c80d83549aa32fa6d06127eb0d4d3533454981f4a3535aa7f38d838ae"
+              }
+            }
+          },
+          {
+            "address": "0x9eb66dea3cfa5c3b60900d2eab57d94bb7a19004086b900fb4f84bc79abcea0f",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+              },
+              "json": {
+                "balance": "250000",
+                "id": "0x9eb66dea3cfa5c3b60900d2eab57d94bb7a19004086b900fb4f84bc79abcea0f"
+              }
+            }
+          }
+        ]
+      },
+      "testCoins": {
+        "pageInfo": {
+          "hasNextPage": false
+        },
+        "nodes": [
+          {
+            "address": "0x32a23ae8faf51eac67c2e4d3399512a89230e4a6afbe5730ffbedb39a0ea568a",
+            "contents": {
+              "json": {
+                "balance": "1000000",
+                "id": "0x32a23ae8faf51eac67c2e4d3399512a89230e4a6afbe5730ffbedb39a0ea568a"
+              }
+            }
+          },
+          {
+            "address": "0x8b2b6b2c80d83549aa32fa6d06127eb0d4d3533454981f4a3535aa7f38d838ae",
+            "contents": {
+              "json": {
+                "balance": "500000",
+                "id": "0x8b2b6b2c80d83549aa32fa6d06127eb0d4d3533454981f4a3535aa7f38d838ae"
+              }
+            }
+          },
+          {
+            "address": "0x9eb66dea3cfa5c3b60900d2eab57d94bb7a19004086b900fb4f84bc79abcea0f",
+            "contents": {
+              "json": {
+                "balance": "250000",
+                "id": "0x9eb66dea3cfa5c3b60900d2eab57d94bb7a19004086b900fb4f84bc79abcea0f"
+              }
+            }
+          }
+        ]
+      },
+      "suiCoins": {
+        "pageInfo": {
+          "hasNextPage": false
+        },
+        "nodes": [
+          {
+            "address": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
+            "contents": {
+              "json": {
+                "balance": "299999973785996",
+                "id": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562"
+              }
+            }
+          },
+          {
+            "address": "0xaed246eecae370ed59ac3fecf309df4de8713c1694297f59c6a26e8950d8fb50",
+            "contents": {
+              "json": {
+                "balance": "500",
+                "id": "0xaed246eecae370ed59ac3fecf309df4de8713c1694297f59c6a26e8950d8fb50"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "accountB": {
+      "allObjects": {
+        "pageInfo": {
+          "hasNextPage": false
+        },
+        "nodes": [
+          {
+            "address": "0xfdc25bc3b2d2b3664199d08f5275c3a6bb360b0629ab5784672f083149163417",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              },
+              "json": {
+                "balance": "300000000000000",
+                "id": "0xfdc25bc3b2d2b3664199d08f5275c3a6bb360b0629ab5784672f083149163417"
+              }
+            }
+          },
+          {
+            "address": "0x44c906c3b3b4be18871c55abc222a3c75383c7a229f8a1700b10584666be47f6",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              },
+              "json": {
+                "balance": "1000",
+                "id": "0x44c906c3b3b4be18871c55abc222a3c75383c7a229f8a1700b10584666be47f6"
+              }
+            }
+          },
+          {
+            "address": "0x16ce72994b48d46e73044edf9974203f4c821988f2bf27e8388ddc254b1cee5a",
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+              },
+              "json": {
+                "balance": "100000",
+                "id": "0x16ce72994b48d46e73044edf9974203f4c821988f2bf27e8388ddc254b1cee5a"
+              }
+            }
+          }
+        ]
+      },
+      "testCoins": {
+        "pageInfo": {
+          "hasNextPage": false
+        },
+        "nodes": [
+          {
+            "address": "0x16ce72994b48d46e73044edf9974203f4c821988f2bf27e8388ddc254b1cee5a",
+            "contents": {
+              "json": {
+                "balance": "100000",
+                "id": "0x16ce72994b48d46e73044edf9974203f4c821988f2bf27e8388ddc254b1cee5a"
+              }
+            }
+          }
+        ]
+      },
+      "suiCoins": {
+        "pageInfo": {
+          "hasNextPage": false
+        },
+        "nodes": [
+          {
+            "address": "0xfdc25bc3b2d2b3664199d08f5275c3a6bb360b0629ab5784672f083149163417",
+            "contents": {
+              "json": {
+                "balance": "300000000000000",
+                "id": "0xfdc25bc3b2d2b3664199d08f5275c3a6bb360b0629ab5784672f083149163417"
+              }
+            }
+          },
+          {
+            "address": "0x44c906c3b3b4be18871c55abc222a3c75383c7a229f8a1700b10584666be47f6",
+            "contents": {
+              "json": {
+                "balance": "1000",
+                "id": "0x44c906c3b3b4be18871c55abc222a3c75383c7a229f8a1700b10584666be47f6"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+task 11, lines 140-159:
+//# run-graphql
+Response: {
+  "data": {
+    "timeTravel": {
+      "query": {
+        "address": {
+          "objects": {
+            "pageInfo": {
+              "hasNextPage": false
+            },
+            "nodes": [
+              {
+                "address": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
+                "contents": {
+                  "type": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                  },
+                  "json": {
+                    "balance": "299999975828860",
+                    "id": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562"
+                  }
+                }
+              },
+              {
+                "address": "0x44c906c3b3b4be18871c55abc222a3c75383c7a229f8a1700b10584666be47f6",
+                "contents": {
+                  "type": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                  },
+                  "json": {
+                    "balance": "1000",
+                    "id": "0x44c906c3b3b4be18871c55abc222a3c75383c7a229f8a1700b10584666be47f6"
+                  }
+                }
+              },
+              {
+                "address": "0xaed246eecae370ed59ac3fecf309df4de8713c1694297f59c6a26e8950d8fb50",
+                "contents": {
+                  "type": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                  },
+                  "json": {
+                    "balance": "500",
+                    "id": "0xaed246eecae370ed59ac3fecf309df4de8713c1694297f59c6a26e8950d8fb50"
+                  }
+                }
+              },
+              {
+                "address": "0x32a23ae8faf51eac67c2e4d3399512a89230e4a6afbe5730ffbedb39a0ea568a",
+                "contents": {
+                  "type": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+                  },
+                  "json": {
+                    "balance": "1000000",
+                    "id": "0x32a23ae8faf51eac67c2e4d3399512a89230e4a6afbe5730ffbedb39a0ea568a"
+                  }
+                }
+              },
+              {
+                "address": "0x8b2b6b2c80d83549aa32fa6d06127eb0d4d3533454981f4a3535aa7f38d838ae",
+                "contents": {
+                  "type": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+                  },
+                  "json": {
+                    "balance": "500000",
+                    "id": "0x8b2b6b2c80d83549aa32fa6d06127eb0d4d3533454981f4a3535aa7f38d838ae"
+                  }
+                }
+              },
+              {
+                "address": "0x9eb66dea3cfa5c3b60900d2eab57d94bb7a19004086b900fb4f84bc79abcea0f",
+                "contents": {
+                  "type": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+                  },
+                  "json": {
+                    "balance": "250000",
+                    "id": "0x9eb66dea3cfa5c3b60900d2eab57d94bb7a19004086b900fb4f84bc79abcea0f"
+                  }
+                }
+              },
+              {
+                "address": "0x16ce72994b48d46e73044edf9974203f4c821988f2bf27e8388ddc254b1cee5a",
+                "contents": {
+                  "type": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x16cd1d50dc483018fc6616139f12074be754e058336d59230d5f6ee1d1aaf85a::test::TEST>"
+                  },
+                  "json": {
+                    "balance": "100000",
+                    "id": "0x16ce72994b48d46e73044edf9974203f4c821988f2bf27e8388ddc254b1cee5a"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/objects.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/objects.move
@@ -70,6 +70,10 @@
       nodes {
         address
         version
+        contents {
+          type { repr }
+          json
+        }
       }
     }
   }
@@ -80,6 +84,10 @@
       nodes {
         address
         version
+        contents {
+          type { repr }
+          json
+        }
       }
     }
   }
@@ -90,6 +98,10 @@
       nodes {
         address
         version
+        contents {
+          type { repr }
+          json
+        }
       }
     }
   }
@@ -100,6 +112,10 @@
       nodes {
         address
         version
+        contents {
+          type { repr }
+          json
+        }
       }
     }
   }
@@ -110,6 +126,10 @@
       nodes {
         address
         version
+        contents {
+          type { repr }
+          json
+        }
       }
     }
   }
@@ -120,6 +140,10 @@
       nodes {
         address
         version
+        contents {
+          type { repr }
+          json
+        }
       }
     }
   }
@@ -135,6 +159,10 @@
           nodes {
             address
             version
+            contents {
+              type { repr }
+              json
+            }
           }
         }
       }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/objects.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/objects.snap
@@ -98,7 +98,7 @@ task 13, line 63:
 //# create-checkpoint
 Checkpoint created: 3
 
-task 14, lines 65-126:
+task 14, lines 65-150:
 //# run-graphql
 Response: {
   "data": {
@@ -110,39 +110,120 @@ Response: {
         "nodes": [
           {
             "address": "0x1dff7845e8b1d28e0310597dc3066b125fb0cc8e2f03ac4b5b67b161243e905d",
-            "version": 10
+            "version": 10,
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::bag::Bag"
+              },
+              "json": {
+                "id": "0x1dff7845e8b1d28e0310597dc3066b125fb0cc8e2f03ac4b5b67b161243e905d",
+                "size": "0"
+              }
+            }
           },
           {
             "address": "0x4ac49e700a4f488dd62454f7d893bbef4017989d31b71d1a99b281795edbc788",
-            "version": 5
+            "version": 5,
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::bag::Bag"
+              },
+              "json": {
+                "id": "0x4ac49e700a4f488dd62454f7d893bbef4017989d31b71d1a99b281795edbc788",
+                "size": "0"
+              }
+            }
           },
           {
             "address": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
-            "version": 11
+            "version": 11,
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              },
+              "json": {
+                "balance": "299999978681550",
+                "id": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562"
+              }
+            }
           },
           {
             "address": "0x1f5dfa57399f499f7bb3370ef305042f0559abe3d17634d1d27714a8c5c069b0",
-            "version": 3
+            "version": 3,
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              },
+              "json": {
+                "balance": "500",
+                "id": "0x1f5dfa57399f499f7bb3370ef305042f0559abe3d17634d1d27714a8c5c069b0"
+              }
+            }
           },
           {
             "address": "0x88d54f8f5a0f13b9f5f84b5dd81e6128ebca0f6218ddae8540c59d4daf947682",
-            "version": 4
+            "version": 4,
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              },
+              "json": {
+                "balance": "250",
+                "id": "0x88d54f8f5a0f13b9f5f84b5dd81e6128ebca0f6218ddae8540c59d4daf947682"
+              }
+            }
           },
           {
             "address": "0x132a01782f67fb6eb24a58fc9c15e6b2f5974e91d4ec4ead56c09c377a2a26ae",
-            "version": 9
+            "version": 9,
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              },
+              "json": {
+                "balance": "200",
+                "id": "0x132a01782f67fb6eb24a58fc9c15e6b2f5974e91d4ec4ead56c09c377a2a26ae"
+              }
+            }
           },
           {
             "address": "0xfd3cb760c22e7a3b60f94d8245271f260d4e3830f42423deae3ee951c0f11608",
-            "version": 8
+            "version": 8,
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              },
+              "json": {
+                "balance": "100",
+                "id": "0xfd3cb760c22e7a3b60f94d8245271f260d4e3830f42423deae3ee951c0f11608"
+              }
+            }
           },
           {
             "address": "0x551553166c1ee7fe077ef331f93b175181d4a11d40dd964fae8e4aacfdcb3bfd",
-            "version": 6
+            "version": 6,
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::table::Table<u64,u64>"
+              },
+              "json": {
+                "id": "0x551553166c1ee7fe077ef331f93b175181d4a11d40dd964fae8e4aacfdcb3bfd",
+                "size": "0"
+              }
+            }
           },
           {
             "address": "0x596881ce97160dec6495f46c715d61f466207d9af2b9fcc5e030c433c1a06cbf",
-            "version": 11
+            "version": 11,
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::table::Table<address,address>"
+              },
+              "json": {
+                "id": "0x596881ce97160dec6495f46c715d61f466207d9af2b9fcc5e030c433c1a06cbf",
+                "size": "0"
+              }
+            }
           }
         ]
       }
@@ -155,11 +236,29 @@ Response: {
         "nodes": [
           {
             "address": "0x1dff7845e8b1d28e0310597dc3066b125fb0cc8e2f03ac4b5b67b161243e905d",
-            "version": 10
+            "version": 10,
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::bag::Bag"
+              },
+              "json": {
+                "id": "0x1dff7845e8b1d28e0310597dc3066b125fb0cc8e2f03ac4b5b67b161243e905d",
+                "size": "0"
+              }
+            }
           },
           {
             "address": "0x4ac49e700a4f488dd62454f7d893bbef4017989d31b71d1a99b281795edbc788",
-            "version": 5
+            "version": 5,
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::bag::Bag"
+              },
+              "json": {
+                "id": "0x4ac49e700a4f488dd62454f7d893bbef4017989d31b71d1a99b281795edbc788",
+                "size": "0"
+              }
+            }
           }
         ]
       }
@@ -172,23 +271,68 @@ Response: {
         "nodes": [
           {
             "address": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
-            "version": 11
+            "version": 11,
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              },
+              "json": {
+                "balance": "299999978681550",
+                "id": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562"
+              }
+            }
           },
           {
             "address": "0x1f5dfa57399f499f7bb3370ef305042f0559abe3d17634d1d27714a8c5c069b0",
-            "version": 3
+            "version": 3,
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              },
+              "json": {
+                "balance": "500",
+                "id": "0x1f5dfa57399f499f7bb3370ef305042f0559abe3d17634d1d27714a8c5c069b0"
+              }
+            }
           },
           {
             "address": "0x88d54f8f5a0f13b9f5f84b5dd81e6128ebca0f6218ddae8540c59d4daf947682",
-            "version": 4
+            "version": 4,
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              },
+              "json": {
+                "balance": "250",
+                "id": "0x88d54f8f5a0f13b9f5f84b5dd81e6128ebca0f6218ddae8540c59d4daf947682"
+              }
+            }
           },
           {
             "address": "0x132a01782f67fb6eb24a58fc9c15e6b2f5974e91d4ec4ead56c09c377a2a26ae",
-            "version": 9
+            "version": 9,
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              },
+              "json": {
+                "balance": "200",
+                "id": "0x132a01782f67fb6eb24a58fc9c15e6b2f5974e91d4ec4ead56c09c377a2a26ae"
+              }
+            }
           },
           {
             "address": "0xfd3cb760c22e7a3b60f94d8245271f260d4e3830f42423deae3ee951c0f11608",
-            "version": 8
+            "version": 8,
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+              },
+              "json": {
+                "balance": "100",
+                "id": "0xfd3cb760c22e7a3b60f94d8245271f260d4e3830f42423deae3ee951c0f11608"
+              }
+            }
           }
         ]
       }
@@ -201,7 +345,16 @@ Response: {
         "nodes": [
           {
             "address": "0x551553166c1ee7fe077ef331f93b175181d4a11d40dd964fae8e4aacfdcb3bfd",
-            "version": 6
+            "version": 6,
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::table::Table<u64,u64>"
+              },
+              "json": {
+                "id": "0x551553166c1ee7fe077ef331f93b175181d4a11d40dd964fae8e4aacfdcb3bfd",
+                "size": "0"
+              }
+            }
           }
         ]
       }
@@ -214,7 +367,16 @@ Response: {
         "nodes": [
           {
             "address": "0x596881ce97160dec6495f46c715d61f466207d9af2b9fcc5e030c433c1a06cbf",
-            "version": 11
+            "version": 11,
+            "contents": {
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::table::Table<address,address>"
+              },
+              "json": {
+                "id": "0x596881ce97160dec6495f46c715d61f466207d9af2b9fcc5e030c433c1a06cbf",
+                "size": "0"
+              }
+            }
           }
         ]
       }
@@ -230,7 +392,7 @@ Response: {
   }
 }
 
-task 15, lines 128-143:
+task 15, lines 152-171:
 //# run-graphql
 Response: {
   "data": {
@@ -244,23 +406,68 @@ Response: {
             "nodes": [
               {
                 "address": "0x4ac49e700a4f488dd62454f7d893bbef4017989d31b71d1a99b281795edbc788",
-                "version": 5
+                "version": 5,
+                "contents": {
+                  "type": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::bag::Bag"
+                  },
+                  "json": {
+                    "id": "0x4ac49e700a4f488dd62454f7d893bbef4017989d31b71d1a99b281795edbc788",
+                    "size": "0"
+                  }
+                }
               },
               {
                 "address": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562",
-                "version": 7
+                "version": 7,
+                "contents": {
+                  "type": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                  },
+                  "json": {
+                    "balance": "299999987342170",
+                    "id": "0x2834d85dbfefdcd66f04811231ba818893793e83a895d53402fd99e132e36562"
+                  }
+                }
               },
               {
                 "address": "0x1f5dfa57399f499f7bb3370ef305042f0559abe3d17634d1d27714a8c5c069b0",
-                "version": 3
+                "version": 3,
+                "contents": {
+                  "type": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                  },
+                  "json": {
+                    "balance": "500",
+                    "id": "0x1f5dfa57399f499f7bb3370ef305042f0559abe3d17634d1d27714a8c5c069b0"
+                  }
+                }
               },
               {
                 "address": "0x88d54f8f5a0f13b9f5f84b5dd81e6128ebca0f6218ddae8540c59d4daf947682",
-                "version": 4
+                "version": 4,
+                "contents": {
+                  "type": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                  },
+                  "json": {
+                    "balance": "250",
+                    "id": "0x88d54f8f5a0f13b9f5f84b5dd81e6128ebca0f6218ddae8540c59d4daf947682"
+                  }
+                }
               },
               {
                 "address": "0x551553166c1ee7fe077ef331f93b175181d4a11d40dd964fae8e4aacfdcb3bfd",
-                "version": 6
+                "version": 6,
+                "contents": {
+                  "type": {
+                    "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::table::Table<u64,u64>"
+                  },
+                  "json": {
+                    "id": "0x551553166c1ee7fe077ef331f93b175181d4a11d40dd964fae8e4aacfdcb3bfd",
+                    "size": "0"
+                  }
+                }
               }
             ]
           }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/as_move_object.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/as_move_object.move
@@ -18,6 +18,10 @@
     asMoveObject {
       objectBcs
       moveObjectBcs
+      contents {
+        type { repr }
+        json
+      }
     }
   }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/as_move_object.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/as_move_object.snap
@@ -17,7 +17,7 @@ task 2, line 10:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 3, lines 12-23:
+task 3, lines 12-27:
 //# run-graphql
 Response: {
   "data": {
@@ -25,13 +25,22 @@ Response: {
       "objectBcs": "AAEBAgAAAAAAAAAov/XpakpcD3NIJZx6v9/ZmUBcArnpwNDVnsZppTsQTHpgalAx2RABAAD8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHiAJXmDaTN9/8Me8Ls9qOM7J6Xg4QCrKcwjLGSUh7RlNrGATDwAAAAAA",
       "asMoveObject": {
         "objectBcs": "AAEBAgAAAAAAAAAov/XpakpcD3NIJZx6v9/ZmUBcArnpwNDVnsZppTsQTHpgalAx2RABAAD8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHiAJXmDaTN9/8Me8Ls9qOM7J6Xg4QCrKcwjLGSUh7RlNrGATDwAAAAAA",
-        "moveObjectBcs": "AQECAAAAAAAAACi/9elqSlwPc0glnHq/39mZQFwCuenA0NWexmmlOxBMemBqUDHZEAEA"
+        "moveObjectBcs": "AQECAAAAAAAAACi/9elqSlwPc0glnHq/39mZQFwCuenA0NWexmmlOxBMemBqUDHZEAEA",
+        "contents": {
+          "type": {
+            "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+          },
+          "json": {
+            "balance": "299999998012000",
+            "id": "0xbff5e96a4a5c0f7348259c7abfdfd999405c02b9e9c0d0d59ec669a53b104c7a"
+          }
+        }
       }
     }
   }
 }
 
-task 4, lines 25-32:
+task 4, lines 29-36:
 //# run-graphql
 Response: {
   "data": {

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/object_versions.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/object_versions.move
@@ -44,6 +44,12 @@
         address
         version
         objectBcs
+        asMoveObject {
+          contents {
+            type { repr }
+            json
+          }
+        }
       }
     }
   }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/object_versions.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/object_versions.snap
@@ -53,7 +53,7 @@ task 8, line 30:
 //# create-checkpoint
 Checkpoint created: 3
 
-task 9, lines 32-50:
+task 9, lines 32-56:
 //# run-graphql
 Response: {
   "data": {
@@ -70,7 +70,18 @@ Response: {
           "node": {
             "address": "0xbff5e96a4a5c0f7348259c7abfdfd999405c02b9e9c0d0d59ec669a53b104c7a",
             "version": 1,
-            "objectBcs": "AAEBAQAAAAAAAAAov/XpakpcD3NIJZx6v9/ZmUBcArnpwNDVnsZppTsQTHoAwG4x2RABAAD8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHiAhYMxtpUe8VbuLRSLzHY4j/iAX6Zq6YBhs7be1Cgf3GgAAAAAAAAAA"
+            "objectBcs": "AAEBAQAAAAAAAAAov/XpakpcD3NIJZx6v9/ZmUBcArnpwNDVnsZppTsQTHoAwG4x2RABAAD8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHiAhYMxtpUe8VbuLRSLzHY4j/iAX6Zq6YBhs7be1Cgf3GgAAAAAAAAAA",
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                },
+                "json": {
+                  "balance": "300000000000000",
+                  "id": "0xbff5e96a4a5c0f7348259c7abfdfd999405c02b9e9c0d0d59ec669a53b104c7a"
+                }
+              }
+            }
           }
         },
         {
@@ -78,7 +89,18 @@ Response: {
           "node": {
             "address": "0xbff5e96a4a5c0f7348259c7abfdfd999405c02b9e9c0d0d59ec669a53b104c7a",
             "version": 2,
-            "objectBcs": "AAEBAgAAAAAAAAAov/XpakpcD3NIJZx6v9/ZmUBcArnpwNDVnsZppTsQTHpgalAx2RABAAD8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHiAJXmDaTN9/8Me8Ls9qOM7J6Xg4QCrKcwjLGSUh7RlNrGATDwAAAAAA"
+            "objectBcs": "AAEBAgAAAAAAAAAov/XpakpcD3NIJZx6v9/ZmUBcArnpwNDVnsZppTsQTHpgalAx2RABAAD8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHiAJXmDaTN9/8Me8Ls9qOM7J6Xg4QCrKcwjLGSUh7RlNrGATDwAAAAAA",
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                },
+                "json": {
+                  "balance": "299999998012000",
+                  "id": "0xbff5e96a4a5c0f7348259c7abfdfd999405c02b9e9c0d0d59ec669a53b104c7a"
+                }
+              }
+            }
           }
         },
         {
@@ -86,7 +108,18 @@ Response: {
           "node": {
             "address": "0xbff5e96a4a5c0f7348259c7abfdfd999405c02b9e9c0d0d59ec669a53b104c7a",
             "version": 3,
-            "objectBcs": "AAEBAwAAAAAAAAAov/XpakpcD3NIJZx6v9/ZmUBcArnpwNDVnsZppTsQTHqIAUEx2RABAAD8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHiDWUsSOzQErUliOrDD0D+QXvoz1w3yXlmqqxLHIMOllUWATDwAAAAAA"
+            "objectBcs": "AAEBAwAAAAAAAAAov/XpakpcD3NIJZx6v9/ZmUBcArnpwNDVnsZppTsQTHqIAUEx2RABAAD8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHiDWUsSOzQErUliOrDD0D+QXvoz1w3yXlmqqxLHIMOllUWATDwAAAAAA",
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                },
+                "json": {
+                  "balance": "299999997002120",
+                  "id": "0xbff5e96a4a5c0f7348259c7abfdfd999405c02b9e9c0d0d59ec669a53b104c7a"
+                }
+              }
+            }
           }
         },
         {
@@ -94,7 +127,18 @@ Response: {
           "node": {
             "address": "0xbff5e96a4a5c0f7348259c7abfdfd999405c02b9e9c0d0d59ec669a53b104c7a",
             "version": 4,
-            "objectBcs": "AAEBBAAAAAAAAAAov/XpakpcD3NIJZx6v9/ZmUBcArnpwNDVnsZppTsQTHqwmDEx2RABAAD8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHiBEF4j2ubw/i05PSuc8wW+G5u+n+iAYppE65LNP6EWO0WATDwAAAAAA"
+            "objectBcs": "AAEBBAAAAAAAAAAov/XpakpcD3NIJZx6v9/ZmUBcArnpwNDVnsZppTsQTHqwmDEx2RABAAD8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHiBEF4j2ubw/i05PSuc8wW+G5u+n+iAYppE65LNP6EWO0WATDwAAAAAA",
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                },
+                "json": {
+                  "balance": "299999995992240",
+                  "id": "0xbff5e96a4a5c0f7348259c7abfdfd999405c02b9e9c0d0d59ec669a53b104c7a"
+                }
+              }
+            }
           }
         },
         {
@@ -102,7 +146,18 @@ Response: {
           "node": {
             "address": "0xbff5e96a4a5c0f7348259c7abfdfd999405c02b9e9c0d0d59ec669a53b104c7a",
             "version": 5,
-            "objectBcs": "AAEBBQAAAAAAAAAov/XpakpcD3NIJZx6v9/ZmUBcArnpwNDVnsZppTsQTHrYLyIx2RABAAD8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHiBeBpKe2ojL1pdSppjgneSTpwq7wxmfLlWyw6UYAFXH9GATDwAAAAAA"
+            "objectBcs": "AAEBBQAAAAAAAAAov/XpakpcD3NIJZx6v9/ZmUBcArnpwNDVnsZppTsQTHrYLyIx2RABAAD8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHiBeBpKe2ojL1pdSppjgneSTpwq7wxmfLlWyw6UYAFXH9GATDwAAAAAA",
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                },
+                "json": {
+                  "balance": "299999994982360",
+                  "id": "0xbff5e96a4a5c0f7348259c7abfdfd999405c02b9e9c0d0d59ec669a53b104c7a"
+                }
+              }
+            }
           }
         },
         {
@@ -110,7 +165,18 @@ Response: {
           "node": {
             "address": "0xbff5e96a4a5c0f7348259c7abfdfd999405c02b9e9c0d0d59ec669a53b104c7a",
             "version": 6,
-            "objectBcs": "AAEBBgAAAAAAAAAov/XpakpcD3NIJZx6v9/ZmUBcArnpwNDVnsZppTsQTHoAxxIx2RABAAD8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHiD0+HVckKf75XBKr9/8sIyj8s7FsGEzAD4kjxYxM/vRaGATDwAAAAAA"
+            "objectBcs": "AAEBBgAAAAAAAAAov/XpakpcD3NIJZx6v9/ZmUBcArnpwNDVnsZppTsQTHoAxxIx2RABAAD8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHiD0+HVckKf75XBKr9/8sIyj8s7FsGEzAD4kjxYxM/vRaGATDwAAAAAA",
+            "asMoveObject": {
+              "contents": {
+                "type": {
+                  "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+                },
+                "json": {
+                  "balance": "299999993972480",
+                  "id": "0xbff5e96a4a5c0f7348259c7abfdfd999405c02b9e9c0d0d59ec669a53b104c7a"
+                }
+              }
+            }
           }
         }
       ]
@@ -118,7 +184,7 @@ Response: {
   }
 }
 
-task 10, lines 52-63:
+task 10, lines 58-69:
 //# run-graphql
 Response: {
   "data": {
@@ -144,7 +210,7 @@ Response: {
   }
 }
 
-task 11, lines 65-76:
+task 11, lines 71-82:
 //# run-graphql
 Response: {
   "data": {
@@ -170,7 +236,7 @@ Response: {
   }
 }
 
-task 12, lines 78-89:
+task 12, lines 84-95:
 //# run-graphql --cursors 1
 Response: {
   "data": {
@@ -196,7 +262,7 @@ Response: {
   }
 }
 
-task 13, lines 91-102:
+task 13, lines 97-108:
 //# run-graphql --cursors 4
 Response: {
   "data": {
@@ -219,7 +285,7 @@ Response: {
   }
 }
 
-task 14, lines 104-115:
+task 14, lines 110-121:
 //# run-graphql --cursors 4
 Response: {
   "data": {
@@ -242,7 +308,7 @@ Response: {
   }
 }
 
-task 15, lines 117-128:
+task 15, lines 123-134:
 //# run-graphql --cursors 5
 Response: {
   "data": {
@@ -268,7 +334,7 @@ Response: {
   }
 }
 
-task 16, lines 130-141:
+task 16, lines 136-147:
 //# run-graphql --cursors 5
 Response: {
   "data": {
@@ -294,7 +360,7 @@ Response: {
   }
 }
 
-task 17, lines 143-154:
+task 17, lines 149-160:
 //# run-graphql --cursors 2
 Response: {
   "data": {
@@ -314,7 +380,7 @@ Response: {
   }
 }
 
-task 18, lines 156-167:
+task 18, lines 162-173:
 //# run-graphql --cursors 2
 Response: {
   "data": {
@@ -334,7 +400,7 @@ Response: {
   }
 }
 
-task 19, lines 169-180:
+task 19, lines 175-186:
 //# run-graphql --cursors 1 4
 Response: {
   "data": {
@@ -357,7 +423,7 @@ Response: {
   }
 }
 
-task 20, lines 182-193:
+task 20, lines 188-199:
 //# run-graphql --cursors 1 4
 Response: {
   "data": {
@@ -377,7 +443,7 @@ Response: {
   }
 }
 
-task 21, lines 195-206:
+task 21, lines 201-212:
 //# run-graphql --cursors 1 4
 Response: {
   "data": {
@@ -397,7 +463,7 @@ Response: {
   }
 }
 
-task 22, lines 208-219:
+task 22, lines 214-225:
 //# run-graphql
 Response: {
   "data": {

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/events.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/events.move
@@ -5,28 +5,29 @@
 
 //# publish
 module test::events_test {
+    use std::ascii;
     use sui::event;
 
     public struct TestEvent has copy, drop {
-        message: vector<u8>,
+        message: ascii::String,
         value: u64,
     }
 
     public entry fun emit_event(value: u64) {
         event::emit(TestEvent {
-            message: b"Hello from test event",
+            message: ascii::string(b"Hello from test event"),
             value,
         });
     }
 
     public entry fun emit_multiple_events() {
         event::emit(TestEvent {
-            message: b"First event",
+            message: ascii::string(b"First event"),
             value: 1,
         });
 
         event::emit(TestEvent {
-            message: b"Second event",
+            message: ascii::string(b"Second event"),
             value: 2,
         });
     }
@@ -60,6 +61,10 @@ module test::events_test {
         sequenceNumber
         timestamp
         eventBcs
+        contents {
+          type { repr }
+          json
+        }
         transaction {
           digest
         }
@@ -83,6 +88,10 @@ module test::events_test {
         sequenceNumber
         timestamp
         eventBcs
+        contents {
+          type { repr }
+          json
+        }
         transaction {
           digest
         }
@@ -106,6 +115,10 @@ module test::events_test {
         sequenceNumber
         timestamp
         eventBcs
+        contents {
+          type { repr }
+          json
+        }
         transaction {
           digest
         }
@@ -129,6 +142,10 @@ module test::events_test {
         sequenceNumber
         timestamp
         eventBcs
+        contents {
+          type { repr }
+          json
+        }
         transaction {
           digest
         }
@@ -152,6 +169,10 @@ module test::events_test {
         sequenceNumber
         timestamp
         eventBcs
+        contents {
+          type { repr }
+          json
+        }
         transaction {
           digest
         }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/events.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/events.snap
@@ -6,25 +6,25 @@ processed 11 tasks
 init:
 A: object(0,0), B: object(0,1)
 
-task 1, lines 6-35:
+task 1, lines 6-36:
 //# publish
 created: object(1,0)
 mutated: object(0,2)
-gas summary: computation_cost: 1000000, storage_cost: 5791200,  storage_rebate: 0, non_refundable_storage_fee: 0
+gas summary: computation_cost: 1000000, storage_cost: 6368800,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 2, lines 36-38:
+task 2, lines 37-39:
 //# run test::events_test::emit_event --sender A --args 42
 events: Event { package_id: test, transaction_module: Identifier("events_test"), sender: A, type_: StructTag { address: test, module: Identifier("events_test"), name: Identifier("TestEvent"), type_params: [] }, contents: [21, 72, 101, 108, 108, 111, 32, 102, 114, 111, 109, 32, 116, 101, 115, 116, 32, 101, 118, 101, 110, 116, 42, 0, 0, 0, 0, 0, 0, 0] }
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
-task 3, lines 39-41:
+task 3, lines 40-42:
 //# run test::events_test::emit_multiple_events --sender A
 events: Event { package_id: test, transaction_module: Identifier("events_test"), sender: A, type_: StructTag { address: test, module: Identifier("events_test"), name: Identifier("TestEvent"), type_params: [] }, contents: [11, 70, 105, 114, 115, 116, 32, 101, 118, 101, 110, 116, 1, 0, 0, 0, 0, 0, 0, 0] }, Event { package_id: test, transaction_module: Identifier("events_test"), sender: A, type_: StructTag { address: test, module: Identifier("events_test"), name: Identifier("TestEvent"), type_params: [] }, contents: [12, 83, 101, 99, 111, 110, 100, 32, 101, 118, 101, 110, 116, 2, 0, 0, 0, 0, 0, 0, 0] }
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 4, lines 42-44:
+task 4, lines 43-45:
 //# programmable --sender A --inputs 100 @B
 //> 0: SplitCoins(Gas, [Input(0)]);
 //> 1: TransferObjects([Result(0)], Input(1))
@@ -32,11 +32,11 @@ created: object(4,0)
 mutated: object(0,0)
 gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
-task 5, line 46:
+task 5, line 47:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 6, lines 48-69:
+task 6, lines 49-74:
 //# run-graphql
 Response: {
   "data": {
@@ -53,9 +53,18 @@ Response: {
             },
             "sequenceNumber": 0,
             "timestamp": "1970-01-01T00:00:00Z",
-            "eventBcs": "edM4dqCRDBjUHGiAu4szEwUBOC1V1mKE2m5fjiGoJY8LZXZlbnRzX3Rlc3T8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHnnTOHagkQwY1BxogLuLMxMFATgtVdZihNpuX44hqCWPC2V2ZW50c190ZXN0CVRlc3RFdmVudAAeFUhlbGxvIGZyb20gdGVzdCBldmVudCoAAAAAAAAA",
+            "eventBcs": "rjWhwYTnKh7Z5VlciyycqsS5lbzrQsRPxfsUNfSDFzELZXZlbnRzX3Rlc3T8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHq41ocGE5yoe2eVZXIssnKrEuZW860LET8X7FDX0gxcxC2V2ZW50c190ZXN0CVRlc3RFdmVudAAeFUhlbGxvIGZyb20gdGVzdCBldmVudCoAAAAAAAAA",
+            "contents": {
+              "type": {
+                "repr": "0xae35a1c184e72a1ed9e5595c8b2c9caac4b995bceb42c44fc5fb1435f4831731::events_test::TestEvent"
+              },
+              "json": {
+                "message": "Hello from test event",
+                "value": "42"
+              }
+            },
             "transaction": {
-              "digest": "EBQvwCcAgXNESe6T4uzbcJjXvcRZMdqcQDab5u87vY4o"
+              "digest": "3QXGQcUWzKsiqfcdrZwMXp6jFZDErSc59PyvJ7osufCf"
             }
           }
         ]
@@ -64,7 +73,7 @@ Response: {
   }
 }
 
-task 7, lines 71-92:
+task 7, lines 76-101:
 //# run-graphql
 Response: {
   "data": {
@@ -81,9 +90,18 @@ Response: {
             },
             "sequenceNumber": 0,
             "timestamp": "1970-01-01T00:00:00Z",
-            "eventBcs": "edM4dqCRDBjUHGiAu4szEwUBOC1V1mKE2m5fjiGoJY8LZXZlbnRzX3Rlc3T8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHnnTOHagkQwY1BxogLuLMxMFATgtVdZihNpuX44hqCWPC2V2ZW50c190ZXN0CVRlc3RFdmVudAAUC0ZpcnN0IGV2ZW50AQAAAAAAAAA=",
+            "eventBcs": "rjWhwYTnKh7Z5VlciyycqsS5lbzrQsRPxfsUNfSDFzELZXZlbnRzX3Rlc3T8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHq41ocGE5yoe2eVZXIssnKrEuZW860LET8X7FDX0gxcxC2V2ZW50c190ZXN0CVRlc3RFdmVudAAUC0ZpcnN0IGV2ZW50AQAAAAAAAAA=",
+            "contents": {
+              "type": {
+                "repr": "0xae35a1c184e72a1ed9e5595c8b2c9caac4b995bceb42c44fc5fb1435f4831731::events_test::TestEvent"
+              },
+              "json": {
+                "message": "First event",
+                "value": "1"
+              }
+            },
             "transaction": {
-              "digest": "2XgXXUkgPn7j8RtqDKeNm6782kHHwbqJ7az6o92sVSg4"
+              "digest": "2KquAhDwgXYraqFkiEJgH4KcETB9bg4Z3PpUp2WqsLwk"
             }
           },
           {
@@ -92,9 +110,18 @@ Response: {
             },
             "sequenceNumber": 1,
             "timestamp": "1970-01-01T00:00:00Z",
-            "eventBcs": "edM4dqCRDBjUHGiAu4szEwUBOC1V1mKE2m5fjiGoJY8LZXZlbnRzX3Rlc3T8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHnnTOHagkQwY1BxogLuLMxMFATgtVdZihNpuX44hqCWPC2V2ZW50c190ZXN0CVRlc3RFdmVudAAVDFNlY29uZCBldmVudAIAAAAAAAAA",
+            "eventBcs": "rjWhwYTnKh7Z5VlciyycqsS5lbzrQsRPxfsUNfSDFzELZXZlbnRzX3Rlc3T8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHq41ocGE5yoe2eVZXIssnKrEuZW860LET8X7FDX0gxcxC2V2ZW50c190ZXN0CVRlc3RFdmVudAAVDFNlY29uZCBldmVudAIAAAAAAAAA",
+            "contents": {
+              "type": {
+                "repr": "0xae35a1c184e72a1ed9e5595c8b2c9caac4b995bceb42c44fc5fb1435f4831731::events_test::TestEvent"
+              },
+              "json": {
+                "message": "Second event",
+                "value": "2"
+              }
+            },
             "transaction": {
-              "digest": "2XgXXUkgPn7j8RtqDKeNm6782kHHwbqJ7az6o92sVSg4"
+              "digest": "2KquAhDwgXYraqFkiEJgH4KcETB9bg4Z3PpUp2WqsLwk"
             }
           }
         ]
@@ -103,7 +130,7 @@ Response: {
   }
 }
 
-task 8, lines 94-115:
+task 8, lines 103-128:
 //# run-graphql
 Response: {
   "data": {
@@ -120,9 +147,18 @@ Response: {
             },
             "sequenceNumber": 0,
             "timestamp": "1970-01-01T00:00:00Z",
-            "eventBcs": "edM4dqCRDBjUHGiAu4szEwUBOC1V1mKE2m5fjiGoJY8LZXZlbnRzX3Rlc3T8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHnnTOHagkQwY1BxogLuLMxMFATgtVdZihNpuX44hqCWPC2V2ZW50c190ZXN0CVRlc3RFdmVudAAUC0ZpcnN0IGV2ZW50AQAAAAAAAAA=",
+            "eventBcs": "rjWhwYTnKh7Z5VlciyycqsS5lbzrQsRPxfsUNfSDFzELZXZlbnRzX3Rlc3T8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHq41ocGE5yoe2eVZXIssnKrEuZW860LET8X7FDX0gxcxC2V2ZW50c190ZXN0CVRlc3RFdmVudAAUC0ZpcnN0IGV2ZW50AQAAAAAAAAA=",
+            "contents": {
+              "type": {
+                "repr": "0xae35a1c184e72a1ed9e5595c8b2c9caac4b995bceb42c44fc5fb1435f4831731::events_test::TestEvent"
+              },
+              "json": {
+                "message": "First event",
+                "value": "1"
+              }
+            },
             "transaction": {
-              "digest": "2XgXXUkgPn7j8RtqDKeNm6782kHHwbqJ7az6o92sVSg4"
+              "digest": "2KquAhDwgXYraqFkiEJgH4KcETB9bg4Z3PpUp2WqsLwk"
             }
           }
         ]
@@ -131,7 +167,7 @@ Response: {
   }
 }
 
-task 9, lines 117-138:
+task 9, lines 130-155:
 //# run-graphql
 Response: {
   "data": {
@@ -148,9 +184,18 @@ Response: {
             },
             "sequenceNumber": 1,
             "timestamp": "1970-01-01T00:00:00Z",
-            "eventBcs": "edM4dqCRDBjUHGiAu4szEwUBOC1V1mKE2m5fjiGoJY8LZXZlbnRzX3Rlc3T8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHnnTOHagkQwY1BxogLuLMxMFATgtVdZihNpuX44hqCWPC2V2ZW50c190ZXN0CVRlc3RFdmVudAAVDFNlY29uZCBldmVudAIAAAAAAAAA",
+            "eventBcs": "rjWhwYTnKh7Z5VlciyycqsS5lbzrQsRPxfsUNfSDFzELZXZlbnRzX3Rlc3T8zJpCG7sTwaZqGqmPCtdQKe3pSFd3nGkVtE+UBouSHq41ocGE5yoe2eVZXIssnKrEuZW860LET8X7FDX0gxcxC2V2ZW50c190ZXN0CVRlc3RFdmVudAAVDFNlY29uZCBldmVudAIAAAAAAAAA",
+            "contents": {
+              "type": {
+                "repr": "0xae35a1c184e72a1ed9e5595c8b2c9caac4b995bceb42c44fc5fb1435f4831731::events_test::TestEvent"
+              },
+              "json": {
+                "message": "Second event",
+                "value": "2"
+              }
+            },
             "transaction": {
-              "digest": "2XgXXUkgPn7j8RtqDKeNm6782kHHwbqJ7az6o92sVSg4"
+              "digest": "2KquAhDwgXYraqFkiEJgH4KcETB9bg4Z3PpUp2WqsLwk"
             }
           }
         ]
@@ -159,7 +204,7 @@ Response: {
   }
 }
 
-task 10, lines 140-161:
+task 10, lines 157-182:
 //# run-graphql
 Response: {
   "data": {

--- a/crates/sui-indexer-alt-graphql/Cargo.toml
+++ b/crates/sui-indexer-alt-graphql/Cargo.toml
@@ -33,6 +33,7 @@ fastcrypto.workspace = true
 futures.workspace = true
 headers.workspace = true
 prometheus.workspace = true
+prost-types.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 telemetry-subscribers.workspace = true

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -643,6 +643,10 @@ type Epoch {
 
 type Event {
 	"""
+	The Move value emitted for this event.
+	"""
+	contents: MoveValue
+	"""
 	The Base64 encoded BCS serialized bytes of the entire Event structure from sui-types.
 	This includes: package_id, transaction_module, sender, type, and contents (which itself contains the BCS-serialized Move struct data).
 	"""

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -852,6 +852,10 @@ Interface implemented by types that represent a Move object on-chain (A Move val
 """
 interface IMoveObject {
 	"""
+	The structured representation of the object's contents.
+	"""
+	contents: MoveValue
+	"""
 	The Base64-encoded BCS serialize of this object, as a `MoveObject`.
 	"""
 	moveObjectBcs: Base64
@@ -898,6 +902,11 @@ type Input {
 	ix: Int
 }
 
+
+"""
+Arbitrary JSON data.
+"""
+scalar JSON
 
 """
 Information used by a package to link to a specific version of its dependency.
@@ -998,6 +1007,10 @@ type MoveObject implements IAddressable & IObject & IMoveObject {
 	32-byte hash that identifies the object's contents, encoded in Base58.
 	"""
 	digest: String!
+	"""
+	The structured representation of the object's contents.
+	"""
+	contents: MoveValue
 	"""
 	The Base64-encoded BCS serialize of this object, as a `MoveObject`.
 	"""
@@ -1229,6 +1242,31 @@ type MoveTypeSignature =
     }
 """
 scalar MoveTypeSignature
+
+type MoveValue {
+	"""
+	The BCS representation of this value, Base64-encoded.
+	"""
+	bcs: Base64
+	"""
+	Representation of a Move value in JSON, where:
+	
+	- Addresses, IDs, and UIDs are represented in canonical form, as JSON strings.
+	- Bools are represented by JSON boolean literals.
+	- u8, u16, and u32 are represented as JSON numbers.
+	- u64, u128, and u256 are represented as JSON strings.
+	- Balances, Strings, and Urls are represented as JSON strings.
+	- Vectors of bytes are represented as Base64 blobs, and other vectors are represented by JSON arrays.
+	- Structs are represented by JSON objects.
+	- Enums are represented by JSON objects, with a field named `@variant` containing the variant name.
+	- Empty optional values are represented by `null`.
+	"""
+	json: JSON
+	"""
+	The value's type.
+	"""
+	type: MoveType
+}
 
 """
 A transaction that wanted to mutate a consensus-managed object but couldn't because it became not-consensus-managed before the transaction executed (for example, it was deleted, turned into an owned object, or wrapped).
@@ -1961,6 +1999,10 @@ type ServiceConfig {
 	Maximum nesting allowed in datatype fields when calculating the layout of a single type.
 	"""
 	maxMoveValueDepth: Int
+	"""
+	Maximum budget in bytes to spend when outputting a structured `MoveValue`.
+	"""
+	maxMoveValueBound: Int
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/api/scalars/json.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/scalars/json.rs
@@ -1,0 +1,31 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::{Description, InputValueResult, Scalar, ScalarType, Value};
+
+/// Arbitrary JSON data.
+#[derive(Debug)]
+pub(crate) struct Json(Value);
+
+#[Scalar(name = "JSON", use_type_description = true)]
+impl ScalarType for Json {
+    fn parse(value: Value) -> InputValueResult<Self> {
+        Ok(Self(value))
+    }
+
+    fn to_value(&self) -> Value {
+        self.0.clone()
+    }
+}
+
+impl Description for Json {
+    fn description() -> &'static str {
+        "Arbitrary JSON data."
+    }
+}
+
+impl From<Value> for Json {
+    fn from(value: Value) -> Self {
+        Self(value)
+    }
+}

--- a/crates/sui-indexer-alt-graphql/src/api/scalars/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/scalars/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod big_int;
 pub(crate) mod cursor;
 pub(crate) mod date_time;
 pub(crate) mod digest;
+pub(crate) mod json;
 pub(crate) mod owner_kind;
 pub(crate) mod sui_address;
 pub(crate) mod type_filter;

--- a/crates/sui-indexer-alt-graphql/src/api/types/event.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event.rs
@@ -14,7 +14,9 @@ use crate::{
     scope::Scope,
 };
 
-use super::{address::Address, transaction::Transaction};
+use super::{
+    address::Address, move_type::MoveType, move_value::MoveValue, transaction::Transaction,
+};
 
 #[derive(Clone)]
 pub(crate) struct Event {
@@ -29,9 +31,14 @@ pub(crate) struct Event {
 }
 
 // TODO(DVX-1200): Support sendingModule - MoveModule
-// TODO(DVX-1203): contents - MoveValue
 #[Object]
 impl Event {
+    /// The Move value emitted for this event.
+    async fn contents(&self) -> Option<MoveValue> {
+        let type_ = MoveType::from_native(self.native.type_.clone().into(), self.scope.clone());
+        Some(MoveValue::new(type_, self.native.contents.clone()))
+    }
+
     /// The Base64 encoded BCS serialized bytes of the entire Event structure from sui-types.
     /// This includes: package_id, transaction_module, sender, type, and contents (which itself contains the BCS-serialized Move struct data).
     async fn event_bcs(&self) -> Result<Option<Base64>, RpcError> {

--- a/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
@@ -14,6 +14,7 @@ mod linkage;
 pub(crate) mod move_object;
 pub(crate) mod move_package;
 pub(crate) mod move_type;
+pub(crate) mod move_value;
 pub(crate) mod object;
 pub(crate) mod object_change;
 pub(crate) mod object_filter;

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_value.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_value.rs
@@ -1,0 +1,93 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::{Context, Name, Object};
+use prost_types::{self as proto, value::Kind};
+use serde_json::Number;
+use sui_types::proto_value::ProtoVisitorBuilder;
+
+use crate::{
+    api::scalars::{base64::Base64, json::Json},
+    config::Limits,
+    error::{resource_exhausted, RpcError},
+};
+
+use super::move_type::MoveType;
+
+pub(crate) struct MoveValue {
+    type_: MoveType,
+    native: Vec<u8>,
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("Move value is too big")]
+pub(crate) struct MoveValueTooBigError;
+
+#[Object]
+impl MoveValue {
+    /// The BCS representation of this value, Base64-encoded.
+    async fn bcs(&self) -> Option<Base64> {
+        Some(Base64::from(self.native.clone()))
+    }
+
+    /// Representation of a Move value in JSON, where:
+    ///
+    /// - Addresses, IDs, and UIDs are represented in canonical form, as JSON strings.
+    /// - Bools are represented by JSON boolean literals.
+    /// - u8, u16, and u32 are represented as JSON numbers.
+    /// - u64, u128, and u256 are represented as JSON strings.
+    /// - Balances, Strings, and Urls are represented as JSON strings.
+    /// - Vectors of bytes are represented as Base64 blobs, and other vectors are represented by JSON arrays.
+    /// - Structs are represented by JSON objects.
+    /// - Enums are represented by JSON objects, with a field named `@variant` containing the variant name.
+    /// - Empty optional values are represented by `null`.
+    async fn json(&self, ctx: &Context<'_>) -> Result<Option<Json>, RpcError> {
+        let limits: &Limits = ctx.data()?;
+
+        let Some(layout) = self.type_.layout_impl().await? else {
+            return Ok(None);
+        };
+
+        let value = ProtoVisitorBuilder::new(limits.max_move_value_bound)
+            .deserialize_value(&self.native, &layout)
+            .map_err(|_| resource_exhausted(MoveValueTooBigError))?;
+
+        Ok(Some(Json::from(proto_to_json(value))))
+    }
+
+    /// The value's type.
+    async fn type_(&self) -> Option<MoveType> {
+        Some(self.type_.clone())
+    }
+}
+
+impl MoveValue {
+    pub(crate) fn new(type_: MoveType, native: Vec<u8>) -> Self {
+        Self { type_, native }
+    }
+}
+
+/// Convert a Protobuf value into a GraphQL JSON value.
+fn proto_to_json(proto: proto::Value) -> async_graphql::Value {
+    match proto.kind {
+        Some(Kind::NullValue(_)) | None => async_graphql::Value::Null,
+        Some(Kind::BoolValue(b)) => async_graphql::Value::Boolean(b),
+        Some(Kind::StringValue(s)) => async_graphql::Value::String(s),
+
+        // The [`ProtoVisitor`] only produces numbers for `u8`, `u16`, and `u32` values, so they
+        // can be encoded as a whole number in JSON without loss of precision by conversion to
+        // `u32`.
+        Some(Kind::NumberValue(n)) => async_graphql::Value::Number(Number::from(n as u32)),
+
+        Some(Kind::StructValue(map)) => async_graphql::Value::Object(
+            map.fields
+                .into_iter()
+                .map(|(k, v)| (Name::new(k), proto_to_json(v)))
+                .collect(),
+        ),
+
+        Some(Kind::ListValue(list)) => {
+            async_graphql::Value::List(list.values.into_iter().map(proto_to_json).collect())
+        }
+    }
+}

--- a/crates/sui-indexer-alt-graphql/src/api/types/service_config.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/service_config.rs
@@ -171,4 +171,10 @@ impl ServiceConfig {
         let limits: &Limits = ctx.data()?;
         Ok(Some(limits.max_move_value_depth))
     }
+
+    /// Maximum budget in bytes to spend when outputting a structured `MoveValue`.
+    async fn max_move_value_bound(&self, ctx: &Context<'_>) -> Result<Option<usize>, RpcError> {
+        let limits: &Limits = ctx.data()?;
+        Ok(Some(limits.max_move_value_bound))
+    }
 }

--- a/crates/sui-indexer-alt-graphql/src/config.rs
+++ b/crates/sui-indexer-alt-graphql/src/config.rs
@@ -127,6 +127,9 @@ pub struct Limits {
 
     /// Maximum nesting allowed in datatype fields when calculating the layout of a single type.
     pub max_move_value_depth: usize,
+
+    /// Maximum budget in bytes to spend when outputting a structured Move value.
+    pub max_move_value_bound: usize,
 }
 
 #[DefaultConfig]
@@ -148,6 +151,7 @@ pub struct LimitsLayer {
     pub max_type_argument_width: Option<usize>,
     pub max_type_nodes: Option<usize>,
     pub max_move_value_depth: Option<usize>,
+    pub max_move_value_bound: Option<usize>,
 
     #[serde(flatten)]
     pub extra: toml::Table,
@@ -299,6 +303,9 @@ impl LimitsLayer {
             max_move_value_depth: self
                 .max_move_value_depth
                 .unwrap_or(base.max_move_value_depth),
+            max_move_value_bound: self
+                .max_move_value_bound
+                .unwrap_or(base.max_move_value_bound),
         }
     }
 }
@@ -343,6 +350,7 @@ impl From<Limits> for LimitsLayer {
             max_type_argument_width: Some(value.max_type_argument_width),
             max_type_nodes: Some(value.max_type_nodes),
             max_move_value_depth: Some(value.max_move_value_depth),
+            max_move_value_bound: Some(value.max_move_value_bound),
             extra: Default::default(),
         }
     }
@@ -409,6 +417,7 @@ impl Default for Limits {
             max_type_argument_width,
             max_type_nodes,
             max_move_value_depth,
+            max_move_value_bound: 1024 * 1024,
         }
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -856,6 +856,10 @@ Interface implemented by types that represent a Move object on-chain (A Move val
 """
 interface IMoveObject {
 	"""
+	The structured representation of the object's contents.
+	"""
+	contents: MoveValue
+	"""
 	The Base64-encoded BCS serialize of this object, as a `MoveObject`.
 	"""
 	moveObjectBcs: Base64
@@ -902,6 +906,11 @@ type Input {
 	ix: Int
 }
 
+
+"""
+Arbitrary JSON data.
+"""
+scalar JSON
 
 """
 Information used by a package to link to a specific version of its dependency.
@@ -1002,6 +1011,10 @@ type MoveObject implements IAddressable & IObject & IMoveObject {
 	32-byte hash that identifies the object's contents, encoded in Base58.
 	"""
 	digest: String!
+	"""
+	The structured representation of the object's contents.
+	"""
+	contents: MoveValue
 	"""
 	The Base64-encoded BCS serialize of this object, as a `MoveObject`.
 	"""
@@ -1233,6 +1246,31 @@ type MoveTypeSignature =
     }
 """
 scalar MoveTypeSignature
+
+type MoveValue {
+	"""
+	The BCS representation of this value, Base64-encoded.
+	"""
+	bcs: Base64
+	"""
+	Representation of a Move value in JSON, where:
+	
+	- Addresses, IDs, and UIDs are represented in canonical form, as JSON strings.
+	- Bools are represented by JSON boolean literals.
+	- u8, u16, and u32 are represented as JSON numbers.
+	- u64, u128, and u256 are represented as JSON strings.
+	- Balances, Strings, and Urls are represented as JSON strings.
+	- Vectors of bytes are represented as Base64 blobs, and other vectors are represented by JSON arrays.
+	- Structs are represented by JSON objects.
+	- Enums are represented by JSON objects, with a field named `@variant` containing the variant name.
+	- Empty optional values are represented by `null`.
+	"""
+	json: JSON
+	"""
+	The value's type.
+	"""
+	type: MoveType
+}
 
 """
 A transaction that wanted to mutate a consensus-managed object but couldn't because it became not-consensus-managed before the transaction executed (for example, it was deleted, turned into an owned object, or wrapped).
@@ -1965,6 +2003,10 @@ type ServiceConfig {
 	Maximum nesting allowed in datatype fields when calculating the layout of a single type.
 	"""
 	maxMoveValueDepth: Int
+	"""
+	Maximum budget in bytes to spend when outputting a structured `MoveValue`.
+	"""
+	maxMoveValueBound: Int
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -647,6 +647,10 @@ type Epoch {
 
 type Event {
 	"""
+	The Move value emitted for this event.
+	"""
+	contents: MoveValue
+	"""
 	The Base64 encoded BCS serialized bytes of the entire Event structure from sui-types.
 	This includes: package_id, transaction_module, sender, type, and contents (which itself contains the BCS-serialized Move struct data).
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -856,6 +856,10 @@ Interface implemented by types that represent a Move object on-chain (A Move val
 """
 interface IMoveObject {
 	"""
+	The structured representation of the object's contents.
+	"""
+	contents: MoveValue
+	"""
 	The Base64-encoded BCS serialize of this object, as a `MoveObject`.
 	"""
 	moveObjectBcs: Base64
@@ -902,6 +906,11 @@ type Input {
 	ix: Int
 }
 
+
+"""
+Arbitrary JSON data.
+"""
+scalar JSON
 
 """
 Information used by a package to link to a specific version of its dependency.
@@ -1002,6 +1011,10 @@ type MoveObject implements IAddressable & IObject & IMoveObject {
 	32-byte hash that identifies the object's contents, encoded in Base58.
 	"""
 	digest: String!
+	"""
+	The structured representation of the object's contents.
+	"""
+	contents: MoveValue
 	"""
 	The Base64-encoded BCS serialize of this object, as a `MoveObject`.
 	"""
@@ -1233,6 +1246,31 @@ type MoveTypeSignature =
     }
 """
 scalar MoveTypeSignature
+
+type MoveValue {
+	"""
+	The BCS representation of this value, Base64-encoded.
+	"""
+	bcs: Base64
+	"""
+	Representation of a Move value in JSON, where:
+	
+	- Addresses, IDs, and UIDs are represented in canonical form, as JSON strings.
+	- Bools are represented by JSON boolean literals.
+	- u8, u16, and u32 are represented as JSON numbers.
+	- u64, u128, and u256 are represented as JSON strings.
+	- Balances, Strings, and Urls are represented as JSON strings.
+	- Vectors of bytes are represented as Base64 blobs, and other vectors are represented by JSON arrays.
+	- Structs are represented by JSON objects.
+	- Enums are represented by JSON objects, with a field named `@variant` containing the variant name.
+	- Empty optional values are represented by `null`.
+	"""
+	json: JSON
+	"""
+	The value's type.
+	"""
+	type: MoveType
+}
 
 """
 A transaction that wanted to mutate a consensus-managed object but couldn't because it became not-consensus-managed before the transaction executed (for example, it was deleted, turned into an owned object, or wrapped).
@@ -1965,6 +2003,10 @@ type ServiceConfig {
 	Maximum nesting allowed in datatype fields when calculating the layout of a single type.
 	"""
 	maxMoveValueDepth: Int
+	"""
+	Maximum budget in bytes to spend when outputting a structured `MoveValue`.
+	"""
+	maxMoveValueBound: Int
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -647,6 +647,10 @@ type Epoch {
 
 type Event {
 	"""
+	The Move value emitted for this event.
+	"""
+	contents: MoveValue
+	"""
 	The Base64 encoded BCS serialized bytes of the entire Event structure from sui-types.
 	This includes: package_id, transaction_module, sender, type, and contents (which itself contains the BCS-serialized Move struct data).
 	"""

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -643,6 +643,10 @@ type Epoch {
 
 type Event {
 	"""
+	The Move value emitted for this event.
+	"""
+	contents: MoveValue
+	"""
 	The Base64 encoded BCS serialized bytes of the entire Event structure from sui-types.
 	This includes: package_id, transaction_module, sender, type, and contents (which itself contains the BCS-serialized Move struct data).
 	"""

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -852,6 +852,10 @@ Interface implemented by types that represent a Move object on-chain (A Move val
 """
 interface IMoveObject {
 	"""
+	The structured representation of the object's contents.
+	"""
+	contents: MoveValue
+	"""
 	The Base64-encoded BCS serialize of this object, as a `MoveObject`.
 	"""
 	moveObjectBcs: Base64
@@ -898,6 +902,11 @@ type Input {
 	ix: Int
 }
 
+
+"""
+Arbitrary JSON data.
+"""
+scalar JSON
 
 """
 Information used by a package to link to a specific version of its dependency.
@@ -998,6 +1007,10 @@ type MoveObject implements IAddressable & IObject & IMoveObject {
 	32-byte hash that identifies the object's contents, encoded in Base58.
 	"""
 	digest: String!
+	"""
+	The structured representation of the object's contents.
+	"""
+	contents: MoveValue
 	"""
 	The Base64-encoded BCS serialize of this object, as a `MoveObject`.
 	"""
@@ -1229,6 +1242,31 @@ type MoveTypeSignature =
     }
 """
 scalar MoveTypeSignature
+
+type MoveValue {
+	"""
+	The BCS representation of this value, Base64-encoded.
+	"""
+	bcs: Base64
+	"""
+	Representation of a Move value in JSON, where:
+	
+	- Addresses, IDs, and UIDs are represented in canonical form, as JSON strings.
+	- Bools are represented by JSON boolean literals.
+	- u8, u16, and u32 are represented as JSON numbers.
+	- u64, u128, and u256 are represented as JSON strings.
+	- Balances, Strings, and Urls are represented as JSON strings.
+	- Vectors of bytes are represented as Base64 blobs, and other vectors are represented by JSON arrays.
+	- Structs are represented by JSON objects.
+	- Enums are represented by JSON objects, with a field named `@variant` containing the variant name.
+	- Empty optional values are represented by `null`.
+	"""
+	json: JSON
+	"""
+	The value's type.
+	"""
+	type: MoveType
+}
 
 """
 A transaction that wanted to mutate a consensus-managed object but couldn't because it became not-consensus-managed before the transaction executed (for example, it was deleted, turned into an owned object, or wrapped).
@@ -1961,6 +1999,10 @@ type ServiceConfig {
 	Maximum nesting allowed in datatype fields when calculating the layout of a single type.
 	"""
 	maxMoveValueDepth: Int
+	"""
+	Maximum budget in bytes to spend when outputting a structured `MoveValue`.
+	"""
+	maxMoveValueBound: Int
 }
 
 """


### PR DESCRIPTION
## Description 

`MoveValue` exposes a structured representation of a Move value. The implementation uses gRPC's visitor to convert to the Move value to JSON, for consistency.

## Test plan 

New E2E tests:

```
$ cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql
```

## Stack

- #23127 
- #23128 
- #23129 
- #23130 
- #23172 
- #23188
- #23210

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
