### PR TITLE
display: transform modifiers

### DIFF
--- a/crates/sui-display/src/v2/mod.rs
+++ b/crates/sui-display/src/v2/mod.rs
@@ -1362,6 +1362,107 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_bcs_modifiers() {
+        let bytes = bcs::to_bytes(&00u8).unwrap();
+        let layout = struct_("0x1::m::S", vec![("dummy_field", T::Bool)]);
+
+        let formats = [
+            ("byte", "{0u8:bcs}"),
+            ("byte_nopad", "{0u8:bcs(nopad)}"),
+            ("byte_url", "{0u8:bcs(url)}"),
+            ("byte_url_nopad", "{0u8:bcs(url, nopad)}"),
+            ("long", "{0xf8fbu64:bcs}"),
+            ("long_nopad", "{0xf8fbu64:bcs(nopad)}"),
+            ("long_url", "{0xf8fbu64:bcs(url)}"),
+            ("long_url_nopad", "{0xf8fbu64:bcs(nopad, url)}"),
+            ("str", "{'hello':bcs}"),
+            ("str_nopad", "{'hello':bcs(nopad)}"),
+            ("str_url", "{'hello':bcs(url)}"),
+            ("str_url_nopad", "{'hello':bcs(url, nopad)}"),
+            (
+                "flatland",
+                "{43920588204278303214855528440570972873796977361529388163322669436471087583698u256:bcs(url)}",
+            ),
+            (
+                "flatland_nopad",
+                "{43920588204278303214855528440570972873796977361529388163322669436471087583698u256:bcs(nopad)}",
+            ),
+            (
+                "flatland_url",
+                "{43920588204278303214855528440570972873796977361529388163322669436471087583698u256:bcs(url)}",
+            ),
+            (
+                "flatland_url_nopad",
+                "{43920588204278303214855528440570972873796977361529388163322669436471087583698u256:bcs(url, nopad)}",
+            ),
+        ];
+
+        let output = format(
+            &MockStore::default(),
+            Limits::default(),
+            &bytes,
+            &layout,
+            ONE_MB,
+            formats,
+        )
+        .await
+        .unwrap();
+
+        assert_debug_snapshot!(output, @r###"
+        {
+            "byte": Ok(
+                String("AA=="),
+            ),
+            "byte_nopad": Ok(
+                String("AA"),
+            ),
+            "byte_url": Ok(
+                String("AA=="),
+            ),
+            "byte_url_nopad": Ok(
+                String("AA"),
+            ),
+            "long": Ok(
+                String("+/gAAAAAAAA="),
+            ),
+            "long_nopad": Ok(
+                String("+/gAAAAAAAA"),
+            ),
+            "long_url": Ok(
+                String("-_gAAAAAAAA="),
+            ),
+            "long_url_nopad": Ok(
+                String("-_gAAAAAAAA"),
+            ),
+            "str": Ok(
+                String("BWhlbGxv"),
+            ),
+            "str_nopad": Ok(
+                String("BWhlbGxv"),
+            ),
+            "str_url": Ok(
+                String("BWhlbGxv"),
+            ),
+            "str_url_nopad": Ok(
+                String("BWhlbGxv"),
+            ),
+            "flatland": Ok(
+                String("0tGFaqPKhfWCrycZHVcT6lgF7C-YIrMMzORXFwcsGmE="),
+            ),
+            "flatland_nopad": Ok(
+                String("0tGFaqPKhfWCrycZHVcT6lgF7C+YIrMMzORXFwcsGmE"),
+            ),
+            "flatland_url": Ok(
+                String("0tGFaqPKhfWCrycZHVcT6lgF7C-YIrMMzORXFwcsGmE="),
+            ),
+            "flatland_url_nopad": Ok(
+                String("0tGFaqPKhfWCrycZHVcT6lgF7C-YIrMMzORXFwcsGmE"),
+            ),
+        }
+        "###);
+    }
+
+    #[tokio::test]
     async fn test_string_hardening() {
         let bytes = bcs::to_bytes(&("ascii", "🔥", vec![0xC3u8])).unwrap();
         let layout = struct_(

--- a/crates/sui-display/src/v2/parser.rs
+++ b/crates/sui-display/src/v2/parser.rs
@@ -128,7 +128,7 @@ pub enum Fields<'s> {
 #[derive(Default, Copy, Clone, PartialEq, Eq)]
 pub enum Transform {
     Base64(Base64Modifier),
-    Bcs,
+    Bcs(Base64Modifier),
     Hex,
     #[default]
     Str,
@@ -933,7 +933,7 @@ impl<'s> Parser<'s> {
 
             Lit(_, T::Ident, _, "bcs") => {
                 self.lexer.next();
-                Transform::Bcs
+                Transform::Bcs(self.parse_xmod()?)
             },
 
             Lit(_, T::Ident, _, "hex") => {
@@ -1197,7 +1197,7 @@ impl fmt::Debug for Transform {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Transform::Base64(xmod) => write!(f, "base64{xmod:?}"),
-            Transform::Bcs => write!(f, "bcs"),
+            Transform::Bcs(xmod) => write!(f, "bcs{xmod:?}"),
             Transform::Hex => write!(f, "hex"),
             Transform::Str => write!(f, "str"),
             Transform::Timestamp => write!(f, "ts"),

--- a/crates/sui-display/src/v2/value.rs
+++ b/crates/sui-display/src/v2/value.rs
@@ -133,7 +133,11 @@ impl Value<'_> {
         // 'display').
         match transform {
             Transform::Base64(xmod) => Atom::try_from(self)?.format_as_base64(xmod.engine(), w),
-            Transform::Bcs => Ok(write!(w, "{}", STANDARD.encode(bcs::to_bytes(&self)?))?),
+            Transform::Bcs(xmod) => {
+                let bytes = bcs::to_bytes(&self)?;
+                Ok(write!(w, "{}", xmod.engine().encode(bytes))?)
+            }
+
             Transform::Hex => Atom::try_from(self)?.format_as_hex(w),
             Transform::Str => Atom::try_from(self)?.format_as_str(w),
             Transform::Timestamp => Atom::try_from(self)?.format_as_timestamp(w),


### PR DESCRIPTION
## Description 

Introduce modifiers for Base64 and BCS transforms, rather than introducing multiple variants as their own transforms.

## Test plan 

Updated existing tests:

```
sui-display$ cargo nextest run
```

## Stack

- #23795 
- #23941 
- #23942 
- #23944 
- #23956 
- #23973
- #23990
- #24231
- #24232 
- #24233 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
