### PR TITLE
[object-runtime] Add logic and protocol config (but do not enable) to charge for initial load vs cached load

### DIFF
--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -785,6 +785,10 @@ struct FeatureFlags {
     // Use abstract size in the object runtime instead the legacy value size.
     #[serde(skip_serializing_if = "is_false")]
     abstract_size_in_object_runtime: bool,
+
+    // If true charge for loads into the cache (i.e., fetches from storage) in the object runtime.
+    #[serde(skip_serializing_if = "is_false")]
+    object_runtime_charge_cache_load_gas: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -2192,6 +2196,10 @@ impl ProtocolConfig {
 
     pub fn abstract_size_in_object_runtime(&self) -> bool {
         self.feature_flags.abstract_size_in_object_runtime
+    }
+
+    pub fn object_runtime_charge_cache_load_gas(&self) -> bool {
+        self.feature_flags.object_runtime_charge_cache_load_gas
     }
 }
 


### PR DESCRIPTION
## Description 

This adds charging logic on top of the cache info that was added in the PR below this one. The charging logic is not yet enabled, but the plan is that we charge the existing object read cost per byte for every byte that was loaded (and not already cached) in the object runtime.

## Test plan 

CI + new feature is not yet enabled so no difference should be found.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
