### PR TITLE
fix(discovery): fix processing of `own_info` from peers

### DIFF
--- a/crates/sui-network/src/discovery/mod.rs
+++ b/crates/sui-network/src/discovery/mod.rs
@@ -509,7 +509,8 @@ fn update_known_peers(
     let our_peer_id = state.read().unwrap().our_info.clone().unwrap().peer_id;
     let known_peers = &mut state.write().unwrap().known_peers;
     // only take the first MAX_PEERS_TO_SEND peers
-    for peer_info in found_peers.into_iter().take(MAX_PEERS_TO_SEND) {
+    for peer_info in found_peers.into_iter().take(MAX_PEERS_TO_SEND + 1) {
+        // +1 to account for the "own_info" of the serving peer
         // Skip peers whose timestamp is too far in the future from our clock
         // or that are too old
         if peer_info.timestamp_ms > now_unix.saturating_add(30 * 1_000) // 30 seconds


### PR DESCRIPTION
## Description 

Peers in the discovery will send up to `MAX_PEERS_TO_SEND` as a response to `get_known_peers_v2`. In the receiving node, the `own_info` of the sending peer is added to the end of the `found_peers` vector. Later in `update_known_peers` this vector is capped at `MAX_PEERS_TO_SEND` again. This causes that basically no node is able to update their `own_info` if there are more than `MAX_PEERS_TO_SEND` known peers in the network.

---

## Release notes

- [ ] Protocol: 
- [x] Nodes (Validators and Full nodes): Fix processing of `own_info` from peers in node discovery
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
