### PR TITLE
[sui-execution][derived-addresses] Update expensive ownership invariant checks for derived addresses

### DIFF
--- a/sui-execution/latest/sui-adapter/src/execution_engine.rs
+++ b/sui-execution/latest/sui-adapter/src/execution_engine.rs
@@ -243,6 +243,7 @@ mod checked {
             temporary_store
                 .check_ownership_invariants(
                     &transaction_signer,
+                    &sponsor,
                     &mut gas_charger,
                     &mutable_inputs,
                     is_epoch_change,


### PR DESCRIPTION
## Description 

This updates the expensive ownership invariant checks to handle receiving an object off of a derived address and tightens up some of the invariant enforcement so gas coins are not special-cased.

## Test plan 

CI + ran test cases for derived addresses on a separate PR locally against this.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
