### PR TITLE
[replay] Command line arguments processing fix

### DIFF
--- a/crates/sui-replay-2/src/lib.rs
+++ b/crates/sui-replay-2/src/lib.rs
@@ -122,7 +122,7 @@ impl Default for ReplayConfigStableInternal {
             terminate_early: false,
             trace: false,
             output_dir: None,
-            show_effects: false,
+            show_effects: true,
             overwrite: false,
         }
     }


### PR DESCRIPTION
## Description 

The problem is related to conflating the meaning of the `default_missing_value` Clap annotation with `default_value`...

We need to explicitly define default flags, because if we use Clap's  `default_value` for them (boolean types: `default_value = Some(true)`), we will never have None for boolean values on the command line and config file values will not kick in for missing command line flags

I also reverted the flag semantics to what it was before, so either "no value" (e..g, --trace) or required value (e.g., -e false). It seem a bit cleaner after all

## Test plan 

Tested manually
