### PR TITLE
docs: fix typo in zkLogin documentation

### DIFF
--- a/docs/content/concepts/cryptography/zklogin.mdx
+++ b/docs/content/concepts/cryptography/zklogin.mdx
@@ -304,7 +304,7 @@ The key differentiators that zkLogin brings to Sui are:
 
 1. Native Support in Sui: Unlike other solutions that are blockchain agnostic, zkLogin is deployed just for Sui. This means a zkLogin transaction can be combined with Multisig and sponsored transactions seamlessly.
 
-1. Self-Custodial without additional trust: Sui leverages the nonce field in JWT to commit to ephemeral public key, so no persistent private key management is required with any trusted parties. In addition, the JWK itself is an oracle agreed upon by the quorum of stakes by the validators with trusting any source of authority.
+1. Self-Custodial without additional trust: Sui leverages the nonce field in JWT to commit to ephemeral public key, so no persistent private key management is required with any trusted parties. In addition, the JWK itself is an oracle agreed upon by the quorum of stakes by the validators without trusting any source of authority.
 
 1. Full privacy: Nothing is required to submit on-chain except the ZK proof and the ephemeral signature.
 


### PR DESCRIPTION
## Description 

Fix typo on docs

https://github.com/MystenLabs/sui/blob/main/docs/content/concepts/cryptography/zklogin.mdx

### How is zkLogin different from other solutions that support social login?
> ... the JWK itself is an oracle agreed upon by the quorum of stakes by the validators with trusting any source of authority.

Fixes typo: “with trusting” → “without trusting” in zkLogin docs.
This correction clarifies that no external authority needs to be trusted.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:

@jessiemongeon1 @ronny-mysten 