### PR TITLE
Fixed "Gas Used" information in the Move unit tests reports

### DIFF
--- a/external-crates/move/crates/move-vm-test-utils/src/tiered_gas_schedule.rs
+++ b/external-crates/move/crates/move-vm-test-utils/src/tiered_gas_schedule.rs
@@ -357,11 +357,6 @@ impl<'a> GasStatus<'a> {
         self.cost_table
     }
 
-    /// Return the gas left.
-    pub fn remaining_gas(&self) -> Gas {
-        self.gas_left.to_unit_round_down()
-    }
-
     /// Charge a given amount of gas and fail if not enough gas units are left.
     pub fn deduct_gas(&mut self, amount: InternalGas) -> PartialVMResult<()> {
         if !self.charge {


### PR DESCRIPTION
This PR addresses an issue occurring when running the `sui move test --statistics` command. In the test reports, the section "Gas Used" misbehaves in two different ways:

1) The number displayed is not the actual gas consumed by the tests, but the number of instructions executed during them.  
2) The TODO comment in the `TestRunInfo::new` call, in `SharedTestingConfig::execute_via_move_vm`, indicates that "This doesn't look quite right...". Indeed, there is a miscomputation due to `self.execution_bound` and `gas_meter.remaining_gas` not having the same unit.

The following changes have been made in order to fix the two points above:

- In `TestRunInfo`, we replaced the field `instructions_executed` with `gas_used`.  
- The function `tiered_gas_schedule::GasStatus::remaining_gas` has been removed. It is no longer needed, as the implementation of `GasMeter` for `GasStatus` already provides a function called `remaining_gas`. The deleted `remaining_gas` function was only used when creating a `TestRunInfo` in `SharedTestingConfig::execute_via_move_vm`. It had the drawback of calling the `to_unit_round_down` function, which causes the Move developer to lose precious gas information by discarding the decimal part of the gas usage.  
- "Gas Used" is now computed as the `execution_bound` value converted to unit, subtracted by the `remaining_gas`, this latter now being already in unit when calling the `From<GasQuantity> for u64` implementation.

I haven't had time to run the unit tests yet, as they take a long time to compile. That's why this PR is still a draft. I'm going to mark it as ready after running the tests on my computer.