### PR TITLE
[rocksdb] enable fsync by default

### DIFF
--- a/consensus/core/src/storage/rocksdb_store.rs
+++ b/consensus/core/src/storage/rocksdb_store.rs
@@ -58,22 +58,17 @@ impl RocksDBStore {
     pub fn new(path: &str) -> Self {
         // Consensus data has high write throughput (all transactions) and is rarely read
         // (only during recovery and when helping peers catch up).
-        let db_options = default_db_options()
-            .optimize_db_for_write_throughput(2)
-            .set_sync_writes(true);
+        let db_options = default_db_options().optimize_db_for_write_throughput(2);
         let mut metrics_conf = MetricConf::new("consensus");
         metrics_conf.read_sample_interval = SamplingInterval::new(Duration::from_secs(60), 0);
-        let cf_options = default_db_options()
-            .optimize_for_write_throughput()
-            .set_sync_writes(true);
+        let cf_options = default_db_options().optimize_for_write_throughput();
         let column_family_options = DBMapTableConfigMap::new(BTreeMap::from([
             (
                 Self::BLOCKS_CF.to_string(),
                 default_db_options()
                     .optimize_for_write_throughput_no_deletion()
                     // Using larger block is ok since there is not much point reads on the cf.
-                    .set_block_options(512, 128 << 10)
-                    .set_sync_writes(true),
+                    .set_block_options(512, 128 << 10),
             ),
             (
                 Self::DIGESTS_BY_AUTHORITIES_CF.to_string(),

--- a/crates/typed-store/src/rocks/options.rs
+++ b/crates/typed-store/src/rocks/options.rs
@@ -58,11 +58,6 @@ impl ReadWriteOptions {
         self.log_value_hash = log_value_hash;
         self
     }
-
-    pub fn set_sync_writes(mut self, sync_writes: bool) -> Self {
-        self.sync_writes = sync_writes;
-        self
-    }
 }
 
 impl Default for ReadWriteOptions {
@@ -275,11 +270,6 @@ impl DBOptions {
         self.options.set_hard_pending_compaction_bytes_limit(0);
         self.options.set_level_zero_slowdown_writes_trigger(512);
         self.options.set_level_zero_stop_writes_trigger(1024);
-        self
-    }
-
-    pub fn set_sync_writes(mut self, sync_writes: bool) -> DBOptions {
-        self.rw_options.sync_writes = sync_writes;
         self
     }
 


### PR DESCRIPTION
## Description 

Avoid db corruptions on restart.

## Test plan 

Load test in PT show acceptable latency increase under high throughput load.