### PR TITLE
sui-kvstore: build protos using cargo-script instead of build.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15333,7 +15333,6 @@ dependencies = [
  "prometheus",
  "prost 0.14.1",
  "prost-types 0.14.1",
- "protox",
  "serde",
  "sui-data-ingestion-core",
  "sui-types",
@@ -15342,7 +15341,6 @@ dependencies = [
  "tokio",
  "tonic 0.14.2",
  "tonic-prost",
- "tonic-prost-build",
  "tracing",
 ]
 

--- a/crates/sui-kvstore/Cargo.toml
+++ b/crates/sui-kvstore/Cargo.toml
@@ -26,7 +26,3 @@ tokio = { workspace = true, features = ["full"] }
 tonic = { workspace = true, features = ["transport"] }
 tonic-prost.workspace = true
 tracing.workspace = true
-
-[build-dependencies]
-tonic-prost-build.workspace = true
-protox.workspace = true

--- a/crates/sui-kvstore/build-protos
+++ b/crates/sui-kvstore/build-protos
@@ -1,24 +1,25 @@
-// Copyright (c) Mysten Labs, Inc.
-// SPDX-License-Identifier: Apache-2.0
+#!/usr/bin/env -S cargo +nightly -Zscript
+---
+[package]
+edition = "2024"
+
+[dependencies]
+tonic-prost-build = "0.14.2"
+protox = "0.9"
+---
 
 use std::path::PathBuf;
 
 fn main() {
     let crate_dir = PathBuf::from(std::env!("CARGO_MANIFEST_DIR"));
     let proto_dir = crate_dir.join("proto");
-    let out_dir = crate_dir.join("src").join("bigtable").join("proto");
-
-    println!("cargo:rerun-if-changed={}", proto_dir.display());
+    let out_dir = crate_dir.join("src/bigtable/proto");
 
     let fds = protox::Compiler::new(&proto_dir)
         .unwrap()
         .include_source_info(false)
         .include_imports(true)
-        .open_files(&[proto_dir
-            .join("google")
-            .join("bigtable")
-            .join("v2")
-            .join("bigtable.proto")])
+        .open_files(&[proto_dir.join("google/bigtable/v2/bigtable.proto")])
         .unwrap()
         .file_descriptor_set();
 


### PR DESCRIPTION
In order to avoid some windows build issues, we'll use a cargo-script to build the proto files instead of a build.rs that is run at build time.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
