### PR TITLE
chore(ci): upgrade checkout to v6

### DIFF
--- a/.github/workflows/move-formatter.yml
+++ b/.github/workflows/move-formatter.yml
@@ -22,7 +22,7 @@ jobs:
       run:
         working-directory: external-crates/move/tooling/tree-sitter
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # pin@v1.0.3
         with:
           command: install
@@ -44,7 +44,7 @@ jobs:
       run:
         working-directory: ${{ matrix.working-directory }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Use Node.js
         uses: actions/setup-node@v4
       - run: npm install --no-warnings @mysten/prettier-plugin-move@${{ env.FORMATTER_VERSION }}


### PR DESCRIPTION
Migrate workflows to checkout@v6 (Node 24 runtime). Min runner: v2.329.0.

https://github.com/actions/checkout/releases/tag/v6.0.0