### PR TITLE
Do not call antithesis_sdk::assert_sometimes in simtest

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -19,9 +19,9 @@ use futures::FutureExt;
 use futures::future::{Either, join_all, select};
 use itertools::{Itertools, izip};
 use move_bytecode_utils::module_cache::SyncModuleCache;
-use mysten_common::assert_reachable;
 use mysten_common::sync::notify_once::NotifyOnce;
 use mysten_common::sync::notify_read::NotifyRead;
+use mysten_common::{assert_reachable, assert_sometimes};
 use mysten_common::{debug_fatal, fatal};
 use mysten_metrics::monitored_scope;
 use nonempty::NonEmpty;
@@ -4704,11 +4704,11 @@ impl AuthorityPerEpochStore {
                     ) {
                         ConsensusCertificateResult::Deferred(deferral_key)
                     } else {
-                        antithesis_sdk::assert_sometimes!(
+                        assert_sometimes!(
                             transaction.transaction_data().uses_randomness(),
                             "cancelled randomness-using transaction (old handler)"
                         );
-                        antithesis_sdk::assert_sometimes!(
+                        assert_sometimes!(
                             !transaction.transaction_data().uses_randomness(),
                             "cancelled non-randomness-using transaction (old handler)"
                         );

--- a/crates/sui-core/src/consensus_handler.rs
+++ b/crates/sui-core/src/consensus_handler.rs
@@ -17,7 +17,7 @@ use fastcrypto_zkp::bn254::zk_login::{JWK, JwkId};
 use itertools::Itertools as _;
 use lru::LruCache;
 use mysten_common::{
-    assert_reachable, debug_fatal, in_test_configuration,
+    assert_reachable, assert_sometimes, debug_fatal, in_test_configuration,
     random_util::randomize_cache_capacity_in_tests,
 };
 use mysten_metrics::{
@@ -1437,11 +1437,11 @@ impl<C: CheckpointServiceNotify + Send + Sync> ConsensusHandler<C> {
                             .or_default()
                             .push(transaction);
                     } else {
-                        antithesis_sdk::assert_sometimes!(
+                        assert_sometimes!(
                             transaction.transaction_data().uses_randomness(),
                             "cancelled randomness-using transaction"
                         );
-                        antithesis_sdk::assert_sometimes!(
+                        assert_sometimes!(
                             !transaction.transaction_data().uses_randomness(),
                             "cancelled non-randomness-using transaction"
                         );


### PR DESCRIPTION
Fixes determinism tests
