### PR TITLE
Fix arith bench and disable vector for now

### DIFF
--- a/external-crates/move/crates/language-benchmarks/benches/criterion.rs
+++ b/external-crates/move/crates/language-benchmarks/benches/criterion.rs
@@ -63,8 +63,8 @@ criterion_group!(
         loops,
         natives,
         transfers,
-        vector,
         cross_module,
+        // vector,
 );
 
 criterion_main!(vm_benches);

--- a/external-crates/move/crates/language-benchmarks/tests/arith.move
+++ b/external-crates/move/crates/language-benchmarks/tests/arith.move
@@ -2,6 +2,10 @@ module 0x1::bench {
     const COUNT: u64 = 10_000u64;
     const MAX_U64: u64 = 18446744073709551615;
 
+    fun check(check: bool, code: u64) {
+        if (check) () else abort code
+    }
+
     public fun bench_add() {
         let mut sum = 0;
         let mut i = 0;


### PR DESCRIPTION
## Description 

The vector benchmark does not run due to missing dep invariant violation. We'll investigate and fix later.

```
thread 'main' panicked at sui/external-crates/move/crates/language-benchmarks/src/move_vm.rs:161:10:
called `Result::unwrap()` on an `Err` value: VMError { major_status: MISSING_DEPENDENCY, sub_status: None, message: None, exec_state: None, location: Package(0000000000000000000000000000000000000000000000000000000000000001), indices: [], offsets: [] }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## Test plan 

cargo bench -- --warm-up-time=1 --measurement-time=1

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
