### PR TITLE
[fix] close lock file before committing tmp file

### DIFF
--- a/crates/sui-package-management/src/lib.rs
+++ b/crates/sui-package-management/src/lib.rs
@@ -140,12 +140,14 @@ pub fn set_package_id(
     id: AccountAddress,
 ) -> Result<Option<AccountAddress>, anyhow::Error> {
     let lock_file_path = package_path.join(SourcePackageLayout::Lock.path());
-    let Ok(mut lock_file) = File::open(lock_file_path.clone()) else {
-        return Ok(None);
+    let managed_package = {
+        let Ok(mut lock_file) = File::open(lock_file_path.clone()) else {
+            return Ok(None);
+        };
+        ManagedPackage::read(&mut lock_file)
+            .ok()
+            .and_then(|m| m.into_iter().find(|(_, v)| v.chain_id == *chain_id))
     };
-    let managed_package = ManagedPackage::read(&mut lock_file)
-        .ok()
-        .and_then(|m| m.into_iter().find(|(_, v)| v.chain_id == *chain_id));
     let Some((env, v)) = managed_package else {
         return Ok(None);
     };


### PR DESCRIPTION
## Description 

Close first move.lock file handle before committing tmp file changes to move.lock.

fixes an issues with windows where an open file handle prevents `sui client publish` from updating the move.lock file and breaks publishing if a move.lock exists.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
