### PR TITLE
feat(sui-rpc-api): Add liquidity pool state capture and streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16373,6 +16373,7 @@ dependencies = [
  "bcs",
  "bytes",
  "fastcrypto",
+ "futures",
  "http 1.3.1",
  "itertools 0.13.0",
  "mime",
@@ -16384,6 +16385,7 @@ dependencies = [
  "prost-types 0.14.1",
  "protox",
  "rand 0.8.5",
+ "regex",
  "roaring 0.10.9",
  "serde",
  "serde_json",
@@ -16400,6 +16402,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite 0.26.2",
  "tonic 0.14.2",
  "tonic-health",
  "tonic-prost",
@@ -16409,6 +16412,7 @@ dependencies = [
  "tower 0.5.2",
  "tracing",
  "url",
+ "uuid 1.2.2",
  "walkdir",
 ]
 

--- a/crates/sui-rpc-api/Cargo.toml
+++ b/crates/sui-rpc-api/Cargo.toml
@@ -31,6 +31,9 @@ tracing.workspace = true
 tokio-stream.workspace = true
 async-stream.workspace = true
 base64.workspace = true
+futures.workspace = true
+regex.workspace = true
+uuid.workspace = true
 
 sui-name-service.workspace = true
 fastcrypto.workspace = true
@@ -52,6 +55,9 @@ bytes.workspace = true
 tonic-health.workspace = true
 tonic-reflection.workspace = true
 tonic-web.workspace = true
+
+[dev-dependencies]
+tokio-tungstenite = "0.26"
 
 [build-dependencies]
 tonic-prost-build.workspace = true

--- a/crates/sui-rpc-api/examples/liquidity_stream_demo.rs
+++ b/crates/sui-rpc-api/examples/liquidity_stream_demo.rs
@@ -1,0 +1,191 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Demo client for streaming liquidity pool updates via WebSocket.
+//!
+//! This example demonstrates how to connect to the custom broadcaster
+//! and subscribe to liquidity pool updates from various DEX protocols.
+//!
+//! # Running the demo
+//!
+//! First, ensure a Sui node with the custom broadcaster is running on port 9003.
+//! Then run this example:
+//!
+//! ```bash
+//! cargo run --example liquidity_stream_demo
+//! ```
+//!
+//! # Protocol
+//!
+//! The WebSocket protocol uses JSON messages:
+//!
+//! ## Subscribe to all pools:
+//! ```json
+//! {"action": "subscribe_liquidity", "protocols": [], "pool_ids": []}
+//! ```
+//!
+//! ## Subscribe to specific protocols (regex supported):
+//! ```json
+//! {"action": "subscribe_liquidity", "protocols": ["cetus", "turbos"]}
+//! ```
+//!
+//! ## Subscribe to specific pool IDs:
+//! ```json
+//! {"action": "subscribe_liquidity", "pool_ids": ["0x..."]}
+//! ```
+//!
+//! ## Unsubscribe:
+//! ```json
+//! {"action": "unsubscribe"}
+//! ```
+
+use futures::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use std::env;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+/// Message types received from the server
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum StreamMessage {
+    LiquidityUpdate(LiquidityUpdate),
+    Subscribed(SubscriptionConfirmation),
+    Error(ErrorMessage),
+    Heartbeat { timestamp_ms: u64 },
+}
+
+#[derive(Debug, Deserialize)]
+struct LiquidityUpdate {
+    pool_id: String,
+    protocol: String,
+    pool_type: String,
+    token_types: Vec<String>,
+    digest: String,
+    version: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    raw_bytes: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SubscriptionConfirmation {
+    subscription_id: String,
+    protocols: Vec<String>,
+    pool_ids: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ErrorMessage {
+    code: String,
+    message: String,
+}
+
+/// Client message types
+#[derive(Debug, Serialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+enum ClientMessage {
+    SubscribeLiquidity(LiquiditySubscription),
+    Unsubscribe,
+    Ping,
+}
+
+#[derive(Debug, Serialize)]
+struct LiquiditySubscription {
+    protocols: Vec<String>,
+    pool_ids: Vec<String>,
+    include_raw_bytes: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Parse command line arguments
+    let args: Vec<String> = env::args().collect();
+
+    let url = if args.len() > 1 {
+        args[1].clone()
+    } else {
+        "ws://localhost:9003/ws".to_string()
+    };
+
+    let protocols: Vec<String> = if args.len() > 2 {
+        args[2].split(',').map(|s| s.trim().to_string()).collect()
+    } else {
+        vec![] // Subscribe to all protocols
+    };
+
+    println!("Connecting to {}...", url);
+    println!("Subscribing to protocols: {:?}", if protocols.is_empty() { vec!["all".to_string()] } else { protocols.clone() });
+
+    // Connect to WebSocket
+    let (ws_stream, _) = connect_async(&url).await?;
+    println!("Connected!");
+
+    let (mut write, mut read) = ws_stream.split();
+
+    // Send subscription request
+    let subscribe_msg = ClientMessage::SubscribeLiquidity(LiquiditySubscription {
+        protocols,
+        pool_ids: vec![],
+        include_raw_bytes: false,
+    });
+
+    let json = serde_json::to_string(&subscribe_msg)?;
+    write.send(Message::Text(json.into())).await?;
+    println!("Subscription request sent\n");
+
+    // Listen for messages
+    let mut update_count = 0u64;
+    while let Some(msg) = read.next().await {
+        match msg {
+            Ok(Message::Text(text)) => {
+                match serde_json::from_str::<StreamMessage>(&text) {
+                    Ok(StreamMessage::LiquidityUpdate(update)) => {
+                        update_count += 1;
+                        println!("=== Liquidity Update #{} ===", update_count);
+                        println!("Pool ID:     {}", update.pool_id);
+                        println!("Protocol:    {}", update.protocol);
+                        println!("Pool Type:   {}", update.pool_type);
+                        println!("Tokens:      {:?}", update.token_types);
+                        println!("Transaction: {}", update.digest);
+                        println!("Version:     {}", update.version);
+                        if let Some(ref bytes) = update.raw_bytes {
+                            println!("Raw Bytes:   {} bytes (base64)", bytes.len());
+                        }
+                        println!();
+                    }
+                    Ok(StreamMessage::Subscribed(confirmation)) => {
+                        println!("=== Subscription Confirmed ===");
+                        println!("Subscription ID: {}", confirmation.subscription_id);
+                        println!("Protocols:       {:?}", confirmation.protocols);
+                        println!("Pool IDs:        {:?}", confirmation.pool_ids);
+                        println!();
+                    }
+                    Ok(StreamMessage::Error(error)) => {
+                        eprintln!("Error [{}]: {}", error.code, error.message);
+                    }
+                    Ok(StreamMessage::Heartbeat { timestamp_ms }) => {
+                        println!("Heartbeat: {}ms", timestamp_ms);
+                    }
+                    Err(e) => {
+                        eprintln!("Failed to parse message: {}", e);
+                        eprintln!("Raw message: {}", text);
+                    }
+                }
+            }
+            Ok(Message::Close(frame)) => {
+                println!("Connection closed: {:?}", frame);
+                break;
+            }
+            Ok(Message::Ping(_)) => {
+                // Pong is automatically sent
+            }
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!("WebSocket error: {}", e);
+                break;
+            }
+        }
+    }
+
+    println!("Total updates received: {}", update_count);
+    Ok(())
+}

--- a/crates/sui-rpc-api/src/custom_broadcaster.rs
+++ b/crates/sui-rpc-api/src/custom_broadcaster.rs
@@ -1,0 +1,596 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Custom broadcaster for streaming liquidity pool updates via WebSocket.
+//!
+//! This module provides a WebSocket-based streaming service for DEX/AMM pool state changes,
+//! enabling ultra-low-latency access to pool state updates before they are committed to RocksDB.
+
+#[cfg(test)]
+use crate::liquidity_decoder::DexProtocol;
+use crate::liquidity_decoder::LiquidityPoolState;
+use axum::{
+    extract::{
+        ws::{Message, WebSocket, WebSocketUpgrade},
+        State,
+    },
+    response::IntoResponse,
+    routing::get,
+    Router,
+};
+use base64::Engine;
+use futures::stream::StreamExt;
+use futures::SinkExt;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use sui_types::base_types::ObjectID;
+use sui_types::digests::TransactionDigest;
+use sui_types::effects::TransactionEffectsAPI;
+use sui_types::full_checkpoint_content::CheckpointTransaction;
+use sui_types::object::Object;
+use tokio::sync::{broadcast, mpsc, RwLock};
+use tracing::{debug, error, info, trace, warn};
+
+/// Configuration for the custom broadcaster
+#[derive(Debug, Clone)]
+pub struct BroadcasterConfig {
+    /// Port to listen on for WebSocket connections
+    pub port: u16,
+    /// Maximum number of concurrent subscribers
+    pub max_subscribers: usize,
+    /// Channel buffer size for each subscriber
+    pub subscriber_buffer_size: usize,
+    /// Whether to include raw bytes in updates by default
+    pub include_raw_bytes: bool,
+}
+
+impl Default for BroadcasterConfig {
+    fn default() -> Self {
+        Self {
+            port: 9003,
+            max_subscribers: 1024,
+            subscriber_buffer_size: 256,
+            include_raw_bytes: false,
+        }
+    }
+}
+
+/// Messages that can be streamed to clients
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum StreamMessage {
+    /// A liquidity pool update
+    LiquidityUpdate(LiquidityUpdate),
+    /// Subscription confirmation
+    Subscribed(SubscriptionConfirmation),
+    /// Error message
+    Error(ErrorMessage),
+    /// Heartbeat to keep connection alive
+    Heartbeat { timestamp_ms: u64 },
+}
+
+/// Liquidity pool update message
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LiquidityUpdate {
+    /// The pool object ID
+    pub pool_id: String,
+    /// The protocol this pool belongs to
+    pub protocol: String,
+    /// Full type string of the pool
+    pub pool_type: String,
+    /// Token types in the pool
+    pub token_types: Vec<String>,
+    /// Transaction digest that caused this update
+    pub digest: String,
+    /// Object version after this update
+    pub version: u64,
+    /// Raw BCS bytes (base64 encoded, optional)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw_bytes: Option<String>,
+}
+
+impl From<LiquidityPoolState> for LiquidityUpdate {
+    fn from(state: LiquidityPoolState) -> Self {
+        Self {
+            pool_id: state.pool_id.to_string(),
+            protocol: state.protocol.to_string(),
+            pool_type: state.pool_type,
+            token_types: state.token_types,
+            digest: state.digest.to_string(),
+            version: state.version,
+            raw_bytes: state
+                .raw_bytes
+                .map(|bytes| base64::engine::general_purpose::STANDARD.encode(&bytes)),
+        }
+    }
+}
+
+/// Subscription confirmation message
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubscriptionConfirmation {
+    /// Subscription ID for this client
+    pub subscription_id: String,
+    /// Protocols being watched
+    pub protocols: Vec<String>,
+    /// Specific pool IDs being watched (if any)
+    pub pool_ids: Vec<String>,
+}
+
+/// Error message
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorMessage {
+    /// Error code
+    pub code: String,
+    /// Error description
+    pub message: String,
+}
+
+/// Subscription request from client
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum ClientMessage {
+    /// Subscribe to liquidity updates
+    SubscribeLiquidity(LiquiditySubscription),
+    /// Unsubscribe from all updates
+    Unsubscribe,
+    /// Ping to keep connection alive
+    Ping,
+}
+
+/// Liquidity subscription parameters
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LiquiditySubscription {
+    /// Protocol patterns to match (regex). If empty, matches all protocols.
+    #[serde(default)]
+    pub protocols: Vec<String>,
+    /// Specific pool IDs to watch. If empty, watches all pools matching protocols.
+    #[serde(default)]
+    pub pool_ids: Vec<String>,
+    /// Whether to include raw bytes in updates
+    #[serde(default)]
+    pub include_raw_bytes: bool,
+}
+
+/// Active subscription state for a client
+#[derive(Debug, Clone)]
+struct ActiveSubscription {
+    /// Compiled regex patterns for protocols
+    protocol_patterns: Vec<Regex>,
+    /// Set of specific pool IDs to watch
+    pool_ids: HashSet<ObjectID>,
+    /// Whether to include raw bytes
+    include_raw_bytes: bool,
+}
+
+impl ActiveSubscription {
+    fn from_request(request: &LiquiditySubscription) -> Result<Self, String> {
+        let protocol_patterns = request
+            .protocols
+            .iter()
+            .map(|p| Regex::new(p).map_err(|e| format!("Invalid regex pattern '{}': {}", p, e)))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let pool_ids = request
+            .pool_ids
+            .iter()
+            .map(|id| {
+                ObjectID::from_hex_literal(id)
+                    .map_err(|e| format!("Invalid pool ID '{}': {}", id, e))
+            })
+            .collect::<Result<HashSet<_>, _>>()?;
+
+        Ok(Self {
+            protocol_patterns,
+            pool_ids,
+            include_raw_bytes: request.include_raw_bytes,
+        })
+    }
+
+    fn matches(&self, state: &LiquidityPoolState) -> bool {
+        // If specific pool IDs are specified and this pool is in the set, match
+        if !self.pool_ids.is_empty() && self.pool_ids.contains(&state.pool_id) {
+            return true;
+        }
+
+        // If no protocol patterns specified, match all (unless pool IDs were specified)
+        if self.protocol_patterns.is_empty() {
+            return self.pool_ids.is_empty();
+        }
+
+        // Check protocol patterns
+        self.protocol_patterns
+            .iter()
+            .any(|pattern| state.protocol.matches_pattern(pattern))
+    }
+}
+
+/// Handle to send pool updates to the broadcaster
+#[derive(Clone)]
+pub struct BroadcasterHandle {
+    sender: broadcast::Sender<Arc<LiquidityPoolState>>,
+}
+
+impl BroadcasterHandle {
+    /// Broadcast a liquidity pool update to all subscribers
+    pub fn broadcast(&self, state: LiquidityPoolState) {
+        let _ = self.sender.send(Arc::new(state));
+    }
+
+    /// Process transaction outputs and broadcast any liquidity pool updates
+    pub fn process_transaction(
+        &self,
+        transaction: &CheckpointTransaction,
+        include_raw_bytes: bool,
+    ) {
+        let digest = *transaction.effects.transaction_digest();
+
+        for object in &transaction.output_objects {
+            if let Some(state) =
+                LiquidityPoolState::from_object(object, digest, include_raw_bytes)
+            {
+                trace!(
+                    "Broadcasting liquidity update for pool {} ({:?})",
+                    state.pool_id,
+                    state.protocol
+                );
+                self.broadcast(state);
+            }
+        }
+    }
+
+    /// Process a batch of objects and broadcast liquidity pool updates
+    pub fn process_objects(&self, objects: &[Object], digest: TransactionDigest, include_raw_bytes: bool) {
+        for object in objects {
+            if let Some(state) = LiquidityPoolState::from_object(object, digest, include_raw_bytes)
+            {
+                self.broadcast(state);
+            }
+        }
+    }
+}
+
+/// Shared state for the broadcaster service
+struct BroadcasterState {
+    config: BroadcasterConfig,
+    update_sender: broadcast::Sender<Arc<LiquidityPoolState>>,
+    subscriber_count: RwLock<usize>,
+}
+
+/// Custom broadcaster service for WebSocket streaming
+pub struct CustomBroadcaster {
+    state: Arc<BroadcasterState>,
+}
+
+impl CustomBroadcaster {
+    /// Create a new broadcaster with the given configuration
+    pub fn new(config: BroadcasterConfig) -> (Self, BroadcasterHandle) {
+        let (sender, _) = broadcast::channel(config.subscriber_buffer_size * 4);
+
+        let state = Arc::new(BroadcasterState {
+            config,
+            update_sender: sender.clone(),
+            subscriber_count: RwLock::new(0),
+        });
+
+        let broadcaster = Self {
+            state,
+        };
+
+        let handle = BroadcasterHandle { sender };
+
+        (broadcaster, handle)
+    }
+
+    /// Start the WebSocket server
+    pub async fn start(self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let addr = SocketAddr::from(([0, 0, 0, 0], self.state.config.port));
+        info!("Starting custom broadcaster WebSocket server on {}", addr);
+
+        let app = Router::new()
+            .route("/ws", get(handle_websocket))
+            .route("/health", get(health_check))
+            .with_state(self.state);
+
+        let listener = tokio::net::TcpListener::bind(addr).await?;
+        axum::serve(listener, app).await?;
+
+        Ok(())
+    }
+}
+
+/// Health check endpoint
+async fn health_check(State(state): State<Arc<BroadcasterState>>) -> impl IntoResponse {
+    let count = *state.subscriber_count.read().await;
+    format!("OK - {} active subscribers", count)
+}
+
+/// WebSocket connection handler
+async fn handle_websocket(
+    ws: WebSocketUpgrade,
+    State(state): State<Arc<BroadcasterState>>,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_socket(socket, state))
+}
+
+/// Handle an individual WebSocket connection
+async fn handle_socket(socket: WebSocket, state: Arc<BroadcasterState>) {
+    // Check subscriber limit
+    {
+        let mut count = state.subscriber_count.write().await;
+        if *count >= state.config.max_subscribers {
+            warn!("Rejecting connection: max subscribers reached");
+            return;
+        }
+        *count += 1;
+    }
+
+    let (mut sender, mut receiver) = socket.split();
+
+    // Create a channel for sending messages to this client
+    let (tx, mut rx) = mpsc::channel::<StreamMessage>(state.config.subscriber_buffer_size);
+
+    // Subscribe to broadcast updates
+    let mut update_receiver = state.update_sender.subscribe();
+
+    // Client subscription state
+    let subscription: Arc<RwLock<Option<ActiveSubscription>>> = Arc::new(RwLock::new(None));
+    let subscription_clone = subscription.clone();
+
+    // Spawn task to send messages to WebSocket
+    let send_task = tokio::spawn(async move {
+        while let Some(msg) = rx.recv().await {
+            match serde_json::to_string(&msg) {
+                Ok(json) => {
+                    if sender.send(Message::Text(json.into())).await.is_err() {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    error!("Failed to serialize message: {}", e);
+                }
+            }
+        }
+    });
+
+    // Spawn task to receive and filter broadcast updates
+    let tx_clone = tx.clone();
+    let filter_task = tokio::spawn(async move {
+        loop {
+            match update_receiver.recv().await {
+                Ok(pool_state) => {
+                    let sub = subscription_clone.read().await;
+                    if let Some(active_sub) = sub.as_ref().filter(|s| s.matches(&pool_state)) {
+                        let mut update: LiquidityUpdate = (*pool_state).clone().into();
+                        // Only include raw bytes if subscription requests it
+                        if !active_sub.include_raw_bytes {
+                            update.raw_bytes = None;
+                        }
+                        let msg = StreamMessage::LiquidityUpdate(update);
+                        if tx_clone.send(msg).await.is_err() {
+                            break;
+                        }
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    warn!("Subscriber lagged, missed {} updates", n);
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    break;
+                }
+            }
+        }
+    });
+
+    // Handle incoming messages from client
+    let subscription_id = uuid::Uuid::new_v4().to_string();
+    while let Some(msg) = receiver.next().await {
+        match msg {
+            Ok(Message::Text(text)) => {
+                match serde_json::from_str::<ClientMessage>(&text) {
+                    Ok(ClientMessage::SubscribeLiquidity(sub_request)) => {
+                        debug!("Client subscribing to liquidity updates: {:?}", sub_request);
+                        match ActiveSubscription::from_request(&sub_request) {
+                            Ok(active_sub) => {
+                                *subscription.write().await = Some(active_sub);
+
+                                let confirmation = StreamMessage::Subscribed(
+                                    SubscriptionConfirmation {
+                                        subscription_id: subscription_id.clone(),
+                                        protocols: sub_request.protocols.clone(),
+                                        pool_ids: sub_request.pool_ids.clone(),
+                                    },
+                                );
+                                let _ = tx.send(confirmation).await;
+                            }
+                            Err(e) => {
+                                let error = StreamMessage::Error(ErrorMessage {
+                                    code: "INVALID_SUBSCRIPTION".to_string(),
+                                    message: e,
+                                });
+                                let _ = tx.send(error).await;
+                            }
+                        }
+                    }
+                    Ok(ClientMessage::Unsubscribe) => {
+                        debug!("Client unsubscribing");
+                        *subscription.write().await = None;
+                    }
+                    Ok(ClientMessage::Ping) => {
+                        let heartbeat = StreamMessage::Heartbeat {
+                            timestamp_ms: std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .unwrap_or_default()
+                                .as_millis() as u64,
+                        };
+                        let _ = tx.send(heartbeat).await;
+                    }
+                    Err(e) => {
+                        let error = StreamMessage::Error(ErrorMessage {
+                            code: "PARSE_ERROR".to_string(),
+                            message: format!("Failed to parse message: {}", e),
+                        });
+                        let _ = tx.send(error).await;
+                    }
+                }
+            }
+            Ok(Message::Close(_)) => {
+                debug!("Client closed connection");
+                break;
+            }
+            Ok(Message::Ping(data)) => {
+                // Pong is automatically handled by axum
+                trace!("Received ping: {:?}", data);
+            }
+            Ok(_) => {}
+            Err(e) => {
+                error!("WebSocket error: {}", e);
+                break;
+            }
+        }
+    }
+
+    // Cleanup
+    send_task.abort();
+    filter_task.abort();
+
+    let mut count = state.subscriber_count.write().await;
+    *count = count.saturating_sub(1);
+    debug!("Client disconnected. Active subscribers: {}", *count);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_subscription_matching() {
+        let request = LiquiditySubscription {
+            protocols: vec!["cetus".to_string()],
+            pool_ids: vec![],
+            include_raw_bytes: false,
+        };
+
+        let sub = ActiveSubscription::from_request(&request).unwrap();
+
+        let state = LiquidityPoolState {
+            pool_id: ObjectID::random(),
+            protocol: DexProtocol::Cetus,
+            pool_type: "test".to_string(),
+            token_types: vec![],
+            digest: TransactionDigest::random(),
+            version: 1,
+            raw_bytes: None,
+        };
+
+        assert!(sub.matches(&state));
+
+        let state2 = LiquidityPoolState {
+            protocol: DexProtocol::Turbos,
+            ..state.clone()
+        };
+
+        assert!(!sub.matches(&state2));
+    }
+
+    #[test]
+    fn test_subscription_with_pool_ids() {
+        let pool_id = ObjectID::random();
+        let request = LiquiditySubscription {
+            protocols: vec![],
+            pool_ids: vec![pool_id.to_string()],
+            include_raw_bytes: false,
+        };
+
+        let sub = ActiveSubscription::from_request(&request).unwrap();
+
+        let state = LiquidityPoolState {
+            pool_id,
+            protocol: DexProtocol::Cetus,
+            pool_type: "test".to_string(),
+            token_types: vec![],
+            digest: TransactionDigest::random(),
+            version: 1,
+            raw_bytes: None,
+        };
+
+        assert!(sub.matches(&state));
+
+        let state2 = LiquidityPoolState {
+            pool_id: ObjectID::random(),
+            ..state.clone()
+        };
+
+        assert!(!sub.matches(&state2));
+    }
+
+    #[test]
+    fn test_empty_subscription_matches_all() {
+        let request = LiquiditySubscription::default();
+        let sub = ActiveSubscription::from_request(&request).unwrap();
+
+        let state = LiquidityPoolState {
+            pool_id: ObjectID::random(),
+            protocol: DexProtocol::Cetus,
+            pool_type: "test".to_string(),
+            token_types: vec![],
+            digest: TransactionDigest::random(),
+            version: 1,
+            raw_bytes: None,
+        };
+
+        assert!(sub.matches(&state));
+    }
+
+    #[test]
+    fn test_regex_protocol_matching() {
+        let request = LiquiditySubscription {
+            protocols: vec!["cetus|turbos".to_string()],
+            pool_ids: vec![],
+            include_raw_bytes: false,
+        };
+
+        let sub = ActiveSubscription::from_request(&request).unwrap();
+
+        let cetus_state = LiquidityPoolState {
+            pool_id: ObjectID::random(),
+            protocol: DexProtocol::Cetus,
+            pool_type: "test".to_string(),
+            token_types: vec![],
+            digest: TransactionDigest::random(),
+            version: 1,
+            raw_bytes: None,
+        };
+
+        let turbos_state = LiquidityPoolState {
+            protocol: DexProtocol::Turbos,
+            ..cetus_state.clone()
+        };
+
+        let deepbook_state = LiquidityPoolState {
+            protocol: DexProtocol::DeepBook,
+            ..cetus_state.clone()
+        };
+
+        assert!(sub.matches(&cetus_state));
+        assert!(sub.matches(&turbos_state));
+        assert!(!sub.matches(&deepbook_state));
+    }
+
+    #[test]
+    fn test_client_message_parsing() {
+        let json = r#"{"action": "subscribe_liquidity", "protocols": ["cetus"], "pool_ids": [], "include_raw_bytes": false}"#;
+        let msg: ClientMessage = serde_json::from_str(json).unwrap();
+        assert!(matches!(msg, ClientMessage::SubscribeLiquidity(_)));
+
+        let json = r#"{"action": "unsubscribe"}"#;
+        let msg: ClientMessage = serde_json::from_str(json).unwrap();
+        assert!(matches!(msg, ClientMessage::Unsubscribe));
+
+        let json = r#"{"action": "ping"}"#;
+        let msg: ClientMessage = serde_json::from_str(json).unwrap();
+        assert!(matches!(msg, ClientMessage::Ping));
+    }
+}

--- a/crates/sui-rpc-api/src/lib.rs
+++ b/crates/sui-rpc-api/src/lib.rs
@@ -11,8 +11,10 @@ use tap::Pipe;
 
 pub mod client;
 mod config;
+pub mod custom_broadcaster;
 mod error;
 pub mod grpc;
+pub mod liquidity_decoder;
 mod metrics;
 mod reader;
 mod response;
@@ -21,9 +23,14 @@ pub mod subscription;
 
 pub use client::Client;
 pub use config::Config;
+pub use custom_broadcaster::{
+    BroadcasterConfig, BroadcasterHandle, ClientMessage, CustomBroadcaster, LiquiditySubscription,
+    LiquidityUpdate, StreamMessage,
+};
 pub use error::{
     CheckpointNotFoundError, ErrorDetails, ErrorReason, ObjectNotFoundError, Result, RpcError,
 };
+pub use liquidity_decoder::{DexProtocol, LiquidityPoolState};
 pub use metrics::{RpcMetrics, RpcMetricsMakeCallbackHandler};
 pub use reader::TransactionNotFoundError;
 pub use sui_rpc::proto;

--- a/crates/sui-rpc-api/src/liquidity_decoder.rs
+++ b/crates/sui-rpc-api/src/liquidity_decoder.rs
@@ -1,0 +1,379 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Liquidity pool detection and decoding module.
+//!
+//! This module identifies Move objects belonging to known DEX protocols
+//! and extracts token type information from generic type parameters.
+
+use move_core_types::language_storage::{StructTag, TypeTag};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
+use sui_types::base_types::ObjectID;
+use sui_types::digests::TransactionDigest;
+use sui_types::object::Object;
+
+/// Known DEX protocol identifiers
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DexProtocol {
+    Cetus,
+    Turbos,
+    SuiSwap,
+    DeepBook,
+    Kriya,
+    Aftermath,
+    Unknown,
+}
+
+impl DexProtocol {
+    /// Returns the protocol name as a string
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            DexProtocol::Cetus => "cetus",
+            DexProtocol::Turbos => "turbos",
+            DexProtocol::SuiSwap => "suiswap",
+            DexProtocol::DeepBook => "deepbook",
+            DexProtocol::Kriya => "kriya",
+            DexProtocol::Aftermath => "aftermath",
+            DexProtocol::Unknown => "unknown",
+        }
+    }
+
+    /// Check if this protocol matches a regex pattern
+    pub fn matches_pattern(&self, pattern: &Regex) -> bool {
+        pattern.is_match(self.as_str())
+    }
+}
+
+impl std::fmt::Display for DexProtocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// Known DEX pool type patterns for detection
+struct DexPattern {
+    protocol: DexProtocol,
+    /// Module name pattern to match
+    module_pattern: &'static str,
+    /// Struct name pattern to match
+    struct_pattern: &'static str,
+}
+
+/// Static list of known DEX patterns
+static DEX_PATTERNS: LazyLock<Vec<DexPattern>> = LazyLock::new(|| {
+    vec![
+        // Cetus Protocol pools
+        DexPattern {
+            protocol: DexProtocol::Cetus,
+            module_pattern: "pool",
+            struct_pattern: "Pool",
+        },
+        DexPattern {
+            protocol: DexProtocol::Cetus,
+            module_pattern: "clmm_pool",
+            struct_pattern: "Pool",
+        },
+        // Turbos Finance pools
+        DexPattern {
+            protocol: DexProtocol::Turbos,
+            module_pattern: "pool",
+            struct_pattern: "Pool",
+        },
+        // SuiSwap pools
+        DexPattern {
+            protocol: DexProtocol::SuiSwap,
+            module_pattern: "pool",
+            struct_pattern: "Pool",
+        },
+        DexPattern {
+            protocol: DexProtocol::SuiSwap,
+            module_pattern: "swap",
+            struct_pattern: "Pool",
+        },
+        // DeepBook orderbook
+        DexPattern {
+            protocol: DexProtocol::DeepBook,
+            module_pattern: "clob",
+            struct_pattern: "Pool",
+        },
+        DexPattern {
+            protocol: DexProtocol::DeepBook,
+            module_pattern: "clob_v2",
+            struct_pattern: "Pool",
+        },
+        DexPattern {
+            protocol: DexProtocol::DeepBook,
+            module_pattern: "pool",
+            struct_pattern: "Pool",
+        },
+        // Kriya DEX pools
+        DexPattern {
+            protocol: DexProtocol::Kriya,
+            module_pattern: "spot_dex",
+            struct_pattern: "Pool",
+        },
+        // Aftermath Finance pools
+        DexPattern {
+            protocol: DexProtocol::Aftermath,
+            module_pattern: "pool",
+            struct_pattern: "Pool",
+        },
+        DexPattern {
+            protocol: DexProtocol::Aftermath,
+            module_pattern: "amm",
+            struct_pattern: "Pool",
+        },
+    ]
+});
+
+/// Known DEX package addresses on mainnet
+static KNOWN_DEX_ADDRESSES: LazyLock<std::collections::HashMap<String, DexProtocol>> =
+    LazyLock::new(|| {
+        let mut map = std::collections::HashMap::new();
+        // Cetus mainnet packages
+        map.insert(
+            "0x1eabed72c53feb3805120a081dc15963c204dc8d091542592abaf7a35689b2fb".to_string(),
+            DexProtocol::Cetus,
+        );
+        map.insert(
+            "0x714a63a0dba6da4f017b42d5d0fb78867f18bcde904868e51d951a5a6f5b7f57".to_string(),
+            DexProtocol::Cetus,
+        );
+        // Turbos mainnet packages
+        map.insert(
+            "0x91bfbc386a41afcfd9b2533058d7e915a1d3829089cc268ff4333d54d6339ca1".to_string(),
+            DexProtocol::Turbos,
+        );
+        // DeepBook mainnet packages
+        map.insert(
+            "0x000000000000000000000000000000000000000000000000000000000000dee9".to_string(),
+            DexProtocol::DeepBook,
+        );
+        map.insert(
+            "0xdee9".to_string(),
+            DexProtocol::DeepBook,
+        );
+        // Kriya mainnet packages
+        map.insert(
+            "0xa0eba10b173538c8fecca1dff298e488402cc9ff374f8a12ca7758eebe830b66".to_string(),
+            DexProtocol::Kriya,
+        );
+        // Aftermath mainnet packages
+        map.insert(
+            "0xefe8b36d5b2e43728cc323298626b83177803521d195cfb11e15b910e892fddf".to_string(),
+            DexProtocol::Aftermath,
+        );
+        map
+    });
+
+/// Represents decoded state of a liquidity pool
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LiquidityPoolState {
+    /// The pool object ID
+    pub pool_id: ObjectID,
+    /// The protocol this pool belongs to
+    pub protocol: DexProtocol,
+    /// Full type string of the pool (e.g., "0x...::pool::Pool<T1, T2>")
+    pub pool_type: String,
+    /// Token types extracted from generic parameters
+    pub token_types: Vec<String>,
+    /// Transaction digest that caused this update
+    pub digest: TransactionDigest,
+    /// Object version after this update
+    pub version: u64,
+    /// Raw BCS bytes of the object contents (optional, for client-side parsing)
+    pub raw_bytes: Option<Vec<u8>>,
+}
+
+impl LiquidityPoolState {
+    /// Create a new LiquidityPoolState from an object and transaction digest
+    pub fn from_object(
+        object: &Object,
+        digest: TransactionDigest,
+        include_raw_bytes: bool,
+    ) -> Option<Self> {
+        let move_obj = object.data.try_as_move()?;
+        let struct_tag: StructTag = move_obj.type_().clone().into();
+
+        let protocol = detect_protocol(&struct_tag)?;
+        let token_types = extract_token_types(&struct_tag);
+        let pool_type = format_struct_tag(&struct_tag);
+
+        Some(LiquidityPoolState {
+            pool_id: object.id(),
+            protocol,
+            pool_type,
+            token_types,
+            digest,
+            version: object.version().value(),
+            raw_bytes: if include_raw_bytes {
+                Some(move_obj.contents().to_vec())
+            } else {
+                None
+            },
+        })
+    }
+}
+
+/// Detect if a struct tag belongs to a known DEX protocol
+pub fn detect_protocol(struct_tag: &StructTag) -> Option<DexProtocol> {
+    let address = struct_tag.address.to_hex_literal();
+
+    // First check if address is a known DEX package
+    if let Some(protocol) = KNOWN_DEX_ADDRESSES.get(&address) {
+        return Some(*protocol);
+    }
+
+    // Check against module/struct patterns
+    let module_name = struct_tag.module.as_str();
+    let struct_name = struct_tag.name.as_str();
+
+    for pattern in DEX_PATTERNS.iter() {
+        if module_name.contains(pattern.module_pattern)
+            && struct_name == pattern.struct_pattern
+        {
+            return Some(pattern.protocol);
+        }
+    }
+
+    None
+}
+
+/// Check if an object is a liquidity pool from a known DEX
+pub fn is_liquidity_pool(object: &Object) -> bool {
+    if let Some(move_obj) = object.data.try_as_move() {
+        let struct_tag: StructTag = move_obj.type_().clone().into();
+        detect_protocol(&struct_tag).is_some()
+    } else {
+        false
+    }
+}
+
+/// Extract token type strings from a pool's generic type parameters
+fn extract_token_types(struct_tag: &StructTag) -> Vec<String> {
+    struct_tag
+        .type_params
+        .iter()
+        .map(format_type_tag)
+        .collect()
+}
+
+/// Format a TypeTag as a human-readable string
+fn format_type_tag(type_tag: &TypeTag) -> String {
+    match type_tag {
+        TypeTag::Bool => "bool".to_string(),
+        TypeTag::U8 => "u8".to_string(),
+        TypeTag::U16 => "u16".to_string(),
+        TypeTag::U32 => "u32".to_string(),
+        TypeTag::U64 => "u64".to_string(),
+        TypeTag::U128 => "u128".to_string(),
+        TypeTag::U256 => "u256".to_string(),
+        TypeTag::Address => "address".to_string(),
+        TypeTag::Signer => "signer".to_string(),
+        TypeTag::Vector(inner) => format!("vector<{}>", format_type_tag(inner)),
+        TypeTag::Struct(s) => format_struct_tag(s),
+    }
+}
+
+/// Format a StructTag as a human-readable string
+fn format_struct_tag(struct_tag: &StructTag) -> String {
+    let base = format!(
+        "{}::{}::{}",
+        struct_tag.address.to_hex_literal(),
+        struct_tag.module,
+        struct_tag.name
+    );
+
+    if struct_tag.type_params.is_empty() {
+        base
+    } else {
+        let params: Vec<String> = struct_tag.type_params.iter().map(format_type_tag).collect();
+        format!("{}<{}>", base, params.join(", "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use move_core_types::account_address::AccountAddress;
+    use move_core_types::ident_str;
+
+    #[test]
+    fn test_detect_cetus_pool() {
+        let struct_tag = StructTag {
+            address: AccountAddress::from_hex_literal(
+                "0x1eabed72c53feb3805120a081dc15963c204dc8d091542592abaf7a35689b2fb",
+            )
+            .unwrap(),
+            module: ident_str!("pool").to_owned(),
+            name: ident_str!("Pool").to_owned(),
+            type_params: vec![],
+        };
+
+        let protocol = detect_protocol(&struct_tag);
+        assert_eq!(protocol, Some(DexProtocol::Cetus));
+    }
+
+    #[test]
+    fn test_detect_deepbook_pool() {
+        let struct_tag = StructTag {
+            address: AccountAddress::from_hex_literal("0xdee9").unwrap(),
+            module: ident_str!("clob_v2").to_owned(),
+            name: ident_str!("Pool").to_owned(),
+            type_params: vec![],
+        };
+
+        let protocol = detect_protocol(&struct_tag);
+        assert_eq!(protocol, Some(DexProtocol::DeepBook));
+    }
+
+    #[test]
+    fn test_extract_token_types() {
+        let sui_type = TypeTag::Struct(Box::new(StructTag {
+            address: AccountAddress::from_hex_literal("0x2").unwrap(),
+            module: ident_str!("sui").to_owned(),
+            name: ident_str!("SUI").to_owned(),
+            type_params: vec![],
+        }));
+
+        let usdc_type = TypeTag::Struct(Box::new(StructTag {
+            address: AccountAddress::from_hex_literal("0xdba").unwrap(),
+            module: ident_str!("usdc").to_owned(),
+            name: ident_str!("USDC").to_owned(),
+            type_params: vec![],
+        }));
+
+        let struct_tag = StructTag {
+            address: AccountAddress::from_hex_literal(
+                "0x1eabed72c53feb3805120a081dc15963c204dc8d091542592abaf7a35689b2fb",
+            )
+            .unwrap(),
+            module: ident_str!("pool").to_owned(),
+            name: ident_str!("Pool").to_owned(),
+            type_params: vec![sui_type, usdc_type],
+        };
+
+        let tokens = extract_token_types(&struct_tag);
+        assert_eq!(tokens.len(), 2);
+        assert!(tokens[0].contains("sui::SUI"));
+        assert!(tokens[1].contains("usdc::USDC"));
+    }
+
+    #[test]
+    fn test_protocol_display() {
+        assert_eq!(DexProtocol::Cetus.as_str(), "cetus");
+        assert_eq!(DexProtocol::Turbos.as_str(), "turbos");
+        assert_eq!(DexProtocol::DeepBook.as_str(), "deepbook");
+    }
+
+    #[test]
+    fn test_protocol_pattern_matching() {
+        let pattern = Regex::new("cetus|turbos").unwrap();
+        assert!(DexProtocol::Cetus.matches_pattern(&pattern));
+        assert!(DexProtocol::Turbos.matches_pattern(&pattern));
+        assert!(!DexProtocol::DeepBook.matches_pattern(&pattern));
+    }
+}


### PR DESCRIPTION
This commit adds infrastructure to capture and stream DEX/AMM liquidity pool state changes before they are committed to RocksDB, enabling ultra-low-latency access to pool updates.

New modules:
- liquidity_decoder.rs: Detects known DEX protocols (Cetus, Turbos, SuiSwap, DeepBook, Kriya, Aftermath) and extracts token types from pool objects
- custom_broadcaster.rs: WebSocket server for streaming pool updates with subscription filtering by protocol regex patterns or specific pool IDs

Key features:
- LiquidityPoolState struct for unified pool state representation
- StreamMessage enum with LiquidityUpdate, Subscribed, Error, Heartbeat variants
- LiquiditySubscription for client-side filtering configuration
- BroadcasterHandle for integrating with transaction output processing
- Demo client example for verification

The broadcaster runs on a separate port (default 9003) to avoid conflict with production services.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
