### PR TITLE
[sui][cli] Add support for shell completion in CLI using clap_complete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3552,6 +3552,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a2d6eec27fce550d708b2be5d798797e5a55b246b323ef36924a0001996352"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13937,6 +13946,7 @@ dependencies = [
  "bip32",
  "camino",
  "clap",
+ "clap_complete",
  "codespan-reporting",
  "colored",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -340,6 +340,7 @@ camino = "1.1.1"
 cfg-if = "1.0.0"
 chrono = { version = "0.4.39", features = ["clock", "serde"] }
 clap = { version = "4.4", features = ["derive", "wrap_help"] }
+clap_complete = "4.4"
 codespan-reporting = "0.11.1"
 collectable = "0.0.2"
 colored = "2.0.0"

--- a/crates/sui/Cargo.toml
+++ b/crates/sui/Cargo.toml
@@ -22,6 +22,7 @@ bin-version.workspace = true
 bip32.workspace = true
 camino.workspace = true
 clap.workspace = true
+clap_complete.workspace = true
 codespan-reporting.workspace = true
 datatest-stable.workspace = true
 futures.workspace = true

--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -407,6 +407,14 @@ pub enum SuiCommand {
         #[command(flatten)]
         replay_config: SR2::ReplayConfigStable,
     },
+
+    /// Generate shell completion scripts for CLI
+    #[clap(name = "completion")]
+    Completion {
+        /// If provided, outputs the completion file for given shell
+        #[arg(long = "generate", value_enum)]
+        generator: clap_complete::Shell,
+    },
 }
 
 impl SuiCommand {
@@ -758,6 +766,12 @@ impl SuiCommand {
                     )?;
                 }
 
+                Ok(())
+            }
+            SuiCommand::Completion { generator } => {
+                let mut app: Command = SuiCommand::command();
+                let name = app.get_name().to_string();
+                clap_complete::generate(generator, &mut app, name, &mut std::io::stdout());
                 Ok(())
             }
         }


### PR DESCRIPTION
## Description 

feat: Add support for shell completion in CLI using [clap_complete](https://docs.rs/crate/clap_complete)

## Test plan 

Tested by hands yet on ZSH

Need help with testing all the targets
```bash
sui completion --generate bash
sui completion --generate elvish
sui completion --generate fish
sui completion --generate powershell
sui completion --generate zsh
```

---

## Release notes

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [x] CLI: Sui CLI now supports auto-complete via clap-complete. 
```
sui completion --generate bash
sui completion --generate elvish
sui completion --generate fish
sui completion --generate powershell
sui completion --generate zsh
```

Put the output in a file in the right directory for your shell (e.g., for fish in `~/.config/fish/completions/sui.fish`) and restart your shell. Use double `TAB` to trigger the auto completion menu.
- [ ] Rust SDK:
- [ ] Indexing Framework:
