### PR TITLE
Improve coin reservation error diagnostics

### DIFF
--- a/crates/sui-core/src/accumulators/coin_reservations.rs
+++ b/crates/sui-core/src/accumulators/coin_reservations.rs
@@ -49,7 +49,13 @@ impl CoinReservationResolver {
                     None,
                     object_id,
                 )
-                .map_err(|e| invalid_res_error!("could not load coin reservation object id {}: {}", object_id, e))?
+                .map_err(|e| {
+                    invalid_res_error!(
+                        "could not load coin reservation object id {}: {}",
+                        object_id,
+                        e
+                    )
+                })?
                 .ok_or_else(|| {
                     invalid_res_error!("coin reservation object id {} not found", object_id)
                 })?;


### PR DESCRIPTION
Updated `CoinReservationResolver` error strings so they include both the coin reservation object ID and the underlying error value. Previously the formatted message mentioned the object ID but only interpolated the error, which made debugging harder. This change is cosmetic only and does not alter control flow or behavior.