### PR TITLE
Add missing call index column to move calls table

### DIFF
--- a/crates/sui-analytics-indexer/src/handlers/move_call_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/move_call_handler.rs
@@ -56,9 +56,10 @@ impl TransactionProcessor<MoveCallEntry> for MoveCallHandler {
         let transaction_digest = transaction.transaction.digest().base58_encode();
 
         let mut entries = Vec::new();
-        for (package, module, function) in move_calls.iter() {
+        for (cmd_idx, package, module, function) in move_calls.iter() {
             let entry = MoveCallEntry {
                 transaction_digest: transaction_digest.clone(),
+                cmd_idx: *cmd_idx as u64,
                 checkpoint: checkpoint_seq,
                 epoch,
                 timestamp_ms,

--- a/crates/sui-analytics-indexer/src/handlers/transaction_handler.rs
+++ b/crates/sui-analytics-indexer/src/handlers/transaction_handler.rs
@@ -69,7 +69,9 @@ impl TransactionProcessor<TransactionEntry> for TransactionHandler {
         let move_calls_vec = txn_data.move_calls();
         let packages: BTreeSet<_> = move_calls_vec
             .iter()
-            .map(|(package, _, _)| package.to_canonical_string(/* with_prefix */ false))
+            .map(|(_cmd_idx, package, _, _)| {
+                package.to_canonical_string(/* with_prefix */ false)
+            })
             .collect();
         let packages = packages
             .iter()

--- a/crates/sui-analytics-indexer/src/tables.rs
+++ b/crates/sui-analytics-indexer/src/tables.rs
@@ -226,6 +226,7 @@ pub(crate) struct TransactionObjectEntry {
 pub(crate) struct MoveCallEntry {
     // indexes
     pub(crate) transaction_digest: String,
+    pub(crate) cmd_idx: u64,
     pub(crate) checkpoint: u64,
     pub(crate) epoch: u64,
     pub(crate) timestamp_ms: u64,

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2989,7 +2989,7 @@ impl AuthorityState {
                 .value
                 .move_calls()
                 .into_iter()
-                .map(|(package, module, function)| {
+                .map(|(_cmd_idx, package, module, function)| {
                     (*package, module.to_owned(), function.to_owned())
                 }),
             events,

--- a/crates/sui-indexer-alt/src/handlers/tx_calls.rs
+++ b/crates/sui-indexer-alt/src/handlers/tx_calls.rs
@@ -45,7 +45,7 @@ impl Processor for TxCalls {
 
                 calls
                     .iter()
-                    .map(|(package, module, function)| StoredTxCalls {
+                    .map(|(_cmd_idx, package, module, function)| StoredTxCalls {
                         tx_sequence_number,
                         package: package.to_vec(),
                         module: module.to_string(),

--- a/crates/sui-indexer/src/handlers/checkpoint_handler.rs
+++ b/crates/sui-indexer/src/handlers/checkpoint_handler.rs
@@ -494,7 +494,7 @@ impl CheckpointHandler {
             let move_calls = tx
                 .move_calls()
                 .into_iter()
-                .map(|(p, m, f)| (*p, m.to_string(), f.to_string()))
+                .map(|(_cmd_idx, p, m, f)| (*p, m.to_string(), f.to_string()))
                 .collect();
 
             db_tx_indices.push(TxIndex {

--- a/crates/sui-json-rpc-types/src/sui_transaction.rs
+++ b/crates/sui-json-rpc-types/src/sui_transaction.rs
@@ -2595,11 +2595,16 @@ impl Filter<EffectsWithInput> for TransactionFilter {
                 package,
                 module,
                 function,
-            } => item.input.move_calls().into_iter().any(|(p, m, f)| {
-                p == package
-                    && (module.is_none() || matches!(module,  Some(m2) if m2 == &m.to_string()))
-                    && (function.is_none() || matches!(function, Some(f2) if f2 == &f.to_string()))
-            }),
+            } => item
+                .input
+                .move_calls()
+                .into_iter()
+                .any(|(_cmd_idx, p, m, f)| {
+                    p == package
+                        && (module.is_none() || matches!(module,  Some(m2) if m2 == &m.to_string()))
+                        && (function.is_none()
+                            || matches!(function, Some(f2) if f2 == &f.to_string()))
+                }),
             TransactionFilter::TransactionKind(kind) => item.input.kind().to_string() == *kind,
             TransactionFilter::TransactionKindIn(kinds) => {
                 kinds.contains(&item.input.kind().to_string())

--- a/crates/sui-types/src/transaction.rs
+++ b/crates/sui-types/src/transaction.rs
@@ -1348,11 +1348,14 @@ impl ProgrammableTransaction {
         })
     }
 
-    fn move_calls(&self) -> Vec<(&ObjectID, &str, &str)> {
+    fn move_calls(&self) -> Vec<(usize, &ObjectID, &str, &str)> {
         self.commands
             .iter()
-            .filter_map(|command| match command {
-                Command::MoveCall(m) => Some((&m.package, m.module.as_str(), m.function.as_str())),
+            .enumerate()
+            .filter_map(|(idx, command)| match command {
+                Command::MoveCall(m) => {
+                    Some((idx, &m.package, m.module.as_str(), m.function.as_str()))
+                }
                 _ => None,
             })
             .collect()
@@ -1582,7 +1585,7 @@ impl TransactionKind {
         }
     }
 
-    fn move_calls(&self) -> Vec<(&ObjectID, &str, &str)> {
+    fn move_calls(&self) -> Vec<(usize, &ObjectID, &str, &str)> {
         match &self {
             Self::ProgrammableTransaction(pt) => pt.move_calls(),
             _ => vec![],
@@ -2390,7 +2393,7 @@ pub trait TransactionDataAPI {
 
     fn expiration(&self) -> &TransactionExpiration;
 
-    fn move_calls(&self) -> Vec<(&ObjectID, &str, &str)>;
+    fn move_calls(&self) -> Vec<(usize, &ObjectID, &str, &str)>;
 
     fn input_objects(&self) -> UserInputResult<Vec<InputObjectKind>>;
 
@@ -2515,7 +2518,7 @@ impl TransactionDataAPI for TransactionDataV1 {
         &self.expiration
     }
 
-    fn move_calls(&self) -> Vec<(&ObjectID, &str, &str)> {
+    fn move_calls(&self) -> Vec<(usize, &ObjectID, &str, &str)> {
         self.kind.move_calls()
     }
 


### PR DESCRIPTION
## Description

We noticed the move call rows aren't unique due to repeated calls to the same function in the same txn. This is causing query problems both for dune and internally. Adding a call idx column to make this unique.

I wont merge this to main until the schema migration is complete.
