### PR TITLE
fix(bridge-cli): remove duplicate committee() call in LoadedBridgeCliConfig

### DIFF
--- a/crates/sui-bridge-cli/src/lib.rs
+++ b/crates/sui-bridge-cli/src/lib.rs
@@ -457,7 +457,6 @@ impl LoadedBridgeCliConfig {
         let eth_bridge_limiter_proxy_address: EthAddress = sui_bridge.limiter().call().await?;
         let eth_committee =
             EthBridgeCommittee::new(eth_bridge_committee_proxy_address, provider.clone());
-        let eth_bridge_committee_proxy_address: EthAddress = sui_bridge.committee().call().await?;
         let eth_bridge_config_proxy_address: EthAddress = eth_committee.config().call().await?;
 
         let eth_address = eth_signer.address();


### PR DESCRIPTION
LoadedBridgeCliConfig::load was calling sui_bridge.committee().call().await? twice and shadowing eth_bridge_committee_proxy_address. This removed a dead assignment, an extra RPC call and a potential source of inconsistency between the committee and config addresses. The code now matches the pattern used in sui-bridge utils, using a single fetched committee address both to build EthBridgeCommittee and to store in the config.