### PR TITLE
[indexer-alt-framework] Set checkpoint_hi_inclusive, reader_lo, pruner_hi if watermark does not exist

### DIFF
--- a/crates/sui-indexer-alt-consistent-store/src/indexer.rs
+++ b/crates/sui-indexer-alt-consistent-store/src/indexer.rs
@@ -116,6 +116,7 @@ impl<S: Schema + Send + Sync + 'static> Indexer<S> {
             H::NAME
         );
 
+        // TODO: Refactor consistent store indexer to use `init_watermark` instead of wrapping `sequential_pipeline`.
         self.sync
             .register_pipeline(H::NAME)
             .with_context(|| format!("Failed to add pipeline {:?} to synchronizer", H::NAME))?;

--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -357,15 +357,13 @@ impl<S: Store> Indexer<S> {
         let pipeline_task =
             pipeline_task::<S>(P::NAME, self.task.as_ref().map(|t| t.task.as_str()))?;
 
-        let watermark = conn
-            .committer_watermark(&pipeline_task)
+        let checkpoint_hi_inclusive = conn
+            .init_watermark(&pipeline_task, self.default_next_checkpoint)
             .await
-            .with_context(|| format!("Failed to get watermark for {pipeline_task}"))?;
+            .with_context(|| format!("Failed to init watermark for {pipeline_task}"))?;
 
-        let next_checkpoint = watermark
-            .as_ref()
-            .map(|w| w.checkpoint_hi_inclusive + 1)
-            .unwrap_or(self.default_next_checkpoint);
+        let next_checkpoint =
+            checkpoint_hi_inclusive.map_or(self.default_next_checkpoint, |c| c + 1);
 
         self.first_ingestion_checkpoint = next_checkpoint.min(self.first_ingestion_checkpoint);
 
@@ -432,6 +430,7 @@ mod tests {
 
     use async_trait::async_trait;
     use clap::Parser;
+    use sui_indexer_alt_framework_store_traits::PrunerWatermark;
     use sui_synthetic_ingestion::synthetic_ingestion;
     use tokio::sync::watch;
 
@@ -583,6 +582,62 @@ mod tests {
     test_pipeline!(MockHandler, "test_processor");
     test_pipeline!(SequentialHandler, "sequential_handler");
     test_pipeline!(MockCheckpointSequenceNumberHandler, "test");
+
+    async fn test_init_watermark(
+        first_checkpoint: Option<u64>,
+        is_concurrent: bool,
+    ) -> (Option<CommitterWatermark>, Option<PrunerWatermark>) {
+        let registry = Registry::new();
+        let store = MockStore::default();
+
+        test_pipeline!(A, "pipeline_name");
+
+        let mut conn = store.connect().await.unwrap();
+
+        let indexer_args = IndexerArgs {
+            first_checkpoint,
+            ..IndexerArgs::default()
+        };
+        let temp_dir = tempfile::tempdir().unwrap();
+        let client_args = ClientArgs {
+            ingestion: IngestionClientArgs {
+                local_ingestion_path: Some(temp_dir.path().to_owned()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let ingestion_config = IngestionConfig::default();
+
+        let mut indexer = Indexer::new(
+            store.clone(),
+            indexer_args,
+            client_args,
+            ingestion_config,
+            None,
+            &registry,
+        )
+        .await
+        .unwrap();
+
+        if is_concurrent {
+            indexer
+                .concurrent_pipeline::<A>(A, ConcurrentConfig::default())
+                .await
+                .unwrap();
+        } else {
+            indexer
+                .sequential_pipeline::<A>(A, SequentialConfig::default())
+                .await
+                .unwrap();
+        }
+
+        (
+            conn.committer_watermark(A::NAME).await.unwrap(),
+            conn.pruner_watermark(A::NAME, Duration::ZERO)
+                .await
+                .unwrap(),
+        )
+    }
 
     #[test]
     fn test_arg_parsing() {
@@ -1634,6 +1689,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_init_watermark_concurrent_no_first_checkpoint() {
+        let (committer_watermark, pruner_watermark) = test_init_watermark(None, true).await;
+        // Indexer will not init the watermark, pipeline tasks will write commit watermarks as normal.
+        assert_eq!(committer_watermark, None);
+        assert_eq!(pruner_watermark, None);
+    }
+
+    #[tokio::test]
+    async fn test_init_watermark_concurrent_first_checkpoint_0() {
+        let (committer_watermark, pruner_watermark) = test_init_watermark(Some(0), true).await;
+        // Indexer will not init the watermark, pipeline tasks will write commit watermarks as normal.
+        assert_eq!(committer_watermark, None);
+        assert_eq!(pruner_watermark, None);
+    }
+
+    #[tokio::test]
+    async fn test_init_watermark_concurrent_first_checkpoint_1() {
+        let (committer_watermark, pruner_watermark) = test_init_watermark(Some(1), true).await;
+
+        let committer_watermark = committer_watermark.unwrap();
+        assert_eq!(committer_watermark.checkpoint_hi_inclusive, 0);
+
+        let pruner_watermark = pruner_watermark.unwrap();
+        assert_eq!(pruner_watermark.reader_lo, 1);
+        assert_eq!(pruner_watermark.pruner_hi, 1);
+    }
+
+    #[tokio::test]
+    async fn test_init_watermark_sequential() {
+        let (committer_watermark, pruner_watermark) = test_init_watermark(Some(1), false).await;
+
+        let committer_watermark = committer_watermark.unwrap();
+        assert_eq!(committer_watermark.checkpoint_hi_inclusive, 0);
+
+        let pruner_watermark = pruner_watermark.unwrap();
+        assert_eq!(pruner_watermark.reader_lo, 1);
+        assert_eq!(pruner_watermark.pruner_hi, 1);
+    }
+
+    #[tokio::test]
     async fn test_multiple_sequential_pipelines_next_checkpoint() {
         let registry = Registry::new();
         let store = MockStore::default();
@@ -1947,7 +2042,7 @@ mod tests {
         assert_eq!(main_pipeline_watermark.reader_lo, 5);
         let tasked_pipeline_watermark = store.watermark("test@task").unwrap();
         assert_eq!(tasked_pipeline_watermark.checkpoint_hi_inclusive, 25);
-        assert_eq!(tasked_pipeline_watermark.reader_lo, 0);
+        assert_eq!(tasked_pipeline_watermark.reader_lo, 9);
     }
 
     /// During a run, the tasked pipeline will stop sending checkpoints below the main pipeline's

--- a/crates/sui-indexer-alt-framework/src/mocks/store.rs
+++ b/crates/sui-indexer-alt-framework/src/mocks/store.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
+    ops::Deref,
     sync::{
         Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
@@ -9,10 +10,9 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use dashmap::DashMap;
-
 use anyhow::ensure;
 use async_trait::async_trait;
+use dashmap::DashMap;
 use scoped_futures::ScopedBoxFuture;
 use tokio::time::Duration;
 
@@ -84,6 +84,40 @@ pub struct MockConnection<'c>(pub &'c MockStore);
 
 #[async_trait]
 impl Connection for MockConnection<'_> {
+    async fn init_watermark(
+        &mut self,
+        pipeline_task: &str,
+        default_next_checkpoint: u64,
+    ) -> anyhow::Result<Option<u64>> {
+        let Some(checkpoint_hi_inclusive) = default_next_checkpoint.checked_sub(1) else {
+            // Do not create a watermark record with checkpoint_hi_inclusive = -1.
+            return Ok(self
+                .committer_watermark(pipeline_task)
+                .await?
+                .map(|w| w.checkpoint_hi_inclusive));
+        };
+
+        let &MockWatermark {
+            checkpoint_hi_inclusive,
+            ..
+        } = self
+            .0
+            .watermarks
+            .entry(pipeline_task.to_string())
+            .or_insert(MockWatermark {
+                epoch_hi_inclusive: 0,
+                checkpoint_hi_inclusive,
+                tx_hi: 0,
+                timestamp_ms_hi_inclusive: 0,
+                reader_lo: default_next_checkpoint,
+                pruner_timestamp: 0,
+                pruner_hi: default_next_checkpoint,
+            })
+            .deref();
+
+        Ok(Some(checkpoint_hi_inclusive))
+    }
+
     async fn committer_watermark(
         &mut self,
         pipeline_task: &str,

--- a/crates/sui-indexer-alt-object-store/src/lib.rs
+++ b/crates/sui-indexer-alt-object-store/src/lib.rs
@@ -79,6 +79,13 @@ impl Store for ObjectStore {
 
 #[async_trait]
 impl Connection for ObjectStoreConnection {
+    async fn init_watermark(&mut self, pipeline_task: &str, _: u64) -> anyhow::Result<Option<u64>> {
+        Ok(self
+            .committer_watermark(pipeline_task)
+            .await?
+            .map(|w| w.checkpoint_hi_inclusive))
+    }
+
     async fn committer_watermark(
         &mut self,
         pipeline_task: &str,


### PR DESCRIPTION
## Description 

Without the change in this PR, the indexer logs these errors when started using a non-zero `--first-checkpoint` for the first time (no watermark record exists):
```
2025-12-03T20:23:45.594924Z ERROR sui_indexer_alt_framework::pipeline::concurrent::pruner: Failed to prune data for range: 121926000 to 121928000: No checkpoint mapping found for checkpoint 121926000 pipeline="kv_epoch_starts"
```

This error is caused by the pruner attempting to prune data that was never indexed because `pruner_hi` is initialized to `0`.

This PR sets `checkpoint_hi_inclusive`, `reader_lo`, `pruner_hi` based on the `default_next_checkpoint` which is either the value from `--first-checkpoint` (defaulting to `0` if not set). When the pruner runs, it uses this value of `pruner_hi` to avoid trying to prune data that was never indexed.

## Test plan 

1. Added unit tests.
2. Tested with sui-indexer-alt-benchmark:
  a. Deploy sui-indexer-alt-benchmark with `pulumi up` (this line causes the benchmark to use the branch from this PR https://github.com/MystenLabs/sui-operations/blob/c3011e3ae777c8b58019c4a83211aefa54f8d372/pulumi/gcp/sui-indexer-alt-benchmark/Pulumi.dev.yaml#L8)
  b. Verify error is not in logs 
    ```
    kubectl logs sui-indexer-alt-benchmark-indexer-89f9c6965-s6hx9 -n sui-indexer-alt-benchmark`
    ```
---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [x] Indexing Framework: Fix pruning for concurrent pipelines when indexer is initialized with `--first-checkpoint`.
