### PR TITLE
[static_ptbs] Fetch dependency packages for publish/updated using cache

### DIFF
--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
@@ -688,7 +688,7 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas> Context<'env, 'pc, 'vm, 'state, 'li
         let [fetched_package] = self.fetch_packages(&[*dependency_id])?.try_into().map_err(
             |_| {
                 make_invariant_violation!(
-                    "We should always fetch a package for each object or return a dependency error."
+                    "We should always fetch a single package for each object or return a dependency error."
                 )
             },
         )?;


### PR DESCRIPTION
## Description 

Before we were skipping the `CachedPackageStore` and going straight to storage. Change this so that we load the package(s) for dependencies from the `CachedPackageStore` instead.

## Test plan 

CI 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
