### PR TITLE
Re-apply coin registry fix for balance api

### DIFF
--- a/crates/sui-e2e-tests/tests/rpc/v2/state_service/balance.rs
+++ b/crates/sui-e2e-tests/tests/rpc/v2/state_service/balance.rs
@@ -469,27 +469,6 @@ async fn test_invalid_requests() {
         error.message()
     );
 
-    // Test with non-existent coin type (well-formed but doesn't exist)
-    let fake_coin_type =
-        "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef::fakecoin::FAKECOIN";
-    let result = grpc_client
-        .state_client()
-        .get_balance({
-            let mut message = GetBalanceRequest::default();
-            message.owner = Some(address.to_string());
-            message.coin_type = Some(fake_coin_type.to_string());
-            message
-        })
-        .await;
-    assert!(result.is_err(), "Expected error for non-existent coin type");
-    let error = result.unwrap_err();
-    assert_eq!(error.code(), tonic::Code::InvalidArgument);
-    assert!(
-        error.message().contains("coin type does not exist"),
-        "Expected error message to contain 'coin type does not exist', but got: {}",
-        error.message()
-    );
-
     // Test ListBalancesRequest with missing owner
     let result = grpc_client
         .state_client()

--- a/crates/sui-rpc-api/src/grpc/v2/state_service/get_balance.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/state_service/get_balance.rs
@@ -48,15 +48,6 @@ pub fn get_balance(service: &RpcService, request: GetBalanceRequest) -> Result<G
 
     let core_coin_type = struct_tag_sdk_to_core(coin_type.clone())?;
 
-    // Check if coin type exists
-    let coin_info = indexes.get_coin_info(&core_coin_type)?;
-    if coin_info.is_none() {
-        return Err(RpcError::new(
-            tonic::Code::InvalidArgument,
-            format!("coin type does not exist: {}", coin_type),
-        ));
-    }
-
     let balance_info = indexes
         .get_balance(&owner, &core_coin_type)?
         .unwrap_or_default(); // Use default (zero) if no balance found


### PR DESCRIPTION
## Description

I initially made this change in <https://github.com/MystenLabs/sui/pull/22954>, but it got lost somehow when we did migration from v2stable to v2. Coin registry coins aren't in the index, and we made the decision to just return 0 for invalid coin types rather than than an error to match the behavior of consistent store.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates.

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [x] gRPC: Fix bug where balance queries errored out for coin registry coins.
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [ ] Rust SDK:
- [ ] Indexing Framework:
