### PR TITLE
display: json transform

### DIFF
--- a/crates/sui-display/src/v2/error.rs
+++ b/crates/sui-display/src/v2/error.rs
@@ -6,8 +6,10 @@ use std::fmt;
 use std::mem;
 use std::sync::Arc;
 
-use move_core_types::annotated_visitor;
+use move_core_types::annotated_visitor as AV;
 use move_core_types::language_storage::TypeTag;
+use sui_types::object::option_visitor as OV;
+use sui_types::object::rpc_visitor as RV;
 
 use crate::v2::lexer::Lexeme;
 use crate::v2::lexer::OwnedLexeme;
@@ -101,7 +103,7 @@ pub enum FormatError {
     VectorTypeMismatch(TypeTag, TypeTag),
 
     #[error("Deserialization error: {0}")]
-    Visitor(#[from] annotated_visitor::Error),
+    Visitor(#[from] AV::Error),
 }
 
 /// The set of patterns that the parser tried to match against the next token, in a given
@@ -239,6 +241,18 @@ impl fmt::Display for ExpectedSet {
         }
 
         Ok(())
+    }
+}
+
+impl From<RV::Error> for FormatError {
+    fn from(RV::Error: RV::Error) -> Self {
+        FormatError::Bcs(bcs::Error::Custom("unexpected type".to_string()))
+    }
+}
+
+impl From<OV::Error> for FormatError {
+    fn from(OV::Error: OV::Error) -> Self {
+        FormatError::Bcs(bcs::Error::ExpectedOption)
     }
 }
 

--- a/crates/sui-display/src/v2/parser.rs
+++ b/crates/sui-display/src/v2/parser.rs
@@ -136,6 +136,7 @@ pub enum Transform {
     Base64(Base64Modifier),
     Bcs(Base64Modifier),
     Hex,
+    Json,
     #[default]
     Str,
     Timestamp,
@@ -269,7 +270,8 @@ macro_rules! match_token_opt {
 ///   xform    ::= 'str'
 ///              | 'hex'
 ///              | 'base64' xmod?
-///              | 'bcs'
+///              | 'bcs' xmod?
+///              | 'json'
 ///              | 'timestamp'
 ///              | 'url'
 ///
@@ -947,6 +949,11 @@ impl<'s> Parser<'s> {
                 Transform::Hex
             },
 
+            Lit(_, T::Ident, _, "json") => {
+                self.lexer.next();
+                Transform::Json
+            },
+
             Lit(_, T::Ident, _, "str") => {
                 self.lexer.next();
                 Transform::Str
@@ -1001,13 +1008,13 @@ impl<'s> Parser<'s> {
 
 impl Base64Modifier {
     /// Use a standard Base64 encoding.
-    const EMPTY: Self = Self(0);
+    pub(crate) const EMPTY: Self = Self(0);
 
     /// Use the URL-safe character set.
-    const URL: Self = Self(1 << 1);
+    pub(crate) const URL: Self = Self(1 << 1);
 
     /// Don't add padding characters.
-    const NOPAD: Self = Self(1 << 2);
+    pub(crate) const NOPAD: Self = Self(1 << 2);
 
     pub fn standard(&self) -> bool {
         self.0 == Self::EMPTY.0
@@ -1205,6 +1212,7 @@ impl fmt::Debug for Transform {
             Transform::Base64(xmod) => write!(f, "base64{xmod:?}"),
             Transform::Bcs(xmod) => write!(f, "bcs{xmod:?}"),
             Transform::Hex => write!(f, "hex"),
+            Transform::Json => write!(f, "json"),
             Transform::Str => write!(f, "str"),
             Transform::Timestamp => write!(f, "ts"),
             Transform::Url => write!(f, "url"),

--- a/crates/sui-display/src/v2/writer.rs
+++ b/crates/sui-display/src/v2/writer.rs
@@ -5,19 +5,36 @@ use std::fmt;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
-/// A writer that tracks an output budget (measured in bytes) shared across multiple writers.
-/// Writes will fail once the total number of bytes sent to be written, across all writers, exceeds
-/// the maximum, and will continue to fail from there on out.
+use sui_types::object::rpc_visitor as RV;
+
+use crate::v2::error::FormatError;
+
+/// A writer of strings that tracks an output budget (measured in bytes) shared across multiple
+/// writers. Writes will fail once the total number of bytes sent to be written, across all
+/// writers, exceeds the maximum, and will continue to fail from there on out.
 ///
 /// Once a write is attempted, the budget is decremented, even if the write fails, meaning that the
 /// error is sticky and not recoverable.
-pub(crate) struct BoundedWriter<'u> {
+pub(crate) struct StringWriter<'u> {
     output: String,
     used: &'u AtomicUsize,
     max: usize,
 }
 
-impl<'u> BoundedWriter<'u> {
+/// A writer of structured JSON values that tracks an output budget (measured in bytes) shared
+/// across multiple writers. Writes will fail once the total number of bytes sent to be written,
+/// across all writers, exceeds the maximum, and will continue to fail from there on out.
+///
+/// Once a write is attempted, the budget is decremented, even if the write fails, meaning that the
+/// error is sticky and not recoverable.
+#[derive(Copy, Clone)]
+pub(crate) struct JsonWriter<'u> {
+    used_size: &'u AtomicUsize,
+    max_size: usize,
+    depth_budget: usize,
+}
+
+impl<'u> StringWriter<'u> {
     pub(crate) fn new(used: &'u AtomicUsize, max: usize) -> Self {
         Self {
             output: String::new(),
@@ -31,7 +48,106 @@ impl<'u> BoundedWriter<'u> {
     }
 }
 
-impl fmt::Write for BoundedWriter<'_> {
+impl<'u> JsonWriter<'u> {
+    pub(crate) fn new(used_size: &'u AtomicUsize, max_size: usize, depth_budget: usize) -> Self {
+        Self {
+            used_size,
+            max_size,
+            depth_budget,
+        }
+    }
+
+    fn debit(&self, size: usize) -> Result<(), FormatError> {
+        let prev = self.used_size.fetch_add(size, Ordering::Relaxed);
+        if prev + size > self.max_size {
+            return Err(FormatError::TooBig);
+        }
+        Ok(())
+    }
+}
+
+impl RV::Writer for JsonWriter<'_> {
+    type Value = serde_json::Value;
+    type Error = FormatError;
+
+    type Vec = Vec<Self::Value>;
+    type Map = serde_json::Map<String, Self::Value>;
+
+    type Nested<'a>
+        = JsonWriter<'a>
+    where
+        Self: 'a;
+
+    fn nest(&mut self) -> Result<Self::Nested<'_>, Self::Error> {
+        if self.depth_budget == 0 {
+            return Err(FormatError::TooDeep);
+        }
+
+        Ok(JsonWriter {
+            used_size: self.used_size,
+            max_size: self.max_size,
+            depth_budget: self.depth_budget - 1,
+        })
+    }
+
+    fn write_null(&mut self) -> Result<Self::Value, Self::Error> {
+        self.debit("null".len())?;
+        Ok(serde_json::Value::Null)
+    }
+
+    fn write_bool(&mut self, value: bool) -> Result<Self::Value, Self::Error> {
+        self.debit(if value { "true".len() } else { "false".len() })?;
+        Ok(serde_json::Value::Bool(value))
+    }
+
+    fn write_number(&mut self, value: u32) -> Result<Self::Value, Self::Error> {
+        self.debit(if value == 0 { 1 } else { value.ilog10() } as usize)?;
+        Ok(serde_json::Value::Number(value.into()))
+    }
+
+    fn write_str(&mut self, value: String) -> Result<Self::Value, Self::Error> {
+        // Account for the quotes around the string.
+        self.debit(2 + value.len())?;
+        Ok(serde_json::Value::String(value))
+    }
+
+    fn write_vec(&mut self, value: Self::Vec) -> Result<Self::Value, Self::Error> {
+        // Account for the opening bracket.
+        self.debit(1)?;
+        Ok(serde_json::Value::Array(value))
+    }
+
+    fn write_map(&mut self, value: Self::Map) -> Result<Self::Value, Self::Error> {
+        // Account for the opening brace.
+        self.debit(1)?;
+        Ok(serde_json::Value::Object(value))
+    }
+
+    fn vec_push_element(
+        &mut self,
+        vec: &mut Self::Vec,
+        val: Self::Value,
+    ) -> Result<(), Self::Error> {
+        // Account for comma (or closing bracket).
+        self.debit(1)?;
+        vec.push(val);
+        Ok(())
+    }
+
+    fn map_push_field(
+        &mut self,
+        map: &mut Self::Map,
+        key: String,
+        val: Self::Value,
+    ) -> Result<(), Self::Error> {
+        // Account for quotes, colon, and comma (or closing brace).
+        self.debit(4 + key.len())?;
+        map.insert(key, val);
+        Ok(())
+    }
+}
+
+impl fmt::Write for StringWriter<'_> {
     fn write_str(&mut self, s: &str) -> std::fmt::Result {
         let prev = self.used.fetch_add(s.len(), Ordering::Relaxed);
         if prev + s.len() > self.max {
@@ -51,7 +167,7 @@ mod tests {
     #[test]
     fn test_bounded_writer_under_limit() {
         let used = AtomicUsize::new(0);
-        let mut w = BoundedWriter::new(&used, 100);
+        let mut w = StringWriter::new(&used, 100);
 
         write!(w, "Hello").unwrap();
         write!(w, " ").unwrap();
@@ -64,7 +180,7 @@ mod tests {
     #[test]
     fn test_bounded_writer_at_limit() {
         let used = AtomicUsize::new(0);
-        let mut w = BoundedWriter::new(&used, 5);
+        let mut w = StringWriter::new(&used, 5);
 
         write!(w, "Hello").unwrap();
 
@@ -75,7 +191,7 @@ mod tests {
     #[test]
     fn test_bounded_writer_exceeds_limit() {
         let used = AtomicUsize::new(0);
-        let mut w = BoundedWriter::new(&used, 5);
+        let mut w = StringWriter::new(&used, 5);
 
         write!(w, "Hello").unwrap();
         write!(w, " World").unwrap_err();
@@ -86,12 +202,12 @@ mod tests {
     fn test_bounded_writer_shared_counter() {
         let used = AtomicUsize::new(0);
 
-        let mut w = BoundedWriter::new(&used, 20);
+        let mut w = StringWriter::new(&used, 20);
         write!(w, "First").unwrap();
         assert_eq!(w.finish(), "First");
         assert_eq!(used.load(Ordering::Relaxed), 5);
 
-        let mut w = BoundedWriter::new(&used, 20);
+        let mut w = StringWriter::new(&used, 20);
         write!(w, "Second").unwrap();
         assert_eq!(w.finish(), "Second");
         assert_eq!(used.load(Ordering::Relaxed), 11);
@@ -101,10 +217,10 @@ mod tests {
     fn test_bounded_writer_shared_counter_exceeds_limit() {
         let used = AtomicUsize::new(0);
 
-        let mut w = BoundedWriter::new(&used, 10);
+        let mut w = StringWriter::new(&used, 10);
         write!(w, "First").unwrap();
 
-        let mut w = BoundedWriter::new(&used, 10);
+        let mut w = StringWriter::new(&used, 10);
         write!(w, "Second").unwrap_err();
 
         assert!(used.load(Ordering::Relaxed) > 10);
@@ -113,7 +229,7 @@ mod tests {
     #[test]
     fn test_bounded_writer_sticky_error() {
         let used = AtomicUsize::new(0);
-        let mut writer = BoundedWriter::new(&used, 6);
+        let mut writer = StringWriter::new(&used, 6);
 
         write!(writer, "Hello").unwrap();
         write!(writer, " World").unwrap_err();
@@ -125,9 +241,9 @@ mod tests {
         let used = AtomicUsize::new(0);
         let limit = 20;
 
-        let mut w0 = BoundedWriter::new(&used, limit);
-        let mut w1 = BoundedWriter::new(&used, limit);
-        let mut w2 = BoundedWriter::new(&used, limit);
+        let mut w0 = StringWriter::new(&used, limit);
+        let mut w1 = StringWriter::new(&used, limit);
+        let mut w2 = StringWriter::new(&used, limit);
 
         write!(w0, "AAA").unwrap();
         write!(w1, "BBBB").unwrap();


### PR DESCRIPTION
## Description

Support outputting the (nested) JSON form of a Move value inside a Display string.

## Test plan

New unit tests:

```
$ cargo nextest run -p sui-display
```

## Stack

- #24601 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
