### PR TITLE
[move][move-vm][bella-ciao] Replace some VM asserts with invariant violations

### DIFF
--- a/external-crates/move/crates/move-unit-test/src/test_runner.rs
+++ b/external-crates/move/crates/move-unit-test/src/test_runner.rs
@@ -344,7 +344,9 @@ impl SharedTestingConfig {
             arguments,
         );
 
-        if !self.report_stacktrace_on_abort && let Err(err) = &mut return_result {
+        if !self.report_stacktrace_on_abort
+            && let Err(err) = &mut return_result
+        {
             err.remove_exec_state();
         }
 

--- a/external-crates/move/crates/move-vm-config/src/runtime.rs
+++ b/external-crates/move/crates/move-vm-config/src/runtime.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::verifier::{VerifierConfig, DEFAULT_MAX_CONSTANT_VECTOR_LEN};
+use crate::verifier::{DEFAULT_MAX_CONSTANT_VECTOR_LEN, VerifierConfig};
 use move_binary_format::binary_config::BinaryConfig;
 use move_binary_format::file_format_common::VERSION_MAX;
 

--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/eval.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/eval.rs
@@ -128,15 +128,16 @@ fn step(
     let instructions = fun_ref.code();
     let pc = state.call_stack.current_frame.pc as usize;
     if pc >= instructions.len() {
-        return Err(state.set_location(
-            PartialVMError::new(StatusCode::PC_OVERFLOW)
-                .with_message(format!(
+        return Err(
+            state.set_location(
+                PartialVMError::new(StatusCode::PC_OVERFLOW).with_message(format!(
                     "PC {} out of bounds for function {} with {} instructions",
                     pc,
                     fun_ref.name(&run_context.vtables.interner),
                     instructions.len()
                 )),
-        ));
+            ),
+        );
     }
     let instruction = &instructions[pc];
     fail_point!("move_vm::interpreter_loop", |_| {

--- a/external-crates/move/crates/move-vm-runtime/src/execution/values/values_impl.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/values/values_impl.rs
@@ -2238,8 +2238,10 @@ impl GlobalValueImpl {
             }
             Self::Filled(container) => {
                 if !matches!(self, Self::Empty) {
-                    return Err(PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                        .with_message("global value is not empty".to_string()));
+                    return Err(
+                        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                            .with_message("global value is not empty".to_string()),
+                    );
                 }
                 container
             }

--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
@@ -251,10 +251,10 @@ pub fn package(
         let loaded_module = module(&mut package_context, version_id, &mut input_module)?;
 
         let key = interner.intern_ident_str(loaded_module.id.name())?;
-        if !package_context
+        if package_context
             .loaded_modules
             .insert(key, loaded_module)
-            .is_none()
+            .is_some()
         {
             return Err(
                 PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(

--- a/external-crates/move/crates/move-vm-runtime/src/validation/deserialization/translate.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/validation/deserialization/translate.rs
@@ -19,28 +19,32 @@ pub(crate) fn package(vm_config: &VMConfig, pkg: SerializedPackage) -> VMResult<
 
         // The name of the module in the mapping, and the name of the module itself should be equal
         if mname.as_ident_str() != module.self_id().name() {
-            return Err(PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                .with_message(format!(
-                    "Module name mismatch: mapping has '{}', module has '{}'",
-                    mname.as_ident_str(),
-                    module.self_id().name()
-                ))
-                .finish(Location::Package(pkg.version_id)));
+            return Err(
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message(format!(
+                        "Module name mismatch: mapping has '{}', module has '{}'",
+                        mname.as_ident_str(),
+                        module.self_id().name()
+                    ))
+                    .finish(Location::Package(pkg.version_id)),
+            );
         }
 
         // The address of the module must match the original package ID
         if module.address() != &original_id {
-            return Err(PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                .with_message(format!(
-                    "Module address mismatch: expected '{}', found '{}'",
-                    original_id,
-                    module.address()
-                ))
-                .finish(Location::Package(pkg.version_id)));
+            return Err(
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message(format!(
+                        "Module address mismatch: expected '{}', found '{}'",
+                        original_id,
+                        module.address()
+                    ))
+                    .finish(Location::Package(pkg.version_id)),
+            );
         }
 
         // Impossible for a package to have two modules with the same name at this point.
-        if !modules.insert(module.self_id(), module).is_none() {
+        if modules.insert(module.self_id(), module).is_some() {
             return Err(PartialVMError::new(StatusCode::DUPLICATE_MODULE_NAME)
                 .with_message(format!(
                     "Duplicate module name found: '{}'",


### PR DESCRIPTION
## Description 

This aims to replace all of the remaining VM asserts with invariant violations (except for in the tracer).

## Test plan 

Tests still pass

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
