### PR TITLE
[bella-ciao] Small cleanup in validation

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/validation/mod.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/validation/mod.rs
@@ -5,7 +5,9 @@ pub mod deserialization;
 pub mod verification;
 
 use crate::{
-    dbg_println, natives::functions::NativeFunctions, shared::types::OriginalId,
+    dbg_println,
+    natives::functions::NativeFunctions,
+    shared::types::{OriginalId, VersionId},
     validation::verification::linkage::verify_linkage_and_cyclic_checks_for_publication,
 };
 
@@ -31,7 +33,7 @@ pub fn validate_for_publish(
     vm_config: &VMConfig,
     original_id: OriginalId,
     package: SerializedPackage,
-    dependencies: BTreeMap<OriginalId, &verification::ast::Package>,
+    dependencies: BTreeMap<VersionId, &verification::ast::Package>,
 ) -> VMResult<verification::ast::Package> {
     dbg_println!(
         "doing verification with linkage context {:#?}\nand type origins {:#?}",
@@ -59,17 +61,9 @@ pub fn validate_for_publish(
     Ok(validated_package)
 }
 
-pub fn validate_for_upgrade(
-    _previous: verification::ast::Package,
-    _package: SerializedPackage,
-    _dependencies: BTreeMap<OriginalId, verification::ast::Package>,
-) -> VMResult<verification::ast::Package> {
-    todo!()
-}
-
 /// Verify a set of packages for VM execution, ensuring linkage is correct and there are no cycles.
 pub fn validate_for_vm_execution(
-    packages: BTreeMap<OriginalId, &verification::ast::Package>,
+    packages: BTreeMap<VersionId, &verification::ast::Package>,
 ) -> VMResult<()> {
     verify_linkage_and_cyclic_checks(&packages)
 }


### PR DESCRIPTION
## Description 

Remove an unused `todo!` function in validation, and also fix misuse of `OriginalId` for `VersionId` in two functions. 

## Test plan 

existing tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
