### PR TITLE
[kv store] alternative watermark implementation

### DIFF
--- a/crates/sui-kvstore/src/bigtable/init.sh
+++ b/crates/sui-kvstore/src/bigtable/init.sh
@@ -10,7 +10,7 @@ if [[ -n $BIGTABLE_EMULATOR_HOST ]]; then
   command+=(-project emulator)
 fi
 
-for table in objects transactions checkpoints checkpoints_by_digest watermark epochs; do
+for table in objects transactions checkpoints checkpoints_by_digest watermark watermark_alt epochs; do
   (
     set -x
     "${command[@]}" createtable $table


### PR DESCRIPTION
## Description 
Alternative implementation of the watermark table.
Instead of using multiple keys and a scan operation, it uses a single key.
For conflict resolution with multiple writers, a timestamp is used (instead of the timestamp watermark itself being passed).
The current version of the client limits the number of returned cell versions to 1, so the latest one (the largest) should be returned.
The same GC policy (maxversions=1) is applied to the table.
This creates a single-key hotspot, so alternative suggestions are welcome, but it may be worth a shot given the poor performance of the existing table


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
