### PR TITLE
[graphql-alt] Support Transactions fields for Address

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/transactions.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/transactions.move
@@ -1,0 +1,111 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --addresses Test=0x0 --accounts A B --simulator
+
+//# publish
+module Test::M1 {
+    public struct Object has key, store {
+        id: UID,
+        value: u64,
+    }
+
+    public entry fun create(value: u64, recipient: address, ctx: &mut TxContext) {
+        transfer::public_transfer(
+            Object { id: object::new(ctx), value },
+            recipient
+        )
+    }
+}
+
+// A sends transaction to A (affects A, sent by A)
+//# run Test::M1::create --sender A --args 0 @A
+
+//# create-checkpoint
+
+// A sends transaction to B (affects B, sent by A)  
+//# run Test::M1::create --sender A --args 1 @B
+
+//# create-checkpoint
+
+// B sends transaction to A (affects A, sent by B)
+//# run Test::M1::create --sender B --args 2 @A
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  # Test default behavior (SENT relationship)
+  addressA_sent: address(address: "@{A}") {
+    transactions {
+      ...TX
+    }
+  }
+  
+  # Test explicit SENT relationship
+  addressA_sent_explicit: address(address: "@{A}") {
+    transactions(relation: SENT) {
+      ...TX
+    }
+  }
+  
+  # Test AFFECTED relationship
+  addressA_affected: address(address: "@{A}") {
+    transactions(relation: AFFECTED) {
+      ...TX
+    }
+  }
+  
+  # Test B's transactions (should have 1 sent, 1 affected)
+  addressB_sent: address(address: "@{B}") {
+    transactions(relation: SENT) {
+      ...TX
+    }
+  }
+  
+  addressB_affected: address(address: "@{B}") {
+    transactions(relation: AFFECTED) {
+      ...TX
+    }
+  }
+  
+  # Test with additional filters
+  addressA_sent_with_filter: address(address: "@{A}") {
+    transactions(relation: SENT, filter: { sentAddress: "@{A}" }) {
+      ...TX
+    }
+  }
+  
+  # Test pagination
+  addressA_affected_first1: address(address: "@{A}") {
+    transactions(relation: AFFECTED, first: 1) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      edges {
+        cursor
+        node {
+          digest
+        }
+      }
+    }
+  }
+}
+
+fragment TX on TransactionConnection {
+  edges {
+    cursor
+    node {
+      digest
+      effects {
+        checkpoint {
+          sequenceNumber
+          digest
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/transactions.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/addressable/transactions.snap
@@ -1,0 +1,272 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 9 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-21:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 5175600,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 22:
+//# run Test::M1::create --sender A --args 0 @A
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 24-26:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 4, line 27:
+//# run Test::M1::create --sender A --args 1 @B
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 29-31:
+//# create-checkpoint
+Checkpoint created: 2
+
+task 6, line 32:
+//# run Test::M1::create --sender B --args 2 @A
+created: object(6,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 2302800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 7, line 34:
+//# create-checkpoint
+Checkpoint created: 3
+
+task 8, lines 36-111:
+//# run-graphql
+Response: {
+  "data": {
+    "addressA_sent": {
+      "transactions": {
+        "edges": [
+          {
+            "cursor": "Mg==",
+            "node": {
+              "digest": "E1TNwiSgMqb53AKG3czxZCCx7phkJ5UbTFRGvBSEdPHN",
+              "effects": {
+                "checkpoint": {
+                  "sequenceNumber": 1,
+                  "digest": "73mbZWx3smA16a67N9ozBN1HVkkLB5mvcLBWqFiQpysD"
+                }
+              }
+            }
+          },
+          {
+            "cursor": "Mw==",
+            "node": {
+              "digest": "EfQeT6HMuzbgyUuXVJfwepuxF8QjZRtQpgjNbkHvGNpJ",
+              "effects": {
+                "checkpoint": {
+                  "sequenceNumber": 2,
+                  "digest": "5LbqZRPvjKX9oyxcknTKH7Km1sYvhNBWcXu6wsqR2ytZ"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "addressA_sent_explicit": {
+      "transactions": {
+        "edges": [
+          {
+            "cursor": "Mg==",
+            "node": {
+              "digest": "E1TNwiSgMqb53AKG3czxZCCx7phkJ5UbTFRGvBSEdPHN",
+              "effects": {
+                "checkpoint": {
+                  "sequenceNumber": 1,
+                  "digest": "73mbZWx3smA16a67N9ozBN1HVkkLB5mvcLBWqFiQpysD"
+                }
+              }
+            }
+          },
+          {
+            "cursor": "Mw==",
+            "node": {
+              "digest": "EfQeT6HMuzbgyUuXVJfwepuxF8QjZRtQpgjNbkHvGNpJ",
+              "effects": {
+                "checkpoint": {
+                  "sequenceNumber": 2,
+                  "digest": "5LbqZRPvjKX9oyxcknTKH7Km1sYvhNBWcXu6wsqR2ytZ"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "addressA_affected": {
+      "transactions": {
+        "edges": [
+          {
+            "cursor": "MA==",
+            "node": {
+              "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
+              "effects": {
+                "checkpoint": {
+                  "sequenceNumber": 0,
+                  "digest": "357p4BZ78NHsVBJaphx25niqgcSy13fpwDdXDaQNKZr9"
+                }
+              }
+            }
+          },
+          {
+            "cursor": "Mg==",
+            "node": {
+              "digest": "E1TNwiSgMqb53AKG3czxZCCx7phkJ5UbTFRGvBSEdPHN",
+              "effects": {
+                "checkpoint": {
+                  "sequenceNumber": 1,
+                  "digest": "73mbZWx3smA16a67N9ozBN1HVkkLB5mvcLBWqFiQpysD"
+                }
+              }
+            }
+          },
+          {
+            "cursor": "Mw==",
+            "node": {
+              "digest": "EfQeT6HMuzbgyUuXVJfwepuxF8QjZRtQpgjNbkHvGNpJ",
+              "effects": {
+                "checkpoint": {
+                  "sequenceNumber": 2,
+                  "digest": "5LbqZRPvjKX9oyxcknTKH7Km1sYvhNBWcXu6wsqR2ytZ"
+                }
+              }
+            }
+          },
+          {
+            "cursor": "NA==",
+            "node": {
+              "digest": "3o2YxT8WFw1c2rWD3t5eFjPMFLjuFJWCiHesTpj3S74q",
+              "effects": {
+                "checkpoint": {
+                  "sequenceNumber": 3,
+                  "digest": "Hp8GWDymM4sx5bTuCo3EeZbXYexx9gKMxtaMEib4ApFf"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "addressB_sent": {
+      "transactions": {
+        "edges": [
+          {
+            "cursor": "NA==",
+            "node": {
+              "digest": "3o2YxT8WFw1c2rWD3t5eFjPMFLjuFJWCiHesTpj3S74q",
+              "effects": {
+                "checkpoint": {
+                  "sequenceNumber": 3,
+                  "digest": "Hp8GWDymM4sx5bTuCo3EeZbXYexx9gKMxtaMEib4ApFf"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "addressB_affected": {
+      "transactions": {
+        "edges": [
+          {
+            "cursor": "MA==",
+            "node": {
+              "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr",
+              "effects": {
+                "checkpoint": {
+                  "sequenceNumber": 0,
+                  "digest": "357p4BZ78NHsVBJaphx25niqgcSy13fpwDdXDaQNKZr9"
+                }
+              }
+            }
+          },
+          {
+            "cursor": "Mw==",
+            "node": {
+              "digest": "EfQeT6HMuzbgyUuXVJfwepuxF8QjZRtQpgjNbkHvGNpJ",
+              "effects": {
+                "checkpoint": {
+                  "sequenceNumber": 2,
+                  "digest": "5LbqZRPvjKX9oyxcknTKH7Km1sYvhNBWcXu6wsqR2ytZ"
+                }
+              }
+            }
+          },
+          {
+            "cursor": "NA==",
+            "node": {
+              "digest": "3o2YxT8WFw1c2rWD3t5eFjPMFLjuFJWCiHesTpj3S74q",
+              "effects": {
+                "checkpoint": {
+                  "sequenceNumber": 3,
+                  "digest": "Hp8GWDymM4sx5bTuCo3EeZbXYexx9gKMxtaMEib4ApFf"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "addressA_sent_with_filter": {
+      "transactions": {
+        "edges": [
+          {
+            "cursor": "Mg==",
+            "node": {
+              "digest": "E1TNwiSgMqb53AKG3czxZCCx7phkJ5UbTFRGvBSEdPHN",
+              "effects": {
+                "checkpoint": {
+                  "sequenceNumber": 1,
+                  "digest": "73mbZWx3smA16a67N9ozBN1HVkkLB5mvcLBWqFiQpysD"
+                }
+              }
+            }
+          },
+          {
+            "cursor": "Mw==",
+            "node": {
+              "digest": "EfQeT6HMuzbgyUuXVJfwepuxF8QjZRtQpgjNbkHvGNpJ",
+              "effects": {
+                "checkpoint": {
+                  "sequenceNumber": 2,
+                  "digest": "5LbqZRPvjKX9oyxcknTKH7Km1sYvhNBWcXu6wsqR2ytZ"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "addressA_affected_first1": {
+      "transactions": {
+        "pageInfo": {
+          "hasNextPage": true,
+          "hasPreviousPage": false,
+          "startCursor": "MA==",
+          "endCursor": "MA=="
+        },
+        "edges": [
+          {
+            "cursor": "MA==",
+            "node": {
+              "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -129,6 +129,13 @@ type Address implements IAddressable {
 	Objects owned by this address, optionally filtered by type.
 	"""
 	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection
+	"""
+	Transactions associated with this address.
+	
+	Similar behavior to the `transactions` in Query but supporting the additional
+	`AddressTransactionRelationship` filter, which defaults to `SENT`.
+	"""
+	transactions(first: Int, after: String, last: Int, before: String, relation: AddressTransactionRelationship, filter: TransactionFilter): TransactionConnection
 }
 
 """
@@ -139,6 +146,21 @@ type AddressOwner {
 	The owner's address.
 	"""
 	address: Address
+}
+
+"""
+The possible relationship types for a transaction: sent or affected.
+"""
+enum AddressTransactionRelationship {
+	"""
+	Transactions this address has sent.
+	"""
+	SENT
+	"""
+	Transactions that this address was involved in, either as the sender, sponsor, or as the
+	owner of some object that was created, modified or transferred.
+	"""
+	AFFECTED
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -132,8 +132,7 @@ type Address implements IAddressable {
 	"""
 	Transactions associated with this address.
 	
-	Similar behavior to the `transactions` in Query but supporting the additional
-	`AddressTransactionRelationship` filter, which defaults to `SENT`.
+	Similar behavior to the `transactions` in Query but supporting the additional `AddressTransactionRelationship` filter, which defaults to `SENT`.
 	"""
 	transactions(first: Int, after: String, last: Int, before: String, relation: AddressTransactionRelationship, filter: TransactionFilter): TransactionConnection
 }
@@ -157,8 +156,7 @@ enum AddressTransactionRelationship {
 	"""
 	SENT
 	"""
-	Transactions that this address was involved in, either as the sender, sponsor, or as the
-	owner of some object that was created, modified or transferred.
+	Transactions that this address was involved in, either as the sender, sponsor, or as the owner of some object that was created, modified or transferred.
 	"""
 	AFFECTED
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/address.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/address.rs
@@ -3,7 +3,7 @@
 
 use async_graphql::{
     connection::{Connection, Edge},
-    Context, Interface, Object,
+    Context, Enum, Interface, Object,
 };
 use futures::future::try_join_all;
 use sui_types::{base_types::SuiAddress as NativeSuiAddress, dynamic_field::DynamicFieldType};
@@ -24,7 +24,21 @@ use super::{
     name_service::address_to_name,
     object::{self, Object, ObjectKey},
     object_filter::{ObjectFilter, Validator as OFValidator},
+    transaction::{
+        filter::{TransactionFilter, TransactionFilterValidator as TFValidator},
+        CTransaction, Transaction,
+    },
 };
+
+/// The possible relationship types for a transaction: sent or affected.
+#[derive(Enum, Copy, Clone, Eq, PartialEq)]
+pub(crate) enum AddressTransactionRelationship {
+    /// Transactions this address has sent.
+    Sent,
+    /// Transactions that this address was involved in, either as the sender, sponsor, or as the
+    /// owner of some object that was created, modified or transferred.
+    Affected,
+}
 
 /// Interface implemented by GraphQL types representing entities that are identified by an address.
 ///
@@ -286,6 +300,49 @@ impl Address {
         }
 
         Ok(Some(move_objects))
+    }
+
+    /// Transactions associated with this address.
+    ///
+    /// Similar behavior to the `transactions` in Query but supporting the additional
+    /// `AddressTransactionRelationship` filter, which defaults to `SENT`.
+    pub(crate) async fn transactions(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<CTransaction>,
+        last: Option<u64>,
+        before: Option<CTransaction>,
+        relation: Option<AddressTransactionRelationship>,
+        #[graphql(validator(custom = "TFValidator"))] filter: Option<TransactionFilter>,
+    ) -> Result<Option<Connection<String, Transaction>>, RpcError> {
+        let pagination: &PaginationConfig = ctx.data()?;
+        let limits = pagination.limits("Address", "transactions");
+        let page = Page::from_params(limits, first, after, last, before)?;
+
+        // Default relation to SENT if not provided
+        let relation = relation.unwrap_or(AddressTransactionRelationship::Sent);
+
+        // Create address-specific filter based on relationship
+        let address_filter = match relation {
+            AddressTransactionRelationship::Sent => TransactionFilter {
+                sent_address: Some(self.address.into()),
+                ..Default::default()
+            },
+            AddressTransactionRelationship::Affected => TransactionFilter {
+                affected_address: Some(self.address.into()),
+                ..Default::default()
+            },
+        };
+
+        // Intersect with user-provided filter
+        let Some(filter) = filter.unwrap_or_default().intersect(address_filter) else {
+            return Ok(Some(Connection::new(false, false)));
+        };
+
+        Transaction::paginate(ctx, self.scope.clone(), page, filter)
+            .await
+            .map(Some)
     }
 }
 

--- a/crates/sui-indexer-alt-graphql/src/api/types/address.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/address.rs
@@ -35,8 +35,7 @@ use super::{
 pub(crate) enum AddressTransactionRelationship {
     /// Transactions this address has sent.
     Sent,
-    /// Transactions that this address was involved in, either as the sender, sponsor, or as the
-    /// owner of some object that was created, modified or transferred.
+    /// Transactions that this address was involved in, either as the sender, sponsor, or as the owner of some object that was created, modified or transferred.
     Affected,
 }
 
@@ -304,8 +303,7 @@ impl Address {
 
     /// Transactions associated with this address.
     ///
-    /// Similar behavior to the `transactions` in Query but supporting the additional
-    /// `AddressTransactionRelationship` filter, which defaults to `SENT`.
+    /// Similar behavior to the `transactions` in Query but supporting the additional `AddressTransactionRelationship` filter, which defaults to `SENT`.
     pub(crate) async fn transactions(
         &self,
         ctx: &Context<'_>,

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -136,8 +136,7 @@ type Address implements IAddressable {
 	"""
 	Transactions associated with this address.
 	
-	Similar behavior to the `transactions` in Query but supporting the additional
-	`AddressTransactionRelationship` filter, which defaults to `SENT`.
+	Similar behavior to the `transactions` in Query but supporting the additional `AddressTransactionRelationship` filter, which defaults to `SENT`.
 	"""
 	transactions(first: Int, after: String, last: Int, before: String, relation: AddressTransactionRelationship, filter: TransactionFilter): TransactionConnection
 }
@@ -161,8 +160,7 @@ enum AddressTransactionRelationship {
 	"""
 	SENT
 	"""
-	Transactions that this address was involved in, either as the sender, sponsor, or as the
-	owner of some object that was created, modified or transferred.
+	Transactions that this address was involved in, either as the sender, sponsor, or as the owner of some object that was created, modified or transferred.
 	"""
 	AFFECTED
 }

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -133,6 +133,13 @@ type Address implements IAddressable {
 	Objects owned by this address, optionally filtered by type.
 	"""
 	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection
+	"""
+	Transactions associated with this address.
+	
+	Similar behavior to the `transactions` in Query but supporting the additional
+	`AddressTransactionRelationship` filter, which defaults to `SENT`.
+	"""
+	transactions(first: Int, after: String, last: Int, before: String, relation: AddressTransactionRelationship, filter: TransactionFilter): TransactionConnection
 }
 
 """
@@ -143,6 +150,21 @@ type AddressOwner {
 	The owner's address.
 	"""
 	address: Address
+}
+
+"""
+The possible relationship types for a transaction: sent or affected.
+"""
+enum AddressTransactionRelationship {
+	"""
+	Transactions this address has sent.
+	"""
+	SENT
+	"""
+	Transactions that this address was involved in, either as the sender, sponsor, or as the
+	owner of some object that was created, modified or transferred.
+	"""
+	AFFECTED
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -136,8 +136,7 @@ type Address implements IAddressable {
 	"""
 	Transactions associated with this address.
 	
-	Similar behavior to the `transactions` in Query but supporting the additional
-	`AddressTransactionRelationship` filter, which defaults to `SENT`.
+	Similar behavior to the `transactions` in Query but supporting the additional `AddressTransactionRelationship` filter, which defaults to `SENT`.
 	"""
 	transactions(first: Int, after: String, last: Int, before: String, relation: AddressTransactionRelationship, filter: TransactionFilter): TransactionConnection
 }
@@ -161,8 +160,7 @@ enum AddressTransactionRelationship {
 	"""
 	SENT
 	"""
-	Transactions that this address was involved in, either as the sender, sponsor, or as the
-	owner of some object that was created, modified or transferred.
+	Transactions that this address was involved in, either as the sender, sponsor, or as the owner of some object that was created, modified or transferred.
 	"""
 	AFFECTED
 }

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -133,6 +133,13 @@ type Address implements IAddressable {
 	Objects owned by this address, optionally filtered by type.
 	"""
 	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection
+	"""
+	Transactions associated with this address.
+	
+	Similar behavior to the `transactions` in Query but supporting the additional
+	`AddressTransactionRelationship` filter, which defaults to `SENT`.
+	"""
+	transactions(first: Int, after: String, last: Int, before: String, relation: AddressTransactionRelationship, filter: TransactionFilter): TransactionConnection
 }
 
 """
@@ -143,6 +150,21 @@ type AddressOwner {
 	The owner's address.
 	"""
 	address: Address
+}
+
+"""
+The possible relationship types for a transaction: sent or affected.
+"""
+enum AddressTransactionRelationship {
+	"""
+	Transactions this address has sent.
+	"""
+	SENT
+	"""
+	Transactions that this address was involved in, either as the sender, sponsor, or as the
+	owner of some object that was created, modified or transferred.
+	"""
+	AFFECTED
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -129,6 +129,13 @@ type Address implements IAddressable {
 	Objects owned by this address, optionally filtered by type.
 	"""
 	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection
+	"""
+	Transactions associated with this address.
+	
+	Similar behavior to the `transactions` in Query but supporting the additional
+	`AddressTransactionRelationship` filter, which defaults to `SENT`.
+	"""
+	transactions(first: Int, after: String, last: Int, before: String, relation: AddressTransactionRelationship, filter: TransactionFilter): TransactionConnection
 }
 
 """
@@ -139,6 +146,21 @@ type AddressOwner {
 	The owner's address.
 	"""
 	address: Address
+}
+
+"""
+The possible relationship types for a transaction: sent or affected.
+"""
+enum AddressTransactionRelationship {
+	"""
+	Transactions this address has sent.
+	"""
+	SENT
+	"""
+	Transactions that this address was involved in, either as the sender, sponsor, or as the
+	owner of some object that was created, modified or transferred.
+	"""
+	AFFECTED
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -132,8 +132,7 @@ type Address implements IAddressable {
 	"""
 	Transactions associated with this address.
 	
-	Similar behavior to the `transactions` in Query but supporting the additional
-	`AddressTransactionRelationship` filter, which defaults to `SENT`.
+	Similar behavior to the `transactions` in Query but supporting the additional `AddressTransactionRelationship` filter, which defaults to `SENT`.
 	"""
 	transactions(first: Int, after: String, last: Int, before: String, relation: AddressTransactionRelationship, filter: TransactionFilter): TransactionConnection
 }
@@ -157,8 +156,7 @@ enum AddressTransactionRelationship {
 	"""
 	SENT
 	"""
-	Transactions that this address was involved in, either as the sender, sponsor, or as the
-	owner of some object that was created, modified or transferred.
+	Transactions that this address was involved in, either as the sender, sponsor, or as the owner of some object that was created, modified or transferred.
 	"""
 	AFFECTED
 }


### PR DESCRIPTION
## Description 

Support a new type `transactions` field for `Address`.

This field is also available in GraphQL alpha:

https://github.com/MystenLabs/sui/blob/2cddd9d8d403e41541a451940ac9f14458b2dba2/crates/sui-graphql-rpc/src/types/address.rs#L160

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
