### PR TITLE
chore(indexer-alt): avoid unnecessary HeaderMap clone

### DIFF
--- a/crates/sui-indexer-alt-jsonrpc/src/config.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/config.rs
@@ -303,7 +303,7 @@ impl NodeConfig {
 
         HttpClientBuilder::default()
             .max_request_size(self.max_request_size)
-            .set_headers(headers.clone())
+            .set_headers(headers)
             .build(&fullnode_rpc_url)
             .context("Failed to initialize fullnode RPC client")
     }


### PR DESCRIPTION
NodeConfig::client was cloning a freshly created HeaderMap before passing it to HttpClientBuilder::set_headers. The builder takes ownership of the HeaderMap, and the local variable is not used afterwards, so the clone had no effect other than extra work. This change passes headers by value instead, keeping the behavior the same while removing redundant allocation and copy.