### PR TITLE
[move][move-model-2] Allow phantom type flags to be missing in summary generation when missing dependencies are allowed.

### DIFF
--- a/external-crates/move/crates/move-model-2/src/compiled_model.rs
+++ b/external-crates/move/crates/move-model-2/src/compiled_model.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    model::{self, ModelBuilderConfig, PackageData},
+    model::{self, ModelConfig, PackageData},
     normalized,
     source_kind::{Uninit, WithoutSource},
     summary,
@@ -28,12 +28,12 @@ impl Model {
         named_address_reverse_map: &BTreeMap<AccountAddress, Symbol>,
         modules: Vec<CompiledModule>,
     ) -> Self {
-        let config = ModelBuilderConfig::default();
-        Self::from_compiled_with_config(&config, named_address_reverse_map, modules)
+        let config = ModelConfig::default();
+        Self::from_compiled_with_config(config, named_address_reverse_map, modules)
     }
 
     pub fn from_compiled_with_config(
-        builder_config: &ModelBuilderConfig,
+        config: ModelConfig,
         named_address_reverse_map: &BTreeMap<AccountAddress, Symbol>,
         modules: Vec<CompiledModule>,
     ) -> Self {
@@ -61,9 +61,10 @@ impl Model {
             compiled,
             packages,
             summary: OnceCell::new(),
+            config,
             _phantom: std::marker::PhantomData,
         };
-        model.compute_dependencies(builder_config);
+        model.compute_dependencies();
         model.compute_function_dependencies();
         model.check_invariants();
         model

--- a/external-crates/move/crates/move-model-2/src/source_model.rs
+++ b/external-crates/move/crates/move-model-2/src/source_model.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     TModuleId,
-    model::{self, ModelBuilderConfig, NamedConstantData, PackageData},
+    model::{self, ModelConfig, NamedConstantData, PackageData},
     normalized,
     source_kind::WithSource,
     summary,
@@ -60,7 +60,7 @@ impl Model {
         compiled_units_vec: Vec<(/* file */ PathBuf, CompiledUnit)>,
     ) -> anyhow::Result<Self> {
         Self::from_source_with_config(
-            &ModelBuilderConfig::default(),
+            ModelConfig::default(),
             files,
             root_package_name,
             root_named_address_map,
@@ -70,7 +70,7 @@ impl Model {
     }
 
     pub fn from_source_with_config(
-        builder_config: &model::ModelBuilderConfig,
+        config: model::ModelConfig,
         files: MappedFiles,
         root_package_name: Option<Symbol>,
         root_named_address_map: BTreeMap<Symbol, AccountAddress>,
@@ -146,9 +146,10 @@ impl Model {
             compiled,
             packages,
             summary: OnceCell::new(),
+            config,
             _phantom: std::marker::PhantomData,
         };
-        model.compute_dependencies(builder_config);
+        model.compute_dependencies();
         model.compute_function_dependencies();
         model.check_invariants();
         Ok(model)

--- a/external-crates/move/crates/move-model-2/src/summary.rs
+++ b/external-crates/move/crates/move-model-2/src/summary.rs
@@ -5,7 +5,13 @@
 //! source code. The summaries include the signatures of all functions (potentially macros) and
 //! datatypes (structs and enums).
 
-use crate::{TModuleId, model::Model, normalized, source_kind::SourceKind, source_model};
+use crate::{
+    TModuleId,
+    model::{Model, ModelConfig},
+    normalized,
+    source_kind::SourceKind,
+    source_model,
+};
 
 use move_binary_format::file_format;
 use move_compiler::{
@@ -244,6 +250,7 @@ pub struct DatatypeTArg {
 //**************************************************************************************************
 
 pub struct Context {
+    config: ModelConfig,
     root_named_address_reverse_map: BTreeMap<AccountAddress, Symbol>,
     phantom_type_positions:
         BTreeMap<normalized::ModuleId, BTreeMap<Symbol, Vec</* is phantom */ bool>>>,
@@ -251,6 +258,7 @@ pub struct Context {
 
 impl Context {
     pub fn new<K: SourceKind>(model: &Model<K>) -> Self {
+        let config = model.config.clone();
         let root_named_address_reverse_map = model.root_named_address_reverse_map.clone();
         let phantom_type_positions = model
             .compiled
@@ -274,6 +282,7 @@ impl Context {
             })
             .collect();
         Self {
+            config,
             root_named_address_reverse_map,
             phantom_type_positions,
         }
@@ -564,8 +573,20 @@ impl DatatypeTArg {
         idx: usize,
         ty: Type,
     ) -> Self {
+        let phantom = if context.config.allow_missing_dependencies {
+            // Default to false if we do not find it.
+            *context
+                .phantom_type_positions
+                .get(module)
+                .and_then(|m| m.get(name))
+                .and_then(|v| v.get(idx))
+                .unwrap_or(&false)
+        } else {
+            // Assume it is there and panic otherwise.
+            context.phantom_type_positions[module][name][idx]
+        };
         Self {
-            phantom: context.phantom_type_positions[module][name][idx],
+            phantom,
             argument: ty,
         }
     }


### PR DESCRIPTION
## Description 

This updates summary generation to use the config, and updates phantom type flag determination to not panic when `allow_missing_deps` is set to true in the config.

## Test plan 

Still works, plus downstream decompiler tests no longer panic when resolving types using the summary.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
