### PR TITLE
Fix RefCell borrow

### DIFF
--- a/crates/sui-replay-2/src/execution.rs
+++ b/crates/sui-replay-2/src/execution.rs
@@ -308,31 +308,34 @@ impl sui_types::storage::ObjectStore for ReplayStore<'_> {
     fn get_object(&self, object_id: &ObjectID) -> Option<Object> {
         trace!("get_object({})", object_id);
 
-        match self.object_cache.borrow().get(object_id) {
-            Some(versions) => versions.last_key_value().map(|(_version, obj)| obj.clone()),
-            None => {
-                let fetched_object = self
-                    .store
-                    .get_objects(&[ObjectKey {
-                        object_id: *object_id,
-                        version_query: VersionQuery::AtCheckpoint(self.checkpoint),
-                    }])
-                    .map_err(|e| SuiErrorKind::Storage(e.to_string()))
-                    .ok()?
-                    .into_iter()
-                    .next()?
-                    .map(|(obj, _version)| obj)?;
-
-                // Add the fetched object to the cache
-                let mut cache = self.object_cache.borrow_mut();
-                cache
-                    .entry(*object_id)
-                    .or_default()
-                    .insert(fetched_object.version().value(), fetched_object.clone());
-
-                Some(fetched_object)
+        // Check cache - use a scope to ensure the borrow is dropped before we fetch from store
+        {
+            let cache = self.object_cache.borrow();
+            if let Some(versions) = cache.get(object_id) {
+                return versions.last_key_value().map(|(_version, obj)| obj.clone());
             }
-        }
+        } // Borrow dropped here
+
+        let fetched_object = self
+            .store
+            .get_objects(&[ObjectKey {
+                object_id: *object_id,
+                version_query: VersionQuery::AtCheckpoint(self.checkpoint),
+            }])
+            .map_err(|e| SuiErrorKind::Storage(e.to_string()))
+            .ok()?
+            .into_iter()
+            .next()?
+            .map(|(obj, _version)| obj)?;
+
+        // Add the fetched object to the cache
+        let mut cache = self.object_cache.borrow_mut();
+        cache
+            .entry(*object_id)
+            .or_default()
+            .insert(fetched_object.version().value(), fetched_object.clone());
+
+        Some(fetched_object)
     }
 
     // Get an object by its ID and version


### PR DESCRIPTION
## Description 

We were trying to insert into the object cache while holding a reference (`borrow`) to the cache, resulting in an "already borrowed" error when trying to get the mutable reference to insert

## Test plan 

local testing of heavy transactions

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
