### PR TITLE
docs: fix incorrect date in data-serving timeline

### DIFF
--- a/docs/content/concepts/data-access/data-serving.mdx
+++ b/docs/content/concepts/data-access/data-serving.mdx
@@ -89,7 +89,7 @@ The target times indicated are tentative and subject to updates based on project
 | -------- | ------- | ------- |
 | :heavy_check_mark: September 2025 | Beta release of GraphQL RPC Server and General-purpose Indexer. | You can start validating the setup of General-purpose Indexer, along with testing the GraphQL RPC Server to access the indexed Sui data. You can also start migrating your application in the non-production environments, and share feedback on the improvements you want to see. |
 | :heavy_check_mark: September-October 2025 | Deprecation of JSON-RPC. | **JSON-RPC is deprecated at this point and migration notice period starts.** |
-| December-January 2025 | GA release of GraphQL RPC Server and General-purpose Indexer. | Begin migration and cutover of your application in the production environment. |
+| December 2025 - January 2026 | GA release of GraphQL RPC Server and General-purpose Indexer. | Begin migration and cutover of your application in the production environment. |
 | April 2026 | End of migration timeline. | **JSON-RPC is fully deactivated at this point.** This timeline assumes about 7 months of migration notice period. |
 
 ### Archival Store and Service


### PR DESCRIPTION
## Summary

Fixes an incorrect date in the GraphQL migration timeline table.

The table in `data-serving.mdx` shows:
- ✅ September 2025 - Beta release (completed)
- ✅ September-October 2025 - JSON-RPC deprecation (completed)
- ❌ **December-January 2025** - GA release ← This date is chronologically impossible

Changed "December-January 2025" to "December 2025 - January 2026" to match the timeline progression leading to the April 2026 migration deadline.

## Test plan

- [x] Verified the date now makes chronological sense in the timeline
- [x] No other files affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)