### PR TITLE
[bella-ciao] Use `original_id` from `SerializedPackage` when loading 

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/validation/deserialization/translate.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/validation/deserialization/translate.rs
@@ -10,12 +10,20 @@ use move_vm_config::runtime::VMConfig;
 use std::collections::BTreeMap;
 
 pub(crate) fn package(vm_config: &VMConfig, pkg: SerializedPackage) -> VMResult<Package> {
+    let original_id = pkg.original_id;
+
     let mut modules = BTreeMap::new();
     for (mname, module) in pkg.modules.iter() {
         let module = CompiledModule::deserialize_with_config(module, &vm_config.binary_config)
             .map_err(|err| err.finish(Location::Package(pkg.version_id)))?;
         // The name of the module in the mapping, and the name of the module itself should be equal
         assert_eq!(mname.as_ident_str(), module.self_id().name());
+
+        assert_eq!(
+            module.address(),
+            &original_id,
+            "Module address does not match package original ID"
+        );
 
         // Impossible for a package to have two modules with the same name at this point.
         assert!(modules.insert(module.self_id(), module).is_none());
@@ -27,8 +35,6 @@ pub(crate) fn package(vm_config: &VMConfig, pkg: SerializedPackage) -> VMResult<
             .with_message("Empty packages are not allowed.".to_string())
             .finish(Location::Package(pkg.version_id)));
     }
-
-    let original_id = *modules.keys().next().expect("non-empty package").address();
 
     Ok(Package::new(
         original_id,


### PR DESCRIPTION

## Description 

Use the original ID from the `SerializedPackage` instead of getting it from the modules, and validate it matches module self_id addresses within the package.

## Test plan 

Existing tests. 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
