### PR TITLE
[consensus] improve protocol config in tests

### DIFF
--- a/consensus/core/src/authority_service.rs
+++ b/consensus/core/src/authority_service.rs
@@ -443,7 +443,7 @@ impl<C: CoreThreadDispatcher> NetworkService for AuthorityService<C> {
                 let selected_num_blocks = max_response_num_blocks.saturating_sub(blocks.len());
                 if selected_num_blocks < missing_ancestors.len() {
                     missing_ancestors = missing_ancestors
-                        .choose_multiple(&mut rand::thread_rng(), selected_num_blocks)
+                        .choose_multiple(&mut mysten_common::random::get_rng(), selected_num_blocks)
                         .copied()
                         .collect::<Vec<_>>();
                 }

--- a/crates/mysten-common/src/lib.rs
+++ b/crates/mysten-common/src/lib.rs
@@ -15,6 +15,11 @@ pub mod sync;
 pub use random_util::tempdir;
 
 #[inline(always)]
+pub fn in_integration_test() -> bool {
+    in_antithesis() || cfg!(msim)
+}
+
+#[inline(always)]
 pub fn in_antithesis() -> bool {
     static IN_ANTITHESIS: Lazy<bool> = Lazy::new(|| {
         let in_antithesis = std::env::var("ANTITHESIS_OUTPUT_DIR").is_ok();

--- a/crates/sui-core/src/transaction_orchestrator.rs
+++ b/crates/sui-core/src/transaction_orchestrator.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use futures::FutureExt;
 use futures::stream::{FuturesUnordered, StreamExt};
-use mysten_common::{backoff, in_antithesis, in_test_configuration};
+use mysten_common::{backoff, in_integration_test};
 use mysten_metrics::{TX_TYPE_SHARED_OBJ_TX, TX_TYPE_SINGLE_WRITER_TX, spawn_monitored_task};
 use mysten_metrics::{add_server_timing, spawn_logged_monitored_task};
 use prometheus::core::{AtomicI64, AtomicU64, GenericCounter, GenericGauge};
@@ -488,7 +488,7 @@ where
         let num_submissions = if !is_new_transaction {
             // No need to submit when the transaction is already being processed.
             0
-        } else if in_test_configuration() {
+        } else if in_integration_test() {
             // Allow duplicated submissions in tests.
             let r = rand::thread_rng().gen_range(1..=100);
             let n = if r <= 10 {

--- a/crates/sui-protocol-config/src/lib.rs
+++ b/crates/sui-protocol-config/src/lib.rs
@@ -14,7 +14,7 @@ use move_binary_format::{
     file_format_common::VERSION_1,
 };
 use move_vm_config::verifier::VerifierConfig;
-use mysten_common::in_test_configuration;
+use mysten_common::in_integration_test;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use sui_protocol_config_macros::{
@@ -4428,9 +4428,11 @@ impl ProtocolConfig {
                 107 => {
                     cfg.feature_flags
                         .consensus_skip_gced_blocks_in_direct_finalization = true;
-                    if in_test_configuration() {
-                        // Trigger GC more often.
+
+                    // Trigger edge cases more often in integration tests.
+                    if in_integration_test() {
                         cfg.consensus_gc_depth = Some(6);
+                        cfg.consensus_max_num_transactions_in_block = Some(8);
                     }
                 }
                 108 => {

--- a/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/simulate/resolve/mod.rs
+++ b/crates/sui-rpc-api/src/grpc/v2/transaction_execution_service/simulate/resolve/mod.rs
@@ -824,14 +824,11 @@ impl<'a> UnresolvedInput<'a> {
                             FieldViolation::new("amount").with_reason(ErrorReason::FieldMissing)
                         })?),
                         type_arg: WithdrawalTypeArg::Balance(
-                            w.coin_type()
-                                .parse::<sui_types::TypeTag>()
-                                .map_err(|e| {
-                                    FieldViolation::new("coin_type")
-                                        .with_description(format!("invalid coin_type: {e}"))
-                                        .with_reason(ErrorReason::FieldInvalid)
-                                })?
-                                .into(),
+                            w.coin_type().parse::<sui_types::TypeTag>().map_err(|e| {
+                                FieldViolation::new("coin_type")
+                                    .with_description(format!("invalid coin_type: {e}"))
+                                    .with_reason(ErrorReason::FieldInvalid)
+                            })?,
                         ),
                         withdraw_from: match w.source() {
                             sui_rpc::proto::sui::rpc::v2::funds_withdrawal::Source::Sender => {


### PR DESCRIPTION
## Description 

- Make full blocks more likely to appear in tests.
- Set test gc depth in protocol 107, to avoid compatibility issues.
- Use antithesis rng, and various other cleanups.

## Test plan 
CI