### PR TITLE
fix docs typo

### DIFF
--- a/docs/content/concepts/archival-store.mdx
+++ b/docs/content/concepts/archival-store.mdx
@@ -40,7 +40,7 @@ Though their goals and usage patterns differ, both developers and RPC / data pro
 
 - Operate a differentiated infrastructure service by offering historical data access to developers.
 - Extend the retention horizon of GraphQL or gRPC-based APIs by using the Archival Service.
-- Maintain operational independence by running your own Archival Store and Service (using Bigtable) or a custom backend).
+- Maintain operational independence by running your own Archival Store and Service (using Bigtable) or a custom backend.
 
 ## Accessing the Archival Service
 


### PR DESCRIPTION
## Description 

Fix small typo. Removed the trailing parenthesis

> Maintain operational independence by running your own Archival Store and Service (using Bigtable) or a custom backend).

->

> Maintain operational independence by running your own Archival Store and Service (using Bigtable) or a custom backend.


## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Docs: 
