### PR TITLE
[graphql-alt] Support JSON-formatted transaction input for Query::simulateTransaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14826,6 +14826,7 @@ dependencies = [
  "move-core-types",
  "prometheus",
  "prost-types",
+ "serde_json",
  "sui-indexer-alt-consistent-api",
  "sui-indexer-alt-metrics",
  "sui-indexer-alt-schema",

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -1,3 +1,5 @@
+directive @oneOf on INPUT_OBJECT
+
 """
 System transaction for creating the accumulator root.
 """
@@ -3223,11 +3225,11 @@ type Query {
 	"""
 	Simulate a transaction to preview its effects without executing it on chain.
 	
-	- `transactionDataBcs` contains the BCS-encoded transaction data (Base64-encoded).
+	Accepts either BCS-encoded transaction data or a JSON representation that can be partially resolved.
 	
 	Unlike `executeTransaction`, this does not require signatures since the transaction is not committed to the blockchain. This allows for previewing transaction effects, estimating gas costs, and testing transaction logic without spending gas or requiring valid signatures.
 	"""
-	simulateTransaction(transactionDataBcs: Base64!): SimulationResult!
+	simulateTransaction(data: SimulateTransactionData!): SimulationResult!
 	"""
 	Look-up an account by its SuiNS name, assuming it has a valid, unexpired name registration.
 	"""
@@ -3468,6 +3470,20 @@ type SharedInput {
 	This has implications for scheduling: Transactions that just read shared objects at a certain version (mutable = false) can be executed concurrently, while transactions that write shared objects (mutable = true) must be executed serially with respect to each other.
 	"""
 	mutable: Boolean
+}
+
+"""
+Input for simulating a transaction, supporting both BCS and JSON formats.
+"""
+input SimulateTransactionData @oneOf {
+	"""
+	Input for simulating a transaction, supporting both BCS and JSON formats.
+	"""
+	bcs: Base64
+	"""
+	Input for simulating a transaction, supporting both BCS and JSON formats.
+	"""
+	json: String
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/api/mutation.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/mutation.rs
@@ -21,6 +21,9 @@ pub enum TransactionInputError {
 
     #[error("Invalid signature format in signature {index}: {err}")]
     InvalidSignatureFormat { index: usize, err: FastCryptoError },
+
+    #[error("Invalid JSON transaction data: {0}")]
+    InvalidTransactionJson(serde_json::Error),
 }
 use crate::{
     api::types::{execution_result::ExecutionResult, transaction_effects::TransactionEffects},

--- a/crates/sui-indexer-alt-graphql/src/api/query.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/query.rs
@@ -1,10 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::anyhow;
-use async_graphql::{connection::Connection, Context, Object, Result};
+use anyhow::{anyhow, Context as _};
+use async_graphql::{connection::Connection, Context, Object, OneofObject, Result};
 use futures::future::try_join_all;
 use sui_indexer_alt_reader::fullnode_client::{Error::GrpcExecutionError, FullnodeClient};
+use sui_rpc::proto::sui::rpc::v2beta2 as proto;
 use sui_types::{digests::ChainIdentifier, transaction::TransactionData};
 
 use crate::{
@@ -45,6 +46,18 @@ use super::{
         },
     },
 };
+
+/// Input for simulating a transaction, supporting both BCS and JSON formats.
+#[derive(OneofObject)]
+pub enum SimulateTransactionData {
+    /// BCS-encoded transaction data (Base64-encoded).
+    Bcs(Base64),
+    /// JSON-encoded transaction following the proto `Transaction` message schema.
+    ///
+    /// The JSON structure must conform to the protobuf message defined in
+    /// `sui-apis/proto/sui/rpc/v2beta2/transaction.proto`.
+    Json(String),
+}
 
 #[derive(Default)]
 pub struct Query {
@@ -555,27 +568,52 @@ impl Query {
 
     /// Simulate a transaction to preview its effects without executing it on chain.
     ///
-    /// - `transactionDataBcs` contains the BCS-encoded transaction data (Base64-encoded).
+    /// Accepts either BCS-encoded transaction data or a JSON representation that can be partially resolved.
     ///
     /// Unlike `executeTransaction`, this does not require signatures since the transaction is not committed to the blockchain. This allows for previewing transaction effects, estimating gas costs, and testing transaction logic without spending gas or requiring valid signatures.
     async fn simulate_transaction(
         &self,
         ctx: &Context<'_>,
-        transaction_data_bcs: Base64,
+        data: SimulateTransactionData,
     ) -> Result<SimulationResult, RpcError<TransactionInputError>> {
         let fullnode_client: &FullnodeClient = ctx.data()?;
 
-        // Parse transaction data from BCS
-        let tx_data: TransactionData = {
-            let bytes: &Vec<u8> = &transaction_data_bcs.0;
-            bcs::from_bytes(bytes)
-                .map_err(|err| bad_user_input(TransactionInputError::InvalidTransactionBcs(err)))?
+        let proto_tx = match data {
+            SimulateTransactionData::Bcs(bcs_data) => {
+                // Parse BCS to get TransactionData first
+                let bytes: &Vec<u8> = &bcs_data.0;
+                let tx_data: TransactionData = bcs::from_bytes(bytes).map_err(|err| {
+                    bad_user_input(TransactionInputError::InvalidTransactionBcs(err))
+                })?;
+
+                // Create proto with BCS
+                let mut proto = proto::Transaction::default();
+                proto.bcs = Some(proto::Bcs::serialize(&tx_data).map_err(|err| {
+                    bad_user_input(TransactionInputError::InvalidTransactionBcs(err))
+                })?);
+                proto
+            }
+            SimulateTransactionData::Json(json_str) => {
+                // Parse JSON directly to proto::Transaction
+                serde_json::from_str(&json_str).map_err(|err| {
+                    bad_user_input(TransactionInputError::InvalidTransactionJson(err))
+                })?
+            }
         };
 
-        // Simulate transaction - no signatures needed
-        match fullnode_client.simulate_transaction(tx_data.clone()).await {
+        // Simulate transaction using proto
+        match fullnode_client.simulate_transaction(proto_tx).await {
             Ok(response) => {
                 let scope = self.scope(ctx)?;
+                let tx_data = response
+                    .transaction
+                    .as_ref()
+                    .and_then(|executed_tx| executed_tx.transaction.as_ref())
+                    .and_then(|tx| tx.bcs.as_ref())
+                    .ok_or_else(|| anyhow!("Missing transaction or BCS in simulation response"))?
+                    .deserialize()
+                    .context("Failed to deserialize transaction from response")?;
+
                 SimulationResult::from_simulation_response(scope, response, tx_data).map_err(upcast)
             }
             Err(GrpcExecutionError(status)) => Ok(SimulationResult {

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -2,6 +2,8 @@
 source: crates/sui-indexer-alt-graphql/src/lib.rs
 expression: sdl
 ---
+directive @oneOf on INPUT_OBJECT
+
 """
 System transaction for creating the accumulator root.
 """
@@ -3227,11 +3229,11 @@ type Query {
 	"""
 	Simulate a transaction to preview its effects without executing it on chain.
 	
-	- `transactionDataBcs` contains the BCS-encoded transaction data (Base64-encoded).
+	Accepts either BCS-encoded transaction data or a JSON representation that can be partially resolved.
 	
 	Unlike `executeTransaction`, this does not require signatures since the transaction is not committed to the blockchain. This allows for previewing transaction effects, estimating gas costs, and testing transaction logic without spending gas or requiring valid signatures.
 	"""
-	simulateTransaction(transactionDataBcs: Base64!): SimulationResult!
+	simulateTransaction(data: SimulateTransactionData!): SimulationResult!
 	"""
 	Look-up an account by its SuiNS name, assuming it has a valid, unexpired name registration.
 	"""
@@ -3472,6 +3474,20 @@ type SharedInput {
 	This has implications for scheduling: Transactions that just read shared objects at a certain version (mutable = false) can be executed concurrently, while transactions that write shared objects (mutable = true) must be executed serially with respect to each other.
 	"""
 	mutable: Boolean
+}
+
+"""
+Input for simulating a transaction, supporting both BCS and JSON formats.
+"""
+input SimulateTransactionData @oneOf {
+	"""
+	Input for simulating a transaction, supporting both BCS and JSON formats.
+	"""
+	bcs: Base64
+	"""
+	Input for simulating a transaction, supporting both BCS and JSON formats.
+	"""
+	json: String
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -2,6 +2,8 @@
 source: crates/sui-indexer-alt-graphql/src/lib.rs
 expression: sdl
 ---
+directive @oneOf on INPUT_OBJECT
+
 """
 System transaction for creating the accumulator root.
 """
@@ -3227,11 +3229,11 @@ type Query {
 	"""
 	Simulate a transaction to preview its effects without executing it on chain.
 	
-	- `transactionDataBcs` contains the BCS-encoded transaction data (Base64-encoded).
+	Accepts either BCS-encoded transaction data or a JSON representation that can be partially resolved.
 	
 	Unlike `executeTransaction`, this does not require signatures since the transaction is not committed to the blockchain. This allows for previewing transaction effects, estimating gas costs, and testing transaction logic without spending gas or requiring valid signatures.
 	"""
-	simulateTransaction(transactionDataBcs: Base64!): SimulationResult!
+	simulateTransaction(data: SimulateTransactionData!): SimulationResult!
 	"""
 	Look-up an account by its SuiNS name, assuming it has a valid, unexpired name registration.
 	"""
@@ -3472,6 +3474,20 @@ type SharedInput {
 	This has implications for scheduling: Transactions that just read shared objects at a certain version (mutable = false) can be executed concurrently, while transactions that write shared objects (mutable = true) must be executed serially with respect to each other.
 	"""
 	mutable: Boolean
+}
+
+"""
+Input for simulating a transaction, supporting both BCS and JSON formats.
+"""
+input SimulateTransactionData @oneOf {
+	"""
+	Input for simulating a transaction, supporting both BCS and JSON formats.
+	"""
+	bcs: Base64
+	"""
+	Input for simulating a transaction, supporting both BCS and JSON formats.
+	"""
+	json: String
 }
 
 """

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -1,3 +1,5 @@
+directive @oneOf on INPUT_OBJECT
+
 """
 System transaction for creating the accumulator root.
 """
@@ -3223,11 +3225,11 @@ type Query {
 	"""
 	Simulate a transaction to preview its effects without executing it on chain.
 	
-	- `transactionDataBcs` contains the BCS-encoded transaction data (Base64-encoded).
+	Accepts either BCS-encoded transaction data or a JSON representation that can be partially resolved.
 	
 	Unlike `executeTransaction`, this does not require signatures since the transaction is not committed to the blockchain. This allows for previewing transaction effects, estimating gas costs, and testing transaction logic without spending gas or requiring valid signatures.
 	"""
-	simulateTransaction(transactionDataBcs: Base64!): SimulationResult!
+	simulateTransaction(data: SimulateTransactionData!): SimulationResult!
 	"""
 	Look-up an account by its SuiNS name, assuming it has a valid, unexpired name registration.
 	"""
@@ -3468,6 +3470,20 @@ type SharedInput {
 	This has implications for scheduling: Transactions that just read shared objects at a certain version (mutable = false) can be executed concurrently, while transactions that write shared objects (mutable = true) must be executed serially with respect to each other.
 	"""
 	mutable: Boolean
+}
+
+"""
+Input for simulating a transaction, supporting both BCS and JSON formats.
+"""
+input SimulateTransactionData @oneOf {
+	"""
+	Input for simulating a transaction, supporting both BCS and JSON formats.
+	"""
+	bcs: Base64
+	"""
+	Input for simulating a transaction, supporting both BCS and JSON formats.
+	"""
+	json: String
 }
 
 """

--- a/crates/sui-indexer-alt-reader/Cargo.toml
+++ b/crates/sui-indexer-alt-reader/Cargo.toml
@@ -20,6 +20,7 @@ diesel-async = { workspace = true, features = ["bb8", "postgres", "async-connect
 futures.workspace = true
 prost-types.workspace = true
 prometheus.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true

--- a/crates/sui-indexer-alt-reader/src/fullnode_client.rs
+++ b/crates/sui-indexer-alt-reader/src/fullnode_client.rs
@@ -132,26 +132,21 @@ impl FullnodeClient {
 
     /// Simulate a transaction on the Sui network via gRPC.
     /// Note: Simulation does not require signatures since the transaction is not committed to the blockchain.
-    #[instrument(skip(self, transaction_data), level = "debug")]
+    #[instrument(skip(self, transaction), level = "debug")]
     pub async fn simulate_transaction(
         &self,
-        transaction_data: TransactionData,
+        transaction: proto::Transaction,
     ) -> Result<proto::SimulateTransactionResponse, Error> {
-        let mut tx_proto = proto::Transaction::default();
-        tx_proto.bcs =
-            Some(proto::Bcs::serialize(&transaction_data).map_err(|e| {
-                Error::Internal(anyhow!("Failed to serialize transaction data: {e}"))
-            })?);
         // No signatures needed for simulation
-
         let mut request = proto::SimulateTransactionRequest::default();
-        request.transaction = Some(tx_proto);
+        request.transaction = Some(transaction);
         request.read_mask = Some(FieldMask::from_paths([
             "transaction.effects.bcs",
             "transaction.events.bcs",
             "transaction.balance_changes",
             "transaction.input_objects.bcs",
             "transaction.output_objects.bcs",
+            "transaction.transaction.bcs",
             "outputs",
         ]));
 


### PR DESCRIPTION
## Description 

This PR implements support for JSON-formatted input within `Query.simulateTransaction` method, which allows us to input a human-readable transaction JSON for simulation like:

```
"sender": "0x123",
"kind": {
            "programmableTransaction": {
                "inputs": [
                    {"objectId": "0xabc"}
                ],
                "commands": []
            }
 }
```

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-e2e-test
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
