### PR TITLE
Remove impl wrappers

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
@@ -14,10 +14,9 @@ use crate::{
 };
 
 use super::{
-    address::AddressableImpl,
     move_type::MoveType,
     move_value::MoveValue,
-    object::{self, CLive, CVersion, Object, ObjectImpl, VersionFilter},
+    object::{self, CLive, CVersion, Object, VersionFilter},
     object_filter::{ObjectFilter, Validator as OFValidator},
     transaction::Transaction,
 };
@@ -55,18 +54,21 @@ pub(crate) enum IMoveObject {
 #[Object]
 impl MoveObject {
     /// The MoveObject's ID.
-    pub(crate) async fn address(&self) -> SuiAddress {
-        AddressableImpl::from(&self.super_.super_).address()
+    pub(crate) async fn address(
+        &self,
+        ctx: &Context<'_>,
+    ) -> Result<SuiAddress, async_graphql::Error> {
+        self.super_.address(ctx).await
     }
 
     /// The version of this object that this content comes from.
-    pub(crate) async fn version(&self) -> UInt53 {
-        ObjectImpl::from(&self.super_).version()
+    pub(crate) async fn version(&self, ctx: &Context<'_>) -> Result<UInt53, async_graphql::Error> {
+        self.super_.version(ctx).await
     }
 
     /// 32-byte hash that identifies the object's contents, encoded in Base58.
-    pub(crate) async fn digest(&self) -> String {
-        ObjectImpl::from(&self.super_).digest()
+    pub(crate) async fn digest(&self, ctx: &Context<'_>) -> Result<String, async_graphql::Error> {
+        self.super_.digest(ctx).await
     }
 
     /// The structured representation of the object's contents.
@@ -109,7 +111,7 @@ impl MoveObject {
         root_version: Option<UInt53>,
         checkpoint: Option<UInt53>,
     ) -> Result<Option<Object>, RpcError<object::Error>> {
-        ObjectImpl::from(&self.super_)
+        self.super_
             .object_at(ctx, version, root_version, checkpoint)
             .await
     }
@@ -119,7 +121,7 @@ impl MoveObject {
         &self,
         ctx: &Context<'_>,
     ) -> Result<Option<Base64>, RpcError<object::Error>> {
-        ObjectImpl::from(&self.super_).object_bcs(ctx).await
+        self.super_.object_bcs(ctx).await
     }
 
     /// Paginate all versions of this object after this one.
@@ -132,7 +134,7 @@ impl MoveObject {
         before: Option<CVersion>,
         filter: Option<VersionFilter>,
     ) -> Result<Connection<String, Object>, RpcError<object::Error>> {
-        ObjectImpl::from(&self.super_)
+        self.super_
             .object_versions_after(ctx, first, after, last, before, filter)
             .await
     }
@@ -147,7 +149,7 @@ impl MoveObject {
         before: Option<CVersion>,
         filter: Option<VersionFilter>,
     ) -> Result<Connection<String, Object>, RpcError<object::Error>> {
-        ObjectImpl::from(&self.super_)
+        self.super_
             .object_versions_before(ctx, first, after, last, before, filter)
             .await
     }
@@ -162,7 +164,7 @@ impl MoveObject {
         before: Option<CLive>,
         #[graphql(validator(custom = "OFValidator::allows_empty()"))] filter: Option<ObjectFilter>,
     ) -> Result<Option<Connection<String, MoveObject>>, RpcError<object::Error>> {
-        AddressableImpl::from(&self.super_.super_)
+        self.super_
             .objects(ctx, first, after, last, before, filter)
             .await
     }
@@ -172,9 +174,7 @@ impl MoveObject {
         &self,
         ctx: &Context<'_>,
     ) -> Result<Option<Transaction>, RpcError<object::Error>> {
-        ObjectImpl::from(&self.super_)
-            .previous_transaction(ctx)
-            .await
+        self.super_.previous_transaction(ctx).await
     }
 }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object.rs
@@ -45,7 +45,7 @@ use crate::{
 };
 
 use super::{
-    address::{Address, AddressableImpl},
+    address::Address,
     move_object::MoveObject,
     move_package::MovePackage,
     object_filter::{ObjectFilter, Validator as OFValidator},
@@ -180,8 +180,11 @@ pub(crate) type CVersion = JsonCursor<u64>;
 #[Object]
 impl Object {
     /// The Object's ID.
-    pub(crate) async fn address(&self, _ctx: &Context<'_>) -> SuiAddress {
-        AddressableImpl::from(&self.super_).address()
+    pub(crate) async fn address(
+        &self,
+        ctx: &Context<'_>,
+    ) -> Result<SuiAddress, async_graphql::Error> {
+        self.super_.address(ctx).await
     }
 
     /// The version of this object that this content comes from.
@@ -319,7 +322,7 @@ impl Object {
         before: Option<CLive>,
         #[graphql(validator(custom = "OFValidator::allows_empty()"))] filter: Option<ObjectFilter>,
     ) -> Result<Option<Connection<String, MoveObject>>, RpcError<Error>> {
-        AddressableImpl::from(&self.super_)
+        self.super_
             .objects(ctx, first, after, last, before, filter)
             .await
     }


### PR DESCRIPTION
## Description 

Removes the `*Impl` classes that the graphql impls delegeate to and moves their functionality into the graphql impls.

## Test plan 

Functionality remains the same so existing tests should pass.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
