### PR TITLE
docs: add x-sui-rpc-request-id to graphql docs

### DIFF
--- a/docs/content/concepts/graphql-rpc.mdx
+++ b/docs/content/concepts/graphql-rpc.mdx
@@ -38,12 +38,14 @@ Switch any apps that still use the GraphQL Alpha endpoints (`https://sui-mainnet
 
 ## Headers
 
-The service accepts the following optional headers:
+The service accepts the following optional HTTP request headers:
 
 - `x-sui-rpc-version` to specify which RPC version to use (currently only one version is supported),
 - `x-sui-rpc-show-usage` returns the response with extra query complexity information.
 
-By default, each request returns the service's version in the response header: `x-sui-rpc-version`.
+By default, each response contains the following HTTP response headers:
+- `x-sui-rpc-request-id` a unique identifier for the request; appears in application logs for debugging.
+- `x-sui-rpc-version` the version of the service that handled the request.
 
 ```sh
 $ curl -i -X POST https://graphql.testnet.sui.io/graphql\
@@ -60,6 +62,7 @@ The response for the previous request looks similar to the following:
 HTTP/2 200 
 content-type: application/json
 content-length: 179
+x-sui-rpc-request-id: f5442058-47ab-4360-8295-61c009f38516
 x-sui-rpc-version: 1.56.1-
 vary: origin, access-control-request-method, access-control-request-headers
 access-control-allow-origin: *


### PR DESCRIPTION
## Description 

Updates docs with `x-sui-rpc-request-id` response header added here #23604.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
