### PR TITLE
graphql-alt: reader and kv loader for transaction events [2/n]

### DIFF
--- a/crates/sui-indexer-alt-reader/src/bigtable_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/bigtable_reader.rs
@@ -109,7 +109,7 @@ impl BigtableReader {
     pub(crate) async fn transactions_events(
         &self,
         keys: &[TransactionDigest],
-    ) -> Result<Vec<TransactionEventsData>, Error> {
+    ) -> anyhow::Result<Vec<(TransactionDigest, TransactionEventsData)>> {
         measure(
             "events",
             &keys,

--- a/crates/sui-indexer-alt-reader/src/bigtable_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/bigtable_reader.rs
@@ -8,7 +8,9 @@ use std::time::Duration;
 use anyhow::{bail, Context};
 use async_graphql::dataloader::DataLoader;
 use prometheus::Registry;
-use sui_kvstore::{BigTableClient, Checkpoint, KeyValueStoreReader, TransactionData};
+use sui_kvstore::{
+    BigTableClient, Checkpoint, KeyValueStoreReader, TransactionData, TransactionEventsData,
+};
 use sui_types::digests::TransactionDigest;
 use sui_types::messages_checkpoint::{CheckpointSequenceNumber, CheckpointSummary};
 use sui_types::object::Object;
@@ -101,6 +103,19 @@ impl BigtableReader {
     /// Multi-get objects by object ID and version.
     pub(crate) async fn objects(&self, keys: &[ObjectKey]) -> anyhow::Result<Vec<Object>> {
         measure("objects", &keys, self.0.clone().get_objects(keys)).await
+    }
+
+    // Multi-get events from transactions.
+    pub(crate) async fn transactions_events(
+        &self,
+        keys: &[TransactionDigest],
+    ) -> Result<Vec<TransactionEventsData>, Error> {
+        measure(
+            "events",
+            &keys,
+            self.0.clone().get_events_for_transactions(keys),
+        )
+        .await
     }
 }
 

--- a/crates/sui-indexer-alt-reader/src/events.rs
+++ b/crates/sui-indexer-alt-reader/src/events.rs
@@ -1,0 +1,91 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::dataloader::Loader;
+use diesel::{ExpressionMethods, QueryDsl, Queryable};
+use std::{
+    collections::{BTreeSet, HashMap},
+    sync::Arc,
+};
+use sui_indexer_alt_schema::schema::kv_transactions;
+use sui_kvstore::TransactionEventsData;
+use sui_types::digests::TransactionDigest;
+
+use crate::{bigtable_reader::BigtableReader, error::Error, pg_reader::PgReader};
+
+/// Key for fetching transaction events contents (TranactionDigest, Events, TimestampMs) by digest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TransactionEventsKey(pub TransactionDigest);
+
+/// Partial transaction and events for when you only need transaction content for events
+#[derive(Debug, Clone, Queryable)]
+pub struct StoredTransactionEvents {
+    pub tx_digest: Vec<u8>,
+    pub events: Vec<u8>,
+    pub timestamp_ms: i64,
+}
+
+#[async_trait::async_trait]
+impl Loader<TransactionEventsKey> for PgReader {
+    type Value = StoredTransactionEvents;
+    type Error = Arc<Error>;
+
+    async fn load(
+        &self,
+        keys: &[TransactionEventsKey],
+    ) -> Result<HashMap<TransactionEventsKey, Self::Value>, Self::Error> {
+        use kv_transactions::dsl as t;
+
+        if keys.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let mut conn = self.connect().await.map_err(Arc::new)?;
+
+        let digests: BTreeSet<_> = keys.iter().map(|d| d.0.into_inner()).collect();
+        let transactions: Vec<StoredTransactionEvents> = conn
+            .results(
+                t::kv_transactions
+                    .select((t::tx_digest, t::events, t::timestamp_ms))
+                    .filter(t::tx_digest.eq_any(digests)),
+            )
+            .await
+            .map_err(Arc::new)?;
+
+        let digest_to_stored: HashMap<_, _> = transactions
+            .into_iter()
+            .map(|stored| (stored.tx_digest.clone(), stored))
+            .collect();
+
+        Ok(keys
+            .iter()
+            .filter_map(|key| {
+                let slice: &[u8] = key.0.as_ref();
+                Some((*key, digest_to_stored.get(slice).cloned()?))
+            })
+            .collect())
+    }
+}
+
+#[async_trait::async_trait]
+impl Loader<TransactionEventsKey> for BigtableReader {
+    type Value = TransactionEventsData;
+    type Error = Arc<Error>;
+
+    async fn load(
+        &self,
+        keys: &[TransactionEventsKey],
+    ) -> Result<HashMap<TransactionEventsKey, Self::Value>, Self::Error> {
+        if keys.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let digests: Vec<_> = keys.iter().map(|k| k.0).collect();
+        Ok(self
+            .transactions_events(&digests)
+            .await?
+            .into_iter()
+            .map(|t| (TransactionEventsKey(t.digest), t))
+            .collect())
+    }
+}

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -7,7 +7,9 @@ use std::sync::Arc;
 use anyhow::Context;
 use async_graphql::dataloader::DataLoader;
 use sui_indexer_alt_schema::transactions::StoredTransaction;
-use sui_kvstore::TransactionData as KVTransactionData;
+use sui_kvstore::{
+    TransactionData as KVTransactionData, TransactionEventsData as KVTransactionEventsData,
+};
 use sui_types::{
     base_types::ObjectID,
     crypto::AuthorityQuorumSignInfo,
@@ -22,8 +24,13 @@ use sui_types::{
 };
 
 use crate::{
-    bigtable_reader::BigtableReader, checkpoints::CheckpointKey, error::Error,
-    objects::VersionedObjectKey, pg_reader::PgReader, transactions::TransactionKey,
+    bigtable_reader::BigtableReader,
+    checkpoints::CheckpointKey,
+    error::Error,
+    events::{StoredTransactionEvents, TransactionEventsKey},
+    objects::VersionedObjectKey,
+    pg_reader::PgReader,
+    transactions::TransactionKey,
 };
 
 /// A loader for point lookups in kv stores backed by either Bigtable or Postgres.
@@ -41,6 +48,12 @@ pub enum KvLoader {
 pub enum TransactionContents {
     Bigtable(KVTransactionData),
     Pg(StoredTransaction),
+}
+
+/// A wrapper for the contents of a transaction's events, either from Bigtable or Postgres.
+pub enum TransactionEventsContents {
+    Bigtable(KVTransactionEventsData),
+    Pg(StoredTransactionEvents),
 }
 
 impl KvLoader {
@@ -145,6 +158,56 @@ impl KvLoader {
             Self::Pg(loader) => Ok(loader.load_one(key).await?.map(TransactionContents::Pg)),
         }
     }
+
+    pub async fn load_many_transaction_events(
+        &self,
+        digests: Vec<TransactionDigest>,
+    ) -> Result<HashMap<TransactionDigest, TransactionEventsContents>, Arc<Error>> {
+        let keys = digests
+            .iter()
+            .map(|d| TransactionEventsKey(*d))
+            .collect::<Vec<_>>();
+        match self {
+            Self::Bigtable(loader) => Ok(loader
+                .load_many(keys)
+                .await?
+                .into_iter()
+                .map(|(key, stored)| (key.0, TransactionEventsContents::Bigtable(stored)))
+                .collect()),
+            Self::Pg(loader) => Ok(loader
+                .load_many(keys)
+                .await?
+                .into_iter()
+                .map(|(key, stored)| (key.0, TransactionEventsContents::Pg(stored)))
+                .collect()),
+        }
+    }
+
+    pub async fn load_many_transactions(
+        &self,
+        digests: Vec<TransactionDigest>,
+    ) -> Result<HashMap<TransactionDigest, TransactionContents>, Arc<Error>> {
+        let keys = digests
+            .iter()
+            .map(|d| TransactionKey(*d))
+            .collect::<Vec<_>>();
+        match self {
+            Self::Bigtable(loader) => Ok(loader
+                .load_many(keys)
+                .await?
+                .into_iter()
+                .map(|(key, stored)| Ok((key.0, TransactionContents::Bigtable(stored))))
+                .collect::<Result<HashMap<TransactionDigest, TransactionContents>, Arc<Error>>>(
+                )?),
+            Self::Pg(loader) => Ok(loader
+                .load_many(keys)
+                .await?
+                .into_iter()
+                .map(|(key, stored)| Ok((key.0, TransactionContents::Pg(stored))))
+                .collect::<Result<HashMap<TransactionDigest, TransactionContents>, Arc<Error>>>(
+                )?),
+        }
+    }
 }
 
 impl TransactionContents {
@@ -229,6 +292,32 @@ impl TransactionContents {
         match self {
             Self::Pg(stored) => stored.cp_sequence_number as u64,
             Self::Bigtable(kv) => kv.checkpoint_number,
+        }
+    }
+}
+
+impl TransactionEventsContents {
+    pub fn events(&self) -> anyhow::Result<Vec<Event>> {
+        match self {
+            Self::Pg(stored) => {
+                bcs::from_bytes(&stored.events).context("Failed to deserialize events")
+            }
+            Self::Bigtable(kv) => Ok(kv.events.clone()),
+        }
+    }
+
+    pub fn digest(&self) -> anyhow::Result<TransactionDigest> {
+        match self {
+            Self::Pg(stored) => TransactionDigest::try_from(stored.tx_digest.clone())
+                .context("Failed to deserialize transaction digest"),
+            Self::Bigtable(kv) => Ok(kv.digest),
+        }
+    }
+
+    pub fn timestamp_ms(&self) -> u64 {
+        match self {
+            Self::Pg(stored) => stored.timestamp_ms as u64,
+            Self::Bigtable(kv) => kv.timestamp_ms,
         }
     }
 }

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -196,16 +196,14 @@ impl KvLoader {
                 .load_many(keys)
                 .await?
                 .into_iter()
-                .map(|(key, stored)| Ok((key.0, TransactionContents::Bigtable(stored))))
-                .collect::<Result<HashMap<TransactionDigest, TransactionContents>, Arc<Error>>>(
-                )?),
+                .map(|(key, stored)| (key.0, TransactionContents::Bigtable(stored)))
+                .collect()),
             Self::Pg(loader) => Ok(loader
                 .load_many(keys)
                 .await?
                 .into_iter()
-                .map(|(key, stored)| Ok((key.0, TransactionContents::Pg(stored))))
-                .collect::<Result<HashMap<TransactionDigest, TransactionContents>, Arc<Error>>>(
-                )?),
+                .map(|(key, stored)| (key.0, TransactionContents::Pg(stored)))
+                .collect()),
         }
     }
 }

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -306,14 +306,6 @@ impl TransactionEventsContents {
         }
     }
 
-    pub fn digest(&self) -> anyhow::Result<TransactionDigest> {
-        match self {
-            Self::Pg(stored) => TransactionDigest::try_from(stored.tx_digest.clone())
-                .context("Failed to deserialize transaction digest"),
-            Self::Bigtable(kv) => Ok(kv.digest),
-        }
-    }
-
     pub fn timestamp_ms(&self) -> u64 {
         match self {
             Self::Pg(stored) => stored.timestamp_ms as u64,

--- a/crates/sui-indexer-alt-reader/src/lib.rs
+++ b/crates/sui-indexer-alt-reader/src/lib.rs
@@ -10,7 +10,6 @@ pub mod displays;
 pub mod epochs;
 pub mod error;
 pub mod events;
-
 pub mod full_node_client;
 pub mod kv_loader;
 pub(crate) mod metrics;

--- a/crates/sui-indexer-alt-reader/src/lib.rs
+++ b/crates/sui-indexer-alt-reader/src/lib.rs
@@ -9,6 +9,8 @@ pub mod cp_sequence_numbers;
 pub mod displays;
 pub mod epochs;
 pub mod error;
+pub mod events;
+
 pub mod full_node_client;
 pub mod kv_loader;
 pub(crate) mod metrics;

--- a/crates/sui-kvstore/src/bigtable/client.rs
+++ b/crates/sui-kvstore/src/bigtable/client.rs
@@ -373,7 +373,7 @@ impl KeyValueStoreReader for BigTableClient {
     async fn get_events_for_transactions(
         &mut self,
         transaction_digests: &[TransactionDigest],
-    ) -> Result<Vec<TransactionEventsData>> {
+    ) -> Result<Vec<(TransactionDigest, TransactionEventsData)>> {
         // Fetch just the events for the transaction.
         let response = self
             .multi_get(
@@ -409,11 +409,13 @@ impl KeyValueStoreReader for BigTableClient {
             let events = transaction_events
                 .ok_or_else(|| anyhow!("events field is missing"))?
                 .data;
-            results.push(TransactionEventsData {
+            results.push((
                 digest,
-                events,
-                timestamp_ms,
-            });
+                TransactionEventsData {
+                    events,
+                    timestamp_ms,
+                },
+            ));
         }
 
         Ok(results)

--- a/crates/sui-kvstore/src/bigtable/client.rs
+++ b/crates/sui-kvstore/src/bigtable/client.rs
@@ -9,7 +9,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context as _, Result};
 use async_trait::async_trait;
 use gcp_auth::{Token, TokenProvider};
 use http::{HeaderValue, Request, Response};
@@ -23,7 +23,6 @@ use sui_types::{
     messages_consensus::TimestampMs,
     object::Object,
     storage::{EpochInfo, ObjectKey},
-    transaction::Transaction,
 };
 use tonic::{
     body::BoxBody,
@@ -223,9 +222,9 @@ impl KeyValueStoreReader for BigTableClient {
                 }
             }
             result.push(TransactionData {
-                transaction: transaction.ok_or_else(|| anyhow!("transaction field is missing"))?,
-                effects: effects.ok_or_else(|| anyhow!("effects field is missing"))?,
-                events: events.ok_or_else(|| anyhow!("events field is missing"))?,
+                transaction: transaction.context("transaction field is missing")?,
+                effects: effects.context("effects field is missing")?,
+                events: events.context("events field is missing")?,
                 timestamp,
                 checkpoint_number,
             })
@@ -259,9 +258,9 @@ impl KeyValueStoreReader for BigTableClient {
                 }
             }
             let checkpoint = Checkpoint {
-                summary: summary.ok_or_else(|| anyhow!("summary field is missing"))?,
-                contents: contents.ok_or_else(|| anyhow!("contents field is missing"))?,
-                signatures: signatures.ok_or_else(|| anyhow!("signatures field is missing"))?,
+                summary: summary.context("summary field is missing")?,
+                contents: contents.context("contents field is missing")?,
+                signatures: signatures.context("signatures field is missing")?,
             };
             checkpoints.push(checkpoint);
         }
@@ -390,35 +389,33 @@ impl KeyValueStoreReader for BigTableClient {
             )
             .await?;
 
-        let mut results = vec![];
-        for row in response {
-            let mut tx: Option<Transaction> = None;
-            let mut transaction_events: Option<TransactionEvents> = None;
-            let mut timestamp_ms = 0;
-            for (column, value) in row {
-                match std::str::from_utf8(&column)? {
-                    TRANSACTION_COLUMN_QUALIFIER => tx = Some(bcs::from_bytes(&value)?),
-                    EVENTS_COLUMN_QUALIFIER => transaction_events = Some(bcs::from_bytes(&value)?),
-                    TIMESTAMP_COLUMN_QUALIFIER => timestamp_ms = bcs::from_bytes(&value)?,
-                    _ => error!("unexpected column {:?} in transactions table", column),
-                }
-            }
-            let digest = *tx
-                .ok_or_else(|| anyhow!("digest field is missing"))?
-                .digest();
-            let events = transaction_events
-                .ok_or_else(|| anyhow!("events field is missing"))?
-                .data;
-            results.push((
-                digest,
-                TransactionEventsData {
-                    events,
-                    timestamp_ms,
-                },
-            ));
-        }
+        transaction_digests
+            .iter()
+            .zip(response)
+            .map(|(&digest, row)| {
+                let mut transaction_events: Option<TransactionEvents> = None;
+                let mut timestamp_ms = 0;
 
-        Ok(results)
+                for (column, value) in row {
+                    match std::str::from_utf8(&column)? {
+                        EVENTS_COLUMN_QUALIFIER => {
+                            transaction_events = Some(bcs::from_bytes(&value)?)
+                        }
+                        TIMESTAMP_COLUMN_QUALIFIER => timestamp_ms = bcs::from_bytes(&value)?,
+                        _ => error!("unexpected column {:?} in transactions table", column),
+                    }
+                }
+
+                let events = transaction_events.context("events field is missing")?.data;
+                Ok((
+                    digest,
+                    TransactionEventsData {
+                        events,
+                        timestamp_ms,
+                    },
+                ))
+            })
+            .collect()
     }
 }
 

--- a/crates/sui-kvstore/src/lib.rs
+++ b/crates/sui-kvstore/src/lib.rs
@@ -12,6 +12,7 @@ use sui_types::committee::EpochId;
 use sui_types::crypto::AuthorityStrongQuorumSignInfo;
 use sui_types::digests::{CheckpointDigest, TransactionDigest};
 use sui_types::effects::{TransactionEffects, TransactionEvents};
+use sui_types::event::Event;
 use sui_types::full_checkpoint_content::CheckpointData;
 use sui_types::messages_checkpoint::{
     CheckpointContents, CheckpointSequenceNumber, CheckpointSummary,
@@ -41,6 +42,10 @@ pub trait KeyValueStoreReader {
     async fn get_latest_object(&mut self, object_id: &ObjectID) -> Result<Option<Object>>;
     async fn get_epoch(&mut self, epoch_id: EpochId) -> Result<Option<EpochInfo>>;
     async fn get_latest_epoch(&mut self) -> Result<Option<EpochInfo>>;
+    async fn get_events_for_transactions(
+        &mut self,
+        keys: &[TransactionDigest],
+    ) -> Result<Vec<TransactionEventsData>>;
 }
 
 #[async_trait]
@@ -66,4 +71,12 @@ pub struct TransactionData {
     pub events: Option<TransactionEvents>,
     pub checkpoint_number: CheckpointSequenceNumber,
     pub timestamp: u64,
+}
+
+/// Partial transaction and events for when we only need transaction content for events
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TransactionEventsData {
+    pub digest: TransactionDigest,
+    pub events: Vec<Event>,
+    pub timestamp_ms: u64,
 }

--- a/crates/sui-kvstore/src/lib.rs
+++ b/crates/sui-kvstore/src/lib.rs
@@ -45,7 +45,7 @@ pub trait KeyValueStoreReader {
     async fn get_events_for_transactions(
         &mut self,
         keys: &[TransactionDigest],
-    ) -> Result<Vec<TransactionEventsData>>;
+    ) -> Result<Vec<(TransactionDigest, TransactionEventsData)>>;
 }
 
 #[async_trait]
@@ -76,7 +76,6 @@ pub struct TransactionData {
 /// Partial transaction and events for when we only need transaction content for events
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TransactionEventsData {
-    pub digest: TransactionDigest,
     pub events: Vec<Event>,
     pub timestamp_ms: u64,
 }


### PR DESCRIPTION
## Description 

Changes:
  - Added events.rs module with `TransactionEventsKey` and
  `StoredTransactionEvents` types for fetching transaction event data by digest
  - `kv_loader.rs` support for loading transaction events from Bigtable and Postgres
  - Added`get_events_for_transactions` method to bigtable client

## Stack:
https://github.com/MystenLabs/sui/pull/23222
https://github.com/MystenLabs/sui/pull/23223 👈 
https://github.com/MystenLabs/sui/pull/23224 


## Test plan 
```
cargo nextest run -p sui-indexer-alt-graphql schema_sdl
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql/
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
