### PR TITLE
[bella-ciao] remove double lookups of cached packages

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/runtime/package_resolution.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/runtime/package_resolution.rs
@@ -189,8 +189,8 @@ pub fn jit_package_for_publish(
     verified_pkg: verification::ast::Package,
 ) -> VMResult<Arc<move_cache::Package>> {
     let version_id = verified_pkg.version_id;
-    if cache.cached_package_at(version_id).is_some() {
-        return Ok(cache.cached_package_at(version_id).unwrap());
+    if let Some(pkg) = cache.cached_package_at(version_id) {
+        return Ok(pkg);
     }
 
     let runtime_pkg = jit::translate_package(
@@ -217,8 +217,8 @@ pub fn jit_and_cache_package(
     // If the package is already in the cache, return it.
     // This is possible since the cache is shared and may be inserted into concurrently by other
     // VMs working over the same cache.
-    if cache.cached_package_at(version_id).is_some() {
-        return Ok(cache.cached_package_at(version_id).unwrap());
+    if let Some(pkg) = cache.cached_package_at(version_id) {
+        return Ok(pkg);
     }
 
     let runtime_pkg = jit::translate_package(


### PR DESCRIPTION
## Description 

We were accessing the cached packages after checking membership. This optimizes this to be a single query. 

## Test plan 

Existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
