### PR TITLE
fix: avoid unnecessary clone when setting env var

### DIFF
--- a/crates/sui-kv-rpc/src/main.rs
+++ b/crates/sui-kv-rpc/src/main.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<()> {
     let _guard = TelemetryConfig::new().with_env().init();
     let app = App::parse();
     unsafe {
-        std::env::set_var("GOOGLE_APPLICATION_CREDENTIALS", app.credentials.clone());
+        std::env::set_var("GOOGLE_APPLICATION_CREDENTIALS", &app.credentials);
     };
     let server_version = Some(ServerVersion::new("sui-kv-rpc", VERSION));
     let registry_service = mysten_metrics::start_prometheus_server(


### PR DESCRIPTION
Replace app.credentials.clone() with a reference when calling std::env::set_var, since the value is only used to initialize the GOOGLE_APPLICATION_CREDENTIALS environment variable and does not need to be duplicated. This removes an unnecessary heap allocation without changing the behavior of the binary.