### PR TITLE
Add ExecutionOutput to support Paused execution

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -1711,9 +1711,9 @@ impl AuthorityPerEpochStore {
         )
     }
 
-    pub fn acquire_tx_guard(&self, cert: &VerifiedExecutableTransaction) -> SuiResult<CertTxGuard> {
+    pub fn acquire_tx_guard(&self, cert: &VerifiedExecutableTransaction) -> CertTxGuard {
         let digest = cert.digest();
-        Ok(CertTxGuard(self.acquire_tx_lock(digest)))
+        CertTxGuard(self.acquire_tx_lock(digest))
     }
 
     /// Acquire the lock for a tx without writing to the WAL.
@@ -2455,8 +2455,8 @@ impl AuthorityPerEpochStore {
             && self.randomness_state_enabled()
             && cert.transaction_data().uses_randomness()
         {
-            // TODO(commit-handler-rewrite): propogate original deferred_from_round when re-deferring
-            // DONE(commit-handler-rewrite): propogate original deferred_from_round when re-deferring
+            // TODO(commit-handler-rewrite): propagate original deferred_from_round when re-deferring
+            // DONE(commit-handler-rewrite): propagate original deferred_from_round when re-deferring
             // (TODO and DONE are in same place because this code is shared between old and new commit handler)
             let deferred_from_round = previously_deferred_tx_digests
                 .get(cert.digest())
@@ -3714,7 +3714,7 @@ impl AuthorityPerEpochStore {
         }
 
         {
-            // TODO(commit-handler-rewrite): propogate deferral deletion to consensus output cache
+            // TODO(commit-handler-rewrite): propagate deferral deletion to consensus output cache
             let mut deferred_transactions =
                 self.consensus_output_cache.deferred_transactions.lock();
             for deleted_deferred_key in output.get_deleted_deferred_txn_keys() {

--- a/crates/sui-core/src/authority/authority_test_utils.rs
+++ b/crates/sui-core/src/authority/authority_test_utils.rs
@@ -129,7 +129,7 @@ pub async fn execute_certificate_with_execution_error(
             &certificate,
             ExecutionEnv::new().with_assigned_versions(assigned_versions.clone()),
         )
-        .await?;
+        .await;
     let state_after =
         state_acc.accumulate_cached_live_object_set_for_testing(include_wrapped_tombstone);
     let effects_acc = state_acc.accumulate_effects(
@@ -146,7 +146,7 @@ pub async fn execute_certificate_with_execution_error(
                 &certificate,
                 ExecutionEnv::new().with_assigned_versions(assigned_versions),
             )
-            .await?;
+            .await;
     }
     Ok((
         certificate.into_inner(),
@@ -408,7 +408,7 @@ pub async fn execute_sequenced_certificate_to_effects(
     authority: &AuthorityState,
     certificate: VerifiedCertificate,
     assigned_versions: AssignedVersions,
-) -> Result<(TransactionEffects, Option<ExecutionError>), SuiError> {
+) -> (TransactionEffects, Option<ExecutionError>) {
     let env = ExecutionEnv::new().with_assigned_versions(assigned_versions);
     authority.execution_scheduler.enqueue(
         vec![(
@@ -418,9 +418,9 @@ pub async fn execute_sequenced_certificate_to_effects(
         &authority.epoch_store_for_testing(),
     );
 
-    let (result, execution_error_opt) = authority.try_execute_for_test(&certificate, env).await?;
+    let (result, execution_error_opt) = authority.try_execute_for_test(&certificate, env).await;
     let effects = result.inner().data().clone();
-    Ok((effects, execution_error_opt))
+    (effects, execution_error_opt)
 }
 
 pub async fn send_consensus(

--- a/crates/sui-core/src/test_utils.rs
+++ b/crates/sui-core/src/test_utils.rs
@@ -74,7 +74,7 @@ pub async fn send_and_confirm_transaction(
         state_acc.accumulate_cached_live_object_set_for_testing(include_wrapped_tombstone);
     let (result, _execution_error_opt) = authority
         .try_execute_for_test(&certificate, ExecutionEnv::new())
-        .await?;
+        .await;
     let state_after =
         state_acc.accumulate_cached_live_object_set_for_testing(include_wrapped_tombstone);
     let effects_acc = state_acc.accumulate_effects(
@@ -88,7 +88,7 @@ pub async fn send_and_confirm_transaction(
     if let Some(fullnode) = fullnode {
         fullnode
             .try_execute_for_test(&certificate, ExecutionEnv::new())
-            .await?;
+            .await;
     }
     Ok((certificate.into_inner(), result.into_inner()))
 }

--- a/crates/sui-core/src/unit_tests/authority_tests.rs
+++ b/crates/sui-core/src/unit_tests/authority_tests.rs
@@ -3634,7 +3634,6 @@ async fn create_and_retrieve_df_info(function: &IdentStr) -> (SuiAddress, Vec<Dy
     let add_effects = authority_state
         .try_execute_for_test(&add_cert, ExecutionEnv::new())
         .await
-        .unwrap()
         .0
         .into_message();
 
@@ -4982,8 +4981,7 @@ async fn test_shared_object_transaction_ok() {
             &certificate,
             ExecutionEnv::new().with_assigned_versions(assigned_versions),
         )
-        .await
-        .unwrap();
+        .await;
 
     // Ensure transaction effects are available.
     authority
@@ -5179,8 +5177,7 @@ async fn test_consensus_message_processed() {
                 &certificate,
                 ExecutionEnv::new().with_assigned_versions(assigned_versions),
             )
-            .await
-            .unwrap();
+            .await;
 
         // now, on authority2, we send 0 or 1 consensus messages, then we either sequence and execute via
         // effects or via handle_certificate_v2, then send 0 or 1 consensus messages.
@@ -5198,7 +5195,6 @@ async fn test_consensus_message_processed() {
                     ExecutionEnv::new().with_assigned_versions(assigned_versions2.unwrap()),
                 )
                 .await
-                .unwrap()
                 .0
                 .into_message()
         } else {
@@ -5215,8 +5211,7 @@ async fn test_consensus_message_processed() {
                     &certificate,
                     ExecutionEnv::new().with_assigned_versions(assigned_versions),
                 )
-                .await
-                .unwrap();
+                .await;
             authority2
                 .get_transaction_cache_reader()
                 .get_executed_effects(transaction_digest)
@@ -6739,12 +6734,10 @@ async fn test_insufficient_balance_for_withdraw_early_error() {
     execution_env.withdraw_status = BalanceWithdrawStatus::InsufficientBalance;
 
     // Test that the transaction fails with InsufficientBalanceForWithdraw error
-    let result = state
+    let (effects, execution_error) = state
         .try_execute_immediately(&certificate, execution_env, &epoch_store)
         .await
         .unwrap();
-
-    let (effects, execution_error) = result;
 
     // Check that we got an execution error due to insufficient balance
     assert!(execution_error.is_some());

--- a/crates/sui-core/src/unit_tests/congestion_control_tests.rs
+++ b/crates/sui-core/src/unit_tests/congestion_control_tests.rs
@@ -361,8 +361,7 @@ async fn test_congestion_control_execution_cancellation() {
     let execution_env = ExecutionEnv::new().with_assigned_versions(assigned_versions);
     let (effects_2, execution_error) = authority_state_2
         .try_execute_for_test(&cert, execution_env)
-        .await
-        .unwrap();
+        .await;
 
     // Should result in the same cancellation.
     assert_eq!(

--- a/crates/sui-core/src/unit_tests/shared_object_deletion_tests.rs
+++ b/crates/sui-core/src/unit_tests/shared_object_deletion_tests.rs
@@ -146,8 +146,7 @@ impl TestRunner {
 
             let _ = self
                 .execute_sequenced_certificate_to_effects(mutate_obj_cert, assigned_versions)
-                .await
-                .unwrap();
+                .await;
 
             n -= 1;
         }
@@ -566,7 +565,7 @@ impl TestRunner {
         &mut self,
         certificate: VerifiedCertificate,
         assigned_versions: AssignedVersions,
-    ) -> Result<(TransactionEffects, Option<ExecutionError>), SuiError> {
+    ) -> (TransactionEffects, Option<ExecutionError>) {
         execute_sequenced_certificate_to_effects(
             &self.authority_state,
             certificate,
@@ -607,8 +606,7 @@ async fn test_delete_shared_object() {
 
     let (effects, error) = user1
         .execute_sequenced_certificate_to_effects(cert, assigned_versions)
-        .await
-        .unwrap();
+        .await;
 
     assert!(error.is_none());
 
@@ -664,8 +662,7 @@ async fn test_delete_shared_object_immut() {
 
     let (effects, _) = user1
         .execute_sequenced_certificate_to_effects(cert, assigned_versions)
-        .await
-        .unwrap();
+        .await;
 
     assert!(effects.status().is_err());
 
@@ -718,8 +715,7 @@ async fn test_delete_shared_object_immut_mut_mut_interleave() {
     // Try and delete the shared object with the object passed as non-mutable
     let (effects, _) = user1
         .execute_sequenced_certificate_to_effects(cert_immut1, assigned_versions_immut1)
-        .await
-        .unwrap();
+        .await;
 
     assert!(effects.status().is_err());
 
@@ -734,8 +730,7 @@ async fn test_delete_shared_object_immut_mut_mut_interleave() {
     // Now do an actual deletion
     let (effects, error) = user1
         .execute_sequenced_certificate_to_effects(cert, assigned_versions)
-        .await
-        .unwrap();
+        .await;
 
     assert!(error.is_none());
     assert_eq!(effects.deleted().len(), 1);
@@ -771,8 +766,7 @@ async fn test_delete_shared_object_immut_mut_mut_interleave() {
     // Try to delete again with the object passed as mutable and make sure we get `InputObjectDeleted`.
     let (effects, _) = user1
         .execute_sequenced_certificate_to_effects(cert_immut2, assigned_versions_immut2)
-        .await
-        .unwrap();
+        .await;
 
     assert!(effects.status().is_err());
     assert_eq!(
@@ -810,8 +804,7 @@ async fn test_delete_shared_object_immut_mut_immut_interleave() {
 
     let (effects, _) = user1
         .execute_sequenced_certificate_to_effects(cert_immut1, assigned_versions_immut1)
-        .await
-        .unwrap();
+        .await;
 
     assert!(effects.status().is_err());
 
@@ -836,8 +829,7 @@ async fn test_delete_shared_object_immut_mut_immut_interleave() {
 
     let (effects, error) = user1
         .execute_sequenced_certificate_to_effects(cert, assigned_versions)
-        .await
-        .unwrap();
+        .await;
 
     assert!(error.is_none());
 
@@ -873,8 +865,7 @@ async fn test_delete_shared_object_immut_mut_immut_interleave() {
 
     let (effects, _) = user1
         .execute_sequenced_certificate_to_effects(cert_immut2, assigned_versions_immut2)
-        .await
-        .unwrap();
+        .await;
 
     assert!(effects.status().is_err());
 }
@@ -910,15 +901,13 @@ async fn test_mutate_after_delete() {
 
     let (orig_effects, _error) = user_1
         .execute_sequenced_certificate_to_effects(delete_cert, assigned_versions_delete)
-        .await
-        .unwrap();
+        .await;
 
     let digest = orig_effects.transaction_digest();
 
     let (effects, error) = user_1
         .execute_sequenced_certificate_to_effects(mutate_cert, assigned_versions_mutate)
-        .await
-        .unwrap();
+        .await;
 
     assert!(matches!(error.unwrap().kind(), InputObjectDeleted));
     assert!(effects.status().is_err());
@@ -965,15 +954,13 @@ async fn test_delete_after_delete() {
 
     let (orig_effects, _error) = user_1
         .execute_sequenced_certificate_to_effects(delete_cert0, assigned_versions_delete0)
-        .await
-        .unwrap();
+        .await;
 
     let digest = orig_effects.transaction_digest();
 
     let (effects, error) = user_1
         .execute_sequenced_certificate_to_effects(delete_cert1, assigned_versions_delete1)
-        .await
-        .unwrap();
+        .await;
 
     assert!(matches!(error.unwrap().kind(), InputObjectDeleted));
     assert!(effects.status().is_err());
@@ -1588,8 +1575,7 @@ async fn test_wrap_not_allowed() {
 
     let (effects, error) = user_1
         .execute_sequenced_certificate_to_effects(wrap_cert, assigned_versions)
-        .await
-        .unwrap();
+        .await;
 
     assert!(matches!(
         error.unwrap().kind(),
@@ -1623,8 +1609,7 @@ async fn test_vec_delete() {
 
     let (_effects, error) = user_1
         .execute_sequenced_certificate_to_effects(cert, assigned_versions)
-        .await
-        .unwrap();
+        .await;
 
     assert!(error.is_none());
 }
@@ -1648,8 +1633,7 @@ async fn test_convert_to_owned_not_allowed() {
 
     let (effects, error) = user_1
         .execute_sequenced_certificate_to_effects(cert, assigned_versions)
-        .await
-        .unwrap();
+        .await;
 
     assert!(matches!(
         error.unwrap().kind(),
@@ -1680,8 +1664,7 @@ async fn test_freeze_not_allowed() {
 
     let (effects, error) = user_1
         .execute_sequenced_certificate_to_effects(cert, assigned_versions)
-        .await
-        .unwrap();
+        .await;
 
     assert!(matches!(
         error.unwrap().kind(),
@@ -1724,13 +1707,11 @@ async fn test_deletion_twice() {
 
     let (_effects, _error) = user_1
         .execute_sequenced_certificate_to_effects(delete_cert, delete_assigned_versions)
-        .await
-        .unwrap();
+        .await;
 
     let (effects, error) = user_1
         .execute_sequenced_certificate_to_effects(delete_cert_2, delete_assigned_versions_2)
-        .await
-        .unwrap();
+        .await;
 
     assert!(matches!(error.unwrap().kind(), InputObjectDeleted));
 
@@ -1761,8 +1742,7 @@ async fn test_certs_fail_after_delete() {
 
     let (_effects, _error) = user_1
         .execute_sequenced_certificate_to_effects(delete_cert, delete_assigned_versions)
-        .await
-        .unwrap();
+        .await;
 
     let mutate_obj_tx = user_1
         .mutate_shared_obj_tx(shared_obj_id, initial_shared_version)
@@ -1820,15 +1800,13 @@ async fn test_delete_before_two_mutations() {
 
     let (delete_effects, _error) = user_1
         .execute_sequenced_certificate_to_effects(delete_cert, delete_assigned_versions)
-        .await
-        .unwrap();
+        .await;
 
     let delete_digest = delete_effects.transaction_digest();
 
     let (effects, error) = user_1
         .execute_sequenced_certificate_to_effects(mutate_cert_1, mutate_assigned_versions_1)
-        .await
-        .unwrap();
+        .await;
 
     assert!(matches!(error.unwrap().kind(), InputObjectDeleted));
     assert!(effects.status().is_err());
@@ -1846,8 +1824,7 @@ async fn test_delete_before_two_mutations() {
 
     let (effects, error) = user_1
         .execute_sequenced_certificate_to_effects(mutate_cert_2, mutate_assigned_versions_2)
-        .await
-        .unwrap();
+        .await;
 
     assert!(matches!(error.unwrap().kind(), InputObjectDeleted));
     assert!(effects.status().is_err());
@@ -1935,16 +1912,14 @@ async fn test_owned_object_version_increments_on_cert_denied() {
 
     user_1
         .execute_sequenced_certificate_to_effects(delete_cert, delete_assigned_versions)
-        .await
-        .unwrap();
+        .await;
 
     let version = user_1.get_object_latest_version(owned_obj_id);
     assert_eq!(version, 4.into());
 
     user_1
         .execute_sequenced_certificate_to_effects(mutate_cert, mutate_assigned_versions)
-        .await
-        .unwrap();
+        .await;
 
     let next_version = user_1.get_object_latest_version(owned_obj_id);
     assert_eq!(next_version, 5.into());
@@ -1995,18 +1970,15 @@ async fn test_interspersed_mutations_with_delete() {
 
     let (_effects, _error) = user_1
         .execute_sequenced_certificate_to_effects(mutate_cert_1, mutate_assigned_versions_1)
-        .await
-        .unwrap();
+        .await;
 
     let (_effects, _error) = user_1
         .execute_sequenced_certificate_to_effects(delete_cert, delete_assigned_versions)
-        .await
-        .unwrap();
+        .await;
 
     let (effects, error) = user_1
         .execute_sequenced_certificate_to_effects(mutate_cert_2, mutate_assigned_versions_2)
-        .await
-        .unwrap();
+        .await;
 
     assert!(matches!(error.unwrap().kind(), InputObjectDeleted));
     assert!(effects.status().is_err());

--- a/crates/sui-core/src/unit_tests/transaction_deny_tests.rs
+++ b/crates/sui-core/src/unit_tests/transaction_deny_tests.rs
@@ -477,10 +477,7 @@ async fn test_certificate_deny() {
         CertifiedTransaction::new(tx.into_message(), vec![signature], epoch_store.committee())
             .unwrap(),
     );
-    let (effects, _) = state
-        .try_execute_for_test(&cert, ExecutionEnv::new())
-        .await
-        .unwrap();
+    let (effects, _) = state.try_execute_for_test(&cert, ExecutionEnv::new()).await;
     assert!(matches!(
         effects.status(),
         &ExecutionStatus::Failure {

--- a/crates/sui-core/src/validator_tx_finalizer.rs
+++ b/crates/sui-core/src/validator_tx_finalizer.rs
@@ -376,7 +376,8 @@ mod tests {
                     ExecutionEnv::new().with_scheduling_source(SchedulingSource::NonFastPath),
                     &epoch_store,
                 )
-                .await?;
+                .await
+                .unwrap();
             let events = if effects.events_digest().is_some() {
                 self.authority
                     .get_transaction_events(effects.transaction_digest())?


### PR DESCRIPTION
## Description 

This PR changes the result from execution to an enum. This allows us add a Paused variant to the result, which we will need when we implement object balance withdraws.
As part of this change we also made some simplifications to the error path:
1. Consolidated the epoch end error case
2. Make the execution for testing case infallable.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
