### PR TITLE
Use within_alive_epoch to shut down checkpoint tasks

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -2965,9 +2965,9 @@ impl AuthorityPerEpochStore {
             .expect("epoch_terminated called twice on same epoch store");
         // This `write` acts as a barrier - it waits for futures executing in
         // `within_alive_epoch` to terminate before we can continue here
-        debug!("Epoch terminated - waiting for pending tasks to complete");
+        info!("Epoch terminated - waiting for pending tasks to complete");
         *self.epoch_alive.write().await = false;
-        debug!("All pending epoch tasks completed");
+        info!("All pending epoch tasks completed");
     }
 
     /// Waits for the notification about epoch termination

--- a/crates/sui-core/src/unit_tests/consensus_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_manager_tests.rs
@@ -43,7 +43,10 @@ pub fn checkpoint_service_for_testing(state: Arc<AuthorityState>) -> Arc<Checkpo
         3,
         100_000,
     );
-    checkpoint_service.spawn(None).now_or_never().unwrap();
+    checkpoint_service
+        .spawn(epoch_store.clone(), None)
+        .now_or_never()
+        .unwrap();
     checkpoint_service
 }
 


### PR DESCRIPTION
This removes a race condition during the previous shutdown method. What was happening was:
- Validator reconfigures
- We call `abort_all()` on the JoinSet
- The state hasher shuts down first
- builder sends a checkpoint to state hasher
- send() call fails because receiver is closed
- we get a spurious antithesis failure from checkpoint builder failing
