### PR TITLE
[3/n][sui-adapter] Update (but dont enable) object runtime to use abstract memory size

### DIFF
--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1297,6 +1297,7 @@
               "maxSupportedProtocolVersion": "96",
               "protocolVersion": "6",
               "featureFlags": {
+                "abstract_size_in_object_runtime": false,
                 "accept_passkey_in_multisig": false,
                 "accept_zklogin_in_multisig": false,
                 "additional_consensus_digest_indirect_state": false,
@@ -1368,6 +1369,7 @@
                 "native_charging_v2": false,
                 "no_extraneous_module_bytes": false,
                 "normalize_ptb_arguments": false,
+                "object_runtime_charge_cache_load_gas": false,
                 "package_digest_hash_module": false,
                 "package_upgrades": true,
                 "passkey_auth": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -805,6 +805,10 @@ struct FeatureFlags {
     // Use abstract size in the object runtime instead the legacy value size.
     #[serde(skip_serializing_if = "is_false")]
     abstract_size_in_object_runtime: bool,
+
+    // If true charge for loads into the cache (i.e., fetches from storage) in the object runtime.
+    #[serde(skip_serializing_if = "is_false")]
+    object_runtime_charge_cache_load_gas: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -2228,6 +2232,10 @@ impl ProtocolConfig {
 
     pub fn abstract_size_in_object_runtime(&self) -> bool {
         self.feature_flags.abstract_size_in_object_runtime
+    }
+
+    pub fn object_runtime_charge_cache_load_gas(&self) -> bool {
+        self.feature_flags.object_runtime_charge_cache_load_gas
     }
 }
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -801,6 +801,10 @@ struct FeatureFlags {
     // Enable coin registry protocol
     #[serde(skip_serializing_if = "is_false")]
     enable_coin_registry: bool,
+
+    // Use abstract size in the object runtime instead the legacy value size.
+    #[serde(skip_serializing_if = "is_false")]
+    abstract_size_in_object_runtime: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -2220,6 +2224,10 @@ impl ProtocolConfig {
 
     pub fn cancel_for_failed_dkg_early(&self) -> bool {
         self.feature_flags.cancel_for_failed_dkg_early
+    }
+
+    pub fn abstract_size_in_object_runtime(&self) -> bool {
+        self.feature_flags.abstract_size_in_object_runtime
     }
 }
 

--- a/sui-execution/latest/sui-move-natives/src/accumulator.rs
+++ b/sui-execution/latest/sui-move-natives/src/accumulator.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    get_extension, get_extension_mut,
     object_runtime::{MoveAccumulatorAction, MoveAccumulatorValue, ObjectRuntime},
     NativesCostTable,
 };
@@ -40,9 +41,7 @@ fn emit_event(
     debug_assert!(ty_args.len() == 1);
     debug_assert!(args.len() == 3);
 
-    let event_emit_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let event_emit_cost_params = get_extension!(context, NativesCostTable)?
         .event_emit_cost_params
         .clone();
 
@@ -64,7 +63,7 @@ fn emit_event(
 
     let ty_tag = context.type_to_type_tag(&ty_args.pop().unwrap())?;
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let obj_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
 
     obj_runtime.emit_accumulator_event(
         accumulator,

--- a/sui-execution/latest/sui-move-natives/src/address.rs
+++ b/sui-execution/latest/sui-move-natives/src/address.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::{account_address::AccountAddress, gas_algebra::InternalGas, u256::U256};
 use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
@@ -30,9 +30,7 @@ pub fn from_bytes(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 1);
 
-    let address_from_bytes_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let address_from_bytes_cost_params = get_extension!(context, NativesCostTable)?
         .address_from_bytes_cost_params
         .clone();
 
@@ -69,9 +67,7 @@ pub fn to_u256(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 1);
 
-    let address_to_u256_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let address_to_u256_cost_params = get_extension!(context, NativesCostTable)?
         .address_to_u256_cost_params
         .clone();
 
@@ -108,9 +104,7 @@ pub fn from_u256(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 1);
 
-    let address_from_u256_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let address_from_u256_cost_params = get_extension!(context, NativesCostTable)?
         .address_from_u256_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/config.rs
+++ b/sui-execution/latest/sui-move-natives/src/config.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{object_runtime::ObjectRuntime, NativesCostTable};
+use crate::{abstract_size, object_runtime::ObjectRuntime, NativesCostTable};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
     account_address::AccountAddress, gas_algebra::InternalGas, language_storage::StructTag,
@@ -97,9 +97,11 @@ pub fn read_setting_impl(
         current_epoch,
     )?;
 
+    let size = abstract_size(object_runtime.protocol_config, &read_value_opt);
+
     native_charge_gas_early_exit!(
         context,
-        config_read_setting_impl_cost_per_byte * u64::from(read_value_opt.legacy_size()).into()
+        config_read_setting_impl_cost_per_byte * u64::from(size).into()
     );
 
     Ok(NativeResult::ok(

--- a/sui-execution/latest/sui-move-natives/src/config.rs
+++ b/sui-execution/latest/sui-move-natives/src/config.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{abstract_size, object_runtime::ObjectRuntime, NativesCostTable};
+use crate::{
+    abstract_size, get_extension, get_extension_mut, object_runtime::ObjectRuntime,
+    NativesCostTable,
+};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
     account_address::AccountAddress, gas_algebra::InternalGas, language_storage::StructTag,
@@ -40,9 +43,7 @@ pub fn read_setting_impl(
     let ConfigReadSettingImplCostParams {
         config_read_setting_impl_cost_base,
         config_read_setting_impl_cost_per_byte,
-    } = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    } = get_extension!(context, NativesCostTable)?
         .config_read_setting_impl_cost_params
         .clone();
 
@@ -83,7 +84,7 @@ pub fn read_setting_impl(
             E_BCS_SERIALIZATION_FAILURE,
         ));
     };
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
 
     let read_value_opt = consistent_value_before_current_epoch(
         object_runtime,

--- a/sui-execution/latest/sui-move-natives/src/crypto/bls12381.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/bls12381.rs
@@ -16,7 +16,7 @@ use move_vm_types::{
 use smallvec::smallvec;
 use std::collections::VecDeque;
 
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 
 const BLS12381_BLOCK_SIZE: usize = 64;
 
@@ -47,9 +47,7 @@ pub fn bls12381_min_sig_verify(
     debug_assert!(args.len() == 3);
 
     // Load the cost parameters from the protocol config
-    let bls12381_bls12381_min_sig_verify_cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let bls12381_bls12381_min_sig_verify_cost_params = get_extension!(context, NativesCostTable)?
         .bls12381_bls12381_min_sig_verify_cost_params
         .clone();
     // Charge the base cost for this oper
@@ -127,9 +125,7 @@ pub fn bls12381_min_pk_verify(
     debug_assert!(args.len() == 3);
 
     // Load the cost parameters from the protocol config
-    let bls12381_bls12381_min_pk_verify_cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let bls12381_bls12381_min_pk_verify_cost_params = get_extension!(context, NativesCostTable)?
         .bls12381_bls12381_min_pk_verify_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_k1.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_k1.rs
@@ -1,3 +1,4 @@
+use crate::get_extension;
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::NativesCostTable;
@@ -80,7 +81,7 @@ pub fn ecrecover(
 
     // Load the cost parameters from the protocol config
     let (ecdsa_k1_ecrecover_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>()?;
+        let cost_table: &NativesCostTable = get_extension!(context)?;
         (
             cost_table.ecdsa_k1_ecrecover_cost_params.clone(),
             cost_table.crypto_invalid_arguments_cost,
@@ -159,9 +160,7 @@ pub fn decompress_pubkey(
     debug_assert!(args.len() == 1);
 
     // Load the cost parameters from the protocol config
-    let ecdsa_k1_decompress_pubkey_cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let ecdsa_k1_decompress_pubkey_cost_params = get_extension!(context, NativesCostTable)?
         .ecdsa_k1_decompress_pubkey_cost_params
         .clone();
     // Charge the base cost for this oper
@@ -226,7 +225,7 @@ pub fn secp256k1_verify(
 
     // Load the cost parameters from the protocol config
     let (ecdsa_k1_secp256k1_verify_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>()?;
+        let cost_table: &NativesCostTable = get_extension!(context)?;
         (
             cost_table.ecdsa_k1_secp256k1_verify_cost_params.clone(),
             cost_table.crypto_invalid_arguments_cost,

--- a/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_r1.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_r1.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 use fastcrypto::error::FastCryptoError;
 use fastcrypto::hash::{Keccak256, Sha256};
 use fastcrypto::traits::RecoverableSignature;
@@ -71,7 +71,7 @@ pub fn ecrecover(
 
     // Load the cost parameters from the protocol config
     let (ecdsa_r1_ecrecover_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>()?;
+        let cost_table: &NativesCostTable = get_extension!(context)?;
         (
             cost_table.ecdsa_r1_ecrecover_cost_params.clone(),
             cost_table.crypto_invalid_arguments_cost,
@@ -175,7 +175,7 @@ pub fn secp256r1_verify(
     debug_assert!(args.len() == 4);
     // Load the cost parameters from the protocol config
     let (ecdsa_r1_secp256_r1_verify_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>()?;
+        let cost_table: &NativesCostTable = get_extension!(context)?;
         (
             cost_table.ecdsa_r1_secp256_r1_verify_cost_params.clone(),
             cost_table.crypto_invalid_arguments_cost,

--- a/sui-execution/latest/sui-move-natives/src/crypto/ecvrf.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/ecvrf.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 use fastcrypto::vrf::ecvrf::{ECVRFProof, ECVRFPublicKey};
 use fastcrypto::vrf::VRFProof;
 use move_binary_format::errors::PartialVMResult;
@@ -48,9 +48,7 @@ pub fn ecvrf_verify(
     debug_assert!(args.len() == 4);
 
     // Load the cost parameters from the protocol config
-    let ecvrf_ecvrf_verify_cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let ecvrf_ecvrf_verify_cost_params = get_extension!(context, NativesCostTable)?
         .ecvrf_ecvrf_verify_cost_params
         .clone();
     // Charge the base cost for this oper

--- a/sui-execution/latest/sui-move-natives/src/crypto/ed25519.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/ed25519.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 use fastcrypto::{
     ed25519::{Ed25519PublicKey, Ed25519Signature},
     traits::{ToFromBytes, VerifyingKey},
@@ -46,9 +46,7 @@ pub fn ed25519_verify(
     debug_assert!(args.len() == 3);
 
     // Load the cost parameters from the protocol config
-    let ed25519_verify_cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let ed25519_verify_cost_params = get_extension!(context, NativesCostTable)?
         .ed25519_verify_cost_params
         .clone();
     // Charge the base cost for this oper

--- a/sui-execution/latest/sui-move-natives/src/crypto/groth16.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/groth16.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::{object_runtime::ObjectRuntime, NativesCostTable};
+use crate::{get_extension, object_runtime::ObjectRuntime, NativesCostTable};
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::gas_algebra::InternalGas;
 use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
@@ -47,7 +47,7 @@ pub fn prepare_verifying_key_internal(
 
     // Load the cost parameters from the protocol config
     let (groth16_prepare_verifying_key_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>()?;
+        let cost_table: &NativesCostTable = get_extension!(context)?;
         (
             cost_table.groth16_prepare_verifying_key_cost_params.clone(),
             cost_table.crypto_invalid_arguments_cost,
@@ -135,7 +135,7 @@ pub fn verify_groth16_proof_internal(
 
     // Load the cost parameters from the protocol config
     let (groth16_verify_groth16_proof_internal_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>()?;
+        let cost_table: &NativesCostTable = get_extension!(context)?;
         (
             cost_table
                 .groth16_verify_groth16_proof_internal_cost_params
@@ -185,9 +185,7 @@ pub fn verify_groth16_proof_internal(
         _ => {
             // Charge for failure but dont fail if we run out of gas otherwise the actual error is masked by OUT_OF_GAS error
             context.charge_gas(crypto_invalid_arguments_cost);
-            let cost = if context
-                .extensions()
-                .get::<ObjectRuntime>()?
+            let cost = if get_extension!(context, ObjectRuntime)?
                 .protocol_config
                 .native_charging_v2()
             {

--- a/sui-execution/latest/sui-move-natives/src/crypto/group_ops.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/group_ops.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::object_runtime::ObjectRuntime;
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 use fastcrypto::error::{FastCryptoError, FastCryptoResult};
 use fastcrypto::groups::{
     bls12381 as bls, FromTrustedByteArray, GroupElement, HashToGroupElement, MultiScalarMul,
@@ -27,34 +27,26 @@ pub const INVALID_INPUT_ERROR: u64 = 1;
 pub const INPUT_TOO_LONG_ERROR: u64 = 2;
 
 fn is_supported(context: &NativeContext) -> PartialVMResult<bool> {
-    Ok(context
-        .extensions()
-        .get::<ObjectRuntime>()?
+    Ok(get_extension!(context, ObjectRuntime)?
         .protocol_config
         .enable_group_ops_native_functions())
 }
 
 fn is_msm_supported(context: &NativeContext) -> PartialVMResult<bool> {
-    Ok(context
-        .extensions()
-        .get::<ObjectRuntime>()?
+    Ok(get_extension!(context, ObjectRuntime)?
         .protocol_config
         .enable_group_ops_native_function_msm())
 }
 
 fn is_uncompressed_g1_supported(context: &NativeContext) -> PartialVMResult<bool> {
-    Ok(context
-        .extensions()
-        .get::<ObjectRuntime>()?
+    Ok(get_extension!(context, ObjectRuntime)?
         .protocol_config
         .uncompressed_g1_group_elements())
 }
 
 fn v2_native_charge(context: &NativeContext, cost: InternalGas) -> PartialVMResult<InternalGas> {
     Ok(
-        if context
-            .extensions()
-            .get::<ObjectRuntime>()?
+        if get_extension!(context, ObjectRuntime)?
             .protocol_config
             .native_charging_v2()
         {
@@ -239,9 +231,7 @@ pub fn internal_validate(
     let bytes = bytes_ref.as_bytes_ref();
     let group_type = pop_arg!(args, u8);
 
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .group_ops_cost_params
         .clone();
 
@@ -291,9 +281,7 @@ pub fn internal_add(
     let e1 = e1_ref.as_bytes_ref();
     let group_type = pop_arg!(args, u8);
 
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .group_ops_cost_params
         .clone();
 
@@ -344,9 +332,7 @@ pub fn internal_sub(
     let e1 = e1_ref.as_bytes_ref();
     let group_type = pop_arg!(args, u8);
 
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .group_ops_cost_params
         .clone();
 
@@ -397,9 +383,7 @@ pub fn internal_mul(
     let e1 = e1_ref.as_bytes_ref();
     let group_type = pop_arg!(args, u8);
 
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .group_ops_cost_params
         .clone();
 
@@ -465,9 +449,7 @@ pub fn internal_div(
     let e1 = e1_ref.as_bytes_ref();
     let group_type = pop_arg!(args, u8);
 
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .group_ops_cost_params
         .clone();
 
@@ -536,9 +518,7 @@ pub fn internal_hash_to(
         return Ok(NativeResult::err(cost, INVALID_INPUT_ERROR));
     }
 
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .group_ops_cost_params
         .clone();
 
@@ -691,9 +671,7 @@ pub fn internal_multi_scalar_mul(
     let scalars = scalars_ref.as_bytes_ref();
     let group_type = pop_arg!(args, u8);
 
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .group_ops_cost_params
         .clone();
 
@@ -763,9 +741,7 @@ pub fn internal_pairing(
     let e1 = e1_ref.as_bytes_ref();
     let group_type = pop_arg!(args, u8);
 
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .group_ops_cost_params
         .clone();
 
@@ -809,9 +785,7 @@ pub fn internal_convert(
     let to_type = pop_arg!(args, u8);
     let from_type = pop_arg!(args, u8);
 
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .group_ops_cost_params
         .clone();
 
@@ -862,9 +836,7 @@ pub fn internal_sum(
         return Ok(NativeResult::err(cost, NOT_SUPPORTED_ERROR));
     }
 
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .group_ops_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/hash.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/hash.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 use fastcrypto::hash::{Blake2b256, HashFunction, Keccak256};
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::gas_algebra::InternalGas;
@@ -76,9 +76,7 @@ pub fn keccak256(
     args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     // Load the cost parameters from the protocol config
-    let hash_keccak256_cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let hash_keccak256_cost_params = get_extension!(context, NativesCostTable)?
         .hash_keccak256_cost_params
         .clone();
     // Charge the base cost for this oper
@@ -116,9 +114,7 @@ pub fn blake2b256(
     args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     // Load the cost parameters from the protocol config
-    let hash_blake2b256_cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let hash_blake2b256_cost_params = get_extension!(context, NativesCostTable)?
         .hash_blake2b256_cost_params
         .clone();
     // Charge the base cost for this oper

--- a/sui-execution/latest/sui-move-natives/src/crypto/hmac.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/hmac.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 use fastcrypto::{hmac, traits::ToFromBytes};
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::gas_algebra::InternalGas;
@@ -43,9 +43,7 @@ pub fn hmac_sha3_256(
     debug_assert!(args.len() == 2);
 
     // Load the cost parameters from the protocol config
-    let hmac_hmac_sha3_256_cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let hmac_hmac_sha3_256_cost_params = get_extension!(context, NativesCostTable)?
         .hmac_hmac_sha3_256_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/nitro_attestation.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/nitro_attestation.rs
@@ -13,7 +13,7 @@ use move_vm_types::{
 use std::collections::{BTreeMap, VecDeque};
 use sui_types::nitro_attestation::{parse_nitro_attestation, verify_nitro_attestation};
 
-use crate::{object_runtime::ObjectRuntime, NativesCostTable};
+use crate::{get_extension, object_runtime::ObjectRuntime, NativesCostTable};
 use move_vm_runtime::native_charge_gas_early_exit;
 
 pub const NOT_SUPPORTED_ERROR: u64 = 0;
@@ -45,17 +45,13 @@ macro_rules! native_charge_gas_early_exit_option {
 }
 
 fn is_supported(context: &NativeContext) -> PartialVMResult<bool> {
-    Ok(context
-        .extensions()
-        .get::<ObjectRuntime>()?
+    Ok(get_extension!(context, ObjectRuntime)?
         .protocol_config
         .enable_nitro_attestation())
 }
 
 fn is_upgraded(context: &NativeContext) -> PartialVMResult<bool> {
-    Ok(context
-        .extensions()
-        .get::<ObjectRuntime>()?
+    Ok(get_extension!(context, ObjectRuntime)?
         .protocol_config
         .enable_nitro_attestation_upgraded_parsing())
 }
@@ -77,9 +73,7 @@ pub fn load_nitro_attestation_internal(
     let attestation_ref = pop_arg!(args, VectorRef);
     let attestation_bytes = attestation_ref.as_bytes_ref();
 
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .nitro_attestation_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/poseidon.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/poseidon.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::object_runtime::ObjectRuntime;
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 use fastcrypto_zkp::bn254::poseidon::poseidon_bytes;
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::gas_algebra::InternalGas;
@@ -22,9 +22,7 @@ pub const NON_CANONICAL_INPUT: u64 = 0;
 pub const NOT_SUPPORTED_ERROR: u64 = 1;
 
 fn is_supported(context: &NativeContext) -> PartialVMResult<bool> {
-    Ok(context
-        .extensions()
-        .get::<ObjectRuntime>()?
+    Ok(get_extension!(context, ObjectRuntime)?
         .protocol_config
         .enable_poseidon())
 }
@@ -54,9 +52,7 @@ pub fn poseidon_bn254_internal(
     }
 
     // Load the cost parameters from the protocol config
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .poseidon_bn254_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/vdf.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/vdf.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::object_runtime::ObjectRuntime;
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 use fastcrypto_vdf::class_group::discriminant::DISCRIMINANT_3072;
 use fastcrypto_vdf::class_group::QuadraticForm;
 use fastcrypto_vdf::vdf::wesolowski::DefaultVDF;
@@ -24,9 +24,7 @@ pub const INVALID_INPUT_ERROR: u64 = 0;
 pub const NOT_SUPPORTED_ERROR: u64 = 1;
 
 fn is_supported(context: &NativeContext) -> PartialVMResult<bool> {
-    Ok(context
-        .extensions()
-        .get::<ObjectRuntime>()?
+    Ok(get_extension!(context, ObjectRuntime)?
         .protocol_config
         .enable_vdf())
 }
@@ -59,9 +57,7 @@ pub fn vdf_verify_internal(
     }
 
     // Load the cost parameters from the protocol config
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .vdf_cost_params
         .clone();
 
@@ -129,9 +125,7 @@ pub fn hash_to_input_internal(
     }
 
     // Load the cost parameters from the protocol config
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .vdf_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/zklogin.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/zklogin.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 use fastcrypto::error::FastCryptoError;
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::account_address::AccountAddress;
@@ -45,9 +45,7 @@ pub fn check_zklogin_id_internal(
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     // Load the cost parameters from the protocol config
-    let check_zklogin_id_cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let check_zklogin_id_cost_params = get_extension!(context, NativesCostTable)?
         .check_zklogin_id_cost_params
         .clone();
 
@@ -147,9 +145,7 @@ pub fn check_zklogin_issuer_internal(
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     // Load the cost parameters from the protocol config
-    let check_zklogin_issuer_cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let check_zklogin_issuer_cost_params = get_extension!(context, NativesCostTable)?
         .check_zklogin_issuer_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/dynamic_field.rs
+++ b/sui-execution/latest/sui-move-natives/src/dynamic_field.rs
@@ -292,7 +292,7 @@ pub fn borrow_child_object(
         dynamic_field_borrow_child_object_cost_params
             .dynamic_field_borrow_child_object_type_cost_per_byte
     );
-    let global_value = match global_value_result {
+    let (_cache_info, global_value) = match global_value_result {
         ObjectResult::MismatchedType => {
             return Ok(NativeResult::err(context.gas_used(), E_FIELD_TYPE_MISMATCH))
         }
@@ -365,7 +365,7 @@ pub fn remove_child_object(
         dynamic_field_remove_child_object_cost_params
             .dynamic_field_remove_child_object_type_cost_per_byte
     );
-    let global_value = match global_value_result {
+    let (_cache_info, global_value) = match global_value_result {
         ObjectResult::MismatchedType => {
             return Ok(NativeResult::err(context.gas_used(), E_FIELD_TYPE_MISMATCH))
         }
@@ -495,7 +495,7 @@ pub fn has_child_object_with_ty(
     );
 
     let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
-    let has_child = object_runtime.child_object_exists_and_has_type(
+    let (_cache_info, has_child) = object_runtime.child_object_exists_and_has_type(
         parent,
         child_id,
         &MoveObjectType::from(tag),

--- a/sui-execution/latest/sui-move-natives/src/dynamic_field.rs
+++ b/sui-execution/latest/sui-move-natives/src/dynamic_field.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    abstract_size, get_nested_struct_field, get_object_id,
+    abstract_size, charge_cache_or_load_gas, get_extension, get_extension_mut,
+    get_nested_struct_field, get_object_id,
     object_runtime::{object_store::ObjectResult, ObjectRuntime},
     NativesCostTable,
 };
@@ -86,9 +87,7 @@ pub fn hash_type_and_key(
     assert_eq!(ty_args.len(), 1);
     assert_eq!(args.len(), 2);
 
-    let dynamic_field_hash_type_and_key_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let dynamic_field_hash_type_and_key_cost_params = get_extension!(context, NativesCostTable)?
         .dynamic_field_hash_type_and_key_cost_params
         .clone();
 
@@ -105,7 +104,7 @@ pub fn hash_type_and_key(
     // Get size info for costing for derivations, serializations, etc
     let k_ty_size = u64::from(k_ty.size());
     let k_value_size = u64::from(abstract_size(
-        context.extensions().get::<ObjectRuntime>()?.protocol_config,
+        get_extension!(context, ObjectRuntime)?.protocol_config,
         &k,
     ));
     native_charge_gas_early_exit!(
@@ -170,9 +169,7 @@ pub fn add_child_object(
     assert!(ty_args.len() == 1);
     assert!(args.len() == 2);
 
-    let dynamic_field_add_child_object_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let dynamic_field_add_child_object_cost_params = get_extension!(context, NativesCostTable)?
         .dynamic_field_add_child_object_cost_params
         .clone();
 
@@ -187,7 +184,7 @@ pub fn add_child_object(
     assert!(args.is_empty());
 
     let child_value_size = u64::from(abstract_size(
-        context.extensions().get::<ObjectRuntime>()?.protocol_config,
+        get_extension!(context, ObjectRuntime)?.protocol_config,
         &child,
     ));
     // ID extraction step
@@ -233,7 +230,7 @@ pub fn add_child_object(
             * struct_tag_size.into()
     );
 
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     object_runtime.add_child_object(parent, child_id, MoveObjectType::from(tag), child)?;
     Ok(NativeResult::ok(context.gas_used(), smallvec![]))
 }
@@ -263,9 +260,7 @@ pub fn borrow_child_object(
     assert!(ty_args.len() == 1);
     assert!(args.len() == 2);
 
-    let dynamic_field_borrow_child_object_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let dynamic_field_borrow_child_object_cost_params = get_extension!(context, NativesCostTable)?
         .dynamic_field_borrow_child_object_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -292,7 +287,7 @@ pub fn borrow_child_object(
         dynamic_field_borrow_child_object_cost_params
             .dynamic_field_borrow_child_object_type_cost_per_byte
     );
-    let (_cache_info, global_value) = match global_value_result {
+    let (cache_info, global_value) = match global_value_result {
         ObjectResult::MismatchedType => {
             return Ok(NativeResult::err(context.gas_used(), E_FIELD_TYPE_MISMATCH))
         }
@@ -305,8 +300,10 @@ pub fn borrow_child_object(
         assert!(err.major_status() != StatusCode::MISSING_DATA);
     })?;
 
+    charge_cache_or_load_gas!(context, cache_info);
+
     let child_ref_size = abstract_size(
-        context.extensions().get::<ObjectRuntime>()?.protocol_config,
+        get_extension!(context, ObjectRuntime)?.protocol_config,
         &child_ref,
     );
 
@@ -365,18 +362,21 @@ pub fn remove_child_object(
         dynamic_field_remove_child_object_cost_params
             .dynamic_field_remove_child_object_type_cost_per_byte
     );
-    let (_cache_info, global_value) = match global_value_result {
+    let (cache_info, global_value) = match global_value_result {
         ObjectResult::MismatchedType => {
             return Ok(NativeResult::err(context.gas_used(), E_FIELD_TYPE_MISMATCH))
         }
         ObjectResult::Loaded(gv) => gv,
     };
+
     if !global_value.exists()? {
         return Ok(NativeResult::err(context.gas_used(), E_KEY_DOES_NOT_EXIST));
     }
     let child = global_value.move_from().inspect_err(|err| {
         assert!(err.major_status() != StatusCode::MISSING_DATA);
     })?;
+
+    charge_cache_or_load_gas!(context, cache_info);
 
     let child_size = abstract_size(
         context.extensions().get::<ObjectRuntime>()?.protocol_config,
@@ -495,11 +495,12 @@ pub fn has_child_object_with_ty(
     );
 
     let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
-    let (_cache_info, has_child) = object_runtime.child_object_exists_and_has_type(
+    let (cache_info, has_child) = object_runtime.child_object_exists_and_has_type(
         parent,
         child_id,
         &MoveObjectType::from(tag),
     )?;
+    charge_cache_or_load_gas!(context, cache_info);
     Ok(NativeResult::ok(
         context.gas_used(),
         smallvec![Value::bool(has_child)],

--- a/sui-execution/latest/sui-move-natives/src/dynamic_field.rs
+++ b/sui-execution/latest/sui-move-natives/src/dynamic_field.rs
@@ -51,7 +51,7 @@ macro_rules! get_or_fetch_object {
             }
         };
 
-        let object_runtime: &mut ObjectRuntime = $context.extensions_mut().get_mut()?;
+        let object_runtime: &mut ObjectRuntime = $crate::get_extension_mut!($context)?;
         object_runtime.get_or_fetch_child_object(
             $parent,
             $child_id,
@@ -341,9 +341,7 @@ pub fn remove_child_object(
     assert!(ty_args.len() == 1);
     assert!(args.len() == 2);
 
-    let dynamic_field_remove_child_object_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let dynamic_field_remove_child_object_cost_params = get_extension!(context, NativesCostTable)?
         .dynamic_field_remove_child_object_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -379,7 +377,7 @@ pub fn remove_child_object(
     charge_cache_or_load_gas!(context, cache_info);
 
     let child_size = abstract_size(
-        context.extensions().get::<ObjectRuntime>()?.protocol_config,
+        get_extension!(context, ObjectRuntime)?.protocol_config,
         &child,
     );
 
@@ -412,9 +410,7 @@ pub fn has_child_object(
     assert!(ty_args.is_empty());
     assert!(args.len() == 2);
 
-    let dynamic_field_has_child_object_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let dynamic_field_has_child_object_cost_params = get_extension!(context, NativesCostTable)?
         .dynamic_field_has_child_object_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -424,7 +420,7 @@ pub fn has_child_object(
 
     let child_id = pop_arg!(args, AccountAddress).into();
     let parent = pop_arg!(args, AccountAddress).into();
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     let has_child = object_runtime.child_object_exists(parent, child_id)?;
     Ok(NativeResult::ok(
         context.gas_used(),
@@ -454,11 +450,10 @@ pub fn has_child_object_with_ty(
     assert!(ty_args.len() == 1);
     assert!(args.len() == 2);
 
-    let dynamic_field_has_child_object_with_ty_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
-        .dynamic_field_has_child_object_with_ty_cost_params
-        .clone();
+    let dynamic_field_has_child_object_with_ty_cost_params =
+        get_extension!(context, NativesCostTable)?
+            .dynamic_field_has_child_object_with_ty_cost_params
+            .clone();
     native_charge_gas_early_exit!(
         context,
         dynamic_field_has_child_object_with_ty_cost_params
@@ -494,7 +489,7 @@ pub fn has_child_object_with_ty(
             * u64::from(tag.abstract_size_for_gas_metering()).into()
     );
 
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     let (cache_info, has_child) = object_runtime.child_object_exists_and_has_type(
         parent,
         child_id,

--- a/sui-execution/latest/sui-move-natives/src/event.rs
+++ b/sui-execution/latest/sui-move-natives/src/event.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{abstract_size, legacy_test_cost, object_runtime::ObjectRuntime, NativesCostTable};
+use crate::{
+    abstract_size, get_extension, get_extension_mut, legacy_test_cost,
+    object_runtime::ObjectRuntime, NativesCostTable,
+};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{gas_algebra::InternalGas, language_storage::TypeTag, vm_status::StatusCode};
 use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
@@ -38,9 +41,7 @@ pub fn emit(
     debug_assert!(ty_args.len() == 1);
     debug_assert!(args.len() == 1);
 
-    let event_emit_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let event_emit_cost_params = get_extension!(context, NativesCostTable)?
         .event_emit_cost_params
         .clone();
 
@@ -50,7 +51,7 @@ pub fn emit(
     let event_value = args.pop_back().unwrap();
 
     let event_value_size = abstract_size(
-        context.extensions().get::<ObjectRuntime>()?.protocol_config,
+        get_extension!(context, ObjectRuntime)?.protocol_config,
         &event_value,
     );
 
@@ -79,7 +80,7 @@ pub fn emit(
             * u64::from(tag_size).into()
     );
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let obj_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     let max_event_emit_size = obj_runtime.protocol_config.max_event_emit_size();
     let ev_size = u64::from(tag_size + event_value_size);
     // Check if the event size is within the limit
@@ -117,7 +118,7 @@ pub fn emit(
         event_emit_cost_params.event_emit_output_cost_per_byte * ev_size.into()
     );
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let obj_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
 
     obj_runtime.emit_event(*tag, event_value)?;
     Ok(NativeResult::ok(context.gas_used(), smallvec![]))
@@ -131,7 +132,7 @@ pub fn num_events(
 ) -> PartialVMResult<NativeResult> {
     assert!(ty_args.is_empty());
     assert!(args.is_empty());
-    let object_runtime_ref: &ObjectRuntime = context.extensions().get()?;
+    let object_runtime_ref: &ObjectRuntime = get_extension!(context)?;
     let num_events = object_runtime_ref.state.events().len();
     Ok(NativeResult::ok(
         legacy_test_cost(),
@@ -149,7 +150,7 @@ pub fn get_events_by_type(
     let specified_ty = ty_args.pop().unwrap();
     let specialization: VectorSpecialization = (&specified_ty).try_into()?;
     assert!(args.is_empty());
-    let object_runtime_ref: &ObjectRuntime = context.extensions().get()?;
+    let object_runtime_ref: &ObjectRuntime = get_extension!(context)?;
     let specified_type_tag = match context.type_to_type_tag(&specified_ty)? {
         TypeTag::Struct(s) => *s,
         _ => return Ok(NativeResult::ok(legacy_test_cost(), smallvec![])),

--- a/sui-execution/latest/sui-move-natives/src/event.rs
+++ b/sui-execution/latest/sui-move-natives/src/event.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{legacy_test_cost, object_runtime::ObjectRuntime, NativesCostTable};
+use crate::{abstract_size, legacy_test_cost, object_runtime::ObjectRuntime, NativesCostTable};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{gas_algebra::InternalGas, language_storage::TypeTag, vm_status::StatusCode};
 use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
@@ -49,7 +49,10 @@ pub fn emit(
     let ty = ty_args.pop().unwrap();
     let event_value = args.pop_back().unwrap();
 
-    let event_value_size = event_value.legacy_size();
+    let event_value_size = abstract_size(
+        context.extensions().get::<ObjectRuntime>()?.protocol_config,
+        &event_value,
+    );
 
     // Deriving event value size can be expensive due to recursion overhead
     native_charge_gas_early_exit!(

--- a/sui-execution/latest/sui-move-natives/src/lib.rs
+++ b/sui-execution/latest/sui-move-natives/src/lib.rs
@@ -51,7 +51,7 @@ use crypto::vdf::{self, VDFCostParams};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
     annotated_value as A,
-    gas_algebra::InternalGas,
+    gas_algebra::{AbstractMemorySize, InternalGas},
     identifier::Identifier,
     language_storage::{StructTag, TypeTag},
     runtime_value as R,
@@ -66,6 +66,7 @@ use move_vm_types::{
     loaded_data::runtime_types::Type,
     natives::function::NativeResult,
     values::{Struct, Value},
+    views::{SizeConfig, ValueView},
 };
 use std::sync::Arc;
 use sui_protocol_config::ProtocolConfig;
@@ -1362,4 +1363,16 @@ macro_rules! make_native {
 
 pub(crate) fn legacy_test_cost() -> InternalGas {
     InternalGas::new(0)
+}
+
+pub(crate) fn abstract_size(protocol_config: &ProtocolConfig, v: &Value) -> AbstractMemorySize {
+    if protocol_config.abstract_size_in_object_runtime() {
+        v.abstract_memory_size(&SizeConfig {
+            include_vector_size: true,
+            traverse_references: false,
+        })
+    } else {
+        // TODO: Remove this (with glee!) in the next execution version cut.
+        v.legacy_size()
+    }
 }

--- a/sui-execution/latest/sui-move-natives/src/lib.rs
+++ b/sui-execution/latest/sui-move-natives/src/lib.rs
@@ -1361,6 +1361,42 @@ macro_rules! make_native {
     };
 }
 
+#[macro_export]
+macro_rules! get_extension {
+    ($context: expr, $ext: ty) => {
+        $context.extensions().get::<$ext>()
+    };
+    ($context: expr) => {
+        $context.extensions().get()
+    };
+}
+
+#[macro_export]
+macro_rules! get_extension_mut {
+    ($context: expr, $ext: ty) => {
+        $context.extensions_mut().get_mut::<$ext>()
+    };
+    ($context: expr) => {
+        $context.extensions_mut().get_mut()
+    };
+}
+
+#[macro_export]
+macro_rules! charge_cache_or_load_gas {
+    ($context:ident, $cache_info:expr) => {
+        match $cache_info {
+            crate::object_runtime::object_store::CacheInfo::Cached => (),
+            crate::object_runtime::object_store::CacheInfo::Loaded(size) => {
+                let config = get_extension!($context, ObjectRuntime)?.protocol_config;
+                if config.object_runtime_charge_cache_load_gas() {
+                    let cost = size * config.obj_access_cost_read_per_byte() as usize;
+                    native_charge_gas_early_exit!($context, InternalGas::new(cost as u64));
+                }
+            }
+        }
+    };
+}
+
 pub(crate) fn legacy_test_cost() -> InternalGas {
     InternalGas::new(0)
 }

--- a/sui-execution/latest/sui-move-natives/src/lib.rs
+++ b/sui-execution/latest/sui-move-natives/src/lib.rs
@@ -1385,8 +1385,8 @@ macro_rules! get_extension_mut {
 macro_rules! charge_cache_or_load_gas {
     ($context:ident, $cache_info:expr) => {
         match $cache_info {
-            crate::object_runtime::object_store::CacheInfo::Cached => (),
-            crate::object_runtime::object_store::CacheInfo::Loaded(size) => {
+            $crate::object_runtime::object_store::CacheInfo::Cached => (),
+            $crate::object_runtime::object_store::CacheInfo::Loaded(size) => {
                 let config = get_extension!($context, ObjectRuntime)?.protocol_config;
                 if config.object_runtime_charge_cache_load_gas() {
                     let cost = size * config.obj_access_cost_read_per_byte() as usize;

--- a/sui-execution/latest/sui-move-natives/src/object.rs
+++ b/sui-execution/latest/sui-move-natives/src/object.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{object_runtime::ObjectRuntime, NativesCostTable};
+use crate::{get_extension, get_extension_mut, object_runtime::ObjectRuntime, NativesCostTable};
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::{account_address::AccountAddress, gas_algebra::InternalGas};
 use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
@@ -31,9 +31,7 @@ pub fn borrow_uid(
     debug_assert!(ty_args.len() == 1);
     debug_assert!(args.len() == 1);
 
-    let borrow_uid_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let borrow_uid_cost_params = get_extension!(context, NativesCostTable)?
         .borrow_uid_cost_params
         .clone();
 
@@ -63,9 +61,7 @@ pub fn delete_impl(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 1);
 
-    let delete_impl_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let delete_impl_cost_params = get_extension!(context, NativesCostTable)?
         .delete_impl_cost_params
         .clone();
 
@@ -78,7 +74,7 @@ pub fn delete_impl(
     // unwrap safe because the interface of native function guarantees it.
     let uid_bytes = pop_arg!(args, AccountAddress);
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let obj_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     obj_runtime.delete_id(uid_bytes.into())?;
     Ok(NativeResult::ok(context.gas_used(), smallvec![]))
 }
@@ -100,9 +96,7 @@ pub fn record_new_uid(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 1);
 
-    let record_new_id_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let record_new_id_cost_params = get_extension!(context, NativesCostTable)?
         .record_new_id_cost_params
         .clone();
 
@@ -115,7 +109,7 @@ pub fn record_new_uid(
     // unwrap safe because the interface of native function guarantees it.
     let uid_bytes = pop_arg!(args, AccountAddress);
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let obj_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     obj_runtime.new_id(uid_bytes.into())?;
     Ok(NativeResult::ok(context.gas_used(), smallvec![]))
 }

--- a/sui-execution/latest/sui-move-natives/src/transfer.rs
+++ b/sui-execution/latest/sui-move-natives/src/transfer.rs
@@ -3,8 +3,8 @@
 
 use super::object_runtime::{ObjectRuntime, TransferResult};
 use crate::{
-    get_receiver_object_id, get_tag_and_layouts, object_runtime::object_store::ObjectResult,
-    NativesCostTable,
+    get_extension, get_extension_mut, get_receiver_object_id, get_tag_and_layouts,
+    object_runtime::object_store::ObjectResult, NativesCostTable,
 };
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
@@ -48,9 +48,7 @@ pub fn receive_object_internal(
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(ty_args.len() == 1);
     debug_assert!(args.len() == 3);
-    let transfer_receive_object_internal_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let transfer_receive_object_internal_cost_params = get_extension!(context, NativesCostTable)?
         .transfer_receive_object_internal_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -76,7 +74,7 @@ pub fn receive_object_internal(
         ));
     };
 
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     let (_cache_info, child) = match object_runtime.receive_object(
         parent,
         child_id,
@@ -122,9 +120,7 @@ pub fn transfer_internal(
     debug_assert!(ty_args.len() == 1);
     debug_assert!(args.len() == 2);
 
-    let transfer_transfer_internal_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let transfer_transfer_internal_cost_params = get_extension!(context, NativesCostTable)?
         .transfer_transfer_internal_cost_params
         .clone();
 
@@ -182,9 +178,7 @@ pub fn party_transfer_internal(
     debug_assert!(ty_args.len() == 1);
     debug_assert!(args.len() == 4);
 
-    let is_supported = context
-        .extensions()
-        .get::<ObjectRuntime>()?
+    let is_supported = get_extension!(context, ObjectRuntime)?
         .protocol_config
         .enable_party_transfer();
     if !is_supported {
@@ -192,9 +186,7 @@ pub fn party_transfer_internal(
         return Ok(NativeResult::err(cost, E_NOT_SUPPORTED));
     }
 
-    let transfer_party_transfer_internal_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let transfer_party_transfer_internal_cost_params = get_extension!(context, NativesCostTable)?
         .transfer_party_transfer_internal_cost_params
         .clone();
 
@@ -256,9 +248,7 @@ pub fn freeze_object(
     debug_assert!(ty_args.len() == 1);
     debug_assert!(args.len() == 1);
 
-    let transfer_freeze_object_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let transfer_freeze_object_cost_params = get_extension!(context, NativesCostTable)?
         .transfer_freeze_object_cost_params
         .clone();
 
@@ -292,9 +282,7 @@ pub fn share_object(
     debug_assert!(ty_args.len() == 1);
     debug_assert!(args.len() == 1);
 
-    let transfer_share_object_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let transfer_share_object_cost_params = get_extension!(context, NativesCostTable)?
         .transfer_share_object_cost_params
         .clone();
 
@@ -340,6 +328,6 @@ fn object_runtime_transfer(
         }
     };
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let obj_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     obj_runtime.transfer(owner, object_type, obj, /* end of transaction */ false)
 }

--- a/sui-execution/latest/sui-move-natives/src/transfer.rs
+++ b/sui-execution/latest/sui-move-natives/src/transfer.rs
@@ -77,7 +77,7 @@ pub fn receive_object_internal(
     };
 
     let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
-    let child = match object_runtime.receive_object(
+    let (_cache_info, child) = match object_runtime.receive_object(
         parent,
         child_id,
         child_receiver_sequence_number,

--- a/sui-execution/latest/sui-move-natives/src/tx_context.rs
+++ b/sui-execution/latest/sui-move-natives/src/tx_context.rs
@@ -12,7 +12,8 @@ use std::collections::VecDeque;
 use sui_types::{base_types::ObjectID, digests::TransactionDigest};
 
 use crate::{
-    object_runtime::ObjectRuntime, transaction_context::TransactionContext, NativesCostTable,
+    get_extension, get_extension_mut, object_runtime::ObjectRuntime,
+    transaction_context::TransactionContext, NativesCostTable,
 };
 
 #[derive(Clone)]
@@ -32,9 +33,7 @@ pub fn derive_id(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 2);
 
-    let tx_context_derive_id_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let tx_context_derive_id_cost_params = get_extension!(context, NativesCostTable)?
         .tx_context_derive_id_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -48,7 +47,7 @@ pub fn derive_id(
     // unwrap safe because all digests in Move are serialized from the Rust `TransactionDigest`
     let digest = TransactionDigest::try_from(tx_hash.as_slice()).unwrap();
     let address = AccountAddress::from(ObjectID::derive_id(digest, ids_created));
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let obj_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     obj_runtime.new_id(address.into())?;
 
     Ok(NativeResult::ok(
@@ -72,9 +71,7 @@ pub fn fresh_id(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.is_empty());
 
-    let tx_context_fresh_id_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let tx_context_fresh_id_cost_params = get_extension!(context, NativesCostTable)?
         .tx_context_fresh_id_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -82,9 +79,9 @@ pub fn fresh_id(
         tx_context_fresh_id_cost_params.tx_context_fresh_id_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
     let fresh_id = transaction_context.fresh_id();
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     object_runtime.new_id(fresh_id)?;
 
     Ok(NativeResult::ok(
@@ -109,9 +106,7 @@ pub fn sender(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.is_empty());
 
-    let tx_context_sender_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let tx_context_sender_cost_params = get_extension!(context, NativesCostTable)?
         .tx_context_sender_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -119,7 +114,7 @@ pub fn sender(
         tx_context_sender_cost_params.tx_context_sender_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
     let sender = transaction_context.sender();
 
     Ok(NativeResult::ok(
@@ -144,9 +139,7 @@ pub fn epoch(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.is_empty());
 
-    let tx_context_epoch_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let tx_context_epoch_cost_params = get_extension!(context, NativesCostTable)?
         .tx_context_epoch_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -154,7 +147,7 @@ pub fn epoch(
         tx_context_epoch_cost_params.tx_context_epoch_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
     let epoch = transaction_context.epoch();
 
     Ok(NativeResult::ok(
@@ -179,9 +172,7 @@ pub fn epoch_timestamp_ms(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.is_empty());
 
-    let tx_context_epoch_timestamp_ms_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let tx_context_epoch_timestamp_ms_cost_params = get_extension!(context, NativesCostTable)?
         .tx_context_epoch_timestamp_ms_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -189,7 +180,7 @@ pub fn epoch_timestamp_ms(
         tx_context_epoch_timestamp_ms_cost_params.tx_context_epoch_timestamp_ms_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
     let timestamp = transaction_context.epoch_timestamp_ms();
 
     Ok(NativeResult::ok(
@@ -214,9 +205,7 @@ pub fn sponsor(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.is_empty());
 
-    let tx_context_sponsor_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let tx_context_sponsor_cost_params = get_extension!(context, NativesCostTable)?
         .tx_context_sponsor_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -224,7 +213,7 @@ pub fn sponsor(
         tx_context_sponsor_cost_params.tx_context_sponsor_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
     let sponsor = transaction_context
         .sponsor()
         .map(|addr| addr.into())
@@ -249,14 +238,12 @@ pub fn rgp(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.is_empty());
 
-    let tx_context_rgp_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let tx_context_rgp_cost_params = get_extension!(context, NativesCostTable)?
         .tx_context_rgp_cost_params
         .clone();
     native_charge_gas_early_exit!(context, tx_context_rgp_cost_params.tx_context_rgp_cost_base);
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
     let rgp = transaction_context.rgp();
 
     Ok(NativeResult::ok(
@@ -280,9 +267,7 @@ pub fn gas_price(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.is_empty());
 
-    let tx_context_gas_price_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let tx_context_gas_price_cost_params = get_extension!(context, NativesCostTable)?
         .tx_context_gas_price_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -290,7 +275,7 @@ pub fn gas_price(
         tx_context_gas_price_cost_params.tx_context_gas_price_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
     let gas_price = transaction_context.gas_price();
 
     Ok(NativeResult::ok(
@@ -315,9 +300,7 @@ pub fn gas_budget(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.is_empty());
 
-    let tx_context_gas_budget_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let tx_context_gas_budget_cost_params = get_extension!(context, NativesCostTable)?
         .tx_context_gas_budget_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -325,7 +308,7 @@ pub fn gas_budget(
         tx_context_gas_budget_cost_params.tx_context_gas_budget_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
     let gas_budget = transaction_context.gas_budget();
 
     Ok(NativeResult::ok(
@@ -350,9 +333,7 @@ pub fn ids_created(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.is_empty());
 
-    let tx_context_ids_created_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let tx_context_ids_created_cost_params = get_extension!(context, NativesCostTable)?
         .tx_context_ids_created_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -360,7 +341,7 @@ pub fn ids_created(
         tx_context_ids_created_cost_params.tx_context_ids_created_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
     let ids_created = transaction_context.ids_created();
 
     Ok(NativeResult::ok(
@@ -404,17 +385,16 @@ pub fn replace(
     debug_assert!(args_len == 8 || args_len == 9);
 
     // use the `TxContextReplaceCostParams` for the cost of this function
-    let tx_context_replace_cost_params: TxContextReplaceCostParams = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
-        .tx_context_replace_cost_params
-        .clone();
+    let tx_context_replace_cost_params: TxContextReplaceCostParams =
+        get_extension!(context, NativesCostTable)?
+            .tx_context_replace_cost_params
+            .clone();
     native_charge_gas_early_exit!(
         context,
         tx_context_replace_cost_params.tx_context_replace_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
     let mut sponsor: Vec<AccountAddress> = pop_arg!(args, Vec<AccountAddress>);
     let gas_budget: u64 = pop_arg!(args, u64);
     let gas_price: u64 = pop_arg!(args, u64);
@@ -460,9 +440,7 @@ pub fn last_created_id(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.is_empty());
 
-    let tx_context_derive_id_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let tx_context_derive_id_cost_params = get_extension!(context, NativesCostTable)?
         .tx_context_derive_id_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -470,7 +448,7 @@ pub fn last_created_id(
         tx_context_derive_id_cost_params.tx_context_derive_id_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
     let mut ids_created = transaction_context.ids_created();
     if ids_created == 0 {
         return Ok(NativeResult::err(context.gas_used(), E_NO_IDS_CREATED));
@@ -478,7 +456,7 @@ pub fn last_created_id(
     ids_created -= 1;
     let digest = transaction_context.digest();
     let address = AccountAddress::from(ObjectID::derive_id(digest, ids_created));
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let obj_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     obj_runtime.new_id(address.into())?;
 
     Ok(NativeResult::ok(

--- a/sui-execution/latest/sui-move-natives/src/types.rs
+++ b/sui-execution/latest/sui-move-natives/src/types.rs
@@ -14,7 +14,7 @@ use move_vm_types::{
 use smallvec::smallvec;
 use std::collections::VecDeque;
 
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 
 pub(crate) fn is_otw_struct(
     struct_layout: &MoveStructLayout,
@@ -59,9 +59,7 @@ pub fn is_one_time_witness(
     debug_assert!(ty_args.len() == 1);
     debug_assert!(args.len() == 1);
 
-    let type_is_one_time_witness_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let type_is_one_time_witness_cost_params = get_extension!(context, NativesCostTable)?
         .type_is_one_time_witness_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/validator.rs
+++ b/sui-execution/latest/sui-move-natives/src/validator.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{gas_algebra::InternalGas, vm_status::StatusCode};
 use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
@@ -31,9 +31,7 @@ pub fn validate_metadata_bcs(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 1);
 
-    let validator_validate_metadata_bcs_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let validator_validate_metadata_bcs_cost_params = get_extension!(context, NativesCostTable)?
         .validator_validate_metadata_bcs_cost_params
         .clone();
 


### PR DESCRIPTION
## Description 

Update the last remaining calls to `legacy_size` to use `abstract_memory_size`.

This means that we will no longer have any calls to `legacy_size` in the next execution version (🥳), and  be able to remove it at that time. We should be able to actually convert all the `legacy_size` calls over to `abstract_memory_size` calls today I believe without gating, but decided to keep the old function around + protocol gate just to be on the safe side....

The changes are protocol gated and the protocol config is not enabled. That will be done at a later date :) 

## Test plan 

CI -- nothing should change.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
