### PR TITLE
allow reuse of the executor across transaction

### DIFF
--- a/crates/sui-replay-2/src/replay_txn.rs
+++ b/crates/sui-replay-2/src/replay_txn.rs
@@ -47,6 +47,50 @@ pub type PackageVersion = u64;
 
 // moved to summary_metrics.rs
 
+/// Provides executors for transaction replay, with optional caching.
+/// When caching is enabled, executors are cached per protocol version to avoid recreation.
+/// When caching is disabled, a fresh executor is created for each transaction.
+pub struct ExecutorProvider {
+    cache: BTreeMap<u64, ReplayExecutor>, // u64 is protocol version
+    cache_enabled: bool,
+}
+
+impl ExecutorProvider {
+    pub fn new(cache_enabled: bool) -> Self {
+        Self {
+            cache: BTreeMap::new(),
+            cache_enabled,
+        }
+    }
+
+    /// Get or create an executor for the given epoch.
+    /// If caching is disabled, always creates a new executor.
+    /// If caching is enabled, reuses cached executors (by protocol version) or creates and caches new ones.
+    pub fn get_or_create(
+        &mut self,
+        epoch: u64,
+        epoch_store: &dyn EpochStore,
+    ) -> anyhow::Result<ReplayExecutor> {
+        let protocol_config = epoch_store
+            .protocol_config(epoch)?
+            .ok_or_else(|| anyhow!("Protocol config missing for epoch {}", epoch))?;
+
+        if !self.cache_enabled {
+            return ReplayExecutor::new(protocol_config);
+        }
+
+        let protocol_version = protocol_config.version.as_u64();
+
+        if let Some(executor) = self.cache.get(&protocol_version) {
+            return Ok(executor.clone());
+        }
+
+        let executor = ReplayExecutor::new(protocol_config)?;
+        self.cache.insert(protocol_version, executor.clone());
+        Ok(executor)
+    }
+}
+
 // `ReplayTransaction` contains all the data needed to replay a transaction.
 // The `object_cache` will contain all the objects and packages touched by the transaction.
 pub struct ReplayTransaction {
@@ -68,11 +112,18 @@ pub(crate) async fn replay_transaction<S: ReadDataStore>(
     data_store: &S,
     network: String,
     trace: bool,
+    executor_provider: &mut ExecutorProvider,
 ) -> Result<u128> {
     let _span = info_span!("replay_tx", tx_digest = %tx_digest).entered();
     // load a `ReplayTransaction`
     tx_metrics_reset();
-    let replay_txn = match ReplayTransaction::load(tx_digest, data_store, data_store, data_store) {
+    let replay_txn = match ReplayTransaction::load(
+        tx_digest,
+        data_store,
+        data_store,
+        data_store,
+        executor_provider,
+    ) {
         Ok(replay_txn) => replay_txn,
         Err(e) => {
             bail!("Failed to load transaction {}: {:?}", tx_digest, e);
@@ -221,6 +272,7 @@ impl ReplayTransaction {
         txn_store: &dyn TransactionStore,
         epoch_store: &dyn EpochStore,
         object_store: &dyn ObjectStore,
+        executor_provider: &mut ExecutorProvider,
     ) -> Result<Self, Error> {
         debug!(op = "load_tx", phase = "start", tx_digest = %tx_digest, "load transaction");
 
@@ -242,20 +294,9 @@ impl ReplayTransaction {
         let object_cache = load_transaction_objects(&txn_data, &effects, checkpoint, object_store)?;
 
         //
-        // instantiate the executor
+        // get or create the executor for this epoch
         let epoch = effects.executed_epoch();
-        let protocol_config = match epoch_store.protocol_config(epoch) {
-            Ok(Some(pc)) => pc,
-            Ok(None) => {
-                error!("Protocol config missing for epoch {}", epoch);
-                return Err(anyhow!("Protocol config missing for epoch {}", epoch));
-            }
-            Err(e) => {
-                error!("Failed to get protocol config for epoch {}: {:?}", epoch, e);
-                return Err(e);
-            }
-        };
-        let executor = ReplayExecutor::new(protocol_config).unwrap_or_else(|e| panic!("{:?}", e));
+        let executor = executor_provider.get_or_create(epoch, epoch_store)?;
 
         debug!(op = "load_tx", phase = "end", tx_digest = %tx_digest, "load transaction");
 
@@ -287,6 +328,106 @@ impl ReplayTransaction {
 
     pub fn checkpoint(&self) -> u64 {
         self.checkpoint
+    }
+
+    pub fn digest(&self) -> &TransactionDigest {
+        &self.digest
+    }
+
+    // Get `InputObjects` from a set of (ObjectId, version) pairs, where version is a u64.
+    // This is currently called from `execute_transaction_to_effects` but it could
+    // be computed for a `ReplayTransaction` and cached.
+    pub fn get_input_objects_for_replay(&self) -> Result<InputObjects, anyhow::Error> {
+        let _deleted_shared_info_map: BTreeMap<ObjectID, (TransactionDigest, SequenceNumber)> =
+            BTreeMap::new();
+        let mut resolved_input_objs = vec![];
+        let input_objects_kind = self.txn_data.input_objects().context(format!(
+            "Failed to get input objects from transaction {}",
+            self.digest,
+        ))?;
+        for kind in input_objects_kind.iter() {
+            match kind {
+                InputObjectKind::MovePackage(pkg_id) => {
+                    self
+                        .object_cache
+                        .get(pkg_id)
+                        .map(|pkgs| {
+                            debug_assert!(
+                                pkgs.len() == 1,
+                                "Expected only one version for package {}",
+                                pkg_id
+                            );
+                            let (_version, pkg) = pkgs.iter().next().unwrap();
+                            resolved_input_objs.push(ObjectReadResult {
+                                input_object_kind: *kind,
+                                object: ObjectReadResultKind::Object(pkg.clone()),
+                            })
+                        })
+                        .ok_or_else(|| anyhow::anyhow!(
+                            format!(
+                                "Package {} not found in transaction cache. Should have been loaded already",
+                                pkg_id,
+                            )
+                        ))?;
+                }
+                InputObjectKind::ImmOrOwnedMoveObject((obj_id, version, _digest)) => {
+                    let object = self
+                        .object_cache
+                        .get(obj_id)
+                        .ok_or_else(|| anyhow::anyhow!(
+                            format!(
+                                "Object id {}[{}] not found in transaction cache. Should have been loaded already",
+                                obj_id, version,
+                            )
+                        ))?
+                        .get(&version.value())
+                        .ok_or_else(|| anyhow::anyhow!(
+                            format!(
+                                "Object version {}[{}] not found in transaction cache. Should have been loaded already",
+                                obj_id, version,
+                            )
+                        ))?;
+                    let input_object_kind =
+                        InputObjectKind::ImmOrOwnedMoveObject(object.compute_object_reference());
+                    resolved_input_objs.push(ObjectReadResult {
+                        input_object_kind,
+                        object: ObjectReadResultKind::Object(object.clone()),
+                    });
+                }
+                InputObjectKind::SharedMoveObject {
+                    id,
+                    initial_shared_version,
+                    mutability,
+                } => {
+                    let input_object_kind = InputObjectKind::SharedMoveObject {
+                        id: *id,
+                        initial_shared_version: *initial_shared_version,
+                        mutability: *mutability,
+                    };
+                    let versions =
+                        self.object_cache
+                            .get(id)
+                            .ok_or_else(|| anyhow::anyhow!(
+                                format!(
+                                    "Shared Object id {} not found in transaction cache. Should have been loaded already",
+                                    id,
+                                )
+                            ))?;
+                    debug_assert!(
+                        versions.len() == 1,
+                        "Expected only one version for shared object {}",
+                        id
+                    );
+                    let (_version, obj) = versions.iter().next().unwrap();
+                    resolved_input_objs.push(ObjectReadResult {
+                        input_object_kind,
+                        object: ObjectReadResultKind::Object(obj.clone()),
+                    });
+                }
+            }
+        }
+        trace!("resolved input objects: {:#?}", resolved_input_objs);
+        Ok(InputObjects::new(resolved_input_objs))
     }
 }
 
@@ -545,108 +686,6 @@ fn get_effects_ids(effects: &TransactionEffects) -> Result<BTreeSet<ObjectKey>, 
             }
         });
     Ok(object_keys)
-}
-
-//
-// `InputObjects` for `execute_transaction_to_effects`
-//
-
-// Get `InputObjects` from a set of (ObjectId, version) pairs, where version is a u64.
-// This is currently called from `execute_transaction_to_effects` but it could
-// be computed for a `ReplayTransactoin` and cached.
-pub fn get_input_objects_for_replay(
-    txn: &TransactionData,
-    tx_digest: &TransactionDigest,
-    object_cache: &BTreeMap<ObjectID, BTreeMap<u64, Object>>, // objects used by the transaction
-) -> Result<InputObjects, Error> {
-    let _deleted_shared_info_map: BTreeMap<ObjectID, (TransactionDigest, SequenceNumber)> =
-        BTreeMap::new();
-    let mut resolved_input_objs = vec![];
-    let input_objects_kind = txn.input_objects().context(format!(
-        "Failed to get input objects from transaction {}",
-        tx_digest
-    ))?;
-    for kind in input_objects_kind.iter() {
-        match kind {
-            InputObjectKind::MovePackage(pkg_id) => {
-                object_cache
-                    .get(pkg_id)
-                    .map(|pkgs| {
-                        debug_assert!(
-                            pkgs.len() == 1,
-                            "Expected only one version for package {}",
-                            pkg_id
-                        );
-                        let (_version, pkg) = pkgs.iter().next().unwrap();
-                        resolved_input_objs.push(ObjectReadResult {
-                            input_object_kind: *kind,
-                            object: ObjectReadResultKind::Object(pkg.clone()),
-                        })
-                    })
-                    .ok_or_else(|| anyhow!(
-                        format!(
-                            "Package {} not found in transaction cache. Should have been loaded already",
-                            pkg_id,
-                        )
-                    ))?;
-            }
-            InputObjectKind::ImmOrOwnedMoveObject((obj_id, version, _digest)) => {
-                let object = object_cache
-                    .get(obj_id)
-                    .ok_or_else(|| anyhow!(
-                        format!(
-                            "Object id {}[{}] not found in transaction cache. Should have been loaded already",
-                            obj_id, version,
-                        )
-                    ))?
-                    .get(&version.value())
-                    .ok_or_else(|| anyhow!(
-                        format!(
-                            "Object version {}[{}] not found in transaction cache. Should have been loaded already",
-                            obj_id, version,
-                        )
-                    ))?;
-                let input_object_kind =
-                    InputObjectKind::ImmOrOwnedMoveObject(object.compute_object_reference());
-                resolved_input_objs.push(ObjectReadResult {
-                    input_object_kind,
-                    object: ObjectReadResultKind::Object(object.clone()),
-                });
-            }
-            InputObjectKind::SharedMoveObject {
-                id,
-                initial_shared_version,
-                mutability,
-            } => {
-                let input_object_kind = InputObjectKind::SharedMoveObject {
-                    id: *id,
-                    initial_shared_version: *initial_shared_version,
-                    mutability: *mutability,
-                };
-                let versions =
-                    object_cache
-                        .get(id)
-                        .ok_or_else(|| anyhow!(
-                            format!(
-                                "Shared Object id {} not found in transaction cache. Should have been loaded already",
-                                id,
-                            )
-                        ))?;
-                debug_assert!(
-                    versions.len() == 1,
-                    "Expected only one version for shared object {}",
-                    id
-                );
-                let (_version, obj) = versions.iter().next().unwrap();
-                resolved_input_objs.push(ObjectReadResult {
-                    input_object_kind,
-                    object: ObjectReadResultKind::Object(obj.clone()),
-                });
-            }
-        }
-    }
-    trace!("resolved input objects: {:#?}", resolved_input_objs);
-    Ok(InputObjects::new(resolved_input_objs))
 }
 
 // get the package info from the type tag and insert the packages of the type tags (if any)


### PR DESCRIPTION
## Description 

When running multiple transaction is helpful to reuse the executors so the VM is reused. 
That speeds up execution but it is particularly helpful to check the behavior of the new VM.
So adding a flag that allows caching of execution.
On 1000 transaction executed (from interesting transactions) the time with and without caching is the following
without cache
Replay run: tx_count=1000 success=1000 failure=0 - exec_ms=36299, total_ms=84993
with cache
Replay run: tx_count=1000 success=1000 failure=0 - exec_ms=10554, total_ms=54759

## Test plan 

Manual run

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
