### PR TITLE
Reduce metric cardinality

### DIFF
--- a/crates/mysten-metrics/src/lib.rs
+++ b/crates/mysten-metrics/src/lib.rs
@@ -34,7 +34,7 @@ pub use guards::*;
 pub const TX_TYPE_SINGLE_WRITER_TX: &str = "single_writer";
 pub const TX_TYPE_SHARED_OBJ_TX: &str = "shared_object";
 
-/// Used when latency is most definitely sub-second.
+/// Used when latency is mostly sub-second.
 pub const SUBSECOND_LATENCY_SEC_BUCKETS: &[f64] = &[
     0.001, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.125, 0.15, 0.175, 0.2, 0.225, 0.25, 0.275, 0.3,
     0.325, 0.35, 0.375, 0.4, 0.425, 0.45, 0.475, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9,

--- a/crates/sui-core/src/transaction_driver/metrics.rs
+++ b/crates/sui-core/src/transaction_driver/metrics.rs
@@ -73,7 +73,7 @@ impl TransactionDriverMetrics {
                 "Time in seconds to successfully submit a transaction to a validator.\n\
                 Includes all retries and measures from the start of submission\n\
                 until a validator accepts the transaction.",
-                &["validator", "tx_type", "ping"],
+                &["tx_type", "ping"],
                 mysten_metrics::LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )

--- a/crates/sui-core/src/transaction_driver/transaction_submitter.rs
+++ b/crates/sui-core/src/transaction_driver/transaction_submitter.rs
@@ -147,7 +147,7 @@ impl TransactionSubmitter {
                     let elapsed = start_time.elapsed().as_secs_f64();
                     self.metrics
                         .submit_transaction_latency
-                        .with_label_values(&[&display_name, tx_type.as_str(), ping_label])
+                        .with_label_values(&[tx_type.as_str(), ping_label])
                         .observe(elapsed);
 
                     return Ok((name, result));

--- a/crates/sui-core/src/validator_client_monitor/metrics.rs
+++ b/crates/sui-core/src/validator_client_monitor/metrics.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use mysten_metrics::{COUNT_BUCKETS, LATENCY_SEC_BUCKETS};
+use mysten_metrics::{COUNT_BUCKETS, SUBSECOND_LATENCY_SEC_BUCKETS};
 use prometheus::{
     GaugeVec, HistogramVec, IntCounterVec, Registry, register_gauge_vec_with_registry,
     register_histogram_vec_with_registry, register_int_counter_vec_with_registry,
@@ -33,7 +33,7 @@ impl ValidatorClientMetrics {
                 "validator_client_observed_latency",
                 "Client-observed latency of operations per validator",
                 &["validator", "operation_type", "ping"],
-                LATENCY_SEC_BUCKETS.to_vec(),
+                SUBSECOND_LATENCY_SEC_BUCKETS.to_vec(),
                 registry,
             )
             .unwrap(),


### PR DESCRIPTION
## Description 

Fine histogram buckets and validator label produce too many metric streams.

## Test plan 

Monitor metric usage after merging
