### PR TITLE
[graphql-alt] Refactor Scope to Optional checkpoint_viewed_at [4/n]

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/latest.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/latest.move
@@ -21,3 +21,9 @@
 {
   checkpoint { sequenceNumber }
 }
+
+//# run-graphql
+{
+  # Test that explicit null defaults to latest checkpoint
+  checkpoint(sequenceNumber: null) { sequenceNumber }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/latest.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/checkpoints/latest.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 6 tasks
+processed 7 tasks
 
 init:
 A: object(0,0)
@@ -35,6 +35,16 @@ task 4, line 18:
 Checkpoint created: 2
 
 task 5, lines 20-23:
+//# run-graphql
+Response: {
+  "data": {
+    "checkpoint": {
+      "sequenceNumber": 2
+    }
+  }
+}
+
+task 6, lines 25-29:
 //# run-graphql
 Response: {
   "data": {

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -80,6 +80,7 @@ type Address implements IAddressable {
 	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	If the address does not own any coins of that type, a balance of zero is returned.
 	"""
 	balance(coinType: String!): Balance
@@ -104,9 +105,10 @@ type Address implements IAddressable {
 	"""
 	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -660,7 +662,7 @@ type DynamicField implements IAddressable & IObject & IMoveObject {
 	
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -901,6 +903,8 @@ type Epoch {
 	systemStateVersion: UInt53
 	"""
 	The total number of checkpoints in this epoch.
+	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	"""
 	totalCheckpoints: UInt53
 	"""
@@ -921,6 +925,8 @@ type Epoch {
 	totalTransactions: UInt53
 	"""
 	The transactions in this epoch, optionally filtered by transaction filters.
+	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	"""
 	transactions(first: Int, after: String, last: Int, before: String, filter: TransactionFilter): TransactionConnection
 	"""
@@ -1175,9 +1181,9 @@ interface IAddressable {
 	"""
 	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Returns `null` when no checkpoint is set in scope (e.g. execution scope). If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Objects owned by this address, optionally filtered by type.
 	"""
@@ -1423,7 +1429,7 @@ type MoveObject implements IAddressable & IObject & IMoveObject {
 	
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -1541,7 +1547,7 @@ type MovePackage implements IAddressable & IObject {
 	
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Fetch the package as an object with the same ID, at a different version, root version bound, or checkpoint.
 	
@@ -1797,9 +1803,10 @@ type Object implements IAddressable & IObject {
 	"""
 	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Fetch the object with the same ID, at a different version, root version bound, or checkpoint.
 	

--- a/crates/sui-indexer-alt-graphql/src/api/mutation.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/mutation.rs
@@ -73,7 +73,7 @@ impl Mutation {
             .await
         {
             Ok(response) => {
-                let scope = Scope::new_execution_context(ctx)?;
+                let scope = Scope::new_execution_output(ctx)?;
                 let effects = TransactionEffects::from_execution_response(
                     scope,
                     response,

--- a/crates/sui-indexer-alt-graphql/src/api/mutation.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/mutation.rs
@@ -73,7 +73,7 @@ impl Mutation {
             .await
         {
             Ok(response) => {
-                let scope = Scope::new(ctx)?;
+                let scope = Scope::new_execution_context(ctx)?;
                 let effects = TransactionEffects::from_execution_response(
                     scope,
                     response,

--- a/crates/sui-indexer-alt-graphql/src/api/mutation.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/mutation.rs
@@ -73,7 +73,7 @@ impl Mutation {
             .await
         {
             Ok(response) => {
-                let scope = Scope::with_execution_output(ctx)?;
+                let scope = Scope::new(ctx)?.with_execution_output();
                 let effects = TransactionEffects::from_execution_response(
                     scope,
                     response,

--- a/crates/sui-indexer-alt-graphql/src/api/mutation.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/mutation.rs
@@ -73,7 +73,7 @@ impl Mutation {
             .await
         {
             Ok(response) => {
-                let scope = Scope::new_execution_output(ctx)?;
+                let scope = Scope::with_execution_output(ctx)?;
                 let effects = TransactionEffects::from_execution_response(
                     scope,
                     response,

--- a/crates/sui-indexer-alt-graphql/src/api/query.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/query.rs
@@ -76,11 +76,10 @@ impl Query {
         sequence_number: Option<UInt53>,
     ) -> Result<Option<Checkpoint>, RpcError> {
         let scope = self.scope(ctx)?;
-        let sequence_number = sequence_number
-            .map(|s| Some(s.into()))
-            .unwrap_or(scope.checkpoint_viewed_at());
-
-        Ok(Checkpoint::with_sequence_number(scope, sequence_number))
+        Ok(Checkpoint::with_sequence_number(
+            scope,
+            sequence_number.map(|s| s.into()),
+        ))
     }
 
     /// Paginate checkpoints in the network, optionally bounded to checkpoints in the given epoch.

--- a/crates/sui-indexer-alt-graphql/src/api/query.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/query.rs
@@ -78,7 +78,7 @@ impl Query {
         let scope = self.scope(ctx)?;
         let sequence_number = sequence_number
             .map(|s| s.into())
-            .unwrap_or(scope.checkpoint_viewed_at());
+            .unwrap_or(scope.checkpoint_viewed_at_or_error()?);
 
         Ok(Checkpoint::with_sequence_number(scope, sequence_number))
     }

--- a/crates/sui-indexer-alt-graphql/src/api/types/balance.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/balance.rs
@@ -58,12 +58,11 @@ impl Balance {
         if scope.root_version().is_some() {
             return Err(bad_user_input(Error::RootVersionOwnership));
         }
-
-        let consistent_reader: &ConsistentReader = ctx.data()?;
         let Some(checkpoint) = scope.checkpoint_viewed_at() else {
             return Ok(None);
         };
 
+        let consistent_reader: &ConsistentReader = ctx.data()?;
         let (coin_type, total_balance) = consistent_reader
             .get_balance(
                 checkpoint,
@@ -90,12 +89,11 @@ impl Balance {
         if scope.root_version().is_some() {
             return Err(bad_user_input(Error::RootVersionOwnership));
         }
-
-        let consistent_reader: &ConsistentReader = ctx.data()?;
         let Some(checkpoint) = scope.checkpoint_viewed_at() else {
             return Ok(None);
         };
 
+        let consistent_reader: &ConsistentReader = ctx.data()?;
         let balances = consistent_reader
             .batch_get_balances(
                 checkpoint,
@@ -130,6 +128,9 @@ impl Balance {
         if scope.root_version().is_some() {
             return Err(bad_user_input(Error::RootVersionOwnership));
         }
+        let Some(checkpoint_viewed_at) = scope.checkpoint_viewed_at() else {
+            return Ok(Connection::new(false, false));
+        };
 
         let consistent_reader: &ConsistentReader = ctx.data()?;
 
@@ -141,13 +142,7 @@ impl Balance {
             (Some(a), Some(b)) if a.0 != b.0 => {
                 return Err(bad_user_input(Error::CursorInconsistency(a.0, b.0)));
             }
-
-            (None, None) => {
-                let Some(cp) = scope.checkpoint_viewed_at() else {
-                    return Ok(Connection::new(false, false));
-                };
-                cp
-            }
+            (None, None) => checkpoint_viewed_at,
             (Some(c), _) | (_, Some(c)) => c.0,
         };
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/balance.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/balance.rs
@@ -47,18 +47,22 @@ pub(crate) type Cursor = cursor::BcsCursor<(u64, Vec<u8>)>;
 impl Balance {
     /// Fetch the balance for a single coin type owned by the given address, live at the current
     /// checkpoint.
+    ///
+    /// Returns `None` when no checkpoint is set in scope (e.g. execution scope).
     pub(crate) async fn fetch_one(
         ctx: &Context<'_>,
         scope: &Scope,
         address: SuiAddress,
         coin_type: TypeTag,
-    ) -> Result<Balance, RpcError<Error>> {
+    ) -> Result<Option<Balance>, RpcError<Error>> {
         if scope.root_version().is_some() {
             return Err(bad_user_input(Error::RootVersionOwnership));
         }
 
         let consistent_reader: &ConsistentReader = ctx.data()?;
-        let checkpoint = scope.checkpoint_viewed_at();
+        let Some(checkpoint) = scope.checkpoint_viewed_at() else {
+            return Ok(None);
+        };
 
         let (coin_type, total_balance) = consistent_reader
             .get_balance(
@@ -69,26 +73,28 @@ impl Balance {
             .await
             .map_err(|e| consistent_error(checkpoint, e))?;
 
-        Ok(Balance {
+        Ok(Some(Balance {
             coin_type: Some(MoveType::from_native(coin_type, scope.clone())),
             total_balance: Some(BigInt::from(total_balance)),
-        })
+        }))
     }
 
     /// Fetch balances for multiple coin types owned by the given address, live at the current
-    /// checkpoint.
+    /// checkpoint. Returns `None` when no checkpoint is set in scope (e.g. execution scope).
     pub(crate) async fn fetch_many(
         ctx: &Context<'_>,
         scope: &Scope,
         address: SuiAddress,
         coin_types: Vec<TypeTag>,
-    ) -> Result<Vec<Balance>, RpcError<Error>> {
+    ) -> Result<Option<Vec<Balance>>, RpcError<Error>> {
         if scope.root_version().is_some() {
             return Err(bad_user_input(Error::RootVersionOwnership));
         }
 
         let consistent_reader: &ConsistentReader = ctx.data()?;
-        let checkpoint = scope.checkpoint_viewed_at();
+        let Some(checkpoint) = scope.checkpoint_viewed_at() else {
+            return Ok(None);
+        };
 
         let balances = consistent_reader
             .batch_get_balances(
@@ -102,13 +108,15 @@ impl Balance {
             .await
             .map_err(|e| consistent_error(checkpoint, e))?;
 
-        Ok(balances
-            .into_iter()
-            .map(|(coin_type, total_balance)| Balance {
-                coin_type: Some(MoveType::from_native(coin_type, scope.clone())),
-                total_balance: Some(BigInt::from(total_balance)),
-            })
-            .collect())
+        Ok(Some(
+            balances
+                .into_iter()
+                .map(|(coin_type, total_balance)| Balance {
+                    coin_type: Some(MoveType::from_native(coin_type, scope.clone())),
+                    total_balance: Some(BigInt::from(total_balance)),
+                })
+                .collect(),
+        ))
     }
 
     /// Paginate through balances for coins owned by the given address, live at the current
@@ -134,7 +142,12 @@ impl Balance {
                 return Err(bad_user_input(Error::CursorInconsistency(a.0, b.0)));
             }
 
-            (None, None) => scope.checkpoint_viewed_at(),
+            (None, None) => {
+                let Some(cp) = scope.checkpoint_viewed_at() else {
+                    return Ok(Connection::new(false, false));
+                };
+                cp
+            }
             (Some(c), _) | (_, Some(c)) => c.0,
         };
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
@@ -201,8 +201,10 @@ impl Checkpoint {
     /// Construct a checkpoint that is represented by just its identifier (its sequence number).
     /// Returns `None` if the checkpoint is set in the future relative to the current scope's
     /// checkpoint.
+    ///
+    /// In execution context, always returns `Some` since no checkpoint is considered future.
     pub(crate) fn with_sequence_number(scope: Scope, sequence_number: u64) -> Option<Self> {
-        (sequence_number <= scope.checkpoint_viewed_at()).then_some(Self {
+        (sequence_number <= scope.checkpoint_viewed_at().unwrap_or(u64::MAX)).then_some(Self {
             scope,
             sequence_number,
         })
@@ -219,7 +221,7 @@ impl Checkpoint {
 
         // TODO: (henrychen) Update when we figure out retention for key-value stores.
         let cp_lo = 0;
-        let cp_hi_inclusive = scope.checkpoint_viewed_at();
+        let cp_hi_inclusive = scope.checkpoint_viewed_at().unwrap_or(u64::MAX);
 
         let Some(cp_bounds) = checkpoint_bounds(
             filter.after_checkpoint.map(u64::from),

--- a/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/checkpoint/mod.rs
@@ -199,12 +199,14 @@ impl CheckpointContents {
 
 impl Checkpoint {
     /// Construct a checkpoint that is represented by just its identifier (its sequence number).
-    /// Returns `None` if `sequence_number` is `None`, or if the checkpoint is set in the future
-    /// relative to the current scope's checkpoint, or when no checkpoint is set in scope
-    /// (e.g. execution scope, where checkpoint queries return None to prevent temporal inconsistency).
+    ///
+    /// If no sequence_number is provided, defaults to the scope's checkpoint.
+    /// Returns `None` if the checkpoint is set in the future relative to the current scope's
+    /// checkpoint, or when no checkpoint is set in scope (e.g. execution scope, where checkpoint
+    /// queries return None to prevent temporal inconsistency).
     pub(crate) fn with_sequence_number(scope: Scope, sequence_number: Option<u64>) -> Option<Self> {
-        let sequence_number = sequence_number?;
         let scope_checkpoint = scope.checkpoint_viewed_at()?;
+        let sequence_number = sequence_number.unwrap_or(scope_checkpoint);
 
         (sequence_number <= scope_checkpoint).then_some(Self {
             scope,

--- a/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
@@ -214,7 +214,7 @@ impl DynamicField {
         &self,
         ctx: &Context<'_>,
         keys: Vec<TypeInput>,
-    ) -> Result<Vec<Balance>, RpcError<balance::Error>> {
+    ) -> Result<Option<Vec<Balance>>, RpcError<balance::Error>> {
         self.super_.multi_get_balances(ctx, keys).await
     }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -127,7 +127,7 @@ impl Event {
             filter.at_checkpoint.map(u64::from),
             filter.before_checkpoint.map(u64::from),
             reader_lo,
-            scope.checkpoint_viewed_at(),
+            scope.checkpoint_viewed_at().unwrap_or(u64::MAX),
         ) else {
             return Ok(Connection::new(false, false));
         };

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -107,14 +107,19 @@ impl Event {
 
 impl Event {
     /// Paginates events based on the provided filters and page parameters.
+    ///
+    /// Returns empty results when no checkpoint is set in scope (e.g. execution scope).
     pub(crate) async fn paginate(
         ctx: &Context<'_>,
         scope: Scope,
         page: Page<CEvent>,
         filter: filter::EventFilter,
     ) -> Result<Connection<String, Event>, RpcError> {
-        let mut c = Connection::new(false, false);
+        let Some(checkpoint_viewed_at) = scope.checkpoint_viewed_at() else {
+            return Ok(Connection::new(false, false));
+        };
 
+        let mut c = Connection::new(false, false);
         let pg_reader: &PgReader = ctx.data()?;
         let watermarks: &Arc<Watermarks> = ctx.data()?;
 
@@ -127,7 +132,7 @@ impl Event {
             filter.at_checkpoint.map(u64::from),
             filter.before_checkpoint.map(u64::from),
             reader_lo,
-            scope.checkpoint_viewed_at().unwrap_or(u64::MAX),
+            checkpoint_viewed_at,
         ) else {
             return Ok(Connection::new(false, false));
         };

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
@@ -246,7 +246,7 @@ impl MoveObject {
         &self,
         ctx: &Context<'_>,
         keys: Vec<TypeInput>,
-    ) -> Result<Vec<Balance>, RpcError<balance::Error>> {
+    ) -> Result<Option<Vec<Balance>>, RpcError<balance::Error>> {
         self.super_.multi_get_balances(ctx, keys).await
     }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
@@ -167,7 +167,7 @@ impl MovePackage {
         &self,
         ctx: &Context<'_>,
         keys: Vec<TypeInput>,
-    ) -> Result<Vec<Balance>, RpcError<balance::Error>> {
+    ) -> Result<Option<Vec<Balance>>, RpcError<balance::Error>> {
         self.super_.multi_get_balances(ctx, keys).await
     }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object.rs
@@ -467,11 +467,10 @@ impl Object {
                 .ok_or_else(|| bad_user_input(Error::Future(cp.into())))?;
 
             Ok(Self::checkpoint_bounded(ctx, scope, key.address, cp).await?)
-        } else {
-            let Some(cp) = scope.checkpoint_viewed_at() else {
-                return Ok(None);
-            };
+        } else if let Some(cp) = scope.checkpoint_viewed_at() {
             Ok(Self::checkpoint_bounded(ctx, scope, key.address, cp.into()).await?)
+        } else {
+            Ok(None)
         }
     }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object.rs
@@ -256,12 +256,13 @@ impl Object {
 
     /// Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
     ///
+    /// Returns `None` when no checkpoint is set in scope (e.g. execution scope).
     /// If the address does not own any coins of a given type, a balance of zero is returned for that type.
     pub(crate) async fn multi_get_balances(
         &self,
         ctx: &Context<'_>,
         keys: Vec<TypeInput>,
-    ) -> Result<Vec<Balance>, RpcError<balance::Error>> {
+    ) -> Result<Option<Vec<Balance>>, RpcError<balance::Error>> {
         self.super_.multi_get_balances(ctx, keys).await
     }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/protocol_configs.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/protocol_configs.rs
@@ -114,11 +114,11 @@ impl ProtocolConfigs {
     ///
     /// Returns `None` when no checkpoint is set in scope (e.g. execution scope).
     pub(crate) async fn latest(ctx: &Context<'_>, scope: &Scope) -> Result<Option<Self>, RpcError> {
-        let pg_loader: &Arc<DataLoader<PgReader>> = ctx.data()?;
-
         let Some(cp) = scope.checkpoint_viewed_at() else {
             return Ok(None);
         };
+
+        let pg_loader: &Arc<DataLoader<PgReader>> = ctx.data()?;
         let Some(stored) = pg_loader
             .load_one(CheckpointBoundedEpochStartKey(cp))
             .await

--- a/crates/sui-indexer-alt-graphql/src/api/types/protocol_configs.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/protocol_configs.rs
@@ -111,10 +111,14 @@ impl ProtocolConfigs {
     }
 
     /// Fetch the protocol config for the latest epoch in scope.
+    ///
+    /// Returns `None` when no checkpoint is set in scope (e.g. execution scope).
     pub(crate) async fn latest(ctx: &Context<'_>, scope: &Scope) -> Result<Option<Self>, RpcError> {
         let pg_loader: &Arc<DataLoader<PgReader>> = ctx.data()?;
 
-        let cp = scope.checkpoint_viewed_at_or_error()?;
+        let Some(cp) = scope.checkpoint_viewed_at() else {
+            return Ok(None);
+        };
         let Some(stored) = pg_loader
             .load_one(CheckpointBoundedEpochStartKey(cp))
             .await

--- a/crates/sui-indexer-alt-graphql/src/api/types/protocol_configs.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/protocol_configs.rs
@@ -114,7 +114,7 @@ impl ProtocolConfigs {
     pub(crate) async fn latest(ctx: &Context<'_>, scope: &Scope) -> Result<Option<Self>, RpcError> {
         let pg_loader: &Arc<DataLoader<PgReader>> = ctx.data()?;
 
-        let cp = scope.checkpoint_viewed_at();
+        let cp = scope.checkpoint_viewed_at_or_error()?;
         let Some(stored) = pg_loader
             .load_one(CheckpointBoundedEpochStartKey(cp))
             .await

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -189,12 +189,18 @@ impl Transaction {
     }
 
     /// Cursor based pagination through transactions with filters applied.
+    ///
+    /// Returns empty results when no checkpoint is set in scope (e.g. execution scope).
     pub(crate) async fn paginate(
         ctx: &Context<'_>,
         scope: Scope,
         page: Page<CTransaction>,
         filter: TransactionFilter,
     ) -> Result<Connection<String, Transaction>, RpcError> {
+        let Some(checkpoint_viewed_at) = scope.checkpoint_viewed_at() else {
+            return Ok(Connection::new(false, false));
+        };
+
         let mut conn = Connection::new(false, false);
 
         if page.limit() == 0 {
@@ -212,7 +218,7 @@ impl Transaction {
             filter.at_checkpoint.map(u64::from),
             filter.before_checkpoint.map(u64::from),
             reader_lo,
-            scope.checkpoint_viewed_at().unwrap_or(u64::MAX),
+            checkpoint_viewed_at,
         ) else {
             return Ok(Connection::new(false, false));
         };
@@ -298,6 +304,9 @@ impl TransactionContents {
         if self.contents.is_some() {
             return Ok(self.clone());
         }
+        let Some(checkpoint_viewed_at) = self.scope.checkpoint_viewed_at() else {
+            return Ok(self.clone());
+        };
 
         let kv_loader: &KvLoader = ctx.data()?;
         let Some(transaction) = kv_loader
@@ -312,7 +321,7 @@ impl TransactionContents {
         let cp_num = transaction
             .cp_sequence_number()
             .context("Any transaction fetched from the DB should have a checkpoint set")?;
-        if cp_num > self.scope.checkpoint_viewed_at().unwrap_or(u64::MAX) {
+        if cp_num > checkpoint_viewed_at {
             return Ok(self.clone());
         }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/mod.rs
@@ -212,7 +212,7 @@ impl Transaction {
             filter.at_checkpoint.map(u64::from),
             filter.before_checkpoint.map(u64::from),
             reader_lo,
-            scope.checkpoint_viewed_at(),
+            scope.checkpoint_viewed_at().unwrap_or(u64::MAX),
         ) else {
             return Ok(Connection::new(false, false));
         };
@@ -312,7 +312,7 @@ impl TransactionContents {
         let cp_num = transaction
             .cp_sequence_number()
             .context("Any transaction fetched from the DB should have a checkpoint set")?;
-        if cp_num > self.scope.checkpoint_viewed_at() {
+        if cp_num > self.scope.checkpoint_viewed_at().unwrap_or(u64::MAX) {
             return Ok(self.clone());
         }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -478,7 +478,7 @@ impl EffectsContents {
 
         // Discard the loaded result if we are viewing it at a checkpoint before it existed.
         if let Some(cp_num) = transaction.cp_sequence_number() {
-            if cp_num > self.scope.checkpoint_viewed_at() {
+            if cp_num > self.scope.checkpoint_viewed_at().unwrap_or(u64::MAX) {
                 return Ok(self.clone());
             }
         }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -102,9 +102,7 @@ impl EffectsContents {
             return None;
         };
 
-        content
-            .cp_sequence_number()
-            .and_then(|cp| Checkpoint::with_sequence_number(self.scope.clone(), cp))
+        Checkpoint::with_sequence_number(self.scope.clone(), content.cp_sequence_number())
     }
 
     /// Whether the transaction executed successfully or not.
@@ -466,8 +464,6 @@ impl EffectsContents {
         if self.contents.is_some() {
             return Ok(self.clone());
         }
-
-        // Skip checkpoint bounds check when no checkpoint is set in scope (e.g. execution scope).
         let Some(checkpoint_viewed_at) = self.scope.checkpoint_viewed_at() else {
             return Ok(self.clone());
         };

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -102,7 +102,9 @@ impl EffectsContents {
             return None;
         };
 
-        Checkpoint::with_sequence_number(self.scope.clone(), content.cp_sequence_number())
+        content
+            .cp_sequence_number()
+            .and_then(|cp| Checkpoint::with_sequence_number(self.scope.clone(), Some(cp)))
     }
 
     /// Whether the transaction executed successfully or not.

--- a/crates/sui-indexer-alt-graphql/src/scope.rs
+++ b/crates/sui-indexer-alt-graphql/src/scope.rs
@@ -70,19 +70,15 @@ impl Scope {
         })
     }
 
-    /// Create a new scope for execution context (freshly executed transaction).
-    pub(crate) fn with_execution_output<E: std::error::Error>(
-        ctx: &Context<'_>,
-    ) -> Result<Self, RpcError<E>> {
-        let package_store: &Arc<PackageCache> = ctx.data()?;
-        let limits: &Limits = ctx.data()?;
-
-        Ok(Self {
+    /// Create a nested scope for execution context (freshly executed transaction).
+    /// This clears the checkpoint context to indicate fresh execution data.
+    pub(crate) fn with_execution_output(&self) -> Self {
+        Self {
             checkpoint_viewed_at: None,
-            root_version: None,
-            package_store: package_store.clone(),
-            resolver_limits: limits.package_resolver(),
-        })
+            root_version: self.root_version,
+            package_store: self.package_store.clone(),
+            resolver_limits: self.resolver_limits.clone(),
+        }
     }
 
     /// Create a nested scope with a root version set.

--- a/crates/sui-indexer-alt-graphql/src/scope.rs
+++ b/crates/sui-indexer-alt-graphql/src/scope.rs
@@ -71,7 +71,7 @@ impl Scope {
     }
 
     /// Create a new scope for execution context (freshly executed transaction).
-    pub(crate) fn new_execution_context<E: std::error::Error>(
+    pub(crate) fn new_execution_output<E: std::error::Error>(
         ctx: &Context<'_>,
     ) -> Result<Self, RpcError<E>> {
         let package_store: &Arc<PackageCache> = ctx.data()?;

--- a/crates/sui-indexer-alt-graphql/src/scope.rs
+++ b/crates/sui-indexer-alt-graphql/src/scope.rs
@@ -71,7 +71,7 @@ impl Scope {
     }
 
     /// Create a new scope for execution context (freshly executed transaction).
-    pub(crate) fn new_execution_output<E: std::error::Error>(
+    pub(crate) fn with_execution_output<E: std::error::Error>(
         ctx: &Context<'_>,
     ) -> Result<Self, RpcError<E>> {
         let package_store: &Arc<PackageCache> = ctx.data()?;

--- a/crates/sui-indexer-alt-graphql/src/scope.rs
+++ b/crates/sui-indexer-alt-graphql/src/scope.rs
@@ -71,16 +71,18 @@ impl Scope {
     }
 
     /// Create a new scope for execution context (freshly executed transaction).
-    pub(crate) fn new_execution_context(
-        package_store: Arc<dyn PackageStore>,
-        resolver_limits: sui_package_resolver::Limits,
-    ) -> Self {
-        Self {
+    pub(crate) fn new_execution_context<E: std::error::Error>(
+        ctx: &Context<'_>,
+    ) -> Result<Self, RpcError<E>> {
+        let package_store: &Arc<PackageCache> = ctx.data()?;
+        let limits: &Limits = ctx.data()?;
+
+        Ok(Self {
             checkpoint_viewed_at: None,
             root_version: None,
-            package_store,
-            resolver_limits,
-        }
+            package_store: package_store.clone(),
+            resolver_limits: limits.package_resolver(),
+        })
     }
 
     /// Create a nested scope with a root version set.

--- a/crates/sui-indexer-alt-graphql/src/scope.rs
+++ b/crates/sui-indexer-alt-graphql/src/scope.rs
@@ -18,7 +18,9 @@ use crate::{config::Limits, error::RpcError, task::watermark::Watermarks};
 pub(crate) struct Scope {
     /// The checkpoint we are viewing this data at. Queries for the latest versions of an entity
     /// are relative to this checkpoint.
-    checkpoint_viewed_at: u64,
+    ///
+    /// None indicates execution context where we're viewing fresh transaction effects not yet indexed.
+    checkpoint_viewed_at: Option<u64>,
 
     /// Root parent object version for dynamic fields.
     ///

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -84,6 +84,7 @@ type Address implements IAddressable {
 	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	If the address does not own any coins of that type, a balance of zero is returned.
 	"""
 	balance(coinType: String!): Balance
@@ -108,9 +109,10 @@ type Address implements IAddressable {
 	"""
 	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -664,7 +666,7 @@ type DynamicField implements IAddressable & IObject & IMoveObject {
 	
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -905,6 +907,8 @@ type Epoch {
 	systemStateVersion: UInt53
 	"""
 	The total number of checkpoints in this epoch.
+	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	"""
 	totalCheckpoints: UInt53
 	"""
@@ -925,6 +929,8 @@ type Epoch {
 	totalTransactions: UInt53
 	"""
 	The transactions in this epoch, optionally filtered by transaction filters.
+	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	"""
 	transactions(first: Int, after: String, last: Int, before: String, filter: TransactionFilter): TransactionConnection
 	"""
@@ -1179,9 +1185,9 @@ interface IAddressable {
 	"""
 	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Returns `null` when no checkpoint is set in scope (e.g. execution scope). If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Objects owned by this address, optionally filtered by type.
 	"""
@@ -1427,7 +1433,7 @@ type MoveObject implements IAddressable & IObject & IMoveObject {
 	
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -1545,7 +1551,7 @@ type MovePackage implements IAddressable & IObject {
 	
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Fetch the package as an object with the same ID, at a different version, root version bound, or checkpoint.
 	
@@ -1801,9 +1807,10 @@ type Object implements IAddressable & IObject {
 	"""
 	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Fetch the object with the same ID, at a different version, root version bound, or checkpoint.
 	

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -84,6 +84,7 @@ type Address implements IAddressable {
 	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	If the address does not own any coins of that type, a balance of zero is returned.
 	"""
 	balance(coinType: String!): Balance
@@ -108,9 +109,10 @@ type Address implements IAddressable {
 	"""
 	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -664,7 +666,7 @@ type DynamicField implements IAddressable & IObject & IMoveObject {
 	
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -905,6 +907,8 @@ type Epoch {
 	systemStateVersion: UInt53
 	"""
 	The total number of checkpoints in this epoch.
+	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	"""
 	totalCheckpoints: UInt53
 	"""
@@ -925,6 +929,8 @@ type Epoch {
 	totalTransactions: UInt53
 	"""
 	The transactions in this epoch, optionally filtered by transaction filters.
+	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	"""
 	transactions(first: Int, after: String, last: Int, before: String, filter: TransactionFilter): TransactionConnection
 	"""
@@ -1179,9 +1185,9 @@ interface IAddressable {
 	"""
 	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Returns `null` when no checkpoint is set in scope (e.g. execution scope). If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Objects owned by this address, optionally filtered by type.
 	"""
@@ -1427,7 +1433,7 @@ type MoveObject implements IAddressable & IObject & IMoveObject {
 	
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -1545,7 +1551,7 @@ type MovePackage implements IAddressable & IObject {
 	
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Fetch the package as an object with the same ID, at a different version, root version bound, or checkpoint.
 	
@@ -1801,9 +1807,10 @@ type Object implements IAddressable & IObject {
 	"""
 	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Fetch the object with the same ID, at a different version, root version bound, or checkpoint.
 	

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -80,6 +80,7 @@ type Address implements IAddressable {
 	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	If the address does not own any coins of that type, a balance of zero is returned.
 	"""
 	balance(coinType: String!): Balance
@@ -104,9 +105,10 @@ type Address implements IAddressable {
 	"""
 	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -660,7 +662,7 @@ type DynamicField implements IAddressable & IObject & IMoveObject {
 	
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -901,6 +903,8 @@ type Epoch {
 	systemStateVersion: UInt53
 	"""
 	The total number of checkpoints in this epoch.
+	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	"""
 	totalCheckpoints: UInt53
 	"""
@@ -921,6 +925,8 @@ type Epoch {
 	totalTransactions: UInt53
 	"""
 	The transactions in this epoch, optionally filtered by transaction filters.
+	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	"""
 	transactions(first: Int, after: String, last: Int, before: String, filter: TransactionFilter): TransactionConnection
 	"""
@@ -1175,9 +1181,9 @@ interface IAddressable {
 	"""
 	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
-	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	Returns `null` when no checkpoint is set in scope (e.g. execution scope). If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Objects owned by this address, optionally filtered by type.
 	"""
@@ -1423,7 +1429,7 @@ type MoveObject implements IAddressable & IObject & IMoveObject {
 	
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Access dynamic fields on an object using their types and BCS-encoded names.
 	
@@ -1541,7 +1547,7 @@ type MovePackage implements IAddressable & IObject {
 	
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Fetch the package as an object with the same ID, at a different version, root version bound, or checkpoint.
 	
@@ -1797,9 +1803,10 @@ type Object implements IAddressable & IObject {
 	"""
 	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
-	multiGetBalances(keys: [String!]!): [Balance!]!
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Fetch the object with the same ID, at a different version, root version bound, or checkpoint.
 	


### PR DESCRIPTION
## Description 

When executing transactions via `executeTransaction`, the effects haven't been indexed into a checkpoint yet. Using the RPC's latest checkpoint as reference is incorrect.

This PR will fix that problem by updating `Scope::checkpoint_viewed_at` from `u64` → `Option<u64>`

**Pattern Applied**
With `checkpoint_viewed_at` being `None` in execution scope, we implemented a consistent "fail early" pattern. For some common operations below, here is what we returned when `checkpoint_viewed_at` is None:

* Pagination (e.g. transaction/mod.rs, event/mod.rs): Return empty Connection
* Object lookups (e.g. object.rs, move_package.rs): Return None or empty contents
* Epoch queries (e.g. epoch.rs): Return None

## Test plan 

How did you test the new or updated feature?

```
 cargo nextest run -p sui-indexer-alt-e2e-tests
```

---

## Stack
- #23145 
- #23332 
- #23351 
- #23398 ⬅️

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
