### PR TITLE
refactor(node): reuse computed ChainIdentifier when deriving Chain

### DIFF
--- a/crates/sui-node/src/lib.rs
+++ b/crates/sui-node/src/lib.rs
@@ -567,7 +567,7 @@ impl SuiNode {
         let chain_id = ChainIdentifier::from(*genesis.checkpoint().digest());
         let chain = match config.chain_override_for_testing {
             Some(chain) => chain,
-            None => ChainIdentifier::from(*genesis.checkpoint().digest()).chain(),
+            None => chain_id.chain(),
         };
 
         let epoch_options = default_db_options().optimize_db_for_write_throughput(4);


### PR DESCRIPTION
SuiNode::start_async was constructing ChainIdentifier twice from the same genesis checkpoint digest: once for chain_id and once more in the None branch when calling .chain(). This change reuses the already computed chain_id (None => chain_id.chain()), eliminating redundant work and matching the pattern used in test_authority_builder.rs, without changing runtime behavior.