### PR TITLE
sui-execution: Fix unused import warning in release mode.

### DIFF
--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/config.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/config.rs
@@ -4,7 +4,7 @@
 use crate::{
     data_store::PackageStore,
     static_programmable_transactions::linkage::resolution::{
-        ResolutionTable, VersionConstraint, add_and_unify, get_package,
+        ResolutionTable, VersionConstraint, add_and_unify,
     },
 };
 use move_binary_format::binary_config::BinaryConfig;
@@ -66,6 +66,7 @@ impl LinkageConfig {
             for id in NATIVE_PACKAGE_IDS {
                 #[cfg(debug_assertions)]
                 {
+                    use crate::static_programmable_transactions::linkage::resolution::get_package;
                     let package = get_package(id, store)?;
                     debug_assert_eq!(package.id(), *id);
                     debug_assert_eq!(package.original_package_id(), *id);


### PR DESCRIPTION
warning: unused import: `get_package`
 --> sui-execution/latest/sui-adapter/src/static_programmable_transactions/linkage/config.rs:7:60
  |
7 |         ResolutionTable, VersionConstraint, add_and_unify, get_package,
  |                                                            ^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
