### PR TITLE
[move-ide] Fixed manifest file warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15374,6 +15374,7 @@ dependencies = [
  "bin-version",
  "clap",
  "move-analyzer",
+ "move-compiler",
  "sui-move-build",
  "sui-package-management",
 ]

--- a/crates/sui-move-lsp/Cargo.toml
+++ b/crates/sui-move-lsp/Cargo.toml
@@ -11,6 +11,7 @@ clap = { version = "4.1.4", features = ["derive"] }
 
 bin-version.workspace = true
 move-analyzer.workspace = true
+move-compiler.workspace = true
 sui-move-build.workspace = true
 sui-package-management.workspace = true
 

--- a/crates/sui-move-lsp/src/bin/move-analyzer.rs
+++ b/crates/sui-move-lsp/src/bin/move-analyzer.rs
@@ -3,7 +3,8 @@
 
 use clap::*;
 use move_analyzer::analyzer;
-use sui_move_build::implicit_deps;
+use move_compiler::editions::Flavor;
+use sui_move_build::{implicit_deps, SuiPackageHooks};
 use sui_package_management::system_package_versions::latest_system_packages;
 
 // Define the `GIT_REVISION` and `VERSION` consts
@@ -20,5 +21,8 @@ struct App {}
 
 fn main() {
     App::parse();
-    analyzer::run(implicit_deps(latest_system_packages()));
+    let sui_implicit_deps = implicit_deps(latest_system_packages());
+    let flavor = Flavor::Sui;
+    let sui_pkg_hooks = Box::new(SuiPackageHooks);
+    analyzer::run(sui_implicit_deps, Some(flavor), Some(sui_pkg_hooks));
 }

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -15,6 +15,7 @@ use colored::Colorize;
 use fastcrypto::traits::KeyPair;
 use move_analyzer::analyzer;
 use move_command_line_common::files::MOVE_COMPILED_EXTENSION;
+use move_compiler::editions::Flavor;
 use move_package::BuildConfig;
 use mysten_common::tempdir;
 use rand::rngs::OsRng;
@@ -778,7 +779,10 @@ impl SuiCommand {
             }
             SuiCommand::FireDrill { fire_drill } => run_fire_drill(fire_drill).await,
             SuiCommand::Analyzer => {
-                analyzer::run(implicit_deps(latest_system_packages()));
+                let sui_implicit_deps = implicit_deps(latest_system_packages());
+                let flavor = Flavor::Sui;
+                let sui_pkg_hooks = Box::new(SuiPackageHooks);
+                analyzer::run(sui_implicit_deps, Some(flavor), Some(sui_pkg_hooks));
                 Ok(())
             }
             SuiCommand::AnalyzeTrace {

--- a/external-crates/move/crates/move-analyzer/src/bin/move-analyzer.rs
+++ b/external-crates/move/crates/move-analyzer/src/bin/move-analyzer.rs
@@ -14,5 +14,5 @@ fn main() {
     // For now, move-analyzer only responds to options built-in to clap,
     // such as `--help` or `--version`.
     Options::parse();
-    analyzer::run(BTreeMap::new());
+    analyzer::run(BTreeMap::new(), None, None);
 }

--- a/external-crates/move/crates/move-analyzer/src/code_action.rs
+++ b/external-crates/move/crates/move-analyzer/src/code_action.rs
@@ -33,6 +33,7 @@ use url::Url;
 use vfs::VfsPath;
 
 use move_compiler::{
+    editions::Flavor,
     expansion::ast::ModuleIdent,
     linters::LintLevel,
     parser::ast::{LeadingNameAccess_, NameAccessChain_},
@@ -86,6 +87,7 @@ pub fn on_code_action_request(
     ide_files_root: VfsPath,
     pkg_dependencies: Arc<Mutex<CachedPackages>>,
     implicit_deps: Dependencies,
+    flavor: Option<Flavor>,
 ) {
     let response = Response::new_ok(
         request.id.clone(),
@@ -95,6 +97,7 @@ pub fn on_code_action_request(
             ide_files_root,
             pkg_dependencies,
             implicit_deps,
+            flavor,
         ),
     );
     eprintln!("code_action_request: {:?}", request);
@@ -110,6 +113,7 @@ fn access_chain_autofix_actions(
     ide_files_root: VfsPath,
     pkg_dependencies: Arc<Mutex<CachedPackages>>,
     implicit_deps: Dependencies,
+    flavor: Option<Flavor>,
 ) -> Vec<CodeAction> {
     let mut code_actions = vec![];
 
@@ -143,6 +147,7 @@ fn access_chain_autofix_actions(
         &pkg_path,
         LintLevel::None,
         implicit_deps,
+        flavor,
     ) else {
         return code_actions;
     };

--- a/external-crates/move/crates/move-analyzer/src/symbols/compilation.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols/compilation.rs
@@ -298,12 +298,13 @@ pub fn get_compiled_pkg(
     pkg_path: &Path,
     lint: LintLevel,
     implicit_deps: Dependencies,
+    flavor: Option<Flavor>,
 ) -> Result<(Option<CompiledPkgInfo>, BTreeMap<PathBuf, Vec<Diagnostic>>)> {
     let cached_deps_exist = has_precompiled_deps(pkg_path, packages_info.clone());
     let build_config = move_package::BuildConfig {
         test_mode: true,
         install_dir: Some(tempdir().unwrap().path().to_path_buf()),
-        default_flavor: Some(Flavor::Sui),
+        default_flavor: flavor,
         lint_flag: lint.into(),
         force_lock_file: cached_deps_exist,
         skip_fetch_latest_git_deps: cached_deps_exist,

--- a/external-crates/move/crates/move-analyzer/src/symbols/mod.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols/mod.rs
@@ -84,7 +84,7 @@ use vfs::VfsPath;
 
 use move_command_line_common::files::FileHash;
 use move_compiler::{
-    editions::{Edition, FeatureGate},
+    editions::{Edition, FeatureGate, Flavor},
     expansion::ast::{self as E, ModuleIdent, ModuleIdent_, Visibility},
     linters::LintLevel,
     naming::ast::{DatatypeTypeParameter, StructFields, Type, Type_, TypeName_, VariantFields},
@@ -156,6 +156,7 @@ pub fn get_symbols(
     lint: LintLevel,
     cursor_info: Option<(&PathBuf, Position)>,
     implicit_deps: Dependencies,
+    flavor: Option<Flavor>,
 ) -> Result<(Option<Symbols>, BTreeMap<PathBuf, Vec<Diagnostic>>)> {
     // helper function to avoid holding the lock for too long
     let has_pkg_entry = || {
@@ -185,6 +186,7 @@ pub fn get_symbols(
             pkg_path,
             lint,
             implicit_deps.clone(),
+            flavor,
         )?;
         eprintln!("compilation complete in: {:?}", compilation_start.elapsed());
         let Some(compiled_pkg_info) = compiled_pkg_info_opt else {

--- a/external-crates/move/crates/move-analyzer/src/symbols/runner.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols/runner.rs
@@ -22,7 +22,7 @@ use std::{
 };
 use vfs::VfsPath;
 
-use move_compiler::linters::LintLevel;
+use move_compiler::{editions::Flavor, linters::LintLevel};
 use move_package::source_package::parsed_manifest::Dependencies;
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
@@ -52,6 +52,7 @@ impl SymbolicatorRunner {
         sender: Sender<Result<BTreeMap<PathBuf, Vec<Diagnostic>>>>,
         lint: LintLevel,
         implicit_deps: Dependencies,
+        flavor: Option<Flavor>,
     ) -> Self {
         let mtx_cvar = Arc::new((Mutex::new(RunnerState::Wait), Condvar::new()));
         let thread_mtx_cvar = mtx_cvar.clone();
@@ -105,6 +106,7 @@ impl SymbolicatorRunner {
                                 lint,
                                 None,
                                 implicit_deps.clone(),
+                                flavor,
                             ) {
                                 Ok((symbols_opt, lsp_diagnostics)) => {
                                     eprintln!("symbolication finished");

--- a/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
+++ b/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
@@ -24,7 +24,7 @@ use move_analyzer::{
     },
 };
 use move_command_line_common::testing::insta_assert;
-use move_compiler::linters::LintLevel;
+use move_compiler::{editions::Flavor, linters::LintLevel};
 use serde::{Deserialize, Serialize};
 use url::Url;
 use vfs::{MemoryFS, VfsPath};
@@ -454,6 +454,7 @@ fn initial_symbols(
             project_path.as_path(),
             LintLevel::None,
             BTreeMap::new(),
+            Some(Flavor::Sui),
         )?;
         let compiled_pkg_info = compiled_pkg_info_opt.ok_or("PACKAGE COMPILATION FAILED")?;
         let symbols = compute_symbols(pkg_deps.clone(), compiled_pkg_info.clone(), None);


### PR DESCRIPTION
## Description 

This PR fixes a long-standing annoyance of unrecognized manifest file fields being incorrectly reported in the logs due to not setting Sui package hooks correctly.

Additionally, this PR makes `move-analyzer` implementation in `external-crates` more Move-flavor independent by moving Sui-specific bits to `crates`

## Test plan 

Verified manually that unrecognized field warnings no longer pop up in the logs
