### PR TITLE
[adapter-tests] Render clever error abort codes/line numbers in adapter transactional tests

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/call/clever_error_code_resolution.move
+++ b/crates/sui-adapter-transactional-tests/tests/call/clever_error_code_resolution.move
@@ -1,0 +1,13 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses Test=0x0 A=0x42
+
+//# publish
+module Test::M1;
+#[error(code = 10)]
+const EError: vector<u8> = b"An error occurred";
+
+public fun foo() { abort EError }
+
+//# run Test::M1::foo

--- a/crates/sui-adapter-transactional-tests/tests/call/clever_error_code_resolution.snap
+++ b/crates/sui-adapter-transactional-tests/tests/call/clever_error_code_resolution.snap
@@ -1,0 +1,15 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 3 tasks
+
+task 1, lines 6-11:
+//# publish
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3716400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 13:
+//# run Test::M1::foo
+Error: Transaction Effects Status: Move Abort in Test::M1::foo (function index 0) at offset 1 at line 10 with clever code 10
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: Test, name: Identifier("M1") }, function: 0, instruction: 1, function_name: Some("foo") }, 13837872847998943233), source: Some(VMError { major_status: ABORTED, sub_status: Some(13837872847998943233), message: Some("Test::M1::foo at offset 1"), exec_state: None, location: Module(ModuleId { address: Test, name: Identifier("M1") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 1)] }), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/call/clever_error_code_resolution@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/call/clever_error_code_resolution@v2.snap
@@ -1,0 +1,15 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 3 tasks
+
+task 1, lines 6-11:
+//# publish
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3716400,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 13:
+//# run Test::M1::foo
+Error: Transaction Effects Status: Move Abort in Test::M1::foo (function index 0) at offset 1 at line 10 with clever code 10
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: Test, name: Identifier("M1") }, function: 0, instruction: 1, function_name: Some("foo") }, 13837872847998943233), source: Some(VMError { major_status: ABORTED, sub_status: Some(13837872847998943233), message: Some("Test::M1::foo at offset 1"), exec_state: None, location: Module(ModuleId { address: Test, name: Identifier("M1") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 1)] }), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/derived_objects/claim_twice.snap
+++ b/crates/sui-adapter-transactional-tests/tests/derived_objects/claim_twice.snap
@@ -26,5 +26,5 @@ gas summary: computation_cost: 1000000, storage_cost: 5981200,  storage_rebate: 
 
 task 4, line 37:
 //# run a::m::derive_object --sender A --args object(2,0) 0
-Error: Transaction Effects Status: Move Runtime Abort. Location: sui::derived_object::claim (function index 0) at offset 20, Abort Code: 13835058231375822849
+Error: Transaction Effects Status: Move Abort in sui::derived_object::claim (function index 0) at offset 20 at line 41 with clever code 0
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("derived_object") }, function: 0, instruction: 20, function_name: Some("claim") }, 13835058231375822849), source: Some(VMError { major_status: ABORTED, sub_status: Some(13835058231375822849), message: Some("sui::derived_object::claim at offset 20"), exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("derived_object") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 20)] }), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/derived_objects/claim_twice@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/derived_objects/claim_twice@v2.snap
@@ -26,5 +26,5 @@ gas summary: computation_cost: 1000000, storage_cost: 5981200,  storage_rebate: 
 
 task 4, line 37:
 //# run a::m::derive_object --sender A --args object(2,0) 0
-Error: Transaction Effects Status: Move Runtime Abort. Location: sui::derived_object::claim (function index 0) at offset 20, Abort Code: 13835058231375822849
+Error: Transaction Effects Status: Move Abort in sui::derived_object::claim (function index 0) at offset 20 at line 41 with clever code 0
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("derived_object") }, function: 0, instruction: 20, function_name: Some("claim") }, 13835058231375822849), source: Some(VMError { major_status: ABORTED, sub_status: Some(13835058231375822849), message: Some("sui::derived_object::claim at offset 20"), exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("derived_object") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 20)] }), command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut.snap
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut.snap
@@ -30,7 +30,7 @@ task 3, lines 54-58:
 //> test::m1::modify_u8(Input(0));
 //> test::m1::assert_string(Input(1));
 // In statically checked PTBs, tests that each type can be borrowed mutably separately
-Error: Transaction Effects Status: Move Runtime Abort. Location: test::m1::assert_string (function index 6) at offset 11, Abort Code: 13906834324667236351
+Error: Transaction Effects Status: Move Abort in test::m1::assert_string (function index 6) at offset 11 at line 34
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m1") }, function: 6, instruction: 11, function_name: Some("assert_string") }, 13906834324667236351), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834324667236351), message: Some("test::m1::assert_string at offset 11"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m1") }), indices: [], offsets: [(FunctionDefinitionIndex(6), 11)] }), command: Some(1) } }
 
 task 4, lines 59-63:

--- a/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut@v2.snap
@@ -30,7 +30,7 @@ task 3, lines 54-58:
 //> test::m1::modify_u8(Input(0));
 //> test::m1::assert_string(Input(1));
 // In statically checked PTBs, tests that each type can be borrowed mutably separately
-Error: Transaction Effects Status: Move Runtime Abort. Location: test::m1::assert_string (function index 6) at offset 11, Abort Code: 13906834324667236351
+Error: Transaction Effects Status: Move Abort in test::m1::assert_string (function index 6) at offset 11 at line 34
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m1") }, function: 6, instruction: 11, function_name: Some("assert_string") }, 13906834324667236351), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834324667236351), message: Some("test::m1::assert_string at offset 11"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m1") }), indices: [], offsets: [(FunctionDefinitionIndex(6), 11)] }), command: Some(1) } }
 
 task 4, lines 59-63:

--- a/crates/sui-graphql-e2e-tests/tests/stable/errors/clever_errors.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/errors/clever_errors.snap
@@ -14,57 +14,57 @@ gas summary: computation_cost: 1000000, storage_cost: 10784400,  storage_rebate:
 
 task 2, line 94:
 //# run P0::m::callU8
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU8 (function index 0) at offset 1, Abort Code: 13906834307487367169
+Error: Transaction Effects Status: Move Abort in P0::m::callU8 (function index 0) at offset 1 at line 31
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("callU8") }, 13906834307487367169), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834307487367169), message: Some("P0::m::callU8 at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 1)] }), command: Some(0) } }
 
 task 3, line 96:
 //# run P0::m::callU16
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU16 (function index 1) at offset 1, Abort Code: 13906834320372400131
+Error: Transaction Effects Status: Move Abort in P0::m::callU16 (function index 1) at offset 1 at line 34
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("callU16") }, 13906834320372400131), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834320372400131), message: Some("P0::m::callU16 at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(1), 1)] }), command: Some(0) } }
 
 task 4, line 98:
 //# run P0::m::callU32
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU32 (function index 2) at offset 1, Abort Code: 13906834333257433093
+Error: Transaction Effects Status: Move Abort in P0::m::callU32 (function index 2) at offset 1 at line 37
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 2, instruction: 1, function_name: Some("callU32") }, 13906834333257433093), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834333257433093), message: Some("P0::m::callU32 at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(2), 1)] }), command: Some(0) } }
 
 task 5, line 100:
 //# run P0::m::callU64
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU64 (function index 3) at offset 1, Abort Code: 13906834346142466055
+Error: Transaction Effects Status: Move Abort in P0::m::callU64 (function index 3) at offset 1 at line 40
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 3, instruction: 1, function_name: Some("callU64") }, 13906834346142466055), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834346142466055), message: Some("P0::m::callU64 at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(3), 1)] }), command: Some(0) } }
 
 task 6, line 102:
 //# run P0::m::callU128
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU128 (function index 4) at offset 1, Abort Code: 13906834359027499017
+Error: Transaction Effects Status: Move Abort in P0::m::callU128 (function index 4) at offset 1 at line 43
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 4, instruction: 1, function_name: Some("callU128") }, 13906834359027499017), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834359027499017), message: Some("P0::m::callU128 at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(4), 1)] }), command: Some(0) } }
 
 task 7, line 104:
 //# run P0::m::callU256
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU256 (function index 5) at offset 1, Abort Code: 13906834371912531979
+Error: Transaction Effects Status: Move Abort in P0::m::callU256 (function index 5) at offset 1 at line 46
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 5, instruction: 1, function_name: Some("callU256") }, 13906834371912531979), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834371912531979), message: Some("P0::m::callU256 at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(5), 1)] }), command: Some(0) } }
 
 task 8, line 106:
 //# run P0::m::callAddress
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callAddress (function index 6) at offset 1, Abort Code: 13906834384797696015
+Error: Transaction Effects Status: Move Abort in P0::m::callAddress (function index 6) at offset 1 at line 49
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 6, instruction: 1, function_name: Some("callAddress") }, 13906834384797696015), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834384797696015), message: Some("P0::m::callAddress at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(6), 1)] }), command: Some(0) } }
 
 task 9, line 108:
 //# run P0::m::callString
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callString (function index 7) at offset 1, Abort Code: 13906834397682728977
+Error: Transaction Effects Status: Move Abort in P0::m::callString (function index 7) at offset 1 at line 52
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 7, instruction: 1, function_name: Some("callString") }, 13906834397682728977), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834397682728977), message: Some("P0::m::callString at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(7), 1)] }), command: Some(0) } }
 
 task 10, line 110:
 //# run P0::m::callU64vec
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU64vec (function index 8) at offset 1, Abort Code: 13906834410567761939
+Error: Transaction Effects Status: Move Abort in P0::m::callU64vec (function index 8) at offset 1 at line 55
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 8, instruction: 1, function_name: Some("callU64vec") }, 13906834410567761939), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834410567761939), message: Some("P0::m::callU64vec at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(8), 1)] }), command: Some(0) } }
 
 task 11, line 112:
 //# run P0::m::callStringWithCode
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callStringWithCode (function index 9) at offset 1, Abort Code: 13835339779368288277
+Error: Transaction Effects Status: Move Abort in P0::m::callStringWithCode (function index 9) at offset 1 at line 58 with clever code 1
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 9, instruction: 1, function_name: Some("callStringWithCode") }, 13835339779368288277), source: Some(VMError { major_status: ABORTED, sub_status: Some(13835339779368288277), message: Some("P0::m::callStringWithCode at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(9), 1)] }), command: Some(0) } }
 
 task 12, line 114:
 //# run P0::m::callNoCodeOrConst
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callNoCodeOrConst (function index 10) at offset 1, Abort Code: 13906834440631353343
+Error: Transaction Effects Status: Move Abort in P0::m::callNoCodeOrConst (function index 10) at offset 1 at line 61
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 10, instruction: 1, function_name: Some("callNoCodeOrConst") }, 13906834440631353343), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834440631353343), message: Some("P0::m::callNoCodeOrConst at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(10), 1)] }), command: Some(0) } }
 
 task 13, line 116:
@@ -74,7 +74,7 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 
 task 14, line 118:
 //# run P0::m::assertLineNo
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::assertLineNo (function index 12) at offset 1, Abort Code: 13906834466401157119
+Error: Transaction Effects Status: Move Abort in P0::m::assertLineNo (function index 12) at offset 1 at line 67
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 12, instruction: 1, function_name: Some("assertLineNo") }, 13906834466401157119), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834466401157119), message: Some("P0::m::assertLineNo at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(12), 1)] }), command: Some(0) } }
 
 task 15, line 120:
@@ -191,47 +191,47 @@ gas summary: computation_cost: 1000000, storage_cost: 10913600,  storage_rebate:
 
 task 18, line 226:
 //# run P0::m::callU8
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU8 (function index 0) at offset 1, Abort Code: 13906834874423050241
+Error: Transaction Effects Status: Move Abort in P0::m::callU8 (function index 0) at offset 1 at line 163
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("callU8") }, 13906834874423050241), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834874423050241), message: Some("fake(1,0)::m::callU8 at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 1)] }), command: Some(0) } }
 
 task 19, line 228:
 //# run P0::m::callU16
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU16 (function index 1) at offset 1, Abort Code: 13906834887308083203
+Error: Transaction Effects Status: Move Abort in P0::m::callU16 (function index 1) at offset 1 at line 166
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("callU16") }, 13906834887308083203), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834887308083203), message: Some("fake(1,0)::m::callU16 at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(1), 1)] }), command: Some(0) } }
 
 task 20, line 230:
 //# run P0::m::callU32
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU32 (function index 2) at offset 1, Abort Code: 13906834900193116165
+Error: Transaction Effects Status: Move Abort in P0::m::callU32 (function index 2) at offset 1 at line 169
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 2, instruction: 1, function_name: Some("callU32") }, 13906834900193116165), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834900193116165), message: Some("fake(1,0)::m::callU32 at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(2), 1)] }), command: Some(0) } }
 
 task 21, line 232:
 //# run P0::m::callU64
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU64 (function index 3) at offset 1, Abort Code: 13906834913078149127
+Error: Transaction Effects Status: Move Abort in P0::m::callU64 (function index 3) at offset 1 at line 172
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 3, instruction: 1, function_name: Some("callU64") }, 13906834913078149127), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834913078149127), message: Some("fake(1,0)::m::callU64 at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(3), 1)] }), command: Some(0) } }
 
 task 22, line 234:
 //# run P0::m::callU128
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU128 (function index 4) at offset 1, Abort Code: 13906834925963182089
+Error: Transaction Effects Status: Move Abort in P0::m::callU128 (function index 4) at offset 1 at line 175
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 4, instruction: 1, function_name: Some("callU128") }, 13906834925963182089), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834925963182089), message: Some("fake(1,0)::m::callU128 at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(4), 1)] }), command: Some(0) } }
 
 task 23, line 236:
 //# run P0::m::callU256
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU256 (function index 5) at offset 1, Abort Code: 13906834938848215051
+Error: Transaction Effects Status: Move Abort in P0::m::callU256 (function index 5) at offset 1 at line 178
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 5, instruction: 1, function_name: Some("callU256") }, 13906834938848215051), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834938848215051), message: Some("fake(1,0)::m::callU256 at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(5), 1)] }), command: Some(0) } }
 
 task 24, line 238:
 //# run P0::m::callAddress
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callAddress (function index 6) at offset 1, Abort Code: 13906834951733379087
+Error: Transaction Effects Status: Move Abort in P0::m::callAddress (function index 6) at offset 1 at line 181
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 6, instruction: 1, function_name: Some("callAddress") }, 13906834951733379087), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834951733379087), message: Some("fake(1,0)::m::callAddress at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(6), 1)] }), command: Some(0) } }
 
 task 25, line 240:
 //# run P0::m::callString
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callString (function index 7) at offset 1, Abort Code: 13906834964618412049
+Error: Transaction Effects Status: Move Abort in P0::m::callString (function index 7) at offset 1 at line 184
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 7, instruction: 1, function_name: Some("callString") }, 13906834964618412049), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834964618412049), message: Some("fake(1,0)::m::callString at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(7), 1)] }), command: Some(0) } }
 
 task 26, line 242:
 //# run P0::m::callU64vec
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::callU64vec (function index 8) at offset 1, Abort Code: 13906834977503445011
+Error: Transaction Effects Status: Move Abort in P0::m::callU64vec (function index 8) at offset 1 at line 187
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 8, instruction: 1, function_name: Some("callU64vec") }, 13906834977503445011), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834977503445011), message: Some("fake(1,0)::m::callU64vec at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(8), 1)] }), command: Some(0) } }
 
 task 27, line 244:
@@ -241,7 +241,7 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 
 task 28, line 246:
 //# run P0::m::assertLineNo
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::assertLineNo (function index 12) at offset 1, Abort Code: 13906835033336840191
+Error: Transaction Effects Status: Move Abort in P0::m::assertLineNo (function index 12) at offset 1 at line 199
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 12, instruction: 1, function_name: Some("assertLineNo") }, 13906835033336840191), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906835033336840191), message: Some("fake(1,0)::m::assertLineNo at offset 1"), exec_state: None, location: Module(ModuleId { address: fake(1,0), name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(12), 1)] }), command: Some(0) } }
 
 task 29, line 248:

--- a/crates/sui-graphql-e2e-tests/tests/stable/errors/clever_errors_in_macros.snap
+++ b/crates/sui-graphql-e2e-tests/tests/stable/errors/clever_errors_in_macros.snap
@@ -14,17 +14,17 @@ gas summary: computation_cost: 1000000, storage_cost: 4187600,  storage_rebate: 
 
 task 2, line 36:
 //# run P0::m::t_a
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::t_a (function index 0) at offset 1, Abort Code: 13906834264537694207
+Error: Transaction Effects Status: Move Abort in P0::m::t_a (function index 0) at offset 1 at line 20
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("t_a") }, 13906834264537694207), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834264537694207), message: Some("P0::m::t_a at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 1)] }), command: Some(0) } }
 
 task 3, line 38:
 //# run P0::m::t_calls_a
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::t_calls_a (function index 1) at offset 1, Abort Code: 13906834277422596095
+Error: Transaction Effects Status: Move Abort in P0::m::t_calls_a (function index 1) at offset 1 at line 23
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("t_calls_a") }, 13906834277422596095), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834277422596095), message: Some("P0::m::t_calls_a at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(1), 1)] }), command: Some(0) } }
 
 task 4, line 40:
 //# run P0::m::t_const_assert
-Error: Transaction Effects Status: Move Runtime Abort. Location: P0::m::t_const_assert (function index 2) at offset 1, Abort Code: 13906834212998086657
+Error: Transaction Effects Status: Move Abort in P0::m::t_const_assert (function index 2) at offset 1 at line 9
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: P0, name: Identifier("m") }, function: 2, instruction: 1, function_name: Some("t_const_assert") }, 13906834212998086657), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834212998086657), message: Some("P0::m::t_const_assert at offset 1"), exec_state: None, location: Module(ModuleId { address: P0, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(2), 1)] }), command: Some(0) } }
 
 task 5, line 42:

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/execution_error.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/execution_error.snap
@@ -29,42 +29,42 @@ Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { k
 
 task 5, line 105:
 //# run test::execution_error_tests::abort_with_clever_u8 --sender B
-Error: Transaction Effects Status: Move Runtime Abort. Location: test::execution_error_tests::abort_with_clever_u8 (function index 3) at offset 1, Abort Code: 13906834328962203649
+Error: Transaction Effects Status: Move Abort in test::execution_error_tests::abort_with_clever_u8 (function index 3) at offset 1 at line 36
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 3, instruction: 1, function_name: Some("abort_with_clever_u8") }, 13906834328962203649), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834328962203649), message: Some("test::execution_error_tests::abort_with_clever_u8 at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(3), 1)] }), command: Some(0) } }
 
 task 6, line 107:
 //# run test::execution_error_tests::abort_with_clever_u16 --sender A
-Error: Transaction Effects Status: Move Runtime Abort. Location: test::execution_error_tests::abort_with_clever_u16 (function index 4) at offset 1, Abort Code: 13906834341847236611
+Error: Transaction Effects Status: Move Abort in test::execution_error_tests::abort_with_clever_u16 (function index 4) at offset 1 at line 39
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 4, instruction: 1, function_name: Some("abort_with_clever_u16") }, 13906834341847236611), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834341847236611), message: Some("test::execution_error_tests::abort_with_clever_u16 at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(4), 1)] }), command: Some(0) } }
 
 task 7, line 109:
 //# run test::execution_error_tests::abort_with_clever_u64 --sender B
-Error: Transaction Effects Status: Move Runtime Abort. Location: test::execution_error_tests::abort_with_clever_u64 (function index 5) at offset 1, Abort Code: 13906834354732269573
+Error: Transaction Effects Status: Move Abort in test::execution_error_tests::abort_with_clever_u64 (function index 5) at offset 1 at line 42
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 5, instruction: 1, function_name: Some("abort_with_clever_u64") }, 13906834354732269573), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834354732269573), message: Some("test::execution_error_tests::abort_with_clever_u64 at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(5), 1)] }), command: Some(0) } }
 
 task 8, line 111:
 //# run test::execution_error_tests::abort_with_clever_address --sender A
-Error: Transaction Effects Status: Move Runtime Abort. Location: test::execution_error_tests::abort_with_clever_address (function index 6) at offset 1, Abort Code: 13906834367617302535
+Error: Transaction Effects Status: Move Abort in test::execution_error_tests::abort_with_clever_address (function index 6) at offset 1 at line 45
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 6, instruction: 1, function_name: Some("abort_with_clever_address") }, 13906834367617302535), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834367617302535), message: Some("test::execution_error_tests::abort_with_clever_address at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(6), 1)] }), command: Some(0) } }
 
 task 9, line 113:
 //# run test::execution_error_tests::abort_with_clever_string --sender B
-Error: Transaction Effects Status: Move Runtime Abort. Location: test::execution_error_tests::abort_with_clever_string (function index 7) at offset 1, Abort Code: 13906834380502335497
+Error: Transaction Effects Status: Move Abort in test::execution_error_tests::abort_with_clever_string (function index 7) at offset 1 at line 48
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 7, instruction: 1, function_name: Some("abort_with_clever_string") }, 13906834380502335497), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834380502335497), message: Some("test::execution_error_tests::abort_with_clever_string at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(7), 1)] }), command: Some(0) } }
 
 task 10, line 115:
 //# run test::execution_error_tests::abort_with_clever_code --sender A
-Error: Transaction Effects Status: Move Runtime Abort. Location: test::execution_error_tests::abort_with_clever_code (function index 8) at offset 1, Abort Code: 13839280398976811019
+Error: Transaction Effects Status: Move Abort in test::execution_error_tests::abort_with_clever_code (function index 8) at offset 1 at line 51 with clever code 15
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 8, instruction: 1, function_name: Some("abort_with_clever_code") }, 13839280398976811019), source: Some(VMError { major_status: ABORTED, sub_status: Some(13839280398976811019), message: Some("test::execution_error_tests::abort_with_clever_code at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(8), 1)] }), command: Some(0) } }
 
 task 11, line 117:
 //# run test::execution_error_tests::abort_with_clever_raw --sender B
-Error: Transaction Effects Status: Move Runtime Abort. Location: test::execution_error_tests::abort_with_clever_raw (function index 9) at offset 1, Abort Code: 13906834406272401421
+Error: Transaction Effects Status: Move Abort in test::execution_error_tests::abort_with_clever_raw (function index 9) at offset 1 at line 54
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 9, instruction: 1, function_name: Some("abort_with_clever_raw") }, 13906834406272401421), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834406272401421), message: Some("test::execution_error_tests::abort_with_clever_raw at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(9), 1)] }), command: Some(0) } }
 
 task 12, line 119:
 //# run test::execution_error_tests::assert_failure --sender B
-Error: Transaction Effects Status: Move Runtime Abort. Location: test::execution_error_tests::assert_failure (function index 10) at offset 1, Abort Code: 13906834423451484159
+Error: Transaction Effects Status: Move Abort in test::execution_error_tests::assert_failure (function index 10) at offset 1 at line 57
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("execution_error_tests") }, function: 10, instruction: 1, function_name: Some("assert_failure") }, 13906834423451484159), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834423451484159), message: Some("test::execution_error_tests::assert_failure at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("execution_error_tests") }), indices: [], offsets: [(FunctionDefinitionIndex(10), 1)] }), command: Some(0) } }
 
 task 13, lines 121-122:


### PR DESCRIPTION
## Summary

This PR enhances the error reporting in adapter transactional tests by rendering "clever error codes" with their associated line numbers and error codes when Move aborts occur. 
  
## Changes
  - Updated test adapter to extract line numbers and error codes from abort codes when available
  - Added new test case `clever_error_code_resolution.move` to verify the enhanced error reporting
  - Updated existing test snapshots to reflect the improved error message format

## Impact

  Previously, Move aborts in tests would display raw abort codes like:
``` 
Move Runtime Abort. Location: sui::derived_object::claim (function index 0) at offset 20, Abort Code: 13835058231375822849
```

Now they provide more readable information:
```
Move Abort in sui::derived_object::claim (function index 0) at offset 20 at line 41 with clever code 10
```

 
## Tests

  - Added new test case specifically for clever error code resolution
  - Updated 4 existing test snapshots to match the new error format

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
