### PR TITLE
[3/n][bella-ciao][sui-adapter] Remove link context from `RootedLinkage` and rename to `ExecutableLinkage`

### DIFF
--- a/sui-execution/latest/sui-adapter/src/data_store/linked_data_store.rs
+++ b/sui-execution/latest/sui-adapter/src/data_store/linked_data_store.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     data_store::PackageStore,
-    static_programmable_transactions::linkage::resolved_linkage::RootedLinkage,
+    static_programmable_transactions::linkage::resolved_linkage::ExecutableLinkage,
 };
 use move_core_types::{
     account_address::AccountAddress,
@@ -19,12 +19,12 @@ use sui_types::error::{SuiError, SuiResult};
 /// construct a valid `DataStore` for execution in the VM as it needs to be able to resolve modules
 /// under a specific linkage.
 pub struct LinkedDataStore<'a> {
-    pub linkage: &'a RootedLinkage,
+    pub linkage: &'a ExecutableLinkage,
     pub store: &'a dyn PackageStore,
 }
 
 impl<'a> LinkedDataStore<'a> {
-    pub fn new(linkage: &'a RootedLinkage, store: &'a dyn PackageStore) -> Self {
+    pub fn new(linkage: &'a ExecutableLinkage, store: &'a dyn PackageStore) -> Self {
         Self { linkage, store }
     }
 

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/analysis.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/analysis.rs
@@ -8,7 +8,7 @@ use crate::{
         config::ResolutionConfig,
         legacy_linkage,
         resolution::{ConflictResolution, ResolutionTable, add_and_unify, get_package},
-        resolved_linkage::ResolvedLinkage,
+        resolved_linkage::{ExecutableLinkage, ResolvedLinkage},
     },
 };
 use sui_protocol_config::ProtocolConfig;
@@ -51,7 +51,7 @@ pub fn linkage_analysis_for_protocol_config<Mode: ExecutionMode>(
 pub fn type_linkage(
     ids: &[ObjectID],
     store: &dyn PackageStore,
-) -> Result<ResolvedLinkage, ExecutionError> {
+) -> Result<ExecutableLinkage, ExecutionError> {
     let mut resolution_table = ResolutionTable::empty();
     for id in ids {
         let pkg = get_package(id, store)?;
@@ -77,5 +77,7 @@ pub fn type_linkage(
         }
     }
 
-    Ok(ResolvedLinkage::from_resolution_table(resolution_table))
+    Ok(ExecutableLinkage::new(
+        ResolvedLinkage::from_resolution_table(resolution_table),
+    ))
 }

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/ast.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/ast.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::static_programmable_transactions::linkage::resolved_linkage::{
-    ResolvedLinkage, RootedLinkage,
+    ExecutableLinkage, ResolvedLinkage,
 };
 use indexmap::IndexSet;
 use move_binary_format::file_format::{
@@ -126,7 +126,7 @@ pub struct LoadedFunction {
     pub name: Identifier,
     pub type_arguments: Vec<Type>,
     pub signature: LoadedFunctionInstantiation,
-    pub linkage: RootedLinkage,
+    pub linkage: ExecutableLinkage,
     pub instruction_length: CodeOffset,
     pub definition_index: FunctionDefinitionIndex,
     pub visibility: Visibility,

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/translate.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/translate.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::static_programmable_transactions::{
-    env::Env, linkage::resolved_linkage::RootedLinkage, loading::ast as L,
+    env::Env, linkage::resolved_linkage::ExecutableLinkage, loading::ast as L,
 };
 use move_core_types::language_storage::StructTag;
 use sui_types::{
@@ -101,7 +101,7 @@ fn command(env: &Env, command: P::Command) -> Result<L::Command, ExecutionError>
                 type_arguments: ptype_arguments,
                 arguments,
             } = *pmc;
-            let linkage = RootedLinkage::new(*package, resolved_linkage);
+            let linkage = ExecutableLinkage::new(resolved_linkage);
             let type_arguments = ptype_arguments
                 .into_iter()
                 .enumerate()

--- a/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
+++ b/sui-execution/latest/sui-adapter/src/type_layout_resolver.rs
@@ -4,7 +4,6 @@
 use crate::data_store::cached_package_store::CachedPackageStore;
 use crate::data_store::linked_data_store::LinkedDataStore;
 use crate::static_programmable_transactions::linkage::analysis::type_linkage;
-use crate::static_programmable_transactions::linkage::resolved_linkage::RootedLinkage;
 use move_core_types::annotated_value as A;
 use move_core_types::language_storage::StructTag;
 use move_vm_runtime::runtime::MoveRuntime;
@@ -37,7 +36,6 @@ impl LayoutResolver for TypeLayoutResolver<'_, '_> {
         &mut self,
         struct_tag: &StructTag,
     ) -> Result<A::MoveDatatypeLayout, SuiError> {
-        let root_address = struct_tag.address.into();
         let ids = struct_tag
             .all_addresses()
             .into_iter()
@@ -45,8 +43,7 @@ impl LayoutResolver for TypeLayoutResolver<'_, '_> {
             .collect::<Vec<_>>();
         let tag_linkage = type_linkage(&ids, &self.resolver)?;
         let link_context = tag_linkage.linkage_context();
-        let rooted_linkage = RootedLinkage::new(root_address, tag_linkage);
-        let data_store = LinkedDataStore::new(&rooted_linkage, &self.resolver);
+        let data_store = LinkedDataStore::new(&tag_linkage, &self.resolver);
         let Ok(vm) = self.vm.make_vm(data_store, link_context) else {
             return Err(SuiError::FailObjectLayout {
                 st: format!("{}", struct_tag),


### PR DESCRIPTION
In the new VM we no longer need the link context and therefore no longer need a "rooted" linkage so rename it to `ExecutableLinkage` and remove the link context. This cleans up a bunch of little areas where we were creating linkages (esp. from types). 