### PR TITLE
Fix term inconsistency

### DIFF
--- a/docs/content/concepts/object-ownership/address-owned.mdx
+++ b/docs/content/concepts/object-ownership/address-owned.mdx
@@ -17,7 +17,7 @@ public fun transfer<T: key>(obj: T, recipient: address)
 public fun public_transfer<T: key + store>(obj: T, recipient: address)
 ```
 
-You should use the `sui::transfer::transfer` function if you are defining a [custom transfer rules](../transfers/custom-rules.mdx) for the object. Use the `sui::transfer::public_transfer` function to create an address-owned object if the object has the `store` capability.
+Use the `sui::transfer::transfer` function if you are defining [custom transfer rules](../transfers/custom-rules.mdx) for the object. Use the `sui::transfer::public_transfer` function to create an address-owned object if the object has the `store` capability.
 
 After you declare an object as address-owned, its ownership can change over the life of that object - either by adding it as a dynamic object field, transferring it to a different address, or making it immutable. Importantly though, after you create an object and set its ownership, it cannot be shared.
 


### PR DESCRIPTION
The term and reference link were inconsistent.
Updated the link text to “custom transfer rules” to match the referenced document (../transfers/custom-rules.mdx).

Change :
>[custom transfer policy](../transfers/custom-rules.mdx)
> -> [custom transfer rules](../transfers/custom-rules.mdx)