### PR TITLE
[sui-indexer-alt-framework] Address `first_checkpoint` + pipeline with no watermark row commit stall (#23209)

### DIFF
--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -35,12 +35,29 @@ pub mod pipeline;
 pub mod postgres;
 pub mod task;
 
+#[cfg(test)]
+pub mod mocks;
+
 /// Command-line arguments for the indexer
 #[derive(clap::Args, Default, Debug, Clone)]
 pub struct IndexerArgs {
-    /// Override for the checkpoint to start ingestion from -- useful for backfills. By default,
-    /// ingestion will start just after the lowest checkpoint watermark across all active
+    /// Override for the checkpoint to start ingestion from -- useful for backfills. Otherwise, by
+    /// default, ingestion will start just after the lowest checkpoint watermark across all active
     /// pipelines.
+    ///
+    /// For both concurrent and sequential pipelines, if a first checkpoint is configured, and a
+    /// watermark does not exist for the pipeline, the indexer will also tell the pipeline to start
+    /// from this value.
+    ///
+    /// Unless `--skip-watermark` is set, this value must be less than or equal to the global high
+    /// watermark (preventing the indexer from introducing a gap in the data). This exception only
+    /// applies to concurrent pipelines, and these pipelines will also not report watermark updates.
+    ///
+    /// Sequential pipelines will always start committing from the next checkpoint after its
+    /// watermark.
+    ///
+    /// Concurrent pipelines will always start committing from `first_checkpoint`. These pipelines
+    /// will not report watermark updates if `skip_watermark` is set.
     #[arg(long)]
     pub first_checkpoint: Option<u64>,
 
@@ -199,16 +216,33 @@ impl<S: Store> Indexer<S> {
             return Ok(());
         };
 
-        // For a concurrent pipeline, if skip_watermark is set, we don't really care about the
-        // watermark consistency. first_checkpoint can be anything since we don't update watermark,
-        // and writes should be idempotent.
-        if !self.skip_watermark {
-            self.check_first_checkpoint_consistency::<H>(&watermark)?;
-        }
+        // If `first_checkpoint` does not violate the consistency check, concurrent pipelines will
+        // prefer to resume from the `first_checkpoint` if configured.
+        let next_checkpoint = match (watermark, self.first_checkpoint) {
+            (Some(watermark), Some(first_checkpoint)) => {
+                // Setting `skip_watermark` allows concurrent pipelines to not be considered in the
+                // consistency check. The indexer will still fail to start if `first_checkpoint`
+                // fails for a sequential pipeline in the indexer.
+                if !self.skip_watermark {
+                    ensure!(
+                        first_checkpoint <= watermark.checkpoint_hi_inclusive + 1,
+                        "For pipeline {}, first checkpoint override {} is too far ahead of watermark {}. \
+                        This could create gaps in the data.",
+                        H::NAME,
+                        first_checkpoint,
+                        watermark.checkpoint_hi_inclusive,
+                    );
+                }
+                first_checkpoint
+            }
+            (Some(watermark), _) => watermark.checkpoint_hi_inclusive + 1,
+            (_, Some(first_checkpoint)) => first_checkpoint,
+            (None, None) => 0,
+        };
 
         self.handles.push(concurrent::pipeline::<H>(
             handler,
-            watermark,
+            next_checkpoint,
             config,
             self.skip_watermark,
             self.store.clone(),
@@ -220,32 +254,13 @@ impl<S: Store> Indexer<S> {
         Ok(())
     }
 
-    /// Checks that the first checkpoint override is consistent with the watermark for the pipeline.
-    /// If the watermark does not exist, the override can be anything. If the watermark exists, the
-    /// override must not leave any gap in the data: it can be in the past, or at the tip of the
-    /// network, but not in the future.
-    fn check_first_checkpoint_consistency<P: Processor>(
-        &self,
-        watermark: &Option<CommitterWatermark>,
-    ) -> Result<()> {
-        if let (Some(watermark), Some(first_checkpoint)) = (watermark, self.first_checkpoint) {
-            ensure!(
-                first_checkpoint <= watermark.checkpoint_hi_inclusive + 1,
-                "For pipeline {}, first checkpoint override {} is too far ahead of watermark {}. \
-                 This could create gaps in the data.",
-                P::NAME,
-                first_checkpoint,
-                watermark.checkpoint_hi_inclusive,
-            );
-        }
-
-        Ok(())
-    }
-
-    /// Start ingesting checkpoints. Ingestion either starts from the configured
-    /// `first_checkpoint`, or it is calculated based on the watermarks of all active pipelines.
-    /// Ingestion will stop after consuming the configured `last_checkpoint`, if one is provided,
-    /// or will continue until it tracks the tip of the network.
+    /// Start ingesting checkpoints. Ingestion either starts from the
+    /// `first_checkpoint_from_watermark` calculated based on the smallest watermark of all active
+    /// pipelines or `first_checkpoint` if configured. Individual pipelines will start processing
+    /// and committing once the ingestion service has caught up to their respective watermarks.
+    ///
+    /// Ingestion will stop after consuming the configured `last_checkpoint`, if one is provided, or
+    /// will continue until it tracks the tip of the network.
     pub async fn run(mut self) -> Result<JoinHandle<()>> {
         if let Some(enabled_pipelines) = self.enabled_pipelines {
             ensure!(
@@ -284,9 +299,9 @@ impl<S: Store> Indexer<S> {
         }))
     }
 
-    /// Update the indexer's first checkpoint based on the watermark for the pipeline by adding for
-    /// handler `H` (as long as it's enabled). Returns `Ok(None)` if the pipeline is disabled,
-    /// `Ok(Some(None))` if the pipeline is enabled but its watermark is not found, and
+    /// Update the indexer's starting ingestion checkpoint based on the watermark for the pipeline
+    /// by adding for handler `H` (as long as it's enabled). Returns `Ok(None)` if the pipeline is
+    /// disabled, `Ok(Some(None))` if the pipeline is enabled but its watermark is not found, and
     /// `Ok(Some(Some(watermark)))` if the pipeline is enabled and the watermark is found.
     async fn add_pipeline<P: Processor + 'static>(
         &mut self,
@@ -357,15 +372,43 @@ impl<T: TransactionalStore> Indexer<T> {
             );
         }
 
-        // For a sequential pipeline, data must be written in the order of checkpoints.
-        // Hence, we do not allow the first_checkpoint override to be in arbitrary positions.
-        self.check_first_checkpoint_consistency::<H>(&watermark)?;
+        // If `first_checkpoint` does not violate the consistency check, sequential pipelines will
+        // prefer to resume from the existing watermark unless no watermark exists.
+        let next_checkpoint = match (watermark, self.first_checkpoint) {
+            (Some(watermark), Some(first_checkpoint)) => {
+                // Sequential pipelines must write data in the order of checkpoints. If there is a
+                // gap, this violates the property.
+                ensure!(
+                    first_checkpoint <= watermark.checkpoint_hi_inclusive + 1,
+                    "For pipeline {}, first checkpoint override {} is too far ahead of watermark {}. \
+                     This could create gaps in the data.",
+                    H::NAME,
+                    first_checkpoint,
+                    watermark.checkpoint_hi_inclusive,
+                );
+                // Otherwise, sequential pipelines will wait until the processed checkpoint next
+                // after its current watermark.
+                warn!(
+                    pipeline = H::NAME,
+                    first_checkpoint,
+                    committer_hi = watermark.checkpoint_hi_inclusive,
+                    "Ignoring --first-checkpoint and will resume from committer_hi",
+                );
+                watermark.checkpoint_hi_inclusive + 1
+            }
+            // If a watermark exists, the pipeline will wait for the processed checkpoint next after
+            // its watermark.
+            (Some(watermark), _) => watermark.checkpoint_hi_inclusive + 1,
+            // If no watermark exists, the first checkpoint can be anything.
+            (_, Some(first_checkpoint)) => first_checkpoint,
+            (None, None) => 0,
+        };
 
         let (checkpoint_rx, watermark_tx) = self.ingestion_service.subscribe();
 
         self.handles.push(sequential::pipeline::<H>(
             handler,
-            watermark,
+            next_checkpoint,
             config,
             self.store.clone(),
             checkpoint_rx,
@@ -379,4 +422,478 @@ impl<T: TransactionalStore> Indexer<T> {
 }
 
 #[cfg(test)]
-pub mod testing;
+mod tests {
+    use super::*;
+    use crate::mocks::store::MockStore;
+    use crate::pipeline::concurrent::ConcurrentConfig;
+    use crate::store::CommitterWatermark;
+    use crate::FieldCount;
+    use std::sync::Arc;
+    use sui_synthetic_ingestion::synthetic_ingestion;
+    use tokio_util::sync::CancellationToken;
+
+    impl Processor for MockHandler {
+        const NAME: &'static str = "test_processor";
+        type Value = MockValue;
+        fn process(
+            &self,
+            _checkpoint: &Arc<sui_types::full_checkpoint_content::CheckpointData>,
+        ) -> anyhow::Result<Vec<Self::Value>> {
+            Ok(vec![MockValue(1)])
+        }
+    }
+
+    #[allow(dead_code)]
+    #[derive(Clone, FieldCount)]
+    struct MockValue(u64);
+
+    struct MockHandler;
+
+    #[async_trait::async_trait]
+    impl crate::pipeline::concurrent::Handler for MockHandler {
+        type Store = MockStore;
+
+        async fn commit<'a>(
+            _values: &[Self::Value],
+            _conn: &mut <Self::Store as Store>::Connection<'a>,
+        ) -> anyhow::Result<usize> {
+            Ok(1)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::pipeline::sequential::Handler for MockHandler {
+        type Store = MockStore;
+        type Batch = Vec<Self::Value>;
+
+        fn batch(batch: &mut Self::Batch, values: Vec<Self::Value>) {
+            batch.extend(values);
+        }
+
+        async fn commit<'a>(
+            _batch: &Self::Batch,
+            _conn: &mut <Self::Store as Store>::Connection<'a>,
+        ) -> anyhow::Result<usize> {
+            Ok(1)
+        }
+    }
+
+    #[tokio::test]
+    async fn test_first_checkpoint_from_watermark() {
+        let cancel = CancellationToken::new();
+        let registry = Registry::new();
+
+        let store = MockStore::default();
+        let mut conn = store.connect().await.unwrap();
+        conn.set_committer_watermark(
+            "test_processor",
+            CommitterWatermark {
+                epoch_hi_inclusive: 1,
+                checkpoint_hi_inclusive: 100,
+                tx_hi: 1000,
+                timestamp_ms_hi_inclusive: 1000000,
+            },
+        )
+        .await
+        .unwrap();
+
+        let indexer_args = IndexerArgs {
+            first_checkpoint: Some(50),
+            last_checkpoint: None,
+            pipeline: vec![],
+            skip_watermark: false,
+        };
+        let temp_dir = tempfile::tempdir().unwrap();
+        let client_args = ClientArgs {
+            local_ingestion_path: Some(temp_dir.path().to_owned()),
+            ..Default::default()
+        };
+
+        let ingestion_config = IngestionConfig::default();
+
+        let mut indexer = Indexer::new(
+            store,
+            indexer_args,
+            client_args,
+            ingestion_config,
+            None,
+            &registry,
+            cancel,
+        )
+        .await
+        .unwrap();
+
+        indexer
+            .concurrent_pipeline::<MockHandler>(MockHandler, ConcurrentConfig::default())
+            .await
+            .unwrap();
+
+        assert_eq!(indexer.first_checkpoint_from_watermark, 101);
+    }
+
+    #[tokio::test]
+    async fn test_indexer_concurrent_pipeline_disallow_inconsistent_first_checkpoint() {
+        let cancel = CancellationToken::new();
+        let registry = Registry::new();
+
+        let store = MockStore::default();
+        let mut conn = store.connect().await.unwrap();
+        conn.set_committer_watermark(
+            "test_processor",
+            CommitterWatermark {
+                epoch_hi_inclusive: 1,
+                checkpoint_hi_inclusive: 100,
+                tx_hi: 1000,
+                timestamp_ms_hi_inclusive: 1000000,
+            },
+        )
+        .await
+        .unwrap();
+
+        let indexer_args = IndexerArgs {
+            first_checkpoint: Some(1001),
+            last_checkpoint: None,
+            pipeline: vec![],
+            skip_watermark: false,
+        };
+        let temp_dir = tempfile::tempdir().unwrap();
+        let client_args = ClientArgs {
+            local_ingestion_path: Some(temp_dir.path().to_owned()),
+            ..Default::default()
+        };
+
+        let ingestion_config = IngestionConfig::default();
+
+        let mut indexer = Indexer::new(
+            store,
+            indexer_args,
+            client_args,
+            ingestion_config,
+            None,
+            &registry,
+            cancel,
+        )
+        .await
+        .unwrap();
+
+        let result = indexer
+            .concurrent_pipeline::<MockHandler>(MockHandler, ConcurrentConfig::default())
+            .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_indexer_concurrent_pipeline_allow_inconsistent_first_checkpoint_with_skip_watermark(
+    ) {
+        let cancel = CancellationToken::new();
+        let registry = Registry::new();
+
+        let store = MockStore::default();
+        let mut conn = store.connect().await.unwrap();
+        conn.set_committer_watermark(
+            "test_processor",
+            CommitterWatermark {
+                epoch_hi_inclusive: 1,
+                checkpoint_hi_inclusive: 100,
+                tx_hi: 1000,
+                timestamp_ms_hi_inclusive: 1000000,
+            },
+        )
+        .await
+        .unwrap();
+
+        let indexer_args = IndexerArgs {
+            first_checkpoint: Some(1001),
+            last_checkpoint: None,
+            pipeline: vec![],
+            skip_watermark: true,
+        };
+        let temp_dir = tempfile::tempdir().unwrap();
+        let client_args = ClientArgs {
+            local_ingestion_path: Some(temp_dir.path().to_owned()),
+            ..Default::default()
+        };
+
+        let ingestion_config = IngestionConfig::default();
+
+        let mut indexer = Indexer::new(
+            store,
+            indexer_args,
+            client_args,
+            ingestion_config,
+            None,
+            &registry,
+            cancel,
+        )
+        .await
+        .unwrap();
+
+        let result = indexer
+            .concurrent_pipeline::<MockHandler>(MockHandler, ConcurrentConfig::default())
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_indexer_sequential_pipeline_disallow_inconsistent_first_checkpoint() {
+        let cancel = CancellationToken::new();
+        let registry = Registry::new();
+
+        let store = MockStore::default();
+        let mut conn = store.connect().await.unwrap();
+        conn.set_committer_watermark(
+            "test_processor",
+            CommitterWatermark {
+                epoch_hi_inclusive: 1,
+                checkpoint_hi_inclusive: 100,
+                tx_hi: 1000,
+                timestamp_ms_hi_inclusive: 1000000,
+            },
+        )
+        .await
+        .unwrap();
+
+        let indexer_args = IndexerArgs {
+            first_checkpoint: Some(1001),
+            last_checkpoint: None,
+            pipeline: vec![],
+            skip_watermark: false,
+        };
+        let temp_dir = tempfile::tempdir().unwrap();
+        let client_args = ClientArgs {
+            local_ingestion_path: Some(temp_dir.path().to_owned()),
+            ..Default::default()
+        };
+
+        let ingestion_config = IngestionConfig::default();
+
+        let mut indexer = Indexer::new(
+            store,
+            indexer_args,
+            client_args,
+            ingestion_config,
+            None,
+            &registry,
+            cancel,
+        )
+        .await
+        .unwrap();
+
+        let result = indexer
+            .sequential_pipeline::<MockHandler>(MockHandler, SequentialConfig::default())
+            .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_indexer_sequential_pipeline_disallow_inconsistent_first_checkpoint_with_skip_watermark(
+    ) {
+        let cancel = CancellationToken::new();
+        let registry = Registry::new();
+
+        let store = MockStore::default();
+        let mut conn = store.connect().await.unwrap();
+        conn.set_committer_watermark(
+            "test_processor",
+            CommitterWatermark {
+                epoch_hi_inclusive: 1,
+                checkpoint_hi_inclusive: 100,
+                tx_hi: 1000,
+                timestamp_ms_hi_inclusive: 1000000,
+            },
+        )
+        .await
+        .unwrap();
+
+        let indexer_args = IndexerArgs {
+            first_checkpoint: Some(1001),
+            last_checkpoint: None,
+            pipeline: vec![],
+            skip_watermark: true,
+        };
+        let temp_dir = tempfile::tempdir().unwrap();
+        let client_args = ClientArgs {
+            local_ingestion_path: Some(temp_dir.path().to_owned()),
+            ..Default::default()
+        };
+
+        let ingestion_config = IngestionConfig::default();
+
+        let mut indexer = Indexer::new(
+            store,
+            indexer_args,
+            client_args,
+            ingestion_config,
+            None,
+            &registry,
+            cancel,
+        )
+        .await
+        .unwrap();
+
+        let result = indexer
+            .sequential_pipeline::<MockHandler>(MockHandler, SequentialConfig::default())
+            .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_indexer_sequential_pipeline_always_resume_from_watermark() {
+        let cancel = CancellationToken::new();
+        let registry = Registry::new();
+        let store = MockStore::default();
+        let pipeline_checkpoint_hi = 10;
+        let indexer_first_checkpoint = 5;
+        let num_ingested_checkpoints = 10;
+
+        let mut conn = store.connect().await.unwrap();
+        conn.set_committer_watermark(
+            "test_processor",
+            CommitterWatermark {
+                epoch_hi_inclusive: 1,
+                checkpoint_hi_inclusive: pipeline_checkpoint_hi,
+                tx_hi: 1000,
+                timestamp_ms_hi_inclusive: 1000000,
+            },
+        )
+        .await
+        .unwrap();
+
+        let indexer_args = IndexerArgs {
+            first_checkpoint: Some(indexer_first_checkpoint),
+            last_checkpoint: Some(indexer_first_checkpoint + num_ingested_checkpoints - 1),
+            pipeline: vec![],
+            skip_watermark: true,
+        };
+        let temp_dir = tempfile::tempdir().unwrap();
+        synthetic_ingestion::generate_ingestion(synthetic_ingestion::Config {
+            ingestion_dir: temp_dir.path().to_owned(),
+            starting_checkpoint: indexer_first_checkpoint,
+            num_checkpoints: num_ingested_checkpoints,
+            checkpoint_size: 2,
+        })
+        .await;
+
+        let client_args = ClientArgs {
+            local_ingestion_path: Some(temp_dir.path().to_owned()),
+            ..Default::default()
+        };
+
+        let ingestion_config = IngestionConfig::default();
+
+        let mut indexer = Indexer::new(
+            store,
+            indexer_args,
+            client_args,
+            ingestion_config,
+            None,
+            &registry,
+            cancel,
+        )
+        .await
+        .unwrap();
+
+        let _ = indexer
+            .sequential_pipeline::<MockHandler>(MockHandler, SequentialConfig::default())
+            .await;
+
+        let metrics = indexer.metrics().clone();
+
+        indexer.run().await.unwrap().await.unwrap();
+
+        assert_eq!(
+            metrics.total_ingested_checkpoints.get(),
+            num_ingested_checkpoints
+        );
+        assert_eq!(
+            metrics
+                .total_watermarks_out_of_order
+                .get_metric_with_label_values(&["test_processor"])
+                .unwrap()
+                .get(),
+            pipeline_checkpoint_hi - indexer_first_checkpoint + 1
+        );
+    }
+
+    #[tokio::test]
+    async fn test_indexer_concurrent_pipeline_always_resume_from_first_checkpoint() {
+        let cancel = CancellationToken::new();
+        let registry = Registry::new();
+        let store = MockStore::default();
+        let pipeline_checkpoint_hi = 10;
+        let indexer_first_checkpoint = 5;
+        let num_ingested_checkpoints = 10;
+
+        let mut conn = store.connect().await.unwrap();
+        conn.set_committer_watermark(
+            "test_processor",
+            CommitterWatermark {
+                epoch_hi_inclusive: 1,
+                checkpoint_hi_inclusive: pipeline_checkpoint_hi,
+                tx_hi: 1000,
+                timestamp_ms_hi_inclusive: 1000000,
+            },
+        )
+        .await
+        .unwrap();
+
+        let indexer_args = IndexerArgs {
+            first_checkpoint: Some(indexer_first_checkpoint),
+            last_checkpoint: Some(indexer_first_checkpoint + num_ingested_checkpoints - 1),
+            pipeline: vec![],
+            skip_watermark: true,
+        };
+        let temp_dir = tempfile::tempdir().unwrap();
+        synthetic_ingestion::generate_ingestion(synthetic_ingestion::Config {
+            ingestion_dir: temp_dir.path().to_owned(),
+            starting_checkpoint: indexer_first_checkpoint,
+            num_checkpoints: num_ingested_checkpoints,
+            checkpoint_size: 2,
+        })
+        .await;
+
+        let client_args = ClientArgs {
+            local_ingestion_path: Some(temp_dir.path().to_owned()),
+            ..Default::default()
+        };
+
+        let ingestion_config = IngestionConfig::default();
+
+        let mut indexer = Indexer::new(
+            store,
+            indexer_args,
+            client_args,
+            ingestion_config,
+            None,
+            &registry,
+            cancel,
+        )
+        .await
+        .unwrap();
+
+        let _ = indexer
+            .concurrent_pipeline::<MockHandler>(MockHandler, ConcurrentConfig::default())
+            .await;
+
+        let metrics = indexer.metrics().clone();
+
+        indexer.run().await.unwrap().await.unwrap();
+
+        assert_eq!(
+            metrics.total_ingested_checkpoints.get(),
+            num_ingested_checkpoints
+        );
+        assert_eq!(
+            metrics
+                .total_watermarks_out_of_order
+                .get_metric_with_label_values(&["test_processor"])
+                .unwrap()
+                .get(),
+            0
+        );
+    }
+}

--- a/crates/sui-indexer-alt-framework/src/mocks/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/mocks/mod.rs
@@ -1,4 +1,4 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod mock_store;
+pub mod store;

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/committer.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/committer.rs
@@ -232,12 +232,12 @@ mod tests {
 
     use crate::{
         metrics::IndexerMetrics,
+        mocks::store::*,
         pipeline::{
             concurrent::{BatchedRows, Handler},
             Processor, WatermarkPart,
         },
         store::CommitterWatermark,
-        testing::mock_store::*,
         FieldCount,
     };
 

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/pruner.rs
@@ -357,7 +357,7 @@ mod tests {
     use tokio::time::Duration;
     use tokio_util::sync::CancellationToken;
 
-    use crate::{metrics::IndexerMetrics, pipeline::Processor, testing::mock_store::*, FieldCount};
+    use crate::{metrics::IndexerMetrics, mocks::store::*, pipeline::Processor, FieldCount};
 
     use super::*;
 
@@ -549,7 +549,7 @@ mod tests {
             pruner_hi: 0,
         };
         let store = MockStore {
-            watermarks: Arc::new(Mutex::new(watermark)),
+            watermark: Arc::new(Mutex::new(Some(watermark))),
             data: Arc::new(Mutex::new(test_data.clone())),
             ..Default::default()
         };
@@ -601,7 +601,7 @@ mod tests {
             assert!(data.contains_key(&3), "Checkpoint 3 should be preserved");
 
             // Check that the pruner_hi was updated past 1
-            let watermark = store.watermarks.lock().unwrap();
+            let watermark = store.watermark().unwrap();
             assert!(
                 watermark.pruner_hi > 1,
                 "Pruner watermark should be updated"
@@ -645,7 +645,7 @@ mod tests {
             pruner_hi: 0,
         };
         let store = MockStore {
-            watermarks: Arc::new(Mutex::new(watermark)),
+            watermark: Arc::new(Mutex::new(Some(watermark))),
             data: Arc::new(Mutex::new(test_data.clone())),
             ..Default::default()
         };
@@ -679,7 +679,7 @@ mod tests {
             assert!(data.contains_key(&3), "Checkpoint 3 should be preserved");
 
             // Check that the pruner_hi was updated past 1
-            let watermark = store.watermarks.lock().unwrap();
+            let watermark = store.watermark().unwrap();
             assert!(
                 watermark.pruner_hi > 1,
                 "Pruner watermark should be updated"
@@ -730,7 +730,7 @@ mod tests {
 
         // Configure failing behavior: range [1,2) should fail once before succeeding
         let store = MockStore {
-            watermarks: Arc::new(Mutex::new(watermark)),
+            watermark: Arc::new(Mutex::new(Some(watermark))),
             data: Arc::new(Mutex::new(test_data.clone())),
             ..Default::default()
         }
@@ -754,7 +754,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(500)).await;
         {
             let data = store.data.lock().unwrap();
-            let watermarks = store.watermarks.lock().unwrap();
+            let watermarks = store.watermark().unwrap();
 
             // Verify watermark doesn't advance past the failed range [1,2)
             assert_eq!(
@@ -771,7 +771,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(3000)).await;
         {
             let data = store.data.lock().unwrap();
-            let watermarks = store.watermarks.lock().unwrap();
+            let watermarks = store.watermark().unwrap();
 
             // Verify watermark advances after all ranges complete successfully
             assert_eq!(

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/committer.rs
@@ -40,7 +40,7 @@ use super::{Handler, SequentialConfig};
 /// The task can be shutdown using its `cancel` token or if either of its channels are closed.
 pub(super) fn committer<H>(
     config: SequentialConfig,
-    watermark: Option<CommitterWatermark>,
+    mut next_checkpoint: u64,
     mut rx: mpsc::Receiver<IndexedCheckpoint<H>>,
     tx: mpsc::UnboundedSender<(&'static str, u64)>,
     store: H::Store,
@@ -71,15 +71,11 @@ where
         let mut batch_rows = 0;
         let mut batch_checkpoints = 0;
 
-        // The task keeps track of the highest (inclusive) checkpoint it has added to the batch,
-        // and whether that batch needs to be written out. By extension it also knows the next
-        // checkpoint to expect and add to the batch.
-        let (mut watermark, mut next_checkpoint) = if let Some(watermark) = watermark {
-            let next = watermark.checkpoint_hi_inclusive + 1;
-            (watermark, next)
-        } else {
-            (CommitterWatermark::default(), 0)
-        };
+        // The task keeps track of the highest (inclusive) checkpoint it has added to the batch, and
+        // whether that batch needs to be written out. By extension it also knows the next
+        // checkpoint to expect and add to the batch. Initially, this watermark is synthetic, and
+        // will be overwritten by a processed checkpoint.
+        let mut watermark = CommitterWatermark::default();
 
         // The committer task will periodically output a log message at a higher log level to
         // demonstrate that the pipeline is making progress.
@@ -394,8 +390,8 @@ fn can_process_pending<T>(
 #[cfg(test)]
 mod tests {
     use crate::{
+        mocks::store::{MockConnection, MockStore},
         pipeline::{CommitterConfig, Processor},
-        testing::mock_store::{MockConnection, MockStore},
     };
 
     use super::*;
@@ -448,11 +444,9 @@ mod tests {
         committer_handle: JoinHandle<()>,
     }
 
-    fn setup_test(
-        initial_watermark: Option<CommitterWatermark>,
-        config: SequentialConfig,
-        store: MockStore,
-    ) -> TestSetup {
+    /// Emulates adding a sequential pipeline to the indexer. The next_checkpoint is the checkpoint
+    /// for the indexer to ingest from.
+    fn setup_test(next_checkpoint: u64, config: SequentialConfig, store: MockStore) -> TestSetup {
         let metrics = IndexerMetrics::new(None, &Registry::default());
         let cancel = CancellationToken::new();
 
@@ -463,7 +457,7 @@ mod tests {
         let store_clone = store.clone();
         let committer_handle = committer(
             config,
-            initial_watermark,
+            next_checkpoint,
             checkpoint_rx,
             watermark_tx,
             store_clone,
@@ -499,13 +493,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_committer_processes_sequential_checkpoints() {
-        // Setup with no initial watermark
-        let initial_watermark = None;
         let config = SequentialConfig {
             committer: CommitterConfig::default(),
             checkpoint_lag: 0, // Zero checkpoint lag to process new batch instantly
         };
-        let mut setup = setup_test(initial_watermark, config, MockStore::default());
+        let mut setup = setup_test(0, config, MockStore::default());
 
         // Send checkpoints in order
         for i in 0..3 {
@@ -520,7 +512,7 @@ mod tests {
 
         // Verify watermark was updated
         {
-            let watermark = setup.store.watermarks.lock().unwrap();
+            let watermark = setup.store.watermark().unwrap();
             assert_eq!(watermark.checkpoint_hi_inclusive, 2);
             assert_eq!(watermark.tx_hi, 2);
         }
@@ -535,15 +527,58 @@ mod tests {
         let _ = setup.committer_handle.await;
     }
 
+    /// Configure the MockStore with no watermark, and emulate `first_checkpoint` by passing the
+    /// `initial_watermark` into the setup.
+    #[tokio::test]
+    async fn test_committer_processes_sequential_checkpoints_with_initial_watermark() {
+        let config = SequentialConfig::default();
+        let mut setup = setup_test(5, config, MockStore::default());
+
+        // Verify watermark hasn't progressed
+        let watermark = setup.store.watermark();
+        assert!(watermark.is_none());
+
+        // Send checkpoints in order
+        for i in 0..5 {
+            send_checkpoint(&mut setup, i).await;
+        }
+
+        // Wait for processing
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+
+        // Verify watermark hasn't progressed
+        let watermark = setup.store.watermark();
+        assert!(watermark.is_none());
+
+        for i in 5..8 {
+            send_checkpoint(&mut setup, i).await;
+        }
+
+        // Wait for processing
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+
+        // Verify data was written in order
+        assert_eq!(setup.store.get_sequential_data(), vec![5, 6, 7]);
+
+        // Verify watermark was updated
+        {
+            let watermark = setup.store.watermark().unwrap();
+            assert_eq!(watermark.checkpoint_hi_inclusive, 7);
+            assert_eq!(watermark.tx_hi, 7);
+        }
+
+        // Clean up
+        drop(setup.checkpoint_tx);
+        let _ = setup.committer_handle.await;
+    }
+
     #[tokio::test]
     async fn test_committer_processes_out_of_order_checkpoints() {
-        // Setup with no initial watermark
-        let initial_watermark = None;
         let config = SequentialConfig {
             committer: CommitterConfig::default(),
             checkpoint_lag: 0, // Zero checkpoint lag to process new batch instantly
         };
-        let mut setup = setup_test(initial_watermark, config, MockStore::default());
+        let mut setup = setup_test(0, config, MockStore::default());
 
         // Send checkpoints out of order
         for i in [1, 0, 2] {
@@ -558,7 +593,7 @@ mod tests {
 
         // Verify watermark was updated
         {
-            let watermark = setup.store.watermarks.lock().unwrap();
+            let watermark = setup.store.watermark().unwrap();
             assert_eq!(watermark.checkpoint_hi_inclusive, 2);
             assert_eq!(watermark.tx_hi, 2);
         }
@@ -575,13 +610,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_committer_commit_up_to_max_batch_checkpoints() {
-        // Setup with no initial watermark
-        let initial_watermark = None;
         let config = SequentialConfig {
             committer: CommitterConfig::default(),
             checkpoint_lag: 0, // Zero checkpoint lag to process new batch instantly
         };
-        let mut setup = setup_test(initial_watermark, config, MockStore::default());
+        let mut setup = setup_test(0, config, MockStore::default());
 
         // Send checkpoints up to MAX_BATCH_CHECKPOINTS
         for i in 0..4 {
@@ -614,13 +647,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_committer_does_not_commit_until_checkpoint_lag() {
-        // Setup with no initial watermark
-        let initial_watermark = None;
         let config = SequentialConfig {
             committer: CommitterConfig::default(),
             checkpoint_lag: 1, // Only commit checkpoints that are at least 1 behind
         };
-        let mut setup = setup_test(initial_watermark, config, MockStore::default());
+        let mut setup = setup_test(0, config, MockStore::default());
 
         // Send checkpoints 0-2
         for i in 0..3 {
@@ -653,8 +684,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_committer_commits_eagerly() {
-        // Setup with no initial watermark
-        let initial_watermark = None;
         let config = SequentialConfig {
             committer: CommitterConfig {
                 collect_interval_ms: 4_000, // Long polling to test eager commit
@@ -662,7 +691,7 @@ mod tests {
             },
             checkpoint_lag: 0, // Zero checkpoint lag to not block the eager logic
         };
-        let mut setup = setup_test(initial_watermark, config, MockStore::default());
+        let mut setup = setup_test(0, config, MockStore::default());
 
         // Wait for initial poll to be over
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -691,8 +720,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_committer_cannot_commit_eagerly_due_to_checkpoint_lag() {
-        // Setup with no initial watermark
-        let initial_watermark = None;
         let config = SequentialConfig {
             committer: CommitterConfig {
                 collect_interval_ms: 4_000, // Long polling to test eager commit
@@ -700,7 +727,7 @@ mod tests {
             },
             checkpoint_lag: 4, // High checkpoint lag to block eager commits
         };
-        let mut setup = setup_test(initial_watermark, config, MockStore::default());
+        let mut setup = setup_test(0, config, MockStore::default());
 
         // Wait for initial poll to be over
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -732,8 +759,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_committer_retries_on_transaction_failure() {
-        // Setup with no initial watermark
-        let initial_watermark = None;
         let config = SequentialConfig {
             committer: CommitterConfig {
                 collect_interval_ms: 1_000, // Long polling to test retry logic
@@ -745,7 +770,7 @@ mod tests {
         // Create store with transaction failure configuration
         let store = MockStore::default().with_transaction_failures(1); // Will fail once before succeeding
 
-        let mut setup = setup_test(initial_watermark, config, store);
+        let mut setup = setup_test(0, config, store);
 
         // Send a checkpoint
         send_checkpoint(&mut setup, 0).await;

--- a/crates/sui-indexer-alt-framework/src/pipeline/sequential/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/sequential/mod.rs
@@ -11,7 +11,7 @@ use super::{processor::processor, CommitterConfig, Processor, PIPELINE_BUFFER};
 
 use crate::{
     metrics::IndexerMetrics,
-    store::{CommitterWatermark, Store, TransactionalStore},
+    store::{Store, TransactionalStore},
     types::full_checkpoint_content::CheckpointData,
 };
 
@@ -102,7 +102,7 @@ pub struct SequentialConfig {
 /// channels close, or any of its independent tasks fail.
 pub(crate) fn pipeline<H: Handler + Send + Sync + 'static>(
     handler: H,
-    initial_watermark: Option<CommitterWatermark>,
+    next_checkpoint: u64,
     config: SequentialConfig,
     db: H::Store,
     checkpoint_rx: mpsc::Receiver<Arc<CheckpointData>>,
@@ -122,7 +122,7 @@ pub(crate) fn pipeline<H: Handler + Send + Sync + 'static>(
 
     let committer = committer::<H>(
         config,
-        initial_watermark,
+        next_checkpoint,
         committer_rx,
         watermark_tx,
         db,


### PR DESCRIPTION
## Description 


Currently, if `first_checkpoint` is configured and a pipeline with no watermark row is added to the indexer, it'll essentially stall since the pipeline's committer task creates a default watermark with checkpoint_hi_inclusive = 0 and waits for this checkpoint. This prevents someone from using `first_checkpoint` to arbitrarily seed the starting point of pipelines for the first time. Consequently, indexer operators have to manually update the watermarks table to set a starting point that isn't 0.

In this PR, the indexer is now responsible for determining the `next_checkpoint` to commit and make watermark updates for each pipeline. In practice, for a valid `first_checkpoint` (`next_checkpoint`), sequential pipelines will wait to commit the next processed checkpoint after its watermark, while concurrent pipelines will start from the same `first_checkpoint`.

Meanwhile, the pipeline tasks initialize a default watermark variable for the logger, but in practice will always be overwritten by the next processed checkpoint for metrics and other reporting.

## Test plan 
- Unit tests for the behavior above
- commit_watermark and sequential committer tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
