### PR TITLE
display: new syntax for dynamic field access.

### DIFF
--- a/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__arrow_missing_index.snap
+++ b/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__arrow_missing_index.snap
@@ -1,0 +1,5 @@
+---
+source: crates/sui-display/src/v2/parser.rs
+expression: "strands(r#\"{foo->bar}\"#)"
+---
+Error: Unexpected identifier "bar" at offset 6, expected '['

--- a/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__double_arrow_missing_index.snap
+++ b/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__double_arrow_missing_index.snap
@@ -1,0 +1,5 @@
+---
+source: crates/sui-display/src/v2/parser.rs
+expression: "strands(r#\"{foo=>}\"#)"
+---
+Error: Unexpected '}' at offset 6, expected '['

--- a/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__index_chain.snap
+++ b/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__index_chain.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/sui-display/src/v2/parser.rs
-expression: "strands(r#\"{foo[bar][[baz]].qux[quy]}\"#)"
+expression: "strands(r#\"{foo[bar]=>[baz].qux->[quy]}\"#)"
 ---
-{ foo[bar][[baz]].qux[quy]
+{ foo[bar]=>[baz].qux->[quy]
 }

--- a/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__index_with_root.snap
+++ b/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__index_with_root.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/sui-display/src/v2/parser.rs
-expression: "strands(r#\"{true[[foo]][bar].baz}\"#)"
+expression: "strands(r#\"{true=>[foo]->[bar].baz}\"#)"
 ---
-{ true[[foo]][bar].baz
+{ true=>[foo]->[bar].baz
 }

--- a/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__spaced_out_left_double_index.snap
+++ b/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__spaced_out_left_double_index.snap
@@ -1,5 +1,0 @@
----
-source: crates/sui-display/src/v2/parser.rs
-expression: "strands(r#\"{foo[ [bar]]}\"#)"
----
-Error: Unexpected whitespace followed by '[' at offset 6, expected one of 'b', 'false', 'true', 'x', '@', an identifier, '[', a decimal number, a hexadecimal number, or a string

--- a/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__spaced_out_right_double_index.snap
+++ b/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__spaced_out_right_double_index.snap
@@ -1,5 +1,0 @@
----
-source: crates/sui-display/src/v2/parser.rs
-expression: "strands(r#\"{foo[[bar] ]}\"#)"
----
-Error: Unexpected whitespace followed by ']' at offset 11, expected ']'

--- a/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__triple_index.snap
+++ b/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__triple_index.snap
@@ -1,5 +1,0 @@
----
-source: crates/sui-display/src/v2/parser.rs
-expression: "strands(r#\"{foo[[[bar]]]}\"#)"
----
-Error: Unexpected '[' at offset 6, expected one of 'b', 'false', 'true', 'x', '@', an identifier, a decimal number, a hexadecimal number, or a string

--- a/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__unbalanced_double_index.snap
+++ b/crates/sui-display/src/v2/snapshots/sui_display__v2__parser__tests__unbalanced_double_index.snap
@@ -1,5 +1,0 @@
----
-source: crates/sui-display/src/v2/parser.rs
-expression: "strands(r#\"{foo[[bar}\"#)"
----
-Error: Unexpected '}' at offset 9, expected ']'


### PR DESCRIPTION
## Description

Differentiate the syntax for vector access from the syntax for dynamic field and dynamic object field access so that we can always determine from the syntax which accesses are going to load objects. The new syntax is as follows:

```
e[f]    # vector or VecMap access
e->[f]  # dynamic field access
e=>[f]  # dynamic object field access
```

In future, we may also supporting "dereferencing" an object by its ID, and fetching a field from that value, with the following syntax:

```
e->f
```

And it is TBD what the syntax would be for loading a value, wholesale.

## Test plan

```
$ cargo nextest run -p sui-display
```

## Stack

- #22290 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
