### PR TITLE
[move-ide] Incremental symbolication fix

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/package-lock.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "move",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "move",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "license": "Apache-2.0",
       "dependencies": {
         "command-exists": "^1.2.9",

--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
   "publisher": "mysten",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "preview": true,
   "repository": {
     "url": "https://github.com/MystenLabs/sui.git",

--- a/external-crates/move/crates/move-analyzer/src/analyzer.rs
+++ b/external-crates/move/crates/move-analyzer/src/analyzer.rs
@@ -173,7 +173,6 @@ pub fn run(implicit_deps: Dependencies) {
                 Arc::new(Mutex::new(CachedPackages::new())),
                 ide_files_root.clone(),
                 p.as_path(),
-                None,
                 lint,
                 None,
                 implicit_deps.clone(),

--- a/external-crates/move/crates/move-analyzer/src/code_action.rs
+++ b/external-crates/move/crates/move-analyzer/src/code_action.rs
@@ -141,7 +141,6 @@ fn access_chain_autofix_actions(
         pkg_dependencies.clone(),
         ide_files_root,
         &pkg_path,
-        Some(vec![]),
         LintLevel::None,
         implicit_deps,
     ) else {

--- a/external-crates/move/crates/move-analyzer/src/completions/mod.rs
+++ b/external-crates/move/crates/move-analyzer/src/completions/mod.rs
@@ -194,7 +194,6 @@ fn compute_completions_new_symbols(
         pkg_dependencies,
         ide_files_root,
         &pkg_path,
-        Some(vec![path.to_path_buf()]),
         LintLevel::None,
         cursor_info,
         implicit_deps,

--- a/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
+++ b/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
@@ -16,11 +16,11 @@ use move_analyzer::{
     completions::{compute_completions_with_symbols, utils::compute_cursor},
     inlay_hints::inlay_hints_internal,
     symbols::{
-        Symbols,
-        compilation::{CachedPackages, CompiledPkgInfo, SymbolsComputationData, get_compiled_pkg},
+        compilation::{get_compiled_pkg, CachedPackages, CompiledPkgInfo, SymbolsComputationData},
         compute_symbols, compute_symbols_parsed_program, compute_symbols_pre_process,
         requests::{def_info_doc_string, maybe_convert_for_guard},
         use_def::UseDefMap,
+        Symbols,
     },
 };
 use move_command_line_common::testing::insta_assert;
@@ -445,7 +445,7 @@ fn initial_symbols(
     let ide_files_root: VfsPath = MemoryFS::new().into();
     let pkg_deps = Arc::new(Mutex::new(CachedPackages::new()));
 
-    /// Similarly to `get_symbols`, we retry to exercise caching
+    // Similarly to `get_symbols`, we retry to exercise caching
     let mut should_retry = true;
     loop {
         let (compiled_pkg_info_opt, _) = get_compiled_pkg(

--- a/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
+++ b/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeMap,
     fs::File,
     io::{self, BufWriter},
     path::{Path, PathBuf},
@@ -437,7 +437,6 @@ fn completion_test(
 
 fn initial_symbols(
     project: String,
-    files: &BTreeSet<&String>,
 ) -> datatest_stable::Result<(PathBuf, CompiledPkgInfo, Symbols)> {
     let base_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let mut project_path = base_path.clone();
@@ -446,38 +445,30 @@ fn initial_symbols(
     let ide_files_root: VfsPath = MemoryFS::new().into();
     let pkg_deps = Arc::new(Mutex::new(CachedPackages::new()));
 
-    let (mut compiled_pkg_info_opt, _) = get_compiled_pkg(
-        pkg_deps.clone(),
-        ide_files_root.clone(),
-        project_path.as_path(),
-        None,
-        LintLevel::None,
-        BTreeMap::new(),
-    )?;
-
-    if let Some(f) = files.first() {
-        let mod_file = project_path.join("sources").join(f);
-        (compiled_pkg_info_opt, _) = get_compiled_pkg(
+    /// Similarly to `get_symbols`, we retry to exercise caching
+    let mut should_retry = true;
+    loop {
+        let (compiled_pkg_info_opt, _) = get_compiled_pkg(
             pkg_deps.clone(),
             ide_files_root.clone(),
             project_path.as_path(),
-            Some(vec![mod_file]),
             LintLevel::None,
             BTreeMap::new(),
         )?;
+        let compiled_pkg_info = compiled_pkg_info_opt.ok_or("PACKAGE COMPILATION FAILED")?;
+        let symbols = compute_symbols(pkg_deps.clone(), compiled_pkg_info.clone(), None);
+        if !should_retry {
+            return Ok((project_path, compiled_pkg_info, symbols));
+        }
+        should_retry = false;
     }
-
-    let compiled_pkg_info = compiled_pkg_info_opt.ok_or("PACKAGE COMPILATION FAILED")?;
-    let symbols = compute_symbols(pkg_deps.clone(), compiled_pkg_info.clone(), None);
-
-    Ok((project_path, compiled_pkg_info, symbols))
 }
 
 fn use_def_test_suite(
     project: String,
     file_tests: BTreeMap<String, Vec<UseDefTest>>,
 ) -> datatest_stable::Result<String> {
-    let (project_path, _, symbols) = initial_symbols(project, &file_tests.keys().collect())?;
+    let (project_path, _, symbols) = initial_symbols(project)?;
 
     let mut output: BufWriter<_> = BufWriter::new(Vec::new());
     let writer: &mut dyn io::Write = output.get_mut();
@@ -511,8 +502,7 @@ fn auto_completion_test_suite(
     project: String,
     file_tests: BTreeMap<String, Vec<AutoCompletionTest>>,
 ) -> datatest_stable::Result<String> {
-    let (project_path, mut compiled_pkg_info, mut symbols) =
-        initial_symbols(project, &file_tests.keys().collect())?;
+    let (project_path, mut compiled_pkg_info, mut symbols) = initial_symbols(project)?;
 
     let mut output: BufWriter<_> = BufWriter::new(Vec::new());
     let writer: &mut dyn io::Write = output.get_mut();
@@ -541,8 +531,7 @@ fn auto_import_test_suite(
     project: String,
     file_tests: BTreeMap<String, Vec<AutoImportTest>>,
 ) -> datatest_stable::Result<String> {
-    let (project_path, mut compiled_pkg_info, mut symbols) =
-        initial_symbols(project, &file_tests.keys().collect())?;
+    let (project_path, mut compiled_pkg_info, mut symbols) = initial_symbols(project)?;
 
     let mut output: BufWriter<_> = BufWriter::new(Vec::new());
     let writer: &mut dyn io::Write = output.get_mut();
@@ -571,8 +560,7 @@ fn cursor_test_suite(
     project: String,
     file_tests: BTreeMap<String, Vec<CursorTest>>,
 ) -> datatest_stable::Result<String> {
-    let (project_path, compiled_pkg_info, mut symbols) =
-        initial_symbols(project, &file_tests.keys().collect())?;
+    let (project_path, compiled_pkg_info, mut symbols) = initial_symbols(project)?;
 
     let mut output: BufWriter<_> = BufWriter::new(Vec::new());
     let writer: &mut dyn io::Write = output.get_mut();
@@ -600,7 +588,7 @@ fn hint_test_suite(
     project: String,
     file_tests: BTreeMap<String, Vec<HintTest>>,
 ) -> datatest_stable::Result<String> {
-    let (project_path, _, symbols) = initial_symbols(project, &file_tests.keys().collect())?;
+    let (project_path, _, symbols) = initial_symbols(project)?;
 
     let mut output: BufWriter<_> = BufWriter::new(Vec::new());
     let writer: &mut dyn io::Write = output.get_mut();
@@ -629,8 +617,7 @@ fn access_chain_quick_fix_test_suite(
     project: String,
     file_tests: BTreeMap<String, Vec<AccessChainQuickFixTest>>,
 ) -> datatest_stable::Result<String> {
-    let (project_path, mut compiled_pkg_info, mut symbols) =
-        initial_symbols(project, &file_tests.keys().collect())?;
+    let (project_path, mut compiled_pkg_info, mut symbols) = initial_symbols(project)?;
 
     let mut output: BufWriter<_> = BufWriter::new(Vec::new());
     let writer: &mut dyn io::Write = output.get_mut();

--- a/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
+++ b/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
@@ -16,11 +16,11 @@ use move_analyzer::{
     completions::{compute_completions_with_symbols, utils::compute_cursor},
     inlay_hints::inlay_hints_internal,
     symbols::{
-        compilation::{get_compiled_pkg, CachedPackages, CompiledPkgInfo, SymbolsComputationData},
+        Symbols,
+        compilation::{CachedPackages, CompiledPkgInfo, SymbolsComputationData, get_compiled_pkg},
         compute_symbols, compute_symbols_parsed_program, compute_symbols_pre_process,
         requests::{def_info_doc_string, maybe_convert_for_guard},
         use_def::UseDefMap,
-        Symbols,
     },
 };
 use move_command_line_common::testing::insta_assert;


### PR DESCRIPTION
## Description 

This fixes a problem with incremental symbolication. What we attempted before was to collect information about which files are modified (i.e., which ones have to be fully compiled) from the messages sent by the client to the LSP server. In some cases, however, this seemed to have led to problems.

In particular, a file might have been deemed unmodified by the analysis but be actually modified before mapped files structure (including file hashes) used throughout analysis was constructed. This would result in the discrepancy in the hash for this file seen by the compiler (as it would used cached data for this file) and mapped files structure (as it would have a hash after modification). This could cause `move-analyzer` to crash.

This PR implements a much more robust way of determining which files are modified that manages to introducing this race condition

## Test plan 

This was difficult to reproduce, but the original reporter of this bug confirms that after trying `move-analyzer` with this fix, the crashes he used to observe no longer happen
