### PR TITLE
sui-indexer-alt: improve error message for pg/kv eventual consistency error

### DIFF
--- a/crates/sui-indexer-alt-jsonrpc/src/data.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/data.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::time::Duration;
 
-use anyhow::Context as _;
+use anyhow::{Context as _, ensure};
 use serde::de::DeserializeOwned;
 use sui_indexer_alt_reader::object_versions::LatestObjectVersionKey;
 use sui_types::base_types::ObjectID;
@@ -59,6 +59,11 @@ pub(crate) async fn load_live(
         .with_label_values(&["kv_object"])
         .observe(retries as f64);
 
+    // Data exists in PG, but not KV yet.
+    ensure!(
+        object.is_some(),
+        "Eventual consistency discrepancy, try again later"
+    );
     Ok(object)
 }
 


### PR DESCRIPTION
## Description 

Before this PR, the error message does not distinguish between records not found in Postgres and records found in Postgres, but not KV:
```
2025-12-16T16:30:47.857516Z ERROR sui_indexer_alt_jsonrpc::metrics::middleware: Request failed with internal error method="suix_getLatestSuiSystemState" params="[]" code=-32603 response="{\"jsonrpc\":\"2.0\",\"id\":379775,\"error\":{\"code\":-32603,\"message\":\"Internal Error: Failed to fetch system state wrapper object: No data found\"}}" elapsed_ms=1006.9102059999999 
```

This PR improves the error message when the record is found in Postgres, but not KV.

## Test plan 

This code is currently untested until kv simulation is added.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
