### PR TITLE
fix: remove duplicate dry run status output

### DIFF
--- a/crates/sui/src/displays/dry_run_tx_block.rs
+++ b/crates/sui/src/displays/dry_run_tx_block.rs
@@ -92,11 +92,6 @@ impl Display for Pretty<'_, DryRunTransactionBlockResponse> {
         }
         writeln!(
             f,
-            "Dry run completed, execution status: {}",
-            response.effects.status()
-        )?;
-        writeln!(
-            f,
             "Estimated gas cost (includes a small buffer): {} MIST",
             estimate_gas_budget_from_gas_cost(
                 response.effects.gas_cost_summary(),


### PR DESCRIPTION
This change removes the second Dry run completed, execution status line from the dry run display, keeping only the initial status output at the top. The goal is to avoid redundant information in the CLI output and make the dry run results easier to read without changing any underlying behavior.