### PR TITLE
Change timing of dkg-failure cancellation for easier compatability with new the commit handler.

### DIFF
--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1310,6 +1310,7 @@
                 "ban_entry_init": false,
                 "better_adapter_type_resolution_errors": false,
                 "bridge": false,
+                "cancel_for_failed_dkg_early": false,
                 "check_for_init_during_upgrade": false,
                 "commit_root_state_digest": false,
                 "consensus_batched_block_sync": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -792,6 +792,10 @@ struct FeatureFlags {
     // If true, use MFP txns in load initial object debts.
     #[serde(skip_serializing_if = "is_false")]
     use_mfp_txns_in_load_initial_object_debts: bool,
+
+    // If true, cancel randomness-using txns when DKG has failed *before* doing other congestion checks.
+    #[serde(skip_serializing_if = "is_false")]
+    cancel_for_failed_dkg_early: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -2203,6 +2207,10 @@ impl ProtocolConfig {
 
     pub fn use_mfp_txns_in_load_initial_object_debts(&self) -> bool {
         self.feature_flags.use_mfp_txns_in_load_initial_object_debts
+    }
+
+    pub fn cancel_for_failed_dkg_early(&self) -> bool {
+        self.feature_flags.cancel_for_failed_dkg_early
     }
 }
 
@@ -3987,6 +3995,7 @@ impl ProtocolConfig {
                     cfg.feature_flags.correct_gas_payment_limit_check = true;
                     cfg.feature_flags.authority_capabilities_v2 = true;
                     cfg.feature_flags.use_mfp_txns_in_load_initial_object_debts = true;
+                    cfg.feature_flags.cancel_for_failed_dkg_early = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_96.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_96.snap
@@ -112,6 +112,7 @@ feature_flags:
   additional_consensus_digest_indirect_state: true
   check_for_init_during_upgrade: true
   use_mfp_txns_in_load_initial_object_debts: true
+  cancel_for_failed_dkg_early: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_96.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_96.snap
@@ -113,6 +113,7 @@ feature_flags:
   additional_consensus_digest_indirect_state: true
   check_for_init_during_upgrade: true
   use_mfp_txns_in_load_initial_object_debts: true
+  cancel_for_failed_dkg_early: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_96.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_96.snap
@@ -116,6 +116,7 @@ feature_flags:
   additional_consensus_digest_indirect_state: true
   check_for_init_during_upgrade: true
   use_mfp_txns_in_load_initial_object_debts: true
+  cancel_for_failed_dkg_early: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000


### PR DESCRIPTION
This change makes the current commit handler compatible with the new one, without forcing the new one to mimic the old behavior exactly, which would be awkward
