### PR TITLE
Removing dead arg

### DIFF
--- a/crates/sui-checkpoint-blob-indexer/src/main.rs
+++ b/crates/sui-checkpoint-blob-indexer/src/main.rs
@@ -57,10 +57,6 @@ struct Args {
     #[arg(long)]
     compression_level: Option<i32>,
 
-    /// Optional watermark task name to override the watermark path
-    #[arg(long)]
-    watermark_task: Option<String>,
-
     #[command(flatten)]
     metrics_args: MetricsArgs,
 


### PR DESCRIPTION
## Description

<https://github.com/MystenLabs/sui/pull/23737> deprecated this arg in favor of the proper task args built into the framework. Just removing the now unused arg now.
