### PR TITLE
[sui-tool] limit sui-tool download concurrency

### DIFF
--- a/crates/sui-tool/src/commands.rs
+++ b/crates/sui-tool/src/commands.rs
@@ -227,8 +227,7 @@ pub enum ToolCommand {
         /// skip downloading indexes dir
         #[clap(long = "skip-indexes")]
         skip_indexes: bool,
-        /// Number of parallel downloads to perform. Defaults to a reasonable
-        /// value based on number of available logical cores.
+        /// Number of parallel downloads to perform. Defaults to 50, max 200.
         #[clap(long = "num-parallel-downloads")]
         num_parallel_downloads: Option<usize>,
         /// Network to download snapshot for. Defaults to "mainnet".
@@ -293,8 +292,7 @@ pub enum ToolCommand {
         genesis: PathBuf,
         #[clap(long = "path")]
         path: PathBuf,
-        /// Number of parallel downloads to perform. Defaults to a reasonable
-        /// value based on number of available logical cores.
+        /// Number of parallel downloads to perform. Defaults to 50, max 200.
         #[clap(long = "num-parallel-downloads")]
         num_parallel_downloads: Option<usize>,
         /// Verification mode to employ.
@@ -691,11 +689,7 @@ impl ToolCommand {
                         .update_log("off")
                         .expect("Failed to update log level");
                 }
-                let num_parallel_downloads = num_parallel_downloads.unwrap_or_else(|| {
-                    num_cpus::get()
-                        .checked_sub(1)
-                        .expect("Failed to get number of CPUs")
-                });
+                let num_parallel_downloads = num_parallel_downloads.unwrap_or(50).min(200);
                 let snapshot_bucket =
                     snapshot_bucket.or_else(|| match (network, no_sign_request) {
                         (Chain::Mainnet, false) => Some(
@@ -846,11 +840,7 @@ impl ToolCommand {
                         .update_log("off")
                         .expect("Failed to update log level");
                 }
-                let num_parallel_downloads = num_parallel_downloads.unwrap_or_else(|| {
-                    num_cpus::get()
-                        .checked_sub(1)
-                        .expect("Failed to get number of CPUs")
-                });
+                let num_parallel_downloads = num_parallel_downloads.unwrap_or(50).min(200);
                 let snapshot_bucket =
                     snapshot_bucket.or_else(|| match (network, no_sign_request) {
                         (Chain::Mainnet, false) => Some(


### PR DESCRIPTION
## Description 

attempting to mitigate increased errors with:
```
Generic HTTP error: error decoding response body

Caused by:
    0: error decoding response body
    1: request or response body error
    2: error reading a body from connection
    3: peer closed connection without sending TLS close_notify: https://docs.rs/rustls/latest/rustls/manual/_03_howto/index.html#unexpected-eof
exit_code=1
failed at Wed Nov 26 03:17:20 PM UTC 2025
```

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
