### PR TITLE
Fork recovery: clear local checkpoints on validator start

### DIFF
--- a/crates/sui-config/src/node.rs
+++ b/crates/sui-config/src/node.rs
@@ -243,7 +243,8 @@ pub struct ForkRecoveryConfig {
     pub transaction_overrides: BTreeMap<String, String>,
 
     /// Map of checkpoint sequence number to checkpoint digest overrides
-    /// Used to repoint checkpoints to correct versions after a fork
+    /// On node start, if we have a locally computed checkpoint with a
+    /// digest mismatch with this table, we will clear any associated local state.
     #[serde(default)]
     pub checkpoint_overrides: BTreeMap<u64, String>,
 

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -830,15 +830,12 @@ pub struct ForkRecoveryState {
     /// Transaction digest to effects digest overrides
     transaction_overrides:
         parking_lot::RwLock<HashMap<TransactionDigest, TransactionEffectsDigest>>,
-    /// Checkpoint sequence to checkpoint digest overrides
-    checkpoint_overrides: parking_lot::RwLock<HashMap<CheckpointSequenceNumber, CheckpointDigest>>,
 }
 
 impl Default for ForkRecoveryState {
     fn default() -> Self {
         Self {
             transaction_overrides: parking_lot::RwLock::new(HashMap::new()),
-            checkpoint_overrides: parking_lot::RwLock::new(HashMap::new()),
         }
     }
 }
@@ -861,21 +858,8 @@ impl ForkRecoveryState {
             transaction_overrides.insert(tx_digest, effects_digest);
         }
 
-        let mut checkpoint_overrides = HashMap::new();
-        for (seq_num, checkpoint_digest_str) in &config.checkpoint_overrides {
-            let checkpoint_digest =
-                CheckpointDigest::from_str(checkpoint_digest_str).map_err(|_| {
-                    SuiError::Unknown(format!(
-                        "Invalid checkpoint digest: {}",
-                        checkpoint_digest_str
-                    ))
-                })?;
-            checkpoint_overrides.insert(*seq_num, checkpoint_digest);
-        }
-
         Ok(Self {
             transaction_overrides: parking_lot::RwLock::new(transaction_overrides),
-            checkpoint_overrides: parking_lot::RwLock::new(checkpoint_overrides),
         })
     }
 
@@ -884,13 +868,6 @@ impl ForkRecoveryState {
         tx_digest: &TransactionDigest,
     ) -> Option<TransactionEffectsDigest> {
         self.transaction_overrides.read().get(tx_digest).copied()
-    }
-
-    pub fn get_checkpoint_override(
-        &self,
-        seq_num: &CheckpointSequenceNumber,
-    ) -> Option<CheckpointDigest> {
-        self.checkpoint_overrides.read().get(seq_num).copied()
     }
 }
 

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -8,6 +8,7 @@ use anemo_tower::trace::DefaultMakeSpan;
 use anemo_tower::trace::DefaultOnFailure;
 use anemo_tower::trace::TraceLayer;
 use anyhow::anyhow;
+use anyhow::Context;
 use anyhow::Result;
 use arc_swap::ArcSwap;
 use fastcrypto_zkp::bn254::zk_login::JwkId;
@@ -2183,8 +2184,34 @@ impl SuiNode {
         checkpoint_store: &CheckpointStore,
         recovery: &ForkRecoveryConfig,
     ) -> Result<()> {
-        if recovery.checkpoint_overrides.is_empty() {
-            return Ok(());
+        // If configured overrides include a checkpoint whose locally computed digest mismatches,
+        // clear locally computed checkpoints from that sequence (inclusive).
+        for (seq, expected_digest_str) in &recovery.checkpoint_overrides {
+            let Ok(expected_digest) = CheckpointDigest::from_str(expected_digest_str) else {
+                anyhow::bail!(
+                    "Invalid checkpoint digest override for seq {}: {}",
+                    seq,
+                    expected_digest_str
+                );
+            };
+
+            if let Some(local_summary) = checkpoint_store.get_locally_computed_checkpoint(*seq)? {
+                let local_digest = sui_types::message_envelope::Message::digest(&local_summary);
+                if local_digest != expected_digest {
+                    info!(
+                        seq,
+                        local = %Self::get_digest_prefix(local_digest),
+                        expected = %Self::get_digest_prefix(expected_digest),
+                        "Fork recovery: clearing locally_computed_checkpoints from {} due to digest mismatch",
+                        seq
+                    );
+                    checkpoint_store
+                        .clear_locally_computed_checkpoints_from(*seq)
+                        .context(
+                            "Failed to clear locally computed checkpoints from override seq",
+                        )?;
+                }
+            }
         }
 
         if let Some((checkpoint_seq, checkpoint_digest)) =


### PR DESCRIPTION
## Description 

Instead of applying checkpoint overrides in CheckpointBuilder, we simply detect and clear invalid local checkpoints when the node starts. This handles both the case when we rebuild a local checkpoint with an different result and the case where we insert a verified checkpoint with a different digest than a locally built checkpoint.

## Test plan 

Simtests pass, new UT. verified with one-off devnet test for both txn fork detected and checkpoint fork detected.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
