### PR TITLE
[tidehunter] tmp disable prune_executed_tx_digests_th

### DIFF
--- a/crates/sui-core/src/authority/authority_store_pruner.rs
+++ b/crates/sui-core/src/authority/authority_store_pruner.rs
@@ -688,7 +688,8 @@ impl AuthorityStorePruner {
         }
         perpetual_db.objects.db.start_relocation()?;
         checkpoint_store.tables.watermarks.db.start_relocation()?;
-        Self::prune_executed_tx_digests_th(perpetual_db, checkpoint_store)?;
+        // tmp disable this while we debug failed: to_inclusive is not the last key in its cell
+        // Self::prune_executed_tx_digests_th(perpetual_db, checkpoint_store)?;
         Ok(())
     }
 


### PR DESCRIPTION
## Description 

revert problematic th call while debugging:
```
assertion `left == right` failed: to_inclusive is not the last key in its cell
```

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
