### PR TITLE
[package-alt] converts documentation in the tests for the new linkage to use mermaid

### DIFF
--- a/external-crates/move/Cargo.lock
+++ b/external-crates/move/Cargo.lock
@@ -122,6 +122,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7992085ec035cfe96992dd31bfd495a2ebd31969bb95f624471cb6c0b349e571"
 
 [[package]]
+name = "aquamarine"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f50776554130342de4836ba542aa85a4ddb361690d7e8df13774d7284c3d5c2"
+dependencies = [
+ "include_dir",
+ "itertools 0.10.5",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1574,6 +1588,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2552,6 +2585,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "append-only-vec",
+ "aquamarine",
  "bimap",
  "clap 4.5.28",
  "codespan-reporting",
@@ -3520,6 +3554,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]

--- a/external-crates/move/Cargo.toml
+++ b/external-crates/move/Cargo.toml
@@ -32,6 +32,7 @@ members = [
 aes-gcm = "0.8.0"
 anyhow = "1.0.52"
 append-only-vec = "0.1.7"
+aquamarine = "0.6.0"
 arbitrary = { version = "1.1.7", features = ["derive", "derive_arbitrary"] }
 async-trait = "0.1.42"
 bcs = "0.1.4"

--- a/external-crates/move/crates/move-package-alt/Cargo.toml
+++ b/external-crates/move/crates/move-package-alt/Cargo.toml
@@ -40,11 +40,7 @@ heck.workspace = true
 walkdir.workspace = true
 
 [dev-dependencies]
-# If we leave these as dev-dependencies then doc generation for tests doesn't
-# work, since rustdoc doesn't include dev-dependencies. Doc generation for
-# tests is nice since we can generate diagrams for the complicated linkage scenarios
-# (see graph::linkage::tests for an example)
-# aquamarine.workspace = true
+aquamarine.workspace = true
 datatest-stable.workspace = true
 insta.workspace = true
 test-log.workspace = true

--- a/external-crates/move/crates/move-package-alt/src/graph/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/mod.rs
@@ -155,3 +155,96 @@ impl<F: MoveFlavor> PackageGraph<F> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    // TODO: example with a --[local]--> a/b --[local]--> a/c
+    use std::collections::BTreeMap;
+
+    use test_log::test;
+
+    use crate::{
+        flavor::Vanilla,
+        graph::{PackageGraph, PackageInfo},
+        schema::PackageName,
+        test_utils::graph_builder::TestPackageGraph,
+    };
+
+    /// Return the packages in the graph, grouped by their name
+    fn packages_by_name(
+        graph: &PackageGraph<Vanilla>,
+    ) -> BTreeMap<PackageName, PackageInfo<Vanilla>> {
+        graph
+            .packages()
+            .expect("failed to get packages from graph")
+            .into_iter()
+            .map(|node| (node.name().clone(), node))
+            .collect()
+    }
+
+    /// Root package `root` depends on `a` which depends on `b` which depends on `c`, which depends
+    /// on `d`; `a`, `b`,
+    /// `c`, and `d` are all legacy packages.
+    ///
+    /// Named addresses for 'a' should contain `c` and `d`
+    #[test(tokio::test)]
+    async fn modern_legacy_legacy_legacy_legacy() {
+        let scenario = TestPackageGraph::new(["root"])
+            .add_legacy_packages(["a", "b", "c", "d"])
+            .add_deps([("root", "a"), ("a", "b"), ("b", "c"), ("c", "d")])
+            .build();
+
+        let graph = scenario.graph_for("root").await;
+
+        let packages = packages_by_name(&graph);
+
+        assert!(packages["a"].named_addresses().unwrap().contains_key("c"));
+        assert!(packages["a"].named_addresses().unwrap().contains_key("d"));
+        assert!(packages["a"].named_addresses().unwrap().contains_key("b"));
+        assert!(packages["a"].named_addresses().unwrap().contains_key("a"));
+        assert!(
+            !packages["root"]
+                .named_addresses()
+                .unwrap()
+                .contains_key("c")
+        );
+    }
+
+    /// Root package `root` depends on `a` which depends on `b` which depends on `c` which depends
+    /// on `d`; `a` and `c` are legacy packages.
+    ///
+    /// After adding legacy transitive deps, `a` should have direct dependencies on `c` and `d`
+    /// (even though they "pass through" a modern package)
+    #[test(tokio::test)]
+    async fn modern_legacy_modern_legacy() {
+        let scenario = TestPackageGraph::new(["root", "b", "d"])
+            .add_legacy_packages(["legacy_a", "legacy_c"])
+            .add_deps([
+                ("root", "legacy_a"),
+                ("legacy_a", "b"),
+                ("b", "legacy_c"),
+                ("legacy_c", "d"),
+            ])
+            .build();
+
+        let graph = scenario.graph_for("root").await;
+
+        let packages = packages_by_name(&graph);
+
+        assert!(
+            packages["legacy_a"]
+                .named_addresses()
+                .unwrap()
+                .contains_key("legacy_c")
+        );
+        assert!(
+            packages["legacy_a"]
+                .named_addresses()
+                .unwrap()
+                .contains_key("d")
+        );
+        assert!(!packages["b"].named_addresses().unwrap().contains_key("d"));
+    }
+
+    // TODO: tests around name conflicts?
+}

--- a/external-crates/move/crates/move-package-alt/src/graph/package_info.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/package_info.rs
@@ -210,6 +210,12 @@ impl<F: MoveFlavor> PackageInfo<'_, F> {
     }
 }
 
+impl<F: MoveFlavor> std::fmt::Debug for PackageInfo<'_, F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.package().fmt(f)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     // TODO: example with a --[local]--> a/b --[local]--> a/c


### PR DESCRIPTION
## Description 

This PR adds a few tests to the linkage checker in the new package system, and also updates the documentation for all the tests to use mermaid. You can now generate diagrams for them using rustdoc (see comments in the `test` module of `linkage.rs` for instructions).

## Test plan 

This is mostly updating the tests, so testing just involves manually comparing the documentation to the implementation for the tests and also reviewing the generated documentation to ensure that the tests are describing expected behavior.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
