### PR TITLE
[ci] Set up the Windows CI for running Sui CLI tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -28,5 +28,8 @@ move-clippy = [
     "-Aclippy::needless_borrows_for_generic_args",
 ]
 
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "link-args=/STACK:8388608"] # increase stack size to 8MB for Windows to avoid stack overflow in main thread
+
 [build]
 rustflags = ["-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes", "-A", "unknown_lints", "-A", "mismatched_lifetime_syntaxes"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -210,6 +210,33 @@ jobs:
         run: |
           cargo build --all-features
 
+  windows-cli-tests:
+    needs: [diff, windows-build]
+    if: needs.diff.outputs.isRust == 'true'
+    timeout-minutes: 120
+    env:
+      # Tests written with #[sim_test] are often flaky if run as #[tokio::test] - this var
+      # causes #[sim_test] to only run under the deterministic `simtest` job, and not the
+      # non-deterministic `test` job.
+      SUI_SKIP_SIMTESTS: 1
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - [ windows-ghcloud ]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # Pin v4.1.1
+        with:
+          ref: ${{ github.event.inputs.sui_repo_ref || github.ref }}
+
+      - uses: taiki-e/install-action@nextest
+
+      - name: cargo test Sui CLI
+        shell: bash
+        run: |
+          cargo nextest run -p sui --no-fail-fast --profile ci
+
   simtest:
     needs: [diff, rustfmt, clippy]
     if: needs.diff.outputs.isRust == 'true' || needs.diff.outputs.isSolidity == 'true'


### PR DESCRIPTION
## Description 

This PR sets up a Windows CI for running the Sui CLI tests on Windows to avoid regressions.

## Test plan 

All current tests should pass.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
