### PR TITLE
[2/n][indexer-framework] integrate grpc streaming into ingestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14942,6 +14942,7 @@ dependencies = [
  "sui-indexer-alt-metrics",
  "sui-pg-db",
  "sui-rpc",
+ "sui-rpc-api",
  "sui-sdk-types",
  "sui-storage",
  "sui-synthetic-ingestion",

--- a/crates/sui-bridge-indexer-alt/src/main.rs
+++ b/crates/sui-bridge-indexer-alt/src/main.rs
@@ -69,10 +69,7 @@ async fn main() -> Result<(), anyhow::Error> {
         indexer_args,
         ClientArgs {
             remote_store_url: Some(remote_store_url),
-            local_ingestion_path: None,
-            rpc_api_url: None,
-            rpc_username: None,
-            rpc_password: None,
+            ..Default::default()
         },
         Default::default(),
         Some(&MIGRATIONS),

--- a/crates/sui-indexer-alt-e2e-tests/src/lib.rs
+++ b/crates/sui-indexer-alt-e2e-tests/src/lib.rs
@@ -694,10 +694,7 @@ pub fn local_ingestion_client_args() -> (ClientArgs, TempDir) {
         .unwrap();
     let client_args = ClientArgs {
         local_ingestion_path: Some(temp_dir.path().to_owned()),
-        remote_store_url: None,
-        rpc_api_url: None,
-        rpc_username: None,
-        rpc_password: None,
+        ..Default::default()
     };
     (client_args, temp_dir)
 }

--- a/crates/sui-indexer-alt-framework/Cargo.toml
+++ b/crates/sui-indexer-alt-framework/Cargo.toml
@@ -38,6 +38,7 @@ sui-indexer-alt-framework-store-traits.workspace = true
 sui-indexer-alt-metrics.workspace = true
 sui-rpc.workspace = true
 sui-sdk-types.workspace = true
+sui-rpc-api.workspace = true
 sui-storage.workspace = true
 sui-types.workspace = true
 prost-types.workspace = true

--- a/crates/sui-indexer-alt-framework/src/cluster.rs
+++ b/crates/sui-indexer-alt-framework/src/cluster.rs
@@ -346,10 +346,7 @@ mod tests {
         let args = Args {
             client_args: Some(ClientArgs {
                 local_ingestion_path: Some(checkpoint_dir.path().to_owned()),
-                remote_store_url: None,
-                rpc_api_url: None,
-                rpc_username: None,
-                rpc_password: None,
+                ..Default::default()
             }),
             indexer_args: IndexerArgs {
                 first_checkpoint: Some(0),

--- a/crates/sui-indexer-alt-framework/src/ingestion/error.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/error.rs
@@ -25,4 +25,7 @@ pub enum Error {
 
     #[error(transparent)]
     RpcClientError(#[from] tonic::Status),
+
+    #[error("Streaming error: {0}")]
+    StreamingError(#[source] anyhow::Error),
 }

--- a/crates/sui-indexer-alt-framework/src/ingestion/streaming_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/streaming_client.rs
@@ -1,0 +1,124 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Context;
+use async_trait::async_trait;
+use futures::{Stream, StreamExt};
+use std::pin::Pin;
+use sui_rpc::proto::sui::rpc::v2::{
+    SubscribeCheckpointsRequest, subscription_service_client::SubscriptionServiceClient,
+};
+use sui_rpc_api::client::checkpoint_data_field_mask;
+use tonic::{Status, transport::Uri};
+
+use crate::ingestion::error::{Error, Result};
+use crate::types::full_checkpoint_content::Checkpoint;
+
+/// Type alias for a stream of checkpoint data.
+pub type CheckpointStream = Pin<Box<dyn Stream<Item = Result<Checkpoint>> + Send>>;
+
+/// Trait representing a client for streaming checkpoint data.
+#[async_trait]
+pub trait CheckpointStreamingClient {
+    async fn connect(&mut self) -> Result<CheckpointStream>;
+}
+
+/// gRPC-based implementation of the CheckpointStreamingClient trait.
+pub struct GrpcStreamingClient {
+    uri: Uri,
+}
+
+impl GrpcStreamingClient {
+    pub fn new(uri: Uri) -> Self {
+        Self { uri }
+    }
+}
+
+#[async_trait]
+impl CheckpointStreamingClient for GrpcStreamingClient {
+    async fn connect(&mut self) -> Result<CheckpointStream> {
+        let mut client = SubscriptionServiceClient::connect(self.uri.clone())
+            .await
+            .map_err(|err| Error::RpcClientError(Status::from_error(err.into())))?;
+
+        let mut request = SubscribeCheckpointsRequest::default();
+        request.read_mask = Some(checkpoint_data_field_mask());
+
+        let stream = client
+            .subscribe_checkpoints(request)
+            .await
+            .map_err(Error::RpcClientError)?
+            .into_inner();
+
+        let converted_stream = stream.map(|result| match result {
+            Ok(response) => response
+                .checkpoint
+                .context("Checkpoint data missing in response")
+                .and_then(|checkpoint| {
+                    sui_types::full_checkpoint_content::Checkpoint::try_from(&checkpoint)
+                        .context("Failed to parse checkpoint")
+                })
+                .map_err(Error::StreamingError),
+            Err(e) => Err(Error::RpcClientError(e)),
+        });
+
+        Ok(Box::pin(converted_stream))
+    }
+}
+
+#[cfg(test)]
+pub mod test_utils {
+    use super::*;
+    use crate::types::test_checkpoint_data_builder::TestCheckpointBuilder;
+    use std::sync::{Arc, Mutex};
+
+    struct MockStreamState {
+        checkpoints: Arc<Mutex<Vec<Result<u64>>>>,
+    }
+
+    impl Stream for MockStreamState {
+        type Item = Result<Checkpoint>;
+
+        fn poll_next(
+            self: Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<Self::Item>> {
+            let mut checkpoints = self.checkpoints.lock().unwrap();
+            if checkpoints.is_empty() {
+                return std::task::Poll::Ready(None);
+            }
+            let result = checkpoints.remove(0);
+            std::task::Poll::Ready(Some(result.map(|seq| {
+                let mut builder = TestCheckpointBuilder::new(seq);
+                builder.build_checkpoint()
+            })))
+        }
+    }
+
+    /// Mock streaming client for testing with predefined checkpoints.
+    pub struct MockStreamingClient {
+        checkpoints: Arc<Mutex<Vec<Result<u64>>>>,
+    }
+
+    impl MockStreamingClient {
+        pub fn new<I>(checkpoint_range: I) -> Self
+        where
+            I: IntoIterator<Item = u64>,
+        {
+            Self {
+                checkpoints: Arc::new(Mutex::new(checkpoint_range.into_iter().map(Ok).collect())),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl CheckpointStreamingClient for MockStreamingClient {
+        async fn connect(&mut self) -> Result<CheckpointStream> {
+            let stream = MockStreamState {
+                checkpoints: Arc::clone(&self.checkpoints),
+            };
+
+            Ok(Box::pin(stream))
+        }
+    }
+}

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -186,7 +186,7 @@ impl<S: Store> Indexer<S> {
 
     /// The ingestion client used by the indexer to fetch checkpoints.
     pub fn ingestion_client(&self) -> &IngestionClient {
-        self.ingestion_service.client()
+        self.ingestion_service.ingestion_client()
     }
 
     /// The indexer's metrics.

--- a/crates/sui-indexer-alt-framework/src/metrics.rs
+++ b/crates/sui-indexer-alt-framework/src/metrics.rs
@@ -53,9 +53,12 @@ pub struct IndexerMetrics {
     pub total_ingested_transient_retries: IntCounterVec,
     pub total_ingested_not_found_retries: IntCounter,
     pub total_ingested_permanent_errors: IntCounterVec,
+    pub total_streamed_checkpoints: IntCounter,
+    pub total_stream_disconnections: IntCounter,
 
     // Checkpoint lag metrics for the ingestion pipeline.
     pub latest_ingested_checkpoint: IntGauge,
+    pub latest_streamed_checkpoint: IntGauge,
     pub latest_ingested_checkpoint_timestamp_lag_ms: IntGauge,
     pub ingested_checkpoint_timestamp_lag: Histogram,
 
@@ -203,9 +206,27 @@ impl IndexerMetrics {
                 registry,
             )
             .unwrap(),
+            total_streamed_checkpoints: register_int_counter_with_registry!(
+                name("total_streamed_checkpoints"),
+                "Total number of checkpoints received from gRPC streaming",
+                registry,
+            )
+            .unwrap(),
+            total_stream_disconnections: register_int_counter_with_registry!(
+                name("total_stream_disconnections"),
+                "Total number of times the gRPC stream was disconnected",
+                registry,
+            )
+            .unwrap(),
             latest_ingested_checkpoint: register_int_gauge_with_registry!(
                 name("latest_ingested_checkpoint"),
                 "Latest checkpoint sequence number fetched from the remote store",
+                registry,
+            )
+            .unwrap(),
+            latest_streamed_checkpoint: register_int_gauge_with_registry!(
+                name("latest_streamed_checkpoint"),
+                "Latest checkpoint sequence number received from gRPC streaming",
                 registry,
             )
             .unwrap(),

--- a/crates/sui-indexer-alt-framework/src/postgres/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/postgres/mod.rs
@@ -89,11 +89,8 @@ impl Indexer<Db> {
             store,
             IndexerArgs::default(),
             ClientArgs {
-                remote_store_url: None,
                 local_ingestion_path: Some(tempdir().unwrap().keep()),
-                rpc_api_url: None,
-                rpc_username: None,
-                rpc_password: None,
+                ..Default::default()
             },
             IngestionConfig::default(),
             None,

--- a/crates/sui-indexer-alt/src/benchmark.rs
+++ b/crates/sui-indexer-alt/src/benchmark.rs
@@ -55,11 +55,8 @@ pub async fn run_benchmark(
     };
 
     let client_args = ClientArgs {
-        remote_store_url: None,
         local_ingestion_path: Some(ingestion_path.clone()),
-        rpc_api_url: None,
-        rpc_username: None,
-        rpc_password: None,
+        ..Default::default()
     };
 
     let cur_time = Instant::now();

--- a/crates/sui-rpc-api/src/client/mod.rs
+++ b/crates/sui-rpc-api/src/client/mod.rs
@@ -80,16 +80,7 @@ impl Client {
         sequence_number: CheckpointSequenceNumber,
     ) -> Result<CheckpointData> {
         let request = proto::GetCheckpointRequest::by_sequence_number(sequence_number)
-            .with_read_mask(FieldMask::from_paths([
-                "summary.bcs",
-                "signature",
-                "contents.bcs",
-                "transactions.transaction.bcs",
-                "transactions.effects.bcs",
-                "transactions.effects.unchanged_loaded_runtime_objects",
-                "transactions.events.bcs",
-                "objects.objects.bcs",
-            ]));
+            .with_read_mask(checkpoint_data_field_mask());
 
         let (metadata, response, _extentions) = self
             .0
@@ -191,6 +182,21 @@ pub struct TransactionExecutionResponse {
     pub events: Option<TransactionEvents>,
     pub balance_changes: Vec<sui_sdk_types::BalanceChange>,
     pub objects: ObjectSet,
+}
+
+/// Field mask for checkpoint data requests.
+pub fn checkpoint_data_field_mask() -> FieldMask {
+    FieldMask::from_paths([
+        "sequence_number",
+        "summary.bcs",
+        "signature",
+        "contents.bcs",
+        "transactions.transaction.bcs",
+        "transactions.effects.bcs",
+        "transactions.effects.unchanged_loaded_runtime_objects",
+        "transactions.events.bcs",
+        "objects.objects.bcs",
+    ])
 }
 
 /// Attempts to parse `CertifiedCheckpointSummary` from a proto::Checkpoint


### PR DESCRIPTION
## Description 

Implement checkpoint broadcasting via grpc streaming, so that broadcaster now streams whenever possible and falls back to ingestion client if the streamed checkpoint is too far away from what we expect. 
This PR assumes no streaming connections errors, which are handled in #24091.

## Test plan 

Added some tests. More tests in #24090.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
