### PR TITLE
docs: adjust code convention regarding capabilities

### DIFF
--- a/docs/content/concepts/sui-move-concepts/conventions.mdx
+++ b/docs/content/concepts/sui-move-concepts/conventions.mdx
@@ -361,7 +361,7 @@ public fun new_shared(deposit: Coin<SUI>, ctx: &mut TxContext) {
 
 ### Admin capability
 
-In admin-gated functions, the first parameter should be the capability. It helps the autocomplete with user types.
+In admin-gated functions, the capability should be placed as the second parameter. This keeps the capability visible in method signatures and maintains method associativity.
 
 ```move
 module conventions::social_network;
@@ -377,17 +377,18 @@ public struct Admin has key {
     id: UID,
 }
 
-// right -> cap.update(&mut account, b"jose".to_string());
+// right -> account.set(&cap, b"jose".to_string()); (normal method associativity)
+public fun set(account: &mut Account, _: &Admin, new_name: String) {
+    // Implementation omitted.
+    abort(0)
+}
+
+// wrong -> cap.update(&mut account, b"jose".to_string()); (reversed associativity)
 public fun update(_: &Admin, account: &mut Account, new_name: String) {
     // Implementation omitted.
     abort(0)
 }
 
-// wrong -> account.update(&cap, b"jose".to_string());
-public fun set(account: &mut Account, _: &Admin, new_name: String) {
-    // Implementation omitted.
-    abort(0)
-}
 ```
 
 ## Documentation

--- a/docs/content/concepts/sui-move-concepts/conventions.mdx
+++ b/docs/content/concepts/sui-move-concepts/conventions.mdx
@@ -388,7 +388,6 @@ public fun update(_: &Admin, account: &mut Account, new_name: String) {
     // Implementation omitted.
     abort(0)
 }
-
 ```
 
 ## Documentation


### PR DESCRIPTION
## Description 

There seem to be two different views on where to put capability objects in function signatures:

1. https://move-book.com/guides/code-quality-checklist#capabilities-go-second
2. https://docs.sui.io/concepts/sui-move-concepts/conventions#admin-capability

Damir noted that the preferred one is the first. This PR proposes those changes. 
https://github.com/MystenLabs/move-book/issues/196

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
