### PR TITLE
[1/n][bella-ciao][move-vm] Update native extensions to be cloneable

### DIFF
--- a/external-crates/move/crates/move-cli/src/sandbox/commands/publish.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/commands/publish.rs
@@ -10,7 +10,7 @@ use anyhow::{Result, bail};
 use move_package::compilation::compiled_package::CompiledPackage;
 use move_vm_runtime::{
     dev_utils::{gas_schedule::CostTable, storage::StoredPackage},
-    natives::{extensions::NativeContextExtensions, functions::NativeFunctions},
+    natives::{extensions::NativeExtensions, functions::NativeFunctions},
     runtime::MoveRuntime,
     shared::{linkage_context::LinkageContext, types::VersionId},
 };
@@ -97,7 +97,7 @@ pub fn publish(
         package_original_id,
         ser_pkg.clone(),
         &mut gas_status,
-        NativeContextExtensions::default(),
+        NativeExtensions::default(),
     )?;
     // TODO: Fix this?
     // if verbose {

--- a/external-crates/move/crates/move-unit-test/src/extensions.rs
+++ b/external-crates/move/crates/move-unit-test/src/extensions.rs
@@ -6,7 +6,7 @@
 //! Such extensions are enabled by cfg features and must be compiled into the test
 //! to be usable.
 
-use move_vm_runtime::natives::extensions::NativeContextExtensions;
+use move_vm_runtime::natives::extensions::{NativeContextExtensions, NativeExtensions};
 use once_cell::sync::Lazy;
 use std::sync::Mutex;
 
@@ -32,10 +32,10 @@ pub fn set_extension_hook(p: Box<dyn Fn(&mut NativeContextExtensions<'_>) + Send
 
 /// Create all available native context extensions.
 #[allow(unused_mut, clippy::let_and_return)]
-pub(crate) fn new_extensions<'a>() -> NativeContextExtensions<'a> {
-    let mut e = NativeContextExtensions::default();
+pub(crate) fn new_extensions<'a>() -> NativeExtensions<'a> {
+    let mut e = NativeExtensions::default();
     if let Some(h) = &*EXTENSION_HOOK.lock().unwrap() {
-        (*h)(&mut e)
+        (*h)(&mut e.write());
     }
     e
 }
@@ -51,7 +51,7 @@ mod tests {
     fn test_extension_hook() {
         set_extension_hook(Box::new(my_hook));
         let ext = new_extensions();
-        let _e = ext.get::<TestExtension>();
+        let _e = ext.read().get::<TestExtension>();
     }
 
     #[derive(Tid)]

--- a/external-crates/move/crates/move-unit-test/src/test_runner.rs
+++ b/external-crates/move/crates/move-unit-test/src/test_runner.rs
@@ -54,8 +54,6 @@ use std::{
 
 use parking_lot::RwLock;
 
-use move_vm_runtime::natives::extensions::NativeContextExtensions;
-
 /// Test state common to all tests
 pub struct SharedTestingConfig {
     report_stacktrace_on_abort: bool,
@@ -291,10 +289,7 @@ impl SharedTestingConfig {
         test_plan: &ModuleTestPlan,
         function_name: &str,
         arguments: Vec<MoveValue>,
-    ) -> (
-        VMResult<(Vec<Vec<u8>>, NativeContextExtensions)>,
-        TestRunInfo,
-    ) {
+    ) -> (VMResult<Vec<Vec<u8>>>, TestRunInfo) {
         // A nicety since Rust doesn't have `try { .. }` yet
         fn do_call(
             test_config: &SharedTestingConfig,
@@ -303,7 +298,7 @@ impl SharedTestingConfig {
             module_id: ModuleId,
             function_name: &str,
             arguments: Vec<MoveValue>,
-        ) -> VMResult<(Vec<Vec<u8>>, NativeContextExtensions<'extensions>)> {
+        ) -> VMResult<Vec<Vec<u8>>> {
             let link_context = test_config
                 .vm_test_adapter
                 .read()
@@ -324,13 +319,10 @@ impl SharedTestingConfig {
                 tracer,
             );
             serialized_return_values_result.map(|res| {
-                (
-                    res.return_values
-                        .into_iter()
-                        .map(|(bytes, _layout)| bytes)
-                        .collect::<Vec<_>>(),
-                    vm_instance.into_extensions(),
-                )
+                res.return_values
+                    .into_iter()
+                    .map(|(bytes, _layout)| bytes)
+                    .collect::<Vec<_>>()
             })
         }
 

--- a/external-crates/move/crates/move-vm-runtime/src/dev_utils/in_memory_test_adapter.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/dev_utils/in_memory_test_adapter.rs
@@ -8,7 +8,7 @@ use crate::{
         vm_test_adapter::VMTestAdapter,
     },
     execution::vm::MoveVM,
-    natives::{extensions::NativeContextExtensions, functions::NativeFunctions},
+    natives::{extensions::NativeExtensions, functions::NativeFunctions},
     runtime::MoveRuntime,
     shared::{
         linkage_context::LinkageContext,
@@ -130,7 +130,7 @@ impl VMTestAdapter<InMemoryStorage> for InMemoryTestAdapter {
             original_id,
             package.clone(),
             &mut gas_meter,
-            NativeContextExtensions::default(),
+            NativeExtensions::default(),
         )
     }
 
@@ -161,7 +161,7 @@ impl VMTestAdapter<InMemoryStorage> for InMemoryTestAdapter {
     fn make_vm_with_native_extensions<'extensions>(
         &self,
         linkage_context: LinkageContext,
-        native_extensions: NativeContextExtensions<'extensions>,
+        native_extensions: NativeExtensions<'extensions>,
     ) -> VMResult<MoveVM<'extensions>> {
         let Self { runtime, storage } = self;
         runtime.make_vm_with_native_extensions(storage, linkage_context, native_extensions)

--- a/external-crates/move/crates/move-vm-runtime/src/dev_utils/vm_test_adapter.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/dev_utils/vm_test_adapter.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     execution::vm::MoveVM,
-    natives::extensions::NativeContextExtensions,
+    natives::extensions::NativeExtensions,
     runtime::MoveRuntime,
     shared::{
         linkage_context::LinkageContext,
@@ -58,7 +58,7 @@ pub trait VMTestAdapter<Storage: ModuleResolver + Sync + Send> {
     fn make_vm_with_native_extensions<'extensions>(
         &self,
         linkage_context: LinkageContext,
-        native_extensions: NativeContextExtensions<'extensions>,
+        native_extensions: NativeExtensions<'extensions>,
     ) -> VMResult<MoveVM<'extensions>>;
 
     /// Generate a linkage context for a given version ID, original ID, and list of compiled modules.

--- a/external-crates/move/crates/move-vm-runtime/src/execution/vm.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/vm.rs
@@ -9,7 +9,7 @@ use crate::{
         interpreter::{self, locals::BaseHeap},
     },
     jit::execution::ast::{Function, Type, TypeSubst},
-    natives::extensions::NativeContextExtensions,
+    natives::extensions::NativeExtensions,
     shared::{
         gas::GasMeter,
         linkage_context::LinkageContext,
@@ -54,7 +54,7 @@ pub struct MoveVM<'extensions> {
     /// The linkage context used to create this VM instance
     pub(crate) link_context: LinkageContext,
     /// Native context extensions for the interpreter
-    pub(crate) native_extensions: NativeContextExtensions<'extensions>,
+    pub(crate) native_extensions: NativeExtensions<'extensions>,
     /// The Move VM's configuration.
     pub(crate) vm_config: Arc<VMConfig>,
     /// Move VM Base Heap, which holds base arguments, including reference return values, etc.
@@ -394,7 +394,7 @@ impl<'extensions> MoveVM<'extensions> {
         let return_values = interpreter::run(
             &mut self.virtual_tables,
             self.vm_config.clone(),
-            &mut self.native_extensions,
+            &mut self.native_extensions.write(),
             tracer,
             gas_meter,
             func,
@@ -428,11 +428,7 @@ impl<'extensions> MoveVM<'extensions> {
     // Into Methods
     // -------------------------------------------
 
-    pub fn into_extensions(self) -> NativeContextExtensions<'extensions> {
-        self.native_extensions
-    }
-
-    pub fn extensions(&self) -> &NativeContextExtensions<'extensions> {
+    pub fn extensions(&self) -> &NativeExtensions<'extensions> {
         &self.native_extensions
     }
 }

--- a/external-crates/move/crates/move-vm-runtime/src/natives/extensions.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/natives/extensions.rs
@@ -5,7 +5,8 @@
 use better_any::{Tid, TidExt};
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::vm_status::StatusCode;
-use std::{any::TypeId, collections::HashMap};
+use parking_lot::RwLock;
+use std::{any::TypeId, collections::HashMap, sync::Arc};
 
 /// A data type to represent a heterogeneous collection of extensions which are available to
 /// native functions. A value to this is passed into the session function execution.
@@ -19,6 +20,10 @@ use std::{any::TypeId, collections::HashMap};
 pub struct NativeContextExtensions<'a> {
     map: HashMap<TypeId, Box<dyn Tid<'a>>>,
 }
+
+/// Arc/RwLock wrapper around the NativeContextExtensions to allow for cloning and interior
+/// mutability of the `NativeContextExtensions`.
+pub type NativeExtensions<'a> = Arc<RwLock<NativeContextExtensions<'a>>>;
 
 /// A marker trait that is used to identify a native extension. We use this as opposed to `TidAble`
 /// since TidAble has auto implementations for various wrappers around a `TidAbles` which we don't

--- a/external-crates/move/crates/move-vm-runtime/src/natives/functions.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/natives/functions.rs
@@ -32,7 +32,7 @@ use move_core_types::{
     identifier::Identifier, language_storage::TypeTag, runtime_value as R, vm_status::StatusType,
 };
 use move_vm_config::runtime::VMRuntimeLimitsConfig;
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 use std::{
     cell::RefCell,
     collections::{HashMap, VecDeque},
@@ -63,7 +63,7 @@ macro_rules! pop_arg {
             None => {
                 return Err(PartialVMError::new(
                     StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
-                ))
+                ));
             }
             Some(Err(e)) => return Err(e),
             Some(Ok(v)) => v,

--- a/external-crates/move/crates/move-vm-runtime/src/runtime/mod.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/runtime/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     dbg_println,
     execution::{dispatch_tables::VMDispatchTables, interpreter::locals::BaseHeap, vm::MoveVM},
     jit,
-    natives::{extensions::NativeContextExtensions, functions::NativeFunctions},
+    natives::{extensions::NativeExtensions, functions::NativeFunctions},
     shared::{gas::GasMeter, linkage_context::LinkageContext, types::OriginalId},
     validation::{validate_for_publish, validate_for_vm_execution, verification::ast as verif_ast},
 };
@@ -86,18 +86,14 @@ impl MoveRuntime {
         data_cache: DataCache,
         link_context: LinkageContext,
     ) -> VMResult<MoveVM<'extensions>> {
-        self.make_vm_with_native_extensions(
-            data_cache,
-            link_context,
-            NativeContextExtensions::default(),
-        )
+        self.make_vm_with_native_extensions(data_cache, link_context, NativeExtensions::default())
     }
 
     pub fn make_vm_with_native_extensions<'extensions, DataCache: ModuleResolver>(
         &self,
         data_cache: DataCache,
         link_context: LinkageContext,
-        native_extensions: NativeContextExtensions<'extensions>,
+        native_extensions: NativeExtensions<'extensions>,
     ) -> VMResult<MoveVM<'extensions>> {
         let all_packages = link_context.all_packages()?;
 
@@ -128,7 +124,7 @@ impl MoveRuntime {
             virtual_tables,
             vm_config: self.vm_config.clone(),
             link_context,
-            native_extensions,
+            native_extensions: native_extensions.clone(),
             base_heap,
         };
         Ok(instance)
@@ -155,7 +151,7 @@ impl MoveRuntime {
         original_id: OriginalId,
         pkg: SerializedPackage,
         _gas_meter: &mut impl GasMeter,
-        native_extensions: NativeContextExtensions<'extensions>,
+        native_extensions: NativeExtensions<'extensions>,
     ) -> VMResult<(verif_ast::Package, MoveVM<'extensions>)> {
         let version_id = pkg.storage_id;
         dbg_println!("\n\nPublishing module at {version_id} (=> {original_id})\n\n");
@@ -207,7 +203,7 @@ impl MoveRuntime {
             virtual_tables,
             vm_config: self.vm_config.clone(),
             link_context,
-            native_extensions,
+            native_extensions: native_extensions.clone(),
             base_heap,
         };
         Ok((verified_pkg, instance))


### PR DESCRIPTION
This wraps the `NativeContextExtensions` in an `Arc<RwLock<` to allow cloneability and interior mutability. We could probably use a `RefCell` or `Mutex` instead of an `RwLock`, but figured this was the most in keeping with what we have elsewhere, and the most "safe" option. Happy to take feedback on it being something else though.

