### PR TITLE
Fix indexer_indexer metric prefix

### DIFF
--- a/crates/sui-checkpoint-blob-indexer/src/main.rs
+++ b/crates/sui-checkpoint-blob-indexer/src/main.rs
@@ -129,7 +129,7 @@ async fn main() -> anyhow::Result<()> {
 
     let cancel = tokio_util::sync::CancellationToken::new();
 
-    let registry = prometheus::Registry::new_custom(Some("checkpoint_blob_indexer".into()), None)?;
+    let registry = prometheus::Registry::new_custom(Some("checkpoint_blob".into()), None)?;
     let metrics_service = sui_indexer_alt_metrics::MetricsService::new(
         args.metrics_args,
         registry.clone(),


### PR DESCRIPTION
## Description

The framework is already appending \_indexer to the metric names so i'm getting stuff like `checkpoint_blob_indexer_indexer_watermark_checkpoint_in_db`
