### PR TITLE
light-clients: fix api pagination and error codes

### DIFF
--- a/crates/sui-e2e-tests/tests/data/auth_event/sources/auth_event.move
+++ b/crates/sui-e2e-tests/tests/data/auth_event/sources/auth_event.move
@@ -7,14 +7,29 @@ use sui::event;
 
 public struct E has copy, drop { value: u64 }
 
+public struct LargeE has copy, drop {
+    value: u64,
+    data: vector<u8>,
+}
+
 public entry fun emit(value: u64) {
     event::emit_authenticated(E { value });
 }
 
-public entry fun emit_multiple(values: vector<u64>) {
+public entry fun emit_multiple(start_value: u64, count: u64) {
     let mut i = 0;
-    while (i < values.length()) {
-        event::emit_authenticated(E { value: values[i] });
+    while (i < count) {
+        event::emit_authenticated(E { value: start_value + i });
         i = i + 1;
     };
+}
+
+public entry fun emit_large(value: u64, size: u64) {
+    let mut data = vector::empty<u8>();
+    let mut i = 0;
+    while (i < size) {
+        data.push_back(0);
+        i = i + 1;
+    };
+    event::emit_authenticated(LargeE { value, data });
 }

--- a/crates/sui-e2e-tests/tests/get_object_inclusion_proof_tests.rs
+++ b/crates/sui-e2e-tests/tests/get_object_inclusion_proof_tests.rs
@@ -211,8 +211,8 @@ async fn test_object_not_found_in_checkpoint() {
 
     assert!(result.is_err());
     let err = result.unwrap_err();
-    assert_eq!(err.code(), tonic::Code::NotFound);
-    assert!(err.message().contains("not found in checkpoint"));
+    assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+    assert!(err.message().contains("was not written at checkpoint"));
 }
 
 #[sim_test]


### PR DESCRIPTION
## Description 

When implementing light-client, I discovered small server-side issues to address:

1. pagination fixed, we now return the next key to return if there are more rather than the last key
2. get_obj_inclusion_proof now returns a distinct error code if the event_stream_head not included in a checkpoint
3. more exhaustive testing around pagination and size limits

## Test plan 

E2e tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
