### PR TITLE
fix: remove redundant LiveObject::to_normal filter_map in par indexer

### DIFF
--- a/crates/sui-core/src/par_index_live_object_set.rs
+++ b/crates/sui-core/src/par_index_live_object_set.rs
@@ -84,15 +84,16 @@ fn live_object_set_index_task<T: LiveObjectIndexer>(
     let end_id = ObjectID::new(id_bytes);
 
     let mut object_scanned: u64 = 0;
-    for live in authority_store.perpetual_tables.range_iter_live_object_set(
-        Some(start_id),
-        Some(end_id),
-        false,
-    ) {
-        let LiveObject::Normal(object) = live else {
-            unreachable!("range_iter_live_object_set(false) must not yield wrapped objects");
-        };
-
+    for object in authority_store
+        .perpetual_tables
+        .range_iter_live_object_set(Some(start_id), Some(end_id), false)
+        .map(|live| {
+            let LiveObject::Normal(object) = live else {
+                unreachable!("range_iter_live_object_set(false) must not yield wrapped objects");
+            };
+            object
+        })
+    {
         object_scanned += 1;
         if object_scanned.is_multiple_of(2_000_000) {
             info!(


### PR DESCRIPTION
range_iter_live_object_set(..., false) already guarantees that the iterator only yields LiveObject::Normal variants and never returns wrapped tombstones. The extra filter_map(LiveObject::to_normal) in live_object_set_index_task does not change behavior, but adds an unnecessary enum match and Option layer on every element. This change removes the redundant filter_map and matches LiveObject::Normal directly, making the contract explicit and slightly reducing per-object overhead during live object set indexing.