### PR TITLE
[graphql-alt] Implement type fields for MakeMoveVec

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/make_move_vec.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/make_move_vec.move
@@ -71,7 +71,7 @@
 
 //# run-graphql
 { 
-  # Test empty vector
+  # Test empty vector with type field
   emptyVector: transaction(digest: "@{digest_5}") {
     kind {
       ... on ProgrammableTransaction {
@@ -79,6 +79,10 @@
           nodes {
             __typename
             ... on MakeMoveVecCommand {
+              type {
+                repr
+                signature
+              }
               elements {
                 __typename
                 ... on Input { ix }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/make_move_vec.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/make_move_vec.snap
@@ -88,7 +88,7 @@ Response: {
   }
 }
 
-task 9, lines 72-94:
+task 9, lines 72-98:
 //# run-graphql
 Response: {
   "data": {
@@ -98,6 +98,10 @@ Response: {
           "nodes": [
             {
               "__typename": "MakeMoveVecCommand",
+              "type": {
+                "repr": "u64",
+                "signature": "u64"
+              },
               "elements": []
             }
           ]

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -1512,6 +1512,10 @@ type MakeMoveVecCommand {
 	The values to pack into the vector, all of the same type.
 	"""
 	elements: [TransactionArgument!]
+	"""
+	If the elements are not objects, or the vector is empty, a type must be supplied.
+	"""
+	type: MoveType
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_type.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_type.rs
@@ -251,6 +251,15 @@ impl MoveType {
         }
     }
 
+    /// Construct a `MoveType` directly from a `TypeInput`. Use this when you already have a
+    /// `TypeInput` (which is MoveType's internal representation) and don't want conversion to fail.
+    pub(crate) fn from_input(input: TypeInput, scope: Scope) -> Self {
+        Self {
+            native: input,
+            scope,
+        }
+    }
+
     /// Get the native `TypeTag` for this type, if it is valid.
     pub(crate) fn to_type_tag(&self) -> Option<TypeTag> {
         self.native.to_type_tag().ok()

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/commands/make_move_vec.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/commands/make_move_vec.rs
@@ -4,8 +4,7 @@
 use async_graphql::*;
 
 use crate::api::types::{
-    move_type::MoveType,
-    transaction_kind::programmable::commands::TransactionArgument,
+    move_type::MoveType, transaction_kind::programmable::commands::TransactionArgument,
 };
 
 /// Create a vector (can be empty).

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/commands/make_move_vec.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/commands/make_move_vec.rs
@@ -3,12 +3,16 @@
 
 use async_graphql::*;
 
-use crate::api::types::transaction_kind::programmable::commands::TransactionArgument;
+use crate::api::types::{
+    move_type::MoveType,
+    transaction_kind::programmable::commands::TransactionArgument,
+};
 
 /// Create a vector (can be empty).
 #[derive(SimpleObject, Clone)]
 pub struct MakeMoveVecCommand {
+    /// If the elements are not objects, or the vector is empty, a type must be supplied.
+    pub type_: Option<MoveType>,
     /// The values to pack into the vector, all of the same type.
     pub elements: Option<Vec<TransactionArgument>>,
-    // TODO(DVX-1373): Support MoveType once available
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/commands/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/commands/mod.rs
@@ -13,7 +13,10 @@ mod upgrade;
 use async_graphql::*;
 use sui_types::transaction::Command as NativeCommand;
 
-use crate::api::{scalars::{base64::Base64, sui_address::SuiAddress}, types::move_type::MoveType};
+use crate::api::{
+    scalars::{base64::Base64, sui_address::SuiAddress},
+    types::move_type::MoveType,
+};
 
 pub use make_move_vec::MakeMoveVecCommand;
 pub use merge_coins::MergeCoinsCommand;
@@ -48,51 +51,49 @@ pub struct OtherCommand {
 }
 
 impl Command {
-    pub fn from(scope: Scope, command: NativeCommand) -> Result<Self, anyhow::Error> {
+    pub fn from(scope: Scope, command: NativeCommand) -> Self {
         match command {
             NativeCommand::MakeMoveVec(type_opt, elements) => {
-                Ok(Command::MakeMoveVec(MakeMoveVecCommand {
-                    type_: match type_opt {
-                        Some(type_input) => Some(MoveType::from_native(type_input.to_type_tag()?, scope.clone())),
-                        None => None,
-                    },
+                Command::MakeMoveVec(MakeMoveVecCommand {
+                    type_: type_opt
+                        .map(|type_input| MoveType::from_input(type_input, scope.clone())),
                     elements: Some(
                         elements
                             .into_iter()
                             .map(TransactionArgument::from)
                             .collect(),
                     ),
-                }))
+                })
             }
-            NativeCommand::MoveCall(call) => Ok(Command::MoveCall(MoveCallCommand {
+            NativeCommand::MoveCall(call) => Command::MoveCall(MoveCallCommand {
                 native: *call,
                 scope,
-            })),
-            NativeCommand::SplitCoins(coin, amounts) => Ok(Command::SplitCoins(SplitCoinsCommand {
+            }),
+            NativeCommand::SplitCoins(coin, amounts) => Command::SplitCoins(SplitCoinsCommand {
                 coin: Some(TransactionArgument::from(coin)),
                 amounts: amounts.into_iter().map(TransactionArgument::from).collect(),
-            })),
-            NativeCommand::MergeCoins(coin, coins) => Ok(Command::MergeCoins(MergeCoinsCommand {
+            }),
+            NativeCommand::MergeCoins(coin, coins) => Command::MergeCoins(MergeCoinsCommand {
                 coin: Some(TransactionArgument::from(coin)),
                 coins: coins.into_iter().map(TransactionArgument::from).collect(),
-            })),
+            }),
             NativeCommand::TransferObjects(objects, address) => {
-                Ok(Command::TransferObjects(TransferObjectsCommand {
+                Command::TransferObjects(TransferObjectsCommand {
                     inputs: objects.into_iter().map(TransactionArgument::from).collect(),
                     address: Some(TransactionArgument::from(address)),
-                }))
+                })
             }
-            NativeCommand::Publish(modules, dependencies) => Ok(Command::Publish(PublishCommand {
+            NativeCommand::Publish(modules, dependencies) => Command::Publish(PublishCommand {
                 modules: Some(modules.into_iter().map(Base64::from).collect()),
                 dependencies: Some(dependencies.into_iter().map(SuiAddress::from).collect()),
-            })),
+            }),
             NativeCommand::Upgrade(modules, dependencies, current_package, upgrade_ticket) => {
-                Ok(Command::Upgrade(UpgradeCommand {
+                Command::Upgrade(UpgradeCommand {
                     modules: Some(modules.into_iter().map(Base64::from).collect()),
                     dependencies: Some(dependencies.into_iter().map(SuiAddress::from).collect()),
                     current_package: Some(SuiAddress::from(current_package)),
                     upgrade_ticket: Some(TransactionArgument::from(upgrade_ticket)),
-                }))
+                })
             }
         }
     }

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/mod.rs
@@ -80,7 +80,7 @@ impl ProgrammableTransaction {
             let command = Command::from(
                 self.scope.clone(),
                 self.native.commands[*edge.cursor].clone(),
-            );
+            )?;
 
             conn.edges
                 .push(Edge::new(edge.cursor.encode_cursor(), command));

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/mod.rs
@@ -80,7 +80,7 @@ impl ProgrammableTransaction {
             let command = Command::from(
                 self.scope.clone(),
                 self.native.commands[*edge.cursor].clone(),
-            )?;
+            );
 
             conn.edges
                 .push(Edge::new(edge.cursor.encode_cursor(), command));

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -1516,6 +1516,10 @@ type MakeMoveVecCommand {
 	The values to pack into the vector, all of the same type.
 	"""
 	elements: [TransactionArgument!]
+	"""
+	If the elements are not objects, or the vector is empty, a type must be supplied.
+	"""
+	type: MoveType
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -1516,6 +1516,10 @@ type MakeMoveVecCommand {
 	The values to pack into the vector, all of the same type.
 	"""
 	elements: [TransactionArgument!]
+	"""
+	If the elements are not objects, or the vector is empty, a type must be supplied.
+	"""
+	type: MoveType
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -1512,6 +1512,10 @@ type MakeMoveVecCommand {
 	The values to pack into the vector, all of the same type.
 	"""
 	elements: [TransactionArgument!]
+	"""
+	If the elements are not objects, or the vector is empty, a type must be supplied.
+	"""
+	type: MoveType
 }
 
 """


### PR DESCRIPTION
## Description 

Support a new `type` fields for `MakeMoveVec` as the `MoveType` is available right now.

This field is also available in GraphQL alpha:

https://github.com/MystenLabs/sui/blob/main/crates/sui-graphql-rpc/schema.graphql#L1731

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
