### PR TITLE
[sui-tool] optional backfill of txn digests

### DIFF
--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -344,6 +344,11 @@ pub enum ToolCommand {
         /// Defaults to 3 retries. Set to 0 to disable retries.
         #[clap(long = "max-retries", default_value = "3")]
         max_retries: usize,
+
+        /// Backfill epoch transaction digests. Defaults to true.
+        /// Required for validators, optional for fullnodes.
+        #[clap(long = "backfill-txn-digests", default_value = "true")]
+        backfill_txn_digests: bool,
     },
 
     #[clap(name = "replay")]
@@ -685,6 +690,7 @@ impl ToolCommand {
                 latest,
                 verbose,
                 max_retries,
+                backfill_txn_digests,
             } => {
                 if !verbose {
                     tracing_handle
@@ -817,6 +823,7 @@ impl ToolCommand {
                     network,
                     verify,
                     max_retries,
+                    backfill_txn_digests,
                 )
                 .await?;
             }


### PR DESCRIPTION
## Description 

fullnodes shouldn't need this table to be populated prior during formal snapshot restore (fact check me @alex-mysten), we can make it opt-out in the event they're trying to download the snapshot as quickly as possible.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
