### PR TITLE
[mfp] TD will return last recorded errors before timeout

### DIFF
--- a/crates/sui-core/src/transaction_driver/mod.rs
+++ b/crates/sui-core/src/transaction_driver/mod.rs
@@ -9,6 +9,7 @@ mod request_retrier;
 mod transaction_submitter;
 
 /// Exports
+pub use error::TransactionDriverError;
 pub use message_types::*;
 pub use metrics::*;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
@@ -21,7 +22,6 @@ use std::{
 
 use arc_swap::ArcSwap;
 use effects_certifier::*;
-use error::*;
 use mysten_metrics::{monitored_future, TX_TYPE_SHARED_OBJ_TX, TX_TYPE_SINGLE_WRITER_TX};
 use parking_lot::Mutex;
 use sui_types::{
@@ -95,6 +95,17 @@ where
         request: SubmitTxRequest,
         options: SubmitTransactionOptions,
     ) -> Result<QuorumTransactionResponse, TransactionDriverError> {
+        self.drive_transaction_with_timeout(request, options, None)
+            .await
+    }
+
+    #[instrument(level = "error", skip_all, fields(tx_digest = ?request.transaction.digest()))]
+    pub async fn drive_transaction_with_timeout(
+        &self,
+        request: SubmitTxRequest,
+        options: SubmitTransactionOptions,
+        timeout_duration: Option<Duration>,
+    ) -> Result<QuorumTransactionResponse, TransactionDriverError> {
         let tx_digest = request.transaction.digest();
         let is_single_writer_tx = !request.transaction.is_consensus_tx();
         let raw_request = request.into_raw().unwrap();
@@ -108,48 +119,70 @@ where
             .max_delay(MAX_RETRY_DELAY)
             .map(jitter);
         let mut attempts = 0;
-        loop {
-            // TODO(fastpath): Check local state before submitting transaction
-            match self
-                .drive_transaction_once(tx_digest, raw_request.clone(), &options)
-                .await
-            {
-                Ok(resp) => {
-                    let settlement_finality_latency = timer.elapsed().as_secs_f64();
-                    self.metrics
-                        .settlement_finality_latency
-                        .with_label_values(&[if is_single_writer_tx {
-                            TX_TYPE_SINGLE_WRITER_TX
-                        } else {
-                            TX_TYPE_SHARED_OBJ_TX
-                        }])
-                        .observe(settlement_finality_latency);
-                    // Record the number of retries for successful transaction
-                    self.metrics
-                        .transaction_retries
-                        .with_label_values(&["success"])
-                        .observe(attempts as f64);
-                    return Ok(resp);
-                }
-                Err(e) => {
-                    if !e.is_retriable() {
-                        // Record the number of retries for failed transaction
+        let mut latest_retriable_error = None;
+
+        let retry_loop = async {
+            loop {
+                // TODO(fastpath): Check local state before submitting transaction
+                match self
+                    .drive_transaction_once(tx_digest, raw_request.clone(), &options)
+                    .await
+                {
+                    Ok(resp) => {
+                        let settlement_finality_latency = timer.elapsed().as_secs_f64();
+                        self.metrics
+                            .settlement_finality_latency
+                            .with_label_values(&[if is_single_writer_tx {
+                                TX_TYPE_SINGLE_WRITER_TX
+                            } else {
+                                TX_TYPE_SHARED_OBJ_TX
+                            }])
+                            .observe(settlement_finality_latency);
+                        // Record the number of retries for successful transaction
                         self.metrics
                             .transaction_retries
-                            .with_label_values(&["failure"])
+                            .with_label_values(&["success"])
                             .observe(attempts as f64);
-                        return Err(e);
+                        return Ok(resp);
                     }
-                    tracing::info!(
-                        "Failed to finalize transaction (attempt {}): {}. Retrying ...",
-                        attempts,
-                        e
-                    );
+                    Err(e) => {
+                        if !e.is_retriable() {
+                            // Record the number of retries for failed transaction
+                            self.metrics
+                                .transaction_retries
+                                .with_label_values(&["failure"])
+                                .observe(attempts as f64);
+                            return Err(e);
+                        }
+                        tracing::info!(
+                            "Failed to finalize transaction (attempt {}): {}. Retrying ...",
+                            attempts,
+                            e
+                        );
+                        // Buffer the latest retriable error to be returned in case of timeout
+                        latest_retriable_error = Some(e);
+                    }
+                }
+
+                sleep(backoff.next().unwrap_or(MAX_RETRY_DELAY)).await;
+                attempts += 1;
+            }
+        };
+
+        match timeout_duration {
+            Some(duration) => {
+                match tokio::time::timeout(duration, retry_loop).await {
+                    Ok(result) => result,
+                    Err(_) => {
+                        // Timeout occurred, return with latest retriable error if available
+                        Err(TransactionDriverError::TimeOutWithLastRetriableError {
+                            latest_error: latest_retriable_error.map(Box::new),
+                            attempts,
+                        })
+                    }
                 }
             }
-
-            sleep(backoff.next().unwrap_or(MAX_RETRY_DELAY)).await;
-            attempts += 1;
+            None => retry_loop.await,
         }
     }
 

--- a/crates/sui-json-rpc/src/error.rs
+++ b/crates/sui-json-rpc/src/error.rs
@@ -160,6 +160,7 @@ impl From<Error> for ErrorObjectOwned {
                         )
                     }
                     QuorumDriverError::TimeoutBeforeFinality
+                    | QuorumDriverError::TimeoutBeforeFinalityWithErrors { .. }
                     | QuorumDriverError::FailedWithTransientErrorAfterMaximumAttempts { .. } => {
                         ErrorObject::owned(TRANSIENT_ERROR_CODE, err.to_string(), None::<()>)
                     }

--- a/crates/sui-rpc-api/src/error.rs
+++ b/crates/sui-rpc-api/src/error.rs
@@ -145,6 +145,13 @@ impl From<sui_types::quorum_driver_types::QuorumDriverError> for RpcError {
                     "timed-out before finality could be reached",
                 )
             }
+            TimeoutBeforeFinalityWithErrors { last_error } => {
+                // TODO add a Retry-After header
+                RpcError::new(
+                    Code::Unavailable,
+                    format!("Transaction timed out before finality could be reached. Last error: {}", last_error),
+                )
+            }
             NonRecoverableTransactionError { errors } => {
                 let new_errors: Vec<String> = errors
                     .into_iter()

--- a/crates/sui-types/src/quorum_driver_types.rs
+++ b/crates/sui-types/src/quorum_driver_types.rs
@@ -43,6 +43,8 @@ pub enum QuorumDriverError {
     },
     #[error("Transaction timed out before reaching finality")]
     TimeoutBeforeFinality,
+    #[error("Transaction timed out before reaching finality. Last recorded retriable error: {last_error}")]
+    TimeoutBeforeFinalityWithErrors { last_error: String },
     #[error("Transaction failed to reach finality with transient error after {total_attempts} attempts.")]
     FailedWithTransientErrorAfterMaximumAttempts { total_attempts: u32 },
     #[error("{NON_RECOVERABLE_ERROR_MSG}: {errors:?}.")]


### PR DESCRIPTION
## Description 

Allow timeouts to be injected into TD drive transaction calls and allow for the last set of retriable errors to be buffered and returned when available

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
