### PR TITLE
[tracing] Move assertion to handle errors in instructions properly in `close_instruction`

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/tracing2/tracer.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/tracing2/tracer.rs
@@ -1714,8 +1714,6 @@ impl VMTracer<'_> {
             | B::ImmBorrowGlobalGenericDeprecated(_) => unreachable!(),
         }
 
-        // At this point the type stack and the operand stack should be in sync.
-        assert_eq!(self.type_stack.len(), interpreter.operand_stack.value.len());
         Some(())
     }
 }
@@ -1854,6 +1852,9 @@ impl<'a> VMTracer<'a> {
         } else if let Some(err) = err {
             self.trace
                 .effect(EF::ExecutionError(format!("{:?}", err.major_status())));
+        } else {
+            // At this point the type stack and the operand stack should be in sync.
+            assert_eq!(self.type_stack.len(), interpreter.operand_stack.value.len());
         }
     }
 }


### PR DESCRIPTION
## Description 

We were not properly handling the case where an instruction errored between pre- and post instruction states. This fixes the assertion to only check in the cases where the instruction was able to be executed and traced without error.

## Test plan 

Ran on a local repro and verified the fix.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
