### PR TITLE
[light-clients] Enable authenticated events in devnet

### DIFF
--- a/crates/sui-e2e-tests/tests/authenticated_events_end_to_end_test.rs
+++ b/crates/sui-e2e-tests/tests/authenticated_events_end_to_end_test.rs
@@ -29,6 +29,16 @@ async fn setup_test_cluster_with_auth_events() -> TestCluster {
     TestClusterBuilder::new().build().await
 }
 
+async fn setup_test_cluster_with_auth_events_disabled() -> TestCluster {
+    let _guard: sui_protocol_config::OverrideGuard =
+        ProtocolConfig::apply_overrides_for_testing(|_, mut cfg| {
+            cfg.disable_authenticated_event_streams_for_testing();
+            cfg
+        });
+
+    TestClusterBuilder::new().build().await
+}
+
 async fn publish_auth_event_package(test_cluster: &TestCluster) -> ObjectID {
     let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("tests/data/auth_event");
@@ -189,7 +199,7 @@ async fn authenticated_events_multiple_events_test() {
 
 #[sim_test]
 async fn authenticated_events_disabled_test() {
-    let mut test_cluster = TestClusterBuilder::new().build().await;
+    let mut test_cluster = setup_test_cluster_with_auth_events_disabled().await;
     let package_id = publish_auth_event_package(&test_cluster).await;
     let sender = test_cluster.wallet.config.keystore.addresses()[0];
 

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -4659,6 +4659,10 @@ impl ProtocolConfig {
             .include_checkpoint_artifacts_digest_in_summary = true;
     }
 
+    pub fn disable_authenticated_event_streams_for_testing(&mut self) {
+        self.feature_flags.enable_authenticated_event_streams = false;
+    }
+
     pub fn enable_non_exclusive_writes_for_testing(&mut self) {
         self.feature_flags.enable_non_exclusive_writes = true;
     }


### PR DESCRIPTION
## Description 

This change enables authenticated events in devnet.

## Test plan 

E2e testing

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
