### PR TITLE
Reduce PR CI cost by running expensive checks after clippy & rustfmt

### DIFF
--- a/.github/workflows/bridge.yml
+++ b/.github/workflows/bridge.yml
@@ -63,8 +63,31 @@ jobs:
         uses: './.github/actions/diffs'
         id: diff
 
-  test:
+  rustfmt:
     needs: diff
+    if: needs.diff.outputs.isRust == 'true'
+    runs-on: [ ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # Pin v4.1.1
+        with:
+          ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
+      - run: rustup component add rustfmt
+      - run: cargo fmt --check
+
+  clippy:
+    needs: diff
+    if: needs.diff.outputs.isRust == 'true'
+    runs-on: [ ubuntu-ghcloud ]
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # Pin v4.1.1
+        with:
+          ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
+      - run: rustup component add clippy
+      - name: cargo clippy
+        run: cargo xclippy -D warnings
+
+  test:
+    needs: [diff, rustfmt, clippy]
     if: needs.diff.outputs.isRust == 'true' || needs.diff.outputs.isSolidity == 'true'
     timeout-minutes: 45
     env:

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -47,7 +47,7 @@ jobs:
         id: diff
 
   external-crates-test:
-    needs: diff
+    needs: [diff, rustfmt, clippy]
     if: needs.diff.outputs.isRust == 'true'
     timeout-minutes: 45
     env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,7 +73,7 @@ jobs:
       - run: cargo xlint
 
   test:
-    needs: diff
+    needs: [diff, rustfmt, clippy]
     if: needs.diff.outputs.isRust == 'true'
     timeout-minutes: 45
     env:
@@ -107,7 +107,7 @@ jobs:
         shell: bash
 
   test-extra:
-    needs: diff
+    needs: [diff, rustfmt, clippy]
     if: needs.diff.outputs.isRust == 'true'
     timeout-minutes: 45
     env:
@@ -179,7 +179,7 @@ jobs:
         shell: bash
 
   windows-build:
-    needs: diff
+    needs: [diff, rustfmt, clippy]
     if: needs.diff.outputs.isRust == 'true'
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
@@ -211,7 +211,7 @@ jobs:
           cargo build --all-features
 
   simtest:
-    needs: diff
+    needs: [diff, rustfmt, clippy]
     if: needs.diff.outputs.isRust == 'true' || needs.diff.outputs.isSolidity == 'true'
     timeout-minutes: 45
     runs-on: [ ubuntu-ghcloud ]
@@ -237,7 +237,7 @@ jobs:
           scripts/simtest/stress-new-tests.sh
 
   simtest-mainnet:
-    needs: diff
+    needs: [diff, rustfmt, clippy]
     if: needs.diff.outputs.isRust == 'true' || needs.diff.outputs.isSolidity == 'true'
     timeout-minutes: 45
     runs-on: [ ubuntu-ghcloud ]
@@ -415,7 +415,7 @@ jobs:
 
   sui-excution-cut:
     name: cutting a new execution layer
-    needs: diff
+    needs: [diff, rustfmt, clippy]
     if: needs.diff.outputs.isRust == 'true'
     runs-on: [ ubuntu-ghcloud ]
     steps:


### PR DESCRIPTION
## Description 

Change CI to run expensive jobs after rustfmt and clippy.

I (claude) did some data analysis:
```
====================================================================================================
COMPLETE COST ANALYSIS FROM 90-DAY DATA
====================================================================================================

====================================================================================================
STEP 1: IDENTIFY GATE JOBS
====================================================================================================

Job                                      Workflow                       Runs     Fail %     $/run     
----------------------------------------------------------------------------------------------------
clippy                                   external.yml                   3735        5.3%  $   0.26
rustfmt                                  external.yml                   3838        8.1%  $   0.01
clippy                                   rust.yml                       3727       14.7%  $   0.83
rustfmt                                  rust.yml                       3852        6.8%  $   0.01

Gate costs and failure rates by workflow:

rust.yml:
  rustfmt: 6.8% failure, $0.01/run
  clippy:  14.7% failure, $0.83/run
  Gate cost (parallel): $0.83/run

external.yml:
  rustfmt: 8.1% failure, $0.01/run
  clippy:  5.3% failure, $0.26/run
  Gate cost (parallel): $0.26/run

bridge.yml:
  rustfmt: 6.8% failure, $0.01/run
  clippy:  14.7% failure, $0.83/run
  Gate cost (parallel): $0.83/run

====================================================================================================
STEP 2: CALCULATE GATE FAILURE RATES (LOWER AND UPPER BOUNDS)
====================================================================================================

rust.yml:
  Lower bound (average): 10.8%
  Upper bound (union):   20.5%

external.yml:
  Lower bound (average): 6.7%
  Upper bound (union):   12.9%

bridge.yml:
  Lower bound (average): 10.8%
  Upper bound (union):   20.5%

====================================================================================================
STEP 3: IDENTIFY GATED JOBS BY WORKFLOW
====================================================================================================

rust.yml:
  Job                                                $/run      Runs    
  ------------------------------------------------------------------------------------------
  test (ubuntu-ghcloud)                              $   5.39  4613    
  test-extra (ubuntu-ghcloud)                        $   4.88  4583    
  simtest                                            $   4.03  3783    
  simtest-mainnet                                    $   4.01  3737    
  windows-build (windows-ghcloud)                    $   2.63  3412    
  cutting a new execution layer                      $   0.44  3723    
  Total gated jobs cost:                             $  21.39

external.yml:
  Job                                                $/run      Runs    
  ------------------------------------------------------------------------------------------
  external-crates-test (ubuntu-ghcloud)              $   1.74  4579    
  Total gated jobs cost:                             $   1.74

bridge.yml:
  Job                                                $/run      Runs    
  ------------------------------------------------------------------------------------------
  test (ubuntu-ghcloud)                              $   4.90  3828    
  Total gated jobs cost:                             $   4.90

====================================================================================================
STEP 4: CALCULATE SAVINGS RANGE
====================================================================================================

rust.yml:
  CI runs per day: 42.8
  Gated jobs cost: $21.39/run
  
  Lower bound (10.8% failure rate):
    Savings per run: $2.30
    Daily savings: $98.40
  
  Upper bound (20.5% failure rate):
    Savings per run: $4.38
    Daily savings: $187.64

external.yml:
  CI runs per day: 42.6
  Gated jobs cost: $1.74/run
  
  Lower bound (6.7% failure rate):
    Savings per run: $0.12
    Daily savings: $4.93
  
  Upper bound (12.9% failure rate):
    Savings per run: $0.22
    Daily savings: $9.55

bridge.yml:
  CI runs per day: 42.5
  Gated jobs cost: $4.90/run
  
  Lower bound (10.8% failure rate):
    Savings per run: $0.53
    Daily savings: $22.42
  
  Upper bound (20.5% failure rate):
    Savings per run: $1.01
    Daily savings: $42.75

====================================================================================================
STEP 5: TOTAL SAVINGS RANGE
====================================================================================================

Daily savings range:   $125.74 - $239.94
Monthly savings range: $3,772.34 - $7,198.23
Annual savings range:  $45,896.74 - $87,578.43

====================================================================================================
STEP 6: PERFORMANCE IMPACT
====================================================================================================

Current wall-clock time (all parallel): 21.57 min
New wall-clock time:
  Gate stage: 3.30 min
  Expensive jobs (if pass): 21.57 min
  Total for passing CI runs: 24.87 min
  Total for failing CI runs: 3.30 min

Impact (using average failure rate of 18.0%):
  PRs that pass (82.0%): +3.30 min
  PRs that fail gate (18.0%): -18.26 min
  Weighted average: -0.57 min (-34 seconds)

====================================================================================================
FINAL SUMMARY
====================================================================================================

Estimated annual savings range: $45,896.74 - $87,578.43
Performance impact: -34 seconds average per CI run, +3.30 min that pass the checks

The savings range reflects uncertainty in gate failure correlation:
  - Lower bound assumes some overlap in rustfmt/clippy failures
  - Upper bound assumes independent failures (union probability)
  - Actual savings likely near upper bound given different failure modes

```

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework: