### PR TITLE
graphql-alt: MoveStruct

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/packages/modules/structs.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/packages/modules/structs.move
@@ -1,0 +1,106 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --addresses P0=0x0 P1=0x0 --simulator
+
+//# run-graphql
+{
+  package(address: "0x2") {
+    coin: module(name: "coin") {
+      struct(name: "Coin") { ...S }
+    }
+
+    tx_context: module(name: "tx_context") {
+      struct(name: "TxContext") { ...S }
+    }
+  }
+}
+
+fragment S on MoveStruct {
+  name
+  abilities
+  typeParameters {
+    constraints
+    isPhantom
+  }
+  fields {
+    name
+    type {
+      repr
+      signature
+    }
+  }
+}
+
+//# publish --upgradeable --sender A
+module P0::M {
+  public struct S has copy, drop { x: u64 }
+}
+
+//# upgrade --package P0 --upgrade-capability 2,1 --sender A
+module P1::M {
+  public struct S has copy, drop { x: u64 }
+  public struct T<U: drop> { y: u64, s: S, u: U }
+  public struct V { t: T<S> }
+}
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  packageVersions(address: "@{P0}") {
+    nodes {
+      version
+      module(name: "M") {
+        structs {
+          nodes { ...S }
+        }
+      }
+    }
+  }
+}
+
+fragment S on MoveStruct {
+  name
+  abilities
+  typeParameters {
+    constraints
+    isPhantom
+  }
+  fields {
+    name
+    type {
+      repr
+      signature
+    }
+  }
+}
+
+//# run-graphql --cursors "Coin" "TreasuryCap"
+{
+  package(address: "0x2") {
+    module(name: "coin") {
+      all: structs(first: 50) { ...S }
+      first: structs(first: 3) { ...S }
+      last: structs(last: 3) { ...S }
+
+      firstBefore: structs(first: 3, before: "@{cursor_1}") { ...S }
+      lastAfter: structs(last: 3, after: "@{cursor_0}") { ...S }
+
+      firstAfter: structs(first: 3, after: "@{cursor_0}") { ...S }
+      lastBefore: structs(last: 3, before: "@{cursor_1}") { ...S }
+
+      afterBefore: structs(after: "@{cursor_0}", before: "@{cursor_1}") { ...S }
+    }
+  }
+}
+
+fragment S on MoveStructConnection {
+  pageInfo {
+    hasPreviousPage
+    hasNextPage
+  }
+  nodes {
+    name
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/packages/modules/structs.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/packages/modules/structs.snap
@@ -1,0 +1,470 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 7 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-33:
+//# run-graphql
+Response: {
+  "data": {
+    "package": {
+      "coin": {
+        "struct": {
+          "name": "Coin",
+          "abilities": [
+            "STORE",
+            "KEY"
+          ],
+          "typeParameters": [
+            {
+              "constraints": [],
+              "isPhantom": true
+            }
+          ],
+          "fields": [
+            {
+              "name": "id",
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::object::UID",
+                "signature": {
+                  "ref": null,
+                  "body": {
+                    "datatype": {
+                      "package": "0x0000000000000000000000000000000000000000000000000000000000000002",
+                      "module": "object",
+                      "type": "UID",
+                      "typeParameters": []
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "name": "balance",
+              "type": {
+                "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::balance::Balance<$0>",
+                "signature": {
+                  "ref": null,
+                  "body": {
+                    "datatype": {
+                      "package": "0x0000000000000000000000000000000000000000000000000000000000000002",
+                      "module": "balance",
+                      "type": "Balance",
+                      "typeParameters": [
+                        {
+                          "typeParameter": 0
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "tx_context": {
+        "struct": {
+          "name": "TxContext",
+          "abilities": [
+            "DROP"
+          ],
+          "typeParameters": [],
+          "fields": [
+            {
+              "name": "sender",
+              "type": {
+                "repr": "address",
+                "signature": {
+                  "ref": null,
+                  "body": "address"
+                }
+              }
+            },
+            {
+              "name": "tx_hash",
+              "type": {
+                "repr": "vector<u8>",
+                "signature": {
+                  "ref": null,
+                  "body": {
+                    "vector": "u8"
+                  }
+                }
+              }
+            },
+            {
+              "name": "epoch",
+              "type": {
+                "repr": "u64",
+                "signature": {
+                  "ref": null,
+                  "body": "u64"
+                }
+              }
+            },
+            {
+              "name": "epoch_timestamp_ms",
+              "type": {
+                "repr": "u64",
+                "signature": {
+                  "ref": null,
+                  "body": "u64"
+                }
+              }
+            },
+            {
+              "name": "ids_created",
+              "type": {
+                "repr": "u64",
+                "signature": {
+                  "ref": null,
+                  "body": "u64"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+
+task 2, lines 35-38:
+//# publish --upgradeable --sender A
+created: object(2,0), object(2,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5213600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 40-45:
+//# upgrade --package P0 --upgrade-capability 2,1 --sender A
+created: object(3,0)
+mutated: object(0,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 6049600,  storage_rebate: 2595780, non_refundable_storage_fee: 26220
+
+task 4, line 47:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 5, lines 49-77:
+//# run-graphql
+Response: {
+  "data": {
+    "packageVersions": {
+      "nodes": [
+        {
+          "version": 1,
+          "module": {
+            "structs": {
+              "nodes": [
+                {
+                  "name": "S",
+                  "abilities": [
+                    "COPY",
+                    "DROP"
+                  ],
+                  "typeParameters": [],
+                  "fields": [
+                    {
+                      "name": "x",
+                      "type": {
+                        "repr": "u64",
+                        "signature": {
+                          "ref": null,
+                          "body": "u64"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "version": 2,
+          "module": {
+            "structs": {
+              "nodes": [
+                {
+                  "name": "S",
+                  "abilities": [
+                    "COPY",
+                    "DROP"
+                  ],
+                  "typeParameters": [],
+                  "fields": [
+                    {
+                      "name": "x",
+                      "type": {
+                        "repr": "u64",
+                        "signature": {
+                          "ref": null,
+                          "body": "u64"
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "name": "T",
+                  "abilities": [],
+                  "typeParameters": [
+                    {
+                      "constraints": [
+                        "DROP"
+                      ],
+                      "isPhantom": false
+                    }
+                  ],
+                  "fields": [
+                    {
+                      "name": "y",
+                      "type": {
+                        "repr": "u64",
+                        "signature": {
+                          "ref": null,
+                          "body": "u64"
+                        }
+                      }
+                    },
+                    {
+                      "name": "s",
+                      "type": {
+                        "repr": "0x76d80fe27d06a6665b97b75cfa75c8168e12079171197eea9d8f447abc4a0be6::M::S",
+                        "signature": {
+                          "ref": null,
+                          "body": {
+                            "datatype": {
+                              "package": "0x76d80fe27d06a6665b97b75cfa75c8168e12079171197eea9d8f447abc4a0be6",
+                              "module": "M",
+                              "type": "S",
+                              "typeParameters": []
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "name": "u",
+                      "type": {
+                        "repr": "$0",
+                        "signature": {
+                          "ref": null,
+                          "body": {
+                            "typeParameter": 0
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "name": "V",
+                  "abilities": [],
+                  "typeParameters": [],
+                  "fields": [
+                    {
+                      "name": "t",
+                      "type": {
+                        "repr": "0x76d80fe27d06a6665b97b75cfa75c8168e12079171197eea9d8f447abc4a0be6::M::T<0x76d80fe27d06a6665b97b75cfa75c8168e12079171197eea9d8f447abc4a0be6::M::S>",
+                        "signature": {
+                          "ref": null,
+                          "body": {
+                            "datatype": {
+                              "package": "0x76d80fe27d06a6665b97b75cfa75c8168e12079171197eea9d8f447abc4a0be6",
+                              "module": "M",
+                              "type": "T",
+                              "typeParameters": [
+                                {
+                                  "datatype": {
+                                    "package": "0x76d80fe27d06a6665b97b75cfa75c8168e12079171197eea9d8f447abc4a0be6",
+                                    "module": "M",
+                                    "type": "S",
+                                    "typeParameters": []
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+task 6, lines 79-106:
+//# run-graphql --cursors "Coin" "TreasuryCap"
+Response: {
+  "data": {
+    "package": {
+      "module": {
+        "all": {
+          "pageInfo": {
+            "hasPreviousPage": false,
+            "hasNextPage": false
+          },
+          "nodes": [
+            {
+              "name": "Coin"
+            },
+            {
+              "name": "CoinMetadata"
+            },
+            {
+              "name": "CurrencyCreated"
+            },
+            {
+              "name": "DenyCap"
+            },
+            {
+              "name": "DenyCapV2"
+            },
+            {
+              "name": "RegulatedCoinMetadata"
+            },
+            {
+              "name": "TreasuryCap"
+            }
+          ]
+        },
+        "first": {
+          "pageInfo": {
+            "hasPreviousPage": false,
+            "hasNextPage": true
+          },
+          "nodes": [
+            {
+              "name": "Coin"
+            },
+            {
+              "name": "CoinMetadata"
+            },
+            {
+              "name": "CurrencyCreated"
+            }
+          ]
+        },
+        "last": {
+          "pageInfo": {
+            "hasPreviousPage": true,
+            "hasNextPage": false
+          },
+          "nodes": [
+            {
+              "name": "DenyCapV2"
+            },
+            {
+              "name": "RegulatedCoinMetadata"
+            },
+            {
+              "name": "TreasuryCap"
+            }
+          ]
+        },
+        "firstBefore": {
+          "pageInfo": {
+            "hasPreviousPage": false,
+            "hasNextPage": true
+          },
+          "nodes": [
+            {
+              "name": "Coin"
+            },
+            {
+              "name": "CoinMetadata"
+            },
+            {
+              "name": "CurrencyCreated"
+            }
+          ]
+        },
+        "lastAfter": {
+          "pageInfo": {
+            "hasPreviousPage": true,
+            "hasNextPage": false
+          },
+          "nodes": [
+            {
+              "name": "DenyCapV2"
+            },
+            {
+              "name": "RegulatedCoinMetadata"
+            },
+            {
+              "name": "TreasuryCap"
+            }
+          ]
+        },
+        "firstAfter": {
+          "pageInfo": {
+            "hasPreviousPage": true,
+            "hasNextPage": true
+          },
+          "nodes": [
+            {
+              "name": "CoinMetadata"
+            },
+            {
+              "name": "CurrencyCreated"
+            },
+            {
+              "name": "DenyCap"
+            }
+          ]
+        },
+        "lastBefore": {
+          "pageInfo": {
+            "hasPreviousPage": true,
+            "hasNextPage": true
+          },
+          "nodes": [
+            {
+              "name": "DenyCap"
+            },
+            {
+              "name": "DenyCapV2"
+            },
+            {
+              "name": "RegulatedCoinMetadata"
+            }
+          ]
+        },
+        "afterBefore": {
+          "pageInfo": {
+            "hasPreviousPage": true,
+            "hasNextPage": true
+          },
+          "nodes": [
+            {
+              "name": "CoinMetadata"
+            },
+            {
+              "name": "CurrencyCreated"
+            },
+            {
+              "name": "DenyCap"
+            },
+            {
+              "name": "DenyCapV2"
+            },
+            {
+              "name": "RegulatedCoinMetadata"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -1507,6 +1507,35 @@ type MoveCallCommand {
 }
 
 """
+Declaration of a type parameter on a Move struct.
+"""
+type MoveDatatypeTypeParameter {
+	"""
+	Ability constraints on this type parameter.
+	"""
+	constraints: [MoveAbility!]!
+	"""
+	Whether this type parameter is marked `phantom` or not.
+	
+	Phantom type parameters are not referenced in the struct's fields.
+	"""
+	isPhantom: Boolean!
+}
+
+type MoveField {
+	"""
+	The field's name.
+	"""
+	name: String
+	"""
+	The field's type.
+	
+	This type can reference type parameters introduced by the defining struct (see `typeParameters`).
+	"""
+	type: OpenMoveType
+}
+
+"""
 A function defined in a Move module.
 """
 type MoveFunction {
@@ -1619,6 +1648,14 @@ type MoveModule {
 	The package that this module was defined in.
 	"""
 	package: MovePackage
+	"""
+	The struct named `name` in this module.
+	"""
+	struct(name: String!): MoveStruct
+	"""
+	Paginate through this module's struct definitions.
+	"""
+	structs(first: Int, after: String, last: Int, before: String): MoveStructConnection
 }
 
 type MoveModuleConnection {
@@ -1930,6 +1967,65 @@ type MovePackageEdge {
 	The item at the end of the edge
 	"""
 	node: MovePackage!
+}
+
+"""
+Description of a struct type, defined in a Move module.
+"""
+type MoveStruct {
+	"""
+	Abilities on this struct definition.
+	"""
+	abilities: [MoveAbility!]
+	"""
+	The names and types of the struct's fields.
+	
+	Field types reference type parameters by their index in the defining struct's `typeParameters` list.
+	"""
+	fields: [MoveField!]
+	"""
+	The module that this struct is defined in.
+	"""
+	module: MoveModule!
+	"""
+	The struct's unqualified name.
+	"""
+	name: String!
+	"""
+	Constraints on the struct's formal type parameters.
+	
+	Move bytecode does not name type parameters, so when they are referenced (e.g. in field types), they are identified by their index in this list.
+	"""
+	typeParameters: [MoveDatatypeTypeParameter!]
+}
+
+type MoveStructConnection {
+	"""
+	A list of edges.
+	"""
+	edges: [MoveStructEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [MoveStruct!]!
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type MoveStructEdge {
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+	"""
+	The item at the end of the edge
+	"""
+	node: MoveStruct!
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod gas;
 pub(crate) mod gas_effects;
 pub(crate) mod gas_input;
 mod linkage;
+pub(crate) mod move_datatype;
 pub(crate) mod move_function;
 pub(crate) mod move_module;
 pub(crate) mod move_object;

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_datatype.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_datatype.rs
@@ -1,0 +1,166 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use async_graphql::{Context, Object, SimpleObject};
+use sui_package_resolver::{DataDef, MoveData, OpenSignatureBody};
+use tokio::sync::OnceCell;
+
+use crate::error::RpcError;
+
+use super::{
+    move_module::MoveModule,
+    move_type::{abilities, MoveAbility},
+    open_move_type::OpenMoveType,
+};
+
+pub(crate) struct MoveStruct {
+    /// The module that this struct is defined in.
+    module: MoveModule,
+
+    /// The struct's unqualified name.
+    name: String,
+
+    /// The lazily loaded definition of the struct.
+    contents: Arc<OnceCell<Option<DataDef>>>,
+}
+
+/// Declaration of a type parameter on a Move struct.
+#[derive(SimpleObject)]
+pub(crate) struct MoveDatatypeTypeParameter {
+    /// Ability constraints on this type parameter.
+    constraints: Vec<MoveAbility>,
+
+    /// Whether this type parameter is marked `phantom` or not.
+    ///
+    /// Phantom type parameters are not referenced in the struct's fields.
+    is_phantom: bool,
+}
+
+struct MoveField<'f> {
+    name: &'f str,
+    type_: &'f OpenSignatureBody,
+}
+
+/// Description of a struct type, defined in a Move module.
+#[Object]
+impl MoveStruct {
+    /// The module that this struct is defined in.
+    async fn module(&self) -> &MoveModule {
+        &self.module
+    }
+
+    /// The struct's unqualified name.
+    async fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Abilities on this struct definition.
+    async fn abilities(&self, ctx: &Context<'_>) -> Result<Option<Vec<MoveAbility>>, RpcError> {
+        let Some(def) = self.contents(ctx).await? else {
+            return Ok(None);
+        };
+
+        Ok(Some(abilities(def.abilities)))
+    }
+
+    /// The names and types of the struct's fields.
+    ///
+    /// Field types reference type parameters by their index in the defining struct's `typeParameters` list.
+    async fn fields(&self, ctx: &Context<'_>) -> Result<Option<Vec<MoveField<'_>>>, RpcError> {
+        let Some(def) = self.contents(ctx).await? else {
+            return Ok(None);
+        };
+
+        let MoveData::Struct(fields) = &def.data else {
+            return Ok(None);
+        };
+
+        Ok(Some(
+            fields
+                .iter()
+                .map(|(name, type_)| MoveField {
+                    name: name.as_str(),
+                    type_,
+                })
+                .collect(),
+        ))
+    }
+
+    /// Constraints on the struct's formal type parameters.
+    ///
+    /// Move bytecode does not name type parameters, so when they are referenced (e.g. in field types), they are identified by their index in this list.
+    async fn type_parameters(
+        &self,
+        ctx: &Context<'_>,
+    ) -> Result<Option<Vec<MoveDatatypeTypeParameter>>, RpcError> {
+        let Some(def) = self.contents(ctx).await? else {
+            return Ok(None);
+        };
+
+        Ok(Some(
+            def.type_params
+                .iter()
+                .map(|param| MoveDatatypeTypeParameter {
+                    constraints: abilities(param.constraints),
+                    is_phantom: param.is_phantom,
+                })
+                .collect(),
+        ))
+    }
+}
+
+#[Object]
+impl MoveField<'_> {
+    /// The field's name.
+    async fn name(&self) -> Option<&str> {
+        Some(self.name)
+    }
+
+    /// The field's type.
+    ///
+    /// This type can reference type parameters introduced by the defining struct (see `typeParameters`).
+    async fn type_(&self) -> Option<OpenMoveType> {
+        Some(OpenMoveType::from(self.type_.clone()))
+    }
+}
+
+impl MoveStruct {
+    /// Construct a struct that is represented by its module and name. This does not check that the
+    /// datatype exists and is a struct, so should not be used to "fetch" a struct based on user
+    /// input.
+    pub(crate) fn with_fq_name(module: MoveModule, name: String) -> Self {
+        Self {
+            module,
+            name,
+            contents: Arc::new(OnceCell::new()),
+        }
+    }
+
+    /// Construct a struct with a pre-loaded struct definition. This does not check that the
+    /// datatype definition is for a struct, so it is the caller's responsibility to check that.
+    pub(crate) fn from_def(module: MoveModule, name: String, def: DataDef) -> Self {
+        Self {
+            module,
+            name,
+            contents: Arc::new(OnceCell::from(Some(def))),
+        }
+    }
+
+    async fn contents(&self, ctx: &Context<'_>) -> Result<&Option<DataDef>, RpcError> {
+        self.contents
+            .get_or_try_init(|| async {
+                let Some(module) = self.module.contents(ctx).await?.as_ref() else {
+                    return Ok(None);
+                };
+
+                Ok(module
+                    .parsed
+                    .struct_def(&self.name)
+                    .context("Failed to deserialize struct definition")?)
+            })
+            .await
+    }
+}

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_function.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_function.rs
@@ -121,9 +121,9 @@ impl MoveFunction {
 }
 
 impl MoveFunction {
-    /// Construct a function that is represented by its module and name. This does not
-    /// check that the function actually exists, so should not be used to "fetch" a function based on
-    /// user input.
+    /// Construct a function that is represented by its module and name. This does not check that
+    /// the function actually exists, so should not be used to "fetch" a function based on user
+    /// input.
     pub(crate) fn with_fq_name(module: MoveModule, name: String) -> Self {
         Self {
             module,

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_module.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_module.rs
@@ -21,7 +21,7 @@ use crate::{
     pagination::{Page, PaginationConfig},
 };
 
-use super::{move_function::MoveFunction, move_package::MovePackage};
+use super::{move_datatype::MoveStruct, move_function::MoveFunction, move_package::MovePackage};
 
 #[derive(Clone)]
 pub(crate) struct MoveModule {
@@ -58,6 +58,9 @@ type CFriend = JsonCursor<usize>;
 
 /// Cursor for iterating over functioons in a module. Points to the function by its name.
 type CFunction = JsonCursor<String>;
+
+/// Cursor for iterating over structs in a module. Points to the struct by its name.
+type CStruct = JsonCursor<String>;
 
 /// Modules are a unit of code organization in Move.
 ///
@@ -217,6 +220,76 @@ impl MoveModule {
             conn.edges.push(Edge::new(
                 JsonCursor::new(function.to_owned()).encode_cursor(),
                 MoveFunction::with_fq_name(self.clone(), function.to_owned()),
+            ));
+        }
+
+        Ok(Some(conn))
+    }
+
+    /// The struct named `name` in this module.
+    async fn r#struct(
+        &self,
+        ctx: &Context<'_>,
+        name: String,
+    ) -> Result<Option<MoveStruct>, RpcError> {
+        let Some(contents) = self.contents(ctx).await?.as_ref() else {
+            return Ok(None);
+        };
+
+        let Some(def) = contents
+            .parsed
+            .struct_def(&name)
+            .context("Failed to get struct definition")?
+        else {
+            return Ok(None);
+        };
+
+        Ok(Some(MoveStruct::from_def(self.clone(), name, def)))
+    }
+
+    /// Paginate through this module's struct definitions.
+    async fn structs(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<CStruct>,
+        last: Option<u64>,
+        before: Option<CStruct>,
+    ) -> Result<Option<Connection<String, MoveStruct>>, RpcError> {
+        let pagination: &PaginationConfig = ctx.data()?;
+        let limits = pagination.limits("MoveModule", "structs");
+        let page = Page::from_params(limits, first, after, last, before)?;
+
+        let Some(contents) = self.contents(ctx).await?.as_ref() else {
+            return Ok(None);
+        };
+
+        let struct_range = contents.parsed.structs(
+            page.after().map(|c| c.as_ref()),
+            page.before().map(|c| c.as_ref()),
+        );
+
+        let mut conn = Connection::new(false, false);
+        let structs = if page.is_from_front() {
+            struct_range.take(page.limit()).collect()
+        } else {
+            let mut ss: Vec<_> = struct_range.rev().take(page.limit()).collect();
+            ss.reverse();
+            ss
+        };
+
+        conn.has_previous_page = structs
+            .first()
+            .is_some_and(|fst| contents.parsed.structs(None, Some(fst)).next().is_some());
+
+        conn.has_next_page = structs
+            .last()
+            .is_some_and(|lst| contents.parsed.structs(Some(lst), None).next().is_some());
+
+        for struct_name in structs {
+            conn.edges.push(Edge::new(
+                JsonCursor::new(struct_name.to_owned()).encode_cursor(),
+                MoveStruct::with_fq_name(self.clone(), struct_name.to_owned()),
             ));
         }
 

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -1511,6 +1511,35 @@ type MoveCallCommand {
 }
 
 """
+Declaration of a type parameter on a Move struct.
+"""
+type MoveDatatypeTypeParameter {
+	"""
+	Ability constraints on this type parameter.
+	"""
+	constraints: [MoveAbility!]!
+	"""
+	Whether this type parameter is marked `phantom` or not.
+	
+	Phantom type parameters are not referenced in the struct's fields.
+	"""
+	isPhantom: Boolean!
+}
+
+type MoveField {
+	"""
+	The field's name.
+	"""
+	name: String
+	"""
+	The field's type.
+	
+	This type can reference type parameters introduced by the defining struct (see `typeParameters`).
+	"""
+	type: OpenMoveType
+}
+
+"""
 A function defined in a Move module.
 """
 type MoveFunction {
@@ -1623,6 +1652,14 @@ type MoveModule {
 	The package that this module was defined in.
 	"""
 	package: MovePackage
+	"""
+	The struct named `name` in this module.
+	"""
+	struct(name: String!): MoveStruct
+	"""
+	Paginate through this module's struct definitions.
+	"""
+	structs(first: Int, after: String, last: Int, before: String): MoveStructConnection
 }
 
 type MoveModuleConnection {
@@ -1934,6 +1971,65 @@ type MovePackageEdge {
 	The item at the end of the edge
 	"""
 	node: MovePackage!
+}
+
+"""
+Description of a struct type, defined in a Move module.
+"""
+type MoveStruct {
+	"""
+	Abilities on this struct definition.
+	"""
+	abilities: [MoveAbility!]
+	"""
+	The names and types of the struct's fields.
+	
+	Field types reference type parameters by their index in the defining struct's `typeParameters` list.
+	"""
+	fields: [MoveField!]
+	"""
+	The module that this struct is defined in.
+	"""
+	module: MoveModule!
+	"""
+	The struct's unqualified name.
+	"""
+	name: String!
+	"""
+	Constraints on the struct's formal type parameters.
+	
+	Move bytecode does not name type parameters, so when they are referenced (e.g. in field types), they are identified by their index in this list.
+	"""
+	typeParameters: [MoveDatatypeTypeParameter!]
+}
+
+type MoveStructConnection {
+	"""
+	A list of edges.
+	"""
+	edges: [MoveStructEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [MoveStruct!]!
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type MoveStructEdge {
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+	"""
+	The item at the end of the edge
+	"""
+	node: MoveStruct!
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -1511,6 +1511,35 @@ type MoveCallCommand {
 }
 
 """
+Declaration of a type parameter on a Move struct.
+"""
+type MoveDatatypeTypeParameter {
+	"""
+	Ability constraints on this type parameter.
+	"""
+	constraints: [MoveAbility!]!
+	"""
+	Whether this type parameter is marked `phantom` or not.
+	
+	Phantom type parameters are not referenced in the struct's fields.
+	"""
+	isPhantom: Boolean!
+}
+
+type MoveField {
+	"""
+	The field's name.
+	"""
+	name: String
+	"""
+	The field's type.
+	
+	This type can reference type parameters introduced by the defining struct (see `typeParameters`).
+	"""
+	type: OpenMoveType
+}
+
+"""
 A function defined in a Move module.
 """
 type MoveFunction {
@@ -1623,6 +1652,14 @@ type MoveModule {
 	The package that this module was defined in.
 	"""
 	package: MovePackage
+	"""
+	The struct named `name` in this module.
+	"""
+	struct(name: String!): MoveStruct
+	"""
+	Paginate through this module's struct definitions.
+	"""
+	structs(first: Int, after: String, last: Int, before: String): MoveStructConnection
 }
 
 type MoveModuleConnection {
@@ -1934,6 +1971,65 @@ type MovePackageEdge {
 	The item at the end of the edge
 	"""
 	node: MovePackage!
+}
+
+"""
+Description of a struct type, defined in a Move module.
+"""
+type MoveStruct {
+	"""
+	Abilities on this struct definition.
+	"""
+	abilities: [MoveAbility!]
+	"""
+	The names and types of the struct's fields.
+	
+	Field types reference type parameters by their index in the defining struct's `typeParameters` list.
+	"""
+	fields: [MoveField!]
+	"""
+	The module that this struct is defined in.
+	"""
+	module: MoveModule!
+	"""
+	The struct's unqualified name.
+	"""
+	name: String!
+	"""
+	Constraints on the struct's formal type parameters.
+	
+	Move bytecode does not name type parameters, so when they are referenced (e.g. in field types), they are identified by their index in this list.
+	"""
+	typeParameters: [MoveDatatypeTypeParameter!]
+}
+
+type MoveStructConnection {
+	"""
+	A list of edges.
+	"""
+	edges: [MoveStructEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [MoveStruct!]!
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type MoveStructEdge {
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+	"""
+	The item at the end of the edge
+	"""
+	node: MoveStruct!
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -1507,6 +1507,35 @@ type MoveCallCommand {
 }
 
 """
+Declaration of a type parameter on a Move struct.
+"""
+type MoveDatatypeTypeParameter {
+	"""
+	Ability constraints on this type parameter.
+	"""
+	constraints: [MoveAbility!]!
+	"""
+	Whether this type parameter is marked `phantom` or not.
+	
+	Phantom type parameters are not referenced in the struct's fields.
+	"""
+	isPhantom: Boolean!
+}
+
+type MoveField {
+	"""
+	The field's name.
+	"""
+	name: String
+	"""
+	The field's type.
+	
+	This type can reference type parameters introduced by the defining struct (see `typeParameters`).
+	"""
+	type: OpenMoveType
+}
+
+"""
 A function defined in a Move module.
 """
 type MoveFunction {
@@ -1619,6 +1648,14 @@ type MoveModule {
 	The package that this module was defined in.
 	"""
 	package: MovePackage
+	"""
+	The struct named `name` in this module.
+	"""
+	struct(name: String!): MoveStruct
+	"""
+	Paginate through this module's struct definitions.
+	"""
+	structs(first: Int, after: String, last: Int, before: String): MoveStructConnection
 }
 
 type MoveModuleConnection {
@@ -1930,6 +1967,65 @@ type MovePackageEdge {
 	The item at the end of the edge
 	"""
 	node: MovePackage!
+}
+
+"""
+Description of a struct type, defined in a Move module.
+"""
+type MoveStruct {
+	"""
+	Abilities on this struct definition.
+	"""
+	abilities: [MoveAbility!]
+	"""
+	The names and types of the struct's fields.
+	
+	Field types reference type parameters by their index in the defining struct's `typeParameters` list.
+	"""
+	fields: [MoveField!]
+	"""
+	The module that this struct is defined in.
+	"""
+	module: MoveModule!
+	"""
+	The struct's unqualified name.
+	"""
+	name: String!
+	"""
+	Constraints on the struct's formal type parameters.
+	
+	Move bytecode does not name type parameters, so when they are referenced (e.g. in field types), they are identified by their index in this list.
+	"""
+	typeParameters: [MoveDatatypeTypeParameter!]
+}
+
+type MoveStructConnection {
+	"""
+	A list of edges.
+	"""
+	edges: [MoveStructEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [MoveStruct!]!
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type MoveStructEdge {
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+	"""
+	The item at the end of the edge
+	"""
+	node: MoveStruct!
 }
 
 """


### PR DESCRIPTION
## Description

Introduce `MoveStruct`, as well as all its fields, and accessors on `MoveModule` to do point look-ups and pagination of structs.

## Test plan

New E2E tests:

```
$ cargo nextest run            \
  -p sui-indexer-alt-e2e-tests \
  -- graphql/packages/modules/structs
```

## Stack

- #23268 
- #23369 
- #23422
- #23423 
- #23424 
- #23425 
- #23438 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
