### PR TITLE
Compile time evaluation of trace function when not enabled

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/eval.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/eval.rs
@@ -153,7 +153,7 @@ fn step(
         ))
     });
 
-    trace(run_context.tracer, |tracer| {
+    trace!(run_context.tracer, |tracer| {
         tracer.start_instruction(
             run_context.vtables,
             state,
@@ -167,7 +167,7 @@ fn step(
     match instruction {
         Bytecode::Ret => {
             let charge_result = gas_meter.charge_simple_instr(SimpleInstruction::Ret);
-            trace(run_context.tracer, |tracer| {
+            trace!(run_context.tracer, |tracer| {
                 tracer.end_instruction(
                     run_context.vtables,
                     state,
@@ -184,7 +184,7 @@ fn step(
                 .charge_drop_frame(non_ref_vals.into_iter())
                 .map_err(|e| state.set_location(e))?;
 
-            trace(run_context.tracer, |tracer| {
+            trace!(run_context.tracer, |tracer| {
                 tracer.exit_frame(
                     run_context.vtables,
                     state,
@@ -204,7 +204,7 @@ fn step(
             }
         }
         Bytecode::CallGeneric(fun_inst_ptr) => {
-            trace(run_context.tracer, |tracer| {
+            trace!(run_context.tracer, |tracer| {
                 tracer.end_instruction(
                     run_context.vtables,
                     state,
@@ -227,7 +227,7 @@ fn step(
             Ok(StepStatus::Running)
         }
         Bytecode::VirtualCall(vtable_key) => {
-            trace(run_context.tracer, |tracer| {
+            trace!(run_context.tracer, |tracer| {
                 tracer.end_instruction(
                     run_context.vtables,
                     state,
@@ -245,7 +245,7 @@ fn step(
             Ok(StepStatus::Running)
         }
         Bytecode::DirectCall(function) => {
-            trace(run_context.tracer, |tracer| {
+            trace!(run_context.tracer, |tracer| {
                 tracer.end_instruction(
                     run_context.vtables,
                     state,
@@ -258,7 +258,7 @@ fn step(
         }
         _ => {
             let step_result = op_step_impl(state, run_context, gas_meter, instruction);
-            trace(run_context.tracer, |tracer| {
+            trace!(run_context.tracer, |tracer| {
                 tracer.end_instruction(
                     run_context.vtables,
                     state,
@@ -859,7 +859,7 @@ fn call_function(
     function: VMPointer<Function>,
     ty_args: Vec<Type>,
 ) -> VMResult<()> {
-    trace(run_context.tracer, |tracer| {
+    trace!(run_context.tracer, |tracer| {
         tracer.enter_frame(
             run_context.vtables,
             state,
@@ -909,7 +909,7 @@ fn call_function(
         let native_result = call_native(state, run_context, gas_meter, &function, ty_args);
 
         // NB: Pass any error into the tracer before raising it.
-        trace(run_context.tracer, |tracer| {
+        trace!(run_context.tracer, |tracer| {
             tracer.exit_frame(
                 run_context.vtables,
                 state,

--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/mod.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/mod.rs
@@ -38,7 +38,7 @@ pub(crate) fn run(
 ) -> VMResult<Vec<Value>> {
     let interpreter_timer = telemetry.make_timer(crate::runtime::telemetry::TimerKind::Interpreter);
     let fun_ref = function.to_ref();
-    trace(tracer, |tracer| {
+    trace!(tracer, |tracer| {
         tracer.enter_initial_frame(
             vtables,
             &gas_meter.remaining_gas().into(),
@@ -66,7 +66,7 @@ pub(crate) fn run(
                         fun_ref.module_id(&vtables.interner).clone(),
                     ))
             });
-            trace(tracer, |tracer| {
+            trace!(tracer, |tracer| {
                 tracer.exit_initial_native_frame(&return_result, &gas_meter.remaining_gas().into())
             });
             return_result.map(|values| values.into_iter().collect())

--- a/external-crates/move/crates/move-vm-runtime/src/execution/tracing/mod.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/tracing/mod.rs
@@ -1,19 +1,40 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use self::tracer::VMTracer;
-
 pub mod tracer;
 
+/// Invoke a tracing operation when the `tracing` feature is enabled.
+///
+/// This macro provides zero-cost tracing when the `tracing` feature is disabled:
+///
+/// Using a macro instead of a generic function ensures that:
+/// 1. No closure types are monomorphized when tracing is disabled
+/// 2. No VMTracer method references appear in the binary
+/// 3. The tracer parameter type can be `()` when disabled (zero-sized)
+///
+/// # Usage
+/// ```ignore
+/// trace!(run_context.tracer, |tracer| {
+///     tracer.start_instruction(vtables, state, &gas_meter.remaining_gas().into())
+/// });
+/// ```
 #[cfg(feature = "tracing")]
-pub(crate) const TRACING_ENABLED: bool = true;
-
-#[cfg(not(feature = "tracing"))]
-pub(crate) const TRACING_ENABLED: bool = false;
-
-#[inline]
-pub(crate) fn trace<'a, F: Fn(&mut VMTracer<'a>)>(tracer: &mut Option<VMTracer<'a>>, op: F) {
-    if TRACING_ENABLED && let Some(tracer) = tracer {
-        op(tracer)
-    }
+macro_rules! trace {
+    ($tracer:expr, |$param:ident| $body:expr) => {
+        if let Some($param) = $tracer.as_mut() {
+            $body
+        }
+    };
 }
+
+/// No-op version.
+#[cfg(not(feature = "tracing"))]
+macro_rules! trace {
+    ($tracer:expr, |$param:ident| $body:expr) => {
+        // Intentionally empty - tracing disabled at compile time
+        // The $body is captured but never expanded, so no code is generated
+        let _ = &$tracer; // Suppress unused warning without evaluating
+    };
+}
+
+pub(crate) use trace;


### PR DESCRIPTION
## Description 

It seems that even without tracing we incur the overhead of trace calls. The trace function does not get optimized away in release builds.

Metric | With tracing Feature | Without tracing Feature | Difference
-- | -- | -- | --
Binary size (rlib) | 6,761,864 bytes (6.45 MB) | 6,755,552 bytes (6.44 MB) | +6,312 bytes
trace references | 185 | 165 | +20
VMTracer references | 21 | 21 | 0
start_instruction | 2 | 2 | 0
end_instruction | 2 | 2 | 0

More Details in: MOVE-276

After this change:

| Metric | With `tracing` | Without `tracing` | Change |
|--------|----------------|-------------------|--------|
| Binary size (rlib) | 6,758,584 bytes (6.45 MB) | 6,330,352 bytes (6.04 MB) | +428,232 bytes (+6.8%) |
| `trace` references | 185 | 9 | +176 |
| `VMTracer` references | 21 | 0 | +21 |
| `start_instruction` | 2 | 0 | +2 |
| `end_instruction` | 2 | 0 | +2 |


## Test plan 

cargo test, manually inspected the binary/assembly.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
