### PR TITLE
Add object cache artifact

### DIFF
--- a/crates/sui-replay-2/src/execution.rs
+++ b/crates/sui-replay-2/src/execution.rs
@@ -16,8 +16,12 @@ use crate::{
     replay_txn::{get_input_objects_for_replay, ReplayTransaction},
 };
 use anyhow::Context;
-use move_core_types::{language_storage::ModuleId, resolver::ModuleResolver};
+use move_core_types::{
+    language_storage::{ModuleId, StructTag},
+    resolver::ModuleResolver,
+};
 use move_trace_format::format::MoveTraceBuilder;
+use serde::{Deserialize, Serialize};
 use std::{
     cell::RefCell,
     collections::{BTreeMap, HashSet},
@@ -57,6 +61,92 @@ pub struct TxnContextAndEffects {
     pub gas_status: SuiGasStatus,              // gas status of the replay execution
     pub object_cache: BTreeMap<ObjectID, BTreeMap<u64, Object>>, // object cache
     pub inner_store: InnerTemporaryStore,      // temporary store used during execution
+    pub checkpoint: u64,                       // checkpoint where the transaction was included
+}
+
+/// Detailed information about a Move package.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PackageInfo {
+    pub published_id: ObjectID,
+    pub original_id: ObjectID,
+    pub module_names: Vec<String>,
+}
+
+/// Type of object in the replay cache with detailed Move information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ObjectType {
+    /// A Move package containing compiled modules
+    Package(PackageInfo),
+    /// A Move object with its struct tag
+    MoveObject(StructTag),
+}
+
+/// Entry in the replay cache summary representing an object accessed during replay.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CacheEntry {
+    pub object_id: ObjectID,
+    pub version: u64,
+    pub object_type: ObjectType,
+}
+
+/// Compact representation of the replay cache for serialization.
+/// Contains the execution context (epoch_id from transaction effects, checkpoint from transaction info)
+/// and a list of all objects accessed during replay, with their type information but without object content.
+/// The epoch_id represents the epoch in which the original transaction was executed.
+/// The checkpoint represents the checkpoint sequence number where the transaction was included.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReplayCacheSummary {
+    pub epoch_id: u64,
+    pub checkpoint: u64,
+    /// List of objects accessed during replay with their version and type information
+    pub cache_entries: Vec<CacheEntry>,
+}
+
+impl ReplayCacheSummary {
+    /// Create a ReplayCacheSummary from the object cache, extracting detailed Move information.
+    pub fn from_cache(
+        epoch_id: u64,
+        checkpoint: u64,
+        object_cache: &BTreeMap<ObjectID, BTreeMap<u64, Object>>,
+    ) -> Self {
+        let mut cache_entries = Vec::new();
+
+        for (object_id, versions) in object_cache {
+            for (version, object) in versions {
+                let object_type = if object.is_package() {
+                    // Extract package information
+                    let package = object
+                        .data
+                        .try_as_package()
+                        .expect("Package object should have package data");
+                    let package_info = PackageInfo {
+                        published_id: package.id(),
+                        original_id: package.original_package_id(),
+                        module_names: package.serialized_module_map().keys().cloned().collect(),
+                    };
+                    ObjectType::Package(package_info)
+                } else {
+                    // Extract Move object struct tag
+                    let struct_tag = object
+                        .struct_tag()
+                        .expect("Move object should have struct tag");
+                    ObjectType::MoveObject(struct_tag)
+                };
+
+                cache_entries.push(CacheEntry {
+                    object_id: *object_id,
+                    version: *version,
+                    object_type,
+                });
+            }
+        }
+
+        Self {
+            epoch_id,
+            checkpoint,
+            cache_entries,
+        }
+    }
 }
 
 // Entry point. Executes a transaction.
@@ -157,6 +247,7 @@ pub fn execute_transaction_to_effects(
             gas_status,
             object_cache,
             inner_store,
+            checkpoint,
         },
     ))
 }

--- a/crates/sui-replay-2/src/tracing/mod.rs
+++ b/crates/sui-replay-2/src/tracing/mod.rs
@@ -41,6 +41,7 @@ pub fn save_trace_output(
         gas_status: _,
         object_cache,
         inner_store: tmp_store,
+        checkpoint: _,
     } = context_and_effects;
 
     // grab all packages from the transaction and save them locally for debug


### PR DESCRIPTION
## Description 

This simply writes the transaction cache (all objects touched) and global info about the execution (epoch, checkpoint) in a json file. 
We will use that with effects, local cache and other transaction info to build a compelling view over a transaction execution.
UI code and flow will be coming in another PR. Suggestions on where to put that code (the UI) welcome

## Test plan 

Manual verification

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
