### PR TITLE
[graphql-alt] Support message, module, and function in ExecutionError

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/execution_error.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/execution_error.move
@@ -141,6 +141,15 @@ module test::execution_error_tests {
       instructionOffset
       identifier
       constant
+      message
+      module {
+        name
+        package { address }
+      }
+      function {
+        name
+        module { name }
+      }
     }
   }
 }
@@ -155,6 +164,15 @@ module test::execution_error_tests {
       instructionOffset
       identifier
       constant
+      message
+      module {
+        name
+        package { address }
+      }
+      function {
+        name
+        module { name }
+      }
     }
   }
   
@@ -165,6 +183,15 @@ module test::execution_error_tests {
       instructionOffset
       identifier
       constant
+      message
+      module {
+        name
+        package { address }
+      }
+      function {
+        name
+        module { name }
+      }
     }
   }
 }
@@ -179,6 +206,15 @@ module test::execution_error_tests {
       instructionOffset
       identifier
       constant
+      message
+      module {
+        name
+        package { address }
+      }
+      function {
+        name
+        module { name }
+      }
     }
   }
   
@@ -189,6 +225,15 @@ module test::execution_error_tests {
       instructionOffset
       identifier
       constant
+      message
+      module {
+        name
+        package { address }
+      }
+      function {
+        name
+        module { name }
+      }
     }
   }
   
@@ -199,6 +244,15 @@ module test::execution_error_tests {
       instructionOffset
       identifier
       constant
+      message
+      module {
+        name
+        package { address }
+      }
+      function {
+        name
+        module { name }
+      }
     }
   }
   
@@ -209,6 +263,15 @@ module test::execution_error_tests {
       instructionOffset
       identifier
       constant
+      message
+      module {
+        name
+        package { address }
+      }
+      function {
+        name
+        module { name }
+      }
     }
   }
   
@@ -219,6 +282,15 @@ module test::execution_error_tests {
       instructionOffset
       identifier
       constant
+      message
+      module {
+        name
+        package { address }
+      }
+      function {
+        name
+        module { name }
+      }
     }
   }
   
@@ -229,6 +301,15 @@ module test::execution_error_tests {
       instructionOffset
       identifier
       constant
+      message
+      module {
+        name
+        package { address }
+      }
+      function {
+        name
+        module { name }
+      }
     }
   }
 
@@ -239,6 +320,15 @@ module test::execution_error_tests {
       instructionOffset
       identifier
       constant
+      message
+      module {
+        name
+        package { address }
+      }
+      function {
+        name
+        module { name }
+      }
     }
   }
   
@@ -249,6 +339,15 @@ module test::execution_error_tests {
       instructionOffset
       identifier
       constant
+      message
+      module {
+        name
+        package { address }
+      }
+      function {
+        name
+        module { name }
+      }
     }
   }
 
@@ -259,13 +358,22 @@ module test::execution_error_tests {
       instructionOffset
       identifier
       constant
+      message
+      module {
+        name
+        package { address }
+      }
+      function {
+        name
+        module { name }
+      }
     }
   }
 }
 
 //# run-graphql
 {
-  # Test MovePrimitiveRuntimeError cases
+  # Test MovePrimitiveRuntimeError cases - these test different error paths
   arithmeticUnderflow: transactionEffects(digest: "@{digest_14}") {
     executionError {
       abortCode
@@ -273,6 +381,15 @@ module test::execution_error_tests {
       instructionOffset
       identifier
       constant
+      message
+      module {
+        name
+        package { address }
+      }
+      function {
+        name
+        module { name }
+      }
     }
   }
   
@@ -283,6 +400,15 @@ module test::execution_error_tests {
       instructionOffset
       identifier
       constant
+      message
+      module {
+        name
+        package { address }
+      }
+      function {
+        name
+        module { name }
+      }
     }
   }
   
@@ -293,6 +419,15 @@ module test::execution_error_tests {
       instructionOffset
       identifier
       constant
+      message
+      module {
+        name
+        package { address }
+      }
+      function {
+        name
+        module { name }
+      }
     }
   }
   
@@ -303,6 +438,15 @@ module test::execution_error_tests {
       instructionOffset
       identifier
       constant
+      message
+      module {
+        name
+        package { address }
+      }
+      function {
+        name
+        module { name }
+      }
     }
   }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/execution_error.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/execution_error.snap
@@ -97,7 +97,7 @@ task 18, line 132:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 19, lines 134-146:
+task 19, lines 134-155:
 //# run-graphql
 Response: {
   "data": {
@@ -107,7 +107,7 @@ Response: {
   }
 }
 
-task 20, lines 148-170:
+task 20, lines 157-197:
 //# run-graphql
 Response: {
   "data": {
@@ -117,7 +117,20 @@ Response: {
         "sourceLineNumber": null,
         "instructionOffset": 1,
         "identifier": null,
-        "constant": null
+        "constant": null,
+        "message": "Error in 1st command, from '0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035::execution_error_tests::abort_with_42' (instruction 1), abort code: 42",
+        "module": {
+          "name": "execution_error_tests",
+          "package": {
+            "address": "0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035"
+          }
+        },
+        "function": {
+          "name": "abort_with_42",
+          "module": {
+            "name": "execution_error_tests"
+          }
+        }
       }
     },
     "abort255": {
@@ -126,13 +139,26 @@ Response: {
         "sourceLineNumber": null,
         "instructionOffset": 1,
         "identifier": null,
-        "constant": null
+        "constant": null,
+        "message": "Error in 1st command, from '0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035::execution_error_tests::abort_with_255' (instruction 1), abort code: 255",
+        "module": {
+          "name": "execution_error_tests",
+          "package": {
+            "address": "0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035"
+          }
+        },
+        "function": {
+          "name": "abort_with_255",
+          "module": {
+            "name": "execution_error_tests"
+          }
+        }
       }
     }
   }
 }
 
-task 21, lines 172-264:
+task 21, lines 199-372:
 //# run-graphql
 Response: {
   "data": {
@@ -142,7 +168,20 @@ Response: {
         "sourceLineNumber": 36,
         "instructionOffset": 1,
         "identifier": "ECleverU8",
-        "constant": "10"
+        "constant": "10",
+        "message": "Error in 1st command, from '0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035::execution_error_tests::abort_with_clever_u8' (line 36), abort 'ECleverU8': 10",
+        "module": {
+          "name": "execution_error_tests",
+          "package": {
+            "address": "0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035"
+          }
+        },
+        "function": {
+          "name": "abort_with_clever_u8",
+          "module": {
+            "name": "execution_error_tests"
+          }
+        }
       }
     },
     "cleverU16": {
@@ -151,7 +190,20 @@ Response: {
         "sourceLineNumber": 39,
         "instructionOffset": 1,
         "identifier": "ECleverU16",
-        "constant": "20"
+        "constant": "20",
+        "message": "Error in 1st command, from '0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035::execution_error_tests::abort_with_clever_u16' (line 39), abort 'ECleverU16': 20",
+        "module": {
+          "name": "execution_error_tests",
+          "package": {
+            "address": "0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035"
+          }
+        },
+        "function": {
+          "name": "abort_with_clever_u16",
+          "module": {
+            "name": "execution_error_tests"
+          }
+        }
       }
     },
     "cleverU64": {
@@ -160,7 +212,20 @@ Response: {
         "sourceLineNumber": 42,
         "instructionOffset": 1,
         "identifier": "ECleverU64",
-        "constant": "100"
+        "constant": "100",
+        "message": "Error in 1st command, from '0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035::execution_error_tests::abort_with_clever_u64' (line 42), abort 'ECleverU64': 100",
+        "module": {
+          "name": "execution_error_tests",
+          "package": {
+            "address": "0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035"
+          }
+        },
+        "function": {
+          "name": "abort_with_clever_u64",
+          "module": {
+            "name": "execution_error_tests"
+          }
+        }
       }
     },
     "cleverAddress": {
@@ -169,7 +234,20 @@ Response: {
         "sourceLineNumber": 45,
         "instructionOffset": 1,
         "identifier": "ECleverAddress",
-        "constant": "0x0000000000000000000000000000000000000000000000000000000000000042"
+        "constant": "0x0000000000000000000000000000000000000000000000000000000000000042",
+        "message": "Error in 1st command, from '0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035::execution_error_tests::abort_with_clever_address' (line 45), abort 'ECleverAddress': 0x0000000000000000000000000000000000000000000000000000000000000042",
+        "module": {
+          "name": "execution_error_tests",
+          "package": {
+            "address": "0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035"
+          }
+        },
+        "function": {
+          "name": "abort_with_clever_address",
+          "module": {
+            "name": "execution_error_tests"
+          }
+        }
       }
     },
     "cleverString": {
@@ -178,7 +256,20 @@ Response: {
         "sourceLineNumber": 48,
         "instructionOffset": 1,
         "identifier": "ECleverString",
-        "constant": "This is a clever error message"
+        "constant": "This is a clever error message",
+        "message": "Error in 1st command, from '0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035::execution_error_tests::abort_with_clever_string' (line 48), abort 'ECleverString': This is a clever error message",
+        "module": {
+          "name": "execution_error_tests",
+          "package": {
+            "address": "0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035"
+          }
+        },
+        "function": {
+          "name": "abort_with_clever_string",
+          "module": {
+            "name": "execution_error_tests"
+          }
+        }
       }
     },
     "cleverWithCode": {
@@ -187,7 +278,20 @@ Response: {
         "sourceLineNumber": 51,
         "instructionOffset": 1,
         "identifier": "ECleverWithCode",
-        "constant": "Error with explicit code"
+        "constant": "Error with explicit code",
+        "message": "Error in 1st command, from '0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035::execution_error_tests::abort_with_clever_code' (line 51), abort(code = 15) 'ECleverWithCode': Error with explicit code",
+        "module": {
+          "name": "execution_error_tests",
+          "package": {
+            "address": "0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035"
+          }
+        },
+        "function": {
+          "name": "abort_with_clever_code",
+          "module": {
+            "name": "execution_error_tests"
+          }
+        }
       }
     },
     "cleverRaw": {
@@ -196,7 +300,20 @@ Response: {
         "sourceLineNumber": 54,
         "instructionOffset": 1,
         "identifier": "ECleverRaw",
-        "constant": "AwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAw=="
+        "constant": "AwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAw==",
+        "message": "Error in 1st command, from '0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035::execution_error_tests::abort_with_clever_raw' (line 54), abort 'ECleverRaw': AwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAw==",
+        "module": {
+          "name": "execution_error_tests",
+          "package": {
+            "address": "0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035"
+          }
+        },
+        "function": {
+          "name": "abort_with_clever_raw",
+          "module": {
+            "name": "execution_error_tests"
+          }
+        }
       }
     },
     "assertFailure": {
@@ -205,7 +322,20 @@ Response: {
         "sourceLineNumber": 57,
         "instructionOffset": 1,
         "identifier": null,
-        "constant": null
+        "constant": null,
+        "message": "Error in 1st command, from '0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035::execution_error_tests::assert_failure' (line 57)",
+        "module": {
+          "name": "execution_error_tests",
+          "package": {
+            "address": "0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035"
+          }
+        },
+        "function": {
+          "name": "assert_failure",
+          "module": {
+            "name": "execution_error_tests"
+          }
+        }
       }
     },
     "nonExistentFunction": {
@@ -214,13 +344,16 @@ Response: {
         "sourceLineNumber": null,
         "instructionOffset": null,
         "identifier": null,
-        "constant": null
+        "constant": null,
+        "message": "Error in 1st command, Function Not Found.",
+        "module": null,
+        "function": null
       }
     }
   }
 }
 
-task 22, lines 266-308:
+task 22, lines 374-452:
 //# run-graphql
 Response: {
   "data": {
@@ -230,7 +363,20 @@ Response: {
         "sourceLineNumber": null,
         "instructionOffset": 2,
         "identifier": null,
-        "constant": null
+        "constant": null,
+        "message": "Error in 1st command, Move Primitive Runtime Error. Location: bcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035::execution_error_tests::arithmetic_underflow (function index 11) at offset 2. Arithmetic error, stack overflow, max value depth, etc.",
+        "module": {
+          "name": "execution_error_tests",
+          "package": {
+            "address": "0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035"
+          }
+        },
+        "function": {
+          "name": "arithmetic_underflow",
+          "module": {
+            "name": "execution_error_tests"
+          }
+        }
       }
     },
     "arithmeticOverflow": {
@@ -239,7 +385,20 @@ Response: {
         "sourceLineNumber": null,
         "instructionOffset": 2,
         "identifier": null,
-        "constant": null
+        "constant": null,
+        "message": "Error in 1st command, Move Primitive Runtime Error. Location: bcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035::execution_error_tests::arithmetic_overflow (function index 12) at offset 2. Arithmetic error, stack overflow, max value depth, etc.",
+        "module": {
+          "name": "execution_error_tests",
+          "package": {
+            "address": "0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035"
+          }
+        },
+        "function": {
+          "name": "arithmetic_overflow",
+          "module": {
+            "name": "execution_error_tests"
+          }
+        }
       }
     },
     "divisionByZero": {
@@ -248,7 +407,20 @@ Response: {
         "sourceLineNumber": null,
         "instructionOffset": 2,
         "identifier": null,
-        "constant": null
+        "constant": null,
+        "message": "Error in 1st command, Move Primitive Runtime Error. Location: bcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035::execution_error_tests::division_by_zero (function index 13) at offset 2. Arithmetic error, stack overflow, max value depth, etc.",
+        "module": {
+          "name": "execution_error_tests",
+          "package": {
+            "address": "0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035"
+          }
+        },
+        "function": {
+          "name": "division_by_zero",
+          "module": {
+            "name": "execution_error_tests"
+          }
+        }
       }
     },
     "vectorOutOfBounds": {
@@ -257,7 +429,20 @@ Response: {
         "sourceLineNumber": null,
         "instructionOffset": 4,
         "identifier": null,
-        "constant": null
+        "constant": null,
+        "message": "Error in 1st command, Move Primitive Runtime Error. Location: bcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035::execution_error_tests::vector_out_of_bounds (function index 14) at offset 4. Arithmetic error, stack overflow, max value depth, etc.",
+        "module": {
+          "name": "execution_error_tests",
+          "package": {
+            "address": "0xbcde1ca8503bc1a1bc686de6ac54ea250bbcb7a33a537b01defa8bfce4995035"
+          }
+        },
+        "function": {
+          "name": "vector_out_of_bounds",
+          "module": {
+            "name": "execution_error_tests"
+          }
+        }
       }
     }
   }

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -1200,6 +1200,10 @@ type ExecutionError {
 	"""
 	constant: String
 	"""
+	The function that the abort originated from. Only populated for Move aborts and primitive runtime errors that have function name information.
+	"""
+	function: MoveFunction
+	"""
 	The error's name. Only populated for clever errors.
 	"""
 	identifier: String
@@ -1207,6 +1211,16 @@ type ExecutionError {
 	The instruction offset in the Move bytecode where the error occurred. Populated for Move aborts and primitive runtime errors.
 	"""
 	instructionOffset: Int
+	"""
+	Human readable explanation of why the transaction failed.
+	
+	For Move aborts, the error message will be resolved to a human-readable form if possible, otherwise it will fall back to displaying the abort code and location.
+	"""
+	message: String!
+	"""
+	The module that the abort originated from. Only populated for Move aborts and primitive runtime errors.
+	"""
+	module: MoveModule
 	"""
 	The source line number for the abort. Only populated for clever errors.
 	"""

--- a/crates/sui-indexer-alt-graphql/src/api/types/execution_error.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/execution_error.rs
@@ -4,6 +4,7 @@
 use anyhow::{self, Context as _};
 use async_graphql::Object;
 use fastcrypto::encoding::{Base64, Encoding};
+use std::fmt::Write;
 use sui_package_resolver::{CleverError, ErrorConstants};
 use sui_types::{
     execution_status::{
@@ -13,11 +14,19 @@ use sui_types::{
 };
 use tokio::sync::OnceCell;
 
-use crate::{api::scalars::big_int::BigInt, error::RpcError, scope::Scope};
+use crate::{
+    api::{
+        scalars::big_int::BigInt,
+        types::{move_function::MoveFunction, move_module::MoveModule, move_package::MovePackage},
+    },
+    error::RpcError,
+    scope::Scope,
+};
 
 #[derive(Clone)]
 pub(crate) struct ExecutionError {
     native: ExecutionFailureStatus,
+    command: Option<usize>,
     clever: OnceCell<Option<CleverError>>,
     scope: Scope,
 }
@@ -29,6 +38,11 @@ impl ExecutionError {
     ///
     /// Returns the explicit code if the abort used `code` annotation (e.g., `abort(ERR, code = 5)` returns 5), otherwise returns the raw abort code containing encoded error information.
     async fn abort_code(&self) -> Option<BigInt> {
+        // Note: This uses full CleverError resolution rather than ErrorBitset bit manipulation for
+        // abort code extraction. While ErrorBitset would be faster for isolated queries, we use
+        // CleverError for consistency and to amortize the expensive resolution cost across multiple
+        // fields (identifier, constant, etc.) that are commonly queried together in GraphQL.
+        
         let ExecutionFailureStatus::MoveAbort(_, raw_code) = &self.native else {
             return None;
         };
@@ -78,6 +92,46 @@ impl ExecutionError {
             ErrorConstants::Raw { bytes, .. } => Some(Base64::encode(bytes)),
         }
     }
+
+    /// The module that the abort originated from. Only populated for Move aborts and primitive runtime errors.
+    async fn module(&self) -> Option<MoveModule> {
+        let location = match &self.native {
+            ExecutionFailureStatus::MoveAbort(location, _) => Some(location),
+            ExecutionFailureStatus::MovePrimitiveRuntimeError(location_opt) => location_opt.0.as_ref(),
+            _ => None,
+        }?;
+
+        // location.module is already the correct storage package ID thanks to resolve_module_id_for_move_abort
+        let package = MovePackage::with_address(self.scope.clone(), (*location.module.address()).into());
+        let module_name = location.module.name().to_string();
+
+        Some(MoveModule::with_fq_name(package, module_name))
+    }
+
+    /// The function that the abort originated from. Only populated for Move aborts and primitive runtime errors that have function name information.
+    async fn function(&self) -> Option<MoveFunction> {
+        let location = match &self.native {
+            ExecutionFailureStatus::MoveAbort(location, _) => Some(location),
+            ExecutionFailureStatus::MovePrimitiveRuntimeError(location_opt) => location_opt.0.as_ref(),
+            _ => None,
+        }?;
+
+        let function_name = location.function_name.as_ref()?;
+
+        // Create the module using the already-resolved module ID
+        let package = MovePackage::with_address(self.scope.clone(), (*location.module.address()).into());
+        let module_name = location.module.name().to_string();
+        let module = MoveModule::with_fq_name(package, module_name);
+
+        Some(MoveFunction::with_fq_name(module, function_name.clone()))
+    }
+
+    /// Human readable explanation of why the transaction failed.
+    ///
+    /// For Move aborts, the error message will be resolved to a human-readable form if possible, otherwise it will fall back to displaying the abort code and location.
+    async fn message(&self) -> Result<String, RpcError> {
+        self.format_error_message().await
+    }
 }
 
 impl ExecutionError {
@@ -102,6 +156,7 @@ impl ExecutionError {
 
         Ok(Some(Self {
             native: native_error,
+            command: *command,
             clever: OnceCell::new(),
             scope: scope.clone(),
         }))
@@ -125,6 +180,103 @@ impl ExecutionError {
             })
             .await
     }
+
+    /// Formats the error message with sophisticated logic.
+    /// 
+    /// Handles command context, Move abort details, and clever error information.
+    async fn format_error_message(&self) -> Result<String, RpcError> {
+        match self.command {
+            None => {
+                // No command context, just return the error string
+                Ok(self.native.to_string())
+            }
+            Some(command) => {
+                // Add command context with ordinal suffix (1st, 2nd, 3rd, 4th, etc.)
+                let command = command + 1;
+                let suffix = match command % 10 {
+                    1 if command % 100 != 11 => "st",
+                    2 if command % 100 != 12 => "nd", 
+                    3 if command % 100 != 13 => "rd",
+                    _ => "th",
+                };
+
+                let mut msg = String::new();
+                write_msg(&mut msg, format_args!("Error in {command}{suffix} command, "))?;
+
+                // Handle Move aborts with detailed formatting. Otherwise, just append the error.
+                let ExecutionFailureStatus::MoveAbort(loc, code) = &self.native else {
+                    write_msg(&mut msg, format_args!("{}", self.native))?;
+                    return Ok(msg);
+                };
+
+                // Format Move abort with module and function info
+                write_msg(&mut msg, format_args!("from '{}", loc.module.to_canonical_display(true)))?;
+                if let Some(fname) = &loc.function_name {
+                    write_msg(&mut msg, format_args!("::{}'", fname))?;
+                } else {
+                    write_msg(&mut msg, format_args!("'"))?;
+                }
+
+                // Try to get clever error information
+                let Some(CleverError {
+                    source_line_number,
+                    error_info,
+                    error_code,
+                    ..
+                }) = self.clever_error().await.as_ref()
+                else {
+                    // No clever error, show basic abort info
+                    write_msg(
+                        &mut msg,
+                        format_args!(" (instruction {}), abort code: {code}", loc.instruction),
+                    )?;
+                    return Ok(msg);
+                };
+
+                // Format with clever error details
+                let error_code_str = match error_code {
+                    Some(code) => format!("(code = {code})"),
+                    _ => String::new(),
+                };
+
+                match error_info {
+                    ErrorConstants::Rendered { identifier, constant } => {
+                        write_msg(
+                            &mut msg,
+                            format_args!(" (line {source_line_number}), abort{error_code_str} '{identifier}': {constant}"),
+                        )?;
+                    }
+                    ErrorConstants::Raw { identifier, bytes } => {
+                        let const_str = Base64::encode(bytes);
+                        write_msg(
+                            &mut msg,
+                            format_args!(" (line {source_line_number}), abort{error_code_str} '{identifier}': {const_str}"),
+                        )?;
+                    }
+                    ErrorConstants::None => {
+                        write_msg(
+                            &mut msg,
+                            format_args!(
+                                " (line {source_line_number}){}",
+                                match error_code {
+                                    Some(code) => format!(" abort(code = {code})"),
+                                    _ => String::new(),
+                                }
+                            ),
+                        )?;
+                    }
+                }
+
+                Ok(msg)
+            }
+        }
+    }
+}
+
+/// Helper function to write to a string with proper error context.
+fn write_msg(msg: &mut String, args: std::fmt::Arguments) -> Result<(), RpcError> {
+    write!(msg, "{}", args).context("Failed to format error message")?;
+    Ok(())
 }
 
 /// Resolves the runtime module ID in Move aborts to the storage package ID.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -1204,6 +1204,10 @@ type ExecutionError {
 	"""
 	constant: String
 	"""
+	The function that the abort originated from. Only populated for Move aborts and primitive runtime errors that have function name information.
+	"""
+	function: MoveFunction
+	"""
 	The error's name. Only populated for clever errors.
 	"""
 	identifier: String
@@ -1211,6 +1215,16 @@ type ExecutionError {
 	The instruction offset in the Move bytecode where the error occurred. Populated for Move aborts and primitive runtime errors.
 	"""
 	instructionOffset: Int
+	"""
+	Human readable explanation of why the transaction failed.
+	
+	For Move aborts, the error message will be resolved to a human-readable form if possible, otherwise it will fall back to displaying the abort code and location.
+	"""
+	message: String!
+	"""
+	The module that the abort originated from. Only populated for Move aborts and primitive runtime errors.
+	"""
+	module: MoveModule
 	"""
 	The source line number for the abort. Only populated for clever errors.
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -1204,6 +1204,10 @@ type ExecutionError {
 	"""
 	constant: String
 	"""
+	The function that the abort originated from. Only populated for Move aborts and primitive runtime errors that have function name information.
+	"""
+	function: MoveFunction
+	"""
 	The error's name. Only populated for clever errors.
 	"""
 	identifier: String
@@ -1211,6 +1215,16 @@ type ExecutionError {
 	The instruction offset in the Move bytecode where the error occurred. Populated for Move aborts and primitive runtime errors.
 	"""
 	instructionOffset: Int
+	"""
+	Human readable explanation of why the transaction failed.
+	
+	For Move aborts, the error message will be resolved to a human-readable form if possible, otherwise it will fall back to displaying the abort code and location.
+	"""
+	message: String!
+	"""
+	The module that the abort originated from. Only populated for Move aborts and primitive runtime errors.
+	"""
+	module: MoveModule
 	"""
 	The source line number for the abort. Only populated for clever errors.
 	"""

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -1200,6 +1200,10 @@ type ExecutionError {
 	"""
 	constant: String
 	"""
+	The function that the abort originated from. Only populated for Move aborts and primitive runtime errors that have function name information.
+	"""
+	function: MoveFunction
+	"""
 	The error's name. Only populated for clever errors.
 	"""
 	identifier: String
@@ -1207,6 +1211,16 @@ type ExecutionError {
 	The instruction offset in the Move bytecode where the error occurred. Populated for Move aborts and primitive runtime errors.
 	"""
 	instructionOffset: Int
+	"""
+	Human readable explanation of why the transaction failed.
+	
+	For Move aborts, the error message will be resolved to a human-readable form if possible, otherwise it will fall back to displaying the abort code and location.
+	"""
+	message: String!
+	"""
+	The module that the abort originated from. Only populated for Move aborts and primitive runtime errors.
+	"""
+	module: MoveModule
 	"""
 	The source line number for the abort. Only populated for clever errors.
 	"""


### PR DESCRIPTION
## Description 

This PR added support for `message`, `module`, and `function` field for `ExecutionError` given that `module` and `function` is now available.

For `message` field, the implementation is similar to errors field in old GraphQL:

https://github.com/MystenLabs/sui/blob/9940de1951d784eee527cc429e9e391022818679/crates/sui-graphql-rpc/src/types/transaction_block_effects.rs#L123

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
