### PR TITLE
[bella-ciao] Check that call stack is empty when returning from from `eval::run`

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/eval.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/eval.rs
@@ -112,9 +112,16 @@ pub(super) fn run(
     } = call_stack;
     heap.free_stack_frame(current_frame.stack_frame)
         .map_err(|e| e.finish(Location::Undefined))?;
-    for frame in frames.into_iter().rev() {
-        heap.free_stack_frame(frame.stack_frame)
-            .map_err(|e| e.finish(Location::Undefined))?;
+    debug_assert!(
+        frames.is_empty(),
+        "Call stack should be empty after execution"
+    );
+    if !frames.is_empty() {
+        return Err(
+            PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                .with_message("Call stack should be empty after execution".to_owned())
+                .finish(Location::Undefined),
+        );
     }
     Ok(operand_stack.value)
 }


### PR DESCRIPTION
## Description 

When `eval::run` returns there should be no remaining call frames on the call stack.

Check this and return an error if any frames remain.

## Test plan 

CI

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
