### PR TITLE
[move][cli] Fix gas profiles for code that aborts

### DIFF
--- a/external-crates/move/crates/move-cli/tests/tracing_tests/tracing-unit-tests/args.exp
+++ b/external-crates/move/crates/move-cli/tests/tracing_tests/tracing-unit-tests/args.exp
@@ -43,3 +43,7 @@ External Command `wc -l f21.diff.lcov.info`:
 26 f21.diff.lcov.info
 Command `profile -i saved_traces/0x1__calls__test_complex_nested_calls.json.zst -o gas_profiles`:
 Saving gas profile to: gas_profiles/gas_profile_0x1__calls__test_complex_nested_calls.json
+Command `profile -i saved_traces/0x1__errors__fail_in_native.json.zst -o gas_profiles`:
+Saving gas profile to: gas_profiles/gas_profile_0x1__errors__fail_in_native.json
+Command `profile -i saved_traces/0x1__errors__aborter.json.zst -o gas_profiles`:
+Saving gas profile to: gas_profiles/gas_profile_0x1__errors__aborter.json

--- a/external-crates/move/crates/move-cli/tests/tracing_tests/tracing-unit-tests/args.txt
+++ b/external-crates/move/crates/move-cli/tests/tracing_tests/tracing-unit-tests/args.txt
@@ -11,3 +11,5 @@ coverage lcov --differential-test f21
 > wc -l f21.diff.lcov.info
 
 profile -i saved_traces/0x1__calls__test_complex_nested_calls.json.zst -o gas_profiles
+profile -i saved_traces/0x1__errors__fail_in_native.json.zst -o gas_profiles
+profile -i saved_traces/0x1__errors__aborter.json.zst -o gas_profiles

--- a/external-crates/move/crates/move-cli/tests/tracing_tests/tracing-unit-tests/gas_profiles/gas_profile_0x1__errors__aborter.json
+++ b/external-crates/move/crates/move-cli/tests/tracing_tests/tracing-unit-tests/gas_profiles/gas_profile_0x1__errors__aborter.json
@@ -1,0 +1,35 @@
+{
+  "exporter": "speedscope@1.15.2",
+  "name": "saved_traces/0x1__errors__aborter.json.zst",
+  "activeProfileIndex": 0,
+  "$schema": "https://www.speedscope.app/file-format-schema.json",
+  "shared": {
+    "frames": [
+      {
+        "name": "aborter",
+        "file": ""
+      }
+    ]
+  },
+  "profiles": [
+    {
+      "type": "evented",
+      "name": "saved_traces/0x1__errors__aborter.json.zst",
+      "unit": "none",
+      "startValue": 0,
+      "endValue": 4,
+      "events": [
+        {
+          "type": "O",
+          "frame": 0,
+          "at": 0
+        },
+        {
+          "type": "C",
+          "frame": 0,
+          "at": 4
+        }
+      ]
+    }
+  ]
+}

--- a/external-crates/move/crates/move-cli/tests/tracing_tests/tracing-unit-tests/gas_profiles/gas_profile_0x1__errors__fail_in_native.json
+++ b/external-crates/move/crates/move-cli/tests/tracing_tests/tracing-unit-tests/gas_profiles/gas_profile_0x1__errors__fail_in_native.json
@@ -1,0 +1,63 @@
+{
+  "exporter": "speedscope@1.15.2",
+  "name": "saved_traces/0x1__errors__fail_in_native.json.zst",
+  "activeProfileIndex": 0,
+  "$schema": "https://www.speedscope.app/file-format-schema.json",
+  "shared": {
+    "frames": [
+      {
+        "name": "fail_in_native",
+        "file": ""
+      },
+      {
+        "name": "internal_sub_string_for_testing",
+        "file": ""
+      },
+      {
+        "name": "internal_sub_string",
+        "file": ""
+      }
+    ]
+  },
+  "profiles": [
+    {
+      "type": "evented",
+      "name": "saved_traces/0x1__errors__fail_in_native.json.zst",
+      "unit": "none",
+      "startValue": 0,
+      "endValue": 4632,
+      "events": [
+        {
+          "type": "O",
+          "frame": 0,
+          "at": 0
+        },
+        {
+          "type": "O",
+          "frame": 1,
+          "at": 20
+        },
+        {
+          "type": "O",
+          "frame": 2,
+          "at": 4632
+        },
+        {
+          "type": "C",
+          "frame": 2,
+          "at": 4632
+        },
+        {
+          "type": "C",
+          "frame": 1,
+          "at": 4632
+        },
+        {
+          "type": "C",
+          "frame": 0,
+          "at": 4632
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description 

Traces for executions that aborted did not have a `CloseFrame` for every `OpenFrame` emitted (which makes sense since the execution aborted). However this meant that when constructing gas profiles, there wouldn't be a matching close frame event for every open frame event in those cases, and the resulting gas profile was incorrect.

This fixes this issue by seeing if there are any remaining open frames at the end of the trace, and if so closing them out in the resulting profile, so the resulting gas profile is valid. 

## Test plan 

Tested locally + saving gas profiles for executions that abort to make sure we capture the correct output for these and track it.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
