### PR TITLE
[static-ptbs] Charge for size of linkages during translation

### DIFF
--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1994,6 +1994,7 @@
                 "translation_metering_step_resolution": null,
                 "translation_per_command_base_charge": null,
                 "translation_per_input_base_charge": null,
+                "translation_per_linkage_entry_charge": null,
                 "translation_per_reference_node_charge": null,
                 "translation_per_type_node_charge": null,
                 "translation_pure_input_per_byte_charge": null,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -1721,6 +1721,10 @@ pub struct ProtocolConfig {
     /// The metering step resolution for translation costs. This is the granularity at which we
     /// step up the metering for translation costs.
     translation_metering_step_resolution: Option<u64>,
+
+    /// The multiplier for each linkage entry when charging for linkage tables that we have
+    /// created.
+    translation_per_linkage_entry_charge: Option<u64>,
 }
 
 /// An aliased address.
@@ -2919,6 +2923,7 @@ impl ProtocolConfig {
             translation_per_type_node_charge: None,
             translation_per_reference_node_charge: None,
             translation_metering_step_resolution: None,
+            translation_per_linkage_entry_charge: None,
             // When adding a new constant, set it to None in the earliest version, like this:
             // new_constant: None,
         };
@@ -4442,6 +4447,7 @@ impl ProtocolConfig {
             self.translation_per_type_node_charge = Some(1);
             self.translation_per_reference_node_charge = Some(1);
             self.translation_metering_step_resolution = Some(1000);
+            self.translation_per_linkage_entry_charge = Some(10);
         }
     }
 

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/metering/translation_meter.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/metering/translation_meter.rs
@@ -71,6 +71,16 @@ impl<'pc, 'gas> TranslationMeter<'pc, 'gas> {
         self.charge(amount)
     }
 
+    pub fn charge_num_linkage_entries(
+        &mut self,
+        num_linkage_entries: usize,
+    ) -> Result<(), ExecutionError> {
+        let amount = (num_linkage_entries as u64)
+            .saturating_mul(self.protocol_config.translation_per_linkage_entry_charge())
+            .max(1);
+        self.charge(amount)
+    }
+
     // We use a non-linear cost function for type references to account for the increased
     // complexity they introduce. The cost is calculated as:
     // cost = (num_type_references * (num_type_references + 1)) / 2


### PR DESCRIPTION
## Description 

Add logic to charge for the size of the number of packages present in a linkage after loading a PTB. Note that this is for the total set of packages, and not just for the final linkage (in particular, we charge per-package, per-version, and not just for per-package that is present post linkage resolution). 

## Test plan 

CI. 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
