### PR TITLE
Add reconfigure to balance withdraw scheduler

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3710,6 +3710,8 @@ impl AuthorityState {
             )
             .await?;
         assert_eq!(new_epoch_store.epoch(), new_epoch);
+        self.execution_scheduler
+            .reconfigure(&new_epoch_store, self.get_child_object_resolver());
         *execution_lock = new_epoch;
         // drop execution_lock after epoch store was updated
         // see also assert in AuthorityState::process_certificate
@@ -3742,9 +3744,12 @@ impl AuthorityState {
                 .map(|c| *c.sequence_number())
                 .unwrap_or_default(),
         );
+        self.execution_scheduler
+            .reconfigure(&new_epoch_store, self.get_child_object_resolver());
         let new_epoch = new_epoch_store.epoch();
         self.epoch_store.store(new_epoch_store);
         epoch_store.epoch_terminated().await;
+
         *execution_lock = new_epoch;
     }
 

--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -4943,6 +4943,11 @@ impl AuthorityPerEpochStore {
             .map(|estimator| estimator.get_observations())
             .unwrap_or_default()
     }
+
+    /// Whether this node is a validator in this epoch.
+    pub fn is_validator(&self) -> bool {
+        self.committee.authority_exists(&self.name)
+    }
 }
 
 impl ExecutionComponents {

--- a/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/tests.rs
+++ b/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/tests.rs
@@ -27,7 +27,7 @@ use tracing::debug;
 #[derive(Clone)]
 struct TestScheduler {
     mock_read: Arc<MockBalanceRead>,
-    schedulers: BTreeMap<String, Arc<BalanceWithdrawScheduler>>,
+    schedulers: BTreeMap<String, BalanceWithdrawScheduler>,
 }
 
 impl TestScheduler {


### PR DESCRIPTION
## Description 

This PR adds reconfigure API to balance withdraw scheduler.
This is necessary because if a node promotes from fullnode to validator during epoch change, we need to set the last settled version at that time, since when the node is running as fullnode we never settle.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
