### PR TITLE
Certora audit fix: L-13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13805,7 +13805,7 @@ dependencies = [
  "once_cell",
  "prometheus",
  "rand 0.8.5",
- "reqwest 0.12.9",
+ "reqwest 0.11.20",
  "serde",
  "serde_json",
  "serde_with",

--- a/crates/sui-bridge-indexer/src/eth_bridge_indexer.rs
+++ b/crates/sui-bridge-indexer/src/eth_bridge_indexer.rs
@@ -14,7 +14,7 @@ use prometheus::IntGauge;
 use sui_bridge::error::BridgeError;
 use sui_bridge::eth_client::EthClient;
 use sui_bridge::eth_syncer::EthSyncer;
-use sui_bridge::metered_eth_provider::MeteredEthHttpProvier;
+use sui_bridge::metered_eth_provider::MeteredEthHttpProvider;
 use sui_bridge::retry_with_max_elapsed_time;
 use sui_indexer_builder::Task;
 use tap::tap::TapFallible;
@@ -50,7 +50,7 @@ pub struct RawEthData {
 // Create max log query range
 const MAX_LOG_QUERY_RANGE: u64 = 1000;
 pub struct EthSubscriptionDatasource {
-    eth_client: Arc<EthClient<MeteredEthHttpProvier>>,
+    eth_client: Arc<EthClient<MeteredEthHttpProvider>>,
     addresses: Vec<EthAddress>,
     eth_ws_url: String,
     metrics: Box<dyn IndexerMetricProvider>,
@@ -60,7 +60,7 @@ pub struct EthSubscriptionDatasource {
 impl EthSubscriptionDatasource {
     pub async fn new(
         eth_sui_bridge_contract_addresses: Vec<EthAddress>,
-        eth_client: Arc<EthClient<MeteredEthHttpProvier>>,
+        eth_client: Arc<EthClient<MeteredEthHttpProvider>>,
         eth_ws_url: String,
         metrics: Box<dyn IndexerMetricProvider>,
         genesis_block: u64,
@@ -229,7 +229,7 @@ impl EthSubscriptionDatasource {
 pub struct EthFinalizedSyncDatasource {
     bridge_addresses: Vec<EthAddress>,
     eth_http_url: String,
-    eth_client: Arc<EthClient<MeteredEthHttpProvier>>,
+    eth_client: Arc<EthClient<MeteredEthHttpProvider>>,
     metrics: Box<dyn IndexerMetricProvider>,
     bridge_metrics: Arc<BridgeMetrics>,
     genesis_block: u64,
@@ -238,7 +238,7 @@ pub struct EthFinalizedSyncDatasource {
 impl EthFinalizedSyncDatasource {
     pub async fn new(
         eth_sui_bridge_contract_addresses: Vec<EthAddress>,
-        eth_client: Arc<EthClient<MeteredEthHttpProvier>>,
+        eth_client: Arc<EthClient<MeteredEthHttpProvider>>,
         eth_http_url: String,
         metrics: Box<dyn IndexerMetricProvider>,
         bridge_metrics: Arc<BridgeMetrics>,
@@ -320,7 +320,7 @@ impl Datasource<RawEthData> for EthFinalizedSyncDatasource {
 
 async fn loop_retrieve_and_process_live_finalized_logs(
     task: Task,
-    client: Arc<EthClient<MeteredEthHttpProvier>>,
+    client: Arc<EthClient<MeteredEthHttpProvider>>,
     provider: Arc<Provider<Http>>,
     addresses: Vec<EthAddress>,
     data_sender: DataSender<RawEthData>,
@@ -369,7 +369,7 @@ async fn loop_retrieve_and_process_live_finalized_logs(
 
 async fn loop_retrieve_and_process_log_range(
     task: Task,
-    client: Arc<EthClient<MeteredEthHttpProvier>>,
+    client: Arc<EthClient<MeteredEthHttpProvider>>,
     provider: Arc<Provider<Http>>,
     addresses: Vec<EthAddress>,
     data_sender: DataSender<RawEthData>,

--- a/crates/sui-bridge-indexer/src/lib.rs
+++ b/crates/sui-bridge-indexer/src/lib.rs
@@ -14,7 +14,7 @@ use ethers::types::Address as EthAddress;
 use std::str::FromStr;
 use std::sync::Arc;
 use sui_bridge::eth_client::EthClient;
-use sui_bridge::metered_eth_provider::MeteredEthHttpProvier;
+use sui_bridge::metered_eth_provider::MeteredEthHttpProvider;
 use sui_bridge::metrics::BridgeMetrics;
 use sui_bridge::utils::get_eth_contract_addresses;
 use sui_bridge_schema::models::{
@@ -204,7 +204,7 @@ pub async fn create_eth_sync_indexer(
     metrics: BridgeIndexerMetrics,
     bridge_metrics: Arc<BridgeMetrics>,
     config: &IndexerConfig,
-    eth_client: Arc<EthClient<MeteredEthHttpProvier>>,
+    eth_client: Arc<EthClient<MeteredEthHttpProvider>>,
 ) -> Result<Indexer<PgBridgePersistent, EthFinalizedSyncDatasource, EthDataMapper>, anyhow::Error> {
     let bridge_addresses = get_eth_bridge_contract_addresses(config).await?;
     // Start the eth sync data source
@@ -232,7 +232,7 @@ pub async fn create_eth_subscription_indexer(
     pool: PgPool,
     metrics: BridgeIndexerMetrics,
     config: &IndexerConfig,
-    eth_client: Arc<EthClient<MeteredEthHttpProvier>>,
+    eth_client: Arc<EthClient<MeteredEthHttpProvider>>,
 ) -> Result<Indexer<PgBridgePersistent, EthSubscriptionDatasource, EthDataMapper>, anyhow::Error> {
     // Start the eth subscription indexer
     let bridge_addresses = get_eth_bridge_contract_addresses(config).await?;

--- a/crates/sui-bridge-indexer/src/main.rs
+++ b/crates/sui-bridge-indexer/src/main.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 use sui_bridge::eth_client::EthClient;
-use sui_bridge::metered_eth_provider::{MeteredEthHttpProvier, new_metered_eth_provider};
+use sui_bridge::metered_eth_provider::{MeteredEthHttpProvider, new_metered_eth_provider};
 use sui_bridge::sui_bridge_watchdog::Observable;
 use sui_bridge::sui_client::SuiBridgeClient;
 use sui_bridge::utils::get_eth_contract_addresses;
@@ -84,8 +84,8 @@ async fn main() -> Result<()> {
     let db_url = config.db_url.clone();
     let pool = get_connection_pool(db_url.clone()).await;
 
-    let eth_client: Arc<EthClient<MeteredEthHttpProvier>> = Arc::new(
-        EthClient::<MeteredEthHttpProvier>::new(
+    let eth_client: Arc<EthClient<MeteredEthHttpProvider>> = Arc::new(
+        EthClient::<MeteredEthHttpProvider>::new(
             &config.eth_rpc_url,
             HashSet::from_iter(vec![]), // dummy
             bridge_metrics.clone(),

--- a/crates/sui-bridge/Cargo.toml
+++ b/crates/sui-bridge/Cargo.toml
@@ -8,6 +8,10 @@ edition = "2024"
 
 [dependencies]
 ethers = "2.0"
+reqwest = {version = "0.11", default-features = false, features = [
+  "json",
+  "rustls-tls",
+]}
 tokio = { workspace = true, features = ["full"] }
 sui-types.workspace = true
 sui-authority-aggregation.workspace = true
@@ -38,7 +42,6 @@ eyre.workspace = true
 tempfile.workspace = true
 axum.workspace = true
 anyhow.workspace = true
-reqwest.workspace = true
 fastcrypto.workspace = true
 tap.workspace = true
 rand.workspace = true

--- a/crates/sui-bridge/src/client/bridge_client.rs
+++ b/crates/sui-bridge/src/client/bridge_client.rs
@@ -37,7 +37,9 @@ impl BridgeClient {
         // Unwrap safe: we passed the `is_active_member` check above
         let member = committee.member(&authority_name).unwrap();
         Ok(Self {
-            inner: reqwest::Client::new(),
+            inner: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()?,
             authority: authority_name.clone(),
             base_url: Url::from_str(&member.base_url).ok(),
             committee,

--- a/crates/sui-bridge/src/config.rs
+++ b/crates/sui-bridge/src/config.rs
@@ -5,7 +5,7 @@ use crate::abi::EthBridgeConfig;
 use crate::crypto::BridgeAuthorityKeyPair;
 use crate::error::BridgeError;
 use crate::eth_client::EthClient;
-use crate::metered_eth_provider::MeteredEthHttpProvier;
+use crate::metered_eth_provider::MeteredEthHttpProvider;
 use crate::metered_eth_provider::new_metered_eth_provider;
 use crate::metrics::BridgeMetrics;
 use crate::sui_client::SuiBridgeClient;
@@ -255,7 +255,7 @@ impl BridgeNodeConfig {
     async fn prepare_for_eth(
         &self,
         metrics: Arc<BridgeMetrics>,
-    ) -> anyhow::Result<(Arc<EthClient<MeteredEthHttpProvier>>, Vec<EthAddress>)> {
+    ) -> anyhow::Result<(Arc<EthClient<MeteredEthHttpProvider>>, Vec<EthAddress>)> {
         info!("Creating Ethereum client provider");
         let bridge_proxy_address = EthAddress::from_str(&self.eth.eth_bridge_proxy_address)?;
         let provider = Arc::new(
@@ -311,7 +311,7 @@ impl BridgeNodeConfig {
         );
 
         let eth_client = Arc::new(
-            EthClient::<MeteredEthHttpProvier>::new(
+            EthClient::<MeteredEthHttpProvider>::new(
                 &self.eth.eth_rpc_url,
                 HashSet::from_iter(vec![
                     bridge_proxy_address,
@@ -416,7 +416,7 @@ pub struct BridgeServerConfig {
     pub eth_bridge_proxy_address: EthAddress,
     pub metrics_port: u16,
     pub sui_client: Arc<SuiBridgeClient>,
-    pub eth_client: Arc<EthClient<MeteredEthHttpProvier>>,
+    pub eth_client: Arc<EthClient<MeteredEthHttpProvider>>,
     /// A list of approved governance actions. Action in this list will be signed when requested by client.
     pub approved_governance_actions: Vec<BridgeAction>,
 }
@@ -427,7 +427,7 @@ pub struct BridgeClientConfig {
     pub gas_object_ref: ObjectRef,
     pub metrics_port: u16,
     pub sui_client: Arc<SuiBridgeClient>,
-    pub eth_client: Arc<EthClient<MeteredEthHttpProvier>>,
+    pub eth_client: Arc<EthClient<MeteredEthHttpProvider>>,
     pub db_path: PathBuf,
     pub eth_contracts: Vec<EthAddress>,
     // See `BridgeNodeConfig` for the explanation of following two fields.

--- a/crates/sui-bridge/src/eth_client.rs
+++ b/crates/sui-bridge/src/eth_client.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use crate::abi::EthBridgeEvent;
 use crate::error::{BridgeError, BridgeResult};
-use crate::metered_eth_provider::{MeteredEthHttpProvier, new_metered_eth_provider};
+use crate::metered_eth_provider::{MeteredEthHttpProvider, new_metered_eth_provider};
 use crate::metrics::BridgeMetrics;
 use crate::types::{BridgeAction, EthLog, RawEthLog};
 use ethers::providers::{JsonRpcClient, Middleware, Provider};
@@ -22,7 +22,7 @@ pub struct EthClient<P> {
     contract_addresses: HashSet<EthAddress>,
 }
 
-impl EthClient<MeteredEthHttpProvier> {
+impl EthClient<MeteredEthHttpProvider> {
     pub async fn new(
         provider_url: &str,
         contract_addresses: HashSet<EthAddress>,
@@ -37,7 +37,7 @@ impl EthClient<MeteredEthHttpProvier> {
         Ok(self_)
     }
 
-    pub fn provider(&self) -> Arc<Provider<MeteredEthHttpProvier>> {
+    pub fn provider(&self) -> Arc<Provider<MeteredEthHttpProvider>> {
         Arc::new(self.provider.clone())
     }
 }

--- a/crates/sui-bridge/src/metered_eth_provider.rs
+++ b/crates/sui-bridge/src/metered_eth_provider.rs
@@ -9,14 +9,14 @@ use std::sync::Arc;
 use url::{ParseError, Url};
 
 #[derive(Debug, Clone)]
-pub struct MeteredEthHttpProvier {
+pub struct MeteredEthHttpProvider {
     inner: Http,
     metrics: Arc<BridgeMetrics>,
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-impl JsonRpcClient for MeteredEthHttpProvier {
+impl JsonRpcClient for MeteredEthHttpProvider {
     type Error = HttpClientError;
 
     async fn request<T: Serialize + Send + Sync + Debug, R: DeserializeOwned + Send>(
@@ -37,9 +37,13 @@ impl JsonRpcClient for MeteredEthHttpProvier {
     }
 }
 
-impl MeteredEthHttpProvier {
+impl MeteredEthHttpProvider {
     pub fn new(url: impl Into<Url>, metrics: Arc<BridgeMetrics>) -> Self {
-        let inner = Http::new(url);
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .unwrap();
+        let inner = Http::new_with_client(url, client);
         Self { inner, metrics }
     }
 }
@@ -47,8 +51,8 @@ impl MeteredEthHttpProvier {
 pub fn new_metered_eth_provider(
     url: &str,
     metrics: Arc<BridgeMetrics>,
-) -> Result<Provider<MeteredEthHttpProvier>, ParseError> {
-    let http_provider = MeteredEthHttpProvier::new(Url::parse(url)?, metrics);
+) -> Result<Provider<MeteredEthHttpProvider>, ParseError> {
+    let http_provider = MeteredEthHttpProvider::new(Url::parse(url)?, metrics);
     Ok(Provider::new(http_provider))
 }
 

--- a/crates/sui-bridge/src/node.rs
+++ b/crates/sui-bridge/src/node.rs
@@ -3,7 +3,7 @@
 
 use crate::config::WatchdogConfig;
 use crate::crypto::BridgeAuthorityPublicKeyBytes;
-use crate::metered_eth_provider::MeteredEthHttpProvier;
+use crate::metered_eth_provider::MeteredEthHttpProvider;
 use crate::sui_bridge_watchdog::eth_bridge_status::EthBridgeStatus;
 use crate::sui_bridge_watchdog::eth_vault_balance::{EthereumVaultBalance, VaultAsset};
 use crate::sui_bridge_watchdog::metrics::WatchdogMetrics;
@@ -152,7 +152,7 @@ pub async fn run_bridge_node(
 async fn start_watchdog(
     watchdog_config: Option<WatchdogConfig>,
     registry: &prometheus::Registry,
-    eth_provider: Arc<Provider<MeteredEthHttpProvier>>,
+    eth_provider: Arc<Provider<MeteredEthHttpProvider>>,
     eth_bridge_proxy_address: EthAddress,
     sui_client: Arc<SuiBridgeClient>,
 ) {

--- a/crates/sui-bridge/src/sui_bridge_watchdog/eth_bridge_status.rs
+++ b/crates/sui-bridge/src/sui_bridge_watchdog/eth_bridge_status.rs
@@ -4,7 +4,7 @@
 //! The EthBridgeStatus observable monitors whether the Eth Bridge is paused.
 
 use crate::abi::EthSuiBridge;
-use crate::metered_eth_provider::MeteredEthHttpProvier;
+use crate::metered_eth_provider::MeteredEthHttpProvider;
 use crate::sui_bridge_watchdog::Observable;
 use async_trait::async_trait;
 use ethers::providers::Provider;
@@ -15,13 +15,13 @@ use tokio::time::Duration;
 use tracing::{error, info};
 
 pub struct EthBridgeStatus {
-    bridge_contract: EthSuiBridge<Provider<MeteredEthHttpProvier>>,
+    bridge_contract: EthSuiBridge<Provider<MeteredEthHttpProvider>>,
     metric: IntGauge,
 }
 
 impl EthBridgeStatus {
     pub fn new(
-        provider: Arc<Provider<MeteredEthHttpProvier>>,
+        provider: Arc<Provider<MeteredEthHttpProvider>>,
         bridge_address: EthAddress,
         metric: IntGauge,
     ) -> Self {

--- a/crates/sui-bridge/src/sui_bridge_watchdog/eth_vault_balance.rs
+++ b/crates/sui-bridge/src/sui_bridge_watchdog/eth_vault_balance.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::abi::EthERC20;
-use crate::metered_eth_provider::MeteredEthHttpProvier;
+use crate::metered_eth_provider::MeteredEthHttpProvider;
 use crate::sui_bridge_watchdog::Observable;
 use async_trait::async_trait;
 use ethers::providers::Provider;
@@ -21,7 +21,7 @@ pub enum VaultAsset {
 }
 
 pub struct EthereumVaultBalance {
-    coin_contract: EthERC20<Provider<MeteredEthHttpProvier>>,
+    coin_contract: EthERC20<Provider<MeteredEthHttpProvider>>,
     asset: VaultAsset,
     decimals: u8,
     vault_address: EthAddress,
@@ -30,7 +30,7 @@ pub struct EthereumVaultBalance {
 
 impl EthereumVaultBalance {
     pub async fn new(
-        provider: Arc<Provider<MeteredEthHttpProvier>>,
+        provider: Arc<Provider<MeteredEthHttpProvider>>,
         vault_address: EthAddress,
         coin_address: EthAddress, // for now this only support one coin which is WETH
         asset: VaultAsset,
@@ -60,7 +60,7 @@ impl Observable for EthereumVaultBalance {
     async fn observe_and_report(&self) {
         let balance: Result<
             U256,
-            ethers::contract::ContractError<Provider<MeteredEthHttpProvier>>,
+            ethers::contract::ContractError<Provider<MeteredEthHttpProvider>>,
         > = self
             .coin_contract
             .balance_of(self.vault_address)

--- a/crates/x/src/lint.rs
+++ b/crates/x/src/lint.rs
@@ -92,6 +92,8 @@ pub fn run(args: Args) -> crate::Result<()> {
             "axum-extra".to_owned(),
             // consistent-store uses a newer version of bincode with breaking interface changes
             "bincode".to_owned(),
+            // TODO: remove once we've migrated ethers to alloy: https://linear.app/mysten-labs/issue/BR-191
+            "reqwest".to_owned(),
         ],
     };
 


### PR DESCRIPTION
## Description 

This is a fix for issue L-13 from the Certora audit of the native bridge.

The audit can be seen [here](https://www.notion.so/mystenlabs/Certora-Audit-2966d9dcb4e980c490e2ee96b63dbe82?source=copy_link).

> Reqwest by default has no timeout. This can cause the request to hang forever and keep a thread running (esp. in the eth client, which has no other timeout). Therefore, it’s best to set a timeout for the client.

I also renamed `MeteredEthHttpProvier` to `MeteredEthHttpProvider`, as that appears to be a typo.

In order to pass a `reqwest::Client` to `ethers::providers::Http::new_with_client`, we need to have a matching `reqwest` version with `ethers`. We were actually using `0.12.9`, but `ethers` expects `0.11.20`. And the `ethers` repo is archived, with no newer version. So to use `ethers` with a timeout we need to downgrade `reqwest` to `0.11`. I implemented this, but we may want to keep the current version instead, and just not bother passing a `Client` with a timeout to ethers.

## Test plan 

Nothing other than CI tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
