### PR TITLE
Fix protocol compatibility check against testnet

### DIFF
--- a/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_105.snap
+++ b/crates/sui-protocol-config/src/snapshots/sui_protocol_config__test__Testnet_version_105.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/sui-protocol-config/src/lib.rs
 expression: "ProtocolConfig::get_for_version(cur, *chain_id)"
+snapshot_kind: text
 ---
 version: 105
 feature_flags:


### PR DESCRIPTION
## Description 
Fix protocol compatibility check against testnet

## Test plan 
```
eugene@eugene-dev ~/code/sui/scripts/compatibility (ebmifa/fix_testnet_protocol_compatibility) $ ./check-protocol-compatibility.sh testnet
Found following versions on testnet:
    123 1.63.1-a14d9e8ddadf
     18 1.62.0-74e8414a4986
      2 1.62.0-74e8414a49
      2 1.60.0-833c3bbde1f0
      1 1.61.2-6c229fe6c04f
      1 1.39.1-e2a147185dbe

Using most frequent version 1.63.1-a14d9e8ddadf for compatibility check
warning: The last gc run reported the following. Please correct the root cause
and remove .git/gc.log
Automatic cleanup will not be performed until the file is removed.

warning: There are too many unreachable loose objects; run 'git prune' to remove them.

Source commit: 9c466f715ffc1e7f4095f4b1becc9adfbc43ca76
Source branch: ebmifa/fix_testnet_protocol_compatibility
Checking protocol compatibility with testnet (a14d9e8ddadf)
Checking out testnet snapshot files
Checking for changes to snapshot files matching *__Testnet_version_*
HEAD is now at 9c466f715f Fix protocol compatibility check against testnet
Running snapshot tests...
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.39s
     Running unittests src/lib.rs (target/debug/deps/sui_protocol_config-b75908d0b8e21b21)

running 1 test
test test::snapshot_tests ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.61s
```