### PR TITLE
[pkg-alt] re-enable ptb test

### DIFF
--- a/crates/sui/tests/ptb_files/publish/publish_valid.ptb
+++ b/crates/sui/tests/ptb_files/publish/publish_valid.ptb
@@ -1,3 +1,1 @@
-# TODO: pkg-alt FAILING TEST -- added a fake call instead of publish so the test passes
---move-call std::option::is_none 0
-# --publish tests/ptb_files/publish/test_pkg
+--publish tests/ptb_files/publish/test_pkg

--- a/crates/sui/tests/ptb_files/publish/test_pkg/Move.toml
+++ b/crates/sui/tests/ptb_files/publish/test_pkg/Move.toml
@@ -1,4 +1,5 @@
-[environments]
-localnet="e0dfde79"
-[environments]
-localnet="4821f05b"
+[package]
+name = "test_pkg"
+edition = "2024"
+system-dependencies = []
+

--- a/crates/sui/tests/snapshots/ptb_files_tests__publish_valid.ptb.snap
+++ b/crates/sui/tests/snapshots/ptb_files_tests__publish_valid.ptb.snap
@@ -3,17 +3,12 @@ source: crates/sui/tests/ptb_files_tests.rs
 expression: "results.join(\"\\n\")"
 ---
  === PREVIEW === 
-╭────────────────────────────────────╮
-│ PTB Preview                        │
-├───────────┬────────────────────────┤
-│ command   │ values                 │
-├───────────┼────────────────────────┤
-│ move-call │ std::option::is_none 0 │
-╰───────────┴────────────────────────╯
- === BUILDING PTB ERRORS === 
-  × Error when processing PTB
-   ╭────
- 1 │ --move-call std::option::is_none 0 
-   ·                                  ┬
-   ·                                  ╰── Not enough type parameters supplied for Move call
-   ╰────
+╭────────────────────────────────────────────╮
+│ PTB Preview                                │
+├─────────┬──────────────────────────────────┤
+│ command │ values                           │
+├─────────┼──────────────────────────────────┤
+│ publish │ tests/ptb_files/publish/test_pkg │
+╰─────────┴──────────────────────────────────╯
+ === BUILT PTB === 
+Command 0: Publish(_,)


### PR DESCRIPTION
## Description 

This PR re-enables a `sui client ptb` publish test.

## Test plan 

Re-enabled test and ensure CI is green.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
