### PR TITLE
Add API for handling multiple return values in ProgrammableTransactionBuilder

### DIFF
--- a/crates/sui-types/src/programmable_transaction_builder.rs
+++ b/crates/sui-types/src/programmable_transaction_builder.rs
@@ -163,6 +163,15 @@ impl ProgrammableTransactionBuilder {
         Argument::Result(i as u16)
     }
 
+    pub fn command_with_multiple_results<const N: usize>(
+        &mut self,
+        command: Command,
+    ) -> [Argument; N] {
+        let i = self.commands.len();
+        self.commands.push(command);
+        std::array::from_fn(|j| Argument::NestedResult(i as u16, j as u16))
+    }
+
     /// Will fail to generate if given an empty ObjVec
     pub fn move_call(
         &mut self,
@@ -195,6 +204,23 @@ impl ProgrammableTransactionBuilder {
         arguments: Vec<Argument>,
     ) -> Argument {
         self.command(Command::move_call(
+            package,
+            module,
+            function,
+            type_arguments,
+            arguments,
+        ))
+    }
+
+    pub fn programmable_move_call_with_multiple_results<const N: usize>(
+        &mut self,
+        package: ObjectID,
+        module: Identifier,
+        function: Identifier,
+        type_arguments: Vec<TypeTag>,
+        arguments: Vec<Argument>,
+    ) -> [Argument; N] {
+        self.command_with_multiple_results(Command::move_call(
             package,
             module,
             function,

--- a/crates/sui-types/src/unit_tests/programmable_transaction_builder_tests.rs
+++ b/crates/sui-types/src/unit_tests/programmable_transaction_builder_tests.rs
@@ -3,8 +3,9 @@
 
 use crate::base_types::random_object_ref;
 use crate::programmable_transaction_builder::ProgrammableTransactionBuilder;
-use crate::transaction::Argument::Input;
+use crate::transaction::Argument::{Input, NestedResult};
 use crate::transaction::{CallArg, Command, ObjectArg};
+use move_core_types::{identifier::Identifier, language_storage::TypeTag};
 
 #[test]
 fn test_builder_merge_coins_one_source() {
@@ -156,4 +157,146 @@ fn test_builder_smash_coins_zero_coin() {
     let result = builder.smash_coins(vec![]);
 
     assert!(result.is_err());
+}
+
+#[test]
+fn test_command_with_multiple_results_n1() {
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let target_coin_ref = random_object_ref();
+    let coin_arg = builder
+        .obj(ObjectArg::ImmOrOwnedObject(target_coin_ref))
+        .unwrap();
+    let amt_arg = builder.pure(100u64).unwrap();
+
+    let [result] =
+        builder.command_with_multiple_results::<1>(Command::SplitCoins(coin_arg, vec![amt_arg]));
+
+    assert_eq!(result, NestedResult(0, 0));
+
+    let tx = builder.finish();
+    assert_eq!(tx.commands.len(), 1);
+}
+
+#[test]
+fn test_command_with_multiple_results_n2() {
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let target_coin_ref = random_object_ref();
+    let coin_arg = builder
+        .obj(ObjectArg::ImmOrOwnedObject(target_coin_ref))
+        .unwrap();
+    let amt1_arg = builder.pure(100u64).unwrap();
+    let amt2_arg = builder.pure(200u64).unwrap();
+
+    let [result1, result2] = builder.command_with_multiple_results::<2>(Command::SplitCoins(
+        coin_arg,
+        vec![amt1_arg, amt2_arg],
+    ));
+
+    assert_eq!(result1, NestedResult(0, 0));
+    assert_eq!(result2, NestedResult(0, 1));
+
+    let tx = builder.finish();
+    assert_eq!(tx.commands.len(), 1);
+}
+
+#[test]
+fn test_command_with_multiple_results_n3() {
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let target_coin_ref = random_object_ref();
+    let coin_arg = builder
+        .obj(ObjectArg::ImmOrOwnedObject(target_coin_ref))
+        .unwrap();
+    let amt1_arg = builder.pure(100u64).unwrap();
+    let amt2_arg = builder.pure(200u64).unwrap();
+    let amt3_arg = builder.pure(300u64).unwrap();
+
+    let [result1, result2, result3] = builder.command_with_multiple_results::<3>(
+        Command::SplitCoins(coin_arg, vec![amt1_arg, amt2_arg, amt3_arg]),
+    );
+
+    assert_eq!(result1, NestedResult(0, 0));
+    assert_eq!(result2, NestedResult(0, 1));
+    assert_eq!(result3, NestedResult(0, 2));
+
+    let tx = builder.finish();
+    assert_eq!(tx.commands.len(), 1);
+}
+
+#[test]
+fn test_programmable_move_call_with_multiple_results_n2() {
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let package = random_object_ref().0;
+    let module = Identifier::new("test_module").unwrap();
+    let function = Identifier::new("test_function").unwrap();
+    let arg1 = builder.pure(42u64).unwrap();
+    let arg2 = builder.pure(100u64).unwrap();
+
+    let [result1, result2] = builder.programmable_move_call_with_multiple_results::<2>(
+        package,
+        module,
+        function,
+        vec![],
+        vec![arg1, arg2],
+    );
+
+    assert_eq!(result1, NestedResult(0, 0));
+    assert_eq!(result2, NestedResult(0, 1));
+
+    let tx = builder.finish();
+    assert_eq!(tx.commands.len(), 1);
+    match &tx.commands[0] {
+        Command::MoveCall(call) => {
+            assert_eq!(call.arguments, vec![arg1, arg2]);
+        }
+        _ => panic!("Expected MoveCall command"),
+    }
+}
+
+#[test]
+fn test_programmable_move_call_with_multiple_results_n3() {
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let package = random_object_ref().0;
+    let module = Identifier::new("test_module").unwrap();
+    let function = Identifier::new("test_function").unwrap();
+    let type_arg = TypeTag::U64;
+    let arg = builder.pure(42u64).unwrap();
+
+    let [result1, result2, result3] = builder.programmable_move_call_with_multiple_results::<3>(
+        package,
+        module,
+        function,
+        vec![type_arg],
+        vec![arg],
+    );
+
+    assert_eq!(result1, NestedResult(0, 0));
+    assert_eq!(result2, NestedResult(0, 1));
+    assert_eq!(result3, NestedResult(0, 2));
+
+    let tx = builder.finish();
+    assert_eq!(tx.commands.len(), 1);
+}
+
+#[test]
+fn test_command_with_multiple_results_sequential_commands() {
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let coin1_ref = random_object_ref();
+    let coin2_ref = random_object_ref();
+    let coin1_arg = builder.obj(ObjectArg::ImmOrOwnedObject(coin1_ref)).unwrap();
+    let coin2_arg = builder.obj(ObjectArg::ImmOrOwnedObject(coin2_ref)).unwrap();
+    let amt1_arg = builder.pure(100u64).unwrap();
+    let amt2_arg = builder.pure(200u64).unwrap();
+
+    let [split1_result1, split1_result2] =
+        builder.command_with_multiple_results::<2>(Command::SplitCoins(coin1_arg, vec![amt1_arg]));
+
+    let [split2_result1] =
+        builder.command_with_multiple_results::<1>(Command::SplitCoins(coin2_arg, vec![amt2_arg]));
+
+    assert_eq!(split1_result1, NestedResult(0, 0));
+    assert_eq!(split1_result2, NestedResult(0, 1));
+    assert_eq!(split2_result1, NestedResult(1, 0));
+
+    let tx = builder.finish();
+    assert_eq!(tx.commands.len(), 2);
 }


### PR DESCRIPTION
Added two new methods to ProgrammableTransactionBuilder that return fixed-size arrays of Arguments when commands return multiple values. command_with_multiple_results<N> works for any command type, and programmable_move_call_with_multiple_results<N> is specialized for Move calls. Both use const generics for compile-time type safety.

The current workaround requires extracting the command index manually and constructing NestedResult arguments one by one. This is error prone and verbose, requiring pattern matching on Result variants and manual index tracking across 7 lines of code.

Implementation details:
- Added command_with_multiple_results<const N: usize> in programmable_transaction_builder.rs at line 166
- Added programmable_move_call_with_multiple_results<const N: usize> at line 212
- Uses std::array::from_fn to construct arrays of NestedResult(cmd_idx, result_idx)
- Added 6 comprehensive tests covering N=1,2,3 and sequential command cases
- All 13 tests pass including existing tests for backward compatibility
- Zero clippy warnings, properly formatted with cargo fmt

Fixes #23571