### PR TITLE
chore: remove unnecessary unused attribute from KeyStore account keys

### DIFF
--- a/crates/simulacrum/src/store/in_mem_store.rs
+++ b/crates/simulacrum/src/store/in_mem_store.rs
@@ -327,7 +327,6 @@ impl ParentSync for InMemoryStore {
 #[derive(Debug)]
 pub struct KeyStore {
     validator_keys: BTreeMap<AuthorityName, AuthorityKeyPair>,
-    #[allow(unused)]
     account_keys: BTreeMap<SuiAddress, AccountKeyPair>,
 }
 


### PR DESCRIPTION
The account_keys field in KeyStore is actively used via the accounts() API and downstream callers, so the #[allow(unused)] attribute is no longer accurate. Removing it aligns with the repository guidelines to avoid suppressing lint warnings when the underlying issue can be fixed, and keeps the intent of the code clearer for future maintenance.