### PR TITLE
add a pre-push hook for rustfmt

### DIFF
--- a/.cargo-husky/hooks/pre-push
+++ b/.cargo-husky/hooks/pre-push
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo "Running rustfmt before push..."
+
+if ! cargo fmt --check; then
+    echo "ERROR: rustfmt check failed!"
+    echo "Run 'cargo fmt' to fix formatting, then try pushing again."
+    exit 1
+fi
+
+echo "✓ rustfmt passed"
+exit 0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2457,6 +2457,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-husky"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
+
+[[package]]
 name = "cargo-platform"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7228,7 +7234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -10730,7 +10736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -10752,7 +10758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.99",
@@ -10765,7 +10771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.99",
@@ -16922,6 +16928,7 @@ dependencies = [
  "bincode 1.3.3",
  "byteorder",
  "bytes",
+ "cargo-husky",
  "chrono",
  "ciborium",
  "consensus-config",

--- a/crates/sui-types/Cargo.toml
+++ b/crates/sui-types/Cargo.toml
@@ -93,6 +93,7 @@ rustls-pemfile.workspace = true
 [dev-dependencies]
 base64.workspace = true
 bincode.workspace = true
+cargo-husky = { version = "1", default-features = false, features = ["user-hooks"] }
 criterion.workspace = true
 proptest.workspace = true
 proptest-derive.workspace = true


### PR DESCRIPTION
## Description 

This change aims to reduce the incidence of developers pushing code that fails in CI, both as a developer convenience and a cost reduction strategy for CI.

## Test plan 

git push ran rustfmt when I pushed this branch for PR

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
