### PR TITLE
[consensus] remove redundant peer_hostname binding in handle_send_block

### DIFF
--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -178,7 +178,6 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
             info!("Block with wrong authority from {}: {}", peer, e);
             return Err(e);
         }
-        let peer_hostname = &self.context.committee.authority(peer).hostname;
 
         // Reject blocks failing validations.
         let (verified_block, reject_txn_votes) = self


### PR DESCRIPTION
Line ~163 and again ~181: let peer_hostname = &self.context.committee.authority(peer).hostname;
The handler was computing peer_hostname twice for the same peer in handle_send_block. This second binding did not change the value or fix any borrow/lifetime issue, and all metric/log uses can safely share the initial binding.