### PR TITLE
perf: reuse raw_content in FileProgressStore::save

### DIFF
--- a/crates/sui-data-ingestion-core/src/progress_store/file.rs
+++ b/crates/sui-data-ingestion-core/src/progress_store/file.rs
@@ -36,7 +36,7 @@ impl ProgressStore for FileProgressStore {
         let mut content: Value = if raw_content.is_empty() {
             Value::Object(serde_json::Map::new())
         } else {
-            serde_json::from_slice(&std::fs::read(self.path.clone())?)?
+            serde_json::from_slice(&raw_content)?
         };
         content[task_name] = Value::Number(Number::from(checkpoint_number));
         std::fs::write(self.path.clone(), serde_json::to_string_pretty(&content)?)?;


### PR DESCRIPTION
Previously FileProgressStore::save was reading the same file twice: once into raw_content to check for emptiness and then again inside serde_json::from_slice. This added an extra system call, allocation and parse input without changing the observable behavior.

This change reuses the already read raw_content buffer when deserializing the existing JSON state. The logic for handling missing, empty or invalid files remains the same, but we avoid redundant work on every save call.