### PR TITLE
perf: avoid cloning HeaderValue in gRPC metrics handler

### DIFF
--- a/crates/mysten-network/src/metrics.rs
+++ b/crates/mysten-network/src/metrics.rs
@@ -78,11 +78,10 @@ impl<B, M: MetricsCallbackProvider> OnResponse<B> for MetricsHandler<M> {
         let grpc_status = Status::from_header_map(response.headers());
         let grpc_status_code = grpc_status.map_or(Code::Ok, |s| s.code());
 
-        let path: HeaderValue = response
+        let path: &HeaderValue = response
             .headers()
             .get(&GRPC_ENDPOINT_PATH_HEADER)
-            .unwrap()
-            .clone();
+            .unwrap();
 
         self.metrics_provider.on_response(
             path.to_str().unwrap().to_string(),


### PR DESCRIPTION
Remove an unnecessary clone of the HeaderValue carrying the gRPC endpoint path in MetricsHandler::on_response. We can safely work with a reference to the header since the response and its headers outlive the callback invocation, and the value is immediately converted to String for the metrics callback. This keeps behavior unchanged while avoiding an extra refcount operation on every request.