### PR TITLE
refactor: replace Into with From for DiagnosticInfo conversion

### DIFF
--- a/crates/sui-indexer-alt-framework/src/ingestion/ingestion_client.rs
+++ b/crates/sui-indexer-alt-framework/src/ingestion/ingestion_client.rs
@@ -77,7 +77,7 @@ pub enum FetchError {
         #[source]
         error: anyhow::Error,
     },
-    #[error("Permenent error in {reason}: {error}")]
+    #[error("Permanent error in {reason}: {error}")]
     Permanent {
         reason: &'static str,
         #[source]

--- a/crates/sui/src/upgrade_compatibility/mod.rs
+++ b/crates/sui/src/upgrade_compatibility/mod.rs
@@ -636,19 +636,19 @@ macro_rules! upgrade_codes {
                 $($code,)*
             }
 
-            #[allow(clippy::from_over_into)]
-            impl Into<DiagnosticInfo> for $cat {
-                fn into(self) -> DiagnosticInfo {
-                    match self {
-                        Self::ZeroPlaceholder =>
-                            panic!("do not use placeholder error code"),
-                        $(Self::$code => custom(
-                            COMPATIBILITY_PREFIX,
-                            Severity::NonblockingError,
-                            Category::$cat as u8,
-                            self as u8,
-                            $code_msg,
-                        ),)*
+            impl From<$cat> for DiagnosticInfo {
+                fn from(cat: $cat) -> DiagnosticInfo {
+                    match cat {
+                        $cat::ZeroPlaceholder => panic!("do not use placeholder error code"),
+                        $(
+                            $cat::$code => custom(
+                                COMPATIBILITY_PREFIX,
+                                Severity::NonblockingError,
+                                Category::$cat as u8,
+                                cat as u8,
+                                $code_msg,
+                            ),
+                        )*
                     }
                 }
             }


### PR DESCRIPTION
## Description 

Describe the changes or additions included in this PR.
- Replace impl Into<DiagnosticInfo> with impl From<$cat>
- Remove #[allow(clippy::from_over_into)] warning suppression
- This follows Rust conventions where From is preferred over Into"
- correct typo "Permenent" → "Permanent" in error message

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
