### PR TITLE
fix: split-cluster-check is now using proper committee size

### DIFF
--- a/scripts/compatibility/split-cluster-check.sh
+++ b/scripts/compatibility/split-cluster-check.sh
@@ -60,7 +60,7 @@ fi
 export SUI_CONFIG_DIR="$WORKING_DIR/config"
 rm -rf "$SUI_CONFIG_DIR"
 
-"$WORKING_DIR/sui-release" genesis --epoch-duration-ms 20000
+"$WORKING_DIR/sui-release" genesis --epoch-duration-ms 20000 --committee-size 4
 
 LOG_DIR="$WORKING_DIR/logs"
 
@@ -99,17 +99,26 @@ if ! grep -q "Node State has been reconfigured" "$LOG_DIR/fullnode.log"; then
 fi
 
 # ensure that the random beacon's DKG completes on both versions.
-# "random beacon: created" indicates that the random beacon is enabled and started.
-if grep -q "random beacon: created" "$LOG_DIR/node-0.log" && ! grep -q "random beacon: DKG complete" "$LOG_DIR/node-0.log"; then
+# Both "random beacon: created" and "random beacon: DKG complete" must be present.
+if ! grep -q "random beacon: created" "$LOG_DIR/node-0.log"; then
+  echo "Could not find 'random beacon: created' in node-0"
+  exit 1
+fi
+
+if ! grep -q "random beacon: DKG complete" "$LOG_DIR/node-0.log"; then
   echo "Could not find 'random beacon: DKG complete' in node-0"
   exit 1
 fi
 
-if grep -q "random beacon: created" "$LOG_DIR/node-2.log" && ! grep -q "random beacon: DKG complete" "$LOG_DIR/node-2.log"; then
-  echo "Could not find 'random beacon: DKG complete' in node-2"
+if ! grep -q "random beacon: created" "$LOG_DIR/node-2.log"; then
+  echo "Could not find 'random beacon: created' in node-2"
   exit 1
 fi
 
+if ! grep -q "random beacon: DKG complete" "$LOG_DIR/node-2.log"; then
+  echo "Could not find 'random beacon: DKG complete' in node-2"
+  exit 1
+fi
 
 
 echo "Cluster reconfigured successfully"


### PR DESCRIPTION
## Description 

The CI running `split-cluster-check.sh` has been returning 100% false positives since the default committee size for the genesis was changed to `1` a while ago.

Only a single authority using the released version was being used and since that single authority can successfully reconfigure itself the tests always passed.

The DKG tests also passed because they only where expecting `random beacon: DKG complete` if the log contained a `random beacon: created` and the logs for node-2 did not contain any of them.


## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
