### PR TITLE
Reduce error return logging severity to INFO / DEBUG

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -530,7 +530,7 @@ impl ValidatorService {
         Ok((tonic::Response::new(info), Weight::zero()))
     }
 
-    #[instrument(name= "ValidatorService::handle_submit_transaction", level = "error", skip_all, err, fields(tx_digest = ?tracing::field::Empty))]
+    #[instrument(name= "ValidatorService::handle_submit_transaction", level = "error", skip_all, err(level = "debug"), fields(tx_digest = ?tracing::field::Empty))]
     async fn handle_submit_transaction(
         &self,
         request: tonic::Request<RawSubmitTxRequest>,
@@ -1177,7 +1177,7 @@ impl ValidatorService {
         ))
     }
 
-    #[instrument(name= "ValidatorService::wait_for_effects_response", level = "error", skip_all, err, fields(consensus_position = ?request.consensus_position, fast_path_effects = tracing::field::Empty))]
+    #[instrument(name= "ValidatorService::wait_for_effects_response", level = "error", skip_all, err(level = "debug"), fields(consensus_position = ?request.consensus_position, fast_path_effects = tracing::field::Empty))]
     async fn wait_for_effects_response(
         &self,
         request: WaitForEffectsRequest,

--- a/crates/sui-core/src/consensus_validator.rs
+++ b/crates/sui-core/src/consensus_validator.rs
@@ -186,7 +186,7 @@ impl SuiTxValidator {
         result
     }
 
-    #[instrument(level = "debug", skip_all, err, fields(tx_digest = ?tx.digest()))]
+    #[instrument(level = "debug", skip_all, err(level = "debug"), fields(tx_digest = ?tx.digest()))]
     fn vote_transaction(
         &self,
         epoch_store: &Arc<AuthorityPerEpochStore>,

--- a/crates/sui-core/src/transaction_driver/effects_certifier.rs
+++ b/crates/sui-core/src/transaction_driver/effects_certifier.rs
@@ -188,7 +188,7 @@ impl EffectsCertifier {
         }
     }
 
-    #[instrument(level = "debug", skip_all, err, fields(tx_digest = ?tx_digest, consensus_position = ?consensus_position, ret_effects_digest = tracing::field::Empty))]
+    #[instrument(level = "debug", skip_all, err(level = "debug"), fields(tx_digest = ?tx_digest, consensus_position = ?consensus_position, ret_effects_digest = tracing::field::Empty))]
     async fn get_full_effects<A>(
         &self,
         client: Arc<SafeClient<A>>,
@@ -241,7 +241,7 @@ impl EffectsCertifier {
         }
     }
 
-    #[instrument(level = "debug", skip_all, err, ret, fields(consensus_position = ?consensus_position))]
+    #[instrument(level = "debug", skip_all, err(level = "debug"), ret, fields(consensus_position = ?consensus_position))]
     async fn wait_for_acknowledgments<A>(
         &self,
         authority_aggregator: &Arc<AuthorityAggregator<A>>,
@@ -498,7 +498,7 @@ impl EffectsCertifier {
         }
     }
 
-    #[instrument(level = "debug", skip_all, err, ret, fields(validator_display_name = ?display_name))]
+    #[instrument(level = "debug", skip_all, err(level = "debug"), ret, fields(validator_display_name = ?display_name))]
     async fn wait_for_acknowledgment_rpc<A>(
         &self,
         name: AuthorityName,

--- a/crates/sui-core/src/transaction_driver/mod.rs
+++ b/crates/sui-core/src/transaction_driver/mod.rs
@@ -89,7 +89,7 @@ where
         driver
     }
 
-    #[instrument(level = "error", skip_all, err, fields(tx_digest = ?request.transaction.digest()))]
+    #[instrument(level = "error", skip_all, err(level = "info"), fields(tx_digest = ?request.transaction.digest()))]
     pub async fn drive_transaction(
         &self,
         request: SubmitTxRequest,

--- a/crates/sui-core/src/transaction_driver/transaction_submitter.rs
+++ b/crates/sui-core/src/transaction_driver/transaction_submitter.rs
@@ -35,7 +35,7 @@ impl TransactionSubmitter {
         Self { metrics }
     }
 
-    #[instrument(level = "debug", skip_all, err, fields(tx_digest = ?tx_digest))]
+    #[instrument(level = "debug", skip_all, err(level = "debug"), fields(tx_digest = ?tx_digest))]
     pub(crate) async fn submit_transaction<A>(
         &self,
         authority_aggregator: &Arc<AuthorityAggregator<A>>,
@@ -106,7 +106,7 @@ impl TransactionSubmitter {
         }
     }
 
-    #[instrument(level = "debug", skip_all, err, ret, fields(validator_display_name = ?display_name))]
+    #[instrument(level = "debug", skip_all, err(level = "debug"), ret, fields(validator_display_name = ?display_name))]
     async fn submit_transaction_once<A>(
         &self,
         client: Arc<SafeClient<A>>,

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -542,7 +542,7 @@ where
         }
     }
 
-    #[instrument(level = "error", skip_all, err, fields(tx_digest = ?request.transaction.digest()))]
+    #[instrument(level = "error", skip_all, err(level = "info"), fields(tx_digest = ?request.transaction.digest()))]
     async fn submit_with_transaction_driver(
         &self,
         td: &Arc<TransactionDriver<A>>,


### PR DESCRIPTION
## Description 

Most of these errors are due to user input and shouldn't be logged at `ERROR`.

## Test plan 

CI