### PR TITLE
[1/n][sui-bridge][JSON RPC -> gRPC Migration] use gRPC for querying bridge events on sui

### DIFF
--- a/crates/sui-bridge/src/config.rs
+++ b/crates/sui-bridge/src/config.rs
@@ -91,6 +91,11 @@ pub struct SuiConfig {
     /// Otherwise, it will miss one event because of fullnode Event query semantics.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sui_bridge_module_last_processed_event_id_override: Option<EventID>,
+    /// Override the next sequence number for SuiSyncer
+    /// When set, SuiSyncer will start from this sequence number (exclusively) instead of the one in storage.
+    /// If the sequence number is not found in storage or override, the query will first fallback to the sequence number corresponding to the last processed EventID from the bridge module `bridge` (which in turn can be overridden via `sui_bridge_module_last_processed_event_id_override`) if available, otherwise fallback to 0.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sui_bridge_next_sequence_number_override: Option<u64>,
 }
 
 #[serde_as]
@@ -246,6 +251,10 @@ impl BridgeNodeConfig {
             sui_bridge_module_last_processed_event_id_override: self
                 .sui
                 .sui_bridge_module_last_processed_event_id_override,
+            sui_bridge_next_sequence_number_override: self
+                .sui
+                .sui_bridge_next_sequence_number_override,
+            sui_bridge_chain_id: self.sui.sui_bridge_chain_id,
         };
 
         info!("Config validation complete");
@@ -434,6 +443,8 @@ pub struct BridgeClientConfig {
     pub eth_contracts_start_block_fallback: u64,
     pub eth_contracts_start_block_override: Option<u64>,
     pub sui_bridge_module_last_processed_event_id_override: Option<EventID>,
+    pub sui_bridge_next_sequence_number_override: Option<u64>,
+    pub sui_bridge_chain_id: u8,
 }
 
 #[serde_as]

--- a/crates/sui-bridge/src/e2e_tests/test_utils.rs
+++ b/crates/sui-bridge/src/e2e_tests/test_utils.rs
@@ -813,6 +813,7 @@ pub(crate) async fn start_bridge_cluster(
                 bridge_client_key_path: None,
                 bridge_client_gas_object: None,
                 sui_bridge_module_last_processed_event_id_override: None,
+                sui_bridge_next_sequence_number_override: None,
             },
             metrics_key_pair: default_ed25519_key_pair(),
             metrics: None,

--- a/crates/sui-bridge/src/sui_client.rs
+++ b/crates/sui-bridge/src/sui_client.rs
@@ -405,6 +405,56 @@ where
             .get_gas_data_panic_if_not_gas(gas_object_id)
             .await
     }
+
+    pub async fn get_bridge_records_in_range(
+        &self,
+        source_chain_id: u8,
+        start_seq_num: u64,
+        end_seq_num: u64,
+    ) -> Result<Vec<(u64, MoveTypeBridgeRecord)>, BridgeError> {
+        self.inner
+            .get_bridge_records_in_range(source_chain_id, start_seq_num, end_seq_num)
+            .await
+    }
+
+    pub async fn get_token_transfer_next_seq_number(
+        &self,
+        source_chain_id: u8,
+    ) -> Result<u64, BridgeError> {
+        self.inner
+            .get_token_transfer_next_seq_number(source_chain_id)
+            .await
+    }
+
+    /// Temporary measure to get corresponding sequence number cursor from a Bridge Module EventID
+    pub async fn get_sequence_number_from_event_id(
+        &self,
+        event_id: EventID,
+    ) -> BridgeResult<Option<u64>> {
+        let events = self
+            .inner
+            .get_events_by_tx_digest(event_id.tx_digest)
+            .await?;
+
+        let event = events
+            .events
+            .get(event_id.event_seq as usize)
+            .ok_or(BridgeError::NoBridgeEventsInTxPosition)?;
+
+        if event.type_.address.as_ref() != BRIDGE_PACKAGE_ID.as_ref() {
+            return Ok(None);
+        }
+
+        let bridge_event = match SuiBridgeEvent::try_from_sui_event(event)? {
+            Some(e) => e,
+            None => return Ok(None),
+        };
+
+        match bridge_event {
+            SuiBridgeEvent::SuiToEthTokenBridgeV1(event) => Ok(Some(event.nonce)),
+            _ => Ok(None),
+        }
+    }
 }
 
 /// Use a trait to abstract over the SuiSDKClient and SuiMockClient for testing.
@@ -467,6 +517,18 @@ pub trait SuiClientInner: Send + Sync {
         &self,
         gas_object_id: ObjectID,
     ) -> (GasCoin, ObjectRef, Owner);
+
+    async fn get_bridge_records_in_range(
+        &self,
+        source_chain_id: u8,
+        start_seq_num: u64,
+        end_seq_num: u64,
+    ) -> Result<Vec<(u64, MoveTypeBridgeRecord)>, BridgeError>;
+
+    async fn get_token_transfer_next_seq_number(
+        &self,
+        source_chain_id: u8,
+    ) -> Result<u64, BridgeError>;
 }
 
 #[async_trait]
@@ -592,6 +654,22 @@ impl SuiClientInner for SuiSdkClient {
                 }
             }
         }
+    }
+
+    async fn get_bridge_records_in_range(
+        &self,
+        _source_chain_id: u8,
+        _start_seq_num: u64,
+        _end_seq_num: u64,
+    ) -> Result<Vec<(u64, MoveTypeBridgeRecord)>, BridgeError> {
+        unimplemented!("use gRPC implementation")
+    }
+
+    async fn get_token_transfer_next_seq_number(
+        &self,
+        _source_chain_id: u8,
+    ) -> Result<u64, BridgeError> {
+        unimplemented!("use gRPC implementation")
     }
 }
 
@@ -1026,6 +1104,35 @@ impl SuiClientInner for sui_rpc::Client {
             }
         }
     }
+
+    async fn get_bridge_records_in_range(
+        &self,
+        source_chain_id: u8,
+        start_seq_num: u64,
+        end_seq_num: u64,
+    ) -> Result<Vec<(u64, MoveTypeBridgeRecord)>, BridgeError> {
+        let mut records = Vec::new();
+        for seq_num in start_seq_num..=end_seq_num {
+            if let Some(record) = self.get_bridge_record(source_chain_id, seq_num).await? {
+                records.push((seq_num, record));
+            }
+        }
+        Ok(records)
+    }
+
+    async fn get_token_transfer_next_seq_number(
+        &self,
+        source_chain_id: u8,
+    ) -> Result<u64, BridgeError> {
+        let summary = self.get_bridge_summary().await?;
+        let seq_num = summary
+            .sequence_nums
+            .iter()
+            .find(|(chain_id, _)| *chain_id == source_chain_id)
+            .map(|(_, seq)| *seq)
+            .unwrap_or(0);
+        Ok(seq_num)
+    }
 }
 
 #[async_trait]
@@ -1133,6 +1240,26 @@ impl SuiClientInner for SuiClientInternal {
     ) -> (GasCoin, ObjectRef, Owner) {
         self.jsonrpc_client
             .get_gas_data_panic_if_not_gas(gas_object_id)
+            .await
+    }
+
+    async fn get_bridge_records_in_range(
+        &self,
+        source_chain_id: u8,
+        start_seq_num: u64,
+        end_seq_num: u64,
+    ) -> Result<Vec<(u64, MoveTypeBridgeRecord)>, BridgeError> {
+        self.grpc_client
+            .get_bridge_records_in_range(source_chain_id, start_seq_num, end_seq_num)
+            .await
+    }
+
+    async fn get_token_transfer_next_seq_number(
+        &self,
+        source_chain_id: u8,
+    ) -> Result<u64, BridgeError> {
+        self.grpc_client
+            .get_token_transfer_next_seq_number(source_chain_id)
             .await
     }
 }

--- a/crates/sui-bridge/src/sui_syncer.rs
+++ b/crates/sui-bridge/src/sui_syncer.rs
@@ -3,12 +3,20 @@
 
 //! The SuiSyncer module is responsible for synchronizing Events emitted
 //! on Sui blockchain from concerned modules of bridge package 0x9.
+//!
+//! There are two modes of operation:
+//! - Event-based (legacy): Uses JSON-RPC to query events by module
+//! - gRPC-based (new): Iterates over bridge records using LinkedTable iteration
+//!
+//! As of now, only the event-based mode is being used.
 
 use crate::{
     error::BridgeResult,
+    events::{EmittedSuiToEthTokenBridgeV1, SuiBridgeEvent},
     metrics::BridgeMetrics,
     retry_with_max_elapsed_time,
     sui_client::{SuiClient, SuiClientInner},
+    types::BridgeAction,
 };
 use mysten_metrics::spawn_logged_monitored_task;
 use std::{collections::HashMap, sync::Arc};
@@ -25,6 +33,8 @@ const SUI_EVENTS_CHANNEL_SIZE: usize = 1000;
 
 /// Map from contract address to their start cursor (exclusive)
 pub type SuiTargetModules = HashMap<Identifier, Option<EventID>>;
+
+pub type GrpcSyncedEvents = (u64, Vec<SuiBridgeEvent>);
 
 pub struct SuiSyncer<C> {
     sui_client: Arc<SuiClient<C>>,
@@ -152,6 +162,188 @@ where
             }
         }
     }
+
+    pub async fn run_grpc(
+        self,
+        source_chain_id: u8,
+        next_sequence_number: u64,
+        query_interval: Duration,
+        batch_size: u64,
+    ) -> BridgeResult<(
+        Vec<JoinHandle<()>>,
+        mysten_metrics::metered_channel::Receiver<GrpcSyncedEvents>,
+    )> {
+        let (events_tx, events_rx) = mysten_metrics::metered_channel::channel(
+            SUI_EVENTS_CHANNEL_SIZE,
+            &mysten_metrics::get_metrics()
+                .unwrap()
+                .channel_inflight
+                .with_label_values(&["sui_grpc_events_queue"]),
+        );
+
+        let task_handle = spawn_logged_monitored_task!(Self::run_grpc_listening_task(
+            source_chain_id,
+            next_sequence_number,
+            events_tx,
+            self.sui_client.clone(),
+            query_interval,
+            batch_size,
+            self.metrics.clone(),
+        ));
+
+        Ok((vec![task_handle], events_rx))
+    }
+
+    async fn run_grpc_listening_task(
+        source_chain_id: u8,
+        mut next_sequence_cursor: u64,
+        events_sender: mysten_metrics::metered_channel::Sender<GrpcSyncedEvents>,
+        sui_client: Arc<SuiClient<C>>,
+        query_interval: Duration,
+        batch_size: u64,
+        metrics: Arc<BridgeMetrics>,
+    ) {
+        tracing::info!(
+            source_chain_id,
+            next_sequence_cursor,
+            "Starting sui grpc records listening task"
+        );
+        let mut interval = time::interval(query_interval);
+        interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+
+        // Create a task to update metrics
+        let notify = Arc::new(Notify::new());
+        let notify_clone = notify.clone();
+        let sui_client_clone = sui_client.clone();
+        let chain_label = source_chain_id.to_string();
+        let last_synced_sui_checkpoints_metric = metrics
+            .last_synced_sui_checkpoints
+            .with_label_values(&[&chain_label]);
+        spawn_logged_monitored_task!(async move {
+            loop {
+                notify_clone.notified().await;
+                let Ok(Ok(latest_checkpoint_sequence_number)) = retry_with_max_elapsed_time!(
+                    sui_client_clone.get_latest_checkpoint_sequence_number(),
+                    Duration::from_secs(120)
+                ) else {
+                    tracing::error!(
+                        "Failed to query latest checkpoint sequence number from sui client after retry"
+                    );
+                    continue;
+                };
+                last_synced_sui_checkpoints_metric.set(latest_checkpoint_sequence_number as i64);
+            }
+        });
+
+        loop {
+            interval.tick().await;
+            let Ok(Ok(on_chain_next_sequence_index)) = retry_with_max_elapsed_time!(
+                sui_client.get_token_transfer_next_seq_number(source_chain_id),
+                Duration::from_secs(120)
+            ) else {
+                tracing::error!(
+                    source_chain_id,
+                    "Failed to get next seq num from sui client after retry"
+                );
+                continue;
+            };
+
+            // start querying from the next_sequence_cursor till on_chain_next_sequence_index in batches
+            let start_index = next_sequence_cursor;
+            if start_index >= on_chain_next_sequence_index {
+                notify.notify_one();
+                continue;
+            }
+
+            let end_index = std::cmp::min(
+                start_index + batch_size - 1,
+                on_chain_next_sequence_index - 1,
+            );
+
+            let Ok(Ok(records)) = retry_with_max_elapsed_time!(
+                sui_client.get_bridge_records_in_range(source_chain_id, start_index, end_index),
+                Duration::from_secs(120)
+            ) else {
+                tracing::error!(
+                    source_chain_id,
+                    start_index,
+                    end_index,
+                    "Failed to get records from sui client after retry"
+                );
+                continue;
+            };
+
+            let len = records.len();
+            if len != 0 {
+                let mut events = Vec::with_capacity(len);
+                let mut batch_last_sequence_index = start_index;
+
+                for (seq_index, record) in records {
+                    let event = match Self::bridge_record_to_event(&record, source_chain_id) {
+                        Ok(event) => event,
+                        Err(e) => {
+                            tracing::error!(
+                                source_chain_id,
+                                seq_index,
+                                "Failed to convert record to event: {:?}",
+                                e
+                            );
+                            continue;
+                        }
+                    };
+
+                    events.push(event);
+                    batch_last_sequence_index = seq_index;
+                }
+
+                if !events.is_empty() {
+                    events_sender
+                        .send((batch_last_sequence_index + 1, events))
+                        .await
+                        .expect("Bridge events channel receiver is closed");
+
+                    next_sequence_cursor = batch_last_sequence_index + 1;
+                    tracing::info!(
+                        source_chain_id,
+                        last_processed_seq = batch_last_sequence_index,
+                        next_sequence_cursor,
+                        "Processed {len} bridge records"
+                    );
+                }
+            }
+
+            if end_index >= on_chain_next_sequence_index - 1 {
+                // we have processed all records up to the latest checkpoint
+                // so we can update the latest checkpoint metric
+                notify.notify_one();
+            }
+        }
+    }
+
+    fn bridge_record_to_event(
+        record: &sui_types::bridge::MoveTypeBridgeRecord,
+        source_chain_id: u8,
+    ) -> Result<SuiBridgeEvent, crate::error::BridgeError> {
+        let action = BridgeAction::try_from_bridge_record(record)?;
+
+        match action {
+            BridgeAction::SuiToEthTokenTransfer(transfer) => Ok(
+                SuiBridgeEvent::SuiToEthTokenBridgeV1(EmittedSuiToEthTokenBridgeV1 {
+                    nonce: transfer.nonce,
+                    sui_chain_id: transfer.sui_chain_id,
+                    eth_chain_id: transfer.eth_chain_id,
+                    sui_address: transfer.sui_address,
+                    eth_address: transfer.eth_address,
+                    token_id: transfer.token_id,
+                    amount_sui_adjusted: transfer.amount_adjusted,
+                }),
+            ),
+            _ => Err(crate::error::BridgeError::Generic(format!(
+                "Unexpected action type for source_chain_id {}: {:?}",
+                source_chain_id, action
+            ))),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -161,6 +353,7 @@ mod tests {
     use crate::{sui_client::SuiClient, sui_mock_client::SuiMockClient};
     use prometheus::Registry;
     use sui_json_rpc_types::EventPage;
+    use sui_types::bridge::{BridgeChainId, MoveTypeBridgeMessage, MoveTypeBridgeRecord};
     use sui_types::{Identifier, digests::TransactionDigest, event::EventID};
     use tokio::time::timeout;
 
@@ -261,9 +454,9 @@ mod tests {
         Ok(())
     }
 
-    async fn assert_no_more_events(
+    async fn assert_no_more_events<T: std::fmt::Debug>(
         interval: Duration,
-        events_rx: &mut mysten_metrics::metered_channel::Receiver<(Identifier, Vec<SuiEvent>)>,
+        events_rx: &mut mysten_metrics::metered_channel::Receiver<T>,
     ) {
         match timeout(interval * 2, events_rx.recv()).await {
             Err(_e) => (),
@@ -278,5 +471,120 @@ mod tests {
         events: EventPage,
     ) {
         mock.add_event_response(BRIDGE_PACKAGE_ID, module.clone(), cursor, events.clone());
+    }
+
+    /// Creates a test bridge record with valid BCS-encoded payload
+    fn create_test_bridge_record(
+        seq_num: u64,
+        source_chain: BridgeChainId,
+        target_chain: BridgeChainId,
+        amount: u64,
+    ) -> MoveTypeBridgeRecord {
+        // Create the payload struct matching SuiToEthOnChainBcsPayload
+        #[derive(serde::Serialize)]
+        struct TestPayload {
+            sui_address: Vec<u8>,
+            target_chain: u8,
+            eth_address: Vec<u8>,
+            token_type: u8,
+            amount: [u8; 8],
+        }
+
+        let payload = TestPayload {
+            sui_address: vec![0u8; 32], // 32-byte SuiAddress
+            target_chain: target_chain as u8,
+            eth_address: vec![0u8; 20], // 20-byte EthAddress
+            token_type: 1,              // SUI token
+            amount: amount.to_be_bytes(),
+        };
+
+        let payload_bytes = bcs::to_bytes(&payload).unwrap();
+
+        MoveTypeBridgeRecord {
+            message: MoveTypeBridgeMessage {
+                message_type: 0, // TokenTransfer
+                message_version: 1,
+                seq_num,
+                source_chain: source_chain as u8,
+                payload: payload_bytes,
+            },
+            verified_signatures: None,
+            claimed: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sui_syncer_grpc_basic() -> anyhow::Result<()> {
+        telemetry_subscribers::init_for_testing();
+        let registry = Registry::new();
+        mysten_metrics::init_metrics(&registry);
+        let metrics = Arc::new(BridgeMetrics::new(&registry));
+        let mock = SuiMockClient::default();
+        let client = Arc::new(SuiClient::new_for_testing(mock.clone()));
+
+        let source_chain_id = BridgeChainId::SuiCustom as u8;
+        let target_modules = HashMap::new(); // Not used for gRPC mode
+
+        let interval = Duration::from_millis(200);
+        let batch_size = 10;
+        let next_sequence_number = 0;
+
+        // Initially, no records on chain
+        mock.set_next_seq_num(source_chain_id, 0);
+
+        let (_handles, mut events_rx) =
+            SuiSyncer::new(client.clone(), target_modules.clone(), metrics.clone())
+                .run_grpc(source_chain_id, next_sequence_number, interval, batch_size)
+                .await
+                .unwrap();
+
+        // Initially there are no records
+        assert_no_more_events(interval, &mut events_rx).await;
+
+        mock.set_latest_checkpoint_sequence_number(1000);
+
+        // Add some bridge records
+        let record_0 =
+            create_test_bridge_record(0, BridgeChainId::SuiCustom, BridgeChainId::EthCustom, 1000);
+        let record_1 =
+            create_test_bridge_record(1, BridgeChainId::SuiCustom, BridgeChainId::EthCustom, 2000);
+
+        mock.add_bridge_record(source_chain_id, 0, record_0);
+        mock.add_bridge_record(source_chain_id, 1, record_1);
+        mock.set_next_seq_num(source_chain_id, 2); // 2 records available (0 and 1)
+
+        let (next_cursor, received_events) = events_rx.recv().await.unwrap();
+        assert_eq!(received_events.len(), 2);
+        assert_eq!(next_cursor, 2); // Next sequence number to process
+
+        match &received_events[0] {
+            SuiBridgeEvent::SuiToEthTokenBridgeV1(event) => {
+                assert_eq!(event.nonce, 0);
+                assert_eq!(event.sui_chain_id, BridgeChainId::SuiCustom);
+                assert_eq!(event.eth_chain_id, BridgeChainId::EthCustom);
+                assert_eq!(event.amount_sui_adjusted, 1000);
+            }
+            _ => panic!("Expected SuiToEthTokenBridgeV1 event"),
+        }
+        match &received_events[1] {
+            SuiBridgeEvent::SuiToEthTokenBridgeV1(event) => {
+                assert_eq!(event.nonce, 1);
+                assert_eq!(event.amount_sui_adjusted, 2000);
+            }
+            _ => panic!("Expected SuiToEthTokenBridgeV1 event"),
+        }
+
+        // No more events should be received
+        assert_no_more_events(interval, &mut events_rx).await;
+        assert_eq!(
+            metrics
+                .last_synced_sui_checkpoints
+                .get_metric_with_label_values(&[&source_chain_id.to_string()])
+                .unwrap()
+                .get(),
+            1000
+        );
+
+        Ok(())
     }
 }

--- a/crates/sui-bridge/src/utils.rs
+++ b/crates/sui-bridge/src/utils.rs
@@ -207,6 +207,7 @@ pub fn generate_bridge_node_config_and_write_to_file(
             bridge_client_key_path: None,
             bridge_client_gas_object: None,
             sui_bridge_module_last_processed_event_id_override: None,
+            sui_bridge_next_sequence_number_override: None,
         },
         eth: EthConfig {
             eth_rpc_url: "your_eth_rpc_url".to_string(),

--- a/crates/sui-types/src/bridge.rs
+++ b/crates/sui-types/src/bridge.rs
@@ -481,7 +481,7 @@ pub struct MoveTypeBridgeTransferRecord {
 }
 
 /// Rust version of the Move message::BridgeMessage type.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct MoveTypeBridgeMessage {
     pub message_type: u8,
     pub message_version: u8,
@@ -491,7 +491,7 @@ pub struct MoveTypeBridgeMessage {
 }
 
 /// Rust version of the Move message::BridgeMessage type.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct MoveTypeBridgeRecord {
     pub message: MoveTypeBridgeMessage,
     pub verified_signatures: Option<Vec<Vec<u8>>>,


### PR DESCRIPTION
## Description 

The gRPC API doesn't support querying for events directly, so I have modified the strategy for sui_syncer to use the linked table records to query for bridge events.

Changes: 

### sui_client
  - 2 new traits on sui_client:
    - get_bridge_records_in_range
    - get_token_transfer_next_seq_number
  - temporary method to get the sequence_number from a given bridge deposit event ID (to migrate from eventID cursor to new cursor on first gRPC run
    - get_sequence_number_from_event_id

### storage
  - add new DBMap for storing current sequence number cursor
  - add getter / setter for it

### sui_syncer
 - add new grpc implementations for `run` and `run_listening_task`
 - add new channel for sending grpc events to orchestrator

### orchestrator
 - add new channel for listening to grpc events from sui_syncer
 - add new grpc implementations for `run` and `run_sui_watcher`

### node
 - add mock channel for grpc events (between orchestrator and sui_syncer)
 - full migration in #24639 

## Test plan 

How did you test the new or updated feature?

- Add unit tests for grpc implementations in:
  - orchestrator
  - sui_syncer
  - storage

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
