### PR TITLE
[bella-ciao-gelato] Change pc assertion to return an error instead

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/eval.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/interpreter/eval.rs
@@ -127,11 +127,18 @@ fn step(
     let fun_ref = state.call_stack.current_frame.function();
     let instructions = fun_ref.code();
     let pc = state.call_stack.current_frame.pc as usize;
-    assert!(
-        pc <= instructions.len(),
-        "PC beyond instruction count for {}",
-        fun_ref.name(&run_context.vtables.interner)
-    );
+    if pc >= instructions.len() {
+        return Err(
+            state.set_location(
+                PartialVMError::new(StatusCode::PC_OVERFLOW).with_message(format!(
+                    "PC {} out of bounds for function {} with {} instructions",
+                    pc,
+                    fun_ref.name(&run_context.vtables.interner),
+                    instructions.len()
+                )),
+            ),
+        );
+    }
     let instruction = &instructions[pc];
     fail_point!("move_vm::interpreter_loop", |_| {
         Err(state.set_location(


### PR DESCRIPTION
## Description 

Change the assertion that the `pc` is in-bounds of the instruction stream to an invariant violation error. 

## Test plan 

Existing tests

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
