### PR TITLE
[indexer-alt-framework] use min next seq checkpoint to compute initial ingest hi

### DIFF
--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -114,6 +114,10 @@ pub struct Indexer<S: Store> {
     /// [Self::first_checkpoint].
     first_checkpoint_from_watermark: u64,
 
+    /// The minimum next_checkpoint across all sequential pipelines. This is used to initialize
+    /// the regulator to prevent ingestion from running too far ahead of sequential pipelines.
+    next_sequential_checkpoint: Option<u64>,
+
     /// The handles for every task spawned by this indexer, used to manage graceful shutdown.
     handles: Vec<JoinHandle<()>>,
 }
@@ -170,6 +174,7 @@ impl<S: Store> Indexer<S> {
             added_pipelines: BTreeSet::new(),
             cancel,
             first_checkpoint_from_watermark: u64::MAX,
+            next_sequential_checkpoint: None,
             handles: vec![],
         })
     }
@@ -196,6 +201,13 @@ impl<S: Store> Indexer<S> {
                 .as_ref()
                 .is_none_or(|e| e.contains(*p))
         })
+    }
+
+    /// The minimum next checkpoint across all sequential pipelines. This value is used to
+    /// initialize the ingestion regulator's high watermark to prevent ingestion from running
+    /// too far ahead of sequential pipelines.
+    pub fn next_sequential_checkpoint(&self) -> Option<u64> {
+        self.next_sequential_checkpoint
     }
 
     /// Adds a new pipeline to this indexer and starts it up. Although their tasks have started,
@@ -282,7 +294,10 @@ impl<S: Store> Indexer<S> {
 
         let (regulator_handle, broadcaster_handle) = self
             .ingestion_service
-            .run(first_checkpoint..=last_checkpoint)
+            .run(
+                first_checkpoint..=last_checkpoint,
+                self.next_sequential_checkpoint,
+            )
             .await
             .context("Failed to start ingestion service")?;
 
@@ -404,6 +419,12 @@ impl<T: TransactionalStore> Indexer<T> {
             (None, None) => 0,
         };
 
+        // Track the minimum next_checkpoint across all sequential pipelines
+        self.next_sequential_checkpoint = Some(
+            self.next_sequential_checkpoint
+                .map_or(next_checkpoint, |n| n.min(next_checkpoint)),
+        );
+
         let (checkpoint_rx, watermark_tx) = self.ingestion_service.subscribe();
 
         self.handles.push(sequential::pipeline::<H>(
@@ -467,6 +488,38 @@ mod tests {
     impl crate::pipeline::sequential::Handler for MockHandler {
         type Store = MockStore;
         type Batch = Vec<Self::Value>;
+
+        fn batch(batch: &mut Self::Batch, values: Vec<Self::Value>) {
+            batch.extend(values);
+        }
+
+        async fn commit<'a>(
+            _batch: &Self::Batch,
+            _conn: &mut <Self::Store as Store>::Connection<'a>,
+        ) -> anyhow::Result<usize> {
+            Ok(1)
+        }
+    }
+
+    // One more test handler for testing multiple sequential pipelines
+    struct SequentialHandler;
+
+    #[async_trait]
+    impl Processor for SequentialHandler {
+        const NAME: &'static str = "sequential_handler";
+        type Value = MockValue;
+        async fn process(
+            &self,
+            _checkpoint: &Arc<sui_types::full_checkpoint_content::CheckpointData>,
+        ) -> anyhow::Result<Vec<Self::Value>> {
+            Ok(vec![MockValue(1)])
+        }
+    }
+
+    #[async_trait]
+    impl crate::pipeline::sequential::Handler for SequentialHandler {
+        type Store = MockStore;
+        type Batch = Vec<MockValue>;
 
         fn batch(batch: &mut Self::Batch, values: Vec<Self::Value>) {
             batch.extend(values);
@@ -897,5 +950,122 @@ mod tests {
                 .get(),
             0
         );
+    }
+
+    #[tokio::test]
+    async fn test_multiple_sequential_pipelines_next_checkpoint() {
+        let cancel = CancellationToken::new();
+        let registry = Registry::new();
+        let store = MockStore::default();
+
+        // Set up different watermarks for three different sequential pipelines
+        let mut conn = store.connect().await.unwrap();
+
+        // First handler at checkpoint 10
+        conn.set_committer_watermark(
+            MockHandler::NAME,
+            CommitterWatermark {
+                epoch_hi_inclusive: 0,
+                checkpoint_hi_inclusive: 10,
+                tx_hi: 20,
+                timestamp_ms_hi_inclusive: 10000,
+            },
+        )
+        .await
+        .unwrap();
+
+        // SequentialHandler at checkpoint 5
+        conn.set_committer_watermark(
+            SequentialHandler::NAME,
+            CommitterWatermark {
+                epoch_hi_inclusive: 0,
+                checkpoint_hi_inclusive: 5,
+                tx_hi: 10,
+                timestamp_ms_hi_inclusive: 5000,
+            },
+        )
+        .await
+        .unwrap();
+
+        // Create synthetic ingestion data
+        let temp_dir = tempfile::tempdir().unwrap();
+        synthetic_ingestion::generate_ingestion(synthetic_ingestion::Config {
+            ingestion_dir: temp_dir.path().to_owned(),
+            starting_checkpoint: 0,
+            num_checkpoints: 20,
+            checkpoint_size: 2,
+        })
+        .await;
+
+        let indexer_args = IndexerArgs {
+            first_checkpoint: None,
+            last_checkpoint: Some(19),
+            pipeline: vec![],
+            skip_watermark: false,
+        };
+
+        let client_args = ClientArgs {
+            local_ingestion_path: Some(temp_dir.path().to_owned()),
+            ..Default::default()
+        };
+
+        let ingestion_config = IngestionConfig::default();
+
+        let mut indexer = Indexer::new(
+            store.clone(),
+            indexer_args,
+            client_args,
+            ingestion_config,
+            None,
+            &registry,
+            cancel.clone(),
+        )
+        .await
+        .unwrap();
+
+        // Add first sequential pipeline
+        indexer
+            .sequential_pipeline(
+                MockHandler,
+                pipeline::sequential::SequentialConfig::default(),
+            )
+            .await
+            .unwrap();
+
+        // Verify next_sequential_checkpoint is set correctly (10 + 1 = 11)
+        assert_eq!(
+            indexer.next_sequential_checkpoint(),
+            Some(11),
+            "next_sequential_checkpoint should be 11"
+        );
+
+        // Add second sequential pipeline
+        indexer
+            .sequential_pipeline(
+                SequentialHandler,
+                pipeline::sequential::SequentialConfig::default(),
+            )
+            .await
+            .unwrap();
+
+        // Should change to 6 (minimum of 6 and 11)
+        assert_eq!(
+            indexer.next_sequential_checkpoint(),
+            Some(6),
+            "next_sequential_checkpoint should still be 6"
+        );
+
+        // Run indexer to verify it can make progress past the initial hi and finish ingesting.
+        indexer.run().await.unwrap().await.unwrap();
+
+        // Verify each pipeline made some progress independently
+        let watermark1 = conn.committer_watermark(MockHandler::NAME).await.unwrap();
+        let watermark2 = conn
+            .committer_watermark(SequentialHandler::NAME)
+            .await
+            .unwrap();
+
+        assert_eq!(watermark1.unwrap().checkpoint_hi_inclusive, 19);
+        assert_eq!(watermark2.unwrap().checkpoint_hi_inclusive, 19);
     }
 }

--- a/crates/sui-indexer-alt-framework/src/mocks/store.rs
+++ b/crates/sui-indexer-alt-framework/src/mocks/store.rs
@@ -529,6 +529,9 @@ impl MockStore {
             }
             tokio::time::sleep(Duration::from_millis(50)).await;
         }
-        panic!("Timeout waiting for watermark to reach {}", checkpoint);
+        panic!(
+            "Timeout waiting for watermark on pipeline {} to reach {}",
+            watermark_key, checkpoint
+        );
     }
 }


### PR DESCRIPTION
## Description 

Currently the ingest_hi is initialized to None, which could cause checkpoints to be sent to sequential pipelines without any regulation before any commit has been made. This PR adds an initial value to make sure there's regulation from the very beginning.
Additionally to align with the `next_checkpoint` change, I've made the value exclusive and changed the name in various places to `commit_hi` to make it more clear that this is the highest commit watermark the pipelines are going to reach next. 

## Test plan 

Added tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
