### PR TITLE
[move][bella-ciao] Add telemetry to track redundant compilations

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/runtime/telemetry.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/runtime/telemetry.rs
@@ -100,6 +100,9 @@ pub(crate) struct TelemetryContext {
     pub(crate) total_time: AtomicU64,
     /// Total Transaction Count
     pub(crate) total_count: AtomicU64,
+    /// Total number of packages that were compiled, but later thrown away since they were already
+    /// cached when we went to insert them into it (i.e., redundant compilations)
+    pub(crate) redundant_compilations: AtomicU64,
 }
 
 /// Transaction Telemetry Information
@@ -117,6 +120,7 @@ pub(crate) struct TransactionTelemetryContext {
     pub execution_time: Option<Duration>,
     pub interpreter_time: Option<Duration>,
     pub total_time: Duration,
+    pub redundant_compilations: u64,
     // TODO(vm-rewrite): Add value sizes, type sizes, etc?
 }
 
@@ -178,6 +182,7 @@ impl TelemetryContext {
             jit_count: AtomicU64::new(0),
             total_time: AtomicU64::new(0),
             total_count: AtomicU64::new(0),
+            redundant_compilations: AtomicU64::new(0),
         }
     }
 
@@ -221,6 +226,7 @@ impl TelemetryContext {
             execution_time,
             interpreter_time,
             total_time,
+            redundant_compilations,
         } = transaction;
 
         update_duration_field!(load_time, load_count, total_load_time, load_count);
@@ -238,6 +244,8 @@ impl TelemetryContext {
         let total_millis = total_time.as_millis() as u64;
         self.total_time.fetch_add(total_millis, Ordering::Release);
         self.total_count.fetch_add(1, Ordering::Release);
+        self.redundant_compilations
+            .fetch_add(redundant_compilations, Ordering::Release);
     }
 
     /// Generate a runtime telemetry report from the telemetry data.
@@ -315,6 +323,7 @@ impl TransactionTelemetryContext {
             execution_time: None,
             interpreter_time: None,
             total_time: Duration::new(0, 0),
+            redundant_compilations: 0,
         }
     }
 
@@ -390,6 +399,10 @@ impl TransactionTelemetryContext {
 
     pub(crate) fn record_total_time(&mut self, total_time: Duration) {
         self.total_time += total_time;
+    }
+
+    pub(crate) fn record_redundant_compilation(&mut self) {
+        self.redundant_compilations += 1;
     }
 }
 


### PR DESCRIPTION
## Description 

Add telemetry to track if/how many redundant compilations we do. 

## Test plan 

Existing tests.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
