### PR TITLE
chore(reader): demote SystemPackageTask error! logs to warn!-s

### DIFF
--- a/crates/sui-indexer-alt-reader/src/system_package_task.rs
+++ b/crates/sui-indexer-alt-reader/src/system_package_task.rs
@@ -11,7 +11,7 @@ use move_core_types::account_address::AccountAddress;
 use sui_futures::service::Service;
 use sui_sql_macro::query;
 use tokio::time;
-use tracing::{error, info};
+use tracing::{info, warn};
 
 use crate::{package_resolver::PackageCache, pg_reader::PgReader};
 
@@ -76,7 +76,7 @@ impl SystemPackageTask {
                 let mut conn = match pg_reader.connect().await {
                     Ok(conn) => conn,
                     Err(e) => {
-                        error!("Failed to connect to database: {:?}", e);
+                        warn!("Failed to connect to database: {:?}", e);
                         continue;
                     }
                 };
@@ -114,12 +114,12 @@ impl SystemPackageTask {
                     }
 
                     Ok(_) => {
-                        error!("Expected exactly one row from the watermarks table");
+                        warn!("Expected exactly one row from the watermarks table");
                         continue;
                     }
 
                     Err(e) => {
-                        error!("Failed to fetch latest epoch: {e}");
+                        warn!("Failed to fetch latest epoch: {e}");
                         continue;
                     }
                 };
@@ -154,7 +154,7 @@ impl SystemPackageTask {
                     Ok(system_packages) => system_packages,
 
                     Err(e) => {
-                        error!("Failed to fetch system packages: {e}");
+                        warn!("Failed to fetch system packages: {e}");
                         continue;
                     }
                 };
@@ -164,7 +164,7 @@ impl SystemPackageTask {
                     .map(|pkg| AccountAddress::from_bytes(pkg.original_id))
                     .collect::<Result<Vec<_>, _>>()
                 else {
-                    error!("Failed to deserialize system package addresses");
+                    warn!("Failed to deserialize system package addresses");
                     continue;
                 };
 


### PR DESCRIPTION
## Description

We typically reserve `error!` for messages related to situations that the system does not know how to recover from, but the `error!` logs in the system package task are related to issues that it is attempting to recover from through retries, so they should really be `warn!` logs.

## Test plan

:eyes:

## Stack

- #24501 
- #24502 
- #24503 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
