### PR TITLE
[graphql-alt] Add timeout to remote store client

### DIFF
--- a/crates/sui-indexer-alt-framework/src/ingestion/remote_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/remote_client.rs
@@ -4,8 +4,14 @@
 use crate::ingestion::client::{FetchData, FetchError, FetchResult, IngestionClientTrait};
 use crate::ingestion::Result as IngestionResult;
 use reqwest::{Client, StatusCode};
+use std::time::Duration;
 use tracing::{debug, error};
 use url::Url;
+
+/// Default timeout for remote checkpoint fetches.
+/// This prevents requests from hanging indefinitely due to network issues,
+/// unresponsive servers, or other connection problems.
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
 
 #[derive(thiserror::Error, Debug, Eq, PartialEq)]
 pub enum HttpError {
@@ -26,7 +32,7 @@ impl RemoteIngestionClient {
     pub(crate) fn new(url: Url) -> IngestionResult<Self> {
         Ok(Self {
             url,
-            client: Client::builder().build()?,
+            client: Client::builder().timeout(DEFAULT_REQUEST_TIMEOUT).build()?,
         })
     }
 }


### PR DESCRIPTION
## Description 

We have been recently observing a few incidents for checkpoint lagging for custom Indexer pipeline. 

The pipeline was stuck at a particular checkpoint N, and the pattern we saw from these pipelines is there was a log:
```
Slow checkpoint fetch operation detected {Checkpoint N + 1}
```
, which indicates that the pipeline was likely to be stuck at checkpoint fetching for checkpoint N + 1. 

The hang could be a bug from Reqwest library, and I saw there is an [open bug](https://github.com/seanmonstar/reqwest/issues/1323) where the request is hanging. The bug is not fixed yet but they mentioned setting the timeout could allow the request to stop. 

## Test plan 

How did you test the new or updated feature?

```
cargo test -p sui-indexer-alt-framework 
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
