### PR TITLE
[tidehunter] insert genesis startup check

### DIFF
--- a/crates/sui-core/src/checkpoints/mod.rs
+++ b/crates/sui-core/src/checkpoints/mod.rs
@@ -363,25 +363,26 @@ impl CheckpointStore {
         );
 
         // Only insert the genesis checkpoint if the DB is empty and doesn't have it already
-        if self
-            .get_checkpoint_by_digest(checkpoint.digest())
-            .unwrap()
-            .is_none()
-        {
-            if epoch_store.epoch() == checkpoint.epoch {
-                epoch_store
-                    .put_genesis_checkpoint_in_builder(checkpoint.data(), &contents)
-                    .unwrap();
-            } else {
-                debug!(
-                    validator_epoch =% epoch_store.epoch(),
-                    genesis_epoch =% checkpoint.epoch(),
-                    "Not inserting checkpoint builder data for genesis checkpoint",
-                );
+        match self.get_checkpoint_by_sequence_number(0).unwrap() {
+            Some(existing_checkpoint) => {
+                assert_eq!(existing_checkpoint.digest(), checkpoint.digest())
             }
-            self.insert_checkpoint_contents(contents).unwrap();
-            self.insert_verified_checkpoint(&checkpoint).unwrap();
-            self.update_highest_synced_checkpoint(&checkpoint).unwrap();
+            None => {
+                if epoch_store.epoch() == checkpoint.epoch {
+                    epoch_store
+                        .put_genesis_checkpoint_in_builder(checkpoint.data(), &contents)
+                        .unwrap();
+                } else {
+                    debug!(
+                        validator_epoch =% epoch_store.epoch(),
+                        genesis_epoch =% checkpoint.epoch(),
+                        "Not inserting checkpoint builder data for genesis checkpoint",
+                    );
+                }
+                self.insert_checkpoint_contents(contents).unwrap();
+                self.insert_verified_checkpoint(&checkpoint).unwrap();
+                self.update_highest_synced_checkpoint(&checkpoint).unwrap();
+            }
         }
     }
 


### PR DESCRIPTION
## Description 

Adjust the insert-genesis check on startup to check the permanent table `certified_checkpoints`. 
The previous implementation was checking the `checkpoint_by_digest` table, whose values can be pruned by the compaction filter, resulting in resetting the highest-synced watermark and causing a panic in state sync on startup

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
