### PR TITLE
Fix accumulator test

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/deny_list_v2/coin_deny_and_undeny_address_balance_receiver.move
+++ b/crates/sui-adapter-transactional-tests/tests/deny_list_v2/coin_deny_and_undeny_address_balance_receiver.move
@@ -6,7 +6,7 @@
 // `balance::send_funds` is callable from PTBs, then confirm the receiver transitions through
 // allowed, denied-after-epoch, and re-enabled states.
 
-//# init --accounts A B --addresses test=0x0 --enable-accumulators --protocol-version 101
+//# init --accounts A B --addresses test=0x0 --enable-accumulators
 
 //# publish --sender A
 module test::regulated_coin;


### PR DESCRIPTION
## Description 

- Transactional tests use snapshot versions of the framework once the protocol config specified is not the current/max. This test will break without this fix once the protocol config hits 102 since it actually isn't compatible with old framework versions.

## Test plan 

- Ran test 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
