### PR TITLE
Return missing instead of internal error for checkpoints that haven't been fully stored yet

### DIFF
--- a/crates/sui-rpc-api/src/error.rs
+++ b/crates/sui-rpc-api/src/error.rs
@@ -65,8 +65,15 @@ impl From<RpcError> for tonic::Status {
 
 impl From<sui_types::storage::error::Error> for RpcError {
     fn from(value: sui_types::storage::error::Error) -> Self {
+        use sui_types::storage::error::Kind;
+
+        let code = match value.kind() {
+            Kind::Missing => Code::NotFound,
+            _ => Code::Internal,
+        };
+
         Self {
-            code: Code::Internal,
+            code,
             message: Some(value.to_string()),
             details: None,
         }


### PR DESCRIPTION
## Description

In the indexer logs we see `Retrying due to error: Failed to fetch checkpoint 211394366: status: 'Internal error'` at the tip-of-chain when a checkpoint hasn't been fully stored yet. This should be a "Not Found" rather than an "Internal Error." This is especially important because the indexing framework retries with exponential back off on internal errors but linear back off on "Not Found" so returning an Internal Error is actually increasing lag.

## Test plan

None really 🙈. It's kind of tough to write a unit test because this requires calling the API at the exact instant where the checkpoint exists but the effects haven't been stored yet.

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [x] gRPC: Return "Not Found" for new checkpoints that haven't been fully stored yet instead of "Internal Error."
