### PR TITLE
test: add `#[test_only]` `sui::coin_registry::share_for_testing`

### DIFF
--- a/crates/sui-framework/packages/sui-framework/sources/registries/coin_registry.move
+++ b/crates/sui-framework/packages/sui-framework/sources/registries/coin_registry.move
@@ -625,6 +625,12 @@ public fun create_coin_data_registry_for_testing(ctx: &mut TxContext): CoinRegis
 }
 
 #[test_only]
+/// For transactional tests (if CoinRegistry is used as a shared object).
+public fun share_for_testing(registry: CoinRegistry) {
+    sui::transfer::share_object(registry);
+}
+
+#[test_only]
 /// Unwrap CurrencyInitializer for testing purposes.
 /// This function is test-only and should only be used in tests.
 public fun unwrap_for_testing<T>(init: CurrencyInitializer<T>): Currency<T> {


### PR DESCRIPTION
## Description 

Adds a test only `share_for_testing` function to allow sharing of the `CoinRegistry` singleton.