### PR TITLE
sui-start: update the wallet config to support non-default fullnode port

### DIFF
--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -1204,6 +1204,22 @@ async fn start(
         info!("GraphQL started at {address}");
     }
 
+    // Update the wallet_context with the configured fullnode rpc url so client operations will
+    // succeed if a non-default port was provided.
+    let mut wallet_context = create_wallet_context(
+        FaucetConfig::default().wallet_client_timeout_secs,
+        config_dir.clone(),
+    )?;
+    if let Some(env) = wallet_context
+        .config
+        .envs
+        .iter_mut()
+        .find(|env| env.alias == "localnet")
+    {
+        env.rpc = fullnode_rpc_url.clone();
+    }
+    wallet_context.config.save()?;
+
     if let Some(input) = with_faucet {
         let faucet_address = parse_host_port(input, DEFAULT_FAUCET_PORT)
             .map_err(|_| anyhow!("Invalid faucet host and port"))?;
@@ -1249,11 +1265,7 @@ async fn start(
             .unwrap();
         }
 
-        let local_faucet = LocalFaucet::new(
-            create_wallet_context(config.wallet_client_timeout_secs, config_dir.clone())?,
-            config.clone(),
-        )
-        .await?;
+        let local_faucet = LocalFaucet::new(wallet_context, config.clone()).await?;
 
         let app_state = Arc::new(AppState {
             faucet: local_faucet,


### PR DESCRIPTION
Update the wallet config when running `sui start` in order to properly handle when a non-default fullnode port is provided, allowing the faucet and/or future `sui client` commands to find the fullnode.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
