### PR TITLE
[mfp] avoid checking inclusion status for GC'ed blocks

### DIFF
--- a/consensus/core/src/core.rs
+++ b/consensus/core/src/core.rs
@@ -625,15 +625,14 @@ impl Core {
             .take_commit_votes(MAX_COMMIT_VOTES_PER_BLOCK);
 
         let transaction_votes = if self.context.protocol_config.mysticeti_fastpath() {
-            let hard_linked_ancestors = {
+            let new_causal_history = {
                 let mut dag_state = self.dag_state.write();
                 ancestors
                     .iter()
                     .flat_map(|ancestor| dag_state.link_causal_history(ancestor.reference()))
                     .collect()
             };
-            self.transaction_certifier
-                .get_own_votes(hard_linked_ancestors)
+            self.transaction_certifier.get_own_votes(new_causal_history)
         } else {
             vec![]
         };

--- a/consensus/core/src/dag_state.rs
+++ b/consensus/core/src/dag_state.rs
@@ -807,22 +807,28 @@ impl DagState {
                 .recent_blocks
                 .get_mut(&block_ref)
                 .unwrap_or_else(|| panic!("Block {:?} is not in DAG state", block_ref));
-            if block_info.hard_linked {
+            if block_info.included {
                 continue;
             }
             linked_blocks.push(block_ref);
-            block_info.hard_linked = true;
+            block_info.included = true;
             targets.extend(block_info.block.ancestors().iter());
         }
         linked_blocks
     }
 
-    /// Returns true if the block is hard linked by a proposed block.
-    pub(crate) fn is_hard_linked(&self, block_ref: &BlockRef) -> bool {
+    /// Returns true if the block has been included in an owned proposed block.
+    /// NOTE: caller should make sure only blocks above GC round are queried.
+    pub(crate) fn has_been_included(&self, block_ref: &BlockRef) -> bool {
         self.recent_blocks
             .get(block_ref)
-            .unwrap_or_else(|| panic!("Attempted to query for hard link status for a block not in cached data {block_ref}"))
-            .hard_linked
+            .unwrap_or_else(|| {
+                panic!(
+                    "Attempted to query for inclusion status for a block not in cached data {}",
+                    block_ref
+                )
+            })
+            .included
     }
 
     pub(crate) fn threshold_clock_round(&self) -> Round {
@@ -1219,8 +1225,13 @@ struct BlockInfo {
     block: VerifiedBlock,
     // Whether the block has been committed
     committed: bool,
-    // Whether the block has been hard linked by a proposed block.
-    hard_linked: bool,
+    // Whether the block has been included in the causal history of an owned proposed block.
+    ///
+    /// There are two usages of this field:
+    /// 1. When proposing blocks, determine the set of blocks to carry votes for.
+    /// 2. When recovering, determine if a block has not been included in a proposed block and
+    ///    should recover transaction votes by voting.
+    included: bool,
 }
 
 impl BlockInfo {
@@ -1228,7 +1239,7 @@ impl BlockInfo {
         Self {
             block,
             committed: false,
-            hard_linked: false,
+            included: false,
         }
     }
 }
@@ -1542,7 +1553,7 @@ mod test {
 
         // No block is linked yet.
         for block in &all_blocks {
-            assert!(!dag_state.is_hard_linked(&block.reference()));
+            assert!(!dag_state.has_been_included(&block.reference()));
         }
 
         // Link causal history from a round 1 block.
@@ -1554,7 +1565,7 @@ mod test {
         assert_eq!(linked_blocks.len(), 1);
         assert_eq!(linked_blocks[0], round_1_block.reference());
         for block_ref in linked_blocks {
-            assert!(dag_state.is_hard_linked(&block_ref));
+            assert!(dag_state.has_been_included(&block_ref));
         }
 
         // Link causal history from a round 2 block.
@@ -1571,9 +1582,9 @@ mod test {
         // Check linked status in dag state.
         for block in &all_blocks {
             if block.round() == 1 || block.reference() == round_2_block.reference() {
-                assert!(dag_state.is_hard_linked(&block.reference()));
+                assert!(dag_state.has_been_included(&block.reference()));
             } else {
-                assert!(!dag_state.is_hard_linked(&block.reference()));
+                assert!(!dag_state.has_been_included(&block.reference()));
             }
         }
 
@@ -1618,9 +1629,9 @@ mod test {
                 || block_ref.round == 5
                 || block_ref == round_6_block.reference()
             {
-                assert!(dag_state.is_hard_linked(&block.reference()));
+                assert!(dag_state.has_been_included(&block.reference()));
             } else {
-                assert!(!dag_state.is_hard_linked(&block.reference()));
+                assert!(!dag_state.has_been_included(&block.reference()));
             }
         }
     }
@@ -2085,9 +2096,9 @@ mod test {
             .iter()
             .for_each(|(block_ref, block_info)| {
                 if block_ref.round < PERSISTED_BLOCK_ROUNDS || block_ref.author.value() == 0 {
-                    assert!(block_info.hard_linked);
+                    assert!(block_info.included);
                 } else {
-                    assert!(!block_info.hard_linked);
+                    assert!(!block_info.included);
                 }
             });
     }


### PR DESCRIPTION
## Description 

Blocks already GC'ed should not need to be voted on, because these blocks are either finalized, or will never get committed.

## Test plan 

CI
