### PR TITLE
graphql-alt: Add Validator.atRisk

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/active_validators.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/active_validators.move
@@ -61,6 +61,8 @@
           nextEpochStake
           nextEpochGasPrice
           nextEpochCommissionRate
+          # todo (ewall) populate atRisk
+          atRisk
         }
       }
     }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/active_validators.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/active_validators.snap
@@ -6,7 +6,7 @@ processed 2 tasks
 init:
 A: object(0,0)
 
-task 1, lines 6-79:
+task 1, lines 6-81:
 //# run-graphql
 Response: {
   "data": {
@@ -76,7 +76,8 @@ Response: {
               "commissionRate": 200,
               "nextEpochStake": "20000000000000000",
               "nextEpochGasPrice": "1000",
-              "nextEpochCommissionRate": 200
+              "nextEpochCommissionRate": 200,
+              "atRisk": 0
             }
           ]
         }

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -3977,6 +3977,10 @@ type Validator implements IAddressable {
 	"""
 	address: SuiAddress!
 	"""
+	The number of epochs for which this validator has been below the low stake threshold.
+	"""
+	atRisk: UInt53
+	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
 	If the address does not own any coins of that type, a balance of zero is returned.

--- a/crates/sui-indexer-alt-graphql/src/api/types/validator.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/validator.rs
@@ -27,6 +27,7 @@ use crate::{
 pub(crate) struct Validator {
     super_: Address,
     native: ValidatorV1,
+    at_risk: u64,
 }
 
 /// The credentials related fields associated with a validator.
@@ -267,12 +268,10 @@ impl Validator {
         Some(self.native.next_epoch_commission_rate)
     }
 
-    // todo (ewall)
-    // /// The number of epochs for which this validator has been below the
-    // /// low stake threshold.
-    // async fn at_risk(&self) -> Option<UInt53> {
-    //     self.at_risk.map(UInt53::from)
-    // }
+    /// The number of epochs for which this validator has been below the low stake threshold.
+    async fn at_risk(&self) -> Option<UInt53> {
+        Some(self.at_risk.into())
+    }
 
     // todo (ewall)
     // /// The addresses of other validators this validator has reported.
@@ -315,10 +314,11 @@ impl Validator {
 }
 
 impl Validator {
-    pub(crate) fn from_validator_v1(scope: Scope, native: ValidatorV1) -> Self {
+    pub(crate) fn from_validator_v1(scope: Scope, native: ValidatorV1, at_risk: u64) -> Self {
         Self {
             super_: Address::with_address(scope, native.metadata.sui_address),
             native,
+            at_risk,
         }
     }
 }

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -3981,6 +3981,10 @@ type Validator implements IAddressable {
 	"""
 	address: SuiAddress!
 	"""
+	The number of epochs for which this validator has been below the low stake threshold.
+	"""
+	atRisk: UInt53
+	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
 	If the address does not own any coins of that type, a balance of zero is returned.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -3981,6 +3981,10 @@ type Validator implements IAddressable {
 	"""
 	address: SuiAddress!
 	"""
+	The number of epochs for which this validator has been below the low stake threshold.
+	"""
+	atRisk: UInt53
+	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
 	If the address does not own any coins of that type, a balance of zero is returned.

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -3977,6 +3977,10 @@ type Validator implements IAddressable {
 	"""
 	address: SuiAddress!
 	"""
+	The number of epochs for which this validator has been below the low stake threshold.
+	"""
+	atRisk: UInt53
+	"""
 	Fetch the total balance for coins with marker type `coinType` (e.g. `0x2::sui::SUI`), owned by this address.
 	
 	If the address does not own any coins of that type, a balance of zero is returned.


### PR DESCRIPTION
## Description 

Adds `Validator.asRisk` based on https://github.com/MystenLabs/sui/blob/f0c3f7efc875f000f7bfbdd0a9bbf465a72be1bf/crates/sui-graphql-rpc/src/types/validator.rs#L324-L326

## Test plan 

Adds `atRisk` to `active_validators.move` snapshot test with a `todo` to populate it.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
