### PR TITLE
[indexer-alt-framework] update task requires arg

### DIFF
--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -81,7 +81,7 @@ pub struct TaskArgs {
     ///
     /// The framework ensures that tasked pipelines never commit checkpoints below the main
     /// pipeline’s pruner watermark. Requires `--reader-interval-ms`.
-    #[arg(long, requires = "reader-interval-ms")]
+    #[arg(long, requires = "reader_interval_ms")]
     task: Option<String>,
 
     /// The interval in milliseconds at which each of the pipelines on a tasked indexer should


### PR DESCRIPTION
## Description 

Noticed an issue while trying to run a tasked indexer locally:
`cargo run --bin sui-indexer-alt -- indexer --help` fails with
`Command indexer: Argument or group 'reader-interval-ms' specified in 'requires*' for 'task' does not exist
note: run with `RUST_B`


## Test plan 

Ran a tasked indexer locally:
```
cargo run --bin sui-indexer-alt -- indexer \
  --database-url "$DB" \
  --remote-store-url $URL \
  --config /tmp/tx_digest_genesis_backfil.toml \
  --first-checkpoint 0 \
  --last-checkpoint 1 \
  --task tx_digest_genesis_backfil \
  --reader-interval-ms 1000
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
