### PR TITLE
[fix][ptb] Fix typing ordering 

### DIFF
--- a/crates/sui-adapter-transactional-tests/tests/programmable/type_check_ordering.move
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/type_check_ordering.move
@@ -1,0 +1,49 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// tests ordering of multiple incorrect arguments
+
+//# init --addresses test=0x0
+
+//# publish
+module test::m;
+
+public struct A has key {
+    id: UID,
+}
+public struct B has key {
+    id: UID,
+}
+public struct C has key {
+    id: UID,
+}
+
+public fun a(ctx: &mut TxContext) {
+    transfer::share_object(A { id: object::new(ctx) });
+}
+
+public fun b(ctx: &mut TxContext) {
+    transfer::share_object(B { id: object::new(ctx) });
+}
+
+public fun c(ctx: &mut TxContext) {
+    transfer::share_object(C { id: object::new(ctx) });
+}
+
+public fun t0(_: &mut A, _: &B, _: &C, _: &TxContext)
+{
+}
+
+//# programmable
+//> test::m::a()
+
+//# programmable
+//> test::m::b()
+
+//# programmable
+//> test::m::c()
+
+
+//# programmable --inputs object(2,0) object(3,0) object(4,0)
+// Should fail with type error in the first argument, even though the third is also incorrect
+//> test::m::t0(Input(2), Input(1), Input(0))

--- a/crates/sui-adapter-transactional-tests/tests/programmable/type_check_ordering.snap
+++ b/crates/sui-adapter-transactional-tests/tests/programmable/type_check_ordering.snap
@@ -1,0 +1,38 @@
+---
+source: external-crates/move/crates/move-transactional-test-runner/src/framework.rs
+---
+processed 6 tasks
+
+task 1, lines 8-35:
+//# publish
+created: object(1,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 6194000,  storage_rebate: 0, non_refundable_storage_fee: 0
+
+task 2, lines 37-38:
+//# programmable
+//> test::m::a()
+created: object(2,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2196400,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 3, lines 40-41:
+//# programmable
+//> test::m::b()
+created: object(3,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2196400,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 4, lines 43-44:
+//# programmable
+//> test::m::c()
+created: object(4,0)
+mutated: object(0,0)
+gas summary: computation_cost: 1000000, storage_cost: 2196400,  storage_rebate: 978120, non_refundable_storage_fee: 9880
+
+task 5, lines 47-49:
+//# programmable --inputs object(2,0) object(3,0) object(4,0)
+// Should fail with type error in the first argument, even though the third is also incorrect
+//> test::m::t0(Input(2), Input(1), Input(0))
+Error: Transaction Effects Status: Invalid command argument at 0. The type of the value does not match the expected type
+Debug of error: CommandArgumentError { arg_idx: 0, kind: TypeMismatch } at command Some(0)

--- a/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/translate.rs
+++ b/sui-execution/latest/sui-adapter/src/static_programmable_transactions/typing/translate.rs
@@ -498,11 +498,10 @@ fn move_call_arguments(
         ));
     }
     // construct arguments, injecting tx context args as needed
-    let mut args = args.into_iter().enumerate().rev();
-    let mut res = params
+    let mut args = args.into_iter().enumerate();
+    let res = params
         .into_iter()
         .enumerate()
-        .rev()
         .map(|(param_idx, (expected_ty, tx_context_kind))| {
             Ok(match tx_context_kind {
                 TxContextKind::None => {
@@ -527,7 +526,6 @@ fn move_call_arguments(
             })
         })
         .collect::<Result<Vec<_>, ExecutionError>>()?;
-    res.reverse();
 
     assert_invariant!(
         args.next().is_none(),


### PR DESCRIPTION
## Description 

- Type checking args should always go "left" to "right" (increasing indices)
- This particular code snippet was refactored one too many times and I messed up the reverses when switching from vectors to iterators

## Test plan 

-  Added a test

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
