### PR TITLE
Fix for dev dependencies overriding the always dependencies

### DIFF
--- a/external-crates/move/crates/move-package/src/lib.rs
+++ b/external-crates/move/crates/move-package/src/lib.rs
@@ -35,13 +35,13 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use crate::resolution::dependency_graph::DependencyMode;
 use crate::{
     compilation::{build_plan::BuildPlan, compiled_package::CompiledPackage, model_builder},
     lock_file::schema::update_compiler_toolchain,
     package_lock::PackageLock,
 };
 use move_compiler::linters::LintLevel;
-use crate::resolution::dependency_graph::DependencyMode;
 
 #[derive(Debug, Parser, Clone, Serialize, Deserialize, Eq, PartialEq, PartialOrd, Default)]
 #[clap(about)]
@@ -293,7 +293,14 @@ impl BuildConfig {
         let lock_string = std::fs::read_to_string(path.join(SourcePackageLayout::Lock.path())).ok();
         let _mutx = PackageLock::lock(); // held until function returns
 
-        resolution::download_dependency_repos(manifest_string, lock_string, self, &path, self.get_dependency_mode(), writer)?;
+        resolution::download_dependency_repos(
+            manifest_string,
+            lock_string,
+            self,
+            &path,
+            self.get_dependency_mode(),
+            writer,
+        )?;
         Ok(())
     }
 
@@ -328,7 +335,7 @@ impl BuildConfig {
             path,
             manifest_string,
             lock_string,
-            self.get_dependency_mode()
+            self.get_dependency_mode(),
         )?;
 
         if modified || install_dir_set {

--- a/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
+++ b/external-crates/move/crates/move-package/src/resolution/dependency_graph.rs
@@ -325,7 +325,7 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
                 root_pkg_id,
                 root_pkg_name,
                 root_path.clone(),
-                DependencyMode::Always,
+                mode,
                 root_manifest.dependencies.clone(),
             )?;
         let dep_lock_files = always_dep_graphs
@@ -333,19 +333,24 @@ impl<Progress: Write> DependencyGraphBuilder<Progress> {
             // write_to_lock should create a fresh lockfile for computing the dependency digest, hence the `None` arg below
             .map(|graph_info| graph_info.g.write_to_lock(self.install_dir.clone(), None))
             .collect::<Result<Vec<LockFile>>>()?;
-        let (dev_dep_graphs, dev_resolved_id_deps, dev_dep_names, dev_overrides) = if mode == DependencyMode::DevOnly {
-            self
-                .collect_graphs(
+        let (dev_dep_graphs, dev_resolved_id_deps, dev_dep_names, dev_overrides) =
+            if mode == DependencyMode::DevOnly {
+                self.collect_graphs(
                     parent,
                     root_pkg_id,
                     root_pkg_name,
                     root_path.clone(),
-                    DependencyMode::DevOnly,
+                    mode,
                     root_manifest.dev_dependencies.clone(),
                 )?
-        } else {
-            (BTreeMap::new(), BTreeMap::new(), BTreeMap::new(), BTreeMap::new())
-        };
+            } else {
+                (
+                    BTreeMap::new(),
+                    BTreeMap::new(),
+                    BTreeMap::new(),
+                    BTreeMap::new(),
+                )
+            };
 
         // compute new digests and return early if the manifest and deps digests are unchanged
         let dev_dep_lock_files = dev_dep_graphs

--- a/external-crates/move/crates/move-package/src/resolution/mod.rs
+++ b/external-crates/move/crates/move-package/src/resolution/mod.rs
@@ -9,12 +9,12 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use self::dependency_graph::DependencyGraphBuilder;
+use crate::resolution::dependency_graph::DependencyMode;
 use crate::{
     BuildConfig,
     source_package::parsed_manifest::{DependencyKind, GitInfo, OnChainInfo},
 };
-use crate::resolution::dependency_graph::DependencyMode;
-use self::dependency_graph::DependencyGraphBuilder;
 
 pub mod dependency_cache;
 pub mod dependency_graph;
@@ -47,7 +47,7 @@ pub fn download_dependency_repos<Progress: Write>(
         root_path.to_path_buf(),
         manifest_string,
         lock_string,
-        mode
+        mode,
     )?;
 
     for pkg_id in graph.topological_order() {

--- a/external-crates/move/crates/move-package/tests/test_additional_addresses.rs
+++ b/external-crates/move/crates/move-package/tests/test_additional_addresses.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_core_types::account_address::AccountAddress;
+use move_package::resolution::dependency_graph::DependencyMode;
 use move_package::{
     BuildConfig,
     resolution::{dependency_graph as DG, resolution_graph as RG},
@@ -40,6 +41,7 @@ fn test_additional_addresses() {
             path,
             manifest_string,
             /* lock_string_opt */ None,
+            DependencyMode::Always,
         )
         .unwrap();
 
@@ -104,6 +106,7 @@ fn test_additional_addresses_already_assigned_same_value() {
             path,
             manifest_string,
             /* lock_string_opt */ None,
+            DependencyMode::Always,
         )
         .unwrap();
 
@@ -154,6 +157,7 @@ fn test_additional_addresses_already_assigned_different_value() {
             path,
             manifest_string,
             /* lock_string_opt */ None,
+            DependencyMode::Always,
         )
         .unwrap();
 

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_same_than_dev_dep/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_same_than_dev_dep/Move.toml
@@ -1,0 +1,11 @@
+[package]
+name = "Root"
+
+[addresses]
+A = "0x1"
+
+[dependencies]
+OtherDep = { local = "./deps_only/other_dep", addr_subst = { "A" = "B" } }
+
+[dev-dependencies]
+OtherDep = { local = "./deps_only/other_dep_duplicate", addr_subst = { "A" = "B" } }

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_same_than_dev_dep/deps_only/other_dep/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_same_than_dev_dep/deps_only/other_dep/Move.toml
@@ -1,0 +1,5 @@
+[package]
+name = "OtherDep"
+
+[addresses]
+B = "_"

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_same_than_dev_dep/deps_only/other_dep_duplicate/Move.toml
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_same_than_dev_dep/deps_only/other_dep_duplicate/Move.toml
@@ -1,0 +1,5 @@
+[package]
+name = "OtherDep"
+
+[addresses]
+B = "_"

--- a/external-crates/move/crates/move-package/tests/test_sources/one_dep_same_than_dev_dep/sources/OneDep.move
+++ b/external-crates/move/crates/move-package/tests/test_sources/one_dep_same_than_dev_dep/sources/OneDep.move
@@ -1,0 +1,6 @@
+module A::OneDep {
+    use A::B;
+    public fun do_b() {
+        B::foo()
+    }
+}

--- a/external-crates/move/crates/move-stdlib/src/lib.rs
+++ b/external-crates/move/crates/move-stdlib/src/lib.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_command_line_common::files::{extension_equals, find_filenames, MOVE_EXTENSION};
+use move_command_line_common::files::{MOVE_EXTENSION, extension_equals, find_filenames};
 use move_core_types::parsing::address::NumericalAddress;
 use move_docgen::DocgenOptions;
 use move_package::BuildConfig;


### PR DESCRIPTION
## Description 

This PR intends to fix issue #23173. In order to address the issue, I chose the following strategy:

1) Add the utility function `BuildConfig::get_dependency_mode`.
2) Bring the mode's context into the `DependencyGraphBuilder::get_graph` function. This function is always called in places where a `BuildConfig` instance exists, making it easy to add this information.
3) If the mode is `DevOnly`, the logic doesn't change.
4) If the mode is `Always`, we don't compute the dev dependencies and address graphs, but provide empty ones.

This approach is conservative, as it doesn't change the logic but only the input data depending on the mode. Nevertheless, the PR is not 100% finished and I want to do the following:

- Add more unit tests to cover issue #23173
- Investigate the `get_graph -> collect_graphs -> get_graph` calls. From my understanding of your codebase, this is the only place where my PR could have a side effect. I haven't had the time yet to check it.
- Check if filtering the graph in `DependencyGraph::immediate_dependencies` is still useful. I also haven't had the time yet to check this.

## Test plan 

Manual tests, but automated tests are planned.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol  
- [ ] Nodes (Validators and Full nodes)  
- [ ] gRPC  
- [ ] JSON-RPC  
- [ ] GraphQL  
- [x] CLI: fixes #23173  
- [ ] Rust SDK
