### PR TITLE
[sui-tool] add max-retries around object store http reqs

### DIFF
--- a/crates/sui-indexer-alt-restorer/src/snapshot.rs
+++ b/crates/sui-indexer-alt-restorer/src/snapshot.rs
@@ -64,6 +64,7 @@ impl SnapshotRestorer {
             NonZeroUsize::new(args.concurrency).unwrap(),
             m,
             true, // skip_reset_local_store
+            3,    // max_retries
         )
         .await?;
         let db = Db::for_write(args.database_url.clone(), args.db_args.clone()).await?;

--- a/crates/sui-snapshot/src/tests.rs
+++ b/crates/sui-snapshot/src/tests.rs
@@ -112,6 +112,7 @@ async fn test_snapshot_basic() -> Result<(), anyhow::Error> {
         NonZeroUsize::new(1).unwrap(),
         MultiProgress::new(),
         false, // skip_reset_local_store
+        3,     // max_retries
     )
     .await?;
     let restored_perpetual_db = AuthorityPerpetualTables::open(&restored_db_path, None);
@@ -167,6 +168,7 @@ async fn test_snapshot_empty_db() -> Result<(), anyhow::Error> {
         NonZeroUsize::new(1).unwrap(),
         MultiProgress::new(),
         false, // skip_reset_local_store
+        3,     // max_retries
     )
     .await?;
     let restored_perpetual_db = AuthorityPerpetualTables::open(&restored_db_path, None);

--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -273,6 +273,10 @@ pub enum ToolCommand {
         /// and output will be reduced to necessary status information.
         #[clap(long = "verbose")]
         verbose: bool,
+        /// Number of retries for failed HTTP requests when downloading snapshot files.
+        /// Defaults to 3 retries. Set to 0 to disable retries.
+        #[clap(long = "max-retries", default_value = "3")]
+        max_retries: usize,
     },
 
     // Restore from formal (slim, DB agnostic) snapshot. Note that this is only supported
@@ -342,6 +346,10 @@ pub enum ToolCommand {
         /// downloaded, and (if --verify is provided) will be verified via committee signature.
         #[clap(long = "all-checkpoints")]
         all_checkpoints: bool,
+        /// Number of retries for failed HTTP requests when downloading snapshot files.
+        /// Defaults to 3 retries. Set to 0 to disable retries.
+        #[clap(long = "max-retries", default_value = "3")]
+        max_retries: usize,
     },
 
     #[clap(name = "replay")]
@@ -683,6 +691,7 @@ impl ToolCommand {
                 latest,
                 verbose,
                 all_checkpoints,
+                max_retries,
             } => {
                 if !verbose {
                     tracing_handle
@@ -815,6 +824,7 @@ impl ToolCommand {
                     network,
                     verify,
                     all_checkpoints,
+                    max_retries,
                 )
                 .await?;
             }
@@ -830,6 +840,7 @@ impl ToolCommand {
                 no_sign_request,
                 latest,
                 verbose,
+                max_retries,
             } => {
                 if !verbose {
                     tracing_handle
@@ -966,6 +977,7 @@ impl ToolCommand {
                     snapshot_store_config,
                     skip_indexes,
                     num_parallel_downloads,
+                    max_retries,
                 )
                 .await?;
             }

--- a/crates/sui-tool/src/lib.rs
+++ b/crates/sui-tool/src/lib.rs
@@ -826,6 +826,7 @@ pub async fn download_formal_snapshot(
     network: Chain,
     verify: SnapshotVerifyMode,
     all_checkpoints: bool,
+    max_retries: usize,
 ) -> Result<(), anyhow::Error> {
     let m = MultiProgress::new();
     m.println(format!(
@@ -884,6 +885,7 @@ pub async fn download_formal_snapshot(
             NonZeroUsize::new(num_parallel_downloads).unwrap(),
             m_clone,
             false, // skip_reset_local_store
+            max_retries,
         )
         .await
         .unwrap_or_else(|err| panic!("Failed to create reader: {}", err));
@@ -1002,6 +1004,7 @@ pub async fn download_db_snapshot(
     snapshot_store_config: ObjectStoreConfig,
     skip_indexes: bool,
     num_parallel_downloads: usize,
+    max_retries: usize,
 ) -> Result<(), anyhow::Error> {
     let remote_store = if snapshot_store_config.no_sign_request {
         snapshot_store_config.make_http()?
@@ -1066,7 +1069,36 @@ pub async fn download_db_snapshot(
                 async move {
                     counter_cloned.fetch_add(1, Ordering::Relaxed);
                     let file_path = get_path(format!("epoch_{}/{}", epoch, file).as_str());
-                    copy_file(&file_path, &file_path, &remote_store, &local_store).await?;
+
+                    let mut attempts = 0;
+                    let max_attempts = max_retries + 1;
+                    loop {
+                        attempts += 1;
+                        match copy_file(&file_path, &file_path, &remote_store, &local_store).await {
+                            Ok(()) => break,
+                            Err(e) if attempts >= max_attempts => {
+                                return Err(anyhow::anyhow!(
+                                    "Failed to download {} after {} attempts: {}",
+                                    file_path,
+                                    attempts,
+                                    e
+                                ));
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    "Failed to download {} (attempt {}/{}): {}, retrying in {}ms",
+                                    file_path,
+                                    attempts,
+                                    max_attempts,
+                                    e,
+                                    1000 * attempts
+                                );
+                                tokio::time::sleep(Duration::from_millis(1000 * attempts as u64))
+                                    .await;
+                            }
+                        }
+                    }
+
                     Ok::<::object_store::path::Path, anyhow::Error>(file_path.clone())
                 }
             })


### PR DESCRIPTION
## Description 

adding configurable retry counts for some sui-tool download reqs

ref: https://github.com/MystenLabs/sui/issues/23168


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
