### PR TITLE
[TransactionDriver] randomize submission validator selection within latency range

### DIFF
--- a/crates/mysten-common/src/moving_window.rs
+++ b/crates/mysten-common/src/moving_window.rs
@@ -1,52 +1,52 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::VecDeque;
+use std::{collections::VecDeque, fmt::Debug, time::Duration};
 
-/// A moving window that maintains the last N values and calculates their average.
-/// This provides a true arithmetic mean of recent values, with all values in the window
-/// having equal weight. When the window is full and a new value is added, the oldest
-/// value is removed to maintain the window size.
+/// A moving window that maintains the last N values of type `T` and calculates their arithmetic
+/// mean. All values in the window have equal weight and the oldest value is dropped when the
+/// window exceeds its configured capacity.
 #[derive(Debug, Clone)]
-pub struct MovingWindow {
-    values: VecDeque<f64>,
+pub struct MovingWindow<T: MovingWindowValue> {
+    values: VecDeque<T>,
     max_size: usize,
-    sum: f64,
+    sum: T,
 }
 
-impl MovingWindow {
-    /// Create a new MovingWindow with the specified maximum size and an `init_value`. The provided `max_size` must be greater than 0.
-    pub fn new(init_value: f64, max_size: usize) -> Self {
+impl<T: MovingWindowValue> MovingWindow<T> {
+    /// Creates a new `MovingWindow` with the specified maximum size and an `init_value`.
+    /// The provided `max_size` must be greater than 0.
+    pub fn new(init_value: T, max_size: usize) -> Self {
         assert!(max_size > 0, "Window size must be greater than 0");
         let mut window = Self {
             values: VecDeque::with_capacity(max_size),
             max_size,
-            sum: 0.0,
+            sum: T::zero(),
         };
         window.add_value(init_value);
         window
     }
 
-    /// Add a new value to the window. If the window is at capacity, the oldest value is removed before adding the new value.
-    pub fn add_value(&mut self, value: f64) {
+    /// Adds a new value to the window. If the window is at capacity, the oldest value is removed
+    /// before adding the new value.
+    pub fn add_value(&mut self, value: T) {
         if self.values.len() == self.max_size {
-            // Remove oldest value
             if let Some(old_value) = self.values.pop_front() {
-                self.sum -= old_value;
+                T::sub_assign(&mut self.sum, old_value);
             }
         }
 
-        // Add new value
         self.values.push_back(value);
-        self.sum += value;
+        T::add_assign(&mut self.sum, value);
     }
 
-    /// Get the current average of all values in the window. Returns 0.0 if the window is empty.
-    pub fn get(&self) -> f64 {
+    /// Get the current average of all values in the window. Returns the value's zero if the
+    /// window is empty.
+    pub fn get(&self) -> T {
         if self.values.is_empty() {
-            0.0
+            T::zero()
         } else {
-            self.sum / self.values.len() as f64
+            T::average(self.sum, self.values.len())
         }
     }
 
@@ -57,6 +57,50 @@ impl MovingWindow {
 
     pub fn is_empty(&self) -> bool {
         self.values.is_empty()
+    }
+}
+
+pub trait MovingWindowValue: Copy + Debug {
+    fn zero() -> Self;
+    fn add_assign(target: &mut Self, value: Self);
+    fn sub_assign(target: &mut Self, value: Self);
+    fn average(total: Self, divisor: usize) -> Self;
+}
+
+impl MovingWindowValue for Duration {
+    fn zero() -> Self {
+        Duration::ZERO
+    }
+
+    fn add_assign(target: &mut Self, value: Self) {
+        *target += value;
+    }
+
+    fn sub_assign(target: &mut Self, value: Self) {
+        *target -= value;
+    }
+
+    fn average(total: Self, divisor: usize) -> Self {
+        let divisor = u32::try_from(divisor).expect("window size too large for Duration average");
+        total / divisor
+    }
+}
+
+impl MovingWindowValue for f64 {
+    fn zero() -> Self {
+        0.0
+    }
+
+    fn add_assign(target: &mut Self, value: Self) {
+        *target += value;
+    }
+
+    fn sub_assign(target: &mut Self, value: Self) {
+        *target -= value;
+    }
+
+    fn average(total: Self, divisor: usize) -> Self {
+        total / divisor as f64
     }
 }
 
@@ -72,45 +116,60 @@ mod tests {
     }
 
     #[test]
-    fn test_add_values_within_capacity() {
-        let mut window = MovingWindow::new(0.0, 3);
+    fn test_duration_window() {
+        let mut window = MovingWindow::new(Duration::ZERO, 3);
+        assert_eq!(window.get(), Duration::ZERO);
 
-        window.add_value(1.0);
-        assert_eq!(window.get(), 0.5);
+        // Adding value within the window size.
+        window.add_value(Duration::from_millis(100));
+        assert_eq!(window.get(), Duration::from_millis(50));
         assert_eq!(window.len(), 2);
 
-        window.add_value(2.0);
-        assert_eq!(window.get(), 1.0);
+        // Adding value within the window size.
+        window.add_value(Duration::from_millis(200));
+        assert_eq!(window.get(), Duration::from_millis(100));
         assert_eq!(window.len(), 3);
 
-        window.add_value(3.0);
-        assert_eq!(window.get(), 2.0);
+        // Adding values exceeding the window size.
+        window.add_value(Duration::from_millis(300));
+        assert_eq!(window.get(), Duration::from_millis(200));
+        assert_eq!(window.len(), 3);
+
+        // Adding values exceeding the window size.
+        window.add_value(Duration::from_millis(400));
+        assert_eq!(window.get(), Duration::from_millis(300));
         assert_eq!(window.len(), 3);
     }
 
     #[test]
-    fn test_add_values_exceeding_capacity() {
-        let mut window = MovingWindow::new(0.0, 3);
+    fn test_float_window() {
+        let mut window = MovingWindow::new(0.0_f64, 3);
+        assert_eq!(window.get(), 0.0);
 
-        // Fill the window
+        // Adding value within the window size.
         window.add_value(1.0);
-        window.add_value(2.0);
-        window.add_value(3.0);
-        assert_eq!(window.get(), 2.0);
+        assert_eq!(window.get(), 0.5);
+        assert_eq!(window.len(), 2);
 
-        // Add fourth value, should remove first
-        window.add_value(4.0);
-        assert_eq!(window.get(), 3.0); // (2 + 3 + 4) / 3
+        // Adding value within the window size.
+        window.add_value(2.0);
+        assert_eq!(window.get(), 1.5);
         assert_eq!(window.len(), 3);
 
-        // Add fifth value, should remove second
-        window.add_value(5.0);
-        assert_eq!(window.get(), 4.0); // (3 + 4 + 5) / 3
+        // Adding value exceeding the window size.
+        window.add_value(3.0);
+        assert_eq!(window.get(), 2.0);
+        assert_eq!(window.len(), 3);
+
+        // Adding value exceeding the window size.
+        window.add_value(4.0);
+        assert_eq!(window.get(), 3.0);
+        assert_eq!(window.len(), 3);
     }
 
     #[test]
     #[should_panic(expected = "Window size must be greater than 0")]
     fn test_zero_size_panics() {
-        MovingWindow::new(0.0, 0);
+        let _window = MovingWindow::new(0.0_f64, 0);
     }
 }

--- a/crates/sui-core/src/transaction_driver/request_retrier.rs
+++ b/crates/sui-core/src/transaction_driver/request_retrier.rs
@@ -16,7 +16,8 @@ use crate::{
     validator_client_monitor::ValidatorClientMonitor,
 };
 
-pub(crate) const TOP_K_VALIDATORS_DENOMINATOR: usize = 3;
+/// Select validators with latencies within 10% of the lowest latency.
+const SELECT_LATENCY_DELTA: f64 = 0.1;
 
 /// Provides the next target validator to retry operations,
 /// and gathers the errors along with the operations.
@@ -30,7 +31,7 @@ pub(crate) const TOP_K_VALIDATORS_DENOMINATOR: usize = 3;
 ///
 /// This component helps to manager this retry pattern.
 pub(crate) struct RequestRetrier<A: Clone> {
-    remaining_clients: VecDeque<(AuthorityName, Arc<SafeClient<A>>)>,
+    ranked_clients: VecDeque<(AuthorityName, Arc<SafeClient<A>>)>,
     pub(crate) non_retriable_errors_aggregator: StatusAggregator<TransactionRequestError>,
     pub(crate) retriable_errors_aggregator: StatusAggregator<TransactionRequestError>,
 }
@@ -42,19 +43,16 @@ impl<A: Clone> RequestRetrier<A> {
         tx_type: TxType,
         allowed_validators: Vec<AuthorityName>,
     ) -> Self {
-        let selected_validators = if !allowed_validators.is_empty() {
-            allowed_validators
-        } else {
-            client_monitor.select_shuffled_preferred_validators(
-                &auth_agg.committee,
-                auth_agg.committee.num_members() / TOP_K_VALIDATORS_DENOMINATOR,
-                tx_type,
-            )
-        };
-        let remaining_clients = selected_validators
+        let ranked_validators = client_monitor.select_shuffled_preferred_validators(
+            &auth_agg.committee,
+            tx_type,
+            SELECT_LATENCY_DELTA,
+        );
+        let ranked_clients = ranked_validators
             .into_iter()
+            .filter(|name| allowed_validators.contains(name))
             .filter_map(|name| {
-                // There is not guarantee that the `selected_validators` are in the `auth_agg.authority_clients` if those are coming from the list
+                // There is not guarantee that the `name` are in the `auth_agg.authority_clients` if those are coming from the list
                 // of `allowed_validators`, as the provided `auth_agg` might have been updated with a new committee that doesn't contain the validator in question.
                 auth_agg
                     .authority_clients
@@ -65,7 +63,7 @@ impl<A: Clone> RequestRetrier<A> {
         let non_retriable_errors_aggregator = StatusAggregator::new(auth_agg.committee.clone());
         let retriable_errors_aggregator = StatusAggregator::new(auth_agg.committee.clone());
         Self {
-            remaining_clients,
+            ranked_clients,
             non_retriable_errors_aggregator,
             retriable_errors_aggregator,
         }
@@ -75,7 +73,7 @@ impl<A: Clone> RequestRetrier<A> {
     pub(crate) fn next_target(
         &mut self,
     ) -> Result<(AuthorityName, Arc<SafeClient<A>>), TransactionDriverError> {
-        if let Some((name, client)) = self.remaining_clients.pop_front() {
+        if let Some((name, client)) = self.ranked_clients.pop_front() {
             return Ok((name, client));
         };
 
@@ -214,8 +212,8 @@ mod tests {
             );
 
             // Should only have 1 remaining client (the known validator)
-            assert_eq!(retrier.remaining_clients.len(), 1);
-            assert_eq!(retrier.remaining_clients[0].0, authorities[0]);
+            assert_eq!(retrier.ranked_clients.len(), 1);
+            assert_eq!(retrier.ranked_clients[0].0, authorities[0]);
         }
 
         println!("Case 2. Only unknown validators are provided");
@@ -230,7 +228,7 @@ mod tests {
             );
 
             // Should have no remaining clients since none of the allowed validators exist
-            assert_eq!(retrier.remaining_clients.len(), 0);
+            assert_eq!(retrier.ranked_clients.len(), 0);
         }
     }
 


### PR DESCRIPTION
## Description 

Current 1/3 of validators by count have equal chances of being submission validators. This change restricts the selection to validators within 10% of lowest latency validator.

## Test plan 

CI