### PR TITLE
[Graphql-alt] Refactor transaction effects with enum data source abstraction [3/n]

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/types/execution_result.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/execution_result.rs
@@ -9,7 +9,6 @@ use super::transaction_effects::TransactionEffects;
 #[derive(Clone, SimpleObject)]
 pub struct ExecutionResult {
     /// The effects of the transaction execution, if successful.
-    /// TODO: Implement data source abstraction to populate this field from TransactionEffects.
     pub effects: Option<TransactionEffects>,
 
     /// errors that occurred during execution (e.g., network errors, validation failures).

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -36,7 +36,7 @@ use super::{
     epoch::Epoch,
     gas_input::GasInput,
     transaction::filter::{tx_bounds, TransactionFilter},
-    transaction_effects::{EffectsContents, TransactionEffects},
+    transaction_effects::{EffectsContents, EffectsDataSource, TransactionEffects},
     user_signature::UserSignature,
 };
 
@@ -322,7 +322,14 @@ impl TransactionContents {
 
 impl From<TransactionEffects> for Transaction {
     fn from(fx: TransactionEffects) -> Self {
-        let EffectsContents { scope, contents } = fx.contents;
+        let EffectsContents { scope, data_source } = fx.contents;
+
+        // Extract stored contents from the data source
+        let contents = match data_source {
+            EffectsDataSource::Stored { contents, .. } => contents,
+            // TODO: Implement DataSource for Transaction type.
+            EffectsDataSource::ExecutedTransaction { .. } => None,
+        };
 
         Self {
             digest: fx.digest,


### PR DESCRIPTION
## Description 

Implements support for just-executed transaction effects from gRPC execution responses using an enum-based data source abstraction.

**Key Changes**

* Added `EffectsDataSource` enum with `Stored` and `ExecutedTransaction`  variants
* Refactored `TransactionEffects` to work with both data sources via helper methods
* `Mutation.execute_transaction` now returns just-executed `TransactionEffects`

The refactoring in `transaction_effects.rs` is the most critical update within this PR. It allows  `TransactionEffects`  to be  backed by a stored transaction, or by a transaction that was just executed.

This PR does not:
1. Support `EffectsDataSource` for `Transaction`, which will be implemented in upcoming PRs
2. Support `input_objects` and `output_objects`,  which will be implemented in upcoming PRs

## Test plan 

How did you test the new or updated feature?

---

## Stack
- #23145 
- #23332 

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
