### PR TITLE
graphql: Infer types for pure PTB call args

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/programmable.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/programmable.move
@@ -48,8 +48,8 @@ module test::simple {
           }
           nodes {
             __typename
-            ... on Pure {
-              bytes
+            ... on MoveValue {
+              json
             }
           }
         }
@@ -91,8 +91,8 @@ module test::simple {
           }
           nodes {
             __typename
-            ... on Pure {
-              bytes
+            ... on MoveValue {
+              json
             }
           }
         }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/programmable.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/programmable.snap
@@ -42,12 +42,12 @@ Response: {
               "__typename": "SharedInput"
             },
             {
-              "__typename": "Pure",
-              "bytes": "KgAAAAAAAAA="
+              "__typename": "MoveValue",
+              "json": "42"
             },
             {
-              "__typename": "Pure",
-              "bytes": "p7AycDh4qnTDEmk1eJ/R1NfhEdWRGwkkfWljBhwxK1o="
+              "__typename": "MoveValue",
+              "json": "0xa7b032703878aa74c3126935789fd1d4d7e111d5911b09247d6963061c312b5a"
             }
           ]
         },
@@ -109,8 +109,8 @@ Response: {
               "__typename": "SharedInput"
             },
             {
-              "__typename": "Pure",
-              "bytes": "KgAAAAAAAAA="
+              "__typename": "MoveValue",
+              "json": "42"
             }
           ]
         },

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/programmable_inputs.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/programmable_inputs.move
@@ -53,7 +53,7 @@ module test::simple {
 //# create-checkpoint
 
 // Test 2: SharedInput only - demonstrates SharedInput TransactionInput type
-//# programmable --sender A --inputs object(1,0) 10  
+//# programmable --sender A --inputs object(1,0) 10
 //> 0: test::simple::add(Input(0), Input(1))
 
 //# create-checkpoint
@@ -66,7 +66,7 @@ module test::simple {
 //# create-checkpoint
 
 // Test 4: Receiving only - demonstrates Receiving TransactionInput type
-//# programmable --sender A --inputs 200u64 @A  
+//# programmable --sender A --inputs 200u64 @A
 // Setup: Create coin and transfer it to A's address for Receiving test
 //> 0: test::simple::new_coin(Input(0));
 //> TransferObjects([Result(0)], Input(1))
@@ -83,7 +83,7 @@ module test::simple {
 
 //# run-graphql
 {
-  # Test 1: Pure input only
+  # Test 1: MoveValue input (Pure with inferred type layout) only
   pureInputTest: transaction(digest: "@{digest_2}") {
     digest
     kind {
@@ -92,8 +92,8 @@ module test::simple {
         inputs(first: 10) {
           nodes {
             __typename
-            ... on Pure {
-              bytes
+            ... on MoveValue {
+              json
             }
           }
         }
@@ -102,7 +102,7 @@ module test::simple {
   }
 }
 
-//# run-graphql  
+//# run-graphql
 {
   # Test 2: SharedInput only
   sharedInputTest: transaction(digest: "@{digest_4}") {
@@ -127,7 +127,7 @@ module test::simple {
 
 //# run-graphql
 {
-  # Test 3: OwnedOrImmutable input only  
+  # Test 3: OwnedOrImmutable input only
   ownedOrImmutableTest: transaction(digest: "@{digest_6}") {
     digest
     kind {
@@ -173,4 +173,4 @@ module test::simple {
       }
     }
   }
-} 
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/programmable_inputs.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transactions/kind/programmable/programmable_inputs.snap
@@ -25,7 +25,7 @@ task 3, lines 53-55:
 Checkpoint created: 1
 
 task 4, lines 56-57:
-//# programmable --sender A --inputs object(1,0) 10  
+//# programmable --sender A --inputs object(1,0) 10
 //> 0: test::simple::add(Input(0), Input(1))
 mutated: object(0,0), object(1,0)
 gas summary: computation_cost: 1000000, storage_cost: 2340800,  storage_rebate: 2317392, non_refundable_storage_fee: 23408
@@ -45,7 +45,7 @@ task 7, lines 66-68:
 Checkpoint created: 3
 
 task 8, lines 69-72:
-//# programmable --sender A --inputs 200u64 @A  
+//# programmable --sender A --inputs 200u64 @A
 // Setup: Create coin and transfer it to A's address for Receiving test
 //> 0: test::simple::new_coin(Input(0));
 //> TransferObjects([Result(0)], Input(1))
@@ -82,12 +82,12 @@ Response: {
         "inputs": {
           "nodes": [
             {
-              "__typename": "Pure",
-              "bytes": "KgAAAAAAAAA="
+              "__typename": "MoveValue",
+              "json": "42"
             },
             {
-              "__typename": "Pure",
-              "bytes": "/MyaQhu7E8GmahqpjwrXUCnt6UhXd5xpFbRPlAaLkh4="
+              "__typename": "MoveValue",
+              "json": "0xfccc9a421bbb13c1a66a1aa98f0ad75029ede94857779c6915b44f94068b921e"
             }
           ]
         }
@@ -97,7 +97,7 @@ Response: {
 }
 
 task 13, lines 105-126:
-//# run-graphql  
+//# run-graphql
 Response: {
   "data": {
     "sharedInputTest": {
@@ -113,7 +113,7 @@ Response: {
               "mutable": true
             },
             {
-              "__typename": "Pure"
+              "__typename": "MoveValue"
             }
           ]
         }
@@ -169,7 +169,7 @@ Response: {
               }
             },
             {
-              "__typename": "Pure"
+              "__typename": "MoveValue"
             }
           ]
         }

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -4061,7 +4061,7 @@ input TransactionFilter {
 """
 Input argument to a Programmable Transaction Block (PTB) command.
 """
-union TransactionInput = Pure | OwnedOrImmutable | SharedInput | Receiving | BalanceWithdraw
+union TransactionInput = Pure | MoveValue | OwnedOrImmutable | SharedInput | Receiving | BalanceWithdraw
 
 type TransactionInputConnection {
 	"""

--- a/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/inputs/mod.rs
+++ b/crates/sui-indexer-alt-graphql/src/api/types/transaction_kind/programmable/inputs/mod.rs
@@ -3,10 +3,11 @@
 
 use async_graphql::Union;
 
-use sui_types::transaction::CallArg;
-use sui_types::transaction::ObjectArg;
+use move_core_types::annotated_value::MoveTypeLayout;
 
 use crate::api::scalars::base64::Base64;
+use crate::api::types::move_type::MoveType;
+use crate::api::types::move_value::MoveValue;
 use crate::scope::Scope;
 
 pub mod balance_withdraw;
@@ -23,6 +24,7 @@ pub use pure::Pure;
 #[derive(Union)]
 pub enum TransactionInput {
     Pure(Pure),
+    Value(MoveValue),
     OwnedOrImmutable(OwnedOrImmutable),
     SharedInput(SharedInput),
     Receiving(Receiving),
@@ -30,32 +32,47 @@ pub enum TransactionInput {
 }
 
 impl TransactionInput {
-    pub fn from(input: CallArg, scope: Scope) -> Self {
-        match input {
-            CallArg::Pure(bytes) => Self::Pure(Pure {
+    pub fn from(
+        input: sui_types::transaction::CallArg,
+        layout: Option<MoveTypeLayout>,
+        scope: Scope,
+    ) -> Self {
+        use sui_types::transaction::CallArg as CA;
+        use sui_types::transaction::ObjectArg as OA;
+
+        match (input, layout) {
+            // If the layout for the pure arg can be inferred, then represent it as a MoveValue.
+            (CA::Pure(native), Some(layout)) => Self::Value(MoveValue {
+                type_: MoveType::from_layout(layout, scope),
+                native,
+            }),
+
+            (CA::Pure(bytes), None) => Self::Pure(Pure {
                 bytes: Some(Base64::from(bytes)),
             }),
-            CallArg::Object(obj_arg) => match obj_arg {
-                ObjectArg::ImmOrOwnedObject((object_id, version, digest)) => {
-                    Self::OwnedOrImmutable(OwnedOrImmutable::from_object_ref(
-                        object_id, version, digest, scope,
-                    ))
-                }
-                ObjectArg::SharedObject {
+
+            (CA::Object(OA::ImmOrOwnedObject((id, version, digest))), _) => Self::OwnedOrImmutable(
+                OwnedOrImmutable::from_object_ref(id, version, digest, scope),
+            ),
+
+            (
+                CA::Object(OA::SharedObject {
                     id,
                     initial_shared_version,
                     mutability,
-                } => Self::SharedInput(SharedInput::from_shared_object(
-                    id,
-                    initial_shared_version,
-                    // TODO: extend schema to expose the full mutability enum
-                    mutability.is_exclusive(),
-                )),
-                ObjectArg::Receiving((object_id, version, digest)) => Self::Receiving(
-                    Receiving::from_object_ref(object_id, version, digest, scope),
-                ),
-            },
-            CallArg::FundsWithdrawal(withdrawal) => {
+                }),
+                _,
+            ) => Self::SharedInput(SharedInput::from_shared_object(
+                id,
+                initial_shared_version,
+                mutability.is_exclusive(),
+            )),
+
+            (CA::Object(OA::Receiving((id, version, digest))), _) => {
+                Self::Receiving(Receiving::from_object_ref(id, version, digest, scope))
+            }
+
+            (CA::FundsWithdrawal(withdrawal), _) => {
                 Self::BalanceWithdraw(BalanceWithdraw::from_native(withdrawal, scope))
             }
         }

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/sui-indexer-alt-graphql/src/lib.rs
-assertion_line: 466
 expression: sdl
 ---
 """
@@ -4066,7 +4065,7 @@ input TransactionFilter {
 """
 Input argument to a Programmable Transaction Block (PTB) command.
 """
-union TransactionInput = Pure | OwnedOrImmutable | SharedInput | Receiving | BalanceWithdraw
+union TransactionInput = Pure | MoveValue | OwnedOrImmutable | SharedInput | Receiving | BalanceWithdraw
 
 type TransactionInputConnection {
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -4065,7 +4065,7 @@ input TransactionFilter {
 """
 Input argument to a Programmable Transaction Block (PTB) command.
 """
-union TransactionInput = Pure | OwnedOrImmutable | SharedInput | Receiving | BalanceWithdraw
+union TransactionInput = Pure | MoveValue | OwnedOrImmutable | SharedInput | Receiving | BalanceWithdraw
 
 type TransactionInputConnection {
 	"""

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -4061,7 +4061,7 @@ input TransactionFilter {
 """
 Input argument to a Programmable Transaction Block (PTB) command.
 """
-union TransactionInput = Pure | OwnedOrImmutable | SharedInput | Receiving | BalanceWithdraw
+union TransactionInput = Pure | MoveValue | OwnedOrImmutable | SharedInput | Receiving | BalanceWithdraw
 
 type TransactionInputConnection {
 	"""


### PR DESCRIPTION
## Description

Use existing functionality in the package resolver to represent pure transaction arguments as `MoveValue`s if we can infer their type (otherwise, keep using `Pure` call args).

## Test plan

Updated unit tests:

```
sui$ cargo nextest run         \
  -p sui-indexer-alt-e2e-tests \
  -- transactions/kind/programmable
```

## Stack

- #24652 
- #24621 
- #24768
- #24769 
- #24770 
- #24771 
- #24772 
- #24773 
- #24774 

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [x] GraphQL: PTB Inputs are represented as `MoveValue`-s, if their types can be inferred.
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
