### PR TITLE
Fix jsonrpc memory leak (#24322)

### DIFF
--- a/crates/sui-json-rpc/src/coin_api.rs
+++ b/crates/sui-json-rpc/src/coin_api.rs
@@ -14,7 +14,6 @@ use sui_core::jsonrpc_index::TotalBalance;
 use tap::TapFallible;
 use tracing::{debug, instrument};
 
-use mysten_metrics::spawn_monitored_task;
 use sui_core::authority::AuthorityState;
 use sui_json_rpc_api::{CoinReadApiOpenRpc, CoinReadApiServer, JsonRpcMetrics, cap_page_limit};
 use sui_json_rpc_types::Balance;
@@ -337,7 +336,7 @@ async fn find_package_object_id(
     object_struct_tag: StructTag,
     kv_store: Arc<TransactionKeyValueStore>,
 ) -> RpcInterimResult<ObjectID> {
-    spawn_monitored_task!(async move {
+    async move {
         let publish_txn_digest = state.find_publish_txn_digest(package_id)?;
 
         let effect = kv_store.get_fx_by_tx_digest(publish_txn_digest).await?;
@@ -355,8 +354,8 @@ async fn find_package_object_id(
             object_struct_tag, package_id,
         ))
         .into())
-    })
-    .await?
+    }
+    .await
 }
 
 /// CoinReadInternal trait to capture logic of interactions with AuthorityState and metrics
@@ -490,10 +489,7 @@ impl CoinReadInternal for CoinReadInternalImpl {
         let limit = cap_page_limit(limit);
         self.metrics.get_coins_limit.observe(limit as f64);
         let state = self.get_state();
-        let mut data = spawn_monitored_task!(async move {
-            state.get_owned_coins(owner, cursor, limit + 1, one_coin_type_only)
-        })
-        .await??;
+        let mut data = state.get_owned_coins(owner, cursor, limit + 1, one_coin_type_only)?;
 
         let has_next_page = data.len() > limit;
         data.truncate(limit);
@@ -1483,6 +1479,7 @@ mod tests {
         async fn test_object_not_found() {
             let transaction_digest = TransactionDigest::from([0; 32]);
             let transaction_effects = TransactionEffects::default();
+            let transaction_effects_clone = transaction_effects.clone();
 
             // Mock object store that returns None for registry lookup
             let mut mock_object_store = MockObjectStore::new();
@@ -1497,9 +1494,20 @@ mod tests {
                 .return_once(move |_| Ok(transaction_digest));
             mock_state
                 .expect_get_executed_transaction_and_effects()
-                .return_once(move |_, _| Ok((create_fake_transaction(), transaction_effects)));
+                .return_once(move |_, _| {
+                    Ok((create_fake_transaction(), transaction_effects.clone()))
+                });
 
-            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state), None);
+            let mut mock_kv_store = MockKeyValueStore::new();
+            mock_kv_store.expect_multi_get().return_once(move |_, _| {
+                Ok((
+                    vec![Some(create_fake_transaction())],
+                    vec![Some(transaction_effects_clone)],
+                ))
+            });
+
+            let coin_read_api =
+                CoinReadApi::new_for_tests(Arc::new(mock_state), Some(Arc::new(mock_kv_store)));
             let response = coin_read_api
                 .get_coin_metadata("0x2::sui::SUI".to_string())
                 .await;
@@ -1683,6 +1691,7 @@ mod tests {
             let (coin_name, _, _, _, _) = get_test_treasury_cap_peripherals(package_id);
             let transaction_digest = TransactionDigest::from([0; 32]);
             let transaction_effects = TransactionEffects::default();
+            let transaction_effects_clone = transaction_effects.clone();
 
             // Mock object store that returns None for registry lookup
             let mut mock_object_store = MockObjectStore::new();
@@ -1697,18 +1706,27 @@ mod tests {
                 .return_once(move |_| Ok(transaction_digest));
             mock_state
                 .expect_multi_get()
-                .return_once(move |_, _| Ok((vec![], vec![Some(transaction_effects)])));
+                .return_once(move |_, _| Ok((vec![], vec![Some(transaction_effects.clone())])));
 
-            let coin_read_api = CoinReadApi::new_for_tests(Arc::new(mock_state), None);
+            let mut mock_kv_store = MockKeyValueStore::new();
+            mock_kv_store.expect_multi_get().return_once(move |_, _| {
+                Ok((
+                    vec![Some(create_fake_transaction())],
+                    vec![Some(transaction_effects_clone)],
+                ))
+            });
+
+            let coin_read_api =
+                CoinReadApi::new_for_tests(Arc::new(mock_state), Some(Arc::new(mock_kv_store)));
             let response = coin_read_api.get_total_supply(coin_name.clone()).await;
 
             assert!(response.is_err());
             let error_object = response.unwrap_err();
-            let expected = expect!["-32000"];
+            let expected = expect!["-32602"];
             expected.assert_eq(&error_object.code().to_string());
-            let expected = expect![[
-                r#"task 1 panicked with message "MockKeyValueStore::multi_get(?, ?): No matching expectation found""#
-            ]];
+            let expected = expect![
+                "Cannot find object with type [0x2::coin::TreasuryCap<0xf::test_coin::TEST_COIN>] from [0x000000000000000000000000000000000000000000000000000000000000000f] package created objects."
+            ];
             expected.assert_eq(error_object.message());
         }
 

--- a/crates/sui-json-rpc/src/governance_api.rs
+++ b/crates/sui-json-rpc/src/governance_api.rs
@@ -13,7 +13,6 @@ use jsonrpsee::RpcModule;
 use jsonrpsee::core::RpcResult;
 use tracing::{info, instrument};
 
-use mysten_metrics::spawn_monitored_task;
 use sui_core::authority::AuthorityState;
 use sui_json_rpc_api::{GovernanceReadApiOpenRpc, GovernanceReadApiServer, JsonRpcMetrics};
 use sui_json_rpc_types::{DelegatedStake, Stake, StakeStatus};
@@ -49,8 +48,7 @@ impl GovernanceReadApi {
 
     async fn get_staked_sui(&self, owner: SuiAddress) -> Result<Vec<StakedSui>, Error> {
         let state = self.state.clone();
-        let result =
-            spawn_monitored_task!(async move { state.get_staked_sui(owner).await }).await??;
+        let result = state.get_staked_sui(owner).await?;
 
         self.metrics
             .get_stake_sui_result_size
@@ -66,13 +64,10 @@ impl GovernanceReadApi {
         staked_sui_ids: Vec<ObjectID>,
     ) -> Result<Vec<DelegatedStake>, Error> {
         let state = self.state.clone();
-        let stakes_read = spawn_monitored_task!(async move {
-            staked_sui_ids
-                .iter()
-                .map(|id| state.get_object_read(id))
-                .collect::<Result<Vec<_>, _>>()
-        })
-        .await??;
+        let stakes_read: Vec<_> = staked_sui_ids
+            .iter()
+            .map(|id| state.get_object_read(id))
+            .collect::<Result<Vec<_>, _>>()?;
 
         if stakes_read.is_empty() {
             return Ok(vec![]);
@@ -119,11 +114,8 @@ impl GovernanceReadApi {
 
         let _timer = self.metrics.get_delegated_sui_latency.start_timer();
 
-        let self_clone = self.clone();
-        spawn_monitored_task!(
-            self_clone.get_delegated_stakes(stakes.into_iter().map(|s| (s, true)).collect())
-        )
-        .await?
+        self.get_delegated_stakes(stakes.into_iter().map(|s| (s, true)).collect())
+            .await
     }
 
     async fn get_delegated_stakes(

--- a/crates/sui-json-rpc/src/transaction_execution_api.rs
+++ b/crates/sui-json-rpc/src/transaction_execution_api.rs
@@ -16,7 +16,6 @@ use crate::{
     ObjectProviderCache, SuiRpcModule, get_balance_changes_from_effect, get_object_changes,
     with_tracing,
 };
-use mysten_metrics::spawn_monitored_task;
 use shared_crypto::intent::{AppId, Intent, IntentMessage, IntentScope, IntentVersion};
 use sui_core::authority::AuthorityState;
 use sui_core::authority_client::NetworkAuthorityClient;
@@ -150,11 +149,10 @@ impl TransactionExecutionApi {
 
         let transaction_orchestrator = self.transaction_orchestrator.clone();
         let orch_timer = self.metrics.orchestrator_latency_ms.start_timer();
-        let (response, is_executed_locally) = spawn_monitored_task!(
-            transaction_orchestrator.execute_transaction_block(request, request_type, None)
-        )
-        .await?
-        .map_err(Error::from)?;
+        let (response, is_executed_locally) = transaction_orchestrator
+            .execute_transaction_block(request, request_type, None)
+            .await
+            .map_err(Error::from)?;
         drop(orch_timer);
 
         self.handle_post_orchestration(


### PR DESCRIPTION
## Description

When RPC requests time out (on the server side,
[here](https://github.com/MystenLabs/sui/blob/a079505cb816f9d3fb6e1677a4de8e139c89eb6f/crates/sui-json-rpc/src/metrics.rs?plain=1#L263))
the tasks spawned with spawn_monitored_task! (which calls tokio::spawn
internally) are not cancelled. I suspect this could be the root cause of
the memory leaks we have seen lately.

I started by trying to wrap the tasks with a cancellation token, but
then I realized there didn't seem to be any good reason to be spawning
tasks in the first place. We were just immediately awaiting on them, and
the spawn_monitored_task! macro just gives us some fairly useluess task
count metrics (we already have inflight metrics from the rpc server
anyway). So I realized we can just remove the spawn and let the timeout
cancel the future which is simpler.

The test expectation changed from -32000 to -32602 because:

- Before: spawn_monitored_task! caught the panic when the object wasn't
  found, wrapped it as an internal error → -32000
- After: The actual SuiRpcInputError::GenericNotFound error propagates
  correctly → maps to InvalidParams → -32602

The test mocks were also set up incorrectly but it was hidden because
the spawn was catching the missing mock error and turning it into a join
error.

## Test plan

This was already manually deployed to mainnet full nodes in asse1.
