### PR TITLE
[trace-view] Fixed image scaling problem in the docs

### DIFF
--- a/docs/content/references/ide/debugger.mdx
+++ b/docs/content/references/ide/debugger.mdx
@@ -103,7 +103,9 @@ Debugging a Move unit test is a two-step process:
 
    - Run the `Move: Trace Move test execution` command.
 
-      <img src="./images/trace_palette.png" width="50%" height="auto" alt="Command palette" />
+      <div class="image-scale-50">
+      ![Command palette](./images/trace_palette.png)
+      </div>
 
       :::info
         This command uses the `sui` binary under the hood which needs to be [pre-installed](#install). The location of the binary needs to be [discoverable by the Move extension](/references/ide/move#build-test-and-trace).
@@ -112,7 +114,9 @@ Debugging a Move unit test is a two-step process:
 
    - The extension displays a filter prompt. Either type a filter string to target specific tests or leave the field blank to run all tests and press <kbd>Enter</kbd>.
 
-      <img src="./images/filter_string.png" width="50%" height="auto" alt="Filter test string" />
+      <div class="image-scale-50">
+      ![Filter test string](./images/filter_string.png)
+      </div>
 
    - Find the generated traces in the `traces` directory.
 
@@ -129,11 +133,15 @@ Debugging a Move unit test is a two-step process:
 
    - Select **Run** -> **Start Debugging** from the main menu.
 
-      <img src="./images/start_debugging.png" width="30%" height="auto" alt="Start test debugging" />
+      <div class="image-scale-30">
+      ![Start test debugging](./images/start_debugging.png)
+      </div>
 
    - If the file has multiple tests, select the specific test from the dropdown menu.
 
-      <img src="./images/test_selection.png" width="50%" height="auto" alt="Test selection" />
+      <div class="image-scale-50">
+      ![Test selection](./images/test_selection.png)
+      </div>
 
 
 ### Debugging on-chain transactions
@@ -157,7 +165,9 @@ Debugging an on-chain transaction is a two-step process:
 
    - Select **Run** -> **Start Debugging** from the main menu.
 
-      <img src="./images/start_debugging.png" width="30%" height="auto" alt="Start txn debugging" />
+      <div class="image-scale-30">
+      ![Start txn debugging](./images/start_debugging.png)
+      </div>
 
       :::info
         The first time you run this command you may be asked to select a debugger type. Select **Move Debugger**.
@@ -235,11 +245,15 @@ To locate the correct version of the source code for a user package, utilize a S
 
 Search for the package in a Sui explorer.
 
-<img src="./images/deepbook_search.png" width="50%" height="auto" alt="Package search" />
+<div class="image-scale-50">
+![Package search](./images/deepbook_search.png)
+</div>
 
 You can see that the the package in question is `deepbook/core`. Look at the detailed information about this package available in the explorer.
 
-<img src="./images/deepbook_explorer.png" width="70%" height="auto" alt="Package explorer" />
+<div class="image-scale-70">
+![Package explorer](./images/deepbook_explorer.png)
+</div>
 
 You can see that the package description in the explorer includes an MVR link. When you follow that link, you get to the MVR page containing a different kind of description for this package. The MVR description includes a link to the package's source code repository and information that the ID represents the 3rd version of this package.
 

--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -888,3 +888,21 @@ h5 {
     margin: 1.5rem auto;
   }
 }
+
+/* Image sizing */
+
+.image-scale-30 img {
+  width: 30%;
+  height: auto;
+}
+
+.image-scale-50 img {
+  width: 50%;
+  height: auto;
+}
+
+.image-scale-70 img {
+  width: 70%;
+  height: auto;
+}
+


### PR DESCRIPTION
## Description 

It seems like Docusaurus does not like `img` tag... I think I did find a way to scale images with `div` tag. At least this tag seems to be supported as per this [piece](https://github.com/MystenLabs/sui/blob/e9a9bcb6bc0318dff4f5296ca8acffda9b80f5c0/docs/content/guides/developer/getting-started/data-serving.mdx?plain=1#L53) of our docs:

```html
<div class="bg-sui-ghost-white">
![Future state data serving stack](../images/dataservingstack.png)
</div>
```
It does not render correctly in [preview](https://github.com/MystenLabs/sui/blob/main/docs/content/guides/developer/getting-started/data-serving.mdx) but the image displays correctly in the docs [themselves](https://sui-docs-git-docs-embed-data-stack-update-videos-sui-foundation.vercel.app/guides/developer/getting-started/data-serving#future-data-access-interfaces)

I hope that my new image class will do the trick here as well

## Test plan 

Needs to render correctly in the docs