### PR TITLE
[state sync] use genesis digest passed from node config

### DIFF
--- a/crates/sui-network/src/state_sync/builder.rs
+++ b/crates/sui-network/src/state_sync/builder.rs
@@ -14,6 +14,7 @@ use std::{
 };
 use sui_config::node::ArchiveReaderConfig;
 use sui_config::p2p::StateSyncConfig;
+use sui_types::digests::CheckpointDigest;
 use sui_types::messages_checkpoint::VerifiedCheckpoint;
 use sui_types::storage::WriteStore;
 use tap::Pipe;
@@ -27,16 +28,18 @@ pub struct Builder<S> {
     config: Option<StateSyncConfig>,
     metrics: Option<Metrics>,
     archive_config: Option<ArchiveReaderConfig>,
+    genesis_checkpoint_digest: CheckpointDigest,
 }
 
 impl Builder<()> {
     #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+    pub fn new(genesis_checkpoint_digest: CheckpointDigest) -> Self {
         Self {
             store: None,
             config: None,
             metrics: None,
             archive_config: None,
+            genesis_checkpoint_digest,
         }
     }
 }
@@ -48,6 +51,7 @@ impl<S> Builder<S> {
             config: self.config,
             metrics: self.metrics,
             archive_config: self.archive_config,
+            genesis_checkpoint_digest: self.genesis_checkpoint_digest,
         }
     }
 
@@ -125,6 +129,7 @@ where
             config,
             metrics,
             archive_config,
+            genesis_checkpoint_digest,
         } = self;
         let store = store.unwrap();
         let config = config.unwrap_or_default();
@@ -165,6 +170,7 @@ where
                 checkpoint_event_sender,
                 metrics,
                 archive_config,
+                genesis_checkpoint_digest,
             },
             server,
         )
@@ -181,6 +187,7 @@ pub struct UnstartedStateSync<S> {
     pub(super) checkpoint_event_sender: broadcast::Sender<VerifiedCheckpoint>,
     pub(super) metrics: Metrics,
     pub(super) archive_config: Option<ArchiveReaderConfig>,
+    pub(super) genesis_checkpoint_digest: CheckpointDigest,
 }
 
 impl<S> UnstartedStateSync<S>
@@ -198,6 +205,7 @@ where
             checkpoint_event_sender,
             metrics,
             archive_config,
+            genesis_checkpoint_digest,
         } = self;
 
         (
@@ -216,6 +224,7 @@ where
                 metrics,
                 sync_checkpoint_from_archive_task: None,
                 archive_config,
+                genesis_checkpoint_digest,
             },
             handle,
         )

--- a/crates/sui-network/src/state_sync/mod.rs
+++ b/crates/sui-network/src/state_sync/mod.rs
@@ -380,6 +380,7 @@ struct StateSyncEventLoop<S> {
 
     sync_checkpoint_from_archive_task: Option<AbortHandle>,
     archive_config: Option<ArchiveReaderConfig>,
+    genesis_checkpoint_digest: CheckpointDigest,
 }
 
 impl<S> StateSyncEventLoop<S>
@@ -630,13 +631,8 @@ where
 
     fn spawn_get_latest_from_peer(&mut self, peer_id: PeerId) {
         if let Some(peer) = self.network.peer(peer_id) {
-            let genesis_checkpoint_digest = *self
-                .store
-                .get_checkpoint_by_sequence_number(0)
-                .expect("store should contain genesis checkpoint")
-                .digest();
             let task = get_latest_from_peer(
-                genesis_checkpoint_digest,
+                self.genesis_checkpoint_digest,
                 peer,
                 self.peer_heights.clone(),
                 self.config.timeout(),

--- a/crates/sui-network/src/state_sync/tests.rs
+++ b/crates/sui-network/src/state_sync/tests.rs
@@ -45,7 +45,9 @@ async fn server_push_checkpoint() {
             ..
         },
         server,
-    ) = Builder::new().store(store).build_internal();
+    ) = Builder::new(*ordered_checkpoints.first().unwrap().digest())
+        .store(store)
+        .build_internal();
     let peer_id = PeerId([9; 32]); // fake PeerId
 
     peer_heights.write().unwrap().peers.insert(
@@ -102,7 +104,7 @@ async fn server_get_checkpoint() {
     let (ordered_checkpoints, _, _sequence_number_to_digest, _checkpoints) =
         committee.make_empty_checkpoints(3, None);
 
-    let (builder, server) = Builder::new()
+    let (builder, server) = Builder::new(*ordered_checkpoints.first().unwrap().digest())
         .store(SharedInMemoryStore::default())
         .build_internal();
 
@@ -185,12 +187,17 @@ async fn isolated_sync_job() {
     // build mock data
     let (ordered_checkpoints, _, sequence_number_to_digest, checkpoints) =
         committee.make_empty_checkpoints(100, None);
+    let genesis_digest = *ordered_checkpoints.first().unwrap().digest();
 
     // Build and connect two nodes
-    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
+    let (builder, server) = Builder::new(genesis_digest)
+        .store(SharedInMemoryStore::default())
+        .build();
     let network_1 = build_network(|router| router.add_rpc_service(server));
     let (mut event_loop_1, _handle_1) = builder.build(network_1.clone());
-    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
+    let (builder, server) = Builder::new(genesis_digest)
+        .store(SharedInMemoryStore::default())
+        .build();
     let network_2 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_2, _handle_2) = builder.build(network_2.clone());
     network_1.connect(network_2.local_addr()).await.unwrap();
@@ -294,13 +301,16 @@ async fn test_state_sync_using_archive() -> anyhow::Result<()> {
     };
     // Build and connect two nodes where Node 1 will be given access to an archive store
     // Node 2 will prune older checkpoints, so Node 1 is forced to backfill from the archive
-    let (builder, server) = Builder::new()
+    let genesis_digest = *ordered_checkpoints.first().unwrap().digest();
+    let (builder, server) = Builder::new(genesis_digest)
         .store(SharedInMemoryStore::default())
         .archive_config(Some(archive_reader_config))
         .build();
     let network_1 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_1, _handle_1) = builder.build(network_1.clone());
-    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
+    let (builder, server) = Builder::new(genesis_digest)
+        .store(SharedInMemoryStore::default())
+        .build();
     let network_2 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_2, _handle_2) = builder.build(network_2.clone());
     network_1.connect(network_2.local_addr()).await.unwrap();
@@ -415,11 +425,16 @@ async fn sync_with_checkpoints_being_inserted() {
     let (ordered_checkpoints, _contents, sequence_number_to_digest, checkpoints) =
         committee.make_empty_checkpoints(4, None);
 
+    let genesis_digest = *ordered_checkpoints.first().unwrap().digest();
     // Build and connect two nodes
-    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
+    let (builder, server) = Builder::new(genesis_digest)
+        .store(SharedInMemoryStore::default())
+        .build();
     let network_1 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_1, handle_1) = builder.build(network_1.clone());
-    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
+    let (builder, server) = Builder::new(genesis_digest)
+        .store(SharedInMemoryStore::default())
+        .build();
     let network_2 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_2, handle_2) = builder.build(network_2.clone());
     network_1.connect(network_2.local_addr()).await.unwrap();
@@ -550,10 +565,15 @@ async fn sync_with_checkpoints_watermark() {
         .unwrap()
         .sequence_number();
     // Build and connect two nodes
-    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
+    let genesis_digest = *ordered_checkpoints.first().unwrap().digest();
+    let (builder, server) = Builder::new(genesis_digest)
+        .store(SharedInMemoryStore::default())
+        .build();
     let network_1 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_1, handle_1) = builder.build(network_1.clone());
-    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
+    let (builder, server) = Builder::new(genesis_digest)
+        .store(SharedInMemoryStore::default())
+        .build();
     let network_2 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_2, handle_2) = builder.build(network_2.clone());
 
@@ -716,7 +736,9 @@ async fn sync_with_checkpoints_watermark() {
     );
 
     // Add Peer 3
-    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
+    let (builder, server) = Builder::new(genesis_digest)
+        .store(SharedInMemoryStore::default())
+        .build();
     let network_3 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_3, handle_3) = builder.build(network_3.clone());
 
@@ -829,7 +851,9 @@ async fn sync_with_checkpoints_watermark() {
         .set_lowest_available_checkpoint(a_very_high_checkpoint_seq);
 
     // Start Peer 4
-    let (builder, server) = Builder::new().store(SharedInMemoryStore::default()).build();
+    let (builder, server) = Builder::new(genesis_digest)
+        .store(SharedInMemoryStore::default())
+        .build();
     let network_4 = build_network(|router| router.add_rpc_service(server));
     let (event_loop_4, handle_4) = builder.build(network_4.clone());
 

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1093,12 +1093,13 @@ impl SuiNode {
         randomness_tx: mpsc::Sender<(EpochId, RandomnessRound, Vec<u8>)>,
         prometheus_registry: &Registry,
     ) -> Result<P2pComponents> {
-        let (state_sync, state_sync_server) = state_sync::Builder::new()
-            .config(config.p2p_config.state_sync.clone().unwrap_or_default())
-            .store(state_sync_store)
-            .archive_config(config.archive_reader_config())
-            .with_metrics(prometheus_registry)
-            .build();
+        let (state_sync, state_sync_server) =
+            state_sync::Builder::new(*config.genesis()?.checkpoint().digest())
+                .config(config.p2p_config.state_sync.clone().unwrap_or_default())
+                .store(state_sync_store)
+                .archive_config(config.archive_reader_config())
+                .with_metrics(prometheus_registry)
+                .build();
 
         let (discovery, discovery_server) = discovery::Builder::new(trusted_peer_change_rx)
             .config(config.p2p_config.clone())


### PR DESCRIPTION
## Description 

skip read from checkpoint store and instead pass genesis checkpoint digest directly from node config

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
