### PR TITLE
[sui-adapter] Simplify event call check in execution

### DIFF
--- a/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
+++ b/sui-execution/latest/sui-adapter/src/programmable_transactions/execution.rs
@@ -78,9 +78,7 @@ mod checked {
     };
     use sui_verifier::{
         INIT_FN_NAME,
-        private_generics::{
-            EVENT_MODULE, PRIVATE_EVENT_FUNCTIONS, PRIVATE_TRANSFER_FUNCTIONS, TRANSFER_MODULE,
-        },
+        private_generics::{EVENT_MODULE, PRIVATE_TRANSFER_FUNCTIONS, TRANSFER_MODULE},
     };
     use tracing::instrument;
 
@@ -1389,9 +1387,7 @@ mod checked {
         function: &IdentStr,
     ) -> Result<(), ExecutionError> {
         let module_ident = (module_id.address(), module_id.name());
-        if module_ident == (&SUI_FRAMEWORK_ADDRESS, EVENT_MODULE)
-            && PRIVATE_EVENT_FUNCTIONS.contains(&function)
-        {
+        if module_ident == (&SUI_FRAMEWORK_ADDRESS, EVENT_MODULE) {
             return Err(ExecutionError::new_with_source(
                 ExecutionErrorKind::NonEntryFunctionInvoked,
                 format!("Cannot directly call functions in sui::{}", EVENT_MODULE),


### PR DESCRIPTION
## Description 

Didn't catch this in #23182 but we don't actually need to add the check against the `PRIVATE_EVENT_FUNCTIONS` and could have kept the existing checks that were there which are a bit more robust (as they ban any calls into the event module not just specific functions even though those are the only ones you can call today), so this moves it back to the pre-existing check.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
