### PR TITLE
tokio runtime fix

### DIFF
--- a/crates/sui-replay-2/src/summary_metrics.rs
+++ b/crates/sui-replay-2/src/summary_metrics.rs
@@ -1,0 +1,119 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::cell::RefCell;
+use tracing::debug;
+
+// Per-transaction query time accumulators (thread-local)
+thread_local! {
+    static TX_QUERY_METRICS_MS: RefCell<(u128, u128, u128)> = const { RefCell::new((0, 0, 0)) }; // (txn, objs, epoch)
+    static TX_OBJS_REQUESTED: RefCell<u64> = const { RefCell::new(0) };
+    static TX_QUERY_COUNTS: RefCell<(u64, u64, u64)> = const { RefCell::new((0, 0, 0)) }; // (txn, objs, epoch)
+}
+
+// Reset per-transaction metrics (timers, requested-objects counter, and query counts).
+pub(crate) fn tx_metrics_reset() {
+    TX_QUERY_METRICS_MS.with(|m| *m.borrow_mut() = (0, 0, 0));
+    TX_OBJS_REQUESTED.with(|c| *c.borrow_mut() = 0);
+    TX_QUERY_COUNTS.with(|c| *c.borrow_mut() = (0, 0, 0));
+}
+
+// Add elapsed milliseconds to the transaction-data query timer for this transaction.
+pub(crate) fn tx_metrics_add_txn(ms: u128) {
+    TX_QUERY_METRICS_MS.with(|m| {
+        let (t, o, e) = *m.borrow();
+        *m.borrow_mut() = (t + ms, o, e);
+    });
+}
+
+// Add elapsed milliseconds to the objects query timer for this transaction.
+pub(crate) fn tx_metrics_add_objs(ms: u128) {
+    TX_QUERY_METRICS_MS.with(|m| {
+        let (t, o, e) = *m.borrow();
+        *m.borrow_mut() = (t, o + ms, e);
+    });
+}
+
+// Add elapsed milliseconds to the epoch query timer for this transaction.
+pub(crate) fn tx_metrics_add_epoch(ms: u128) {
+    TX_QUERY_METRICS_MS.with(|m| {
+        let (t, o, e) = *m.borrow();
+        *m.borrow_mut() = (t, o, e + ms);
+    });
+}
+
+// Snapshot of per-transaction query timers: (txn_ms, objs_ms, epoch_ms).
+pub(crate) fn tx_metrics_snapshot() -> (u128, u128, u128) {
+    TX_QUERY_METRICS_MS.with(|m| *m.borrow())
+}
+
+// Increment the number of objects requested in the current multi-get batch.
+pub(crate) fn tx_objs_add(n: usize) {
+    TX_OBJS_REQUESTED.with(|c| *c.borrow_mut() += n as u64);
+}
+
+// Snapshot of how many objects were requested for this transaction.
+pub(crate) fn tx_objs_snapshot() -> u64 {
+    TX_OBJS_REQUESTED.with(|c| *c.borrow())
+}
+
+// Increment the number of transaction-data queries executed for this transaction.
+pub(crate) fn tx_counts_add_txn() {
+    TX_QUERY_COUNTS.with(|c| {
+        let (t, o, e) = *c.borrow();
+        *c.borrow_mut() = (t + 1, o, e);
+    });
+}
+
+// Increment the number of object batches (multi-get objects) executed for this transaction.
+pub(crate) fn tx_counts_add_objs() {
+    TX_QUERY_COUNTS.with(|c| {
+        let (t, o, e) = *c.borrow();
+        *c.borrow_mut() = (t, o + 1, e);
+    });
+}
+
+// Increment the number of epoch-info queries executed for this transaction.
+pub(crate) fn tx_counts_add_epoch() {
+    TX_QUERY_COUNTS.with(|c| {
+        let (t, o, e) = *c.borrow();
+        *c.borrow_mut() = (t, o, e + 1);
+    });
+}
+
+// Snapshot of query counts: (txn_count, objs_count, epoch_count).
+pub(crate) fn tx_query_counts_snapshot() -> (u64, u64, u64) {
+    TX_QUERY_COUNTS.with(|c| *c.borrow())
+}
+
+// Log a concise summary of replay metrics for a transaction at debug level.
+pub(crate) fn log_replay_metrics(tx_digest: &str, total_ms: u128, exec_ms: u128) {
+    let (txn_ms, objs_ms, epoch_ms) = tx_metrics_snapshot();
+    let objs_requested = tx_objs_snapshot();
+    let (txn_q, objs_q, epoch_q) = tx_query_counts_snapshot();
+    let bucket = if total_ms <= 10_000 {
+        "le10"
+    } else if total_ms <= 20_000 {
+        "gt10le20"
+    } else if total_ms <= 30_000 {
+        "gt20le30"
+    } else if total_ms <= 60_000 {
+        "gt30le60"
+    } else {
+        "gt60"
+    };
+    debug!(
+        "Tx metrics {}: bucket={} total_ms={} exec_ms={} txn_ms={} objs_ms={} epoch_ms={} objs_requested={} q_counts(txn,objs,epoch)=({},{},{})",
+        tx_digest,
+        bucket,
+        total_ms,
+        exec_ms,
+        txn_ms,
+        objs_ms,
+        epoch_ms,
+        objs_requested,
+        txn_q,
+        objs_q,
+        epoch_q
+    );
+}


### PR DESCRIPTION
## Description 
The key change in in data_store.rs and it's picking a proper tokio runtime. The code before was hanging in mysterious ways after a number of transactions. After investigations the hang appeared related to tokio and the runtime picked to block on. The code as is now executes thousands of transactions and it seems stable.
There is a bunch of logging changes that I am adding because they helped me diagnose the issue with the hang/deadlock. Also they provide a good overview of what is going on. So I am leaving them here for now. The file `summary_metrics.rs` si questionable but it is ok for now in my opinion

## Test plan 

Run a subset of a few thousands transactions to verify code works

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
