### PR TITLE
docs: update graphql data-access retention docs

### DIFF
--- a/docs/content/concepts/data-access/graphql-rpc.mdx
+++ b/docs/content/concepts/data-access/graphql-rpc.mdx
@@ -320,11 +320,12 @@ Query the available checkpoint range using `serviceConfig.availableRange`:
 availableRange(type: String!, field: String, filters: [String!]): AvailableRange!
 ```
 
-- **`type`**: The GraphQL type name, such as `"Query"` or `"Address"`
-- **`field`**: The field on that type, such as `"transactions"` or `"events"`
+- **`type`**: The GraphQL type name, such as `"Query"` or `"Address"`.
+- **`field`**: The field on that type, such as `"transactions"` or `"events"`.
 - **`filters`**: Filter field names from the filter input type, such as `["affectedAddress"]` for `TransactionFilter`, `["module"]` for `EventFilter`, or direct query parameter names like `["version"]`.
 
 Match your query parameters to filter names: if your query uses `filter: { affectedAddress: "0x..." }`, pass `filters: ["affectedAddress"]`.
+
 :::info Strictest retention is returned by the available range query.
 Datasource pipelines can be configured with different retention ranges based on pruning configurations.
 When multiple filters are passed to the available range query, the strictest retention range of the pipelines that support the filters is returned.


### PR DESCRIPTION
## Description 

Changes:
- Added more docs and examples for retention and available range - https://github.com/MystenLabs/sui/compare/hc/update-retention-docs?expand=1#diff-2487aeecbfc816ce6487cd0f7d2a50242d31b29d4585b5fa2eb17f2ef0c58e48L308

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
