### PR TITLE
Refactored code to break up artifacts from execution

### DIFF
--- a/crates/sui-replay-2/src/artifacts/cache_summary.rs
+++ b/crates/sui-replay-2/src/artifacts/cache_summary.rs
@@ -1,0 +1,98 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use move_core_types::language_storage::StructTag;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use sui_types::{base_types::ObjectID, object::Object};
+
+/// Detailed information about a Move package.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PackageInfo {
+    pub published_id: ObjectID,
+    pub original_id: ObjectID,
+    pub module_names: Vec<String>,
+}
+
+/// Type of object in the replay cache with detailed Move information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ObjectType {
+    /// A Move package containing compiled modules
+    Package(PackageInfo),
+    /// A Move object with its struct tag
+    MoveObject(StructTag),
+}
+
+/// Entry in the replay cache summary representing an object accessed during replay.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ObjectCacheEntry {
+    pub object_id: ObjectID,
+    pub version: u64,
+    pub object_type: ObjectType,
+}
+
+/// Compact representation of the replay cache for serialization.
+/// Contains the execution context (epoch_id from transaction effects, checkpoint from transaction info)
+/// and a list of all objects accessed during replay, with their type information but without object content.
+/// The epoch_id represents the epoch in which the original transaction was executed.
+/// The checkpoint represents the checkpoint sequence number where the transaction was included.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReplayCacheSummary {
+    pub epoch_id: u64,
+    pub checkpoint: u64,
+    pub network: String,
+    pub protocol_version: u64,
+    /// List of objects accessed during replay with their version and type information
+    pub cache_entries: Vec<ObjectCacheEntry>,
+}
+
+impl ReplayCacheSummary {
+    /// Create a ReplayCacheSummary from the object cache, extracting detailed Move information.
+    pub fn from_cache(
+        epoch_id: u64,
+        checkpoint: u64,
+        network: String,
+        protocol_version: u64,
+        object_cache: &BTreeMap<ObjectID, BTreeMap<u64, Object>>,
+    ) -> Self {
+        let mut cache_entries = Vec::new();
+
+        for (object_id, versions) in object_cache {
+            for (version, object) in versions {
+                let object_type = if object.is_package() {
+                    // Extract package information
+                    let package = object
+                        .data
+                        .try_as_package()
+                        .expect("Package object should have package data");
+                    let package_info = PackageInfo {
+                        published_id: package.id(),
+                        original_id: package.original_package_id(),
+                        module_names: package.serialized_module_map().keys().cloned().collect(),
+                    };
+                    ObjectType::Package(package_info)
+                } else {
+                    // Extract Move object struct tag
+                    let struct_tag = object
+                        .struct_tag()
+                        .expect("Move object should have struct tag");
+                    ObjectType::MoveObject(struct_tag)
+                };
+
+                cache_entries.push(ObjectCacheEntry {
+                    object_id: *object_id,
+                    version: *version,
+                    object_type,
+                });
+            }
+        }
+
+        Self {
+            epoch_id,
+            checkpoint,
+            network,
+            protocol_version,
+            cache_entries,
+        }
+    }
+}

--- a/crates/sui-replay-2/src/artifacts/manager.rs
+++ b/crates/sui-replay-2/src/artifacts/manager.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::execution::{MoveCallInfo, ReplayCacheSummary};
-use anyhow::bail;
+use crate::artifacts::{MoveCallInfo, ReplayCacheSummary};
+use anyhow::{anyhow, bail, Result};
 use move_trace_format::format::{MoveTrace, MoveTraceReader};
 use std::{
     io::Write,
@@ -69,9 +69,9 @@ impl EncodingType {
 
 impl<'b> ArtifactManager<'b> {
     /// Creates a new `ArtifactManager` with the given base path and whether overrides are allowed.
-    pub fn new(base_path: &'b Path, overrides_allowed: bool) -> anyhow::Result<Self> {
+    pub fn new(base_path: &'b Path, overrides_allowed: bool) -> Result<Self> {
         std::fs::create_dir_all(base_path).map_err(|e| {
-            anyhow::anyhow!(
+            anyhow!(
                 "Failed to create base path for replay artifacts at {}: {e}",
                 base_path.display()
             )
@@ -134,7 +134,7 @@ impl ArtifactMember<'_, '_> {
 
     /// Deserialize the artifact into json. This should always succeed if the artifact exists and
     /// is well-formed.
-    pub fn get_json(&self) -> anyhow::Result<serde_json::Value> {
+    pub fn get_json(&self) -> Result<serde_json::Value> {
         let file_content = std::fs::read(&self.artifact_path)?;
         let contents = match self.artifact_type.encoding_type() {
             EncodingType::Json => file_content,
@@ -149,13 +149,13 @@ impl ArtifactMember<'_, '_> {
 
     /// Try to get the trace reader if the artifact type is a trace.
     /// If the artifact type is not `Trace` `None` is returned.
-    pub fn try_get_trace(&self) -> Option<anyhow::Result<MoveTraceReader<std::fs::File>>> {
+    pub fn try_get_trace(&self) -> Option<Result<MoveTraceReader<std::fs::File>>> {
         if self.artifact_type == Artifact::Trace {
             Some(
                 std::fs::File::open(&self.artifact_path)
                     .and_then(MoveTraceReader::new)
                     .map_err(|e| {
-                        anyhow::anyhow!(
+                        anyhow!(
                             "Failed to open trace file {}: {e}",
                             self.artifact_path.display()
                         )
@@ -168,14 +168,14 @@ impl ArtifactMember<'_, '_> {
 
     /// Try to get the transaction effects if the artifact type is `TransactionEffects`.
     /// If the artifact type is not `TransactionEffects` `None` is returned.
-    pub fn try_get_transaction_effects(&self) -> Option<anyhow::Result<TransactionEffects>> {
+    pub fn try_get_transaction_effects(&self) -> Option<Result<TransactionEffects>> {
         if matches!(
             self.artifact_type,
             Artifact::TransactionEffects | Artifact::ForkedTransactionEffects
         ) {
             Some(self.get_json().and_then(|json| {
                 serde_json::from_value::<TransactionEffects>(json).map_err(|e| {
-                    anyhow::anyhow!(
+                    anyhow!(
                         "Failed to deserialize transaction effects from {}: {e}",
                         self.artifact_path.display()
                     )
@@ -188,11 +188,11 @@ impl ArtifactMember<'_, '_> {
 
     /// Try to get the GasUsageReport if the artifact type is `TransactionGasReport`.
     /// If the artifact type is not `TransactionGasReport` `None` is returned.
-    pub fn try_get_gas_report(&self) -> Option<anyhow::Result<GasUsageReport>> {
+    pub fn try_get_gas_report(&self) -> Option<Result<GasUsageReport>> {
         if self.artifact_type == Artifact::TransactionGasReport {
             Some(self.get_json().and_then(|json| {
                 serde_json::from_value::<GasUsageReport>(json).map_err(|e| {
-                    anyhow::anyhow!(
+                    anyhow!(
                         "Failed to deserialize gas usage report from {}: {e}",
                         self.artifact_path.display()
                     )
@@ -205,11 +205,11 @@ impl ArtifactMember<'_, '_> {
 
     /// Try to get the ReplayCacheSummary if the artifact type is `ReplayCacheSummary`.
     /// If the artifact type is not `ReplayCacheSummary` `None` is returned.
-    pub fn try_get_cache_summary(&self) -> Option<anyhow::Result<ReplayCacheSummary>> {
+    pub fn try_get_cache_summary(&self) -> Option<Result<ReplayCacheSummary>> {
         if self.artifact_type == Artifact::ReplayCacheSummary {
             Some(self.get_json().and_then(|json| {
                 serde_json::from_value::<ReplayCacheSummary>(json).map_err(|e| {
-                    anyhow::anyhow!(
+                    anyhow!(
                         "Failed to deserialize replay cache summary from {}: {e}",
                         self.artifact_path.display()
                     )
@@ -222,11 +222,11 @@ impl ArtifactMember<'_, '_> {
 
     /// Try to get the MoveCallInfo if the artifact type is `MoveCallInfo`.
     /// If the artifact type is not `MoveCallInfo` `None` is returned.
-    pub fn try_get_move_call_info(&self) -> Option<anyhow::Result<MoveCallInfo>> {
+    pub fn try_get_move_call_info(&self) -> Option<Result<MoveCallInfo>> {
         if self.artifact_type == Artifact::MoveCallInfo {
             Some(self.get_json().and_then(|json| {
                 serde_json::from_value::<MoveCallInfo>(json).map_err(|e| {
-                    anyhow::anyhow!(
+                    anyhow!(
                         "Failed to deserialize move call info from {}: {e}",
                         self.artifact_path.display()
                     )
@@ -240,13 +240,13 @@ impl ArtifactMember<'_, '_> {
 
 /// Serialization methods for `ArtifactManager`.
 impl ArtifactMember<'_, '_> {
-    pub fn serialize_move_trace(&self, trace: MoveTrace) -> Option<anyhow::Result<()>> {
+    pub fn serialize_move_trace(&self, trace: MoveTrace) -> Option<Result<()>> {
         if self.artifact_type != Artifact::Trace {
             return None;
         }
 
         if !self.manager.overrides_allowed && self.artifact_path.exists() {
-            return Some(Err(anyhow::anyhow!(
+            return Some(Err(anyhow!(
                 "Trace file already exists at {}",
                 self.artifact_path.display()
             )));
@@ -254,7 +254,7 @@ impl ArtifactMember<'_, '_> {
 
         Some(
             std::fs::write(&self.artifact_path, trace.into_compressed_json_bytes()).map_err(|e| {
-                anyhow::anyhow!(
+                anyhow!(
                     "Failed to write trace to {}: {e}",
                     self.artifact_path.display()
                 )
@@ -262,20 +262,20 @@ impl ArtifactMember<'_, '_> {
         )
     }
 
-    pub fn serialize_artifact(&self, data: &impl serde::Serialize) -> Option<anyhow::Result<()>> {
+    pub fn serialize_artifact(&self, data: &impl serde::Serialize) -> Option<Result<()>> {
         if self.artifact_type == Artifact::Trace {
             return None;
         }
 
         if !self.manager.overrides_allowed && self.artifact_path.exists() {
-            return Some(Err(anyhow::anyhow!(
+            return Some(Err(anyhow!(
                 "File for {} already exists at {}",
                 self.artifact_type.as_str(),
                 self.artifact_path.display()
             )));
         }
         let mut file = match std::fs::File::create(&self.artifact_path).map_err(|e| {
-            anyhow::anyhow!(
+            anyhow!(
                 "Failed to create file {}: {e}",
                 self.artifact_path.display()
             )
@@ -285,21 +285,22 @@ impl ArtifactMember<'_, '_> {
         };
 
         Some(match self.artifact_type.encoding_type() {
-            EncodingType::Json => serde_json::to_writer(file, &data)
-                .map_err(|e| anyhow::anyhow!("Failed to write JSON: {e}")),
+            EncodingType::Json => {
+                serde_json::to_writer(file, &data).map_err(|e| anyhow!("Failed to write JSON: {e}"))
+            }
             EncodingType::JsonCompressed => {
                 let mut buf = Vec::new();
                 let mut compressed_buf = Vec::new();
                 if let Err(e) = serde_json::to_writer(&mut buf, &data)
-                    .map_err(|e| anyhow::anyhow!("Failed to write JSON: {e}"))
+                    .map_err(|e| anyhow!("Failed to write JSON: {e}"))
                 {
                     return Some(Err(e));
                 }
                 zstd::bulk::compress_to_buffer(&buf, &mut compressed_buf, 0)
-                    .map_err(|e| anyhow::anyhow!("Failed to compress JSON: {e}"))
+                    .map_err(|e| anyhow!("Failed to compress JSON: {e}"))
                     .and_then(|_| {
                         file.write_all(&buf).map_err(|e| {
-                            anyhow::anyhow!(
+                            anyhow!(
                                 "Failed to write compressed JSON to {}: {e}",
                                 self.artifact_path.display()
                             )
@@ -309,7 +310,7 @@ impl ArtifactMember<'_, '_> {
         })
     }
 
-    pub fn try_remove_artifact(&self) -> anyhow::Result<()> {
+    pub fn try_remove_artifact(&self) -> Result<()> {
         if self.manager.overrides_allowed {
             if let Err(e) = std::fs::remove_file(&self.artifact_path) {
                 if e.kind() != std::io::ErrorKind::NotFound {

--- a/crates/sui-replay-2/src/artifacts/mod.rs
+++ b/crates/sui-replay-2/src/artifacts/mod.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+mod cache_summary;
+mod manager;
+mod move_call_info;
+
+pub use cache_summary::*;
+pub use manager::*;
+pub use move_call_info::*;

--- a/crates/sui-replay-2/src/artifacts/move_call_info.rs
+++ b/crates/sui-replay-2/src/artifacts/move_call_info.rs
@@ -1,0 +1,312 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{anyhow, Result};
+use move_binary_format::{
+    binary_config::BinaryConfig,
+    file_format::{CompiledModule, SignatureToken},
+};
+use move_core_types::account_address::AccountAddress;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use sui_types::{
+    base_types::ObjectID, object::Object, transaction::ProgrammableTransaction,
+    type_input::TypeInput,
+};
+use tracing::{debug, warn};
+
+/// Datatype definition: (address, module, name, formal_type_params).
+/// This contains linking information in the binary format.
+pub type Datatype = (AccountAddress, String, String, Vec<MoveType>);
+
+/// Custom Move type representation for JSON serialization.
+/// This provides the exact type information we want to expose in the JSON output.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum MoveType {
+    Bool,
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+    U256,
+    Address,
+    Vector(Box<MoveType>),
+    Datatype(Datatype),
+    DatatypeInstantiation(Box<(Datatype, Vec<MoveType>)>),
+    Reference(Box<MoveType>),
+    MutableReference(Box<MoveType>),
+    TypeParameter(u16),
+}
+
+/// Function signature information for MoveCall commands in a ProgrammableTransaction.
+/// Contains detailed parameter and return type information for each function call.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FunctionSignature {
+    /// Package ID where the function is defined
+    pub package: ObjectID,
+    /// Module name containing the function
+    pub module: String,
+    /// Function name
+    pub function: String,
+    /// Parameter types
+    pub parameters: Vec<MoveType>,
+    /// Return types
+    pub return_types: Vec<MoveType>,
+}
+
+/// Move call information containing extracted function signatures.
+/// This provides type information for all commands in the transaction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MoveCallInfo {
+    /// Vector of function signatures, one for each command
+    /// None for non-MoveCall commands, Some(signature) for MoveCall commands
+    pub command_signatures: Vec<Option<FunctionSignature>>,
+}
+
+impl MoveCallInfo {
+    /// Create MoveCallInfo by extracting function signatures from a ProgrammableTransaction.
+    /// Creates a vector with one entry per command, None for non-MoveCall commands.
+    pub fn from_transaction(
+        ptb: &ProgrammableTransaction,
+        object_cache: &BTreeMap<ObjectID, BTreeMap<u64, Object>>,
+    ) -> Result<Self> {
+        let mut command_signatures = Vec::with_capacity(ptb.commands.len());
+
+        for command in ptb.commands.iter() {
+            let signature = if let sui_types::transaction::Command::MoveCall(move_call) = command {
+                // Extract function signature from the MoveCall
+                match Self::extract_function_signature(move_call, object_cache) {
+                    Ok(signature) => {
+                        debug!(
+                            "Successfully extracted signature for {}::{}::{}",
+                            signature.package, signature.module, signature.function
+                        );
+                        Some(signature)
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Failed to extract signature for {}::{}::{}: {}",
+                            move_call.package, move_call.module, move_call.function, e
+                        );
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+            command_signatures.push(signature);
+        }
+
+        Ok(MoveCallInfo { command_signatures })
+    }
+
+    /// Extract function signature information from a MoveCall command.
+    fn extract_function_signature(
+        move_call: &sui_types::transaction::ProgrammableMoveCall,
+        object_cache: &BTreeMap<ObjectID, BTreeMap<u64, Object>>,
+    ) -> Result<FunctionSignature> {
+        let package_id = move_call.package;
+        let module_name = move_call.module.as_str();
+        let function_name = move_call.function.as_str();
+
+        // Find the package in the object cache
+        let package_obj = object_cache
+            .get(&package_id)
+            .and_then(|versions| versions.values().next())
+            .ok_or_else(|| anyhow!("Package {} not found in cache", package_id))?;
+
+        // Extract MovePackage from the object
+        let move_package = package_obj
+            .data
+            .try_as_package()
+            .ok_or_else(|| anyhow!("Object {} is not a package", package_id))?;
+
+        // Get the module bytecode from the package
+        let module_bytes = move_package
+            .serialized_module_map()
+            .get(module_name)
+            .ok_or_else(|| anyhow!("Module {} not found in package {}", module_name, package_id))?;
+
+        // Deserialize the module
+        let binary_config = BinaryConfig::standard();
+        let compiled_module = CompiledModule::deserialize_with_config(module_bytes, &binary_config)
+            .map_err(|e| anyhow!("Failed to deserialize module {}: {}", module_name, e))?;
+
+        // Find the function definition
+        let (_, function_def) = compiled_module
+            .find_function_def_by_name(function_name)
+            .ok_or_else(|| {
+                anyhow!(
+                    "Function {} not found in module {}::{}",
+                    function_name,
+                    package_id,
+                    module_name
+                )
+            })?;
+
+        // Get the function handle
+        let function_handle = compiled_module.function_handle_at(function_def.function);
+
+        // Get parameter and return signatures
+        let param_signature = compiled_module.signature_at(function_handle.parameters);
+        let return_signature = compiled_module.signature_at(function_handle.return_);
+
+        // Convert TypeInputs to MoveTypes for signature processing
+        let type_arguments_as_move_types: Vec<MoveType> = move_call
+            .type_arguments
+            .iter()
+            .map(Self::type_input_to_move_type)
+            .collect();
+
+        // Convert SignatureTokens to MoveTypes
+        let parameters = param_signature
+            .0
+            .iter()
+            .map(|token| {
+                Self::signature_token_to_move_type(
+                    token,
+                    &compiled_module,
+                    &type_arguments_as_move_types,
+                )
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let return_types = return_signature
+            .0
+            .iter()
+            .map(|token| {
+                Self::signature_token_to_move_type(
+                    token,
+                    &compiled_module,
+                    &type_arguments_as_move_types,
+                )
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(FunctionSignature {
+            package: package_id,
+            module: module_name.to_string(),
+            function: function_name.to_string(),
+            parameters,
+            return_types,
+        })
+    }
+
+    /// Convert TypeInput to MoveType.
+    /// TypeInput comes from the transaction's type arguments.
+    fn type_input_to_move_type(type_input: &TypeInput) -> MoveType {
+        match type_input {
+            TypeInput::Bool => MoveType::Bool,
+            TypeInput::U8 => MoveType::U8,
+            TypeInput::U16 => MoveType::U16,
+            TypeInput::U32 => MoveType::U32,
+            TypeInput::U64 => MoveType::U64,
+            TypeInput::U128 => MoveType::U128,
+            TypeInput::U256 => MoveType::U256,
+            TypeInput::Address => MoveType::Address,
+            TypeInput::Signer => MoveType::Address, // Signer is treated as Address
+            TypeInput::Vector(element) => {
+                MoveType::Vector(Box::new(Self::type_input_to_move_type(element)))
+            }
+            TypeInput::Struct(struct_input) => {
+                let type_params: Vec<MoveType> = struct_input
+                    .type_params
+                    .iter()
+                    .map(Self::type_input_to_move_type)
+                    .collect();
+
+                let datatype = (
+                    struct_input.address,
+                    struct_input.module.clone(),
+                    struct_input.name.clone(),
+                    vec![], // Empty variants - we ignore enum variants
+                );
+
+                if type_params.is_empty() {
+                    // Non-generic datatype
+                    MoveType::Datatype(datatype)
+                } else {
+                    // Generic instantiation
+                    MoveType::DatatypeInstantiation(Box::new((datatype, type_params)))
+                }
+            }
+        }
+    }
+
+    /// Convert SignatureToken to MoveType.
+    /// This is the core conversion that bridges Move's type system with our custom representation.
+    fn signature_token_to_move_type(
+        token: &SignatureToken,
+        module: &CompiledModule,
+        type_arguments: &[MoveType],
+    ) -> Result<MoveType> {
+        match token {
+            SignatureToken::Bool => Ok(MoveType::Bool),
+            SignatureToken::U8 => Ok(MoveType::U8),
+            SignatureToken::U16 => Ok(MoveType::U16),
+            SignatureToken::U32 => Ok(MoveType::U32),
+            SignatureToken::U64 => Ok(MoveType::U64),
+            SignatureToken::U128 => Ok(MoveType::U128),
+            SignatureToken::U256 => Ok(MoveType::U256),
+            SignatureToken::Address => Ok(MoveType::Address),
+            SignatureToken::Signer => Ok(MoveType::Address), // Signer is treated as Address
+            SignatureToken::Vector(element_type) => {
+                let element =
+                    Self::signature_token_to_move_type(element_type, module, type_arguments)?;
+                Ok(MoveType::Vector(Box::new(element)))
+            }
+            SignatureToken::Datatype(datatype_handle_idx) => {
+                let datatype_handle = module.datatype_handle_at(*datatype_handle_idx);
+                let module_handle = module.module_handle_at(datatype_handle.module);
+                let address = *module.address_identifier_at(module_handle.address);
+                let module_name = module.identifier_at(module_handle.name).to_string();
+                let struct_name = module.identifier_at(datatype_handle.name).to_string();
+
+                // Non-generic datatype - empty type params
+                let datatype = (address, module_name, struct_name, vec![]);
+                Ok(MoveType::Datatype(datatype))
+            }
+            SignatureToken::DatatypeInstantiation(instantiation) => {
+                let (datatype_handle_idx, type_args) = instantiation.as_ref();
+                let datatype_handle = module.datatype_handle_at(*datatype_handle_idx);
+                let module_handle = module.module_handle_at(datatype_handle.module);
+                let address = *module.address_identifier_at(module_handle.address);
+                let module_name = module.identifier_at(module_handle.name).to_string();
+                let struct_name = module.identifier_at(datatype_handle.name).to_string();
+
+                // Resolve the type arguments
+                let resolved_type_args = type_args
+                    .iter()
+                    .map(|arg| Self::signature_token_to_move_type(arg, module, type_arguments))
+                    .collect::<Result<Vec<_>>>()?;
+
+                // Base datatype with empty type params
+                let datatype = (address, module_name, struct_name, vec![]);
+
+                // Generic instantiation with resolved type arguments
+                Ok(MoveType::DatatypeInstantiation(Box::new((
+                    datatype,
+                    resolved_type_args,
+                ))))
+            }
+            SignatureToken::Reference(inner) => {
+                let inner_type = Self::signature_token_to_move_type(inner, module, type_arguments)?;
+                Ok(MoveType::Reference(Box::new(inner_type)))
+            }
+            SignatureToken::MutableReference(inner) => {
+                let inner_type = Self::signature_token_to_move_type(inner, module, type_arguments)?;
+                Ok(MoveType::MutableReference(Box::new(inner_type)))
+            }
+            SignatureToken::TypeParameter(idx) => {
+                // Resolve type parameter using the provided type_arguments
+                if (*idx as usize) < type_arguments.len() {
+                    Ok(type_arguments[*idx as usize].clone())
+                } else {
+                    // Return TypeParameter variant if not resolved
+                    Ok(MoveType::TypeParameter(*idx))
+                }
+            }
+        }
+    }
+}

--- a/crates/sui-replay-2/src/data-stores/data_store.rs
+++ b/crates/sui-replay-2/src/data-stores/data_store.rs
@@ -5,16 +5,16 @@
 //! backed by the RPC GQL endpoint. Schema in `crates/sui-indexer-alt-graphql/schema.graphql`.
 //! The RPC calls are implemented in `gql_queries.rs`.
 
-use crate::summary_metrics::*;
 use crate::{
     data_stores::gql_queries,
     replay_interface::{
         EpochData, EpochStore, ObjectKey, ObjectStore, SetupStore, StoreSummary, TransactionInfo,
         TransactionStore, VersionQuery,
     },
+    summary_metrics::*,
     Node,
 };
-use anyhow::Context;
+use anyhow::{Context, Error, Result};
 use cynic::{GraphQlResponse, Operation};
 use reqwest::header::USER_AGENT;
 use std::time::Instant;
@@ -107,10 +107,7 @@ macro_rules! block_on {
 }
 
 impl TransactionStore for DataStore {
-    fn transaction_data_and_effects(
-        &self,
-        digest: &str,
-    ) -> Result<Option<TransactionInfo>, anyhow::Error> {
+    fn transaction_data_and_effects(&self, digest: &str) -> Result<Option<TransactionInfo>, Error> {
         match block_on!(self.transaction(digest)) {
             Ok(Some((data, effects, checkpoint))) => {
                 self.metrics.txn_hit.fetch_add(1, Ordering::Relaxed);
@@ -133,7 +130,7 @@ impl TransactionStore for DataStore {
 }
 
 impl EpochStore for DataStore {
-    fn epoch_info(&self, epoch: u64) -> Result<Option<EpochData>, anyhow::Error> {
+    fn epoch_info(&self, epoch: u64) -> Result<Option<EpochData>, Error> {
         if let Some(epoch_data) = self.epoch_map.read().unwrap().get(&epoch) {
             self.metrics.epoch_hit.fetch_add(1, Ordering::Relaxed);
             return Ok(Some(epoch_data.clone()));
@@ -159,7 +156,7 @@ impl EpochStore for DataStore {
     }
 
     // Get the protocol config for an epoch directly from the binary
-    fn protocol_config(&self, epoch: u64) -> Result<Option<ProtocolConfig>, anyhow::Error> {
+    fn protocol_config(&self, epoch: u64) -> Result<Option<ProtocolConfig>, Error> {
         match self.epoch_info(epoch) {
             Ok(Some(epoch)) => {
                 self.metrics.proto_hit.fetch_add(1, Ordering::Relaxed);
@@ -181,7 +178,7 @@ impl EpochStore for DataStore {
 }
 
 impl ObjectStore for DataStore {
-    fn get_objects(&self, keys: &[ObjectKey]) -> Result<Vec<Option<(Object, u64)>>, anyhow::Error> {
+    fn get_objects(&self, keys: &[ObjectKey]) -> Result<Vec<Option<(Object, u64)>>, Error> {
         match block_on!(self.objects(keys)) {
             Ok(results) => {
                 assert_eq!(results.len(), keys.len());
@@ -244,14 +241,14 @@ impl ObjectStore for DataStore {
 }
 
 impl SetupStore for DataStore {
-    fn setup(&self, _chain_id: Option<String>) -> Result<Option<String>, anyhow::Error> {
+    fn setup(&self, _chain_id: Option<String>) -> Result<Option<String>, Error> {
         // Return the chain identifier
         Ok(Some(block_on!(gql_queries::chain_id_query::query(self))?))
     }
 }
 
 impl DataStore {
-    pub fn new(node: Node, version: &str) -> Result<Self, anyhow::Error> {
+    pub fn new(node: Node, version: &str) -> Result<Self, Error> {
         debug!("Start stores creation");
         let client = reqwest::Client::builder()
             .connect_timeout(std::time::Duration::from_secs(3))
@@ -283,7 +280,7 @@ impl DataStore {
     pub(crate) async fn run_query<T, V>(
         &self,
         operation: &Operation<T, V>,
-    ) -> Result<GraphQlResponse<T>, anyhow::Error>
+    ) -> Result<GraphQlResponse<T>, Error>
     where
         T: serde::de::DeserializeOwned,
         V: serde::Serialize,
@@ -296,7 +293,7 @@ impl DataStore {
         rpc: &reqwest::Url,
         version: &str,
         operation: &Operation<T, V>,
-    ) -> Result<GraphQlResponse<T>, anyhow::Error>
+    ) -> Result<GraphQlResponse<T>, Error>
     where
         T: serde::de::DeserializeOwned,
         V: serde::Serialize,
@@ -316,7 +313,7 @@ impl DataStore {
     async fn transaction(
         &self,
         digest: &str,
-    ) -> Result<Option<(TransactionData, TransactionEffects, u64)>, anyhow::Error> {
+    ) -> Result<Option<(TransactionData, TransactionEffects, u64)>, Error> {
         let _span = debug_span!("gql_txn_query", digest = %digest).entered();
         debug!(op = "txn_query", phase = "start", "transaction query");
         let t0 = Instant::now();
@@ -332,7 +329,7 @@ impl DataStore {
         data
     }
 
-    async fn epoch(&self, epoch_id: u64) -> Result<Option<EpochData>, anyhow::Error> {
+    async fn epoch(&self, epoch_id: u64) -> Result<Option<EpochData>, Error> {
         let _span = debug_span!("gql_epoch_query", epoch = epoch_id).entered();
         debug!(op = "epoch_query", phase = "start", "epoch query");
         let t0 = Instant::now();
@@ -348,10 +345,7 @@ impl DataStore {
         data
     }
 
-    async fn objects(
-        &self,
-        keys: &[ObjectKey],
-    ) -> Result<Vec<Option<(Object, u64)>>, anyhow::Error> {
+    async fn objects(&self, keys: &[ObjectKey]) -> Result<Vec<Option<(Object, u64)>>, Error> {
         let _span = debug_span!("gql_objects_query", num_keys = keys.len()).entered();
         debug!(op = "objects_query", phase = "start", "objects query");
         let t0 = Instant::now();
@@ -369,7 +363,7 @@ impl DataStore {
 }
 
 impl StoreSummary for DataStore {
-    fn summary<W: std::io::Write>(&self, w: &mut W) -> anyhow::Result<()> {
+    fn summary<W: std::io::Write>(&self, w: &mut W) -> Result<()> {
         let m = &self.metrics;
         let txn_hit = m.txn_hit.load(Ordering::Relaxed);
         let txn_miss = m.txn_miss.load(Ordering::Relaxed);

--- a/crates/sui-replay-2/src/execution.rs
+++ b/crates/sui-replay-2/src/execution.rs
@@ -15,18 +15,9 @@ use crate::{
     replay_interface::{EpochStore, ObjectKey, ObjectStore, VersionQuery},
     replay_txn::{get_input_objects_for_replay, ReplayTransaction},
 };
-use anyhow::Context;
-use move_binary_format::{
-    binary_config::BinaryConfig,
-    file_format::{CompiledModule, SignatureToken},
-};
-use move_core_types::{
-    account_address::AccountAddress,
-    language_storage::{ModuleId, StructTag},
-    resolver::ModuleResolver,
-};
+use anyhow::{anyhow, Context, Error};
+use move_core_types::{language_storage::ModuleId, resolver::ModuleResolver};
 use move_trace_format::format::MoveTraceBuilder;
-use serde::{Deserialize, Serialize};
 use std::{
     cell::RefCell,
     collections::{BTreeMap, HashSet},
@@ -46,10 +37,7 @@ use sui_types::{
     object::Object,
     storage::{BackingPackageStore, ChildObjectResolver, PackageObject, ParentSync},
     supported_protocol_versions::ProtocolConfig,
-    transaction::{
-        CheckedInputObjects, ProgrammableTransaction, TransactionData, TransactionDataAPI,
-    },
-    type_input::TypeInput,
+    transaction::{CheckedInputObjects, TransactionData, TransactionDataAPI},
 };
 use tracing::{debug, debug_span, trace};
 
@@ -74,400 +62,6 @@ pub struct TxnContextAndEffects {
     pub protocol_version: u64,                 // protocol version used for execution
 }
 
-/// Detailed information about a Move package.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PackageInfo {
-    pub published_id: ObjectID,
-    pub original_id: ObjectID,
-    pub module_names: Vec<String>,
-}
-
-/// Type of object in the replay cache with detailed Move information.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum ObjectType {
-    /// A Move package containing compiled modules
-    Package(PackageInfo),
-    /// A Move object with its struct tag
-    MoveObject(StructTag),
-}
-
-/// Entry in the replay cache summary representing an object accessed during replay.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CacheEntry {
-    pub object_id: ObjectID,
-    pub version: u64,
-    pub object_type: ObjectType,
-}
-
-/// Compact representation of the replay cache for serialization.
-/// Contains the execution context (epoch_id from transaction effects, checkpoint from transaction info)
-/// and a list of all objects accessed during replay, with their type information but without object content.
-/// The epoch_id represents the epoch in which the original transaction was executed.
-/// The checkpoint represents the checkpoint sequence number where the transaction was included.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ReplayCacheSummary {
-    pub epoch_id: u64,
-    pub checkpoint: u64,
-    pub network: String,
-    pub protocol_version: u64,
-    /// List of objects accessed during replay with their version and type information
-    pub cache_entries: Vec<CacheEntry>,
-}
-
-impl ReplayCacheSummary {
-    /// Create a ReplayCacheSummary from the object cache, extracting detailed Move information.
-    pub fn from_cache(
-        epoch_id: u64,
-        checkpoint: u64,
-        network: String,
-        protocol_version: u64,
-        object_cache: &BTreeMap<ObjectID, BTreeMap<u64, Object>>,
-    ) -> Self {
-        let mut cache_entries = Vec::new();
-
-        for (object_id, versions) in object_cache {
-            for (version, object) in versions {
-                let object_type = if object.is_package() {
-                    // Extract package information
-                    let package = object
-                        .data
-                        .try_as_package()
-                        .expect("Package object should have package data");
-                    let package_info = PackageInfo {
-                        published_id: package.id(),
-                        original_id: package.original_package_id(),
-                        module_names: package.serialized_module_map().keys().cloned().collect(),
-                    };
-                    ObjectType::Package(package_info)
-                } else {
-                    // Extract Move object struct tag
-                    let struct_tag = object
-                        .struct_tag()
-                        .expect("Move object should have struct tag");
-                    ObjectType::MoveObject(struct_tag)
-                };
-
-                cache_entries.push(CacheEntry {
-                    object_id: *object_id,
-                    version: *version,
-                    object_type,
-                });
-            }
-        }
-
-        Self {
-            epoch_id,
-            checkpoint,
-            network,
-            protocol_version,
-            cache_entries,
-        }
-    }
-}
-
-/// Datatype definition: (address, module, name, formal_type_params).
-/// This contains linking information in the binary format.
-pub type Datatype = (AccountAddress, String, String, Vec<MoveType>);
-
-/// Custom Move type representation for JSON serialization.
-/// This provides the exact type information we want to expose in the JSON output.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum MoveType {
-    Bool,
-    U8,
-    U16,
-    U32,
-    U64,
-    U128,
-    U256,
-    Address,
-    Vector(Box<MoveType>),
-    Datatype(Datatype),
-    DatatypeInstantiation(Box<(Datatype, Vec<MoveType>)>),
-    Reference(Box<MoveType>),
-    MutableReference(Box<MoveType>),
-    TypeParameter(u16),
-}
-
-/// Function signature information for MoveCall commands in a ProgrammableTransaction.
-/// Contains detailed parameter and return type information for each function call.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FunctionSignature {
-    /// Package ID where the function is defined
-    pub package: ObjectID,
-    /// Module name containing the function
-    pub module: String,
-    /// Function name
-    pub function: String,
-    /// Parameter types
-    pub parameters: Vec<MoveType>,
-    /// Return types
-    pub return_types: Vec<MoveType>,
-}
-
-/// Move call information containing extracted function signatures.
-/// This provides type information for all commands in the transaction.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MoveCallInfo {
-    /// Vector of function signatures, one for each command
-    /// None for non-MoveCall commands, Some(signature) for MoveCall commands
-    pub command_signatures: Vec<Option<FunctionSignature>>,
-}
-
-impl MoveCallInfo {
-    /// Create MoveCallInfo by extracting function signatures from a ProgrammableTransaction.
-    /// Creates a vector with one entry per command, None for non-MoveCall commands.
-    pub fn from_transaction(
-        ptb: &ProgrammableTransaction,
-        object_cache: &BTreeMap<ObjectID, BTreeMap<u64, Object>>,
-    ) -> anyhow::Result<Self> {
-        let mut command_signatures = Vec::with_capacity(ptb.commands.len());
-
-        for command in ptb.commands.iter() {
-            let signature = if let sui_types::transaction::Command::MoveCall(move_call) = command {
-                // Extract function signature from the MoveCall
-                match Self::extract_function_signature(move_call, object_cache) {
-                    Ok(signature) => {
-                        tracing::debug!(
-                            "Successfully extracted signature for {}::{}::{}",
-                            signature.package,
-                            signature.module,
-                            signature.function
-                        );
-                        Some(signature)
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "Failed to extract signature for {}::{}::{}: {}",
-                            move_call.package,
-                            move_call.module,
-                            move_call.function,
-                            e
-                        );
-                        None
-                    }
-                }
-            } else {
-                None
-            };
-            command_signatures.push(signature);
-        }
-
-        Ok(MoveCallInfo { command_signatures })
-    }
-
-    /// Extract function signature information from a MoveCall command.
-    fn extract_function_signature(
-        move_call: &sui_types::transaction::ProgrammableMoveCall,
-        object_cache: &BTreeMap<ObjectID, BTreeMap<u64, Object>>,
-    ) -> anyhow::Result<FunctionSignature> {
-        let package_id = move_call.package;
-        let module_name = move_call.module.as_str();
-        let function_name = move_call.function.as_str();
-
-        // Find the package in the object cache
-        let package_obj = object_cache
-            .get(&package_id)
-            .and_then(|versions| versions.values().next())
-            .ok_or_else(|| anyhow::anyhow!("Package {} not found in cache", package_id))?;
-
-        // Extract MovePackage from the object
-        let move_package = package_obj
-            .data
-            .try_as_package()
-            .ok_or_else(|| anyhow::anyhow!("Object {} is not a package", package_id))?;
-
-        // Get the module bytecode from the package
-        let module_bytes = move_package
-            .serialized_module_map()
-            .get(module_name)
-            .ok_or_else(|| {
-                anyhow::anyhow!("Module {} not found in package {}", module_name, package_id)
-            })?;
-
-        // Deserialize the module
-        let binary_config = BinaryConfig::standard();
-        let compiled_module = CompiledModule::deserialize_with_config(module_bytes, &binary_config)
-            .map_err(|e| anyhow::anyhow!("Failed to deserialize module {}: {}", module_name, e))?;
-
-        // Find the function definition
-        let (_, function_def) = compiled_module
-            .find_function_def_by_name(function_name)
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Function {} not found in module {}::{}",
-                    function_name,
-                    package_id,
-                    module_name
-                )
-            })?;
-
-        // Get the function handle
-        let function_handle = compiled_module.function_handle_at(function_def.function);
-
-        // Get parameter and return signatures
-        let param_signature = compiled_module.signature_at(function_handle.parameters);
-        let return_signature = compiled_module.signature_at(function_handle.return_);
-
-        // Convert TypeInputs to MoveTypes for signature processing
-        let type_arguments_as_move_types: Vec<MoveType> = move_call
-            .type_arguments
-            .iter()
-            .map(Self::type_input_to_move_type)
-            .collect();
-
-        // Convert SignatureTokens to MoveTypes
-        let parameters = param_signature
-            .0
-            .iter()
-            .map(|token| {
-                Self::signature_token_to_move_type(
-                    token,
-                    &compiled_module,
-                    &type_arguments_as_move_types,
-                )
-            })
-            .collect::<anyhow::Result<Vec<_>>>()?;
-
-        let return_types = return_signature
-            .0
-            .iter()
-            .map(|token| {
-                Self::signature_token_to_move_type(
-                    token,
-                    &compiled_module,
-                    &type_arguments_as_move_types,
-                )
-            })
-            .collect::<anyhow::Result<Vec<_>>>()?;
-
-        Ok(FunctionSignature {
-            package: package_id,
-            module: module_name.to_string(),
-            function: function_name.to_string(),
-            parameters,
-            return_types,
-        })
-    }
-
-    /// Convert TypeInput to MoveType.
-    /// TypeInput comes from the transaction's type arguments.
-    fn type_input_to_move_type(type_input: &TypeInput) -> MoveType {
-        match type_input {
-            TypeInput::Bool => MoveType::Bool,
-            TypeInput::U8 => MoveType::U8,
-            TypeInput::U16 => MoveType::U16,
-            TypeInput::U32 => MoveType::U32,
-            TypeInput::U64 => MoveType::U64,
-            TypeInput::U128 => MoveType::U128,
-            TypeInput::U256 => MoveType::U256,
-            TypeInput::Address => MoveType::Address,
-            TypeInput::Signer => MoveType::Address, // Signer is treated as Address
-            TypeInput::Vector(element) => {
-                MoveType::Vector(Box::new(Self::type_input_to_move_type(element)))
-            }
-            TypeInput::Struct(struct_input) => {
-                let type_params: Vec<MoveType> = struct_input
-                    .type_params
-                    .iter()
-                    .map(Self::type_input_to_move_type)
-                    .collect();
-
-                let datatype = (
-                    struct_input.address,
-                    struct_input.module.clone(),
-                    struct_input.name.clone(),
-                    vec![], // Empty variants - we ignore enum variants
-                );
-
-                if type_params.is_empty() {
-                    // Non-generic datatype
-                    MoveType::Datatype(datatype)
-                } else {
-                    // Generic instantiation
-                    MoveType::DatatypeInstantiation(Box::new((datatype, type_params)))
-                }
-            }
-        }
-    }
-
-    /// Convert SignatureToken to MoveType.
-    /// This is the core conversion that bridges Move's type system with our custom representation.
-    fn signature_token_to_move_type(
-        token: &SignatureToken,
-        module: &CompiledModule,
-        type_arguments: &[MoveType],
-    ) -> anyhow::Result<MoveType> {
-        match token {
-            SignatureToken::Bool => Ok(MoveType::Bool),
-            SignatureToken::U8 => Ok(MoveType::U8),
-            SignatureToken::U16 => Ok(MoveType::U16),
-            SignatureToken::U32 => Ok(MoveType::U32),
-            SignatureToken::U64 => Ok(MoveType::U64),
-            SignatureToken::U128 => Ok(MoveType::U128),
-            SignatureToken::U256 => Ok(MoveType::U256),
-            SignatureToken::Address => Ok(MoveType::Address),
-            SignatureToken::Signer => Ok(MoveType::Address), // Signer is treated as Address
-            SignatureToken::Vector(element_type) => {
-                let element =
-                    Self::signature_token_to_move_type(element_type, module, type_arguments)?;
-                Ok(MoveType::Vector(Box::new(element)))
-            }
-            SignatureToken::Datatype(datatype_handle_idx) => {
-                let datatype_handle = module.datatype_handle_at(*datatype_handle_idx);
-                let module_handle = module.module_handle_at(datatype_handle.module);
-                let address = *module.address_identifier_at(module_handle.address);
-                let module_name = module.identifier_at(module_handle.name).to_string();
-                let struct_name = module.identifier_at(datatype_handle.name).to_string();
-
-                // Non-generic datatype - empty type params
-                let datatype = (address, module_name, struct_name, vec![]);
-                Ok(MoveType::Datatype(datatype))
-            }
-            SignatureToken::DatatypeInstantiation(instantiation) => {
-                let (datatype_handle_idx, type_args) = instantiation.as_ref();
-                let datatype_handle = module.datatype_handle_at(*datatype_handle_idx);
-                let module_handle = module.module_handle_at(datatype_handle.module);
-                let address = *module.address_identifier_at(module_handle.address);
-                let module_name = module.identifier_at(module_handle.name).to_string();
-                let struct_name = module.identifier_at(datatype_handle.name).to_string();
-
-                // Resolve the type arguments
-                let resolved_type_args = type_args
-                    .iter()
-                    .map(|arg| Self::signature_token_to_move_type(arg, module, type_arguments))
-                    .collect::<anyhow::Result<Vec<_>>>()?;
-
-                // Base datatype with empty type params
-                let datatype = (address, module_name, struct_name, vec![]);
-
-                // Generic instantiation with resolved type arguments
-                Ok(MoveType::DatatypeInstantiation(Box::new((
-                    datatype,
-                    resolved_type_args,
-                ))))
-            }
-            SignatureToken::Reference(inner) => {
-                let inner_type = Self::signature_token_to_move_type(inner, module, type_arguments)?;
-                Ok(MoveType::Reference(Box::new(inner_type)))
-            }
-            SignatureToken::MutableReference(inner) => {
-                let inner_type = Self::signature_token_to_move_type(inner, module, type_arguments)?;
-                Ok(MoveType::MutableReference(Box::new(inner_type)))
-            }
-            SignatureToken::TypeParameter(idx) => {
-                // Resolve type parameter using the provided type_arguments
-                if (*idx as usize) < type_arguments.len() {
-                    Ok(type_arguments[*idx as usize].clone())
-                } else {
-                    // Return TypeParameter variant if not resolved
-                    Ok(MoveType::TypeParameter(*idx))
-                }
-            }
-        }
-    }
-}
-
 // Entry point. Executes a transaction.
 // Return all the information that can be used by a client
 // to verify execution.
@@ -482,7 +76,7 @@ pub fn execute_transaction_to_effects(
         Result<(), ExecutionError>, // transaction result
         TxnContextAndEffects,       // data touched and changed during execution
     ),
-    anyhow::Error,
+    Error,
 > {
     debug!(op = "execute_tx", phase = "start", "execution");
     // TODO: Hook up...
@@ -503,7 +97,7 @@ pub fn execute_transaction_to_effects(
     let protocol_config = &executor.protocol_config;
     let epoch_data = epoch_store
         .epoch_info(epoch)?
-        .ok_or_else(|| anyhow::anyhow!(format!("Epoch {} not found", epoch)))?;
+        .ok_or_else(|| anyhow!(format!("Epoch {} not found", epoch)))?;
     let epoch_start_timestamp = epoch_data.start_timestamp;
     let gas_status = if txn_data.kind().is_system_tx() {
         SuiGasStatus::new_unmetered()
@@ -569,7 +163,7 @@ pub fn execute_transaction_to_effects(
                 .insert(object.version().value(), object.clone());
         } else {
             // Return error if created object is not found in inner_store
-            return Err(anyhow::anyhow!(
+            return Err(anyhow!(
                 "Created object {} not found in inner_store written objects",
                 object_id
             ));
@@ -593,7 +187,7 @@ pub fn execute_transaction_to_effects(
 }
 
 impl ReplayExecutor {
-    pub fn new(protocol_config: ProtocolConfig) -> Result<Self, anyhow::Error> {
+    pub fn new(protocol_config: ProtocolConfig) -> Result<Self, Error> {
         let silent = true; // disable Move debug API
         let executor = sui_execution::executor(&protocol_config, silent)
             .context("Filed to create executor. ProtocolConfig inconsistency?")?;
@@ -820,7 +414,7 @@ impl ParentSync for ReplayStore<'_> {
 }
 
 impl ModuleResolver for ReplayStore<'_> {
-    type Error = anyhow::Error;
+    type Error = Error;
 
     fn get_module(&self, id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
         unreachable!("unexpected ModuleResolver::get_module({})", id)

--- a/crates/sui-replay-2/src/lib.rs
+++ b/crates/sui-replay-2/src/lib.rs
@@ -12,7 +12,7 @@ use crate::{
     replay_txn::replay_transaction,
     summary_metrics::TotalMetrics,
 };
-use anyhow::{anyhow, bail};
+use anyhow::{anyhow, bail, Result};
 use clap::{Parser, ValueEnum};
 use serde::Deserialize;
 use similar::{ChangeTag, TextDiff};
@@ -306,7 +306,7 @@ impl FromStr for Node {
 
 /// Load replay configuration from ~/.sui/sui_config/replay.toml file.
 /// Returns default config (all fields set to None) if file cannot be found or read.
-pub fn load_config_file() -> anyhow::Result<ReplayConfigStable> {
+pub fn load_config_file() -> Result<ReplayConfigStable> {
     let config_dir = match sui_config_dir() {
         Ok(dir) => dir,
         Err(e) => {
@@ -384,7 +384,7 @@ pub async fn handle_replay_config(
     stable_config: &ReplayConfigStableInternal,
     experimental_config: &ReplayConfigExperimental,
     version: &str,
-) -> anyhow::Result<PathBuf> {
+) -> Result<PathBuf> {
     let ReplayConfigStableInternal {
         digest,
         digests_path,
@@ -552,7 +552,7 @@ async fn run_replay<S>(
     verbose: bool,
     terminate_early: bool,
     track_time: bool,
-) -> anyhow::Result<()>
+) -> Result<()>
 where
     S: ReadDataStore + StoreSummary + SetupStore,
 {
@@ -635,7 +635,7 @@ pub fn print_effects_or_fork<W: Write>(
     output_root: &Path,
     show_effects: bool,
     w: &mut W,
-) -> anyhow::Result<()> {
+) -> Result<()> {
     let output_dir = output_root.join(digest);
     let manager = ArtifactManager::new(&output_dir, false)?;
     if manager.member(Artifact::ForkedTransactionEffects).exists() {
@@ -665,7 +665,7 @@ pub fn print_effects_or_fork<W: Write>(
             w,
             "{}",
             SuiTransactionBlockEffects::try_from(tx_effects.clone())
-                .map_err(|e| anyhow::anyhow!("Failed to convert effects: {e}"))?
+                .map_err(|e| anyhow!("Failed to convert effects: {e}"))?
         )?;
         manager
             .member(Artifact::TransactionGasReport)

--- a/crates/sui-replay-2/src/main.rs
+++ b/crates/sui-replay-2/src/main.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{anyhow, Result};
 use clap::*;
 use core::panic;
 use std::str::FromStr;
@@ -15,7 +16,7 @@ use sui_types::base_types::ObjectID;
 bin_version::bin_version!();
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> Result<()> {
     let _guard = telemetry_subscribers::TelemetryConfig::new()
         .with_env()
         .init();
@@ -32,7 +33,7 @@ async fn main() -> anyhow::Result<()> {
                 node,
             } => {
                 let object_id = ObjectID::from_str(package_id)
-                    .map_err(|e| anyhow::anyhow!("Invalid package ID: {}", e))?;
+                    .map_err(|e| anyhow!("Invalid package ID: {}", e))?;
 
                 rebuild_package(
                     node.clone(),
@@ -49,7 +50,7 @@ async fn main() -> anyhow::Result<()> {
                 node,
             } => {
                 let object_id = ObjectID::from_str(package_id)
-                    .map_err(|e| anyhow::anyhow!("Invalid package ID: {}", e))?;
+                    .map_err(|e| anyhow!("Invalid package ID: {}", e))?;
 
                 extract_package(node.clone(), object_id, output_path.clone())?;
 
@@ -61,7 +62,7 @@ async fn main() -> anyhow::Result<()> {
                 node,
             } => {
                 let object_id = ObjectID::from_str(package_id)
-                    .map_err(|e| anyhow::anyhow!("Invalid package ID: {}", e))?;
+                    .map_err(|e| anyhow!("Invalid package ID: {}", e))?;
 
                 overwrite_package(node.clone(), object_id, package_path.clone())?;
 

--- a/crates/sui-replay-2/src/replay_interface.rs
+++ b/crates/sui-replay-2/src/replay_interface.rs
@@ -16,6 +16,7 @@
 //! A `DataStore` with reasonable defaults is provided for convenience (`data_store.rs`).
 //! Other styles of data stores are also provided in `data_stores` for different use cases.
 
+use anyhow::{Error, Result};
 use std::io::Write;
 use sui_types::{
     base_types::ObjectID, effects::TransactionEffects, object::Object,
@@ -46,7 +47,7 @@ pub trait TransactionStore {
     fn transaction_data_and_effects(
         &self,
         tx_digest: &str,
-    ) -> Result<Option<TransactionInfo>, anyhow::Error>;
+    ) -> Result<Option<TransactionInfo>, Error>;
 }
 
 /// Epoch data required to reaplay a transaction.
@@ -65,9 +66,9 @@ pub struct EpochData {
 /// and never hit a server.
 pub trait EpochStore {
     /// Return the `EpochData` for a given epoch.
-    fn epoch_info(&self, epoch: u64) -> Result<Option<EpochData>, anyhow::Error>;
+    fn epoch_info(&self, epoch: u64) -> Result<Option<EpochData>, Error>;
     /// Return the `ProtocolConfig` for a given epoch.
-    fn protocol_config(&self, epoch: u64) -> Result<Option<ProtocolConfig>, anyhow::Error>;
+    fn protocol_config(&self, epoch: u64) -> Result<Option<ProtocolConfig>, Error>;
 }
 
 /// Query for an object.
@@ -103,7 +104,7 @@ pub trait ObjectStore {
     /// Otherwise each tuple contains:
     /// - `Object`: The object data
     /// - `u64`: The actual version of the object
-    fn get_objects(&self, keys: &[ObjectKey]) -> Result<Vec<Option<(Object, u64)>>, anyhow::Error>;
+    fn get_objects(&self, keys: &[ObjectKey]) -> Result<Vec<Option<(Object, u64)>>, Error>;
 }
 
 // ============================================================================
@@ -125,7 +126,7 @@ pub trait SetupStore {
     /// When `chain_id` is `Some(chain_id)` the given data store should override
     /// the map from network to chain id if it has one.
     /// That is a meaningful operation only for the FileSystemStore.
-    fn setup(&self, chain_id: Option<String>) -> Result<Option<String>, anyhow::Error>;
+    fn setup(&self, chain_id: Option<String>) -> Result<Option<String>, Error>;
 }
 
 // ============================================================================
@@ -140,14 +141,14 @@ pub trait TransactionStoreWriter: TransactionStore {
         &self,
         tx_digest: &str,
         transaction_info: TransactionInfo,
-    ) -> Result<(), anyhow::Error>;
+    ) -> Result<(), Error>;
 }
 
 /// Write-back trait for epoch data.
 /// Allows storing epoch information.
 pub trait EpochStoreWriter: EpochStore {
     /// Store epoch data for a given epoch.
-    fn write_epoch_info(&self, epoch: u64, epoch_data: EpochData) -> Result<(), anyhow::Error>;
+    fn write_epoch_info(&self, epoch: u64, epoch_data: EpochData) -> Result<(), Error>;
 }
 
 /// Write-back trait for object data.
@@ -166,7 +167,7 @@ pub trait ObjectStoreWriter: ObjectStore {
         key: &ObjectKey,
         object: Object,
         actual_version: u64,
-    ) -> Result<(), anyhow::Error>;
+    ) -> Result<(), Error>;
 }
 
 // ============================================================================
@@ -178,7 +179,7 @@ pub trait ObjectStoreWriter: ObjectStore {
 /// Implementors are free to print any relevant statistics or configuration details.
 /// The writer allows callers to decide where summaries go (stdout, file, buffers, etc.).
 pub trait StoreSummary {
-    fn summary<W: Write>(&self, writer: &mut W) -> anyhow::Result<()>;
+    fn summary<W: Write>(&self, writer: &mut W) -> Result<()>;
 }
 
 // ============================================================================

--- a/crates/sui-replay-2/src/tracing/mod.rs
+++ b/crates/sui-replay-2/src/tracing/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     artifacts::{Artifact, ArtifactManager},
     execution::TxnContextAndEffects,
 };
-use anyhow::Context;
+use anyhow::{Context, Error};
 use move_binary_format::CompiledModule;
 use move_bytecode_source_map::utils::serialize_to_json_string;
 use move_command_line_common::files::MOVE_BYTECODE_EXTENSION;
@@ -27,7 +27,7 @@ pub fn save_trace_output(
     artifact_manager: &ArtifactManager<'_>,
     trace_builder: MoveTraceBuilder,
     context_and_effects: &TxnContextAndEffects,
-) -> Result<(), anyhow::Error> {
+) -> Result<(), Error> {
     let trace = trace_builder.into_trace();
     let trace_member = artifact_manager.member(Artifact::Trace);
     trace_member


### PR DESCRIPTION
## Description 

This builds on top of #23933. It is a pretty simple refactoring that moves artifacts in its own directory/submodule and cleans up execution.rs

## Test plan 

It works

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
