### PR TITLE
Two fixes for commit handler v2

### DIFF
--- a/crates/sui-core/src/authority/epoch_start_configuration.rs
+++ b/crates/sui-core/src/authority/epoch_start_configuration.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use enum_dispatch::enum_dispatch;
+use mysten_common::in_test_configuration;
 use serde::{Deserialize, Serialize};
 use sui_config::NodeConfig;
 use sui_types::accumulator_root::get_accumulator_root_obj_initial_shared_version;
@@ -101,7 +102,7 @@ impl EpochFlag {
     fn default_flags_impl() -> Vec<Self> {
         let mut flags = vec![EpochFlag::DataQuarantineFromBeginningOfEpoch];
 
-        if std::env::var("SUI_USE_NEW_COMMIT_HANDLER").is_ok() {
+        if std::env::var("SUI_USE_NEW_COMMIT_HANDLER").is_ok() || in_test_configuration() {
             flags.push(EpochFlag::UseCommitHandlerV2);
         }
 

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -1913,6 +1913,10 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
             let name = self.epoch_store.name;
             let authority_index = self.epoch_store.committee().authority_index(&name).unwrap();
             authority_index < 2
+                && self
+                    .epoch_store
+                    .epoch_start_config()
+                    .use_commit_handler_v2()
         } else if self.epoch_store.protocol_config().use_new_commit_handler() {
             true
         } else {


### PR DESCRIPTION
- Fix bug in deferred transaction loading
- Fix upgrade tests on antithesis by requiring the epoch flag
