### PR TITLE
[consensus] avoid cloning subscribed block before handling

### DIFF
--- a/consensus/core/src/subscriber.rs
+++ b/consensus/core/src/subscriber.rs
@@ -202,9 +202,7 @@ impl<C: NetworkClient, S: NetworkService> Subscriber<C, S> {
                             .subscribed_blocks
                             .with_label_values(&[peer_hostname])
                             .inc();
-                        let result = authority_service
-                            .handle_send_block(peer, block)
-                            .await;
+                        let result = authority_service.handle_send_block(peer, block).await;
                         if let Err(e) = result {
                             match e {
                                 ConsensusError::BlockRejected { block_ref, reason } => {


### PR DESCRIPTION
This change removes an unnecessary clone of the subscribed block before passing it to the authority service. The 
ExtendedSerializedBlock is already owned by the stream, so it can be moved directly into handle_send_block without duplicating its internal buffers.

By avoiding this extra clone on the subscription hot path, we reduce redundant allocations and copies for every received block, while keeping the behavior and semantics of the subscriber unchanged.