### PR TITLE
docs: fix typo in scalar_div comment - 'a' should be 'e1'

### DIFF
--- a/crates/sui-framework/packages/sui-framework/sources/crypto/bls12381.move
+++ b/crates/sui-framework/packages/sui-framework/sources/crypto/bls12381.move
@@ -107,7 +107,7 @@ public fun scalar_mul(e1: &Element<Scalar>, e2: &Element<Scalar>): Element<Scala
     group_ops::mul(SCALAR_TYPE, e1, e2)
 }
 
-/// Returns e2/e1, fails if a is zero.
+/// Returns e2/e1, fails if e1 is zero.
 public fun scalar_div(e1: &Element<Scalar>, e2: &Element<Scalar>): Element<Scalar> {
     group_ops::div(SCALAR_TYPE, e1, e2)
 }


### PR DESCRIPTION
## Summary
Fixes #24547

The doc comment for `scalar_div` in `bls12381.move` incorrectly references a non-existent parameter `a`:

```move
/// Returns e2/e1, fails if a is zero.
public fun scalar_div(e1: &Element<Scalar>, e2: &Element<Scalar>): Element<Scalar>
```

Changed to reference the actual parameter `e1`:

```move
/// Returns e2/e1, fails if e1 is zero.
```

## Test plan
- [x] Documentation change only, no functional impact

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=101010297