### PR TITLE
[static ptbs] Flag for allowing references 

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_coin_op_writes_invalid.move
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_coin_op_writes_invalid.move
@@ -3,7 +3,7 @@
 
 // tests invalid writes of mut references using coin operations
 
-//# init --addresses test=0x0 --accounts A
+//# init --addresses test=0x0 --accounts A --allow-references-in-ptbs
 
 //# publish
 module test::m {
@@ -25,33 +25,33 @@ module test::m {
 //> SplitCoins(Gas, [Input(0), Input(0), Input(0)]);
 //> TransferObjects([NestedResult(0,0), NestedResult(0,1), NestedResult(0,2)], Input(1))
 
-//# programmable --dev-inspect --inputs 10 @A
+//# programmable --sender A --inputs 10 @A
 // Cannot write to borrowed gas coin via split coins
 //> 0: test::m::borrow_mut(Gas);
 //> 1: SplitCoins(Gas, [Input(0)]);
 //> 2: TransferObjects([Result(1)], Input(1));
-//> 3: test::m::borrow_mut(Gas);
+//> 3: test::m::borrow_mut(Result(0));
 
-//# programmable --dev-inspect --inputs 10 @A object(2,0)
+//# programmable --sender A --inputs 10 @A object(2,0)
 // Cannot write to borrowed gas coin via Merge coins
 //> 0: test::m::borrow_mut(Gas);
 //> 1: MergeCoins(Gas, [Input(2)]);
-//> 2: test::m::borrow_mut(Gas);
+//> 2: test::m::borrow_mut(Result(0));
 
-//# programmable --dev-inspect --inputs 10 @A object(2,0)
+//# programmable --sender A --inputs 10 @A object(2,0)
 // Cannot write to borrowed coin via split coins
 //> 0: test::m::borrow_mut(Input(2));
 //> 1: SplitCoins(Input(2), [Input(0)]);
 //> 2: TransferObjects([Result(1)], Input(1));
-//> 3: test::m::borrow_mut(Input(2));
+//> 3: test::m::borrow_mut(Result(0));
 
-//# programmable --dev-inspect --inputs 10 @A object(2,0) object(2,1)
+//# programmable --sender A --inputs 10 @A object(2,0) object(2,1)
 // Cannot write to borrowed coin via Merge coins
 //> 0: test::m::borrow_mut(Input(2));
 //> 1: MergeCoins(Input(2), [Input(3)]);
-//> 2: test::m::borrow_mut(Input(2));
+//> 2: test::m::borrow_mut(Result(0));
 
-//# programmable --dev-inspect --inputs 10 @A
+//# programmable --sender A --inputs 10 @A
 // Cannot write to borrowed fresh coin via split coins
 //> 0: sui::coin::zero<sui::sui::SUI>();
 //> 1: test::m::borrow_mut(Result(0));
@@ -60,7 +60,7 @@ module test::m {
 //> 4: test::m::borrow_mut(Result(1));
 //> TransferObjects([Result(0)], Input(1))
 
-//# programmable --dev-inspect --inputs 10 @A object(2,0)
+//# programmable --sender A --inputs 10 @A object(2,0)
 // Cannot write to borrowed fresh coin via Merge coins
 //> 0: sui::coin::zero<sui::sui::SUI>();
 //> 1: test::m::borrow_mut(Result(0));
@@ -68,7 +68,7 @@ module test::m {
 //> 3: test::m::borrow_mut(Result(1));
 //> TransferObjects([Result(0)], Input(1))
 
-//# programmable --dev-inspect --inputs 10 @A
+//# programmable --sender A --inputs 10 @A
 // Cannot write to borrowed coin via split coins
 //> 0: test::m::new_mut();
 //> 1: test::m::borrow_mut(Result(0));
@@ -76,7 +76,7 @@ module test::m {
 //> 3: TransferObjects([Result(2)], Input(1));
 //> 4: test::m::borrow_mut(Result(1));
 
-//# programmable --dev-inspect --inputs 10 @A object(2,0)
+//# programmable --sender A --inputs 10 @A object(2,0)
 // Cannot write to borrowed coin via Merge coins
 //> 0: test::m::new_mut();
 //> 1: test::m::borrow_mut(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_coin_op_writes_invalid.snap
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_coin_op_writes_invalid.snap
@@ -22,49 +22,45 @@ mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 3952000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 3, lines 28-33:
-//# programmable --dev-inspect --inputs 10 @A
+//# programmable --sender A --inputs 10 @A
 // Cannot write to borrowed gas coin via split coins
 //> 0: test::m::borrow_mut(Gas);
 //> 1: SplitCoins(Gas, [Input(0)]);
 //> 2: TransferObjects([Result(1)], Input(1));
-//> 3: test::m::borrow_mut(Gas);
-created: object(3,0)
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+//> 3: test::m::borrow_mut(Result(0));
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(0) } }
 
 task 4, lines 35-39:
-//# programmable --dev-inspect --inputs 10 @A object(2,0)
+//# programmable --sender A --inputs 10 @A object(2,0)
 // Cannot write to borrowed gas coin via Merge coins
 //> 0: test::m::borrow_mut(Gas);
 //> 1: MergeCoins(Gas, [Input(2)]);
-//> 2: test::m::borrow_mut(Gas);
-mutated: object(_)
-deleted: object(2,0)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+//> 2: test::m::borrow_mut(Result(0));
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(0) } }
 
 task 5, lines 41-46:
-//# programmable --dev-inspect --inputs 10 @A object(2,0)
+//# programmable --sender A --inputs 10 @A object(2,0)
 // Cannot write to borrowed coin via split coins
 //> 0: test::m::borrow_mut(Input(2));
 //> 1: SplitCoins(Input(2), [Input(0)]);
 //> 2: TransferObjects([Result(1)], Input(1));
-//> 3: test::m::borrow_mut(Input(2));
-created: object(5,0)
-mutated: object(_), object(2,0)
-gas summary: computation_cost: 500000, storage_cost: 2964000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+//> 3: test::m::borrow_mut(Result(0));
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(0) } }
 
 task 6, lines 48-52:
-//# programmable --dev-inspect --inputs 10 @A object(2,0) object(2,1)
+//# programmable --sender A --inputs 10 @A object(2,0) object(2,1)
 // Cannot write to borrowed coin via Merge coins
 //> 0: test::m::borrow_mut(Input(2));
 //> 1: MergeCoins(Input(2), [Input(3)]);
-//> 2: test::m::borrow_mut(Input(2));
-mutated: object(_), object(2,0)
-deleted: object(2,1)
-gas summary: computation_cost: 500000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+//> 2: test::m::borrow_mut(Result(0));
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(0) } }
 
 task 7, lines 54-61:
-//# programmable --dev-inspect --inputs 10 @A
+//# programmable --sender A --inputs 10 @A
 // Cannot write to borrowed fresh coin via split coins
 //> 0: sui::coin::zero<sui::sui::SUI>();
 //> 1: test::m::borrow_mut(Result(0));
@@ -72,39 +68,37 @@ task 7, lines 54-61:
 //> 3: TransferObjects([Result(2)], Input(1));
 //> 4: test::m::borrow_mut(Result(1));
 //> TransferObjects([Result(0)], Input(1))
-Error: Transaction Effects Status: InsufficientCoinBalance in command 2
-Execution Error: InsufficientCoinBalance in command 2
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(1) } }
 
 task 8, lines 63-69:
-//# programmable --dev-inspect --inputs 10 @A object(2,0)
+//# programmable --sender A --inputs 10 @A object(2,0)
 // Cannot write to borrowed fresh coin via Merge coins
 //> 0: sui::coin::zero<sui::sui::SUI>();
 //> 1: test::m::borrow_mut(Result(0));
 //> 2: MergeCoins(Result(0), [Input(2)]);
 //> 3: test::m::borrow_mut(Result(1));
 //> TransferObjects([Result(0)], Input(1))
-created: object(8,0)
-mutated: object(_)
-deleted: object(2,0)
-gas summary: computation_cost: 500000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(1) } }
 
 task 9, lines 71-77:
-//# programmable --dev-inspect --inputs 10 @A
+//# programmable --sender A --inputs 10 @A
 // Cannot write to borrowed coin via split coins
 //> 0: test::m::new_mut();
 //> 1: test::m::borrow_mut(Result(0));
 //> 2: SplitCoins(Result(0), [Input(0)]);
 //> 3: TransferObjects([Result(2)], Input(1));
 //> 4: test::m::borrow_mut(Result(1));
-Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("new_mut") }, 0) in command 0
-Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("new_mut") }, 0) in command 0
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(0) } }
 
 task 10, lines 79-84:
-//# programmable --dev-inspect --inputs 10 @A object(2,0)
+//# programmable --sender A --inputs 10 @A object(2,0)
 // Cannot write to borrowed coin via Merge coins
 //> 0: test::m::new_mut();
 //> 1: test::m::borrow_mut(Result(0));
 //> 2: MergeCoins(Result(0), [Input(2)]);
 //> 3: test::m::borrow_mut(Result(1));
-Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("new_mut") }, 0) in command 0
-Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("new_mut") }, 0) in command 0
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_coin_op_writes_invalid@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_coin_op_writes_invalid@v2.snap
@@ -22,49 +22,45 @@ mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 3952000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 3, lines 28-33:
-//# programmable --dev-inspect --inputs 10 @A
+//# programmable --sender A --inputs 10 @A
 // Cannot write to borrowed gas coin via split coins
 //> 0: test::m::borrow_mut(Gas);
 //> 1: SplitCoins(Gas, [Input(0)]);
 //> 2: TransferObjects([Result(1)], Input(1));
-//> 3: test::m::borrow_mut(Gas);
-created: object(3,0)
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+//> 3: test::m::borrow_mut(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot write to an argument location that is still borrowed, and where that borrow is an extension of that reference. This is likely due to this argument being used in a Move call that returns a reference, and that reference is used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotWriteToExtendedReference }, source: None, command: Some(1) } }
 
 task 4, lines 35-39:
-//# programmable --dev-inspect --inputs 10 @A object(2,0)
+//# programmable --sender A --inputs 10 @A object(2,0)
 // Cannot write to borrowed gas coin via Merge coins
 //> 0: test::m::borrow_mut(Gas);
 //> 1: MergeCoins(Gas, [Input(2)]);
-//> 2: test::m::borrow_mut(Gas);
-mutated: object(_)
-deleted: object(2,0)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+//> 2: test::m::borrow_mut(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot write to an argument location that is still borrowed, and where that borrow is an extension of that reference. This is likely due to this argument being used in a Move call that returns a reference, and that reference is used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotWriteToExtendedReference }, source: None, command: Some(1) } }
 
 task 5, lines 41-46:
-//# programmable --dev-inspect --inputs 10 @A object(2,0)
+//# programmable --sender A --inputs 10 @A object(2,0)
 // Cannot write to borrowed coin via split coins
 //> 0: test::m::borrow_mut(Input(2));
 //> 1: SplitCoins(Input(2), [Input(0)]);
 //> 2: TransferObjects([Result(1)], Input(1));
-//> 3: test::m::borrow_mut(Input(2));
-created: object(5,0)
-mutated: object(_), object(2,0)
-gas summary: computation_cost: 500000, storage_cost: 2964000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+//> 3: test::m::borrow_mut(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot write to an argument location that is still borrowed, and where that borrow is an extension of that reference. This is likely due to this argument being used in a Move call that returns a reference, and that reference is used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotWriteToExtendedReference }, source: None, command: Some(1) } }
 
 task 6, lines 48-52:
-//# programmable --dev-inspect --inputs 10 @A object(2,0) object(2,1)
+//# programmable --sender A --inputs 10 @A object(2,0) object(2,1)
 // Cannot write to borrowed coin via Merge coins
 //> 0: test::m::borrow_mut(Input(2));
 //> 1: MergeCoins(Input(2), [Input(3)]);
-//> 2: test::m::borrow_mut(Input(2));
-mutated: object(_), object(2,0)
-deleted: object(2,1)
-gas summary: computation_cost: 500000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+//> 2: test::m::borrow_mut(Result(0));
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot write to an argument location that is still borrowed, and where that borrow is an extension of that reference. This is likely due to this argument being used in a Move call that returns a reference, and that reference is used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotWriteToExtendedReference }, source: None, command: Some(1) } }
 
 task 7, lines 54-61:
-//# programmable --dev-inspect --inputs 10 @A
+//# programmable --sender A --inputs 10 @A
 // Cannot write to borrowed fresh coin via split coins
 //> 0: sui::coin::zero<sui::sui::SUI>();
 //> 1: test::m::borrow_mut(Result(0));
@@ -72,37 +68,37 @@ task 7, lines 54-61:
 //> 3: TransferObjects([Result(2)], Input(1));
 //> 4: test::m::borrow_mut(Result(1));
 //> TransferObjects([Result(0)], Input(1))
-Error: Transaction Effects Status: CommandArgumentError { arg_idx: 0, kind: CannotWriteToExtendedReference } in command 2
-Execution Error: CommandArgumentError { arg_idx: 0, kind: CannotWriteToExtendedReference } in command 2
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot write to an argument location that is still borrowed, and where that borrow is an extension of that reference. This is likely due to this argument being used in a Move call that returns a reference, and that reference is used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotWriteToExtendedReference }, source: None, command: Some(2) } }
 
 task 8, lines 63-69:
-//# programmable --dev-inspect --inputs 10 @A object(2,0)
+//# programmable --sender A --inputs 10 @A object(2,0)
 // Cannot write to borrowed fresh coin via Merge coins
 //> 0: sui::coin::zero<sui::sui::SUI>();
 //> 1: test::m::borrow_mut(Result(0));
 //> 2: MergeCoins(Result(0), [Input(2)]);
 //> 3: test::m::borrow_mut(Result(1));
 //> TransferObjects([Result(0)], Input(1))
-Error: Transaction Effects Status: CommandArgumentError { arg_idx: 0, kind: CannotWriteToExtendedReference } in command 2
-Execution Error: CommandArgumentError { arg_idx: 0, kind: CannotWriteToExtendedReference } in command 2
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot write to an argument location that is still borrowed, and where that borrow is an extension of that reference. This is likely due to this argument being used in a Move call that returns a reference, and that reference is used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotWriteToExtendedReference }, source: None, command: Some(2) } }
 
 task 9, lines 71-77:
-//# programmable --dev-inspect --inputs 10 @A
+//# programmable --sender A --inputs 10 @A
 // Cannot write to borrowed coin via split coins
 //> 0: test::m::new_mut();
 //> 1: test::m::borrow_mut(Result(0));
 //> 2: SplitCoins(Result(0), [Input(0)]);
 //> 3: TransferObjects([Result(2)], Input(1));
 //> 4: test::m::borrow_mut(Result(1));
-Error: Transaction Effects Status: CommandArgumentError { arg_idx: 0, kind: CannotWriteToExtendedReference } in command 2
-Execution Error: CommandArgumentError { arg_idx: 0, kind: CannotWriteToExtendedReference } in command 2
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot write to an argument location that is still borrowed, and where that borrow is an extension of that reference. This is likely due to this argument being used in a Move call that returns a reference, and that reference is used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotWriteToExtendedReference }, source: None, command: Some(2) } }
 
 task 10, lines 79-84:
-//# programmable --dev-inspect --inputs 10 @A object(2,0)
+//# programmable --sender A --inputs 10 @A object(2,0)
 // Cannot write to borrowed coin via Merge coins
 //> 0: test::m::new_mut();
 //> 1: test::m::borrow_mut(Result(0));
 //> 2: MergeCoins(Result(0), [Input(2)]);
 //> 3: test::m::borrow_mut(Result(1));
-Error: Transaction Effects Status: CommandArgumentError { arg_idx: 0, kind: CannotWriteToExtendedReference } in command 2
-Execution Error: CommandArgumentError { arg_idx: 0, kind: CannotWriteToExtendedReference } in command 2
+Error: Transaction Effects Status: Invalid command argument at 0. Cannot write to an argument location that is still borrowed, and where that borrow is an extension of that reference. This is likely due to this argument being used in a Move call that returns a reference, and that reference is used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 0, kind: CannotWriteToExtendedReference }, source: None, command: Some(2) } }

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_coin_op_writes_valid.move
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_coin_op_writes_valid.move
@@ -3,7 +3,7 @@
 
 // tests valid writes of mut references using coin operations
 
-//# init --addresses test=0x0 --accounts A
+//# init --addresses test=0x0 --accounts A --allow-references-in-ptbs
 
 //# publish
 module test::m {
@@ -20,12 +20,12 @@ module test::m {
 
 }
 
-//# programmable --inputs 10 @A
+//# programmable --sender A --inputs 0 @A
 // generate some coins for testing
 //> SplitCoins(Gas, [Input(0), Input(0), Input(0)]);
 //> TransferObjects([NestedResult(0,0), NestedResult(0,1), NestedResult(0,2)], Input(1))
 
-//# programmable --dev-inspect --inputs 10 @A
+//# programmable --sender A --inputs 0 @A
 // Can write to same coin ref via split coins
 //> 0: sui::coin::zero<sui::sui::SUI>();
 //> 1: test::m::borrow_mut(Result(0));
@@ -34,7 +34,7 @@ module test::m {
 //> 4: test::m::borrow_mut(Result(1));
 //> TransferObjects([Result(0)], Input(1))
 
-//# programmable --dev-inspect --inputs 10 @A object(2,0)
+//# programmable --sender A --inputs 0 @A object(2,0)
 // Can write to same coin ref via Merge coins
 //> 0: sui::coin::zero<sui::sui::SUI>();
 //> 1: test::m::borrow_mut(Result(0));
@@ -42,7 +42,7 @@ module test::m {
 //> 3: test::m::borrow_mut(Result(1));
 //> TransferObjects([Result(0)], Input(1))
 
-//# programmable --dev-inspect --inputs 10 @A
+//# programmable --sender A --inputs 0 @A
 // Can write to same coin via split coins
 //> 0: sui::coin::zero<sui::sui::SUI>();
 //> 1: test::m::borrow_mut(Result(0));
@@ -51,8 +51,8 @@ module test::m {
 //> 4: test::m::borrow_mut(Result(0));
 //> TransferObjects([Result(0)], Input(1))
 
-//# programmable --dev-inspect --inputs 10 @A object(2,0)
-// Can write to same coin r via Merge coins
+//# programmable --sender A --inputs 0 @A object(2,1)
+// Can write to same coin via Merge coins
 //> 0: sui::coin::zero<sui::sui::SUI>();
 //> 1: test::m::borrow_mut(Result(0));
 //> 2: MergeCoins(Result(0), [Input(2)]);

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_coin_op_writes_valid.snap
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_coin_op_writes_valid.snap
@@ -13,16 +13,16 @@ mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 4233200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2, lines 23-26:
-//# programmable --inputs 10 @A
+//# programmable --sender A --inputs 0 @A
 // generate some coins for testing
 //> SplitCoins(Gas, [Input(0), Input(0), Input(0)]);
 //> TransferObjects([NestedResult(0,0), NestedResult(0,1), NestedResult(0,2)], Input(1))
 created: object(2,0), object(2,1), object(2,2)
-mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 3952000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3952000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 3, lines 28-35:
-//# programmable --dev-inspect --inputs 10 @A
+//# programmable --sender A --inputs 0 @A
 // Can write to same coin ref via split coins
 //> 0: sui::coin::zero<sui::sui::SUI>();
 //> 1: test::m::borrow_mut(Result(0));
@@ -30,24 +30,22 @@ task 3, lines 28-35:
 //> 3: TransferObjects([Result(2)], Input(1));
 //> 4: test::m::borrow_mut(Result(1));
 //> TransferObjects([Result(0)], Input(1))
-Error: Transaction Effects Status: InsufficientCoinBalance in command 2
-Execution Error: InsufficientCoinBalance in command 2
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(1) } }
 
 task 4, lines 37-43:
-//# programmable --dev-inspect --inputs 10 @A object(2,0)
+//# programmable --sender A --inputs 0 @A object(2,0)
 // Can write to same coin ref via Merge coins
 //> 0: sui::coin::zero<sui::sui::SUI>();
 //> 1: test::m::borrow_mut(Result(0));
 //> 2: MergeCoins(Result(1), [Input(2)]);
 //> 3: test::m::borrow_mut(Result(1));
 //> TransferObjects([Result(0)], Input(1))
-created: object(4,0)
-mutated: object(_)
-deleted: object(2,0)
-gas summary: computation_cost: 500000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(1) } }
 
 task 5, lines 45-52:
-//# programmable --dev-inspect --inputs 10 @A
+//# programmable --sender A --inputs 0 @A
 // Can write to same coin via split coins
 //> 0: sui::coin::zero<sui::sui::SUI>();
 //> 1: test::m::borrow_mut(Result(0));
@@ -55,18 +53,16 @@ task 5, lines 45-52:
 //> 3: TransferObjects([Result(2)], Input(1));
 //> 4: test::m::borrow_mut(Result(0));
 //> TransferObjects([Result(0)], Input(1))
-Error: Transaction Effects Status: InsufficientCoinBalance in command 2
-Execution Error: InsufficientCoinBalance in command 2
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(1) } }
 
 task 6, lines 54-60:
-//# programmable --dev-inspect --inputs 10 @A object(2,0)
-// Can write to same coin r via Merge coins
+//# programmable --sender A --inputs 0 @A object(2,1)
+// Can write to same coin via Merge coins
 //> 0: sui::coin::zero<sui::sui::SUI>();
 //> 1: test::m::borrow_mut(Result(0));
 //> 2: MergeCoins(Result(0), [Input(2)]);
 //> 3: test::m::borrow_mut(Result(0));
 //> TransferObjects([Result(0)], Input(1))
-created: object(6,0)
-mutated: object(_)
-deleted: object(2,0)
-gas summary: computation_cost: 500000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_coin_op_writes_valid@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_coin_op_writes_valid@v2.snap
@@ -13,16 +13,16 @@ mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 4233200,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2, lines 23-26:
-//# programmable --inputs 10 @A
+//# programmable --sender A --inputs 0 @A
 // generate some coins for testing
 //> SplitCoins(Gas, [Input(0), Input(0), Input(0)]);
 //> TransferObjects([NestedResult(0,0), NestedResult(0,1), NestedResult(0,2)], Input(1))
 created: object(2,0), object(2,1), object(2,2)
-mutated: object(0,1)
-gas summary: computation_cost: 1000000, storage_cost: 3952000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 3952000,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 3, lines 28-35:
-//# programmable --dev-inspect --inputs 10 @A
+//# programmable --sender A --inputs 0 @A
 // Can write to same coin ref via split coins
 //> 0: sui::coin::zero<sui::sui::SUI>();
 //> 1: test::m::borrow_mut(Result(0));
@@ -30,11 +30,12 @@ task 3, lines 28-35:
 //> 3: TransferObjects([Result(2)], Input(1));
 //> 4: test::m::borrow_mut(Result(1));
 //> TransferObjects([Result(0)], Input(1))
-Error: Transaction Effects Status: InsufficientCoinBalance in command 2
-Execution Error: InsufficientCoinBalance in command 2
+created: object(3,0), object(3,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2964000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4, lines 37-43:
-//# programmable --dev-inspect --inputs 10 @A object(2,0)
+//# programmable --sender A --inputs 0 @A object(2,0)
 // Can write to same coin ref via Merge coins
 //> 0: sui::coin::zero<sui::sui::SUI>();
 //> 1: test::m::borrow_mut(Result(0));
@@ -42,12 +43,12 @@ task 4, lines 37-43:
 //> 3: test::m::borrow_mut(Result(1));
 //> TransferObjects([Result(0)], Input(1))
 created: object(4,0)
-mutated: object(_)
+mutated: object(0,0)
 deleted: object(2,0)
-gas summary: computation_cost: 500000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
 
 task 5, lines 45-52:
-//# programmable --dev-inspect --inputs 10 @A
+//# programmable --sender A --inputs 0 @A
 // Can write to same coin via split coins
 //> 0: sui::coin::zero<sui::sui::SUI>();
 //> 1: test::m::borrow_mut(Result(0));
@@ -55,18 +56,19 @@ task 5, lines 45-52:
 //> 3: TransferObjects([Result(2)], Input(1));
 //> 4: test::m::borrow_mut(Result(0));
 //> TransferObjects([Result(0)], Input(1))
-Error: Transaction Effects Status: InsufficientCoinBalance in command 2
-Execution Error: InsufficientCoinBalance in command 2
+created: object(5,0), object(5,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2964000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 6, lines 54-60:
-//# programmable --dev-inspect --inputs 10 @A object(2,0)
-// Can write to same coin r via Merge coins
+//# programmable --sender A --inputs 0 @A object(2,1)
+// Can write to same coin via Merge coins
 //> 0: sui::coin::zero<sui::sui::SUI>();
 //> 1: test::m::borrow_mut(Result(0));
 //> 2: MergeCoins(Result(0), [Input(2)]);
 //> 3: test::m::borrow_mut(Result(0));
 //> TransferObjects([Result(0)], Input(1))
 created: object(6,0)
-mutated: object(_)
-deleted: object(2,0)
-gas summary: computation_cost: 500000, storage_cost: 1976000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+mutated: object(0,0)
+deleted: object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_no_inputs.move
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_no_inputs.move
@@ -3,7 +3,7 @@
 
 // tests returning a reference without any inputs
 
-//# init --addresses test=0x0 --accounts A
+//# init --addresses test=0x0 --accounts A --allow-references-in-ptbs
 
 //# publish
 module test::m {
@@ -29,12 +29,12 @@ module test::m {
 }
 
 
-//# programmable --dev-inspect
+//# programmable
 // This should be allowed and should abort
 //> 0: test::m::pair_mut();
 //> test::m::increment(Result(0));
 
-//# programmable --dev-inspect
+//# programmable
 // This should be allowed and should abort
 //> 0: test::m::box_mut();
 //> test::m::increment(NestedResult(0,0));
@@ -42,12 +42,12 @@ module test::m {
 //> test::m::increment(NestedResult(0,0));
 //> test::m::swap_x(NestedResult(0,0), NestedResult(0,1));
 
-//# programmable --dev-inspect
+//# programmable
 // This should be rejected by the borrow checker (in static PTBs)
 //> 0: test::m::pair_mut();
 //> test::m::swap_x(Result(0), Result(0));
 
-//# programmable --dev-inspect
+//# programmable
 // This should be rejected by the borrow checker (in static PTBs)
 //> 0: test::m::box_mut();
 //> test::m::swap_x(NestedResult(0,0), NestedResult(0,0));

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_no_inputs.snap
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_no_inputs.snap
@@ -13,36 +13,36 @@ mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 5137600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2, lines 32-35:
-//# programmable --dev-inspect
+//# programmable
 // This should be allowed and should abort
 //> 0: test::m::pair_mut();
 //> test::m::increment(Result(0));
-Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("pair_mut") }, 0) in command 0
-Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("pair_mut") }, 0) in command 0
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(0) } }
 
 task 3, lines 37-43:
-//# programmable --dev-inspect
+//# programmable
 // This should be allowed and should abort
 //> 0: test::m::box_mut();
 //> test::m::increment(NestedResult(0,0));
 //> test::m::increment(NestedResult(0,1));
 //> test::m::increment(NestedResult(0,0));
 //> test::m::swap_x(NestedResult(0,0), NestedResult(0,1));
-Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("box_mut") }, 1) in command 0
-Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("box_mut") }, 1) in command 0
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(0) } }
 
 task 4, lines 45-48:
-//# programmable --dev-inspect
+//# programmable
 // This should be rejected by the borrow checker (in static PTBs)
 //> 0: test::m::pair_mut();
 //> test::m::swap_x(Result(0), Result(0));
-Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("pair_mut") }, 0) in command 0
-Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("pair_mut") }, 0) in command 0
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(0) } }
 
 task 5, lines 50-53:
-//# programmable --dev-inspect
+//# programmable
 // This should be rejected by the borrow checker (in static PTBs)
 //> 0: test::m::box_mut();
 //> test::m::swap_x(NestedResult(0,0), NestedResult(0,0));
-Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("box_mut") }, 1) in command 0
-Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("box_mut") }, 1) in command 0
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_no_inputs@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_no_inputs@v2.snap
@@ -13,36 +13,36 @@ mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 5137600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2, lines 32-35:
-//# programmable --dev-inspect
+//# programmable
 // This should be allowed and should abort
 //> 0: test::m::pair_mut();
 //> test::m::increment(Result(0));
-Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("pair_mut") }, 0) in command 0
-Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("pair_mut") }, 0) in command 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::m::pair_mut (function index 0) at offset 1, Abort Code: 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 0, instruction: 1, function_name: Some("pair_mut") }, 0), source: Some(VMError { major_status: ABORTED, sub_status: Some(0), message: Some("test::m::pair_mut at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 1)] }), command: Some(0) } }
 
 task 3, lines 37-43:
-//# programmable --dev-inspect
+//# programmable
 // This should be allowed and should abort
 //> 0: test::m::box_mut();
 //> test::m::increment(NestedResult(0,0));
 //> test::m::increment(NestedResult(0,1));
 //> test::m::increment(NestedResult(0,0));
 //> test::m::swap_x(NestedResult(0,0), NestedResult(0,1));
-Error: Transaction Effects Status: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("box_mut") }, 1) in command 0
-Execution Error: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("box_mut") }, 1) in command 0
+Error: Transaction Effects Status: Move Runtime Abort. Location: test::m::box_mut (function index 1) at offset 1, Abort Code: 1
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m") }, function: 1, instruction: 1, function_name: Some("box_mut") }, 1), source: Some(VMError { major_status: ABORTED, sub_status: Some(1), message: Some("test::m::box_mut at offset 1"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m") }), indices: [], offsets: [(FunctionDefinitionIndex(1), 1)] }), command: Some(0) } }
 
 task 4, lines 45-48:
-//# programmable --dev-inspect
+//# programmable
 // This should be rejected by the borrow checker (in static PTBs)
 //> 0: test::m::pair_mut();
 //> test::m::swap_x(Result(0), Result(0));
-Error: Transaction Effects Status: CommandArgumentError { arg_idx: 1, kind: InvalidReferenceArgument } in command 1
-Execution Error: CommandArgumentError { arg_idx: 1, kind: InvalidReferenceArgument } in command 1
+Error: Transaction Effects Status: Invalid command argument at 1. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: InvalidReferenceArgument }, source: None, command: Some(1) } }
 
 task 5, lines 50-53:
-//# programmable --dev-inspect
+//# programmable
 // This should be rejected by the borrow checker (in static PTBs)
 //> 0: test::m::box_mut();
 //> test::m::swap_x(NestedResult(0,0), NestedResult(0,0));
-Error: Transaction Effects Status: CommandArgumentError { arg_idx: 1, kind: InvalidReferenceArgument } in command 1
-Execution Error: CommandArgumentError { arg_idx: 1, kind: InvalidReferenceArgument } in command 1
+Error: Transaction Effects Status: Invalid command argument at 1. The argument specified cannot be used as a reference argument in the Move call. Either the argument is a mutable reference and it conflicts with another argument to the call, or the argument is mutable and another reference extends it and will be used in a later command.
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: CommandArgumentError { arg_idx: 1, kind: InvalidReferenceArgument }, source: None, command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_writes_valid.move
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_writes_valid.move
@@ -3,7 +3,7 @@
 
 // tests valid transfers/writes of mut references
 
-//# init --addresses test=0x0 --accounts A
+//# init --addresses test=0x0 --accounts A --allow-references-in-ptbs
 
 //# publish
 module test::m {
@@ -51,21 +51,21 @@ module test::m {
 
 // single mut child
 
-//# programmable --dev-inspect
+//# programmable
 // write to child, write to parent
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_mut(Result(0));
 //> 2: test::m::write_u64(Result(1));
 //> 3: test::m::write_pair(Result(0));
 
-//# programmable --dev-inspect
+//# programmable
 // read parent, write to child
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_mut(Result(0));
 //> 2: test::m::use_ref<test::m::Pair>(Result(0));
 //> 3: test::m::write_u64(Result(1));
 
-//# programmable --dev-inspect
+//# programmable
 // borrow parent, write to child, write to parent
 //> 0: test::m::pair();
 //> 1: test::m::borrow_mut<test::m::Pair>(Result(0));
@@ -73,7 +73,7 @@ module test::m {
 //> 3: test::m::write_u64(Result(2));
 //> test::m::write_pair(Result(1));
 
-//# programmable --dev-inspect
+//# programmable
 // borrow parent, read parent, write to child
 //> 0: test::m::pair();
 //> 1: test::m::borrow_mut<test::m::Pair>(Result(0));
@@ -84,7 +84,7 @@ module test::m {
 
 // multiple mut children
 
-//# programmable --dev-inspect
+//# programmable
 // write to children, write to parent
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_y_mut(Result(0));
@@ -92,7 +92,7 @@ module test::m {
 //> 3: test::m::write_u64(NestedResult(1,1));
 //> 4: test::m::write_pair(Result(0));
 
-//# programmable --dev-inspect
+//# programmable
 // borrow parent, write to children, read parent
 //> 0: test::m::pair();
 //> 1: test::m::borrow_mut<test::m::Pair>(Result(0));
@@ -103,7 +103,7 @@ module test::m {
 
 // mut child, imm child
 
-//# programmable --dev-inspect
+//# programmable
 // write to child, read child, write to parent
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_mut_y_imm(Result(0));
@@ -113,7 +113,7 @@ module test::m {
 //> 5: test::m::use_ref<u64>(NestedResult(1,1));
 //> 6: test::m::write_pair(Result(0));
 
-//# programmable --dev-inspect
+//# programmable
 // borrow parent, write to child, read child, read parent
 //> 0: test::m::pair();
 //> 1: test::m::borrow_mut<test::m::Pair>(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_writes_valid.snap
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_writes_valid.snap
@@ -13,38 +13,38 @@ mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 6429600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2, lines 54-59:
-//# programmable --dev-inspect
+//# programmable
 // write to child, write to parent
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_mut(Result(0));
 //> 2: test::m::write_u64(Result(1));
 //> 3: test::m::write_pair(Result(0));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(1) } }
 
 task 3, lines 61-66:
-//# programmable --dev-inspect
+//# programmable
 // read parent, write to child
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_mut(Result(0));
 //> 2: test::m::use_ref<test::m::Pair>(Result(0));
 //> 3: test::m::write_u64(Result(1));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(1) } }
 
 task 4, lines 68-74:
-//# programmable --dev-inspect
+//# programmable
 // borrow parent, write to child, write to parent
 //> 0: test::m::pair();
 //> 1: test::m::borrow_mut<test::m::Pair>(Result(0));
 //> 2: test::m::borrow_x_mut(Result(1));
 //> 3: test::m::write_u64(Result(2));
 //> test::m::write_pair(Result(1));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(1) } }
 
 task 5, lines 76-85:
-//# programmable --dev-inspect
+//# programmable
 // borrow parent, read parent, write to child
 //> 0: test::m::pair();
 //> 1: test::m::borrow_mut<test::m::Pair>(Result(0));
@@ -53,22 +53,22 @@ task 5, lines 76-85:
 //> 4: test::m::write_u64(Result(2));
 //> 5: test::m::use_ref<test::m::Pair>(Result(1));
 // multiple mut children
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(1) } }
 
 task 6, lines 87-93:
-//# programmable --dev-inspect
+//# programmable
 // write to children, write to parent
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_y_mut(Result(0));
 //> 2: test::m::write_u64(NestedResult(1,0));
 //> 3: test::m::write_u64(NestedResult(1,1));
 //> 4: test::m::write_pair(Result(0));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(1) } }
 
 task 7, lines 95-104:
-//# programmable --dev-inspect
+//# programmable
 // borrow parent, write to children, read parent
 //> 0: test::m::pair();
 //> 1: test::m::borrow_mut<test::m::Pair>(Result(0));
@@ -77,11 +77,11 @@ task 7, lines 95-104:
 //> 4: test::m::write_u64(NestedResult(2,1));
 //> 5: test::m::use_ref<test::m::Pair>(Result(1));
 // mut child, imm child
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(1) } }
 
 task 8, lines 106-114:
-//# programmable --dev-inspect
+//# programmable
 // write to child, read child, write to parent
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_mut_y_imm(Result(0));
@@ -90,11 +90,11 @@ task 8, lines 106-114:
 //> 4: test::m::write_u64(NestedResult(1,0));
 //> 5: test::m::use_ref<u64>(NestedResult(1,1));
 //> 6: test::m::write_pair(Result(0));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(1) } }
 
 task 9, lines 116-125:
-//# programmable --dev-inspect
+//# programmable
 // borrow parent, write to child, read child, read parent
 //> 0: test::m::pair();
 //> 1: test::m::borrow_mut<test::m::Pair>(Result(0));
@@ -104,5 +104,5 @@ task 9, lines 116-125:
 //> 5: test::m::write_u64(NestedResult(2,0));
 //> 6: test::m::use_ref<u64>(NestedResult(2,1));
 //> 7: test::m::use_ref<test::m::Pair>(Result(1));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_writes_valid@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_writes_valid@v2.snap
@@ -13,38 +13,38 @@ mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 6429600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2, lines 54-59:
-//# programmable --dev-inspect
+//# programmable
 // write to child, write to parent
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_mut(Result(0));
 //> 2: test::m::write_u64(Result(1));
 //> 3: test::m::write_pair(Result(0));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 3, lines 61-66:
-//# programmable --dev-inspect
+//# programmable
 // read parent, write to child
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_mut(Result(0));
 //> 2: test::m::use_ref<test::m::Pair>(Result(0));
 //> 3: test::m::write_u64(Result(1));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4, lines 68-74:
-//# programmable --dev-inspect
+//# programmable
 // borrow parent, write to child, write to parent
 //> 0: test::m::pair();
 //> 1: test::m::borrow_mut<test::m::Pair>(Result(0));
 //> 2: test::m::borrow_x_mut(Result(1));
 //> 3: test::m::write_u64(Result(2));
 //> test::m::write_pair(Result(1));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 5, lines 76-85:
-//# programmable --dev-inspect
+//# programmable
 // borrow parent, read parent, write to child
 //> 0: test::m::pair();
 //> 1: test::m::borrow_mut<test::m::Pair>(Result(0));
@@ -53,22 +53,22 @@ task 5, lines 76-85:
 //> 4: test::m::write_u64(Result(2));
 //> 5: test::m::use_ref<test::m::Pair>(Result(1));
 // multiple mut children
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 6, lines 87-93:
-//# programmable --dev-inspect
+//# programmable
 // write to children, write to parent
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_y_mut(Result(0));
 //> 2: test::m::write_u64(NestedResult(1,0));
 //> 3: test::m::write_u64(NestedResult(1,1));
 //> 4: test::m::write_pair(Result(0));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 7, lines 95-104:
-//# programmable --dev-inspect
+//# programmable
 // borrow parent, write to children, read parent
 //> 0: test::m::pair();
 //> 1: test::m::borrow_mut<test::m::Pair>(Result(0));
@@ -77,11 +77,11 @@ task 7, lines 95-104:
 //> 4: test::m::write_u64(NestedResult(2,1));
 //> 5: test::m::use_ref<test::m::Pair>(Result(1));
 // mut child, imm child
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 8, lines 106-114:
-//# programmable --dev-inspect
+//# programmable
 // write to child, read child, write to parent
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_mut_y_imm(Result(0));
@@ -90,11 +90,11 @@ task 8, lines 106-114:
 //> 4: test::m::write_u64(NestedResult(1,0));
 //> 5: test::m::use_ref<u64>(NestedResult(1,1));
 //> 6: test::m::write_pair(Result(0));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 9, lines 116-125:
-//# programmable --dev-inspect
+//# programmable
 // borrow parent, write to child, read child, read parent
 //> 0: test::m::pair();
 //> 1: test::m::borrow_mut<test::m::Pair>(Result(0));
@@ -104,5 +104,5 @@ task 9, lines 116-125:
 //> 5: test::m::write_u64(NestedResult(2,0));
 //> 6: test::m::use_ref<u64>(NestedResult(2,1));
 //> 7: test::m::use_ref<test::m::Pair>(Result(1));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_writes_valid_auto_drop.move
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_writes_valid_auto_drop.move
@@ -4,7 +4,7 @@
 // tests valid transfers/writes of mut references, which are valid only because of automatically
 // dropping references
 
-//# init --addresses test=0x0 --accounts A
+//# init --addresses test=0x0 --accounts A --allow-references-in-ptbs
 
 //# publish
 module test::m {
@@ -50,33 +50,33 @@ module test::m {
 
 }
 
-//# programmable --dev-inspect
+//# programmable
 // transfer parent (dropped child)
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_mut(Result(0));
 //> 2: test::m::write_pair(Result(0));
 
-//# programmable --dev-inspect
+//# programmable
 // borrow parent, transfer parent (dropped child)
 //> 0: test::m::pair();
 //> 1: test::m::borrow_mut<test::m::Pair>(Result(0));
 //> 2: test::m::borrow_x_mut(Result(1));
 //> 3: test::m::write_pair(Result(1));
 
-//# programmable --dev-inspect
+//# programmable
 // transfer parent (drop one, use one)
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_y_mut(Result(0));
 //> 2: test::m::write_u64(NestedResult(1,0));
 //> 3: test::m::write_pair(Result(0));
 
-//# programmable --dev-inspect
+//# programmable
 // transfer parent (drop two)
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_y_mut(Result(0));
 //> 2: test::m::write_pair(Result(0));
 
-//# programmable --dev-inspect
+//# programmable
 // write to parent with imm child (write mut drop imm)
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_mut_y_imm(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_writes_valid_auto_drop.snap
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_writes_valid_auto_drop.snap
@@ -13,49 +13,49 @@ mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 6429600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2, lines 53-57:
-//# programmable --dev-inspect
+//# programmable
 // transfer parent (dropped child)
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_mut(Result(0));
 //> 2: test::m::write_pair(Result(0));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(1) } }
 
 task 3, lines 59-64:
-//# programmable --dev-inspect
+//# programmable
 // borrow parent, transfer parent (dropped child)
 //> 0: test::m::pair();
 //> 1: test::m::borrow_mut<test::m::Pair>(Result(0));
 //> 2: test::m::borrow_x_mut(Result(1));
 //> 3: test::m::write_pair(Result(1));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(1) } }
 
 task 4, lines 66-71:
-//# programmable --dev-inspect
+//# programmable
 // transfer parent (drop one, use one)
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_y_mut(Result(0));
 //> 2: test::m::write_u64(NestedResult(1,0));
 //> 3: test::m::write_pair(Result(0));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(1) } }
 
 task 5, lines 73-77:
-//# programmable --dev-inspect
+//# programmable
 // transfer parent (drop two)
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_y_mut(Result(0));
 //> 2: test::m::write_pair(Result(0));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(1) } }
 
 task 6, lines 79-84:
-//# programmable --dev-inspect
+//# programmable
 // write to parent with imm child (write mut drop imm)
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_mut_y_imm(Result(0));
 //> 2: test::m::write_u64(NestedResult(1,0));
 //> 3: test::m::write_pair(Result(0));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(1) } }

--- a/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_writes_valid_auto_drop@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/dev_inspect/reference_return_writes_valid_auto_drop@v2.snap
@@ -13,49 +13,49 @@ mutated: object(0,1)
 gas summary: computation_cost: 1000000, storage_cost: 6429600,  storage_rebate: 0, non_refundable_storage_fee: 0
 
 task 2, lines 53-57:
-//# programmable --dev-inspect
+//# programmable
 // transfer parent (dropped child)
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_mut(Result(0));
 //> 2: test::m::write_pair(Result(0));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 3, lines 59-64:
-//# programmable --dev-inspect
+//# programmable
 // borrow parent, transfer parent (dropped child)
 //> 0: test::m::pair();
 //> 1: test::m::borrow_mut<test::m::Pair>(Result(0));
 //> 2: test::m::borrow_x_mut(Result(1));
 //> 3: test::m::write_pair(Result(1));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 4, lines 66-71:
-//# programmable --dev-inspect
+//# programmable
 // transfer parent (drop one, use one)
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_y_mut(Result(0));
 //> 2: test::m::write_u64(NestedResult(1,0));
 //> 3: test::m::write_pair(Result(0));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 5, lines 73-77:
-//# programmable --dev-inspect
+//# programmable
 // transfer parent (drop two)
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_y_mut(Result(0));
 //> 2: test::m::write_pair(Result(0));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 6, lines 79-84:
-//# programmable --dev-inspect
+//# programmable
 // write to parent with imm child (write mut drop imm)
 //> 0: test::m::pair();
 //> 1: test::m::borrow_x_mut_y_imm(Result(0));
 //> 2: test::m::write_u64(NestedResult(1,0));
 //> 3: test::m::write_pair(Result(0));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut.move
@@ -3,7 +3,7 @@
 
 // tests that pure arguments have distinct values/locals per type usage
 
-//# init --addresses test=0x0 --accounts A
+//# init --addresses test=0x0 --accounts A --allow-references-in-ptbs
 
 //# publish
 module test::m1 {
@@ -56,13 +56,13 @@ module test::m1 {
 //> test::m1::assert_string(Input(1));
 
 // In statically checked PTBs, tests that each type can be borrowed mutably separately
-//# programmable --inputs 0u8 --dev-inspect
+//# programmable --inputs 0u8
 //> 0: test::m1::borrow_mut<u8>(Input(0));
 //> 1: test::m1::borrow_mut<std::ascii::String>(Input(0));
 //> test::m1::modify_ascii(Result(1));
 //> test::m1::modify_u8(Result(0));
 
-//# programmable --inputs 0u8 --dev-inspect
+//# programmable --inputs 0u8
 //> 0: test::m1::borrow_mut<u8>(Input(0));
 //> 1: test::m1::borrow_mut<std::ascii::String>(Input(0));
 //> test::m1::modify_u8(Result(0));

--- a/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut.snap
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut.snap
@@ -34,19 +34,19 @@ Error: Transaction Effects Status: Move Abort in test::m1::assert_string (functi
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m1") }, function: 6, instruction: 11, function_name: Some("assert_string") }, 13906834324667236351), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834324667236351), message: Some("test::m1::assert_string at offset 11"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m1") }), indices: [], offsets: [(FunctionDefinitionIndex(6), 11)] }), command: Some(1) } }
 
 task 4, lines 59-63:
-//# programmable --inputs 0u8 --dev-inspect
+//# programmable --inputs 0u8
 //> 0: test::m1::borrow_mut<u8>(Input(0));
 //> 1: test::m1::borrow_mut<std::ascii::String>(Input(0));
 //> test::m1::modify_ascii(Result(1));
 //> test::m1::modify_u8(Result(0));
-Error: Transaction Effects Status: CommandArgumentError { arg_idx: 0, kind: TypeMismatch } in command 1
-Execution Error: CommandArgumentError { arg_idx: 0, kind: TypeMismatch } in command 1
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(0) } }
 
 task 5, lines 65-69:
-//# programmable --inputs 0u8 --dev-inspect
+//# programmable --inputs 0u8
 //> 0: test::m1::borrow_mut<u8>(Input(0));
 //> 1: test::m1::borrow_mut<std::ascii::String>(Input(0));
 //> test::m1::modify_u8(Result(0));
 //> test::m1::modify_ascii(Result(1));
-Error: Transaction Effects Status: CommandArgumentError { arg_idx: 0, kind: TypeMismatch } in command 1
-Execution Error: CommandArgumentError { arg_idx: 0, kind: TypeMismatch } in command 1
+Error: Transaction Effects Status: Invalid public Move function signature. Unsupported return type for return value 0
+Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: InvalidPublicFunctionReturnType { idx: 0 }, source: None, command: Some(0) } }

--- a/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/pure_arg_mut@v2.snap
@@ -34,19 +34,19 @@ Error: Transaction Effects Status: Move Abort in test::m1::assert_string (functi
 Execution Error: ExecutionError: ExecutionError { inner: ExecutionErrorInner { kind: MoveAbort(MoveLocation { module: ModuleId { address: test, name: Identifier("m1") }, function: 6, instruction: 11, function_name: Some("assert_string") }, 13906834324667236351), source: Some(VMError { major_status: ABORTED, sub_status: Some(13906834324667236351), message: Some("test::m1::assert_string at offset 11"), exec_state: None, location: Module(ModuleId { address: test, name: Identifier("m1") }), indices: [], offsets: [(FunctionDefinitionIndex(6), 11)] }), command: Some(1) } }
 
 task 4, lines 59-63:
-//# programmable --inputs 0u8 --dev-inspect
+//# programmable --inputs 0u8
 //> 0: test::m1::borrow_mut<u8>(Input(0));
 //> 1: test::m1::borrow_mut<std::ascii::String>(Input(0));
 //> test::m1::modify_ascii(Result(1));
 //> test::m1::modify_u8(Result(0));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
 
 task 5, lines 65-69:
-//# programmable --inputs 0u8 --dev-inspect
+//# programmable --inputs 0u8
 //> 0: test::m1::borrow_mut<u8>(Input(0));
 //> 1: test::m1::borrow_mut<std::ascii::String>(Input(0));
 //> test::m1::modify_u8(Result(0));
 //> test::m1::modify_ascii(Result(1));
-mutated: object(_)
-gas summary: computation_cost: 500000, storage_cost: 988000,  storage_rebate: 0, non_refundable_storage_fee: 0
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 978120, non_refundable_storage_fee: 9880

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1307,6 +1307,7 @@
                 "advance_to_highest_supported_protocol_version": false,
                 "allow_private_accumulator_entrypoints": false,
                 "allow_receiving_object_id": false,
+                "allow_references_in_ptbs": false,
                 "allow_unbounded_system_objects": false,
                 "authority_capabilities_v2": false,
                 "ban_entry_init": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -837,6 +837,10 @@ struct FeatureFlags {
     // If true generate layouts for dynamic fields
     #[serde(skip_serializing_if = "is_false")]
     generate_df_type_layouts: bool,
+
+    // If true, allow Move functions called in PTBs to return references
+    #[serde(skip_serializing_if = "is_false")]
+    allow_references_in_ptbs: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -2273,6 +2277,10 @@ impl ProtocolConfig {
 
     pub fn generate_df_type_layouts(&self) -> bool {
         self.feature_flags.generate_df_type_layouts
+    }
+
+    pub fn allow_references_in_ptbs(&self) -> bool {
+        self.feature_flags.allow_references_in_ptbs
     }
 }
 
@@ -4343,6 +4351,10 @@ impl ProtocolConfig {
 
     pub fn set_authority_capabilities_v2_for_testing(&mut self, val: bool) {
         self.feature_flags.authority_capabilities_v2 = val;
+    }
+
+    pub fn allow_references_in_ptbs_for_testing(&mut self) {
+        self.feature_flags.allow_references_in_ptbs = true;
     }
 }
 

--- a/crates/sui-transactional-test-runner/src/args.rs
+++ b/crates/sui-transactional-test-runner/src/args.rs
@@ -90,6 +90,9 @@ pub struct SuiInitArgs {
     /// Enable authenticated event streams for testing
     #[clap(long = "enable-authenticated-event-streams")]
     pub enable_authenticated_event_streams: bool,
+    /// Enable references in PTBs
+    #[clap(long = "allow-references-in-ptbs")]
+    pub allow_references_in_ptbs: bool,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/crates/sui-transactional-test-runner/src/test_adapter.rs
+++ b/crates/sui-transactional-test-runner/src/test_adapter.rs
@@ -241,6 +241,7 @@ impl AdapterInitConfig {
             rest_api_url,
             enable_accumulators,
             enable_authenticated_event_streams,
+            allow_references_in_ptbs,
         } = sui_args;
 
         let map = verify_and_create_named_address_mapping(named_addresses).unwrap();
@@ -258,6 +259,9 @@ impl AdapterInitConfig {
         }
         if enable_authenticated_event_streams {
             protocol_config.enable_authenticated_event_streams_for_testing();
+        }
+        if allow_references_in_ptbs {
+            protocol_config.allow_references_in_ptbs_for_testing();
         }
         if let Some(enable) = shared_object_deletion {
             protocol_config.set_shared_object_deletion_for_testing(enable);


### PR DESCRIPTION
## Description 

- We have some tests that return references from PTBs, they were using dev inspect
- Just adding the protocol config flag now makes other tests easier

## Test plan 

- Updated relevant tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
