### PR TITLE
Update submask filter for balance_change in simulate transaction

### DIFF
--- a/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/simulate/mod.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/simulate/mod.rs
@@ -175,7 +175,7 @@ pub fn simulate_transaction(
         let mut message = ExecutedTransaction::default();
         let transaction = sui_sdk_types::Transaction::try_from(transaction)?;
 
-        message.balance_changes = read_mask
+        message.balance_changes = submask
             .contains(ExecutedTransaction::BALANCE_CHANGES_FIELD.name)
             .then(|| {
                 derive_balance_changes_2(&effects, &objects)

--- a/crates/sui-rpc-api/src/grpc/v2beta2/live_data_service/simulate/mod.rs
+++ b/crates/sui-rpc-api/src/grpc/v2beta2/live_data_service/simulate/mod.rs
@@ -186,7 +186,7 @@ pub fn simulate_transaction(
             .filter_map(|(object_ref, _owner, _kind)| objects.get(&object_ref.into()).cloned())
             .collect::<Vec<_>>();
 
-        message.balance_changes = read_mask
+        message.balance_changes = submask
             .contains(ExecutedTransaction::BALANCE_CHANGES_FIELD.name)
             .then(|| {
                 derive_balance_changes(&effects, &input_objects, &output_objects)


### PR DESCRIPTION
## Description 

Currently, the balance change is not returned in gRPC simulateTransaction when we defined the submask `transaction.balance_changes`.

The culprit is the filtering logic is not using `transaction` subtree, and it happened for both v2 and v2beta.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
