### PR TITLE
[static_ptbs] Simplify addition into `all_versions_resolution_table`

### DIFF
--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/config.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/config.rs
@@ -64,13 +64,13 @@ impl LinkageConfig {
         let mut resolution_table = ResolutionTable::empty();
         if self.always_include_system_packages {
             for id in NATIVE_PACKAGE_IDS {
-                let package = get_package(id, store)?;
-                debug_assert_eq!(package.id(), *id);
-                debug_assert_eq!(package.original_package_id(), *id);
+                #[cfg(debug_assertions)]
+                {
+                    let package = get_package(id, store)?;
+                    debug_assert_eq!(package.id(), *id);
+                    debug_assert_eq!(package.original_package_id(), *id);
+                }
                 add_and_unify(id, store, &mut resolution_table, ConflictResolution::exact)?;
-                resolution_table
-                    .all_versions_resolution_table
-                    .insert(*id, *id);
             }
         }
 


### PR DESCRIPTION
## Description

Don't need to add into `all_versions_resolution_table` after calling `add_and_unify` and also move the `get_package` and `debug_assert`s into a CFG-debug-assertions block.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
