### PR TITLE
[WIP] Glibc cross compilation of Sui inside musl-based StageX build container

### DIFF
--- a/docker/sui-node-deterministic/Dockerfile
+++ b/docker/sui-node-deterministic/Dockerfile
@@ -18,7 +18,7 @@ FROM stagex/user-glibc@sha256:287280459258953d86a8e42b87003d2b0b1ddf0aa2e0fa70ba
 ################
 
 FROM pallet-rust AS build
-ARG PROFILE=release
+ARG PROFILE
 ARG CARGO_BUILD_TARGET
 ARG GIT_REVISION
 
@@ -63,7 +63,7 @@ RUN cargo build --profile ${PROFILE} --target ${CARGO_BUILD_TARGET} --bin sui-no
 ##################
 
 FROM scratch AS package
-ARG PROFILE=release
+ARG PROFILE
 ARG CARGO_BUILD_TARGET
 WORKDIR /sui
 ENV LD_LIBRARY_PATH=/lib64

--- a/docker/sui-node-deterministic/build.sh
+++ b/docker/sui-node-deterministic/build.sh
@@ -12,15 +12,13 @@ DOCKERFILE="$DIR/Dockerfile"
 GIT_REVISION="$(git describe --always --abbrev=12 --dirty --exclude '*')"
 BUILD_DATE="$(date -u +'%Y-%m-%d')"
 PLATFORM="linux/amd64"
-#1="asdf"
 # option to build using debug symbols
-#if [ "$1" = "--debug-symbols" ]; then
-#	PROFILE="bench"
-#	echo "Building with full debug info enabled ... WARNING: binary size might significantly increase"
-#	shift
-#else
 PROFILE="release"
-#fi
+if [ "$1" = "--debug-symbols" ]; then
+	PROFILE="bench"
+	echo "Building with full debug info enabled ... WARNING: binary size might significantly increase"
+	shift
+fi
 
 echo
 echo "Building sui-node-deterministic docker image"


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.

This PR cross-compiles Sui with glibc but using a musl-based StageX build container

## Test plan 

How did you test the new or updated feature?

I built the container with `./docker/sui-node-deterministic/build.sh` (run from the `sui` repo root) which put OCI artifacts into a directory called `$SUI_REPO/build/oci/sui-node-deterministic`

I then created a tagged Docker image from  the resulting OCI image using `[skopeo](https://github.com/containers/skopeo)`:

`skopeo copy oci:build/oci/sui-node-deterministic docker-daemon:sui-node-deterministic:latest`

I created a container and ran it with:

`docker run -it --rm sui-node-deterministic:latest`

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [x] Nodes (Validators and Full nodes): This is a fully deterministic StageX build using a fairly experimental cross-compilation technique. It's possible that when running the resulting binary, there could be issues related to missing or misplaced shared library files.
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
