### PR TITLE
chore(common): fix ExponentialBackoff default backoff test

### DIFF
--- a/crates/mysten-common/src/backoff.rs
+++ b/crates/mysten-common/src/backoff.rs
@@ -99,7 +99,8 @@ fn test_exponential_backoff_default() {
         (Duration::from_millis(50), Duration::from_millis(100)),
         (Duration::from_millis(60), Duration::from_millis(170)),
     ];
-    for ((lower, upper), delay) in bounds.into_iter().zip(backoff.next()) {
+    for (lower, upper) in bounds {
+        let delay = backoff.next().unwrap();
         assert!(delay >= lower && delay <= upper);
     }
 }


### PR DESCRIPTION
The default ExponentialBackoff test was only validating the first delay because it zipped the bounds vector with a single call to backoff.next(), which returns an Option and thus produces at most one item as an iterator. This left the second set of bounds unused and effectively untested. The test now iterates over the expected bounds and calls backoff.next() on each iteration, ensuring that both the first and second backoff delays stay within the configured ranges.