### PR TITLE
[indexer-alt-framework] flakey test fix

### DIFF
--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -2082,8 +2082,7 @@ mod tests {
         let lt_250 = data.iter().filter(|e| *e.key() < 250).count();
         // Checkpoints 250 to 500 inclusive must have been committed.
         assert_eq!(ge_250, 251);
-        // Lenient check that not all checkpoints < 250 were committed.
-        assert!(lt_250 < 250);
+        assert_eq!(lt_250, 11);
         assert_eq!(
             conn.committer_watermark(
                 &pipeline_task::<MockStore>(ControllableHandler::NAME, Some("task")).unwrap()


### PR DESCRIPTION
## Description 

the default ingestion concurrency of 200 means that if the indexer is unlucky enough to not be able to process the first 11 checkpoints before saturation, we'll stall forever

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
