### PR TITLE
docs: Fix format of GraphQL object list

### DIFF
--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -764,8 +764,6 @@ h5 {
   padding: 0;
 }
 
-
-/* Optional: if your bullets have a known class or role, you can be stricter */
 .theme-doc-markdown p .badge + .bullet,
 .theme-doc-markdown p .badge + [role="separator"] {
   display: block !important;


### PR DESCRIPTION
## Description 

Separates the GraphQL objects into a list with new lines rather than one single line.

Before:
<img width="734" height="158" alt="Screenshot 2025-09-12 at 10 14 47 AM" src="https://github.com/user-attachments/assets/1224559c-ad6b-4d2a-860a-88f90dc1063a" />

After:
<img width="328" height="307" alt="Screenshot 2025-09-12 at 10 16 55 AM" src="https://github.com/user-attachments/assets/c1295797-8be2-4519-8570-ec7822269d8c" />

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
