### PR TITLE
perf: avoid extra allocation when reading Move.toml

### DIFF
--- a/crates/sui/src/upgrade_compatibility/mod.rs
+++ b/crates/sui/src/upgrade_compatibility/mod.rs
@@ -751,11 +751,9 @@ fn compare_packages(
 
     // add move toml
     let move_toml_path = package_path.join("Move.toml");
-    let move_toml_contents = Arc::from(
-        fs::read_to_string(&move_toml_path)
-            .context("Unable to read Move.toml")?
-            .to_string(),
-    );
+    let move_toml_contents: Arc<str> = fs::read_to_string(&move_toml_path)
+        .context("Unable to read Move.toml")?
+        .into();
     let move_toml_hash = FileHash::new(&move_toml_contents);
 
     new_package.package.file_map.add(


### PR DESCRIPTION
Use the String returned by fs::read_to_string and convert it directly into Arc<str> instead of calling to_string() and allocating a second String.

This removes a redundant allocation on the compatibility check path while keeping the existing behavior and diagnostics unchanged.