### PR TITLE
Disable fullnode pruning for test_get_objects_read

### DIFF
--- a/crates/sui-e2e-tests/tests/full_node_tests.rs
+++ b/crates/sui-e2e-tests/tests/full_node_tests.rs
@@ -969,7 +969,10 @@ async fn get_past_obj_read_from_node(
 #[sim_test]
 async fn test_get_objects_read() -> Result<(), anyhow::Error> {
     telemetry_subscribers::init_for_testing();
-    let test_cluster = TestClusterBuilder::new().build().await;
+    let test_cluster = TestClusterBuilder::new()
+        .disable_fullnode_pruning()
+        .build()
+        .await;
     let rgp = test_cluster.get_reference_gas_price().await;
     let node = &test_cluster.fullnode_handle.sui_node;
     let package_id = publish_nfts_package(&test_cluster.wallet).await.0;


### PR DESCRIPTION
Otherwise test is flaky (object can be pruned before read)
