### PR TITLE
fix(indexer-alt-framework): fix clap requires attribute for task arg

### DIFF
--- a/crates/sui-indexer-alt-framework/src/lib.rs
+++ b/crates/sui-indexer-alt-framework/src/lib.rs
@@ -81,7 +81,7 @@ pub struct TaskArgs {
     ///
     /// The framework ensures that tasked pipelines never commit checkpoints below the main
     /// pipeline’s pruner watermark. Requires `--reader-interval-ms`.
-    #[arg(long, requires = "reader-interval-ms")]
+    #[arg(long, requires = "reader_interval_ms")]
     task: Option<String>,
 
     /// The interval in milliseconds at which each of the pipelines on a tasked indexer should


### PR DESCRIPTION
## Summary
Fixes #24740

The `requires` attribute in clap must reference the **field name** (with underscores), not the CLI argument name (with hyphens).

## The Bug
When running the basic Sui indexer example:
```
cargo run -- --remote-store-url https://checkpoints.testnet.sui.io
```

Users get this error:
```
Command sui-indexer-alt-framework: Argument or group 'reader-interval-ms' specified in 'requires*' for 'task' does not exist
```

## The Fix
Changed:
```rust
#[arg(long, requires = "reader-interval-ms")]  // ❌ Wrong - CLI name
```
To:
```rust
#[arg(long, requires = "reader_interval_ms")]  // ✅ Correct - field name
```

## Test plan
- [x] Verified the fix matches what's already on main branch
- [x] The clap `requires` attribute now correctly references the field name

---
Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=101010297