### PR TITLE
[1/n][move] Remove `legacy_abstract_memory_size` and generalize API to `abstract_memory_size`

### DIFF
--- a/external-crates/move/crates/move-stdlib-natives/src/vector.rs
+++ b/external-crates/move/crates/move-stdlib-natives/src/vector.rs
@@ -122,7 +122,7 @@ pub fn native_push_back(
             * std::cmp::max(
                 e.abstract_memory_size(&SizeConfig {
                     traverse_references: false,
-                    wide_vector_size: false,
+                    include_vector_size: false,
                 }),
                 1.into(),
             );

--- a/external-crates/move/crates/move-vm-test-utils/src/gas_schedule.rs
+++ b/external-crates/move/crates/move-vm-test-utils/src/gas_schedule.rs
@@ -58,9 +58,10 @@ pub const STRUCT_SIZE: AbstractMemorySize = AbstractMemorySize::new(2);
 /// For exists checks on data that doesn't exists this is the multiplier that is used.
 pub const MIN_EXISTS_DATA_SIZE: AbstractMemorySize = AbstractMemorySize::new(100);
 
-const SIZE_CONFIG: SizeConfig = SizeConfig {
+/// Default size config for gas metering when running Move unit tests.
+const MOVE_TEST_SIZE_CONFIG: SizeConfig = SizeConfig {
     traverse_references: false,
-    wide_vector_size: false,
+    include_vector_size: false,
 };
 
 /// The cost tables, keyed by the serialized form of the bytecode instruction.  We use the
@@ -324,15 +325,24 @@ impl GasMeter for GasStatus<'_> {
     }
 
     fn charge_copy_loc(&mut self, val: impl ValueView) -> PartialVMResult<()> {
-        self.charge_instr_with_size(Opcodes::COPY_LOC, val.abstract_memory_size(&SIZE_CONFIG))
+        self.charge_instr_with_size(
+            Opcodes::COPY_LOC,
+            val.abstract_memory_size(&MOVE_TEST_SIZE_CONFIG),
+        )
     }
 
     fn charge_move_loc(&mut self, val: impl ValueView) -> PartialVMResult<()> {
-        self.charge_instr_with_size(Opcodes::MOVE_LOC, val.abstract_memory_size(&SIZE_CONFIG))
+        self.charge_instr_with_size(
+            Opcodes::MOVE_LOC,
+            val.abstract_memory_size(&MOVE_TEST_SIZE_CONFIG),
+        )
     }
 
     fn charge_store_loc(&mut self, val: impl ValueView) -> PartialVMResult<()> {
-        self.charge_instr_with_size(Opcodes::ST_LOC, val.abstract_memory_size(&SIZE_CONFIG))
+        self.charge_instr_with_size(
+            Opcodes::ST_LOC,
+            val.abstract_memory_size(&MOVE_TEST_SIZE_CONFIG),
+        )
     }
 
     fn charge_pack(
@@ -348,7 +358,7 @@ impl GasMeter for GasStatus<'_> {
                 Opcodes::PACK
             },
             args.fold(field_count, |acc, val| {
-                acc + val.abstract_memory_size(&SIZE_CONFIG)
+                acc + val.abstract_memory_size(&MOVE_TEST_SIZE_CONFIG)
             }),
         )
     }
@@ -366,7 +376,7 @@ impl GasMeter for GasStatus<'_> {
                 Opcodes::UNPACK
             },
             args.fold(field_count, |acc, val| {
-                acc + val.abstract_memory_size(&SIZE_CONFIG)
+                acc + val.abstract_memory_size(&MOVE_TEST_SIZE_CONFIG)
             }),
         )
     }
@@ -374,14 +384,14 @@ impl GasMeter for GasStatus<'_> {
     fn charge_variant_switch(&mut self, val: impl ValueView) -> PartialVMResult<()> {
         self.charge_instr_with_size(
             Opcodes::VARIANT_SWITCH,
-            val.abstract_memory_size(&SIZE_CONFIG),
+            val.abstract_memory_size(&MOVE_TEST_SIZE_CONFIG),
         )
     }
 
     fn charge_read_ref(&mut self, ref_val: impl ValueView) -> PartialVMResult<()> {
         self.charge_instr_with_size(
             Opcodes::READ_REF,
-            ref_val.abstract_memory_size(&SIZE_CONFIG),
+            ref_val.abstract_memory_size(&MOVE_TEST_SIZE_CONFIG),
         )
     }
 
@@ -392,21 +402,23 @@ impl GasMeter for GasStatus<'_> {
     ) -> PartialVMResult<()> {
         self.charge_instr_with_size(
             Opcodes::WRITE_REF,
-            new_val.abstract_memory_size(&SIZE_CONFIG),
+            new_val.abstract_memory_size(&MOVE_TEST_SIZE_CONFIG),
         )
     }
 
     fn charge_eq(&mut self, lhs: impl ValueView, rhs: impl ValueView) -> PartialVMResult<()> {
         self.charge_instr_with_size(
             Opcodes::EQ,
-            lhs.abstract_memory_size(&SIZE_CONFIG) + rhs.abstract_memory_size(&SIZE_CONFIG),
+            lhs.abstract_memory_size(&MOVE_TEST_SIZE_CONFIG)
+                + rhs.abstract_memory_size(&MOVE_TEST_SIZE_CONFIG),
         )
     }
 
     fn charge_neq(&mut self, lhs: impl ValueView, rhs: impl ValueView) -> PartialVMResult<()> {
         self.charge_instr_with_size(
             Opcodes::NEQ,
-            lhs.abstract_memory_size(&SIZE_CONFIG) + rhs.abstract_memory_size(&SIZE_CONFIG),
+            lhs.abstract_memory_size(&MOVE_TEST_SIZE_CONFIG)
+                + rhs.abstract_memory_size(&MOVE_TEST_SIZE_CONFIG),
         )
     }
 
@@ -444,7 +456,7 @@ impl GasMeter for GasStatus<'_> {
     ) -> PartialVMResult<()> {
         self.charge_instr_with_size(
             Opcodes::VEC_PUSH_BACK,
-            val.abstract_memory_size(&SIZE_CONFIG),
+            val.abstract_memory_size(&MOVE_TEST_SIZE_CONFIG),
         )
     }
 

--- a/external-crates/move/crates/move-vm-test-utils/src/tiered_gas_schedule.rs
+++ b/external-crates/move/crates/move-vm-test-utils/src/tiered_gas_schedule.rs
@@ -781,14 +781,14 @@ pub fn initial_cost_schedule() -> CostTable {
 
 fn abstract_memory_size(v: impl ValueView) -> AbstractMemorySize {
     v.abstract_memory_size(&SizeConfig {
+        include_vector_size: true,
         traverse_references: false,
-        wide_vector_size: true,
     })
 }
 
 fn abstract_memory_size_with_traversal(v: impl ValueView) -> AbstractMemorySize {
     v.abstract_memory_size(&SizeConfig {
-        wide_vector_size: true,
+        include_vector_size: true,
         traverse_references: true,
     })
 }

--- a/external-crates/move/crates/move-vm-types/src/values/value_tests.rs
+++ b/external-crates/move/crates/move-vm-types/src/values/value_tests.rs
@@ -6,9 +6,10 @@ use crate::{loaded_data::runtime_types::Type, values::*, views::*};
 use move_binary_format::errors::*;
 use move_core_types::{account_address::AccountAddress, runtime_value, u256::U256};
 
+#[cfg(test)]
 const SIZE_CONFIG: SizeConfig = SizeConfig {
     traverse_references: false,
-    wide_vector_size: false,
+    include_vector_size: false,
 };
 
 #[test]

--- a/external-crates/move/crates/move-vm-types/src/views.rs
+++ b/external-crates/move/crates/move-vm-types/src/views.rs
@@ -6,10 +6,10 @@ use move_core_types::{
 };
 
 pub struct SizeConfig {
-    /// If true, the value will be traversed recursively.
+    /// If true, the reference values will be traversed recursively.
     pub traverse_references: bool,
     /// If true, the size of the vector will be included in the abstract memory size.
-    pub wide_vector_size: bool,
+    pub include_vector_size: bool,
 }
 
 /// Trait that provides an abstract view into a Move type.
@@ -32,122 +32,128 @@ pub trait ValueView {
     fn abstract_memory_size(&self, config: &SizeConfig) -> AbstractMemorySize {
         use crate::values::{LEGACY_CONST_SIZE, LEGACY_REFERENCE_SIZE, LEGACY_STRUCT_SIZE};
 
-        struct Acc<'b>(AbstractMemorySize, &'b SizeConfig);
+        struct Acc<'b> {
+            accumulated_size: AbstractMemorySize,
+            config: &'b SizeConfig,
+        }
 
         impl ValueVisitor for Acc<'_> {
             fn visit_u8(&mut self, _depth: usize, _val: u8) {
-                self.0 += LEGACY_CONST_SIZE;
+                self.accumulated_size += LEGACY_CONST_SIZE;
             }
 
             fn visit_u16(&mut self, _depth: usize, _val: u16) {
-                self.0 += LEGACY_CONST_SIZE;
+                self.accumulated_size += LEGACY_CONST_SIZE;
             }
 
             fn visit_u32(&mut self, _depth: usize, _val: u32) {
-                self.0 += LEGACY_CONST_SIZE;
+                self.accumulated_size += LEGACY_CONST_SIZE;
             }
 
             fn visit_u64(&mut self, _depth: usize, _val: u64) {
-                self.0 += LEGACY_CONST_SIZE;
+                self.accumulated_size += LEGACY_CONST_SIZE;
             }
 
             fn visit_u128(&mut self, _depth: usize, _val: u128) {
-                self.0 += LEGACY_CONST_SIZE;
+                self.accumulated_size += LEGACY_CONST_SIZE;
             }
 
             fn visit_u256(&mut self, _depth: usize, _val: move_core_types::u256::U256) {
-                self.0 += LEGACY_CONST_SIZE;
+                self.accumulated_size += LEGACY_CONST_SIZE;
             }
 
             fn visit_bool(&mut self, _depth: usize, _val: bool) {
-                self.0 += LEGACY_CONST_SIZE;
+                self.accumulated_size += LEGACY_CONST_SIZE;
             }
 
             fn visit_address(&mut self, _depth: usize, _val: AccountAddress) {
-                self.0 += AbstractMemorySize::new(AccountAddress::LENGTH as u64);
+                self.accumulated_size += AbstractMemorySize::new(AccountAddress::LENGTH as u64);
             }
 
             fn visit_struct(&mut self, _depth: usize, _len: usize) -> bool {
-                self.0 += LEGACY_STRUCT_SIZE;
+                self.accumulated_size += LEGACY_STRUCT_SIZE;
                 true
             }
 
             fn visit_variant(&mut self, _depth: usize, _len: usize) -> bool {
-                self.0 += LEGACY_STRUCT_SIZE;
+                self.accumulated_size += LEGACY_STRUCT_SIZE;
                 true
             }
 
             fn visit_vec(&mut self, _depth: usize, _len: usize) -> bool {
-                self.0 += LEGACY_STRUCT_SIZE;
+                self.accumulated_size += LEGACY_STRUCT_SIZE;
                 true
             }
 
             fn visit_vec_u8(&mut self, _depth: usize, vals: &[u8]) {
-                if self.1.wide_vector_size {
-                    self.0 += LEGACY_STRUCT_SIZE;
+                if self.config.include_vector_size {
+                    self.accumulated_size += LEGACY_STRUCT_SIZE;
                 }
-                self.0 += (std::mem::size_of_val(vals) as u64).into();
+                self.accumulated_size += (std::mem::size_of_val(vals) as u64).into();
             }
 
             fn visit_vec_u16(&mut self, _depth: usize, vals: &[u16]) {
-                if self.1.wide_vector_size {
-                    self.0 += LEGACY_STRUCT_SIZE;
+                if self.config.include_vector_size {
+                    self.accumulated_size += LEGACY_STRUCT_SIZE;
                 }
-                self.0 += (std::mem::size_of_val(vals) as u64).into();
+                self.accumulated_size += (std::mem::size_of_val(vals) as u64).into();
             }
 
             fn visit_vec_u32(&mut self, _depth: usize, vals: &[u32]) {
-                if self.1.wide_vector_size {
-                    self.0 += LEGACY_STRUCT_SIZE;
+                if self.config.include_vector_size {
+                    self.accumulated_size += LEGACY_STRUCT_SIZE;
                 }
-                self.0 += (std::mem::size_of_val(vals) as u64).into();
+                self.accumulated_size += (std::mem::size_of_val(vals) as u64).into();
             }
 
             fn visit_vec_u64(&mut self, _depth: usize, vals: &[u64]) {
-                if self.1.wide_vector_size {
-                    self.0 += LEGACY_STRUCT_SIZE;
+                if self.config.include_vector_size {
+                    self.accumulated_size += LEGACY_STRUCT_SIZE;
                 }
-                self.0 += (std::mem::size_of_val(vals) as u64).into();
+                self.accumulated_size += (std::mem::size_of_val(vals) as u64).into();
             }
 
             fn visit_vec_u128(&mut self, _depth: usize, vals: &[u128]) {
-                if self.1.wide_vector_size {
-                    self.0 += LEGACY_STRUCT_SIZE;
+                if self.config.include_vector_size {
+                    self.accumulated_size += LEGACY_STRUCT_SIZE;
                 }
-                self.0 += (std::mem::size_of_val(vals) as u64).into();
+                self.accumulated_size += (std::mem::size_of_val(vals) as u64).into();
             }
 
             fn visit_vec_u256(&mut self, _depth: usize, vals: &[move_core_types::u256::U256]) {
-                if self.1.wide_vector_size {
-                    self.0 += LEGACY_STRUCT_SIZE;
+                if self.config.include_vector_size {
+                    self.accumulated_size += LEGACY_STRUCT_SIZE;
                 }
-                self.0 += (std::mem::size_of_val(vals) as u64).into();
+                self.accumulated_size += (std::mem::size_of_val(vals) as u64).into();
             }
 
             fn visit_vec_bool(&mut self, _depth: usize, vals: &[bool]) {
-                if self.1.wide_vector_size {
-                    self.0 += LEGACY_STRUCT_SIZE;
+                if self.config.include_vector_size {
+                    self.accumulated_size += LEGACY_STRUCT_SIZE;
                 }
-                self.0 += (std::mem::size_of_val(vals) as u64).into();
+                self.accumulated_size += (std::mem::size_of_val(vals) as u64).into();
             }
 
             fn visit_vec_address(&mut self, _depth: usize, vals: &[AccountAddress]) {
-                if self.1.wide_vector_size {
-                    self.0 += LEGACY_STRUCT_SIZE;
+                if self.config.include_vector_size {
+                    self.accumulated_size += LEGACY_STRUCT_SIZE;
                 }
-                self.0 += (std::mem::size_of_val(vals) as u64).into();
+                self.accumulated_size += (std::mem::size_of_val(vals) as u64).into();
             }
 
             fn visit_ref(&mut self, _depth: usize, _is_global: bool) -> bool {
-                self.0 += LEGACY_REFERENCE_SIZE;
-                self.1.traverse_references
+                self.accumulated_size += LEGACY_REFERENCE_SIZE;
+                self.config.traverse_references
             }
         }
 
-        let mut acc = Acc(0.into(), config);
+        let mut acc = Acc {
+            accumulated_size: 0.into(),
+            config,
+        };
         self.visit(&mut acc);
 
-        acc.0
+        acc.accumulated_size
     }
 }
 

--- a/sui-execution/latest/sui-adapter/src/gas_meter.rs
+++ b/sui-execution/latest/sui-adapter/src/gas_meter.rs
@@ -280,7 +280,7 @@ impl GasMeter for SuiGasMeter<'_> {
     fn charge_neq(&mut self, lhs: impl ValueView, rhs: impl ValueView) -> PartialVMResult<()> {
         let size_reduction = abstract_memory_size_with_traversal(self.0, lhs)
             + abstract_memory_size_with_traversal(self.0, rhs);
-        let size_increase = if traverse_refs(self.0.gas_model_version) {
+        let size_increase = if enable_traverse_refs(self.0.gas_model_version) {
             Type::Bool.size() + size_reduction
         } else {
             Type::Bool.size()
@@ -371,36 +371,40 @@ impl GasMeter for SuiGasMeter<'_> {
 }
 
 fn abstract_memory_size(status: &GasStatus, val: impl ValueView) -> AbstractMemorySize {
-    if use_legacy_abstract_size(status.gas_model_version) {
-        val.abstract_memory_size(&SizeConfig {
-            traverse_references: false,
-            wide_vector_size: false,
-        })
-    } else {
-        val.abstract_memory_size(&SizeConfig {
-            traverse_references: false,
-            wide_vector_size: true,
-        })
-    }
+    let config = size_config_for_gas_model_version(status.gas_model_version, false);
+    val.abstract_memory_size(&config)
 }
 
 fn abstract_memory_size_with_traversal(
     status: &GasStatus,
     val: impl ValueView,
 ) -> AbstractMemorySize {
-    if use_legacy_abstract_size(status.gas_model_version) {
-        val.abstract_memory_size(&SizeConfig {
-            traverse_references: false,
-            wide_vector_size: false,
-        })
-    } else {
-        val.abstract_memory_size(&SizeConfig {
-            traverse_references: traverse_refs(status.gas_model_version),
-            wide_vector_size: true,
-        })
-    }
+    let config = size_config_for_gas_model_version(status.gas_model_version, true);
+    val.abstract_memory_size(&config)
 }
 
-fn traverse_refs(gas_model_version: u64) -> bool {
+fn enable_traverse_refs(gas_model_version: u64) -> bool {
     gas_model_version > 9
+}
+
+fn size_config_for_gas_model_version(
+    gas_model_version: u64,
+    should_traverse_refs: bool,
+) -> SizeConfig {
+    if use_legacy_abstract_size(gas_model_version) {
+        SizeConfig {
+            traverse_references: false,
+            include_vector_size: false,
+        }
+    } else if should_traverse_refs {
+        SizeConfig {
+            traverse_references: enable_traverse_refs(gas_model_version),
+            include_vector_size: true,
+        }
+    } else {
+        SizeConfig {
+            traverse_references: false,
+            include_vector_size: true,
+        }
+    }
 }


### PR DESCRIPTION
## Description 

This PR 
1. Adds a `SizeConfig` for `abstract_memory_size` that can be used to configure the size calculation behavior.
2. It removes `legacy_abstract_memory_size` and replaces its usages with `abstract_memory_size` with the appropriate config settings.

## Test plan 

CI -- nothing should change
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
