### PR TITLE
Use 1 validator to make protocol upgrades reliable

### DIFF
--- a/crates/sui-e2e-tests/tests/address_balance_tests.rs
+++ b/crates/sui-e2e-tests/tests/address_balance_tests.rs
@@ -101,6 +101,7 @@ async fn test_accumulators_root_created() {
     });
 
     let test_cluster = TestClusterBuilder::new()
+        .with_num_validators(1)
         .with_supported_protocol_versions(SupportedProtocolVersions::new_for_testing(
             ProtocolVersion::MAX.as_u64(),
             ProtocolVersion::MAX_ALLOWED.as_u64(),


### PR DESCRIPTION
Occasionally, protocol upgrades were failing because validators were not able to submit their capabilities (vote for the upgrade) quickly enough.

This could also be fixed by adding sleeps, but this way also makes the test run faster
