### PR TITLE
indexer-alt: add local setup instructions for alloydb omni

### DIFF
--- a/crates/sui-indexer-alt/README.md
+++ b/crates/sui-indexer-alt/README.md
@@ -2,12 +2,41 @@
 
 ## Set-up
 
-Running the indexer requires Postgres to be installed and running on the
-system. The indexer has been tested with Postgres 15:
+Running the indexer requires a Postgres-compatible database to be installed and running on the
+system.
 
-```sh
-brew install postgresql@15
-```
+### Postgres
+
+#### Postgres 15 setup
+1. Install postgres
+   ```sh
+   brew install postgresql@15
+   ```
+   Resulting in this connection string
+   ```
+   postgresql://$(whoami):postgres@localhost:5432/postgres
+   ```
+
+### AlloyDB Omni
+
+#### Docker setup
+1. Install docker
+   ```sh
+   brew install --cask docker
+   ```
+2. Run docker (requires password)
+   ```sh
+   open -a Docker
+   ```
+#### AlloyDB setup
+1. Run AlloyDB Omni in docker
+   ```sh
+   docker run --detach --publish 5433:5432 --env POSTGRES_PASSWORD=postgres_pw google/alloydbomni
+   ```
+   Resulting in this connection string
+   ```
+   postgresql://postgres:postgres_pw@localhost:5433/postgres
+   ```
 
 The indexer will try to connect to the following database URL by default:
 


### PR DESCRIPTION
## Description 

This PR updates the readme to add setup instructions for running AlloyDB Omni locally with docker.

## Test plan 

Ran setup instructions and tested with 
```
cargo run --bin sui-indexer-alt -- generate-config > indexer_alt_config.toml
```
then
```
cargo run --bin sui-indexer-alt -- indexer \
  --database-url postgresql://postgres:postgres@localhost:5433/postgres \
  --remote-store-url https://checkpoints.mainnet.sui.io \
  --config indexer_alt_config.toml
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
