### PR TITLE
fix: align p2p config defaults and discovery docs

### DIFF
--- a/crates/sui-config/src/p2p.rs
+++ b/crates/sui-config/src/p2p.rs
@@ -60,7 +60,7 @@ impl Default for P2pConfig {
 
 impl P2pConfig {
     pub fn excessive_message_size(&self) -> usize {
-        const EXCESSIVE_MESSAGE_SIZE: usize = 32 << 20;
+        const EXCESSIVE_MESSAGE_SIZE: usize = 8 << 20;
 
         self.excessive_message_size
             .unwrap_or(EXCESSIVE_MESSAGE_SIZE)
@@ -245,7 +245,7 @@ impl StateSyncConfig {
     }
 
     pub fn checkpoint_content_timeout(&self) -> Duration {
-        const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
+        const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 
         self.checkpoint_content_timeout_ms
             .map(Duration::from_millis)
@@ -292,7 +292,7 @@ pub enum AccessType {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct DiscoveryConfig {
-    /// Query peers for their latest checkpoint every interval period.
+    /// Query a subset of peers for their known peers every interval period.
     ///
     /// If unspecified, this will default to `5,000` milliseconds.
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
This change brings the p2p configuration in line with its documentation and existing expectations. The default 
excessive_message_size for P2pConfig is adjusted to 8 MiB to match the documented value. The default checkpoint content timeout in StateSyncConfig is reduced from 60s to 10s so that the runtime behavior matches the documented checkpoint_content_timeout_ms default and the values used in swarm/test builders. Additionally, the comment on DiscoveryConfig::interval_period_ms is updated to describe periodic peer discovery instead of checkpoint polling, fixing a misleading copy‑paste doc.