### PR TITLE
perf: avoid cloning objects in `ObjectProviderCache`

### DIFF
--- a/crates/sui-json-rpc/src/balance_changes.rs
+++ b/crates/sui-json-rpc/src/balance_changes.rs
@@ -154,7 +154,7 @@ impl<P> ObjectProviderCache<P> {
             let version = object.version();
 
             let key = (object_id, version);
-            object_cache.insert(key, object.clone());
+            object_cache.insert(key, object);
 
             match last_version_cache.get_mut(&key) {
                 Some(existing_seq_number) => {
@@ -178,7 +178,7 @@ impl<P> ObjectProviderCache<P> {
 
         for (object_id, (object_ref, object, _)) in written_objects {
             let key = (object_id, object_ref.1);
-            object_cache.insert(key, object.clone());
+            object_cache.insert(key, object);
 
             match last_version_cache.get_mut(&key) {
                 Some(existing_seq_number) => {


### PR DESCRIPTION
`ObjectProviderCache` was cloning Object values when inserting them into the internal object_cache map, both in 
`insert_objects_into_cache` and in `new_with_cache`. In both cases the Object instances are already owned (Vec<Object> argument and owned values from written_objects), so cloning them before insertion adds unnecessary allocations and CPU overhead.

This change updates the code to move the Object into object_cache instead of cloning it. The rest of the logic is unchanged: we still compute object_id and version from the same values and update last_version_cache in the same way. The behavior of the cache is preserved, while avoiding redundant work on every cached object insert.