### PR TITLE
cli: support external postgres DBs

### DIFF
--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -1072,13 +1072,13 @@ async fn start(
             };
 
             let url = db.url().clone();
-            info!("Starting indexer with local database at {url}");
+            info!("Starting indexer with local database");
             (Some(db), Some(url))
         }
 
         // Use provided database URL
         Some(Some(url)) => {
-            info!("Starting indexer with provided database at {url}");
+            info!("Starting indexer with provided database");
             (None, Some(url))
         }
     };


### PR DESCRIPTION
## Description

Add a way to connect the CLI to an external postgres database, by passing a postgres URL as an argument to the `--with-indexer` flag:

## Test plan

Tested that the following all worked

```sh
# Implicitly create a temporary database
$ sui start --force-regenesis --with-graphql

# Explicitly create a temporary database
$ sui start --force-regenesis --with-graphql --with-indexer

# Explicitly connect to an existing, external DB
$ dropdb sui_indexer
$ createdb sui_indexer
$ sui start --force-regenesis --with-graphql \
  --with-indexer=postgres://postgres:postgrespw@localhost:5432/sui_indexer
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Adds the ability to talk to an existing, remote Postgres database when running the indexer and/or GraphQL for a local network.
- [ ] Rust SDK:
