### PR TITLE
docs(sui-framework): Clarify copy behavior in destroy, do, and zip vector macros

### DIFF
--- a/crates/sui-framework/packages/move-stdlib/sources/vector.move
+++ b/crates/sui-framework/packages/move-stdlib/sources/vector.move
@@ -207,7 +207,17 @@ public macro fun destroy<$T, $R: drop>($v: vector<$T>, $f: |$T| -> $R) {
 }
 
 /// Destroy the vector `v` by calling `f` on each element and then destroying the vector.
-/// Preserves the order of elements in the vector.
+/// Preserves the order of elements in the vector. 
+///
+/// If `T` has the `copy` ability, the original vector still exists after the macro call
+/// because `vector<T>` can be copied:
+///
+/// ```move
+/// struct Data has copy, drop, store { value: u64 }
+/// let mut v = vector[Data { value: 42 }];
+/// v.do!(|data| data.value);
+/// let len = v.length(); // v still exists!
+/// ```
 public macro fun do<$T, $R: drop>($v: vector<$T>, $f: |$T| -> $R) {
     let mut v = $v;
     v.reverse();


### PR DESCRIPTION
## Description 

Fixes documentation that incorrectly suggests vector macros always destroy the original vector. When  `T`  has a `copy`
ability, the original vector persists because vector<T>  can be copied.

Updated `destroy `,  `do` ,  `zip_do` ,  `zip_do_reverse` , and `zip_map`  to accurately document this copy behavior with clear examples.

## Test plan 


---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
