### PR TITLE
graphql-alt: cleanup Event and CoinMetadata pipelines

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/available_range.rs
@@ -175,10 +175,7 @@ collect_pipelines! {
     CoinMetadata.[objectAt, objectVersionsAfter, objectVersionsBefore] => IObject.*;
     CoinMetadata.[digest, objectBcs, owner, previousTransaction, storageRebate, version] => IObject.*;
     CoinMetadata.[receivedTransactions] => IObject.receivedTransactions();
-    CoinMetadata.[supply] |pipelines, _filters| {
-        pipelines.insert("consistent".to_string());
-    };
-    CoinMetadata.[supplyState] |pipelines, _filters| {
+    CoinMetadata.[allowGlobalPause, denyCap, regulatedState, supply, supplyState] |pipelines, _filters| {
         pipelines.insert("consistent".to_string());
     };
 
@@ -199,11 +196,6 @@ collect_pipelines! {
         pipelines.insert("obj_versions".to_string());
     };
     Epoch.[transactions] => Query.transactions(.., "atCheckpoint");
-
-    Event.[contents, eventBcs, sender, sequenceNumber, timestamp, transaction, transactionModule] |pipelines, _filters| {
-        pipelines.insert("ev_struct_inst".to_string());
-        pipelines.insert("tx_digests".to_string());
-    };
 
     IAddressable.[balance, balances, multiGetBalances, objects] |pipelines, _filters| {
         pipelines.insert("consistent".to_string());

--- a/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
+++ b/crates/sui-indexer-alt-graphql/src/api/types/snapshots/sui_indexer_alt_graphql__api__types__available_range__field_piplines_tests__registry_collect_pipelines_snapshot.snap
@@ -285,13 +285,13 @@ CoinMetadata.receivedTransactions
   => {"cp_sequence_numbers", "tx_affected_addresses", "tx_digests"}
 
 CoinMetadata.regulatedState
-  => {}
+  => {"consistent"}
 
 CoinMetadata.allowGlobalPause
-  => {}
+  => {"consistent"}
 
 CoinMetadata.denyCap
-  => {}
+  => {"consistent"}
 
 CoinMetadata.supplyState
   => {"consistent"}
@@ -531,25 +531,25 @@ Epoch.liveObjectSetDigest
   => {}
 
 Event.contents
-  => {"ev_struct_inst", "tx_digests"}
+  => {}
 
 Event.eventBcs
-  => {"ev_struct_inst", "tx_digests"}
+  => {}
 
 Event.sender
-  => {"ev_struct_inst", "tx_digests"}
+  => {}
 
 Event.sequenceNumber
-  => {"ev_struct_inst", "tx_digests"}
+  => {}
 
 Event.timestamp
-  => {"ev_struct_inst", "tx_digests"}
+  => {}
 
 Event.transaction
-  => {"ev_struct_inst", "tx_digests"}
+  => {}
 
 Event.transactionModule
-  => {"ev_struct_inst", "tx_digests"}
+  => {}
 
 ExecutionError.abortCode
   => {}


### PR DESCRIPTION
## Description 

Changes:
- add missing `CoinMetadata` pipelines
- `Event` available range should fallthrough to the catch all instead of being bounded by pipelines, once events are fetched from the store the fields do not require additional queries.

## Test plan 

```
cargo nextest run -p sui-indexer-alt-graphql available_range
cargo test --package sui-indexer-alt-e2e-tests --test graphql_available_range_tests
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
