### PR TITLE
graphql-alt: Add TransactionFilter.sentAddress

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/filter/affected_address.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/filter/affected_address.snap
@@ -50,7 +50,7 @@ task 9, line 41:
 //# create-checkpoint
 Checkpoint created: 5
 
-task 10, lines 43-69:
+task 10, lines 43-70:
 //# run-graphql
 Response: {
   "data": {
@@ -98,6 +98,28 @@ Response: {
             }
           }
         },
+        {
+          "cursor": "Ng==",
+          "node": {
+            "digest": "FWhG55VRbd5R18idh5VwGhmALvjCSDsm8whBEoVeVvpr",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 5,
+                "digest": "JBuK9Poczpwt2beck9eXbum6KNYiJSLfhR24BGQdMsMv"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "transactionsA_sentByC": {
+      "pageInfo": {
+        "startCursor": "Ng==",
+        "endCursor": "Ng==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
         {
           "cursor": "Ng==",
           "node": {

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/filter/sent_address.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/filter/sent_address.move
@@ -30,22 +30,14 @@ module Test::M1 {
 
 //# advance-epoch
 
-//# run Test::M1::create --sender A --args 1 @B
-
-//# create-checkpoint
-
-//# advance-epoch
-
-//# run Test::M1::create --sender C --args 2 @A
+//# run Test::M1::create --sender B --args 1 @A
 
 //# create-checkpoint
 
 //# run-graphql
 {
-  transactionsA: transactions(filter: { affectedAddress: "@{A}" }) { ...TX }
-  transactionsA_sentByC: transactions(filter: { affectedAddress: "@{A}", sentAddress: "@{C}" }) { ...TX }
-  transactionsB: transactions(filter: { affectedAddress: "@{B}" }) { ...TX }
-  transactionsC: transactions(filter: { affectedAddress: "@{C}" }) { ...TX }
+  transactionsA: transactions(filter: { sentAddress: "@{A}" }) { ...TX }
+  transactionsB: transactions(filter: { sentAddress: "@{B}" }) { ...TX }
 }
 
 fragment TX on TransactionConnection {

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/filter/sent_address.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/filter/sent_address.snap
@@ -1,0 +1,88 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 8 tasks
+
+init:
+A: object(0,0), B: object(0,1), C: object(0,2)
+
+task 1, lines 6-25:
+//# publish
+created: object(1,0)
+mutated: object(0,3)
+gas summary: computation_cost: 1000000, storage_cost: 5570800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 27:
+//# run Test::M1::create --sender A --args 0 @A
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 29:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, line 31:
+//# advance-epoch
+Epoch advanced: 1
+
+task 5, line 33:
+//# run Test::M1::create --sender B --args 1 @A
+created: object(5,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 6, line 35:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 7, lines 37-62:
+//# run-graphql
+Response: {
+  "data": {
+    "transactionsA": {
+      "pageInfo": {
+        "startCursor": "Mg==",
+        "endCursor": "Mg==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "Mg==",
+          "node": {
+            "digest": "4HNKX56jo22koiR5KGwVKTS4wuwzKrxroHCeeGaYpuMU",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 1,
+                "digest": "Cj5q38QZLxjVbxUY4V9FfiWbPCFr4hAAJBirteUorDXv"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "transactionsB": {
+      "pageInfo": {
+        "startCursor": "NA==",
+        "endCursor": "NA==",
+        "hasPreviousPage": false,
+        "hasNextPage": false
+      },
+      "edges": [
+        {
+          "cursor": "NA==",
+          "node": {
+            "digest": "2NaVm8WExVGjbVuT2So99qdhY2XNd7RxbKDstDqVE9Qg",
+            "effects": {
+              "checkpoint": {
+                "sequenceNumber": 3,
+                "digest": "9PyPNWMz5bmpWuyrW7jiKcFqHH1ErBBVCLyspra3nxoN"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -3533,6 +3533,10 @@ input TransactionFilter {
 	Filter to transaction that occurred strictly before the given checkpoint.
 	"""
 	beforeCheckpoint: UInt53
+	"""
+	Limit to transactions that were sent by the given address.
+	"""
+	sentAddress: SuiAddress
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/filter.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/filter.rs
@@ -28,6 +28,9 @@ pub(crate) struct TransactionFilter {
     /// Limit to transactions that interacted with the given address.
     /// The address could be a sender, sponsor, or recipient of the transaction.
     pub affected_address: Option<SuiAddress>,
+
+    /// Limit to transactions that were sent by the given address.
+    pub sent_address: Option<SuiAddress>,
 }
 
 pub(crate) struct TransactionFilterValidator;
@@ -70,6 +73,7 @@ impl TransactionFilter {
             at_checkpoint: intersect!(at_checkpoint, intersect::by_eq)?,
             before_checkpoint: intersect!(before_checkpoint, intersect::by_min)?,
             affected_address: intersect!(affected_address, intersect::by_eq)?,
+            sent_address: intersect!(sent_address, intersect::by_eq)?,
         })
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -3537,6 +3537,10 @@ input TransactionFilter {
 	Filter to transaction that occurred strictly before the given checkpoint.
 	"""
 	beforeCheckpoint: UInt53
+	"""
+	Limit to transactions that were sent by the given address.
+	"""
+	sentAddress: SuiAddress
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -3537,6 +3537,10 @@ input TransactionFilter {
 	Filter to transaction that occurred strictly before the given checkpoint.
 	"""
 	beforeCheckpoint: UInt53
+	"""
+	Limit to transactions that were sent by the given address.
+	"""
+	sentAddress: SuiAddress
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -3533,6 +3533,10 @@ input TransactionFilter {
 	Filter to transaction that occurred strictly before the given checkpoint.
 	"""
 	beforeCheckpoint: UInt53
+	"""
+	Limit to transactions that were sent by the given address.
+	"""
+	sentAddress: SuiAddress
 }
 
 """


### PR DESCRIPTION
## Description 

Implements the `TransactionFilter.sentAddress` filter both as an extension to the `affectedAddress` filter and as its own filter.

## Test plan 

Added a new test case to the `affected_address.move` test and a new `sent_address.move` test file.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
