### PR TITLE
chore(display): standardize imports

### DIFF
--- a/crates/sui-display/src/v1/mod.rs
+++ b/crates/sui-display/src/v1/mod.rs
@@ -1,19 +1,22 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, fmt::Write};
+use std::collections::BTreeMap;
+use std::fmt::Write;
 
-use anyhow::{Context, anyhow, bail};
-use move_core_types::{
-    annotated_extractor::Extractor,
-    annotated_value::{MoveTypeLayout, MoveValue},
-};
-use parser::{Parser, Strand};
+use anyhow::Context;
+use anyhow::anyhow;
+use anyhow::bail;
+use move_core_types::annotated_extractor::Extractor;
+use move_core_types::annotated_value::MoveTypeLayout;
+use move_core_types::annotated_value::MoveValue;
 use sui_json_rpc_types::SuiMoveValue;
-use sui_types::{
-    collection_types::{Entry, VecMap},
-    object::bounded_visitor::BoundedVisitor,
-};
+use sui_types::collection_types::Entry;
+use sui_types::collection_types::VecMap;
+use sui_types::object::bounded_visitor::BoundedVisitor;
+
+use self::parser::Parser;
+use self::parser::Strand;
 
 pub(crate) mod lexer;
 pub(crate) mod parser;

--- a/crates/sui-display/src/v1/parser.rs
+++ b/crates/sui-display/src/v1/parser.rs
@@ -1,11 +1,18 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{borrow::Cow, fmt, iter::Peekable};
+use std::borrow::Cow;
+use std::fmt;
+use std::iter::Peekable;
 
-use move_core_types::{annotated_extractor::Element, identifier};
+use move_core_types::annotated_extractor::Element;
+use move_core_types::identifier;
 
-use super::lexer::{Lexeme as L, Lexer, OwnedLexeme, Token as T, TokenSet};
+use crate::v1::lexer::Lexeme as L;
+use crate::v1::lexer::Lexer;
+use crate::v1::lexer::OwnedLexeme;
+use crate::v1::lexer::Token as T;
+use crate::v1::lexer::TokenSet;
 
 /// A strand is a single component of a format string, it can either be a piece of literal text
 /// that needs to be preserved in the output, or a reference to a nested field (as a sequence of

--- a/crates/sui-display/src/v2/error.rs
+++ b/crates/sui-display/src/v2/error.rs
@@ -1,14 +1,18 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeSet;
+use std::fmt;
 use std::mem;
 use std::sync::Arc;
-use std::{collections::BTreeSet, fmt};
 
-use move_core_types::{annotated_visitor, language_storage::TypeTag};
+use move_core_types::annotated_visitor;
+use move_core_types::language_storage::TypeTag;
 
-use super::lexer::{Lexeme, OwnedLexeme, Token};
-use super::peek::Peekable2Ext;
+use crate::v2::lexer::Lexeme;
+use crate::v2::lexer::OwnedLexeme;
+use crate::v2::lexer::Token;
+use crate::v2::peek::Peekable2Ext;
 
 /// Errors related to the display format as a whole.
 ///

--- a/crates/sui-display/src/v2/interpreter.rs
+++ b/crates/sui-display/src/v2/interpreter.rs
@@ -1,29 +1,33 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    borrow::Cow,
-    fmt::Write as _,
-    sync::{Arc, atomic::AtomicUsize},
-};
+use std::borrow::Cow;
+use std::fmt::Write as _;
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
 
-use futures::{
-    future::{OptionFuture, join_all},
-    join,
-};
+use futures::future::OptionFuture;
+use futures::future::join_all;
+use futures::join;
 use move_core_types::account_address::AccountAddress;
-use sui_types::dynamic_field::{
-    DynamicFieldInfo, DynamicFieldType, derive_dynamic_field_id,
-    visitor::{self as DFV, FieldVisitor},
-};
+use sui_types::dynamic_field::DynamicFieldInfo;
+use sui_types::dynamic_field::DynamicFieldType;
+use sui_types::dynamic_field::derive_dynamic_field_id;
+use sui_types::dynamic_field::visitor as DFV;
+use sui_types::dynamic_field::visitor::FieldVisitor;
 
-use super::{
-    error::FormatError,
-    parser as P,
-    value::{Accessor, Enum, Fields, Slice, Store, Struct, Value, Vector},
-    visitor::extractor::Extractor,
-    writer::BoundedWriter,
-};
+use crate::v2::error::FormatError;
+use crate::v2::parser as P;
+use crate::v2::value::Accessor;
+use crate::v2::value::Enum;
+use crate::v2::value::Fields;
+use crate::v2::value::Slice;
+use crate::v2::value::Store;
+use crate::v2::value::Struct;
+use crate::v2::value::Value;
+use crate::v2::value::Vector;
+use crate::v2::visitor::extractor::Extractor;
+use crate::v2::writer::BoundedWriter;
 
 /// The interpreter is responsible for evaluating expressions inside format strings into values.
 pub(crate) struct Interpreter<'s, S: Store<'s>> {

--- a/crates/sui-display/src/v2/meter.rs
+++ b/crates/sui-display/src/v2/meter.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::error::FormatError;
+use crate::v2::error::FormatError;
 
 /// Limits that the parser enforces while parsing potentially multiple Display formats.
 #[derive(Clone)]

--- a/crates/sui-display/src/v2/mod.rs
+++ b/crates/sui-display/src/v2/mod.rs
@@ -3,18 +3,22 @@
 
 use std::sync::Arc;
 
-use error::FormatError;
 use futures::future::try_join_all;
 use futures::join;
 use indexmap::IndexMap;
 use move_core_types::annotated_value::MoveTypeLayout;
-use sui_types::collection_types::{Entry, VecMap};
+use sui_types::collection_types::Entry;
+use sui_types::collection_types::VecMap;
 
 use self::error::Error;
+use self::error::FormatError;
 use self::interpreter::Interpreter;
-use self::meter::{Limits, Meter};
-use self::parser::{Parser, Strand};
-use self::value::{Slice, Store};
+use self::meter::Limits;
+use self::meter::Meter;
+use self::parser::Parser;
+use self::parser::Strand;
+use self::value::Slice;
+use self::value::Store;
 
 pub mod error;
 pub(crate) mod interpreter;

--- a/crates/sui-display/src/v2/parser.rs
+++ b/crates/sui-display/src/v2/parser.rs
@@ -5,22 +5,28 @@
 use std::borrow::Cow;
 use std::fmt;
 
-use base64::engine::general_purpose::{
-    GeneralPurpose, STANDARD, STANDARD_NO_PAD, URL_SAFE, URL_SAFE_NO_PAD,
-};
-use move_core_types::{
-    account_address::AccountAddress,
-    identifier::{IdentStr, Identifier},
-    language_storage::{StructTag, TypeTag},
-    u256::U256,
-};
+use base64::engine::general_purpose::GeneralPurpose;
+use base64::engine::general_purpose::STANDARD;
+use base64::engine::general_purpose::STANDARD_NO_PAD;
+use base64::engine::general_purpose::URL_SAFE;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use move_core_types::account_address::AccountAddress;
+use move_core_types::identifier::IdentStr;
+use move_core_types::identifier::Identifier;
+use move_core_types::language_storage::StructTag;
+use move_core_types::language_storage::TypeTag;
+use move_core_types::u256::U256;
 
-use super::error::{Expected, ExpectedSet, FormatError, Match};
-use super::peek::{Peekable2, Peekable2Ext};
-use super::{
-    lexer::{Lexeme as Lex, Lexer, Token as T},
-    meter::Meter,
-};
+use crate::v2::error::Expected;
+use crate::v2::error::ExpectedSet;
+use crate::v2::error::FormatError;
+use crate::v2::error::Match;
+use crate::v2::lexer::Lexeme as Lex;
+use crate::v2::lexer::Lexer;
+use crate::v2::lexer::Token as T;
+use crate::v2::meter::Meter;
+use crate::v2::peek::Peekable2;
+use crate::v2::peek::Peekable2Ext;
 
 /// A single Display string template is a sequence of strands.
 #[derive(PartialEq, Eq)]

--- a/crates/sui-display/src/v2/value.rs
+++ b/crates/sui-display/src/v2/value.rs
@@ -2,34 +2,41 @@
 // SPDX-License-Identifier: Apache-2.0
 #![allow(unused)]
 
-use std::{borrow::Cow, fmt::Write as _, str};
+use std::borrow::Cow;
+use std::fmt::Write as _;
+use std::str;
 
 use async_trait::async_trait;
-use base64::engine::{
-    Engine,
-    general_purpose::{STANDARD, STANDARD_NO_PAD, URL_SAFE, URL_SAFE_NO_PAD},
-};
-use chrono::{DateTime, Utc};
-use move_core_types::{
-    account_address::AccountAddress,
-    annotated_value::{MoveFieldLayout, MoveTypeLayout},
-    language_storage::{StructTag, TypeTag},
-    u256::U256,
-};
-use serde::{
-    Serialize,
-    ser::{SerializeSeq as _, SerializeTuple as _, SerializeTupleVariant},
-};
-use sui_types::{
-    MOVE_STDLIB_ADDRESS,
-    base_types::{
-        RESOLVED_UTF8_STR, STD_OPTION_MODULE_NAME, STD_OPTION_STRUCT_NAME, move_ascii_str_layout,
-        move_utf8_str_layout, url_layout,
-    },
-    id::{ID, UID},
-};
+use base64::engine::Engine;
+use base64::engine::general_purpose::STANDARD;
+use base64::engine::general_purpose::STANDARD_NO_PAD;
+use base64::engine::general_purpose::URL_SAFE;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use chrono::DateTime;
+use chrono::Utc;
+use move_core_types::account_address::AccountAddress;
+use move_core_types::annotated_value::MoveFieldLayout;
+use move_core_types::annotated_value::MoveTypeLayout;
+use move_core_types::language_storage::StructTag;
+use move_core_types::language_storage::TypeTag;
+use move_core_types::u256::U256;
+use serde::Serialize;
+use serde::ser::SerializeSeq as _;
+use serde::ser::SerializeTuple as _;
+use serde::ser::SerializeTupleVariant;
+use sui_types::MOVE_STDLIB_ADDRESS;
+use sui_types::base_types::RESOLVED_UTF8_STR;
+use sui_types::base_types::STD_OPTION_MODULE_NAME;
+use sui_types::base_types::STD_OPTION_STRUCT_NAME;
+use sui_types::base_types::move_ascii_str_layout;
+use sui_types::base_types::move_utf8_str_layout;
+use sui_types::base_types::url_layout;
+use sui_types::id::ID;
+use sui_types::id::UID;
 
-use super::{error::FormatError, parser::Transform, writer::BoundedWriter};
+use crate::v2::error::FormatError;
+use crate::v2::parser::Transform;
+use crate::v2::writer::BoundedWriter;
 
 /// Dynamically load objects by their ID. The output should be a `Slice` containing references to
 /// the raw BCS bytes and the corresponding `MoveTypeLayout` for the object. This implies the

--- a/crates/sui-display/src/v2/visitor/extractor.rs
+++ b/crates/sui-display/src/v2/visitor/extractor.rs
@@ -6,11 +6,13 @@ use move_core_types::annotated_value as A;
 use move_core_types::annotated_visitor as AV;
 use move_core_types::u256::U256;
 
-use super::address::AddressExtractor;
-use super::option::OptionExtractor;
-use super::option::is_option;
 use crate::v2::error::FormatError;
-use crate::v2::value::{Accessor, Slice, Value};
+use crate::v2::value::Accessor;
+use crate::v2::value::Slice;
+use crate::v2::value::Value;
+use crate::v2::visitor::address::AddressExtractor;
+use crate::v2::visitor::option::OptionExtractor;
+use crate::v2::visitor::option::is_option;
 use crate::v2::visitor::vec_map::VecMapVisitor;
 use crate::v2::visitor::vec_map::is_vec_map;
 

--- a/crates/sui-display/src/v2/visitor/vec_map.rs
+++ b/crates/sui-display/src/v2/visitor/vec_map.rs
@@ -6,10 +6,13 @@ use move_core_types::annotated_visitor as AV;
 use move_core_types::language_storage::StructTag;
 use move_core_types::u256::U256;
 use sui_types::SUI_FRAMEWORK_ADDRESS;
-use sui_types::base_types::{VEC_MAP_ENTRY_STRUCT_NAME, VEC_MAP_MODULE_NAME, VEC_MAP_STRUCT_NAME};
+use sui_types::base_types::VEC_MAP_ENTRY_STRUCT_NAME;
+use sui_types::base_types::VEC_MAP_MODULE_NAME;
+use sui_types::base_types::VEC_MAP_STRUCT_NAME;
 
 use crate::v2::error::FormatError;
-use crate::v2::value::{Accessor, Value};
+use crate::v2::value::Accessor;
+use crate::v2::value::Value;
 use crate::v2::visitor::extractor::Extractor;
 
 /// A visitor that looks for a specific key in a `0x2::vec_map::VecMap<_, _>` and continues

--- a/crates/sui-display/src/v2/writer.rs
+++ b/crates/sui-display/src/v2/writer.rs
@@ -1,10 +1,9 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    fmt,
-    sync::atomic::{AtomicUsize, Ordering},
-};
+use std::fmt;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 
 /// A writer that tracks an output budget (measured in bytes) shared across multiple writers.
 /// Writes will fail once the total number of bytes sent to be written, across all writers, exceeds


### PR DESCRIPTION
## Description

Avoid using `super::` imports (except `super::*` for tests), and otherwise standardize imports to one-per-line, grouped into `std`, third party, `crate`, and `self` imports.

## Test plan

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
