### PR TITLE
Ignore flaky test

### DIFF
--- a/crates/sui-rosetta/tests/dust_tests/pay_coin_with_dust.rs
+++ b/crates/sui-rosetta/tests/dust_tests/pay_coin_with_dust.rs
@@ -19,7 +19,11 @@ use super::rosetta_client::{start_rosetta_test_server, RosettaError};
 mod test_coin_utils;
 use test_coin_utils::{init_package, mint, TEST_COIN_DECIMALS};
 
+// This test is flaky in CI. Ignoring it for now to avoid blocking CI.
+// This is a new test for some recent changes that have yet to be integration tested with Coinbase.
+// TODO Debug this flakiness and un-ignore it before deploying to coinbase.
 #[tokio::test]
+#[ignore]
 async fn test_pay_custom_coin_with_multiple_coins() -> anyhow::Result<()> {
     let test_cluster = TestClusterBuilder::new()
         .with_epoch_duration_ms(36000000)


### PR DESCRIPTION
## Description

This test was recently added and appears to be flaky in CI. Ignoring it while we debug it to avoid blocking CI for everyone in the company.
