### PR TITLE
get_obj_inclusion_proof API and e2e light-client test

### DIFF
--- a/crates/sui-core/src/mock_checkpoint_builder.rs
+++ b/crates/sui-core/src/mock_checkpoint_builder.rs
@@ -131,15 +131,17 @@ impl MockCheckpointBuilder {
             .map(|e| e.effects.clone())
             .collect();
 
-        let builder = AccumulatorSettlementTxBuilder::new(None, &effects, 0);
-
         let checkpoint_height = self.get_next_checkpoint_number();
+        let checkpoint_seq = checkpoint_height;
+
+        let builder = AccumulatorSettlementTxBuilder::new(None, &effects, checkpoint_seq, 0);
 
         let (settlement_txns, barrier_tx) = builder.build_tx(
             protocol_config,
             self.epoch,
             OBJECT_START_VERSION,
             checkpoint_height,
+            checkpoint_seq,
         );
 
         settlement_txns

--- a/crates/sui-e2e-tests/tests/authenticated_events_api_tests.rs
+++ b/crates/sui-e2e-tests/tests/authenticated_events_api_tests.rs
@@ -1,15 +1,37 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use move_core_types::language_storage::StructTag;
+use std::collections::BTreeMap;
+use std::str::FromStr;
 use sui_keys::keystore::AccountKeystore;
+use sui_light_client::mmr::apply_stream_updates;
+use sui_light_client::proof::base::{Proof, ProofContents, ProofTarget, ProofVerifier};
+use sui_light_client::proof::committee::extract_new_committee_info;
+use sui_light_client::proof::ocs::{OCSInclusionProof, OCSProof, OCSTarget};
 use sui_macros::sim_test;
 use sui_protocol_config::ProtocolConfig;
-use sui_rpc::proto::sui::rpc::v2::Event;
-use sui_rpc_api::grpc::alpha::event_service_proto::ListAuthenticatedEventsRequest;
+use sui_rpc::field::FieldMask;
+use sui_rpc::field::FieldMaskUtil;
+use sui_rpc::proto::sui::rpc::v2::ledger_service_client::LedgerServiceClient;
+use sui_rpc::proto::sui::rpc::v2::{Event, GetCheckpointRequest, GetEpochRequest};
 use sui_rpc_api::grpc::alpha::event_service_proto::event_service_client::EventServiceClient;
-use sui_types::base_types::{ObjectID, SuiAddress};
+use sui_rpc_api::grpc::alpha::event_service_proto::{
+    AuthenticatedEvent, ListAuthenticatedEventsRequest,
+};
+use sui_rpc_api::grpc::alpha::proof_service_proto::GetObjectInclusionProofRequest;
+use sui_rpc_api::grpc::alpha::proof_service_proto::proof_service_client::ProofServiceClient;
+use sui_sdk_types::ValidatorCommittee;
+use sui_types::accumulator_root as ar;
+use sui_types::accumulator_root::EventCommitment;
+use sui_types::base_types::{ObjectID, SequenceNumber, SuiAddress};
+use sui_types::committee::Committee;
+use sui_types::digests::{Digest, ObjectDigest};
+use sui_types::dynamic_field::{DynamicFieldKey, Field};
+use sui_types::object::Object;
 use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
 use sui_types::transaction::TransactionData;
+use sui_types::{MoveTypeTagTraitGeneric, SUI_ACCUMULATOR_ROOT_OBJECT_ID, SUI_FRAMEWORK_ADDRESS};
 use test_cluster::{TestCluster, TestClusterBuilder};
 
 fn create_rpc_config_with_authenticated_events() -> sui_config::RpcConfig {
@@ -103,6 +125,388 @@ async fn query_authenticated_events(
         .map(|r| r.into_inner())
 }
 
+fn proto_object_ref_to_sui_object_ref(
+    object_ref_proto: &sui_rpc::proto::sui::rpc::v2::ObjectReference,
+) -> Result<(ObjectID, SequenceNumber, ObjectDigest), String> {
+    let object_id_str = object_ref_proto
+        .object_id
+        .as_ref()
+        .ok_or("Missing object_id")?;
+    let object_id =
+        ObjectID::from_str(object_id_str).map_err(|e| format!("Invalid object_id: {}", e))?;
+
+    let version = SequenceNumber::from_u64(object_ref_proto.version.ok_or("Missing version")?);
+
+    let digest_str = object_ref_proto.digest.as_ref().ok_or("Missing digest")?;
+    let digest =
+        ObjectDigest::from_str(digest_str).map_err(|e| format!("Invalid digest: {}", e))?;
+
+    Ok((object_id, version, digest))
+}
+
+fn proto_bytes_to_digest(bytes: &[u8]) -> Result<Digest, String> {
+    let digest: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| format!("Invalid digest length: expected 32, got {}", bytes.len()))?;
+    Ok(Digest::new(digest))
+}
+
+fn proto_ocs_inclusion_proof_to_light_client_proof(
+    grpc_proof: &sui_rpc_api::grpc::alpha::proof_service_proto::OcsInclusionProof,
+) -> Result<OCSInclusionProof, String> {
+    let merkle_proof_bytes = grpc_proof
+        .merkle_proof
+        .as_ref()
+        .ok_or("Missing merkle_proof")?;
+    let merkle_proof = bcs::from_bytes(merkle_proof_bytes)
+        .map_err(|e| format!("Failed to deserialize merkle_proof: {}", e))?;
+
+    let leaf_index = grpc_proof.leaf_index.ok_or("Missing leaf_index")? as usize;
+
+    let tree_root_bytes = grpc_proof.tree_root.as_ref().ok_or("Missing tree_root")?;
+    let tree_root = proto_bytes_to_digest(tree_root_bytes)?;
+
+    Ok(OCSInclusionProof {
+        merkle_proof,
+        leaf_index,
+        tree_root,
+    })
+}
+
+fn convert_grpc_event_to_commitment(
+    auth_event: &AuthenticatedEvent,
+) -> Result<EventCommitment, String> {
+    let checkpoint = auth_event.checkpoint.ok_or("Missing checkpoint")?;
+    let transaction_idx = auth_event
+        .transaction_idx
+        .ok_or("Missing transaction_idx")? as u64;
+    let event_idx = auth_event.event_idx.ok_or("Missing event_idx")? as u64;
+
+    let event = auth_event.event.as_ref().ok_or("Missing event")?;
+    let bcs_contents = event.contents.as_ref().ok_or("Missing event contents")?;
+    let bcs_bytes = bcs_contents.value.as_ref().ok_or("Missing BCS value")?;
+
+    let package_id = event.package_id.as_ref().ok_or("Missing package_id")?;
+    let module = event.module.as_ref().ok_or("Missing module")?;
+    let sender = event.sender.as_ref().ok_or("Missing sender")?;
+    let event_type = event.event_type.as_ref().ok_or("Missing event_type")?;
+
+    let package_id = sui_types::base_types::ObjectID::from_hex_literal(package_id)
+        .map_err(|e| format!("Failed to parse package_id: {}", e))?;
+    let module = move_core_types::identifier::Identifier::new(module.as_str())
+        .map_err(|e| format!("Failed to parse module: {}", e))?;
+    let sender = sui_types::base_types::SuiAddress::from_str(sender)
+        .map_err(|e| format!("Failed to parse sender: {}", e))?;
+    let type_tag: move_core_types::language_storage::StructTag = event_type
+        .parse()
+        .map_err(|e| format!("Failed to parse event_type: {}", e))?;
+
+    let sui_event = sui_types::event::Event {
+        package_id,
+        transaction_module: module,
+        sender,
+        type_: type_tag,
+        contents: bcs_bytes.to_vec(),
+    };
+
+    let digest = sui_event.digest();
+
+    Ok(EventCommitment::new(
+        checkpoint,
+        transaction_idx,
+        event_idx,
+        digest,
+    ))
+}
+
+fn get_event_stream_head_object_id(
+    stream_id: sui_types::base_types::SuiAddress,
+) -> Result<sui_types::base_types::ObjectID, String> {
+    let key = ar::AccumulatorKey { owner: stream_id };
+    let type_tag = move_core_types::language_storage::TypeTag::Struct(Box::new(StructTag {
+        address: SUI_FRAMEWORK_ADDRESS,
+        module: ar::ACCUMULATOR_SETTLEMENT_MODULE.to_owned(),
+        name: ar::ACCUMULATOR_SETTLEMENT_EVENT_STREAM_HEAD.to_owned(),
+        type_params: vec![],
+    }));
+    let key_type_tag = ar::AccumulatorKey::get_type_tag(&[type_tag]);
+
+    let field_id = DynamicFieldKey(SUI_ACCUMULATOR_ROOT_OBJECT_ID, key, key_type_tag)
+        .into_unbounded_id()
+        .map_err(|e| e.to_string())?
+        .as_object_id();
+
+    Ok(field_id)
+}
+
+async fn get_committee_for_epoch_via_api(
+    ledger_client: &mut LedgerServiceClient<tonic::transport::Channel>,
+    epoch: u64,
+) -> Result<sui_types::committee::Committee, String> {
+    let response = ledger_client
+        .get_epoch(GetEpochRequest::new(epoch).with_read_mask(FieldMask::from_paths(["committee"])))
+        .await
+        .map_err(|e| format!("Failed to get epoch {} from API: {}", epoch, e))?
+        .into_inner();
+
+    let proto_committee = response
+        .epoch
+        .ok_or("Missing epoch in response")?
+        .committee
+        .ok_or("Missing committee in epoch response")?;
+
+    let sdk_committee = ValidatorCommittee::try_from(&proto_committee).map_err(|e| {
+        format!(
+            "Failed to convert proto committee to SDK committee: {:?}",
+            e
+        )
+    })?;
+
+    Ok(sui_types::committee::Committee::from(sdk_committee))
+}
+
+async fn get_last_checkpoint_of_epoch(
+    ledger_client: &mut LedgerServiceClient<tonic::transport::Channel>,
+    epoch: u64,
+) -> Result<u64, String> {
+    let next_epoch_response = ledger_client
+        .get_epoch(
+            GetEpochRequest::new(epoch + 1)
+                .with_read_mask(FieldMask::from_paths(["first_checkpoint"])),
+        )
+        .await
+        .map_err(|e| format!("Failed to get epoch {} from API: {}", epoch + 1, e))?
+        .into_inner();
+
+    let next_epoch = next_epoch_response
+        .epoch
+        .ok_or_else(|| format!("Missing epoch {} in response", epoch + 1))?;
+
+    let first_checkpoint = next_epoch
+        .first_checkpoint
+        .ok_or_else(|| format!("Missing first_checkpoint for epoch {}", epoch + 1))?;
+
+    Ok(first_checkpoint - 1)
+}
+
+async fn get_genesis_committee(test_cluster: &TestCluster) -> Result<Committee, String> {
+    let mut ledger_client = LedgerServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .map_err(|e| format!("Failed to connect to ledger service: {}", e))?;
+
+    get_committee_for_epoch_via_api(&mut ledger_client, 0).await
+}
+
+struct EpochCache {
+    committees: Vec<(u64, u64, Committee)>, // (start_checkpoint, end_checkpoint, committee)
+}
+
+impl EpochCache {
+    fn get_committee_for_checkpoint(&self, checkpoint_seq: u64) -> Result<&Committee, String> {
+        self.committees
+            .iter()
+            .find(|(start, end, _)| checkpoint_seq >= *start && checkpoint_seq <= *end)
+            .map(|(_, _, committee)| committee)
+            .ok_or_else(|| {
+                format!(
+                    "No committee found for checkpoint {}. Available ranges: {:?}",
+                    checkpoint_seq,
+                    self.committees
+                        .iter()
+                        .map(|(start, end, _)| (start, end))
+                        .collect::<Vec<_>>()
+                )
+            })
+    }
+}
+
+async fn build_epoch_cache(
+    ledger_client: &mut LedgerServiceClient<tonic::transport::Channel>,
+    genesis_committee: Committee,
+    current_epoch: u64,
+) -> Result<EpochCache, String> {
+    let mut committees = Vec::new();
+    let mut current_committee = genesis_committee;
+    let mut prev_epoch_end_checkpoint = 0u64;
+
+    for epoch in 0..current_epoch {
+        let end_of_epoch_checkpoint_seq = get_last_checkpoint_of_epoch(ledger_client, epoch)
+            .await
+            .map_err(|e| format!("Failed to get last checkpoint of epoch {}: {}", epoch, e))?;
+
+        committees.push((
+            prev_epoch_end_checkpoint,
+            end_of_epoch_checkpoint_seq,
+            current_committee.clone(),
+        ));
+
+        let checkpoint_response = ledger_client
+            .get_checkpoint(
+                GetCheckpointRequest::by_sequence_number(end_of_epoch_checkpoint_seq)
+                    .with_read_mask(FieldMask::from_paths(["summary", "signature", "contents"])),
+            )
+            .await
+            .map_err(|e| {
+                format!(
+                    "Failed to fetch checkpoint {}: {}",
+                    end_of_epoch_checkpoint_seq, e
+                )
+            })?
+            .into_inner();
+
+        let proto_checkpoint = checkpoint_response
+            .checkpoint
+            .ok_or("Missing checkpoint in response")?;
+
+        let checkpoint: sui_types::full_checkpoint_content::Checkpoint = (&proto_checkpoint)
+            .try_into()
+            .map_err(|e| format!("Failed to convert checkpoint: {:?}", e))?;
+
+        checkpoint
+            .summary
+            .verify_with_contents(&current_committee, None)
+            .map_err(|e| {
+                format!(
+                    "Failed to verify checkpoint {}: {}",
+                    end_of_epoch_checkpoint_seq, e
+                )
+            })?;
+
+        let next_committee = extract_new_committee_info(&checkpoint.summary).map_err(|e| {
+            format!(
+                "Failed to extract committee from checkpoint {}: {}",
+                end_of_epoch_checkpoint_seq, e
+            )
+        })?;
+
+        current_committee = next_committee;
+        prev_epoch_end_checkpoint = end_of_epoch_checkpoint_seq + 1;
+    }
+
+    committees.push((prev_epoch_end_checkpoint, u64::MAX, current_committee));
+
+    Ok(EpochCache { committees })
+}
+
+async fn verify_ocs_inclusion_proof(
+    epoch_cache: &EpochCache,
+    checkpoint_summary: &sui_types::messages_checkpoint::CertifiedCheckpointSummary,
+    object_ref_proto: &sui_rpc::proto::sui::rpc::v2::ObjectReference,
+    grpc_proof: &sui_rpc_api::grpc::alpha::proof_service_proto::OcsInclusionProof,
+    checkpoint_seq: u64,
+) -> Result<(), String> {
+    let object_ref = proto_object_ref_to_sui_object_ref(object_ref_proto)?;
+    let ocs_inclusion_proof = proto_ocs_inclusion_proof_to_light_client_proof(grpc_proof)?;
+
+    let target = OCSTarget::new_inclusion_target(object_ref);
+
+    let proof = Proof {
+        targets: ProofTarget::ObjectCheckpointState(target),
+        checkpoint_summary: checkpoint_summary.clone(),
+        proof_contents: ProofContents::ObjectCheckpointStateProof(OCSProof::Inclusion(
+            ocs_inclusion_proof,
+        )),
+    };
+
+    let committee = epoch_cache.get_committee_for_checkpoint(checkpoint_seq)?;
+
+    proof
+        .verify(committee)
+        .map_err(|e| format!("Proof verification failed: {:?}", e))?;
+
+    Ok(())
+}
+
+async fn fetch_and_verify_event_stream_head(
+    proof_client: &mut ProofServiceClient<tonic::transport::Channel>,
+    ledger_client: &mut LedgerServiceClient<tonic::transport::Channel>,
+    epoch_cache: &EpochCache,
+    object_id: ObjectID,
+    checkpoint: u64,
+) -> Field<ar::AccumulatorKey, ar::EventStreamHead> {
+    let mut req = GetObjectInclusionProofRequest::default();
+    req.object_id = Some(object_id.to_string());
+    req.checkpoint = Some(checkpoint);
+
+    let response = proof_client
+        .get_object_inclusion_proof(req)
+        .await
+        .unwrap()
+        .into_inner();
+
+    let object_ref = response.object_ref.expect("object_ref should be present");
+
+    assert!(
+        object_ref.object_id.is_some(),
+        "object_id should be present in object_ref"
+    );
+    assert!(
+        object_ref.version.is_some(),
+        "version should be present in object_ref"
+    );
+    assert!(
+        object_ref.digest.is_some(),
+        "digest should be present in object_ref"
+    );
+
+    let inclusion_proof = response
+        .inclusion_proof
+        .expect("inclusion_proof should be present");
+
+    assert!(
+        inclusion_proof.merkle_proof.is_some(),
+        "merkle_proof should be present"
+    );
+    assert!(
+        inclusion_proof.tree_root.is_some(),
+        "tree_root should be present"
+    );
+
+    let object_data_bytes = response.object_data.expect("object_data should be present");
+
+    let object: Object =
+        bcs::from_bytes(&object_data_bytes).expect("should deserialize object from BCS");
+
+    let move_obj = object.data.try_as_move().expect("should be move object");
+    let stream_head: Field<ar::AccumulatorKey, ar::EventStreamHead> = move_obj
+        .to_rust()
+        .expect("should deserialize to EventStreamHead");
+
+    assert_eq!(
+        stream_head.value.checkpoint_seq, checkpoint,
+        "EventStreamHead checkpoint_seq should match requested checkpoint"
+    );
+
+    let checkpoint_response = ledger_client
+        .get_checkpoint(
+            GetCheckpointRequest::by_sequence_number(checkpoint)
+                .with_read_mask(FieldMask::from_paths(["summary", "signature", "contents"])),
+        )
+        .await
+        .expect("Failed to fetch checkpoint")
+        .into_inner();
+
+    let proto_checkpoint = checkpoint_response
+        .checkpoint
+        .expect("Missing checkpoint in response");
+
+    let checkpoint_data: sui_types::full_checkpoint_content::Checkpoint = (&proto_checkpoint)
+        .try_into()
+        .expect("Failed to convert checkpoint");
+
+    verify_ocs_inclusion_proof(
+        epoch_cache,
+        &checkpoint_data.summary,
+        &object_ref,
+        &inclusion_proof,
+        checkpoint,
+    )
+    .await
+    .expect("EventStreamHead inclusion proof should verify with committee");
+
+    stream_head
+}
+
 #[sim_test]
 async fn list_authenticated_events_end_to_end() {
     let _guard: sui_protocol_config::OverrideGuard =
@@ -116,20 +520,37 @@ async fn list_authenticated_events_end_to_end() {
     let test_cluster = TestClusterBuilder::new()
         .disable_fullnode_pruning()
         .with_rpc_config(rpc_config)
+        .with_epoch_duration_ms(5000)
         .build()
         .await;
 
     let package_id = publish_test_package(&test_cluster).await;
+
     let sender = test_cluster.wallet.config.keystore.addresses()[0];
 
-    for i in 0..10 {
+    // we want to emit events across epochs to exercise trust ratcheting / inclusion proof committee validation
+    emit_test_event(&test_cluster, package_id, sender, 100).await;
+
+    test_cluster.wait_for_epoch(None).await;
+
+    for i in 1..10 {
         emit_test_event(&test_cluster, package_id, sender, 100 + i).await;
     }
 
-    let response =
-        query_authenticated_events(test_cluster.rpc_url(), &package_id.to_string(), 0, None)
-            .await
-            .unwrap();
+    let mut event_client = EventServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
+
+    let mut req = ListAuthenticatedEventsRequest::default();
+    req.stream_id = Some(package_id.to_string());
+    req.start_checkpoint = Some(0);
+    req.page_size = None;
+    req.page_token = None;
+    let response = event_client
+        .list_authenticated_events(req)
+        .await
+        .unwrap()
+        .into_inner();
 
     let count = response.events.len();
     assert_eq!(count, 10, "expected 10 authenticated events, got {count}");
@@ -142,6 +563,88 @@ async fn list_authenticated_events_end_to_end() {
         _ => false,
     });
     assert!(found, "expected authenticated event for the stream");
+
+    let first_event_checkpoint = response.events[0].checkpoint.unwrap();
+    let last_event_checkpoint = response.events.last().unwrap().checkpoint.unwrap();
+
+    let stream_id = sui_types::base_types::SuiAddress::from(package_id);
+    let event_stream_head_id = get_event_stream_head_object_id(stream_id).unwrap();
+
+    let mut proof_client = ProofServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
+
+    let mut ledger_client = LedgerServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
+
+    // Build committee cache once by doing trust ratcheting
+    let current_epoch = test_cluster
+        .fullnode_handle
+        .sui_node
+        .state()
+        .epoch_store_for_testing()
+        .epoch();
+    let genesis_committee = get_genesis_committee(&test_cluster).await.unwrap();
+    let epoch_cache = build_epoch_cache(&mut ledger_client, genesis_committee, current_epoch)
+        .await
+        .expect("Failed to build epoch cache");
+
+    let stream_head = fetch_and_verify_event_stream_head(
+        &mut proof_client,
+        &mut ledger_client,
+        &epoch_cache,
+        event_stream_head_id,
+        first_event_checkpoint,
+    )
+    .await;
+
+    assert!(!stream_head.value.mmr.is_empty(), "MMR should not be empty");
+
+    let last_stream_head = fetch_and_verify_event_stream_head(
+        &mut proof_client,
+        &mut ledger_client,
+        &epoch_cache,
+        event_stream_head_id,
+        last_event_checkpoint,
+    )
+    .await;
+
+    assert_eq!(
+        last_stream_head.value.num_events, 10,
+        "expected 10 events in final stream head"
+    );
+
+    let events_by_checkpoint: BTreeMap<u64, Vec<EventCommitment>> =
+        response
+            .events
+            .iter()
+            .fold(BTreeMap::new(), |mut map, event| {
+                let commitment = convert_grpc_event_to_commitment(event)
+                    .expect("should convert event to commitment");
+                map.entry(commitment.checkpoint_seq)
+                    .or_default()
+                    .push(commitment);
+                map
+            });
+
+    let checkpoints_with_events: Vec<Vec<EventCommitment>> = events_by_checkpoint
+        .iter()
+        .filter(|(cp, _)| **cp > first_event_checkpoint)
+        .map(|(_cp, events)| events.clone())
+        .collect();
+
+    let calculated_stream_head = apply_stream_updates(&stream_head.value, checkpoints_with_events);
+
+    assert_eq!(
+        calculated_stream_head.num_events, last_stream_head.value.num_events,
+        "Calculated event count should match actual event count"
+    );
+
+    assert_eq!(
+        calculated_stream_head.mmr, last_stream_head.value.mmr,
+        "Calculated MMR should match actual MMR from EventStreamHead"
+    );
 }
 
 #[sim_test]

--- a/crates/sui-e2e-tests/tests/authenticated_events_end_to_end_test.rs
+++ b/crates/sui-e2e-tests/tests/authenticated_events_end_to_end_test.rs
@@ -102,7 +102,8 @@ fn build_event_commitments_from_checkpoint(
         let accumulator_events = effects.accumulator_events();
         for acc_event in accumulator_events.iter() {
             if let AccumulatorValue::EventDigest(event_idx, digest) = &acc_event.write.value {
-                let event_commitment = EventCommitment::new(0, idx as u64, *event_idx, *digest);
+                let event_commitment =
+                    EventCommitment::new(checkpoint_seq, idx as u64, *event_idx, *digest);
                 event_commitments.push(event_commitment);
             }
         }

--- a/crates/sui-e2e-tests/tests/get_object_inclusion_proof_tests.rs
+++ b/crates/sui-e2e-tests/tests/get_object_inclusion_proof_tests.rs
@@ -1,0 +1,290 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use sui_keys::keystore::AccountKeystore;
+use sui_macros::sim_test;
+use sui_rpc_api::grpc::alpha::proof_service_proto::GetObjectInclusionProofRequest;
+use sui_rpc_api::grpc::alpha::proof_service_proto::proof_service_client::ProofServiceClient;
+use sui_types::base_types::ObjectID;
+use test_cluster::{TestCluster, TestClusterBuilder};
+
+fn create_rpc_config_with_authenticated_events() -> sui_config::RpcConfig {
+    sui_config::RpcConfig {
+        authenticated_events_indexing: Some(true),
+        enable_indexing: Some(true),
+        ..Default::default()
+    }
+}
+
+fn create_rpc_config_without_authenticated_events() -> sui_config::RpcConfig {
+    sui_config::RpcConfig {
+        authenticated_events_indexing: Some(false),
+        enable_indexing: Some(true),
+        ..Default::default()
+    }
+}
+
+async fn get_test_object(test_cluster: &TestCluster) -> ObjectID {
+    let sender = test_cluster.wallet.config.keystore.addresses()[0];
+    test_cluster
+        .wallet
+        .get_one_gas_object_owned_by_address(sender)
+        .await
+        .unwrap()
+        .unwrap()
+        .0
+}
+
+#[sim_test]
+async fn test_feature_flag_disabled() {
+    let test_cluster = TestClusterBuilder::new()
+        .disable_fullnode_pruning()
+        .with_rpc_config(create_rpc_config_without_authenticated_events())
+        .build()
+        .await;
+
+    let mut proof_client = ProofServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
+
+    let mut req = GetObjectInclusionProofRequest::default();
+    req.object_id = Some(ObjectID::random().to_string());
+    req.checkpoint = Some(1);
+
+    let result = proof_client.get_object_inclusion_proof(req).await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.code(), tonic::Code::Unimplemented);
+    assert!(
+        err.message()
+            .contains("Authenticated events indexing is disabled")
+    );
+}
+
+#[sim_test]
+async fn test_missing_object_id() {
+    let test_cluster = TestClusterBuilder::new()
+        .disable_fullnode_pruning()
+        .with_rpc_config(create_rpc_config_with_authenticated_events())
+        .build()
+        .await;
+
+    let mut proof_client = ProofServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
+
+    let mut req = GetObjectInclusionProofRequest::default();
+    req.object_id = None;
+    req.checkpoint = Some(1);
+
+    let result = proof_client.get_object_inclusion_proof(req).await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    assert!(err.message().contains("missing object_id"));
+}
+
+#[sim_test]
+async fn test_empty_object_id() {
+    let test_cluster = TestClusterBuilder::new()
+        .disable_fullnode_pruning()
+        .with_rpc_config(create_rpc_config_with_authenticated_events())
+        .build()
+        .await;
+
+    let mut proof_client = ProofServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
+
+    let mut req = GetObjectInclusionProofRequest::default();
+    req.object_id = Some("".to_string());
+    req.checkpoint = Some(1);
+
+    let result = proof_client.get_object_inclusion_proof(req).await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    assert!(err.message().contains("object_id cannot be empty"));
+}
+
+#[sim_test]
+async fn test_invalid_object_id_format() {
+    let test_cluster = TestClusterBuilder::new()
+        .disable_fullnode_pruning()
+        .with_rpc_config(create_rpc_config_with_authenticated_events())
+        .build()
+        .await;
+
+    let mut proof_client = ProofServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
+
+    let mut req = GetObjectInclusionProofRequest::default();
+    req.object_id = Some("invalid_object_id".to_string());
+    req.checkpoint = Some(1);
+
+    let result = proof_client.get_object_inclusion_proof(req).await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    assert!(err.message().contains("invalid object_id"));
+}
+
+#[sim_test]
+async fn test_missing_checkpoint() {
+    let test_cluster = TestClusterBuilder::new()
+        .disable_fullnode_pruning()
+        .with_rpc_config(create_rpc_config_with_authenticated_events())
+        .build()
+        .await;
+
+    let object_id = get_test_object(&test_cluster).await;
+
+    let mut proof_client = ProofServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
+
+    let mut req = GetObjectInclusionProofRequest::default();
+    req.object_id = Some(object_id.to_string());
+    req.checkpoint = None;
+
+    let result = proof_client.get_object_inclusion_proof(req).await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    assert!(err.message().contains("missing checkpoint"));
+}
+
+#[sim_test]
+async fn test_checkpoint_not_yet_indexed() {
+    let test_cluster = TestClusterBuilder::new()
+        .disable_fullnode_pruning()
+        .with_rpc_config(create_rpc_config_with_authenticated_events())
+        .build()
+        .await;
+
+    let object_id = get_test_object(&test_cluster).await;
+
+    let mut proof_client = ProofServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
+
+    let mut req = GetObjectInclusionProofRequest::default();
+    req.object_id = Some(object_id.to_string());
+    req.checkpoint = Some(999999);
+
+    let result = proof_client.get_object_inclusion_proof(req).await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.code(), tonic::Code::NotFound);
+    assert!(err.message().contains("not yet indexed"));
+}
+
+#[sim_test]
+async fn test_object_not_found_in_checkpoint() {
+    let test_cluster = TestClusterBuilder::new()
+        .disable_fullnode_pruning()
+        .with_rpc_config(create_rpc_config_with_authenticated_events())
+        .build()
+        .await;
+
+    let state = test_cluster.fullnode_handle.sui_node.state();
+    let latest_checkpoint = state.get_latest_checkpoint_sequence_number().unwrap();
+
+    let non_existent_object_id = ObjectID::random();
+
+    let mut proof_client = ProofServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
+
+    let mut req = GetObjectInclusionProofRequest::default();
+    req.object_id = Some(non_existent_object_id.to_string());
+    req.checkpoint = Some(latest_checkpoint);
+
+    let result = proof_client.get_object_inclusion_proof(req).await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.code(), tonic::Code::NotFound);
+    assert!(err.message().contains("not found in checkpoint"));
+}
+
+#[sim_test]
+async fn test_valid_request() {
+    let test_cluster = TestClusterBuilder::new()
+        .disable_fullnode_pruning()
+        .with_rpc_config(create_rpc_config_with_authenticated_events())
+        .build()
+        .await;
+
+    let object_id = get_test_object(&test_cluster).await;
+
+    let state = test_cluster.fullnode_handle.sui_node.state();
+    let latest_checkpoint = state.get_latest_checkpoint_sequence_number().unwrap();
+
+    let mut proof_client = ProofServiceClient::connect(test_cluster.rpc_url().to_owned())
+        .await
+        .unwrap();
+
+    let mut found_checkpoint = None;
+    for checkpoint_seq in 0..=latest_checkpoint {
+        let mut req = GetObjectInclusionProofRequest::default();
+        req.object_id = Some(object_id.to_string());
+        req.checkpoint = Some(checkpoint_seq);
+
+        let result = proof_client.get_object_inclusion_proof(req).await;
+        if result.is_ok() {
+            found_checkpoint = Some(checkpoint_seq);
+            break;
+        }
+    }
+
+    assert!(
+        found_checkpoint.is_some(),
+        "Object not found in any checkpoint"
+    );
+    let checkpoint_seq = found_checkpoint.unwrap();
+
+    let mut req = GetObjectInclusionProofRequest::default();
+    req.object_id = Some(object_id.to_string());
+    req.checkpoint = Some(checkpoint_seq);
+
+    let result = proof_client.get_object_inclusion_proof(req).await;
+    assert!(result.is_ok());
+    let response = result.unwrap().into_inner();
+
+    let object_ref = response.object_ref.expect("object_ref should be present");
+    assert!(
+        object_ref.object_id.is_some(),
+        "object_id should be present"
+    );
+    assert!(object_ref.version.is_some(), "version should be present");
+    assert!(object_ref.digest.is_some(), "digest should be present");
+
+    let inclusion_proof = response
+        .inclusion_proof
+        .expect("inclusion_proof should be present");
+    assert!(
+        inclusion_proof.merkle_proof.is_some(),
+        "merkle_proof should be present"
+    );
+    assert!(
+        inclusion_proof.leaf_index.is_some(),
+        "leaf_index should be present"
+    );
+    assert!(
+        inclusion_proof.tree_root.is_some(),
+        "tree_root should be present"
+    );
+
+    assert!(
+        response.object_data.is_some(),
+        "object_data should be present"
+    );
+}

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -4533,6 +4533,8 @@ impl ProtocolConfig {
     pub fn enable_authenticated_event_streams_for_testing(&mut self) {
         self.enable_accumulators_for_testing();
         self.feature_flags.enable_authenticated_event_streams = true;
+        self.feature_flags
+            .include_checkpoint_artifacts_digest_in_summary = true;
     }
 
     pub fn enable_non_exclusive_writes_for_testing(&mut self) {

--- a/crates/sui-rpc-api/build.rs
+++ b/crates/sui-rpc-api/build.rs
@@ -60,6 +60,8 @@ fn main() {
         }
     }
 
+    proto_files.sort();
+
     let file_descriptors = protox::compile(proto_files, [sui_proto_dir, sui_rpc_proto_dir])
         .expect("failed to compile proto files");
 

--- a/crates/sui-rpc-api/proto/sui/rpc/alpha/proof_service.proto
+++ b/crates/sui-rpc-api/proto/sui/rpc/alpha/proof_service.proto
@@ -1,0 +1,46 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+package sui.rpc.alpha;
+
+import "sui/rpc/v2/object_reference.proto";
+
+// ProofService provides cryptographic proofs for blockchain objects.
+service ProofService {
+  // Returns an inclusion proof if a specified object id was written in a specified checkpoint.
+  rpc GetObjectInclusionProof(GetObjectInclusionProofRequest) returns (GetObjectInclusionProofResponse);
+}
+
+// Object Checkpoint State inclusion proof.
+message OCSInclusionProof {
+  // BCS-encoded merkle proof nodes.
+  optional bytes merkle_proof = 1;
+
+  // Leaf index in the merkle tree.
+  optional uint64 leaf_index = 2;
+
+  // Tree root digest (32 bytes).
+  optional bytes tree_root = 3;
+}
+
+// Request for object inclusion proof at a checkpoint.
+message GetObjectInclusionProofRequest {
+  // Required. Object ID to get inclusion proof for.
+  optional string object_id = 1;
+
+  // Required. Checkpoint sequence number.
+  optional uint64 checkpoint = 2;
+}
+
+// Response containing object inclusion proof and object data.
+message GetObjectInclusionProofResponse {
+  // Object reference being proven (object_id, version, digest).
+  optional sui.rpc.v2.ObjectReference object_ref = 1;
+
+  // Object inclusion proof.
+  optional OCSInclusionProof inclusion_proof = 2;
+
+  // BCS-encoded object data.
+  optional bytes object_data = 3;
+}

--- a/crates/sui-rpc-api/src/grpc/alpha/mod.rs
+++ b/crates/sui-rpc-api/src/grpc/alpha/mod.rs
@@ -3,7 +3,12 @@
 
 pub mod event_service;
 pub mod list_authenticated_events;
+pub mod proof_service;
 
 pub mod event_service_proto {
+    include!("../../proto/generated/sui.rpc.alpha.rs");
+}
+
+pub mod proof_service_proto {
     include!("../../proto/generated/sui.rpc.alpha.rs");
 }

--- a/crates/sui-rpc-api/src/grpc/alpha/proof_service.rs
+++ b/crates/sui-rpc-api/src/grpc/alpha/proof_service.rs
@@ -1,0 +1,234 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::RpcError;
+use crate::RpcService;
+use crate::grpc::alpha::proof_service_proto::{
+    GetObjectInclusionProofRequest, GetObjectInclusionProofResponse, OcsInclusionProof,
+    proof_service_server::ProofService,
+};
+use bcs;
+use fastcrypto::hash::Blake2b256;
+use fastcrypto::merkle::MerkleTree;
+use std::str::FromStr;
+use sui_types::{
+    base_types::{ObjectID, ObjectRef},
+    digests::Digest,
+    messages_checkpoint::CheckpointArtifacts,
+};
+
+pub struct ProofServiceImpl {
+    service: RpcService,
+}
+
+impl ProofServiceImpl {
+    pub fn new(service: RpcService) -> Self {
+        Self { service }
+    }
+}
+
+#[tonic::async_trait]
+impl ProofService for ProofServiceImpl {
+    async fn get_object_inclusion_proof(
+        &self,
+        request: tonic::Request<GetObjectInclusionProofRequest>,
+    ) -> Result<tonic::Response<GetObjectInclusionProofResponse>, tonic::Status> {
+        let response = get_object_inclusion_proof_impl(&self.service, request.into_inner())
+            .map_err(tonic::Status::from)?;
+        Ok(tonic::Response::new(response))
+    }
+}
+
+fn build_ocs_inclusion_proof(
+    checkpoint: &sui_types::full_checkpoint_content::Checkpoint,
+    object_id: ObjectID,
+) -> Result<(OcsInclusionProof, ObjectRef), RpcError> {
+    let effects_refs: Vec<&_> = checkpoint
+        .transactions
+        .iter()
+        .map(|tx| &tx.effects)
+        .collect();
+
+    let checkpoint_artifacts = CheckpointArtifacts::from(effects_refs.as_slice());
+
+    let object_states = checkpoint_artifacts
+        .object_states()
+        .map_err(|e| RpcError::new(tonic::Code::Internal, e.to_string()))?;
+
+    let object_ref_from_checkpoint = object_states.get(&object_id).ok_or_else(|| {
+        RpcError::new(
+            tonic::Code::NotFound,
+            format!("Object {} not found in checkpoint", object_id),
+        )
+    })?;
+
+    let object_ref = (
+        object_id,
+        object_ref_from_checkpoint.0,
+        object_ref_from_checkpoint.1,
+    );
+
+    let leaves: Vec<ObjectRef> = object_states
+        .iter()
+        .map(|(id, (seq, digest))| (*id, *seq, *digest))
+        .collect();
+
+    let leaf_index = leaves
+        .iter()
+        .position(|r| *r == object_ref)
+        .ok_or_else(|| {
+            RpcError::new(
+                tonic::Code::Internal,
+                format!("Object {} not found in checkpoint", object_ref.0),
+            )
+        })?;
+
+    let tree = MerkleTree::<Blake2b256>::build_from_unserialized(leaves.iter())
+        .map_err(|e| RpcError::new(tonic::Code::Internal, e.to_string()))?;
+
+    let merkle_proof = tree
+        .get_proof(leaf_index)
+        .map_err(|e| RpcError::new(tonic::Code::Internal, e.to_string()))?;
+
+    let tree_root = Digest::new(tree.root().bytes());
+
+    let merkle_proof_bytes = bcs::to_bytes(&merkle_proof)
+        .map_err(|e| RpcError::new(tonic::Code::Internal, e.to_string()))?;
+
+    let proto_inclusion_proof = OcsInclusionProof {
+        merkle_proof: Some(merkle_proof_bytes),
+        leaf_index: Some(leaf_index as u64),
+        tree_root: Some(<Digest as AsRef<[u8; 32]>>::as_ref(&tree_root).to_vec()),
+    };
+
+    Ok((proto_inclusion_proof, object_ref))
+}
+
+#[tracing::instrument(skip(service))]
+fn get_object_inclusion_proof_impl(
+    service: &RpcService,
+    request: GetObjectInclusionProofRequest,
+) -> Result<GetObjectInclusionProofResponse, RpcError> {
+    if !service.config.authenticated_events_indexing() {
+        return Err(RpcError::new(
+            tonic::Code::Unimplemented,
+            "Authenticated events indexing is disabled".to_string(),
+        ));
+    }
+
+    let object_id_str = request.object_id.ok_or_else(|| {
+        RpcError::new(
+            tonic::Code::InvalidArgument,
+            "missing object_id".to_string(),
+        )
+    })?;
+
+    if object_id_str.trim().is_empty() {
+        return Err(RpcError::new(
+            tonic::Code::InvalidArgument,
+            "object_id cannot be empty".to_string(),
+        ));
+    }
+
+    let object_id = ObjectID::from_str(&object_id_str).map_err(|e| {
+        RpcError::new(
+            tonic::Code::InvalidArgument,
+            format!("invalid object_id: {e}"),
+        )
+    })?;
+
+    let checkpoint_seq = request.checkpoint.ok_or_else(|| {
+        RpcError::new(
+            tonic::Code::InvalidArgument,
+            "missing checkpoint".to_string(),
+        )
+    })?;
+
+    let reader = service.reader.inner();
+    let indexes = reader.indexes().ok_or_else(RpcError::not_found)?;
+
+    let highest_indexed = indexes
+        .get_highest_indexed_checkpoint_seq_number()
+        .map_err(|e| RpcError::new(tonic::Code::Internal, e.to_string()))?
+        .unwrap_or(0);
+
+    let lowest_available = reader
+        .get_lowest_available_checkpoint_objects()
+        .map_err(|e| RpcError::new(tonic::Code::Internal, e.to_string()))?;
+
+    if checkpoint_seq < lowest_available {
+        return Err(RpcError::new(
+            tonic::Code::NotFound,
+            format!(
+                "Requested checkpoint {} has been pruned. Lowest available checkpoint is {}",
+                checkpoint_seq, lowest_available
+            ),
+        ));
+    }
+
+    if checkpoint_seq > highest_indexed {
+        return Err(RpcError::new(
+            tonic::Code::NotFound,
+            format!(
+                "Requested checkpoint {} is not yet indexed. Highest indexed checkpoint is {}",
+                checkpoint_seq, highest_indexed
+            ),
+        ));
+    }
+
+    let checkpoint = reader
+        .get_checkpoint_by_sequence_number(checkpoint_seq)
+        .ok_or_else(|| {
+            RpcError::new(
+                tonic::Code::NotFound,
+                format!("checkpoint {} not found", checkpoint_seq),
+            )
+        })?;
+
+    let checkpoint_contents = reader
+        .get_checkpoint_contents_by_sequence_number(checkpoint_seq)
+        .ok_or_else(|| {
+            RpcError::new(
+                tonic::Code::NotFound,
+                format!("checkpoint contents for {} not found", checkpoint_seq),
+            )
+        })?;
+
+    let checkpoint_data = reader
+        .get_checkpoint_data(checkpoint, checkpoint_contents)
+        .map_err(|e| RpcError::new(tonic::Code::Internal, e.to_string()))?;
+
+    let (proto_inclusion_proof, object_ref) =
+        build_ocs_inclusion_proof(&checkpoint_data, object_id)?;
+
+    let object = reader
+        .get_object_by_key(&object_id, object_ref.1)
+        .ok_or_else(|| {
+            RpcError::new(
+                tonic::Code::NotFound,
+                format!("Object {} not found at version {}", object_id, object_ref.1),
+            )
+        })?;
+
+    debug_assert_eq!(
+        object.compute_object_reference().2,
+        object_ref.2,
+        "Object digest mismatch for object {} at version {}",
+        object_id,
+        object_ref.1
+    );
+
+    let object_data_bytes =
+        bcs::to_bytes(&object).map_err(|e| RpcError::new(tonic::Code::Internal, e.to_string()))?;
+
+    let mut obj_ref = sui_rpc::proto::sui::rpc::v2::ObjectReference::default();
+    obj_ref.object_id = Some(object_ref.0.to_string());
+    obj_ref.version = Some(object_ref.1.value());
+    obj_ref.digest = Some(object_ref.2.to_string());
+
+    Ok(GetObjectInclusionProofResponse {
+        object_ref: Some(obj_ref),
+        inclusion_proof: Some(proto_inclusion_proof),
+        object_data: Some(object_data_bytes),
+    })
+}

--- a/crates/sui-rpc-api/src/lib.rs
+++ b/crates/sui-rpc-api/src/lib.rs
@@ -135,6 +135,10 @@ impl RpcService {
                 crate::grpc::alpha::event_service_proto::event_service_server::EventServiceServer::new(
                     self.clone(),
                 );
+            let proof_service_alpha =
+                crate::grpc::alpha::proof_service_proto::proof_service_server::ProofServiceServer::new(
+                    crate::grpc::alpha::proof_service::ProofServiceImpl::new(self.clone()),
+                );
 
             let (health_reporter, health_service) = tonic_health::server::health_reporter();
 
@@ -178,6 +182,7 @@ impl RpcService {
                 service_name(&move_package_service),
                 service_name(&name_service),
                 service_name(&event_service_alpha),
+                service_name(&proof_service_alpha),
                 service_name(&reflection_v1),
                 service_name(&reflection_v1alpha),
             ] {
@@ -196,6 +201,7 @@ impl RpcService {
                 .add_service(name_service)
                 // alpha
                 .add_service(event_service_alpha)
+                .add_service(proof_service_alpha)
                 // Reflection
                 .add_service(reflection_v1)
                 .add_service(reflection_v1alpha);

--- a/crates/sui-rpc-api/src/proto/generated/sui.rpc.alpha.rs
+++ b/crates/sui-rpc-api/src/proto/generated/sui.rpc.alpha.rs
@@ -363,3 +363,358 @@ pub mod event_service_server {
         const NAME: &'static str = SERVICE_NAME;
     }
 }
+/// Object Checkpoint State inclusion proof.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct OcsInclusionProof {
+    /// BCS-encoded merkle proof nodes.
+    #[prost(bytes = "vec", optional, tag = "1")]
+    pub merkle_proof: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    /// Leaf index in the merkle tree.
+    #[prost(uint64, optional, tag = "2")]
+    pub leaf_index: ::core::option::Option<u64>,
+    /// Tree root digest (32 bytes).
+    #[prost(bytes = "vec", optional, tag = "3")]
+    pub tree_root: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+}
+/// Request for object inclusion proof at a checkpoint.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetObjectInclusionProofRequest {
+    /// Required. Object ID to get inclusion proof for.
+    #[prost(string, optional, tag = "1")]
+    pub object_id: ::core::option::Option<::prost::alloc::string::String>,
+    /// Required. Checkpoint sequence number.
+    #[prost(uint64, optional, tag = "2")]
+    pub checkpoint: ::core::option::Option<u64>,
+}
+/// Response containing object inclusion proof and object data.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetObjectInclusionProofResponse {
+    /// Object reference being proven (object_id, version, digest).
+    #[prost(message, optional, tag = "1")]
+    pub object_ref: ::core::option::Option<
+        ::sui_rpc::proto::sui::rpc::v2::ObjectReference,
+    >,
+    /// Object inclusion proof.
+    #[prost(message, optional, tag = "2")]
+    pub inclusion_proof: ::core::option::Option<OcsInclusionProof>,
+    /// BCS-encoded object data.
+    #[prost(bytes = "vec", optional, tag = "3")]
+    pub object_data: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+}
+/// Generated client implementations.
+pub mod proof_service_client {
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::wildcard_imports,
+        clippy::let_unit_value,
+    )]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    /// ProofService provides cryptographic proofs for blockchain objects.
+    #[derive(Debug, Clone)]
+    pub struct ProofServiceClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl ProofServiceClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> ProofServiceClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::Body>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> ProofServiceClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::Body>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::Body>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::Body>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+        {
+            ProofServiceClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        /// Returns an inclusion proof if a specified object id was written in a specified checkpoint.
+        pub async fn get_object_inclusion_proof(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetObjectInclusionProofRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetObjectInclusionProofResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/sui.rpc.alpha.ProofService/GetObjectInclusionProof",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "sui.rpc.alpha.ProofService",
+                        "GetObjectInclusionProof",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+pub mod proof_service_server {
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::wildcard_imports,
+        clippy::let_unit_value,
+    )]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with ProofServiceServer.
+    #[async_trait]
+    pub trait ProofService: std::marker::Send + std::marker::Sync + 'static {
+        /// Returns an inclusion proof if a specified object id was written in a specified checkpoint.
+        async fn get_object_inclusion_proof(
+            &self,
+            request: tonic::Request<super::GetObjectInclusionProofRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetObjectInclusionProofResponse>,
+            tonic::Status,
+        >;
+    }
+    /// ProofService provides cryptographic proofs for blockchain objects.
+    #[derive(Debug)]
+    pub struct ProofServiceServer<T> {
+        inner: Arc<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    impl<T> ProofServiceServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for ProofServiceServer<T>
+    where
+        T: ProofService,
+        B: Body + std::marker::Send + 'static,
+        B::Error: Into<StdError> + std::marker::Send + 'static,
+    {
+        type Response = http::Response<tonic::body::Body>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            match req.uri().path() {
+                "/sui.rpc.alpha.ProofService/GetObjectInclusionProof" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetObjectInclusionProofSvc<T: ProofService>(pub Arc<T>);
+                    impl<
+                        T: ProofService,
+                    > tonic::server::UnaryService<super::GetObjectInclusionProofRequest>
+                    for GetObjectInclusionProofSvc<T> {
+                        type Response = super::GetObjectInclusionProofResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::GetObjectInclusionProofRequest,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as ProofService>::get_object_inclusion_proof(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetObjectInclusionProofSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(
+                            tonic::body::Body::default(),
+                        );
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
+            }
+        }
+    }
+    impl<T> Clone for ProofServiceServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    /// Generated gRPC service name
+    pub const SERVICE_NAME: &str = "sui.rpc.alpha.ProofService";
+    impl<T> tonic::server::NamedService for ProofServiceServer<T> {
+        const NAME: &'static str = SERVICE_NAME;
+    }
+}


### PR DESCRIPTION
## Description 

Add a new API to fetch an object version at a given checkpoint sequence number along with an inclusion proof the object was written during that checkpoint sequence number.

## Test plan 

Light client e2e tested + get_object_inclusion_proof happy / unhappy cases

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
