### PR TITLE
Pass next accumulator version to BalanceSettlement

### DIFF
--- a/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/e2e_tests.rs
+++ b/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/e2e_tests.rs
@@ -175,6 +175,7 @@ impl TestEnv {
         let mut accumulator_object = self.get_accumulator_object();
         let next_version = accumulator_object.version().next();
         self.scheduler.settle_balances(BalanceSettlement {
+            next_accumulator_version: next_version,
             balance_changes: balance_changes.clone(),
         });
         for (object_id, balance_change) in balance_changes {

--- a/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/mod.rs
+++ b/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/mod.rs
@@ -3,7 +3,9 @@
 
 use std::collections::BTreeMap;
 
-use sui_types::{accumulator_root::AccumulatorObjId, digests::TransactionDigest};
+use sui_types::{
+    accumulator_root::AccumulatorObjId, base_types::SequenceNumber, digests::TransactionDigest,
+};
 
 mod balance_read;
 mod naive_scheduler;
@@ -40,6 +42,10 @@ pub(crate) struct ScheduleResult {
 /// Details regarding a balance settlement, generated when a settlement transaction has been executed
 /// and committed to the writeback cache.
 pub struct BalanceSettlement {
+    // After this settlement, the accumulator object will be at this version.
+    // This means that all transactions that read `next_accumulator_version - 1`
+    // are settled as part of this settlement.
+    pub next_accumulator_version: SequenceNumber,
     /// The balance changes for each account object ID.
     /// This is currently unused because the naive scheduler
     /// always load the latest balance during scheduling.

--- a/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/naive_scheduler.rs
+++ b/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/naive_scheduler.rs
@@ -115,11 +115,12 @@ impl BalanceWithdrawSchedulerTrait for NaiveBalanceWithdrawScheduler {
         }
     }
 
-    // We don't use the settlement information in the naive scheduler.
+    // We don't use the balance changes information in the naive scheduler.
     // Instead, the withdraw scheduling always read the balance state fro storage.
-    async fn settle_balances(&self, _settlement: BalanceSettlement) {
+    async fn settle_balances(&self, settlement: BalanceSettlement) {
         let next_version = self.last_settled_version_receiver.borrow().next();
         debug!("Settling balances for version {:?}", next_version);
+        assert_eq!(next_version, settlement.next_accumulator_version);
         let _ = self.last_settled_version_sender.send(next_version);
     }
 }

--- a/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/tests.rs
+++ b/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/tests.rs
@@ -88,19 +88,21 @@ impl TestScheduler {
     }
 
     /// Settles the balance changes for all schedulers.
-    fn settle_balance_changes(&self, changes: BTreeMap<ObjectID, i128>) {
-        let accumulator_changes = changes
+    fn settle_balance_changes(
+        &self,
+        next_accumulator_version: SequenceNumber,
+        changes: BTreeMap<ObjectID, i128>,
+    ) {
+        let accumulator_changes: BTreeMap<_, _> = changes
             .iter()
             .map(|(id, value)| (AccumulatorObjId::new_unchecked(*id), *value))
             .collect();
-        self.mock_read.settle_balance_changes(accumulator_changes);
+        self.mock_read
+            .settle_balance_changes(accumulator_changes.clone());
         self.schedulers.values().for_each(|scheduler| {
-            let accumulator_changes = changes
-                .iter()
-                .map(|(id, value)| (AccumulatorObjId::new_unchecked(*id), *value))
-                .collect();
             scheduler.settle_balances(BalanceSettlement {
-                balance_changes: accumulator_changes,
+                next_accumulator_version,
+                balance_changes: accumulator_changes.clone(),
             });
         });
     }
@@ -175,7 +177,7 @@ async fn test_schedules_and_settles() {
     let receivers = test.schedule_withdraws(v1, vec![withdraw1.clone()]);
 
     // 100 -> 40, v0 -> v1
-    test.settle_balance_changes(BTreeMap::from([(account, -60)]));
+    test.settle_balance_changes(v1, BTreeMap::from([(account, -60)]));
 
     wait_for_results(
         receivers,
@@ -187,7 +189,7 @@ async fn test_schedules_and_settles() {
     let receivers = test.schedule_withdraws(v2, vec![withdraw2.clone()]);
 
     // 40 -> 60, v1 -> v2
-    test.settle_balance_changes(BTreeMap::from([(account, 20)]));
+    test.settle_balance_changes(v2, BTreeMap::from([(account, 20)]));
 
     wait_for_results(
         receivers,
@@ -207,7 +209,7 @@ async fn test_already_executed() {
     );
 
     // Advance the accumulator version
-    test.settle_balance_changes(BTreeMap::new());
+    test.settle_balance_changes(init_version.next(), BTreeMap::new());
 
     tokio::time::sleep(Duration::from_millis(10)).await;
 
@@ -398,8 +400,9 @@ async fn balance_withdraw_scheduler_stress_test() {
         let results = tokio::time::timeout(
             Duration::from_secs(30),
             async {
+                let mut version = SequenceNumber::from_u64(0);
                 let test = TestScheduler::new(
-                    SequenceNumber::from_u64(0),
+                    version,
                     init_balances,
                 );
 
@@ -430,7 +433,8 @@ async fn balance_withdraw_scheduler_stress_test() {
                             settlements.lock().push(balance_changes);
                         }
 
-                        test_clone.settle_balance_changes(settlements.lock()[idx].clone());
+                        version = version.next();
+                        test_clone.settle_balance_changes(version, settlements.lock()[idx].clone());
                         idx += 1;
                     }
                 });


### PR DESCRIPTION
## Description 

This PR passes the next accumulator version in the BalanceSettlement. This allows us to do invariant check against the internal version tracked by the balance withdraw scheduler. Useful for catching bugs then the scheduler runs out of sync.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
