### PR TITLE
refactor: simplify write_chain_identifier mappings update

### DIFF
--- a/crates/sui-data-store/src/stores/filesystem.rs
+++ b/crates/sui-data-store/src/stores/filesystem.rs
@@ -772,9 +772,9 @@ impl FileSystemStore {
 
         // Update or add the mapping for this node
         let mut found = false;
-        for (node, _) in &mut mappings {
+        for (node, existing_chain_id) in &mut mappings {
             if node == node_key {
-                *node = node_key.to_string();
+                *existing_chain_id = chain_id.clone();
                 found = true;
                 break;
             }
@@ -782,14 +782,6 @@ impl FileSystemStore {
 
         if !found {
             mappings.push((node_key.to_string(), chain_id.clone()));
-        } else {
-            // Update the existing mapping
-            for (node, existing_chain_id) in &mut mappings {
-                if node == node_key {
-                    *existing_chain_id = chain_id.clone();
-                    break;
-                }
-            }
         }
 
         // Write the updated mappings back to the file


### PR DESCRIPTION
This change removes a redundant first loop over the mappings vector in write_chain_identifier and merges the “update or add” logic into a single pass. The previous loop only reassigned node to the same value when node == node_key, so it had no effect on the actual data and existed solely to set the found flag.

The new implementation updates existing_chain_id in one loop, sets found when an entry is updated, and appends a new (node_key, chain_id) pair if no existing entry is found. This keeps the external behavior identical while eliminating dead code and an unnecessary extra traversal.