### PR TITLE
Check coin deny list during signing for address balances

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -41,6 +41,7 @@ use serde::{Deserialize, Serialize};
 use shared_object_version_manager::AssignedVersions;
 use shared_object_version_manager::Schedulable;
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -1045,11 +1046,42 @@ impl AuthorityState {
             &self.config.verifier_signing_config,
         )?;
 
+        self.handle_coin_deny_list_checks(
+            tx_data,
+            &checked_input_objects,
+            &receiving_objects,
+            epoch_store,
+        )?;
+
+        Ok(checked_input_objects)
+    }
+
+    fn handle_coin_deny_list_checks(
+        &self,
+        tx_data: &TransactionData,
+        checked_input_objects: &CheckedInputObjects,
+        receiving_objects: &ReceivingObjects,
+        epoch_store: &Arc<AuthorityPerEpochStore>,
+    ) -> SuiResult<()> {
+        let funds_withdraw_types = tx_data
+            .get_funds_withdrawals()
+            .into_iter()
+            .map(|withdraw| {
+                withdraw
+                    .type_arg
+                    .get_type_param()
+                    // unwrap safe because we already verified the transaction.
+                    .unwrap()
+                    .to_canonical_string(false)
+            })
+            .collect::<BTreeSet<_>>();
+
         if epoch_store.coin_deny_list_v1_enabled() {
             check_coin_deny_list_v1(
                 tx_data.sender(),
-                &checked_input_objects,
-                &receiving_objects,
+                checked_input_objects,
+                receiving_objects,
+                funds_withdraw_types.clone(),
                 &self.get_object_store(),
             )?;
         }
@@ -1057,13 +1089,14 @@ impl AuthorityState {
         if epoch_store.protocol_config().enable_coin_deny_list_v2() {
             check_coin_deny_list_v2_during_signing(
                 tx_data.sender(),
-                &checked_input_objects,
-                &receiving_objects,
+                checked_input_objects,
+                receiving_objects,
+                funds_withdraw_types.clone(),
                 &self.get_object_store(),
             )?;
         }
 
-        Ok(checked_input_objects)
+        Ok(())
     }
 
     /// This is a private method and should be kept that way. It doesn't check whether

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -1066,13 +1066,13 @@ impl AuthorityState {
         let funds_withdraw_types = tx_data
             .get_funds_withdrawals()
             .into_iter()
-            .map(|withdraw| {
+            .filter_map(|withdraw| {
                 withdraw
                     .type_arg
-                    .get_type_param()
+                    .get_balance_type_param()
                     // unwrap safe because we already verified the transaction.
                     .unwrap()
-                    .to_canonical_string(false)
+                    .map(|ty| ty.to_canonical_string(false))
             })
             .collect::<BTreeSet<_>>();
 

--- a/crates/sui-types/src/deny_list_v1.rs
+++ b/crates/sui-types/src/deny_list_v1.rs
@@ -53,9 +53,12 @@ pub fn check_coin_deny_list_v1(
     sender: SuiAddress,
     input_objects: &CheckedInputObjects,
     receiving_objects: &ReceivingObjects,
+    funds_withdraw_types: BTreeSet<String>,
     object_store: &dyn ObjectStore,
 ) -> UserInputResult {
-    let coin_types = input_object_coin_types_for_denylist_check(input_objects, receiving_objects);
+    let mut coin_types =
+        input_object_coin_types_for_denylist_check(input_objects, receiving_objects);
+    coin_types.extend(funds_withdraw_types);
 
     let Some(deny_list) = get_coin_deny_list(object_store) else {
         // TODO: This is where we should fire an invariant violation metric.

--- a/crates/sui-types/src/deny_list_v2.rs
+++ b/crates/sui-types/src/deny_list_v2.rs
@@ -104,9 +104,13 @@ pub fn check_coin_deny_list_v2_during_signing(
     address: SuiAddress,
     input_objects: &CheckedInputObjects,
     receiving_objects: &ReceivingObjects,
+    funds_withdraw_types: BTreeSet<String>,
     object_store: &dyn ObjectStore,
 ) -> UserInputResult {
-    let coin_types = input_object_coin_types_for_denylist_check(input_objects, receiving_objects);
+    let mut coin_types =
+        input_object_coin_types_for_denylist_check(input_objects, receiving_objects);
+    coin_types.extend(funds_withdraw_types);
+
     for coin_type in coin_types {
         let Some(deny_list) = get_per_type_coin_deny_list_v2(&coin_type, object_store) else {
             continue;

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -139,6 +139,8 @@ pub enum WithdrawalTypeArg {
 }
 
 impl WithdrawalTypeArg {
+    /// Convert the withdrawal type argument to a full type tag,
+    /// e.g. `Balance<T>` -> `0x2::balance::Balance<T>`
     pub fn to_type_tag(&self) -> UserInputResult<TypeTag> {
         match self {
             WithdrawalTypeArg::Balance(type_param) => {
@@ -148,6 +150,14 @@ impl WithdrawalTypeArg {
                     },
                 )?))
             }
+        }
+    }
+
+    /// Get the type parameter of the withdrawal type argument,
+    /// e.g. `Balance<T>` -> `T`
+    pub fn get_type_param(&self) -> anyhow::Result<TypeTag> {
+        match self {
+            WithdrawalTypeArg::Balance(type_param) => type_param.to_type_tag(),
         }
     }
 }
@@ -2206,6 +2216,9 @@ pub trait TransactionDataAPI {
     // A cheap way to quickly check if the transaction has funds withdraws.
     fn has_funds_withdrawals(&self) -> bool;
 
+    // Get all the funds withdrawals args in the transaction.
+    fn get_funds_withdrawals(&self) -> Vec<FundsWithdrawalArg>;
+
     fn validity_check(&self, config: &ProtocolConfig) -> UserInputResult;
 
     fn validity_check_no_gas_check(&self, config: &ProtocolConfig) -> UserInputResult;
@@ -2330,25 +2343,17 @@ impl TransactionDataAPI for TransactionDataV1 {
     }
 
     fn process_funds_withdrawals(&self) -> UserInputResult<BTreeMap<AccumulatorObjId, u64>> {
-        let mut withdraws = Vec::new();
+        let withdraws = self.get_funds_withdrawals();
         // TODO(address-balances): Once we support paying gas using address balances,
         // we add gas reservations here.
         // TODO(address-balances): Use a protocol config parameter for max_withdraws.
         let max_withdraws = 10;
-        // First get all withdraw arguments.
-        if let TransactionKind::ProgrammableTransaction(pt) = &self.kind {
-            for input in &pt.inputs {
-                if let CallArg::FundsWithdrawal(withdraw) = input {
-                    withdraws.push(withdraw.clone());
-                    if withdraws.len() > max_withdraws {
-                        return Err(UserInputError::InvalidWithdrawReservation {
-                            error: format!(
-                                "Maximum number of balance withdraw reservations is {max_withdraws}"
-                            ),
-                        });
-                    }
-                }
-            }
+        if withdraws.len() > max_withdraws {
+            return Err(UserInputError::InvalidWithdrawReservation {
+                error: format!(
+                    "Maximum number of balance withdraw reservations is {max_withdraws}"
+                ),
+            });
         }
 
         // Accumulate all withdraws per account.
@@ -2404,6 +2409,23 @@ impl TransactionDataAPI for TransactionDataV1 {
             }
         }
         false
+    }
+
+    fn get_funds_withdrawals(&self) -> Vec<FundsWithdrawalArg> {
+        if let TransactionKind::ProgrammableTransaction(pt) = &self.kind {
+            pt.inputs
+                .iter()
+                .filter_map(|input| {
+                    if let CallArg::FundsWithdrawal(withdraw) = input {
+                        Some(withdraw.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        } else {
+            vec![]
+        }
     }
 
     fn validity_check(&self, config: &ProtocolConfig) -> UserInputResult {

--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/context.rs
@@ -1532,6 +1532,7 @@ mod checked {
             })
             .collect();
 
+        // TODO(address-balances): Also check deny list v2 for funds transfers.
         let accumulator_events = accumulator_events
             .into_iter()
             .map(|accum_event| match accum_event.value {


### PR DESCRIPTION
## Description 

When checking coin deny list during signing, we also include all the coin types from balance withdraw reservations.
TODO: We also need to do this during execution for coin deny list v2. That's a bit more involving and will come in a separate PR.

## Test plan 

Added test

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
