### PR TITLE
[package-alt] rename-from improvements

### DIFF
--- a/external-crates/move/crates/move-package-alt/src/dependency/pin.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/pin.rs
@@ -181,8 +181,8 @@ impl Pinned {
                 let rev = fmt_truncated(git.inner.sha(), 6, 2);
                 format!(r#"git = "{repo}", path = "{path}", rev = "{rev}""#)
             }
-            Pinned::OnChain(_on_chain) => format!("on-chain = true"),
-            Pinned::Root(_) => format!("local = \".\""),
+            Pinned::OnChain(_on_chain) => "on-chain = true".to_string(),
+            Pinned::Root(_) => "local = \".\"".to_string(),
         }
     }
 }
@@ -263,7 +263,7 @@ impl From<Pinned> for LockfileDependencyInfo {
 impl fmt::Display for Pinned {
     // TODO: this is maybe misguided; we should perhaps only display manifest dependencies?
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{{ {}, ... }}", self.abbreviated())
+        write!(f, "{{ {} }}", self.abbreviated())
     }
 }
 
@@ -441,7 +441,7 @@ mod tests {
     #[test]
     fn display_local() {
         let dep = new_pinned_local_from("", "foo/bar");
-        assert_snapshot!(format!("{dep}"), @r###"{ local = "foo/bar", ... }"###);
+        assert_snapshot!(format!("{dep}"), @r###"{ local = "foo/bar" }"###);
     }
 
     #[test]
@@ -451,13 +451,13 @@ mod tests {
             "ac4911261dd71cac55cf5bf2dd3288f3a12f2563",
             "foo/bar/baz",
         );
-        assert_snapshot!(format!("{dep}"), @r###"{ git = "https://...org/repo.git", path = "foo/bar/baz", rev = "ac4911...63", ... }"###);
+        assert_snapshot!(format!("{dep}"), @r###"{ git = "https://...org/repo.git", path = "foo/bar/baz", rev = "ac4911...63" }"###);
     }
 
     #[test]
     fn display_root() {
         let (_, dep) = new_pinned_root("");
-        assert_snapshot!(format!("{dep}"), @r###"{ local = ".", ... }"###);
+        assert_snapshot!(format!("{dep}"), @r###"{ local = "." }"###);
     }
 
     // Test infrastructure /////////////////////////////////////////////////////////////////////////

--- a/external-crates/move/crates/move-package-alt/src/graph/linkage.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/linkage.rs
@@ -469,8 +469,8 @@ mod tests {
         assert_snapshot!(linkage_err(&scenario, "root").await, @r###"
         Package depends on multiple versions of the package with ID 0x00...0001:
 
-          root::a::b::d1 refers to { local = "../d1", ... }
-          root::a::c::d2 refers to { local = "../d2", ... }
+          root::a::b::d1 refers to { local = "../d1" }
+          root::a::c::d2 refers to { local = "../d2" }
 
         To resolve this, you must explicitly add an override in your Move.toml:
 
@@ -481,8 +481,8 @@ mod tests {
         assert_snapshot!(linkage_err(&scenario, "a").await, @r###"
         Package depends on multiple versions of the package with ID 0x00...0001:
 
-          a::b::d1 refers to { local = "../d1", ... }
-          a::c::d2 refers to { local = "../d2", ... }
+          a::b::d1 refers to { local = "../d1" }
+          a::c::d2 refers to { local = "../d2" }
 
         To resolve this, you must explicitly add an override in your Move.toml:
 
@@ -519,8 +519,8 @@ mod tests {
         assert_snapshot!(linkage_err(&scenario, "root").await, @r###"
         Package depends on multiple versions of the package with ID 0x00...0001:
 
-          root::a::b::d1 refers to { local = "../d1", ... }
-          root::a::c::d2 refers to { local = "../d2", ... }
+          root::a::b::d1 refers to { local = "../d1" }
+          root::a::c::d2 refers to { local = "../d2" }
 
         To resolve this, you must explicitly add an override in your Move.toml:
 
@@ -531,8 +531,8 @@ mod tests {
         assert_snapshot!(linkage_err(&scenario, "a").await, @r###"
         Package depends on multiple versions of the package with ID 0x00...0001:
 
-          a::b::d1 refers to { local = "../d1", ... }
-          a::c::d2 refers to { local = "../d2", ... }
+          a::b::d1 refers to { local = "../d1" }
+          a::c::d2 refers to { local = "../d2" }
 
         To resolve this, you must explicitly add an override in your Move.toml:
 
@@ -600,8 +600,8 @@ mod tests {
         assert_snapshot!(linkage_err(&scenario, "root").await, @r###"
         Package depends on multiple versions of the package with ID 0x00...0001:
 
-          root::a::d3 refers to { local = "../d3", ... }
-          root::a::b::d1 refers to { local = "../d1", ... }
+          root::a::d3 refers to { local = "../d3" }
+          root::a::b::d1 refers to { local = "../d1" }
 
         To resolve this, you must explicitly add an override in your Move.toml:
 
@@ -612,8 +612,8 @@ mod tests {
         assert_snapshot!(linkage_err(&scenario, "a").await, @r###"
         Package depends on multiple versions of the package with ID 0x00...0001:
 
-          a::d3 refers to { local = "../d3", ... }
-          a::b::d1 refers to { local = "../d1", ... }
+          a::d3 refers to { local = "../d3" }
+          a::b::d1 refers to { local = "../d1" }
 
         To resolve this, you must explicitly add an override in your Move.toml:
 
@@ -642,8 +642,8 @@ mod tests {
         assert_snapshot!(linkage_err(&scenario, "root").await, @r###"
         Package depends on multiple versions of the package with ID 0x00...0001:
 
-          root::a::d1 refers to { local = "../d1", ... }
-          root::a::b::d2 refers to { local = "../d2", ... }
+          root::a::d1 refers to { local = "../d1" }
+          root::a::b::d2 refers to { local = "../d2" }
 
         To resolve this, you must explicitly add an override in your Move.toml:
 
@@ -654,8 +654,8 @@ mod tests {
         assert_snapshot!(linkage_err(&scenario, "a").await, @r###"
         Package depends on multiple versions of the package with ID 0x00...0001:
 
-          a::d1 refers to { local = "../d1", ... }
-          a::b::d2 refers to { local = "../d2", ... }
+          a::d1 refers to { local = "../d1" }
+          a::b::d2 refers to { local = "../d2" }
 
         To resolve this, you must explicitly add an override in your Move.toml:
 
@@ -684,8 +684,8 @@ mod tests {
         assert_snapshot!(linkage_err(&scenario, "root").await, @r###"
         Package depends on multiple versions of the package with ID 0x00...0001:
 
-          root::a::b1 refers to { local = "../b1", ... }
-          root::a::b2 refers to { local = "../b2", ... }
+          root::a::b1 refers to { local = "../b1" }
+          root::a::b2 refers to { local = "../b2" }
 
         To resolve this, you must explicitly add an override in your Move.toml:
 
@@ -696,8 +696,8 @@ mod tests {
         assert_snapshot!(linkage_err(&scenario, "a").await, @r###"
         Package depends on multiple versions of the package with ID 0x00...0001:
 
-          a::b1 refers to { local = "../b1", ... }
-          a::b2 refers to { local = "../b2", ... }
+          a::b1 refers to { local = "../b1" }
+          a::b2 refers to { local = "../b2" }
 
         To resolve this, you must explicitly add an override in your Move.toml:
 
@@ -735,8 +735,8 @@ mod tests {
         assert_snapshot!(linkage_err(&scenario, "root").await, @r###"
         Package depends on multiple versions of the package with ID 0x00...0001:
 
-          root::a::b1 refers to { local = "../b1", ... }
-          root::a::b2 refers to { local = "../b2", ... }
+          root::a::b1 refers to { local = "../b1" }
+          root::a::b2 refers to { local = "../b2" }
 
         To resolve this, you must explicitly add an override in your Move.toml:
 
@@ -747,8 +747,8 @@ mod tests {
         assert_snapshot!(linkage_err(&scenario, "a").await, @r###"
         Package depends on multiple versions of the package with ID 0x00...0001:
 
-          a::b1 refers to { local = "../b1", ... }
-          a::b2 refers to { local = "../b2", ... }
+          a::b1 refers to { local = "../b1" }
+          a::b2 refers to { local = "../b2" }
 
         To resolve this, you must explicitly add an override in your Move.toml:
 
@@ -942,8 +942,8 @@ mod tests {
         assert_snapshot!(linkage_err(&scenario, "root").await, @r###"
         Package depends on multiple versions of the package with ID 0x00...0001:
 
-          root::a::c::e2 refers to { local = "../e2", ... }
-          root::a::c::d::e1 refers to { local = "../e1", ... }
+          root::a::c::e2 refers to { local = "../e2" }
+          root::a::c::d::e1 refers to { local = "../e1" }
 
         To resolve this, you must explicitly add an override in your Move.toml:
 
@@ -954,8 +954,8 @@ mod tests {
         assert_snapshot!(linkage_err(&scenario, "a").await, @r###"
         Package depends on multiple versions of the package with ID 0x00...0001:
 
-          a::c::e2 refers to { local = "../e2", ... }
-          a::c::d::e1 refers to { local = "../e1", ... }
+          a::c::e2 refers to { local = "../e2" }
+          a::c::d::e1 refers to { local = "../e1" }
 
         To resolve this, you must explicitly add an override in your Move.toml:
 
@@ -1076,8 +1076,8 @@ mod tests {
         assert_snapshot!(linkage_err(&scenario, "root").await, @r###"
         Package depends on multiple versions of the package with ID 0x00...0003:
 
-          root::a::c1 refers to { local = "../c1", ... }
-          root::a::e::c2 refers to { local = "../c2", ... }
+          root::a::c1 refers to { local = "../c1" }
+          root::a::e::c2 refers to { local = "../c2" }
 
         To resolve this, you must explicitly add an override in your Move.toml:
 
@@ -1089,8 +1089,8 @@ mod tests {
         assert_snapshot!(linkage_err(&scenario, "a").await, @r###"
         Package depends on multiple versions of the package with ID 0x00...0003:
 
-          a::c1 refers to { local = "../c1", ... }
-          a::e::c2 refers to { local = "../c2", ... }
+          a::c1 refers to { local = "../c1" }
+          a::e::c2 refers to { local = "../c2" }
 
         To resolve this, you must explicitly add an override in your Move.toml:
 

--- a/external-crates/move/crates/move-package-alt/src/graph/rename_from.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/rename_from.rs
@@ -92,14 +92,12 @@ impl<F: MoveFlavor> PackageGraph<F> {
                         actual_dep_name,
                     });
                 }
-            } else {
-                if local_dep_name != actual_dep_name {
-                    return Err(RenameError::MismatchedNames {
-                        local_dep_name,
-                        dep_location: dep.as_ref().abbreviated(),
-                        actual_dep_name,
-                    });
-                }
+            } else if local_dep_name != actual_dep_name {
+                return Err(RenameError::MismatchedNames {
+                    local_dep_name,
+                    dep_location: dep.as_ref().abbreviated(),
+                    actual_dep_name,
+                });
             }
         }
 

--- a/external-crates/move/crates/move-package-alt/src/package/root_package.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/root_package.rs
@@ -1250,8 +1250,8 @@ pkg_b = { local = "../pkg_b" }"#,
         assert_snapshot!(root.unwrap_err().to_string(), @r###"
         Package depends on multiple versions of the package with ID 0x00...0001:
 
-          root::dep1 refers to { local = "../dep1", ... }
-          root::dep2 refers to { local = "../dep2", ... }
+          root::dep1 refers to { local = "../dep1" }
+          root::dep2 refers to { local = "../dep2" }
 
         To resolve this, you must explicitly add an override in your Move.toml:
 


### PR DESCRIPTION
## Description 

This PR changes a few things about rename-from checks:
 - we only check the root package
 - we produce much better error messages
 - the legacy code paths are clearer
 - most of the large legacy tests have been split up and the error messages snapshotted

## Test plan 

Updated unit tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
