### PR TITLE
Use a single AuthorityPerEpochStore in SuiTxValidator

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,7 @@ CHANGELOG.md
 /crates/sui-core/src/consensus_adapter.rs @MystenLabs/consensus
 /crates/sui-core/src/consensus_handler.rs @MystenLabs/consensus
 /crates/sui-core/src/consensus_manager/ @MystenLabs/consensus
+/crates/sui-core/src/consensus_validator.rs @MystenLabs/consensus
 /crates/sui-core/src/transaction_driver/ @MystenLabs/consensus
 /crates/sui-core/src/transaction_orchestrator.rs @MystenLabs/consensus
 /crates/sui-core/src/validator_client_monitor/ @MystenLabs/consensus

--- a/crates/sui-core/src/unit_tests/consensus_manager_tests.rs
+++ b/crates/sui-core/src/unit_tests/consensus_manager_tests.rs
@@ -95,6 +95,7 @@ async fn test_consensus_manager() {
                 consensus_handler_initializer,
                 SuiTxValidator::new(
                     state.clone(),
+                    epoch_store.clone(),
                     Arc::new(CheckpointServiceNoop {}),
                     SuiTxValidatorMetrics::new(&Registry::new()),
                 ),

--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -1418,6 +1418,7 @@ impl SuiNode {
             let epoch_store = epoch_store.clone();
             let sui_tx_validator = SuiTxValidator::new(
                 state.clone(),
+                epoch_store.clone(),
                 checkpoint_service.clone(),
                 sui_tx_validator_metrics.clone(),
             );


### PR DESCRIPTION
## Description 

This avoids a race between epoch change and transaction validation when epoch store is used.

## Test plan 

CI