### PR TITLE
[indexer-alt-framework] remove `skip_watermark` and standardize `first_checkpoint` behavior

### DIFF
--- a/crates/sui-indexer-alt-framework/src/pipeline/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/mod.rs
@@ -21,9 +21,6 @@ const PIPELINE_BUFFER: usize = 5;
 /// happen if the pipeline was started with its initial checkpoint overridden to be strictly
 /// greater than its current watermark -- in that case, the pipeline will never be able to update
 /// its watermarks.
-///
-/// This may be a legitimate thing to do when backfilling a table, but in that case
-/// `--skip-watermarks` should be used.
 const WARN_PENDING_WATERMARKS: usize = 10000;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/sui-indexer-alt-framework/src/postgres/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/postgres/mod.rs
@@ -160,7 +160,7 @@ pub mod tests {
             .concurrent_pipeline(ConcurrentPipeline1, ConcurrentConfig::default())
             .await
             .unwrap();
-        assert_eq!(indexer.first_checkpoint_from_watermark, 0);
+        assert_eq!(indexer.first_ingestion_checkpoint, 0);
     }
 
     #[tokio::test]
@@ -179,7 +179,7 @@ pub mod tests {
             .concurrent_pipeline(ConcurrentPipeline1, ConcurrentConfig::default())
             .await
             .unwrap();
-        assert_eq!(indexer.first_checkpoint_from_watermark, 11);
+        assert_eq!(indexer.first_ingestion_checkpoint, 11);
     }
 
     #[tokio::test]
@@ -205,11 +205,11 @@ pub mod tests {
             .concurrent_pipeline(ConcurrentPipeline2, ConcurrentConfig::default())
             .await
             .unwrap();
-        assert_eq!(indexer.first_checkpoint_from_watermark, 21);
+        assert_eq!(indexer.first_ingestion_checkpoint, 21);
         indexer
             .concurrent_pipeline(ConcurrentPipeline1, ConcurrentConfig::default())
             .await
             .unwrap();
-        assert_eq!(indexer.first_checkpoint_from_watermark, 11);
+        assert_eq!(indexer.first_ingestion_checkpoint, 11);
     }
 }

--- a/crates/sui-indexer-alt/src/benchmark.rs
+++ b/crates/sui-indexer-alt/src/benchmark.rs
@@ -51,7 +51,6 @@ pub async fn run_benchmark(
         first_checkpoint: Some(first_checkpoint),
         last_checkpoint: Some(last_checkpoint),
         pipeline,
-        ..Default::default()
     };
 
     let client_args = ClientArgs {

--- a/docs/content/guides/developer/advanced/custom-indexer/indexer-runtime-perf.mdx
+++ b/docs/content/guides/developer/advanced/custom-indexer/indexer-runtime-perf.mdx
@@ -75,10 +75,6 @@ Include the following command-line arguments to help focus processing. These val
 --pipeline "tx_counts"          # Run specific pipeline only
 --pipeline "events"             # Can specify multiple pipelines
 
-# Watermark behavior
---skip-watermark  
-```
-
 **Use cases:**
 
 - **Checkpoint range:** Essential for backfills and historical data processing.


### PR DESCRIPTION
## Description 

This PR standardizes behavior around `--first-checkpoint` and its effects on
A. The checkpoint to start ingesting from
B. The checkpoint for a pipeline to resume processing from

- When an indexer starts, it will always start ingesting from the next checkpoint after the smallest committed checkpoint across all pipelines added to it. 
- Pipelines without a watermark are by default to be backfilled from genesis.
- Providing `--first-checkpoint` overrides this behavior, and tells the indexer that these pipelines are to process checkpoints from `--first-checkpoint` instead.

## Test plan 

New tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
