### PR TITLE
[4/n][indexer-framework] handle streaming connection errors with backoffs

### DIFF
--- a/crates/sui-indexer-alt-consistent-store/src/config.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/config.rs
@@ -38,6 +38,8 @@ pub struct IngestionConfig {
     pub checkpoint_buffer_size: usize,
     pub ingest_concurrency: usize,
     pub retry_interval_ms: u64,
+    pub streaming_backoff_initial_batch_size: usize,
+    pub streaming_backoff_max_batch_size: usize,
 }
 
 #[DefaultConfig]
@@ -138,6 +140,8 @@ impl From<framework::ingestion::IngestionConfig> for IngestionConfig {
             checkpoint_buffer_size: config.checkpoint_buffer_size,
             ingest_concurrency: config.ingest_concurrency,
             retry_interval_ms: config.retry_interval_ms,
+            streaming_backoff_initial_batch_size: config.streaming_backoff_initial_batch_size,
+            streaming_backoff_max_batch_size: config.streaming_backoff_max_batch_size,
         }
     }
 }
@@ -148,6 +152,8 @@ impl From<IngestionConfig> for framework::ingestion::IngestionConfig {
             checkpoint_buffer_size: config.checkpoint_buffer_size,
             ingest_concurrency: config.ingest_concurrency,
             retry_interval_ms: config.retry_interval_ms,
+            streaming_backoff_initial_batch_size: config.streaming_backoff_initial_batch_size,
+            streaming_backoff_max_batch_size: config.streaming_backoff_max_batch_size,
         }
     }
 }

--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -71,6 +71,12 @@ pub struct IngestionConfig {
 
     /// Polling interval to retry fetching checkpoints that do not exist, in milliseconds.
     pub retry_interval_ms: u64,
+
+    /// Initial number of checkpoints to process using ingestion after a streaming connection failure.
+    pub streaming_backoff_initial_batch_size: usize,
+
+    /// Maximum number of checkpoints to process using ingestion after repeated streaming connection failures.
+    pub streaming_backoff_max_batch_size: usize,
 }
 
 pub struct IngestionService {
@@ -215,6 +221,8 @@ impl Default for IngestionConfig {
             checkpoint_buffer_size: 5000,
             ingest_concurrency: 200,
             retry_interval_ms: 200,
+            streaming_backoff_initial_batch_size: 10, // 10 checkpoints, ~ 2 seconds
+            streaming_backoff_max_batch_size: 10000,  // 10000 checkpoints, ~ 40 minutes
         }
     }
 }

--- a/crates/sui-indexer-alt-framework/src/metrics.rs
+++ b/crates/sui-indexer-alt-framework/src/metrics.rs
@@ -55,6 +55,7 @@ pub struct IndexerMetrics {
     pub total_ingested_permanent_errors: IntCounterVec,
     pub total_streamed_checkpoints: IntCounter,
     pub total_stream_disconnections: IntCounter,
+    pub total_streaming_connection_failures: IntCounter,
 
     // Checkpoint lag metrics for the ingestion pipeline.
     pub latest_ingested_checkpoint: IntGauge,
@@ -215,6 +216,12 @@ impl IndexerMetrics {
             total_stream_disconnections: register_int_counter_with_registry!(
                 name("total_stream_disconnections"),
                 "Total number of times the gRPC stream was disconnected",
+                registry,
+            )
+            .unwrap(),
+            total_streaming_connection_failures: register_int_counter_with_registry!(
+                name("total_streaming_connection_failures"),
+                "Total number of failures due to streaming service connection or peek failures",
                 registry,
             )
             .unwrap(),

--- a/crates/sui-indexer-alt/src/config.rs
+++ b/crates/sui-indexer-alt/src/config.rs
@@ -53,6 +53,8 @@ pub struct IngestionLayer {
     pub checkpoint_buffer_size: Option<usize>,
     pub ingest_concurrency: Option<usize>,
     pub retry_interval_ms: Option<u64>,
+    pub streaming_backoff_initial_batch_size: Option<usize>,
+    pub streaming_backoff_max_batch_size: Option<usize>,
 }
 
 #[DefaultConfig]
@@ -170,6 +172,12 @@ impl IngestionLayer {
                 .unwrap_or(base.checkpoint_buffer_size),
             ingest_concurrency: self.ingest_concurrency.unwrap_or(base.ingest_concurrency),
             retry_interval_ms: self.retry_interval_ms.unwrap_or(base.retry_interval_ms),
+            streaming_backoff_initial_batch_size: self
+                .streaming_backoff_initial_batch_size
+                .unwrap_or(base.streaming_backoff_initial_batch_size),
+            streaming_backoff_max_batch_size: self
+                .streaming_backoff_max_batch_size
+                .unwrap_or(base.streaming_backoff_max_batch_size),
         })
     }
 }
@@ -276,6 +284,12 @@ impl Merge for IngestionLayer {
             checkpoint_buffer_size: other.checkpoint_buffer_size.or(self.checkpoint_buffer_size),
             ingest_concurrency: other.ingest_concurrency.or(self.ingest_concurrency),
             retry_interval_ms: other.retry_interval_ms.or(self.retry_interval_ms),
+            streaming_backoff_initial_batch_size: other
+                .streaming_backoff_initial_batch_size
+                .or(self.streaming_backoff_initial_batch_size),
+            streaming_backoff_max_batch_size: other
+                .streaming_backoff_max_batch_size
+                .or(self.streaming_backoff_max_batch_size),
         })
     }
 }
@@ -374,6 +388,8 @@ impl From<IngestionConfig> for IngestionLayer {
             checkpoint_buffer_size: Some(config.checkpoint_buffer_size),
             ingest_concurrency: Some(config.ingest_concurrency),
             retry_interval_ms: Some(config.retry_interval_ms),
+            streaming_backoff_initial_batch_size: Some(config.streaming_backoff_initial_batch_size),
+            streaming_backoff_max_batch_size: Some(config.streaming_backoff_max_batch_size),
         }
     }
 }


### PR DESCRIPTION
## Description 

Handle streaming startup errors where we only retry connections after some backoff period has passed. And the backoff duration is doubled with every connection retry failure. During the time, we use ingestion client for checkpoints broadcasting.

## Test plan 

Added tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
