### PR TITLE
graphql-alt: Add Validator pagination

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/active_validators.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/active_validators.move
@@ -8,51 +8,60 @@
   epoch(epochId: 0) {
     epochId
     validatorSet {
+      # todo (ewall) add more validators to test pagination
       activeValidators {
-        address
-        balance(coinType: "0x2::sui::SUI") {
-          totalBalance
+        pageInfo {
+         hasPreviousPage
+         hasNextPage
+         startCursor
+         endCursor
         }
-        balances {
-          __typename
+        nodes {
+          address
+          balance(coinType: "0x2::sui::SUI") {
+            totalBalance
+          }
+          balances {
+            __typename
+          }
+          # todo (ewall) populate defaultSuinsName
+          defaultSuinsName
+          multiGetBalances(keys: ["0x2::sui::SUI"]) {
+            totalBalance
+          }
+          objects {
+            __typename
+          }
+          credentials { ...VC }
+          # todo (ewall) populate nextEpochCredentials
+          nextEpochCredentials { ...VC }
+          name
+          # todo (ewall) populate description
+          description
+          # todo (ewall) populate imageUrl
+          imageUrl
+          # todo (ewall) populate projectUrl
+          projectUrl
+          stakingPoolId
+          exchangeRatesSize
+          stakingPoolActivationEpoch
+          stakingPoolSuiBalance
+          # todo (ewall) populate rewardsPool
+          rewardsPool
+          poolTokenBalance
+          # todo (ewall) populate pendingStake
+          pendingStake
+          # todo (ewall) populate pendingTotalSuiWithdraw
+          pendingTotalSuiWithdraw
+          # todo (ewall) populate pendingPoolTokenWithdraw
+          pendingPoolTokenWithdraw
+          votingPower
+          gasPrice
+          commissionRate
+          nextEpochStake
+          nextEpochGasPrice
+          nextEpochCommissionRate
         }
-        # todo (ewall) populate defaultSuinsName
-        defaultSuinsName
-        multiGetBalances(keys: ["0x2::sui::SUI"]) {
-          totalBalance
-        }
-        objects {
-          __typename
-        }
-        credentials { ...VC }
-        # todo (ewall) populate nextEpochCredentials
-        nextEpochCredentials { ...VC }
-        name
-        # todo (ewall) populate description
-        description
-        # todo (ewall) populate imageUrl
-        imageUrl
-        # todo (ewall) populate projectUrl
-        projectUrl
-        stakingPoolId
-        exchangeRatesSize
-        stakingPoolActivationEpoch
-        stakingPoolSuiBalance
-        # todo (ewall) populate rewardsPool
-        rewardsPool
-        poolTokenBalance
-        # todo (ewall) populate pendingStake
-        pendingStake
-        # todo (ewall) populate pendingTotalSuiWithdraw
-        pendingTotalSuiWithdraw
-        # todo (ewall) populate pendingPoolTokenWithdraw
-        pendingPoolTokenWithdraw
-        votingPower
-        gasPrice
-        commissionRate
-        nextEpochStake
-        nextEpochGasPrice
-        nextEpochCommissionRate
       }
     }
   }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/active_validators.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/active_validators.snap
@@ -6,72 +6,80 @@ processed 2 tasks
 init:
 A: object(0,0)
 
-task 1, lines 6-70:
+task 1, lines 6-79:
 //# run-graphql
 Response: {
   "data": {
     "epoch": {
       "epochId": 0,
       "validatorSet": {
-        "activeValidators": [
-          {
-            "address": "0xda83166d01afd7ddcf8af5f844f45aaa53f48548e5117c23f5a2978cfd422244",
-            "balance": {
-              "totalBalance": "30000000000000000"
-            },
-            "balances": {
-              "__typename": "BalanceConnection"
-            },
-            "defaultSuinsName": null,
-            "multiGetBalances": [
-              {
+        "activeValidators": {
+          "pageInfo": {
+            "hasPreviousPage": false,
+            "hasNextPage": false,
+            "startCursor": "MA==",
+            "endCursor": "MA=="
+          },
+          "nodes": [
+            {
+              "address": "0xda83166d01afd7ddcf8af5f844f45aaa53f48548e5117c23f5a2978cfd422244",
+              "balance": {
                 "totalBalance": "30000000000000000"
-              }
-            ],
-            "objects": {
-              "__typename": "MoveObjectConnection"
-            },
-            "credentials": {
-              "protocolPubKey": "qqgbtEP57SCwGrO7tmcKwy/daeoOFwANmrMTm1Qu4jUJRhi2VePz/brF9YAcjmJ7BLOpN8c5Ia7zYzTNmGtGoaUnjoYrbvDG9E05s9antwSmkHAIGsM8mkmeBkSjSBrt",
-              "networkPubKey": "ZeETulurG5EpRBoewpF26pyLQtpUqwH1T6LqgugHBIU=",
-              "workerPubKey": "3sE4/d+MbOSh9pesKr7b89TSO5gFBuyGUjVa4GldmFU=",
-              "proofOfPossession": "sIupbWI7yiRvXM22F2E5sJFRricflowHFu7yqXnzglaAvYTxInm4MSDNAgeMzHyJ",
-              "netAddress": "/ip4/127.0.0.1/tcp/8000/http",
-              "p2PAddress": "/ip4/127.0.0.1/udp/8001/http",
-              "primaryAddress": "/ip4/127.0.0.1/udp/8004/http",
-              "workerAddress": "/ip4/127.0.0.1/udp/8005/http"
-            },
-            "nextEpochCredentials": {
-              "protocolPubKey": null,
-              "networkPubKey": null,
-              "workerPubKey": null,
-              "proofOfPossession": null,
-              "netAddress": null,
-              "p2PAddress": null,
-              "primaryAddress": null,
-              "workerAddress": null
-            },
-            "name": "validator-0",
-            "description": "",
-            "imageUrl": "",
-            "projectUrl": "",
-            "stakingPoolId": "0x2f4c0b14e06a9dd4724e823b2289e3356b2e987fd0f3435e3e00b616bbec111f",
-            "exchangeRatesSize": 1,
-            "stakingPoolActivationEpoch": 0,
-            "stakingPoolSuiBalance": "20000000000000000",
-            "rewardsPool": "0",
-            "poolTokenBalance": "20000000000000000",
-            "pendingStake": "0",
-            "pendingTotalSuiWithdraw": "0",
-            "pendingPoolTokenWithdraw": "0",
-            "votingPower": 10000,
-            "gasPrice": "1000",
-            "commissionRate": 200,
-            "nextEpochStake": "20000000000000000",
-            "nextEpochGasPrice": "1000",
-            "nextEpochCommissionRate": 200
-          }
-        ]
+              },
+              "balances": {
+                "__typename": "BalanceConnection"
+              },
+              "defaultSuinsName": null,
+              "multiGetBalances": [
+                {
+                  "totalBalance": "30000000000000000"
+                }
+              ],
+              "objects": {
+                "__typename": "MoveObjectConnection"
+              },
+              "credentials": {
+                "protocolPubKey": "qqgbtEP57SCwGrO7tmcKwy/daeoOFwANmrMTm1Qu4jUJRhi2VePz/brF9YAcjmJ7BLOpN8c5Ia7zYzTNmGtGoaUnjoYrbvDG9E05s9antwSmkHAIGsM8mkmeBkSjSBrt",
+                "networkPubKey": "ZeETulurG5EpRBoewpF26pyLQtpUqwH1T6LqgugHBIU=",
+                "workerPubKey": "3sE4/d+MbOSh9pesKr7b89TSO5gFBuyGUjVa4GldmFU=",
+                "proofOfPossession": "sIupbWI7yiRvXM22F2E5sJFRricflowHFu7yqXnzglaAvYTxInm4MSDNAgeMzHyJ",
+                "netAddress": "/ip4/127.0.0.1/tcp/8000/http",
+                "p2PAddress": "/ip4/127.0.0.1/udp/8001/http",
+                "primaryAddress": "/ip4/127.0.0.1/udp/8004/http",
+                "workerAddress": "/ip4/127.0.0.1/udp/8005/http"
+              },
+              "nextEpochCredentials": {
+                "protocolPubKey": null,
+                "networkPubKey": null,
+                "workerPubKey": null,
+                "proofOfPossession": null,
+                "netAddress": null,
+                "p2PAddress": null,
+                "primaryAddress": null,
+                "workerAddress": null
+              },
+              "name": "validator-0",
+              "description": "",
+              "imageUrl": "",
+              "projectUrl": "",
+              "stakingPoolId": "0x2f4c0b14e06a9dd4724e823b2289e3356b2e987fd0f3435e3e00b616bbec111f",
+              "exchangeRatesSize": 1,
+              "stakingPoolActivationEpoch": 0,
+              "stakingPoolSuiBalance": "20000000000000000",
+              "rewardsPool": "0",
+              "poolTokenBalance": "20000000000000000",
+              "pendingStake": "0",
+              "pendingTotalSuiWithdraw": "0",
+              "pendingPoolTokenWithdraw": "0",
+              "votingPower": 10000,
+              "gasPrice": "1000",
+              "commissionRate": 200,
+              "nextEpochStake": "20000000000000000",
+              "nextEpochGasPrice": "1000",
+              "nextEpochCommissionRate": 200
+            }
+          ]
+        }
       }
     }
   }

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -4102,6 +4102,21 @@ type ValidatorAggregatedSignature {
 	signersMap: [Int!]!
 }
 
+type ValidatorConnection {
+	"""
+	A list of edges.
+	"""
+	edges: [ValidatorEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Validator!]!
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+}
+
 """
 The credentials related fields associated with a validator.
 """
@@ -4117,13 +4132,27 @@ type ValidatorCredentials {
 }
 
 """
+An edge in a connection.
+"""
+type ValidatorEdge {
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+	"""
+	The item at the end of the edge
+	"""
+	node: Validator!
+}
+
+"""
 Representation of `0x3::validator_set::ValidatorSet`.
 """
 type ValidatorSet {
 	"""
 	The current list of active validators.
 	"""
-	activeValidators: [Validator!]
+	activeValidators(first: Int, after: String, last: Int, before: String): ValidatorConnection!
 	"""
 	Object ID of the `Table` storing the inactive staking pools.
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -4106,6 +4106,21 @@ type ValidatorAggregatedSignature {
 	signersMap: [Int!]!
 }
 
+type ValidatorConnection {
+	"""
+	A list of edges.
+	"""
+	edges: [ValidatorEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Validator!]!
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+}
+
 """
 The credentials related fields associated with a validator.
 """
@@ -4121,13 +4136,27 @@ type ValidatorCredentials {
 }
 
 """
+An edge in a connection.
+"""
+type ValidatorEdge {
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+	"""
+	The item at the end of the edge
+	"""
+	node: Validator!
+}
+
+"""
 Representation of `0x3::validator_set::ValidatorSet`.
 """
 type ValidatorSet {
 	"""
 	The current list of active validators.
 	"""
-	activeValidators: [Validator!]
+	activeValidators(first: Int, after: String, last: Int, before: String): ValidatorConnection!
 	"""
 	Object ID of the `Table` storing the inactive staking pools.
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -4106,6 +4106,21 @@ type ValidatorAggregatedSignature {
 	signersMap: [Int!]!
 }
 
+type ValidatorConnection {
+	"""
+	A list of edges.
+	"""
+	edges: [ValidatorEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Validator!]!
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+}
+
 """
 The credentials related fields associated with a validator.
 """
@@ -4121,13 +4136,27 @@ type ValidatorCredentials {
 }
 
 """
+An edge in a connection.
+"""
+type ValidatorEdge {
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+	"""
+	The item at the end of the edge
+	"""
+	node: Validator!
+}
+
+"""
 Representation of `0x3::validator_set::ValidatorSet`.
 """
 type ValidatorSet {
 	"""
 	The current list of active validators.
 	"""
-	activeValidators: [Validator!]
+	activeValidators(first: Int, after: String, last: Int, before: String): ValidatorConnection!
 	"""
 	Object ID of the `Table` storing the inactive staking pools.
 	"""

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -4102,6 +4102,21 @@ type ValidatorAggregatedSignature {
 	signersMap: [Int!]!
 }
 
+type ValidatorConnection {
+	"""
+	A list of edges.
+	"""
+	edges: [ValidatorEdge!]!
+	"""
+	A list of nodes.
+	"""
+	nodes: [Validator!]!
+	"""
+	Information to aid in pagination.
+	"""
+	pageInfo: PageInfo!
+}
+
 """
 The credentials related fields associated with a validator.
 """
@@ -4117,13 +4132,27 @@ type ValidatorCredentials {
 }
 
 """
+An edge in a connection.
+"""
+type ValidatorEdge {
+	"""
+	A cursor for use in pagination
+	"""
+	cursor: String!
+	"""
+	The item at the end of the edge
+	"""
+	node: Validator!
+}
+
+"""
 Representation of `0x3::validator_set::ValidatorSet`.
 """
 type ValidatorSet {
 	"""
 	The current list of active validators.
 	"""
-	activeValidators: [Validator!]
+	activeValidators(first: Int, after: String, last: Int, before: String): ValidatorConnection!
 	"""
 	Object ID of the `Table` storing the inactive staking pools.
 	"""


### PR DESCRIPTION
## Description 

Changes `ValidatorSet.activeValidators` to use pagination API.

## Test plan 

Updates existing `active_validators.move` snapshot test. Adding multiple validators to test pagination is left as a todo.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
