### PR TITLE
Always run both balance withdraw schedulers

### DIFF
--- a/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/mod.rs
+++ b/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/mod.rs
@@ -44,7 +44,7 @@ pub(crate) struct ScheduleResult {
 
 /// Details regarding a balance settlement, generated when a settlement transaction has been executed
 /// and committed to the writeback cache.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BalanceSettlement {
     // After this settlement, the accumulator object will be at this version.
     // This means that all transactions that read `next_accumulator_version - 1`

--- a/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/scheduler.rs
+++ b/crates/sui-core/src/execution_scheduler/balance_withdraw_scheduler/scheduler.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeSet, sync::Arc};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
 
 use crate::execution_scheduler::balance_withdraw_scheduler::{
     balance_read::AccountBalanceRead, eager_scheduler::EagerBalanceWithdrawScheduler,
@@ -31,7 +34,7 @@ pub(crate) struct WithdrawReservations {
 
 #[derive(Clone)]
 pub(crate) struct BalanceWithdrawScheduler {
-    inner: Arc<dyn BalanceWithdrawSchedulerTrait>,
+    innards: BTreeMap<String, Arc<dyn BalanceWithdrawSchedulerTrait>>,
     /// Use channels to process withdraws and settlements asynchronously without blocking the caller.
     withdraw_sender: UnboundedSender<WithdrawReservations>,
     settlement_sender: UnboundedSender<BalanceSettlement>,
@@ -84,19 +87,30 @@ impl BalanceWithdrawScheduler {
     pub fn new(
         balance_read: Arc<dyn AccountBalanceRead>,
         starting_accumulator_version: SequenceNumber,
-        use_eager_scheduler: bool,
     ) -> Self {
-        let inner: Arc<dyn BalanceWithdrawSchedulerTrait> = if use_eager_scheduler {
-            EagerBalanceWithdrawScheduler::new(balance_read, starting_accumulator_version)
-        } else {
-            NaiveBalanceWithdrawScheduler::new(balance_read, starting_accumulator_version)
-        };
+        // TODO: Currently, scheduling will be as slow as the slowest scheduler (i.e., the naive scheduler).
+        // Once we ensure that the eager scheduler is correct, it will become the only scheduler needed here,
+        // and we would only run the naive scheduler in tests for correctness verification.
+        let innards = BTreeMap::from([
+            (
+                "naive".to_string(),
+                NaiveBalanceWithdrawScheduler::new(
+                    balance_read.clone(),
+                    starting_accumulator_version,
+                ) as Arc<dyn BalanceWithdrawSchedulerTrait>,
+            ),
+            (
+                "eager".to_string(),
+                EagerBalanceWithdrawScheduler::new(balance_read, starting_accumulator_version)
+                    as Arc<dyn BalanceWithdrawSchedulerTrait>,
+            ),
+        ]);
         let (withdraw_sender, withdraw_receiver) =
             unbounded_channel("withdraw_scheduler_withdraws");
         let (settlement_sender, settlement_receiver) =
             unbounded_channel("withdraw_scheduler_settlements");
         let scheduler = Self {
-            inner,
+            innards,
             withdraw_sender,
             settlement_sender,
         };
@@ -134,12 +148,30 @@ impl BalanceWithdrawScheduler {
     }
 
     pub fn close_epoch(&self) {
-        self.inner.close_epoch();
+        for (name, scheduler) in &self.innards {
+            debug!("Closing epoch for scheduler: {}", name);
+            scheduler.close_epoch();
+        }
     }
 
     #[cfg(test)]
     pub fn get_current_accumulator_version(&self) -> SequenceNumber {
-        self.inner.get_current_accumulator_version()
+        let versions: Vec<_> = self
+            .innards
+            .iter()
+            .map(|(name, scheduler)| (name, scheduler.get_current_accumulator_version()))
+            .collect();
+
+        let first_version = versions[0].1;
+        for (name, version) in versions.iter().skip(1) {
+            assert_eq!(
+                *version, first_version,
+                "Scheduler '{}' has version {:?}, but expected {:?}",
+                name, version, first_version
+            );
+        }
+
+        first_version
     }
 
     async fn process_withdraw_task(
@@ -152,9 +184,91 @@ impl BalanceWithdrawScheduler {
                 "Processing withdraws: {:?}",
                 event.withdraws,
             );
-            self.inner.schedule_withdraws(event).await;
+
+            let accumulator_version = event.accumulator_version;
+            let withdraws = event.withdraws.clone();
+            let original_senders = event.senders;
+
+            // Create intermediate channels for each scheduler
+            let mut scheduler_receivers = BTreeMap::new();
+            for (name, scheduler) in &self.innards {
+                let (intermediate_senders, receivers): (Vec<_>, Vec<_>) =
+                    withdraws.iter().map(|_| oneshot::channel()).unzip();
+                scheduler_receivers.insert(name.clone(), receivers);
+
+                let reservations = WithdrawReservations {
+                    accumulator_version,
+                    withdraws: withdraws.clone(),
+                    senders: intermediate_senders,
+                };
+                debug!("Scheduling withdraws on scheduler: {}", name);
+                scheduler.schedule_withdraws(reservations).await;
+            }
+
+            // Collect results from all schedulers
+            for (tx_idx, original_sender) in original_senders.into_iter().enumerate() {
+                let mut results = Vec::new();
+                for (name, receivers) in &mut scheduler_receivers {
+                    if let Some(receiver) = receivers.get_mut(tx_idx) {
+                        match receiver.await {
+                            Ok(result) => {
+                                debug!(
+                                    scheduler = %name,
+                                    tx_digest =? result.tx_digest,
+                                    status =? result.status,
+                                    "Received scheduling result"
+                                );
+                                results.push(result);
+                            }
+                            Err(_) => {
+                                tracing::error!(
+                                    "Failed to receive result from scheduler: {}",
+                                    name
+                                );
+                            }
+                        }
+                    }
+                }
+
+                // Aggregate results according to the rules
+                let final_result = Self::aggregate_results(results);
+                let _ = original_sender.send(final_result);
+            }
         }
         tracing::info!("Balance withdraw receiver closed");
+    }
+
+    fn aggregate_results(results: Vec<ScheduleResult>) -> ScheduleResult {
+        assert!(!results.is_empty(), "Must have at least one result");
+
+        let tx_digest = results[0].tx_digest;
+        let non_skip_results: Vec<_> = results
+            .iter()
+            .filter(|r| r.status != ScheduleStatus::SkipSchedule)
+            .collect();
+
+        if non_skip_results.is_empty() {
+            // All schedulers returned SkipSchedule
+            return ScheduleResult {
+                tx_digest,
+                status: ScheduleStatus::SkipSchedule,
+            };
+        }
+
+        // Verify all non-skip results agree
+        let first_status = non_skip_results[0].status;
+        for result in &non_skip_results {
+            assert_eq!(
+                result.status, first_status,
+                "Schedulers returned different results for tx {:?}: expected {:?}, got {:?}",
+                tx_digest, first_status, result.status
+            );
+        }
+
+        ScheduleResult {
+            tx_digest,
+            status: first_status,
+        }
     }
 
     async fn process_settlement_task(
@@ -167,7 +281,10 @@ impl BalanceWithdrawScheduler {
                 "Settling balance changes: {:?}",
                 settlement.balance_changes,
             );
-            self.inner.settle_balances(settlement).await;
+            for (name, scheduler) in &self.innards {
+                debug!("Settling balances on scheduler: {}", name);
+                scheduler.settle_balances(settlement.clone()).await;
+            }
         }
         tracing::info!("Balance settlement receiver closed");
     }

--- a/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
+++ b/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
@@ -120,8 +120,6 @@ impl ExecutionScheduler {
         Some(BalanceWithdrawScheduler::new(
             Arc::new(object_store.clone()),
             starting_accumulator_version,
-            // Use naive scheduler for now.
-            false,
         ))
     }
 


### PR DESCRIPTION
## Description 

Always run both naive and eager scheduler, check that their results are always identical.
This will help increase coverage of the eager scheduler.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
