### PR TITLE
Lance/sui node deterministic rust1.91

### DIFF
--- a/docker/sui-node-deterministic/Dockerfile
+++ b/docker/sui-node-deterministic/Dockerfile
@@ -1,21 +1,130 @@
-FROM stagex/pallet-rust@sha256:740b9ed5f2a897d45cafdc806976d84231aa50a64998610750b42a48f8daacab AS pallet-rust
-FROM stagex/core-cross-x86_64-gnu-gcc@sha256:88a885049fddb21b48511d36b65d944322f3edfb699e95f1876b6ded8aa91da4 AS cross-x86_64-gnu-gcc
-FROM stagex/core-cross-x86_64-gnu-rust@sha256:a779edf05a1de1594b83970d3e6dfa921ed04e0332e51e35850d498944b337f5 AS cross-x86_64-gnu-rust
+ARG PROFILE=release
+ARG BUILD_DATE
+ARG GIT_REVISION
 
-FROM pallet-rust AS build
-COPY --from=cross-x86_64-gnu-gcc . /
-COPY --from=cross-x86_64-gnu-rust . /
-ENV RUST_BACKTRACE=1
-ENV RUSTFLAGS="-C codegen-units=1"
-ENV RUSTFLAGS="${RUSTFLAGS} -C target-feature=+crt-static"
-ENV RUSTFLAGS="${RUSTFLAGS} -C linker=/usr/bin/x86_64-linux-gnu-gcc"
-ENV CARGO_BUILD_TARGET=x86_64-unknown-linux-gnu
-ENV CARGO_TARGET_DIR=/rootfs/opt/sui/bin/
+FROM stagex/pallet-clang-cmake-busybox@sha256:d83c2f27ccacbc20efff56f8d46f53146cae1b3e2271f13800e36869bef6616d AS pallet-clang-cmake-busybox
+FROM stagex/pallet-clang-gnu-busybox@sha256:5ec4a554d07f5aed890dcdf2aa31b5d94ba0132425d71feb231866c7bacebc1a AS pallet-clang-gnu-busybox
+FROM stagex/core-cross-x86_64-gnu-gcc@sha256:72382cbb0267dd86e83fe25abe5d0f12fd51e494e0bf8a45974d3b15bc4e317f AS core-cross-x86_64-gnu-gcc
+FROM stagex/pallet-rust@sha256:4062550919db682ebaeea07661551b5b89b3921e3f3a2b0bc665ddea7f6af1ca AS pallet-rust
+FROM stagex/core-ncurses@sha256:35d72c3b114e43b754efaa7888b4998bc1871aa8fac9bad5c085e9c30689419f AS core-ncurses
+FROM stagex/core-bash@sha256:5b598c14eef61148baf3f5a2830a214a5985b5d3544b019e3d0ed53c6b66989a AS core-bash
+FROM stagex/core-make@sha256:2e75f157275b517738d0ae6af1b3cd0aca0a61d0aff1402f25d6754065e65c7a AS core-make
+FROM stagex/core-coreutils@sha256:d53c34b74dd99125fbdd8a274d750e7758cd4bb4d5d3d528f9f07a694333d2e7 AS core-coreutils
+FROM stagex/core-openssl@sha256:4ecf4f42ad958a25d4622b246aacdbccd523aacbb8ce036f387d39e8a17b9840 AS core-openssl
+FROM stagex/core-busybox@sha256:d608daa946e4799cf28b105aba461db00187657bd55ea7c2935ff11dac237e27 AS core-busybox
 
-COPY . .
-RUN cargo fetch
+FROM scratch as base
+COPY --from=core-cross-x86_64-gnu-gcc . /
+ENV ZSTD_VERSION=1.5.7
+ENV ZSTD_HASH=37d7284556b20954e56e1ca85b80226768902e2edabd3b649e9e72c0c9012ee3
+ENV ROCKSDB_VERSION=9.10.0
+ENV ROCKSDB_HASH=fdccab16133c9d927a183c2648bcea8d956fb41eb1df2aacaa73eb0b95e43724
+ENV ZLIB_VERSION=1.3.1
+ENV ZLIB_HASH=9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
+ENV ARCH=x86_64
+ENV TARGET=${ARCH}-linux-gnu
+ENV CARGO_TARGET=${ARCH}-unknown-linux-gnu
+ENV GCC_VERSION=15.2.0
+ENV GCC_INSTALL_DIR=/opt/cross/lib/gcc/${TARGET}/${GCC_VERSION}
 ARG PROFILE
-RUN --network=none cargo build --frozen --bin sui-node
+ENV PROFILE=${PROFILE}
+ARG BUILD_DATE
+ENV BUILD_DATE=${BUILD_DATE}
+ARG GIT_REVISION
+ENV GIT_REVISION=${GIT_REVISION}
+ENV PREFIX=/opt/cross/${TARGET}
+ENV CC=clang
+ENV CXX=clang++
+ENV LDFLAGS="--ld-path=/usr/bin/ld.lld"
+ENV PREFIX=${PREFIX}
+ENV DESTDIR=/rootfs
+ENV LIBDIR=${PREFIX}/lib
+COPY <<-EOF /etc/clang/clang.cfg
+--target=${TARGET} --gcc-install-dir=${GCC_INSTALL_DIR} -rtlib=libgcc -unwindlib=libgcc -stdlib=libstdc++
+EOF
+COPY <<-EOF /etc/clang/clang++.cfg
+--target=${TARGET} --gcc-install-dir=${GCC_INSTALL_DIR} -rtlib=libgcc -unwindlib=libgcc -stdlib=libstdc++
+EOF
+WORKDIR /build
+
+FROM base as build-rocksdb
+COPY --from=pallet-clang-gnu-busybox . /
+COPY --from=core-bash . /
+COPY --from=core-ncurses . /
+COPY --from=core-openssl . /
+COPY --from=core-coreutils . /
+ADD --checksum=sha256:${ROCKSDB_HASH} https://github.com/facebook/rocksdb/archive/refs/tags/v${ROCKSDB_VERSION}.tar.gz .
+ENV EXTRA_CXXFLAGS="-include cstdint -Wno-error=nontrivial-memcall -Wno-error=unused-parameter -Wno-error=unused-command-line-argument -Wno-error=deprecated-declarations"
+RUN --network=none <<-EOF
+	tar -xf v${ROCKSDB_VERSION}.tar.gz
+	cd rocksdb-${ROCKSDB_VERSION}
+	make static_lib shared_lib install
+EOF
+FROM scratch as package-rocksdb
+COPY --from=build-rocksdb /rootfs/ /
+
+FROM base as build-zlib
+COPY --from=pallet-clang-gnu-busybox . /
+ADD --checksum=sha256:${ZLIB_HASH} https://www.zlib.net/zlib-${ZLIB_VERSION}.tar.gz .
+RUN --network=none <<-EOF
+	set -eu
+	tar -xf zlib-${ZLIB_VERSION}.tar.gz
+	cd zlib-${ZLIB_VERSION}
+	./configure --prefix=${PREFIX} --shared
+	make install
+EOF
+FROM scratch as package-zlib
+COPY --from=build-zlib /rootfs/ /
+
+FROM base as build-zstd
+COPY --from=pallet-clang-cmake-busybox . /
+COPY --from=core-make . /
+COPY --from=package-zlib . /
+ADD --checksum=sha256:${ZSTD_HASH} https://github.com/facebook/zstd/archive/v${ZSTD_VERSION}.tar.gz .
+RUN --network=none <<-EOF
+	set -eu
+	tar -xf v${ZSTD_VERSION}.tar.gz
+	cd zstd-${ZSTD_VERSION}/lib
+	make DESTDIR=${DESTDIR} PREFIX=${PREFIX} install
+EOF
+FROM scratch as package-zstd
+COPY --from=build-zstd /rootfs/ /
+
+FROM base AS build
+COPY --from=pallet-rust . /
+COPY --from=package-rocksdb . /
+COPY --from=package-zlib . /
+COPY --from=package-zstd . /
+COPY . .
+RUN rm -rf /etc/clang
+ENV RUSTFLAGS="-C codegen-units=1 -Clink-arg=--target=${TARGET} -Clink-arg=--gcc-install-dir=${GCC_INSTALL_DIR} -Clink-arg=-rtlib=libgcc -Clink-arg=-unwindlib=libgcc -Clink-arg=-stdlib=libstdc++"
+ENV RUSTC_BOOTSTRAP=1
+ENV CARGO_ARGS="-Zbuild-std=std,alloc,proc_macro,panic_abort -Zbuild-std-features=compiler-builtins-mem -Zunstable-options"
+ENV ROCKSDB_LIB_DIR=${PREFIX}/lib
+RUN cargo fetch ${CARGO_ARGS}
+RUN --network=none <<-EOF
+	cargo build \
+		${CARGO_ARGS} \
+		--target=${CARGO_TARGET} \
+		--profile=${PROFILE} \
+		--frozen \
+		--artifact-dir=/rootfs \
+		--bin sui-node
+	install -D ${PREFIX}/lib64/libgcc_s.so.1 -t ${DESTDIR}/usr/lib/
+	install -D ${PREFIX}/lib64/libstdc++.so.6.0.34 ${DESTDIR}/usr/lib/libstdc++.so.6
+	install -D ${PREFIX}/lib/ld-linux-x86-64.so.2 -t ${DESTDIR}/usr/lib/
+	install -D ${PREFIX}/lib/libz.so.1 -t ${DESTDIR}/usr/lib/
+	install -D ${PREFIX}/lib/libzstd.so.1 -t ${DESTDIR}/usr/lib/
+	install -D ${PREFIX}/lib/librocksdb.so.9.10 -t ${DESTDIR}/usr/lib/
+	install -D ${PREFIX}/lib/libm.so.6 -t ${DESTDIR}/usr/lib/
+	install -D ${PREFIX}/lib/libc.so.6 -t ${DESTDIR}/usr/lib/
+	ln -s libc.so.6 ${DESTDIR}/usr/lib/libc.so
+EOF
+# HACK: sui-node seems to have a hard dependency on /bin/exec for no obvious reason.
+# For now we include busybox until this is fixed in sui-node
+COPY --from=core-busybox . ${DESTDIR}/
 
 FROM scratch AS package
-COPY --from=build /rootfs /
+COPY --from=build /rootfs/ /
+ENV LD_LIBRARY_PATH=/usr/lib
+ENTRYPOINT ["/sui-node"]

--- a/docker/sui-node-deterministic/build.sh
+++ b/docker/sui-node-deterministic/build.sh
@@ -7,7 +7,7 @@ set -e
 
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-OCI_OUTPUT="$REPO_ROOT/build/oci"
+OCI_OUTPUT="$REPO_ROOT/build/sui-node"
 DOCKERFILE="$DIR/Dockerfile"
 GIT_REVISION="$(git describe --always --abbrev=12 --dirty --exclude '*')"
 BUILD_DATE="$(date -u +'%Y-%m-%d')"
@@ -34,10 +34,13 @@ echo
 export DOCKER_BUILDKIT=1
 export SOURCE_DATE_EPOCH=1
 
+rm -rf $OCI_OUTPUT || :
 docker build -f "$DOCKERFILE" "$REPO_ROOT" \
 	--build-arg GIT_REVISION="$GIT_REVISION" \
 	--build-arg BUILD_DATE="$BUILD_DATE" \
 	--build-arg PROFILE="$PROFILE" \
 	--platform "$PLATFORM" \
-	--output type=oci,rewrite-timestamp=true,force-compression=true,tar=false,dest=$OCI_OUTPUT/sui-node,name=sui-node \
+	--tag "sui-node:local" \
+	--output type=local,dest=$OCI_OUTPUT/local \
+	--output type=oci,rewrite-timestamp=true,tar=false,dest=$OCI_OUTPUT/oci,name=sui-node \
 	"$@"

--- a/docker/sui-node-deterministic/update.py
+++ b/docker/sui-node-deterministic/update.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+from requests import Session
+from fileinput import FileInput
+
+target = "Dockerfile"
+source = "https://codeberg.org/stagex/stagex/raw/branch/main/digests/"
+stages = ["core","user","bootstrap","pallet"]
+
+digests = {}
+for stage in stages:
+    response = Session().get(f"{source}{stage}.txt")
+    for line in response.iter_lines():
+        if not line:
+            continue
+        (digest, name) = line.decode("utf-8").split(" ")
+        print(digest, name)
+        digests[name] = digest
+
+with FileInput(target, inplace=True, backup='.bak') as f:
+    for line in f:
+        if line.startswith("FROM stagex/"):
+            # NOTE: split by '@' in case a tag is not provided
+            # Matches:
+            # stagex/tag:version@sha256:hash
+            # stagex/tag@sha256:hash
+            # stagex/tag:version
+            # stagex/tag
+            name = line.split("/")[1].split(":")[0].split('@')[0]
+            if name not in digests:
+                for stage in stages:
+                    if f"{stage}-{name}" in digests:
+                        name = f"{stage}-{name}"
+            print(f"FROM stagex/{name}@sha256:{digests[name]} AS {name}")
+        else:
+            print(line,end='')


### PR DESCRIPTION
## Description 

- Migrate sui-node-deterministic to new llvm-based stagex w/ rust 1.91.1
- Switch to build-std build strategy
- Switch to dynamic linking by default to allow sui team telemetry/debug engines to work
- Build _all_ c deps with clang targeting x86_64-linux-gnu to fix backtrace conflict
- Ensure final image is able to function as standalone runtime image without need for debian etc
- Unclude "update.py" script to update to latest stagex release hashes when needed

## Background

While we had static deterministic builds in prior musl, and glibc passes, it was discovered the monitoring tooling required for dynamic linking, and all attempts to do that resulted in us getting segfaults when backtracing was used.

After months of investigation and experiments which we can chronicle elsewhere later on getting dynamic linking to work at all, this backtrace issue was blocking, and needed to be understood. After several more weeks of debugging binary headers and doing terribly mean things to compilers and learning how ELF headers actually work, we discovered the current attempt at dynamic binaries had mixed linking as the root cause of this blocking issue thus making binaries that really were broken.

Librocksdb was in fact being linked against glibc, along with a glibc rust binary, BUT cargo and the sys-* packages are not smart enough to build transitive dependencies with your preferred --target. Librocksdb itself was still linked against dependencies that were linked on musl from the system. Musl and glibc implement backtrace wildly differently, so any attempts to call backtrace codepaths caused a crash.

In parallel we had been doing extensive research experimentation with LLVM, and on hitting the brick wall above we realized we needed to double down on that to solve cases like these reliably. We concluded the most reasonable path was to make stagex the first reproducible and full source bootstrapped linux distribution to have a default toolchain that can build binaries for a totally foreign libc/triple, and cross compile all the dependencies to link the binary as glibc all the way down.

So we did all that, and it was published yesterday as stagex 2026.01.0

This PR switches to the complete LLVM build strategy for sui-node, rocksdb, and dependencies to be built with clang targeting x86_64-linux-gnu

The resulting last layer of the container image contains sui-node and everything it should need to run, and so a non deterministic distribution with weaker supply chain security than stagex, like debian or ubuntu, are no longer required at all.

This does result in a fairly custom set of hash locked build dependencies for the requirements of sui, that would be somewhat painful to update by land, so we also included an update.py helper script to make this easy to maintain as new stagex/rust releases come out.

## Testing steps

1. Build image

    ```
    $ docker/sui-node-deterministic/build.sh
    ```

2. Verify hashes of all objects in image:

    ```
    $ find build/bin/ -type f -exec openssl sha256 {} \; | sort -k2 | sha256sum
    8d53ef62ee949cd37416babdf825af1589cd7e7f9cd9ed914702ee9f9ba37e70  -
    ```

3. Verify digest 

    ```
    $ cat build/oci/sui-node/index.json | jq -r '.manifests[0].digest'
    sha256:9e16f65dfddd8fd9e00b3b1496dd7f3543e5134847ff95084ecad2ee56153521
    ```
    Note: this step may not work reliably on MacOS

4. Import image:

    ```
    $ tar -C out/sui-node/oci -cf - .  |  docker load
    ```

5. Run image:

    ```
    $ docker run sui-node:local
    ```

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [x] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
