### PR TITLE
[static-ptbs] Relax allowed linkages in publish/upgrade commands a bit

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/upgrade/duplicate_dep.move
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/duplicate_dep.move
@@ -1,0 +1,13 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//# init --addresses TestV1=0x0 TestV2=0x0 DepV1=0x0 --accounts A
+
+//# publish --upgradeable --sender A
+module DepV1::dep;
+
+//# publish --upgradeable --dependencies DepV1 DepV1 --sender A
+module TestV1::m;
+
+//# upgrade --package TestV1 --upgrade-capability 2,1 --dependencies DepV1 DepV1 --sender A
+module TestV2::m;

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/duplicate_dep.snap
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/duplicate_dep.snap
@@ -1,0 +1,25 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-7:
+//# publish --upgradeable --sender A
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 4841200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 9-10:
+//# publish --upgradeable --dependencies DepV1 DepV1 --sender A
+created: object(2,0), object(2,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5358000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 12-13:
+//# upgrade --package TestV1 --upgrade-capability 2,1 --dependencies DepV1 DepV1 --sender A
+created: object(3,0)
+mutated: object(0,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 5358000,  storage_rebate: 2595780, non_refundable_storage_fee: 26220

--- a/crates/sui-adapter-transactional-tests/tests/upgrade/duplicate_dep@v2.snap
+++ b/crates/sui-adapter-transactional-tests/tests/upgrade/duplicate_dep@v2.snap
@@ -1,0 +1,25 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 4 tasks
+
+init:
+A: object(0,0)
+
+task 1, lines 6-7:
+//# publish --upgradeable --sender A
+created: object(1,0), object(1,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 4841200,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 9-10:
+//# publish --upgradeable --dependencies DepV1 DepV1 --sender A
+created: object(2,0), object(2,1)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 5358000,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 12-13:
+//# upgrade --package TestV1 --upgrade-capability 2,1 --dependencies DepV1 DepV1 --sender A
+created: object(3,0)
+mutated: object(0,0), object(2,1)
+gas summary: computation_cost: 1000000, storage_cost: 5358000,  storage_rebate: 2595780, non_refundable_storage_fee: 26220

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/execution/context.rs
@@ -706,7 +706,10 @@ impl<'env, 'pc, 'vm, 'state, 'linkage, 'gas> Context<'env, 'pc, 'vm, 'state, 'li
         let mut fetched = vec![];
         let mut missing = vec![];
 
-        for id in dependency_ids {
+        // Collect into a set to avoid duplicate fetches and preserve existing behavior
+        let dependency_ids: BTreeSet<_> = dependency_ids.iter().collect();
+
+        for id in &dependency_ids {
             match self.env.linkable_store.get_package(id) {
                 Err(e) => {
                     return Err(ExecutionError::new_with_source(


### PR DESCRIPTION
## Description 

Relax restrictions in the new static PTBs to match the old PTBs (allow duplicate dep IDs but setify them before fetching packages).

## Test plan 

Existing + added a new test to check new behavior/parity between old and new adapters in the presence of duplicate dep IDs in publish/upgrade.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
