### PR TITLE
fix: correct IPv6 port checks in multiaddr tests

### DIFF
--- a/crates/mysten-network/src/multiaddr.rs
+++ b/crates/mysten-network/src/multiaddr.rs
@@ -493,7 +493,7 @@ mod test {
         ))
         .with_zero_ip();
         assert_eq!(Some("::".to_string()), multi_addr_ip6.hostname());
-        assert_eq!(Some(10500u16), multi_addr_ip4.port());
+        assert_eq!(Some(10500u16), multi_addr_ip6.port());
 
         let multi_addr_dns = Multiaddr(multiaddr!(Dns("mysten.sui"), Tcp(10501u16))).with_zero_ip();
         assert_eq!(Some("0.0.0.0".to_string()), multi_addr_dns.hostname());
@@ -513,7 +513,7 @@ mod test {
         ))
         .with_localhost_ip();
         assert_eq!(Some("::1".to_string()), multi_addr_ip6.hostname());
-        assert_eq!(Some(10500u16), multi_addr_ip4.port());
+        assert_eq!(Some(10500u16), multi_addr_ip6.port());
 
         let multi_addr_dns =
             Multiaddr(multiaddr!(Dns("mysten.sui"), Tcp(10501u16))).with_localhost_ip();


### PR DESCRIPTION
The tests for with_zero_ip and with_localhost_ip were incorrectly asserting the TCP port on the IPv4 multiaddr even in the IPv6 sections, leaving the IPv6 port effectively untested. This change updates those assertions to use multi_addr_ip6.port(), ensuring the intended behavior of preserving the port for IPv6 addresses is actually verified by the tests.