### PR TITLE
bugfix(consistency): Correctly index Effects V1 input objects

### DIFF
--- a/crates/simulacrum/src/lib.rs
+++ b/crates/simulacrum/src/lib.rs
@@ -148,6 +148,17 @@ where
         Self::new_with_network_config_in_mem(&config, rng)
     }
 
+    /// Create a new Simulacrum instance with a specific protocol version.
+    pub fn new_with_protocol_version(mut rng: R, protocol_version: ProtocolVersion) -> Self {
+        let config = ConfigBuilder::new_with_temp_dir()
+            .rng(&mut rng)
+            .with_chain_start_timestamp_ms(1)
+            .deterministic_committee_size(NonZeroUsize::new(1).unwrap())
+            .with_protocol_version(protocol_version)
+            .build();
+        Self::new_with_network_config_in_mem(&config, rng)
+    }
+
     pub fn new_with_protocol_version_and_accounts(
         mut rng: R,
         chain_start_timestamp_ms: u64,


### PR DESCRIPTION
## Description

In Effects V1, the input state of modified objects doesn't include the digest. The consistent store expected the input state to have both the version and the digest, so it wasn't correctly deleting the previous version of the modified object.

## Test plan

New regression test:

```
$ cargo nextest run            \
  -p sui-indexer-alt-e2e-tests \
  --test consistent_store_list_owned_objects_tests
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
