### PR TITLE
Perf: reuse fullnode HttpClient and remove redundant HeaderMap clones

### DIFF
--- a/crates/sui-indexer-alt-jsonrpc/src/api/coin.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/coin.rs
@@ -26,7 +26,6 @@ use sui_types::{
 };
 
 use crate::{
-    config::NodeConfig,
     context::Context,
     data::load_live,
     error::{InternalContext, RpcError, client_error_to_error_object, invalid_params},
@@ -111,9 +110,8 @@ struct BalanceCursor {
 type Cursor = BcsCursor<BalanceCursor>;
 
 impl DelegationCoins {
-    pub fn new(fullnode_rpc_url: url::Url, config: NodeConfig) -> anyhow::Result<Self> {
-        let client = config.client(fullnode_rpc_url)?;
-        Ok(Self(client))
+    pub(crate) fn new(client: HttpClient) -> Self {
+        Self(client)
     }
 }
 

--- a/crates/sui-indexer-alt-jsonrpc/src/api/governance.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/governance.rs
@@ -24,7 +24,6 @@ use sui_types::{
 };
 
 use crate::{
-    config::NodeConfig,
     context::Context,
     data::load_live_deserialized,
     error::{RpcError, client_error_to_error_object, rpc_bail},
@@ -67,9 +66,8 @@ pub(crate) struct Governance(pub Context);
 pub(crate) struct DelegationGovernance(HttpClient);
 
 impl DelegationGovernance {
-    pub fn new(fullnode_rpc_url: url::Url, config: NodeConfig) -> anyhow::Result<Self> {
-        let client = config.client(fullnode_rpc_url)?;
-        Ok(Self(client))
+    pub(crate) fn new(client: HttpClient) -> Self {
+        Self(client)
     }
 }
 

--- a/crates/sui-indexer-alt-jsonrpc/src/api/write.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/api/write.rs
@@ -10,10 +10,7 @@ use sui_open_rpc::Module;
 use sui_open_rpc_macros::open_rpc;
 use sui_types::quorum_driver_types::ExecuteTransactionRequestType;
 
-use crate::{
-    config::NodeConfig,
-    error::{client_error_to_error_object, invalid_params},
-};
+use crate::error::{client_error_to_error_object, invalid_params};
 
 use super::rpc_module::RpcModule;
 
@@ -54,9 +51,8 @@ pub enum Error {
 }
 
 impl Write {
-    pub fn new(fullnode_rpc_url: url::Url, config: NodeConfig) -> anyhow::Result<Self> {
-        let client = config.client(fullnode_rpc_url)?;
-        Ok(Self(client))
+    pub(crate) fn new(client: HttpClient) -> Self {
+        Self(client)
     }
 }
 

--- a/crates/sui-indexer-alt-jsonrpc/src/lib.rs
+++ b/crates/sui-indexer-alt-jsonrpc/src/lib.rs
@@ -285,15 +285,10 @@ pub async fn start_rpc(
     rpc.add_module(Transactions(context.clone()))?;
 
     if let Some(fullnode_rpc_url) = node_args.fullnode_rpc_url {
-        rpc.add_module(DelegationCoins::new(
-            fullnode_rpc_url.clone(),
-            context.config().node.clone(),
-        )?)?;
-        rpc.add_module(DelegationGovernance::new(
-            fullnode_rpc_url.clone(),
-            context.config().node.clone(),
-        )?)?;
-        rpc.add_module(Write::new(fullnode_rpc_url, context.config().node.clone())?)?;
+        let client = context.config().node.client(fullnode_rpc_url)?;
+        rpc.add_module(DelegationCoins::new(client.clone()))?;
+        rpc.add_module(DelegationGovernance::new(client.clone()))?;
+        rpc.add_module(Write::new(client))?;
     } else {
         warn!(
             "No fullnode rpc url provided, DelegationCoins, DelegationGovernance, and Write modules will not be added."

--- a/crates/sui-indexer/src/lib.rs
+++ b/crates/sui-indexer/src/lib.rs
@@ -81,7 +81,7 @@ fn get_http_client(rpc_client_url: &str) -> Result<HttpClient, IndexerError> {
 
     HttpClientBuilder::default()
         .max_request_size(2 << 30)
-        .set_headers(headers.clone())
+        .set_headers(headers)
         .build(rpc_client_url)
         .map_err(|e| {
             warn!("Failed to get new Http client with error: {:?}", e);

--- a/crates/sui-sdk/src/lib.rs
+++ b/crates/sui-sdk/src/lib.rs
@@ -275,7 +275,7 @@ impl SuiClientBuilder {
 
         let mut http_builder = HttpClientBuilder::default()
             .max_request_size(2 << 30)
-            .set_headers(headers.clone())
+            .set_headers(headers)
             .request_timeout(self.request_timeout);
 
         if let Some(max_concurrent_requests) = self.max_concurrent_requests {


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.
- Replace redundant set_headers(headers.clone()) with set_headers(headers) where applicable.
- In sui-sdk, move headers into the HTTP client builder and only clone for the optional WS client.
- In sui-indexer-alt-jsonrpc, build the fullnode HttpClient once in start_rpc and reuse it across DelegationCoins, DelegationGovernance, and Write.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
