### PR TITLE
[graphql-alt] Set SimulateTransaction events timestamp to null

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql_simulate_transaction_tests.rs
@@ -340,6 +340,7 @@ async fn test_simulate_transaction_with_events() {
                         status
                         events {
                             nodes {
+                                timestamp
                                 contents {
                                     json
                                 }
@@ -380,6 +381,7 @@ async fn test_simulate_transaction_with_events() {
         "events": {
           "nodes": [
             {
+              "timestamp": null,
               "contents": {
                 "json": {
                   "message": "Package published successfully!",

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -1258,6 +1258,8 @@ type Event {
 	"""
 	Timestamp corresponding to the checkpoint this event's transaction was finalized in.
 	All events from the same transaction share the same timestamp.
+	
+	`null` for simulated/executed transactions as they are not included in a checkpoint.
 	"""
 	timestamp: DateTime
 	"""
@@ -3821,6 +3823,8 @@ type TransactionEffects {
 	status: ExecutionStatus
 	"""
 	Timestamp corresponding to the checkpoint this transaction was finalized in.
+	
+	`null` for executed/simulated transactions that have not been included in a checkpoint.
 	"""
 	timestamp: DateTime
 	"""

--- a/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/event/mod.rs
@@ -56,8 +56,8 @@ pub(crate) struct Event {
     pub(crate) transaction_digest: TransactionDigest,
     /// Position of this event within the transaction's events list (0-indexed)
     pub(crate) sequence_number: u64,
-    /// Timestamp when the transaction containing this event was finalized (checkpoint time)
-    pub(crate) timestamp_ms: u64,
+    /// Timestamp of the checkpoint that includes the transaction containing this event.
+    pub(crate) timestamp_ms: Option<u64>,
 }
 
 #[Object]
@@ -94,8 +94,12 @@ impl Event {
 
     /// Timestamp corresponding to the checkpoint this event's transaction was finalized in.
     /// All events from the same transaction share the same timestamp.
+    ///
+    /// `null` for simulated/executed transactions as they are not included in a checkpoint.
     async fn timestamp(&self) -> Result<Option<DateTime>, RpcError> {
-        Ok(Some(DateTime::from_ms(self.timestamp_ms as i64)?))
+        self.timestamp_ms
+            .map(|ms| DateTime::from_ms(ms as i64))
+            .transpose()
     }
 
     /// The transaction that emitted this event. This information is only available for events from indexed transactions, and not from transactions that have just been executed or dry-run.

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_effects.rs
@@ -150,12 +150,17 @@ impl EffectsContents {
     }
 
     /// Timestamp corresponding to the checkpoint this transaction was finalized in.
+    ///
+    /// `null` for executed/simulated transactions that have not been included in a checkpoint.
     async fn timestamp(&self) -> Result<Option<DateTime>, RpcError> {
         let Some(content) = &self.contents else {
             return Ok(None);
         };
 
-        Ok(Some(DateTime::from_ms(content.timestamp_ms() as i64)?))
+        content
+            .timestamp_ms()
+            .map(|ms| DateTime::from_ms(ms as i64))
+            .transpose()
     }
 
     /// The epoch this transaction was finalized in.

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -1262,6 +1262,8 @@ type Event {
 	"""
 	Timestamp corresponding to the checkpoint this event's transaction was finalized in.
 	All events from the same transaction share the same timestamp.
+	
+	`null` for simulated/executed transactions as they are not included in a checkpoint.
 	"""
 	timestamp: DateTime
 	"""
@@ -3825,6 +3827,8 @@ type TransactionEffects {
 	status: ExecutionStatus
 	"""
 	Timestamp corresponding to the checkpoint this transaction was finalized in.
+	
+	`null` for executed/simulated transactions that have not been included in a checkpoint.
 	"""
 	timestamp: DateTime
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -1262,6 +1262,8 @@ type Event {
 	"""
 	Timestamp corresponding to the checkpoint this event's transaction was finalized in.
 	All events from the same transaction share the same timestamp.
+	
+	`null` for simulated/executed transactions as they are not included in a checkpoint.
 	"""
 	timestamp: DateTime
 	"""
@@ -3825,6 +3827,8 @@ type TransactionEffects {
 	status: ExecutionStatus
 	"""
 	Timestamp corresponding to the checkpoint this transaction was finalized in.
+	
+	`null` for executed/simulated transactions that have not been included in a checkpoint.
 	"""
 	timestamp: DateTime
 	"""

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -1258,6 +1258,8 @@ type Event {
 	"""
 	Timestamp corresponding to the checkpoint this event's transaction was finalized in.
 	All events from the same transaction share the same timestamp.
+	
+	`null` for simulated/executed transactions as they are not included in a checkpoint.
 	"""
 	timestamp: DateTime
 	"""
@@ -3821,6 +3823,8 @@ type TransactionEffects {
 	status: ExecutionStatus
 	"""
 	Timestamp corresponding to the checkpoint this transaction was finalized in.
+	
+	`null` for executed/simulated transactions that have not been included in a checkpoint.
 	"""
 	timestamp: DateTime
 	"""

--- a/crates/sui-indexer-alt-jsonrpc/src/api/transactions/response.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/transactions/response.rs
@@ -69,7 +69,7 @@ pub(super) async fn transaction(
 
     let mut response = SuiTransactionBlockResponse::new(digest);
 
-    response.timestamp_ms = Some(tx.timestamp_ms());
+    response.timestamp_ms = tx.timestamp_ms();
     response.checkpoint = tx.cp_sequence_number();
 
     if options.show_input {
@@ -155,9 +155,8 @@ async fn events(
             ),
         };
 
-        let sui_event =
-            SuiEvent::try_from(event, digest, ix as u64, Some(tx.timestamp_ms()), layout)
-                .with_context(|| format!("Failed to convert Event {ix} into response"))?;
+        let sui_event = SuiEvent::try_from(event, digest, ix as u64, tx.timestamp_ms(), layout)
+            .with_context(|| format!("Failed to convert Event {ix} into response"))?;
 
         sui_events.push(sui_event)
     }

--- a/crates/sui-indexer-alt-reader/src/kv_loader.rs
+++ b/crates/sui-indexer-alt-reader/src/kv_loader.rs
@@ -371,12 +371,12 @@ impl TransactionContents {
         }
     }
 
-    pub fn timestamp_ms(&self) -> u64 {
+    pub fn timestamp_ms(&self) -> Option<u64> {
         match self {
-            Self::Pg(stored) => stored.timestamp_ms as u64,
-            Self::Bigtable(kv) => kv.timestamp,
-            Self::LedgerGrpc(txn) => txn.timestamp_ms.unwrap_or_default(),
-            Self::ExecutedTransaction { .. } => 0,
+            Self::Pg(stored) => Some(stored.timestamp_ms as u64),
+            Self::Bigtable(kv) => Some(kv.timestamp),
+            Self::LedgerGrpc(txn) => txn.timestamp_ms,
+            Self::ExecutedTransaction { .. } => None, // No timestamp until checkpointed
         }
     }
 
@@ -400,10 +400,10 @@ impl TransactionEventsContents {
         }
     }
 
-    pub fn timestamp_ms(&self) -> u64 {
+    pub fn timestamp_ms(&self) -> Option<u64> {
         match self {
-            Self::Serialized(stored) => stored.timestamp_ms as u64,
-            Self::Deserialized(kv) => kv.timestamp_ms,
+            Self::Serialized(stored) => Some(stored.timestamp_ms as u64),
+            Self::Deserialized(kv) => Some(kv.timestamp_ms),
         }
     }
 }


### PR DESCRIPTION
## Description 

Events on transactions that have been simulated have their timestamps set to zero, and the events response will be like this:

```
"events": {
      "nodes": [
        {
          "sequenceNumber": 0,
          "timestamp": "1970-01-01T00:00:00Z",
          "contents": {
            "json": {
              "foo": 1
            }
          },
}
```

This PR fixed that by using None for event timestamp for Transaction execution and simulation as the transaction is not checkpointed yet

## Test plan 

How did you test the new or updated feature?

```
cargo nextest run -p sui-indexer-alt-e2e-tests
cargo nextest run -p sui-indexer-alt-framework
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [x] GraphQL: Returns `null` for simulated/executed transactions timestamp as they are not included in a checkpoint.
- [ ] CLI: 
- [ ] Rust SDK:
