### PR TITLE
Fix stress setup in antithesis

### DIFF
--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -527,6 +527,12 @@ pub struct FullNodeProxy {
 
 impl FullNodeProxy {
     pub async fn from_url(http_url: &str) -> Result<Self, anyhow::Error> {
+        let http_url = if http_url.starts_with("http://") || http_url.starts_with("https://") {
+            http_url.to_string()
+        } else {
+            format!("http://{http_url}")
+        };
+
         // Each request times out after 60s (default value)
         let sui_client = SuiClientBuilder::default()
             .max_concurrent_requests(500_000)

--- a/deny.toml
+++ b/deny.toml
@@ -42,6 +42,8 @@ ignore = [
     "RUSTSEC-2025-0010",
     # AES functions in `ring` may panic when overflow checking is enabled
     "RUSTSEC-2025-0009",
+    # Upgrade tracing.* libs to resolve.
+    "RUSTSEC-2025-0055", 
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/external-crates/move/deny.toml
+++ b/external-crates/move/deny.toml
@@ -50,11 +50,12 @@ ignore = [
     "RUSTSEC-2024-0375",
     # Potential unaligned read in `atty`
     "RUSTSEC-2021-0145",
-
     # allow unmaintained instant crate used in transitive dependencies (backoff, cached, fastrand, parking_lot_*)
     "RUSTSEC-2024-0384",
     # `paste` is unmaintained
     "RUSTSEC-2024-0436",
+    # Upgrade tracing.* libs to resolve.
+    "RUSTSEC-2025-0055",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories
@@ -95,8 +96,6 @@ confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
-
-
   # Each entry is the crate and version constraint, and its specific allow
   # list
   # { allow = ["Zlib"], name = "adler32", version = "*" },


### PR DESCRIPTION
## Description 

Support full node URL without `http://` prefix.

Fix cargo deny error.

## Test plan 

https://github.com/MystenLabs/sui-operations/actions/runs/17421966286/job/49462963361
Run Id: bd675f55f55c03aa9eddae6867de9050-36-12
