### PR TITLE
graphql-alt: refactor object_changes to return cursor as a String

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -337,8 +337,7 @@ impl EffectsContents {
         after: Option<CUnchangedConsensusObject>,
         last: Option<u64>,
         before: Option<CUnchangedConsensusObject>,
-    ) -> Result<Option<Connection<CUnchangedConsensusObject, UnchangedConsensusObject>>, RpcError>
-    {
+    ) -> Result<Option<Connection<String, UnchangedConsensusObject>>, RpcError> {
         let pagination: &PaginationConfig = ctx.data()?;
         let limits = pagination.limits("TransactionEffects", "unchangedConsensusObjects");
         let page = Page::from_params(limits, first, after, last, before)?;
@@ -360,8 +359,10 @@ impl EffectsContents {
                 unchanged_consensus_objects[*edge.cursor].clone(),
                 epoch,
             );
-            conn.edges
-                .push(Edge::new(edge.cursor, unchanged_consensus_object));
+            conn.edges.push(Edge::new(
+                edge.cursor.encode_cursor(),
+                unchanged_consensus_object,
+            ));
         }
 
         Ok(Some(conn))


### PR DESCRIPTION
## Description 

Changes:
Use `String` for `C` when paginated APIs return Connection<C, T> to have a single cursor type for paginating `T`

## Test plan 

```
cargo nextest run -p sui-indexer-alt-e2e-tests -- graphql/
cargo nextest run -p sui-indexer-alt-graphql schema_sdl
cargo nextest run -p sui-indexer-alt-graphql --features=staging schema_sdl
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
