### PR TITLE
graphql-alt: Implement IAddressable with Validator

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/active_validators.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/active_validators.move
@@ -5,43 +5,55 @@
 
 //# run-graphql
 {
-  epoch(epochId: 0) { ...E }
-}
-
-fragment E on Epoch {
-  epochId
-  validatorSet {
-    activeValidators {
-      address
-      credentials { ...VC }
-      # todo (ewall) populate nextEpochCredentials
-      nextEpochCredentials { ...VC }
-      name
-      # todo (ewall) populate description
-      description
-      # todo (ewall) populate imageUrl
-      imageUrl
-      # todo (ewall) populate projectUrl
-      projectUrl
-      stakingPoolId
-      exchangeRatesSize
-      stakingPoolActivationEpoch
-      stakingPoolSuiBalance
-      # todo (ewall) populate rewardsPool
-      rewardsPool
-      poolTokenBalance
-      # todo (ewall) populate pendingStake
-      pendingStake
-      # todo (ewall) populate pendingTotalSuiWithdraw
-      pendingTotalSuiWithdraw
-      # todo (ewall) populate pendingPoolTokenWithdraw
-      pendingPoolTokenWithdraw
-      votingPower
-      gasPrice
-      commissionRate
-      nextEpochStake
-      nextEpochGasPrice
-      nextEpochCommissionRate
+  epoch(epochId: 0) {
+    epochId
+    validatorSet {
+      activeValidators {
+        address
+        balance(coinType: "0x2::sui::SUI") {
+          totalBalance
+        }
+        balances {
+          __typename
+        }
+        # todo (ewall) populate defaultSuinsName
+        defaultSuinsName
+        multiGetBalances(keys: ["0x2::sui::SUI"]) {
+          totalBalance
+        }
+        objects {
+          __typename
+        }
+        credentials { ...VC }
+        # todo (ewall) populate nextEpochCredentials
+        nextEpochCredentials { ...VC }
+        name
+        # todo (ewall) populate description
+        description
+        # todo (ewall) populate imageUrl
+        imageUrl
+        # todo (ewall) populate projectUrl
+        projectUrl
+        stakingPoolId
+        exchangeRatesSize
+        stakingPoolActivationEpoch
+        stakingPoolSuiBalance
+        # todo (ewall) populate rewardsPool
+        rewardsPool
+        poolTokenBalance
+        # todo (ewall) populate pendingStake
+        pendingStake
+        # todo (ewall) populate pendingTotalSuiWithdraw
+        pendingTotalSuiWithdraw
+        # todo (ewall) populate pendingPoolTokenWithdraw
+        pendingPoolTokenWithdraw
+        votingPower
+        gasPrice
+        commissionRate
+        nextEpochStake
+        nextEpochGasPrice
+        nextEpochCommissionRate
+      }
     }
   }
 }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/active_validators.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/active_validators.snap
@@ -6,7 +6,7 @@ processed 2 tasks
 init:
 A: object(0,0)
 
-task 1, lines 6-58:
+task 1, lines 6-70:
 //# run-graphql
 Response: {
   "data": {
@@ -16,6 +16,21 @@ Response: {
         "activeValidators": [
           {
             "address": "0xda83166d01afd7ddcf8af5f844f45aaa53f48548e5117c23f5a2978cfd422244",
+            "balance": {
+              "totalBalance": "30000000000000000"
+            },
+            "balances": {
+              "__typename": "BalanceConnection"
+            },
+            "defaultSuinsName": null,
+            "multiGetBalances": [
+              {
+                "totalBalance": "30000000000000000"
+              }
+            ],
+            "objects": {
+              "__typename": "MoveObjectConnection"
+            },
             "credentials": {
               "protocolPubKey": "qqgbtEP57SCwGrO7tmcKwy/daeoOFwANmrMTm1Qu4jUJRhi2VePz/brF9YAcjmJ7BLOpN8c5Ia7zYzTNmGtGoaUnjoYrbvDG9E05s9antwSmkHAIGsM8mkmeBkSjSBrt",
               "networkPubKey": "ZeETulurG5EpRBoewpF26pyLQtpUqwH1T6LqgugHBIU=",

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -3971,11 +3971,21 @@ type UserSignature {
 	signatureBytes: Base64
 }
 
-type Validator {
+type Validator implements IAddressable {
 	"""
 	The validator's address.
 	"""
 	address: SuiAddress!
+	"""
+	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	
+	If the address does not own any coins of that type, a balance of zero is returned.
+	"""
+	balance(coinType: String!): Balance
+	"""
+	Total balance across coins owned by this address, grouped by coin type.
+	"""
+	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
 	The fee charged by the validator for staking services.
 	"""
@@ -3984,6 +3994,10 @@ type Validator {
 	Validator's set of credentials such as public keys, network addresses and others.
 	"""
 	credentials: ValidatorCredentials
+	"""
+	The domain explicitly configured as the default SuiNS name for this address.
+	"""
+	defaultSuinsName: String
 	"""
 	Validator's description.
 	"""
@@ -4000,6 +4014,13 @@ type Validator {
 	Validator's url containing their custom image.
 	"""
 	imageUrl: String
+	"""
+	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
+	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	"""
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Validator's name.
 	"""
@@ -4020,6 +4041,10 @@ type Validator {
 	The total number of SUI tokens in this pool plus the pending stake amount for this epoch.
 	"""
 	nextEpochStake: BigInt
+	"""
+	Objects owned by this object, optionally filtered by type.
+	"""
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection
 	"""
 	Pending pool token withdrawn during the current epoch, emptied at epoch boundaries.
 	"""

--- a/crates/sui-indexer-alt-graphql/src/api/types/address.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/address.rs
@@ -9,7 +9,10 @@ use futures::future::try_join_all;
 use sui_types::{base_types::SuiAddress as NativeSuiAddress, dynamic_field::DynamicFieldType};
 
 use crate::{
-    api::scalars::{owner_kind::OwnerKind, sui_address::SuiAddress, type_filter::TypeInput},
+    api::{
+        scalars::{owner_kind::OwnerKind, sui_address::SuiAddress, type_filter::TypeInput},
+        types::validator::Validator,
+    },
     error::RpcError,
     pagination::{Page, PaginationConfig},
     scope::Scope,
@@ -91,9 +94,10 @@ pub(crate) enum IAddressable {
     MoveObject(MoveObject),
     MovePackage(MovePackage),
     Object(Object),
+    Validator(Validator),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct Address {
     pub(crate) scope: Scope,
     pub(crate) address: NativeSuiAddress,

--- a/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
@@ -237,14 +237,17 @@ impl Epoch {
             return Ok(None);
         };
 
-        let validator_set = match system_state {
-            SuiSystemState::V1(inner) => inner.validators.into(),
-            SuiSystemState::V2(inner) => inner.validators.into(),
+        let validator_set_v1 = match system_state {
+            SuiSystemState::V1(inner) => inner.validators,
+            SuiSystemState::V2(inner) => inner.validators,
             #[cfg(msim)]
             SuiSystemState::SimTestV1(_)
             | SuiSystemState::SimTestShallowV2(_)
             | SuiSystemState::SimTestDeepV2(_) => return Ok(None),
         };
+
+        let validator_set =
+            ValidatorSet::from_validator_set_v1(self.scope.clone(), validator_set_v1);
 
         Ok(Some(validator_set))
     }

--- a/crates/sui-indexer-alt-graphql/src/api/types/validator.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/validator.rs
@@ -1,15 +1,31 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use async_graphql::{Object, SimpleObject};
+use async_graphql::{connection::Connection, Context, Object, SimpleObject};
 use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorV1;
 
-use crate::api::scalars::{
-    base64::Base64, big_int::BigInt, sui_address::SuiAddress, uint53::UInt53,
+use crate::{
+    api::{
+        scalars::{
+            base64::Base64, big_int::BigInt, sui_address::SuiAddress, type_filter::TypeInput,
+            uint53::UInt53,
+        },
+        types::{
+            address::Address,
+            balance,
+            balance::Balance,
+            move_object::MoveObject,
+            object::{CLive, Error},
+            object_filter::{ObjectFilter, ObjectFilterValidator as OFValidator},
+        },
+    },
+    error::RpcError,
+    scope::Scope,
 };
 
 #[derive(Clone, Debug)]
 pub(crate) struct Validator {
+    super_: Address,
     native: ValidatorV1,
 }
 
@@ -26,12 +42,69 @@ pub(crate) struct ValidatorCredentials {
     pub worker_address: Option<String>,
 }
 
-// todo (ewall) implement IAddressable
 #[Object]
 impl Validator {
     /// The validator's address.
-    async fn address(&self) -> SuiAddress {
-        self.native.metadata.sui_address.into()
+    pub(crate) async fn address(&self, ctx: &Context<'_>) -> Result<SuiAddress, RpcError> {
+        self.super_.address(ctx).await
+    }
+
+    /// Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+    ///
+    /// If the address does not own any coins of that type, a balance of zero is returned.
+    pub(crate) async fn balance(
+        &self,
+        ctx: &Context<'_>,
+        coin_type: TypeInput,
+    ) -> Result<Option<Balance>, RpcError<balance::Error>> {
+        self.super_.balance(ctx, coin_type).await
+    }
+
+    /// Total balance across coins owned by this address, grouped by coin type.
+    pub(crate) async fn balances(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<balance::Cursor>,
+        last: Option<u64>,
+        before: Option<balance::Cursor>,
+    ) -> Result<Option<Connection<String, Balance>>, RpcError<balance::Error>> {
+        self.super_.balances(ctx, first, after, last, before).await
+    }
+
+    /// The domain explicitly configured as the default SuiNS name for this address.
+    pub(crate) async fn default_suins_name(
+        &self,
+        ctx: &Context<'_>,
+    ) -> Result<Option<String>, RpcError> {
+        self.super_.default_suins_name(ctx).await
+    }
+
+    /// Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+    ///
+    /// Returns `None` when no checkpoint is set in scope (e.g. execution scope).
+    /// If the address does not own any coins of a given type, a balance of zero is returned for that type.
+    pub(crate) async fn multi_get_balances(
+        &self,
+        ctx: &Context<'_>,
+        keys: Vec<TypeInput>,
+    ) -> Result<Option<Vec<Balance>>, RpcError<balance::Error>> {
+        self.super_.multi_get_balances(ctx, keys).await
+    }
+
+    /// Objects owned by this object, optionally filtered by type.
+    pub(crate) async fn objects(
+        &self,
+        ctx: &Context<'_>,
+        first: Option<u64>,
+        after: Option<CLive>,
+        last: Option<u64>,
+        before: Option<CLive>,
+        #[graphql(validator(custom = "OFValidator::allows_empty()"))] filter: Option<ObjectFilter>,
+    ) -> Result<Option<Connection<String, MoveObject>>, RpcError<Error>> {
+        self.super_
+            .objects(ctx, first, after, last, before, filter)
+            .await
     }
 
     /// Validator's set of credentials such as public keys, network addresses and others.
@@ -241,8 +314,11 @@ impl Validator {
     // }
 }
 
-impl From<ValidatorV1> for Validator {
-    fn from(native: ValidatorV1) -> Self {
-        Self { native }
+impl Validator {
+    pub(crate) fn from_validator_v1(scope: Scope, native: ValidatorV1) -> Self {
+        Self {
+            super_: Address::with_address(scope, native.metadata.sui_address),
+            native,
+        }
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/api/types/validator_set.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/validator_set.rs
@@ -4,9 +4,12 @@
 use async_graphql::SimpleObject;
 use sui_types::sui_system_state::sui_system_state_inner_v1::ValidatorSetV1;
 
-use crate::api::{
-    scalars::{big_int::BigInt, sui_address::SuiAddress},
-    types::validator::Validator,
+use crate::{
+    api::{
+        scalars::{big_int::BigInt, sui_address::SuiAddress},
+        types::validator::Validator,
+    },
+    scope::Scope,
 };
 
 /// Representation of `0x3::validator_set::ValidatorSet`.
@@ -50,15 +53,15 @@ pub(crate) struct ValidatorSet {
     pub validator_candidates_size: Option<u64>,
 }
 
-impl From<ValidatorSetV1> for ValidatorSet {
-    fn from(value: ValidatorSetV1) -> Self {
-        ValidatorSet {
+impl ValidatorSet {
+    pub(crate) fn from_validator_set_v1(scope: Scope, value: ValidatorSetV1) -> Self {
+        Self {
             total_stake: Some(BigInt::from(value.total_stake)),
             active_validators: Some(
                 value
                     .active_validators
                     .iter()
-                    .map(|v| v.clone().into())
+                    .map(|v| Validator::from_validator_v1(scope.clone(), v.clone()))
                     // todo (ewall)
                     // remove this and add pagination
                     .take(1)

--- a/crates/sui-indexer-alt-graphql/src/scope.rs
+++ b/crates/sui-indexer-alt-graphql/src/scope.rs
@@ -1,7 +1,12 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::{
+    collections::BTreeMap,
+    fmt,
+    fmt::{Debug, Formatter},
+    sync::Arc,
+};
 
 use async_graphql::Context;
 use sui_indexer_alt_reader::package_resolver::PackageCache;
@@ -159,5 +164,15 @@ impl Scope {
     /// A package resolver with access to the packages known at this scope.
     pub(crate) fn package_resolver(&self) -> Resolver<Arc<dyn PackageStore>> {
         Resolver::new_with_limits(self.package_store.clone(), self.resolver_limits.clone())
+    }
+}
+
+impl Debug for Scope {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Scope")
+            .field("checkpoint_viewed_at", &self.checkpoint_viewed_at)
+            .field("root_version", &self.root_version)
+            .field("resolver_limits", &self.resolver_limits)
+            .finish()
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -3975,11 +3975,21 @@ type UserSignature {
 	signatureBytes: Base64
 }
 
-type Validator {
+type Validator implements IAddressable {
 	"""
 	The validator's address.
 	"""
 	address: SuiAddress!
+	"""
+	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	
+	If the address does not own any coins of that type, a balance of zero is returned.
+	"""
+	balance(coinType: String!): Balance
+	"""
+	Total balance across coins owned by this address, grouped by coin type.
+	"""
+	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
 	The fee charged by the validator for staking services.
 	"""
@@ -3988,6 +3998,10 @@ type Validator {
 	Validator's set of credentials such as public keys, network addresses and others.
 	"""
 	credentials: ValidatorCredentials
+	"""
+	The domain explicitly configured as the default SuiNS name for this address.
+	"""
+	defaultSuinsName: String
 	"""
 	Validator's description.
 	"""
@@ -4004,6 +4018,13 @@ type Validator {
 	Validator's url containing their custom image.
 	"""
 	imageUrl: String
+	"""
+	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
+	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	"""
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Validator's name.
 	"""
@@ -4024,6 +4045,10 @@ type Validator {
 	The total number of SUI tokens in this pool plus the pending stake amount for this epoch.
 	"""
 	nextEpochStake: BigInt
+	"""
+	Objects owned by this object, optionally filtered by type.
+	"""
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection
 	"""
 	Pending pool token withdrawn during the current epoch, emptied at epoch boundaries.
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -3975,11 +3975,21 @@ type UserSignature {
 	signatureBytes: Base64
 }
 
-type Validator {
+type Validator implements IAddressable {
 	"""
 	The validator's address.
 	"""
 	address: SuiAddress!
+	"""
+	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	
+	If the address does not own any coins of that type, a balance of zero is returned.
+	"""
+	balance(coinType: String!): Balance
+	"""
+	Total balance across coins owned by this address, grouped by coin type.
+	"""
+	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
 	The fee charged by the validator for staking services.
 	"""
@@ -3988,6 +3998,10 @@ type Validator {
 	Validator's set of credentials such as public keys, network addresses and others.
 	"""
 	credentials: ValidatorCredentials
+	"""
+	The domain explicitly configured as the default SuiNS name for this address.
+	"""
+	defaultSuinsName: String
 	"""
 	Validator's description.
 	"""
@@ -4004,6 +4018,13 @@ type Validator {
 	Validator's url containing their custom image.
 	"""
 	imageUrl: String
+	"""
+	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
+	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	"""
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Validator's name.
 	"""
@@ -4024,6 +4045,10 @@ type Validator {
 	The total number of SUI tokens in this pool plus the pending stake amount for this epoch.
 	"""
 	nextEpochStake: BigInt
+	"""
+	Objects owned by this object, optionally filtered by type.
+	"""
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection
 	"""
 	Pending pool token withdrawn during the current epoch, emptied at epoch boundaries.
 	"""

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -3971,11 +3971,21 @@ type UserSignature {
 	signatureBytes: Base64
 }
 
-type Validator {
+type Validator implements IAddressable {
 	"""
 	The validator's address.
 	"""
 	address: SuiAddress!
+	"""
+	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
+	
+	If the address does not own any coins of that type, a balance of zero is returned.
+	"""
+	balance(coinType: String!): Balance
+	"""
+	Total balance across coins owned by this address, grouped by coin type.
+	"""
+	balances(first: Int, after: String, last: Int, before: String): BalanceConnection
 	"""
 	The fee charged by the validator for staking services.
 	"""
@@ -3984,6 +3994,10 @@ type Validator {
 	Validator's set of credentials such as public keys, network addresses and others.
 	"""
 	credentials: ValidatorCredentials
+	"""
+	The domain explicitly configured as the default SuiNS name for this address.
+	"""
+	defaultSuinsName: String
 	"""
 	Validator's description.
 	"""
@@ -4000,6 +4014,13 @@ type Validator {
 	Validator's url containing their custom image.
 	"""
 	imageUrl: String
+	"""
+	Fetch the total balances keyed by coin types (e.g. `0x2::sui::SUI`) owned by this address.
+	
+	Returns `None` when no checkpoint is set in scope (e.g. execution scope).
+	If the address does not own any coins of a given type, a balance of zero is returned for that type.
+	"""
+	multiGetBalances(keys: [String!]!): [Balance!]
 	"""
 	Validator's name.
 	"""
@@ -4020,6 +4041,10 @@ type Validator {
 	The total number of SUI tokens in this pool plus the pending stake amount for this epoch.
 	"""
 	nextEpochStake: BigInt
+	"""
+	Objects owned by this object, optionally filtered by type.
+	"""
+	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection
 	"""
 	Pending pool token withdrawn during the current epoch, emptied at epoch boundaries.
 	"""


### PR DESCRIPTION
## Description 

Implement `IAddressable` with `Validator` by delegating to the methods on `Address`.

## Test plan 

Added new fields to `validator_set.move `.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
