### PR TITLE
[pkg-alt] Move git caches to avoid overlap with legacy ones

### DIFF
--- a/external-crates/move/crates/move-package-alt/src/git/cache.rs
+++ b/external-crates/move/crates/move-package-alt/src/git/cache.rs
@@ -25,7 +25,7 @@ static CONFIG: OnceCell<String> = OnceCell::new();
 pub(crate) fn get_cache_path() -> &'static str {
     CONFIG.get_or_init(|| {
         PathBuf::from(move_command_line_common::env::MOVE_HOME.clone())
-            .join("alt")
+            .join("git")
             .to_string_lossy()
             .to_string()
     })


### PR DESCRIPTION
## Description 

While testing the package system, I had an explosion (crash without recovery) being caused by conflict with the legacy package system for the git source. Moving our cache a directory should most likely solve this.

## Test plan 

Existing tests should pass.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
