### PR TITLE
Dump transaction data artifacts and ptb signatures

### DIFF
--- a/crates/sui-replay-2/src/data-stores/data_store.rs
+++ b/crates/sui-replay-2/src/data-stores/data_store.rs
@@ -257,7 +257,7 @@ impl DataStore {
             .connect_timeout(std::time::Duration::from_secs(3))
             .timeout(std::time::Duration::from_secs(5))
             .build()?;
-        let url = node.rpc_url();
+        let url = node.gql_url();
         let rpc =
             reqwest::Url::parse(url).context(format!("Failed to parse GQL RPC URL {}", url))?;
         let epoch_map = RwLock::new(BTreeMap::new());

--- a/crates/sui-replay-2/src/execution.rs
+++ b/crates/sui-replay-2/src/execution.rs
@@ -16,7 +16,12 @@ use crate::{
     replay_txn::{get_input_objects_for_replay, ReplayTransaction},
 };
 use anyhow::Context;
+use move_binary_format::{
+    binary_config::BinaryConfig,
+    file_format::{CompiledModule, SignatureToken},
+};
 use move_core_types::{
+    account_address::AccountAddress,
     language_storage::{ModuleId, StructTag},
     resolver::ModuleResolver,
 };
@@ -41,7 +46,10 @@ use sui_types::{
     object::Object,
     storage::{BackingPackageStore, ChildObjectResolver, PackageObject, ParentSync},
     supported_protocol_versions::ProtocolConfig,
-    transaction::{CheckedInputObjects, TransactionDataAPI},
+    transaction::{
+        CheckedInputObjects, ProgrammableTransaction, TransactionData, TransactionDataAPI,
+    },
+    type_input::TypeInput,
 };
 use tracing::{debug, debug_span, trace};
 
@@ -56,12 +64,14 @@ pub struct ReplayExecutor {
 // Transaction data and effects (both expected and actual) and the caches containing
 // the objects used during execution.
 pub struct TxnContextAndEffects {
+    pub txn_data: TransactionData,             // original transaction data
     pub execution_effects: TransactionEffects, // effects of the replay execution
     pub expected_effects: TransactionEffects,  // expected effects as found in the transaction data
     pub gas_status: SuiGasStatus,              // gas status of the replay execution
     pub object_cache: BTreeMap<ObjectID, BTreeMap<u64, Object>>, // object cache
     pub inner_store: InnerTemporaryStore,      // temporary store used during execution
     pub checkpoint: u64,                       // checkpoint where the transaction was included
+    pub protocol_version: u64,                 // protocol version used for execution
 }
 
 /// Detailed information about a Move package.
@@ -98,6 +108,8 @@ pub struct CacheEntry {
 pub struct ReplayCacheSummary {
     pub epoch_id: u64,
     pub checkpoint: u64,
+    pub network: String,
+    pub protocol_version: u64,
     /// List of objects accessed during replay with their version and type information
     pub cache_entries: Vec<CacheEntry>,
 }
@@ -107,6 +119,8 @@ impl ReplayCacheSummary {
     pub fn from_cache(
         epoch_id: u64,
         checkpoint: u64,
+        network: String,
+        protocol_version: u64,
         object_cache: &BTreeMap<ObjectID, BTreeMap<u64, Object>>,
     ) -> Self {
         let mut cache_entries = Vec::new();
@@ -144,7 +158,311 @@ impl ReplayCacheSummary {
         Self {
             epoch_id,
             checkpoint,
+            network,
+            protocol_version,
             cache_entries,
+        }
+    }
+}
+
+/// Datatype definition: (address, module, name, variants)
+pub type Datatype = (AccountAddress, String, String, Vec<MoveType>);
+
+/// Custom Move type representation for JSON serialization.
+/// This provides the exact type information we want to expose in the JSON output.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum MoveType {
+    Bool,
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+    U256,
+    Address,
+    Vector(Box<MoveType>),
+    Datatype(Datatype),
+    DatatypeInstantiation(Box<(Datatype, Vec<MoveType>)>),
+    Reference(Box<MoveType>),
+    MutableReference(Box<MoveType>),
+    TypeParameter(u16),
+}
+
+/// Function signature information for MoveCall commands in a ProgrammableTransaction.
+/// Contains detailed parameter and return type information for each function call.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FunctionSignature {
+    /// Package ID where the function is defined
+    pub package: ObjectID,
+    /// Module name containing the function
+    pub module: String,
+    /// Function name
+    pub function: String,
+    /// Parameter types
+    pub parameters: Vec<MoveType>,
+    /// Return types
+    pub return_types: Vec<MoveType>,
+}
+
+/// Move call information containing extracted function signatures.
+/// This provides type information for all commands in the transaction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MoveCallInfo {
+    /// Vector of function signatures, one for each command
+    /// None for non-MoveCall commands, Some(signature) for MoveCall commands
+    pub command_signatures: Vec<Option<FunctionSignature>>,
+}
+
+impl MoveCallInfo {
+    /// Create MoveCallInfo by extracting function signatures from a ProgrammableTransaction.
+    /// Creates a vector with one entry per command, None for non-MoveCall commands.
+    pub fn from_transaction(
+        ptb: &ProgrammableTransaction,
+        object_cache: &BTreeMap<ObjectID, BTreeMap<u64, Object>>,
+    ) -> anyhow::Result<Self> {
+        let mut command_signatures = Vec::with_capacity(ptb.commands.len());
+
+        for command in ptb.commands.iter() {
+            let signature = if let sui_types::transaction::Command::MoveCall(move_call) = command {
+                // Extract function signature from the MoveCall
+                match Self::extract_function_signature(move_call, object_cache) {
+                    Ok(signature) => {
+                        tracing::debug!(
+                            "Successfully extracted signature for {}::{}::{}",
+                            signature.package,
+                            signature.module,
+                            signature.function
+                        );
+                        Some(signature)
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to extract signature for {}::{}::{}: {}",
+                            move_call.package,
+                            move_call.module,
+                            move_call.function,
+                            e
+                        );
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+            command_signatures.push(signature);
+        }
+
+        Ok(MoveCallInfo { command_signatures })
+    }
+
+    /// Extract function signature information from a MoveCall command.
+    fn extract_function_signature(
+        move_call: &sui_types::transaction::ProgrammableMoveCall,
+        object_cache: &BTreeMap<ObjectID, BTreeMap<u64, Object>>,
+    ) -> anyhow::Result<FunctionSignature> {
+        let package_id = move_call.package;
+        let module_name = move_call.module.as_str();
+        let function_name = move_call.function.as_str();
+
+        // Find the package in the object cache
+        let package_obj = object_cache
+            .get(&package_id)
+            .and_then(|versions| versions.values().next())
+            .ok_or_else(|| anyhow::anyhow!("Package {} not found in cache", package_id))?;
+
+        // Extract MovePackage from the object
+        let move_package = package_obj
+            .data
+            .try_as_package()
+            .ok_or_else(|| anyhow::anyhow!("Object {} is not a package", package_id))?;
+
+        // Get the module bytecode from the package
+        let module_bytes = move_package
+            .serialized_module_map()
+            .get(module_name)
+            .ok_or_else(|| {
+                anyhow::anyhow!("Module {} not found in package {}", module_name, package_id)
+            })?;
+
+        // Deserialize the module
+        let binary_config = BinaryConfig::standard();
+        let compiled_module = CompiledModule::deserialize_with_config(module_bytes, &binary_config)
+            .map_err(|e| anyhow::anyhow!("Failed to deserialize module {}: {}", module_name, e))?;
+
+        // Find the function definition
+        let (_, function_def) = compiled_module
+            .find_function_def_by_name(function_name)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Function {} not found in module {}::{}",
+                    function_name,
+                    package_id,
+                    module_name
+                )
+            })?;
+
+        // Get the function handle
+        let function_handle = compiled_module.function_handle_at(function_def.function);
+
+        // Get parameter and return signatures
+        let param_signature = compiled_module.signature_at(function_handle.parameters);
+        let return_signature = compiled_module.signature_at(function_handle.return_);
+
+        // Convert TypeInputs to MoveTypes for signature processing
+        let type_arguments_as_move_types: Vec<MoveType> = move_call
+            .type_arguments
+            .iter()
+            .map(Self::type_input_to_move_type)
+            .collect();
+
+        // Convert SignatureTokens to MoveTypes
+        let parameters = param_signature
+            .0
+            .iter()
+            .map(|token| {
+                Self::signature_token_to_move_type(
+                    token,
+                    &compiled_module,
+                    &type_arguments_as_move_types,
+                )
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        let return_types = return_signature
+            .0
+            .iter()
+            .map(|token| {
+                Self::signature_token_to_move_type(
+                    token,
+                    &compiled_module,
+                    &type_arguments_as_move_types,
+                )
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        Ok(FunctionSignature {
+            package: package_id,
+            module: module_name.to_string(),
+            function: function_name.to_string(),
+            parameters,
+            return_types,
+        })
+    }
+
+    /// Convert TypeInput to MoveType.
+    /// TypeInput comes from the transaction's type arguments.
+    fn type_input_to_move_type(type_input: &TypeInput) -> MoveType {
+        match type_input {
+            TypeInput::Bool => MoveType::Bool,
+            TypeInput::U8 => MoveType::U8,
+            TypeInput::U16 => MoveType::U16,
+            TypeInput::U32 => MoveType::U32,
+            TypeInput::U64 => MoveType::U64,
+            TypeInput::U128 => MoveType::U128,
+            TypeInput::U256 => MoveType::U256,
+            TypeInput::Address => MoveType::Address,
+            TypeInput::Signer => MoveType::Address, // Signer is treated as Address
+            TypeInput::Vector(element) => {
+                MoveType::Vector(Box::new(Self::type_input_to_move_type(element)))
+            }
+            TypeInput::Struct(struct_input) => {
+                let type_params: Vec<MoveType> = struct_input
+                    .type_params
+                    .iter()
+                    .map(Self::type_input_to_move_type)
+                    .collect();
+
+                let datatype = (
+                    struct_input.address,
+                    struct_input.module.clone(),
+                    struct_input.name.clone(),
+                    vec![], // Empty variants - we ignore enum variants
+                );
+
+                if type_params.is_empty() {
+                    // Non-generic datatype
+                    MoveType::Datatype(datatype)
+                } else {
+                    // Generic instantiation
+                    MoveType::DatatypeInstantiation(Box::new((datatype, type_params)))
+                }
+            }
+        }
+    }
+
+    /// Convert SignatureToken to MoveType.
+    /// This is the core conversion that bridges Move's type system with our custom representation.
+    fn signature_token_to_move_type(
+        token: &SignatureToken,
+        module: &CompiledModule,
+        type_arguments: &[MoveType],
+    ) -> anyhow::Result<MoveType> {
+        match token {
+            SignatureToken::Bool => Ok(MoveType::Bool),
+            SignatureToken::U8 => Ok(MoveType::U8),
+            SignatureToken::U16 => Ok(MoveType::U16),
+            SignatureToken::U32 => Ok(MoveType::U32),
+            SignatureToken::U64 => Ok(MoveType::U64),
+            SignatureToken::U128 => Ok(MoveType::U128),
+            SignatureToken::U256 => Ok(MoveType::U256),
+            SignatureToken::Address => Ok(MoveType::Address),
+            SignatureToken::Signer => Ok(MoveType::Address), // Signer is treated as Address
+            SignatureToken::Vector(element_type) => {
+                let element =
+                    Self::signature_token_to_move_type(element_type, module, type_arguments)?;
+                Ok(MoveType::Vector(Box::new(element)))
+            }
+            SignatureToken::Datatype(datatype_handle_idx) => {
+                let datatype_handle = module.datatype_handle_at(*datatype_handle_idx);
+                let module_handle = module.module_handle_at(datatype_handle.module);
+                let address = *module.address_identifier_at(module_handle.address);
+                let module_name = module.identifier_at(module_handle.name).to_string();
+                let struct_name = module.identifier_at(datatype_handle.name).to_string();
+
+                // Non-generic datatype - empty type params
+                let datatype = (address, module_name, struct_name, vec![]);
+                Ok(MoveType::Datatype(datatype))
+            }
+            SignatureToken::DatatypeInstantiation(instantiation) => {
+                let (datatype_handle_idx, type_args) = instantiation.as_ref();
+                let datatype_handle = module.datatype_handle_at(*datatype_handle_idx);
+                let module_handle = module.module_handle_at(datatype_handle.module);
+                let address = *module.address_identifier_at(module_handle.address);
+                let module_name = module.identifier_at(module_handle.name).to_string();
+                let struct_name = module.identifier_at(datatype_handle.name).to_string();
+
+                // Resolve the type arguments
+                let resolved_type_args = type_args
+                    .iter()
+                    .map(|arg| Self::signature_token_to_move_type(arg, module, type_arguments))
+                    .collect::<anyhow::Result<Vec<_>>>()?;
+
+                // Base datatype with empty type params
+                let datatype = (address, module_name, struct_name, vec![]);
+
+                // Generic instantiation with resolved type arguments
+                Ok(MoveType::DatatypeInstantiation(Box::new((
+                    datatype,
+                    resolved_type_args,
+                ))))
+            }
+            SignatureToken::Reference(inner) => {
+                let inner_type = Self::signature_token_to_move_type(inner, module, type_arguments)?;
+                Ok(MoveType::Reference(Box::new(inner_type)))
+            }
+            SignatureToken::MutableReference(inner) => {
+                let inner_type = Self::signature_token_to_move_type(inner, module, type_arguments)?;
+                Ok(MoveType::MutableReference(Box::new(inner_type)))
+            }
+            SignatureToken::TypeParameter(idx) => {
+                // Resolve type parameter using the provided type_arguments
+                if (*idx as usize) < type_arguments.len() {
+                    Ok(type_arguments[*idx as usize].clone())
+                } else {
+                    // Return TypeParameter variant if not resolved
+                    Ok(MoveType::TypeParameter(*idx))
+                }
+            }
         }
     }
 }
@@ -237,17 +555,38 @@ pub fn execute_transaction_to_effects(
         checkpoint: _,
         store: _,
     } = store;
-    let object_cache = object_cache.into_inner();
+    let mut object_cache = object_cache.into_inner();
+
+    // Get created objects from transaction effects
+    for (object_ref, _owner) in effects.created() {
+        let object_id = object_ref.0;
+        // Look for the created object in inner_store's written objects
+        if let Some(object) = inner_store.written.get(&object_id) {
+            object_cache
+                .entry(object_id)
+                .or_default()
+                .insert(object.version().value(), object.clone());
+        } else {
+            // Return error if created object is not found in inner_store
+            return Err(anyhow::anyhow!(
+                "Created object {} not found in inner_store written objects",
+                object_id
+            ));
+        }
+    }
+
     debug!(op = "execute_tx", phase = "end", "execution");
     Ok((
         result,
         TxnContextAndEffects {
+            txn_data,
             execution_effects: effects,
             expected_effects,
             gas_status,
             object_cache,
             inner_store,
             checkpoint,
+            protocol_version: protocol_config.version.as_u64(),
         },
     ))
 }
@@ -372,17 +711,28 @@ impl sui_types::storage::ObjectStore for ReplayStore<'_> {
         trace!("get_object({})", object_id);
         let object = match self.object_cache.borrow().get(object_id) {
             Some(versions) => versions.last_key_value().map(|(_version, obj)| obj.clone()),
-            None => self
-                .store
-                .get_objects(&[ObjectKey {
-                    object_id: *object_id,
-                    version_query: VersionQuery::AtCheckpoint(self.checkpoint),
-                }])
-                .map_err(|e| SuiError::Storage(e.to_string()))
-                .ok()?
-                .into_iter()
-                .next()?
-                .map(|(obj, _version)| obj),
+            None => {
+                let fetched_object = self
+                    .store
+                    .get_objects(&[ObjectKey {
+                        object_id: *object_id,
+                        version_query: VersionQuery::AtCheckpoint(self.checkpoint),
+                    }])
+                    .map_err(|e| SuiError::Storage(e.to_string()))
+                    .ok()?
+                    .into_iter()
+                    .next()?
+                    .map(|(obj, _version)| obj)?;
+
+                // Add the fetched object to the cache
+                let mut cache = self.object_cache.borrow_mut();
+                cache
+                    .entry(*object_id)
+                    .or_default()
+                    .insert(fetched_object.version().value(), fetched_object.clone());
+
+                Some(fetched_object)
+            }
         };
         object
     }
@@ -423,6 +773,15 @@ impl ChildObjectResolver for ReplayStore<'_> {
             .next()
             .unwrap()
             .map(|(obj, _version)| obj);
+
+        // Add object to cache if it exists and not already cached
+        if let Some(ref obj) = object {
+            self.object_cache
+                .borrow_mut()
+                .entry(obj.id())
+                .or_default()
+                .insert(obj.version().value(), obj.clone());
+        }
         Ok(object)
     }
 

--- a/crates/sui-replay-2/src/lib.rs
+++ b/crates/sui-replay-2/src/lib.rs
@@ -254,26 +254,25 @@ impl Node {
         }
     }
 
-    pub fn rpc_url(&self) -> &str {
+    pub fn network_name(&self) -> String {
+        match self {
+            Node::Mainnet => "mainnet".to_string(),
+            Node::Testnet => "testnet".to_string(),
+            // Node::Devnet => "devnet".to_string(),
+            Node::Custom(url) => url.clone(),
+        }
+    }
+
+    pub fn gql_url(&self) -> &str {
         match self {
             Node::Mainnet => MAINNET_GQL_URL,
             Node::Testnet => TESTNET_GQL_URL,
             // Node::Devnet => "",
-            Node::Custom(url) => url.as_str(),
+            Node::Custom(_url) => todo!("custom gql url not implemented"),
         }
     }
 
-    pub fn node_dir(&self) -> &str {
-        match self {
-            Node::Mainnet => "mainnet",
-            Node::Testnet => "testnet",
-            // Node::Devnet => "devnet",
-            // TODO: custom provides a URL which has to be translated to a valid directory name
-            Node::Custom(_) => "custom",
-        }
-    }
-
-    pub fn get_rpc_url(&self) -> &str {
+    pub fn node_url(&self) -> &str {
         match self {
             Node::Mainnet => MAINNET_RPC_URL,
             Node::Testnet => TESTNET_RPC_URL,
@@ -445,6 +444,7 @@ pub async fn handle_replay_config(
                 &gql_store,
                 &output_root_dir,
                 &digests,
+                node,
                 *overwrite_existing,
                 *trace,
                 *verbose,
@@ -462,6 +462,7 @@ pub async fn handle_replay_config(
                 &store,
                 &output_root_dir,
                 &digests,
+                node,
                 *overwrite_existing,
                 *trace,
                 *verbose,
@@ -476,6 +477,7 @@ pub async fn handle_replay_config(
                 &fs_store,
                 &output_root_dir,
                 &digests,
+                node,
                 *overwrite_existing,
                 *trace,
                 *verbose,
@@ -495,6 +497,7 @@ pub async fn handle_replay_config(
                 &store,
                 &output_root_dir,
                 &digests,
+                node,
                 *overwrite_existing,
                 *trace,
                 *verbose,
@@ -511,6 +514,7 @@ async fn run_replay<S>(
     data_store: &S,
     output_root_dir: &Path,
     digests: &[String],
+    node: &Node,
     overwrite_existing: bool,
     trace: bool,
     verbose: bool,
@@ -524,9 +528,15 @@ where
         let tx_dir = output_root_dir.join(tx_digest);
         let artifact_manager = ArtifactManager::new(&tx_dir, overwrite_existing)?;
         let span = info_span!("replay", tx_digest = %tx_digest);
-        let result = replay_transaction(&artifact_manager, tx_digest, data_store, trace)
-            .instrument(span)
-            .await;
+        let result = replay_transaction(
+            &artifact_manager,
+            tx_digest,
+            data_store,
+            node.network_name(),
+            trace,
+        )
+        .instrument(span)
+        .await;
         match result {
             Err(e) if terminate_early => {
                 error!(tx_digest = %tx_digest, error = ?e, "Replay error; terminating early");

--- a/crates/sui-replay-2/src/tracing/mod.rs
+++ b/crates/sui-replay-2/src/tracing/mod.rs
@@ -36,12 +36,14 @@ pub fn save_trace_output(
         .unwrap();
 
     let TxnContextAndEffects {
+        txn_data: _,
         execution_effects: _,
         expected_effects: _,
         gas_status: _,
         object_cache,
         inner_store: tmp_store,
         checkpoint: _,
+        protocol_version: _,
     } = context_and_effects;
 
     // grab all packages from the transaction and save them locally for debug


### PR DESCRIPTION
## Description 

More artifacts are generated to offer information on transaction in a simple and succinct way.
The replay viewer use those to display PTB in a richer way

## Test plan 

Tried manually

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
