### PR TITLE
add bigtable app-profile-id support to bigtable reader

### DIFF
--- a/crates/sui-indexer-alt-reader/src/bigtable_reader.rs
+++ b/crates/sui-indexer-alt-reader/src/bigtable_reader.rs
@@ -66,7 +66,7 @@ impl BigtableReader {
                 bigtable_args.statement_timeout(),
                 client_name,
                 Some(registry),
-                bigtable_args.bigtable_app_profile_id.clone(),
+                bigtable_args.bigtable_app_profile_id,
             )
             .await
             .context("Failed to create BigTable client")?,


### PR DESCRIPTION
## Description 

Allow specifying bigtable app-profile-id for bigtable client.

## Test plan 

How did you test the new or updated feature?

ran jsonrpc-alt locally and verified I saw requests on different app-profiles as I tested queries.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
