### PR TITLE
[move-ide] Version bump to publish with derived addresses change

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/package-lock.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "move",
-  "version": "1.0.26",
+  "version": "1.0.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "move",
-      "version": "1.0.26",
+      "version": "1.0.28",
       "license": "Apache-2.0",
       "dependencies": {
         "command-exists": "^1.2.9",

--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
   "publisher": "mysten",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "preview": true,
   "repository": {
     "url": "https://github.com/MystenLabs/sui.git",


### PR DESCRIPTION
## Description 

Derived addresses introduced a leak verifier change which causes compilation error in the old version of the build pipeline. We need to update bundled version of `move-analyzer` to accommodate it and hence the version bump required to re-publish in the marketplaces
