### PR TITLE
[TransactionDriver] improve error categorization

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -27,7 +27,6 @@ use sui_network::{
     api::{Validator, ValidatorServer},
     tonic,
 };
-use sui_types::effects::TransactionEvents;
 use sui_types::message_envelope::Message;
 use sui_types::messages_consensus::ConsensusPosition;
 use sui_types::messages_consensus::{ConsensusTransaction, ConsensusTransactionKind};
@@ -59,6 +58,7 @@ use sui_types::{
 use sui_types::{
     effects::TransactionEffectsAPI, executable_transaction::VerifiedExecutableTransaction,
 };
+use sui_types::{effects::TransactionEvents, messages_grpc::SubmitTxType};
 use sui_types::{error::*, transaction::*};
 use sui_types::{
     fp_ensure,
@@ -591,23 +591,37 @@ impl ValidatorService {
         }
 
         let request = request.into_inner();
+        let submit_type = SubmitTxType::try_from(request.submit_type).map_err(|e| {
+            SuiError::GrpcMessageDeserializeError {
+                type_info: "RawSubmitTxRequest.submit_type".to_string(),
+                error: e.to_string(),
+            }
+        })?;
 
-        // Treat an empty transactions as a ping request.
-        let is_ping_request = request.transactions.is_empty();
-
+        let is_ping_request = submit_type == SubmitTxType::Ping;
         if is_ping_request {
             fp_ensure!(
-                !request.soft_bundle,
-                SuiError::UserInputError {
-                    error: UserInputError::InvalidBatchTransaction {
-                        error: "Soft bundle transactions cannot be empty".to_string()
-                    },
-                }
+                request.transactions.is_empty(),
+                SuiError::InvalidRequest(format!(
+                    "Ping request cannot contain {} transactions",
+                    request.transactions.len()
+                ))
+                .into()
+            );
+        } else {
+            // Ensure default and soft bundle requests contain at least one transaction.
+            fp_ensure!(
+                !request.transactions.is_empty(),
+                SuiError::InvalidRequest(
+                    "At least one transaction needs to be submitted".to_string(),
+                )
                 .into()
             );
         }
 
-        let max_num_transactions = if request.soft_bundle {
+        let is_soft_bundle_request = submit_type == SubmitTxType::SoftBundle;
+
+        let max_num_transactions = if is_soft_bundle_request {
             // Soft bundle cannot contain too many transactions.
             // Otherwise it is hard to include all of them in a single block.
             epoch_store.protocol_config().max_soft_bundle_size()
@@ -619,12 +633,11 @@ impl ValidatorService {
         };
         fp_ensure!(
             request.transactions.len() <= max_num_transactions as usize,
-            SuiError::UserInputError {
-                error: UserInputError::TooManyTransactionsInBatch {
-                    size: request.transactions.len(),
-                    limit: max_num_transactions,
-                },
-            }
+            SuiError::InvalidRequest(format!(
+                "Too many transactions in request: {} vs {}",
+                request.transactions.len(),
+                max_num_transactions
+            ))
             .into()
         );
 
@@ -641,7 +654,7 @@ impl ValidatorService {
             "ping"
         } else if request.transactions.len() == 1 {
             "single_transaction"
-        } else if request.soft_bundle {
+        } else if is_soft_bundle_request {
             "soft_bundle"
         } else {
             "batch"
@@ -678,7 +691,7 @@ impl ValidatorService {
                     .with_label_values(&[error.as_ref()])
                     .inc();
                 // Avoid breaking the soft bundle if one transaction is rejected.
-                if request.soft_bundle {
+                if is_soft_bundle_request {
                     return Err(error.into());
                 }
                 results[idx] = Some(SubmitTxResult::Rejected { error });
@@ -714,7 +727,7 @@ impl ValidatorService {
                 let effects_digest = effects.digest();
                 if let Ok(executed_data) = self.complete_executed_data(effects, None).await {
                     // Avoid breaking the soft bundle if one transaction has already been executed.
-                    if request.soft_bundle {
+                    if is_soft_bundle_request {
                         return Err(SuiError::UserInputError {
                             error: UserInputError::AlreadyExecutedInSoftBundleError {
                                 digest: *tx_digest,
@@ -756,7 +769,7 @@ impl ValidatorService {
                         if let Ok(executed_data) = self.complete_executed_data(effects, None).await
                         {
                             // Avoid breaking the soft bundle if one transaction has already been executed.
-                            if request.soft_bundle {
+                            if is_soft_bundle_request {
                                 return Err(SuiError::UserInputError {
                                     error: UserInputError::AlreadyExecutedInSoftBundleError {
                                         digest: *tx_digest,
@@ -774,7 +787,7 @@ impl ValidatorService {
                         }
                     }
                     // Avoid breaking the soft bundle if one transaction is rejected.
-                    if request.soft_bundle {
+                    if is_soft_bundle_request {
                         return Err(e.into());
                     }
                     // Otherwise, record the error for the transaction.
@@ -801,7 +814,7 @@ impl ValidatorService {
         // Set the max bytes size of the soft bundle to be half of the consensus max transactions in block size.
         // We do this to account for serialization overheads and to ensure that the soft bundle is not too large
         // when is attempted to be posted via consensus.
-        let max_transaction_bytes = if request.soft_bundle {
+        let max_transaction_bytes = if is_soft_bundle_request {
             epoch_store
                 .protocol_config()
                 .consensus_max_transactions_in_block_bytes()
@@ -836,7 +849,7 @@ impl ValidatorService {
             .with_label_values(&[req_type])
             .start_timer();
 
-        let consensus_positions = if request.soft_bundle || is_ping_request {
+        let consensus_positions = if is_soft_bundle_request || is_ping_request {
             // We only allow the `consensus_transactions` to be empty for ping requests. This is how it should and is be treated from the downstream components.
             // For any other case, having an empty `consensus_transactions` vector is an invalid state and we should have never reached at this point.
             assert!(
@@ -1412,12 +1425,9 @@ impl ValidatorService {
         }
 
         let Some(tx_digest) = request.transaction_digest else {
-            return Err(SuiError::UserInputError {
-                error: UserInputError::InvalidWaitForEffectsRequest {
-                    error: "Transaction digest is required for wait for effects requests"
-                        .to_string(),
-                },
-            });
+            return Err(SuiError::InvalidRequest(
+                "Transaction digest is required for wait for effects requests".to_string(),
+            ));
         };
         let tx_digests = [tx_digest];
 
@@ -1483,20 +1493,16 @@ impl ValidatorService {
         };
 
         let Some(consensus_position) = request.consensus_position else {
-            return Err(SuiError::UserInputError {
-                error: UserInputError::InvalidWaitForEffectsRequest {
-                    error: "Consensus position is required for ping requests".to_string(),
-                },
-            });
+            return Err(SuiError::InvalidRequest(
+                "Consensus position is required for Ping requests".to_string(),
+            ));
         };
 
         // We assume that the caller has already checked for the existence of the `ping` field, but handling it gracefully here.
         let Some(ping) = request.ping else {
-            return Err(SuiError::UserInputError {
-                error: UserInputError::InvalidWaitForEffectsRequest {
-                    error: "Ping type is required for ping requests".to_string(),
-                },
-            });
+            return Err(SuiError::InvalidRequest(
+                "Ping type is required for ping requests".to_string(),
+            ));
         };
 
         let _metrics_guard = self

--- a/crates/sui-core/src/transaction_driver/effects_certifier.rs
+++ b/crates/sui-core/src/transaction_driver/effects_certifier.rs
@@ -92,7 +92,7 @@ impl EffectsCertifier {
                 None => (None, None),
             },
             SubmitTxResult::Rejected { error } => {
-                return Err(TransactionDriverError::Internal {
+                return Err(TransactionDriverError::ClientInternal {
                     error: format!(
                         "Unexpected submission error in get_certified_finalized_effects(): {}",
                         error
@@ -242,7 +242,9 @@ impl EffectsCertifier {
                         Ok((effects_digest, details, fast_path))
                     } else {
                         tracing::debug!("Execution data not found, retrying...");
-                        Err(TransactionRequestError::ExecutionDataNotFound)
+                        Err(TransactionRequestError::ValidatorInternal(
+                            "Execution data not found".to_string(),
+                        ))
                     }
                 }
                 WaitForEffectsResponse::Rejected { error } => match error {
@@ -466,7 +468,7 @@ impl EffectsCertifier {
             if total_weight >= committee.quorum_threshold() {
                 // Try returning non-retriable aggregated error first.
                 if non_retriable_errors_aggregator.total_votes() >= committee.validity_threshold() {
-                    return Err(TransactionDriverError::InvalidTransaction {
+                    return Err(TransactionDriverError::RejectedByValidators {
                         submission_non_retriable_errors: aggregate_request_errors(
                             non_retriable_errors_aggregator.status_by_authority(),
                         ),

--- a/crates/sui-core/src/transaction_driver/error.rs
+++ b/crates/sui-core/src/transaction_driver/error.rs
@@ -9,7 +9,7 @@ use sui_types::{
     base_types::{AuthorityName, ConciseableName},
     committee::{EpochId, StakeUnit},
     digests::TransactionEffectsDigest,
-    error::SuiError,
+    error::{ErrorCategory, SuiError},
 };
 use thiserror::Error;
 
@@ -26,8 +26,8 @@ pub(crate) enum TransactionRequestError {
     TimedOutSubmittingTransaction,
     #[error("Request timed out getting full effects")]
     TimedOutGettingFullEffectsAtValidator,
-    #[error("Failed to find execution data")]
-    ExecutionDataNotFound,
+    #[error("{0}")]
+    ValidatorInternal(String),
 
     // Rejected by the validator when voting on the transaction.
     #[error("{0}")]
@@ -43,14 +43,23 @@ pub(crate) enum TransactionRequestError {
 }
 
 impl TransactionRequestError {
-    pub fn is_submission_retriable(&self) -> bool {
+    pub(crate) fn categorize(&self) -> ErrorCategory {
         match self {
-            TransactionRequestError::RejectedAtValidator(error) => {
-                error.is_transaction_submission_retriable()
+            TransactionRequestError::TimedOutSubmittingTransaction => ErrorCategory::Unavailable,
+            TransactionRequestError::TimedOutGettingFullEffectsAtValidator => {
+                ErrorCategory::Unavailable
             }
-            TransactionRequestError::Aborted(error) => error.is_transaction_submission_retriable(),
-            _ => true,
+            TransactionRequestError::ValidatorInternal(_) => ErrorCategory::Internal,
+
+            TransactionRequestError::RejectedAtValidator(error) => error.categorize(),
+            TransactionRequestError::RejectedByConsensus => ErrorCategory::Aborted,
+            TransactionRequestError::StatusExpired(_, _) => ErrorCategory::Aborted,
+            TransactionRequestError::Aborted(error) => error.categorize(),
         }
+    }
+
+    pub(crate) fn is_submission_retriable(&self) -> bool {
+        self.categorize().is_submission_retriable()
     }
 }
 
@@ -60,21 +69,21 @@ impl TransactionRequestError {
 #[derive(Eq, PartialEq, Clone)]
 pub enum TransactionDriverError {
     /// TransactionDriver encountered an internal error.
-    /// Retriable.
-    Internal { error: String },
+    /// Non-retriable.
+    ClientInternal { error: String },
+    /// The transaction failed validation from local state.
+    /// Non-retriable.
+    ValidationFailed { error: String },
     /// Transient failure during transaction processing that prevents the transaction from finalization.
-    /// Retriable with new transaction submission / call to TransactionDriver.
+    /// Retriable with new transaction submission.
     Aborted {
         submission_non_retriable_errors: AggregatedRequestErrors,
         submission_retriable_errors: AggregatedRequestErrors,
         observed_effects_digests: AggregatedEffectsDigests,
     },
-    /// The transaction failed validation from local state.
-    /// Non-retriable.
-    ValidationFailed { error: String },
     /// Over validity threshold of validators rejected the transaction as invalid.
     /// Non-retriable.
-    InvalidTransaction {
+    RejectedByValidators {
         submission_non_retriable_errors: AggregatedRequestErrors,
         submission_retriable_errors: AggregatedRequestErrors,
     },
@@ -96,14 +105,38 @@ pub enum TransactionDriverError {
 }
 
 impl TransactionDriverError {
-    pub fn is_retriable(&self) -> bool {
+    pub fn is_local_retriable(&self) -> bool {
+        self.categorize().is_submission_retriable()
+    }
+
+    pub fn categorize(&self) -> ErrorCategory {
         match self {
-            TransactionDriverError::Internal { .. } => true,
-            TransactionDriverError::Aborted { .. } => true,
-            TransactionDriverError::ValidationFailed { .. } => false,
-            TransactionDriverError::InvalidTransaction { .. } => false,
-            TransactionDriverError::ForkedExecution { .. } => false,
-            TransactionDriverError::TimeoutWithLastRetriableError { .. } => true,
+            TransactionDriverError::ClientInternal { .. } => ErrorCategory::Internal,
+            TransactionDriverError::ValidationFailed { .. } => ErrorCategory::InvalidTransaction,
+            TransactionDriverError::Aborted {
+                submission_retriable_errors,
+                ..
+            } => {
+                if let Some((_, _, _, category)) = submission_retriable_errors.errors.first() {
+                    *category
+                } else {
+                    ErrorCategory::Internal
+                }
+            }
+            TransactionDriverError::RejectedByValidators {
+                submission_non_retriable_errors,
+                ..
+            } => {
+                if let Some((_, _, _, category)) = submission_non_retriable_errors.errors.first() {
+                    *category
+                } else {
+                    ErrorCategory::Internal
+                }
+            }
+            TransactionDriverError::ForkedExecution { .. } => ErrorCategory::Internal,
+            TransactionDriverError::TimeoutWithLastRetriableError { .. } => {
+                ErrorCategory::Unavailable
+            }
         }
     }
 
@@ -116,9 +149,8 @@ impl TransactionDriverError {
         else {
             return Ok(());
         };
-        let mut msgs = vec![
-            "Transaction processing aborted (retriable with the same transaction).".to_string(),
-        ];
+        let mut msgs =
+            vec!["Transaction processing aborted (retriable with another submission).".to_string()];
         if submission_retriable_errors.total_stake > 0 {
             msgs.push(format!(
                 "Retriable errors: [{submission_retriable_errors}]."
@@ -145,7 +177,7 @@ impl TransactionDriverError {
     }
 
     fn display_invalid_transaction(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let TransactionDriverError::InvalidTransaction {
+        let TransactionDriverError::RejectedByValidators {
             submission_non_retriable_errors,
             submission_retriable_errors,
         } = self
@@ -197,10 +229,12 @@ impl TransactionDriverError {
 impl std::fmt::Display for TransactionDriverError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TransactionDriverError::Internal { error } => write!(f, "Internal error: {}", error),
+            TransactionDriverError::ClientInternal { error } => {
+                write!(f, "TransactionDriver internal error: {}", error)
+            }
             TransactionDriverError::Aborted { .. } => self.display_aborted(f),
             TransactionDriverError::ValidationFailed { .. } => self.display_validation_failed(f),
-            TransactionDriverError::InvalidTransaction { .. } => {
+            TransactionDriverError::RejectedByValidators { .. } => {
                 self.display_invalid_transaction(f)
             }
             TransactionDriverError::ForkedExecution { .. } => self.display_forked_execution(f),
@@ -234,7 +268,8 @@ impl std::error::Error for TransactionDriverError {}
 
 #[derive(Eq, PartialEq, Clone, Debug, Default)]
 pub struct AggregatedRequestErrors {
-    pub errors: Vec<(String, Vec<AuthorityName>, StakeUnit)>,
+    pub errors: Vec<(String, Vec<AuthorityName>, StakeUnit, ErrorCategory)>,
+    // The total stake of all errors.
     pub total_stake: StakeUnit,
 }
 
@@ -243,7 +278,7 @@ impl std::fmt::Display for AggregatedRequestErrors {
         let msg = self
             .errors
             .iter()
-            .map(|(error, names, stake)| {
+            .map(|(error, names, stake, _category)| {
                 format!(
                     "{} {{ {} }} with {} stake",
                     error,
@@ -273,21 +308,24 @@ pub(crate) fn aggregate_request_errors(
     errors: Vec<(AuthorityName, StakeUnit, TransactionRequestError)>,
 ) -> AggregatedRequestErrors {
     let mut total_stake = 0;
-    let mut aggregated_errors = BTreeMap::<String, (Vec<AuthorityName>, StakeUnit)>::new();
+    let mut aggregated_errors =
+        BTreeMap::<String, (Vec<AuthorityName>, StakeUnit, ErrorCategory)>::new();
 
     for (name, stake, error) in errors {
         total_stake += stake;
         let key = format_transaction_request_error(&error);
-        let entry = aggregated_errors.entry(key).or_default();
+        let entry = aggregated_errors
+            .entry(key)
+            .or_insert_with(|| (vec![], 0, error.categorize()));
         entry.0.push(name);
         entry.1 += stake;
     }
 
     let mut errors: Vec<_> = aggregated_errors
         .into_iter()
-        .map(|(error, (names, stake))| (error, names, stake))
+        .map(|(error, (names, stake, category))| (error, names, stake, category))
         .collect();
-    errors.sort_by_key(|(_, _, stake)| std::cmp::Reverse(*stake));
+    errors.sort_by_key(|(_, _, stake, _)| std::cmp::Reverse(*stake));
 
     AggregatedRequestErrors {
         errors,

--- a/crates/sui-core/src/transaction_driver/error.rs
+++ b/crates/sui-core/src/transaction_driver/error.rs
@@ -105,7 +105,7 @@ pub enum TransactionDriverError {
 }
 
 impl TransactionDriverError {
-    pub fn is_local_retriable(&self) -> bool {
+    pub(crate) fn is_submission_retriable(&self) -> bool {
         self.categorize().is_submission_retriable()
     }
 

--- a/crates/sui-core/src/transaction_driver/error.rs
+++ b/crates/sui-core/src/transaction_driver/error.rs
@@ -115,21 +115,31 @@ impl TransactionDriverError {
             TransactionDriverError::ValidationFailed { .. } => ErrorCategory::InvalidTransaction,
             TransactionDriverError::Aborted {
                 submission_retriable_errors,
+                submission_non_retriable_errors,
                 ..
             } => {
                 if let Some((_, _, _, category)) = submission_retriable_errors.errors.first() {
                     *category
+                } else if let Some((_, _, _, category)) =
+                    submission_non_retriable_errors.errors.first()
+                {
+                    *category
                 } else {
-                    ErrorCategory::Internal
+                    ErrorCategory::Aborted
                 }
             }
             TransactionDriverError::RejectedByValidators {
                 submission_non_retriable_errors,
+                submission_retriable_errors,
                 ..
             } => {
                 if let Some((_, _, _, category)) = submission_non_retriable_errors.errors.first() {
                     *category
+                } else if let Some((_, _, _, category)) = submission_retriable_errors.errors.first()
+                {
+                    *category
                 } else {
+                    // There should be at least one error.
                     ErrorCategory::Internal
                 }
             }

--- a/crates/sui-core/src/transaction_driver/mod.rs
+++ b/crates/sui-core/src/transaction_driver/mod.rs
@@ -281,7 +281,7 @@ where
                         return Ok(resp);
                     }
                     Err(e) => {
-                        if !e.is_local_retriable() {
+                        if !e.is_submission_retriable() {
                             // Record the number of retries for failed transaction
                             self.metrics
                                 .transaction_retries
@@ -355,7 +355,9 @@ where
             )
             .await?;
         if let SubmitTxResult::Rejected { error } = &submit_txn_result {
-            panic!("SubmitTxResult should not be rejected: {}", error);
+            return Err(TransactionDriverError::ClientInternal {
+                error: format!("SubmitTxResult::Rejected should have been returned as an error in submit_transaction(): {}", error),
+            });
         }
 
         // Wait for quorum effects using EffectsCertifier

--- a/crates/sui-core/src/transaction_driver/request_retrier.rs
+++ b/crates/sui-core/src/transaction_driver/request_retrier.rs
@@ -166,14 +166,20 @@ mod tests {
         let mut retrier =
             RequestRetrier::new(&auth_agg, &client_monitor, TxType::SingleWriter, vec![]);
 
-        for _ in 0..4 {
+        for name in auth_agg.committee.names() {
             retrier.next_target().unwrap();
+            retrier
+                .add_error(
+                    *name,
+                    TransactionRequestError::TimedOutSubmittingTransaction,
+                )
+                .unwrap();
         }
 
         let Err(error) = retrier.next_target() else {
             panic!("Expected an error");
         };
-        assert!(error.is_submission_retriable());
+        assert!(error.is_submission_retriable(), "{}", error);
     }
 
     #[tokio::test]

--- a/crates/sui-core/src/transaction_driver/request_retrier.rs
+++ b/crates/sui-core/src/transaction_driver/request_retrier.rs
@@ -83,7 +83,7 @@ impl<A: Clone> RequestRetrier<A> {
             .non_retriable_errors_aggregator
             .reached_validity_threshold()
         {
-            Err(TransactionDriverError::InvalidTransaction {
+            Err(TransactionDriverError::RejectedByValidators {
                 submission_non_retriable_errors: aggregate_request_errors(
                     self.non_retriable_errors_aggregator.status_by_authority(),
                 ),
@@ -124,7 +124,7 @@ impl<A: Clone> RequestRetrier<A> {
                 .non_retriable_errors_aggregator
                 .reached_validity_threshold()
             {
-                return Err(TransactionDriverError::InvalidTransaction {
+                return Err(TransactionDriverError::RejectedByValidators {
                     submission_non_retriable_errors: aggregate_request_errors(
                         self.non_retriable_errors_aggregator.status_by_authority(),
                     ),
@@ -173,7 +173,7 @@ mod tests {
         let Err(error) = retrier.next_target() else {
             panic!("Expected an error");
         };
-        assert!(error.is_retriable());
+        assert!(error.is_local_retriable());
     }
 
     #[tokio::test]
@@ -302,7 +302,7 @@ mod tests {
                 )
                 .unwrap_err();
             // The aggregated error is non-retriable.
-            assert!(!aggregated_error.is_retriable());
+            assert!(!aggregated_error.is_local_retriable());
         }
     }
 }

--- a/crates/sui-core/src/transaction_driver/request_retrier.rs
+++ b/crates/sui-core/src/transaction_driver/request_retrier.rs
@@ -173,7 +173,7 @@ mod tests {
         let Err(error) = retrier.next_target() else {
             panic!("Expected an error");
         };
-        assert!(error.is_local_retriable());
+        assert!(error.is_submission_retriable());
     }
 
     #[tokio::test]
@@ -302,7 +302,7 @@ mod tests {
                 )
                 .unwrap_err();
             // The aggregated error is non-retriable.
-            assert!(!aggregated_error.is_local_retriable());
+            assert!(!aggregated_error.is_submission_retriable());
         }
     }
 }

--- a/crates/sui-core/src/transaction_driver/transaction_submitter.rs
+++ b/crates/sui-core/src/transaction_driver/transaction_submitter.rs
@@ -9,7 +9,7 @@ use std::{
 use futures::stream::{FuturesUnordered, StreamExt};
 use sui_types::{
     base_types::AuthorityName,
-    error::SuiError,
+    error::ErrorCategory,
     messages_grpc::{SubmitTxRequest, SubmitTxResult, TxType},
 };
 use tokio::time::timeout;
@@ -208,21 +208,37 @@ impl TransactionSubmitter {
             });
             TransactionRequestError::TimedOutSubmittingTransaction
         })?
-        // TODO(fastpath): Note that we do not record this error in the client monitor
-        // because it may be due to invalid transactions.
-        // To fully utilize this error, we need to either pre-check the transaction
-        // on the fullnode, or be able to categorize the error.
-        .map_err(TransactionRequestError::RejectedAtValidator)?;
-
-        let result = resp.results.into_iter().next().ok_or_else(|| {
-            TransactionRequestError::Aborted(SuiError::GenericAuthorityError {
-                error: "No result in SubmitTxResponse".to_string(),
-            })
+        .map_err(|error| {
+            if is_validator_error(error.categorize()) {
+                client_monitor.record_interaction_result(OperationFeedback {
+                    authority_name: validator,
+                    display_name: display_name.clone(),
+                    operation: OperationType::Submit,
+                    result: Err(()),
+                });
+            }
+            TransactionRequestError::RejectedAtValidator(error)
         })?;
 
+        if resp.results.len() != 1 {
+            return Err(TransactionRequestError::ValidatorInternal(format!(
+                "Expected exactly 1 result, got {}",
+                resp.results.len()
+            )));
+        }
+        let result = resp.results.into_iter().next().unwrap();
+
         // Since only one transaction is submitted, it is ok to return error when the submission is rejected.
-        if let SubmitTxResult::Rejected { error } = result {
-            return Err(TransactionRequestError::RejectedAtValidator(error));
+        if let SubmitTxResult::Rejected { error } = &result {
+            if is_validator_error(error.categorize()) {
+                client_monitor.record_interaction_result(OperationFeedback {
+                    authority_name: validator,
+                    display_name,
+                    operation: OperationType::Submit,
+                    result: Err(()),
+                });
+            }
+            return Err(TransactionRequestError::RejectedAtValidator(error.clone()));
         }
 
         let latency = submit_start.elapsed();
@@ -234,4 +250,15 @@ impl TransactionSubmitter {
         });
         Ok(result)
     }
+}
+
+// Whether the failure is caused by the peer validator, as opposed to the user or this node.
+fn is_validator_error(category: ErrorCategory) -> bool {
+    matches!(
+        category,
+        ErrorCategory::Aborted
+            | ErrorCategory::Internal
+            | ErrorCategory::ValidatorOverloaded
+            | ErrorCategory::Unavailable
+    )
 }

--- a/crates/sui-core/src/transaction_driver/unit_tests/effects_certifier_tests.rs
+++ b/crates/sui-core/src/transaction_driver/unit_tests/effects_certifier_tests.rs
@@ -395,7 +395,7 @@ async fn test_transaction_rejected_non_retriable() {
 
     assert!(result.is_err());
     match result.unwrap_err() {
-        TransactionDriverError::InvalidTransaction {
+        TransactionDriverError::RejectedByValidators {
             submission_non_retriable_errors,
             submission_retriable_errors,
         } => {
@@ -533,7 +533,7 @@ async fn test_transaction_rejected_with_conflicts() {
 
     assert!(result.is_err());
     match result.unwrap_err() {
-        TransactionDriverError::InvalidTransaction {
+        TransactionDriverError::RejectedByValidators {
             submission_non_retriable_errors,
             submission_retriable_errors,
         } => {
@@ -679,7 +679,7 @@ async fn test_mixed_rejected_and_expired() {
 
     assert!(result.is_err());
     match result.unwrap_err() {
-        TransactionDriverError::InvalidTransaction {
+        TransactionDriverError::RejectedByValidators {
             submission_non_retriable_errors,
             submission_retriable_errors,
         } => {
@@ -813,7 +813,7 @@ async fn test_mixed_rejected_reasons() {
 
         assert!(result.is_err());
         match result.unwrap_err() {
-            TransactionDriverError::InvalidTransaction {
+            TransactionDriverError::RejectedByValidators {
                 submission_non_retriable_errors,
                 submission_retriable_errors: _,
             } => {
@@ -864,7 +864,7 @@ async fn test_mixed_rejected_reasons() {
 
         assert!(result.is_err());
         match result.unwrap_err() {
-            TransactionDriverError::InvalidTransaction {
+            TransactionDriverError::RejectedByValidators {
                 submission_non_retriable_errors,
                 submission_retriable_errors: _,
             } => {

--- a/crates/sui-core/src/transaction_driver/unit_tests/transaction_submitter_tests.rs
+++ b/crates/sui-core/src/transaction_driver/unit_tests/transaction_submitter_tests.rs
@@ -535,7 +535,7 @@ async fn test_submit_transaction_invalid_input() {
 
     assert!(result.is_err());
     match result.unwrap_err() {
-        TransactionDriverError::InvalidTransaction { .. } => {
+        TransactionDriverError::RejectedByValidators { .. } => {
             // Expected - non-retriable error
         }
         e => panic!("Expected InvalidTransaction error, got: {:?}", e),

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -653,7 +653,7 @@ where
                     timeout,
                 },
                 other => QuorumDriverError::TransactionFailed {
-                    retriable: other.is_retriable(),
+                    category: other.categorize(),
                     details: other.to_string(),
                 },
             });

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -285,9 +285,6 @@ pub enum UserInputError {
 
     #[error("Invalid withdraw reservation: {error}")]
     InvalidWithdrawReservation { error: String },
-
-    #[error("Invalid wait for effects request: {error}")]
-    InvalidWaitForEffectsRequest { error: String },
 }
 
 #[derive(
@@ -692,8 +689,12 @@ pub enum SuiError {
         round: u32,
         last_committed_round: u32,
     },
+
     #[error("Invalid admin request: {0}")]
     InvalidAdminRequest(String),
+
+    #[error("Invalid request: {0}")]
+    InvalidRequest(String),
 }
 
 #[repr(u64)]
@@ -877,53 +878,6 @@ impl SuiError {
         (retryable, true)
     }
 
-    /// Checks if this error is retriable with transaction resubmission attempts,
-    /// when this error is received outside of validators during transaction lifecycle.
-    ///
-    /// When a non-retriable error is returned by an honest validator during
-    /// transaction submission or effects query, this and other honest validators will
-    /// never vote to accept the same transaction with the same user signature.
-    /// So this transaction can never be finalized and retrying submission will not help.
-    ///
-    /// Also, when an error is categorized as non-retriable, we expect some consistency
-    /// among honest validators in also returning non-retriable errors for the same transaction
-    /// when there are no other temporary failures (network, overload, etc).
-    ///
-    /// SuiError contains many variants unrelated to transaction processing.
-    /// They can be returned externally by malicious validators or due to software bugs.
-    /// These variants are considered retriable, because they don't meet the criteria for
-    /// non-retriable errors above.
-    pub fn is_transaction_submission_retriable(&self) -> bool {
-        match self {
-            SuiError::UserInputError { error } => {
-                match error {
-                    // ObjectNotFound and DependentPackageNotFound are potentially retriable because the missing
-                    // input can be created by other transactions.
-                    UserInputError::ObjectNotFound { .. } => true,
-                    UserInputError::DependentPackageNotFound { .. } => true,
-                    // Other UserInputError variants are not retriable with resubmission.
-                    _ => false,
-                }
-            }
-
-            // Non retryable errors
-            SuiError::ByzantineAuthoritySuspicion { .. } => false,
-            SuiError::ObjectLockConflict { .. } => false,
-            SuiError::TransactionExpired => false,
-            SuiError::InvalidTxKindInSoftBundle { .. } => false,
-            SuiError::UnsupportedFeatureError { .. } => false,
-
-            SuiError::InvalidSignature { .. } => false,
-            SuiError::SignerSignatureAbsent { .. } => false,
-            SuiError::SignerSignatureNumberMismatch { .. } => false,
-            SuiError::IncorrectSigner { .. } => false,
-            SuiError::UnknownSigner { .. } => false,
-
-            // Other variants are assumed to be retriable.
-            _ => true,
-        }
-    }
-
     pub fn is_object_or_package_not_found(&self) -> bool {
         match self {
             SuiError::UserInputError { error } => {
@@ -986,7 +940,8 @@ impl SuiError {
             | SuiError::GrpcMessageDeserializeError { .. }
             | SuiError::ByzantineAuthoritySuspicion { .. }
             | SuiError::InvalidTxKindInSoftBundle { .. }
-            | SuiError::UnsupportedFeatureError { .. } => ErrorCategory::Internal,
+            | SuiError::UnsupportedFeatureError { .. }
+            | SuiError::InvalidRequest { .. } => ErrorCategory::Internal,
 
             SuiError::TooManyTransactionsPendingExecution { .. }
             | SuiError::TooManyTransactionsPendingOnObject { .. }

--- a/crates/sui-types/src/quorum_driver_types.rs
+++ b/crates/sui-types/src/quorum_driver_types.rs
@@ -12,7 +12,7 @@ use crate::effects::{
     CertifiedTransactionEffects, TransactionEffects, TransactionEvents,
     VerifiedCertifiedTransactionEffects,
 };
-use crate::error::SuiError;
+use crate::error::{ErrorCategory, SuiError};
 use crate::messages_checkpoint::CheckpointSequenceNumber;
 use crate::object::Object;
 use crate::transaction::{Transaction, VerifiedTransaction};
@@ -30,7 +30,7 @@ pub const NON_RECOVERABLE_ERROR_MSG: &str =
 
 /// Client facing errors regarding transaction submission via Quorum Driver.
 /// Every invariant needs detailed documents to instruct client handling.
-#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Error, Hash, AsRefStr)]
+#[derive(Eq, PartialEq, Clone, Debug, Error, Hash, AsRefStr)]
 pub enum QuorumDriverError {
     #[error("QuorumDriver internal error: {0}.")]
     QuorumDriverInternalError(SuiError),
@@ -69,8 +69,11 @@ pub enum QuorumDriverError {
     },
 
     // Wrapped error from Transaction Driver.
-    #[error("Transaction processing failed. Retriable with new attempts: {retriable}. Details: {details}")]
-    TransactionFailed { retriable: bool, details: String },
+    #[error("Transaction processing failed. Details: {details}")]
+    TransactionFailed {
+        category: ErrorCategory,
+        details: String,
+    },
 
     #[error("Transaction is already being processed in transaction orchestrator (most likely by quorum driver), wait for results")]
     PendingExecutionInTransactionOrchestrator,


### PR DESCRIPTION
## Description 

Use finer error categories for RPC error codes.

Use enum to represent request type for RawSubmitTxRequest.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
