### PR TITLE
fix: correct fetch_latest_blocks error label

### DIFF
--- a/consensus/core/src/network/tonic_network.rs
+++ b/consensus/core/src/network/tonic_network.rs
@@ -251,9 +251,11 @@ impl NetworkClient for TonicClient {
             .await
             .map_err(|e| {
                 if e.code() == tonic::Code::DeadlineExceeded {
-                    ConsensusError::NetworkRequestTimeout(format!("fetch_blocks failed: {e:?}"))
+                    ConsensusError::NetworkRequestTimeout(format!(
+                        "fetch_latest_blocks failed: {e:?}"
+                    ))
                 } else {
-                    ConsensusError::NetworkRequest(format!("fetch_blocks failed: {e:?}"))
+                    ConsensusError::NetworkRequest(format!("fetch_latest_blocks failed: {e:?}"))
                 }
             })?
             .into_inner();


### PR DESCRIPTION
The client-side error mapping for fetch_latest_blocks was still using the fetch_blocks label, which made logs and diagnostics misleading when debugging failures of the latest-blocks RPC. This change updates the error messages to correctly reference fetch_latest_blocks in both timeout and non-timeout paths, without altering any behavior of the call itself.