### PR TITLE
fix(indexer-alt-framework): Fix client_args not being parsed from CLI

### DIFF
--- a/crates/sui-indexer-alt-framework/src/cluster.rs
+++ b/crates/sui-indexer-alt-framework/src/cluster.rs
@@ -31,7 +31,7 @@ pub struct Args {
 
     /// Where to get checkpoint data from.
     #[clap(flatten)]
-    pub client_args: Option<ClientArgs>,
+    pub client_args: ClientArgs,
 
     /// How to expose metrics.
     #[clap(flatten)]
@@ -104,7 +104,7 @@ impl IndexerClusterBuilder {
     /// Set client arguments (where to get checkpoint data from).
     /// This overwrites any previously set client args.
     pub fn with_client_args(mut self, args: ClientArgs) -> Self {
-        self.args.client_args = Some(args);
+        self.args.client_args = args;
         self
     }
 
@@ -149,7 +149,7 @@ impl IndexerClusterBuilder {
 
         let registry = Registry::new();
         let metrics = MetricsService::new(self.args.metrics_args, registry);
-        let client_args = self.args.client_args.context("client_args is required")?;
+        let client_args = self.args.client_args;
 
         let indexer = Indexer::new_from_pg(
             database_url,
@@ -317,13 +317,13 @@ mod tests {
             SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), get_available_port());
 
         let args = Args {
-            client_args: Some(ClientArgs {
+            client_args: ClientArgs {
                 ingestion: IngestionClientArgs {
                     local_ingestion_path: Some(checkpoint_dir.path().to_owned()),
                     ..Default::default()
                 },
                 ..Default::default()
-            }),
+            },
             indexer_args: IndexerArgs {
                 first_checkpoint: Some(0),
                 last_checkpoint: Some(9),
@@ -410,13 +410,13 @@ mod tests {
                     first_checkpoint: Some(100),
                     ..Default::default()
                 },
-                client_args: Some(ClientArgs {
+                client_args: ClientArgs {
                     ingestion: IngestionClientArgs {
                         local_ingestion_path: Some("/bundled".into()),
                         ..Default::default()
                     },
                     ..Default::default()
-                }),
+                },
                 metrics_args: MetricsArgs {
                     metrics_address: "127.0.0.1:8080".parse().unwrap(),
                 },
@@ -441,9 +441,9 @@ mod tests {
             builder
                 .args
                 .client_args
-                .unwrap()
                 .ingestion
                 .local_ingestion_path
+                .as_ref()
                 .unwrap()
                 .to_string_lossy(),
             "/individual"
@@ -476,13 +476,13 @@ mod tests {
                     first_checkpoint: Some(100),
                     ..Default::default()
                 },
-                client_args: Some(ClientArgs {
+                client_args: ClientArgs {
                     ingestion: IngestionClientArgs {
                         local_ingestion_path: Some("/bundled".into()),
                         ..Default::default()
                     },
                     ..Default::default()
-                }),
+                },
                 metrics_args: MetricsArgs {
                     metrics_address: "127.0.0.1:8080".parse().unwrap(),
                 },
@@ -493,9 +493,9 @@ mod tests {
             builder
                 .args
                 .client_args
-                .unwrap()
                 .ingestion
                 .local_ingestion_path
+                .as_ref()
                 .unwrap()
                 .to_string_lossy(),
             "/bundled"


### PR DESCRIPTION
## Description 

Fixes a bug where `client_args` was None when parsed from CLI arguments, causing Error: `client_args is required` even when `--remote-store-url` was provided.

Root cause: https://github.com/clap-rs/clap/issues/5809 - when using `#[clap(flatten)]` with `Option<T>` and the inner type contains nested #[clap(flatten)], the parsed values are discarded and the Option stays None.

After #24261 added nested flattening inside `ClientArgs` (for `IngestionClientArgs` and `StreamingClientArgs`), the clap bug was triggered.

Fix: Remove the Option wrapper from client_args in the Args struct. The #[group(required = true)] on IngestionClientArgs already enforces that one source option is provided.

## Test plan 

How did you test the new or updated feature?

Verified the basic-sui-indexer example now runs successfully with 

`cargo run -- --remote-store-url https://checkpoints.testnet.sui.io`

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
