### PR TITLE
fix: replace ONCE.get().unwrap() with get_or_init in DBMetrics

### DIFF
--- a/crates/typed-store/src/metrics.rs
+++ b/crates/typed-store/src/metrics.rs
@@ -1,5 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
 use mysten_metrics::RegistryService;
 use once_cell::sync::OnceCell;
 use prometheus::{
@@ -8,10 +14,8 @@ use prometheus::{
 };
 use rocksdb::perf::set_perf_stats;
 use rocksdb::{PerfContext, PerfMetric, PerfStatsLevel};
-use std::cell::RefCell;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
-use std::time::Duration;
+use tap::TapFallible;
+use tracing::warn;
 
 thread_local! {
     static PER_THREAD_ROCKS_PERF_CONTEXT: std::cell::RefCell<rocksdb::PerfContext>  = RefCell::new(PerfContext::default());
@@ -980,31 +984,36 @@ impl DBMetrics {
             registry_serivce: registry_service,
         }
     }
-    pub fn init(registry_service: RegistryService) -> &'static Arc<DBMetrics> {
+
+    // TODO: Remove static initialization (init() and get()) by constructing DBMetrics
+    // and accessing it without static variables.
+    pub fn init(registry_service: RegistryService) {
         // Initialize this before creating any instance of DBMap
-        // TODO: Remove static initialization because this basically means we can
-        // only ever initialize db metrics once with a registry whereas
-        // in the code we might want to initialize it with different
-        // registries. The problem is underlying metrics cannot be re-initialized
-        // or prometheus complains. We essentially need to pass in DBMetrics
-        // everywhere we create DBMap as the right fix
-        ONCE.get_or_init(|| Arc::new(DBMetrics::new(registry_service)))
+        let _ = ONCE
+            .set(Arc::new(DBMetrics::new(registry_service)))
+            // this happens many times during tests
+            .tap_err(|_| warn!("DBMetrics registry overwritten"));
     }
+
     pub fn increment_num_active_dbs(&self, db_name: &str) {
         self.op_metrics
             .rocksdb_num_active_db_handles
             .with_label_values(&[db_name])
             .inc();
     }
+
     pub fn decrement_num_active_dbs(&self, db_name: &str) {
         self.op_metrics
             .rocksdb_num_active_db_handles
             .with_label_values(&[db_name])
             .dec();
     }
+
     pub fn get() -> &'static Arc<DBMetrics> {
-        ONCE.get().unwrap_or_else(|| {
-            DBMetrics::init(RegistryService::new(prometheus::default_registry().clone()))
+        ONCE.get_or_init(|| {
+            Arc::new(DBMetrics::new(RegistryService::new(
+                prometheus::default_registry().clone(),
+            )))
         })
     }
 }


### PR DESCRIPTION
## Description 

This change fixes a potential panic in DBMetrics::init() by replacing the unsafe ONCE.get().unwrap() pattern with the safer get_or_init() method. This eliminates the race condition of creating DBMetrics concurrently.

The get_or_init() method ensures thread-safe initialization and eliminates the need for separate set() and get() calls, making the code more robust and eliminating the warning about registry overwriting during tests.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
