### PR TITLE
docs: update dryRunTransactionBlock to simulateTransaction

### DIFF
--- a/docs/content/references/sui-graphql.mdx
+++ b/docs/content/references/sui-graphql.mdx
@@ -34,7 +34,7 @@ To get started with GraphQL for the Sui RPC, check out the [Getting Started](/gu
 
 All GraphQL API elements are accessible via the left sidebar, the following are good starting points to explore from.
 
-- "Queries" lists all top-level queries for reading the chain state, from reading details about addresses and objects to <UnsafeLink href="/references/sui-api/sui-graphql/beta/reference/operations/queries/simulate-transaction.mdx">dryRunTransactionBlock</UnsafeLink>, which has an execution-like interface but does not modify the chain.
+- "Queries" lists all top-level queries for reading the chain state, from reading details about addresses and objects to <UnsafeLink href="/references/sui-api/sui-graphql/beta/reference/operations/queries/simulate-transaction.mdx">simulateTransaction</UnsafeLink>, which has an execution-like interface but does not modify the chain.
 - "Mutations" lists operations that can modify chain state, like <UnsafeLink href="/references/sui-api/sui-graphql/beta/reference/operations/mutations/execute-transaction.mdx">executeTransactionBlock</UnsafeLink>.
 - <UnsafeLink href="/references/sui-api/sui-graphql/alpha/reference/types/objects/object">Object</UnsafeLink> is the type representing all on-chain objects (Move values and packages).
 - <UnsafeLink href="/references/sui-api/sui-graphql/alpha/reference/types/objects/address">Address</UnsafeLink> corresponds to account addresses (derived from the public keys of signatures that sign transactions) and can be used to query the objects owned by these accounts and the transactions they have signed or been affected by.


### PR DESCRIPTION
## Summary

Updates the link text from the deprecated JSON-RPC method name to the current GraphQL API name.

**Before:**
```
<UnsafeLink href="...simulate-transaction.mdx">dryRunTransactionBlock</UnsafeLink>
```

**After:**
```
<UnsafeLink href="...simulate-transaction.mdx">simulateTransaction</UnsafeLink>
```

The href was already correctly pointing to `simulate-transaction.mdx`, but the display text still referenced the deprecated `dryRunTransactionBlock` name. This fixes the inconsistency.

This aligns with the Beta GraphQL schema changes mentioned in the API reference, where `dryRunTransactionBlock` was renamed to `simulateTransaction`.

## Test plan

- [x] Link text now matches the destination file name
- [x] Consistent with GraphQL Beta API naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)