### PR TITLE
[sui-adapter] Fix to make sure we charge correctly for historical txs

### DIFF
--- a/sui-execution/latest/sui-move-natives/src/dynamic_field.rs
+++ b/sui-execution/latest/sui-move-natives/src/dynamic_field.rs
@@ -408,9 +408,7 @@ pub fn remove_child_object(
 
     let protocol_config = get_extension!(context, ObjectRuntime)?.protocol_config;
     let child_size = match cache_info {
-        CacheInfo::CachedValue if !protocol_config.abstract_size_in_object_runtime() => {
-            child.legacy_size()
-        }
+        _ if !protocol_config.abstract_size_in_object_runtime() => child.legacy_size(),
         CacheInfo::CachedValue => {
             // The value already existed
             PRE_EXISTING_ABSTRACT_SIZE.into()


### PR DESCRIPTION
## Description 

We should always use legacy size regardless of cache status if `abstract_size_in_object_runtime` is not set.

## Test plan 

CI + local replay

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
