### PR TITLE
graphql-alt: Query.events filter performance

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction/filter.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction/filter.rs
@@ -1,11 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ops::RangeInclusive;
-
 use async_graphql::{CustomValidator, Enum, InputObject, InputValueError};
-use sui_pg_db::query::Query;
-use sui_sql_macro::query;
 
 use crate::{
     api::scalars::{fq_name_filter::FqNameFilter, sui_address::SuiAddress, uint53::UInt53},
@@ -99,67 +95,4 @@ impl TransactionFilter {
             sent_address: intersect!(sent_address, intersect::by_eq)?,
         })
     }
-}
-
-/// The tx_sequence_numbers within checkpoint bounds, further filtered by the after and before cursors.
-/// The checkpoint lower and upper bounds are used to determine the inclusive lower (tx_lo) and exclusive
-/// upper (tx_hi) bounds of the sequence of tx_sequence_numbers.
-///
-/// tx_lo: The greatest of the after cursor tx_sequence_number and the tx_lo of the checkpoint at the start of the bounds.
-/// tx_hi: The least of the before cursor tx_sequence_number and the tx_hi of the checkpoint directly after the cp_bounds.end(),
-///        or the tx_hi of the context's watermark (global_tx_hi) if the checkpoint directly after the cp_bounds.end() does not exist.
-///
-/// NOTE: for consistency, assume that lowerbounds are inclusive and upperbounds are exclusive.
-/// Bounds that do not follow this convention will be annotated explicitly (e.g. `lo_exclusive` or
-/// `hi_inclusive`).
-/// TODO: (henry) merge this with lookups::tx_bounds
-pub(crate) fn tx_bounds_query(
-    cp_bounds: &RangeInclusive<u64>,
-    global_tx_hi: u64,
-    cursor_lo: u64,
-    cursor_hi: u64,
-) -> Query<'static> {
-    query!(
-        r#"
-        WITH
-        tx_lo AS (
-            SELECT
-                tx_lo
-            FROM
-                cp_sequence_numbers
-            WHERE
-                cp_sequence_number = {BigInt}
-            LIMIT 1
-        ),
-
-        -- tx_hi is the tx_lo of the checkpoint directly after the cp_bounds.end()
-        tx_hi AS (
-            SELECT
-                tx_lo AS tx_hi
-            FROM
-                cp_sequence_numbers
-            WHERE
-                cp_sequence_number = {BigInt} + 1
-            LIMIT 1
-        )
-
-        SELECT
-            (
-            SELECT
-            -- tx_hi is the greatest of the after cursor, cp_bounds.start()
-            GREATEST(tx_lo, {BigInt})
-            FROM tx_lo
-            ) AS tx_lo,
-            -- tx_hi is the least of the before cursor and cp_bounds.end()
-            LEAST(
-                -- If we cannot get the tx_hi from the checkpoint directly after the cp_bounds.end() we use global_tx_hi
-                COALESCE((SELECT tx_hi FROM tx_hi), {BigInt}),
-                {BigInt}
-            ) AS tx_hi"#,
-        *cp_bounds.start() as i64,
-        *cp_bounds.end() as i64,
-        cursor_lo as i64,
-        global_tx_hi as i64,
-        cursor_hi as i64,
-    )
 }


### PR DESCRIPTION
## Description 

Improve performance of events query by querying `tx_lo` and `tx_hi` from `cp_bounds` first instead of in a subquery.

## Test plan 
- local testing connected to testnet kv and pg

Before:
<img width="1664" height="76" alt="Screenshot 2025-09-10 at 11 26 48 PM" src="https://github.com/user-attachments/assets/52c04546-d71b-4905-b13c-9f16cd011af3" />

After:
<img width="1662" height="66" alt="Screenshot 2025-09-10 at 11 05 19 PM" src="https://github.com/user-attachments/assets/342abe54-8bac-48a4-9e16-8a54f892948b" />


How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
