### PR TITLE
Give an earlier warning if publish is used in simtests

### DIFF
--- a/crates/sui-test-transaction-builder/src/lib.rs
+++ b/crates/sui-test-transaction-builder/src/lib.rs
@@ -425,6 +425,9 @@ impl TestTransactionBuilder {
     }
 
     pub fn publish(self, path: PathBuf) -> Self {
+        if cfg!(msim) {
+            panic!("In simtests, you must use publish_async() instead");
+        }
         self.publish_with_data(PublishData::Source(path, false))
     }
 


### PR DESCRIPTION
The error that eventually happens without this is quite unclear
