### PR TITLE
Retry tx submission after reconfiguration

### DIFF
--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -3839,12 +3839,6 @@ impl AuthorityState {
             .map_err(|_| SuiErrorKind::ValidatorHaltedAtEpochEnd.into())
     }
 
-    /// When a ValidatorHaltedAtEpochEnd error occurs, you can call this to wait until the next
-    /// epoch begins.
-    pub async fn wait_for_reconfiguration_to_finish(&self) -> ExecutionLockReadGuard<'_> {
-        self.execution_lock.read().await
-    }
-
     pub async fn execution_lock_for_reconfiguration(&self) -> ExecutionLockWriteGuard<'_> {
         self.execution_lock.write().await
     }
@@ -3943,7 +3937,7 @@ impl AuthorityState {
         Ok(new_epoch_store)
     }
 
-    pub fn notify_epoch(&self, new_epoch: EpochId) {
+    fn notify_epoch(&self, new_epoch: EpochId) {
         self.notify_epoch.send_modify(|epoch| *epoch = new_epoch);
     }
 

--- a/crates/sui-core/src/authority_server.rs
+++ b/crates/sui-core/src/authority_server.rs
@@ -631,24 +631,20 @@ impl ValidatorService {
                         debug!(
                             "ValidatorHaltedAtEpochEnd. Will retry after validator reconfigures"
                         );
-                        match timeout(Duration::from_secs(15), state.wait_for_epoch(next_epoch))
-                            .await
-                        {
-                            Ok(Ok(new_epoch)) => {
-                                assert_reachable!("retry submission at epoch end");
-                                if new_epoch == next_epoch {
-                                    continue;
-                                }
 
-                                debug_fatal!(
-                                    "expected epoch {} after reconfiguration. got {}",
-                                    next_epoch,
-                                    new_epoch
-                                );
+                        if let Ok(Ok(new_epoch)) =
+                            timeout(Duration::from_secs(15), state.wait_for_epoch(next_epoch)).await
+                        {
+                            assert_reachable!("retry submission at epoch end");
+                            if new_epoch == next_epoch {
+                                continue;
                             }
-                            // Fall through on either timeout or `wait_for_epoch` error and reject
-                            // the request.
-                            Ok(Err(_err)) | Err(_) => {}
+
+                            debug_fatal!(
+                                "expected epoch {} after reconfiguration. got {}",
+                                next_epoch,
+                                new_epoch
+                            );
                         }
                     }
                     return Err(err.into());


### PR DESCRIPTION
This helps eliminate test failures due to repeated transaction submission timeouts, and should increase submission reliability in production as well.
