### PR TITLE
Pick #23658 to 1.57

### DIFF
--- a/crates/sui-core/src/transaction_driver/metrics.rs
+++ b/crates/sui-core/src/transaction_driver/metrics.rs
@@ -32,6 +32,7 @@ pub struct TransactionDriverMetrics {
     pub(crate) certified_effects_ack_successes: IntCounterVec,
     pub(crate) validator_selections: IntCounterVec,
     pub(crate) submit_amplification_factor: Histogram,
+    pub(crate) latency_check_runs: IntCounterVec,
 }
 
 impl TransactionDriverMetrics {
@@ -156,6 +157,13 @@ impl TransactionDriverMetrics {
                 "transaction_driver_submit_amplification_factor",
                 "The amplification factor used by transaction driver to submit to validators",
                 COUNT_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            latency_check_runs: register_int_counter_vec_with_registry!(
+                "transaction_driver_latency_check_runs",
+                "Number of times the latency check runs",
+                &["tx_type"],
                 registry,
             )
             .unwrap(),

--- a/crates/sui-core/src/transaction_driver/mod.rs
+++ b/crates/sui-core/src/transaction_driver/mod.rs
@@ -161,6 +161,11 @@ where
         let auth_agg = self.authority_aggregator.load().clone();
         let validators = auth_agg.committee.names().cloned().collect::<Vec<_>>();
 
+        self.metrics
+            .latency_check_runs
+            .with_label_values(&[tx_type.as_str()])
+            .inc();
+
         for name in validators {
             let display_name = auth_agg.get_display_name(&name);
             let delay_ms = rand::thread_rng().gen_range(0..max_delay_ms);


### PR DESCRIPTION
## Description 

When converting the `SubmitTxRequest` to `RawSubmitTxRequest` the `Default::default` was used for the fields other than the `transaction`, ending up not serialising the tx type. The `SubmitTxType::Default` is used in this case eventually treating all the requests as `Default` - ping transactions couldn't work.

## Test plan 

CI/PT
