### PR TITLE
[package-alt] implement --allow-dirty and fix --install-dir (#24715)

### DIFF
--- a/crates/sui-source-validation/src/tests.rs
+++ b/crates/sui-source-validation/src/tests.rs
@@ -3,6 +3,7 @@
 
 use expect_test::expect;
 use move_core_types::account_address::AccountAddress;
+use move_package_alt::package::package_loader::PackageLoader;
 use std::collections::HashMap;
 use std::{fs, io, path::Path};
 use std::{path::PathBuf, str};
@@ -1001,7 +1002,7 @@ async fn write_published_toml(
     let env_name = Chain::Testnet.as_str().to_string();
     let chain_id = get_testnet_chain_identifier().to_string();
     let env = Environment::new(env_name, chain_id.clone());
-    let mut root_pkg = RootPackage::<SuiFlavor>::load(pkg_path, env.clone(), vec![]).await?;
+    let mut root_pkg: RootPackage<SuiFlavor> = PackageLoader::new(pkg_path, env).load().await?;
     root_pkg.write_publish_data(move_package_alt::schema::Publication {
         chain_id,
         addresses: PublishAddresses {

--- a/crates/sui/src/client_commands.rs
+++ b/crates/sui/src/client_commands.rs
@@ -32,7 +32,7 @@ use move_bytecode_verifier_meter::Scope;
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, language_storage::TypeTag,
 };
-use move_package_alt::schema::ModeName;
+use move_package_alt::{package::package_loader::PackageLoader, schema::ModeName};
 use move_package_alt_compilation::build_config::BuildConfig as MoveBuildConfig;
 use prometheus::Registry;
 use serde::Serialize;
@@ -3522,7 +3522,7 @@ pub async fn load_root_pkg_for_publish_upgrade(
     path: &Path,
 ) -> anyhow::Result<RootPackage<SuiFlavor>> {
     let env = find_environment(path, build_config.environment.clone(), wallet).await?;
-    Ok(RootPackage::<SuiFlavor>::load(path, env, build_config.mode_set()).await?)
+    Ok(build_config.package_loader(path, &env).load().await?)
 }
 
 async fn load_root_pkg_for_test_publish(
@@ -3536,14 +3536,12 @@ async fn load_root_pkg_for_test_publish(
     let pubfile_path =
         pubfile_path.unwrap_or_else(|| PathBuf::from(format!("Pub.{active_env}.toml")));
 
-    Ok(RootPackage::<SuiFlavor>::load_ephemeral(
-        package_path,
-        build_env,
-        chain_id,
-        pubfile_path,
-        modes,
+    Ok(
+        PackageLoader::new_ephemeral(package_path, build_env, chain_id, pubfile_path)
+            .modes(modes)
+            .load()
+            .await?,
     )
-    .await?)
 }
 
 /// Return the update publication data, without writing it to lockfile

--- a/crates/sui/tests/cli_tests.rs
+++ b/crates/sui/tests/cli_tests.rs
@@ -225,6 +225,7 @@ upgrade-capability = "{}""#,
         let mut build_config = BuildConfig::new_for_testing();
         build_config.config.environment = Some(environment.name.clone());
         build_config.environment = environment.clone();
+        build_config.config.install_dir = None;
         let compiled_package = build_config.build_async(&package_path).await.unwrap();
 
         let context = self.test_cluster.wallet_mut();
@@ -263,7 +264,8 @@ upgrade-capability = "{}""#,
         upgrade_capability: ObjectID,
     ) -> Result<ObjectID, anyhow::Error> {
         let mut build_config = BuildConfig::new_for_testing().config;
-        build_config.lock_file = Some(self.package_path(package_name).join("Move.lock"));
+        build_config.install_dir = None;
+
         let resp = SuiClientCommands::Upgrade {
             package_path: self.package_path(package_name),
             upgrade_capability: Some(upgrade_capability),
@@ -317,8 +319,7 @@ async fn test_publish_package(
     pubfile: Option<PathBuf>,
 ) -> Result<(ObjectID, ObjectID), anyhow::Error> {
     let mut build_config = BuildConfig::new_for_testing().config;
-    let move_lock_path = package_path.clone().join("Move.lock");
-    build_config.lock_file = Some(move_lock_path.clone());
+    build_config.install_dir = None;
 
     let pubfile_path = pubfile.unwrap_or(package_path.join("localnet.toml"));
     let resp = SuiClientCommands::TestPublish(TestPublishArgs {
@@ -372,8 +373,7 @@ async fn publish_package(
     with_unpublished_dependencies: bool,
 ) -> Result<(ObjectID, ObjectID), anyhow::Error> {
     let mut build_config = BuildConfig::new_for_testing().config;
-    let move_lock_path = package_path.clone().join("Move.lock");
-    build_config.lock_file = Some(move_lock_path.clone());
+    build_config.install_dir = None;
 
     let resp = SuiClientCommands::Publish(PublishArgs {
         package_path: package_path.clone(),
@@ -1318,7 +1318,8 @@ async fn test_package_management_on_publish_command() -> Result<(), anyhow::Erro
     // Check log output contains all object ids.
     let gas_obj_id = object_refs.first().unwrap().object().unwrap().object_id;
 
-    let build_config = BuildConfig::new_for_testing().config;
+    let mut build_config = BuildConfig::new_for_testing().config;
+    build_config.install_dir = None;
 
     let (_tmp, pkg_path) =
         create_temp_dir_with_framework_packages("pkg_mgmt_modules_publish", Some(chain_id))?;
@@ -2339,7 +2340,9 @@ async fn test_package_upgrade_command() -> Result<(), anyhow::Error> {
     let (_tmp, package_path) =
         create_temp_dir_with_framework_packages("dummy_modules_upgrade", Some(chain_id))?;
 
-    let build_config = BuildConfig::new_for_testing().config;
+    let mut build_config = BuildConfig::new_for_testing().config;
+    build_config.install_dir = None; // build in-place so that the publish info is recorded
+
     let resp = SuiClientCommands::Publish(PublishArgs {
         package_path: package_path.clone(),
         build_config: build_config.clone(),
@@ -2445,7 +2448,9 @@ async fn test_package_management_on_upgrade_command() -> Result<(), anyhow::Erro
     let (_tmp, package_path) =
         create_temp_dir_with_framework_packages("dummy_modules_upgrade", Some(chain_id))?;
 
-    let build_config = BuildConfig::new_for_testing().config;
+    let mut build_config = BuildConfig::new_for_testing().config;
+    build_config.install_dir = None;
+
     let resp = SuiClientCommands::Publish(PublishArgs {
         package_path: package_path.clone(),
         build_config: build_config.clone(),

--- a/external-crates/move/crates/move-analyzer/src/symbols/compilation.rs
+++ b/external-crates/move/crates/move-analyzer/src/symbols/compilation.rs
@@ -24,7 +24,6 @@ use std::{
     sync::{Arc, Mutex},
     vec,
 };
-use tempfile::tempdir;
 use vfs::{
     VfsPath,
     impls::{memory::MemoryFS, overlay::OverlayFS, physical::PhysicalFS},
@@ -306,13 +305,11 @@ pub fn get_compiled_pkg<F: MoveFlavor>(
     flavor: Option<Flavor>,
     cursor_file_opt: Option<&PathBuf>,
 ) -> Result<(Option<CompiledPkgInfo>, BTreeMap<PathBuf, Vec<Diagnostic>>)> {
-    let cached_deps_exist = has_precompiled_deps(pkg_path, packages_info.clone());
     let build_config = move_package_alt_compilation::build_config::BuildConfig {
         test_mode: true,
-        install_dir: Some(tempdir().unwrap().path().to_path_buf()),
         default_flavor: flavor,
         lint_flag: lint.into(),
-        force_lock_file: cached_deps_exist,
+        allow_dirty: true,
         ..Default::default()
     };
 
@@ -808,11 +805,6 @@ fn merge_diagnostics_for_file(
     }
 }
 
-fn has_precompiled_deps(pkg_path: &Path, pkg_dependencies: Arc<Mutex<CachedPackages>>) -> bool {
-    let pkg_deps = pkg_dependencies.lock().unwrap();
-    pkg_deps.pkg_info.contains_key(pkg_path)
-}
-
 fn compute_mapped_files<F: MoveFlavor>(
     root_pkg: &RootPackage<F>,
     build_config: &BuildConfig,
@@ -1082,8 +1074,7 @@ fn load_root_pkg<F: MoveFlavor>(
     path: &Path,
 ) -> anyhow::Result<RootPackage<F>> {
     let env = find_env::<F>(path, build_config)?;
-    let mut root_pkg =
-        RootPackage::<F>::load_sync(path.to_path_buf(), env, build_config.mode_set())?;
+    let mut root_pkg = build_config.package_loader(path, &env).load_sync()?;
 
     root_pkg.save_lockfile_to_disk()?;
 

--- a/external-crates/move/crates/move-cli/src/base/summary.rs
+++ b/external-crates/move/crates/move-cli/src/base/summary.rs
@@ -106,7 +106,8 @@ impl Summary {
         } else {
             let path = reroot_path(path)?;
             let env = find_env::<F>(&path, &config)?;
-            let root_pkg = RootPackage::<F>::load(&path, env, config.mode_set()).await?;
+            let root_pkg: RootPackage<F> = config.package_loader(&path, &env).load().await?;
+
             // Get named addresses from the root package graph
             let named_addresses: BuildNamedAddresses =
                 root_pkg.package_info().named_addresses()?.into();

--- a/external-crates/move/crates/move-cli/src/base/test.rs
+++ b/external-crates/move/crates/move-cli/src/base/test.rs
@@ -166,8 +166,7 @@ pub async fn run_move_unit_tests<F: MoveFlavor, W: Write + Send>(
     // Load the package (package graph diagnostics are only needed for CLI commands so
     // ignore them by passing a vector as the writer)
     let env = find_env::<F>(pkg_path, &build_config)?;
-    let root_pkg =
-        RootPackage::<F>::load(pkg_path.to_path_buf(), env, build_config.mode_set()).await?;
+    let root_pkg: RootPackage<F> = build_config.package_loader(pkg_path, &env).load().await?;
     let root_pkg_name = Symbol::from(root_pkg.name().as_str());
 
     let mut addresses: Vec<(String, NumericalAddress)> = vec![];

--- a/external-crates/move/crates/move-cli/src/base/update_deps.rs
+++ b/external-crates/move/crates/move-cli/src/base/update_deps.rs
@@ -31,14 +31,12 @@ impl UpdateDeps {
     ) -> anyhow::Result<()> {
         let default = PathBuf::from(".");
         let path = path.unwrap_or(&default);
-        let modes = build_config
-            .modes
-            .clone()
-            .into_iter()
-            .map(|x| x.to_string())
-            .collect::<Vec<_>>();
 
-        let mut root_package = RootPackage::<F>::load_force_repin(&path, env, modes).await?;
+        let mut root_package: RootPackage<F> = build_config
+            .package_loader(path, &env)
+            .force_repin(true)
+            .load()
+            .await?;
         root_package.save_lockfile_to_disk()?;
         Ok(())
     }

--- a/external-crates/move/crates/move-cli/src/sandbox/commands/test.rs
+++ b/external-crates/move/crates/move-cli/src/sandbox/commands/test.rs
@@ -13,7 +13,7 @@ use move_coverage::coverage_map::{CoverageMap, ExecCoverageMapWithModules};
 
 use move_package_alt::{
     flavor::{Vanilla, vanilla},
-    package::{RootPackage, layout::SourcePackageLayout},
+    package::{RootPackage, layout::SourcePackageLayout, package_loader::PackageLoader},
 };
 use move_package_alt_compilation::{
     layout::CompiledPackageLayout, on_disk_package::OnDiskCompiledPackage,
@@ -156,13 +156,10 @@ fn copy_pkg_and_deps(tmp_dir: &Path, pkg_dir: &Path) -> anyhow::Result<PathBuf> 
 /// use moded dependencies with any other modes, those dependencies won't be copied and this code
 /// will need to be fixed.
 fn package_paths(pkg_dir: &Path) -> anyhow::Result<Vec<PathBuf>> {
-    let rt = tokio::runtime::Runtime::new()?;
-
-    let root_pkg = rt.block_on(RootPackage::<Vanilla>::load(
-        pkg_dir,
-        vanilla::default_environment(),
-        vec!["test".into()],
-    ))?;
+    let root_pkg: RootPackage<Vanilla> =
+        PackageLoader::new(pkg_dir, vanilla::default_environment())
+            .modes(vec!["test".into()])
+            .load_sync()?;
 
     let packages = root_pkg.packages();
 

--- a/external-crates/move/crates/move-cli/tests/build_tests/help/args.exp
+++ b/external-crates/move/crates/move-cli/tests/build_tests/help/args.exp
@@ -32,6 +32,8 @@ Options:
           Installation directory for compiled artifacts. Defaults to current directory
       --force
           Force recompilation of all packages
+      --allow-dirty
+          Allow building, even if some cached git dependencies in `~/.move` are modified
       --default-move-flavor <DEFAULT_FLAVOR>
           Default flavor for move compilation, if not specified in the package's config
       --default-move-edition <DEFAULT_EDITION>

--- a/external-crates/move/crates/move-decompiler/tests/tests.rs
+++ b/external-crates/move/crates/move-decompiler/tests/tests.rs
@@ -4,7 +4,7 @@
 use move_decompiler::{generate_from_model, testing::structuring_unit_test};
 
 use move_command_line_common::insta_assert;
-use move_package_alt::package::RootPackage;
+use move_package_alt::{flavor::Vanilla, package::RootPackage};
 use move_package_alt_compilation::{build_config::BuildConfig, model_builder};
 use move_symbol_pool::Symbol;
 
@@ -42,11 +42,7 @@ fn run_move_test(file_path: &Path) -> datatest_stable::Result<()> {
 
     let mut writer = Vec::new();
     let env = move_package_alt::flavor::vanilla::default_environment();
-    let root_pkg = RootPackage::<move_package_alt::flavor::Vanilla>::load_sync(
-        pkg_dir.to_path_buf(),
-        env,
-        config.mode_set(),
-    )?;
+    let root_pkg: RootPackage<Vanilla> = config.package_loader(pkg_dir, &env).load_sync()?;
 
     let model = model_builder::build(&mut writer, &root_pkg, &config)?;
 
@@ -95,11 +91,7 @@ fn run_full_test(file_path: &Path) -> datatest_stable::Result<()> {
 
     let mut writer = Vec::new();
     let env = move_package_alt::flavor::vanilla::default_environment();
-    let loaded_root_pkg = RootPackage::<move_package_alt::flavor::Vanilla>::load_sync(
-        pkg_dir.to_path_buf(),
-        env,
-        config.mode_set(),
-    )?;
+    let loaded_root_pkg: RootPackage<Vanilla> = config.package_loader(pkg_dir, &env).load_sync()?;
     let root_pkg_info = loaded_root_pkg.package_info();
     let root_pkg = root_pkg_info.display_name();
 

--- a/external-crates/move/crates/move-docgen-tests/tests/testsuite.rs
+++ b/external-crates/move/crates/move-docgen-tests/tests/testsuite.rs
@@ -53,11 +53,9 @@ fn test_impl(toml_path: &Path, flags: DocgenFlags, test_case: &str) -> datatest_
 
     // Block on the async function
     let env = move_package_alt::flavor::vanilla::default_environment();
-    let root_pkg = RootPackage::<Vanilla>::load_sync(
-        toml_path.parent().unwrap().to_path_buf(),
-        env,
-        config.mode_set(),
-    )?;
+    let root_pkg: RootPackage<Vanilla> = config
+        .package_loader(toml_path.parent().unwrap(), &env)
+        .load_sync()?;
     let model = model_builder::build(&mut w, &root_pkg, &config)?;
     let root_doc_template: PathBuf = test_dir.join(ROOT_DOC_TEMPLATE_NAME);
     let root_doc_template = if root_doc_template.is_file() {

--- a/external-crates/move/crates/move-package-alt-compilation/src/compilation.rs
+++ b/external-crates/move/crates/move-package-alt-compilation/src/compilation.rs
@@ -48,7 +48,7 @@ pub async fn compile_package<W: Write + Send, F: MoveFlavor>(
     env: &Environment,
     writer: &mut W,
 ) -> anyhow::Result<CompiledPackage> {
-    let root_pkg = RootPackage::<F>::load(path, env.clone(), build_config.mode_set()).await?;
+    let root_pkg: RootPackage<F> = build_config.package_loader(path, env).load().await?;
     BuildPlan::create(&root_pkg, build_config)?.compile(writer, |compiler| compiler)
 }
 

--- a/external-crates/move/crates/move-package-alt-compilation/tests/install_dir_tests.rs
+++ b/external-crates/move/crates/move-package-alt-compilation/tests/install_dir_tests.rs
@@ -86,12 +86,14 @@ async fn test_install_dir_creates_directory() {
 #[tokio::test]
 async fn test_install_dir_relative_path() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    std::env::set_current_dir(&temp_dir).unwrap();
+
     let package_path = temp_dir.path().join("test_package");
     fs::create_dir(&package_path).expect("Failed to create package dir");
 
     create_test_package(&package_path).expect("Failed to create test package");
 
-    let relative_install_dir = PathBuf::from("../install_output");
+    let relative_install_dir = PathBuf::from("install_output");
 
     let build_config = BuildConfig {
         install_dir: Some(relative_install_dir.clone()),
@@ -111,7 +113,7 @@ async fn test_install_dir_relative_path() {
         result.unwrap_err()
     );
 
-    let expected_install_path = package_path.join("../install_output");
+    let expected_install_path = package_path.join("install_output");
     assert!(
         expected_install_path.exists(),
         "Install dir should be created at relative path"
@@ -142,10 +144,9 @@ async fn test_install_dir_absolute_path() {
     let env = default_environment();
     let mut output = Cursor::new(Vec::new());
 
-    let result =
-        compile_package::<_, Vanilla>(&package_path, &build_config, &env, &mut output).await;
-
-    assert!(result.is_ok(), "Compilation should succeed");
+    compile_package::<_, Vanilla>(&package_path, &build_config, &env, &mut output)
+        .await
+        .expect("compilation succeeds");
 
     assert!(
         absolute_install_dir.exists(),

--- a/external-crates/move/crates/move-package-alt/src/dependency/fetch.rs
+++ b/external-crates/move/crates/move-package-alt/src/dependency/fetch.rs
@@ -39,11 +39,11 @@ impl FetchedDependency {
     /// Assumes that `pinned` is already normalized - paths of any local dependencies are relative
     /// to the current working directory, and local dependencies of git dependencies have been
     /// transformed into git dependencies
-    pub async fn fetch(pinned: &Pinned) -> FetchResult<PackagePath> {
+    pub async fn fetch(pinned: &Pinned, allow_dirty: bool) -> FetchResult<PackagePath> {
         let path = match &pinned {
             Pinned::Git(dep) => dep
                 .inner
-                .fetch()
+                .checkout_repo(allow_dirty)
                 .await
                 .map_err(FetchError::from_git(pinned))?,
             _ => pinned.unfetched_path(),

--- a/external-crates/move/crates/move-package-alt/src/git/cache.rs
+++ b/external-crates/move/crates/move-package-alt/src/git/cache.rs
@@ -42,7 +42,7 @@ pub struct GitCache {
 }
 
 /// A subdirectory within a particular commit of a git repository. The files may or may not have
-/// been downloaded, but you can ensure that they have by calling `fetch()`
+/// been downloaded, but you can ensure that they have by calling `checkout_repo(false)`
 #[derive(Clone, Debug)]
 pub struct GitTree {
     /// Repository URL
@@ -128,19 +128,6 @@ impl GitTree {
         self.path_to_repo.join(&self.path_in_repo)
     }
 
-    /// Ensure that the files are downloaded to `self.path_to_tree()`. Fails if there was already a
-    /// dirty checkout there (call [Self::fetch_allow_dirty] if you don't want to
-    /// fail). Returns `self.path_to_tree()`.
-    pub async fn fetch(&self) -> GitResult<PathBuf> {
-        self.checkout_repo(false).await
-    }
-
-    /// Ensure that there are files downloaded to `self.path_to_tree()`. Has no effect if
-    /// `self.path_to_tree()` already exists. Returns `self.path_to_tree()`
-    pub async fn fetch_allow_dirty(&self) -> GitResult<PathBuf> {
-        self.checkout_repo(true).await
-    }
-
     /// The url of the repository for this commit
     pub fn repo_url(&self) -> &str {
         &self.repo
@@ -176,7 +163,7 @@ impl GitTree {
     /// given sha.
     ///
     /// Fails if `allow_dirty` is false and a dirty checkout of the directory already exists
-    async fn checkout_repo(&self, allow_dirty: bool) -> GitResult<PathBuf> {
+    pub async fn checkout_repo(&self, allow_dirty: bool) -> GitResult<PathBuf> {
         // Checking out at `<repo>_<sha>` is sequential to prevent corruptions.
         let _lock =
             PackageSystemLock::new_for_git(&self.repo_id()).map_err(GitError::LockingError)?;
@@ -259,8 +246,10 @@ impl GitTree {
             .run_git(&[
                 "status",
                 "--porcelain",
-                "--untracked-files=no",
+                "--",
                 path_in_repo,
+                ":!*/Move.lock",
+                ":!*/Published.toml",
             ])
             .await
         else {
@@ -567,7 +556,7 @@ mod tests {
             .unwrap();
 
         // Fetch the dependency
-        let _ = git_tree.fetch().await.unwrap();
+        let _ = git_tree.checkout_repo(false).await.unwrap();
 
         // Verify only pkg_a was checked out
         assert_exactly_paths(git_tree.repo_fs_path(), ["pkg_a/Move.toml"]);
@@ -592,7 +581,7 @@ mod tests {
             .unwrap();
 
         // Fetch the dependency
-        let _ = git_tree.fetch().await.unwrap();
+        let _ = git_tree.checkout_repo(false).await.unwrap();
 
         // Verify only pkg_a was checked out
         assert_exactly_paths(git_tree.repo_fs_path(), ["a/Move.toml"]);
@@ -620,7 +609,7 @@ mod tests {
             .unwrap();
 
         // Fetch the dependency
-        let _ = git_tree.fetch().await.unwrap();
+        let _ = git_tree.checkout_repo(false).await.unwrap();
 
         // Verify only pkg_a was checked out
         assert_exactly_paths(git_tree.repo_fs_path(), ["pkg_a/Move.toml"]);
@@ -656,8 +645,8 @@ mod tests {
             .unwrap();
 
         // Fetch the dependencies
-        git_tree_a.fetch().await.unwrap();
-        git_tree_b.fetch().await.unwrap();
+        git_tree_a.checkout_repo(false).await.unwrap();
+        git_tree_b.checkout_repo(false).await.unwrap();
 
         assert_eq!(git_tree_a.repo_fs_path(), git_tree_b.repo_fs_path());
         assert_exactly_paths(
@@ -691,7 +680,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = git_tree.fetch().await;
+        let result = git_tree.checkout_repo(false).await;
 
         assert!(result.is_err());
     }
@@ -734,7 +723,7 @@ mod tests {
             .await
             .unwrap();
 
-        git_tree.fetch().await.unwrap();
+        git_tree.checkout_repo(false).await.unwrap();
     }
 
     /// Fetching should fail if a dirty checkout exists
@@ -764,7 +753,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = git_tree.fetch().await;
+        let result = git_tree.checkout_repo(false).await;
         assert!(result.is_err());
     }
 
@@ -789,7 +778,7 @@ mod tests {
             .unwrap();
 
         // First do a clean checkout
-        git_tree.fetch().await.unwrap();
+        git_tree.checkout_repo(false).await.unwrap();
 
         // Now dirty the checkout
         debug!(
@@ -803,7 +792,53 @@ mod tests {
         .unwrap();
 
         // fetch_allow_dirty should succeed despite the dirty state
-        git_tree.fetch_allow_dirty().await.unwrap();
+        git_tree.checkout_repo(true).await.unwrap();
+    }
+
+    /// If we touch the `Move.lock` file, we
+    #[test(tokio::test)]
+    async fn test_fetch_dirty_lockfile_should_succeed() {
+        let project = git::new().await;
+        let _commit = project
+            .commit(|project| project.add_packages(["pkg_a"]))
+            .await;
+
+        let cache_dir = tempdir().unwrap();
+        let cache = GitCache::new_from_dir(cache_dir.path());
+
+        let git_tree = cache
+            .resolve_to_tree(
+                &project.repo_path_str(),
+                &None,
+                Some(PathBuf::from("pkg_a")),
+            )
+            .await
+            .unwrap();
+
+        // First do a clean checkout
+        git_tree.checkout_repo(false).await.unwrap();
+
+        fs::write(git_tree.path_to_tree().join("Move.lock"), "random content").unwrap();
+        fs::write(
+            git_tree.path_to_tree().join("Published.toml"),
+            "random content",
+        )
+        .unwrap();
+
+        fs::create_dir(git_tree.path_to_tree().join("random_dir")).unwrap();
+        fs::write(
+            git_tree.path_to_tree().join("random_dir/Move.lock"),
+            "random content",
+        )
+        .unwrap();
+        fs::write(
+            git_tree.path_to_tree().join("random_dir/Published.toml"),
+            "random content",
+        )
+        .unwrap();
+
+        // checkout_repo should succeed despite the dirty state because `Move.lock` is excluded.
+        git_tree.checkout_repo(false).await.unwrap();
     }
 
     /// Fetching should succeed if a clean checkout exists
@@ -826,7 +861,7 @@ mod tests {
             .await
             .unwrap();
 
-        git_tree.fetch().await.unwrap();
+        git_tree.checkout_repo(false).await.unwrap();
 
         // same as above
         let git_tree = cache
@@ -838,7 +873,7 @@ mod tests {
             .await
             .unwrap();
 
-        git_tree.fetch().await.unwrap();
+        git_tree.checkout_repo(false).await.unwrap();
     }
 
     /// Fetching should succeed if the path is clean but other paths are not
@@ -862,18 +897,15 @@ mod tests {
             .unwrap();
 
         // fetch
-        git_tree.fetch().await.unwrap();
+        git_tree.checkout_repo(false).await.unwrap();
 
         // create dirty file in dep's parent directory
-        fs::create_dir_all(git_tree.path_to_tree().parent().unwrap()).unwrap();
-        fs::write(
-            git_tree.path_to_tree().join("garbage.txt"),
-            "something to dirty the repo",
-        )
-        .unwrap();
+        let dirty_dir = git_tree.path_to_tree().parent().unwrap().to_path_buf();
+        fs::create_dir_all(&dirty_dir).unwrap();
+        fs::write(dirty_dir.join("garbage.txt"), "something to dirty the repo").unwrap();
 
         // fetch again - subtree should still be clean so it should succeed
-        git_tree.fetch().await.unwrap();
+        git_tree.checkout_repo(false).await.unwrap();
     }
 
     #[test(tokio::test)]
@@ -894,7 +926,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = git_tree.fetch().await;
+        let result = git_tree.checkout_repo(false).await;
         assert!(result.is_ok());
 
         let commit2 = project
@@ -913,7 +945,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = git_tree.fetch().await;
+        let result = git_tree.checkout_repo(false).await;
         assert!(result.is_ok());
     }
 
@@ -970,7 +1002,7 @@ mod tests {
             .unwrap();
 
         // Fetch the dependency
-        let _checkout_path = git_tree.fetch().await.unwrap();
+        let _checkout_path = git_tree.checkout_repo(false).await.unwrap();
 
         // Verify only a was checked out
         assert_exactly_paths(git_tree.repo_fs_path(), ["a/Move.toml", "a/sources/a.move"]);
@@ -1000,7 +1032,7 @@ mod tests {
             .unwrap();
 
         // Fetch the dependency
-        let _checkout_path = git_tree.fetch().await.unwrap();
+        let _checkout_path = git_tree.checkout_repo(false).await.unwrap();
         // Verify only a was checked out
         assert_exactly_paths(git_tree.repo_fs_path(), ["a/Move.toml"]);
     }
@@ -1025,8 +1057,8 @@ mod tests {
             .await
             .unwrap();
 
-        tree_a.fetch().await.unwrap();
-        tree_b.fetch().await.unwrap();
+        tree_a.checkout_repo(false).await.unwrap();
+        tree_b.checkout_repo(false).await.unwrap();
 
         assert_exactly_paths(tree_a.repo_fs_path(), ["a/Move.toml", "b/Move.toml"]);
     }
@@ -1051,8 +1083,8 @@ mod tests {
             .await
             .unwrap();
 
-        tree_root.fetch().await.unwrap();
-        tree_a.fetch().await.unwrap();
+        tree_root.checkout_repo(false).await.unwrap();
+        tree_a.checkout_repo(false).await.unwrap();
 
         assert_exactly_paths(
             tree_a.repo_fs_path(),
@@ -1084,7 +1116,7 @@ mod tests {
             .await
             .unwrap();
 
-        tree_d.fetch().await.unwrap();
+        tree_d.checkout_repo(false).await.unwrap();
 
         // note that `a/Move.toml` should be included because git sparse-checkout always includes
         // the files in directories that are on the path to the added files, but `a/e/Move.toml`

--- a/external-crates/move/crates/move-package-alt/src/git/errors.rs
+++ b/external-crates/move/crates/move-package-alt/src/git/errors.rs
@@ -14,7 +14,11 @@ pub type GitResult<T> = std::result::Result<T, GitError>;
 #[derive(Error, Debug)]
 pub enum GitError {
     #[error(
-        "{repo} repo is dirty. Please clean it up before proceeding or pass the `--allow-dirty` flag"
+        "The following cached dependency repository is dirty:
+
+    {repo}
+
+Please clean it up before proceeding or pass the `--allow-dirty` flag to proceed with the modified files."
     )]
     Dirty { repo: String },
 

--- a/external-crates/move/crates/move-package-alt/src/graph/builder.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/builder.rs
@@ -8,8 +8,8 @@ use crate::{
     flavor::MoveFlavor,
     logging::user_note,
     package::{
-        EnvironmentName, Package, lockfile::Lockfiles, package_lock::PackageSystemLock,
-        paths::PackagePath,
+        EnvironmentName, Package, lockfile::Lockfiles, package_loader::PackageConfig,
+        package_lock::PackageSystemLock, paths::PackagePath,
     },
     schema::{Environment, PackageID, PackageName},
 };
@@ -57,14 +57,16 @@ struct PackageCache<F: MoveFlavor> {
     cache: Mutex<BTreeMap<PathBuf, Arc<OnceCell<Option<Arc<Package<F>>>>>>>,
 }
 
-pub struct PackageGraphBuilder<F: MoveFlavor> {
+pub struct PackageGraphBuilder<'a, F: MoveFlavor> {
     cache: PackageCache<F>,
+    config: &'a PackageConfig,
 }
 
-impl<F: MoveFlavor> PackageGraphBuilder<F> {
-    pub fn new() -> Self {
+impl<'a, F: MoveFlavor> PackageGraphBuilder<'a, F> {
+    pub fn new(config: &'a PackageConfig) -> Self {
         Self {
             cache: PackageCache::new(),
+            config,
         }
     }
 
@@ -115,7 +117,7 @@ impl<F: MoveFlavor> PackageGraphBuilder<F> {
         // First pass: create nodes for all packages
         for (pkg_id, pin) in pins.iter() {
             let dep = Pinned::from_lockfile(lockfile.file(), &pin.source)?;
-            let package = self.cache.fetch(&dep, env, mtx).await?;
+            let package = self.cache.fetch(&dep, env, mtx, self.config).await?;
             let package_manifest_digest = package.digest();
             if check_digests && package_manifest_digest != &pin.manifest_digest {
                 user_note!(
@@ -196,7 +198,7 @@ impl<F: MoveFlavor> PackageGraphBuilder<F> {
 
         let root = self
             .cache
-            .fetch(&Pinned::Root(path.clone()), env, mtx)
+            .fetch(&Pinned::Root(path.clone()), env, mtx, self.config)
             .await?;
 
         // TODO: should we add `root` to `visited`? we may have a problem if there is a cyclic
@@ -210,11 +212,11 @@ impl<F: MoveFlavor> PackageGraphBuilder<F> {
 
         let inner: DiGraph<Arc<Package<F>>, PinnedDependencyInfo> =
             graph.lock().expect("unpoisoned").map(
-                |_, node| {
-                    node.clone()
-                        .expect("add_transitive_packages removes all `None`s before returning")
+                |_, node: &Option<Arc<Package<F>>>| {
+                    let n = node.clone();
+                    n.expect("add_transitive_packages removes all `None`s before returning")
                 },
-                |_, e| e.clone(),
+                |_, e: &PinnedDependencyInfo| e.clone(),
             );
 
         let package_ids = Self::create_ids(&inner);
@@ -308,7 +310,10 @@ impl<F: MoveFlavor> PackageGraphBuilder<F> {
         for dep in pinned {
             // We retain the defined environment name, but we assign a consistent chain id (environmentID).
             let new_env = Environment::new(dep.use_environment().clone(), env.id().clone());
-            let fetched = self.cache.fetch(dep.as_ref(), &new_env, mtx).await?;
+            let fetched = self
+                .cache
+                .fetch(dep.as_ref(), &new_env, mtx, self.config)
+                .await?;
 
             let future = self.add_transitive_manifest_deps(
                 fetched.clone(),
@@ -350,6 +355,7 @@ impl<F: MoveFlavor> PackageCache<F> {
         dep: &Pinned,
         env: &Environment,
         mtx: &PackageSystemLock,
+        config: &PackageConfig,
     ) -> PackageResult<Arc<Package<F>>> {
         let cell = self
             .cache
@@ -367,7 +373,7 @@ impl<F: MoveFlavor> PackageCache<F> {
         }
 
         // If not cached, load and cache
-        match Package::load(dep.clone(), env, mtx).await {
+        match Package::load(dep.clone(), env, mtx, config).await {
             Ok(package) => {
                 let node = Arc::new(package);
                 cell.get_or_init(async || Some(node.clone())).await;

--- a/external-crates/move/crates/move-package-alt/src/graph/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/graph/mod.rs
@@ -19,6 +19,7 @@ use tracing::debug;
 
 use std::{collections::BTreeMap, sync::Arc};
 
+use crate::package::package_loader::PackageConfig;
 use crate::package::package_lock::PackageSystemLock;
 use crate::schema::{LockfileDependencyInfo, ModeName, Publication};
 use crate::{
@@ -61,8 +62,9 @@ impl<F: MoveFlavor> PackageGraph<F> {
         path: &PackagePath,
         env: &Environment,
         mtx: &PackageSystemLock,
+        config: &PackageConfig,
     ) -> PackageResult<Self> {
-        let builder = PackageGraphBuilder::<F>::new();
+        let builder = PackageGraphBuilder::<F>::new(config);
 
         if let Some(graph) = builder.load_from_lockfile(path, env, mtx).await? {
             debug!("successfully loaded lockfile");
@@ -79,8 +81,9 @@ impl<F: MoveFlavor> PackageGraph<F> {
         path: &PackagePath,
         env: &Environment,
         mtx: &PackageSystemLock,
+        config: &PackageConfig,
     ) -> PackageResult<Self> {
-        PackageGraphBuilder::new()
+        PackageGraphBuilder::new(config)
             .load_from_manifests(path, env, mtx)
             .await
     }
@@ -92,8 +95,9 @@ impl<F: MoveFlavor> PackageGraph<F> {
         path: &PackagePath,
         env: &Environment,
         mtx: &PackageSystemLock,
+        config: &PackageConfig,
     ) -> PackageResult<Option<Self>> {
-        PackageGraphBuilder::new()
+        PackageGraphBuilder::new(config)
             .load_from_lockfile_ignore_digests(path, env, mtx)
             .await
     }

--- a/external-crates/move/crates/move-package-alt/src/package/mod.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/mod.rs
@@ -10,6 +10,7 @@ pub mod paths;
 pub mod root_package;
 pub use package_impl::*;
 pub use root_package::RootPackage;
+pub mod package_loader;
 
 /// Convert an async task into a single-threaded task. Copied from `sui-replay-2`
 macro_rules! block_on {

--- a/external-crates/move/crates/move-package-alt/src/package/package_loader.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/package_loader.rs
@@ -1,0 +1,177 @@
+use std::path::{Path, PathBuf};
+
+use crate::{
+    errors::PackageResult,
+    flavor::MoveFlavor,
+    package::{EnvironmentID, EnvironmentName, RootPackage, block_on},
+    schema::{Environment, ModeName},
+};
+
+/// A Builder for the [RootPackage] type
+pub struct PackageLoader {
+    config: PackageConfig,
+}
+
+#[derive(Clone, Debug)]
+pub struct PackageConfig {
+    /// The path to read all input files from (e.g. lockfiles, pubfiles, etc). If this path is
+    /// different from `output_path`, the package system won't touch any files here Note that in
+    /// the case of ephemeral loads, `self.load_type.ephemeral_file` may also be read
+    pub input_path: PathBuf,
+
+    /// The chain ID to build for
+    pub chain_id: EnvironmentID,
+
+    /// The ephemeral or persistent environment to load for
+    pub load_type: LoadType,
+
+    /// The directory to write all output files into (e.g. updated lockfiles, etc)
+    /// Note that in the case of ephemeral loads, `self.load_type.ephemeral_file` may also be
+    /// written
+    pub output_path: PathBuf,
+
+    /// The modes to load for
+    pub modes: Vec<ModeName>,
+
+    /// Repin the dependencies even if the lockfile is up-to-date
+    pub force_repin: bool,
+
+    /// Use the lockfile even if the manifest digests are out of date
+    pub ignore_digests: bool,
+
+    /// Don't fail if git cache is dirty
+    pub allow_dirty: bool,
+}
+
+impl PackageLoader {
+    /// A loader that loads the root package from `root_dir` for `env`
+    pub fn new(root_dir: impl AsRef<Path>, env: Environment) -> Self {
+        Self {
+            config: PackageConfig::persistent(root_dir, env, vec![]),
+        }
+    }
+
+    /// Loads the root package from `root` in environment `build_env`, but replaces all the
+    /// addresses with the addresses in `pubfile`. Saving publication data will also save to the
+    /// output to `pubfile` rather than `Published.toml`
+    ///
+    /// If `pubfile` does not exist, one is created with the provided `chain_id` and `build_env`;
+    /// If the file does exist but these fields differ, then an error is returned.
+    pub fn new_ephemeral(
+        root_dir: impl AsRef<Path>,
+        build_env: Option<EnvironmentName>,
+        chain_id: EnvironmentID,
+        pubfile_path: impl AsRef<Path>,
+    ) -> Self {
+        let config = PackageConfig {
+            input_path: root_dir.as_ref().to_path_buf(),
+            chain_id,
+            load_type: LoadType::Ephemeral {
+                build_env,
+                ephemeral_file: pubfile_path.as_ref().to_path_buf(),
+            },
+            output_path: root_dir.as_ref().to_path_buf(),
+            modes: vec![],
+            force_repin: false,
+            ignore_digests: false,
+            allow_dirty: false,
+        };
+        Self { config }
+    }
+
+    /// dependencies with modes will be filtered out if those modes don't intersect with `modes`
+    pub fn modes(mut self, modes: Vec<ModeName>) -> Self {
+        self.config.modes = modes;
+        self
+    }
+
+    /// Ignore the lockfile and automatically repin all dependencies for the current environment
+    pub fn force_repin(mut self, force_repin: bool) -> Self {
+        self.config.force_repin = force_repin;
+        self
+    }
+
+    /// Do not repin dependencies even if their manifests have changed. This will fail if the
+    /// lockfile does not have the correct dependencies stored (e.g. if a new dependency was added
+    /// to the manifest)
+    pub fn ignore_digests(mut self, ignore_digests: bool) -> Self {
+        self.config.ignore_digests = ignore_digests;
+        self
+    }
+
+    /// Do not fail if the git cache is dirty
+    pub fn allow_dirty(mut self, allow_dirty: bool) -> Self {
+        self.config.allow_dirty = allow_dirty;
+        self
+    }
+
+    /// Write the output (generated pubfiles, lockfiles, etc) to `dir` instead of the input path
+    pub fn output_path(mut self, output_dir: Option<impl AsRef<Path>>) -> Self {
+        if let Some(output_dir) = output_dir {
+            self.config.output_path = output_dir.as_ref().to_path_buf();
+        }
+        self
+    }
+
+    /// Load the root package. Note that loading does not write to the lockfile; you should call
+    /// [RootPackage::write_pinned_deps] to save the results.
+    ///
+    /// By default `load` attempts to load the package from the lockfile, and repins if it is
+    /// missing or out-of-date. However, this behavior can be changed using [Self::ignore_digests] and
+    /// [Self::force_repin]
+    pub async fn load<F: MoveFlavor>(self) -> PackageResult<RootPackage<F>> {
+        RootPackage::validate_and_construct(self.config).await
+    }
+
+    /// Block the current thread and call [Self::load]
+    pub fn load_sync<F: MoveFlavor>(self) -> PackageResult<RootPackage<F>> {
+        block_on!(RootPackage::validate_and_construct(self.config))
+    }
+
+    pub(crate) fn config(&self) -> &PackageConfig {
+        &self.config
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum LoadType {
+    Persistent {
+        env: EnvironmentName,
+    },
+    Ephemeral {
+        /// The environment to build for. If it is `None`, the value in `ephemeral_file` will be
+        /// used; if that file also doesn't exist, then the load will fail
+        build_env: Option<EnvironmentName>,
+
+        /// The ephemeral file to use for addresses, relative to the current working directory (not
+        /// to `input_path`). This file will be written if the package is published (i.e. if
+        /// [RootPackage::write_publish_data] is called). It does not have to exist a priori, but
+        /// if it does, the addresses will be used.
+        ephemeral_file: PathBuf,
+    },
+}
+
+impl PackageConfig {
+    fn persistent(path: impl AsRef<Path>, env: Environment, modes: Vec<ModeName>) -> Self {
+        Self {
+            input_path: path.as_ref().to_path_buf(),
+            chain_id: env.id,
+            load_type: LoadType::Persistent { env: env.name },
+            output_path: path.as_ref().to_path_buf(),
+            modes,
+            force_repin: false,
+            ignore_digests: false,
+            allow_dirty: false,
+        }
+    }
+}
+
+impl LoadType {
+    /// return `Some(path)` if `self` is a valid ephemeral load, or None if it is a persistent load
+    pub fn ephemeral_file(&self) -> Option<&Path> {
+        match self {
+            LoadType::Persistent { .. } => None,
+            LoadType::Ephemeral { ephemeral_file, .. } => Some(ephemeral_file),
+        }
+    }
+}

--- a/external-crates/move/crates/move-package-alt/src/package/paths.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/paths.rs
@@ -248,11 +248,12 @@ impl OutputPath {
     /// directory at `dir` and that it contains a valid Move package, i.e., it has a `Move.toml`
     /// file.
     pub fn new(dir: PathBuf) -> PackagePathResult<Self> {
-        if !dir.is_dir() {
-            Err(PackagePathError::InvalidDirectory { path: dir.clone() })
-        } else {
-            Ok(Self(dir))
+        if let Err(e) = std::fs::create_dir_all(&dir) {
+            debug!("unexpected error creating directory: {e:?}");
+            return Err(PackagePathError::InvalidDirectory { path: dir.clone() });
         }
+
+        Ok(Self(dir))
     }
 
     /// Acquire an exclusive lock for the files in this package

--- a/external-crates/move/crates/move-package-alt/src/package/root_package.rs
+++ b/external-crates/move/crates/move-package-alt/src/package/root_package.rs
@@ -2,7 +2,6 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::PathBuf;
 use std::{collections::BTreeMap, fmt, path::Path};
 
 use indexmap::IndexMap;
@@ -11,7 +10,7 @@ use tracing::debug;
 use super::paths::{EphemeralPubfilePath, OutputPath, PackagePath};
 use super::{EnvironmentID, manifest::Manifest};
 use crate::graph::PackageInfo;
-use crate::package::block_on;
+use crate::package::package_loader::{LoadType, PackageConfig, PackageLoader};
 use crate::package::package_lock::PackageSystemLock;
 use crate::schema::{
     Environment, LocalPub, LockfileDependencyInfo, ModeName, PackageID, ParsedEphemeralPubs,
@@ -24,55 +23,6 @@ use crate::{
     package::EnvironmentName,
     schema::ParsedLockfile,
 };
-
-#[derive(Clone, Debug)]
-pub struct PackageConfig {
-    /// The path to read all input files from (e.g. lockfiles, pubfiles, etc). If this path is
-    /// different from `output_path`, the package system won't touch any files here Note that in
-    /// the case of ephemeral loads, `self.load_type.ephemeral_file` may also be read
-    input_path: PathBuf,
-
-    /// The chain ID to build for
-    chain_id: EnvironmentID,
-
-    /// The ephemeral or persistent environment to load for
-    load_type: LoadType,
-
-    /// The directory to write all output files into (e.g. updated lockfiles, etc)
-    /// Note that in the case of ephemeral loads, `self.load_type.ephemeral_file` may also be
-    /// written
-    output_path: PathBuf,
-
-    /// The modes to load for
-    modes: Vec<ModeName>,
-
-    /// Repin the dependencies even if the lockfile is up-to-date
-    pub(crate) force_repin: bool,
-
-    /// Use the lockfile even if the manifest digests are out of date
-    pub(crate) ignore_digests: bool,
-    // TODO: The directory to use for the git cache (defaults to `~/.move`)
-    // cache_dir: Option<PathBuf>,
-    // TODO: `--allow-dirty`
-}
-
-#[derive(Clone, Debug)]
-pub enum LoadType {
-    Persistent {
-        env: EnvironmentName,
-    },
-    Ephemeral {
-        /// The environment to build for. If it is `None`, the value in `ephemeral_file` will be
-        /// used; if that file also doesn't exist, then the load will fail
-        build_env: Option<EnvironmentName>,
-
-        /// The ephemeral file to use for addresses, relative to the current working directory (not
-        /// to `input_path`). This file will be written if the package is published (i.e. if
-        /// [RootPackage::write_publish_data] is called). It does not have to exist a priori, but
-        /// if it does, the addresses will be used.
-        ephemeral_file: EphemeralPubfilePath,
-    },
-}
 
 /// A package that is defined as the root of a Move project.
 ///
@@ -105,30 +55,6 @@ pub struct RootPackage<F: MoveFlavor + fmt::Debug> {
     mutex: PackageSystemLock,
 }
 
-impl PackageConfig {
-    fn persistent(path: impl AsRef<Path>, env: Environment, modes: Vec<ModeName>) -> Self {
-        Self {
-            input_path: path.as_ref().to_path_buf(),
-            chain_id: env.id,
-            load_type: LoadType::Persistent { env: env.name },
-            output_path: path.as_ref().to_path_buf(),
-            modes,
-            force_repin: false,
-            ignore_digests: false,
-        }
-    }
-}
-
-impl LoadType {
-    /// return `Some(path)` if `self` is a valid ephemeral load, or None if it is a persistent load
-    fn ephemeral_file(&self) -> Option<&EphemeralPubfilePath> {
-        match self {
-            LoadType::Persistent { .. } => None,
-            LoadType::Ephemeral { ephemeral_file, .. } => Some(ephemeral_file),
-        }
-    }
-}
-
 /// Root package is the "public" entrypoint for operations with the package management.
 /// It's like a facade for all functionality, controlled by this.
 impl<F: MoveFlavor + fmt::Debug> RootPackage<F> {
@@ -151,88 +77,29 @@ impl<F: MoveFlavor + fmt::Debug> RootPackage<F> {
     /// not write to the lockfile; you should call [Self::write_pinned_deps] to save the results.
     ///
     /// dependencies with modes will be filtered out if those modes don't intersect with `modes`
-    pub async fn load(
+    pub(crate) async fn load(
         path: impl AsRef<Path>,
         env: Environment,
         modes: Vec<ModeName>,
     ) -> PackageResult<Self> {
-        let config = PackageConfig::persistent(path, env, modes);
-
-        Self::validate_and_construct(config).await
-    }
-
-    /// A synchronous version of `load` that can be used to load a package while blocking in place.
-    pub fn load_sync(path: PathBuf, env: Environment, modes: Vec<ModeName>) -> PackageResult<Self> {
-        block_on!(Self::load(path.as_path(), env, modes))
-    }
-
-    /// Load the root package from `root` in environment `build_env`, but replace all the addresses
-    /// with the addresses in `pubfile`. Saving publication data will also save to the output to
-    /// `pubfile` rather than `Published.toml`
-    ///
-    /// If `pubfile` does not exist, one is created with the provided `chain_id` and `build_env`;
-    /// If the file does exist but these fields differ, then an error is returned.
-    ///
-    /// dependencies with modes will be filtered out if those modes don't intersect with `modes`
-    pub async fn load_ephemeral(
-        root: impl AsRef<Path>,
-        build_env: Option<EnvironmentName>,
-        chain_id: EnvironmentID,
-        pubfile_path: impl AsRef<Path>,
-        modes: Vec<ModeName>,
-    ) -> PackageResult<Self> {
-        let ephemeral_file = EphemeralPubfilePath::new(pubfile_path)?;
-        let config = PackageConfig {
-            input_path: root.as_ref().to_path_buf(),
-            chain_id,
-            load_type: LoadType::Ephemeral {
-                build_env,
-                ephemeral_file,
-            },
-            output_path: root.as_ref().to_path_buf(),
-            modes,
-            force_repin: false,
-            ignore_digests: false,
-        };
-
-        Self::validate_and_construct(config).await
+        PackageLoader::new(path, env).modes(modes).load().await
     }
 
     /// Loads the root package from path and builds a dependency graph from the manifests.
     /// This forcefully re-pins all dependencies even if the manifest digests match. Note that it
     /// does not write to the lockfile; you should call [Self::save_to_disk] to save the results.
     ///
-    /// TODO: We should load from lockfiles instead of manifests for deps.
     /// dependencies with modes will be filtered out if those modes don't intersect with `modes`
-    pub async fn load_force_repin(
+    pub(crate) async fn load_force_repin(
         path: impl AsRef<Path>,
         env: Environment,
         modes: Vec<ModeName>,
     ) -> PackageResult<Self> {
-        let mut config = PackageConfig::persistent(path, env, modes);
-        config.force_repin = true;
-        /*
-        let graph = PackageGraph::<F>::load_from_manifests(&package_path, &env).await?;
-        */
-
-        Self::validate_and_construct(config).await
-    }
-
-    /// Loads the root lockfile only, ignoring all manifests. Returns an error if the lockfile
-    /// doesn't exist of if it doesn't contain a dependency graph for `env`.
-    ///
-    /// Note that this still fetches all of the dependencies, it just doesn't look at their
-    /// manifests.
-    ///
-    /// dependencies with modes will be filtered out if those modes don't intersect with `modes`
-    pub async fn load_ignore_digests(
-        path: impl AsRef<Path>,
-        env: Environment,
-        modes: Vec<ModeName>,
-    ) -> PackageResult<Self> {
-        let mut config = PackageConfig::persistent(path, env, modes);
-        config.ignore_digests = true;
-        Self::validate_and_construct(config).await
+        PackageLoader::new(path, env)
+            .modes(modes)
+            .force_repin(true)
+            .load()
+            .await
     }
 
     /// The metadata for the root package in [PackageInfo] form
@@ -247,11 +114,16 @@ impl<F: MoveFlavor + fmt::Debug> RootPackage<F> {
     ///
     /// This helps validate:
     /// 1. TODO: Fill this in! (deduplicate nodes etc)
-    async fn validate_and_construct(mut config: PackageConfig) -> PackageResult<Self> {
+    pub(crate) async fn validate_and_construct(mut config: PackageConfig) -> PackageResult<Self> {
         let input_path = PackagePath::new(config.input_path.clone())?;
         let mutex = input_path.lock()?;
 
-        let ephemeral_file = config.load_type.ephemeral_file().cloned();
+        let ephemeral_file = config
+            .load_type
+            .ephemeral_file()
+            .map(EphemeralPubfilePath::new)
+            .transpose()?;
+
         let output_path = OutputPath::new(config.output_path.clone())?;
 
         debug!(
@@ -264,13 +136,13 @@ impl<F: MoveFlavor + fmt::Debug> RootPackage<F> {
 
         debug!("loading unfiltered graph");
         let unfiltered_graph = if config.force_repin {
-            PackageGraph::<F>::load_from_manifests(&input_path, &env, &mutex).await?
+            PackageGraph::<F>::load_from_manifests(&input_path, &env, &mutex, &config).await?
         } else if config.ignore_digests {
-            PackageGraph::<F>::load_from_lockfile_ignore_digests(&input_path, &env, &mutex)
+            PackageGraph::<F>::load_from_lockfile_ignore_digests(&input_path, &env, &mutex, &config)
                 .await?
                 .unwrap()
         } else {
-            PackageGraph::<F>::load(&input_path, &env, &mutex).await?
+            PackageGraph::<F>::load(&input_path, &env, &mutex, &config).await?
         };
 
         debug!("filtering graph");
@@ -317,8 +189,9 @@ impl<F: MoveFlavor + fmt::Debug> RootPackage<F> {
                 build_env,
                 ephemeral_file,
             } => {
+                let mut ephemeral_file = EphemeralPubfilePath::new(ephemeral_file)?;
                 let ephemeral =
-                    Self::load_ephemeral_pubfile(build_env, &config.chain_id, ephemeral_file)?;
+                    Self::load_ephemeral_pubfile(build_env, &config.chain_id, &mut ephemeral_file)?;
                 (
                     Environment::new(ephemeral.build_env.clone(), config.chain_id.clone()),
                     Some(ephemeral),
@@ -912,10 +785,11 @@ pkg_b = { local = "../pkg_b" }"#,
 
         // modify the manifest and then reload
         project.extend_file("root/Move.toml", "\n# extra stuff\n");
-        let mut root_pkg =
-            RootPackage::<Vanilla>::load_force_repin(project.path_for("root"), env.clone(), vec![])
-                .await
-                .unwrap();
+        let mut root_pkg = PackageLoader::new(project.path_for("root"), env.clone())
+            .force_repin(true)
+            .load()
+            .await
+            .unwrap();
         root_pkg.save_lockfile_to_disk().unwrap();
 
         // since the manifest changed, we should have repinned, so the sha should be for commit 2
@@ -959,10 +833,11 @@ pkg_b = { local = "../pkg_b" }"#,
 
         // modify the manifest for `dirty` and then reload
         project.extend_file("dirty/Move.toml", "\n# extra stuff\n");
-        let mut root_pkg =
-            RootPackage::<Vanilla>::load_force_repin(project.path_for("root"), env.clone(), vec![])
-                .await
-                .unwrap();
+        let mut root_pkg = PackageLoader::new(project.path_for("root"), env.clone())
+            .force_repin(true)
+            .load()
+            .await
+            .unwrap();
         root_pkg.save_lockfile_to_disk().unwrap();
 
         // since the dependency's manifest changed, we should have repinned, so the sha should be
@@ -983,6 +858,75 @@ pkg_b = { local = "../pkg_b" }"#,
             panic!("expected git dep");
         };
         git.rev.to_string()
+    }
+
+    /// Using `allow_dirty` when loading a package succeeds even if a dependency repo is dirty
+    /// See also [disallow_dirty]
+    #[test(tokio::test)]
+    async fn allow_dirty() {
+        let repo = git::new().await;
+        let commit = repo
+            .commit(|project| project.add_packages(["git_dep"]))
+            .await;
+        commit.branch("branch-name").await;
+
+        let project = TestPackageGraph::new(["root"])
+            .add_git_dep("root", &repo, "git_dep", "branch-name", |dep| dep)
+            .build();
+
+        // Get the dependency cached and find its path
+        let root_package = project.root_package("root").await;
+        let cached_dep_path = root_package
+            .packages()
+            .iter()
+            .find(|pkg| pkg.name().as_str() == "git_dep")
+            .unwrap()
+            .path()
+            .clone();
+
+        drop(root_package);
+
+        // Dirty the cached package
+        std::fs::write(cached_dep_path.path().join("dirty_file.txt"), "dirty stuff").unwrap();
+
+        // Reload root package with `allow_dirty`; should succeed
+        let _ = project
+            .root_package_with_config("root", |loader| loader.allow_dirty(true))
+            .await;
+    }
+
+    /// Loading a package fails without `allow_dirty` if a dependency repo is dirty
+    /// See also [allow_dirty]
+    #[test(tokio::test)]
+    async fn disallow_dirty() {
+        let repo = git::new().await;
+        let commit = repo
+            .commit(|project| project.add_packages(["git_dep"]))
+            .await;
+        commit.branch("branch-name").await;
+
+        let project = TestPackageGraph::new(["root"])
+            .add_git_dep("root", &repo, "git_dep", "branch-name", |dep| dep)
+            .build();
+
+        // Get the dependency cached and find its path
+        let root_package = project.root_package("root").await;
+        let cached_dep_path = root_package
+            .packages()
+            .iter()
+            .find(|pkg| pkg.name().as_str() == "git_dep")
+            .unwrap()
+            .path()
+            .clone();
+
+        drop(root_package);
+
+        // Dirty the cached package
+        std::fs::write(cached_dep_path.path().join("dirty_file.txt"), "dirty stuff").unwrap();
+
+        // Reload root package, expecting an error
+        let error = project.root_package_err("root").await;
+        assert!(error.contains("is dirty"));
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1014,13 +958,13 @@ pkg_b = { local = "../pkg_b" }"#,
         .unwrap();
 
         // load root package with ephemeral file
-        let root = RootPackage::<Vanilla>::load_ephemeral(
+        let root: RootPackage<Vanilla> = PackageLoader::new_ephemeral(
             scenario.path_for("root"),
             None,
             "localnet".into(),
             ephemeral.path(),
-            vec![],
         )
+        .load()
         .await
         .unwrap();
 
@@ -1064,13 +1008,13 @@ pkg_b = { local = "../pkg_b" }"#,
 
         // load root package with ephemeral file
 
-        let root = RootPackage::<Vanilla>::load_ephemeral(
+        let root: RootPackage<Vanilla> = PackageLoader::new_ephemeral(
             scenario.path_for("root"),
             None,
             "localnet".into(),
             ephemeral.path(),
-            vec![],
         )
+        .load()
         .await
         .unwrap();
 
@@ -1120,13 +1064,13 @@ pkg_b = { local = "../pkg_b" }"#,
 
         // load root package with ephemeral file
 
-        let err = RootPackage::<Vanilla>::load_ephemeral(
+        let err = PackageLoader::new_ephemeral(
             scenario.path_for("root"),
             None,
             "localnet".into(),
             ephemeral.path(),
-            vec![],
         )
+        .load::<Vanilla>()
         .await
         .unwrap_err();
 
@@ -1154,13 +1098,13 @@ pkg_b = { local = "../pkg_b" }"#,
 
         // load root package with ephemeral file
 
-        let root = RootPackage::<Vanilla>::load_ephemeral(
+        let root: RootPackage<Vanilla> = PackageLoader::new_ephemeral(
             scenario.path_for("root"),
             None,
             "localnet".into(),
             ephemeral.path(),
-            vec![],
         )
+        .load()
         .await
         .unwrap();
 
@@ -1204,13 +1148,13 @@ pkg_b = { local = "../pkg_b" }"#,
 
         // load root package with ephemeral file
 
-        let root = RootPackage::<Vanilla>::load_ephemeral(
+        let root: RootPackage<Vanilla> = PackageLoader::new_ephemeral(
             scenario.path_for("root"),
             None,
             "localnet".into(),
             ephemeral.path(),
-            vec![],
         )
+        .load()
         .await
         .unwrap();
 
@@ -1248,13 +1192,13 @@ pkg_b = { local = "../pkg_b" }"#,
 
         // load root package with ephemeral file
 
-        let root = RootPackage::<Vanilla>::load_ephemeral(
+        let root: RootPackage<Vanilla> = PackageLoader::new_ephemeral(
             scenario.path_for("root"),
             None,
             "localnet".into(),
             ephemeral.path(),
-            vec![],
         )
+        .load()
         .await
         .unwrap();
 
@@ -1300,13 +1244,13 @@ pkg_b = { local = "../pkg_b" }"#,
         )
         .unwrap();
 
-        RootPackage::<Vanilla>::load_ephemeral(
+        PackageLoader::new_ephemeral(
             scenario.path_for("root"),
             None,
             "localnet".into(),
             ephemeral.path(),
-            vec![],
         )
+        .load::<Vanilla>()
         .await
         .unwrap();
     }
@@ -1343,13 +1287,13 @@ pkg_b = { local = "../pkg_b" }"#,
         )
         .unwrap();
 
-        let root = RootPackage::<Vanilla>::load_ephemeral(
+        let root = PackageLoader::new_ephemeral(
             scenario.path_for("root"),
             None,
             "localnet".into(),
             ephemeral.path(),
-            vec![],
         )
+        .load::<Vanilla>()
         .await;
 
         assert_snapshot!(root.unwrap_err().to_string(), @r###"
@@ -1379,13 +1323,13 @@ pkg_b = { local = "../pkg_b" }"#,
 
         // load root package with ephemeral file
 
-        let root = RootPackage::<Vanilla>::load_ephemeral(
+        let root: RootPackage<Vanilla> = PackageLoader::new_ephemeral(
             scenario.path_for("root"),
             Some(DEFAULT_ENV_NAME.to_string()),
             "localnet".into(),
             ephemeral.as_path(),
-            vec![],
         )
+        .load()
         .await
         .unwrap();
 
@@ -1424,13 +1368,13 @@ pkg_b = { local = "../pkg_b" }"#,
 
         // load root package with ephemeral file
 
-        let mut root = RootPackage::<Vanilla>::load_ephemeral(
+        let mut root: RootPackage<Vanilla> = PackageLoader::new_ephemeral(
             scenario.path_for("root"),
             None,
             "localnet".into(),
             ephemeral.path(),
-            vec![],
         )
+        .load()
         .await
         .unwrap();
 
@@ -1488,13 +1432,13 @@ pkg_b = { local = "../pkg_b" }"#,
 
         // load root package with ephemeral file
 
-        let root = RootPackage::<Vanilla>::load_ephemeral(
+        let root = PackageLoader::new_ephemeral(
             scenario.path_for("root"),
             None,
             "localnet".into(),
             ephemeral.path(),
-            vec![],
         )
+        .load::<Vanilla>()
         .await;
 
         let message = root
@@ -1522,13 +1466,13 @@ pkg_b = { local = "../pkg_b" }"#,
 
         // load root package with ephemeral file
 
-        let root = RootPackage::<Vanilla>::load_ephemeral(
+        let root = PackageLoader::new_ephemeral(
             scenario.path_for("root"),
             Some(DEFAULT_ENV_NAME.to_string()),
             "localnet".into(),
             ephemeral.path(),
-            vec![],
         )
+        .load::<Vanilla>()
         .await;
 
         let message = root
@@ -1549,13 +1493,13 @@ pkg_b = { local = "../pkg_b" }"#,
 
         // load root package with ephemeral file
 
-        let root = RootPackage::<Vanilla>::load_ephemeral(
+        let root = PackageLoader::new_ephemeral(
             scenario.path_for("root"),
             None,
             "localnet".into(),
             ephemeral.join("nonexistent.toml"),
-            vec![],
         )
+        .load::<Vanilla>()
         .await;
 
         let message = root
@@ -1576,13 +1520,13 @@ pkg_b = { local = "../pkg_b" }"#,
 
         // load root package with ephemeral file
 
-        let root = RootPackage::<Vanilla>::load_ephemeral(
+        let root = PackageLoader::new_ephemeral(
             scenario.path_for("root"),
             Some("unknown environment".into()),
             "localnet".into(),
             ephemeral.clone(),
-            vec![],
         )
+        .load::<Vanilla>()
         .await;
 
         let message = root.unwrap_err().to_string().replace(

--- a/external-crates/move/crates/move-package-alt/src/test_utils/graph_builder.rs
+++ b/external-crates/move/crates/move-package-alt/src/test_utils/graph_builder.rs
@@ -57,7 +57,9 @@ use crate::{
         vanilla::{self, DEFAULT_ENV_ID, DEFAULT_ENV_NAME, default_environment},
     },
     package::{
-        EnvironmentID, EnvironmentName, RootPackage, package_lock::PackageSystemLock,
+        EnvironmentID, EnvironmentName, RootPackage,
+        package_loader::{LoadType, PackageConfig, PackageLoader},
+        package_lock::PackageSystemLock,
         paths::PackagePath,
     },
     schema::{Environment, ModeName, OriginalID, PublishAddresses, PublishedID},
@@ -771,16 +773,37 @@ impl Scenario {
         &self,
         package: impl AsRef<str>,
     ) -> PackageResult<PackageGraph<Vanilla>> {
-        let path = PackagePath::new(self.path_for(package)).unwrap();
+        let path = PackagePath::new(self.path_for(&package)).unwrap();
+
+        let config = PackageLoader::new(self.path_for(&package), default_environment())
+            .config()
+            .clone();
+
         let mtx = path.lock().unwrap();
 
-        PackageGraph::<Vanilla>::load_from_manifests(&path, &vanilla::default_environment(), &mtx)
-            .await
+        PackageGraph::<Vanilla>::load_from_manifests(
+            &path,
+            &vanilla::default_environment(),
+            &mtx,
+            &config,
+        )
+        .await
     }
 
     /// Loads the root package for `package` in the default environment and with no modes
     pub async fn root_package(&self, package: impl AsRef<str>) -> RootPackage<Vanilla> {
-        self.try_root_package(package)
+        self.try_root_package(package, |cfg| cfg)
+            .await
+            .map_err(|e| e.emit())
+            .expect("could load package")
+    }
+
+    pub async fn root_package_with_config(
+        &self,
+        package: impl AsRef<str>,
+        config: impl Fn(PackageLoader) -> PackageLoader,
+    ) -> RootPackage<Vanilla> {
+        self.try_root_package(package, config)
             .await
             .map_err(|e| e.emit())
             .expect("could load package")
@@ -789,7 +812,7 @@ impl Scenario {
     /// Loads the root package for `package` and expects an error; returns the (redacted) contents
     /// of the error
     pub async fn root_package_err(&self, package: impl AsRef<str>) -> String {
-        match self.try_root_package(package).await {
+        match self.try_root_package(package, |cfg| cfg).await {
             Ok(_) => panic!("expected root package to fail to load"),
             Err(err) => err
                 .to_string()
@@ -801,8 +824,14 @@ impl Scenario {
     pub async fn try_root_package(
         &self,
         package: impl AsRef<str>,
+        config: impl Fn(PackageLoader) -> PackageLoader,
     ) -> PackageResult<RootPackage<Vanilla>> {
-        RootPackage::<Vanilla>::load(self.path_for(package), default_environment(), vec![]).await
+        config(PackageLoader::new(
+            self.path_for(package),
+            default_environment(),
+        ))
+        .load()
+        .await
     }
 
     pub fn read_file(&self, file: impl AsRef<Path>) -> String {

--- a/external-crates/move/crates/move-stackless-bytecode-2/tests/from_source.rs
+++ b/external-crates/move/crates/move-stackless-bytecode-2/tests/from_source.rs
@@ -25,10 +25,8 @@ fn run_test(file_path: &Path) -> datatest_stable::Result<()> {
 
     let mut writer = Vec::new();
 
-    // Block on the async function
     let env = move_package_alt::flavor::vanilla::default_environment();
-    let root_pkg =
-        RootPackage::<Vanilla>::load_sync(pkg_dir.to_path_buf(), env, config.mode_set())?;
+    let root_pkg: RootPackage<Vanilla> = config.package_loader(pkg_dir, &env).load_sync()?;
 
     let test_module_names = std::io::BufReader::new(std::fs::File::open(file_path)?)
         .lines()

--- a/external-crates/move/crates/move-stackless-bytecode-2/tests/tests.rs
+++ b/external-crates/move/crates/move-stackless-bytecode-2/tests/tests.rs
@@ -27,8 +27,7 @@ fn run_test(file_path: &Path) -> datatest_stable::Result<()> {
 
     // Block on the async function
     let env = move_package_alt::flavor::vanilla::default_environment();
-    let root_pkg =
-        RootPackage::<Vanilla>::load_sync(pkg_dir.to_path_buf(), env, config.mode_set())?;
+    let root_pkg: RootPackage<Vanilla> = config.package_loader(pkg_dir, &env).load_sync()?;
 
     let test_module_names = std::io::BufReader::new(std::fs::File::open(file_path)?)
         .lines()


### PR DESCRIPTION
This PR plumbs through the package loader type through the sui CLI. This type encapsulates the different configuration and loading options for the package system. It also fixes the `--install-dir` support and adds the `--allow-dirty` flag.

## Description 

Describe the changes or additions included in this PR.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
