### PR TITLE
fix(graphql): filter wrapped/deleted object versions

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/object_version_wrapping.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/object_version_wrapping.move
@@ -1,0 +1,64 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --protocol-version 70 --accounts A --addresses P=0x0 --simulator
+// Track the versions of an object as it is being wrapped, unwrapped, and deleted.
+
+//# publish
+module P::M {
+  use sui::coin::Coin;
+  use sui::sui::SUI;
+
+  public struct Wrapper has key, store {
+    id: UID,
+    coin: Coin<SUI>,
+  }
+
+  public fun wrap(coin: Coin<SUI>, ctx: &mut TxContext): Wrapper {
+    Wrapper { id: object::new(ctx), coin }
+  }
+
+  public fun unwrap(wrapper: Wrapper): Coin<SUI> {
+    let Wrapper { id, coin } = wrapper;
+    id.delete();
+    coin
+  }
+}
+
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs object(2,0) 1
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+
+//# programmable --sender A --inputs object(2,0) @A
+//> 0: P::M::wrap(Input(0));
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs object(4,0) @A
+//> 0: P::M::unwrap(Input(0));
+//> 1: TransferObjects([Result(0)], Input(1))
+
+//# programmable --sender A --inputs object(2,0)
+//> 0: MergeCoins(Gas, [Input(0)])
+
+//# create-checkpoint
+
+//# run-graphql
+{
+  objectVersions(address: "@{obj_2_0}") {
+    pageInfo {
+      hasNextPage
+    }
+    nodes {
+      version
+      asMoveObject {
+        contents {
+          json
+        }
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/object_version_wrapping.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/objects/object_version_wrapping.snap
@@ -1,0 +1,104 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 9 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 7-26:
+//# publish
+created: object(1,0)
+mutated: object(0,1)
+gas summary: computation_cost: 1000000, storage_cost: 5411200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 28-30:
+//# programmable --sender A --inputs 42 @A
+//> 0: SplitCoins(Gas, [Input(0)]);
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 3, lines 32-34:
+//# programmable --sender A --inputs object(2,0) 1
+//> 0: SplitCoins(Input(0), [Input(1)]);
+//> 1: MergeCoins(Gas, [Result(0)])
+mutated: object(0,0), object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 4, lines 36-38:
+//# programmable --sender A --inputs object(2,0) @A
+//> 0: P::M::wrap(Input(0));
+//> 1: TransferObjects([Result(0)], Input(1))
+created: object(4,0)
+mutated: object(0,0)
+wrapped: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 2546000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 5, lines 40-42:
+//# programmable --sender A --inputs object(4,0) @A
+//> 0: P::M::unwrap(Input(0));
+//> 1: TransferObjects([Result(0)], Input(1))
+mutated: object(0,0)
+unwrapped: object(2,0)
+deleted: object(4,0)
+gas summary: computation_cost: 1000000, storage_cost: 1976000,  storage_rebate: 2520540, non_refundable_storage_fee: 25460
+
+task 6, lines 44-45:
+//# programmable --sender A --inputs object(2,0)
+//> 0: MergeCoins(Gas, [Input(0)])
+mutated: object(0,0)
+deleted: object(2,0)
+gas summary: computation_cost: 1000000, storage_cost: 988000,  storage_rebate: 1956240, non_refundable_storage_fee: 19760
+
+task 7, line 47:
+//# create-checkpoint
+Checkpoint created: 1
+
+task 8, lines 49-64:
+//# run-graphql
+Response: {
+  "data": {
+    "objectVersions": {
+      "pageInfo": {
+        "hasNextPage": false
+      },
+      "nodes": [
+        {
+          "version": 2,
+          "asMoveObject": {
+            "contents": {
+              "json": {
+                "balance": "42",
+                "id": "0x0d3cdda4062f7fc8c47b50b6db0d053d8c4eaa841bc152a1b1ffdbe0915a180c"
+              }
+            }
+          }
+        },
+        {
+          "version": 3,
+          "asMoveObject": {
+            "contents": {
+              "json": {
+                "balance": "41",
+                "id": "0x0d3cdda4062f7fc8c47b50b6db0d053d8c4eaa841bc152a1b1ffdbe0915a180c"
+              }
+            }
+          }
+        },
+        {
+          "version": 5,
+          "asMoveObject": {
+            "contents": {
+              "json": {
+                "balance": "41",
+                "id": "0x0d3cdda4062f7fc8c47b50b6db0d053d8c4eaa841bc152a1b1ffdbe0915a180c"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/crates/sui-indexer-alt-graphql/src/api/types/object.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/object.rs
@@ -861,6 +861,7 @@ impl Object {
 
         let mut query = v::obj_versions
             .filter(v::object_id.eq(address.to_vec()))
+            .filter(v::object_digest.is_not_null())
             .filter(sql!(as Bool,
                 r#"
                     object_version <= (SELECT


### PR DESCRIPTION
## Description

When paginating object versions, we need to filter out the versions corresponding to wrapped/deleted objects in `obj_versions`. They exist as rows in `obj_versions` so we know when an object has been deleted/wrapped as of a particular checkpoint, but we will fail to fetch contents for that entry (obviously).

## Test plan

New E2E test:

```
$ cargo nextest run            \
  -p sui-indexer-alt-e2e-tests \
  -- object_version_wrapping
```

Also confirmed that the change still results in a good query plan by testing the following GraphQL query:

```graphql
{
  objectVersions(address: "0x6", first: 50) {
    nodes {
      address
      version
      digest
    }
  }
}
```

Which results in the following SQL query:

```
EXPLAIN ANALYZE
SELECT "obj_versions"."object_id", "obj_versions"."object_version", "obj_versions"."object_digest", "obj_versions"."cp_sequence_number"
FROM "obj_versions"
WHERE ((("obj_versions"."object_id" = '\x0000000000000000000000000000000000000000000000000000000000000006'::bytea)
    AND ("obj_versions"."object_digest" IS NOT NULL))
    AND object_version <= (
        SELECT m.object_version
        FROM obj_versions m
        WHERE m.object_id = obj_versions.object_id
        AND m.cp_sequence_number <= 209005383
        ORDER BY m.cp_sequence_number DESC, m.object_version DESC
        LIMIT 1
    )
)
ORDER BY "obj_versions"."object_version"
LIMIT 52;
```

Producing the following query plan:

```
 Limit  (cost=0.84..892.36 rows=52 width=82) (actual time=0.110..0.504 rows=52 loops=1)
   ->  Index Scan using obj_versions_pkey on obj_versions  (cost=0.84..2944780166.37 rows=171760972 width=82) (actual time=0.107..0.495 rows=52 loops=1)
         Index Cond: (object_id = '\x0000000000000000000000000000000000000000000000000000000000000006'::bytea)
         Filter: ((object_digest IS NOT NULL) AND (object_version <= (SubPlan 1)))
         SubPlan 1
           ->  Limit  (cost=0.84..1.00 rows=1 width=16) (actual time=0.007..0.008 rows=1 loops=52)
                 ->  Index Only Scan using obj_versions_id_cp_version on obj_versions m  (cost=0.84..96585.19 rows=583857 width=16) (actual time=0.007..0.007 rows=1 loops=52)
                       Index Cond: ((object_id = obj_versions.object_id) AND (cp_sequence_number <= 209005383))
                       Heap Fetches: 52
 Planning Time: 0.426 ms
 Execution Time: 0.568 ms
```

Which runs quickly and is identical to the old query plan excluding the extra filter condition.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [x] GraphQL: Fixes a bug related to paginating object versions for an object that has been deleted/wrapped at some point.
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
