### PR TITLE
[consistent-store] Respect top-level rocksdb configuration

### DIFF
--- a/crates/sui-indexer-alt-consistent-store/src/schema/balances.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/schema/balances.rs
@@ -18,8 +18,8 @@ pub(crate) struct Key {
 }
 
 /// Options for creating this index's column family in RocksDB.
-pub(crate) fn options() -> rocksdb::Options {
-    let mut opts = rocksdb::Options::default();
+pub(crate) fn options(base_options: &rocksdb::Options) -> rocksdb::Options {
+    let mut opts = base_options.clone();
     opts.set_merge_operator_associative("merge_balances", merge_balances);
     opts.set_compaction_filter("compact_balances", compact_balances);
     opts

--- a/crates/sui-indexer-alt-consistent-store/src/schema/mod.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/schema/mod.rs
@@ -28,11 +28,11 @@ pub(crate) struct Schema {
 }
 
 impl store::Schema for Schema {
-    fn cfs() -> Vec<(&'static str, rocksdb::Options)> {
+    fn cfs(base_options: &rocksdb::Options) -> Vec<(&'static str, rocksdb::Options)> {
         vec![
-            ("balances", balances::options()),
-            ("object_by_owner", object_by_owner::options()),
-            ("object_by_type", object_by_type::options()),
+            ("balances", balances::options(base_options)),
+            ("object_by_owner", object_by_owner::options(base_options)),
+            ("object_by_type", object_by_type::options(base_options)),
         ]
     }
 

--- a/crates/sui-indexer-alt-consistent-store/src/schema/object_by_owner.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/schema/object_by_owner.rs
@@ -113,8 +113,8 @@ impl<C> Decode<C> for OwnerKind {
 }
 
 /// Options for creating this index's column family in RocksDB.
-pub(crate) fn options() -> rocksdb::Options {
-    rocksdb::Options::default()
+pub(crate) fn options(base_options: &rocksdb::Options) -> rocksdb::Options {
+    base_options.clone()
 }
 
 #[cfg(test)]

--- a/crates/sui-indexer-alt-consistent-store/src/schema/object_by_type.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/schema/object_by_type.rs
@@ -27,6 +27,6 @@ impl Key {
 }
 
 /// Options for creating this index's column family in RocksDB.
-pub(crate) fn options() -> rocksdb::Options {
-    rocksdb::Options::default()
+pub(crate) fn options(base_options: &rocksdb::Options) -> rocksdb::Options {
+    base_options.clone()
 }


### PR DESCRIPTION
## Description 

Today, we allow database-level configurations, and the consistent store in testnet and mainnet are configured as such:
```
[rocksdb]
write-buffer-size-mb = 4096
max-wal-size-mb = 4096
block-size-kb = 32
block-cache-slots = 8192
db-parallelism = 8
```

The issue is that rocksdb will privilege cf-level configs if provided, and the consistent store code creates default options for all cfs with some cfs having additional configs (set_merge_operator_associative, set_compaction_filter). But this means that the configured values are not being respected, resulting in the cfs defaulting to 65 mb buffer size (memtable) instead of 4096 mb, for example. This PR passes database-level configs to the Schema's `cfs` function as the `base_options` that each cf can then extend on. Later on, we likely want to extend to allow per-cf settings on the .toml file, but this change ensures that the database-level configurations are properly inherited by all column families while still allowing individual cfs to add their specific customizations like merge operators and compaction filters.


## Test plan 

Separate deployment, verified from rocksdb logs that the column families were provisioned with buffer size 4096 mb.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
