### PR TITLE
Handle unindexed balance_changes (#24794)

### DIFF
--- a/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_checkpoint.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/ledger_service/get_checkpoint.rs
@@ -67,6 +67,16 @@ pub fn get_checkpoint(
     let sequence_number = summary.sequence_number;
     let timestamp_ms = summary.timestamp_ms;
 
+    let latest_checkpoint = service
+        .reader
+        .inner()
+        .get_latest_checkpoint()?
+        .sequence_number;
+
+    if sequence_number > latest_checkpoint {
+        return Err(CheckpointNotFoundError::sequence_number(sequence_number).into());
+    }
+
     let mut checkpoint = Checkpoint::default();
 
     checkpoint.merge(summary, &read_mask);


### PR DESCRIPTION
## Description

Cherry picking <https://github.com/MystenLabs/sui/pull/24794>

## Release notes

- [x] gRPC: Return an error when `balance_changes` is requested but the
      transactions have not been indexed yet.
