### PR TITLE
[cli] fix bug when there's no client.yaml file and --force-regenesis is passed

### DIFF
--- a/crates/sui/src/sui_commands.rs
+++ b/crates/sui/src/sui_commands.rs
@@ -1206,7 +1206,6 @@ async fn start(
     // Update the wallet_context with the configured fullnode rpc url so client operations will
     // succeed if a non-default port was provided.
 
-    println!("Config dir {:?}", config_dir.display());
     if config_dir.join(SUI_CLIENT_CONFIG).exists() {
         let _ = update_wallet_config_rpc(config_dir.clone(), fullnode_rpc_url.clone())?;
     }


### PR DESCRIPTION
## Description 

This PR is a follow-up to the `sui start` fix in #24478. It fixes the case when there's no `sui_config` folder and `--force-regenesis` is passed.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
