### PR TITLE
Fix single-gas-coin bug

### DIFF
--- a/crates/sui-rosetta/src/operations.rs
+++ b/crates/sui-rosetta/src/operations.rs
@@ -768,6 +768,7 @@ impl Operations {
                         } else if account.address == new_gas_owner && amount.currency == *SUI {
                             amount.value += gas_used;
                         }
+                        operation.type_ = OperationType::PaySui;
                     }
                     _ => {
                         return Err(anyhow!(

--- a/crates/sui-rosetta/tests/end_to_end_tests.rs
+++ b/crates/sui-rosetta/tests/end_to_end_tests.rs
@@ -786,14 +786,22 @@ async fn test_transfer_single_gas_coin() {
     .unwrap();
 
     let mut balance = 0;
-    operations.into_iter().for_each(|op| {
+    let mut pay_sui_count = 0;
+    for op in operations {
+        assert_ne!(
+            op.type_,
+            OperationType::SuiBalanceChange,
+            "Expected PaySui operations, not SuiBalanceChange"
+        );
         if op.type_ == OperationType::Gas {
             assert_eq!(op.account.unwrap().address, sender);
         }
         if op.type_ == OperationType::PaySui {
             balance += op.amount.unwrap().value;
+            pay_sui_count += 1;
         }
-    });
+    }
+    assert_eq!(pay_sui_count, 2, "Expected exactly 2 PaySui operations");
     assert_eq!(balance, 0);
 }
 


### PR DESCRIPTION
## Description

From Slack:

```
Kevin Jones
  35 minutes ago
:wave: To add to @sajjad.zaidi's list. There was also this PR which has been merged. Is the original issue now solved? For this tx I'm still getting:
ProgrammableTransaction
SuiBalanceChange
SuiBalanceChange
Gas
Brandon Williams
  19 minutes ago
yes AFAIK all the past reported issues should be solved. regarding that txn what is the output that you expected?
Kevin Jones
  17 minutes ago
This was the original discussion on Slack (deleted now):
A transfer SUI transaction that uses only a single Gas coin for both transferring the balance and for the gas fee translates as a series of the following operations in Rosetta:
ProgrammableTransaction
SuiBalanceChange
SuiBalanceChange
Gas
It should be:
PaySui
PaySui
Gas
Example transaction and the corresponding operation:
https://suiscan.xyz/mainnet/tx/9p6TGsaYy7yodYxAyhTEryQda3hvFmLeKzFMH9VJ5GYM
Sajjad Zaidi
  14 minutes ago
@Kevin Jones just a few thoughts, i think we should avoid referring back to original thread since we only have pieces of it now and lack context. Lets confirm, that for above operations our internal indexer can parse the transfer and if we will run into any issues with dust coins
Nick Vikeras
  9 minutes ago
IIUC this test that was included with the linked PR is trying to check that the PaySui amounts cancel out, but it would also just ignore if the service actually created SuiBalanceChange instead of PaySui - https://github.com/MystenLabs/sui/blob/20453d8502a6e448d7a77973ad11c42db8be092a/crates/sui-rosetta/tests/end_to_end_tests.rs?plain=1#L789-L796
So if producing PaySui here is required then this might still be broken
```

## Test plan

Updated existing test to assert expected operation types correctly.
