### PR TITLE
Speed up SDK read polling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16399,6 +16399,7 @@ dependencies = [
  "futures-core",
  "jsonrpsee",
  "move-core-types",
+ "mysten-common",
  "prometheus",
  "rand 0.8.5",
  "reqwest 0.12.9",

--- a/crates/sui-sdk/Cargo.toml
+++ b/crates/sui-sdk/Cargo.toml
@@ -31,6 +31,7 @@ bcs.workspace = true
 thiserror.workspace = true
 reqwest.workspace = true
 
+mysten-common.workspace = true
 sui-json-rpc-api.workspace = true
 sui-transaction-builder.workspace = true
 sui-json-rpc-types.workspace = true

--- a/crates/sui-sdk/src/apis.rs
+++ b/crates/sui-sdk/src/apis.rs
@@ -42,9 +42,8 @@ use sui_types::sui_serde::BigInt;
 use sui_types::sui_system_state::sui_system_state_summary::SuiSystemStateSummary;
 use sui_types::transaction::{Transaction, TransactionData, TransactionKind};
 
-const WAIT_FOR_LOCAL_EXECUTION_DELAY: Duration = Duration::from_millis(200);
-
-const WAIT_FOR_LOCAL_EXECUTION_INTERVAL: Duration = Duration::from_secs(2);
+const WAIT_FOR_LOCAL_EXECUTION_MIN_INTERVAL: Duration = Duration::from_millis(100);
+const WAIT_FOR_LOCAL_EXECUTION_MAX_INTERVAL: Duration = Duration::from_secs(2);
 
 /// The main read API structure with functions for retrieving data about different objects and transactions
 #[derive(Debug)]
@@ -1180,12 +1179,15 @@ impl QuorumDriverApi {
             Duration::from_secs(60)
         };
         let mut poll_response = tokio::time::timeout(wait_for_local_execution_timeout, async {
-            // Apply a short delay to give the full node a chance to catch up.
-            tokio::time::sleep(WAIT_FOR_LOCAL_EXECUTION_DELAY).await;
-
-            let mut interval = tokio::time::interval(WAIT_FOR_LOCAL_EXECUTION_INTERVAL);
+            let mut backoff = mysten_common::backoff::ExponentialBackoff::new(
+                WAIT_FOR_LOCAL_EXECUTION_MIN_INTERVAL,
+                WAIT_FOR_LOCAL_EXECUTION_MAX_INTERVAL,
+            );
             loop {
-                interval.tick().await;
+                // Intentionally waiting for a short delay (MIN_INTERVAL) before the 1st iteration,
+                // to leave time for the checkpoint containing the transaction to be certified, propagate
+                // to the full node, and get executed.
+                tokio::time::sleep(backoff.next().unwrap()).await;
 
                 if let Ok(poll_response) = self
                     .api


### PR DESCRIPTION
## Description 

Waiting for 2s after the 1st failure to poll transaction can be too long.

## Test plan 

CI
`python ./scripts/simtest/seed-search.py per_epoch_config_stress_test --test per_epoch_config_stress_tests --num-seeds 10`