### PR TITLE
graphql-alt: rename object_filter::Validator to ObjectFilterValidator

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/query.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/query.rs
@@ -36,7 +36,7 @@ use super::{
         move_type::{self, MoveType},
         name_service::name_to_address,
         object::{self, Object, ObjectKey, VersionFilter},
-        object_filter::{ObjectFilter, Validator as OFValidator},
+        object_filter::{ObjectFilter, ObjectFilterValidator as OFValidator},
         protocol_configs::ProtocolConfigs,
         service_config::ServiceConfig,
         transaction::{

--- a/crates/sui-indexer-alt-graphql/src/api/types/address.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/address.rs
@@ -23,7 +23,7 @@ use super::{
     move_package::MovePackage,
     name_service::address_to_name,
     object::{self, Object, ObjectKey},
-    object_filter::{ObjectFilter, Validator as OFValidator},
+    object_filter::{ObjectFilter, ObjectFilterValidator as OFValidator},
     transaction::{
         filter::{TransactionFilter, TransactionFilterValidator as TFValidator},
         CTransaction, Transaction,

--- a/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
@@ -28,7 +28,7 @@ use super::{
     move_object::MoveObject,
     move_value::MoveValue,
     object::{self, CLive, CVersion, Object, VersionFilter},
-    object_filter::{ObjectFilter, Validator as OFValidator},
+    object_filter::{ObjectFilter, ObjectFilterValidator as OFValidator},
     owner::Owner,
     transaction::{filter::TransactionFilter, CTransaction, Transaction},
 };

--- a/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/dynamic_field.rs
@@ -36,7 +36,7 @@ use super::{
     move_type::MoveType,
     move_value::MoveValue,
     object::{self, CLive, CVersion, Object, VersionFilter},
-    object_filter::{ObjectFilter, Validator as OFValidator},
+    object_filter::{ObjectFilter, ObjectFilterValidator as OFValidator},
     owner::Owner,
     transaction::{filter::TransactionFilter, CTransaction, Transaction},
 };

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_object.rs
@@ -25,7 +25,7 @@ use super::{
     move_type::MoveType,
     move_value::MoveValue,
     object::{self, CLive, CVersion, Object, VersionFilter},
-    object_filter::{ObjectFilter, Validator as OFValidator},
+    object_filter::{ObjectFilter, ObjectFilterValidator as OFValidator},
     owner::Owner,
     transaction::{filter::TransactionFilter, CTransaction, Transaction},
 };

--- a/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/move_package.rs
@@ -48,7 +48,7 @@ use super::{
     move_module::MoveModule,
     move_object::MoveObject,
     object::{self, CLive, CVersion, Object, VersionFilter},
-    object_filter::{ObjectFilter, Validator as OFValidator},
+    object_filter::{ObjectFilter, ObjectFilterValidator as OFValidator},
     owner::Owner,
     transaction::{filter::TransactionFilter, CTransaction, Transaction},
     type_origin::TypeOrigin,

--- a/crates/sui-indexer-alt-graphql/src/api/types/object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object.rs
@@ -58,7 +58,7 @@ use super::{
     dynamic_field::{DynamicField, DynamicFieldName},
     move_object::MoveObject,
     move_package::MovePackage,
-    object_filter::{ObjectFilter, Validator as OFValidator},
+    object_filter::{ObjectFilter, ObjectFilterValidator as OFValidator},
     owner::Owner,
     transaction::{filter::TransactionFilter, CTransaction, Transaction},
 };

--- a/crates/sui-indexer-alt-graphql/src/api/types/object_filter.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object_filter.rs
@@ -39,12 +39,12 @@ pub(crate) struct ObjectFilter {
 }
 
 #[derive(Default)]
-pub(crate) struct Validator {
+pub(crate) struct ObjectFilterValidator {
     /// Whether to allow an empty filter on input.
     allow_empty: bool,
 }
 
-impl Validator {
+impl ObjectFilterValidator {
     /// Create a validator that allows empty filters.
     pub(crate) fn allows_empty() -> Self {
         Self { allow_empty: true }
@@ -69,7 +69,7 @@ impl ObjectFilter {
     }
 }
 
-impl CustomValidator<ObjectFilter> for Validator {
+impl CustomValidator<ObjectFilter> for ObjectFilterValidator {
     fn check(&self, filter: &ObjectFilter) -> Result<(), InputValueError<ObjectFilter>> {
         match filter {
             ObjectFilter {


### PR DESCRIPTION
## Description 

This helps distinguish the object filter validator which is a GraphQL input validator with the SUI validator model added in https://github.com/MystenLabs/sui/pull/23582. It follows the naming convention of [TransactionFilterValidator](https://github.com/MystenLabs/sui/blob/2a4de175579d35869f9520d7fdeba375741b5087/crates/sui-indexer-alt-graphql/src/api/types/transaction/filter.rs#L51).

## Test plan 

Rename only - no testing changes.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
