### PR TITLE
[td] add a metric for drive_transaction() errors

### DIFF
--- a/crates/sui-core/src/transaction_driver/metrics.rs
+++ b/crates/sui-core/src/transaction_driver/metrics.rs
@@ -16,6 +16,7 @@ const SUBMIT_TRANSACTION_RETRIES_BUCKETS: &[f64] = &[
 #[derive(Clone)]
 pub struct TransactionDriverMetrics {
     pub(crate) settlement_finality_latency: HistogramVec,
+    pub(crate) drive_transaction_errors: IntCounterVec,
     pub(crate) total_transactions_submitted: IntCounterVec,
     pub(crate) submit_transaction_retries: Histogram,
     pub(crate) submit_transaction_latency: HistogramVec,
@@ -43,6 +44,13 @@ impl TransactionDriverMetrics {
                 "Settlement finality latency observed from transaction driver",
                 &["tx_type", "ping"],
                 mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
+                registry,
+            )
+            .unwrap(),
+            drive_transaction_errors: register_int_counter_vec_with_registry!(
+                "transaction_driver_drive_transaction_errors",
+                "Number of errors observed from drive_transaction() attempts.",
+                &["error_type", "tx_type", "ping"],
                 registry,
             )
             .unwrap(),

--- a/crates/sui-core/src/transaction_driver/mod.rs
+++ b/crates/sui-core/src/transaction_driver/mod.rs
@@ -290,6 +290,14 @@ where
                         return Ok(resp);
                     }
                     Err(e) => {
+                        self.metrics
+                            .drive_transaction_errors
+                            .with_label_values(&[
+                                e.categorize().into(),
+                                tx_type.as_str(),
+                                ping_label,
+                            ])
+                            .inc();
                         if !e.is_submission_retriable() {
                             // Record the number of retries for failed transaction
                             self.metrics

--- a/crates/sui-core/src/transaction_driver/transaction_submitter.rs
+++ b/crates/sui-core/src/transaction_driver/transaction_submitter.rs
@@ -152,11 +152,7 @@ impl TransactionSubmitter {
                     return Ok((name, result));
                 }
                 Some((name, display_name, Err(e))) => {
-                    let error_type = if e.is_submission_retriable() {
-                        "retriable"
-                    } else {
-                        "non_retriable"
-                    };
+                    let error_type = e.categorize().into();
                     self.metrics
                         .validator_submit_transaction_errors
                         .with_label_values(&[

--- a/crates/sui-types/src/error.rs
+++ b/crates/sui-types/src/error.rs
@@ -1148,7 +1148,7 @@ pub fn command_argument_error(e: CommandArgumentError, arg_idx: usize) -> Execut
 }
 
 /// Types of SuiError.
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, IntoStaticStr)]
 pub enum ErrorCategory {
     // A generic error that is retriable with new transaction resubmissions.
     Aborted,


### PR DESCRIPTION
## Description 

TransactionDriver only had a counter for submit errors, not overall drive_transaction_once() errors.

## Test plan 

Check deployment