### PR TITLE
[consensus] avoid redundant String allocation in median_timestamp_by_stake error

### DIFF
--- a/consensus/core/src/linearizer.rs
+++ b/consensus/core/src/linearizer.rs
@@ -308,8 +308,7 @@ pub(crate) fn median_timestamp_by_stake(
             "Total stake {} < quorum threshold {}",
             total_stake,
             context.committee.quorum_threshold()
-        )
-        .to_string());
+        ));
     }
 
     Ok(median_timestamps_by_stake_inner(timestamps, total_stake))


### PR DESCRIPTION
The error branch for insufficient stake wrapped a format! call with an extra .to_string(), even though format! already returns a String. Removing the redundant conversion avoids an unnecessary allocation and makes the intent of the code clearer without changing behavior.