### PR TITLE
graphql-alt: Query.events stable sorting

### DIFF
--- a/crates/sui-kvstore/src/bigtable/client.rs
+++ b/crates/sui-kvstore/src/bigtable/client.rs
@@ -802,6 +802,18 @@ impl BigTableClient {
         raw_key.extend(object_key.1.value().to_be_bytes());
         Ok(raw_key)
     }
+
+    /// Creates a row filter for column qualifiers
+    fn column_filter(qualifiers: &[&str]) -> RowFilter {
+        let pattern = match qualifiers {
+            [single] => format!("^{single}$"),
+            multiple => format!("^({})$", multiple.join("|")),
+        };
+
+        RowFilter {
+            filter: Some(Filter::ColumnQualifierRegexFilter(pattern.into())),
+        }
+    }
 }
 
 impl Service<Request<BoxBody>> for AuthChannel {

--- a/crates/sui-kvstore/src/bigtable/client.rs
+++ b/crates/sui-kvstore/src/bigtable/client.rs
@@ -802,18 +802,6 @@ impl BigTableClient {
         raw_key.extend(object_key.1.value().to_be_bytes());
         Ok(raw_key)
     }
-
-    /// Creates a row filter for column qualifiers
-    fn column_filter(qualifiers: &[&str]) -> RowFilter {
-        let pattern = match qualifiers {
-            [single] => format!("^{single}$"),
-            multiple => format!("^({})$", multiple.join("|")),
-        };
-
-        RowFilter {
-            filter: Some(Filter::ColumnQualifierRegexFilter(pattern.into())),
-        }
-    }
 }
 
 impl Service<Request<BoxBody>> for AuthChannel {

--- a/crates/sui-kvstore/src/bigtable/client.rs
+++ b/crates/sui-kvstore/src/bigtable/client.rs
@@ -409,7 +409,7 @@ impl KeyValueStoreReader for BigTableClient {
             let transaction = transaction.context("transaction field is missing")?;
 
             results.push((
-                transaction.digest().clone(),
+                *transaction.digest(),
                 TransactionEventsData {
                     events,
                     timestamp_ms,


### PR DESCRIPTION
## Description 

Bigtable multi_get does not return the results in order of keys  (digests) resulting in an incorrect mapping between digests and transaction events when zipping keys and results. This leads to incorrect lookups on `Query.events` when trying to map `tx_sequence_numbers` -> `digest` -> `events`

## Test plan 

- local test connected to testnet kv and db

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
