### PR TITLE
[5/n][bella-ciao][values] Remove old global fingerprint for values and use the object runtime's fingerprints

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/value_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/value_tests.rs
@@ -155,11 +155,11 @@ fn vec_and_ref_eq() -> PartialVMResult<()> {
 #[test]
 fn global_value_non_struct() -> PartialVMResult<()> {
     assert!(
-        GlobalValue::cached(Value::u64(100)).is_err(),
+        GlobalValue::create(Value::u64(100)).is_err(),
         "cache error 0"
     );
     assert!(
-        GlobalValue::cached(Value::bool(false)).is_err(),
+        GlobalValue::create(Value::bool(false)).is_err(),
         "cache error 1"
     );
 
@@ -168,7 +168,7 @@ fn global_value_non_struct() -> PartialVMResult<()> {
 
     locals.store_loc(0, Value::u8(0)).expect("stored");
     let r = locals.borrow_loc(0).expect("borrowed");
-    assert!(GlobalValue::cached(r).is_err(), "cache error 2");
+    assert!(GlobalValue::create(r).is_err(), "cache error 2");
 
     let _ = heap.free_stack_frame(locals);
 

--- a/sui-execution/latest/sui-move-natives/src/object_runtime/fingerprint.rs
+++ b/sui-execution/latest/sui-move-natives/src/object_runtime/fingerprint.rs
@@ -4,7 +4,6 @@
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::vm_status::StatusCode;
 use move_vm_runtime::execution::values::Value;
-use sui_protocol_config::ProtocolConfig;
 use sui_types::base_types::{MoveObjectType, ObjectID};
 
 /// This type is used to track if an object has changed since it was read from storage. Ideally,
@@ -25,38 +24,24 @@ enum ObjectFingerprint_ {
 }
 
 impl ObjectFingerprint {
-    #[cfg(debug_assertions)]
-    pub fn is_disabled(&self) -> bool {
-        self.0.is_none()
-    }
-
     /// Creates a new object fingerprint for a child object not found in storage.
     /// Will be internally disabled if the feature is not enabled in the protocol config.
-    pub fn none(protocol_config: &ProtocolConfig) -> Self {
-        if !protocol_config.minimize_child_object_mutations() {
-            Self(None)
-        } else {
-            Self(Some(ObjectFingerprint_::Empty))
-        }
+    pub fn none() -> Self {
+        Self(Some(ObjectFingerprint_::Empty))
     }
 
     /// Creates a new object fingerprint for a child found in storage.
     /// Will be internally disabled if the feature is not enabled in the protocol config.
     pub fn preexisting(
-        protocol_config: &ProtocolConfig,
         preexisting_owner: &ObjectID,
         preexisting_type: &MoveObjectType,
         preexisting_value: &Value,
     ) -> PartialVMResult<Self> {
-        Ok(if !protocol_config.minimize_child_object_mutations() {
-            Self(None)
-        } else {
-            Self(Some(ObjectFingerprint_::Preexisting {
-                owner: *preexisting_owner,
-                ty: preexisting_type.clone(),
-                value: preexisting_value.copy_value(),
-            }))
-        })
+        Ok(Self(Some(ObjectFingerprint_::Preexisting {
+            owner: *preexisting_owner,
+            ty: preexisting_type.clone(),
+            value: preexisting_value.copy_value(),
+        })))
     }
 
     /// Checks if the object has changed since it was read from storage.


### PR DESCRIPTION
## Description 

@tnowacki added global value fingerprints to the object runtime a while ago in anticipation of this. This completes the job by removing the hacky global fingerprints that we used as an interim solution in the VM.

This removes mutation tracking for global values from the VM values (and instead this is the underlying responsibility of the runtime). This allows us to simplify the internal representation of global values so they are no longer a four-state value but instead a two-state (empty or filled).

## Test plan 

Move tests are green. 


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
