### PR TITLE
graphql-alt: IMoveObject.hasPublicTransfer

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/has_public_transfer.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/has_public_transfer.move
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --addresses P=0x0 --simulator
+
+//# publish
+module P::M {
+  public struct Foo has key {
+    id: UID,
+  }
+
+  public fun new(ctx: &mut TxContext) {
+    transfer::transfer(Foo { id: object::new(ctx) }, ctx.sender());
+  }
+}
+
+//# programmable --sender A --inputs @A
+//> P::M::new();
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  coinHasPublicTransfer: object(address: "@{obj_0_0}") {
+    asMoveObject {
+      contents { type { repr abilities } }
+      hasPublicTransfer
+    }
+  }
+
+  fooDoesNot: object(address: "@{obj_2_0}") {
+    asMoveObject {
+      contents { type { repr abilities } }
+      hasPublicTransfer
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/has_public_transfer.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/has_public_transfer.snap
@@ -1,0 +1,58 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 5 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-15:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 4962800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 17-18:
+//# programmable --sender A --inputs @A
+//> P::M::new();
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2211600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, line 20:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, lines 22-37:
+//# run-graphql
+Response: {
+  "data": {
+    "coinHasPublicTransfer": {
+      "asMoveObject": {
+        "contents": {
+          "type": {
+            "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>",
+            "abilities": [
+              "STORE",
+              "KEY"
+            ]
+          }
+        },
+        "hasPublicTransfer": true
+      }
+    },
+    "fooDoesNot": {
+      "asMoveObject": {
+        "contents": {
+          "type": {
+            "repr": "0x133f390eae854c57b1ad00a0b6f642edc12e601c0d8eb61596ce309894aa57da::M::Foo",
+            "abilities": [
+              "KEY"
+            ]
+          }
+        },
+        "hasPublicTransfer": false
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -516,6 +516,12 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
+	Whether this object can be transfered using the `TransferObjects` Programmable Transaction Command or `sui::transfer::public_transfer`.
+	
+	Both these operations require the object to have both the `key` and `store` abilities.
+	"""
+	hasPublicTransfer: Boolean
+	"""
 	URL for the coin logo.
 	"""
 	iconUrl: String
@@ -794,6 +800,12 @@ type DynamicField implements IAddressable & IMoveObject & IObject {
 	Access a dynamic object field on an object using its type and BCS-encoded name.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
+	"""
+	Whether this object can be transfered using the `TransferObjects` Programmable Transaction Command or `sui::transfer::public_transfer`.
+	
+	Both these operations require the object to have both the `key` and `store` abilities.
+	"""
+	hasPublicTransfer: Boolean
 	"""
 	The Base64-encoded BCS serialize of this object, as a `MoveObject`.
 	"""
@@ -1389,6 +1401,12 @@ interface IMoveObject {
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
+	Whether this object can be transfered using the `TransferObjects` Programmable Transaction Command or `sui::transfer::public_transfer`.
+	
+	Both these operations require the object to have both the `key` and `store` abilities.
+	"""
+	hasPublicTransfer: Boolean
+	"""
 	The Base64-encoded BCS serialize of this object, as a `MoveObject`.
 	"""
 	moveObjectBcs: Base64
@@ -1925,6 +1943,12 @@ type MoveObject implements IAddressable & IMoveObject & IObject {
 	Access a dynamic object field on an object using its type and BCS-encoded name.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
+	"""
+	Whether this object can be transfered using the `TransferObjects` Programmable Transaction Command or `sui::transfer::public_transfer`.
+	
+	Both these operations require the object to have both the `key` and `store` abilities.
+	"""
+	hasPublicTransfer: Boolean
 	"""
 	The Base64-encoded BCS serialize of this object, as a `MoveObject`.
 	"""

--- a/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
@@ -145,6 +145,16 @@ impl CoinMetadata {
         self.super_.dynamic_object_field(ctx, name).await
     }
 
+    /// Whether this object can be transfered using the `TransferObjects` Programmable Transaction Command or `sui::transfer::public_transfer`.
+    ///
+    /// Both these operations require the object to have both the `key` and `store` abilities.
+    pub(crate) async fn has_public_transfer(
+        &self,
+        ctx: &Context<'_>,
+    ) -> Result<Option<bool>, RpcError> {
+        self.super_.has_public_transfer(ctx).await
+    }
+
     /// URL for the coin logo.
     pub(crate) async fn icon_url(&self, ctx: &Context<'_>) -> Result<Option<&str>, RpcError> {
         let Some(native) = self.native(ctx).await? else {

--- a/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
@@ -182,6 +182,16 @@ impl DynamicField {
         self.super_.dynamic_object_field(ctx, name).await
     }
 
+    /// Whether this object can be transfered using the `TransferObjects` Programmable Transaction Command or `sui::transfer::public_transfer`.
+    ///
+    /// Both these operations require the object to have both the `key` and `store` abilities.
+    pub(crate) async fn has_public_transfer(
+        &self,
+        ctx: &Context<'_>,
+    ) -> Result<Option<bool>, RpcError> {
+        self.super_.has_public_transfer(ctx).await
+    }
+
     /// Access dynamic fields on an object using their types and BCS-encoded names.
     ///
     /// Returns a list of dynamic fields that is guaranteed to be the same length as `keys`. If a dynamic field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -520,6 +520,12 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
+	Whether this object can be transfered using the `TransferObjects` Programmable Transaction Command or `sui::transfer::public_transfer`.
+	
+	Both these operations require the object to have both the `key` and `store` abilities.
+	"""
+	hasPublicTransfer: Boolean
+	"""
 	URL for the coin logo.
 	"""
 	iconUrl: String
@@ -798,6 +804,12 @@ type DynamicField implements IAddressable & IMoveObject & IObject {
 	Access a dynamic object field on an object using its type and BCS-encoded name.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
+	"""
+	Whether this object can be transfered using the `TransferObjects` Programmable Transaction Command or `sui::transfer::public_transfer`.
+	
+	Both these operations require the object to have both the `key` and `store` abilities.
+	"""
+	hasPublicTransfer: Boolean
 	"""
 	The Base64-encoded BCS serialize of this object, as a `MoveObject`.
 	"""
@@ -1393,6 +1405,12 @@ interface IMoveObject {
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
+	Whether this object can be transfered using the `TransferObjects` Programmable Transaction Command or `sui::transfer::public_transfer`.
+	
+	Both these operations require the object to have both the `key` and `store` abilities.
+	"""
+	hasPublicTransfer: Boolean
+	"""
 	The Base64-encoded BCS serialize of this object, as a `MoveObject`.
 	"""
 	moveObjectBcs: Base64
@@ -1929,6 +1947,12 @@ type MoveObject implements IAddressable & IMoveObject & IObject {
 	Access a dynamic object field on an object using its type and BCS-encoded name.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
+	"""
+	Whether this object can be transfered using the `TransferObjects` Programmable Transaction Command or `sui::transfer::public_transfer`.
+	
+	Both these operations require the object to have both the `key` and `store` abilities.
+	"""
+	hasPublicTransfer: Boolean
 	"""
 	The Base64-encoded BCS serialize of this object, as a `MoveObject`.
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -520,6 +520,12 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
+	Whether this object can be transfered using the `TransferObjects` Programmable Transaction Command or `sui::transfer::public_transfer`.
+	
+	Both these operations require the object to have both the `key` and `store` abilities.
+	"""
+	hasPublicTransfer: Boolean
+	"""
 	URL for the coin logo.
 	"""
 	iconUrl: String
@@ -798,6 +804,12 @@ type DynamicField implements IAddressable & IMoveObject & IObject {
 	Access a dynamic object field on an object using its type and BCS-encoded name.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
+	"""
+	Whether this object can be transfered using the `TransferObjects` Programmable Transaction Command or `sui::transfer::public_transfer`.
+	
+	Both these operations require the object to have both the `key` and `store` abilities.
+	"""
+	hasPublicTransfer: Boolean
 	"""
 	The Base64-encoded BCS serialize of this object, as a `MoveObject`.
 	"""
@@ -1393,6 +1405,12 @@ interface IMoveObject {
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
+	Whether this object can be transfered using the `TransferObjects` Programmable Transaction Command or `sui::transfer::public_transfer`.
+	
+	Both these operations require the object to have both the `key` and `store` abilities.
+	"""
+	hasPublicTransfer: Boolean
+	"""
 	The Base64-encoded BCS serialize of this object, as a `MoveObject`.
 	"""
 	moveObjectBcs: Base64
@@ -1929,6 +1947,12 @@ type MoveObject implements IAddressable & IMoveObject & IObject {
 	Access a dynamic object field on an object using its type and BCS-encoded name.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
+	"""
+	Whether this object can be transfered using the `TransferObjects` Programmable Transaction Command or `sui::transfer::public_transfer`.
+	
+	Both these operations require the object to have both the `key` and `store` abilities.
+	"""
+	hasPublicTransfer: Boolean
 	"""
 	The Base64-encoded BCS serialize of this object, as a `MoveObject`.
 	"""

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -516,6 +516,12 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
+	Whether this object can be transfered using the `TransferObjects` Programmable Transaction Command or `sui::transfer::public_transfer`.
+	
+	Both these operations require the object to have both the `key` and `store` abilities.
+	"""
+	hasPublicTransfer: Boolean
+	"""
 	URL for the coin logo.
 	"""
 	iconUrl: String
@@ -794,6 +800,12 @@ type DynamicField implements IAddressable & IMoveObject & IObject {
 	Access a dynamic object field on an object using its type and BCS-encoded name.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
+	"""
+	Whether this object can be transfered using the `TransferObjects` Programmable Transaction Command or `sui::transfer::public_transfer`.
+	
+	Both these operations require the object to have both the `key` and `store` abilities.
+	"""
+	hasPublicTransfer: Boolean
 	"""
 	The Base64-encoded BCS serialize of this object, as a `MoveObject`.
 	"""
@@ -1389,6 +1401,12 @@ interface IMoveObject {
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
+	Whether this object can be transfered using the `TransferObjects` Programmable Transaction Command or `sui::transfer::public_transfer`.
+	
+	Both these operations require the object to have both the `key` and `store` abilities.
+	"""
+	hasPublicTransfer: Boolean
+	"""
 	The Base64-encoded BCS serialize of this object, as a `MoveObject`.
 	"""
 	moveObjectBcs: Base64
@@ -1925,6 +1943,12 @@ type MoveObject implements IAddressable & IMoveObject & IObject {
 	Access a dynamic object field on an object using its type and BCS-encoded name.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
+	"""
+	Whether this object can be transfered using the `TransferObjects` Programmable Transaction Command or `sui::transfer::public_transfer`.
+	
+	Both these operations require the object to have both the `key` and `store` abilities.
+	"""
+	hasPublicTransfer: Boolean
 	"""
 	The Base64-encoded BCS serialize of this object, as a `MoveObject`.
 	"""


### PR DESCRIPTION
## Description

Add support for `hasPublicTransfer` based on the implementation in GraphQL Alpha.

## Test plan

New E2E tests:

```
$ cargo nextest run            \
  -p sui-indexer-alt-e2e-tests \
  -- graphql/objects/has_public_transfer
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
