### PR TITLE
Fix unit test note to reference #[random_test]

### DIFF
--- a/external-crates/move/crates/move-compiler/src/unit_test/filter_test_members.rs
+++ b/external-crates/move/crates/move-compiler/src/unit_test/filter_test_members.rs
@@ -70,7 +70,7 @@ impl FilterContext for Context<'_> {
     }
 
     // Mode filtering happens in the mode filter for `#[mode(test)]`. We further remove any
-    // `#[test]` or `#[rand_test]` that is not in our source definition. This means we will filter
+    // `#[test]` or `#[random_test]` that is not in our source definition. This means we will filter
     // the following definitions:
     // * Definitions annotated as a test function (test, random_test, abort) and test mode is not set
     // * Definitions in a library annotated with the same

--- a/external-crates/move/crates/move-compiler/src/unit_test/plan_builder.rs
+++ b/external-crates/move/crates/move-compiler/src/unit_test/plan_builder.rs
@@ -227,7 +227,7 @@ fn build_test_info<'func>(
             (function.loc, "Invalid test function")
         );
         diag.add_note("Test functions with arguments have been deprecated");
-        diag.add_note("If you would like to test functions with random inputs, consider using '#[rand_test]' instead");
+        diag.add_note("If you would like to test functions with random inputs, consider using '#[random_test]' instead");
         context.add_diag(diag);
         return None;
     }

--- a/external-crates/move/crates/move-compiler/tests/move_2024/unit_test/random_test_not_rand_test_attr@unit_test.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_2024/unit_test/random_test_not_rand_test_attr@unit_test.snap
@@ -14,7 +14,7 @@ warning[W10007]: issue with attribute value
   │ ╰─────^ Invalid test function
   │  
   = Test functions with arguments have been deprecated
-  = If you would like to test functions with random inputs, consider using '#[rand_test]' instead
+  = If you would like to test functions with random inputs, consider using '#[random_test]' instead
 
 warning[W10007]: issue with attribute value
    ┌─ tests/move_2024/unit_test/random_test_not_rand_test_attr.move:8:5
@@ -25,7 +25,7 @@ warning[W10007]: issue with attribute value
    │ ╰─────^ Invalid test function
    │  
    = Test functions with arguments have been deprecated
-   = If you would like to test functions with random inputs, consider using '#[rand_test]' instead
+   = If you would like to test functions with random inputs, consider using '#[random_test]' instead
 
 warning[W10007]: issue with attribute value
    ┌─ tests/move_2024/unit_test/random_test_not_rand_test_attr.move:13:5
@@ -37,7 +37,7 @@ warning[W10007]: issue with attribute value
    │ ╰─────^ Invalid test function
    │  
    = Test functions with arguments have been deprecated
-   = If you would like to test functions with random inputs, consider using '#[rand_test]' instead
+   = If you would like to test functions with random inputs, consider using '#[random_test]' instead
 
 warning[W10007]: issue with attribute value
    ┌─ tests/move_2024/unit_test/random_test_not_rand_test_attr.move:19:5
@@ -48,4 +48,4 @@ warning[W10007]: issue with attribute value
    │ ╰─────^ Invalid test function
    │  
    = Test functions with arguments have been deprecated
-   = If you would like to test functions with random inputs, consider using '#[rand_test]' instead
+   = If you would like to test functions with random inputs, consider using '#[random_test]' instead

--- a/external-crates/move/crates/move-compiler/tests/move_check/typing/used_const@unused.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/typing/used_const@unused.snap
@@ -23,4 +23,4 @@ warning[W10007]: issue with attribute value
    │ ╰─────^ Invalid test function
    │  
    = Test functions with arguments have been deprecated
-   = If you would like to test functions with random inputs, consider using '#[rand_test]' instead
+   = If you would like to test functions with random inputs, consider using '#[random_test]' instead

--- a/external-crates/move/crates/move-compiler/tests/move_check/unit_test/multiple_errors@unit_test.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/unit_test/multiple_errors@unit_test.snap
@@ -49,7 +49,7 @@ warning[W10007]: issue with attribute value
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid test function
    │
    = Test functions with arguments have been deprecated
-   = If you would like to test functions with random inputs, consider using '#[rand_test]' instead
+   = If you would like to test functions with random inputs, consider using '#[random_test]' instead
 
 error[E10001]: invalid duplicate attribute
    ┌─ tests/move_check/unit_test/multiple_errors.move:36:7

--- a/external-crates/move/crates/move-compiler/tests/move_check/unit_test/multiple_test_annotations@unit_test.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/unit_test/multiple_test_annotations@unit_test.snap
@@ -48,7 +48,7 @@ warning[W10007]: issue with attribute value
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid test function
   │
   = Test functions with arguments have been deprecated
-  = If you would like to test functions with random inputs, consider using '#[rand_test]' instead
+  = If you would like to test functions with random inputs, consider using '#[random_test]' instead
 
 warning[W10007]: issue with attribute value
    ┌─ tests/move_check/unit_test/multiple_test_annotations.move:10:7
@@ -84,4 +84,4 @@ warning[W10007]: issue with attribute value
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid test function
    │
    = Test functions with arguments have been deprecated
-   = If you would like to test functions with random inputs, consider using '#[rand_test]' instead
+   = If you would like to test functions with random inputs, consider using '#[random_test]' instead

--- a/external-crates/move/crates/move-compiler/tests/move_check/unit_test/named_address_no_value_in_annotation@unit_test.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/unit_test/named_address_no_value_in_annotation@unit_test.snap
@@ -21,4 +21,4 @@ warning[W10007]: issue with attribute value
   │     ^^^^^^^^^^^^^^^^^^^^^^^^ Invalid test function
   │
   = Test functions with arguments have been deprecated
-  = If you would like to test functions with random inputs, consider using '#[rand_test]' instead
+  = If you would like to test functions with random inputs, consider using '#[random_test]' instead

--- a/external-crates/move/crates/move-compiler/tests/move_check/unit_test/test_and_test_only_annotation@unit_test.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/unit_test/test_and_test_only_annotation@unit_test.snap
@@ -31,4 +31,4 @@ warning[W10007]: issue with attribute value
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid test function
   │
   = Test functions with arguments have been deprecated
-  = If you would like to test functions with random inputs, consider using '#[rand_test]' instead
+  = If you would like to test functions with random inputs, consider using '#[random_test]' instead

--- a/external-crates/move/crates/move-compiler/tests/move_check/unit_test/valid_test_module@unit_test.snap
+++ b/external-crates/move/crates/move-compiler/tests/move_check/unit_test/valid_test_module@unit_test.snap
@@ -21,7 +21,7 @@ warning[W10007]: issue with attribute value
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid test function
    │
    = Test functions with arguments have been deprecated
-   = If you would like to test functions with random inputs, consider using '#[rand_test]' instead
+   = If you would like to test functions with random inputs, consider using '#[random_test]' instead
 
 warning[W10007]: issue with attribute value
    ┌─ tests/move_check/unit_test/valid_test_module.move:22:7
@@ -39,7 +39,7 @@ warning[W10007]: issue with attribute value
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid test function
    │
    = Test functions with arguments have been deprecated
-   = If you would like to test functions with random inputs, consider using '#[rand_test]' instead
+   = If you would like to test functions with random inputs, consider using '#[random_test]' instead
 
 warning[W10007]: issue with attribute value
    ┌─ tests/move_check/unit_test/valid_test_module.move:26:7
@@ -57,7 +57,7 @@ warning[W10007]: issue with attribute value
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid test function
    │
    = Test functions with arguments have been deprecated
-   = If you would like to test functions with random inputs, consider using '#[rand_test]' instead
+   = If you would like to test functions with random inputs, consider using '#[random_test]' instead
 
 warning[W10007]: issue with attribute value
    ┌─ tests/move_check/unit_test/valid_test_module.move:30:7
@@ -75,7 +75,7 @@ warning[W10007]: issue with attribute value
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid test function
    │
    = Test functions with arguments have been deprecated
-   = If you would like to test functions with random inputs, consider using '#[rand_test]' instead
+   = If you would like to test functions with random inputs, consider using '#[random_test]' instead
 
 warning[W10007]: issue with attribute value
    ┌─ tests/move_check/unit_test/valid_test_module.move:35:7
@@ -93,7 +93,7 @@ warning[W10007]: issue with attribute value
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid test function
    │
    = Test functions with arguments have been deprecated
-   = If you would like to test functions with random inputs, consider using '#[rand_test]' instead
+   = If you would like to test functions with random inputs, consider using '#[random_test]' instead
 
 warning[W10007]: issue with attribute value
    ┌─ tests/move_check/unit_test/valid_test_module.move:40:7
@@ -111,4 +111,4 @@ warning[W10007]: issue with attribute value
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid test function
    │
    = Test functions with arguments have been deprecated
-   = If you would like to test functions with random inputs, consider using '#[rand_test]' instead
+   = If you would like to test functions with random inputs, consider using '#[random_test]' instead


### PR DESCRIPTION
## Description 

Update the Move compiler warning note for deprecated test function arguments to point to #[random_test], and refresh affected snapshot outputs.

## Test plan 

Ran `cargo test -p move-compiler --test move_check_testsuite` in `external-crates/move`

---

## Release notes

Check each box that your changes affect. If none of the boxes relate to your changes, release notes aren't required.

For each box you select, include information after the relevant heading that describes the impact of your changes that a user might notice and any actions they must take to implement updates. 

- [ ] Protocol: 
- [ ] Nodes (Validators and Full nodes): 
- [ ] gRPC:
- [ ] JSON-RPC: 
- [ ] GraphQL: 
- [ ] CLI: 
- [ ] Rust SDK:
- [ ] Indexing Framework:
