### PR TITLE
[cli] Try to fix the normalization due to end line differences on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13430,6 +13430,7 @@ dependencies = [
  "move-vm-profiler",
  "msim",
  "mysten-common",
+ "normalize-line-endings",
  "num-bigint 0.4.4",
  "prometheus",
  "rand 0.8.5",

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -107,6 +107,7 @@ move-ir-types.workspace = true
 move-command-line-common.workspace = true
 move-cli.workspace = true
 move-symbol-pool.workspace = true
+normalize-line-endings = "0.3.0"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemalloc-ctl.workspace = true

--- a/crates/sui/tests/ptb_files_tests.rs
+++ b/crates/sui/tests/ptb_files_tests.rs
@@ -93,9 +93,13 @@ async fn test_ptb_files(path: &Path) -> datatest_stable::Result<()> {
             results.push(format!("{:?}", e));
         }
     }
+    use normalize_line_endings::normalized;
 
     // === FINALLY DO THE ASSERTION ===
-    insta::assert_snapshot!(fname(), results.join("\n"));
+    insta::assert_snapshot!(
+        fname(),
+        &String::from_iter(normalized(results.join("\n").chars()))
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Description 

One of the issues with running ptb-files on windows is that cargo outputs crlf line endings on insta snapshots. I am not sure this is the right way to fix it, but this is what I came up with: use normalized crate to normalize line endings in the insta snapshot output.

## Test plan 

Run `cargo nextest run -- ptb_files` on Windows machine and tests pass (except 1, windows error when file not found is different than unix). All tests here should pass.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
