### PR TITLE
Use newtype for accumulator object IDs

### DIFF
--- a/crates/sui-core/src/accumulators/mod.rs
+++ b/crates/sui-core/src/accumulators/mod.rs
@@ -6,11 +6,10 @@ use std::collections::HashMap;
 use mysten_common::fatal;
 use sui_types::accumulator_event::AccumulatorEvent;
 use sui_types::accumulator_root::{
-    ACCUMULATOR_ROOT_SETTLEMENT_PROLOGUE_FUNC, ACCUMULATOR_ROOT_SETTLE_U128_FUNC,
+    AccumulatorObjId, ACCUMULATOR_ROOT_SETTLEMENT_PROLOGUE_FUNC, ACCUMULATOR_ROOT_SETTLE_U128_FUNC,
     ACCUMULATOR_SETTLEMENT_MODULE,
 };
 use sui_types::balance::{BALANCE_MODULE_NAME, BALANCE_STRUCT_NAME};
-use sui_types::base_types::ObjectID;
 use sui_types::effects::{
     AccumulatorAddress, AccumulatorOperation, AccumulatorValue, AccumulatorWriteV1,
     TransactionEffects, TransactionEffectsAPI,
@@ -155,8 +154,8 @@ struct Update {
 }
 
 pub(crate) struct AccumulatorSettlementTxBuilder {
-    updates: HashMap<ObjectID, Update>,
-    addresses: HashMap<ObjectID, AccumulatorAddress>,
+    updates: HashMap<AccumulatorObjId, Update>,
+    addresses: HashMap<AccumulatorObjId, AccumulatorAddress>,
 
     total_input_sui: u64,
     total_output_sui: u64,

--- a/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/mod.rs
+++ b/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/mod.rs
@@ -3,7 +3,7 @@
 
 use std::collections::BTreeMap;
 
-use sui_types::{base_types::ObjectID, digests::TransactionDigest};
+use sui_types::{accumulator_root::AccumulatorObjId, digests::TransactionDigest};
 
 mod balance_read;
 mod naive_scheduler;
@@ -44,12 +44,12 @@ pub struct BalanceSettlement {
     /// This is currently unused because the naive scheduler
     /// always load the latest balance during scheduling.
     #[allow(unused)]
-    pub balance_changes: BTreeMap<ObjectID, i128>,
+    pub balance_changes: BTreeMap<AccumulatorObjId, i128>,
 }
 
 /// Details regarding all balance withdraw reservations in a transaction.
 #[derive(Clone, Debug)]
 pub(crate) struct TxBalanceWithdraw {
     pub tx_digest: TransactionDigest,
-    pub reservations: BTreeMap<ObjectID, u64>,
+    pub reservations: BTreeMap<AccumulatorObjId, u64>,
 }

--- a/crates/sui-types/src/accumulator_event.rs
+++ b/crates/sui-types/src/accumulator_event.rs
@@ -5,7 +5,7 @@ use move_core_types::ident_str;
 use move_core_types::identifier::IdentStr;
 use mysten_common::fatal;
 
-use crate::base_types::ObjectID;
+use crate::accumulator_root::AccumulatorObjId;
 use crate::effects::{
     AccumulatorAddress, AccumulatorOperation, AccumulatorValue, AccumulatorWriteV1,
 };
@@ -16,12 +16,12 @@ pub const ACCUMULATOR_MODULE_NAME: &IdentStr = ident_str!("accumulator");
 
 #[derive(Debug, Clone)]
 pub struct AccumulatorEvent {
-    pub accumulator_obj: ObjectID,
+    pub accumulator_obj: AccumulatorObjId,
     pub write: AccumulatorWriteV1,
 }
 
 impl AccumulatorEvent {
-    pub fn new(accumulator_obj: ObjectID, write: AccumulatorWriteV1) -> Self {
+    pub fn new(accumulator_obj: AccumulatorObjId, write: AccumulatorWriteV1) -> Self {
         Self {
             accumulator_obj,
             write,

--- a/crates/sui-types/src/effects/effects_v2.rs
+++ b/crates/sui-types/src/effects/effects_v2.rs
@@ -4,6 +4,7 @@
 use super::object_change::{AccumulatorWriteV1, ObjectIn, ObjectOut};
 use super::{EffectsObjectChange, IDOperation, ObjectChange};
 use crate::accumulator_event::AccumulatorEvent;
+use crate::accumulator_root::AccumulatorObjId;
 use crate::base_types::{
     EpochId, ObjectDigest, ObjectID, ObjectRef, SequenceNumber, SuiAddress, TransactionDigest,
     VersionDigest,
@@ -411,9 +412,10 @@ impl TransactionEffectsAPI for TransactionEffectsV2 {
         self.changed_objects
             .iter()
             .filter_map(|(id, change)| match &change.output_state {
-                ObjectOut::AccumulatorWriteV1(write) => {
-                    Some(AccumulatorEvent::new(*id, write.clone()))
-                }
+                ObjectOut::AccumulatorWriteV1(write) => Some(AccumulatorEvent::new(
+                    AccumulatorObjId::new_unchecked(*id),
+                    write.clone(),
+                )),
                 _ => None,
             })
             .collect()

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{base_types::*, error::*, SUI_BRIDGE_OBJECT_ID};
-use crate::accumulator_root::AccumulatorValue;
+use crate::accumulator_root::{AccumulatorObjId, AccumulatorValue};
 use crate::authenticator_state::ActiveJwk;
 use crate::balance::Balance;
 use crate::committee::{Committee, EpochId, ProtocolVersion};
@@ -2201,7 +2201,7 @@ pub trait TransactionDataAPI {
     /// reserved amount. This method aggregates all withdraw operations for the same account by
     /// merging their reservations. Each account object ID is derived from the type parameter of
     /// each withdraw operation.
-    fn process_funds_withdrawals(&self) -> UserInputResult<BTreeMap<ObjectID, u64>>;
+    fn process_funds_withdrawals(&self) -> UserInputResult<BTreeMap<AccumulatorObjId, u64>>;
 
     // A cheap way to quickly check if the transaction has funds withdraws.
     fn has_funds_withdrawals(&self) -> bool;
@@ -2329,7 +2329,7 @@ impl TransactionDataAPI for TransactionDataV1 {
         Ok((move_objects, packages, receiving_objects))
     }
 
-    fn process_funds_withdrawals(&self) -> UserInputResult<BTreeMap<ObjectID, u64>> {
+    fn process_funds_withdrawals(&self) -> UserInputResult<BTreeMap<AccumulatorObjId, u64>> {
         let mut withdraws = Vec::new();
         // TODO(address-balances): Once we support paying gas using address balances,
         // we add gas reservations here.

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -57,6 +57,7 @@ mod checked {
     use sui_protocol_config::ProtocolConfig;
     use sui_types::{
         accumulator_event::AccumulatorEvent,
+        accumulator_root::AccumulatorObjId,
         balance::Balance,
         base_types::{MoveObjectType, ObjectID, SuiAddress, TxContext},
         coin::Coin,
@@ -1547,7 +1548,10 @@ mod checked {
                         value,
                     };
 
-                    AccumulatorEvent::new(accum_event.accumulator_id, write)
+                    AccumulatorEvent::new(
+                        AccumulatorObjId::new_unchecked(accum_event.accumulator_id),
+                        write,
+                    )
                 }
             })
             .collect();

--- a/sui-execution/latest/sui-adapter/src/temporary_store.rs
+++ b/sui-execution/latest/sui-adapter/src/temporary_store.rs
@@ -212,7 +212,7 @@ impl<'backing> TemporaryStore<'backing> {
                      write,
                  }| {
                     (
-                        accumulator_obj,
+                        *accumulator_obj.inner(),
                         EffectsObjectChange::new_from_accumulator_write(write),
                     )
                 },


### PR DESCRIPTION
This has no behavioral changes, just intended to make it difficult to inadvertently read an accumulator via an ID that wasn't obtained by computing a dynamic field key.
