### PR TITLE
[cli] Try to fix upgrade tests path delimiter issue

### DIFF
--- a/crates/sui/src/unit_tests/upgrade_compatibility_tests.rs
+++ b/crates/sui/src/unit_tests/upgrade_compatibility_tests.rs
@@ -304,11 +304,18 @@ fn get_packages(name: &str) -> (Vec<CompiledModule>, CompiledPackage, PathBuf) {
 
 /// Snapshots will differ on each machine, normalize to prevent test failures
 fn normalize_path(err_string: String) -> String {
-    //test
-    let re = regex::Regex::new(r"^(.*)┌─ .*(\/fixtures\/.*\.(move|toml):\d+:\d+)$").unwrap();
+    let re =
+        regex::Regex::new(r"^(.*?┌─ ).*?([\\/]fixtures[\\/].*\.(move|toml):\d+:\d+)$").unwrap();
+
     err_string
         .lines()
-        .map(|line| re.replace(line, "$1┌─ $2").into_owned())
+        .map(|line| {
+            re.replace(line, |caps: &regex::Captures| {
+                let normalized_path = caps[2].replace("\\", "/");
+                format!("{}{}", &caps[1], normalized_path)
+            })
+            .into_owned()
+        })
         .collect::<Vec<String>>()
         .join("\n")
 }


### PR DESCRIPTION
## Description 

This fixes issues with Windows delimiter being used in the output of these tests, which makes the snapshots fail.

## Test plan 

Current tests should pass on Windows as well. Passed locally on Windows machine.

https://github.com/MystenLabs/sui/actions/runs/19391832548/job/55486391620?pr=24228

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
