### PR TITLE
[object-runtime][derived-addresses] Add `generated_runtime_ids` to track created-then-deleted object IDs for expensive invariant checks

### DIFF
--- a/crates/sui-types/src/storage/mod.rs
+++ b/crates/sui-types/src/storage/mod.rs
@@ -42,7 +42,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 pub use shared_in_memory_store::SharedInMemoryStore;
 pub use shared_in_memory_store::SingleCheckpointSharedInMemoryStore;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 pub use write_store::WriteStore;
@@ -229,6 +229,8 @@ pub trait Storage {
     /// Check coin denylist during execution,
     /// and the number of non-gas-coin owners.
     fn check_coin_deny_list(&self, written_objects: &BTreeMap<ObjectID, Object>) -> DenyListResult;
+
+    fn record_generated_object_ids(&mut self, generated_ids: BTreeSet<ObjectID>);
 }
 
 pub type PackageFetchResults<Package> = Result<Vec<Package>, Vec<ObjectID>>;

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
@@ -182,6 +182,8 @@ mod checked {
         // We record what objects were contained in at the start of the transaction
         // for expensive invariant checks
         let wrapped_object_containers = object_runtime.wrapped_object_containers();
+        // We record the generated object IDs for expensive invariant checks
+        let generated_object_ids = object_runtime.generated_object_ids();
 
         // apply changes
         let finished = context.finish::<Mode>();
@@ -189,6 +191,7 @@ mod checked {
         state_view.save_loaded_runtime_objects(loaded_runtime_objects);
         state_view.save_wrapped_object_containers(wrapped_object_containers);
         state_view.record_execution_results(finished?);
+        state_view.record_generated_object_ids(generated_object_ids);
         Ok(mode_results)
     }
 

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -61,6 +61,11 @@ pub struct TemporaryStore<'backing> {
     /// any of the objects referenced in this set.
     receiving_objects: Vec<ObjectRef>,
 
+    /// The set of all generated object IDs from the object runtime during the transaction. This includes any
+    /// created-and-then-deleted objects in addition to any `new_ids` which contains only the set
+    /// of created (but not deleted) IDs in the transaction.
+    generated_runtime_ids: BTreeSet<ObjectID>,
+
     // TODO: Now that we track epoch here, there are a few places we don't need to pass it around.
     /// The current epoch.
     cur_epoch: EpochId,
@@ -115,6 +120,7 @@ impl<'backing> TemporaryStore<'backing> {
             wrapped_object_containers: BTreeMap::new(),
             runtime_packages_loaded_from_db: RwLock::new(BTreeMap::new()),
             receiving_objects,
+            generated_runtime_ids: BTreeSet::new(),
             cur_epoch,
             loaded_per_epoch_config_objects: RwLock::new(BTreeSet::new()),
         }
@@ -441,6 +447,19 @@ impl<'backing> TemporaryStore<'backing> {
             .extend(wrapped_object_containers);
     }
 
+    pub fn save_generated_object_ids(&mut self, generated_ids: BTreeSet<ObjectID>) {
+        #[cfg(debug_assertions)]
+        {
+            self.generated_runtime_ids
+                .iter()
+                .for_each(|id| assert!(!generated_ids.contains(id)));
+            generated_ids.iter().for_each(|id| {
+                assert!(!self.generated_runtime_ids.contains(id));
+            });
+        }
+        self.generated_runtime_ids.extend(generated_ids);
+    }
+
     pub fn estimate_effects_size_upperbound(&self) -> usize {
         TransactionEffects::estimate_effects_size_upperbound_v2(
             self.execution_results.written_objects.len(),
@@ -586,8 +605,9 @@ impl TemporaryStore<'_> {
                 mutable_inputs.contains(id)
             })
             .copied()
-            // Add any object IDs created during execution to the authenticated set
-            .chain(self.execution_results.created_object_ids.iter().copied())
+            // Add any object IDs generated in the object runtime during execution to the
+            // authenticated set (i.e., new (non-package) objects, and possibly ephemeral UIDs).
+            .chain(self.generated_runtime_ids.iter().copied())
             .collect();
 
         // Add sender and sponsor (if present) to authenticated set
@@ -1090,6 +1110,10 @@ impl Storage for TemporaryStore<'_> {
                 .insert(SUI_DENY_LIST_OBJECT_ID);
         }
         result
+    }
+
+    fn record_generated_object_ids(&mut self, generated_ids: BTreeSet<ObjectID>) {
+        TemporaryStore::save_generated_object_ids(self, generated_ids)
     }
 }
 

--- a/sui-execution/v0/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v0/sui-adapter/src/temporary_store.rs
@@ -3,7 +3,7 @@
 
 use crate::gas_charger::GasCharger;
 use parking_lot::RwLock;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use sui_protocol_config::ProtocolConfig;
 use sui_types::committee::EpochId;
 use sui_types::effects::{TransactionEffects, TransactionEvents};
@@ -1025,6 +1025,12 @@ impl Storage for TemporaryStore<'_> {
         _written_objects: &BTreeMap<ObjectID, Object>,
     ) -> DenyListResult {
         unreachable!("Coin denylist v2 is not supported in sui-execution v0");
+    }
+
+    fn record_generated_object_ids(&mut self, _generated_ids: BTreeSet<ObjectID>) {
+        unreachable!(
+            "Generated object IDs are not recorded in ExecutionResults in sui-execution v0"
+        );
     }
 }
 

--- a/sui-execution/v1/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v1/sui-adapter/src/temporary_store.rs
@@ -1132,6 +1132,12 @@ impl Storage for TemporaryStore<'_> {
     ) -> DenyListResult {
         unreachable!("Coin denylist v2 is not supported in sui-execution v1");
     }
+
+    fn record_generated_object_ids(&mut self, _generated_ids: BTreeSet<ObjectID>) {
+        unreachable!(
+            "Generated object IDs are not recorded in ExecutionResults in sui-execution v1"
+        );
+    }
 }
 
 impl BackingPackageStore for TemporaryStore<'_> {

--- a/sui-execution/v2/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/v2/sui-adapter/src/temporary_store.rs
@@ -1184,6 +1184,12 @@ impl Storage for TemporaryStore<'_> {
     ) -> DenyListResult {
         unreachable!("Coin denylist v2 is not supported in sui-execution v2");
     }
+
+    fn record_generated_object_ids(&mut self, _generated_ids: BTreeSet<ObjectID>) {
+        unreachable!(
+            "Generated object IDs are not recorded in ExecutionResults in sui-execution v2"
+        );
+    }
 }
 
 impl BackingPackageStore for TemporaryStore<'_> {


### PR DESCRIPTION
## Description 

The `created_object_ids` set does not contain ephemeral IDs created in the transaction, which we need to factor in, in the presence of derived addresses. This adds this to the object runtime, and plumbs this out and into the expensive invariant checks.

## Test plan 

CI (nothing should change) + local testing of Manos' changes for derived addresses.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
