### PR TITLE
Increase checkpoint message size limit in ingestion client (#24313)

### DIFF
--- a/crates/sui-indexer-alt-framework/src/ingestion/client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/client.rs
@@ -16,6 +16,7 @@ use tracing::{debug, error, warn};
 use url::Url;
 
 use crate::ingestion::Error as IngestionError;
+use crate::ingestion::MAX_GRPC_MESSAGE_SIZE_BYTES;
 use crate::ingestion::Result as IngestionResult;
 use crate::ingestion::local_client::LocalIngestionClient;
 use crate::ingestion::remote_client::RemoteIngestionClient;
@@ -105,9 +106,12 @@ impl IngestionClient {
         let client = if let Some(username) = username {
             let mut headers = HeadersInterceptor::new();
             headers.basic_auth(username, password);
-            Client::new(url.to_string())?.with_headers(headers)
+            Client::new(url.to_string())?
+                .with_headers(headers)
+                .with_max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE_BYTES)
         } else {
             Client::new(url.to_string())?
+                .with_max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE_BYTES)
         };
         Ok(Self::new_impl(Arc::new(client), metrics))
     }

--- a/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/mod.rs
@@ -31,6 +31,8 @@ mod streaming_client;
 #[cfg(test)]
 mod test_utils;
 
+pub(crate) const MAX_GRPC_MESSAGE_SIZE_BYTES: usize = 128 * 1024 * 1024;
+
 #[derive(clap::Args, Clone, Debug, Default)]
 #[group(required = true)]
 pub struct ClientArgs {

--- a/crates/sui-indexer-alt-framework/src/ingestion/streaming_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/streaming_client.rs
@@ -11,6 +11,7 @@ use sui_rpc::proto::sui::rpc::v2::{
 use sui_rpc_api::client::checkpoint_data_field_mask;
 use tonic::{Status, transport::Uri};
 
+use crate::ingestion::MAX_GRPC_MESSAGE_SIZE_BYTES;
 use crate::ingestion::error::{Error, Result};
 use crate::types::full_checkpoint_content::Checkpoint;
 
@@ -39,7 +40,8 @@ impl CheckpointStreamingClient for GrpcStreamingClient {
     async fn connect(&mut self) -> Result<CheckpointStream> {
         let mut client = SubscriptionServiceClient::connect(self.uri.clone())
             .await
-            .map_err(|err| Error::RpcClientError(Status::from_error(err.into())))?;
+            .map_err(|err| Error::RpcClientError(Status::from_error(err.into())))?
+            .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE_BYTES);
 
         let mut request = SubscribeCheckpointsRequest::default();
         request.read_mask = Some(checkpoint_data_field_mask());


### PR DESCRIPTION
## Description

We were seeing client-side errors due to messages that exceeded the
default 4mb limit. Bumping it up to 128mb (the biggest I've seen so far
is ~90mb).
