### PR TITLE
graphql-alt: Add Validator.operationCap

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/active_validators.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/active_validators.move
@@ -42,6 +42,9 @@
           imageUrl
           # todo (ewall) populate projectUrl
           projectUrl
+          operationCap {
+            address
+          }
           stakingPoolId
           exchangeRatesSize
           stakingPoolActivationEpoch

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/active_validators.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/active_validators.snap
@@ -6,7 +6,7 @@ processed 2 tasks
 init:
 A: object(0,0)
 
-task 1, lines 6-81:
+task 1, lines 6-84:
 //# run-graphql
 Response: {
   "data": {
@@ -62,6 +62,9 @@ Response: {
               "description": "",
               "imageUrl": "",
               "projectUrl": "",
+              "operationCap": {
+                "address": "0x03c47745906988d806cf7b623cebf960c79b370bb8b95c3ad24616e2aa29ca7b"
+              },
               "stakingPoolId": "0x2f4c0b14e06a9dd4724e823b2289e3356b2e987fd0f3435e3e00b616bbec111f",
               "exchangeRatesSize": 1,
               "stakingPoolActivationEpoch": 0,

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -4050,6 +4050,11 @@ type Validator implements IAddressable {
 	"""
 	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection
 	"""
+	The validator's current valid `Cap` object. Validators can delegate the operation ability to another address.
+	The address holding this `Cap` object can then update the reference gas price and tallying rule on behalf of the validator.
+	"""
+	operationCap: MoveObject
+	"""
 	Pending pool token withdrawn during the current epoch, emptied at epoch boundaries.
 	"""
 	pendingPoolTokenWithdraw: BigInt

--- a/crates/sui-indexer-alt-graphql/src/api/types/object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object.rs
@@ -250,7 +250,10 @@ impl Object {
     }
 
     /// Attempts to convert the object into a MoveObject.
-    async fn as_move_object(&self, ctx: &Context<'_>) -> Result<Option<MoveObject>, RpcError> {
+    pub(crate) async fn as_move_object(
+        &self,
+        ctx: &Context<'_>,
+    ) -> Result<Option<MoveObject>, RpcError> {
         MoveObject::from_object(self, ctx).await
     }
 

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -4054,6 +4054,11 @@ type Validator implements IAddressable {
 	"""
 	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection
 	"""
+	The validator's current valid `Cap` object. Validators can delegate the operation ability to another address.
+	The address holding this `Cap` object can then update the reference gas price and tallying rule on behalf of the validator.
+	"""
+	operationCap: MoveObject
+	"""
 	Pending pool token withdrawn during the current epoch, emptied at epoch boundaries.
 	"""
 	pendingPoolTokenWithdraw: BigInt

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -4054,6 +4054,11 @@ type Validator implements IAddressable {
 	"""
 	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection
 	"""
+	The validator's current valid `Cap` object. Validators can delegate the operation ability to another address.
+	The address holding this `Cap` object can then update the reference gas price and tallying rule on behalf of the validator.
+	"""
+	operationCap: MoveObject
+	"""
 	Pending pool token withdrawn during the current epoch, emptied at epoch boundaries.
 	"""
 	pendingPoolTokenWithdraw: BigInt

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -4050,6 +4050,11 @@ type Validator implements IAddressable {
 	"""
 	objects(first: Int, after: String, last: Int, before: String, filter: ObjectFilter): MoveObjectConnection
 	"""
+	The validator's current valid `Cap` object. Validators can delegate the operation ability to another address.
+	The address holding this `Cap` object can then update the reference gas price and tallying rule on behalf of the validator.
+	"""
+	operationCap: MoveObject
+	"""
 	Pending pool token withdrawn during the current epoch, emptied at epoch boundaries.
 	"""
 	pendingPoolTokenWithdraw: BigInt


### PR DESCRIPTION
## Description 

Implements `Validator.operationCap` based on https://github.com/MystenLabs/sui/blob/f98169a6f18935290b184e1d3d3e43fe5b2cf442/crates/sui-graphql-rpc/src/types/validator.rs#L195-L203.

## Test plan 

Adds new field to `active_validators.move` snapshot test.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [x] GraphQL: Adds `Validator.operationCap` that displays address that the operation ability was delegated to if it exists. 
- [ ] CLI: 
- [ ] Rust SDK:
