### PR TITLE
Add lint.sh, update CLAUDE.md, minor housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 **/.vscode/
 **/.idea/
 **/CLAUDE-local.md
+**/CLAUDE.local.md
 **/.claude/
 
 # OSX

--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -1,0 +1,1 @@
+# Contains user-specific overrides to CLAUDE.md. Do not commit changes to this file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Always consult CLAUDE.md files in sub-crates. Instructions in local CLAUDE.md files override instructions
 in this file when they are in conflict.
 
-## CLAUDE-local.md files
-CLAUDE-local.md files are not checked in, and are maintained by individuals. Consult them if they are present.
+# Individual Preferences
+Individual preferences supercede and extend project preferences:
+- @CLAUDE.local.md
 
 ## Essential Development Commands
 
@@ -24,17 +25,11 @@ cargo check
 ### Testing
 
 ```bash
-# Run Rust unittests
-cargo nextest run                    # Preferred test runner
+# Run e2e tests. simtests must be run with `cargo simtest` to avoid false negatives
+cargo simtest -p sui-e2e-tests
 
-# Run specific test suite
-cargo nextest run -p sui-e2e-tests
-
-# Skip simulation tests for deterministic results
+# Run Rust unittests. skip simulation tests as they may cause false negatives with `cargo nextest`
 SUI_SKIP_SIMTESTS=1 cargo nextest run
-
-# Run deterministic simtests
-cargo simtest
 ```
 
 **Important Notes for Testing:**
@@ -46,7 +41,10 @@ cargo simtest
 ### Linting and Formatting
 
 ```bash
-# Rust
+# Formats & lints all Rust & Move, run before commit:
+./scripts/lint.sh
+
+# Alternatively, run individual lints:
 cargo fmt --all -- --check
 cargo xclippy
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Sui offers the following benefits and capabilities:
  * Ability to define rich and composable on-chain assets
  * Better user experience for web3 apps
 
-Sui is the only blockchain today that can scale with the growth of web3 while achieving industry-leading performance, cost, programmability, and usability. As Sui approaches Mainnet launch, it will demonstrate capacity beyond the transaction processing capabilities of established systems – traditional and blockchain alike. Sui is the first internet-scale programmable blockchain platform, a foundational layer for web3.
+Sui is the only blockchain today that can scale with the growth of web3 while achieving industry-leading performance, cost, programmability, and usability. Sui demonstrates capacity beyond the transaction processing capabilities of established systems – traditional and blockchain alike. Sui is the first internet-scale programmable blockchain platform, a foundational layer for web3.
 
 ## Sui Architecture
 

--- a/crates/sui-e2e-tests/tests/rpc/v2beta2/live_data_service/get_coin_info.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2beta2/live_data_service/get_coin_info.rs
@@ -3,6 +3,7 @@
 
 use prost_types::FieldMask;
 use std::path::PathBuf;
+#[allow(unused_imports)]
 use std::str::FromStr;
 use sui_macros::sim_test;
 use sui_rpc::field::FieldMaskUtil;

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Copyright (c) Mysten Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Formats and lints code. Run before committing.
+
+set -e
+
+echo "Formatting and linting changed files..."
+
+CHANGED_MOVE_FILES=$(git diff --name-only remotes/origin/main | grep '\.move$' || true)
+
+echo "Running cargo fmt..."
+cargo fmt
+
+if [ -n "$CHANGED_MOVE_FILES" ]; then
+    echo "Running prettier-move on changed .move files:"
+    echo "$CHANGED_MOVE_FILES"
+
+    # Install prettier globally if not available
+    if ! command -v prettier &> /dev/null; then
+        echo "Installing prettier globally..."
+        npm install -g prettier
+    fi
+
+    # Check if prettier-move is built, build if not
+    if [ ! -f "external-crates/move/tooling/prettier-move/out/index.js" ]; then
+        echo "Building prettier-move..."
+        cd external-crates/move/tooling/prettier-move
+        npm install --no-save
+        npm run build
+        cd - > /dev/null
+    fi
+
+    echo "$CHANGED_MOVE_FILES" | while read -r file; do
+        if [ -f "$file" ]; then
+            echo "  Formatting: $file"
+            npx --prefix external-crates/move/tooling/prettier-move prettier-move -c "$file" --write
+        fi
+    done
+
+    echo "Prettier-move formatting complete"
+else
+    echo "No .move files changed since origin/main"
+fi
+
+echo "Running cargo xclippy with warnings as errors..."
+cargo xclippy -D warnings
+
+echo "Running cargo xlint with warnings as errors..."
+cargo xlint
+
+echo "All formatting and linting complete!"


### PR DESCRIPTION
## Description 

A few minor housekeeping and convenience items:
- README.md updated to remove pre-Mainnet verbiage
- scripts/lint.sh added to apply all linting and formatting checks to ensure PRs pass CI checks
- CLAUDE.md updated to know about lint.sh
- CLAUDE.md updated to use explicit import of canonical CLAUDE.local.md (refer to [claude docs](https://docs.claude.com/en/docs/claude-code/memory))
- Empty CLAUDE.local.md added for demonstrative purposes
- Build warning suppressed on get_coin_info in test

## Test plan 

Ran script on clean workspace

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
