### PR TITLE
graphql-alt: Object.dynamicField et al

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/dynamic_field.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/dynamic_field.move
@@ -45,20 +45,22 @@
 { # Successfully fetch a dynamic field with primitive value
   object(address: "@{obj_1_0}") {
     address
+    dynamicField(name: { type: "u64", bcs: "@{cursor_0}" }) { ...DF }
     asMoveObject {
-      dynamicField(name: { type: "u64", bcs: "@{cursor_0}" }) {
-        name {
-          type { repr }
-          json
-        }
+      dynamicField(name: { type: "u64", bcs: "@{cursor_0}" }) { ...DF }
+    }
+  }
+}
 
-        value {
-          ... on MoveValue {
-            type { repr }
-            json
-          }
-        }
-      }
+fragment DF on DynamicField {
+  name {
+    type { repr }
+    json
+  }
+  value {
+    ... on MoveValue {
+      type { repr }
+      json
     }
   }
 }
@@ -67,20 +69,22 @@
 { # Successfully fetch a dynamic field with object value (wrapped)
   object(address: "@{obj_1_0}") {
     address
+      dynamicField(name: { type: "u64", bcs: "@{cursor_0}" }) { ...DF }
     asMoveObject {
-      dynamicField(name: { type: "u64", bcs: "@{cursor_0}" }) {
-        name {
-          type { repr }
-          json
-        }
+      dynamicField(name: { type: "u64", bcs: "@{cursor_0}" }) { ...DF }
+    }
+  }
+}
 
-        value {
-          ... on MoveValue {
-            type { repr }
-            bcs
-          }
-        }
-      }
+fragment DF on DynamicField {
+  name {
+    type { repr }
+    json
+  }
+  value {
+    ... on MoveValue {
+      type { repr }
+      json
     }
   }
 }
@@ -89,24 +93,26 @@
 { # Successfully fetch a dynamic object field
   object(address: "@{obj_2_0}") {
     address
+    dynamicObjectField(name: { type: "u64", bcs: "@{cursor_0}" }) { ...DOF }
     asMoveObject {
-      dynamicObjectField(name: { type: "u64", bcs: "@{cursor_0}" }) {
-        name {
-          type { repr }
-          json
-        }
+      dynamicObjectField(name: { type: "u64", bcs: "@{cursor_0}" }) { ...DOF }
+    }
+  }
+}
 
-        value {
-          ... on MoveObject {
-            address
-            version
+fragment DOF on DynamicField {
+  name {
+    type { repr }
+    json
+  }
+  value {
+    ... on MoveObject {
+      address
+      version
 
-            contents {
-              type { repr }
-              json
-            }
-          }
-        }
+      contents {
+        type { repr }
+        json
       }
     }
   }
@@ -195,6 +201,10 @@ fragment asDF on Object {
     nodes {
       version
 
+      df42: dynamicField(name: { type: "u64", bcs: "@{cursor_0}" }) { ...DF }
+      df43: dynamicField(name: { type: "u64", bcs: "@{cursor_1}" }) { ...DF }
+      df45: dynamicField(name: { type: "u64", bcs: "@{cursor_2}" }) { ...DF }
+
       asMoveObject {
         df42: dynamicField(name: { type: "u64", bcs: "@{cursor_0}" }) { ...DF }
         df43: dynamicField(name: { type: "u64", bcs: "@{cursor_1}" }) { ...DF }
@@ -218,6 +228,11 @@ fragment DF on DynamicField {
 
 fragment Parent on Object {
   version
+
+  df42: dynamicField(name: { type: "u64", bcs: "@{cursor_0}" }) { ...DF }
+  df43: dynamicField(name: { type: "u64", bcs: "@{cursor_1}" }) { ...DF }
+  df45: dynamicField(name: { type: "u64", bcs: "@{cursor_2}" }) { ...DF }
+
   asMoveObject {
     df42: dynamicField(name: { type: "u64", bcs: "@{cursor_0}" }) { ...DF }
     df43: dynamicField(name: { type: "u64", bcs: "@{cursor_1}" }) { ...DF }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/dynamic_field.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/dynamic_field.snap
@@ -88,12 +88,26 @@ task 12, line 42:
 //# create-checkpoint
 Checkpoint created: 3
 
-task 13, lines 44-64:
+task 13, lines 44-66:
 //# run-graphql --cursors bcs(42u64)
 Response: {
   "data": {
     "object": {
       "address": "0xdd806f262555a167b932495c24765daccc1ba6ebee5e8a696155818e6b5e93ad",
+      "dynamicField": {
+        "name": {
+          "type": {
+            "repr": "u64"
+          },
+          "json": "42"
+        },
+        "value": {
+          "type": {
+            "repr": "u64"
+          },
+          "json": "999"
+        }
+      },
       "asMoveObject": {
         "dynamicField": {
           "name": {
@@ -114,12 +128,29 @@ Response: {
   }
 }
 
-task 14, lines 66-86:
+task 14, lines 68-90:
 //# run-graphql --cursors bcs(43u64)
 Response: {
   "data": {
     "object": {
       "address": "0xdd806f262555a167b932495c24765daccc1ba6ebee5e8a696155818e6b5e93ad",
+      "dynamicField": {
+        "name": {
+          "type": {
+            "repr": "u64"
+          },
+          "json": "43"
+        },
+        "value": {
+          "type": {
+            "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+          },
+          "json": {
+            "balance": "100",
+            "id": "0xe784c8e18a196785fd5c242f0a16365483177ac0c19bdc31ec45384b39e82497"
+          }
+        }
+      },
       "asMoveObject": {
         "dynamicField": {
           "name": {
@@ -132,7 +163,10 @@ Response: {
             "type": {
               "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
             },
-            "bcs": "54TI4YoZZ4X9XCQvChY2VIMXesDBm9wx7EU4SznoJJdkAAAAAAAAAA=="
+            "json": {
+              "balance": "100",
+              "id": "0xe784c8e18a196785fd5c242f0a16365483177ac0c19bdc31ec45384b39e82497"
+            }
           }
         }
       }
@@ -140,12 +174,33 @@ Response: {
   }
 }
 
-task 15, lines 88-113:
+task 15, lines 92-119:
 //# run-graphql --cursors bcs(44u64)
 Response: {
   "data": {
     "object": {
       "address": "0x3129d37b70d881020c3293a8875a555c0e0df81841a167ba52ec963d56a9b182",
+      "dynamicObjectField": {
+        "name": {
+          "type": {
+            "repr": "u64"
+          },
+          "json": "44"
+        },
+        "value": {
+          "address": "0x9db0db4cb1b8de097d8b0d50cd4bc3d142a20c329438af3629aacc32132c42d8",
+          "version": 9,
+          "contents": {
+            "type": {
+              "repr": "0x0000000000000000000000000000000000000000000000000000000000000002::coin::Coin<0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI>"
+            },
+            "json": {
+              "balance": "200",
+              "id": "0x9db0db4cb1b8de097d8b0d50cd4bc3d142a20c329438af3629aacc32132c42d8"
+            }
+          }
+        }
+      },
       "asMoveObject": {
         "dynamicObjectField": {
           "name": {
@@ -173,7 +228,7 @@ Response: {
   }
 }
 
-task 16, lines 115-137:
+task 16, lines 121-143:
 //# run-graphql
 Response: {
   "data": {
@@ -181,7 +236,7 @@ Response: {
   }
 }
 
-task 17, lines 139-150:
+task 17, lines 145-156:
 //# run-graphql
 Response: {
   "data": {
@@ -192,7 +247,7 @@ Response: {
   }
 }
 
-task 18, lines 152-158:
+task 18, lines 158-164:
 //# run-graphql
 Response: {
   "data": {
@@ -200,7 +255,7 @@ Response: {
   }
 }
 
-task 19, lines 160-172:
+task 19, lines 166-178:
 //# run-graphql
 Response: {
   "data": {
@@ -222,7 +277,7 @@ Response: {
   }
 }
 
-task 20, lines 174-190:
+task 20, lines 180-196:
 //# run-graphql
 Response: {
   "data": {
@@ -281,7 +336,7 @@ Response: {
   }
 }
 
-task 21, lines 192-210:
+task 21, lines 198-220:
 //# run-graphql --cursors bcs(42u64) bcs(43u64) bcs(45u64)
 Response: {
   "data": {
@@ -289,6 +344,9 @@ Response: {
       "nodes": [
         {
           "version": 2,
+          "df42": null,
+          "df43": null,
+          "df45": null,
           "asMoveObject": {
             "df42": null,
             "df43": null,
@@ -297,6 +355,16 @@ Response: {
         },
         {
           "version": 7,
+          "df42": {
+            "name": {
+              "json": "42"
+            },
+            "value": {
+              "json": "999"
+            }
+          },
+          "df43": null,
+          "df45": null,
           "asMoveObject": {
             "df42": {
               "name": {
@@ -312,6 +380,26 @@ Response: {
         },
         {
           "version": 8,
+          "df42": {
+            "name": {
+              "json": "42"
+            },
+            "value": {
+              "json": "999"
+            }
+          },
+          "df43": {
+            "name": {
+              "json": "43"
+            },
+            "value": {
+              "json": {
+                "balance": "100",
+                "id": "0xe784c8e18a196785fd5c242f0a16365483177ac0c19bdc31ec45384b39e82497"
+              }
+            }
+          },
+          "df45": null,
           "asMoveObject": {
             "df42": {
               "name": {
@@ -337,6 +425,36 @@ Response: {
         },
         {
           "version": 10,
+          "df42": {
+            "name": {
+              "json": "42"
+            },
+            "value": {
+              "json": "999"
+            }
+          },
+          "df43": {
+            "name": {
+              "json": "43"
+            },
+            "value": {
+              "json": {
+                "balance": "100",
+                "id": "0xe784c8e18a196785fd5c242f0a16365483177ac0c19bdc31ec45384b39e82497"
+              }
+            }
+          },
+          "df45": {
+            "name": {
+              "json": "45"
+            },
+            "value": {
+              "json": {
+                "balance": "300",
+                "id": "0x35c792c185e1133d9942f8fb6149433944092148f980d990b0d100f9f9f83103"
+              }
+            }
+          },
           "asMoveObject": {
             "df42": {
               "name": {
@@ -375,12 +493,22 @@ Response: {
   }
 }
 
-task 22, lines 212-231:
+task 22, lines 222-246:
 //# run-graphql --cursors bcs(42u64) bcs(43u64) bcs(45u64)
 Response: {
   "data": {
     "atCp1": {
       "version": 7,
+      "df42": {
+        "name": {
+          "json": "42"
+        },
+        "value": {
+          "json": "999"
+        }
+      },
+      "df43": null,
+      "df45": null,
       "asMoveObject": {
         "df42": {
           "name": {
@@ -396,6 +524,26 @@ Response: {
     },
     "atCp2": {
       "version": 8,
+      "df42": {
+        "name": {
+          "json": "42"
+        },
+        "value": {
+          "json": "999"
+        }
+      },
+      "df43": {
+        "name": {
+          "json": "43"
+        },
+        "value": {
+          "json": {
+            "balance": "100",
+            "id": "0xe784c8e18a196785fd5c242f0a16365483177ac0c19bdc31ec45384b39e82497"
+          }
+        }
+      },
+      "df45": null,
       "asMoveObject": {
         "df42": {
           "name": {
@@ -421,6 +569,36 @@ Response: {
     },
     "atCp3": {
       "version": 10,
+      "df42": {
+        "name": {
+          "json": "42"
+        },
+        "value": {
+          "json": "999"
+        }
+      },
+      "df43": {
+        "name": {
+          "json": "43"
+        },
+        "value": {
+          "json": {
+            "balance": "100",
+            "id": "0xe784c8e18a196785fd5c242f0a16365483177ac0c19bdc31ec45384b39e82497"
+          }
+        }
+      },
+      "df45": {
+        "name": {
+          "json": "45"
+        },
+        "value": {
+          "json": {
+            "balance": "300",
+            "id": "0x35c792c185e1133d9942f8fb6149433944092148f980d990b0d100f9f9f83103"
+          }
+        }
+      },
       "asMoveObject": {
         "df42": {
           "name": {

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -2476,12 +2476,36 @@ type Object implements IAddressable & IObject {
 	"""
 	digest: String
 	"""
+	Access a dynamic field on an object using its type and BCS-encoded name.
+	"""
+	dynamicField(name: DynamicFieldName!): DynamicField
+	"""
+	Dynamic fields owned by this object.
+	"""
+	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
+	"""
+	Access a dynamic object field on an object using its type and BCS-encoded name.
+	"""
+	dynamicObjectField(name: DynamicFieldName!): DynamicField
+	"""
 	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
 	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access dynamic fields on an object using their types and BCS-encoded names.
+	
+	Returns a list of dynamic fields that is guaranteed to be the same length as `keys`. If a dynamic field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.
+	"""
+	multiGetDynamicFields(keys: [DynamicFieldName!]!): [DynamicField]!
+	"""
+	Access dynamic object fields on an object using their types and BCS-encoded names.
+	
+	Returns a list of dynamic object fields that is guaranteed to be the same length as `keys`. If a dynamic object field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.
+	"""
+	multiGetDynamicObjectFields(keys: [DynamicFieldName!]!): [DynamicField]!
 	"""
 	Fetch the object with the same ID, at a different version, root version bound, or checkpoint.
 	

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -94,6 +94,8 @@ type Address implements IAddressable {
 	defaultSuinsName: String
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to the object with this address.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -104,6 +106,8 @@ type Address implements IAddressable {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to the object with this address.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
@@ -503,6 +507,8 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	digest: String
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to this object.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -513,6 +519,8 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to this object.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
@@ -818,6 +826,8 @@ type DynamicField implements IAddressable & IMoveObject & IObject {
 	digest: String
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to this object.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -828,6 +838,8 @@ type DynamicField implements IAddressable & IMoveObject & IObject {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to this object.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
@@ -1436,6 +1448,8 @@ interface IMoveObject {
 	contents: MoveValue
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to this object.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -1446,6 +1460,8 @@ interface IMoveObject {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to this object.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
@@ -1983,6 +1999,8 @@ type MoveObject implements IAddressable & IMoveObject & IObject {
 	digest: String
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to this object.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -1993,6 +2011,8 @@ type MoveObject implements IAddressable & IMoveObject & IObject {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to this object.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
@@ -2477,6 +2497,8 @@ type Object implements IAddressable & IObject {
 	digest: String
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to this object.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -2485,6 +2507,8 @@ type Object implements IAddressable & IObject {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to this object.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""

--- a/crates/sui-indexer-alt-graphql/src/api/types/address.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/address.rs
@@ -149,6 +149,8 @@ impl Address {
     }
 
     /// Access a dynamic field on an object using its type and BCS-encoded name.
+    ///
+    /// Returns `null` if a dynamic field with that name could not be found attached to the object with this address.
     pub(crate) async fn dynamic_field(
         &self,
         ctx: &Context<'_>,
@@ -186,6 +188,8 @@ impl Address {
     }
 
     /// Access a dynamic object field on an object using its type and BCS-encoded name.
+    ///
+    /// Returns `null` if a dynamic object field with that name could not be found attached to the object with this address.
     pub(crate) async fn dynamic_object_field(
         &self,
         ctx: &Context<'_>,

--- a/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
@@ -112,6 +112,8 @@ impl CoinMetadata {
     }
 
     /// Access a dynamic field on an object using its type and BCS-encoded name.
+    ///
+    /// Returns `null` if a dynamic field with that name could not be found attached to this object.
     pub(crate) async fn dynamic_field(
         &self,
         ctx: &Context<'_>,
@@ -137,6 +139,8 @@ impl CoinMetadata {
     }
 
     /// Access a dynamic object field on an object using its type and BCS-encoded name.
+    ///
+    /// Returns `null` if a dynamic object field with that name could not be found attached to this object.
     pub(crate) async fn dynamic_object_field(
         &self,
         ctx: &Context<'_>,

--- a/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
@@ -149,6 +149,8 @@ impl DynamicField {
     }
 
     /// Access a dynamic field on an object using its type and BCS-encoded name.
+    ///
+    /// Returns `null` if a dynamic field with that name could not be found attached to this object.
     pub(crate) async fn dynamic_field(
         &self,
         ctx: &Context<'_>,
@@ -174,6 +176,8 @@ impl DynamicField {
     }
 
     /// Access a dynamic object field on an object using its type and BCS-encoded name.
+    ///
+    /// Returns `null` if a dynamic object field with that name could not be found attached to this object.
     pub(crate) async fn dynamic_object_field(
         &self,
         ctx: &Context<'_>,

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
@@ -53,13 +53,13 @@ pub(crate) struct MoveObject {
         name = "dynamic_field",
         arg(name = "name", ty = "DynamicFieldName"),
         ty = "Result<Option<DynamicField>, RpcError<object::Error>>",
-        desc = "Access a dynamic field on an object using its type and BCS-encoded name.",
+        desc = "Access a dynamic field on an object using its type and BCS-encoded name.\n\nReturns `null` if a dynamic field with that name could not be found attached to this object.",
     ),
     field(
         name = "dynamic_object_field",
         arg(name = "name", ty = "DynamicFieldName"),
         ty = "Result<Option<DynamicField>, RpcError<object::Error>>",
-        desc = "Access a dynamic object field on an object using its type and BCS-encoded name.",
+        desc = "Access a dynamic object field on an object using its type and BCS-encoded name.\n\nReturns `null` if a dynamic object field with that name could not be found attached to this object.",
     ),
     field(
         name = "has_public_transfer",
@@ -179,6 +179,8 @@ impl MoveObject {
     }
 
     /// Access a dynamic field on an object using its type and BCS-encoded name.
+    ///
+    /// Returns `null` if a dynamic field with that name could not be found attached to this object.
     pub(crate) async fn dynamic_field(
         &self,
         ctx: &Context<'_>,
@@ -222,6 +224,8 @@ impl MoveObject {
     }
 
     /// Access a dynamic object field on an object using its type and BCS-encoded name.
+    ///
+    /// Returns `null` if a dynamic object field with that name could not be found attached to this object.
     pub(crate) async fn dynamic_object_field(
         &self,
         ctx: &Context<'_>,

--- a/crates/sui-indexer-alt-graphql/src/api/types/object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object.rs
@@ -11,6 +11,7 @@ use async_graphql::{
 };
 use diesel::{sql_types::Bool, ExpressionMethods, QueryDsl};
 use fastcrypto::encoding::{Base58, Encoding};
+use futures::future::try_join_all;
 use move_core_types::language_storage::StructTag;
 use sui_indexer_alt_reader::{
     consistent_reader::{self, ConsistentReader},
@@ -28,6 +29,7 @@ use sui_types::{
         SequenceNumber, SuiAddress as NativeSuiAddress, TransactionDigest, VersionDigest,
     },
     digests::ObjectDigest,
+    dynamic_field::DynamicFieldType,
     object::Object as NativeObject,
     transaction::GenesisObject,
 };
@@ -53,7 +55,7 @@ use super::{
     address::Address,
     balance::{self, Balance},
     coin_metadata::CoinMetadata,
-    dynamic_field::DynamicField,
+    dynamic_field::{DynamicField, DynamicFieldName},
     move_object::MoveObject,
     move_package::MovePackage,
     object_filter::{ObjectFilter, Validator as OFValidator},
@@ -276,6 +278,106 @@ impl Object {
         ctx: &Context<'_>,
     ) -> Result<Option<String>, RpcError> {
         self.super_.default_suins_name(ctx).await
+    }
+
+    /// Access a dynamic field on an object using its type and BCS-encoded name.
+    pub(crate) async fn dynamic_field(
+        &self,
+        ctx: &Context<'_>,
+        name: DynamicFieldName,
+    ) -> Result<Option<DynamicField>, RpcError<Error>> {
+        DynamicField::by_name(
+            ctx,
+            self.super_.scope.clone(),
+            self.super_.address.into(),
+            DynamicFieldType::DynamicField,
+            name,
+        )
+        .await
+        .map_err(upcast)
+    }
+
+    /// Dynamic fields owned by this object.
+    pub(crate) async fn dynamic_fields(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<CLive>,
+        last: Option<u64>,
+        before: Option<CLive>,
+    ) -> Result<Option<Connection<String, DynamicField>>, RpcError<Error>> {
+        let pagination: &PaginationConfig = ctx.data()?;
+        let limits = pagination.limits("Object", "dynamicFields");
+        let page = Page::from_params(limits, first, after, last, before)?;
+
+        let dynamic_fields = DynamicField::paginate(
+            ctx,
+            self.super_.scope.clone(),
+            self.super_.address.into(),
+            page,
+        )
+        .await?;
+
+        Ok(Some(dynamic_fields))
+    }
+
+    /// Access a dynamic object field on an object using its type and BCS-encoded name.
+    pub(crate) async fn dynamic_object_field(
+        &self,
+        ctx: &Context<'_>,
+        name: DynamicFieldName,
+    ) -> Result<Option<DynamicField>, RpcError<Error>> {
+        DynamicField::by_name(
+            ctx,
+            self.super_.scope.clone(),
+            self.super_.address.into(),
+            DynamicFieldType::DynamicObject,
+            name,
+        )
+        .await
+        .map_err(upcast)
+    }
+
+    /// Access dynamic fields on an object using their types and BCS-encoded names.
+    ///
+    /// Returns a list of dynamic fields that is guaranteed to be the same length as `keys`. If a dynamic field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.
+    pub(crate) async fn multi_get_dynamic_fields(
+        &self,
+        ctx: &Context<'_>,
+        keys: Vec<DynamicFieldName>,
+    ) -> Result<Vec<Option<DynamicField>>, RpcError<Error>> {
+        try_join_all(keys.into_iter().map(|key| {
+            DynamicField::by_name(
+                ctx,
+                self.super_.scope.clone(),
+                self.super_.address.into(),
+                DynamicFieldType::DynamicField,
+                key,
+            )
+        }))
+        .await
+        .map_err(upcast)
+    }
+
+    /// Access dynamic object fields on an object using their types and BCS-encoded names.
+    ///
+    /// Returns a list of dynamic object fields that is guaranteed to be the same length as `keys`. If a dynamic object field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.
+    pub(crate) async fn multi_get_dynamic_object_fields(
+        &self,
+        ctx: &Context<'_>,
+        keys: Vec<DynamicFieldName>,
+    ) -> Result<Vec<Option<DynamicField>>, RpcError<Error>> {
+        try_join_all(keys.into_iter().map(|key| {
+            DynamicField::by_name(
+                ctx,
+                self.super_.scope.clone(),
+                self.super_.address.into(),
+                DynamicFieldType::DynamicObject,
+                key,
+            )
+        }))
+        .await
+        .map_err(upcast)
     }
 
     /// Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.

--- a/crates/sui-indexer-alt-graphql/src/api/types/object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object.rs
@@ -281,6 +281,8 @@ impl Object {
     }
 
     /// Access a dynamic field on an object using its type and BCS-encoded name.
+    ///
+    /// Returns `null` if a dynamic field with that name could not be found attached to this object.
     pub(crate) async fn dynamic_field(
         &self,
         ctx: &Context<'_>,
@@ -322,6 +324,8 @@ impl Object {
     }
 
     /// Access a dynamic object field on an object using its type and BCS-encoded name.
+    ///
+    /// Returns `null` if a dynamic object field with that name could not be found attached to this object.
     pub(crate) async fn dynamic_object_field(
         &self,
         ctx: &Context<'_>,

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -2480,12 +2480,36 @@ type Object implements IAddressable & IObject {
 	"""
 	digest: String
 	"""
+	Access a dynamic field on an object using its type and BCS-encoded name.
+	"""
+	dynamicField(name: DynamicFieldName!): DynamicField
+	"""
+	Dynamic fields owned by this object.
+	"""
+	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
+	"""
+	Access a dynamic object field on an object using its type and BCS-encoded name.
+	"""
+	dynamicObjectField(name: DynamicFieldName!): DynamicField
+	"""
 	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
 	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access dynamic fields on an object using their types and BCS-encoded names.
+	
+	Returns a list of dynamic fields that is guaranteed to be the same length as `keys`. If a dynamic field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.
+	"""
+	multiGetDynamicFields(keys: [DynamicFieldName!]!): [DynamicField]!
+	"""
+	Access dynamic object fields on an object using their types and BCS-encoded names.
+	
+	Returns a list of dynamic object fields that is guaranteed to be the same length as `keys`. If a dynamic object field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.
+	"""
+	multiGetDynamicObjectFields(keys: [DynamicFieldName!]!): [DynamicField]!
 	"""
 	Fetch the object with the same ID, at a different version, root version bound, or checkpoint.
 	

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -98,6 +98,8 @@ type Address implements IAddressable {
 	defaultSuinsName: String
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to the object with this address.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -108,6 +110,8 @@ type Address implements IAddressable {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to the object with this address.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
@@ -507,6 +511,8 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	digest: String
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to this object.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -517,6 +523,8 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to this object.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
@@ -822,6 +830,8 @@ type DynamicField implements IAddressable & IMoveObject & IObject {
 	digest: String
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to this object.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -832,6 +842,8 @@ type DynamicField implements IAddressable & IMoveObject & IObject {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to this object.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
@@ -1440,6 +1452,8 @@ interface IMoveObject {
 	contents: MoveValue
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to this object.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -1450,6 +1464,8 @@ interface IMoveObject {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to this object.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
@@ -1987,6 +2003,8 @@ type MoveObject implements IAddressable & IMoveObject & IObject {
 	digest: String
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to this object.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -1997,6 +2015,8 @@ type MoveObject implements IAddressable & IMoveObject & IObject {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to this object.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
@@ -2481,6 +2501,8 @@ type Object implements IAddressable & IObject {
 	digest: String
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to this object.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -2489,6 +2511,8 @@ type Object implements IAddressable & IObject {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to this object.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -2480,12 +2480,36 @@ type Object implements IAddressable & IObject {
 	"""
 	digest: String
 	"""
+	Access a dynamic field on an object using its type and BCS-encoded name.
+	"""
+	dynamicField(name: DynamicFieldName!): DynamicField
+	"""
+	Dynamic fields owned by this object.
+	"""
+	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
+	"""
+	Access a dynamic object field on an object using its type and BCS-encoded name.
+	"""
+	dynamicObjectField(name: DynamicFieldName!): DynamicField
+	"""
 	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
 	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access dynamic fields on an object using their types and BCS-encoded names.
+	
+	Returns a list of dynamic fields that is guaranteed to be the same length as `keys`. If a dynamic field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.
+	"""
+	multiGetDynamicFields(keys: [DynamicFieldName!]!): [DynamicField]!
+	"""
+	Access dynamic object fields on an object using their types and BCS-encoded names.
+	
+	Returns a list of dynamic object fields that is guaranteed to be the same length as `keys`. If a dynamic object field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.
+	"""
+	multiGetDynamicObjectFields(keys: [DynamicFieldName!]!): [DynamicField]!
 	"""
 	Fetch the object with the same ID, at a different version, root version bound, or checkpoint.
 	

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -98,6 +98,8 @@ type Address implements IAddressable {
 	defaultSuinsName: String
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to the object with this address.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -108,6 +110,8 @@ type Address implements IAddressable {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to the object with this address.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
@@ -507,6 +511,8 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	digest: String
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to this object.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -517,6 +523,8 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to this object.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
@@ -822,6 +830,8 @@ type DynamicField implements IAddressable & IMoveObject & IObject {
 	digest: String
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to this object.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -832,6 +842,8 @@ type DynamicField implements IAddressable & IMoveObject & IObject {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to this object.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
@@ -1440,6 +1452,8 @@ interface IMoveObject {
 	contents: MoveValue
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to this object.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -1450,6 +1464,8 @@ interface IMoveObject {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to this object.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
@@ -1987,6 +2003,8 @@ type MoveObject implements IAddressable & IMoveObject & IObject {
 	digest: String
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to this object.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -1997,6 +2015,8 @@ type MoveObject implements IAddressable & IMoveObject & IObject {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to this object.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
@@ -2481,6 +2501,8 @@ type Object implements IAddressable & IObject {
 	digest: String
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to this object.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -2489,6 +2511,8 @@ type Object implements IAddressable & IObject {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to this object.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -2476,12 +2476,36 @@ type Object implements IAddressable & IObject {
 	"""
 	digest: String
 	"""
+	Access a dynamic field on an object using its type and BCS-encoded name.
+	"""
+	dynamicField(name: DynamicFieldName!): DynamicField
+	"""
+	Dynamic fields owned by this object.
+	"""
+	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
+	"""
+	Access a dynamic object field on an object using its type and BCS-encoded name.
+	"""
+	dynamicObjectField(name: DynamicFieldName!): DynamicField
+	"""
 	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
 	
 	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
 	If the address does not own any coins of a given type, a balance of zero is returned for that type.
 	"""
 	multiGetBalances(keys: [String!]!): [Balance!]
+	"""
+	Access dynamic fields on an object using their types and BCS-encoded names.
+	
+	Returns a list of dynamic fields that is guaranteed to be the same length as `keys`. If a dynamic field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.
+	"""
+	multiGetDynamicFields(keys: [DynamicFieldName!]!): [DynamicField]!
+	"""
+	Access dynamic object fields on an object using their types and BCS-encoded names.
+	
+	Returns a list of dynamic object fields that is guaranteed to be the same length as `keys`. If a dynamic object field in `keys` could not be found in the store, its corresponding entry in the result will be `null`.
+	"""
+	multiGetDynamicObjectFields(keys: [DynamicFieldName!]!): [DynamicField]!
 	"""
 	Fetch the object with the same ID, at a different version, root version bound, or checkpoint.
 	

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -94,6 +94,8 @@ type Address implements IAddressable {
 	defaultSuinsName: String
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to the object with this address.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -104,6 +106,8 @@ type Address implements IAddressable {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to the object with this address.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
@@ -503,6 +507,8 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	digest: String
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to this object.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -513,6 +519,8 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to this object.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
@@ -818,6 +826,8 @@ type DynamicField implements IAddressable & IMoveObject & IObject {
 	digest: String
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to this object.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -828,6 +838,8 @@ type DynamicField implements IAddressable & IMoveObject & IObject {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to this object.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
@@ -1436,6 +1448,8 @@ interface IMoveObject {
 	contents: MoveValue
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to this object.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -1446,6 +1460,8 @@ interface IMoveObject {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to this object.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
@@ -1983,6 +1999,8 @@ type MoveObject implements IAddressable & IMoveObject & IObject {
 	digest: String
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to this object.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -1993,6 +2011,8 @@ type MoveObject implements IAddressable & IMoveObject & IObject {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to this object.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""
@@ -2477,6 +2497,8 @@ type Object implements IAddressable & IObject {
 	digest: String
 	"""
 	Access a dynamic field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic field with that name could not be found attached to this object.
 	"""
 	dynamicField(name: DynamicFieldName!): DynamicField
 	"""
@@ -2485,6 +2507,8 @@ type Object implements IAddressable & IObject {
 	dynamicFields(first: Int, after: String, last: Int, before: String): DynamicFieldConnection
 	"""
 	Access a dynamic object field on an object using its type and BCS-encoded name.
+	
+	Returns `null` if a dynamic object field with that name could not be found attached to this object.
 	"""
 	dynamicObjectField(name: DynamicFieldName!): DynamicField
 	"""


### PR DESCRIPTION
## Description

Add dynamic fields to `Object`. Previously these functions existed on `Address` and on `MoveObject` but not on `Object`, but I spotted based on the example queries that we did used to have it there.

The reason it's not part of the `IAddress` interface is that this would require us to implement it on `MovePackage` where it would be entirely redundant.

## Test plan

Updated E2E tests:

```
$ cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql/objects/dynamic_field
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
