### PR TITLE
[Consensus] cleanup unused code in synchronizer

### DIFF
--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -88,68 +88,6 @@ impl<C: CoreThreadDispatcher> AuthorityService<C> {
             round_tracker,
         }
     }
-
-    async fn handle_fetch_blocks_old(
-        &self,
-        _peer: AuthorityIndex,
-        mut block_refs: Vec<BlockRef>,
-        highest_accepted_rounds: Vec<Round>,
-    ) -> ConsensusResult<Vec<Bytes>> {
-        const MAX_ADDITIONAL_BLOCKS: usize = 10;
-        block_refs.truncate(self.context.parameters.max_blocks_per_fetch);
-
-        if !highest_accepted_rounds.is_empty()
-            && highest_accepted_rounds.len() != self.context.committee.size()
-        {
-            return Err(ConsensusError::InvalidSizeOfHighestAcceptedRounds(
-                highest_accepted_rounds.len(),
-                self.context.committee.size(),
-            ));
-        }
-
-        // Some quick validation of the requested block refs
-        for block in &block_refs {
-            if !self.context.committee.is_valid_index(block.author) {
-                return Err(ConsensusError::InvalidAuthorityIndex {
-                    index: block.author,
-                    max: self.context.committee.size(),
-                });
-            }
-            if block.round == GENESIS_ROUND {
-                return Err(ConsensusError::UnexpectedGenesisBlockRequested);
-            }
-        }
-
-        // For now ask dag state directly
-        let blocks = self.dag_state.read().get_blocks(&block_refs);
-
-        // Now check if an ancestor's round is higher than the one that the peer has. If yes, then serve
-        // that ancestor blocks up to `MAX_ADDITIONAL_BLOCKS`.
-        let mut ancestor_blocks = vec![];
-        if !highest_accepted_rounds.is_empty() {
-            let all_ancestors = blocks
-                .iter()
-                .flatten()
-                .flat_map(|block| block.ancestors().to_vec())
-                .filter(|block_ref| highest_accepted_rounds[block_ref.author] < block_ref.round)
-                .take(MAX_ADDITIONAL_BLOCKS)
-                .collect::<Vec<_>>();
-
-            if !all_ancestors.is_empty() {
-                ancestor_blocks = self.dag_state.read().get_blocks(&all_ancestors);
-            }
-        }
-
-        // Return the serialised blocks & the ancestor blocks
-        let result = blocks
-            .into_iter()
-            .chain(ancestor_blocks)
-            .flatten()
-            .map(|block| block.serialized().clone())
-            .collect::<Vec<_>>();
-
-        Ok(result)
-    }
 }
 
 #[async_trait]
@@ -408,18 +346,12 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
     //    - max_blocks_per_fetch blocks should be returned.
     async fn handle_fetch_blocks(
         &self,
-        peer: AuthorityIndex,
+        _peer: AuthorityIndex,
         mut block_refs: Vec<BlockRef>,
         highest_accepted_rounds: Vec<Round>,
         breadth_first: bool,
     ) -> ConsensusResult<Vec<Bytes>> {
         fail_point_async!("consensus-rpc-response");
-
-        if !self.context.protocol_config.consensus_batched_block_sync() {
-            return self
-                .handle_fetch_blocks_old(peer, block_refs, highest_accepted_rounds)
-                .await;
-        }
 
         if !highest_accepted_rounds.is_empty()
             && highest_accepted_rounds.len() != self.context.committee.size()
@@ -1073,10 +1005,7 @@ mod tests {
         // Use NUM_AUTHORITIES and NUM_ROUNDS higher than max_blocks_per_sync to test limits.
         const NUM_AUTHORITIES: usize = 40;
         const NUM_ROUNDS: usize = 40;
-        let (mut context, _keys) = Context::new_for_test(NUM_AUTHORITIES);
-        context
-            .protocol_config
-            .set_consensus_batched_block_sync_for_testing(true);
+        let (context, _keys) = Context::new_for_test(NUM_AUTHORITIES);
         let context = Arc::new(context);
         let block_verifier = Arc::new(crate::block_verifier::NoopBlockVerifier {});
         let commit_vote_monitor = Arc::new(CommitVoteMonitor::new(context.clone()));

--- a/consensus/core/src/synchronizer.rs
+++ b/consensus/core/src/synchronizer.rs
@@ -522,20 +522,7 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         }
 
         // Limit the number of the returned blocks processed.
-        if context.protocol_config.consensus_batched_block_sync() {
-            serialized_blocks.truncate(context.parameters.max_blocks_per_sync);
-        } else {
-            // The maximum number of blocks that can be additionally fetched from the one requested - those
-            // are potentially missing ancestors.
-            const MAX_ADDITIONAL_BLOCKS: usize = 10;
-
-            // Ensure that all the returned blocks do not go over the total max allowed returned blocks
-            if serialized_blocks.len()
-                > requested_blocks_guard.block_refs.len() + MAX_ADDITIONAL_BLOCKS
-            {
-                return Err(ConsensusError::TooManyFetchedBlocksReturned(peer_index));
-            }
-        }
+        serialized_blocks.truncate(context.parameters.max_blocks_per_sync);
 
         // Verify all the fetched blocks
         let blocks = Handle::current()
@@ -554,29 +541,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
             })
             .await
             .expect("Spawn blocking should not fail")?;
-
-        if !context.protocol_config.consensus_batched_block_sync() {
-            // Get all the ancestors of the requested blocks only
-            let ancestors = blocks
-                .iter()
-                .filter(|b| requested_blocks_guard.block_refs.contains(&b.reference()))
-                .flat_map(|b| b.ancestors().to_vec())
-                .collect::<BTreeSet<BlockRef>>();
-
-            // Now confirm that the blocks are either between the ones requested, or they are parents of the requested blocks
-            for block in &blocks {
-                if !requested_blocks_guard
-                    .block_refs
-                    .contains(&block.reference())
-                    && !ancestors.contains(&block.reference())
-                {
-                    return Err(ConsensusError::UnexpectedFetchedBlock {
-                        index: peer_index,
-                        block_ref: block.reference(),
-                    });
-                }
-            }
-        }
 
         // Record commit votes from the verified blocks.
         for block in &blocks {
@@ -935,13 +899,8 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
                 let total_requested = missing_blocks.len();
 
                 fail_point_async!("consensus-delay");
-
                 // Fetch blocks from peers
-                let results = if context.protocol_config.consensus_batched_block_sync() {
-                    Self::fetch_blocks_from_authorities(context.clone(), blocks_to_fetch.clone(), network_client, missing_blocks, dag_state).await
-                } else {
-                    Self::fetch_blocks_from_authorities_old(context.clone(), blocks_to_fetch.clone(), network_client, missing_blocks, dag_state).await
-                };
+                let results = Self::fetch_blocks_from_authorities(context.clone(), blocks_to_fetch.clone(), network_client, missing_blocks, dag_state).await;
                 context.metrics.node_metrics.fetch_blocks_scheduler_inflight.dec();
                 if results.is_empty() {
                     return;
@@ -969,151 +928,6 @@ impl<C: NetworkClient, V: BlockVerifier, D: CoreThreadDispatcher> Synchronizer<C
         let commit_threshold = last_commit_index
             + self.context.parameters.commit_sync_batch_size * COMMIT_LAG_MULTIPLIER;
         commit_threshold < quorum_commit_index
-    }
-
-    /// Fetches the `missing_blocks` from available peers. The method will attempt to split the load amongst multiple (random) peers.
-    /// The method returns a vector with the fetched blocks from each peer that successfully responded and any corresponding additional ancestor blocks.
-    /// Each element of the vector is a tuple which contains the requested missing block refs, the returned blocks and the peer authority index.
-    async fn fetch_blocks_from_authorities_old(
-        context: Arc<Context>,
-        inflight_blocks: Arc<InflightBlocksMap>,
-        network_client: Arc<C>,
-        missing_blocks: BTreeSet<BlockRef>,
-        dag_state: Arc<RwLock<DagState>>,
-    ) -> Vec<(BlocksGuard, Vec<Bytes>, AuthorityIndex)> {
-        const MAX_PEERS: usize = 3;
-        const MAX_BLOCKS_PER_FETCH: usize = 32;
-
-        // Attempt to fetch only up to a max of blocks
-        let missing_blocks = missing_blocks
-            .into_iter()
-            .take(MAX_PEERS * MAX_BLOCKS_PER_FETCH)
-            .collect::<Vec<_>>();
-
-        let mut missing_blocks_per_authority = vec![0; context.committee.size()];
-        for block in &missing_blocks {
-            missing_blocks_per_authority[block.author] += 1;
-        }
-        for (missing, (_, authority)) in missing_blocks_per_authority
-            .into_iter()
-            .zip(context.committee.authorities())
-        {
-            context
-                .metrics
-                .node_metrics
-                .synchronizer_missing_blocks_by_authority
-                .with_label_values(&[&authority.hostname])
-                .inc_by(missing as u64);
-            context
-                .metrics
-                .node_metrics
-                .synchronizer_current_missing_blocks_by_authority
-                .with_label_values(&[&authority.hostname])
-                .set(missing as i64);
-        }
-        let mut peers = context
-            .committee
-            .authorities()
-            .filter_map(|(peer_index, _)| (peer_index != context.own_index).then_some(peer_index))
-            .collect::<Vec<_>>();
-        // TODO: probably inject the RNG to allow unit testing - this is a work around for now.
-        if cfg!(not(test)) {
-            // Shuffle the peers
-            peers.shuffle(&mut ThreadRng::default());
-        }
-        let mut peers = peers.into_iter();
-        let mut request_futures = FuturesUnordered::new();
-
-        let highest_rounds = Self::get_highest_accepted_rounds(dag_state, &context);
-
-        // Send the initial requests
-        for blocks in missing_blocks.chunks(MAX_BLOCKS_PER_FETCH) {
-            let peer = peers
-                .next()
-                .expect("Possible misconfiguration as a peer should be found");
-            let peer_hostname = &context.committee.authority(peer).hostname;
-            let block_refs = blocks.iter().cloned().collect::<BTreeSet<_>>();
-
-            // lock the blocks to be fetched. If no lock can be acquired for any of the blocks then don't bother
-            if let Some(blocks_guard) = inflight_blocks.lock_blocks(block_refs.clone(), peer) {
-                info!(
-                    "Periodic sync of {} missing blocks from peer {} {}: {}",
-                    block_refs.len(),
-                    peer,
-                    peer_hostname,
-                    block_refs
-                        .iter()
-                        .map(|b| b.to_string())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                );
-                request_futures.push(Self::fetch_blocks_request(
-                    network_client.clone(),
-                    peer,
-                    blocks_guard,
-                    highest_rounds.clone(),
-                    true,
-                    FETCH_REQUEST_TIMEOUT,
-                    1,
-                ));
-            }
-        }
-        let mut results = Vec::new();
-        let fetcher_timeout = sleep(FETCH_FROM_PEERS_TIMEOUT);
-        tokio::pin!(fetcher_timeout);
-        loop {
-            tokio::select! {
-                Some((response, blocks_guard, _retries, peer_index, highest_rounds)) = request_futures.next() => {
-                    let peer_hostname = &context.committee.authority(peer_index).hostname;
-                    match response {
-                        Ok(fetched_blocks) => {
-                            results.push((blocks_guard, fetched_blocks, peer_index));
-                            // no more pending requests are left, just break the loop
-                            if request_futures.is_empty() {
-                                break;
-                            }
-                        },
-                        Err(_) => {
-                            context.metrics.node_metrics.synchronizer_fetch_failures.with_label_values(&[peer_hostname, "periodic_old"]).inc();
-                            // try again if there is any peer left
-                            if let Some(next_peer) = peers.next() {
-                                // do best effort to lock guards. If we can't lock then don't bother at this run.
-                                if let Some(blocks_guard) = inflight_blocks.swap_locks(blocks_guard, next_peer) {
-                                    info!(
-                                        "Retrying syncing {} missing blocks from peer {}: {}",
-                                        blocks_guard.block_refs.len(),
-                                        peer_hostname,
-                                        blocks_guard.block_refs
-                                            .iter()
-                                            .map(|b| b.to_string())
-                                            .collect::<Vec<_>>()
-                                            .join(", ")
-                                    );
-                                    request_futures.push(Self::fetch_blocks_request(
-                                        network_client.clone(),
-                                        next_peer,
-                                        blocks_guard,
-                                        highest_rounds,
-                                        true,
-                                        FETCH_REQUEST_TIMEOUT,
-                                        1,
-                                    ));
-                                } else {
-                                    debug!("Couldn't acquire locks to fetch blocks from peer {next_peer}.")
-                                }
-                            } else {
-                                debug!("No more peers left to fetch blocks");
-                            }
-                        }
-                    }
-                },
-                _ = &mut fetcher_timeout => {
-                    debug!("Timed out while fetching missing blocks");
-                    break;
-                }
-            }
-        }
-        results
     }
 
     /// Fetches the `missing_blocks` from peers. Requests the same number of authorities with missing blocks from each peer.
@@ -1751,10 +1565,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn synchronizer_periodic_task_when_commit_lagging_gets_disabled() {
         // GIVEN
-        let (mut context, _) = Context::new_for_test(4);
-        context
-            .protocol_config
-            .set_consensus_batched_block_sync_for_testing(true);
+        let (context, _) = Context::new_for_test(4);
         let context = Arc::new(context);
         let block_verifier = Arc::new(NoopBlockVerifier {});
         let core_dispatcher = Arc::new(MockCoreThreadDispatcher::default());


### PR DESCRIPTION
## Description 

The `consensus_batched_block_sync` is now enabled for mainnet since protocol version 84 (a few months ago). Old path is no longer needed.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
