### PR TITLE
[pkg-alt] Fix lockfile consistency for legacy dep names on edges

### DIFF
--- a/external-crates/move/crates/move-package-alt/src/compatibility/legacy.rs
+++ b/external-crates/move/crates/move-package-alt/src/compatibility/legacy.rs
@@ -23,6 +23,10 @@ pub struct LegacyData {
     /// things after parsing
     pub legacy_name: String,
 
+    /// The `legacy_name` transformed into a normalized name from the parser.
+    /// This is helpful for `rename-from` validation.
+    pub normalized_legacy_name: Identifier,
+
     /// These addresses should store all addresses that were part of the package.
     pub named_addresses: BTreeMap<Identifier, AccountAddress>,
 

--- a/external-crates/move/crates/move-package-alt/src/compatibility/legacy_parser.rs
+++ b/external-crates/move/crates/move-package-alt/src/compatibility/legacy_parser.rs
@@ -197,6 +197,11 @@ fn parse_source_manifest(
                 None
             };
 
+            // We create a normalized legacy name, to make sure we can always use a package
+            // as an Identifier.
+            let normalized_legacy_name =
+                normalize_legacy_name_to_identifier(&metadata.legacy_name.as_str())?;
+
             Ok(ParsedManifest {
                 package: PackageMetadata {
                     name: new_name,
@@ -217,6 +222,7 @@ fn parse_source_manifest(
 
                 legacy_data: Some(LegacyData {
                     legacy_name: metadata.legacy_name,
+                    normalized_legacy_name,
                     named_addresses: programmatic_addresses,
                     manifest_address_info,
                     legacy_publications: try_load_legacy_lockfile_publications(path)
@@ -286,7 +292,7 @@ fn parse_package_info(tval: TV) -> Result<LegacyPackageMetadata> {
                 .unwrap_or("legacy".to_string());
 
             Ok(LegacyPackageMetadata {
-                legacy_name: name,
+                legacy_name: name.clone(),
                 edition,
                 published_at,
                 unrecognized_fields: table.into_iter().collect(),
@@ -300,18 +306,26 @@ fn parse_package_info(tval: TV) -> Result<LegacyPackageMetadata> {
     }
 }
 
+/// Given a "legacy" string, we produce an Identifier that is as "consistent"
+/// as possible.
+fn normalize_legacy_name_to_identifier(name: &str) -> Result<Identifier> {
+    // We could also, potentially, hash the String into a valid identifier,
+    // but these cases are super rare so "readability" is probably better for us.
+    Identifier::new(name.replace("-", "__").replace(" ", "____")).map_err(|_| {
+        anyhow!(
+            "Failed to convert legacy name {} to a normalized identifier",
+            name
+        )
+    })
+}
+
 fn parse_dependencies(tval: TV) -> Result<BTreeMap<PackageName, DefaultDependency>> {
     match tval {
         TV::Table(table) => {
             let mut deps = BTreeMap::new();
 
             for (dep_name, dep) in table.into_iter() {
-                // TODO(manos): This could fail if we have names that are not `Identifier` compatible.
-                // Though this is a super rare case, we'll probably not handle it more complex until we need to.
-                // TODO: we need to support whitespace and decide if that's how we need to keep
-                // this working
-                let dep_name = dep_name.replace("-", "___");
-                let dep_name_ident = PackageName::new(dep_name)?;
+                let dep_name_ident = normalize_legacy_name_to_identifier(&dep_name)?;
                 let dep = parse_dependency(dep)?;
                 deps.insert(dep_name_ident, dep);
             }
@@ -784,5 +798,20 @@ mod tests {
         let published_at = Some("invalid_address".to_string());
         let result = get_manifest_address_info(original_id, published_at);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn normalize_legacy_names() {
+        let names = vec![
+            ("foo", "foo"),
+            ("foo-bar", "foo__bar"),
+            ("foo bar", "foo____bar"),
+            ("is_normal", "is_normal"),
+        ];
+
+        for (name, expected) in names {
+            let identifier = normalize_legacy_name_to_identifier(name).unwrap();
+            assert_eq!(identifier.to_string(), expected);
+        }
     }
 }

--- a/external-crates/move/crates/move-package-alt/src/graph/builder.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/builder.rs
@@ -256,19 +256,11 @@ impl<F: MoveFlavor> PackageGraphBuilder<F> {
             );
             let dep_index = Box::pin(future).await?;
 
-            // If we're dealing with legacy packages, we are fixing the naming in the outgoing edge,
-            // to match our modern system names.
-            let edge_name = if fetched.is_legacy() {
-                fetched.name()
-            } else {
-                name
-            };
-
             graph.lock().expect("unpoisoned").add_edge(
                 index,
                 dep_index,
                 PackageGraphEdge {
-                    name: edge_name.clone(),
+                    name: name.clone(),
                     dep: dep.clone(),
                 },
             );


### PR DESCRIPTION
## Description 

Fixes the generated lockfile edge names to be consistent, and extends the `rename-from` checks to support either legacy or modern names.

## Test plan 

Unit & manual testing -- we need some e2e ones too on sui side `sui-pkg-alt`

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
