### PR TITLE
docs: Adding CODEOWNER for .md + .mdx files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,8 @@
 /crates/sui-keys/ @joyqvq @patrickkuo
 /crates/sui-protocol-config @mystenmark
 
-*.md @ronny-mysten
+*.md @ronny-mysten @jessiemongeon1
+*.mdx @ronny-mysten @jessiemongeon1
 # Omit auto-generated changelogs and changesets from docs review:
 /.changeset/*.md
 CHANGELOG.md


### PR DESCRIPTION
## Description 

Adding myself alongside @ronny-mysten as codeowner for .md files, plus adding .mdx files, as most of the docs are .mdx per Docusaurus's rendering.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
