### PR TITLE
[move-ide] Implemented server restart command

### DIFF
--- a/external-crates/move/crates/move-analyzer/editors/code/package-lock.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "move",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "move",
-      "version": "1.0.34",
+      "version": "1.0.35",
       "license": "Apache-2.0",
       "dependencies": {
         "command-exists": "^1.2.9",

--- a/external-crates/move/crates/move-analyzer/editors/code/package.json
+++ b/external-crates/move/crates/move-analyzer/editors/code/package.json
@@ -5,7 +5,7 @@
   "publisher": "mysten",
   "icon": "images/move.png",
   "license": "Apache-2.0",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "preview": true,
   "repository": {
     "url": "https://github.com/MystenLabs/sui.git",
@@ -35,6 +35,11 @@
       {
         "command": "move.serverVersion",
         "title": "Show Server Version",
+        "category": "Move"
+      },
+      {
+        "command": "move.serverRestart",
+        "title": "Restart Server",
         "category": "Move"
       },
       {

--- a/external-crates/move/crates/move-analyzer/editors/code/src/main.ts
+++ b/external-crates/move/crates/move-analyzer/editors/code/src/main.ts
@@ -36,6 +36,16 @@ async function serverVersion(context: Readonly<Context>): Promise<void> {
     }
 }
 
+/**
+ * An extension command that restarts the language server. Modeled
+ * after a similar command in `rust-analyzer`.
+ */
+async function serverRestart(context: Readonly<Context>): Promise<void> {
+    await context.stopClient();
+    await context.startClient();
+}
+
+
 async function findPkgRoot(): Promise<string | undefined> {
     const activeEditor = vscode.window.activeTextEditor;
     if (!activeEditor) {
@@ -159,6 +169,7 @@ export async function activate(extensionContext: Readonly<vscode.ExtensionContex
 
     // Register handlers for VS Code commands that the user explicitly issues.
     context.registerCommand('serverVersion', serverVersion);
+    context.registerCommand('serverRestart', serverRestart);
     context.registerCommand('build', buildProject);
     context.registerCommand('test', testProject);
     context.registerCommand('trace', traceProject);


### PR DESCRIPTION
## Description 

Due to popular demand, implemented a command similar to the one available in `rust-analyzer` to restart the LSP server if it gets into a "funky" state

## Test plan 

Tested manually that the command indeed works
