### PR TITLE
[tidehunter] disable pruning for certified_checkpoints table

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -242,15 +242,7 @@ impl CheckpointStoreTables {
                     true,
                 )),
             ),
-            (
-                "certified_checkpoints",
-                config_u64.clone().with_config(apply_relocation_filter(
-                    override_dirty_keys_config.clone(),
-                    pruner_watermarks.checkpoint_id.clone(),
-                    |checkpoint: TrustedCheckpoint| checkpoint.inner().epoch,
-                    false,
-                )),
-            ),
+            ("certified_checkpoints", config_u64.clone()),
             (
                 "checkpoint_by_digest",
                 digest_config.clone().with_config(apply_relocation_filter(


### PR DESCRIPTION
## Description 

disables TH pruning for certified_checkpoints table 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
