### PR TITLE
indexer-alt db reset fix for rust v1.90 upgrade

### DIFF
--- a/crates/mysten-metrics/src/histogram.rs
+++ b/crates/mysten-metrics/src/histogram.rs
@@ -193,7 +193,8 @@ impl Histogram {
         }
     }
 
-    pub fn start_timer(&self) -> HistogramTimerGuard {
+    pub fn start_timer(&self) -> HistogramTimerGuard<'_> {
+        
         HistogramTimerGuard {
             histogram: self,
             start: Instant::now(),

--- a/external-crates/move/crates/move-borrow-graph/src/references.rs
+++ b/external-crates/move/crates/move-borrow-graph/src/references.rs
@@ -130,7 +130,7 @@ impl<Loc: Copy, Lbl: Clone + Ord> BorrowEdgeSet<Loc, Lbl> {
         self.edges.is_empty()
     }
 
-    pub(crate) fn iter(&self) -> std::collections::btree_set::Iter<BorrowEdge<Loc, Lbl>> {
+    pub(crate) fn iter(&self) -> std::collections::btree_set::Iter<'_, BorrowEdge<Loc, Lbl>> {
         debug_assert!(self.overflown || !self.is_empty());
         self.edges.iter()
     }

--- a/external-crates/move/crates/move-compiler/src/expansion/ast.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/ast.rs
@@ -724,7 +724,7 @@ impl AbilitySet {
         self.0.is_subset(&other.0)
     }
 
-    pub fn iter(&self) -> AbilitySetIter {
+    pub fn iter(&self) -> AbilitySetIter<'_> {
         self.into_iter()
     }
 

--- a/external-crates/move/crates/move-compiler/src/expansion/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/expansion/translate.rs
@@ -162,7 +162,7 @@ impl<'env> Context<'env> {
         self.defn_context.env
     }
 
-    pub(super) fn reporter(&self) -> &DiagnosticReporter {
+    pub(super) fn reporter(&self) -> &DiagnosticReporter<'_> {
         &self.defn_context.reporter
     }
 

--- a/external-crates/move/crates/move-compiler/src/hlir/translate.rs
+++ b/external-crates/move/crates/move-compiler/src/hlir/translate.rs
@@ -274,7 +274,7 @@ impl MatchContext<true> for Context<'_> {
         self.env
     }
 
-    fn reporter(&self) -> &DiagnosticReporter {
+    fn reporter(&self) -> &DiagnosticReporter<'_> {
         &self.reporter
     }
 

--- a/external-crates/move/crates/move-compiler/src/shared/matching.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/matching.rs
@@ -67,7 +67,7 @@ pub struct ArmResult {
 /// compilation in HLIR lowering.
 pub trait MatchContext<const AFTER_TYPING: bool> {
     fn env(&self) -> &CompilationEnv;
-    fn reporter(&self) -> &DiagnosticReporter;
+    fn reporter(&self) -> &DiagnosticReporter<'_>;
     fn new_match_var(&mut self, name: String, loc: Loc) -> N::Var;
     fn program_info(&self) -> &ProgramInfo<AFTER_TYPING>;
 

--- a/external-crates/move/crates/move-compiler/src/shared/mod.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/mod.rs
@@ -351,7 +351,7 @@ impl CompilationEnv {
         &self.mapped_files
     }
 
-    pub fn diagnostic_reporter_at_top_level(&self) -> DiagnosticReporter {
+    pub fn diagnostic_reporter_at_top_level(&self) -> DiagnosticReporter<'_> {
         DiagnosticReporter::new(
             &self.flags,
             &self.known_filter_names,
@@ -361,7 +361,7 @@ impl CompilationEnv {
         )
     }
 
-    pub fn dummy_diagnostic_reporter(&self) -> DiagnosticReporter {
+    pub fn dummy_diagnostic_reporter(&self) -> DiagnosticReporter<'_> {
         DiagnosticReporter::dummy_reporter(
             &self.flags,
             &self.known_filter_names,

--- a/external-crates/move/crates/move-compiler/src/shared/remembering_unique_map.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/remembering_unique_map.rs
@@ -104,11 +104,11 @@ impl<K: TName, V> RememberingUniqueMap<K, V> {
         }
     }
 
-    pub fn iter(&self) -> Iter<K, V> {
+    pub fn iter(&self) -> Iter<'_, K, V> {
         self.into_iter()
     }
 
-    pub fn iter_mut(&mut self) -> IterMut<K, V> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
         self.into_iter()
     }
 

--- a/external-crates/move/crates/move-compiler/src/shared/unique_map.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/unique_map.rs
@@ -184,7 +184,7 @@ impl<K: TName, V> UniqueMap<K, V> {
         joined
     }
 
-    pub fn iter(&self) -> Iter<K, V> {
+    pub fn iter(&self) -> Iter<'_, K, V> {
         self.into_iter()
     }
 
@@ -193,7 +193,7 @@ impl<K: TName, V> UniqueMap<K, V> {
             .map(|(loc, k_, v)| (K::add_loc(loc, k_.clone()), v))
     }
 
-    pub fn iter_mut(&mut self) -> IterMut<K, V> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
         self.into_iter()
     }
 

--- a/external-crates/move/crates/move-compiler/src/shared/unique_set.rs
+++ b/external-crates/move/crates/move-compiler/src/shared/unique_set.rs
@@ -87,7 +87,7 @@ impl<T: TName> UniqueSet<T> {
         self.iter().all(|(_, x_)| other.contains_(x_))
     }
 
-    pub fn iter(&self) -> Iter<T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         self.into_iter()
     }
 

--- a/external-crates/move/crates/move-compiler/src/typing/core.rs
+++ b/external-crates/move/crates/move-compiler/src/typing/core.rs
@@ -1265,7 +1265,7 @@ impl MatchContext<false> for Context<'_, '_> {
         self.env()
     }
 
-    fn reporter(&self) -> &DiagnosticReporter {
+    fn reporter(&self) -> &DiagnosticReporter<'_> {
         &self.reporter
     }
 

--- a/external-crates/move/crates/move-ir-to-bytecode/src/context.rs
+++ b/external-crates/move/crates/move-ir-to-bytecode/src/context.rs
@@ -836,7 +836,7 @@ impl<'a> Context<'a> {
     // Dependency Resolution
     //**********************************************************************************************
 
-    fn dependency(&self, m: &ModuleIdent) -> Result<&CompiledDependencyView> {
+    fn dependency(&self, m: &ModuleIdent) -> Result<&CompiledDependencyView<'_>> {
         let dep = self
             .dependencies
             .get(m)


### PR DESCRIPTION
## Description 
indexer-alt db reset fix for rust v1.90 upgrade (credit to `claude`)
"...The issue is that the lifetime from `&self` is implicitly connected to the return type's `Iter`, but it's not being made explicit. By adding `'_`, you're making it clear that the iterator borrows from `self` for some lifetime..."

## Test plan 
https://github.com/MystenLabs/sui-operations/actions/runs/18732554383