### PR TITLE
Patch coin metadata logic.

### DIFF
--- a/crates/sui-e2e-tests/tests/rpc/v2/state_service/get_coin_info.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/state_service/get_coin_info.rs
@@ -72,7 +72,7 @@ async fn get_coin_info_sui() {
     let regulated_metadata = regulated_metadata.unwrap();
     assert_eq!(
         regulated_metadata.coin_regulated_state,
-        Some(CoinRegulatedState::Unknown as i32)
+        Some(CoinRegulatedState::Unregulated as i32)
     );
 }
 


### PR DESCRIPTION
## Description

Patching coin metadata logic from [pull/23705](https://github.com/MystenLabs/sui/pull/23705) into 1.57 release
