### PR TITLE
Use cfg gated TRACING_ENABLED inside macro

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/execution/tracing/mod.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/execution/tracing/mod.rs
@@ -26,10 +26,8 @@ pub(crate) const TRACING_ENABLED: bool = false;
 
 macro_rules! trace {
     ($tracer:expr, |$param:ident| $body:expr) => {
-        if crate::execution::tracing::TRACING_ENABLED {
-            if let Some($param) = $tracer.as_mut() {
-                $body
-            }
+        if crate::execution::tracing::TRACING_ENABLED && let Some($param) = $tracer.as_mut() {
+            $body
         }
     };
 }


### PR DESCRIPTION
## Description 
As per @cgswords , with TRACING_ENABLED...
```
We are isolating their usage, while also generalizing the design: other parts of the crate can check if tracing is enabled without going through that code path. Here the macro is the only thing that even knows, and it is selected under Rust’s bizarre cfg rules.
```
## Test plan 

output of nm.

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
