### PR TITLE
Fix compiler warn in execution_time_estimator when running simtests

### DIFF
--- a/crates/sui-core/src/authority/execution_time_estimator.rs
+++ b/crates/sui-core/src/authority/execution_time_estimator.rs
@@ -5,7 +5,7 @@ use std::{
     collections::HashMap,
     hash::{Hash, Hasher},
     num::NonZeroUsize,
-    sync::{Arc, OnceLock, Weak},
+    sync::{Arc, Weak},
     time::{Duration, SystemTime},
 };
 
@@ -52,6 +52,7 @@ const OBJECT_UTILIZATION_METRIC_HASH_MODULUS: u8 = 32;
 ///    (enabled by default)
 #[cfg(not(msim))]
 fn antithesis_enable_injecting_synthetic_execution_time() -> bool {
+    use std::sync::OnceLock;
     static ENABLE_INJECTION: OnceLock<bool> = OnceLock::new();
     *ENABLE_INJECTION.get_or_init(|| {
         if !in_antithesis() {


### PR DESCRIPTION
## Description 

Fix compiler warn in execution_time_estimator when running simtests

## Test plan 

Ran simtest -> no compiler warn

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
