### PR TITLE
[traffic_controller] metrics improvements

### DIFF
--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -1564,6 +1564,7 @@ impl ValidatorService {
         &self,
         client: Option<IpAddr>,
         wrapped_response: WrappedServiceResponse<T>,
+        method_name: &str,
     ) -> Result<tonic::Response<T>, tonic::Status> {
         let (error, spam_weight, unwrapped_response) = match wrapped_response {
             Ok((result, spam_weight)) => (None, spam_weight.clone(), Ok(result)),
@@ -1585,6 +1586,7 @@ impl ValidatorService {
                 }),
                 spam_weight,
                 timestamp: SystemTime::now(),
+                method: Some(method_name.to_string()),
             })
         }
         unwrapped_response
@@ -1612,7 +1614,7 @@ fn normalize(err: SuiError) -> Weight {
 /// unless it is necessary to override the return value.
 #[macro_export]
 macro_rules! handle_with_decoration {
-    ($self:ident, $func_name:ident, $request:ident) => {{
+    ($self:ident, $func_name:ident, $request:ident, $method_name:expr) => {{
         if $self.client_id_source.is_none() {
             return $self.$func_name($request).await.map(|(result, _)| result);
         }
@@ -1624,7 +1626,7 @@ macro_rules! handle_with_decoration {
 
         // handle traffic tallying
         let wrapped_response = $self.$func_name($request).await;
-        $self.handle_traffic_resp(client, wrapped_response)
+        $self.handle_traffic_resp(client, wrapped_response, $method_name)
     }};
 }
 
@@ -1641,7 +1643,12 @@ impl Validator for ValidatorService {
         spawn_monitored_task!(async move {
             // NB: traffic tally wrapping handled within the task rather than on task exit
             // to prevent an attacker from subverting traffic control by severing the connection
-            handle_with_decoration!(validator_service, handle_submit_transaction_impl, request)
+            handle_with_decoration!(
+                validator_service,
+                handle_submit_transaction_impl,
+                request,
+                "submit_transaction"
+            )
         })
         .await
         .unwrap()
@@ -1651,42 +1658,47 @@ impl Validator for ValidatorService {
         &self,
         request: tonic::Request<RawWaitForEffectsRequest>,
     ) -> Result<tonic::Response<RawWaitForEffectsResponse>, tonic::Status> {
-        handle_with_decoration!(self, wait_for_effects_impl, request)
+        handle_with_decoration!(self, wait_for_effects_impl, request, "wait_for_effects")
     }
 
     async fn object_info(
         &self,
         request: tonic::Request<ObjectInfoRequest>,
     ) -> Result<tonic::Response<ObjectInfoResponse>, tonic::Status> {
-        handle_with_decoration!(self, object_info_impl, request)
+        handle_with_decoration!(self, object_info_impl, request, "object_info")
     }
 
     async fn transaction_info(
         &self,
         request: tonic::Request<TransactionInfoRequest>,
     ) -> Result<tonic::Response<TransactionInfoResponse>, tonic::Status> {
-        handle_with_decoration!(self, transaction_info_impl, request)
+        handle_with_decoration!(self, transaction_info_impl, request, "transaction_info")
     }
 
     async fn checkpoint(
         &self,
         request: tonic::Request<CheckpointRequest>,
     ) -> Result<tonic::Response<CheckpointResponse>, tonic::Status> {
-        handle_with_decoration!(self, checkpoint_impl, request)
+        handle_with_decoration!(self, checkpoint_impl, request, "checkpoint")
     }
 
     async fn checkpoint_v2(
         &self,
         request: tonic::Request<CheckpointRequestV2>,
     ) -> Result<tonic::Response<CheckpointResponseV2>, tonic::Status> {
-        handle_with_decoration!(self, checkpoint_v2_impl, request)
+        handle_with_decoration!(self, checkpoint_v2_impl, request, "checkpoint_v2")
     }
 
     async fn get_system_state_object(
         &self,
         request: tonic::Request<SystemStateRequest>,
     ) -> Result<tonic::Response<SuiSystemState>, tonic::Status> {
-        handle_with_decoration!(self, get_system_state_object_impl, request)
+        handle_with_decoration!(
+            self,
+            get_system_state_object_impl,
+            request,
+            "get_system_state_object"
+        )
     }
 
     async fn validator_health(
@@ -1694,6 +1706,6 @@ impl Validator for ValidatorService {
         request: tonic::Request<sui_types::messages_grpc::RawValidatorHealthRequest>,
     ) -> Result<tonic::Response<sui_types::messages_grpc::RawValidatorHealthResponse>, tonic::Status>
     {
-        handle_with_decoration!(self, validator_health_impl, request)
+        handle_with_decoration!(self, validator_health_impl, request, "validator_health")
     }
 }

--- a/crates/sui-core/src/traffic_controller/policies.rs
+++ b/crates/sui-core/src/traffic_controller/policies.rs
@@ -235,6 +235,7 @@ pub struct TrafficTally {
     pub error_info: Option<(Weight, String)>,
     pub spam_weight: Weight,
     pub timestamp: SystemTime,
+    pub method: Option<String>,
 }
 
 impl TrafficTally {
@@ -250,7 +251,13 @@ impl TrafficTally {
             error_info,
             spam_weight,
             timestamp: SystemTime::now(),
+            method: None,
         }
+    }
+
+    pub fn with_method(mut self, method: String) -> Self {
+        self.method = Some(method);
+        self
     }
 }
 
@@ -548,6 +555,7 @@ mod tests {
             error_info: None,
             spam_weight: Weight::one(),
             timestamp: SystemTime::now(),
+            method: None,
         };
         let bob = TrafficTally {
             direct: Some(IpAddr::V4(Ipv4Addr::new(8, 7, 6, 5))),
@@ -555,6 +563,7 @@ mod tests {
             error_info: None,
             spam_weight: Weight::one(),
             timestamp: SystemTime::now(),
+            method: None,
         };
         let charlie = TrafficTally {
             direct: Some(IpAddr::V4(Ipv4Addr::new(8, 7, 6, 5))),
@@ -562,6 +571,7 @@ mod tests {
             error_info: None,
             spam_weight: Weight::one(),
             timestamp: SystemTime::now(),
+            method: None,
         };
 
         // initial 2 tallies for alice, should not block

--- a/crates/sui-json-rpc/src/traffic_control.rs
+++ b/crates/sui-json-rpc/src/traffic_control.rs
@@ -98,6 +98,7 @@ async fn handle_traffic_resp(
         // to provide a weight distribution based on the method being called.
         spam_weight: Weight::one(),
         timestamp: SystemTime::now(),
+        method: None,
     });
 }
 


### PR DESCRIPTION
## Description 

  Added traffic controller metrics for debugging high blocked request rates:

  1. Added method label to tallies metric - track which RPC methods generate most traffic
  2. Added dry_run and ip labels to requests_blocked_at_protocol metric - track blocked requests by dry-run status and source IP
  3. IP bucketing - IPs hashed to bucket_0..bucket_99 to limit cardinality (200 series max vs 1000s of unique IPs)
  4. Trace logging - logs IP→bucket mapping for correlation with specific addresses

  Metrics consolidated:
  - Removed: num_dry_run_blocked_requests, blocked_requests_by_ip
  - Enhanced: requests_blocked_at_protocol{dry_run="true/false", ip="bucket_X"}
  - Enhanced: tallies{method="submit_transaction/checkpoint/etc"}

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
