### PR TITLE
Remove redundant check in State::Visiting

### DIFF
--- a/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
+++ b/external-crates/move/crates/move-vm-runtime/src/jit/execution/translate.rs
@@ -300,26 +300,26 @@ fn modules(
                     continue;
                 }
                 State::Visiting => {
-                    // all deps done, now load if needed
-                    if !package_context.loaded_modules.contains_key(&cur_key) {
-                        let input_module = input_modules.get(&cur_id).ok_or_else(|| {
-                            make_invariant_violation!(format!(
-                                "Module {} not found in initial modules",
-                                cur_id
-                            ))
-                        })?;
-                        let loaded_module =
-                            module(package_context, package_context.version_id, input_module)?;
-                        if package_context
-                            .loaded_modules
-                            .insert(cur_key, loaded_module)
-                            .is_some()
-                        {
-                            return Err(make_invariant_violation!(format!(
-                                "Module {} already loaded in package context",
-                                cur_id
-                            )));
-                        }
+                    // All deps done, now load. No need to check if already loaded: a module
+                    // enters Visiting only from NotVisited, and transitions to Visited
+                    // immediately after loading, so we never reach here twice for the same module.
+                    let input_module = input_modules.get(&cur_id).ok_or_else(|| {
+                        make_invariant_violation!(format!(
+                            "Module {} not found in initial modules",
+                            cur_id
+                        ))
+                    })?;
+                    let loaded_module =
+                        module(package_context, package_context.version_id, input_module)?;
+                    if package_context
+                        .loaded_modules
+                        .insert(cur_key, loaded_module)
+                        .is_some()
+                    {
+                        return Err(make_invariant_violation!(format!(
+                            "Module {} already loaded in package context",
+                            cur_id
+                        )));
                     }
                     state.insert(cur_id, State::Visited);
                 }


### PR DESCRIPTION
## Description 

This if statement (src/jit/execution/translate.rs#L304) could be removed to perform an invariant check later(src/jit/execution/translate.rs#L318). When module's state is  State::Visiting , it should not have been loaded yet. The stack could have duplicate ModuleId s in it but whenever the first one is popped and loaded, the state is changed in the global state(src/jit/execution/translate.rs#L279), so when we pop the second duplicate, it will be State::Visited.

## Test plan 

How did you test the new or updated feature?

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
