### PR TITLE
Fix command_outputs field mask

### DIFF
--- a/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/simulate/mod.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/simulate/mod.rs
@@ -281,7 +281,7 @@ pub fn simulate_transaction(
         None
     };
 
-    let outputs = if read_mask.contains("outputs") {
+    let outputs = if read_mask.contains("command_outputs") {
         execution_result
             .into_iter()
             .flatten()


### PR DESCRIPTION
## Description

Noticed this was broken when I migrated rosetta to stable.

## Test plan

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
