### PR TITLE
[MFP] Run periodic latency checks using the transaction driver

### DIFF
--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -363,9 +363,7 @@ impl LocalValidatorAggregatorProxy {
         let response = self
             .td
             .drive_transaction(
-                SubmitTxRequest {
-                    transaction: tx.clone(),
-                },
+                SubmitTxRequest::new_transaction(tx.clone()),
                 SubmitTransactionOptions::default(),
                 Some(Duration::from_secs(60)),
             )

--- a/crates/sui-config/src/validator_client_monitor_config.rs
+++ b/crates/sui-config/src/validator_client_monitor_config.rs
@@ -244,13 +244,13 @@ fn default_effects_latency_weight() -> f64 {
 }
 
 fn default_health_check_latency_weight() -> f64 {
-    0.1
+    0.0
 }
 
 fn default_fast_path_latency_weight() -> f64 {
-    0.9
+    1.0
 }
 
 fn default_consensus_latency_weight() -> f64 {
-    0.9
+    1.0
 }

--- a/crates/sui-core/src/quorum_driver/mod.rs
+++ b/crates/sui-core/src/quorum_driver/mod.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use sui_types::base_types::TransactionDigest;
 use sui_types::committee::{Committee, EpochId};
-use sui_types::messages_grpc::HandleCertificateRequestV3;
+use sui_types::messages_grpc::{HandleCertificateRequestV3, TxType};
 use sui_types::quorum_driver_types::{
     ExecuteTransactionRequestV3, QuorumDriverEffectsQueueResult, QuorumDriverError,
     QuorumDriverResponse, QuorumDriverResult,
@@ -31,7 +31,6 @@ use crate::authority_aggregator::{
     ProcessTransactionResult,
 };
 use crate::authority_client::AuthorityAPI;
-use crate::validator_client_monitor::TxType;
 use mysten_common::sync::notify_read::{NotifyRead, Registration};
 use mysten_metrics::{spawn_monitored_task, GaugeGuard};
 use std::fmt::Write;

--- a/crates/sui-core/src/transaction_driver/effects_certifier.rs
+++ b/crates/sui-core/src/transaction_driver/effects_certifier.rs
@@ -359,18 +359,18 @@ impl EffectsCertifier {
                     details: _,
                     fast_path,
                 }) => {
-                    let aggregator = effects_digest_aggregators
-                        .entry(effects_digest)
-                        .or_insert_with(|| StatusAggregator::<()>::new(committee.clone()));
-                    aggregator.insert(name, ());
-
                     if fast_path {
                         if tx_type != TxType::SingleWriter {
-                            tracing::warn!("Fast path is only supported for single writer transactions, tx_digest={tx_digest:?}, name={name}");
+                            tracing::warn!("Fast path is only supported for single writer transactions, name={name}");
                         } else {
                             fast_path_aggregator.insert(name, ());
                         }
                     }
+
+                    let aggregator = effects_digest_aggregators
+                        .entry(effects_digest)
+                        .or_insert_with(|| StatusAggregator::<()>::new(committee.clone()));
+                    aggregator.insert(name, ());
 
                     if aggregator.reached_quorum_threshold() {
                         let quorum_weight = aggregator.total_votes();

--- a/crates/sui-core/src/transaction_driver/effects_certifier.rs
+++ b/crates/sui-core/src/transaction_driver/effects_certifier.rs
@@ -17,7 +17,7 @@ use sui_types::{
     error::SuiError,
     messages_consensus::ConsensusPosition,
     messages_grpc::{
-        ExecutedData, RawWaitForEffectsRequest, SubmitTxResult, WaitForEffectsRequest,
+        ExecutedData, PingType, RawWaitForEffectsRequest, SubmitTxResult, WaitForEffectsRequest,
         WaitForEffectsResponse,
     },
     quorum_driver_types::{EffectsFinalityInfo, FinalizedEffects},
@@ -63,13 +63,14 @@ impl EffectsCertifier {
         &self,
         authority_aggregator: &Arc<AuthorityAggregator<A>>,
         client_monitor: &Arc<ValidatorClientMonitor<A>>,
-        tx_digest: &TransactionDigest,
+        tx_digest: Option<TransactionDigest>,
         tx_type: TxType,
         // This keeps track of the current target for getting full effects.
         mut current_target: AuthorityName,
         // Guaranteed to be not the Rejected variant.
         submit_txn_result: SubmitTxResult,
         options: &SubmitTransactionOptions,
+        ping: Option<PingType>,
     ) -> Result<QuorumTransactionResponse, TransactionDriverError>
     where
         A: AuthorityAPI + Send + Sync + 'static + Clone,
@@ -100,7 +101,8 @@ impl EffectsCertifier {
             }
         };
 
-        let mut retrier = RequestRetrier::new(authority_aggregator, client_monitor, tx_type);
+        let mut retrier =
+            RequestRetrier::new(authority_aggregator, client_monitor, tx_type, vec![]);
 
         // Setting this to None at first because if the full effects are already provided,
         // we do not need to record the latency. We track the time in this function instead of inside
@@ -114,7 +116,8 @@ impl EffectsCertifier {
                 tx_type,
                 consensus_position,
                 options,
-                current_target
+                current_target,
+                ping
             ),
             async {
                 // No need to send a full effects request if it is already provided.
@@ -129,7 +132,7 @@ impl EffectsCertifier {
                     .expect("there should be at least 1 target");
                 current_target = name;
                 full_effects_start_time = Some(Instant::now());
-                self.get_full_effects(client, tx_digest, consensus_position, options)
+                self.get_full_effects(client, tx_digest, consensus_position, options, ping)
                     .await
             },
         );
@@ -197,7 +200,7 @@ impl EffectsCertifier {
             current_target = name;
             full_effects_start_time = Some(Instant::now());
             full_effects_result = self
-                .get_full_effects(client, tx_digest, consensus_position, options)
+                .get_full_effects(client, tx_digest, consensus_position, options, ping)
                 .await;
         }
     }
@@ -206,18 +209,19 @@ impl EffectsCertifier {
     async fn get_full_effects<A>(
         &self,
         client: Arc<SafeClient<A>>,
-        tx_digest: &TransactionDigest,
+        tx_digest: Option<TransactionDigest>,
         consensus_position: Option<ConsensusPosition>,
         options: &SubmitTransactionOptions,
+        ping: Option<PingType>,
     ) -> Result<(TransactionEffectsDigest, Box<ExecutedData>, bool), TransactionRequestError>
     where
         A: AuthorityAPI + Send + Sync + 'static + Clone,
     {
         let request = WaitForEffectsRequest {
-            transaction_digest: Some(*tx_digest),
+            transaction_digest: tx_digest,
             consensus_position,
             include_details: true,
-            ping: None,
+            ping,
         };
 
         match timeout(
@@ -261,18 +265,20 @@ impl EffectsCertifier {
         &self,
         authority_aggregator: &Arc<AuthorityAggregator<A>>,
         client_monitor: &Arc<ValidatorClientMonitor<A>>,
-        tx_digest: &TransactionDigest,
+        tx_digest: Option<TransactionDigest>,
         tx_type: TxType,
         consensus_position: Option<ConsensusPosition>,
         options: &SubmitTransactionOptions,
         submitted_tx_to_validator: AuthorityName,
+        ping: Option<PingType>,
     ) -> Result<TransactionEffectsDigest, TransactionDriverError>
     where
         A: AuthorityAPI + Send + Sync + 'static + Clone,
     {
+        let ping_label = if ping.is_some() { "true" } else { "false" };
         self.metrics
             .certified_effects_ack_attempts
-            .with_label_values(&[tx_type.as_str()])
+            .with_label_values(&[tx_type.as_str(), ping_label])
             .inc();
         let timer = tokio::time::Instant::now();
         let clients = authority_aggregator
@@ -281,10 +287,10 @@ impl EffectsCertifier {
             .collect::<Vec<_>>();
         let committee = authority_aggregator.committee.clone();
         let raw_request = RawWaitForEffectsRequest::try_from(WaitForEffectsRequest {
-            transaction_digest: Some(*tx_digest),
+            transaction_digest: tx_digest,
             consensus_position,
             include_details: false,
-            ping: None,
+            ping,
         })
         .unwrap();
 
@@ -360,7 +366,7 @@ impl EffectsCertifier {
 
                     if fast_path {
                         if tx_type != TxType::SingleWriter {
-                            tracing::warn!("Fast path is only supported for single writer transactions, tx_digest={tx_digest}, name={name}");
+                            tracing::warn!("Fast path is only supported for single writer transactions, tx_digest={tx_digest:?}, name={name}");
                         } else {
                             fast_path_aggregator.insert(name, ());
                         }
@@ -381,11 +387,11 @@ impl EffectsCertifier {
                         // Record success and latency
                         self.metrics
                             .certified_effects_ack_successes
-                            .with_label_values(&[tx_type.as_str()])
+                            .with_label_values(&[tx_type.as_str(), ping_label])
                             .inc();
                         self.metrics
                             .certified_effects_ack_latency
-                            .with_label_values(&[tx_type.as_str()])
+                            .with_label_values(&[tx_type.as_str(), ping_label])
                             .observe(timer.elapsed().as_secs_f64());
 
                         if fast_path_aggregator.reached_quorum_threshold() {
@@ -395,7 +401,7 @@ impl EffectsCertifier {
 
                             self.metrics
                                 .transaction_fastpath_acked
-                                .with_label_values(&[&display_name])
+                                .with_label_values(&[&display_name, ping_label])
                                 .inc();
                         }
 
@@ -415,13 +421,19 @@ impl EffectsCertifier {
                         tracing::trace!(name = ?name.concise(), "Not found at validator");
                         reason_not_found_aggregator.insert(name, ());
                     }
-                    self.metrics.rejection_acks.inc();
+                    self.metrics
+                        .rejection_acks
+                        .with_label_values(&[tx_type.as_str(), ping_label])
+                        .inc();
                 }
                 Ok(WaitForEffectsResponse::Expired { epoch, round }) => {
                     let error = TransactionRequestError::StatusExpired(epoch, round.unwrap_or(0));
                     // Expired status is submission retriable.
                     retriable_errors_aggregator.insert(name, error);
-                    self.metrics.expiration_acks.inc();
+                    self.metrics
+                        .expiration_acks
+                        .with_label_values(&[tx_type.as_str(), ping_label])
+                        .inc();
                 }
                 Err(error) => {
                     let error = TransactionRequestError::Aborted(error);

--- a/crates/sui-core/src/transaction_driver/effects_certifier.rs
+++ b/crates/sui-core/src/transaction_driver/effects_certifier.rs
@@ -17,8 +17,8 @@ use sui_types::{
     error::SuiError,
     messages_consensus::ConsensusPosition,
     messages_grpc::{
-        ExecutedData, PingType, RawWaitForEffectsRequest, SubmitTxResult, WaitForEffectsRequest,
-        WaitForEffectsResponse,
+        ExecutedData, PingType, RawWaitForEffectsRequest, SubmitTxResult, TxType,
+        WaitForEffectsRequest, WaitForEffectsResponse,
     },
     quorum_driver_types::{EffectsFinalityInfo, FinalizedEffects},
 };
@@ -40,7 +40,7 @@ use crate::{
         request_retrier::RequestRetrier,
         QuorumTransactionResponse, SubmitTransactionOptions,
     },
-    validator_client_monitor::{OperationFeedback, OperationType, TxType, ValidatorClientMonitor},
+    validator_client_monitor::{OperationFeedback, OperationType, ValidatorClientMonitor},
 };
 
 #[cfg(test)]

--- a/crates/sui-core/src/transaction_driver/metrics.rs
+++ b/crates/sui-core/src/transaction_driver/metrics.rs
@@ -16,14 +16,14 @@ const SUBMIT_TRANSACTION_RETRIES_BUCKETS: &[f64] = &[
 #[derive(Clone)]
 pub struct TransactionDriverMetrics {
     pub(crate) settlement_finality_latency: HistogramVec,
-    pub(crate) total_transactions_submitted: IntCounter,
+    pub(crate) total_transactions_submitted: IntCounterVec,
     pub(crate) submit_transaction_retries: Histogram,
     pub(crate) submit_transaction_latency: Histogram,
     pub(crate) validator_submit_transaction_errors: IntCounterVec,
     pub(crate) validator_submit_transaction_successes: IntCounterVec,
     pub(crate) executed_transactions: IntCounter,
-    pub(crate) rejection_acks: IntCounter,
-    pub(crate) expiration_acks: IntCounter,
+    pub(crate) rejection_acks: IntCounterVec,
+    pub(crate) expiration_acks: IntCounterVec,
     pub(crate) effects_digest_mismatches: IntCounter,
     pub(crate) transaction_retries: HistogramVec,
     pub(crate) transaction_fastpath_acked: IntCounterVec,
@@ -40,14 +40,15 @@ impl TransactionDriverMetrics {
             settlement_finality_latency: register_histogram_vec_with_registry!(
                 "transaction_driver_settlement_finality_latency",
                 "Settlement finality latency observed from transaction driver",
-                &["tx_type"],
+                &["tx_type", "ping"],
                 mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),
-            total_transactions_submitted: register_int_counter_with_registry!(
+            total_transactions_submitted: register_int_counter_vec_with_registry!(
                 "transaction_driver_total_transactions_submitted",
                 "Total number of transactions submitted through the transaction driver",
+                &["tx_type", "ping"],
                 registry,
             )
             .unwrap(),
@@ -87,15 +88,17 @@ impl TransactionDriverMetrics {
                 registry,
             )
             .unwrap(),
-            rejection_acks: register_int_counter_with_registry!(
+            rejection_acks: register_int_counter_vec_with_registry!(
                 "transaction_driver_rejected_acks",
                 "Number of rejection acknowledgments observed by the transaction driver",
+                &["tx_type", "ping"],
                 registry,
             )
             .unwrap(),
-            expiration_acks: register_int_counter_with_registry!(
+            expiration_acks: register_int_counter_vec_with_registry!(
                 "transaction_driver_expiration_acks",
                 "Number of expiration acknowledgments observed by the transaction driver",
+                &["tx_type", "ping"],
                 registry,
             )
             .unwrap(),
@@ -108,7 +111,7 @@ impl TransactionDriverMetrics {
             transaction_retries: register_histogram_vec_with_registry!(
                 "transaction_driver_transaction_retries",
                 "Number of retries per transaction attempt in drive_transaction",
-                &["result"],
+                &["result", "tx_type", "ping"],
                 SUBMIT_TRANSACTION_RETRIES_BUCKETS.to_vec(),
                 registry,
             )
@@ -116,14 +119,14 @@ impl TransactionDriverMetrics {
             transaction_fastpath_acked: register_int_counter_vec_with_registry!(
                 "transaction_driver_transaction_fastpath_acked",
                 "Number of transactions that were executed using fast path",
-                &["validator"],
+                &["validator", "ping"],
                 registry,
             )
             .unwrap(),
             certified_effects_ack_latency: register_histogram_vec_with_registry!(
                 "transaction_driver_certified_effects_ack_latency",
                 "Latency in seconds for getting certified effects acknowledgment",
-                &["tx_type"],
+                &["tx_type", "ping"],
                 mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
@@ -131,14 +134,14 @@ impl TransactionDriverMetrics {
             certified_effects_ack_attempts: register_int_counter_vec_with_registry!(
                 "transaction_driver_certified_effects_ack_attempts",
                 "Total number of transactions that went through certified effects ack process",
-                &["tx_type"],
+                &["tx_type", "ping"],
                 registry,
             )
             .unwrap(),
             certified_effects_ack_successes: register_int_counter_vec_with_registry!(
                 "transaction_driver_certified_effects_ack_successes",
                 "Number of successful certified effects acknowledgments",
-                &["tx_type"],
+                &["tx_type", "ping"],
                 registry,
             )
             .unwrap(),

--- a/crates/sui-core/src/transaction_driver/mod.rs
+++ b/crates/sui-core/src/transaction_driver/mod.rs
@@ -10,6 +10,7 @@ mod transaction_submitter;
 /// Exports
 pub use error::TransactionDriverError;
 pub use metrics::*;
+use tokio_retry::strategy::{jitter, ExponentialBackoff};
 
 use std::{
     net::SocketAddr,
@@ -19,14 +20,21 @@ use std::{
 
 use arc_swap::ArcSwap;
 use effects_certifier::*;
-use mysten_metrics::monitored_future;
+use mysten_metrics::{monitored_future, spawn_logged_monitored_task};
 use parking_lot::Mutex;
+use rand::Rng;
 use sui_types::{
-    committee::EpochId, digests::TransactionDigest, error::UserInputError,
-    messages_grpc::SubmitTxRequest, transaction::TransactionDataAPI as _,
+    base_types::AuthorityName,
+    committee::EpochId,
+    digests::TransactionDigest,
+    error::UserInputError,
+    messages_grpc::{PingType, SubmitTxRequest},
+    transaction::TransactionDataAPI as _,
 };
-use tokio::{task::JoinSet, time::sleep};
-use tokio_retry::strategy::{jitter, ExponentialBackoff};
+use tokio::{
+    task::JoinSet,
+    time::{interval, sleep},
+};
 use tracing::instrument;
 use transaction_submitter::*;
 
@@ -39,13 +47,16 @@ use crate::{
     },
 };
 use sui_config::NodeConfig;
-
 /// Options for submitting a transaction.
 #[derive(Clone, Default, Debug)]
 pub struct SubmitTransactionOptions {
     /// When forwarding transactions on behalf of a client, this is the client's address
     /// specified for ddos protection.
     pub forwarded_client_addr: Option<SocketAddr>,
+
+    /// When submitting a transaction, only the validators in the allowed validator list can be used to submit the transaction to.
+    /// When the allowed validator list is empty, any validator can be used.
+    pub allowed_validators: Vec<AuthorityName>,
 }
 
 #[derive(Clone, Debug)]
@@ -99,40 +110,156 @@ where
             client_monitor,
         });
 
+        let driver_clone = driver.clone();
+
+        spawn_logged_monitored_task!(Self::run_latency_checks(driver_clone));
+
         driver.enable_reconfig(reconfig_observer);
         driver
     }
 
-    #[instrument(level = "error", skip_all, fields(tx_digest = ?request.transaction.digest()))]
+    // Runs a background task to send ping transactions to all validators to perform latency checks to test both the fast path and the consensus path.
+    async fn run_latency_checks(self: Arc<Self>) {
+        const INTERVAL_BETWEEN_RUNS: Duration = Duration::from_millis(15_000);
+        const MAX_DELAY_BETWEEN_REQUESTS_MS: u64 = 10_000;
+        const PING_REQUEST_TIMEOUT: Duration = Duration::from_millis(5_000);
+
+        let mut interval = interval(INTERVAL_BETWEEN_RUNS);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        loop {
+            interval.tick().await;
+
+            for tx_type in [TxType::SingleWriter, TxType::SharedObject] {
+                Self::execute_latency_for_tx_type(
+                    self.clone(),
+                    MAX_DELAY_BETWEEN_REQUESTS_MS,
+                    PING_REQUEST_TIMEOUT,
+                    tx_type,
+                )
+                .await;
+            }
+        }
+    }
+
+    /// Executes a single round of latency checks for all validators and the provided transaction type.
+    async fn execute_latency_for_tx_type(
+        self: Arc<Self>,
+        max_delay_ms: u64,
+        ping_timeout: Duration,
+        tx_type: TxType,
+    ) {
+        // We are iterating over the single writer and shared object transaction types to test both the fast path and the consensus path.
+        let mut tasks = JoinSet::new();
+        let auth_agg = self.authority_aggregator.load().clone();
+        let validators = auth_agg.committee.names().cloned().collect::<Vec<_>>();
+
+        for name in validators {
+            let display_name = auth_agg.get_display_name(&name);
+            let delay_ms = rand::thread_rng().gen_range(0..max_delay_ms);
+            let self_clone = self.clone();
+
+            let task = async move {
+                // Add some random delay to the task to avoid all tasks running at the same time
+                if delay_ms > 0 {
+                    tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                }
+                let start_time = Instant::now();
+
+                let ping = if tx_type == TxType::SingleWriter {
+                    PingType::FastPath
+                } else {
+                    PingType::Consensus
+                };
+
+                // Now send a ping transaction to the chosen validator for the provided tx type
+                match self_clone
+                    .drive_transaction(
+                        SubmitTxRequest::new_ping(ping),
+                        SubmitTransactionOptions {
+                            allowed_validators: vec![name],
+                            ..Default::default()
+                        },
+                        Some(ping_timeout),
+                    )
+                    .await
+                {
+                    Ok(_) => {
+                        tracing::debug!(
+                            "Ping transaction to validator {} for tx type {} completed end to end in {} seconds",
+                            display_name,
+                            tx_type.as_str(),
+                            start_time.elapsed().as_secs_f64()
+                        );
+                    }
+                    Err(err) => {
+                        tracing::info!("Failed to get certified finalized effects for tx type {}, for ping transaction to validator {}: {}", tx_type.as_str(), display_name, err);
+                    }
+                }
+            };
+
+            tasks.spawn(task);
+        }
+
+        while let Some(result) = tasks.join_next().await {
+            if let Err(e) = result {
+                tracing::info!("Error while driving ping transaction: {}", e);
+            }
+        }
+    }
+
+    /// Drives transaction to submission and effects certification. If ping is provided, then the requested will be treated as a ping transaction.
+    #[instrument(level = "error", skip_all, fields(tx_digest = ?request.transaction.as_ref().map(|t| t.digest()), ping = ?request.ping))]
     pub async fn drive_transaction(
         &self,
         request: SubmitTxRequest,
         options: SubmitTransactionOptions,
         timeout_duration: Option<Duration>,
     ) -> Result<QuorumTransactionResponse, TransactionDriverError> {
-        let tx_digest = request.transaction.digest();
-        let tx_type = if request.transaction.is_consensus_tx() {
-            TxType::SharedObject
+        // To determine the tx type, give priority to the provided ping type (if present).
+        // Also, for ping requests, the amplification factor is always 1.
+        let (tx_type, tx_digest, amplification_factor) = if let Some(ping) = request.ping {
+            let tx_type = if ping == PingType::FastPath {
+                TxType::SingleWriter
+            } else {
+                TxType::SharedObject
+            };
+            (tx_type, None, 1)
         } else {
-            TxType::SingleWriter
+            let transaction = request.transaction.as_ref().unwrap();
+
+            let tx_type = if transaction.is_consensus_tx() {
+                TxType::SharedObject
+            } else {
+                TxType::SingleWriter
+            };
+
+            let gas_price = transaction.transaction_data().gas_price();
+            let reference_gas_price = self.authority_aggregator.load().reference_gas_price;
+            let amplification_factor = gas_price / reference_gas_price.max(1);
+            if amplification_factor == 0 {
+                return Err(TransactionDriverError::ValidationFailed {
+                    error: UserInputError::GasPriceUnderRGP {
+                        gas_price,
+                        reference_gas_price,
+                    }
+                    .to_string(),
+                });
+            }
+            (tx_type, Some(*transaction.digest()), amplification_factor)
         };
 
-        let gas_price = request.transaction.transaction_data().gas_price();
-        let reference_gas_price = self.authority_aggregator.load().reference_gas_price;
-        let amplification_factor = gas_price / reference_gas_price.max(1);
-        if amplification_factor == 0 {
-            return Err(TransactionDriverError::ValidationFailed {
-                error: UserInputError::GasPriceUnderRGP {
-                    gas_price,
-                    reference_gas_price,
-                }
-                .to_string(),
-            });
-        }
-
+        let ping_label = if request.ping.is_some() {
+            "true"
+        } else {
+            "false"
+        };
         let timer = Instant::now();
 
-        self.metrics.total_transactions_submitted.inc();
+        self.metrics
+            .total_transactions_submitted
+            .with_label_values(&[tx_type.as_str(), ping_label])
+            .inc();
 
         const MAX_RETRY_DELAY: Duration = Duration::from_secs(10);
         // Exponential backoff with jitter to prevent thundering herd on retries
@@ -152,6 +279,7 @@ where
                         amplification_factor,
                         request.clone(),
                         &options,
+                        request.ping,
                     )
                     .await
                 {
@@ -159,12 +287,12 @@ where
                         let settlement_finality_latency = timer.elapsed().as_secs_f64();
                         self.metrics
                             .settlement_finality_latency
-                            .with_label_values(&[tx_type.as_str()])
+                            .with_label_values(&[tx_type.as_str(), ping_label])
                             .observe(settlement_finality_latency);
                         // Record the number of retries for successful transaction
                         self.metrics
                             .transaction_retries
-                            .with_label_values(&["success"])
+                            .with_label_values(&["success", tx_type.as_str(), ping_label])
                             .observe(attempts as f64);
                         return Ok(resp);
                     }
@@ -173,7 +301,7 @@ where
                             // Record the number of retries for failed transaction
                             self.metrics
                                 .transaction_retries
-                                .with_label_values(&["failure"])
+                                .with_label_values(&["failure", tx_type.as_str(), ping_label])
                                 .observe(attempts as f64);
                             tracing::info!("Failed to finalize transaction with non-retriable error after {} attempts: {}", attempts, e);
                             return Err(e);
@@ -219,11 +347,12 @@ where
     #[instrument(level = "error", skip_all, err)]
     async fn drive_transaction_once(
         &self,
-        tx_digest: &TransactionDigest,
+        tx_digest: Option<TransactionDigest>,
         tx_type: TxType,
         amplification_factor: u64,
         request: SubmitTxRequest,
         options: &SubmitTransactionOptions,
+        ping: Option<PingType>,
     ) -> Result<QuorumTransactionResponse, TransactionDriverError> {
         let auth_agg = self.authority_aggregator.load();
         let amplification_factor =
@@ -235,7 +364,6 @@ where
             .submit_transaction(
                 &auth_agg,
                 &self.client_monitor,
-                tx_digest,
                 tx_type,
                 amplification_factor,
                 request,
@@ -254,6 +382,7 @@ where
                 name,
                 submit_txn_result,
                 options,
+                ping,
             )
             .await;
 

--- a/crates/sui-core/src/transaction_driver/request_retrier.rs
+++ b/crates/sui-core/src/transaction_driver/request_retrier.rs
@@ -16,12 +16,17 @@ use crate::{
     validator_client_monitor::{TxType, ValidatorClientMonitor},
 };
 
+pub(crate) const TOP_K_VALIDATORS_DENOMINATOR: usize = 3;
+
 /// Provides the next target validator to retry operations,
 /// and gathers the errors along with the operations.
 ///
 /// In TransactionDriver, submitting a transaction and getting full effects follow the same pattern:
 /// 1. Retry against all validators until the operation succeeds.
 /// 2. If non‑retriable errors from a quorum of validators are returned, the operation should fail permanently.
+///
+/// When an `allowed_validators` is provided, only the validators in the list will be used to submit the transaction to.
+/// When the allowed validator list is empty, any validator can be used an then the validators are selected based on their scores.
 ///
 /// This component helps to manager this retry pattern.
 pub(crate) struct RequestRetrier<A: Clone> {
@@ -35,15 +40,27 @@ impl<A: Clone> RequestRetrier<A> {
         auth_agg: &Arc<AuthorityAggregator<A>>,
         client_monitor: &Arc<ValidatorClientMonitor<A>>,
         tx_type: TxType,
+        allowed_validators: Vec<AuthorityName>,
     ) -> Self {
-        let selected_validators = client_monitor.select_shuffled_preferred_validators(
-            &auth_agg.committee,
-            auth_agg.committee.num_members() / 3,
-            tx_type,
-        );
+        let selected_validators = if !allowed_validators.is_empty() {
+            allowed_validators
+        } else {
+            client_monitor.select_shuffled_preferred_validators(
+                &auth_agg.committee,
+                auth_agg.committee.num_members() / TOP_K_VALIDATORS_DENOMINATOR,
+                tx_type,
+            )
+        };
         let remaining_clients = selected_validators
             .into_iter()
-            .map(|name| (name, auth_agg.authority_clients[&name].clone()))
+            .filter_map(|name| {
+                // There is not guarantee that the `selected_validators` are in the `auth_agg.authority_clients` if those are coming from the list
+                // of `allowed_validators`, as the provided `auth_agg` might have been updated with a new committee that doesn't contain the validator in question.
+                auth_agg
+                    .authority_clients
+                    .get(&name)
+                    .map(|client| (name, client.clone()))
+            })
             .collect::<VecDeque<_>>();
         let non_retriable_errors_aggregator = StatusAggregator::new(auth_agg.committee.clone());
         let retriable_errors_aggregator = StatusAggregator::new(auth_agg.committee.clone());
@@ -146,7 +163,8 @@ mod tests {
     async fn test_next_target() {
         let auth_agg = Arc::new(get_authority_aggregator(4));
         let client_monitor = Arc::new(ValidatorClientMonitor::new_for_test(auth_agg.clone()));
-        let mut retrier = RequestRetrier::new(&auth_agg, &client_monitor, TxType::SingleWriter);
+        let mut retrier =
+            RequestRetrier::new(&auth_agg, &client_monitor, TxType::SingleWriter, vec![]);
 
         for _ in 0..4 {
             retrier.next_target().unwrap();
@@ -159,6 +177,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_allowed_validators() {
+        use sui_types::crypto::{get_key_pair, AuthorityKeyPair, KeypairTraits};
+
+        let auth_agg = Arc::new(get_authority_aggregator(4));
+        let client_monitor = Arc::new(ValidatorClientMonitor::new_for_test(auth_agg.clone()));
+
+        // Create validators that don't exist in the auth_agg
+        let (_, key_pair1): (_, AuthorityKeyPair) = get_key_pair();
+        let (_, key_pair2): (_, AuthorityKeyPair) = get_key_pair();
+        let unknown_validator1: AuthorityName = key_pair1.public().into();
+        let unknown_validator2: AuthorityName = key_pair2.public().into();
+
+        // Mix of unknown validators and one known validator
+        let authorities: Vec<_> = auth_agg.committee.names().copied().collect();
+
+        println!("Case 1. Mix of unknown validators and one known validator");
+        {
+            let allowed_validators = vec![
+                unknown_validator1,
+                unknown_validator2,
+                authorities[0], // This one exists in auth_agg
+            ];
+
+            let retrier = RequestRetrier::new(
+                &auth_agg,
+                &client_monitor,
+                TxType::SingleWriter,
+                allowed_validators,
+            );
+
+            // Should only have 1 remaining client (the known validator)
+            assert_eq!(retrier.remaining_clients.len(), 1);
+            assert_eq!(retrier.remaining_clients[0].0, authorities[0]);
+        }
+
+        println!("Case 2. Only unknown validators are provided");
+        {
+            let allowed_validators = vec![unknown_validator1, unknown_validator2];
+
+            let retrier = RequestRetrier::new(
+                &auth_agg,
+                &client_monitor,
+                TxType::SingleWriter,
+                allowed_validators,
+            );
+
+            // Should have no remaining clients since none of the allowed validators exist
+            assert_eq!(retrier.remaining_clients.len(), 0);
+        }
+    }
+
+    #[tokio::test]
     async fn test_add_error() {
         let auth_agg = Arc::new(get_authority_aggregator(4));
         let authorities: Vec<_> = auth_agg.committee.names().copied().collect();
@@ -166,7 +236,8 @@ mod tests {
         // Add retriable errors.
         {
             let client_monitor = Arc::new(ValidatorClientMonitor::new_for_test(auth_agg.clone()));
-            let mut retrier = RequestRetrier::new(&auth_agg, &client_monitor, TxType::SingleWriter);
+            let mut retrier =
+                RequestRetrier::new(&auth_agg, &client_monitor, TxType::SingleWriter, vec![]);
 
             // 25% stake.
             retrier
@@ -202,7 +273,8 @@ mod tests {
         // Add mix of retriable and non-retriable errors.
         {
             let client_monitor = Arc::new(ValidatorClientMonitor::new_for_test(auth_agg.clone()));
-            let mut retrier = RequestRetrier::new(&auth_agg, &client_monitor, TxType::SingleWriter);
+            let mut retrier =
+                RequestRetrier::new(&auth_agg, &client_monitor, TxType::SingleWriter, vec![]);
 
             // 25% stake retriable error.
             retrier

--- a/crates/sui-core/src/transaction_driver/request_retrier.rs
+++ b/crates/sui-core/src/transaction_driver/request_retrier.rs
@@ -3,7 +3,7 @@
 
 use std::{collections::VecDeque, sync::Arc};
 
-use sui_types::base_types::AuthorityName;
+use sui_types::{base_types::AuthorityName, messages_grpc::TxType};
 
 use crate::{
     authority_aggregator::AuthorityAggregator,
@@ -13,7 +13,7 @@ use crate::{
         aggregate_request_errors, AggregatedEffectsDigests, TransactionDriverError,
         TransactionRequestError,
     },
-    validator_client_monitor::{TxType, ValidatorClientMonitor},
+    validator_client_monitor::ValidatorClientMonitor,
 };
 
 pub(crate) const TOP_K_VALIDATORS_DENOMINATOR: usize = 3;

--- a/crates/sui-core/src/transaction_driver/transaction_submitter.rs
+++ b/crates/sui-core/src/transaction_driver/transaction_submitter.rs
@@ -10,7 +10,7 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use sui_types::{
     base_types::AuthorityName,
     error::SuiError,
-    messages_grpc::{SubmitTxRequest, SubmitTxResult},
+    messages_grpc::{SubmitTxRequest, SubmitTxResult, TxType},
 };
 use tokio::time::timeout;
 use tracing::instrument;
@@ -27,7 +27,7 @@ use crate::{
         request_retrier::RequestRetrier,
         SubmitTransactionOptions, TransactionDriverMetrics,
     },
-    validator_client_monitor::{OperationFeedback, OperationType, TxType, ValidatorClientMonitor},
+    validator_client_monitor::{OperationFeedback, OperationType, ValidatorClientMonitor},
 };
 
 #[cfg(test)]

--- a/crates/sui-core/src/transaction_driver/transaction_submitter.rs
+++ b/crates/sui-core/src/transaction_driver/transaction_submitter.rs
@@ -9,7 +9,6 @@ use std::{
 use futures::stream::{FuturesUnordered, StreamExt};
 use sui_types::{
     base_types::AuthorityName,
-    digests::TransactionDigest,
     error::SuiError,
     messages_grpc::{SubmitTxRequest, SubmitTxResult},
 };
@@ -48,12 +47,11 @@ impl TransactionSubmitter {
         Self { metrics }
     }
 
-    #[instrument(level = "debug", skip_all, err(level = "debug"), fields(tx_digest = ?tx_digest))]
+    #[instrument(level = "debug", skip_all, err(level = "debug"))]
     pub(crate) async fn submit_transaction<A>(
         &self,
         authority_aggregator: &Arc<AuthorityAggregator<A>>,
         client_monitor: &Arc<ValidatorClientMonitor<A>>,
-        tx_digest: &TransactionDigest,
         tx_type: TxType,
         amplification_factor: u64,
         request: SubmitTxRequest,
@@ -68,7 +66,12 @@ impl TransactionSubmitter {
             .submit_amplification_factor
             .observe(amplification_factor as f64);
 
-        let mut retrier = RequestRetrier::new(authority_aggregator, client_monitor, tx_type);
+        let mut retrier = RequestRetrier::new(
+            authority_aggregator,
+            client_monitor,
+            tx_type,
+            options.allowed_validators.clone(),
+        );
         let mut retries = 0;
         let mut request_rpcs = FuturesUnordered::new();
 
@@ -177,7 +180,7 @@ impl TransactionSubmitter {
     }
 
     #[instrument(level = "debug", skip_all, err(level = "debug"), ret, fields(validator_display_name = ?display_name))]
-    async fn submit_transaction_once<A>(
+    pub(crate) async fn submit_transaction_once<A>(
         &self,
         client: Arc<SafeClient<A>>,
         request: &SubmitTxRequest,

--- a/crates/sui-core/src/transaction_driver/unit_tests/effects_certifier_tests.rs
+++ b/crates/sui-core/src/transaction_driver/unit_tests/effects_certifier_tests.rs
@@ -280,11 +280,12 @@ async fn test_successful_certified_effects() {
         .get_certified_finalized_effects(
             &authority_aggregator,
             &client_monitor,
-            &tx_digest,
+            Some(tx_digest),
             TxType::SingleWriter,
             *name,
             submit_tx_result,
             &options,
+            None,
         )
         .await;
 
@@ -319,11 +320,12 @@ async fn test_successful_certified_effects() {
         .get_certified_finalized_effects(
             &authority_aggregator,
             &client_monitor,
-            &tx_digest,
+            Some(tx_digest),
             TxType::SingleWriter,
             *name,
             submit_tx_result,
             &options,
+            None,
         )
         .await;
 
@@ -382,11 +384,12 @@ async fn test_transaction_rejected_non_retriable() {
         .get_certified_finalized_effects(
             &authority_aggregator,
             &client_monitor,
-            &tx_digest,
+            Some(tx_digest),
             TxType::SingleWriter,
             *name,
             SubmitTxResult::Submitted { consensus_position },
             &options,
+            None,
         )
         .await;
 
@@ -447,11 +450,12 @@ async fn test_transaction_rejected_retriable() {
         .get_certified_finalized_effects(
             &authority_aggregator,
             &client_monitor,
-            &tx_digest,
+            Some(tx_digest),
             TxType::SingleWriter,
             *name,
             SubmitTxResult::Submitted { consensus_position },
             &options,
+            None,
         )
         .await;
 
@@ -518,11 +522,12 @@ async fn test_transaction_rejected_with_conflicts() {
         .get_certified_finalized_effects(
             &authority_aggregator,
             &client_monitor,
-            &tx_digest,
+            Some(tx_digest),
             TxType::SingleWriter,
             *name,
             SubmitTxResult::Submitted { consensus_position },
             &options,
+            None,
         )
         .await;
 
@@ -579,11 +584,12 @@ async fn test_transaction_expired() {
         .get_certified_finalized_effects(
             &authority_aggregator,
             &client_monitor,
-            &tx_digest,
+            Some(tx_digest),
             TxType::SingleWriter,
             *name,
             SubmitTxResult::Submitted { consensus_position },
             &options,
+            None,
         )
         .await;
 
@@ -662,11 +668,12 @@ async fn test_mixed_rejected_and_expired() {
         .get_certified_finalized_effects(
             &authority_aggregator,
             &client_monitor,
-            &tx_digest,
+            Some(tx_digest),
             TxType::SingleWriter,
             *name,
             SubmitTxResult::Submitted { consensus_position },
             &options,
+            None,
         )
         .await;
 
@@ -703,11 +710,12 @@ async fn test_mixed_rejected_and_expired() {
         .get_certified_finalized_effects(
             &authority_aggregator,
             &client_monitor,
-            &tx_digest,
+            Some(tx_digest),
             TxType::SingleWriter,
             *name,
             SubmitTxResult::Submitted { consensus_position },
             &options,
+            None,
         )
         .await;
 
@@ -794,11 +802,12 @@ async fn test_mixed_rejected_reasons() {
             .get_certified_finalized_effects(
                 &authority_aggregator,
                 &client_monitor,
-                &tx_digest,
+                Some(tx_digest),
                 TxType::SingleWriter,
                 *name,
                 SubmitTxResult::Submitted { consensus_position },
                 &options,
+                None,
             )
             .await;
 
@@ -844,11 +853,12 @@ async fn test_mixed_rejected_reasons() {
             .get_certified_finalized_effects(
                 &authority_aggregator,
                 &client_monitor,
-                &tx_digest,
+                Some(tx_digest),
                 TxType::SingleWriter,
                 *name,
                 SubmitTxResult::Submitted { consensus_position },
                 &options,
+                None,
             )
             .await;
 
@@ -892,11 +902,12 @@ async fn test_mixed_rejected_reasons() {
             .get_certified_finalized_effects(
                 &authority_aggregator,
                 &client_monitor,
-                &tx_digest,
+                Some(tx_digest),
                 TxType::SingleWriter,
                 *name,
                 SubmitTxResult::Submitted { consensus_position },
                 &options,
+                None,
             )
             .await;
 
@@ -943,11 +954,12 @@ async fn test_mixed_rejected_reasons() {
             .get_certified_finalized_effects(
                 &authority_aggregator,
                 &client_monitor,
-                &tx_digest,
+                Some(tx_digest),
                 TxType::SingleWriter,
                 *name,
                 SubmitTxResult::Submitted { consensus_position },
                 &options,
+                None,
             )
             .await;
 
@@ -990,11 +1002,12 @@ async fn test_mixed_rejected_reasons() {
             .get_certified_finalized_effects(
                 &authority_aggregator,
                 &client_monitor,
-                &tx_digest,
+                Some(tx_digest),
                 TxType::SingleWriter,
                 *name,
                 SubmitTxResult::Submitted { consensus_position },
                 &options,
+                None,
             )
             .await;
 
@@ -1075,11 +1088,12 @@ async fn test_forked_execution() {
         .get_certified_finalized_effects(
             &authority_aggregator,
             &client_monitor,
-            &tx_digest,
+            Some(tx_digest),
             TxType::SingleWriter,
             *name,
             SubmitTxResult::Submitted { consensus_position },
             &options,
+            None,
         )
         .await;
 
@@ -1165,11 +1179,12 @@ async fn test_aborted_with_multiple_effects() {
         .get_certified_finalized_effects(
             &authority_aggregator,
             &client_monitor,
-            &tx_digest,
+            Some(tx_digest),
             TxType::SingleWriter,
             *name,
             SubmitTxResult::Submitted { consensus_position },
             &options,
+            None,
         )
         .await;
 
@@ -1260,11 +1275,12 @@ async fn test_full_effects_retry_loop() {
         .get_certified_finalized_effects(
             &authority_aggregator,
             &client_monitor,
-            &tx_digest,
+            Some(tx_digest),
             TxType::SingleWriter,
             *name,
             SubmitTxResult::Submitted { consensus_position },
             &options,
+            None,
         )
         .await;
 
@@ -1347,11 +1363,12 @@ async fn test_full_effects_digest_mismatch() {
         .get_certified_finalized_effects(
             &authority_aggregator,
             &client_monitor,
-            &tx_digest,
+            Some(tx_digest),
             TxType::SingleWriter,
             *name,
             SubmitTxResult::Submitted { consensus_position },
             &options,
+            None,
         )
         .await;
 
@@ -1422,11 +1439,12 @@ async fn test_request_retrier_exhaustion() {
         .get_certified_finalized_effects(
             &authority_aggregator,
             &client_monitor,
-            &tx_digest,
+            Some(tx_digest),
             TxType::SingleWriter,
             *name,
             SubmitTxResult::Submitted { consensus_position },
             &options,
+            None,
         )
         .await;
 

--- a/crates/sui-core/src/transaction_driver/unit_tests/effects_certifier_tests.rs
+++ b/crates/sui-core/src/transaction_driver/unit_tests/effects_certifier_tests.rs
@@ -8,7 +8,7 @@ use crate::{
         effects_certifier::EffectsCertifier, error::TransactionDriverError,
         metrics::TransactionDriverMetrics, SubmitTransactionOptions,
     },
-    validator_client_monitor::{TxType, ValidatorClientMonitor},
+    validator_client_monitor::ValidatorClientMonitor,
 };
 use async_trait::async_trait;
 use consensus_types::block::BlockRef;
@@ -27,7 +27,7 @@ use sui_types::{
         CheckpointRequest, CheckpointRequestV2, CheckpointResponse, CheckpointResponseV2,
     },
     messages_consensus::ConsensusPosition,
-    messages_grpc::{ExecutedData, SubmitTxRequest, SubmitTxResponse, SubmitTxResult},
+    messages_grpc::{ExecutedData, SubmitTxRequest, SubmitTxResponse, SubmitTxResult, TxType},
     messages_grpc::{
         HandleCertificateRequestV3, HandleCertificateResponseV2, HandleCertificateResponseV3,
         HandleSoftBundleCertificatesRequestV3, HandleSoftBundleCertificatesResponseV3,

--- a/crates/sui-core/src/transaction_driver/unit_tests/transaction_submitter_tests.rs
+++ b/crates/sui-core/src/transaction_driver/unit_tests/transaction_submitter_tests.rs
@@ -247,10 +247,7 @@ fn create_test_submit_request(gas_price: u64) -> SubmitTxRequest {
 
     let tx = Transaction::from_data_and_signer(tx_data, vec![&keypair]);
 
-    SubmitTxRequest {
-        transaction: Some(tx),
-        ping: None,
-    }
+    SubmitTxRequest::new_transaction(tx)
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/crates/sui-core/src/transaction_driver/unit_tests/transaction_submitter_tests.rs
+++ b/crates/sui-core/src/transaction_driver/unit_tests/transaction_submitter_tests.rs
@@ -247,7 +247,10 @@ fn create_test_submit_request(gas_price: u64) -> SubmitTxRequest {
 
     let tx = Transaction::from_data_and_signer(tx_data, vec![&keypair]);
 
-    SubmitTxRequest { transaction: tx }
+    SubmitTxRequest {
+        transaction: Some(tx),
+        ping: None,
+    }
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
@@ -274,7 +277,7 @@ async fn test_submit_transaction_with_amplification() {
 
         let gas_price = reference_gas_price;
         let request = create_test_submit_request(gas_price);
-        let tx_digest = *request.transaction.digest();
+        let tx_digest = *request.transaction.as_ref().unwrap().digest();
 
         // Set up successful response from all authorities
         for mock_authority in &mock_authorities {
@@ -297,7 +300,6 @@ async fn test_submit_transaction_with_amplification() {
             .submit_transaction(
                 &authority_aggregator,
                 &client_monitor,
-                &tx_digest,
                 TxType::SingleWriter,
                 amplification_factor,
                 request,
@@ -324,7 +326,7 @@ async fn test_submit_transaction_with_amplification() {
 
         let gas_price = reference_gas_price * 3;
         let request = create_test_submit_request(gas_price);
-        let tx_digest = *request.transaction.digest();
+        let tx_digest = *request.transaction.as_ref().unwrap().digest();
 
         // Set up successful response from all authorities
         for mock_authority in &mock_authorities {
@@ -349,7 +351,6 @@ async fn test_submit_transaction_with_amplification() {
             .submit_transaction(
                 &authority_aggregator,
                 &client_monitor,
-                &tx_digest,
                 TxType::SingleWriter,
                 amplification_factor,
                 request,
@@ -376,7 +377,7 @@ async fn test_submit_transaction_with_amplification() {
 
         let gas_price = reference_gas_price * 100; // Very high gas price
         let request = create_test_submit_request(gas_price);
-        let tx_digest = *request.transaction.digest();
+        let tx_digest = *request.transaction.as_ref().unwrap().digest();
 
         // Set up successful response from all authorities
         for mock_authority in &mock_authorities {
@@ -401,7 +402,6 @@ async fn test_submit_transaction_with_amplification() {
             .submit_transaction(
                 &authority_aggregator,
                 &client_monitor,
-                &tx_digest,
                 TxType::SingleWriter,
                 amplification_factor,
                 request,
@@ -432,7 +432,7 @@ async fn test_submit_transaction_with_amplification() {
 
         let gas_price = reference_gas_price * 4;
         let request = create_test_submit_request(gas_price);
-        let tx_digest = *request.transaction.digest();
+        let tx_digest = *request.transaction.as_ref().unwrap().digest();
 
         // Set up successful response from all authorities
         for (i, mock_authority) in mock_authorities.iter().enumerate() {
@@ -466,7 +466,6 @@ async fn test_submit_transaction_with_amplification() {
             .submit_transaction(
                 &authority_aggregator,
                 &client_monitor,
-                &tx_digest,
                 TxType::SingleWriter,
                 amplification_factor,
                 request,
@@ -507,7 +506,7 @@ async fn test_submit_transaction_invalid_input() {
     // Transaction with 2x RGP for amplification factor = 2
     let gas_price = reference_gas_price * 2;
     let request = create_test_submit_request(gas_price);
-    let tx_digest = *request.transaction.digest();
+    let tx_digest = *request.transaction.as_ref().unwrap().digest();
 
     // Set up all authorities to return non-retriable errors
     for mock_authority in &mock_authorities {
@@ -529,7 +528,6 @@ async fn test_submit_transaction_invalid_input() {
         .submit_transaction(
             &authority_aggregator,
             &client_monitor,
-            &tx_digest,
             TxType::SingleWriter,
             amplification_factor,
             request,

--- a/crates/sui-core/src/transaction_driver/unit_tests/transaction_submitter_tests.rs
+++ b/crates/sui-core/src/transaction_driver/unit_tests/transaction_submitter_tests.rs
@@ -8,7 +8,7 @@ use crate::{
         error::TransactionDriverError, metrics::TransactionDriverMetrics,
         transaction_submitter::TransactionSubmitter, SubmitTransactionOptions,
     },
-    validator_client_monitor::{TxType, ValidatorClientMonitor},
+    validator_client_monitor::ValidatorClientMonitor,
 };
 use async_trait::async_trait;
 use consensus_types::block::BlockRef;
@@ -29,6 +29,7 @@ use sui_types::{
         CheckpointRequest, CheckpointRequestV2, CheckpointResponse, CheckpointResponseV2,
     },
     messages_consensus::ConsensusPosition,
+    messages_grpc::TxType,
     messages_grpc::{
         HandleCertificateRequestV3, HandleCertificateResponseV2, HandleCertificateResponseV3,
         HandleSoftBundleCertificatesRequestV3, HandleSoftBundleCertificatesResponseV3,

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -633,11 +633,11 @@ where
 
         let td_response = td
             .drive_transaction(
-                SubmitTxRequest {
-                    transaction: request.transaction.clone(),
-                },
+                SubmitTxRequest::new_transaction(request.transaction.clone()),
                 SubmitTransactionOptions {
                     forwarded_client_addr: client_addr,
+                    // TODO: provide a list of validators to submit the transaction via config
+                    allowed_validators: vec![],
                 },
                 timeout_duration,
             )

--- a/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
+++ b/crates/sui-core/src/unit_tests/submit_transaction_tests.rs
@@ -101,7 +101,10 @@ impl TestContext {
     }
 
     fn build_submit_request(&self, transaction: Transaction) -> SubmitTxRequest {
-        SubmitTxRequest { transaction }
+        SubmitTxRequest {
+            transaction: Some(transaction),
+            ping: None,
+        }
     }
 }
 

--- a/crates/sui-core/src/validator_client_monitor/mod.rs
+++ b/crates/sui-core/src/validator_client_monitor/mod.rs
@@ -10,12 +10,9 @@ mod tests;
 
 pub use metrics::ValidatorClientMetrics;
 pub use monitor::ValidatorClientMonitor;
-use mysten_metrics::TX_TYPE_SHARED_OBJ_TX;
-use mysten_metrics::TX_TYPE_SINGLE_WRITER_TX;
+use std::time::Duration;
 use strum::EnumIter;
 use sui_types::base_types::AuthorityName;
-
-use std::time::Duration;
 
 /// Operation types for validator performance tracking
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumIter)]
@@ -35,21 +32,6 @@ impl OperationType {
             OperationType::HealthCheck => "health_check",
             OperationType::FastPath => "fast_path",
             OperationType::Consensus => "consensus",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumIter)]
-pub enum TxType {
-    SingleWriter,
-    SharedObject,
-}
-
-impl TxType {
-    pub fn as_str(&self) -> &str {
-        match self {
-            TxType::SingleWriter => TX_TYPE_SINGLE_WRITER_TX,
-            TxType::SharedObject => TX_TYPE_SHARED_OBJ_TX,
         }
     }
 }

--- a/crates/sui-core/src/validator_client_monitor/monitor.rs
+++ b/crates/sui-core/src/validator_client_monitor/monitor.rs
@@ -4,7 +4,6 @@
 use crate::authority_aggregator::AuthorityAggregator;
 use crate::authority_client::AuthorityAPI;
 use crate::validator_client_monitor::stats::ClientObservedStats;
-use crate::validator_client_monitor::TxType;
 use crate::validator_client_monitor::{
     metrics::ValidatorClientMetrics, OperationFeedback, OperationType,
 };
@@ -16,6 +15,7 @@ use std::{sync::Arc, time::Instant};
 use strum::IntoEnumIterator;
 use sui_config::validator_client_monitor_config::ValidatorClientMonitorConfig;
 use sui_types::committee::Committee;
+use sui_types::messages_grpc::TxType;
 use sui_types::{base_types::AuthorityName, messages_grpc::ValidatorHealthRequest};
 use tokio::{
     task::JoinSet,

--- a/crates/sui-core/src/validator_client_monitor/stats.rs
+++ b/crates/sui-core/src/validator_client_monitor/stats.rs
@@ -21,9 +21,9 @@ use tracing::debug;
 //    report is more critical than a submit report in terms of failures status.
 
 /// Size of the moving window for reliability measurements
-const RELIABILITY_MOVING_WINDOW_SIZE: usize = 100;
+const RELIABILITY_MOVING_WINDOW_SIZE: usize = 40;
 /// Size of the moving window for latency measurements
-const LATENCY_MOVING_WINDOW_SIZE: usize = 100;
+const LATENCY_MOVING_WINDOW_SIZE: usize = 40;
 
 /// Complete client-observed statistics for validator interactions.
 ///

--- a/crates/sui-core/src/validator_client_monitor/stats.rs
+++ b/crates/sui-core/src/validator_client_monitor/stats.rs
@@ -1,9 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::validator_client_monitor::{
-    OperationFeedback, OperationType, TxType, ValidatorClientMetrics,
-};
+use crate::validator_client_monitor::{OperationFeedback, OperationType, ValidatorClientMetrics};
 use mysten_common::moving_window::MovingWindow;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
@@ -12,6 +10,7 @@ use strum::IntoEnumIterator;
 use sui_config::validator_client_monitor_config::ValidatorClientMonitorConfig;
 use sui_types::base_types::AuthorityName;
 use sui_types::committee::Committee;
+use sui_types::messages_grpc::TxType;
 use tracing::debug;
 
 // TODO: A few optimization to consider:

--- a/crates/sui-core/src/validator_client_monitor/tests.rs
+++ b/crates/sui-core/src/validator_client_monitor/tests.rs
@@ -16,6 +16,7 @@ mod client_stats_tests {
     use super::*;
     use crate::validator_client_monitor::metrics::ValidatorClientMetrics;
     use prometheus::Registry;
+    use sui_types::messages_grpc::TxType;
 
     /// Helper to create test validator names
     fn create_test_validator_names(n: usize) -> Vec<AuthorityName> {
@@ -506,6 +507,8 @@ mod client_stats_tests {
 
 #[cfg(test)]
 mod client_monitor_tests {
+    use sui_types::messages_grpc::TxType;
+
     use crate::{
         authority_aggregator::{AuthorityAggregator, AuthorityAggregatorBuilder},
         test_authority_clients::MockAuthorityApi,

--- a/crates/sui-types/src/messages_grpc.rs
+++ b/crates/sui-types/src/messages_grpc.rs
@@ -281,22 +281,37 @@ pub struct RawExecutedData {
 
 #[derive(Clone, Debug)]
 pub struct SubmitTxRequest {
-    pub transaction: Transaction,
+    pub transaction: Option<Transaction>,
+    pub ping: Option<PingType>,
 }
 
 impl SubmitTxRequest {
     pub fn new_transaction(transaction: Transaction) -> Self {
-        Self { transaction }
+        Self {
+            transaction: Some(transaction),
+            ping: None,
+        }
+    }
+
+    pub fn new_ping(ping: PingType) -> Self {
+        Self {
+            transaction: None,
+            ping: Some(ping),
+        }
     }
 }
 
 impl SubmitTxRequest {
     pub fn into_raw(&self) -> Result<RawSubmitTxRequest, SuiError> {
-        let transactions = vec![bcs::to_bytes(&self.transaction)
-            .map_err(|e| SuiError::TransactionSerializationError {
-                error: e.to_string(),
-            })?
-            .into()];
+        let transactions = if let Some(transaction) = &self.transaction {
+            vec![bcs::to_bytes(&transaction)
+                .map_err(|e| SuiError::TransactionSerializationError {
+                    error: e.to_string(),
+                })?
+                .into()]
+        } else {
+            vec![]
+        };
         Ok(RawSubmitTxRequest {
             transactions,
             ..Default::default()


### PR DESCRIPTION
## Description 

Spinning up a task in transaction driver to periodically send ping requests to measure the e2e latency for every validator for both the:
* fast path
* consensus

## Test plan 

CI/PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
