### PR TITLE
fix: replace ONCE.get().unwrap() with get_or_init in DBMetrics

### DIFF
--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -990,11 +990,9 @@ impl DBMetrics {
         // registries. The problem is underlying metrics cannot be re-initialized
         // or prometheus complains. We essentially need to pass in DBMetrics
         // everywhere we create DBMap as the right fix
-        let _ = ONCE
-            .set(Arc::new(DBMetrics::new(registry_service)))
-            // this happens many times during tests
-            .tap_err(|_| warn!("DBMetrics registry overwritten"));
-        ONCE.get().unwrap()
+        ONCE.get_or_init(|| {
+            Arc::new(DBMetrics::new(registry_service))
+        })
     }
     pub fn increment_num_active_dbs(&self, db_name: &str) {
         self.op_metrics


### PR DESCRIPTION
This change fixes a potential panic in DBMetrics::init() by replacing the unsafe ONCE.get().unwrap() pattern with the safer get_or_init() method. This eliminates the race condition for creating `DBMetrics`.

The get_or_init() method ensures thread-safe initialization and eliminates the need for separate set() and get() calls, making the code more robust and eliminating the warning about registry overwriting during tests.

