### PR TITLE
graphql-alt: Add Validator model with ValidatorV1 fields

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/active_validators.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/active_validators.move
@@ -1,0 +1,58 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --simulator
+
+//# run-graphql
+{
+  epoch(epochId: 0) { ...E }
+}
+
+fragment E on Epoch {
+  epochId
+  validatorSet {
+    activeValidators {
+      address
+      credentials { ...VC }
+      # todo (ewall) populate nextEpochCredentials
+      nextEpochCredentials { ...VC }
+      name
+      # todo (ewall) populate description
+      description
+      # todo (ewall) populate imageUrl
+      imageUrl
+      # todo (ewall) populate projectUrl
+      projectUrl
+      stakingPoolId
+      exchangeRatesSize
+      stakingPoolActivationEpoch
+      stakingPoolSuiBalance
+      # todo (ewall) populate rewardsPool
+      rewardsPool
+      poolTokenBalance
+      # todo (ewall) populate pendingStake
+      pendingStake
+      # todo (ewall) populate pendingTotalSuiWithdraw
+      pendingTotalSuiWithdraw
+      # todo (ewall) populate pendingPoolTokenWithdraw
+      pendingPoolTokenWithdraw
+      votingPower
+      gasPrice
+      commissionRate
+      nextEpochStake
+      nextEpochGasPrice
+      nextEpochCommissionRate
+    }
+  }
+}
+
+fragment VC on ValidatorCredentials {
+  protocolPubKey
+  networkPubKey
+  workerPubKey
+  proofOfPossession
+  netAddress
+  p2PAddress
+  primaryAddress
+  workerAddress
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/active_validators.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/active_validators.snap
@@ -1,0 +1,63 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 2 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-58:
+//# run-graphql
+Response: {
+  "data": {
+    "epoch": {
+      "epochId": 0,
+      "validatorSet": {
+        "activeValidators": [
+          {
+            "address": "0xda83166d01afd7ddcf8af5f844f45aaa53f48548e5117c23f5a2978cfd422244",
+            "credentials": {
+              "protocolPubKey": "qqgbtEP57SCwGrO7tmcKwy/daeoOFwANmrMTm1Qu4jUJRhi2VePz/brF9YAcjmJ7BLOpN8c5Ia7zYzTNmGtGoaUnjoYrbvDG9E05s9antwSmkHAIGsM8mkmeBkSjSBrt",
+              "networkPubKey": "ZeETulurG5EpRBoewpF26pyLQtpUqwH1T6LqgugHBIU=",
+              "workerPubKey": "3sE4/d+MbOSh9pesKr7b89TSO5gFBuyGUjVa4GldmFU=",
+              "proofOfPossession": "sIupbWI7yiRvXM22F2E5sJFRricflowHFu7yqXnzglaAvYTxInm4MSDNAgeMzHyJ",
+              "netAddress": "/ip4/127.0.0.1/tcp/8000/http",
+              "p2PAddress": "/ip4/127.0.0.1/udp/8001/http",
+              "primaryAddress": "/ip4/127.0.0.1/udp/8004/http",
+              "workerAddress": "/ip4/127.0.0.1/udp/8005/http"
+            },
+            "nextEpochCredentials": {
+              "protocolPubKey": null,
+              "networkPubKey": null,
+              "workerPubKey": null,
+              "proofOfPossession": null,
+              "netAddress": null,
+              "p2PAddress": null,
+              "primaryAddress": null,
+              "workerAddress": null
+            },
+            "name": "validator-0",
+            "description": "",
+            "imageUrl": "",
+            "projectUrl": "",
+            "stakingPoolId": "0x2f4c0b14e06a9dd4724e823b2289e3356b2e987fd0f3435e3e00b616bbec111f",
+            "exchangeRatesSize": 1,
+            "stakingPoolActivationEpoch": 0,
+            "stakingPoolSuiBalance": "20000000000000000",
+            "rewardsPool": "0",
+            "poolTokenBalance": "20000000000000000",
+            "pendingStake": "0",
+            "pendingTotalSuiWithdraw": "0",
+            "pendingPoolTokenWithdraw": "0",
+            "votingPower": 10000,
+            "gasPrice": "1000",
+            "commissionRate": 200,
+            "nextEpochStake": "20000000000000000",
+            "nextEpochGasPrice": "1000",
+            "nextEpochCommissionRate": 200
+          }
+        ]
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -3960,6 +3960,97 @@ type UserSignature {
 	signatureBytes: Base64
 }
 
+type Validator {
+	"""
+	The validator's address.
+	"""
+	address: SuiAddress!
+	"""
+	The fee charged by the validator for staking services.
+	"""
+	commissionRate: Int
+	"""
+	Validator's set of credentials such as public keys, network addresses and others.
+	"""
+	credentials: ValidatorCredentials
+	"""
+	Validator's description.
+	"""
+	description: String
+	"""
+	Number of exchange rates in the table.
+	"""
+	exchangeRatesSize: UInt53
+	"""
+	The reference gas price for this epoch.
+	"""
+	gasPrice: BigInt
+	"""
+	Validator's url containing their custom image.
+	"""
+	imageUrl: String
+	"""
+	Validator's name.
+	"""
+	name: String
+	"""
+	The proposed next epoch fee for the validator's staking services.
+	"""
+	nextEpochCommissionRate: Int
+	"""
+	Validator's set of credentials for the next epoch.
+	"""
+	nextEpochCredentials: ValidatorCredentials
+	"""
+	The validator's gas price quote for the next epoch.
+	"""
+	nextEpochGasPrice: BigInt
+	"""
+	The total number of SUI tokens in this pool plus the pending stake amount for this epoch.
+	"""
+	nextEpochStake: BigInt
+	"""
+	Pending pool token withdrawn during the current epoch, emptied at epoch boundaries.
+	"""
+	pendingPoolTokenWithdraw: BigInt
+	"""
+	Pending stake amount for this epoch.
+	"""
+	pendingStake: BigInt
+	"""
+	Pending stake withdrawn during the current epoch, emptied at epoch boundaries.
+	"""
+	pendingTotalSuiWithdraw: BigInt
+	"""
+	Total number of pool tokens issued by the pool.
+	"""
+	poolTokenBalance: BigInt
+	"""
+	Validator's homepage URL.
+	"""
+	projectUrl: String
+	"""
+	The epoch stake rewards will be added here at the end of each epoch.
+	"""
+	rewardsPool: BigInt
+	"""
+	The epoch at which this pool became active.
+	"""
+	stakingPoolActivationEpoch: UInt53
+	"""
+	The ID of this validator's `0x3::staking_pool::StakingPool`.
+	"""
+	stakingPoolId: SuiAddress!
+	"""
+	The total number of SUI tokens in this pool.
+	"""
+	stakingPoolSuiBalance: BigInt
+	"""
+	The voting power of this validator in basis points (e.g., 100 = 1% voting power).
+	"""
+	votingPower: Int
+}
+
 type ValidatorAggregatedSignature {
 	"""
 	The epoch when this aggregate signature was produced.
@@ -3976,9 +4067,27 @@ type ValidatorAggregatedSignature {
 }
 
 """
+The credentials related fields associated with a validator.
+"""
+type ValidatorCredentials {
+	netAddress: String
+	networkPubKey: Base64
+	p2PAddress: String
+	primaryAddress: String
+	proofOfPossession: Base64
+	protocolPubKey: Base64
+	workerAddress: String
+	workerPubKey: Base64
+}
+
+"""
 Representation of `0x3::validator_set::ValidatorSet`.
 """
 type ValidatorSet {
+	"""
+	The current list of active validators.
+	"""
+	activeValidators: [Validator!]
 	"""
 	Object ID of the `Table` storing the inactive staking pools.
 	"""

--- a/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/mod.rs
@@ -44,5 +44,6 @@ pub(crate) mod transaction_kind;
 mod type_origin;
 pub(crate) mod unchanged_consensus_object;
 pub(crate) mod user_signature;
+pub(crate) mod validator;
 pub(crate) mod validator_aggregated_signature;
 pub(crate) mod validator_set;

--- a/crates/sui-indexer-alt-graphql/src/api/types/validator.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/validator.rs
@@ -1,0 +1,248 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::{Object, SimpleObject};
+use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorV1;
+
+use crate::api::scalars::{
+    base64::Base64, big_int::BigInt, sui_address::SuiAddress, uint53::UInt53,
+};
+
+#[derive(Clone, Debug)]
+pub(crate) struct Validator {
+    native: ValidatorV1,
+}
+
+/// The credentials related fields associated with a validator.
+#[derive(Clone, Debug, PartialEq, Eq, SimpleObject)]
+pub(crate) struct ValidatorCredentials {
+    pub protocol_pub_key: Option<Base64>,
+    pub network_pub_key: Option<Base64>,
+    pub worker_pub_key: Option<Base64>,
+    pub proof_of_possession: Option<Base64>,
+    pub net_address: Option<String>,
+    pub p2p_address: Option<String>,
+    pub primary_address: Option<String>,
+    pub worker_address: Option<String>,
+}
+
+// todo (ewall) implement IAddressable
+#[Object]
+impl Validator {
+    /// The validator's address.
+    async fn address(&self) -> SuiAddress {
+        self.native.metadata.sui_address.into()
+    }
+
+    /// Validator's set of credentials such as public keys, network addresses and others.
+    async fn credentials(&self) -> Option<ValidatorCredentials> {
+        let v = &self.native.metadata;
+        let credentials = ValidatorCredentials {
+            protocol_pub_key: Some(Base64::from(v.protocol_pubkey_bytes.clone())),
+            network_pub_key: Some(Base64::from(v.network_pubkey_bytes.clone())),
+            worker_pub_key: Some(Base64::from(v.worker_pubkey_bytes.clone())),
+            proof_of_possession: Some(Base64::from(v.proof_of_possession_bytes.clone())),
+            net_address: Some(v.net_address.clone()),
+            p2p_address: Some(v.p2p_address.clone()),
+            primary_address: Some(v.primary_address.clone()),
+            worker_address: Some(v.worker_address.clone()),
+        };
+        Some(credentials)
+    }
+
+    /// Validator's set of credentials for the next epoch.
+    async fn next_epoch_credentials(&self) -> Option<ValidatorCredentials> {
+        let v = &self.native.metadata;
+        let credentials = ValidatorCredentials {
+            protocol_pub_key: v
+                .next_epoch_protocol_pubkey_bytes
+                .as_ref()
+                .map(Base64::from),
+            network_pub_key: v.next_epoch_network_pubkey_bytes.as_ref().map(Base64::from),
+            worker_pub_key: v.next_epoch_worker_pubkey_bytes.as_ref().map(Base64::from),
+            proof_of_possession: v.next_epoch_proof_of_possession.as_ref().map(Base64::from),
+            net_address: v.next_epoch_net_address.clone(),
+            p2p_address: v.next_epoch_p2p_address.clone(),
+            primary_address: v.next_epoch_primary_address.clone(),
+            worker_address: v.next_epoch_worker_address.clone(),
+        };
+        Some(credentials)
+    }
+
+    /// Validator's name.
+    async fn name(&self) -> Option<String> {
+        Some(self.native.metadata.name.clone())
+    }
+
+    /// Validator's description.
+    async fn description(&self) -> Option<String> {
+        Some(self.native.metadata.description.clone())
+    }
+
+    /// Validator's url containing their custom image.
+    async fn image_url(&self) -> Option<String> {
+        Some(self.native.metadata.image_url.clone())
+    }
+
+    /// Validator's homepage URL.
+    async fn project_url(&self) -> Option<String> {
+        Some(self.native.metadata.project_url.clone())
+    }
+
+    // todo (ewall)
+    // /// The validator's current valid `Cap` object. Validators can delegate
+    // /// the operation ability to another address. The address holding this `Cap` object
+    // /// can then update the reference gas price and tallying rule on behalf of the validator.
+    // async fn operation_cap(&self, ctx: &Context<'_>) -> async_graphql::Result<Option<MoveObject>> {
+    //     MoveObject::query(
+    //         ctx,
+    //         self.operation_cap_id(),
+    //         Object::latest_at(self.checkpoint_viewed_at),
+    //     )
+    //         .await
+    //         .extend()
+    // }
+
+    /// The ID of this validator's `0x3::staking_pool::StakingPool`.
+    async fn staking_pool_id(&self) -> SuiAddress {
+        self.native.staking_pool.id.into()
+    }
+
+    // todo (ewall)
+    // /// A wrapped object containing the validator's exchange rates. This is a table from epoch
+    // /// number to `PoolTokenExchangeRate` value. The exchange rate is used to determine the amount
+    // /// of SUI tokens that each past SUI staker can withdraw in the future.
+    // async fn exchange_rates_table(&self) -> async_graphql::Result<Option<Owner>> {
+    //     Ok(Some(Owner {
+    //         address: self.validator_summary.exchange_rates_id.into(),
+    //         checkpoint_viewed_at: self.checkpoint_viewed_at,
+    //         root_version: None,
+    //     }))
+    // }
+
+    /// Number of exchange rates in the table.
+    async fn exchange_rates_size(&self) -> Option<UInt53> {
+        Some(self.native.staking_pool.exchange_rates.size.into())
+    }
+
+    /// The epoch at which this pool became active.
+    async fn staking_pool_activation_epoch(&self) -> Option<UInt53> {
+        self.native.staking_pool.activation_epoch.map(UInt53::from)
+    }
+
+    /// The total number of SUI tokens in this pool.
+    async fn staking_pool_sui_balance(&self) -> Option<BigInt> {
+        Some(BigInt::from(self.native.staking_pool.sui_balance))
+    }
+
+    /// The epoch stake rewards will be added here at the end of each epoch.
+    async fn rewards_pool(&self) -> Option<BigInt> {
+        Some(BigInt::from(self.native.staking_pool.rewards_pool.value()))
+    }
+
+    /// Total number of pool tokens issued by the pool.
+    async fn pool_token_balance(&self) -> Option<BigInt> {
+        Some(BigInt::from(self.native.staking_pool.pool_token_balance))
+    }
+
+    /// Pending stake amount for this epoch.
+    async fn pending_stake(&self) -> Option<BigInt> {
+        Some(BigInt::from(self.native.staking_pool.pending_stake))
+    }
+
+    /// Pending stake withdrawn during the current epoch, emptied at epoch boundaries.
+    async fn pending_total_sui_withdraw(&self) -> Option<BigInt> {
+        Some(BigInt::from(
+            self.native.staking_pool.pending_total_sui_withdraw,
+        ))
+    }
+
+    /// Pending pool token withdrawn during the current epoch, emptied at epoch boundaries.
+    async fn pending_pool_token_withdraw(&self) -> Option<BigInt> {
+        Some(BigInt::from(
+            self.native.staking_pool.pending_pool_token_withdraw,
+        ))
+    }
+
+    /// The voting power of this validator in basis points (e.g., 100 = 1% voting power).
+    async fn voting_power(&self) -> Option<u64> {
+        Some(self.native.voting_power)
+    }
+
+    /// The reference gas price for this epoch.
+    async fn gas_price(&self) -> Option<BigInt> {
+        Some(BigInt::from(self.native.gas_price))
+    }
+
+    /// The fee charged by the validator for staking services.
+    async fn commission_rate(&self) -> Option<u64> {
+        Some(self.native.commission_rate)
+    }
+
+    /// The total number of SUI tokens in this pool plus the pending stake amount for this epoch.
+    async fn next_epoch_stake(&self) -> Option<BigInt> {
+        Some(BigInt::from(self.native.next_epoch_stake))
+    }
+
+    /// The validator's gas price quote for the next epoch.
+    async fn next_epoch_gas_price(&self) -> Option<BigInt> {
+        Some(BigInt::from(self.native.next_epoch_gas_price))
+    }
+
+    /// The proposed next epoch fee for the validator's staking services.
+    async fn next_epoch_commission_rate(&self) -> Option<u64> {
+        Some(self.native.next_epoch_commission_rate)
+    }
+
+    // todo (ewall)
+    // /// The number of epochs for which this validator has been below the
+    // /// low stake threshold.
+    // async fn at_risk(&self) -> Option<UInt53> {
+    //     self.at_risk.map(UInt53::from)
+    // }
+
+    // todo (ewall)
+    // /// The addresses of other validators this validator has reported.
+    // async fn report_records(
+    //     &self,
+    //     ctx: &Context<'_>,
+    //     first: Option<u64>,
+    //     before: Option<CAddr>,
+    //     last: Option<u64>,
+    //     after: Option<CAddr>,
+    // ) -> async_graphql::Result<Connection<String, Address>> {
+    //     let page = Page::from_params(ctx.data_unchecked(), first, after, last, before)?;
+    //
+    //     let mut connection = Connection::new(false, false);
+    //     let Some(addresses) = &self.report_records else {
+    //         return Ok(connection);
+    //     };
+    //
+    //     let Some((prev, next, _, cs)) =
+    //         page.paginate_consistent_indices(addresses.len(), self.checkpoint_viewed_at)?
+    //     else {
+    //         return Ok(connection);
+    //     };
+    //
+    //     connection.has_previous_page = prev;
+    //     connection.has_next_page = next;
+    //
+    //     for c in cs {
+    //         connection.edges.push(Edge::new(
+    //             c.encode_cursor(),
+    //             Address {
+    //                 address: addresses[c.ix].address,
+    //                 checkpoint_viewed_at: c.c,
+    //             },
+    //         ));
+    //     }
+    //
+    //     Ok(connection)
+    // }
+}
+
+impl From<ValidatorV1> for Validator {
+    fn from(native: ValidatorV1) -> Self {
+        Self { native }
+    }
+}

--- a/crates/sui-indexer-alt-graphql/src/api/types/validator_set.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/validator_set.rs
@@ -1,16 +1,22 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::api::scalars::big_int::BigInt;
-use crate::api::scalars::sui_address::SuiAddress;
 use async_graphql::SimpleObject;
 use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorSetV1;
+
+use crate::api::{
+    scalars::{big_int::BigInt, sui_address::SuiAddress},
+    types::validator::Validator,
+};
 
 /// Representation of `0x3::validator_set::ValidatorSet`.
 #[derive(Clone, Debug, SimpleObject, Default)]
 pub(crate) struct ValidatorSet {
     /// Total amount of stake for all active validators at the beginning of the epoch.
     pub total_stake: Option<BigInt>,
+
+    /// The current list of active validators.
+    pub active_validators: Option<Vec<Validator>>,
 
     /// Validators that are pending removal from the active validator set, expressed as indices in
     /// to `activeValidators`.
@@ -48,6 +54,16 @@ impl From<ValidatorSetV1> for ValidatorSet {
     fn from(value: ValidatorSetV1) -> Self {
         ValidatorSet {
             total_stake: Some(BigInt::from(value.total_stake)),
+            active_validators: Some(
+                value
+                    .active_validators
+                    .iter()
+                    .map(|v| v.clone().into())
+                    // todo (ewall)
+                    // remove this and add pagination
+                    .take(1)
+                    .collect(),
+            ),
             pending_removals: Some(value.pending_removals),
             pending_active_validators_id: Some(value.pending_active_validators.contents.id.into()),
             pending_active_validators_size: Some(value.pending_active_validators.contents.size),

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -3964,6 +3964,97 @@ type UserSignature {
 	signatureBytes: Base64
 }
 
+type Validator {
+	"""
+	The validator's address.
+	"""
+	address: SuiAddress!
+	"""
+	The fee charged by the validator for staking services.
+	"""
+	commissionRate: Int
+	"""
+	Validator's set of credentials such as public keys, network addresses and others.
+	"""
+	credentials: ValidatorCredentials
+	"""
+	Validator's description.
+	"""
+	description: String
+	"""
+	Number of exchange rates in the table.
+	"""
+	exchangeRatesSize: UInt53
+	"""
+	The reference gas price for this epoch.
+	"""
+	gasPrice: BigInt
+	"""
+	Validator's url containing their custom image.
+	"""
+	imageUrl: String
+	"""
+	Validator's name.
+	"""
+	name: String
+	"""
+	The proposed next epoch fee for the validator's staking services.
+	"""
+	nextEpochCommissionRate: Int
+	"""
+	Validator's set of credentials for the next epoch.
+	"""
+	nextEpochCredentials: ValidatorCredentials
+	"""
+	The validator's gas price quote for the next epoch.
+	"""
+	nextEpochGasPrice: BigInt
+	"""
+	The total number of SUI tokens in this pool plus the pending stake amount for this epoch.
+	"""
+	nextEpochStake: BigInt
+	"""
+	Pending pool token withdrawn during the current epoch, emptied at epoch boundaries.
+	"""
+	pendingPoolTokenWithdraw: BigInt
+	"""
+	Pending stake amount for this epoch.
+	"""
+	pendingStake: BigInt
+	"""
+	Pending stake withdrawn during the current epoch, emptied at epoch boundaries.
+	"""
+	pendingTotalSuiWithdraw: BigInt
+	"""
+	Total number of pool tokens issued by the pool.
+	"""
+	poolTokenBalance: BigInt
+	"""
+	Validator's homepage URL.
+	"""
+	projectUrl: String
+	"""
+	The epoch stake rewards will be added here at the end of each epoch.
+	"""
+	rewardsPool: BigInt
+	"""
+	The epoch at which this pool became active.
+	"""
+	stakingPoolActivationEpoch: UInt53
+	"""
+	The ID of this validator's `0x3::staking_pool::StakingPool`.
+	"""
+	stakingPoolId: SuiAddress!
+	"""
+	The total number of SUI tokens in this pool.
+	"""
+	stakingPoolSuiBalance: BigInt
+	"""
+	The voting power of this validator in basis points (e.g., 100 = 1% voting power).
+	"""
+	votingPower: Int
+}
+
 type ValidatorAggregatedSignature {
 	"""
 	The epoch when this aggregate signature was produced.
@@ -3980,9 +4071,27 @@ type ValidatorAggregatedSignature {
 }
 
 """
+The credentials related fields associated with a validator.
+"""
+type ValidatorCredentials {
+	netAddress: String
+	networkPubKey: Base64
+	p2PAddress: String
+	primaryAddress: String
+	proofOfPossession: Base64
+	protocolPubKey: Base64
+	workerAddress: String
+	workerPubKey: Base64
+}
+
+"""
 Representation of `0x3::validator_set::ValidatorSet`.
 """
 type ValidatorSet {
+	"""
+	The current list of active validators.
+	"""
+	activeValidators: [Validator!]
 	"""
 	Object ID of the `Table` storing the inactive staking pools.
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -3964,6 +3964,97 @@ type UserSignature {
 	signatureBytes: Base64
 }
 
+type Validator {
+	"""
+	The validator's address.
+	"""
+	address: SuiAddress!
+	"""
+	The fee charged by the validator for staking services.
+	"""
+	commissionRate: Int
+	"""
+	Validator's set of credentials such as public keys, network addresses and others.
+	"""
+	credentials: ValidatorCredentials
+	"""
+	Validator's description.
+	"""
+	description: String
+	"""
+	Number of exchange rates in the table.
+	"""
+	exchangeRatesSize: UInt53
+	"""
+	The reference gas price for this epoch.
+	"""
+	gasPrice: BigInt
+	"""
+	Validator's url containing their custom image.
+	"""
+	imageUrl: String
+	"""
+	Validator's name.
+	"""
+	name: String
+	"""
+	The proposed next epoch fee for the validator's staking services.
+	"""
+	nextEpochCommissionRate: Int
+	"""
+	Validator's set of credentials for the next epoch.
+	"""
+	nextEpochCredentials: ValidatorCredentials
+	"""
+	The validator's gas price quote for the next epoch.
+	"""
+	nextEpochGasPrice: BigInt
+	"""
+	The total number of SUI tokens in this pool plus the pending stake amount for this epoch.
+	"""
+	nextEpochStake: BigInt
+	"""
+	Pending pool token withdrawn during the current epoch, emptied at epoch boundaries.
+	"""
+	pendingPoolTokenWithdraw: BigInt
+	"""
+	Pending stake amount for this epoch.
+	"""
+	pendingStake: BigInt
+	"""
+	Pending stake withdrawn during the current epoch, emptied at epoch boundaries.
+	"""
+	pendingTotalSuiWithdraw: BigInt
+	"""
+	Total number of pool tokens issued by the pool.
+	"""
+	poolTokenBalance: BigInt
+	"""
+	Validator's homepage URL.
+	"""
+	projectUrl: String
+	"""
+	The epoch stake rewards will be added here at the end of each epoch.
+	"""
+	rewardsPool: BigInt
+	"""
+	The epoch at which this pool became active.
+	"""
+	stakingPoolActivationEpoch: UInt53
+	"""
+	The ID of this validator's `0x3::staking_pool::StakingPool`.
+	"""
+	stakingPoolId: SuiAddress!
+	"""
+	The total number of SUI tokens in this pool.
+	"""
+	stakingPoolSuiBalance: BigInt
+	"""
+	The voting power of this validator in basis points (e.g., 100 = 1% voting power).
+	"""
+	votingPower: Int
+}
+
 type ValidatorAggregatedSignature {
 	"""
 	The epoch when this aggregate signature was produced.
@@ -3980,9 +4071,27 @@ type ValidatorAggregatedSignature {
 }
 
 """
+The credentials related fields associated with a validator.
+"""
+type ValidatorCredentials {
+	netAddress: String
+	networkPubKey: Base64
+	p2PAddress: String
+	primaryAddress: String
+	proofOfPossession: Base64
+	protocolPubKey: Base64
+	workerAddress: String
+	workerPubKey: Base64
+}
+
+"""
 Representation of `0x3::validator_set::ValidatorSet`.
 """
 type ValidatorSet {
+	"""
+	The current list of active validators.
+	"""
+	activeValidators: [Validator!]
 	"""
 	Object ID of the `Table` storing the inactive staking pools.
 	"""

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -3960,6 +3960,97 @@ type UserSignature {
 	signatureBytes: Base64
 }
 
+type Validator {
+	"""
+	The validator's address.
+	"""
+	address: SuiAddress!
+	"""
+	The fee charged by the validator for staking services.
+	"""
+	commissionRate: Int
+	"""
+	Validator's set of credentials such as public keys, network addresses and others.
+	"""
+	credentials: ValidatorCredentials
+	"""
+	Validator's description.
+	"""
+	description: String
+	"""
+	Number of exchange rates in the table.
+	"""
+	exchangeRatesSize: UInt53
+	"""
+	The reference gas price for this epoch.
+	"""
+	gasPrice: BigInt
+	"""
+	Validator's url containing their custom image.
+	"""
+	imageUrl: String
+	"""
+	Validator's name.
+	"""
+	name: String
+	"""
+	The proposed next epoch fee for the validator's staking services.
+	"""
+	nextEpochCommissionRate: Int
+	"""
+	Validator's set of credentials for the next epoch.
+	"""
+	nextEpochCredentials: ValidatorCredentials
+	"""
+	The validator's gas price quote for the next epoch.
+	"""
+	nextEpochGasPrice: BigInt
+	"""
+	The total number of SUI tokens in this pool plus the pending stake amount for this epoch.
+	"""
+	nextEpochStake: BigInt
+	"""
+	Pending pool token withdrawn during the current epoch, emptied at epoch boundaries.
+	"""
+	pendingPoolTokenWithdraw: BigInt
+	"""
+	Pending stake amount for this epoch.
+	"""
+	pendingStake: BigInt
+	"""
+	Pending stake withdrawn during the current epoch, emptied at epoch boundaries.
+	"""
+	pendingTotalSuiWithdraw: BigInt
+	"""
+	Total number of pool tokens issued by the pool.
+	"""
+	poolTokenBalance: BigInt
+	"""
+	Validator's homepage URL.
+	"""
+	projectUrl: String
+	"""
+	The epoch stake rewards will be added here at the end of each epoch.
+	"""
+	rewardsPool: BigInt
+	"""
+	The epoch at which this pool became active.
+	"""
+	stakingPoolActivationEpoch: UInt53
+	"""
+	The ID of this validator's `0x3::staking_pool::StakingPool`.
+	"""
+	stakingPoolId: SuiAddress!
+	"""
+	The total number of SUI tokens in this pool.
+	"""
+	stakingPoolSuiBalance: BigInt
+	"""
+	The voting power of this validator in basis points (e.g., 100 = 1% voting power).
+	"""
+	votingPower: Int
+}
+
 type ValidatorAggregatedSignature {
 	"""
 	The epoch when this aggregate signature was produced.
@@ -3976,9 +4067,27 @@ type ValidatorAggregatedSignature {
 }
 
 """
+The credentials related fields associated with a validator.
+"""
+type ValidatorCredentials {
+	netAddress: String
+	networkPubKey: Base64
+	p2PAddress: String
+	primaryAddress: String
+	proofOfPossession: Base64
+	protocolPubKey: Base64
+	workerAddress: String
+	workerPubKey: Base64
+}
+
+"""
 Representation of `0x3::validator_set::ValidatorSet`.
 """
 type ValidatorSet {
+	"""
+	The current list of active validators.
+	"""
+	activeValidators: [Validator!]
 	"""
 	Object ID of the `Table` storing the inactive staking pools.
 	"""


### PR DESCRIPTION
## Description 

1. Adds `ValidatorSet.activeValidators` based on a new `Validator` type.
2. Implements `Validator` fields that depend on `ValidatorV1`.

## Test plan 

Adds a new `active_validators.move` test file. Some fields are currently not populated and are marked with a `todo`.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
