### PR TITLE
chore: remove duplicate async_trait attribute in tests

### DIFF
--- a/consensus/core/src/round_prober.rs
+++ b/consensus/core/src/round_prober.rs
@@ -310,7 +310,6 @@ mod test {
     }
 
     #[async_trait]
-    #[async_trait::async_trait]
     impl NetworkClient for FakeNetworkClient {
         async fn send_block(
             &self,


### PR DESCRIPTION
The FakeNetworkClient test implementation in round_prober.rs was annotated with both #[async_trait] and #[async_trait::async_trait]. This double expansion is not intended, is inconsistent with the rest of the codebase, and may become brittle with future async_trait updates. Keep a single #[async_trait] attribute to match the prevailing style in consensus core tests.