### PR TITLE
[graphql-alt] Load input and output objects change from just-executed transaction [5/n]

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_execute_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_execute_transaction_tests.rs
@@ -17,6 +17,7 @@ use sui_indexer_alt_reader::{
 use sui_macros::sim_test;
 use sui_pg_db::{temp::get_available_port, DbArgs};
 use sui_test_transaction_builder::make_transfer_sui_transaction;
+use sui_types::gas_coin::GasCoin;
 
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -30,6 +31,7 @@ use test_cluster::{TestCluster, TestClusterBuilder};
 
 // Unified struct for all GraphQL transaction effects parsing
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct TransactionEffects {
     status: String,
     checkpoint: Option<serde_json::Value>,
@@ -37,6 +39,7 @@ struct TransactionEffects {
     events: Option<Events>,
     #[serde(rename = "unchangedConsensusObjects")]
     unchanged_consensus_objects: Option<UnchangedConsensusObjects>,
+    object_changes: Option<ObjectChanges>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -133,6 +136,33 @@ impl GraphQlTestCluster {
         self.cancel.cancel();
         let _ = self.handle.await;
     }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ObjectChanges {
+    edges: Vec<ObjectChangeEdge>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ObjectChangeEdge {
+    node: ObjectChangeNode,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ObjectChangeNode {
+    id_created: bool,
+    id_deleted: bool,
+    input_state: Option<ObjectState>,
+    output_state: Option<ObjectState>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ObjectState {
+    version: u64,
+    as_move_object: Option<Value>,
 }
 
 async fn create_graphql_test_cluster(validator_cluster: &TestCluster) -> GraphQlTestCluster {
@@ -518,4 +548,136 @@ async fn test_execute_transaction_unchanged_consensus_objects() {
     assert!(object.version > 0, "Version should be greater than 0");
 
     graphql_cluster.stopped().await;
+}
+
+#[sim_test]
+async fn test_execute_transaction_object_changes_input_output() {
+    let validator_cluster = TestClusterBuilder::new().build().await;
+    let graphql_cluster = create_graphql_test_cluster(&validator_cluster).await;
+
+    // Create a transfer transaction that will modify objects
+    let recipient = SuiAddress::random_for_testing_only();
+    let signed_tx =
+        make_transfer_sui_transaction(&validator_cluster.wallet, Some(recipient), Some(1_000_000))
+            .await;
+    let (tx_bytes, signatures) = signed_tx.to_tx_bytes_and_signatures();
+
+    let result = graphql_cluster
+        .execute_graphql(
+            r#"
+            mutation($txData: Base64!, $sigs: [Base64!]!) {
+                executeTransaction(transactionDataBcs: $txData, signatures: $sigs) {
+                    effects {
+                        digest
+                        status
+                        objectChanges {
+                            edges {
+                                node {
+                                    address
+                                    idCreated
+                                    idDeleted
+                                    inputState {
+                                        version
+                                        asMoveObject {
+                                            contents {
+                                                type {
+                                                    repr
+                                                }
+                                            }
+                                        }
+                                    }
+                                    outputState {
+                                        version
+                                        asMoveObject {
+                                            contents {
+                                                type {
+                                                    repr
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    errors
+                }
+            }
+        "#,
+            json!({
+                "txData": tx_bytes.encoded(),
+                "sigs": signatures.iter().map(|s| s.encoded()).collect::<Vec<_>>()
+            }),
+        )
+        .await
+        .expect("GraphQL request failed");
+
+    let effects: TransactionEffects = serde_json::from_value(
+        result
+            .pointer("/data/executeTransaction/effects")
+            .unwrap()
+            .clone(),
+    )
+    .unwrap();
+
+    // Verify the transaction succeeded
+    assert_eq!(effects.status, "SUCCESS");
+
+    let nodes: Vec<ObjectChangeNode> = effects
+        .object_changes
+        .unwrap()
+        .edges
+        .into_iter()
+        .map(|edge| edge.node)
+        .collect();
+
+    // There are 2 objects (gas coin + newly created coin)
+    assert_eq!(nodes.len(), 2);
+
+    // Filter out the gas object (modified, has both input and output states)
+    let gas_coin = nodes
+        .iter()
+        .find(|node| !node.id_created && !node.id_deleted)
+        .unwrap();
+    let input_state = gas_coin.input_state.as_ref().unwrap();
+    let output_state = gas_coin.output_state.as_ref().unwrap();
+    let input_move_obj = input_state.as_move_object.as_ref().unwrap();
+    let output_move_obj = output_state.as_move_object.as_ref().unwrap();
+    let input_type = input_move_obj
+        .pointer("/contents/type/repr")
+        .unwrap()
+        .as_str()
+        .unwrap();
+    let output_type = output_move_obj
+        .pointer("/contents/type/repr")
+        .unwrap()
+        .as_str()
+        .unwrap();
+    let sui_coin_type = GasCoin::type_().to_canonical_string(true);
+
+    // Gas coin versions: 1 → 2 (modified for gas payment)
+    assert_eq!(input_state.version, 1);
+    assert_eq!(output_state.version, 2);
+
+    // Both should be SUI coins
+    assert_eq!(input_type, sui_coin_type);
+    assert_eq!(output_type, sui_coin_type);
+
+    // Filter out the newly created coin (created for recipient)
+    let created_coin = nodes.iter().find(|node| node.id_created).unwrap();
+    let created_output = created_coin.output_state.as_ref().unwrap();
+
+    // Created coin should only have output state
+    assert!(created_coin.input_state.is_none());
+    assert!(created_coin.output_state.is_some());
+    assert_eq!(created_output.version, 2);
+
+    // Created object should be SUI coins
+    let created_move_obj = created_output.as_move_object.as_ref().unwrap();
+    let created_type = created_move_obj
+        .pointer("/contents/type/repr")
+        .unwrap()
+        .as_str()
+        .unwrap();
+    assert_eq!(created_type, sui_coin_type);
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object.rs
@@ -465,7 +465,7 @@ impl Object {
     ) -> Self {
         // Set root_version since we're creating an object at a specific version
         let scope = scope.with_root_version(version.into());
-        let super_ = Address::with_address(scope.clone(), address);
+        let super_ = Address::with_address(scope, address);
 
         Self {
             super_,
@@ -974,7 +974,7 @@ impl Object {
                 if let Some(cached_object) = self
                     .super_
                     .scope
-                    .execution_output_object(self.super_.address.into(), version)
+                    .execution_output_object(self.super_.address.into(), version.into())
                 {
                     Ok(Some(cached_object.clone()))
                 } else {

--- a/crates/sui-indexer-alt-graphql/src/api/types/object_change.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object_change.rs
@@ -8,15 +8,13 @@ use crate::{api::scalars::sui_address::SuiAddress, scope::Scope};
 
 use super::object::Object;
 
-pub(crate) struct ObjectChange<'a> {
+pub(crate) struct ObjectChange {
     pub(crate) scope: Scope,
     pub(crate) native: NativeObjectChange,
-    pub(crate) input_object: Option<&'a sui_types::object::Object>,
-    pub(crate) output_object: Option<&'a sui_types::object::Object>,
 }
 
 #[Object]
-impl ObjectChange<'_> {
+impl ObjectChange {
     /// The address of the object that has changed.
     async fn address(&self) -> SuiAddress {
         self.native.id.into()
@@ -24,14 +22,6 @@ impl ObjectChange<'_> {
 
     /// The contents of the object immediately before the transaction.
     async fn input_state(&self) -> Option<Object> {
-        // Use execution data if available
-        if let Some(input_obj) = self.input_object {
-            return Some(Object::from_contents(
-                self.scope.clone(),
-                input_obj.clone(),
-            ));
-        }
-
         let NativeObjectChange {
             id,
             input_version: Some(version),
@@ -47,14 +37,6 @@ impl ObjectChange<'_> {
 
     /// The contents of the object immediately after the transaction.
     async fn output_state(&self) -> Option<Object> {
-        // Use execution data if available
-        if let Some(output_obj) = self.output_object {
-            return Some(Object::from_contents(
-                self.scope.clone(),
-                output_obj.clone(),
-            ));
-        }
-
         let NativeObjectChange {
             id,
             output_version: Some(version),

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -306,9 +306,21 @@ impl EffectsContents {
 
         let mut conn = Connection::new(cursors.has_previous_page, cursors.has_next_page);
         for edge in cursors.edges {
+            let native_change = &object_changes[*edge.cursor];
+
+            // Look up input and output objects from execution data if available
+            let input_object = native_change
+                .input_version
+                .and_then(|version| content.executed_input_object(native_change.id, version));
+            let output_object = native_change
+                .output_version
+                .and_then(|version| content.executed_output_object(native_change.id, version));
+
             let object_change = ObjectChange {
                 scope: self.scope.clone(),
-                native: object_changes[*edge.cursor].clone(),
+                native: native_change.clone(),
+                input_object,
+                output_object,
             };
 
             conn.edges
@@ -408,12 +420,31 @@ impl TransactionEffects {
         transaction_data: TransactionData,
         signatures: Vec<GenericSignature>,
     ) -> Self {
+        use std::collections::HashMap;
+        use sui_types::base_types::{ObjectID, SequenceNumber};
+
         let digest = *response.effects.transaction_digest();
+
+        let input_objects: HashMap<(ObjectID, SequenceNumber), sui_types::object::Object> =
+            response
+                .input_objects
+                .into_iter()
+                .map(|obj| ((obj.id(), obj.version()), obj))
+                .collect();
+        let output_objects: HashMap<(ObjectID, SequenceNumber), sui_types::object::Object> =
+            response
+                .output_objects
+                .into_iter()
+                .map(|obj| ((obj.id(), obj.version()), obj))
+                .collect();
+
         let contents = NativeTransactionContents::ExecutedTransaction {
             effects: Box::new(response.effects),
             events: response.events.map(|events| events.data),
             transaction_data: Box::new(transaction_data),
             signatures,
+            input_objects,
+            output_objects,
         };
 
         Self {

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -306,11 +306,9 @@ impl EffectsContents {
 
         let mut conn = Connection::new(cursors.has_previous_page, cursors.has_next_page);
         for edge in cursors.edges {
-            let native_change = &object_changes[*edge.cursor];
-
             let object_change = ObjectChange {
                 scope: self.scope.clone(),
-                native: native_change.clone(),
+                native: object_changes[*edge.cursor].clone(),
             };
 
             conn.edges

--- a/crates/sui-indexer-alt-graphql/src/scope.rs
+++ b/crates/sui-indexer-alt-graphql/src/scope.rs
@@ -1,11 +1,15 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use async_graphql::Context;
 use sui_indexer_alt_reader::package_resolver::PackageCache;
 use sui_package_resolver::{PackageStore, Resolver};
+use sui_types::{
+    base_types::{ObjectID, SequenceNumber},
+    object::Object as NativeObject,
+};
 
 use crate::{config::Limits, error::RpcError, task::watermark::Watermarks};
 
@@ -35,6 +39,11 @@ pub(crate) struct Scope {
     /// the root object, and not the immediate parent.
     root_version: Option<u64>,
 
+    /// Cache of objects available in execution context (freshly executed transaction).
+    /// Maps (ObjectID, SequenceNumber) to the actual object data.
+    /// This enables any Object GraphQL type to access fresh data without database queries.
+    execution_objects: HashMap<(ObjectID, SequenceNumber), NativeObject>,
+
     /// Access to packages for type resolution.
     package_store: Arc<dyn PackageStore>,
 
@@ -53,6 +62,7 @@ impl Scope {
         Ok(Self {
             checkpoint_viewed_at: Some(watermark.high_watermark().checkpoint()),
             root_version: None,
+            execution_objects: HashMap::new(),
             package_store: package_store.clone(),
             resolver_limits: limits.package_resolver(),
         })
@@ -65,6 +75,7 @@ impl Scope {
         (checkpoint_viewed_at <= current_cp).then(|| Self {
             checkpoint_viewed_at: Some(checkpoint_viewed_at),
             root_version: self.root_version,
+            execution_objects: self.execution_objects.clone(),
             package_store: self.package_store.clone(),
             resolver_limits: self.resolver_limits.clone(),
         })
@@ -76,6 +87,26 @@ impl Scope {
         Self {
             checkpoint_viewed_at: None,
             root_version: self.root_version,
+            execution_objects: self.execution_objects.clone(),
+            package_store: self.package_store.clone(),
+            resolver_limits: self.resolver_limits.clone(),
+        }
+    }
+
+    /// Create a nested scope for execution context with a batch of execution objects.
+    pub(crate) fn with_execution_objects<I>(&self, objects: I) -> Self
+    where
+        I: IntoIterator<Item = NativeObject>,
+    {
+        let execution_objects = objects
+            .into_iter()
+            .map(|obj| ((obj.id(), obj.version()), obj))
+            .collect();
+
+        Self {
+            checkpoint_viewed_at: self.checkpoint_viewed_at,
+            root_version: self.root_version,
+            execution_objects,
             package_store: self.package_store.clone(),
             resolver_limits: self.resolver_limits.clone(),
         }
@@ -86,6 +117,7 @@ impl Scope {
         Self {
             checkpoint_viewed_at: self.checkpoint_viewed_at,
             root_version: Some(root_version),
+            execution_objects: self.execution_objects.clone(),
             package_store: self.package_store.clone(),
             resolver_limits: self.resolver_limits.clone(),
         }
@@ -96,6 +128,7 @@ impl Scope {
         Self {
             checkpoint_viewed_at: self.checkpoint_viewed_at,
             root_version: None,
+            execution_objects: self.execution_objects.clone(),
             package_store: self.package_store.clone(),
             resolver_limits: self.resolver_limits.clone(),
         }
@@ -120,6 +153,15 @@ impl Scope {
     /// Returns `None` in execution context (freshly executed transaction).
     pub(crate) fn checkpoint_viewed_at_exclusive_bound(&self) -> Option<u64> {
         self.checkpoint_viewed_at.map(|cp| cp + 1)
+    }
+
+    /// Get an object from the execution context cache, if available.
+    pub(crate) fn execution_output_object(
+        &self,
+        object_id: ObjectID,
+        version: SequenceNumber,
+    ) -> Option<&NativeObject> {
+        self.execution_objects.get(&(object_id, version))
     }
 
     /// A package resolver with access to the packages known at this scope.


### PR DESCRIPTION
## Description 

This PR implements the logic to load object contents (under `objectChanges` in `TransactionEffects`) from just-executed transaction data. This will help us avoid unnecessary DB lookup since the data is already returned by gRPC execution method


## Test plan 

How did you test the new or updated feature?

```
cargo check -p sui-indexer-alt-graphql
```

---

## Stack
- #23145 
- #23332 
- #23351 
- #23398
- #23426 ⬅️

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
