### PR TITLE
graphql: Epoch.totalTransactions for in-progress epochs

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/total_transactions/total_transactions_empty_epoch.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/total_transactions/total_transactions_empty_epoch.snap
@@ -11,7 +11,7 @@ task 1, lines 6-15:
 Response: {
   "data": {
     "e0": {
-      "totalTransactions": null
+      "totalTransactions": 1
     },
     "e1": null,
     "e2": null

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/total_transactions/total_transactions_with_transaction.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/total_transactions/total_transactions_with_transaction.snap
@@ -19,7 +19,7 @@ task 2, lines 10-19:
 Response: {
   "data": {
     "e0": {
-      "totalTransactions": null
+      "totalTransactions": 1
     },
     "e1": null,
     "e2": null

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/transactions/tranactions_at_checkpoint.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/transactions/tranactions_at_checkpoint.snap
@@ -115,7 +115,7 @@ Response: {
       }
     },
     "epoch1AtCheckpoint2": {
-      "totalTransactions": null,
+      "totalTransactions": 3,
       "transactions": {
         "edges": [
           {

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/transactions/transactions_after_checkpoint.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/transactions/transactions_after_checkpoint.snap
@@ -11,7 +11,7 @@ task 1, lines 6-14:
 Response: {
   "data": {
     "epoch0AfterCp0NoTx": {
-      "totalTransactions": null,
+      "totalTransactions": 1,
       "transactions": {
         "edges": []
       }
@@ -44,7 +44,7 @@ task 5, lines 26-34:
 Response: {
   "data": {
     "epoch0AfterCp0WithTx": {
-      "totalTransactions": null,
+      "totalTransactions": 3,
       "transactions": {
         "edges": [
           {
@@ -106,7 +106,7 @@ task 9, lines 46-54:
 Response: {
   "data": {
     "epoch0AfterCp1WithTx": {
-      "totalTransactions": null,
+      "totalTransactions": 5,
       "transactions": {
         "edges": [
           {
@@ -171,7 +171,7 @@ task 14, lines 68-82:
 Response: {
   "data": {
     "epoch1AfterCp2": {
-      "totalTransactions": null,
+      "totalTransactions": 2,
       "transactions": {
         "edges": [
           {
@@ -206,7 +206,7 @@ Response: {
       }
     },
     "epoch1AfterNonExistentCp5": {
-      "totalTransactions": null,
+      "totalTransactions": 2,
       "transactions": {
         "edges": []
       }

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/transactions/transactions_before_checkpoint.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/epochs/transactions/transactions_before_checkpoint.snap
@@ -11,7 +11,7 @@ task 1, lines 6-14:
 Response: {
   "data": {
     "epoch0BeforeCp0NotTx": {
-      "totalTransactions": null,
+      "totalTransactions": 1,
       "transactions": {
         "edges": []
       }

--- a/crates/sui-indexer-alt-graphql/schema.graphql
+++ b/crates/sui-indexer-alt-graphql/schema.graphql
@@ -1219,7 +1219,9 @@ type Epoch implements Node {
 	"""
 	totalStakeSubsidies: BigInt
 	"""
-	The total number of transaction blocks in this epoch (or `null` if the epoch has not finished yet).
+	The total number of transaction blocks in this epoch.
+	
+	If the epoch has not finished yet, this number is computed based on the number of transactions at the latest known checkpoint.
 	"""
 	totalTransactions: UInt53
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__schema.graphql.snap
@@ -1223,7 +1223,9 @@ type Epoch implements Node {
 	"""
 	totalStakeSubsidies: BigInt
 	"""
-	The total number of transaction blocks in this epoch (or `null` if the epoch has not finished yet).
+	The total number of transaction blocks in this epoch.
+	
+	If the epoch has not finished yet, this number is computed based on the number of transactions at the latest known checkpoint.
 	"""
 	totalTransactions: UInt53
 	"""

--- a/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
+++ b/crates/sui-indexer-alt-graphql/src/snapshots/sui_indexer_alt_graphql__tests__staging.graphql.snap
@@ -1223,7 +1223,9 @@ type Epoch implements Node {
 	"""
 	totalStakeSubsidies: BigInt
 	"""
-	The total number of transaction blocks in this epoch (or `null` if the epoch has not finished yet).
+	The total number of transaction blocks in this epoch.
+	
+	If the epoch has not finished yet, this number is computed based on the number of transactions at the latest known checkpoint.
 	"""
 	totalTransactions: UInt53
 	"""

--- a/crates/sui-indexer-alt-graphql/staging.graphql
+++ b/crates/sui-indexer-alt-graphql/staging.graphql
@@ -1219,7 +1219,9 @@ type Epoch implements Node {
 	"""
 	totalStakeSubsidies: BigInt
 	"""
-	The total number of transaction blocks in this epoch (or `null` if the epoch has not finished yet).
+	The total number of transaction blocks in this epoch.
+	
+	If the epoch has not finished yet, this number is computed based on the number of transactions at the latest known checkpoint.
 	"""
 	totalTransactions: UInt53
 	"""


### PR DESCRIPTION
## Description

Support queries for `Epoch.totalTransactions` on whatever the GraphQL service considers to be the current epoch/checkpoint (either the tip of the chain, or some artificial "latest" checkpoint if the query is nested under a `checkpoint(sequenceNumber: ...) { query { ... } }`.

## Test plan

Existing tests:

```
$ cargo nextest run -p sui-indexer-alt-e2e-tests -- epoch
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [x] GraphQL: `Epoch.totalTransactions` now returns a value for the latest epoch as of the checkpoint being viewed, rather than `null`.
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
