### PR TITLE
[graphql-alt] Implement system-packages-snapshot for end-of-epoch snapshot test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12558,6 +12558,7 @@ dependencies = [
  "sui-config",
  "sui-execution",
  "sui-framework",
+ "sui-framework-snapshot",
  "sui-genesis-builder",
  "sui-keys",
  "sui-protocol-config",

--- a/crates/simulacrum/Cargo.toml
+++ b/crates/simulacrum/Cargo.toml
@@ -24,6 +24,7 @@ move-bytecode-utils.workspace = true
 shared-crypto.workspace = true
 sui-config.workspace = true
 sui-framework.workspace = true
+sui-framework-snapshot.workspace = true
 sui-keys.workspace = true
 sui-protocol-config.workspace = true
 sui-storage.workspace = true

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -19,7 +19,6 @@ use fastcrypto::traits::Signer;
 use rand::rngs::OsRng;
 use sui_config::verifier_signing_config::VerifierSigningConfig;
 use sui_config::{genesis, transaction_deny_config::TransactionDenyConfig};
-use sui_framework::BuiltInFramework;
 use sui_framework_snapshot::load_bytecode_snapshot;
 use sui_protocol_config::ProtocolVersion;
 use sui_storage::blob::{Blob, BlobEncoding};
@@ -77,13 +76,10 @@ pub struct AdvanceEpochConfig {
     pub create_bridge_state: bool,
     /// Controls whether to create bridge committee.
     pub create_bridge_committee: bool,
-    /// Controls whether to include system packages in the epoch change transaction.
-    /// When enabled, includes framework packages (Move stdlib, Sui framework,
-    /// Sui system, DeepBook, and Bridge packages) in the change epoch transaction.
-    pub include_system_packages: bool,
     /// When specified, loads system packages from a framework snapshot for the given
-    /// protocol version. When None, uses the current built-in framework packages.
+    /// protocol version and includes them in the epoch change transaction.
     /// This provides test stability as snapshot packages don't change when the framework is updated.
+    /// If None, no system packages are included in the epoch change transaction.
     pub system_packages_snapshot: Option<u64>,
 }
 
@@ -290,28 +286,19 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
         let gas_cost_summary = self.checkpoint_builder.epoch_rolling_gas_cost_summary();
         let epoch_start_timestamp_ms = self.store.get_clock().timestamp_ms();
 
-        let next_epoch_system_package_bytes = if config.include_system_packages {
-            let packages: Vec<_> = match config.system_packages_snapshot {
-                Some(snapshot_version) => match load_bytecode_snapshot(snapshot_version) {
-                    Ok(snapshot_packages) => snapshot_packages,
-                    Err(e) => {
-                        panic!(
-                            "Failed to load bytecode snapshot for version {}: {}",
-                            snapshot_version, e
-                        );
-                    }
-                },
-                None => BuiltInFramework::iter_system_packages().cloned().collect(),
+        let next_epoch_system_package_bytes = if let Some(snapshot_version) =
+            config.system_packages_snapshot
+        {
+            let packages = match load_bytecode_snapshot(snapshot_version) {
+                Ok(snapshot_packages) => snapshot_packages,
+                Err(e) => {
+                    panic!("Failed to load bytecode snapshot for version {snapshot_version}: {e}");
+                }
             };
 
             packages
                 .into_iter()
-                .map(|pkg| {
-                    let version = SequenceNumber::from(1u64);
-                    let modules = pkg.bytes;
-                    let deps = pkg.dependencies;
-                    (version, modules, deps)
-                })
+                .map(|pkg| (SequenceNumber::from(1u64), pkg.bytes, pkg.dependencies))
                 .collect()
         } else {
             vec![]

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.move
@@ -3,7 +3,7 @@
 
 //# init --protocol-version 70 --simulator
 
-//# advance-epoch --create-random-state --create-authenticator-state --create-authenticator-state-expire --create-deny-list-state --create-bridge-state --create-bridge-committee --include-system-packages
+//# advance-epoch --create-random-state --create-authenticator-state --create-authenticator-state-expire --create-deny-list-state --create-bridge-state --create-bridge-committee --include-system-packages --system-packages-snapshot=70
 
 //# create-checkpoint
 

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.move
@@ -3,7 +3,7 @@
 
 //# init --protocol-version 70 --simulator
 
-//# advance-epoch --create-random-state --create-authenticator-state --create-authenticator-state-expire --create-deny-list-state --create-bridge-state --create-bridge-committee --include-system-packages --system-packages-snapshot=70
+//# advance-epoch --create-random-state --create-authenticator-state --create-authenticator-state-expire --create-deny-list-state --create-bridge-state --create-bridge-committee --system-packages-snapshot=70
 
 //# create-checkpoint
 

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.snap
@@ -4,7 +4,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 processed 4 tasks
 
 task 1, line 6:
-//# advance-epoch --create-random-state --create-authenticator-state --create-authenticator-state-expire --create-deny-list-state --create-bridge-state --create-bridge-committee --include-system-packages
+//# advance-epoch --create-random-state --create-authenticator-state --create-authenticator-state-expire --create-deny-list-state --create-bridge-state --create-bridge-committee --include-system-packages --system-packages-snapshot=70
 Epoch advanced: 1
 
 task 2, line 8:
@@ -18,7 +18,7 @@ Response: {
     "endOfEpochTransaction": {
       "nodes": [
         {
-          "digest": "VPCqrfxYRLLBuF7WSFsbqCcUgtxhCBUehdxBk5uS17v",
+          "digest": "5q9xzeSxcmuRJdfi9ictFzmMnXYWF7FszV7dWjNpaRK8",
           "kind": {
             "__typename": "EndOfEpochTransaction",
             "transactions": {
@@ -68,27 +68,27 @@ Response: {
                       {
                         "address": "0x0000000000000000000000000000000000000000000000000000000000000001",
                         "version": 1,
-                        "digest": "Cf8c79YVKYkoEjGWmR599jVXsdLvDKrvAgsCdXBFGKzu"
+                        "digest": "HZxcU44WBxMCvCpAeDYWS8hnSMM3qJUR328GF5oWbGHu"
                       },
                       {
                         "address": "0x0000000000000000000000000000000000000000000000000000000000000002",
                         "version": 1,
-                        "digest": "By4Sq7nahY3ZM5FfsdqTtgpDCQ6jmHVqh9C4daFVNiAG"
+                        "digest": "8H3dtgbzFSLaQ5Czp3j49dKWSTVgAQKtpLAvHnFQCj3p"
                       },
                       {
                         "address": "0x0000000000000000000000000000000000000000000000000000000000000003",
                         "version": 1,
-                        "digest": "HjUqDATfMdcEGdhoKaerBfpx1tqesHDy67XEp8YKAoP5"
+                        "digest": "3E1gx1JSCtUSu45Z6A3j2T6uhVNmG6dMbKuW8Ck7xauR"
                       },
                       {
                         "address": "0x000000000000000000000000000000000000000000000000000000000000dee9",
                         "version": 1,
-                        "digest": "AiuUdqUdc9KBX9zqNf3YVZMznwTuMSkza3Be2yyFgHLS"
+                        "digest": "7fWrrdTzwKSmjHVgbRDhB3oYFj2DbjbxZZYtwkTPFj2A"
                       },
                       {
                         "address": "0x000000000000000000000000000000000000000000000000000000000000000b",
                         "version": 1,
-                        "digest": "6ifF7D6ueAjDovYfSnsjcUa4HCxqpPXPQ5Vupd9sPdcu"
+                        "digest": "QzUWtfGF1DL5sSMpX9yZ9VWoKjkWiwQZyHU6JJ6RzcT"
                       }
                     ]
                   }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/end_of_epoch.snap
@@ -4,7 +4,7 @@ source: external-crates/move/crates/move-transactional-test-runner/src/framework
 processed 4 tasks
 
 task 1, line 6:
-//# advance-epoch --create-random-state --create-authenticator-state --create-authenticator-state-expire --create-deny-list-state --create-bridge-state --create-bridge-committee --include-system-packages --system-packages-snapshot=70
+//# advance-epoch --create-random-state --create-authenticator-state --create-authenticator-state-expire --create-deny-list-state --create-bridge-state --create-bridge-committee --system-packages-snapshot=70
 Epoch advanced: 1
 
 task 2, line 8:

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -228,6 +228,8 @@ pub struct AdvanceEpochCommand {
     pub create_bridge_committee: bool,
     #[clap(long = "include-system-packages")]
     pub include_system_packages: bool,
+    #[clap(long = "system-packages-snapshot")]
+    pub system_packages_snapshot: Option<u64>,
 }
 
 impl From<&AdvanceEpochCommand> for simulacrum::AdvanceEpochConfig {
@@ -240,6 +242,7 @@ impl From<&AdvanceEpochCommand> for simulacrum::AdvanceEpochConfig {
             create_bridge_state: cmd.create_bridge_state,
             create_bridge_committee: cmd.create_bridge_committee,
             include_system_packages: cmd.include_system_packages,
+            system_packages_snapshot: cmd.system_packages_snapshot,
         }
     }
 }

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -226,8 +226,6 @@ pub struct AdvanceEpochCommand {
     pub create_bridge_state: bool,
     #[clap(long = "create-bridge-committee")]
     pub create_bridge_committee: bool,
-    #[clap(long = "include-system-packages")]
-    pub include_system_packages: bool,
     #[clap(long = "system-packages-snapshot")]
     pub system_packages_snapshot: Option<u64>,
 }
@@ -241,7 +239,6 @@ impl From<&AdvanceEpochCommand> for simulacrum::AdvanceEpochConfig {
             create_deny_list_state: cmd.create_deny_list_state,
             create_bridge_state: cmd.create_bridge_state,
             create_bridge_committee: cmd.create_bridge_committee,
-            include_system_packages: cmd.include_system_packages,
             system_packages_snapshot: cmd.system_packages_snapshot,
         }
     }


### PR DESCRIPTION
## Description 

End of epoch transaction test uses the current system packages as fixtures, which means that every time someone updates those system packages, they will need to be updated. 

This PR fixed that by implementing `system-packages-snapshot` flag which allows e2e test to use framework snapshot from [`sui-framework-snapshot`](https://github.com/MystenLabs/sui/tree/9dddc8e190f6865574060c8c9f3664c438341b6d/crates/sui-framework-snapshot)

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-e2e-tests
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
