### PR TITLE
Output and metrics in the replay

### DIFF
--- a/crates/sui-replay-2/src/data-stores/data_store.rs
+++ b/crates/sui-replay-2/src/data-stores/data_store.rs
@@ -319,7 +319,6 @@ impl DataStore {
     ) -> Result<Option<(TransactionData, TransactionEffects, u64)>, anyhow::Error> {
         let _span = debug_span!("gql_txn_query", digest = %digest).entered();
         debug!(op = "txn_query", phase = "start", "transaction query");
-        tx_counts_add_txn();
         let t0 = Instant::now();
         let data = gql_queries::txn_query::query(digest.to_string(), self).await;
         let elapsed = t0.elapsed().as_millis();
@@ -336,7 +335,6 @@ impl DataStore {
     async fn epoch(&self, epoch_id: u64) -> Result<Option<EpochData>, anyhow::Error> {
         let _span = debug_span!("gql_epoch_query", epoch = epoch_id).entered();
         debug!(op = "epoch_query", phase = "start", "epoch query");
-        tx_counts_add_epoch();
         let t0 = Instant::now();
         let data = gql_queries::epoch_query::query(epoch_id, self).await;
         let elapsed = t0.elapsed().as_millis();
@@ -356,9 +354,6 @@ impl DataStore {
     ) -> Result<Vec<Option<(Object, u64)>>, anyhow::Error> {
         let _span = debug_span!("gql_objects_query", num_keys = keys.len()).entered();
         debug!(op = "objects_query", phase = "start", "objects query");
-        // Track how many objects were requested in this batch
-        tx_objs_add(keys.len());
-        tx_counts_add_objs();
         let t0 = Instant::now();
         let data = gql_queries::object_query::query(keys, self).await?;
         let elapsed = t0.elapsed().as_millis();

--- a/crates/sui-replay-2/src/execution.rs
+++ b/crates/sui-replay-2/src/execution.rs
@@ -165,7 +165,8 @@ impl ReplayCacheSummary {
     }
 }
 
-/// Datatype definition: (address, module, name, variants)
+/// Datatype definition: (address, module, name, formal_type_params).
+/// This contains linking information in the binary format.
 pub type Datatype = (AccountAddress, String, String, Vec<MoveType>);
 
 /// Custom Move type representation for JSON serialization.


### PR DESCRIPTION
## Description 

Small change in the output of the replay, adding println for every transaction executed
\> Replayed txn 3a5rwWp4dnKQPsxmhuRCb8cn9zp7MsoeswVM8BMz9Rpa (OK): exec_ms=47 total_ms=670
that is with no flags and no logs
Also started to move code around, in this pr metrics for execution are the most change. More coming

## Test plan 

I tried it

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
