### PR TITLE
fix(callback): remove unnecessary RequestBody Body bound in Service impl

### DIFF
--- a/crates/mysten-network/src/callback/service.rs
+++ b/crates/mysten-network/src/callback/service.rs
@@ -60,7 +60,6 @@ where
             Error: std::fmt::Display + 'static,
         >,
     M: MakeCallbackHandler,
-    RequestBody: http_body::Body<Error: std::fmt::Display + 'static>,
     ResponseBodyT: http_body::Body<Error: std::fmt::Display + 'static>,
 {
     type Response = Response<ResponseBody<ResponseBodyT, M::Handler>>;


### PR DESCRIPTION
The Callback middleware doesn’t interact with the request body as an http_body::Body, so constraining RequestBody to Body (and its Error to Display + 'static) is unnecessary and over-restrictive. Removing this bound improves compatibility with services whose request bodies aren’t http_body::Body, matching the approach used by GrpcTimeout and common tower middleware patterns. ResponseBody remains constrained since it is wrapped and processed.