### PR TITLE
[object-runtime][cleanup] Replace `.extensions().get()`/`extensions_mut().get_mut()` with `get_extension`/`get_extension_mut`

### DIFF
--- a/sui-execution/latest/sui-move-natives/src/accumulator.rs
+++ b/sui-execution/latest/sui-move-natives/src/accumulator.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    get_extension, get_extension_mut,
     object_runtime::{MoveAccumulatorAction, MoveAccumulatorValue, ObjectRuntime},
     NativesCostTable,
 };
@@ -40,9 +41,7 @@ fn emit_event(
     debug_assert!(ty_args.len() == 1);
     debug_assert!(args.len() == 3);
 
-    let event_emit_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let event_emit_cost_params = get_extension!(context, NativesCostTable)?
         .event_emit_cost_params
         .clone();
 
@@ -64,7 +63,7 @@ fn emit_event(
 
     let ty_tag = context.type_to_type_tag(&ty_args.pop().unwrap())?;
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let obj_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
 
     obj_runtime.emit_accumulator_event(
         accumulator,

--- a/sui-execution/latest/sui-move-natives/src/address.rs
+++ b/sui-execution/latest/sui-move-natives/src/address.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::{account_address::AccountAddress, gas_algebra::InternalGas, u256::U256};
 use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
@@ -30,9 +30,7 @@ pub fn from_bytes(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 1);
 
-    let address_from_bytes_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let address_from_bytes_cost_params = get_extension!(context, NativesCostTable)?
         .address_from_bytes_cost_params
         .clone();
 
@@ -69,9 +67,7 @@ pub fn to_u256(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 1);
 
-    let address_to_u256_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let address_to_u256_cost_params = get_extension!(context, NativesCostTable)?
         .address_to_u256_cost_params
         .clone();
 
@@ -108,9 +104,7 @@ pub fn from_u256(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 1);
 
-    let address_from_u256_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let address_from_u256_cost_params = get_extension!(context, NativesCostTable)?
         .address_from_u256_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/config.rs
+++ b/sui-execution/latest/sui-move-natives/src/config.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{abstract_size, object_runtime::ObjectRuntime, NativesCostTable};
+use crate::{
+    abstract_size, get_extension, get_extension_mut, object_runtime::ObjectRuntime,
+    NativesCostTable,
+};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
     account_address::AccountAddress, gas_algebra::InternalGas, language_storage::StructTag,
@@ -40,9 +43,7 @@ pub fn read_setting_impl(
     let ConfigReadSettingImplCostParams {
         config_read_setting_impl_cost_base,
         config_read_setting_impl_cost_per_byte,
-    } = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    } = get_extension!(context, NativesCostTable)?
         .config_read_setting_impl_cost_params
         .clone();
 
@@ -83,7 +84,7 @@ pub fn read_setting_impl(
             E_BCS_SERIALIZATION_FAILURE,
         ));
     };
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
 
     let read_value_opt = consistent_value_before_current_epoch(
         object_runtime,

--- a/sui-execution/latest/sui-move-natives/src/crypto/bls12381.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/bls12381.rs
@@ -16,7 +16,7 @@ use move_vm_types::{
 use smallvec::smallvec;
 use std::collections::VecDeque;
 
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 
 const BLS12381_BLOCK_SIZE: usize = 64;
 
@@ -47,9 +47,7 @@ pub fn bls12381_min_sig_verify(
     debug_assert!(args.len() == 3);
 
     // Load the cost parameters from the protocol config
-    let bls12381_bls12381_min_sig_verify_cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let bls12381_bls12381_min_sig_verify_cost_params = get_extension!(context, NativesCostTable)?
         .bls12381_bls12381_min_sig_verify_cost_params
         .clone();
     // Charge the base cost for this oper
@@ -127,9 +125,7 @@ pub fn bls12381_min_pk_verify(
     debug_assert!(args.len() == 3);
 
     // Load the cost parameters from the protocol config
-    let bls12381_bls12381_min_pk_verify_cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let bls12381_bls12381_min_pk_verify_cost_params = get_extension!(context, NativesCostTable)?
         .bls12381_bls12381_min_pk_verify_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_k1.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_k1.rs
@@ -1,3 +1,4 @@
+use crate::get_extension;
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::NativesCostTable;
@@ -80,7 +81,7 @@ pub fn ecrecover(
 
     // Load the cost parameters from the protocol config
     let (ecdsa_k1_ecrecover_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>()?;
+        let cost_table: &NativesCostTable = get_extension!(context)?;
         (
             cost_table.ecdsa_k1_ecrecover_cost_params.clone(),
             cost_table.crypto_invalid_arguments_cost,
@@ -159,9 +160,7 @@ pub fn decompress_pubkey(
     debug_assert!(args.len() == 1);
 
     // Load the cost parameters from the protocol config
-    let ecdsa_k1_decompress_pubkey_cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let ecdsa_k1_decompress_pubkey_cost_params = get_extension!(context, NativesCostTable)?
         .ecdsa_k1_decompress_pubkey_cost_params
         .clone();
     // Charge the base cost for this oper
@@ -226,7 +225,7 @@ pub fn secp256k1_verify(
 
     // Load the cost parameters from the protocol config
     let (ecdsa_k1_secp256k1_verify_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>()?;
+        let cost_table: &NativesCostTable = get_extension!(context)?;
         (
             cost_table.ecdsa_k1_secp256k1_verify_cost_params.clone(),
             cost_table.crypto_invalid_arguments_cost,

--- a/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_r1.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/ecdsa_r1.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 use fastcrypto::error::FastCryptoError;
 use fastcrypto::hash::{Keccak256, Sha256};
 use fastcrypto::traits::RecoverableSignature;
@@ -71,7 +71,7 @@ pub fn ecrecover(
 
     // Load the cost parameters from the protocol config
     let (ecdsa_r1_ecrecover_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>()?;
+        let cost_table: &NativesCostTable = get_extension!(context)?;
         (
             cost_table.ecdsa_r1_ecrecover_cost_params.clone(),
             cost_table.crypto_invalid_arguments_cost,
@@ -175,7 +175,7 @@ pub fn secp256r1_verify(
     debug_assert!(args.len() == 4);
     // Load the cost parameters from the protocol config
     let (ecdsa_r1_secp256_r1_verify_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>()?;
+        let cost_table: &NativesCostTable = get_extension!(context)?;
         (
             cost_table.ecdsa_r1_secp256_r1_verify_cost_params.clone(),
             cost_table.crypto_invalid_arguments_cost,

--- a/sui-execution/latest/sui-move-natives/src/crypto/ecvrf.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/ecvrf.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 use fastcrypto::vrf::ecvrf::{ECVRFProof, ECVRFPublicKey};
 use fastcrypto::vrf::VRFProof;
 use move_binary_format::errors::PartialVMResult;
@@ -48,9 +48,7 @@ pub fn ecvrf_verify(
     debug_assert!(args.len() == 4);
 
     // Load the cost parameters from the protocol config
-    let ecvrf_ecvrf_verify_cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let ecvrf_ecvrf_verify_cost_params = get_extension!(context, NativesCostTable)?
         .ecvrf_ecvrf_verify_cost_params
         .clone();
     // Charge the base cost for this oper

--- a/sui-execution/latest/sui-move-natives/src/crypto/ed25519.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/ed25519.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 use fastcrypto::{
     ed25519::{Ed25519PublicKey, Ed25519Signature},
     traits::{ToFromBytes, VerifyingKey},
@@ -46,9 +46,7 @@ pub fn ed25519_verify(
     debug_assert!(args.len() == 3);
 
     // Load the cost parameters from the protocol config
-    let ed25519_verify_cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let ed25519_verify_cost_params = get_extension!(context, NativesCostTable)?
         .ed25519_verify_cost_params
         .clone();
     // Charge the base cost for this oper

--- a/sui-execution/latest/sui-move-natives/src/crypto/groth16.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/groth16.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::{object_runtime::ObjectRuntime, NativesCostTable};
+use crate::{get_extension, object_runtime::ObjectRuntime, NativesCostTable};
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::gas_algebra::InternalGas;
 use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
@@ -47,7 +47,7 @@ pub fn prepare_verifying_key_internal(
 
     // Load the cost parameters from the protocol config
     let (groth16_prepare_verifying_key_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>()?;
+        let cost_table: &NativesCostTable = get_extension!(context)?;
         (
             cost_table.groth16_prepare_verifying_key_cost_params.clone(),
             cost_table.crypto_invalid_arguments_cost,
@@ -135,7 +135,7 @@ pub fn verify_groth16_proof_internal(
 
     // Load the cost parameters from the protocol config
     let (groth16_verify_groth16_proof_internal_cost_params, crypto_invalid_arguments_cost) = {
-        let cost_table = &context.extensions().get::<NativesCostTable>()?;
+        let cost_table: &NativesCostTable = get_extension!(context)?;
         (
             cost_table
                 .groth16_verify_groth16_proof_internal_cost_params
@@ -185,9 +185,7 @@ pub fn verify_groth16_proof_internal(
         _ => {
             // Charge for failure but dont fail if we run out of gas otherwise the actual error is masked by OUT_OF_GAS error
             context.charge_gas(crypto_invalid_arguments_cost);
-            let cost = if context
-                .extensions()
-                .get::<ObjectRuntime>()?
+            let cost = if get_extension!(context, ObjectRuntime)?
                 .protocol_config
                 .native_charging_v2()
             {

--- a/sui-execution/latest/sui-move-natives/src/crypto/group_ops.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/group_ops.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::object_runtime::ObjectRuntime;
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 use fastcrypto::error::{FastCryptoError, FastCryptoResult};
 use fastcrypto::groups::{
     bls12381 as bls, FromTrustedByteArray, GroupElement, HashToGroupElement, MultiScalarMul,
@@ -27,34 +27,26 @@ pub const INVALID_INPUT_ERROR: u64 = 1;
 pub const INPUT_TOO_LONG_ERROR: u64 = 2;
 
 fn is_supported(context: &NativeContext) -> PartialVMResult<bool> {
-    Ok(context
-        .extensions()
-        .get::<ObjectRuntime>()?
+    Ok(get_extension!(context, ObjectRuntime)?
         .protocol_config
         .enable_group_ops_native_functions())
 }
 
 fn is_msm_supported(context: &NativeContext) -> PartialVMResult<bool> {
-    Ok(context
-        .extensions()
-        .get::<ObjectRuntime>()?
+    Ok(get_extension!(context, ObjectRuntime)?
         .protocol_config
         .enable_group_ops_native_function_msm())
 }
 
 fn is_uncompressed_g1_supported(context: &NativeContext) -> PartialVMResult<bool> {
-    Ok(context
-        .extensions()
-        .get::<ObjectRuntime>()?
+    Ok(get_extension!(context, ObjectRuntime)?
         .protocol_config
         .uncompressed_g1_group_elements())
 }
 
 fn v2_native_charge(context: &NativeContext, cost: InternalGas) -> PartialVMResult<InternalGas> {
     Ok(
-        if context
-            .extensions()
-            .get::<ObjectRuntime>()?
+        if get_extension!(context, ObjectRuntime)?
             .protocol_config
             .native_charging_v2()
         {
@@ -239,9 +231,7 @@ pub fn internal_validate(
     let bytes = bytes_ref.as_bytes_ref();
     let group_type = pop_arg!(args, u8);
 
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .group_ops_cost_params
         .clone();
 
@@ -291,9 +281,7 @@ pub fn internal_add(
     let e1 = e1_ref.as_bytes_ref();
     let group_type = pop_arg!(args, u8);
 
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .group_ops_cost_params
         .clone();
 
@@ -344,9 +332,7 @@ pub fn internal_sub(
     let e1 = e1_ref.as_bytes_ref();
     let group_type = pop_arg!(args, u8);
 
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .group_ops_cost_params
         .clone();
 
@@ -397,9 +383,7 @@ pub fn internal_mul(
     let e1 = e1_ref.as_bytes_ref();
     let group_type = pop_arg!(args, u8);
 
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .group_ops_cost_params
         .clone();
 
@@ -465,9 +449,7 @@ pub fn internal_div(
     let e1 = e1_ref.as_bytes_ref();
     let group_type = pop_arg!(args, u8);
 
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .group_ops_cost_params
         .clone();
 
@@ -536,9 +518,7 @@ pub fn internal_hash_to(
         return Ok(NativeResult::err(cost, INVALID_INPUT_ERROR));
     }
 
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .group_ops_cost_params
         .clone();
 
@@ -691,9 +671,7 @@ pub fn internal_multi_scalar_mul(
     let scalars = scalars_ref.as_bytes_ref();
     let group_type = pop_arg!(args, u8);
 
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .group_ops_cost_params
         .clone();
 
@@ -763,9 +741,7 @@ pub fn internal_pairing(
     let e1 = e1_ref.as_bytes_ref();
     let group_type = pop_arg!(args, u8);
 
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .group_ops_cost_params
         .clone();
 
@@ -809,9 +785,7 @@ pub fn internal_convert(
     let to_type = pop_arg!(args, u8);
     let from_type = pop_arg!(args, u8);
 
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .group_ops_cost_params
         .clone();
 
@@ -862,9 +836,7 @@ pub fn internal_sum(
         return Ok(NativeResult::err(cost, NOT_SUPPORTED_ERROR));
     }
 
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .group_ops_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/hash.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/hash.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 use fastcrypto::hash::{Blake2b256, HashFunction, Keccak256};
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::gas_algebra::InternalGas;
@@ -76,9 +76,7 @@ pub fn keccak256(
     args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     // Load the cost parameters from the protocol config
-    let hash_keccak256_cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let hash_keccak256_cost_params = get_extension!(context, NativesCostTable)?
         .hash_keccak256_cost_params
         .clone();
     // Charge the base cost for this oper
@@ -116,9 +114,7 @@ pub fn blake2b256(
     args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     // Load the cost parameters from the protocol config
-    let hash_blake2b256_cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let hash_blake2b256_cost_params = get_extension!(context, NativesCostTable)?
         .hash_blake2b256_cost_params
         .clone();
     // Charge the base cost for this oper

--- a/sui-execution/latest/sui-move-natives/src/crypto/hmac.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/hmac.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 use fastcrypto::{hmac, traits::ToFromBytes};
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::gas_algebra::InternalGas;
@@ -43,9 +43,7 @@ pub fn hmac_sha3_256(
     debug_assert!(args.len() == 2);
 
     // Load the cost parameters from the protocol config
-    let hmac_hmac_sha3_256_cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let hmac_hmac_sha3_256_cost_params = get_extension!(context, NativesCostTable)?
         .hmac_hmac_sha3_256_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/nitro_attestation.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/nitro_attestation.rs
@@ -13,7 +13,7 @@ use move_vm_types::{
 use std::collections::{BTreeMap, VecDeque};
 use sui_types::nitro_attestation::{parse_nitro_attestation, verify_nitro_attestation};
 
-use crate::{object_runtime::ObjectRuntime, NativesCostTable};
+use crate::{get_extension, object_runtime::ObjectRuntime, NativesCostTable};
 use move_vm_runtime::native_charge_gas_early_exit;
 
 pub const NOT_SUPPORTED_ERROR: u64 = 0;
@@ -45,17 +45,13 @@ macro_rules! native_charge_gas_early_exit_option {
 }
 
 fn is_supported(context: &NativeContext) -> PartialVMResult<bool> {
-    Ok(context
-        .extensions()
-        .get::<ObjectRuntime>()?
+    Ok(get_extension!(context, ObjectRuntime)?
         .protocol_config
         .enable_nitro_attestation())
 }
 
 fn is_upgraded(context: &NativeContext) -> PartialVMResult<bool> {
-    Ok(context
-        .extensions()
-        .get::<ObjectRuntime>()?
+    Ok(get_extension!(context, ObjectRuntime)?
         .protocol_config
         .enable_nitro_attestation_upgraded_parsing())
 }
@@ -77,9 +73,7 @@ pub fn load_nitro_attestation_internal(
     let attestation_ref = pop_arg!(args, VectorRef);
     let attestation_bytes = attestation_ref.as_bytes_ref();
 
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .nitro_attestation_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/poseidon.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/poseidon.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::object_runtime::ObjectRuntime;
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 use fastcrypto_zkp::bn254::poseidon::poseidon_bytes;
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::gas_algebra::InternalGas;
@@ -22,9 +22,7 @@ pub const NON_CANONICAL_INPUT: u64 = 0;
 pub const NOT_SUPPORTED_ERROR: u64 = 1;
 
 fn is_supported(context: &NativeContext) -> PartialVMResult<bool> {
-    Ok(context
-        .extensions()
-        .get::<ObjectRuntime>()?
+    Ok(get_extension!(context, ObjectRuntime)?
         .protocol_config
         .enable_poseidon())
 }
@@ -54,9 +52,7 @@ pub fn poseidon_bn254_internal(
     }
 
     // Load the cost parameters from the protocol config
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .poseidon_bn254_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/vdf.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/vdf.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 use crate::object_runtime::ObjectRuntime;
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 use fastcrypto_vdf::class_group::discriminant::DISCRIMINANT_3072;
 use fastcrypto_vdf::class_group::QuadraticForm;
 use fastcrypto_vdf::vdf::wesolowski::DefaultVDF;
@@ -24,9 +24,7 @@ pub const INVALID_INPUT_ERROR: u64 = 0;
 pub const NOT_SUPPORTED_ERROR: u64 = 1;
 
 fn is_supported(context: &NativeContext) -> PartialVMResult<bool> {
-    Ok(context
-        .extensions()
-        .get::<ObjectRuntime>()?
+    Ok(get_extension!(context, ObjectRuntime)?
         .protocol_config
         .enable_vdf())
 }
@@ -59,9 +57,7 @@ pub fn vdf_verify_internal(
     }
 
     // Load the cost parameters from the protocol config
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .vdf_cost_params
         .clone();
 
@@ -129,9 +125,7 @@ pub fn hash_to_input_internal(
     }
 
     // Load the cost parameters from the protocol config
-    let cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let cost_params = get_extension!(context, NativesCostTable)?
         .vdf_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/crypto/zklogin.rs
+++ b/sui-execution/latest/sui-move-natives/src/crypto/zklogin.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 use fastcrypto::error::FastCryptoError;
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::account_address::AccountAddress;
@@ -45,9 +45,7 @@ pub fn check_zklogin_id_internal(
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     // Load the cost parameters from the protocol config
-    let check_zklogin_id_cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let check_zklogin_id_cost_params = get_extension!(context, NativesCostTable)?
         .check_zklogin_id_cost_params
         .clone();
 
@@ -147,9 +145,7 @@ pub fn check_zklogin_issuer_internal(
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     // Load the cost parameters from the protocol config
-    let check_zklogin_issuer_cost_params = &context
-        .extensions()
-        .get::<NativesCostTable>()?
+    let check_zklogin_issuer_cost_params = get_extension!(context, NativesCostTable)?
         .check_zklogin_issuer_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/dynamic_field.rs
+++ b/sui-execution/latest/sui-move-natives/src/dynamic_field.rs
@@ -51,7 +51,7 @@ macro_rules! get_or_fetch_object {
             }
         };
 
-        let object_runtime: &mut ObjectRuntime = $context.extensions_mut().get_mut()?;
+        let object_runtime: &mut ObjectRuntime = $crate::get_extension_mut!($context)?;
         object_runtime.get_or_fetch_child_object(
             $parent,
             $child_id,
@@ -341,9 +341,7 @@ pub fn remove_child_object(
     assert!(ty_args.len() == 1);
     assert!(args.len() == 2);
 
-    let dynamic_field_remove_child_object_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let dynamic_field_remove_child_object_cost_params = get_extension!(context, NativesCostTable)?
         .dynamic_field_remove_child_object_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -376,7 +374,7 @@ pub fn remove_child_object(
     })?;
 
     let child_size = abstract_size(
-        context.extensions().get::<ObjectRuntime>()?.protocol_config,
+        get_extension!(context, ObjectRuntime)?.protocol_config,
         &child,
     );
 
@@ -411,9 +409,7 @@ pub fn has_child_object(
     assert!(ty_args.is_empty());
     assert!(args.len() == 2);
 
-    let dynamic_field_has_child_object_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let dynamic_field_has_child_object_cost_params = get_extension!(context, NativesCostTable)?
         .dynamic_field_has_child_object_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -423,7 +419,7 @@ pub fn has_child_object(
 
     let child_id = pop_arg!(args, AccountAddress).into();
     let parent = pop_arg!(args, AccountAddress).into();
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     let has_child = object_runtime.child_object_exists(parent, child_id)?;
     Ok(NativeResult::ok(
         context.gas_used(),
@@ -453,11 +449,10 @@ pub fn has_child_object_with_ty(
     assert!(ty_args.len() == 1);
     assert!(args.len() == 2);
 
-    let dynamic_field_has_child_object_with_ty_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
-        .dynamic_field_has_child_object_with_ty_cost_params
-        .clone();
+    let dynamic_field_has_child_object_with_ty_cost_params =
+        get_extension!(context, NativesCostTable)?
+            .dynamic_field_has_child_object_with_ty_cost_params
+            .clone();
     native_charge_gas_early_exit!(
         context,
         dynamic_field_has_child_object_with_ty_cost_params
@@ -493,7 +488,7 @@ pub fn has_child_object_with_ty(
             * u64::from(tag.abstract_size_for_gas_metering()).into()
     );
 
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     let (cache_info, has_child) = object_runtime.child_object_exists_and_has_type(
         parent,
         child_id,

--- a/sui-execution/latest/sui-move-natives/src/event.rs
+++ b/sui-execution/latest/sui-move-natives/src/event.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{abstract_size, legacy_test_cost, object_runtime::ObjectRuntime, NativesCostTable};
+use crate::{
+    abstract_size, get_extension, get_extension_mut, legacy_test_cost,
+    object_runtime::ObjectRuntime, NativesCostTable,
+};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{gas_algebra::InternalGas, language_storage::TypeTag, vm_status::StatusCode};
 use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
@@ -38,9 +41,7 @@ pub fn emit(
     debug_assert!(ty_args.len() == 1);
     debug_assert!(args.len() == 1);
 
-    let event_emit_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let event_emit_cost_params = get_extension!(context, NativesCostTable)?
         .event_emit_cost_params
         .clone();
 
@@ -50,7 +51,7 @@ pub fn emit(
     let event_value = args.pop_back().unwrap();
 
     let event_value_size = abstract_size(
-        context.extensions().get::<ObjectRuntime>()?.protocol_config,
+        get_extension!(context, ObjectRuntime)?.protocol_config,
         &event_value,
     );
 
@@ -79,7 +80,7 @@ pub fn emit(
             * u64::from(tag_size).into()
     );
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let obj_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     let max_event_emit_size = obj_runtime.protocol_config.max_event_emit_size();
     let ev_size = u64::from(tag_size + event_value_size);
     // Check if the event size is within the limit
@@ -117,7 +118,7 @@ pub fn emit(
         event_emit_cost_params.event_emit_output_cost_per_byte * ev_size.into()
     );
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let obj_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
 
     obj_runtime.emit_event(*tag, event_value)?;
     Ok(NativeResult::ok(context.gas_used(), smallvec![]))
@@ -131,7 +132,7 @@ pub fn num_events(
 ) -> PartialVMResult<NativeResult> {
     assert!(ty_args.is_empty());
     assert!(args.is_empty());
-    let object_runtime_ref: &ObjectRuntime = context.extensions().get()?;
+    let object_runtime_ref: &ObjectRuntime = get_extension!(context)?;
     let num_events = object_runtime_ref.state.events().len();
     Ok(NativeResult::ok(
         legacy_test_cost(),
@@ -149,7 +150,7 @@ pub fn get_events_by_type(
     let specified_ty = ty_args.pop().unwrap();
     let specialization: VectorSpecialization = (&specified_ty).try_into()?;
     assert!(args.is_empty());
-    let object_runtime_ref: &ObjectRuntime = context.extensions().get()?;
+    let object_runtime_ref: &ObjectRuntime = get_extension!(context)?;
     let specified_type_tag = match context.type_to_type_tag(&specified_ty)? {
         TypeTag::Struct(s) => *s,
         _ => return Ok(NativeResult::ok(legacy_test_cost(), smallvec![])),

--- a/sui-execution/latest/sui-move-natives/src/object.rs
+++ b/sui-execution/latest/sui-move-natives/src/object.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{object_runtime::ObjectRuntime, NativesCostTable};
+use crate::{get_extension, get_extension_mut, object_runtime::ObjectRuntime, NativesCostTable};
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::{account_address::AccountAddress, gas_algebra::InternalGas};
 use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
@@ -31,9 +31,7 @@ pub fn borrow_uid(
     debug_assert!(ty_args.len() == 1);
     debug_assert!(args.len() == 1);
 
-    let borrow_uid_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let borrow_uid_cost_params = get_extension!(context, NativesCostTable)?
         .borrow_uid_cost_params
         .clone();
 
@@ -63,9 +61,7 @@ pub fn delete_impl(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 1);
 
-    let delete_impl_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let delete_impl_cost_params = get_extension!(context, NativesCostTable)?
         .delete_impl_cost_params
         .clone();
 
@@ -78,7 +74,7 @@ pub fn delete_impl(
     // unwrap safe because the interface of native function guarantees it.
     let uid_bytes = pop_arg!(args, AccountAddress);
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let obj_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     obj_runtime.delete_id(uid_bytes.into())?;
     Ok(NativeResult::ok(context.gas_used(), smallvec![]))
 }
@@ -100,9 +96,7 @@ pub fn record_new_uid(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 1);
 
-    let record_new_id_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let record_new_id_cost_params = get_extension!(context, NativesCostTable)?
         .record_new_id_cost_params
         .clone();
 
@@ -115,7 +109,7 @@ pub fn record_new_uid(
     // unwrap safe because the interface of native function guarantees it.
     let uid_bytes = pop_arg!(args, AccountAddress);
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let obj_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     obj_runtime.new_id(uid_bytes.into())?;
     Ok(NativeResult::ok(context.gas_used(), smallvec![]))
 }

--- a/sui-execution/latest/sui-move-natives/src/test_scenario.rs
+++ b/sui-execution/latest/sui-move-natives/src/test_scenario.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    get_nth_struct_field, get_tag_and_layouts, legacy_test_cost,
+    get_extension, get_extension_mut, get_nth_struct_field, get_tag_and_layouts, legacy_test_cost,
     object_runtime::{object_store::ChildObjectEffects, ObjectRuntime, RuntimeResults},
 };
 use better_any::{Tid, TidAble};
@@ -97,7 +97,7 @@ pub fn end_transaction(
 ) -> PartialVMResult<NativeResult> {
     assert!(ty_args.is_empty());
     assert!(args.is_empty());
-    let object_runtime_ref: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime_ref: &mut ObjectRuntime = get_extension_mut!(context)?;
     let taken_shared_or_imm: BTreeMap<_, _> = object_runtime_ref
         .test_inventories
         .taken
@@ -156,7 +156,7 @@ pub fn end_transaction(
             ));
         }
     };
-    let object_runtime_ref: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime_ref: &mut ObjectRuntime = get_extension_mut!(context)?;
     let all_active_child_objects_with_values = object_runtime_ref
         .all_active_child_objects()
         .filter(|child| child.copied_value.is_some())
@@ -244,7 +244,7 @@ pub fn end_transaction(
     }
 
     // For any unused allocated tickets, remove them from the store.
-    let store: &&InMemoryTestStore = context.extensions().get()?;
+    let store: &&InMemoryTestStore = get_extension!(context)?;
     for id in unreceived {
         if store
             .0
@@ -269,7 +269,7 @@ pub fn end_transaction(
     }
     // find all wrapped objects
     let mut all_wrapped = BTreeSet::new();
-    let object_runtime_ref: &ObjectRuntime = context.extensions().get()?;
+    let object_runtime_ref: &ObjectRuntime = get_extension!(context)?;
     find_all_wrapped_objects(
         context,
         &mut all_wrapped,
@@ -303,7 +303,7 @@ pub fn end_transaction(
     }
 
     // new input objects are remaining taken objects not written/deleted
-    let object_runtime_ref: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime_ref: &mut ObjectRuntime = get_extension_mut!(context)?;
     let mut config_settings = vec![];
     for child in object_runtime_ref.all_active_child_objects() {
         let s: StructTag = child.ty.clone().into();
@@ -381,7 +381,7 @@ pub fn take_from_address_by_id(
     pop_arg!(args, StructRef);
     assert!(args.is_empty());
     let specified_obj_ty = object_type_of_type(context, &specified_ty)?;
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     let inventories = &mut object_runtime.test_inventories;
     let res = take_from_inventory(
         |x| {
@@ -414,7 +414,7 @@ pub fn ids_for_address(
     let account: SuiAddress = pop_arg!(args, AccountAddress).into();
     assert!(args.is_empty());
     let specified_obj_ty = object_type_of_type(context, &specified_ty)?;
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     let inventories = &mut object_runtime.test_inventories;
     let ids = inventories
         .address_inventories
@@ -436,7 +436,7 @@ pub fn most_recent_id_for_address(
     let account: SuiAddress = pop_arg!(args, AccountAddress).into();
     assert!(args.is_empty());
     let specified_obj_ty = object_type_of_type(context, &specified_ty)?;
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     let inventories = &mut object_runtime.test_inventories;
     let most_recent_id = match inventories.address_inventories.get(&account) {
         None => pack_option(vector_specialization(&specified_ty), None),
@@ -458,7 +458,7 @@ pub fn was_taken_from_address(
     let id = pop_id(&mut args)?;
     let account: SuiAddress = pop_arg!(args, AccountAddress).into();
     assert!(args.is_empty());
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     let inventories = &mut object_runtime.test_inventories;
     let was_taken = inventories
         .taken
@@ -482,7 +482,7 @@ pub fn take_immutable_by_id(
     pop_arg!(args, StructRef);
     assert!(args.is_empty());
     let specified_obj_ty = object_type_of_type(context, &specified_ty)?;
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     let inventories = &mut object_runtime.test_inventories;
     let res = take_from_inventory(
         |x| {
@@ -520,7 +520,7 @@ pub fn most_recent_immutable_id(
     let specified_ty = get_specified_ty(ty_args);
     assert!(args.is_empty());
     let specified_obj_ty = object_type_of_type(context, &specified_ty)?;
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     let inventories = &mut object_runtime.test_inventories;
     let most_recent_id = most_recent_at_ty(
         &inventories.taken,
@@ -543,7 +543,7 @@ pub fn was_taken_immutable(
     assert!(ty_args.is_empty());
     let id = pop_id(&mut args)?;
     assert!(args.is_empty());
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     let inventories = &mut object_runtime.test_inventories;
     let was_taken = inventories
         .taken
@@ -567,7 +567,7 @@ pub fn take_shared_by_id(
     pop_arg!(args, StructRef);
     assert!(args.is_empty());
     let specified_obj_ty = object_type_of_type(context, &specified_ty)?;
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     let inventories = &mut object_runtime.test_inventories;
     let res = take_from_inventory(
         |x| {
@@ -598,7 +598,7 @@ pub fn most_recent_id_shared(
     let specified_ty = get_specified_ty(ty_args);
     assert!(args.is_empty());
     let specified_obj_ty = object_type_of_type(context, &specified_ty)?;
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     let inventories = &mut object_runtime.test_inventories;
     let most_recent_id = most_recent_at_ty(
         &inventories.taken,
@@ -621,7 +621,7 @@ pub fn was_taken_shared(
     assert!(ty_args.is_empty());
     let id = pop_id(&mut args)?;
     assert!(args.is_empty());
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     let inventories = &mut object_runtime.test_inventories;
     let was_taken = inventories
         .taken
@@ -649,7 +649,7 @@ pub fn allocate_receiving_ticket_for_object(
             E_UNABLE_TO_ALLOCATE_RECEIVING_TICKET,
         ));
     };
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     let object_version = SequenceNumber::new();
     let inventories = &mut object_runtime.test_inventories;
     if inventories.allocated_tickets.contains_key(&id) {
@@ -710,7 +710,7 @@ pub fn allocate_receiving_ticket_for_object(
     );
 
     // NB: Must be a `&&` reference since the extension stores a static ref to the object storage.
-    let store: &&InMemoryTestStore = context.extensions().get()?;
+    let store: &&InMemoryTestStore = get_extension!(context)?;
     store.0.with_borrow_mut(|store| store.insert_object(object));
 
     Ok(NativeResult::ok(
@@ -726,7 +726,7 @@ pub fn deallocate_receiving_ticket_for_object(
 ) -> PartialVMResult<NativeResult> {
     let id = pop_id(&mut args)?;
 
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     let inventories = &mut object_runtime.test_inventories;
     // Deallocate the ticket -- we should never hit this scenario
     let Some((_, value)) = inventories.allocated_tickets.remove(&id) else {
@@ -741,7 +741,7 @@ pub fn deallocate_receiving_ticket_for_object(
     inventories.objects.insert(id, value);
 
     // Remove the object from storage. We should never hit this scenario either.
-    let store: &&InMemoryTestStore = context.extensions().get()?;
+    let store: &&InMemoryTestStore = get_extension!(context)?;
     if store
         .0
         .with_borrow_mut(|store| store.remove_object(id).is_none())

--- a/sui-execution/latest/sui-move-natives/src/transfer.rs
+++ b/sui-execution/latest/sui-move-natives/src/transfer.rs
@@ -3,8 +3,8 @@
 
 use super::object_runtime::{ObjectRuntime, TransferResult};
 use crate::{
-    get_receiver_object_id, get_tag_and_layouts, object_runtime::object_store::ObjectResult,
-    NativesCostTable,
+    get_extension, get_extension_mut, get_receiver_object_id, get_tag_and_layouts,
+    object_runtime::object_store::ObjectResult, NativesCostTable,
 };
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
@@ -48,9 +48,7 @@ pub fn receive_object_internal(
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(ty_args.len() == 1);
     debug_assert!(args.len() == 3);
-    let transfer_receive_object_internal_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let transfer_receive_object_internal_cost_params = get_extension!(context, NativesCostTable)?
         .transfer_receive_object_internal_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -76,7 +74,7 @@ pub fn receive_object_internal(
         ));
     };
 
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     let (_cache_info, child) = match object_runtime.receive_object(
         parent,
         child_id,
@@ -122,9 +120,7 @@ pub fn transfer_internal(
     debug_assert!(ty_args.len() == 1);
     debug_assert!(args.len() == 2);
 
-    let transfer_transfer_internal_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let transfer_transfer_internal_cost_params = get_extension!(context, NativesCostTable)?
         .transfer_transfer_internal_cost_params
         .clone();
 
@@ -182,9 +178,7 @@ pub fn party_transfer_internal(
     debug_assert!(ty_args.len() == 1);
     debug_assert!(args.len() == 4);
 
-    let is_supported = context
-        .extensions()
-        .get::<ObjectRuntime>()?
+    let is_supported = get_extension!(context, ObjectRuntime)?
         .protocol_config
         .enable_party_transfer();
     if !is_supported {
@@ -192,9 +186,7 @@ pub fn party_transfer_internal(
         return Ok(NativeResult::err(cost, E_NOT_SUPPORTED));
     }
 
-    let transfer_party_transfer_internal_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let transfer_party_transfer_internal_cost_params = get_extension!(context, NativesCostTable)?
         .transfer_party_transfer_internal_cost_params
         .clone();
 
@@ -256,9 +248,7 @@ pub fn freeze_object(
     debug_assert!(ty_args.len() == 1);
     debug_assert!(args.len() == 1);
 
-    let transfer_freeze_object_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let transfer_freeze_object_cost_params = get_extension!(context, NativesCostTable)?
         .transfer_freeze_object_cost_params
         .clone();
 
@@ -292,9 +282,7 @@ pub fn share_object(
     debug_assert!(ty_args.len() == 1);
     debug_assert!(args.len() == 1);
 
-    let transfer_share_object_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let transfer_share_object_cost_params = get_extension!(context, NativesCostTable)?
         .transfer_share_object_cost_params
         .clone();
 
@@ -340,6 +328,6 @@ fn object_runtime_transfer(
         }
     };
 
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let obj_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     obj_runtime.transfer(owner, object_type, obj, /* end of transaction */ false)
 }

--- a/sui-execution/latest/sui-move-natives/src/tx_context.rs
+++ b/sui-execution/latest/sui-move-natives/src/tx_context.rs
@@ -12,7 +12,8 @@ use std::collections::VecDeque;
 use sui_types::{base_types::ObjectID, digests::TransactionDigest};
 
 use crate::{
-    object_runtime::ObjectRuntime, transaction_context::TransactionContext, NativesCostTable,
+    get_extension, get_extension_mut, object_runtime::ObjectRuntime,
+    transaction_context::TransactionContext, NativesCostTable,
 };
 
 #[derive(Clone)]
@@ -32,9 +33,7 @@ pub fn derive_id(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 2);
 
-    let tx_context_derive_id_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let tx_context_derive_id_cost_params = get_extension!(context, NativesCostTable)?
         .tx_context_derive_id_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -48,7 +47,7 @@ pub fn derive_id(
     // unwrap safe because all digests in Move are serialized from the Rust `TransactionDigest`
     let digest = TransactionDigest::try_from(tx_hash.as_slice()).unwrap();
     let address = AccountAddress::from(ObjectID::derive_id(digest, ids_created));
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let obj_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     obj_runtime.new_id(address.into())?;
 
     Ok(NativeResult::ok(
@@ -72,9 +71,7 @@ pub fn fresh_id(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.is_empty());
 
-    let tx_context_fresh_id_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let tx_context_fresh_id_cost_params = get_extension!(context, NativesCostTable)?
         .tx_context_fresh_id_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -82,9 +79,9 @@ pub fn fresh_id(
         tx_context_fresh_id_cost_params.tx_context_fresh_id_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
     let fresh_id = transaction_context.fresh_id();
-    let object_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let object_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     object_runtime.new_id(fresh_id)?;
 
     Ok(NativeResult::ok(
@@ -109,9 +106,7 @@ pub fn sender(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.is_empty());
 
-    let tx_context_sender_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let tx_context_sender_cost_params = get_extension!(context, NativesCostTable)?
         .tx_context_sender_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -119,7 +114,7 @@ pub fn sender(
         tx_context_sender_cost_params.tx_context_sender_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
     let sender = transaction_context.sender();
 
     Ok(NativeResult::ok(
@@ -144,9 +139,7 @@ pub fn epoch(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.is_empty());
 
-    let tx_context_epoch_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let tx_context_epoch_cost_params = get_extension!(context, NativesCostTable)?
         .tx_context_epoch_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -154,7 +147,7 @@ pub fn epoch(
         tx_context_epoch_cost_params.tx_context_epoch_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
     let epoch = transaction_context.epoch();
 
     Ok(NativeResult::ok(
@@ -179,9 +172,7 @@ pub fn epoch_timestamp_ms(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.is_empty());
 
-    let tx_context_epoch_timestamp_ms_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let tx_context_epoch_timestamp_ms_cost_params = get_extension!(context, NativesCostTable)?
         .tx_context_epoch_timestamp_ms_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -189,7 +180,7 @@ pub fn epoch_timestamp_ms(
         tx_context_epoch_timestamp_ms_cost_params.tx_context_epoch_timestamp_ms_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
     let timestamp = transaction_context.epoch_timestamp_ms();
 
     Ok(NativeResult::ok(
@@ -214,9 +205,7 @@ pub fn sponsor(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.is_empty());
 
-    let tx_context_sponsor_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let tx_context_sponsor_cost_params = get_extension!(context, NativesCostTable)?
         .tx_context_sponsor_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -224,7 +213,7 @@ pub fn sponsor(
         tx_context_sponsor_cost_params.tx_context_sponsor_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
     let sponsor = transaction_context
         .sponsor()
         .map(|addr| addr.into())
@@ -249,14 +238,12 @@ pub fn rgp(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.is_empty());
 
-    let tx_context_rgp_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let tx_context_rgp_cost_params = get_extension!(context, NativesCostTable)?
         .tx_context_rgp_cost_params
         .clone();
     native_charge_gas_early_exit!(context, tx_context_rgp_cost_params.tx_context_rgp_cost_base);
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
     let rgp = transaction_context.rgp();
 
     Ok(NativeResult::ok(
@@ -280,9 +267,7 @@ pub fn gas_price(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.is_empty());
 
-    let tx_context_gas_price_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let tx_context_gas_price_cost_params = get_extension!(context, NativesCostTable)?
         .tx_context_gas_price_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -290,7 +275,7 @@ pub fn gas_price(
         tx_context_gas_price_cost_params.tx_context_gas_price_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
     let gas_price = transaction_context.gas_price();
 
     Ok(NativeResult::ok(
@@ -315,9 +300,7 @@ pub fn gas_budget(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.is_empty());
 
-    let tx_context_gas_budget_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let tx_context_gas_budget_cost_params = get_extension!(context, NativesCostTable)?
         .tx_context_gas_budget_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -325,7 +308,7 @@ pub fn gas_budget(
         tx_context_gas_budget_cost_params.tx_context_gas_budget_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
     let gas_budget = transaction_context.gas_budget();
 
     Ok(NativeResult::ok(
@@ -350,9 +333,7 @@ pub fn ids_created(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.is_empty());
 
-    let tx_context_ids_created_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let tx_context_ids_created_cost_params = get_extension!(context, NativesCostTable)?
         .tx_context_ids_created_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -360,7 +341,7 @@ pub fn ids_created(
         tx_context_ids_created_cost_params.tx_context_ids_created_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
     let ids_created = transaction_context.ids_created();
 
     Ok(NativeResult::ok(
@@ -404,17 +385,16 @@ pub fn replace(
     debug_assert!(args_len == 8 || args_len == 9);
 
     // use the `TxContextReplaceCostParams` for the cost of this function
-    let tx_context_replace_cost_params: TxContextReplaceCostParams = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
-        .tx_context_replace_cost_params
-        .clone();
+    let tx_context_replace_cost_params: TxContextReplaceCostParams =
+        get_extension!(context, NativesCostTable)?
+            .tx_context_replace_cost_params
+            .clone();
     native_charge_gas_early_exit!(
         context,
         tx_context_replace_cost_params.tx_context_replace_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
     let mut sponsor: Vec<AccountAddress> = pop_arg!(args, Vec<AccountAddress>);
     let gas_budget: u64 = pop_arg!(args, u64);
     let gas_price: u64 = pop_arg!(args, u64);
@@ -460,9 +440,7 @@ pub fn last_created_id(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.is_empty());
 
-    let tx_context_derive_id_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let tx_context_derive_id_cost_params = get_extension!(context, NativesCostTable)?
         .tx_context_derive_id_cost_params
         .clone();
     native_charge_gas_early_exit!(
@@ -470,7 +448,7 @@ pub fn last_created_id(
         tx_context_derive_id_cost_params.tx_context_derive_id_cost_base
     );
 
-    let transaction_context: &mut TransactionContext = context.extensions_mut().get_mut()?;
+    let transaction_context: &mut TransactionContext = get_extension_mut!(context)?;
     let mut ids_created = transaction_context.ids_created();
     if ids_created == 0 {
         return Ok(NativeResult::err(context.gas_used(), E_NO_IDS_CREATED));
@@ -478,7 +456,7 @@ pub fn last_created_id(
     ids_created -= 1;
     let digest = transaction_context.digest();
     let address = AccountAddress::from(ObjectID::derive_id(digest, ids_created));
-    let obj_runtime: &mut ObjectRuntime = context.extensions_mut().get_mut()?;
+    let obj_runtime: &mut ObjectRuntime = get_extension_mut!(context)?;
     obj_runtime.new_id(address.into())?;
 
     Ok(NativeResult::ok(

--- a/sui-execution/latest/sui-move-natives/src/types.rs
+++ b/sui-execution/latest/sui-move-natives/src/types.rs
@@ -14,7 +14,7 @@ use move_vm_types::{
 use smallvec::smallvec;
 use std::collections::VecDeque;
 
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 
 pub(crate) fn is_otw_struct(
     struct_layout: &MoveStructLayout,
@@ -59,9 +59,7 @@ pub fn is_one_time_witness(
     debug_assert!(ty_args.len() == 1);
     debug_assert!(args.len() == 1);
 
-    let type_is_one_time_witness_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let type_is_one_time_witness_cost_params = get_extension!(context, NativesCostTable)?
         .type_is_one_time_witness_cost_params
         .clone();
 

--- a/sui-execution/latest/sui-move-natives/src/validator.rs
+++ b/sui-execution/latest/sui-move-natives/src/validator.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::NativesCostTable;
+use crate::{get_extension, NativesCostTable};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{gas_algebra::InternalGas, vm_status::StatusCode};
 use move_vm_runtime::{native_charge_gas_early_exit, native_functions::NativeContext};
@@ -31,9 +31,7 @@ pub fn validate_metadata_bcs(
     debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 1);
 
-    let validator_validate_metadata_bcs_cost_params = context
-        .extensions_mut()
-        .get::<NativesCostTable>()?
+    let validator_validate_metadata_bcs_cost_params = get_extension!(context, NativesCostTable)?
         .validator_validate_metadata_bcs_cost_params
         .clone();
 


### PR DESCRIPTION

## Description 

No semantic change. This is strictly just moving things over to use the macros introduced in the PR below this one.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
