### PR TITLE
[graphql-alt] Remove module ID resolution in ExecutionError

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -18,12 +18,9 @@ use sui_indexer_alt_reader::{
 use sui_indexer_alt_schema::transactions::BalanceChange as NativeBalanceChange;
 use sui_rpc::proto::sui::rpc::v2beta2::ExecutedTransaction;
 use sui_types::{
-    digests::TransactionDigest,
-    effects::TransactionEffectsAPI,
-    execution_status::ExecutionStatus as NativeExecutionStatus,
-    object::Object as NativeObject,
-    signature::GenericSignature,
-    transaction::{TransactionData, TransactionDataAPI},
+    digests::TransactionDigest, effects::TransactionEffectsAPI,
+    execution_status::ExecutionStatus as NativeExecutionStatus, object::Object as NativeObject,
+    signature::GenericSignature, transaction::TransactionData,
 };
 
 use crate::{
@@ -142,16 +139,7 @@ impl EffectsContents {
         let effects = content.effects()?;
         let status = effects.status();
 
-        // Extract programmable transaction if available
-        let programmable_tx = content
-            .data()
-            .ok()
-            .and_then(|tx_data| match tx_data.into_kind() {
-                sui_types::transaction::TransactionKind::ProgrammableTransaction(tx) => Some(tx),
-                _ => None,
-            });
-
-        ExecutionError::from_execution_status(&self.scope, status, programmable_tx.as_ref()).await
+        ExecutionError::from_execution_status(&self.scope, status).await
     }
 
     /// Timestamp corresponding to the checkpoint this transaction was finalized in.


### PR DESCRIPTION
## Description 

The module ID resolution is already available since Protocol Version 48. Before version 48, we are fine with None clever error as we are having other error context available

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
