### PR TITLE
[move-ide] Better on-hover value display for string constants

### DIFF
--- a/external-crates/move/crates/move-analyzer/src/symbols/ide_strings.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols/ide_strings.rs
@@ -4,7 +4,10 @@
 //! This module contains the implementation of functions supporting conversion of various
 //! constructs to their IDE-friendly string representations.
 
-use crate::symbols::def_info::{FunType, VariantInfo};
+use crate::{
+    compiler_info::CompilerAnalysisInfo,
+    symbols::def_info::{FunType, VariantInfo},
+};
 use move_compiler::{
     expansion::{
         ast::{self as E, AbilitySet, ModuleIdent_, Value, Value_, Visibility},
@@ -186,7 +189,13 @@ pub fn ret_type_to_ide_str(ret_type: &Type, verbose: bool) -> String {
 }
 /// Conversions of constant values to strings is currently best-effort which is why this function
 /// returns an Option (in the worst case we will display constant name and type but no value).
-pub fn const_val_to_ide_string(exp: &Exp) -> Option<String> {
+pub fn const_val_to_ide_string(
+    exp: &Exp,
+    compiler_analysis_info: &CompilerAnalysisInfo,
+) -> Option<String> {
+    if let Some(string) = compiler_analysis_info.string_values.get(&exp.exp.loc) {
+        return Some(string.clone());
+    }
     ast_exp_to_ide_string(exp)
 }
 

--- a/external-crates/move/crates/move-analyzer/tests/consts.snap
+++ b/external-crates/move/crates/move-analyzer/tests/consts.snap
@@ -40,7 +40,7 @@ Use: 'BYTES', start: 10, end: 15
 Def: 'BYTES', line: 10, def char: 10
 TypeDef: no info
 On Hover:
-const Symbols::M8::BYTES: vector<u8> = [104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]
+const Symbols::M8::BYTES: vector<u8> = b"hello world"
 
 -- test 5 -------------------
 use line: 13, use_ndx: 0
@@ -48,7 +48,7 @@ Use: 'HEX_BYTES', start: 10, end: 19
 Def: 'HEX_BYTES', line: 12, def char: 10
 TypeDef: no info
 On Hover:
-const Symbols::M8::HEX_BYTES: vector<u8> = [222, 173, 190, 239]
+const Symbols::M8::HEX_BYTES: vector<u8> = x"DEADBEEF"
 
 -- test 6 -------------------
 use line: 15, use_ndx: 0

--- a/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
+++ b/external-crates/move/crates/move-analyzer/tests/ide_testsuite.rs
@@ -573,7 +573,7 @@ fn use_def_test_suite<F: MoveFlavor>(
             // We do incremental compilation only for the first file in the test suite.
             // The results for remaining files should still be correct due to all symbols
             // being computed during the initial full compilation at suite level, and
-            // due to merging of symbols from modified and unmofdified files
+            // due to merging of symbols from modified and unmodified files
             // (which is what it is being tested here).
 
             let original = std::fs::read_to_string(&cpath)?;


### PR DESCRIPTION
## Description 

What the subject says. Before, for byte vectors that are defined in source code using strings we were displaying byte values due to loss of some information during compilation:

<img width="1850" height="154" alt="image" src="https://github.com/user-attachments/assets/ecd80c69-6b3d-42fd-9893-b35f0f13e222" />

When the compiler was modified to preserve the necessary data (https://github.com/MystenLabs/sui/pull/24645), we could fix this in `move-analyzer` as well:

<img width="1850" height="158" alt="image" src="https://github.com/user-attachments/assets/f7faec5d-2d50-4ef7-8332-92be42292a60" />



## Test plan 

Test output has been updated to reflect new display format. All tests must pass
