### PR TITLE
[MFP] disable transaction driver for a protocol config < 96

### DIFF
--- a/crates/sui-benchmark/src/lib.rs
+++ b/crates/sui-benchmark/src/lib.rs
@@ -347,6 +347,7 @@ impl LocalValidatorAggregatorProxy {
             transaction_driver_metrics,
             None,
             client_metrics,
+            true,
         );
         Self {
             _qd_handler: qd_handler,

--- a/crates/sui-core/src/transaction_driver/mod.rs
+++ b/crates/sui-core/src/transaction_driver/mod.rs
@@ -14,7 +14,10 @@ use tokio_retry::strategy::{jitter, ExponentialBackoff};
 
 use std::{
     net::SocketAddr,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
     time::{Duration, Instant},
 };
 
@@ -78,6 +81,8 @@ pub struct TransactionDriver<A: Clone> {
     submitter: TransactionSubmitter,
     certifier: EffectsCertifier,
     client_monitor: Arc<ValidatorClientMonitor<A>>,
+    // TODO: remove this after protocol config version 96
+    enable_checks: Arc<AtomicBool>,
 }
 
 impl<A> TransactionDriver<A>
@@ -90,15 +95,21 @@ where
         metrics: Arc<TransactionDriverMetrics>,
         node_config: Option<&NodeConfig>,
         client_metrics: Arc<ValidatorClientMetrics>,
+        enable_checks: bool,
     ) -> Arc<Self> {
         let shared_swap = Arc::new(ArcSwap::new(authority_aggregator));
+        let enable_checks = Arc::new(AtomicBool::new(enable_checks));
 
         // Extract validator client monitor config from NodeConfig or use default
         let monitor_config = node_config
             .and_then(|nc| nc.validator_client_monitor_config.clone())
             .unwrap_or_default();
-        let client_monitor =
-            ValidatorClientMonitor::new(monitor_config, client_metrics, shared_swap.clone());
+        let client_monitor = ValidatorClientMonitor::new(
+            monitor_config,
+            client_metrics,
+            shared_swap.clone(),
+            enable_checks.clone(),
+        );
 
         let driver = Arc::new(Self {
             authority_aggregator: shared_swap,
@@ -107,6 +118,7 @@ where
             submitter: TransactionSubmitter::new(metrics.clone()),
             certifier: EffectsCertifier::new(metrics),
             client_monitor,
+            enable_checks,
         });
 
         let driver_clone = driver.clone();
@@ -217,6 +229,9 @@ where
         options: SubmitTransactionOptions,
         timeout_duration: Option<Duration>,
     ) -> Result<QuorumTransactionResponse, TransactionDriverError> {
+        // If we do have at least one transaction submitted, then we enable the latency checker, if not already enabled.
+        self.enable_checks.store(true, Ordering::Relaxed);
+
         // For ping requests, the amplification factor is always 1.
         let amplification_factor = if request.ping.is_some() {
             1

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -29,7 +29,7 @@ use prometheus::{
 };
 use rand::Rng;
 use sui_config::NodeConfig;
-use sui_protocol_config::Chain;
+use sui_protocol_config::{Chain, ProtocolVersion};
 use sui_storage::write_path_pending_tx_log::WritePathPendingTransactionLog;
 use sui_types::base_types::TransactionDigest;
 use sui_types::effects::TransactionEffectsAPI;
@@ -155,12 +155,14 @@ where
             let client_metrics = Arc::new(
                 crate::validator_client_monitor::ValidatorClientMetrics::new(prometheus_registry),
             );
+            let run_latency_checks = Self::is_transaction_driver_enabled(&epoch_store);
             Some(TransactionDriver::new(
                 validators.clone(),
                 reconfig_observer.clone(),
                 td_metrics,
                 Some(node_config),
                 client_metrics,
+                run_latency_checks,
             ))
         } else {
             None
@@ -778,6 +780,10 @@ where
         epoch_store: &Arc<AuthorityPerEpochStore>,
         tx_digest: TransactionDigest,
     ) -> bool {
+        if !Self::is_transaction_driver_enabled(epoch_store) {
+            return false;
+        }
+
         const MAX_PERCENTAGE: u8 = 100;
         let unknown_network = epoch_store.get_chain() == Chain::Unknown;
         let v = if unknown_network {
@@ -791,6 +797,14 @@ where
             v, self.td_percentage
         );
         v <= self.td_percentage
+    }
+
+    // TODO: remove this after protocol config version 96
+    // We want to enable transaction driver for protocol version 96 and above.
+    // As the new ping latency changes went in the same node version, we can't run transaction driver properly until
+    // we do have at least a quorum of nodes running the new version.
+    fn is_transaction_driver_enabled(epoch_store: &Arc<AuthorityPerEpochStore>) -> bool {
+        epoch_store.protocol_config().version >= ProtocolVersion::new(96)
     }
 
     // TODO: Potentially cleanup this function and pending transaction log.

--- a/crates/sui-core/src/validator_client_monitor/tests.rs
+++ b/crates/sui-core/src/validator_client_monitor/tests.rs
@@ -3,7 +3,7 @@
 
 use super::*;
 use crate::validator_client_monitor::stats::{ClientObservedStats, ValidatorClientStats};
-use std::sync::Arc;
+use std::sync::{atomic::AtomicBool, Arc};
 use std::time::Duration;
 use sui_config::validator_client_monitor_config::{ScoreWeights, ValidatorClientMonitorConfig};
 use sui_types::base_types::{AuthorityName, ConciseableName};
@@ -774,7 +774,12 @@ mod client_monitor_tests {
 
         let metrics = Arc::new(ValidatorClientMetrics::new(&Registry::default()));
         let auth_agg_swap = Arc::new(ArcSwap::new(initial_auth_agg.clone()));
-        let monitor = ValidatorClientMonitor::new(config, metrics, auth_agg_swap.clone());
+        let monitor = ValidatorClientMonitor::new(
+            config,
+            metrics,
+            auth_agg_swap.clone(),
+            Arc::new(AtomicBool::new(true)),
+        );
 
         // Record stats for all initial validators
         for validator in &initial_validators {
@@ -848,7 +853,12 @@ mod client_monitor_tests {
 
         let metrics = Arc::new(ValidatorClientMetrics::new(&Registry::default()));
         let auth_agg_swap = Arc::new(ArcSwap::new(initial_auth_agg.clone()));
-        let monitor = ValidatorClientMonitor::new(config, metrics, auth_agg_swap.clone());
+        let monitor = ValidatorClientMonitor::new(
+            config,
+            metrics,
+            auth_agg_swap.clone(),
+            Arc::new(AtomicBool::new(true)),
+        );
 
         // Record stats for initial validators
         for validator in &initial_validators {


### PR DESCRIPTION
## Description 

As the required API changes for the ping requests will go out with the current node version, the ping task will not function properly as the submit transaction endpoint will error (no empty txes array will be supported yet , or the wait for effects will not do either). This can have unpredictable effects to the end to end latency. 

The PR is disabling:
* Transaction Driver for protocol version < 96 (the current node software)
* The latency checks & score update for protocol version < 96

Once the FNs deploy this node version, then we'll see the rate of MFP transactions decrease (most probably up to 0) and then go back to the original rate once network upgrades to protocol version 96.

## Test plan 

CI/PT

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
