### PR TITLE
Support Transaction Filtering based on status and MinGasCost

### DIFF
--- a/crates/sui-indexer/src/indexer_reader.rs
+++ b/crates/sui-indexer/src/indexer_reader.rs
@@ -774,6 +774,16 @@ impl IndexerReader {
                     "ToAddress filter is not supported, please use FromOrToAddress instead.".into()
                 ))
             }
+            Some(TransactionFilter::TransactionStatus(_)) => {
+                return Err(IndexerError::NotSupportedError(
+                    "TransactionStatus filter is not supported by the indexer yet. Use the JSON-RPC API directly.".into()
+                ))
+            }
+            Some(TransactionFilter::MinGasCost(_)) => {
+                return Err(IndexerError::NotSupportedError(
+                    "MinGasCost filter is not supported by the indexer yet. Use the JSON-RPC API directly.".into()
+                ))
+            }
             None => {
                 // apply no filter
                 ("transactions".to_owned(), "1 = 1".into())


### PR DESCRIPTION
## Description 

Adds server-side filtering capabilities to Sui's JSON-RPC API, enabling clients to query transactions by execution status (success/failure) and minimum gas cost.

More details in: DVX-1883


## Test plan 

Follow up patch coming for downloading transactions based on these filters.


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
