### PR TITLE
pick(24785) graphql: clamp indices for pagination

### DIFF
--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/events.move
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/events.move
@@ -200,3 +200,18 @@ module test::events_test {
     }
   }
 }
+
+//# run-graphql --cursors 1000 2000
+{ # Test cursors being out of bounds
+  outOfBounds: transactionEffects(digest: "@{digest_3}") {
+    events(after: "@{cursor_0}", before: "@{cursor_1}") {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+      }
+      nodes {
+        sequenceNumber
+      }
+    }
+  }
+}

--- a/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/events.snap
+++ b/crates/sui-indexer-alt-e2e-tests/tests/graphql/transaction_effects/events.snap
@@ -1,7 +1,7 @@
 ---
 source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
 ---
-processed 11 tasks
+processed 12 tasks
 
 init:
 A: object(0,0), B: object(0,1)
@@ -239,6 +239,22 @@ task 10, lines 173-202:
 Response: {
   "data": {
     "noEventsTransaction": {
+      "events": {
+        "pageInfo": {
+          "hasNextPage": false,
+          "hasPreviousPage": false
+        },
+        "nodes": []
+      }
+    }
+  }
+}
+
+task 11, lines 204-217:
+//# run-graphql --cursors 1000 2000
+Response: {
+  "data": {
+    "outOfBounds": {
       "events": {
         "pageInfo": {
           "hasNextPage": false,

--- a/crates/sui-indexer-alt-graphql/src/pagination.rs
+++ b/crates/sui-indexer-alt-graphql/src/pagination.rs
@@ -187,8 +187,8 @@ impl Page<JsonCursor<usize>> {
         total: usize,
         node: impl Fn(usize) -> Result<N, E>,
     ) -> Result<Connection<String, N>, E> {
-        let mut lo = self.after().map_or(0, |a| a.saturating_add(1));
-        let mut hi = self.before().map_or(total, |b| **b);
+        let mut lo = self.after().map_or(0, |a| a.saturating_add(1)).min(total);
+        let mut hi = self.before().map_or(total, |b| **b).min(total);
         let mut conn = Connection::new(false, false);
 
         if hi <= lo {


### PR DESCRIPTION
## Description
When paginating sequences whose cursors are indices, clamp the indices in the range of the sequence being paginted.

## Test plan

New E2E test:

```
$ cargo nextest run            \
  -p sui-indexer-alt-e2e-tests \
  -- graphql/transaction_effects/events
```

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
