### PR TITLE
[static ptb][hardening] check object type at the beginning of execution

### DIFF
--- a/crates/sui-graphql-rpc/src/types/coin_metadata.rs
+++ b/crates/sui-graphql-rpc/src/types/coin_metadata.rs
@@ -333,7 +333,7 @@ impl CoinMetadata {
 
         let supply = CoinMetadata::query_total_supply(
             ctx.data_unchecked(),
-            coin_type,
+            coin_type.into_owned(),
             self.super_.super_.checkpoint_viewed_at,
         )
         .await

--- a/crates/sui-types/src/base_types.rs
+++ b/crates/sui-types/src/base_types.rs
@@ -76,6 +76,7 @@ use serde_with::DeserializeAs;
 use serde_with::SerializeAs;
 use serde_with::serde_as;
 use shared_crypto::intent::HashingIntentScope;
+use std::borrow::Cow;
 use std::cmp::max;
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
@@ -309,18 +310,24 @@ impl MoveObjectType {
         }
     }
 
-    pub fn type_params(&self) -> Vec<TypeTag> {
+    pub fn type_params(&self) -> Vec<Cow<'_, TypeTag>> {
         match &self.0 {
-            MoveObjectType_::GasCoin => vec![GAS::type_tag()],
+            MoveObjectType_::GasCoin => vec![Cow::Owned(GAS::type_tag())],
             MoveObjectType_::StakedSui => vec![],
-            MoveObjectType_::Coin(inner) => vec![inner.clone()],
+            MoveObjectType_::Coin(inner) => vec![Cow::Borrowed(inner)],
             MoveObjectType_::SuiBalanceAccumulatorField => {
                 Self::balance_accumulator_field_type_params(GAS::type_tag())
+                    .into_iter()
+                    .map(Cow::Owned)
+                    .collect()
             }
             MoveObjectType_::BalanceAccumulatorField(inner) => {
                 Self::balance_accumulator_field_type_params(inner.clone())
+                    .into_iter()
+                    .map(Cow::Owned)
+                    .collect()
             }
-            MoveObjectType_::Other(s) => s.type_params.clone(),
+            MoveObjectType_::Other(s) => s.type_params.iter().map(Cow::Borrowed).collect(),
         }
     }
 

--- a/crates/sui-types/src/unit_tests/accumulator_types_tests.rs
+++ b/crates/sui-types/src/unit_tests/accumulator_types_tests.rs
@@ -107,8 +107,8 @@ fn test_accumulator_field_type_params() {
     // Check type_params returns the correct Field type parameters
     let type_params = move_type.type_params();
     assert_eq!(type_params.len(), 2);
-    assert_eq!(type_params[0], key_type);
-    assert_eq!(type_params[1], u128_type);
+    assert_eq!(&*type_params[0], &key_type);
+    assert_eq!(&*type_params[1], &u128_type);
 }
 
 #[test]

--- a/crates/sui-types/src/unit_tests/base_types_tests.rs
+++ b/crates/sui-types/src/unit_tests/base_types_tests.rs
@@ -427,7 +427,13 @@ fn move_object_type_consistency() {
         assert_eq!(ty.address(), tag.address);
         assert_eq!(ty.module(), tag.module.as_ident_str());
         assert_eq!(ty.name(), tag.name.as_ident_str());
-        assert_eq!(&ty.type_params(), &tag.type_params);
+        assert_eq!(
+            &ty.type_params()
+                .into_iter()
+                .map(|t| t.into_owned())
+                .collect::<Vec<_>>(),
+            &tag.type_params
+        );
         assert_eq!(ty.module_id(), tag.module_id());
         // sanity check special cases
         assert!(!ty.is_gas_coin() || ty.is_coin());


### PR DESCRIPTION
## Description 

- We will double check the type on disk against the type once we reach execution. The type on disk is how we got it in the first place, but this is just an added invariant check done at the beginning of execution. 
- We can safely remove this at anytime we feel comfortable

## Test plan 

- Ran tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
