### PR TITLE
[sui-indexer-alt] flakey `test_tasked_pipelines_skip_checkpoints_trailing_main_reader_lo`

### DIFF
--- a/crates/sui-indexer-alt-framework/src/metrics.rs
+++ b/crates/sui-indexer-alt-framework/src/metrics.rs
@@ -517,7 +517,7 @@ impl IndexerMetrics {
             ).unwrap(),
             collector_reader_lo: register_int_gauge_vec_with_registry!(
                 name("collector_reader_lo"),
-                "Reader lo watermark as observed by the collector",
+                "Reader low watermark as observed by the collector",
                 &["pipeline"],
                 registry,
             )

--- a/crates/sui-indexer-alt-framework/src/pipeline/concurrent/collector.rs
+++ b/crates/sui-indexer-alt-framework/src/pipeline/concurrent/collector.rs
@@ -185,10 +185,6 @@ pub(super) fn collector<H: Handler + 'static>(
                     // Clear the values of outdated checkpoints, so that we don't commit data to the
                     // store, but can still advance watermarks.
                     let reader_lo = main_reader_lo.wait().await.load(Ordering::Relaxed);
-                    metrics
-                        .collector_reader_lo
-                        .with_label_values(&[H::NAME])
-                        .set(reader_lo as i64);
                     if indexed.checkpoint() < reader_lo {
                         indexed.values.clear();
                         metrics.total_collector_skipped_checkpoints
@@ -204,6 +200,10 @@ pub(super) fn collector<H: Handler + 'static>(
                         .total_collector_checkpoints_received
                         .with_label_values(&[H::NAME])
                         .inc();
+                    metrics
+                        .collector_reader_lo
+                        .with_label_values(&[H::NAME])
+                        .set(reader_lo as i64);
 
                     pending_rows += indexed.len();
                     pending.insert(indexed.checkpoint(), indexed.into());


### PR DESCRIPTION
## Description 

Fix flakiness in `test_tasked_pipelines_skip_checkpoints_trailing_main_reader_lo` by replacing a timing-dependent sleep with metric-based synchronization. The test now uses real time instead of paused time because the collector "advances" not on time jumps but on receiving checkpoints from the processor. In paused time, we would end up allowing all checkpoints to be processed near instantly, preventing the collector from having enough time to pick up the new reader_lo value.

When a tasked pipeline's collector observes a new reader_lo, it correctly:
  - Commits checkpoints >= reader_lo
  - Skips in-flight checkpoints < reader_lo

The previous approach used a 1-second sleep after setting reader_lo. Instead, the following changes have been made:

1.  Added collector_reader_lo metric - Tracks the reader_lo value as observed by the collector (not just what's in the atomic). This gives us visibility into what the collector is actually using for filtering.
2. Loop-based synchronization - Instead of sleeping, the test:
 - Sets reader_lo = 250 in the DB
 - Releases checkpoints one at a time (11, 12, 13...)
 -  Monitors collector_reader_lo metric until it shows 250
 - Then releases all remaining checkpoints
3. New asserts:
 - `[0, 10]`: committed (baseline, before reader_lo was set)
 - (allow_process, 250): skipped (in-flight, filtered after collector observed reader_lo)
 - `[250, 500]`: committed (>= reader_lo)

## Test plan 

Existing test passes multiple runs locally

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
