### PR TITLE
[move][move-model] Allow missing dependencies via configuration

### DIFF
--- a/external-crates/move/crates/move-model-2/src/compiled_model.rs
+++ b/external-crates/move/crates/move-model-2/src/compiled_model.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    model::{self, PackageData},
+    model::{self, ModelBuilderConfig, PackageData},
     normalized,
     source_kind::{Uninit, WithoutSource},
     summary,
@@ -25,6 +25,15 @@ pub type CompiledConstant<'a> = model::CompiledConstant<'a, WithoutSource>;
 
 impl Model {
     pub fn from_compiled(
+        named_address_reverse_map: &BTreeMap<AccountAddress, Symbol>,
+        modules: Vec<CompiledModule>,
+    ) -> Self {
+        let config = ModelBuilderConfig::default();
+        Self::from_compiled_with_config(&config, named_address_reverse_map, modules)
+    }
+
+    pub fn from_compiled_with_config(
+        builder_config: &ModelBuilderConfig,
         named_address_reverse_map: &BTreeMap<AccountAddress, Symbol>,
         modules: Vec<CompiledModule>,
     ) -> Self {
@@ -54,7 +63,7 @@ impl Model {
             summary: OnceCell::new(),
             _phantom: std::marker::PhantomData,
         };
-        model.compute_dependencies();
+        model.compute_dependencies(builder_config);
         model.compute_function_dependencies();
         model.check_invariants();
         model

--- a/external-crates/move/crates/move-model-2/src/model.rs
+++ b/external-crates/move/crates/move-model-2/src/model.rs
@@ -155,6 +155,10 @@ pub struct CompiledConstant<'a, K: SourceKind> {
     pub(crate) data: &'a ConstantData,
 }
 
+pub struct ModelBuilderConfig {
+    pub allow_missing_dependencies: bool,
+}
+
 //**************************************************************************************************
 // API
 //**************************************************************************************************
@@ -762,8 +766,10 @@ pub(crate) struct NamedConstantData {
 //**************************************************************************************************
 
 impl<K: SourceKind> Model<K> {
-    pub(crate) fn compute_dependencies(&mut self) {
+    /// Panics if a dependency is missing and `allow_missing_dependencies` is false.
+    pub(crate) fn compute_dependencies(&mut self, builder_config: &ModelBuilderConfig) {
         fn visit(
+            allow_missing_dependencies: bool,
             packages: &BTreeMap<AccountAddress, normalized::Package>,
             acc: &mut BTreeMap<ModuleId, BTreeMap<ModuleId, bool>>,
             id: ModuleId,
@@ -774,16 +780,48 @@ impl<K: SourceKind> Model<K> {
             }
 
             for immediate_dep in &module.immediate_dependencies {
-                let unit = &packages[&immediate_dep.address].modules[&immediate_dep.name];
-                visit(packages, acc, *immediate_dep, unit);
+                let Some(pkg) = packages.get(&immediate_dep.address) else {
+                    if allow_missing_dependencies {
+                        continue;
+                    } else {
+                        panic!(
+                            "Module {:?} depends on missing package {:?}",
+                            id, immediate_dep.address
+                        );
+                    }
+                };
+                let Some(unit) = pkg.modules.get(&immediate_dep.name) else {
+                    if allow_missing_dependencies {
+                        continue;
+                    } else {
+                        panic!(
+                            "Module {:?} depends on missing module {:?}",
+                            id, immediate_dep
+                        );
+                    }
+                };
+                visit(
+                    allow_missing_dependencies,
+                    packages,
+                    acc,
+                    *immediate_dep,
+                    unit,
+                );
             }
             let mut deps = BTreeMap::new();
             for immediate_dep in &module.immediate_dependencies {
                 deps.insert(*immediate_dep, true);
-                for transitive_dep in acc.get(immediate_dep).unwrap().keys() {
-                    if !deps.contains_key(transitive_dep) {
-                        deps.insert(*transitive_dep, false);
+                if let Some(acc) = acc.get(immediate_dep) {
+                    for transitive_dep in acc.get(immediate_dep).unwrap().keys() {
+                        if *transitive_dep != id {
+                            deps.insert(*transitive_dep, false);
+                        }
                     }
+                } else if !allow_missing_dependencies {
+                    panic!(
+                        "Module {:?} depends on missing module {:?}",
+                        id, immediate_dep
+                    );
                 }
             }
             acc.insert(id, deps);
@@ -798,7 +836,13 @@ impl<K: SourceKind> Model<K> {
         for (a, package) in &self.compiled.packages {
             for (m, module) in &package.modules {
                 let id = (a, m).module_id();
-                visit(&self.compiled.packages, &mut module_deps, id, module);
+                visit(
+                    builder_config.allow_missing_dependencies,
+                    &self.compiled.packages,
+                    &mut module_deps,
+                    id,
+                    module,
+                );
             }
         }
         let mut module_used_by = module_deps
@@ -808,7 +852,13 @@ impl<K: SourceKind> Model<K> {
         for (id, deps) in &module_deps {
             for (dep, immediate) in deps {
                 let immediate = *immediate;
-                let used_by = module_used_by.get_mut(dep).unwrap();
+                let Some(used_by) = module_used_by.get_mut(dep) else {
+                    if builder_config.allow_missing_dependencies {
+                        continue;
+                    } else {
+                        panic!("Module {:?} depends on missing module {:?}", id, dep);
+                    }
+                };
                 let is_immediate = used_by.entry(*id).or_insert(false);
                 *is_immediate = *is_immediate || immediate;
             }
@@ -1153,3 +1203,16 @@ derive_all!(Enum);
 derive_all!(Variant);
 derive_all!(Function);
 derive_all!(CompiledConstant);
+
+//**************************************************************************************************
+// Impls
+//**************************************************************************************************
+
+#[allow(clippy::derivable_impls)]
+impl Default for ModelBuilderConfig {
+    fn default() -> Self {
+        Self {
+            allow_missing_dependencies: false,
+        }
+    }
+}

--- a/external-crates/move/crates/move-model-2/src/model.rs
+++ b/external-crates/move/crates/move-model-2/src/model.rs
@@ -817,10 +817,10 @@ impl<K: SourceKind> Model<K> {
                             deps.insert(*transitive_dep, false);
                         }
                     }
-                } else if !allow_missing_dependencies {
-                    panic!(
-                        "Module {:?} depends on missing module {:?}",
-                        id, immediate_dep
+                } else {
+                    assert!(
+                        allow_missing_dependencies,
+                        "Module {id:?} depends on missing module {immediate_dep:?}",
                     );
                 }
             }

--- a/external-crates/move/crates/move-model-2/src/model.rs
+++ b/external-crates/move/crates/move-model-2/src/model.rs
@@ -811,8 +811,8 @@ impl<K: SourceKind> Model<K> {
             let mut deps = BTreeMap::new();
             for immediate_dep in &module.immediate_dependencies {
                 deps.insert(*immediate_dep, true);
-                if let Some(acc) = acc.get(immediate_dep) {
-                    for transitive_dep in acc.get(immediate_dep).unwrap().keys() {
+                if let Some(imm_dep) = acc.get(immediate_dep) {
+                    for transitive_dep in imm_dep.keys() {
                         if *transitive_dep != id {
                             deps.insert(*transitive_dep, false);
                         }

--- a/external-crates/move/crates/move-model-2/src/source_model.rs
+++ b/external-crates/move/crates/move-model-2/src/source_model.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     TModuleId,
-    model::{self, NamedConstantData, PackageData},
+    model::{self, ModelBuilderConfig, NamedConstantData, PackageData},
     normalized,
     source_kind::WithSource,
     summary,
@@ -53,6 +53,24 @@ pub struct NamedConstant<'a> {
 
 impl Model {
     pub fn from_source(
+        files: MappedFiles,
+        root_package_name: Option<Symbol>,
+        root_named_address_map: BTreeMap<Symbol, AccountAddress>,
+        info: Arc<TypingProgramInfo>,
+        compiled_units_vec: Vec<(/* file */ PathBuf, CompiledUnit)>,
+    ) -> anyhow::Result<Self> {
+        Self::from_source_with_config(
+            &ModelBuilderConfig::default(),
+            files,
+            root_package_name,
+            root_named_address_map,
+            info,
+            compiled_units_vec,
+        )
+    }
+
+    pub fn from_source_with_config(
+        builder_config: &model::ModelBuilderConfig,
         files: MappedFiles,
         root_package_name: Option<Symbol>,
         root_named_address_map: BTreeMap<Symbol, AccountAddress>,
@@ -130,7 +148,7 @@ impl Model {
             summary: OnceCell::new(),
             _phantom: std::marker::PhantomData,
         };
-        model.compute_dependencies();
+        model.compute_dependencies(builder_config);
         model.compute_function_dependencies();
         model.check_invariants();
         Ok(model)


### PR DESCRIPTION
## Description 

This adds a `ModelBuilderConfig` and a flag to allow missing dependencies when generating a move model.

## Test plan 

Testing was done downstream in the decompiler.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
