### PR TITLE
graphql-alt: CoinMetadata.supplyState

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/coin_metadata/coin_metadata.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/coin_metadata/coin_metadata.move
@@ -53,6 +53,7 @@ fragment CM on CoinMetadata {
   description
   iconUrl
   supply
+  supplyState
 }
 
 //# programmable --sender A --inputs object(1,2) 100 @A

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/coin_metadata/coin_metadata.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/coin_metadata/coin_metadata.snap
@@ -16,7 +16,7 @@ task 2, line 20:
 //# create-checkpoint
 Checkpoint created: 1
 
-task 3, lines 22-56:
+task 3, lines 22-57:
 //# run-graphql
 Response: {
   "data": {
@@ -51,7 +51,8 @@ Response: {
                   "symbol": "FAKE",
                   "description": "",
                   "iconUrl": null,
-                  "supply": "0"
+                  "supply": "0",
+                  "supplyState": null
                 }
               }
             }
@@ -69,7 +70,8 @@ Response: {
               "symbol": "FAKE",
               "description": "",
               "iconUrl": null,
-              "supply": "0"
+              "supply": "0",
+              "supplyState": null
             }
           }
         }
@@ -81,7 +83,8 @@ Response: {
       "symbol": "FAKE",
       "description": "",
       "iconUrl": null,
-      "supply": "0"
+      "supply": "0",
+      "supplyState": null
     },
     "sui": {
       "decimals": 9,
@@ -89,12 +92,13 @@ Response: {
       "symbol": "SUI",
       "description": "",
       "iconUrl": null,
-      "supply": "10000000000000000000"
+      "supply": "10000000000000000000",
+      "supplyState": "FIXED"
     }
   }
 }
 
-task 4, lines 58-60:
+task 4, lines 59-61:
 //# programmable --sender A --inputs object(1,2) 100 @A
 //> 0: sui::coin::mint<P::fake::FAKE>(Input(0), Input(1));
 //> TransferObjects([Result(0)], Input(2))
@@ -103,11 +107,11 @@ mutated: object(0,0), object(1,2)
 unchanged_shared: 0x0000000000000000000000000000000000000000000000000000000000000403
 gas summary: computation_cost: 1000000, storage_cost: 4012800,  storage_rebate: 2663496, non_refundable_storage_fee: 26904
 
-task 5, line 62:
+task 5, line 63:
 //# create-checkpoint
 Checkpoint created: 2
 
-task 6, lines 64-74:
+task 6, lines 65-75:
 //# run-graphql
 Response: {
   "data": {

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/coin_metadata/immutable.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/coin_metadata/immutable.move
@@ -1,0 +1,33 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --addresses P=0x0 --accounts A --simulator
+
+//# publish --sender A
+#[allow(deprecated_usage)]
+module P::fake {
+    use sui::coin;
+
+    public struct FAKE has drop {}
+
+    fun init(witness: FAKE, ctx: &mut TxContext){
+        let (treasury_cap, metadata) = coin::create_currency(witness, 2, b"FAKE", b"", b"", option::none(), ctx);
+        transfer::public_freeze_object(metadata);
+        transfer::public_freeze_object(treasury_cap);
+    }
+}
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  coinMetadata(coinType: "@{P}::fake::FAKE") {
+    decimals
+    name
+    symbol
+    description
+    iconUrl
+    supply
+    supplyState
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/coin_metadata/immutable.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/coin_metadata/immutable.snap
@@ -1,0 +1,33 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-18:
+//# publish --sender A
+created: object(1,0), object(1,1), object(1,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 10244800,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 20:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 22-33:
+//# run-graphql
+Response: {
+  "data": {
+    "coinMetadata": {
+      "decimals": 2,
+      "name": "",
+      "symbol": "FAKE",
+      "description": "",
+      "iconUrl": null,
+      "supply": "0",
+      "supplyState": "FIXED"
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/coin_metadata/owned_by_zero.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/coin_metadata/owned_by_zero.move
@@ -1,0 +1,33 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --addresses P=0x0 --accounts A --simulator
+
+//# publish --sender A
+#[allow(deprecated_usage)]
+module P::fake {
+    use sui::coin;
+
+    public struct FAKE has drop {}
+
+    fun init(witness: FAKE, ctx: &mut TxContext){
+        let (treasury_cap, metadata) = coin::create_currency(witness, 2, b"FAKE", b"", b"", option::none(), ctx);
+        transfer::public_freeze_object(metadata);
+        transfer::public_transfer(treasury_cap, @0x0);
+    }
+}
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  coinMetadata(coinType: "@{P}::fake::FAKE") {
+    decimals
+    name
+    symbol
+    description
+    iconUrl
+    supply
+    supplyState
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/coin_metadata/owned_by_zero.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/coin_metadata/owned_by_zero.snap
@@ -1,0 +1,33 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-18:
+//# publish --sender A
+created: object(1,0), object(1,1), object(1,2)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 10716000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, line 20:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 3, lines 22-33:
+//# run-graphql
+Response: {
+  "data": {
+    "coinMetadata": {
+      "decimals": 2,
+      "name": "",
+      "symbol": "FAKE",
+      "description": "",
+      "iconUrl": null,
+      "supply": "0",
+      "supplyState": "FIXED"
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_coin_registry_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_coin_registry_tests.rs
@@ -32,6 +32,7 @@ query GetCoinMetadata($coinType: String!) {
         description
         iconUrl
         supply
+        supplyState
         symbol
     }
 }
@@ -46,6 +47,7 @@ struct CoinMetadata {
     icon_url: Option<String>,
     supply: Option<String>,
     symbol: String,
+    supply_state: Option<String>,
 }
 
 #[tokio::test]
@@ -69,6 +71,9 @@ async fn test_sui() {
             "10000000000000000000",
         ),
         symbol: "SUI",
+        supply_state: Some(
+            "FIXED",
+        ),
     }
     "###);
 }
@@ -103,6 +108,9 @@ async fn test_fixed_supply() {
             "1000000000",
         ),
         symbol: "FIXED",
+        supply_state: Some(
+            "FIXED",
+        ),
     }
     "###);
 }
@@ -163,6 +171,9 @@ async fn test_dynamic() {
             "1000000000",
         ),
         symbol: "DYNAMIC",
+        supply_state: Some(
+            "FIXED",
+        ),
     }
     "###);
 }
@@ -201,6 +212,9 @@ async fn test_burn_only() {
             "1000000000",
         ),
         symbol: "BURN",
+        supply_state: Some(
+            "BURN_ONLY",
+        ),
     }
     "###);
 
@@ -272,6 +286,7 @@ async fn test_unknown() {
             "1000000000",
         ),
         symbol: "UNKNOWN",
+        supply_state: None,
     }
     "###);
 
@@ -436,6 +451,7 @@ async fn test_legacy() {
             "1000000000",
         ),
         symbol: "LEGACY",
+        supply_state: None,
     }
     "###);
 

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -620,6 +620,10 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	supply: BigInt
 	"""
+	Future behavior of the supply. `null` indicates that the future behavior of the supply is not known because the currency's treasury still exists.
+	"""
+	supplyState: SupplyState
+	"""
 	Symbol for the coin.
 	"""
 	symbol: String
@@ -704,7 +708,7 @@ type CommandResult {
 }
 
 """
-Object is exclusively owned by a single adderss and sequenced via consensis.
+Object is exclusively owned by a single adderss and sequenced via consensus.
 """
 type ConsensusAddressOwner {
 	"""
@@ -3580,6 +3584,20 @@ type StoreExecutionTimeObservationsTransaction {
 String containing 32 byte hex-encoded address, with a leading '0x'. Leading zeroes can be omitted on input but will always appear in outputs (SuiAddress in output is guaranteed to be 66 characters long).
 """
 scalar SuiAddress
+
+"""
+Future behavior of a currency's supply.
+"""
+enum SupplyState {
+	"""
+	The supply can only decrease.
+	"""
+	BURN_ONLY
+	"""
+	The supply can neither increase nor decrease.
+	"""
+	FIXED
+}
 
 """
 Details of the system that are decided during genesis.

--- a/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/coin_metadata.rs
@@ -2,14 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{anyhow, Context as _};
-use async_graphql::{connection::Connection, Context, Object};
+use async_graphql::{connection::Connection, Context, Enum, Object, SimpleObject};
 use move_core_types::language_storage::StructTag;
 use sui_types::{
+    base_types::SuiAddress as NativeAddress,
     coin::{
         CoinMetadata as NativeMetadata, TreasuryCap, COIN_METADATA_STRUCT_NAME, COIN_MODULE_NAME,
     },
-    coin_registry::{Currency as NativeCurrency, SupplyState},
+    coin_registry::{Currency as NativeCurrency, SupplyState as NativeSupply},
     gas_coin::{GAS, TOTAL_SUPPLY_MIST},
+    object::Owner as NativeOwner,
     TypeTag, SUI_FRAMEWORK_ADDRESS,
 };
 use tokio::sync::OnceCell;
@@ -38,6 +40,25 @@ pub(crate) struct CoinMetadata {
     pub(crate) super_: MoveObject,
 
     contents: OnceCell<Option<MetadataContents>>,
+}
+
+/// Future behavior of a currency's supply.
+#[derive(Enum, Copy, Clone, Eq, PartialEq)]
+pub(crate) enum SupplyState {
+    /// The supply can only decrease.
+    BurnOnly,
+
+    /// The supply can neither increase nor decrease.
+    Fixed,
+}
+
+#[derive(SimpleObject, Default)]
+pub(crate) struct SupplyFields {
+    /// Future behavior of the supply. `null` indicates that the future behavior of the supply is not known because the currency's treasury still exists.
+    supply_state: Option<SupplyState>,
+
+    /// The overall balance of coins issued.
+    supply: Option<BigInt>,
 }
 
 struct MetadataContents {
@@ -340,53 +361,90 @@ impl CoinMetadata {
             .await
     }
 
-    /// The overall balance of coins issued.
-    pub(crate) async fn supply(
+    #[graphql(flatten)]
+    pub(crate) async fn supply_fields(
         &self,
         ctx: &Context<'_>,
-    ) -> Result<Option<BigInt>, RpcError<object::Error>> {
+    ) -> Result<SupplyFields, RpcError<object::Error>> {
         let Some(contents) = self.metadata_contents(ctx).await.map_err(upcast)? else {
-            return Ok(None);
+            return Ok(SupplyFields::default());
         };
 
         // If the currency's metadata is stored in the Coin Registry, and its supply is known,
         // return it.
-        if let NativeContents::Registry(NativeCurrency {
-            supply: Some(SupplyState::Fixed(s) | SupplyState::BurnOnly(s)),
-            ..
-        }) = &contents.native
-        {
-            return Ok(Some(BigInt::from(*s)));
+        match &contents.native {
+            NativeContents::Registry(NativeCurrency {
+                supply: Some(NativeSupply::Fixed(s)),
+                ..
+            }) => {
+                return Ok(SupplyFields {
+                    supply_state: Some(SupplyState::Fixed),
+                    supply: Some(BigInt::from(*s)),
+                })
+            }
+
+            NativeContents::Registry(NativeCurrency {
+                supply: Some(NativeSupply::BurnOnly(s)),
+                ..
+            }) => {
+                return Ok(SupplyFields {
+                    supply_state: Some(SupplyState::BurnOnly),
+                    supply: Some(BigInt::from(*s)),
+                })
+            }
+
+            _ => {}
         }
 
         // ...otherwise fall back to looking up the TreasuryCap singleton object (for coin registry
         // currencies where the supply state is not known and for legacy currencies).
         let TypeTag::Struct(coin_type) = &contents.coin_type else {
-            return Ok(None);
+            return Ok(SupplyFields::default());
         };
 
         if GAS::is_gas(coin_type.as_ref()) {
-            return Ok(Some(BigInt::from(TOTAL_SUPPLY_MIST)));
+            return Ok(SupplyFields {
+                supply_state: Some(SupplyState::Fixed),
+                supply: Some(BigInt::from(TOTAL_SUPPLY_MIST)),
+            });
         }
 
         let type_ = TreasuryCap::type_(*coin_type.clone());
         let scope = self.super_.super_.super_.scope.without_root_version();
         let Some(object) = Object::singleton(ctx, scope, type_).await? else {
-            return Ok(None);
+            return Ok(SupplyFields::default());
         };
 
         let Some(contents) = object.contents(ctx).await.map_err(upcast)? else {
-            return Ok(None);
+            return Ok(SupplyFields::default());
         };
 
         let Some(move_object) = contents.data.try_as_move() else {
-            return Ok(None);
+            return Ok(SupplyFields::default());
         };
 
         let treasury_cap: TreasuryCap =
             bcs::from_bytes(move_object.contents()).context("Failed to deserialize TreasuryCap")?;
 
-        Ok(Some(BigInt::from(treasury_cap.total_supply.value)))
+        // Treat the supply as fixed if the TreasuryCap is immutable, or owned by the zero address.
+        let supply_state = if matches!(
+            contents.owner(),
+            NativeOwner::Immutable
+                | NativeOwner::AddressOwner(NativeAddress::ZERO)
+                | NativeOwner::ConsensusAddressOwner {
+                    owner: NativeAddress::ZERO,
+                    ..
+                }
+        ) {
+            Some(SupplyState::Fixed)
+        } else {
+            None
+        };
+
+        Ok(SupplyFields {
+            supply_state,
+            supply: Some(BigInt::from(treasury_cap.total_supply.value)),
+        })
     }
 
     /// Symbol for the coin.

--- a/crates/sui-indexer-alt-graphql/src/api/types/owner.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/owner.rs
@@ -46,7 +46,7 @@ pub(crate) struct Immutable {
     dummy: Option<bool>,
 }
 
-/// Object is exclusively owned by a single adderss and sequenced via consensis.
+/// Object is exclusively owned by a single adderss and sequenced via consensus.
 #[derive(SimpleObject, Clone)]
 pub(crate) struct ConsensusAddressOwner {
     /// The version at which the object most recently bcame a consensus object. This serves the same function as `Shared.initialSharedVersion`, except it may change if the object's `owner` type changes.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -624,6 +624,10 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	supply: BigInt
 	"""
+	Future behavior of the supply. `null` indicates that the future behavior of the supply is not known because the currency's treasury still exists.
+	"""
+	supplyState: SupplyState
+	"""
 	Symbol for the coin.
 	"""
 	symbol: String
@@ -708,7 +712,7 @@ type CommandResult {
 }
 
 """
-Object is exclusively owned by a single adderss and sequenced via consensis.
+Object is exclusively owned by a single adderss and sequenced via consensus.
 """
 type ConsensusAddressOwner {
 	"""
@@ -3584,6 +3588,20 @@ type StoreExecutionTimeObservationsTransaction {
 String containing 32 byte hex-encoded address, with a leading '0x'. Leading zeroes can be omitted on input but will always appear in outputs (SuiAddress in output is guaranteed to be 66 characters long).
 """
 scalar SuiAddress
+
+"""
+Future behavior of a currency's supply.
+"""
+enum SupplyState {
+	"""
+	The supply can only decrease.
+	"""
+	BURN_ONLY
+	"""
+	The supply can neither increase nor decrease.
+	"""
+	FIXED
+}
 
 """
 Details of the system that are decided during genesis.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -624,6 +624,10 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	supply: BigInt
 	"""
+	Future behavior of the supply. `null` indicates that the future behavior of the supply is not known because the currency's treasury still exists.
+	"""
+	supplyState: SupplyState
+	"""
 	Symbol for the coin.
 	"""
 	symbol: String
@@ -708,7 +712,7 @@ type CommandResult {
 }
 
 """
-Object is exclusively owned by a single adderss and sequenced via consensis.
+Object is exclusively owned by a single adderss and sequenced via consensus.
 """
 type ConsensusAddressOwner {
 	"""
@@ -3584,6 +3588,20 @@ type StoreExecutionTimeObservationsTransaction {
 String containing 32 byte hex-encoded address, with a leading '0x'. Leading zeroes can be omitted on input but will always appear in outputs (SuiAddress in output is guaranteed to be 66 characters long).
 """
 scalar SuiAddress
+
+"""
+Future behavior of a currency's supply.
+"""
+enum SupplyState {
+	"""
+	The supply can only decrease.
+	"""
+	BURN_ONLY
+	"""
+	The supply can neither increase nor decrease.
+	"""
+	FIXED
+}
 
 """
 Details of the system that are decided during genesis.

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -620,6 +620,10 @@ type CoinMetadata implements IAddressable & IMoveObject & IObject {
 	"""
 	supply: BigInt
 	"""
+	Future behavior of the supply. `null` indicates that the future behavior of the supply is not known because the currency's treasury still exists.
+	"""
+	supplyState: SupplyState
+	"""
 	Symbol for the coin.
 	"""
 	symbol: String
@@ -704,7 +708,7 @@ type CommandResult {
 }
 
 """
-Object is exclusively owned by a single adderss and sequenced via consensis.
+Object is exclusively owned by a single adderss and sequenced via consensus.
 """
 type ConsensusAddressOwner {
 	"""
@@ -3580,6 +3584,20 @@ type StoreExecutionTimeObservationsTransaction {
 String containing 32 byte hex-encoded address, with a leading '0x'. Leading zeroes can be omitted on input but will always appear in outputs (SuiAddress in output is guaranteed to be 66 characters long).
 """
 scalar SuiAddress
+
+"""
+Future behavior of a currency's supply.
+"""
+enum SupplyState {
+	"""
+	The supply can only decrease.
+	"""
+	BURN_ONLY
+	"""
+	The supply can neither increase nor decrease.
+	"""
+	FIXED
+}
 
 """
 Details of the system that are decided during genesis.


### PR DESCRIPTION
## Description

Support returning the `SupplyState` for a `CoinMetadata`, based on the appropriate field in the `Currency<T>` type that was introduced as part of the Coin Registry work.

Also supports inferring when a legacy currency is effectively fixed based on some heuristics:

- When it is `SUI`.
- When its `TreasuryCap` is owned by 0x0.
- When its `TreasuryCap` is frozen/immutable.

## Test plan

```
$ cargo nextest run -p sui-indexer-alt-e2e-tests
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
