### PR TITLE
fix: type error with `require.context`

### DIFF
--- a/docs/site/src/components/ImportContent/index.tsx
+++ b/docs/site/src/components/ImportContent/index.tsx
@@ -29,7 +29,7 @@ function resolveMdxComponent(mod: AnyMod): ResolvedComp {
 
 const SNIPPET_MAP: Record<string, React.ComponentType<any>> = {};
 snippetReq.keys().forEach((k: string) => {
-  const Comp = resolveMdxComponent(snippetReq<AnyMod>(k));
+  const Comp = resolveMdxComponent(snippetReq(k) as AnyMod);
   if (!Comp) return;
   const key = k.replace(/^\.\//, ""); // "sub/x.mdx"
   SNIPPET_MAP[key] = Comp;


### PR DESCRIPTION
## Description 

fixed a TypeScript error with `require.context` - it was used with a generic, but it’s not generic.
replaced it with a simple cast:
```ts
const Comp = resolveMdxComponent(snippetReq(k) as AnyMod);
````

## Test plan

built locally, no more `Expected 0 type arguments, but got 1` error. everything runs fine.

---

## Release notes

no user-facing changes.
