### PR TITLE
sui-core: track and store unchanged loaded runtime objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13920,7 +13920,7 @@ dependencies = [
 [[package]]
 name = "sui-crypto"
 version = "0.0.7"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=8eee97380cac1a1899d3cca427bde7ac906abdb9#8eee97380cac1a1899d3cca427bde7ac906abdb9"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=fe561f3089b3b4acbbd67ff48a278a6c448e488c#fe561f3089b3b4acbbd67ff48a278a6c448e488c"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -15960,7 +15960,7 @@ dependencies = [
 [[package]]
 name = "sui-rpc"
 version = "0.0.7"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=8eee97380cac1a1899d3cca427bde7ac906abdb9#8eee97380cac1a1899d3cca427bde7ac906abdb9"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=fe561f3089b3b4acbbd67ff48a278a6c448e488c#fe561f3089b3b4acbbd67ff48a278a6c448e488c"
 dependencies = [
  "base64 0.22.1",
  "bcs",
@@ -16119,7 +16119,7 @@ dependencies = [
 [[package]]
 name = "sui-sdk-types"
 version = "0.0.7"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=8eee97380cac1a1899d3cca427bde7ac906abdb9#8eee97380cac1a1899d3cca427bde7ac906abdb9"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=fe561f3089b3b4acbbd67ff48a278a6c448e488c#fe561f3089b3b4acbbd67ff48a278a6c448e488c"
 dependencies = [
  "base64ct",
  "bcs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -662,9 +662,9 @@ anemo-cli = { git = "https://github.com/mystenlabs/anemo.git", rev = "9c52c3c794
 anemo-tower = { git = "https://github.com/mystenlabs/anemo.git", rev = "9c52c3c7946532163a79129db15180cdb984bab4" }
 
 # core-types from the new sdk for use in gRPC
-sui-sdk-types = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "8eee97380cac1a1899d3cca427bde7ac906abdb9", features = [ "hash", "serde" ] }
-sui-crypto = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "8eee97380cac1a1899d3cca427bde7ac906abdb9", features = [ "ed25519", "secp256r1", "secp256k1", "passkey", "zklogin" ] }
-sui-rpc = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "8eee97380cac1a1899d3cca427bde7ac906abdb9" }
+sui-sdk-types = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "fe561f3089b3b4acbbd67ff48a278a6c448e488c", features = [ "hash", "serde" ] }
+sui-crypto = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "fe561f3089b3b4acbbd67ff48a278a6c448e488c", features = [ "ed25519", "secp256r1", "secp256k1", "passkey", "zklogin" ] }
+sui-rpc = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "fe561f3089b3b4acbbd67ff48a278a6c448e488c" }
 
 ### Workspace Members ###
 anemo-benchmark = { path = "crates/anemo-benchmark" }

--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -31,6 +31,7 @@ use sui_types::digests::{ChainIdentifier, ConsensusCommitDigest};
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::messages_consensus::ConsensusDeterminedVersionAssignments;
 use sui_types::object::{Object, Owner};
+use sui_types::storage::ObjectKey;
 use sui_types::storage::{ObjectStore, ReadStore, RpcStateReader};
 use sui_types::sui_system_state::epoch_start_sui_system_state::EpochStartSystemState;
 use sui_types::transaction::EndOfEpochTransactionKind;
@@ -538,7 +539,9 @@ impl<R, S: store::SimulatorStore> Simulacrum<R, S> {
     ) -> anyhow::Result<()> {
         if let Some(path) = &self.data_ingestion_path {
             let file_name = format!("{}.chk", checkpoint.sequence_number);
-            let checkpoint_data = self.get_checkpoint_data(checkpoint, checkpoint_contents)?;
+            let checkpoint_data: sui_types::full_checkpoint_content::CheckpointData = self
+                .get_checkpoint_data(checkpoint, checkpoint_contents)?
+                .into();
             std::fs::create_dir_all(path)?;
             let blob = Blob::encode(&checkpoint_data, BlobEncoding::Bcs)?;
             std::fs::write(path.join(file_name), blob.to_bytes())?;
@@ -678,6 +681,13 @@ impl<T, V: store::SimulatorStore> ReadStore for Simulacrum<T, V> {
         _digest: &sui_types::messages_checkpoint::CheckpointContentsDigest,
     ) -> Option<sui_types::messages_checkpoint::FullCheckpointContents> {
         todo!()
+    }
+
+    fn get_unchanged_loaded_runtime_objects(
+        &self,
+        _digest: &sui_types::digests::TransactionDigest,
+    ) -> Option<Vec<ObjectKey>> {
+        None
     }
 }
 

--- a/crates/sui-analytics-indexer/src/handlers/transaction_bcs_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/transaction_bcs_handler.rs
@@ -89,11 +89,13 @@ mod tests {
 
         // Create a checkpoint which should include the transaction we executed.
         let checkpoint = sim.create_checkpoint();
-        let checkpoint_data = sim.get_checkpoint_data(
-            checkpoint.clone(),
-            sim.get_checkpoint_contents_by_digest(&checkpoint.content_digest)
-                .unwrap(),
-        )?;
+        let checkpoint_data: sui_types::full_checkpoint_content::CheckpointData = sim
+            .get_checkpoint_data(
+                checkpoint.clone(),
+                sim.get_checkpoint_contents_by_digest(&checkpoint.content_digest)
+                    .unwrap(),
+            )?
+            .into();
         let txn_handler = TransactionBCSHandler::new();
         let transaction_entries: Vec<_> = txn_handler
             .process_checkpoint(&Arc::new(checkpoint_data))

--- a/crates/sui-analytics-indexer/src/handlers/transaction_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/transaction_handler.rs
@@ -227,11 +227,13 @@ mod tests {
 
         // Create a checkpoint which should include the transaction we executed.
         let checkpoint = sim.create_checkpoint();
-        let checkpoint_data = sim.get_checkpoint_data(
-            checkpoint.clone(),
-            sim.get_checkpoint_contents_by_digest(&checkpoint.content_digest)
-                .unwrap(),
-        )?;
+        let checkpoint_data: sui_types::full_checkpoint_content::CheckpointData = sim
+            .get_checkpoint_data(
+                checkpoint.clone(),
+                sim.get_checkpoint_contents_by_digest(&checkpoint.content_digest)
+                    .unwrap(),
+            )?
+            .into();
         let txn_handler = TransactionHandler::new();
         let transaction_entries: Vec<_> = txn_handler
             .process_checkpoint(&Arc::new(checkpoint_data))

--- a/crates/sui-core/src/authority/authority_store.rs
+++ b/crates/sui-core/src/authority/authority_store.rs
@@ -332,6 +332,15 @@ impl AuthorityStore {
             .collect::<Result<Vec<_>, _>>()?)
     }
 
+    pub fn get_unchanged_loaded_runtime_objects(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Result<Option<Vec<ObjectKey>>, TypedStoreError> {
+        self.perpetual_tables
+            .unchanged_loaded_runtime_objects
+            .get(digest)
+    }
+
     pub fn multi_get_effects<'a>(
         &self,
         effects_digests: impl Iterator<Item = &'a TransactionEffectsDigest>,
@@ -763,6 +772,7 @@ impl AuthorityStore {
             deleted,
             written,
             events,
+            unchanged_loaded_runtime_objects,
             locks_to_delete,
             new_locks_to_init,
             ..
@@ -806,6 +816,14 @@ impl AuthorityStore {
             write_batch.insert_batch(
                 &self.perpetual_tables.events_2,
                 [(transaction_digest, events)],
+            )?;
+        }
+
+        // Write unchanged_loaded_runtime_objects
+        if !unchanged_loaded_runtime_objects.is_empty() {
+            write_batch.insert_batch(
+                &self.perpetual_tables.unchanged_loaded_runtime_objects,
+                [(transaction_digest, unchanged_loaded_runtime_objects)],
             )?;
         }
 

--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -256,7 +256,7 @@ impl AuthorityStorePruner {
         perpetual_batch.delete_batch(&perpetual_db.executed_effects, transactions.iter())?;
         perpetual_batch.delete_batch(
             &perpetual_db.executed_transactions_to_checkpoint,
-            transactions,
+            transactions.iter(),
         )?;
 
         let mut effect_digests = vec![];
@@ -270,6 +270,10 @@ impl AuthorityStorePruner {
                     .delete_batch(&perpetual_db.events_2, [effects.transaction_digest()])?;
             }
         }
+        perpetual_batch.delete_batch(
+            &perpetual_db.unchanged_loaded_runtime_objects,
+            transactions.iter(),
+        )?;
         perpetual_batch.delete_batch(&perpetual_db.effects, effect_digests)?;
 
         let mut checkpoints_batch = checkpoint_db.tables.certified_checkpoints.batch();

--- a/crates/sui-core/src/authority/authority_store_tables.rs
+++ b/crates/sui-core/src/authority/authority_store_tables.rs
@@ -102,6 +102,9 @@ pub struct AuthorityPerpetualTables {
     // Events keyed by the digest of the transaction that produced them.
     pub(crate) events_2: DBMap<TransactionDigest, TransactionEvents>,
 
+    // Loaded (and unchanged) runtime object references.
+    pub(crate) unchanged_loaded_runtime_objects: DBMap<TransactionDigest, Vec<ObjectKey>>,
+
     /// DEPRECATED in favor of the table of the same name in authority_per_epoch_store.
     /// Please do not add new accessors/callsites.
     /// When transaction is executed via checkpoint executor, we store association here
@@ -316,6 +319,16 @@ impl AuthorityPerpetualTables {
             ),
             (
                 "events_2".to_string(),
+                ThConfig::new_with_rm_prefix(
+                    32,
+                    mutexes,
+                    uniform_key,
+                    KeySpaceConfig::default().with_relocation_filter(|_, _| Decision::Remove),
+                    digest_prefix.clone(),
+                ),
+            ),
+            (
+                "unchanged_loaded_runtime_objects".to_string(),
                 ThConfig::new_with_rm_prefix(
                     32,
                     mutexes,

--- a/crates/sui-core/src/checkpoints/checkpoint_executor/data_ingestion_handler.rs
+++ b/crates/sui-core/src/checkpoints/checkpoint_executor/data_ingestion_handler.rs
@@ -3,71 +3,15 @@
 
 use crate::checkpoints::checkpoint_executor::{CheckpointExecutionData, CheckpointTransactionData};
 use crate::execution_cache::TransactionCacheRead;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::Path;
 use sui_storage::blob::{Blob, BlobEncoding};
 use sui_types::effects::TransactionEffectsAPI;
 use sui_types::error::{SuiError, SuiResult};
-use sui_types::full_checkpoint_content::{CheckpointData, CheckpointTransaction};
+use sui_types::full_checkpoint_content::{
+    Checkpoint, CheckpointData, ExecutedTransaction, ObjectSet,
+};
 use sui_types::storage::ObjectStore;
-
-pub(crate) fn load_checkpoint_data(
-    ckpt_data: &CheckpointExecutionData,
-    ckpt_tx_data: &CheckpointTransactionData,
-    object_store: &dyn ObjectStore,
-    transaction_cache_reader: &dyn TransactionCacheRead,
-) -> SuiResult<CheckpointData> {
-    let event_tx_digests = ckpt_tx_data
-        .effects
-        .iter()
-        .flat_map(|fx| fx.events_digest().map(|_| fx.transaction_digest()).copied())
-        .collect::<Vec<_>>();
-
-    let events = transaction_cache_reader
-        .multi_get_events(&event_tx_digests)
-        .into_iter()
-        .zip(event_tx_digests)
-        .map(|(maybe_event, tx_digest)| {
-            maybe_event
-                .ok_or(SuiError::TransactionEventsNotFound { digest: tx_digest })
-                .map(|event| (tx_digest, event))
-        })
-        .collect::<SuiResult<HashMap<_, _>>>()?;
-
-    let mut full_transactions = Vec::with_capacity(ckpt_tx_data.transactions.len());
-    for (tx, fx) in ckpt_tx_data
-        .transactions
-        .iter()
-        .zip(ckpt_tx_data.effects.iter())
-    {
-        let events = fx.events_digest().map(|_event_digest| {
-            events
-                .get(fx.transaction_digest())
-                .cloned()
-                .expect("event was already checked to be present")
-        });
-
-        let input_objects = sui_types::storage::get_transaction_input_objects(object_store, fx)
-            .map_err(|e| SuiError::Unknown(e.to_string()))?;
-        let output_objects = sui_types::storage::get_transaction_output_objects(object_store, fx)
-            .map_err(|e| SuiError::Unknown(e.to_string()))?;
-
-        let full_transaction = CheckpointTransaction {
-            transaction: (*tx).clone().into_unsigned().into(),
-            effects: fx.clone(),
-            events,
-            input_objects,
-            output_objects,
-        };
-        full_transactions.push(full_transaction);
-    }
-    let checkpoint_data = CheckpointData {
-        checkpoint_summary: ckpt_data.checkpoint.clone().into(),
-        checkpoint_contents: ckpt_data.checkpoint_contents.clone(),
-        transactions: full_transactions,
-    };
-    Ok(checkpoint_data)
-}
 
 pub(crate) fn store_checkpoint_locally(
     path: impl AsRef<Path>,
@@ -94,4 +38,92 @@ pub(crate) fn store_checkpoint_locally(
         })?;
 
     Ok(())
+}
+
+pub(crate) fn load_checkpoint(
+    ckpt_data: &CheckpointExecutionData,
+    ckpt_tx_data: &CheckpointTransactionData,
+    object_store: &dyn ObjectStore,
+    transaction_cache_reader: &dyn TransactionCacheRead,
+) -> SuiResult<Checkpoint> {
+    let event_tx_digests = ckpt_tx_data
+        .effects
+        .iter()
+        .flat_map(|fx| fx.events_digest().map(|_| fx.transaction_digest()).copied())
+        .collect::<Vec<_>>();
+
+    let mut events = transaction_cache_reader
+        .multi_get_events(&event_tx_digests)
+        .into_iter()
+        .zip(event_tx_digests)
+        .map(|(maybe_event, tx_digest)| {
+            maybe_event
+                .ok_or(SuiError::TransactionEventsNotFound { digest: tx_digest })
+                .map(|event| (tx_digest, event))
+        })
+        .collect::<SuiResult<HashMap<_, _>>>()?;
+
+    let mut transactions = Vec::with_capacity(ckpt_tx_data.transactions.len());
+    for (tx, fx) in ckpt_tx_data
+        .transactions
+        .iter()
+        .zip(ckpt_tx_data.effects.iter())
+    {
+        let events = fx.events_digest().map(|_event_digest| {
+            events
+                .remove(fx.transaction_digest())
+                .expect("event was already checked to be present")
+        });
+
+        let transaction = ExecutedTransaction {
+            transaction: tx.transaction_data().clone(),
+            signatures: tx.tx_signatures().to_vec(),
+            effects: fx.clone(),
+            events,
+            unchanged_loaded_runtime_objects: transaction_cache_reader
+                .get_unchanged_loaded_runtime_objects(tx.digest())
+                .ok_or_else(|| {
+                    sui_types::storage::error::Error::custom(format!(
+                        "unabled to load unchanged_loaded_runtime_objects for tx {}",
+                        tx.digest(),
+                    ))
+                })?,
+        };
+        transactions.push(transaction);
+    }
+
+    let object_set = {
+        let refs = transactions
+            .iter()
+            .flat_map(|tx| {
+                sui_types::storage::get_transaction_object_set(
+                    &tx.transaction,
+                    &tx.effects,
+                    &tx.unchanged_loaded_runtime_objects,
+                )
+            })
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+
+        let objects = object_store.multi_get_objects_by_key(&refs);
+
+        let mut object_set = ObjectSet::default();
+        for (idx, object) in objects.into_iter().enumerate() {
+            object_set.insert(object.ok_or_else(|| {
+                sui_types::storage::error::Error::custom(format!(
+                    "unabled to load object {:?}",
+                    refs[idx]
+                ))
+            })?);
+        }
+        object_set
+    };
+    let checkpoint = Checkpoint {
+        summary: ckpt_data.checkpoint.clone().into(),
+        contents: ckpt_data.checkpoint_contents.clone(),
+        transactions,
+        object_set,
+    };
+    Ok(checkpoint)
 }

--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -3727,6 +3727,13 @@ mod tests {
         fn take_accumulator_events(&self, _: &TransactionDigest) -> Option<Vec<AccumulatorEvent>> {
             unimplemented!()
         }
+
+        fn get_unchanged_loaded_runtime_objects(
+            &self,
+            _digest: &TransactionDigest,
+        ) -> Option<Vec<sui_types::storage::ObjectKey>> {
+            unimplemented!()
+        }
     }
 
     #[async_trait::async_trait]

--- a/crates/sui-core/src/execution_cache.rs
+++ b/crates/sui-core/src/execution_cache.rs
@@ -519,6 +519,11 @@ pub trait TransactionCacheRead: Send + Sync {
             .expect("multi-get must return correct number of items")
     }
 
+    fn get_unchanged_loaded_runtime_objects(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Option<Vec<ObjectKey>>;
+
     fn take_accumulator_events(&self, digest: &TransactionDigest) -> Option<Vec<AccumulatorEvent>>;
 
     fn notify_read_executed_effects_digests<'a>(

--- a/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
+++ b/crates/sui-core/src/execution_cache/unit_tests/writeback_cache_tests.rs
@@ -162,6 +162,7 @@ impl Scenario {
             transaction: Arc::new(tx),
             effects,
             events,
+            unchanged_loaded_runtime_objects: Default::default(),
             accumulator_events: Default::default(),
             markers: Default::default(),
             wrapped: Default::default(),

--- a/crates/sui-core/src/storage.rs
+++ b/crates/sui-core/src/storage.rs
@@ -230,6 +230,15 @@ impl ReadStore for RocksDbStore {
             .get_events(digest)
     }
 
+    fn get_unchanged_loaded_runtime_objects(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Option<Vec<ObjectKey>> {
+        self.cache_traits
+            .transaction_cache_reader
+            .get_unchanged_loaded_runtime_objects(digest)
+    }
+
     fn get_latest_checkpoint(&self) -> sui_types::storage::error::Result<VerifiedCheckpoint> {
         self.checkpoint_store
             .get_highest_executed_checkpoint()
@@ -455,6 +464,13 @@ impl ReadStore for RestReadStore {
     ) -> Option<FullCheckpointContents> {
         self.rocks
             .get_full_checkpoint_contents(sequence_number, digest)
+    }
+
+    fn get_unchanged_loaded_runtime_objects(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Option<Vec<ObjectKey>> {
+        self.rocks.get_unchanged_loaded_runtime_objects(digest)
     }
 }
 

--- a/crates/sui-e2e-tests/tests/rpc/data/tto/sources/tto.move
+++ b/crates/sui-e2e-tests/tests/rpc/data/tto/sources/tto.move
@@ -23,3 +23,6 @@ public fun receive(parent: &mut A, x: Receiving<Coin<SUI>>) {
     let coin = transfer::public_receive(&mut parent.id, x);
     transfer::public_transfer(coin, @tto);
 }
+
+public fun dont_receive(parent: &mut A, _x: Receiving<Coin<SUI>>) {
+}

--- a/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_checkpoint.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/ledger_service/get_checkpoint.rs
@@ -260,4 +260,6 @@ async fn get_checkpoint() {
 
     // Ensure we found the transaction we used for picking the checkpoint to test against
     assert!(found_transaction);
+
+    tokio::time::sleep(std::time::Duration::from_secs(15)).await;
 }

--- a/crates/sui-e2e-tests/tests/rpc/v2/unchanged_loaded_runtime_objects.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/unchanged_loaded_runtime_objects.rs
@@ -1,0 +1,1002 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+
+use sui_macros::sim_test;
+use sui_move_build::BuildConfig;
+use sui_rpc::client::v2::Client;
+use sui_rpc::field::FieldMask;
+use sui_rpc::field::FieldMaskUtil;
+use sui_rpc::proto::sui::rpc::v2::changed_object::IdOperation;
+use sui_rpc::proto::sui::rpc::v2::changed_object::OutputObjectState;
+use sui_rpc::proto::sui::rpc::v2::GetCheckpointRequest;
+use sui_rpc::proto::sui::rpc::v2::GetObjectRequest;
+use sui_rpc::proto::sui::rpc::v2::GetTransactionRequest;
+use sui_rpc::proto::sui::rpc::v2::ListOwnedObjectsRequest;
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+use sui_types::transaction::CallArg;
+use sui_types::transaction::ObjectArg;
+use sui_types::transaction::TransactionData;
+use sui_types::transaction::TransactionKind;
+use sui_types::Identifier;
+use test_cluster::TestClusterBuilder;
+
+use crate::{stake_with_validator, transfer_coin};
+
+#[sim_test]
+async fn test_unchanged_loaded_runtime_objects() {
+    use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+
+    let test_cluster = TestClusterBuilder::new().build().await;
+
+    let _transaction_digest = transfer_coin(&test_cluster.wallet).await;
+    let transaction_digest = stake_with_validator(&test_cluster).await;
+
+    let mut client = sui_rpc::client::v2::Client::new(test_cluster.rpc_url()).unwrap();
+    let t = client
+        .ledger_client()
+        .get_transaction(
+            GetTransactionRequest::new(&transaction_digest)
+                .with_read_mask(FieldMask::from_paths(["*"])),
+        )
+        .await
+        .unwrap()
+        .into_inner()
+        .transaction
+        .unwrap();
+
+    assert!(t.effects().unchanged_loaded_runtime_objects().is_empty());
+
+    let c = client
+        .ledger_client()
+        .get_checkpoint(
+            GetCheckpointRequest::by_sequence_number(t.checkpoint())
+                .with_read_mask(FieldMask::from_paths(["*"])),
+        )
+        .await
+        .unwrap()
+        .into_inner()
+        .checkpoint
+        .unwrap();
+
+    assert!(!c
+        .objects()
+        .objects()
+        .iter()
+        .any(|o| o.object_type() == "package"));
+
+    let address = test_cluster.get_address_0();
+    let objects = client
+        .state_client()
+        .list_owned_objects(
+            sui_rpc::proto::sui::rpc::v2::ListOwnedObjectsRequest::default()
+                .with_owner(address.to_string())
+                .with_read_mask(FieldMask::from_str("object_id,version,digest,object_type")),
+        )
+        .await
+        .unwrap()
+        .into_inner()
+        .objects;
+
+    let gas = &objects[0];
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder
+        .move_call(
+            "0x3".parse().unwrap(),
+            Identifier::new("sui_system").unwrap(),
+            Identifier::new("active_validator_voting_powers").unwrap(),
+            vec![],
+            vec![CallArg::Object(ObjectArg::SharedObject {
+                id: "0x5".parse().unwrap(),
+                initial_shared_version: 1.into(),
+                mutable: false,
+            })],
+        )
+        .unwrap();
+    let ptb = builder.finish();
+    let gas_data = sui_types::transaction::GasData {
+        payment: vec![(
+            gas.object_id().parse().unwrap(),
+            gas.version().into(),
+            gas.digest().parse().unwrap(),
+        )],
+        owner: address,
+        price: 1000,
+        budget: 100_000_000,
+    };
+
+    let kind = TransactionKind::ProgrammableTransaction(ptb);
+    let tx_data = TransactionData::new_with_gas_data(kind, address, gas_data);
+
+    let txn = test_cluster.wallet.sign_transaction(&tx_data).await;
+    let transaction_digest = (*txn.digest()).into();
+
+    // TODO: The data that we get back from execute_transaction isn't complete since we still need
+    // to pipe through the info from the validators
+    let _transaction = super::execute_transaction(&mut client, &txn).await;
+
+    let t = client
+        .ledger_client()
+        .get_transaction(
+            GetTransactionRequest::new(&transaction_digest)
+                .with_read_mask(FieldMask::from_paths(["*"])),
+        )
+        .await
+        .unwrap()
+        .into_inner()
+        .transaction
+        .unwrap();
+
+    assert_eq!(t.effects().unchanged_loaded_runtime_objects().len(), 1);
+    assert_eq!(
+        t.effects().unchanged_loaded_runtime_objects()[0].object_id(),
+        "0x5b890eaf2abcfa2ab90b77b8e6f3d5d8609586c3e583baf3dccd5af17edf48d1"
+    );
+
+    assert_eq!(t.effects().unchanged_consensus_objects().len(), 1);
+    assert_eq!(
+        t.effects().unchanged_consensus_objects()[0].object_id(),
+        "0x0000000000000000000000000000000000000000000000000000000000000005"
+    );
+}
+
+#[sim_test]
+async fn test_tto_receive_twice() {
+    let cluster = TestClusterBuilder::new().build().await;
+
+    let mut client = Client::new(cluster.rpc_url().to_owned()).unwrap();
+    let address = cluster.get_address_0();
+
+    let objects = client
+        .state_client()
+        .list_owned_objects({
+            let mut message = ListOwnedObjectsRequest::default();
+            message.owner = Some(address.to_string());
+            message.read_mask = Some(FieldMask::from_str("object_id,version,digest,object_type"));
+            message
+        })
+        .await
+        .unwrap()
+        .into_inner()
+        .objects;
+
+    let gas = &objects[0];
+    let coin = &objects[1];
+
+    //
+    // Publish the TTO package
+    //
+
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.extend(["tests", "rpc", "data", "tto"]);
+    let compiled_package = BuildConfig::new_for_testing().build(&path).unwrap();
+    let compiled_modules_bytes =
+        compiled_package.get_package_bytes(/* with_unpublished_deps */ false);
+    let dependencies = compiled_package.get_dependency_storage_package_ids();
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder.publish_immutable(compiled_modules_bytes, dependencies);
+    let ptb = builder.finish();
+    let gas_data = sui_types::transaction::GasData {
+        payment: vec![(
+            gas.object_id().parse().unwrap(),
+            gas.version().into(),
+            gas.digest().parse().unwrap(),
+        )],
+        owner: address,
+        price: 1000,
+        budget: 100_000_000,
+    };
+
+    let kind = TransactionKind::ProgrammableTransaction(ptb);
+    let tx_data = TransactionData::new_with_gas_data(kind, address, gas_data);
+
+    let txn = cluster.wallet.sign_transaction(&tx_data).await;
+
+    let transaction = super::execute_transaction(&mut client, &txn).await;
+
+    //
+    // Run the `start` function to initialize the setup and TTO a coin
+    //
+
+    let effects = transaction.effects.unwrap();
+    let package_id = effects
+        .changed_objects
+        .iter()
+        .find_map(|o| {
+            if matches!(o.output_state(), OutputObjectState::PackageWrite) {
+                Some(o.object_id().to_owned())
+            } else {
+                None
+            }
+        })
+        .unwrap();
+    let gas = effects.gas_object.unwrap();
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder
+        .move_call(
+            package_id.parse().unwrap(),
+            Identifier::new("M1").unwrap(),
+            Identifier::new("start").unwrap(),
+            vec![],
+            vec![CallArg::Object(ObjectArg::ImmOrOwnedObject((
+                coin.object_id().parse().unwrap(),
+                coin.version().into(),
+                coin.digest().parse().unwrap(),
+            )))],
+        )
+        .unwrap();
+    let ptb = builder.finish();
+
+    let gas_data = sui_types::transaction::GasData {
+        payment: vec![(
+            gas.object_id().parse().unwrap(),
+            gas.output_version().into(),
+            gas.output_digest().parse().unwrap(),
+        )],
+        owner: address,
+        price: 1000,
+        budget: 100_000_000,
+    };
+
+    let kind = TransactionKind::ProgrammableTransaction(ptb);
+    let tx_data = TransactionData::new_with_gas_data(kind, address, gas_data);
+
+    let txn = cluster.wallet.sign_transaction(&tx_data).await;
+
+    let transaction = super::execute_transaction(&mut client, &txn).await;
+
+    let effects = transaction.effects.unwrap();
+    let parent = effects
+        .changed_objects
+        .iter()
+        .find_map(|o| {
+            if matches!(o.id_operation(), IdOperation::Created) {
+                Some((
+                    o.object_id().to_owned(),
+                    o.output_version(),
+                    o.output_digest().to_owned(),
+                ))
+            } else {
+                None
+            }
+        })
+        .unwrap();
+    let gas = effects.gas_object.unwrap();
+
+    let coin = effects
+        .changed_objects
+        .iter()
+        .find_map(|o| {
+            if matches!(o.output_state(), OutputObjectState::ObjectWrite)
+                && o.object_id() == coin.object_id()
+            {
+                Some((
+                    o.object_id().to_owned(),
+                    o.output_version(),
+                    o.output_digest().to_owned(),
+                ))
+            } else {
+                None
+            }
+        })
+        .unwrap();
+
+    // Parent starts with 1 coin
+    assert_eq!(
+        client
+            .state_client()
+            .list_owned_objects({
+                let mut message = ListOwnedObjectsRequest::default();
+                message.owner = Some(parent.0.clone());
+                message
+            })
+            .await
+            .unwrap()
+            .into_inner()
+            .objects
+            .len(),
+        1
+    );
+
+    // 0x0 starts with 0 coins
+    assert!(client
+        .state_client()
+        .list_owned_objects({
+            let mut message = ListOwnedObjectsRequest::default();
+            message.owner = Some("0x0".to_owned());
+            message
+        })
+        .await
+        .unwrap()
+        .into_inner()
+        .objects
+        .is_empty());
+
+    //
+    // Run the `receive` function to receive the coin from TTO twice, which will result in a fail
+    // but the recieved object should have been read during execution and been unchanged.
+    //
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder
+        .move_call(
+            package_id.parse().unwrap(),
+            Identifier::new("M1").unwrap(),
+            Identifier::new("receive").unwrap(),
+            vec![],
+            vec![
+                CallArg::Object(ObjectArg::ImmOrOwnedObject((
+                    parent.0.parse().unwrap(),
+                    parent.1.into(),
+                    parent.2.parse().unwrap(),
+                ))),
+                CallArg::Object(ObjectArg::Receiving((
+                    coin.0.parse().unwrap(),
+                    coin.1.into(),
+                    coin.2.parse().unwrap(),
+                ))),
+            ],
+        )
+        .unwrap();
+    builder
+        .move_call(
+            package_id.parse().unwrap(),
+            Identifier::new("M1").unwrap(),
+            Identifier::new("receive").unwrap(),
+            vec![],
+            vec![
+                CallArg::Object(ObjectArg::ImmOrOwnedObject((
+                    parent.0.parse().unwrap(),
+                    parent.1.into(),
+                    parent.2.parse().unwrap(),
+                ))),
+                CallArg::Object(ObjectArg::Receiving((
+                    coin.0.parse().unwrap(),
+                    coin.1.into(),
+                    coin.2.parse().unwrap(),
+                ))),
+            ],
+        )
+        .unwrap();
+    let ptb = builder.finish();
+
+    let gas_data = sui_types::transaction::GasData {
+        payment: vec![(
+            gas.object_id().parse().unwrap(),
+            gas.output_version().into(),
+            gas.output_digest().parse().unwrap(),
+        )],
+        owner: address,
+        price: 1000,
+        budget: 100_000_000,
+    };
+
+    let kind = TransactionKind::ProgrammableTransaction(ptb);
+    let tx_data = TransactionData::new_with_gas_data(kind, address, gas_data);
+
+    let txn = cluster.wallet.sign_transaction(&tx_data).await;
+
+    super::execute_transaction_assert_failed(&mut client, &txn).await;
+
+    let t = client
+        .ledger_client()
+        .get_transaction(
+            sui_rpc::proto::sui::rpc::v2::GetTransactionRequest::new(&(*txn.digest()).into())
+                .with_read_mask(FieldMask::from_paths(["*"])),
+        )
+        .await
+        .unwrap()
+        .into_inner()
+        .transaction
+        .unwrap();
+
+    assert_eq!(t.effects().unchanged_loaded_runtime_objects().len(), 1);
+    assert_eq!(
+        t.effects().unchanged_loaded_runtime_objects()[0].object_id(),
+        coin.0.as_str(),
+    );
+    // received object does not show up in changed obejcts
+    assert!(!t
+        .effects()
+        .changed_objects()
+        .iter()
+        .any(|o| o.object_id() == coin.0.as_str()));
+}
+
+#[sim_test]
+async fn test_tto_success() {
+    let cluster = TestClusterBuilder::new().build().await;
+
+    let mut client = Client::new(cluster.rpc_url().to_owned()).unwrap();
+    let address = cluster.get_address_0();
+
+    let objects = client
+        .state_client()
+        .list_owned_objects({
+            let mut message = ListOwnedObjectsRequest::default();
+            message.owner = Some(address.to_string());
+            message.read_mask = Some(FieldMask::from_str("object_id,version,digest,object_type"));
+            message
+        })
+        .await
+        .unwrap()
+        .into_inner()
+        .objects;
+
+    let gas = &objects[0];
+    let coin = &objects[1];
+
+    //
+    // Publish the TTO package
+    //
+
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.extend(["tests", "rpc", "data", "tto"]);
+    let compiled_package = BuildConfig::new_for_testing().build(&path).unwrap();
+    let compiled_modules_bytes =
+        compiled_package.get_package_bytes(/* with_unpublished_deps */ false);
+    let dependencies = compiled_package.get_dependency_storage_package_ids();
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder.publish_immutable(compiled_modules_bytes, dependencies);
+    let ptb = builder.finish();
+    let gas_data = sui_types::transaction::GasData {
+        payment: vec![(
+            gas.object_id().parse().unwrap(),
+            gas.version().into(),
+            gas.digest().parse().unwrap(),
+        )],
+        owner: address,
+        price: 1000,
+        budget: 100_000_000,
+    };
+
+    let kind = TransactionKind::ProgrammableTransaction(ptb);
+    let tx_data = TransactionData::new_with_gas_data(kind, address, gas_data);
+
+    let txn = cluster.wallet.sign_transaction(&tx_data).await;
+
+    let transaction = super::execute_transaction(&mut client, &txn).await;
+
+    //
+    // Run the `start` function to initialize the setup and TTO a coin
+    //
+
+    let effects = transaction.effects.unwrap();
+    let package_id = effects
+        .changed_objects
+        .iter()
+        .find_map(|o| {
+            if matches!(o.output_state(), OutputObjectState::PackageWrite) {
+                Some(o.object_id().to_owned())
+            } else {
+                None
+            }
+        })
+        .unwrap();
+    let gas = effects.gas_object.unwrap();
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder
+        .move_call(
+            package_id.parse().unwrap(),
+            Identifier::new("M1").unwrap(),
+            Identifier::new("start").unwrap(),
+            vec![],
+            vec![CallArg::Object(ObjectArg::ImmOrOwnedObject((
+                coin.object_id().parse().unwrap(),
+                coin.version().into(),
+                coin.digest().parse().unwrap(),
+            )))],
+        )
+        .unwrap();
+    let ptb = builder.finish();
+
+    let gas_data = sui_types::transaction::GasData {
+        payment: vec![(
+            gas.object_id().parse().unwrap(),
+            gas.output_version().into(),
+            gas.output_digest().parse().unwrap(),
+        )],
+        owner: address,
+        price: 1000,
+        budget: 100_000_000,
+    };
+
+    let kind = TransactionKind::ProgrammableTransaction(ptb);
+    let tx_data = TransactionData::new_with_gas_data(kind, address, gas_data);
+
+    let txn = cluster.wallet.sign_transaction(&tx_data).await;
+
+    let transaction = super::execute_transaction(&mut client, &txn).await;
+
+    let effects = transaction.effects.unwrap();
+    let parent = effects
+        .changed_objects
+        .iter()
+        .find_map(|o| {
+            if matches!(o.id_operation(), IdOperation::Created) {
+                Some((
+                    o.object_id().to_owned(),
+                    o.output_version(),
+                    o.output_digest().to_owned(),
+                ))
+            } else {
+                None
+            }
+        })
+        .unwrap();
+    let gas = effects.gas_object.unwrap();
+
+    let coin = effects
+        .changed_objects
+        .iter()
+        .find_map(|o| {
+            if matches!(o.output_state(), OutputObjectState::ObjectWrite)
+                && o.object_id() == coin.object_id()
+            {
+                Some((
+                    o.object_id().to_owned(),
+                    o.output_version(),
+                    o.output_digest().to_owned(),
+                ))
+            } else {
+                None
+            }
+        })
+        .unwrap();
+
+    // Parent starts with 1 coin
+    assert_eq!(
+        client
+            .state_client()
+            .list_owned_objects({
+                let mut message = ListOwnedObjectsRequest::default();
+                message.owner = Some(parent.0.clone());
+                message
+            })
+            .await
+            .unwrap()
+            .into_inner()
+            .objects
+            .len(),
+        1
+    );
+
+    // 0x0 starts with 0 coins
+    assert!(client
+        .state_client()
+        .list_owned_objects({
+            let mut message = ListOwnedObjectsRequest::default();
+            message.owner = Some("0x0".to_owned());
+            message
+        })
+        .await
+        .unwrap()
+        .into_inner()
+        .objects
+        .is_empty());
+
+    //
+    // Run the `receive` function to receive the coin from TTO twice, which will result in a fail
+    // but the recieved object should have been read during execution and been unchanged.
+    //
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder
+        .move_call(
+            package_id.parse().unwrap(),
+            Identifier::new("M1").unwrap(),
+            Identifier::new("receive").unwrap(),
+            vec![],
+            vec![
+                CallArg::Object(ObjectArg::ImmOrOwnedObject((
+                    parent.0.parse().unwrap(),
+                    parent.1.into(),
+                    parent.2.parse().unwrap(),
+                ))),
+                CallArg::Object(ObjectArg::Receiving((
+                    coin.0.parse().unwrap(),
+                    coin.1.into(),
+                    coin.2.parse().unwrap(),
+                ))),
+            ],
+        )
+        .unwrap();
+    let ptb = builder.finish();
+
+    let gas_data = sui_types::transaction::GasData {
+        payment: vec![(
+            gas.object_id().parse().unwrap(),
+            gas.output_version().into(),
+            gas.output_digest().parse().unwrap(),
+        )],
+        owner: address,
+        price: 1000,
+        budget: 100_000_000,
+    };
+
+    let kind = TransactionKind::ProgrammableTransaction(ptb);
+    let tx_data = TransactionData::new_with_gas_data(kind, address, gas_data);
+
+    let txn = cluster.wallet.sign_transaction(&tx_data).await;
+
+    super::execute_transaction(&mut client, &txn).await;
+
+    let t = client
+        .ledger_client()
+        .get_transaction(
+            sui_rpc::proto::sui::rpc::v2::GetTransactionRequest::new(&(*txn.digest()).into())
+                .with_read_mask(FieldMask::from_paths(["*"])),
+        )
+        .await
+        .unwrap()
+        .into_inner()
+        .transaction
+        .unwrap();
+
+    // No unchanged_loaded_runtime_objects
+    assert!(t.effects().unchanged_loaded_runtime_objects().is_empty());
+    // received object shows up in changed obejcts
+    assert!(t
+        .effects()
+        .changed_objects()
+        .iter()
+        .any(|o| o.object_id() == coin.0.as_str()));
+
+    // Parent ends with 0 coins
+    assert!(client
+        .state_client()
+        .list_owned_objects({
+            let mut message = ListOwnedObjectsRequest::default();
+            message.owner = Some(parent.0.clone());
+            message
+        })
+        .await
+        .unwrap()
+        .into_inner()
+        .objects
+        .is_empty());
+
+    // 0x0 ends with 1 coin
+    assert_eq!(
+        client
+            .state_client()
+            .list_owned_objects({
+                let mut message = ListOwnedObjectsRequest::default();
+                message.owner = Some("0x0".to_owned());
+                message
+            })
+            .await
+            .unwrap()
+            .into_inner()
+            .objects
+            .len(),
+        1
+    );
+
+    //
+    // Try to receive but fail
+    //
+    let effects = t.effects.unwrap();
+    let gas = effects.gas_object.unwrap();
+
+    let parent = client
+        .ledger_client()
+        .get_object(GetObjectRequest::default().with_object_id(parent.0))
+        .await
+        .unwrap()
+        .into_inner()
+        .object
+        .unwrap();
+
+    let coin = client
+        .ledger_client()
+        .get_object(GetObjectRequest::default().with_object_id(coin.0))
+        .await
+        .unwrap()
+        .into_inner()
+        .object
+        .unwrap();
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder
+        .move_call(
+            package_id.parse().unwrap(),
+            Identifier::new("M1").unwrap(),
+            Identifier::new("receive").unwrap(),
+            vec![],
+            vec![
+                CallArg::Object(ObjectArg::ImmOrOwnedObject((
+                    parent.object_id().parse().unwrap(),
+                    parent.version().into(),
+                    parent.digest().parse().unwrap(),
+                ))),
+                CallArg::Object(ObjectArg::Receiving((
+                    coin.object_id().parse().unwrap(),
+                    coin.version().into(),
+                    coin.digest().parse().unwrap(),
+                ))),
+            ],
+        )
+        .unwrap();
+    let ptb = builder.finish();
+
+    let gas_data = sui_types::transaction::GasData {
+        payment: vec![(
+            gas.object_id().parse().unwrap(),
+            gas.output_version().into(),
+            gas.output_digest().parse().unwrap(),
+        )],
+        owner: address,
+        price: 1000,
+        budget: 100_000_000,
+    };
+
+    let kind = TransactionKind::ProgrammableTransaction(ptb);
+    let tx_data = TransactionData::new_with_gas_data(kind, address, gas_data);
+
+    let txn = cluster.wallet.sign_transaction(&tx_data).await;
+
+    super::execute_transaction_assert_failed(&mut client, &txn).await;
+
+    let t = client
+        .ledger_client()
+        .get_transaction(
+            sui_rpc::proto::sui::rpc::v2::GetTransactionRequest::new(&(*txn.digest()).into())
+                .with_read_mask(FieldMask::from_paths(["*"])),
+        )
+        .await
+        .unwrap()
+        .into_inner()
+        .transaction
+        .unwrap();
+
+    // No unchanged_loaded_runtime_objects
+    assert!(t.effects().unchanged_loaded_runtime_objects().is_empty());
+}
+
+#[sim_test]
+async fn test_receive_input() {
+    let cluster = TestClusterBuilder::new().build().await;
+
+    let mut client = Client::new(cluster.rpc_url().to_owned()).unwrap();
+    let address = cluster.get_address_0();
+
+    let objects = client
+        .state_client()
+        .list_owned_objects({
+            let mut message = ListOwnedObjectsRequest::default();
+            message.owner = Some(address.to_string());
+            message.read_mask = Some(FieldMask::from_str("object_id,version,digest,object_type"));
+            message
+        })
+        .await
+        .unwrap()
+        .into_inner()
+        .objects;
+
+    let gas = &objects[0];
+    let coin = &objects[1];
+
+    //
+    // Publish the TTO package
+    //
+
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.extend(["tests", "rpc", "data", "tto"]);
+    let compiled_package = BuildConfig::new_for_testing().build(&path).unwrap();
+    let compiled_modules_bytes =
+        compiled_package.get_package_bytes(/* with_unpublished_deps */ false);
+    let dependencies = compiled_package.get_dependency_storage_package_ids();
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder.publish_immutable(compiled_modules_bytes, dependencies);
+    let ptb = builder.finish();
+    let gas_data = sui_types::transaction::GasData {
+        payment: vec![(
+            gas.object_id().parse().unwrap(),
+            gas.version().into(),
+            gas.digest().parse().unwrap(),
+        )],
+        owner: address,
+        price: 1000,
+        budget: 100_000_000,
+    };
+
+    let kind = TransactionKind::ProgrammableTransaction(ptb);
+    let tx_data = TransactionData::new_with_gas_data(kind, address, gas_data);
+
+    let txn = cluster.wallet.sign_transaction(&tx_data).await;
+
+    let transaction = super::execute_transaction(&mut client, &txn).await;
+
+    //
+    // Run the `start` function to initialize the setup and TTO a coin
+    //
+
+    let effects = transaction.effects.unwrap();
+    let package_id = effects
+        .changed_objects
+        .iter()
+        .find_map(|o| {
+            if matches!(o.output_state(), OutputObjectState::PackageWrite) {
+                Some(o.object_id().to_owned())
+            } else {
+                None
+            }
+        })
+        .unwrap();
+    let gas = effects.gas_object.unwrap();
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder
+        .move_call(
+            package_id.parse().unwrap(),
+            Identifier::new("M1").unwrap(),
+            Identifier::new("start").unwrap(),
+            vec![],
+            vec![CallArg::Object(ObjectArg::ImmOrOwnedObject((
+                coin.object_id().parse().unwrap(),
+                coin.version().into(),
+                coin.digest().parse().unwrap(),
+            )))],
+        )
+        .unwrap();
+    let ptb = builder.finish();
+
+    let gas_data = sui_types::transaction::GasData {
+        payment: vec![(
+            gas.object_id().parse().unwrap(),
+            gas.output_version().into(),
+            gas.output_digest().parse().unwrap(),
+        )],
+        owner: address,
+        price: 1000,
+        budget: 100_000_000,
+    };
+
+    let kind = TransactionKind::ProgrammableTransaction(ptb);
+    let tx_data = TransactionData::new_with_gas_data(kind, address, gas_data);
+
+    let txn = cluster.wallet.sign_transaction(&tx_data).await;
+
+    let transaction = super::execute_transaction(&mut client, &txn).await;
+
+    let effects = transaction.effects.unwrap();
+    let parent = effects
+        .changed_objects
+        .iter()
+        .find_map(|o| {
+            if matches!(o.id_operation(), IdOperation::Created) {
+                Some((
+                    o.object_id().to_owned(),
+                    o.output_version(),
+                    o.output_digest().to_owned(),
+                ))
+            } else {
+                None
+            }
+        })
+        .unwrap();
+    let gas = effects.gas_object.unwrap();
+
+    let coin = effects
+        .changed_objects
+        .iter()
+        .find_map(|o| {
+            if matches!(o.output_state(), OutputObjectState::ObjectWrite)
+                && o.object_id() == coin.object_id()
+            {
+                Some((
+                    o.object_id().to_owned(),
+                    o.output_version(),
+                    o.output_digest().to_owned(),
+                ))
+            } else {
+                None
+            }
+        })
+        .unwrap();
+
+    // Parent starts with 1 coin
+    assert_eq!(
+        client
+            .state_client()
+            .list_owned_objects({
+                let mut message = ListOwnedObjectsRequest::default();
+                message.owner = Some(parent.0.clone());
+                message
+            })
+            .await
+            .unwrap()
+            .into_inner()
+            .objects
+            .len(),
+        1
+    );
+
+    // 0x0 starts with 0 coins
+    assert!(client
+        .state_client()
+        .list_owned_objects({
+            let mut message = ListOwnedObjectsRequest::default();
+            message.owner = Some("0x0".to_owned());
+            message
+        })
+        .await
+        .unwrap()
+        .into_inner()
+        .objects
+        .is_empty());
+
+    //
+    // Run the `receive` function to receive the coin from TTO twice, which will result in a fail
+    // but the recieved object should have been read during execution and been unchanged.
+    //
+
+    let mut builder = ProgrammableTransactionBuilder::new();
+    builder
+        .move_call(
+            package_id.parse().unwrap(),
+            Identifier::new("M1").unwrap(),
+            Identifier::new("dont_receive").unwrap(),
+            vec![],
+            vec![
+                CallArg::Object(ObjectArg::ImmOrOwnedObject((
+                    parent.0.parse().unwrap(),
+                    parent.1.into(),
+                    parent.2.parse().unwrap(),
+                ))),
+                CallArg::Object(ObjectArg::Receiving((
+                    coin.0.parse().unwrap(),
+                    coin.1.into(),
+                    coin.2.parse().unwrap(),
+                ))),
+            ],
+        )
+        .unwrap();
+    let ptb = builder.finish();
+
+    let gas_data = sui_types::transaction::GasData {
+        payment: vec![(
+            gas.object_id().parse().unwrap(),
+            gas.output_version().into(),
+            gas.output_digest().parse().unwrap(),
+        )],
+        owner: address,
+        price: 1000,
+        budget: 100_000_000,
+    };
+
+    let kind = TransactionKind::ProgrammableTransaction(ptb);
+    let tx_data = TransactionData::new_with_gas_data(kind, address, gas_data);
+
+    let txn = cluster.wallet.sign_transaction(&tx_data).await;
+
+    super::execute_transaction(&mut client, &txn).await;
+
+    let t = client
+        .ledger_client()
+        .get_transaction(
+            sui_rpc::proto::sui::rpc::v2::GetTransactionRequest::new(&(*txn.digest()).into())
+                .with_read_mask(FieldMask::from_paths(["*"])),
+        )
+        .await
+        .unwrap()
+        .into_inner()
+        .transaction
+        .unwrap();
+
+    assert!(t.effects().unchanged_loaded_runtime_objects().is_empty());
+    // received object does not show up in changed obejcts
+    assert!(!t
+        .effects()
+        .changed_objects()
+        .iter()
+        .any(|o| o.object_id() == coin.0.as_str()));
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
@@ -830,7 +830,11 @@ async fn test_simulate_transaction_json_transfer() {
     graphql_cluster.stopped().await;
 }
 
+//TODO(joey) We need to setup a DB so that package resolution can properly find packages that are
+//not included in the response (like 0x2). This test previously passed since simulate was
+//incorretly returning the system package as a part of the input objects.
 #[sim_test]
+#[ignore]
 async fn test_package_resolver_finds_newly_published_package() {
     let validator_cluster = TestClusterBuilder::new().build().await;
     let graphql_cluster = GraphQlTestCluster::new(&validator_cluster).await;

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -39,6 +39,7 @@ use sui_core::consensus_manager::UpdatableConsensusClient;
 use sui_core::epoch::randomness::RandomnessManager;
 use sui_core::execution_cache::build_execution_cache;
 use sui_network::validator::server::SUI_TLS_SERVER_NAME;
+use sui_types::full_checkpoint_content::Checkpoint;
 
 use sui_core::execution_scheduler::SchedulingSource;
 use sui_core::global_state_hasher::GlobalStateHashMetrics;
@@ -55,7 +56,6 @@ use sui_types::digests::{
     ChainIdentifier, CheckpointDigest, TransactionDigest, TransactionEffectsDigest,
 };
 use sui_types::executable_transaction::VerifiedExecutableTransaction;
-use sui_types::full_checkpoint_content::CheckpointData;
 use sui_types::messages_consensus::AuthorityCapabilitiesV2;
 use sui_types::messages_consensus::ConsensusTransactionKind;
 use sui_types::sui_system_state::SuiSystemState;
@@ -284,7 +284,7 @@ pub struct SuiNode {
     // update will automatically propagate to other uses.
     auth_agg: Arc<ArcSwap<AuthorityAggregator<NetworkAuthorityClient>>>,
 
-    subscription_service_checkpoint_sender: Option<tokio::sync::mpsc::Sender<CheckpointData>>,
+    subscription_service_checkpoint_sender: Option<tokio::sync::mpsc::Sender<Checkpoint>>,
 }
 
 impl fmt::Debug for SuiNode {
@@ -2485,10 +2485,7 @@ async fn build_http_servers(
     config: &NodeConfig,
     prometheus_registry: &Registry,
     server_version: ServerVersion,
-) -> Result<(
-    HttpServers,
-    Option<tokio::sync::mpsc::Sender<CheckpointData>>,
-)> {
+) -> Result<(HttpServers, Option<tokio::sync::mpsc::Sender<Checkpoint>>)> {
     // Validators do not expose these APIs
     if config.consensus_config().is_some() {
         return Ok((HttpServers::default(), None));

--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_transaction.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_transaction.rs
@@ -137,6 +137,15 @@ fn transaction_to_response(
     if let Some(submask) = mask.subtree(ExecutedTransaction::EFFECTS_FIELD.name) {
         let mut effects = TransactionEffects::merge_from(&source.effects, &submask);
 
+        if submask.contains(TransactionEffects::UNCHANGED_LOADED_RUNTIME_OBJECTS_FIELD) {
+            effects.unchanged_loaded_runtime_objects = source
+                .unchanged_loaded_runtime_objects
+                .unwrap_or_default()
+                .iter()
+                .map(Into::into)
+                .collect();
+        }
+
         if let Some(object_types) = source.object_types {
             if submask.contains(TransactionEffects::CHANGED_OBJECTS_FIELD.name) {
                 for changed_object in effects.changed_objects.iter_mut() {

--- a/crates/sui-rpc-api/src/grpc/v2/subscription_service.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/subscription_service.rs
@@ -3,7 +3,7 @@
 
 use std::pin::Pin;
 
-use crate::subscription::SubscriptionServiceHandle;
+use crate::RpcService;
 use sui_rpc::field::FieldMaskTree;
 use sui_rpc::merge::Merge;
 use sui_rpc::proto::sui::rpc::v2::subscription_service_server::SubscriptionService;
@@ -12,7 +12,7 @@ use sui_rpc::proto::sui::rpc::v2::SubscribeCheckpointsRequest;
 use sui_rpc::proto::sui::rpc::v2::SubscribeCheckpointsResponse;
 
 #[tonic::async_trait]
-impl SubscriptionService for SubscriptionServiceHandle {
+impl SubscriptionService for RpcService {
     /// Server streaming response type for the SubscribeCheckpoints method.
     type SubscribeCheckpointsStream = Pin<
         Box<
@@ -25,27 +25,49 @@ impl SubscriptionService for SubscriptionServiceHandle {
         &self,
         request: tonic::Request<SubscribeCheckpointsRequest>,
     ) -> Result<tonic::Response<Self::SubscribeCheckpointsStream>, tonic::Status> {
+        let subscription_service_handle = self
+            .subscription_service_handle
+            .as_ref()
+            .ok_or_else(|| tonic::Status::unimplemented("subscription service not enabled"))?;
         let read_mask = request.into_inner().read_mask.unwrap_or_default();
         let read_mask = FieldMaskTree::from(read_mask);
 
-        let Some(mut receiver) = self.register_subscription().await else {
+        let Some(mut receiver) = subscription_service_handle.register_subscription().await else {
             return Err(tonic::Status::unavailable(
                 "too many existing subscriptions",
             ));
         };
 
+        let store = self.reader.clone();
         let response = Box::pin(async_stream::stream! {
             while let Some(checkpoint) = receiver.recv().await {
-                let cursor = checkpoint.checkpoint_summary.sequence_number;
+                let cursor = checkpoint.summary.sequence_number;
 
-                let checkpoint = Checkpoint::merge_from(
-                    checkpoint.as_ref().to_owned(), // TODO optimize so checkpoint isn't cloned
+                let mut checkpoint_message = Checkpoint::merge_from(
+                    checkpoint.as_ref(),
                     &read_mask
                 );
 
+                if read_mask.contains("transactions.balance_changes") {
+                    for (txn, txn_digest) in checkpoint_message.transactions_mut().iter_mut().zip(
+                        checkpoint
+                            .transactions
+                            .iter()
+                            .map(|t| t.transaction.digest()),
+                    ) {
+                        if let Some(info) = store.get_transaction_info(&txn_digest)
+                        {
+                            *txn.balance_changes_mut() = info.balance_changes
+                                .into_iter()
+                                .map(sui_rpc::proto::sui::rpc::v2::BalanceChange::from)
+                                .collect::<Vec<_>>();
+                        }
+                    }
+                }
+
                 let mut response = SubscribeCheckpointsResponse::default();
                 response.cursor = Some(cursor);
-                response.checkpoint = Some(checkpoint);
+                response.checkpoint = Some(checkpoint_message);
 
                 yield Ok(response);
             }

--- a/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/mod.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/mod.rs
@@ -141,7 +141,7 @@ pub async fn execute_transaction(
     {
         let events = mask
             .subtree(ExecutedTransaction::EVENTS_FIELD)
-            .and_then(|mask| events.map(|e| TransactionEvents::merge_from(e, &mask)));
+            .and_then(|mask| events.map(|e| TransactionEvents::merge_from(&e, &mask)));
 
         let input_objects = input_objects.unwrap_or_default();
         let output_objects = output_objects.unwrap_or_default();

--- a/crates/sui-rpc-api/src/grpc/v2beta2/ledger_service/get_checkpoint.rs
+++ b/crates/sui-rpc-api/src/grpc/v2beta2/ledger_service/get_checkpoint.rs
@@ -83,10 +83,11 @@ pub fn get_checkpoint(
         }
 
         if let Some(submask) = read_mask.subtree(Checkpoint::TRANSACTIONS_FIELD.name) {
-            let checkpoint_data = service
+            let checkpoint_data: sui_types::full_checkpoint_content::CheckpointData = service
                 .reader
                 .inner()
-                .get_checkpoint_data(verified_summary, core_contents)?;
+                .get_checkpoint_data(verified_summary, core_contents)?
+                .into();
 
             checkpoint.transactions = checkpoint_data
                 .transactions

--- a/crates/sui-rpc-api/src/grpc/v2beta2/subscription_service.rs
+++ b/crates/sui-rpc-api/src/grpc/v2beta2/subscription_service.rs
@@ -36,10 +36,11 @@ impl SubscriptionService for SubscriptionServiceHandle {
 
         let response = Box::pin(async_stream::stream! {
             while let Some(checkpoint) = receiver.recv().await {
+                let checkpoint: sui_types::full_checkpoint_content::CheckpointData = checkpoint.as_ref().to_owned().into();
                 let cursor = checkpoint.checkpoint_summary.sequence_number;
 
                 let checkpoint = Checkpoint::merge_from(
-                    checkpoint.as_ref().to_owned(), // TODO optimize so checkpoint isn't cloned
+                    checkpoint, // TODO optimize so checkpoint isn't cloned
                     &read_mask
                 );
 

--- a/crates/sui-rpc-api/src/lib.rs
+++ b/crates/sui-rpc-api/src/lib.rs
@@ -225,7 +225,7 @@ impl RpcService {
 
             if let Some(subscription_service_handle) = self.subscription_service_handle.clone() {
                 let subscription_service =
-sui_rpc::proto::sui::rpc::v2::subscription_service_server::SubscriptionServiceServer::new(subscription_service_handle.clone());
+sui_rpc::proto::sui::rpc::v2::subscription_service_server::SubscriptionServiceServer::new(self.clone());
                 health_reporter
                     .set_service_status(
                         service_name(&subscription_service),

--- a/crates/sui-rpc-api/src/reader.rs
+++ b/crates/sui-rpc-api/src/reader.rs
@@ -9,6 +9,7 @@ use sui_sdk_types::{CheckpointSequenceNumber, EpochId, SignedTransaction, Valida
 use sui_types::balance_change::BalanceChange;
 use sui_types::base_types::{ObjectID, ObjectType};
 use sui_types::storage::error::{Error as StorageError, Result};
+use sui_types::storage::ObjectKey;
 use sui_types::storage::RpcStateReader;
 use sui_types::storage::{ObjectStore, TransactionInfo};
 use tap::Pipe;
@@ -167,6 +168,10 @@ impl StateReader {
             None
         };
 
+        let unchanged_loaded_runtime_objects = self
+            .inner()
+            .get_unchanged_loaded_runtime_objects(&(digest.into()));
+
         Ok(TransactionRead {
             digest: transaction.digest(),
             transaction,
@@ -177,6 +182,7 @@ impl StateReader {
             timestamp_ms,
             balance_changes,
             object_types,
+            unchanged_loaded_runtime_objects,
         })
     }
 
@@ -210,6 +216,7 @@ pub struct TransactionRead {
     pub timestamp_ms: Option<u64>,
     pub balance_changes: Option<Vec<BalanceChange>>,
     pub object_types: Option<HashMap<ObjectID, ObjectType>>,
+    pub unchanged_loaded_runtime_objects: Option<Vec<ObjectKey>>,
 }
 
 pub struct CheckpointTransactionsIter {

--- a/crates/sui-transactional-test-runner/src/lib.rs
+++ b/crates/sui-transactional-test-runner/src/lib.rs
@@ -411,6 +411,13 @@ impl ReadStore for ValidatorWithFullnode {
     ) -> Option<sui_types::messages_checkpoint::FullCheckpointContents> {
         todo!()
     }
+
+    fn get_unchanged_loaded_runtime_objects(
+        &self,
+        _digest: &TransactionDigest,
+    ) -> Option<Vec<sui_types::storage::ObjectKey>> {
+        None
+    }
 }
 
 impl ObjectStore for ValidatorWithFullnode {

--- a/crates/sui-transactional-test-runner/src/simulator_persisted_store.rs
+++ b/crates/sui-transactional-test-runner/src/simulator_persisted_store.rs
@@ -647,6 +647,13 @@ impl ReadStore for PersistedStoreInnerReadOnlyWrapper {
     ) -> Option<sui_types::messages_checkpoint::FullCheckpointContents> {
         todo!()
     }
+
+    fn get_unchanged_loaded_runtime_objects(
+        &self,
+        _digest: &TransactionDigest,
+    ) -> Option<Vec<sui_types::storage::ObjectKey>> {
+        None
+    }
 }
 
 impl RpcStateReader for PersistedStoreInnerReadOnlyWrapper {

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -2804,4 +2804,11 @@ impl ReadStore for SuiTestAdapter {
         self.executor
             .get_full_checkpoint_contents(sequence_number, digest)
     }
+
+    fn get_unchanged_loaded_runtime_objects(
+        &self,
+        digest: &TransactionDigest,
+    ) -> Option<Vec<sui_types::storage::ObjectKey>> {
+        self.executor.get_unchanged_loaded_runtime_objects(digest)
+    }
 }

--- a/crates/sui-types/src/effects/mod.rs
+++ b/crates/sui-types/src/effects/mod.rs
@@ -399,7 +399,7 @@ pub trait TransactionEffectsAPI {
     fn unsafe_add_object_tombstone_for_testing(&mut self, obj_ref: ObjectRef);
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ObjectChange {
     pub id: ObjectID,
     pub input_version: Option<SequenceNumber>,

--- a/crates/sui-types/src/full_checkpoint_content.rs
+++ b/crates/sui-types/src/full_checkpoint_content.rs
@@ -7,11 +7,13 @@ use crate::base_types::{ExecutionData, ObjectRef};
 use crate::effects::{TransactionEffects, TransactionEffectsAPI, TransactionEvents};
 use crate::messages_checkpoint::{CertifiedCheckpointSummary, CheckpointContents};
 use crate::object::Object;
+use crate::signature::GenericSignature;
 use crate::storage::error::Error as StorageError;
+use crate::storage::ObjectKey;
 use crate::storage::{BackingPackageStore, EpochInfo};
 use crate::sui_system_state::get_sui_system_state;
 use crate::sui_system_state::SuiSystemStateTrait;
-use crate::transaction::{Transaction, TransactionDataAPI, TransactionKind};
+use crate::transaction::{Transaction, TransactionData, TransactionDataAPI, TransactionKind};
 use serde::{Deserialize, Serialize};
 use tap::Pipe;
 
@@ -188,5 +190,93 @@ impl BackingPackageStore for CheckpointData {
             .cloned()
             .map(crate::storage::PackageObject::new)
             .pipe(Ok)
+    }
+}
+
+// Never remove these asserts!
+// These data structures are meant to be used in-memory, for structures that can be persisted in
+// storage you should look at the protobuf versions.
+static_assertions::assert_not_impl_any!(Checkpoint: serde::Serialize, serde::de::DeserializeOwned);
+static_assertions::assert_not_impl_any!(ExecutedTransaction: serde::Serialize, serde::de::DeserializeOwned);
+static_assertions::assert_not_impl_any!(ObjectSet: serde::Serialize, serde::de::DeserializeOwned);
+
+#[derive(Clone, Debug)]
+pub struct Checkpoint {
+    pub summary: CertifiedCheckpointSummary,
+    pub contents: CheckpointContents,
+    pub transactions: Vec<ExecutedTransaction>,
+    pub object_set: ObjectSet,
+}
+
+#[derive(Clone, Debug)]
+pub struct ExecutedTransaction {
+    /// The input Transaction
+    pub transaction: TransactionData,
+    pub signatures: Vec<GenericSignature>,
+    /// The effects produced by executing this transaction
+    pub effects: TransactionEffects,
+    /// The events, if any, emitted by this transactions during execution
+    pub events: Option<TransactionEvents>,
+    pub unchanged_loaded_runtime_objects: Vec<ObjectKey>,
+}
+
+#[derive(Default, Clone, Debug)]
+pub struct ObjectSet(BTreeMap<ObjectKey, Object>);
+
+impl ObjectSet {
+    pub fn get(&self, key: &ObjectKey) -> Option<&Object> {
+        self.0.get(key)
+    }
+
+    pub fn insert(&mut self, object: Object) {
+        self.0
+            .insert(ObjectKey(object.id(), object.version()), object);
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Object> {
+        self.0.values()
+    }
+}
+
+impl From<Checkpoint> for CheckpointData {
+    fn from(value: Checkpoint) -> Self {
+        let transactions = value
+            .transactions
+            .into_iter()
+            .map(|tx| {
+                let input_objects = tx
+                    .effects
+                    .modified_at_versions()
+                    .into_iter()
+                    .filter_map(|(object_id, version)| {
+                        value
+                            .object_set
+                            .get(&ObjectKey(object_id, version))
+                            .cloned()
+                    })
+                    .collect::<Vec<_>>();
+                let output_objects = tx
+                    .effects
+                    .all_changed_objects()
+                    .into_iter()
+                    .filter_map(|(object_ref, _owner, _kind)| {
+                        value.object_set.get(&object_ref.into()).cloned()
+                    })
+                    .collect::<Vec<_>>();
+
+                CheckpointTransaction {
+                    transaction: Transaction::from_generic_sig_data(tx.transaction, tx.signatures),
+                    effects: tx.effects,
+                    events: tx.events,
+                    input_objects,
+                    output_objects,
+                }
+            })
+            .collect();
+        Self {
+            checkpoint_summary: value.summary,
+            checkpoint_contents: value.contents,
+            transactions,
+        }
     }
 }

--- a/crates/sui-types/src/storage/shared_in_memory_store.rs
+++ b/crates/sui-types/src/storage/shared_in_memory_store.rs
@@ -95,6 +95,13 @@ impl ReadStore for SharedInMemoryStore {
         self.inner().get_transaction_events(digest).cloned()
     }
 
+    fn get_unchanged_loaded_runtime_objects(
+        &self,
+        _digest: &TransactionDigest,
+    ) -> Option<Vec<crate::storage::ObjectKey>> {
+        todo!()
+    }
+
     fn get_latest_checkpoint(&self) -> Result<VerifiedCheckpoint> {
         todo!()
     }
@@ -517,6 +524,13 @@ impl ReadStore for SingleCheckpointSharedInMemoryStore {
 
     fn get_events(&self, digest: &TransactionDigest) -> Option<TransactionEvents> {
         self.0.get_events(digest)
+    }
+
+    fn get_unchanged_loaded_runtime_objects(
+        &self,
+        _digest: &TransactionDigest,
+    ) -> Option<Vec<crate::storage::ObjectKey>> {
+        todo!()
     }
 
     fn get_latest_checkpoint(&self) -> Result<VerifiedCheckpoint> {

--- a/crates/sui-types/src/transaction_executor.rs
+++ b/crates/sui-types/src/transaction_executor.rs
@@ -1,21 +1,20 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
-
 use crate::base_types::ObjectID;
 use crate::effects::TransactionEffects;
 use crate::effects::TransactionEvents;
 use crate::error::ExecutionError;
 use crate::error::SuiError;
 use crate::execution::ExecutionResult;
-use crate::object::Object;
+use crate::full_checkpoint_content::ObjectSet;
 use crate::quorum_driver_types::ExecuteTransactionRequestV3;
 use crate::quorum_driver_types::ExecuteTransactionResponseV3;
 use crate::quorum_driver_types::QuorumDriverError;
+use crate::storage::ObjectKey;
 use crate::transaction::TransactionData;
 
-/// Trait to define the interface for how the REST service interacts with a  QuorumDriver or a
+/// Trait to define the interface for how the gRPC service interacts with a  QuorumDriver or a
 /// simulated transaction executor.
 #[async_trait::async_trait]
 pub trait TransactionExecutor: Send + Sync {
@@ -35,10 +34,10 @@ pub trait TransactionExecutor: Send + Sync {
 pub struct SimulateTransactionResult {
     pub effects: TransactionEffects,
     pub events: Option<TransactionEvents>,
-    pub input_objects: BTreeMap<ObjectID, Object>,
-    pub output_objects: BTreeMap<ObjectID, Object>,
+    pub objects: ObjectSet,
     pub execution_result: Result<Vec<ExecutionResult>, ExecutionError>,
     pub mock_gas_id: Option<ObjectID>,
+    pub unchanged_loaded_runtime_objects: Vec<ObjectKey>,
 }
 
 #[derive(Default, Debug, Copy, Clone)]


### PR DESCRIPTION
This patch implements tracking of unchanged loaded runtime objects and stores this information in the perpetual store. This is done so that we can package up a checkpoint that includes full information necessary to either perform any analysis based on the objects read or written by a transaction or to efficiently replay a transaction without needing to fetch any additional objects (except packages).

The tracking is done by wrapping the BackingStore that is provided to the VM with one that tracks and saves all objects that were loaded during execution. This is more accurate than the existing "loaded_runtime_objects" structure returned from the execution layer since it also will capture things like the coin deny list.

In addition to this a new `Checkpoint` structure is introduced that is intended to eventually replace the existing `CheckpointData` structure. This new type is intended to only be used in-memory (if you need a persisted structure the proto version of the message should instead be used) and it explicitly does not implement Serialize/Deserialize so that it cannot be accidentally be persisted.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
