### PR TITLE
Revert "[rpc-alt] report name of unknown methods in metrics too (#224…

### DIFF
--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -561,7 +561,7 @@ mod tests {
         assert_eq!(
             metrics
                 .requests_received
-                .with_label_values(&["UNKNOWN:test_baz"])
+                .with_label_values(&["<UNKNOWN>"])
                 .get(),
             1
         );
@@ -569,7 +569,7 @@ mod tests {
         assert_eq!(
             metrics
                 .requests_succeeded
-                .with_label_values(&["UNKNOWN:test_baz"])
+                .with_label_values(&["<UNKNOWN>"])
                 .get(),
             0
         );
@@ -577,7 +577,7 @@ mod tests {
         assert_eq!(
             metrics
                 .requests_failed
-                .with_label_values(&["UNKNOWN:test_baz", &format!("{METHOD_NOT_FOUND_CODE}")])
+                .with_label_values(&["<UNKNOWN>", &format!("{METHOD_NOT_FOUND_CODE}")])
                 .get(),
             1
         );

--- a/crates/sui-indexer-alt-jsonrpc/src/metrics/middleware.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/metrics/middleware.rs
@@ -94,11 +94,7 @@ where
         let method = if self.layer.methods.contains(request.method_name()) {
             request.method.clone()
         } else {
-            // TODO(DVX-1210): the request method name is only here to make sure we know
-            // about all the methods called by first party apps. We should change
-            // this back to "<UNKNOWN>" once we have stabilized the API to avoid
-            // high cardinality of metrics labels.
-            format!("UNKNOWN:{}", request.method_name()).into()
+            "<UNKNOWN>".into()
         };
 
         self.layer


### PR DESCRIPTION
…58)"

## Description 

This reverts commit 37ded1c5ada5af038aba59f2b3d97923c86c5e7f.
And closing out this [task](https://linear.app/mysten-labs/issue/DVX-1210/revert-pr-to-report-unknown-method-in-metrics) now that jsonrpc-alt is pretty stable.


## Test plan 

Existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
