### PR TITLE
fix: correct committee url update error texts

### DIFF
--- a/crates/sui-bridge/src/events.rs
+++ b/crates/sui-bridge/src/events.rs
@@ -280,10 +280,10 @@ impl TryFrom<MoveCommitteeMemberUrlUpdateEvent> for CommitteeMemberUrlUpdateEven
 
     fn try_from(event: MoveCommitteeMemberUrlUpdateEvent) -> BridgeResult<Self> {
         let member = BridgeAuthorityPublicKey::from_bytes(&event.member).map_err(|e|
-            BridgeError::Generic(format!("Failed to convert MoveBlocklistValidatorEvent to BlocklistValidatorEvent. Failed to convert public key to BridgeAuthorityPublicKey: {:?}", e))
+            BridgeError::Generic(format!("Failed to convert MoveCommitteeMemberUrlUpdateEvent to CommitteeMemberUrlUpdateEvent. Failed to convert public key to BridgeAuthorityPublicKey: {:?}", e))
         )?;
         let new_url = String::from_utf8(event.new_url).map_err(|e|
-            BridgeError::Generic(format!("Failed to convert MoveBlocklistValidatorEvent to BlocklistValidatorEvent. Failed to convert new_url to String: {:?}", e))
+            BridgeError::Generic(format!("Failed to convert MoveCommitteeMemberUrlUpdateEvent to CommitteeMemberUrlUpdateEvent. Failed to convert new_url to String: {:?}", e))
         )?;
         Ok(Self { member, new_url })
     }


### PR DESCRIPTION
Clarify conversion error messages for committee URL update events to reference the right event and field, making debugging of malformed keys/URLs straightforward.