### PR TITLE
[Cherrypick] Refactor consensus commit prologue creation (#24529)

### DIFF
--- a/crates/sui-core/src/authority/authority_per_epoch_store.rs
+++ b/crates/sui-core/src/authority/authority_per_epoch_store.rs
@@ -2965,6 +2965,7 @@ impl AuthorityPerEpochStore {
                 }
                 Schedulable::RandomnessStateUpdate(_, _) => None,
                 Schedulable::AccumulatorSettlement(_, _) => None,
+                Schedulable::ConsensusCommitPrologue(_, _, _) => None,
             })
             .collect();
 

--- a/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
+++ b/crates/sui-core/src/execution_scheduler/execution_scheduler_impl.rs
@@ -519,6 +519,12 @@ impl ExecutionScheduler {
                 Schedulable::AccumulatorSettlement(_, _) => {
                     settlement_txns.push((schedulable.key(), env));
                 }
+                Schedulable::ConsensusCommitPrologue(_, _, _) => {
+                    // we only use Schedulable::ConsensusCommitPrologue as a temporary placeholder
+                    // during version assignment, by the time we schedule transactions it should be
+                    // converted to Schedulable::Transaction
+                    unreachable!("Schedulable::ConsensusCommitPrologue should not be enqueued");
+                }
             }
         }
 

--- a/crates/sui-open-rpc/spec/openrpc.json
+++ b/crates/sui-open-rpc/spec/openrpc.json
@@ -1365,6 +1365,7 @@
                 "generate_df_type_layouts": false,
                 "hardened_otw_check": false,
                 "ignore_execution_time_observations_after_certs_closed": false,
+                "include_cancelled_randomness_txns_in_prologue": false,
                 "include_checkpoint_artifacts_digest_in_summary": false,
                 "include_consensus_digest_in_prologue": false,
                 "loaded_child_object_format": false,

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -894,6 +894,10 @@ struct FeatureFlags {
     // If true, skip GC'ed accept votes in CommitFinalizer.
     #[serde(skip_serializing_if = "is_false")]
     consensus_skip_gced_accept_votes: bool,
+
+    // If true, include cancelled randomness txns in the consensus commit prologue.
+    #[serde(skip_serializing_if = "is_false")]
+    include_cancelled_randomness_txns_in_prologue: bool,
 }
 
 fn is_false(b: &bool) -> bool {
@@ -2407,6 +2411,11 @@ impl ProtocolConfig {
 
     pub fn consensus_skip_gced_accept_votes(&self) -> bool {
         self.feature_flags.consensus_skip_gced_accept_votes
+    }
+
+    pub fn include_cancelled_randomness_txns_in_prologue(&self) -> bool {
+        self.feature_flags
+            .include_cancelled_randomness_txns_in_prologue
     }
 }
 
@@ -4293,6 +4302,9 @@ impl ProtocolConfig {
                         cfg.feature_flags
                             .enable_nitro_attestation_all_nonzero_pcrs_parsing = true;
                     }
+
+                    cfg.feature_flags
+                        .include_cancelled_randomness_txns_in_prologue = true;
                 }
                 // Use this template when making changes:
                 //

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_104.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Mainnet_version_104.snap
@@ -127,6 +127,7 @@ feature_flags:
   private_generics_verifier_v2: true
   deprecate_global_storage_ops: true
   consensus_skip_gced_accept_votes: true
+  include_cancelled_randomness_txns_in_prologue: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_104.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_104.snap
@@ -129,6 +129,7 @@ feature_flags:
   private_generics_verifier_v2: true
   deprecate_global_storage_ops: true
   consensus_skip_gced_accept_votes: true
+  include_cancelled_randomness_txns_in_prologue: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_104.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__version_104.snap
@@ -132,6 +132,7 @@ feature_flags:
   private_generics_verifier_v2: true
   deprecate_global_storage_ops: true
   consensus_skip_gced_accept_votes: true
+  include_cancelled_randomness_txns_in_prologue: true
 max_tx_size_bytes: 131072
 max_input_objects: 2048
 max_size_written_objects: 5000000

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -4250,6 +4250,7 @@ pub enum TransactionKey {
     Digest(TransactionDigest),
     RandomnessRound(EpochId, RandomnessRound),
     AccumulatorSettlement(EpochId, u64 /* checkpoint height */),
+    ConsensusCommitPrologue(EpochId, u64 /* round */, u32 /* sub_dag_index */),
 }
 
 impl TransactionKey {


### PR DESCRIPTION
- Refactor add_consensus_commit_prologue so that we don't have to
recompute version assignments.
- Enable include_cancelled_randomness_txns_in_prologue
- Remove old version of process_transactions

Note: This exposed a pre-existing bug where cancelled randomness
transactions were not added to the commit prologue. The bug is fixed,
along with a protocol flag.
