### PR TITLE
pick(24319): fix(graphql): structured transaction query limits

### DIFF
--- a/crates/sui-indexer-alt-graphql/src/config.rs
+++ b/crates/sui-indexer-alt-graphql/src/config.rs
@@ -265,7 +265,7 @@ impl Limits {
             tx_payload_args: BTreeSet::from([
                 ("Mutation", "executeTransaction", "txBytes"),
                 ("Mutation", "executeTransaction", "signatures"),
-                ("Query", "simulateTransaction", "txBytes"),
+                ("Query", "simulateTransaction", "transaction"),
                 ("Query", "verifyZkloginSignature", "bytes"),
                 ("Query", "verifyZkloginSignature", "signature"),
             ]),


### PR DESCRIPTION
## Description

Update the query limits checker to be able to account for transactions given as structured payloads instead of just raw bytes.

## Test plan

New unit tests:

```
sui-indexer-alt-graphql$ cargo nextest run
```

And testing the following repro, on a local network:

```
sui$ cargo run -p sui -- start --with-graphql --force-regenesis
```

And then execute the following query on `http://localhost:9125/graphql`:

```graphql
fragment BaseObject on Object {
  version
  object_digest: digest
  object_id: address
}

fragment ObjectStandard on Object {
  bcs: objectBcs
  ...BaseObject
  owner {
    ... on AddressOwner {
      address_id: address {
        address
      }
      obj_owner_kind: __typename
    }
    ... on Shared {
      initial_version: initialSharedVersion
      obj_owner_kind: __typename
    }
    ... on Immutable {
      obj_owner_kind: __typename
    }
    ... on ObjectOwner {
      parent_id: address {
        address
      }
      obj_owner_kind: __typename
    }
  }
  storage_rebate: storageRebate
  prior_transaction: previousTransaction {
    previous_transaction_digest: digest
  }
  as_move_content: asMoveObject {
    has_public_transfer: hasPublicTransfer
    as_object: contents {
      content: json
      object_type_repr: type {
        object_type: repr
      }
    }
  }
  as_move_package: asMovePackage {
    bcs: moduleBcs
  }
}

fragment GasSummary on GasCostSummary {
  computationCost
  storageCost
  storageRebate
  nonRefundableStorageFee
}

fragment TxEffects on TransactionEffects {
  status
  executionError {
    abortCode
    sourceLineNumber
    instructionOffset
    identifier
    constant
    message
  }
  timestamp
  balanceChanges {
    nodes {
      coinType {
        coin_type: repr
      }
      balance_change: amount
      change_to: owner {
        object_id: address
      }
    }
  }
  gasEffects {
    gasObject {
      gas_object_id: address
    }
    gasSummary {
      ...GasSummary
    }
  }
  objectChanges {
    nodes {
      address: address
      deleted: idDeleted
      created: idCreated
      input_state: inputState {
        ...ObjectStandard
      }
      output_state: outputState {
        ...ObjectStandard
      }
    }
  }
  checkpoint {
    sequenceNumber
    networkTotalTransactions
    timestamp
    epoch {
      epochId
      startTimestamp
      endTimestamp
    }
  }
  events {
    nodes {
      sequenceNumber
      timestamp
      contents {
        json
      }
      transactionModule {
        package {
          version
          package_id: address
        }
        module_name: name
      }
    }
  }
}

{
  dryRun: simulateTransaction(
    transaction: {kind: {programmable_transaction: {inputs: [{kind: "PURE", pure: "qeLbOF8FXMAhWjzeJot2JwU1uUQ4B1FPGDvoaSbCGfQ="}], commands: [{publish: {modules: ["oRzrCwcAAAUOAQAYAhhQA2jpAQTRAiIF8wKxAwekBqMHCMcNYAanDh8Kxg5gC6YPAgyoD/wDDaQTBBGoExoTwhMCAFQBUwFdAhcCKwIvAjICUgJeAmACYQJjAAoDAAAJBAAAAAcAAA4MAAAHBwEBAAAMBAAACwgAAA0EAAEIBwEAAAIRBwADAQQBAAEEAgwBAAEHBAcABxMEAAgQAgAKEgIACxQHAgEAAAAALAABAABbAgMAACUEAwAAIAUDAAAmBgMAAB8HAwAAKggDAAApCQMAACcKAwAAGwsDAAAeDAMAACINAwAAIw4DAAAkDwMAACgQAwAAXxESAQAAHRMDAABEABQAABwVAwEDAEkAAwAALQADAAAhFhcAABoYAwAAVRkDAABFGhsAATQ5LgEAAUwxFwEAAVEDIwEAAmIgIQADTTY3AQADXDUfAQADZDQfAQADZQMfAQAEGDM0AQAEQzo7AQAFFiwDAgcEBTMqFwEHBjAuAwEDBy4dAwAHUAAdAAlgLwMBCApZJBQACzEDKAIBACAeGyIbJionJCAjKyUtKAEoMBowIR4eHh0eGjcZNx8eIh4BBwgPAQgGAQcIBgAGDQ4DBA8HCA8GCwgBDQsIAQ4LCAEDCwgBBAsIAQ8HCA8GCg0KDgoDCgQKDwcIDwYLCAEKDQsIAQoOCwgBCgMLCAEKBAsIAQoPBwgPAgoCBwgPAgsIAQoCBwgPAgoKCgIHCA8CCgUHCA8CCggMBwgPAgYICQcIDwILCAEICQcIDwIKCAkHCA8CCgsIAQgJBwgPAgoLCwEJAAcIDwEKCwsBCQACAQcIDwEFCgECDwgJCwgBCAkKAgoICQYIBQoLBAEJAAcIDwIHCwgBCAMHCA8BAQIIAwcIDwMHCAYHCwsBCA4HCA8DBwgGBwsIAQMHCA8BCwsBCA4FCA0LCgEIDggJCAUIBgEIDQEIDgELCgEJAAEKAgEICQECAQsIAQkAAQYIDwEKCAcBCAcCAwMBCxACCQAJAQEIAgIGCA0JAAIKAgIDBwgNCQAJAQEIAAEJAAIJAAUBCAMBBgsIAQkAAQcLCgEIDgEHCwsBCQABBwsKAQkAAgcLCgEJAAMCBwsKAQkACwoBCQABAwILCgEIDgMBBwsIAQkAAgsKAQkABwgPAQsLAQkABUFLaW5kB0JhbGFuY2UEQ29pbgZESVJFQ1QCSUQDTVRPA01UUwdNYXlUeXBlBk9wdGlvbghQYXJtRW51bQlQYXJtRXZlbnQKUGFybU9iamVjdAtQYXJtU2NhbGFycwpQYXJtU3RydWN0BlBob25leQNSR0IDU1VJBlN0cmluZwlUeENvbnRleHQDVUlEBlZlY01hcARhX3U4A2FkZAdiYWxhbmNlC2JhbGFuY2VfbXV0BGJsdWULYnVybl9waG9uZXkRY2hlY2tfYWRkcmVzc192ZWMJY2hlY2tfYWxsCmNoZWNrX2Jvb2wMY2hlY2tfaWRfdmVjG2NoZWNrX29wdGlvbmFsX3VpbnRfdmVjdG9ycxRjaGVja19vcHRpb25hbF91aW50cwxjaGVja19waG9uZXkMY2hlY2tfc3RyaW5nE2NoZWNrX3N0cmluZ19vcHRpb24QY2hlY2tfc3RyaW5nX3ZlYwtjaGVja191aW50cxNjaGVja191aW50c192ZWN0b3JzEWNoZWNrX3ZlY19kZWVwX3U4F2NoZWNrX3ZlY19vcHRpb25fc3RyaW5nFWNoZWNrX3ZlY19vcHRpb25hbF91OAxjaGVja192ZWNfdTgEY29pbhJjcmVhdGVfcGFybV9vYmplY3QNY3JlYXRlX3Bob25leQZkZWxldGUNZHluYW1pY19maWVsZARlbWl0BWVtcHR5BWV2ZW50B2V4aXN0c18HZXh0cmFjdAlmX2FkZHJlc3MGZl9lbnVtDWZfbmVzdF92ZWN0b3IGZl9vX3U4CmZfb3B0aW9uYWwGZl91MTI4BWZfdTE2BmZfdTI1NgVmX3UzMgVmX3U2NARmX3U4CWZfdmVjX21hcAhmX3ZlY3RvcgNmb28MZnJvbV9iYWxhbmNlCmdldF9zZW5kZXILZ2V0X3NlcnZpY2UFZ3JlZW4CaWQFaW5kZXgEaW5pdAdpbm5hcmRzBWlubmVyB2lzX3NvbWUEam9pbgZteW5hbWUGbXl0eXBlA25ldwRub25lBm9iamVjdAZvcHRpb24FcGFybXMLcGF5X3NlcnZpY2UEcG9zMARwb3MxA3JlZAZzZW5kZXIHc2VydmljZRJzZXRfb2JqZWN0X3ZlcnNpb24Fc3BsaXQGc3RyaW5nA3N1aQhzd2FwX2FfYgh0cmFuc2Zlcgp0eF9jb250ZXh0BHV0ZjgHdmVjX21hcAx3aXRoZHJhd19hbGwEemVybwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgMIQEIPAAAAAAACAQEKAgQDZm9vCgIIB3ZlcnNpb24AAgFCAgICARUCAwIBRwgNBAIBSwkABQINPwI7DT0OPgM6BDwPOAsIAQI1BUEKAjcKCggHOQsIAQgHQAsQAgMDNggBBgIFRwgNSggFWgsKAQgOTggJTwsEAQgCBwIBSAIDKQABAAAcJwoAEScMATgADAIHAhEcDAMxAEgAAEkAAAAABgAAAAAAAAAAMgAAAAAAAAAAAAAAAAAAAABKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA4AQsALhEpQCIAAAAAAAAAAEAlAAAAAAAAAAA4AjgDMQBOABIEDAQLAQsECwILAzEPEgE5ABIFDAUNBREBCwUCAAEAAAADDgoAEAAHAzgEBAgLAAEFDQsADwAHAwcBOAUCAAIBAAADBDEAEgA4BgIAAwEAAAMEMQESADgGAgAEAQAAAwECAAUBAAADAQIABgEAAAMBAgAHAQAAAwECAAgBAAADAQIACQEAAAMBAgAKAQAAAwECAAsBAAADAQIADAEAAAMBAgANAQAAAwECAA4BAAADAQIADwEAAAMCCwACABABAAADAQIAEQEAAAMECwAuESkCABIBAAADAQIAEwAAAAMHCgARAAsALhEpOAcCABQBAAADCAoAEScSAgsALhEpOAgCABUBAAAXCwsALjgJBAcIDAIFCQkMAgsCAgAWAQAAAwQLABMCESYCABcBAAAyDQoAEQELATgKDAMLAA8BCwMHADgLOAwBAgAYAQAAOBkKABEBCgEuOA0EDwsBOA4MBAsADwELBDgLDAMFFQsBAQsADwE4DwwDCwMLAjgQAgAFAAUCAQIEAwFWAg8DWAJGAhkCBQJWAlcCBgFWCAcAAAA="], dependencies: ["0x000000000000000000000000000000000000000000000000000000000000000b", "0x0000000000000000000000000000000000000000000000000000000000000001", "0x0000000000000000000000000000000000000000000000000000000000000002", "0x0000000000000000000000000000000000000000000000000000000000000003"]}}, {transfer_objects: {objects: [{kind: "RESULT", result: 0}], address: {kind: "INPUT", input: 0}}}]}}, sender: "0xa9e2db385f055cc0215a3cde268b76270535b9443807514f183be86926c219f4"}
  ) {
    error
    results: outputs {
      returnValues {
        value {
          type {
            repr
          }
          bcs
        }
      }
    }
    transactionBlock: effects {
      ...TxEffects
    }
  }
}
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] gRPC:
- [ ] JSON-RPC:
- [x] GraphQL: Fixes a bug where the transaction payloads that were part of `simulateTransaction` calls were incorrectly classified as part of the query payload (and therefore subject to a lower payload size limit).
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework: