### PR TITLE
[17/n][bella-ciao] Variable renaming of `runtime_id` and `storage_id`

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/dev_utils/in_memory_test_adapter.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/dev_utils/in_memory_test_adapter.rs
@@ -12,7 +12,7 @@ use crate::{
     runtime::MoveRuntime,
     shared::{
         linkage_context::LinkageContext,
-        types::{DefiningTypeId, OriginalId},
+        types::{OriginalId, VersionId},
     },
     validation::verification::ast as verif_ast,
 };
@@ -175,7 +175,7 @@ impl VMTestAdapter<InMemoryStorage> for InMemoryTestAdapter {
     fn generate_linkage_context(
         &self,
         original_id: OriginalId,
-        version_id: DefiningTypeId,
+        version_id: VersionId,
         modules: &[CompiledModule],
     ) -> VMResult<LinkageContext> {
         let mut all_dependencies: BTreeSet<AccountAddress> = BTreeSet::new();
@@ -213,7 +213,7 @@ impl VMTestAdapter<InMemoryStorage> for InMemoryTestAdapter {
         Ok(linkage_context)
     }
 
-    fn get_package_from_store(&self, version_id: &DefiningTypeId) -> VMResult<SerializedPackage> {
+    fn get_package_from_store(&self, version_id: &VersionId) -> VMResult<SerializedPackage> {
         self.get_package(version_id)
     }
 

--- a/external-crates/move/crates/move-vm-runtime/src/dev_utils/vm_arguments.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/dev_utils/vm_arguments.rs
@@ -52,7 +52,7 @@ impl ValueFrame {
 
     pub fn serialized_call(
         vm: &mut MoveVM<'_>,
-        runtime_id: &ModuleId,
+        original_id: &ModuleId,
         function_name: &IdentStr,
         ty_args: Vec<Type>,
         serialized_args: Vec<impl Borrow<[u8]>>,
@@ -61,7 +61,7 @@ impl ValueFrame {
         bypass_declared_entry_check: bool,
     ) -> VMResult<Self> {
         let mut frame = Self::empty();
-        let fun = vm.find_function(runtime_id, function_name, &ty_args)?;
+        let fun = vm.find_function(original_id, function_name, &ty_args)?;
         let arg_types = fun
             .parameters
             .into_iter()
@@ -73,7 +73,7 @@ impl ValueFrame {
             .map_err(|e| e.finish(Location::Undefined))?;
         let return_values = if bypass_declared_entry_check {
             vm.execute_function_bypass_visibility(
-                runtime_id,
+                original_id,
                 function_name,
                 ty_args,
                 frame.values,
@@ -82,7 +82,7 @@ impl ValueFrame {
             )?
         } else {
             debug_assert!(tracer.is_none());
-            vm.execute_entry_function(runtime_id, function_name, ty_args, frame.values, gas_meter)?
+            vm.execute_entry_function(original_id, function_name, ty_args, frame.values, gas_meter)?
         };
         frame.values = return_values;
         Ok(frame)

--- a/external-crates/move/crates/move-vm-runtime/src/dev_utils/vm_test_adapter.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/dev_utils/vm_test_adapter.rs
@@ -7,7 +7,7 @@ use crate::{
     runtime::MoveRuntime,
     shared::{
         linkage_context::LinkageContext,
-        types::{DefiningTypeId, OriginalId},
+        types::{OriginalId, VersionId},
     },
     validation::verification::ast as verif_ast,
 };
@@ -68,17 +68,17 @@ pub trait VMTestAdapter<Storage: ModuleResolver + Sync + Send> {
     fn generate_linkage_context(
         &self,
         original_id: OriginalId,
-        version_id: DefiningTypeId,
+        version_id: VersionId,
         modules: &[CompiledModule],
     ) -> VMResult<LinkageContext>;
 
     /// Retrieve the linkage context for the given package in `Storage`.
-    fn get_linkage_context(&self, version_id: DefiningTypeId) -> VMResult<LinkageContext> {
+    fn get_linkage_context(&self, version_id: VersionId) -> VMResult<LinkageContext> {
         let pkg = self.get_package_from_store(&version_id)?;
         Ok(LinkageContext::new(pkg.linkage_table))
     }
 
-    fn get_package_from_store(&self, version_id: &DefiningTypeId) -> VMResult<SerializedPackage>;
+    fn get_package_from_store(&self, version_id: &VersionId) -> VMResult<SerializedPackage>;
 
     /// Get the move runtime associated with the adapter.
     fn runtime(&mut self) -> &mut MoveRuntime;

--- a/external-crates/move/crates/move-vm-runtime/src/execution/tracing/tracer.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/tracing/tracer.rs
@@ -1841,9 +1841,9 @@ fn into_annotated_move_value(
     Some(value.as_annotated_move_value(type_)?.into())
 }
 
-fn get_version_id(vtables: &VMDispatchTables, runtime_id: &ModuleId) -> AccountAddress {
+fn get_version_id(vtables: &VMDispatchTables, original_id: &ModuleId) -> AccountAddress {
     vtables
-        .get_package(runtime_id.address())
+        .get_package(original_id.address())
         .expect("Package must be loaded")
         .version_id
 }

--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/ast.rs
@@ -280,7 +280,7 @@ pub(crate) enum ArenaType {
 pub struct DatatypeDescriptor {
     pub(crate) name: IdentifierKey,
     pub defining_id: ModuleIdKey,
-    pub runtime_id: ModuleIdKey,
+    pub original_id: ModuleIdKey,
     pub datatype_info: ArenaBox<Datatype>,
 }
 
@@ -996,13 +996,13 @@ impl DatatypeDescriptor {
     pub(crate) fn new(
         name: IdentifierKey,
         defining_id: ModuleIdKey,
-        runtime_id: ModuleIdKey,
+        original_id: ModuleIdKey,
         datatype_info: ArenaBox<Datatype>,
     ) -> Self {
         Self {
             name,
             defining_id,
-            runtime_id,
+            original_id,
             datatype_info,
         }
     }

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/loader_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/loader_tests.rs
@@ -173,10 +173,10 @@ impl Adapter {
         if !self.store.type_origin.is_empty() {
             pkg.0.type_origin_table = self.store.type_origin.clone();
         }
-        let runtime_id = pkg.0.original_id;
+        let original_id = pkg.0.original_id;
         self.runtime_adapter
             .write()
-            .publish_package(runtime_id, pkg.into_serialized_package())
+            .publish_package(original_id, pkg.into_serialized_package())
             .unwrap_or_else(|e| panic!("failure publishing modules: {e:?}"));
     }
 
@@ -187,10 +187,10 @@ impl Adapter {
         if !self.store.type_origin.is_empty() {
             pkg.0.type_origin_table = self.store.type_origin.clone();
         }
-        let runtime_id = pkg.0.original_id;
+        let original_id = pkg.0.original_id;
         self.runtime_adapter
             .write()
-            .publish_package(runtime_id, pkg.into_serialized_package())
+            .publish_package(original_id, pkg.into_serialized_package())
             .expect_err("publishing must fail");
     }
 

--- a/external-crates/move/crates/move-vm-runtime/src/unit_tests/package_cache_tests.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/unit_tests/package_cache_tests.rs
@@ -633,9 +633,9 @@ fn relink() {
     let st_c_v1_addr = AccountAddress::from_hex_literal("0x42").unwrap();
     let st_b_v1_addr = AccountAddress::from_hex_literal("0x43").unwrap();
 
-    let c_runtime_addr = AccountAddress::from_hex_literal("0x2").unwrap();
-    let b_runtime_addr = AccountAddress::from_hex_literal("0x3").unwrap();
-    let _a_runtime_addr = AccountAddress::from_hex_literal("0x4").unwrap();
+    let c_original_addr = AccountAddress::from_hex_literal("0x2").unwrap();
+    let b_original_addr = AccountAddress::from_hex_literal("0x3").unwrap();
+    let _a_original_addr = AccountAddress::from_hex_literal("0x4").unwrap();
 
     // publish c v0
     let packages = compile_modules_in_file("rt_c_v0.move", &[]);
@@ -667,7 +667,7 @@ fn relink() {
                     ModuleId::new(runtime_package_id, Identifier::new("c").unwrap()),
                     Identifier::new("S").unwrap(),
                 ),
-                ModuleId::new(c_runtime_addr, Identifier::new("c").unwrap()),
+                ModuleId::new(c_original_addr, Identifier::new("c").unwrap()),
             )]
             .into_iter()
             .collect(),
@@ -687,7 +687,7 @@ fn relink() {
             runtime_package_id,
             modules,
             BTreeMap::new(),
-            [c_runtime_addr].into_iter().collect(),
+            [c_original_addr].into_iter().collect(),
         )
         .unwrap();
 
@@ -705,10 +705,10 @@ fn relink() {
             [
                 (
                     (
-                        ModuleId::new(c_runtime_addr, Identifier::new("c").unwrap()),
+                        ModuleId::new(c_original_addr, Identifier::new("c").unwrap()),
                         Identifier::new("S").unwrap(),
                     ),
-                    ModuleId::new(c_runtime_addr, Identifier::new("c").unwrap()),
+                    ModuleId::new(c_original_addr, Identifier::new("c").unwrap()),
                 ),
                 (
                     (
@@ -738,10 +738,10 @@ fn relink() {
             [
                 (
                     (
-                        ModuleId::new(c_runtime_addr, Identifier::new("c").unwrap()),
+                        ModuleId::new(c_original_addr, Identifier::new("c").unwrap()),
                         Identifier::new("S").unwrap(),
                     ),
-                    ModuleId::new(c_runtime_addr, Identifier::new("c").unwrap()),
+                    ModuleId::new(c_original_addr, Identifier::new("c").unwrap()),
                 ),
                 (
                     (
@@ -753,7 +753,7 @@ fn relink() {
             ]
             .into_iter()
             .collect(),
-            [st_c_v1_addr, b_runtime_addr].into_iter().collect(),
+            [st_c_v1_addr, b_original_addr].into_iter().collect(),
         )
         .unwrap();
 
@@ -770,14 +770,14 @@ fn relink() {
             modules,
             [(
                 (
-                    ModuleId::new(c_runtime_addr, Identifier::new("c").unwrap()),
+                    ModuleId::new(c_original_addr, Identifier::new("c").unwrap()),
                     Identifier::new("S").unwrap(),
                 ),
-                ModuleId::new(c_runtime_addr, Identifier::new("c").unwrap()),
+                ModuleId::new(c_original_addr, Identifier::new("c").unwrap()),
             )]
             .into_iter()
             .collect(),
-            [c_runtime_addr, b_runtime_addr].into_iter().collect(),
+            [c_original_addr, b_original_addr].into_iter().collect(),
         )
         .unwrap_err();
 

--- a/external-crates/move/crates/move-vm-runtime/src/validation/deserialization/ast.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/validation/deserialization/ast.rs
@@ -1,4 +1,4 @@
-use crate::shared::types::{DefiningTypeId, OriginalId};
+use crate::shared::types::{DefiningTypeId, OriginalId, VersionId};
 use indexmap::IndexMap;
 use move_binary_format::CompiledModule;
 use move_core_types::{
@@ -10,12 +10,12 @@ use std::collections::BTreeMap;
 #[derive(Debug, Clone)]
 pub(crate) struct Package {
     pub(crate) original_id: OriginalId,
-    pub(crate) version_id: DefiningTypeId,
+    pub(crate) version_id: VersionId,
     pub(crate) modules: BTreeMap<ModuleId, CompiledModule>,
     #[allow(dead_code)]
     pub(crate) type_origin_table: IndexMap<IntraPackageName, DefiningTypeId>,
     #[allow(dead_code)]
-    pub(crate) linkage_table: BTreeMap<OriginalId, DefiningTypeId>,
+    pub(crate) linkage_table: BTreeMap<OriginalId, VersionId>,
     pub(crate) version: u64,
 }
 

--- a/external-crates/move/crates/move-vm-runtime/src/validation/deserialization/translate.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/validation/deserialization/translate.rs
@@ -29,10 +29,10 @@ pub(crate) fn package(vm_config: &VMConfig, pkg: SerializedPackage) -> VMResult<
             .finish(Location::Undefined));
     }
 
-    let runtime_id = *modules.keys().next().expect("non-empty package").address();
+    let original_id = *modules.keys().next().expect("non-empty package").address();
 
     Ok(Package::new(
-        runtime_id,
+        original_id,
         modules.into_values().collect(),
         pkg,
     ))

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/env.rs
@@ -240,8 +240,8 @@ impl<'pc, 'vm, 'state, 'linkage> Env<'pc, 'vm, 'state, 'linkage> {
                 package
             );
         };
-        let storage_id = ModuleId::new(package.into(), module.clone());
-        let runtime_id = ModuleId::new(original_id.into(), module);
+        let version_mid = ModuleId::new(package.into(), module.clone());
+        let original_mid = ModuleId::new(original_id.into(), module);
         let data_store = &self.linkable_store.package_store;
         let linkage_context = linkage.linkage_context();
         let loaded_type_arguments = type_arguments
@@ -254,14 +254,14 @@ impl<'pc, 'vm, 'state, 'linkage> Env<'pc, 'vm, 'state, 'linkage> {
             .make_vm(data_store, linkage_context)
             .map_err(|e| self.convert_linked_vm_error(e, &linkage))?;
         let runtime_signature = vm
-            .function_information(&runtime_id, name.as_ident_str(), &loaded_type_arguments)
+            .function_information(&original_mid, name.as_ident_str(), &loaded_type_arguments)
             .map_err(|e| {
                 if e.major_status() == StatusCode::EXTERNAL_RESOLUTION_REQUEST_ERROR {
                     ExecutionError::new_with_source(
                         ExecutionErrorKind::FunctionNotFound,
                         format!(
                             "Could not resolve function '{}' in module {}",
-                            name, &storage_id,
+                            name, &version_mid,
                         ),
                     )
                 } else {
@@ -286,8 +286,8 @@ impl<'pc, 'vm, 'state, 'linkage> Env<'pc, 'vm, 'state, 'linkage> {
             return_,
         };
         Ok(LoadedFunction {
-            storage_id,
-            runtime_id,
+            version_mid,
+            original_mid,
             name,
             type_arguments,
             signature,

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/interpreter.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/interpreter.rs
@@ -246,7 +246,7 @@ fn execute_command<Mode: ExecutionMode>(
             let modules =
                 context.deserialize_modules(&module_bytes, /* is upgrade */ false)?;
 
-            let runtime_id = context.publish_and_init_package::<Mode>(
+            let original_id = context.publish_and_init_package::<Mode>(
                 modules,
                 &dep_ids,
                 linkage,
@@ -257,7 +257,7 @@ fn execute_command<Mode: ExecutionMode>(
                 // no upgrade cap for genesis modules
                 std::vec![]
             } else {
-                std::vec![context.new_upgrade_cap(runtime_id)?]
+                std::vec![context.new_upgrade_cap(original_id)?]
             }
         }
         T::Command__::Upgrade(

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/ast.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/loading/ast.rs
@@ -121,8 +121,8 @@ pub struct LoadedFunctionInstantiation {
 
 #[derive(Debug)]
 pub struct LoadedFunction {
-    pub storage_id: ModuleId,
-    pub runtime_id: ModuleId,
+    pub version_mid: ModuleId,
+    pub original_mid: ModuleId,
     pub name: Identifier,
     pub type_arguments: Vec<Type>,
     pub signature: LoadedFunctionInstantiation,

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/translate.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/translate.rs
@@ -294,7 +294,7 @@ fn command<Mode: ExecutionMode>(
                         "Expected {} argument{} calling function '{}::{}', but found {}",
                         num_parameters,
                         if num_parameters == 1 { "" } else { "s" },
-                        function.storage_id,
+                        function.version_mid,
                         function.name,
                         num_args,
                     ),

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/move_functions.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/verify/move_functions.rs
@@ -165,7 +165,7 @@ fn move_call<Mode: ExecutionMode>(
         arguments: args,
     } = call;
     check_signature::<Mode>(function)?;
-    check_private_generics(&function.runtime_id, function.name.as_ident_str())?;
+    check_private_generics(&function.original_mid, function.name.as_ident_str())?;
     let (vis, is_entry) = check_visibility::<Mode>(env, function)?;
     let arg_dirties = args
         .iter()
@@ -228,7 +228,7 @@ fn check_visibility<Mode: ExecutionMode>(
                 // Special case: allow private accumulator entrypoints in test/simtest environments
                 // TODO: delete this as soon as the accumulator Move API is available
                 if env.protocol_config.allow_private_accumulator_entrypoints()
-                    && function.runtime_id.name() == BALANCE_MODULE_NAME
+                    && function.original_mid.name() == BALANCE_MODULE_NAME
                     && (function.name.as_ident_str() == SEND_TO_ACCOUNT_FUNCTION_NAME
                         || function.name.as_ident_str() == WITHDRAW_FROM_ACCOUNT_FUNCTION_NAME)
                 {


### PR DESCRIPTION
Go through the VM and adapter to make sure that we consistently use `version_id` and `original_id` instead of `storage_id` and `runtime_id`.

Also check that the type aliases that we use in the VM for `OriginalId`/`VersionId` and `DefiningTypeId` all match up with what they should be using.

No semantic changes, should only be renames of variables/types

