### PR TITLE
Certora audit fix: L-06

### DIFF
--- a/crates/sui-bridge/src/encoding.rs
+++ b/crates/sui-bridge/src/encoding.rs
@@ -272,7 +272,7 @@ impl BridgeMessageEncoding for AssetPriceUpdateAction {
         // Add message type
         bytes.push(BridgeActionType::AssetPriceUpdate as u8);
         // Add message version
-        bytes.push(EMERGENCY_BUTTON_MESSAGE_VERSION);
+        bytes.push(ASSET_PRICE_UPDATE_MESSAGE_VERSION);
         // Add nonce
         bytes.extend_from_slice(&self.nonce.to_be_bytes());
         // Add chain id


### PR DESCRIPTION
## Description 

This is a fix for issue L-06 from the Certora audit of the native bridge.

The audit can be seen [here](https://www.notion.so/mystenlabs/Certora-Audit-2966d9dcb4e980c490e2ee96b63dbe82?source=copy_link).

> While encoding `AssetPriceUpdateAction` the program uses the wrong version variable - `EMERGENCY_BUTTON_MESSAGE_VERSION` instead of `ASSET_PRICE_UPDATE_MESSAGE_VERSION`.
> Currently, this has no effect because they both have the value of 1, but in case any of them is bumped, it’d cause the bridge to encode and sign the wrong version number.

## Test plan 

This is my first commit to this repo, and I am not sure how to test. I will be sure to ask the reviewers if/how I should do any testing in addition to that of CI.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
