### PR TITLE
examples(tic-tac-toe): Fix Rust CLI

### DIFF
--- a/crates/sui-transaction-builder/src/lib.rs
+++ b/crates/sui-transaction-builder/src/lib.rs
@@ -220,9 +220,6 @@ impl TransactionBuilder {
     }
 
     /// Construct a transaction kind for the PaySui transaction type
-    ///
-    /// Use this function together with tx_data_for_dry_run or tx_data
-    /// for maximum reusability
     pub fn pay_sui_tx_kind(
         &self,
         recipients: Vec<SuiAddress>,

--- a/examples/tic-tac-toe/cli/Cargo.toml
+++ b/examples/tic-tac-toe/cli/Cargo.toml
@@ -8,7 +8,7 @@ anyhow = "1.0.86"
 bcs = "0.1.6"
 clap = { version = "4.5", features = ["derive", "env", "wrap_help"] }
 dirs = "5.0.1"
-fastcrypto = { workspace = true }
+fastcrypto = "0.1.9"
 move-core-types = { path = "../../../external-crates/move/crates/move-core-types" }
 serde = { version = "1.0.203", features = ["derive"] }
 shared-crypto = { path = "../../../crates/shared-crypto" }


### PR DESCRIPTION
## Description

Get the Rust CLI building and running again:

- Remove references to `tx_data_for_dry_run` which no longer exists.
- Don't try and depend on workspace dependencies, because examples aren't part of the monorepo's workspace.
- Fix up references to the keystore API that had been refactored a while back.

## Test plan

Manually tested. We need to have a more robust strategy for testing example code outside of Move packages in CI -- that would have helped us avoid some of these issues proactively, but that is a bigger problem that I'm not going to try and tackle in this PR.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
