### PR TITLE
graphql-alt: Add TransactionFilter.affectedObject

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/filter/affected_object.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/filter/affected_object.move
@@ -1,0 +1,145 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --addresses P=0x0 --accounts A B --simulator
+
+//# publish
+module P::M {
+  use sui::transfer::Receiving;
+
+  public struct Object has key, store {
+    id: UID,
+    xs: u64,
+  }
+
+  public struct Wrapper has key, store {
+    id: UID,
+    obj: Object,
+  }
+
+  public fun new(xs: u64, ctx: &mut TxContext): Object {
+    Object { id: object::new(ctx), xs }
+  }
+
+  public fun inc(o: &mut Object) {
+    o.xs = o.xs + 1;
+  }
+
+  public fun destroy(o: Object) {
+    let Object { id, xs: _ } = o;
+    id.delete();
+  }
+
+  public fun wrap(o: Object, ctx: &mut TxContext): Wrapper {
+    Wrapper { id: object::new(ctx), obj: o }
+  }
+
+  public fun incw(w: &mut Wrapper) {
+    w.obj.xs = w.obj.xs + 1;
+  }
+
+  public fun unwrap(w: Wrapper): Object {
+    let Wrapper { id, obj } = w;
+    id.delete();
+    obj
+  }
+
+  public fun receive(p: &mut Object, r: Receiving<Object>): Object {
+    transfer::receive(&mut p.id, r)
+  }
+
+  public fun drop_receiving(_: Receiving<Object>) {}
+
+  public fun transfer(to: &Object, from: Object) {
+    transfer::transfer(from, to.id.to_address())
+  }
+}
+
+//# programmable --sender A --inputs 1 @A
+//> P::M::new(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 2 @A
+//> P::M::new(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 3 @A
+//> P::M::new(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs 4 @A
+//> P::M::new(Input(0));
+//> P::M::wrap(Result(0));
+//> TransferObjects([Result(1)], Input(1))
+
+//# programmable --sender A --inputs object(2,0)
+//> P::M::inc(Input(0))
+
+//# programmable --sender A --inputs object(5,0)
+//> P::M::incw(Input(0))
+
+//# programmable --sender A --inputs object(2,0) @A
+//> P::M::wrap(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs object(8,0)
+//> P::M::incw(Input(0))
+
+//# programmable --sender A --inputs object(8,0) @A
+//> P::M::unwrap(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs object(3,0) object(2,0)
+//> P::M::transfer(Input(0), Input(1))
+
+//# programmable --sender A --inputs receiving(2,0)
+//> P::M::drop_receiving(Input(0))
+
+//# programmable --sender A --inputs object(4,0) receiving(2,0) @A
+//> P::M::receive(Input(0), Input(1));
+//> TransferObjects([Result(0)], Input(2))
+
+//# programmable --sender A --inputs object(3,0) receiving(2,0) @A
+//> P::M::receive(Input(0), Input(1));
+//> TransferObjects([Result(0)], Input(2))
+
+//# programmable --sender A --inputs object(2,0)
+//> P::M::destroy(Input(0))
+
+//# programmable --sender A --inputs object(3,0)
+//> P::M::destroy(Input(0))
+
+//# programmable --sender A --inputs object(4,0)
+//> P::M::destroy(Input(0))
+
+//# programmable --sender A --inputs object(5,0) @A
+//> P::M::unwrap(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs object(18,0) @A
+//> P::M::wrap(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs object(19,0)
+//> P::M::unwrap(Input(0));
+//> P::M::destroy(Result(0))
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  all: transactions { ...TX }
+  affect2: transactions(filter: { affectedObject: "@{obj_2_0}" }) { ...TX }
+  affect3: transactions(filter: { affectedObject: "@{obj_3_0}" }) { ...TX }
+  affect4: transactions(filter: { affectedObject: "@{obj_4_0}" }) { ...TX }
+  # The object that was first created at transaction 5 was unwrapped at transaction 18, so that's
+  # the variable we refer to it at.
+  affect5: transactions(filter: { affectedObject: "@{obj_18_0}" }) { ...TX }
+  senderB_empty: transactions(filter: { affectedObject: "@{obj_2_0}", sentAddress: "@{B}" }) { ...TX }
+}
+
+fragment TX on TransactionConnection {
+  nodes {
+    digest
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/filter/affected_object.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/filter/affected_object.snap
@@ -1,0 +1,304 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 23 tasks
+
+init:
+A: object(0,0), B: object(0,1)
+
+task 1, lines 6-56:
+//# publish
+created: object(1,0)
+mutated: object(0,2)
+gas summary: computation_cost: 1000000, storage_cost: 8147200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 58-60:
+//# programmable --sender A --inputs 1 @A
+//> P::M::new(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2295200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 62-64:
+//# programmable --sender A --inputs 2 @A
+//> P::M::new(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2295200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 66-68:
+//# programmable --sender A --inputs 3 @A
+//> P::M::new(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2295200,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 70-73:
+//# programmable --sender A --inputs 4 @A
+//> P::M::new(Input(0));
+//> P::M::wrap(Result(0));
+//> TransferObjects([Result(1)], Input(1))
+created: object(5,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2546000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 6, lines 75-76:
+//# programmable --sender A --inputs object(2,0)
+//> P::M::inc(Input(0))
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2295200,  storage_rebate: 2272248, non_refundable_storage_fee: 22952
+
+task 7, lines 78-79:
+//# programmable --sender A --inputs object(5,0)
+//> P::M::incw(Input(0))
+mutated: object(0,0), object(5,0)
+gas summary: computation_cost: 1000000, storage_cost: 2546000,  storage_rebate: 2520540, non_refundable_storage_fee: 25460
+
+task 8, lines 81-83:
+//# programmable --sender A --inputs object(2,0) @A
+//> P::M::wrap(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+created: object(8,0)
+mutated: object(0,0)
+wrapped: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2546000,  storage_rebate: 2272248, non_refundable_storage_fee: 22952
+
+task 9, lines 85-86:
+//# programmable --sender A --inputs object(8,0)
+//> P::M::incw(Input(0))
+mutated: object(0,0), object(8,0)
+gas summary: computation_cost: 1000000, storage_cost: 2546000,  storage_rebate: 2520540, non_refundable_storage_fee: 25460
+
+task 10, lines 88-90:
+//# programmable --sender A --inputs object(8,0) @A
+//> P::M::unwrap(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+mutated: object(0,0)
+unwrapped: object(2,0)
+deleted: object(8,0)
+gas summary: computation_cost: 1000000, storage_cost: 2295200,  storage_rebate: 2520540, non_refundable_storage_fee: 25460
+
+task 11, lines 92-93:
+//# programmable --sender A --inputs object(3,0) object(2,0)
+//> P::M::transfer(Input(0), Input(1))
+mutated: object(0,0), object(2,0), object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 3602400,  storage_rebate: 3566376, non_refundable_storage_fee: 36024
+
+task 12, lines 95-96:
+//# programmable --sender A --inputs receiving(2,0)
+//> P::M::drop_receiving(Input(0))
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 13, lines 98-100:
+//# programmable --sender A --inputs object(4,0) receiving(2,0) @A
+//> P::M::receive(Input(0), Input(1));
+//> TransferObjects([Result(0)], Input(2))
+Error: Transaction Effects Status: Move Runtime Abort. Location: sui::transfer::receive_impl (function index 12) at offset 0, Abort Code: 3
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: sui, name: Identifier("transfer") }, function: 12, instruction: 0, function_name: Some("receive_impl") }, 3), source: Some(VMError { major_status: ABORTED, sub_status: Some(3), message: None, exec_state: None, location: Module(ModuleId { address: sui, name: Identifier("transfer") }), indices: [], offsets: [(FunctionDefinitionIndex(12), 0)] }), command: Some(0) } }
+
+task 14, lines 102-104:
+//# programmable --sender A --inputs object(3,0) receiving(2,0) @A
+//> P::M::receive(Input(0), Input(1));
+//> TransferObjects([Result(0)], Input(2))
+mutated: object(0,0), object(2,0), object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 3602400,  storage_rebate: 3566376, non_refundable_storage_fee: 36024
+
+task 15, lines 106-107:
+//# programmable --sender A --inputs object(2,0)
+//> P::M::destroy(Input(0))
+mutated: object(0,0)
+deleted: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2272248, non_refundable_storage_fee: 22952
+
+task 16, lines 109-110:
+//# programmable --sender A --inputs object(3,0)
+//> P::M::destroy(Input(0))
+mutated: object(0,0)
+deleted: object(3,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2272248, non_refundable_storage_fee: 22952
+
+task 17, lines 112-113:
+//# programmable --sender A --inputs object(4,0)
+//> P::M::destroy(Input(0))
+mutated: object(0,0)
+deleted: object(4,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2272248, non_refundable_storage_fee: 22952
+
+task 18, lines 115-117:
+//# programmable --sender A --inputs object(5,0) @A
+//> P::M::unwrap(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+mutated: object(0,0)
+unwrapped: object(18,0)
+deleted: object(5,0)
+gas summary: computation_cost: 1000000, storage_cost: 2295200,  storage_rebate: 2520540, non_refundable_storage_fee: 25460
+
+task 19, lines 119-121:
+//# programmable --sender A --inputs object(18,0) @A
+//> P::M::wrap(Input(0));
+//> TransferObjects([Result(0)], Input(1))
+created: object(19,0)
+mutated: object(0,0)
+wrapped: object(18,0)
+gas summary: computation_cost: 1000000, storage_cost: 2546000,  storage_rebate: 2272248, non_refundable_storage_fee: 22952
+
+task 20, lines 123-125:
+//# programmable --sender A --inputs object(19,0)
+//> P::M::unwrap(Input(0));
+//> P::M::destroy(Result(0))
+mutated: object(0,0)
+deleted: object(19,0)
+unwrapped_then_deleted: object(18,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 2520540, non_refundable_storage_fee: 25460
+
+task 21, line 127:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 22, lines 129-145:
+//# run-graphql
+Response: {
+  "data": {
+    "all": {
+      "nodes": [
+        {
+          "digest": "9YaSDYB2hY7DwGwATGe2y5D4d8BwtQjE8bj2wRQecqnr"
+        },
+        {
+          "digest": "51T1KWFJgaiBEXuCqqCCBim7pQpS7WfpiLBKKe868WLa"
+        },
+        {
+          "digest": "8ZKx7QU5RBsh4oAGxE9yw4J8uhD8zURfgTBPMGn8oDNu"
+        },
+        {
+          "digest": "8RSv9PsNGkTqovymcXjeMNNddhbioBsG3ALemyKFXfUh"
+        },
+        {
+          "digest": "Fsuvmr4YaV3qhrbeqeDRDfopedv6R39rSUdtSNXrt5K1"
+        },
+        {
+          "digest": "EHZgdaXZDUQVeczRqubbfbNTj4dV1ZSRwahmbGfS7EsJ"
+        },
+        {
+          "digest": "DQ5MKeojorc58W6GWJmHTeYcmtQPyghALdtmtSjC6mHe"
+        },
+        {
+          "digest": "27FtoqH5AvCDtvE71jkLAqKVrsFR5APqXZGpEDmNhND3"
+        },
+        {
+          "digest": "2FVwwjuMCZm2oSo6Q476da793Txcwj1dSNdRqUy67396"
+        },
+        {
+          "digest": "CtfSDXGxGbmWYSqtZLrxDKQvfm85L8Yh5VP32PyJAp3J"
+        },
+        {
+          "digest": "EkorP7Z3JLSKV33HDeh1d6AZJ7AynTT1iJGb11y3z35D"
+        },
+        {
+          "digest": "5cvSVqW6vRyjumSwMLioaoYKHspPpbb6RUuQvY89q8Cy"
+        },
+        {
+          "digest": "31azr79BtpdjS3VibiEudBE63Gtrii9GCQZmXX3UkLc7"
+        },
+        {
+          "digest": "8EQmLCFchyjB1QkSsJYAuuewFQyXh4iZ4FVCSXNE9jF2"
+        },
+        {
+          "digest": "8noCZgswE8jjUXb13R8fRqFMQwifvbzUiPZ8MUDCQrpr"
+        },
+        {
+          "digest": "EjBhQ1nmgqYDHajHAMFC6e2H4Lzwd6fNFeW9aa3vyrMM"
+        },
+        {
+          "digest": "BDjQCK5SeifEiNhBvskGiE3FFDtkYUjxS1u9GuuNiJVf"
+        },
+        {
+          "digest": "2A9J5aXGxKp4fwbKd1gWJx3xw5NmF7MxcRbFWkYg9C8Y"
+        },
+        {
+          "digest": "HMMTRjt13etNonS2AhRz1Tnk7XMUEff1wiGhisGhm8Zu"
+        },
+        {
+          "digest": "D1UZkWaaxpiqR1Z2LrLnqeQQvMAV4kFBL6jJdj8jk9vD"
+        }
+      ]
+    },
+    "affect2": {
+      "nodes": [
+        {
+          "digest": "8ZKx7QU5RBsh4oAGxE9yw4J8uhD8zURfgTBPMGn8oDNu"
+        },
+        {
+          "digest": "DQ5MKeojorc58W6GWJmHTeYcmtQPyghALdtmtSjC6mHe"
+        },
+        {
+          "digest": "2FVwwjuMCZm2oSo6Q476da793Txcwj1dSNdRqUy67396"
+        },
+        {
+          "digest": "EkorP7Z3JLSKV33HDeh1d6AZJ7AynTT1iJGb11y3z35D"
+        },
+        {
+          "digest": "5cvSVqW6vRyjumSwMLioaoYKHspPpbb6RUuQvY89q8Cy"
+        },
+        {
+          "digest": "8noCZgswE8jjUXb13R8fRqFMQwifvbzUiPZ8MUDCQrpr"
+        },
+        {
+          "digest": "EjBhQ1nmgqYDHajHAMFC6e2H4Lzwd6fNFeW9aa3vyrMM"
+        }
+      ]
+    },
+    "affect3": {
+      "nodes": [
+        {
+          "digest": "8RSv9PsNGkTqovymcXjeMNNddhbioBsG3ALemyKFXfUh"
+        },
+        {
+          "digest": "5cvSVqW6vRyjumSwMLioaoYKHspPpbb6RUuQvY89q8Cy"
+        },
+        {
+          "digest": "8noCZgswE8jjUXb13R8fRqFMQwifvbzUiPZ8MUDCQrpr"
+        },
+        {
+          "digest": "BDjQCK5SeifEiNhBvskGiE3FFDtkYUjxS1u9GuuNiJVf"
+        }
+      ]
+    },
+    "affect4": {
+      "nodes": [
+        {
+          "digest": "Fsuvmr4YaV3qhrbeqeDRDfopedv6R39rSUdtSNXrt5K1"
+        },
+        {
+          "digest": "8EQmLCFchyjB1QkSsJYAuuewFQyXh4iZ4FVCSXNE9jF2"
+        },
+        {
+          "digest": "2A9J5aXGxKp4fwbKd1gWJx3xw5NmF7MxcRbFWkYg9C8Y"
+        }
+      ]
+    },
+    "affect5": {
+      "nodes": [
+        {
+          "digest": "EHZgdaXZDUQVeczRqubbfbNTj4dV1ZSRwahmbGfS7EsJ"
+        },
+        {
+          "digest": "HMMTRjt13etNonS2AhRz1Tnk7XMUEff1wiGhisGhm8Zu"
+        },
+        {
+          "digest": "D1UZkWaaxpiqR1Z2LrLnqeQQvMAV4kFBL6jJdj8jk9vD"
+        },
+        {
+          "digest": "HzTNVJVtPtbsWqSS2MoNcvXUGoS3T1nTRHCeUBW7uj8E"
+        }
+      ]
+    },
+    "senderB_empty": {
+      "nodes": []
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/filter/transaction_filter_validator.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/filter/transaction_filter_validator.move
@@ -40,9 +40,37 @@ module Test::M1 {
 
 //# run-graphql
 {
+  transactions(filter: { function: "@{Test}::M1::create", affectedObject: "@{A}" }) {
+    edges {
+      cursor
+    }
+  }
+}
+
+//# run-graphql
+{
   transactions(filter: { kind: PROGRAMMABLE_TX, affectedAddress: "@{A}" }) {
     edges {
       cursor
     }
   }
 }
+
+//# run-graphql
+{
+  transactions(filter: { kind: PROGRAMMABLE_TX, affectedObject: "@{A}" }) {
+    edges {
+      cursor
+    }
+  }
+}
+
+//# run-graphql
+{
+  transactions(filter: { affectedAddress: "@{A}", affectedObject: "@{A}" }) {
+    edges {
+      cursor
+    }
+  }
+}
+

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/filter/transaction_filter_validator.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/filter/transaction_filter_validator.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 6 tasks
+processed 9 tasks
 
 init:
 A: object(0,0)
@@ -22,7 +22,7 @@ Response: {
   "data": null,
   "errors": [
     {
-      "message": "Failed to parse \"TransactionFilter\": At most one of [affectedAddress, function, kind] can be specified",
+      "message": "Failed to parse \"TransactionFilter\": At most one of [affectedAddress, affectedObject, function, kind] can be specified",
       "locations": [
         {
           "line": 2,
@@ -42,7 +42,7 @@ Response: {
   "data": null,
   "errors": [
     {
-      "message": "Failed to parse \"TransactionFilter\": At most one of [affectedAddress, function, kind] can be specified",
+      "message": "Failed to parse \"TransactionFilter\": At most one of [affectedAddress, affectedObject, function, kind] can be specified",
       "locations": [
         {
           "line": 2,
@@ -62,7 +62,67 @@ Response: {
   "data": null,
   "errors": [
     {
-      "message": "Failed to parse \"TransactionFilter\": At most one of [affectedAddress, function, kind] can be specified",
+      "message": "Failed to parse \"TransactionFilter\": At most one of [affectedAddress, affectedObject, function, kind] can be specified",
+      "locations": [
+        {
+          "line": 2,
+          "column": 24
+        }
+      ],
+      "path": [
+        "transactions"
+      ]
+    }
+  ]
+}
+
+task 6, lines 50-57:
+//# run-graphql
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Failed to parse \"TransactionFilter\": At most one of [affectedAddress, affectedObject, function, kind] can be specified",
+      "locations": [
+        {
+          "line": 2,
+          "column": 24
+        }
+      ],
+      "path": [
+        "transactions"
+      ]
+    }
+  ]
+}
+
+task 7, lines 59-66:
+//# run-graphql
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Failed to parse \"TransactionFilter\": At most one of [affectedAddress, affectedObject, function, kind] can be specified",
+      "locations": [
+        {
+          "line": 2,
+          "column": 24
+        }
+      ],
+      "path": [
+        "transactions"
+      ]
+    }
+  ]
+}
+
+task 8, lines 68-75:
+//# run-graphql
+Response: {
+  "data": null,
+  "errors": [
+    {
+      "message": "Failed to parse \"TransactionFilter\": At most one of [affectedAddress, affectedObject, function, kind] can be specified",
       "locations": [
         {
           "line": 2,

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -3716,6 +3716,12 @@ input TransactionFilter {
 	"""
 	affectedAddress: SuiAddress
 	"""
+	Limit to transactions that interacted with the given object.
+	The object could have been created, read, modified, deleted, wrapped, or unwrapped by the transaction.
+	Objects that were passed as a `Receiving` input are not considered to have been affected by a transaction unless they were actually received.
+	"""
+	affectedObject: SuiAddress
+	"""
 	Filter to transactions that occurred strictly after the given checkpoint.
 	"""
 	afterCheckpoint: UInt53

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -3720,6 +3720,12 @@ input TransactionFilter {
 	"""
 	affectedAddress: SuiAddress
 	"""
+	Limit to transactions that interacted with the given object.
+	The object could have been created, read, modified, deleted, wrapped, or unwrapped by the transaction.
+	Objects that were passed as a `Receiving` input are not considered to have been affected by a transaction unless they were actually received.
+	"""
+	affectedObject: SuiAddress
+	"""
 	Filter to transactions that occurred strictly after the given checkpoint.
 	"""
 	afterCheckpoint: UInt53

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -3720,6 +3720,12 @@ input TransactionFilter {
 	"""
 	affectedAddress: SuiAddress
 	"""
+	Limit to transactions that interacted with the given object.
+	The object could have been created, read, modified, deleted, wrapped, or unwrapped by the transaction.
+	Objects that were passed as a `Receiving` input are not considered to have been affected by a transaction unless they were actually received.
+	"""
+	affectedObject: SuiAddress
+	"""
 	Filter to transactions that occurred strictly after the given checkpoint.
 	"""
 	afterCheckpoint: UInt53

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -3716,6 +3716,12 @@ input TransactionFilter {
 	"""
 	affectedAddress: SuiAddress
 	"""
+	Limit to transactions that interacted with the given object.
+	The object could have been created, read, modified, deleted, wrapped, or unwrapped by the transaction.
+	Objects that were passed as a `Receiving` input are not considered to have been affected by a transaction unless they were actually received.
+	"""
+	affectedObject: SuiAddress
+	"""
 	Filter to transactions that occurred strictly after the given checkpoint.
 	"""
 	afterCheckpoint: UInt53


### PR DESCRIPTION
## Description

Implements the `TransactionFilter.affectedObject` filter and adds validation that it cannot be used with `function`, `kind`, or `affectedAddress`.

## Test plan

Adds new `affected_object.move` test file and `transaction_filter_validator.move` test cases.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
