### PR TITLE
graphql-alt: Add Validator.reportRecords

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/report_records.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/report_records.move
@@ -1,0 +1,24 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --simulator --num-custom-validator-accounts 2
+
+//# run-graphql
+{
+  epoch(epochId: 0) {
+    epochId
+    validatorSet {
+      activeValidators {
+        nodes {
+          name
+          # todo DVX-1697 populate reportRecords
+          reportRecords {
+            nodes {
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/report_records.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/validator_set/report_records.snap
@@ -1,0 +1,35 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 2 tasks
+
+init:
+A: object(0,0), validator_0: object(0,1), validator_1: object(0,2)
+
+task 1, lines 6-24:
+//# run-graphql
+Response: {
+  "data": {
+    "epoch": {
+      "epochId": 0,
+      "validatorSet": {
+        "activeValidators": {
+          "nodes": [
+            {
+              "name": "validator-0",
+              "reportRecords": {
+                "nodes": []
+              }
+            },
+            {
+              "name": "validator-1",
+              "reportRecords": {
+                "nodes": []
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -4128,6 +4128,10 @@ type Validator implements IAddressable {
 	"""
 	projectUrl: String
 	"""
+	Other validators this validator has reported.
+	"""
+	reportRecords(first: Int, before: String, last: Int, after: String): ValidatorConnection
+	"""
 	The epoch stake rewards will be added here at the end of each epoch.
 	"""
 	rewardsPool: BigInt

--- a/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/epoch.rs
@@ -236,17 +236,20 @@ impl Epoch {
             return Ok(None);
         };
 
-        let validator_set_v1 = match system_state {
-            SuiSystemState::V1(inner) => inner.validators,
-            SuiSystemState::V2(inner) => inner.validators,
+        let (validator_set_v1, report_records) = match system_state {
+            SuiSystemState::V1(inner) => (inner.validators, inner.validator_report_records),
+            SuiSystemState::V2(inner) => (inner.validators, inner.validator_report_records),
             #[cfg(msim)]
             SuiSystemState::SimTestV1(_)
             | SuiSystemState::SimTestShallowV2(_)
             | SuiSystemState::SimTestDeepV2(_) => return Ok(None),
         };
 
-        let validator_set =
-            ValidatorSet::from_validator_set_v1(self.scope.clone(), validator_set_v1);
+        let validator_set = ValidatorSet::from_validator_set_v1(
+            self.scope.clone(),
+            validator_set_v1,
+            report_records,
+        );
 
         Ok(Some(validator_set))
     }

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -4132,6 +4132,10 @@ type Validator implements IAddressable {
 	"""
 	projectUrl: String
 	"""
+	Other validators this validator has reported.
+	"""
+	reportRecords(first: Int, before: String, last: Int, after: String): ValidatorConnection
+	"""
 	The epoch stake rewards will be added here at the end of each epoch.
 	"""
 	rewardsPool: BigInt

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -4132,6 +4132,10 @@ type Validator implements IAddressable {
 	"""
 	projectUrl: String
 	"""
+	Other validators this validator has reported.
+	"""
+	reportRecords(first: Int, before: String, last: Int, after: String): ValidatorConnection
+	"""
 	The epoch stake rewards will be added here at the end of each epoch.
 	"""
 	rewardsPool: BigInt

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -4128,6 +4128,10 @@ type Validator implements IAddressable {
 	"""
 	projectUrl: String
 	"""
+	Other validators this validator has reported.
+	"""
+	reportRecords(first: Int, before: String, last: Int, after: String): ValidatorConnection
+	"""
 	The epoch stake rewards will be added here at the end of each epoch.
 	"""
 	rewardsPool: BigInt


### PR DESCRIPTION
## Description 

Implements `reportRecords` based on https://github.com/MystenLabs/sui/blob/7e9cd53ef28bf64470790c6b1ffb978fc07512b7/crates/sui-graphql-rpc/src/types/validator.rs#L329-L364.

The return type is now `Validator` instead of `Address`.

## Test plan 

This PR adds new `report_records.move` snapshot test file. Testing pagination is left as a `todo`.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
