### PR TITLE
Fix non-deterministic metadata query bug

### DIFF
--- a/crates/sui-rosetta/src/unit_tests/lib_tests.rs
+++ b/crates/sui-rosetta/src/unit_tests/lib_tests.rs
@@ -86,14 +86,17 @@ async fn test_cache() {
         .into_iter()
         .find_map(|change| {
             if let ObjectChange::Created { object_type, .. } = change {
-                if object_type.to_string().contains("2::coin::TreasuryCap") {
+                let type_str = object_type.to_string();
+                if type_str.contains("2::coin::TreasuryCap")
+                    && type_str.contains("::my_coin::MY_COIN>")
+                {
                     let coin_tag = object_type.type_params.into_iter().next().unwrap();
                     return Some(coin_tag);
                 }
             }
             None
         })
-        .unwrap();
+        .expect("MY_COIN treasury cap not found");
 
     let coin_cache = CoinMetadataCache::new(client.clone(), NonZeroUsize::new(1).unwrap());
 


### PR DESCRIPTION
## Description

The rosetta test was flaky because it was randomly selecting any coin from the example coin package, including coins using the new coin_registry API (MY_COIN_NEW, REGCOIN_NEW) which require finalize_registration to be called before their metadata is accessible. Since the test never calls finalize_registration, these coins would fail the metadata lookup. The fix ensures the test specifically selects MY_COIN, which uses the old coin::create_currency API that directly creates and freezes metadata without requiring registration.
