### PR TITLE
[pkg-alt] no longer converting published root package to 0 address

### DIFF
--- a/external-crates/move/crates/move-package-alt-compilation/src/compiled_package.rs
+++ b/external-crates/move/crates/move-package-alt-compilation/src/compiled_package.rs
@@ -194,7 +194,8 @@ impl From<BTreeMap<PackageName, NamedAddress>> for BuildNamedAddresses {
             let name = dep_name.as_str().into();
 
             let addr = match dep {
-                NamedAddress::RootPackage(_) => AccountAddress::ZERO,
+                NamedAddress::RootPackage(Some(addr)) => addr.0,
+                NamedAddress::RootPackage(None) => AccountAddress::ZERO,
                 NamedAddress::Unpublished { dummy_addr } => dummy_addr.0,
                 NamedAddress::Defined(original_id) => original_id.0,
             };


### PR DESCRIPTION
## PR stack

#23646 don't change to 0 address except for publish
#23643 sui-pkg-alt
#23637 move-cli and move-analyzer tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
