### PR TITLE
[cli] use the same file handle in save_with_lock

### DIFF
--- a/crates/sui-config/src/lib.rs
+++ b/crates/sui-config/src/lib.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use tracing::trace;
 
@@ -138,7 +139,7 @@ where
         debug!("Writing config with lock to {}", path.display());
         let config_str = serde_yaml::to_string(&self)?;
 
-        let file = fs::OpenOptions::new()
+        let mut file = fs::OpenOptions::new()
             .write(true)
             .create(true)
             .truncate(true)
@@ -153,7 +154,7 @@ where
         file.lock()
             .with_context(|| format!("Unable to acquire exclusive lock on {}", path.display()))?;
 
-        fs::write(path, config_str)
+        file.write_all(config_str.as_bytes())
             .with_context(|| format!("Unable to save config to {}", path.display()))?;
 
         file.unlock()?;


### PR DESCRIPTION
## Description 

Fixes major windows bug, use same file handle for lock and writing config files in CLI

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
